### PR TITLE
fix: a failed root-exec manifest re-record fails the update loudly (TASK-584)

### DIFF
--- a/config/clawbox-root-manifest.sh
+++ b/config/clawbox-root-manifest.sh
@@ -42,6 +42,8 @@
 # Usage (root only):
 #   clawbox-root-manifest.sh --write     record the tree as it is now
 #   clawbox-root-manifest.sh --verify    exit 0 if it still matches, 65 if not
+#   clawbox-root-manifest.sh --selftest  print SELFTEST_TOKEN — proof this file
+#                                        is complete, which no exit status is
 #
 # Installed by install.sh::install_root_libexec to
 # /usr/local/libexec/clawbox/clawbox-root-manifest.sh, root:root 0755.
@@ -55,6 +57,23 @@ set -euo pipefail
 PROJECT_DIR="/home/clawbox/clawbox"
 MANIFEST_DIR="/etc/clawbox"
 MANIFEST_FILE="/etc/clawbox/root-exec.manifest"
+
+# What --selftest prints, and the only thing that makes the exit statuses of the
+# verbs above worth reading.
+#
+# `install` writes into the destination inode with O_TRUNC, so a copy of this
+# file that dies part way through — a full or read-only root filesystem — leaves
+# an executable helper containing some prefix of it. That prefix has no case
+# statement at the bottom, so it runs to EOF and exits 0 for `--write`, for
+# `--verify` and for `--verify-file` without doing any of them. An empty file
+# does the same. Both callers — install.sh and the root dispatcher — then read
+# "the tree is recorded and matches" out of a program that never looked, and
+# clawbox-root-step.sh execs a clawbox-writable tree as root on the strength of
+# it. So callers ask for this token first; only a copy that reaches the last
+# line of this file can print it. Repeated as a literal in install.sh and
+# config/clawbox-root-step.sh, which are installed separately and cannot share a
+# constant; src/tests/unit/root-exec-manifest.test.ts pins them against this one.
+SELFTEST_TOKEN="clawbox-root-manifest alive"
 
 # Everything the clawbox-root-update@ chain can end up running as root:
 # install.sh, the scripts it hands to bash, and the config/unit files it installs.
@@ -197,8 +216,9 @@ case "${1:-}" in
   --write)  write_manifest ;;
   --verify) verify_manifest ;;
   --verify-file) verify_file "${2:-}" "${3:-}" ;;
+  --selftest) printf '%s\n' "$SELFTEST_TOKEN" ;;
   *)
-    echo "usage: $0 --write|--verify|--verify-file <recorded path> <file>" >&2
+    echo "usage: $0 --write|--verify|--verify-file <recorded path> <file>|--selftest" >&2
     exit 64
     ;;
 esac

--- a/config/clawbox-root-manifest.sh
+++ b/config/clawbox-root-manifest.sh
@@ -42,8 +42,9 @@
 # Usage (root only):
 #   clawbox-root-manifest.sh --write     record the tree as it is now
 #   clawbox-root-manifest.sh --verify    exit 0 if it still matches, 65 if not
-#   clawbox-root-manifest.sh --selftest  print SELFTEST_TOKEN — proof this file
-#                                        is complete, which no exit status is
+#   clawbox-root-manifest.sh --selftest  print SELFTEST_TOKEN — proof that this
+#                                        file is complete, which no exit status
+#                                        of the verbs above can give
 #
 # Installed by install.sh::install_root_libexec to
 # /usr/local/libexec/clawbox/clawbox-root-manifest.sh, root:root 0755.
@@ -73,6 +74,15 @@ MANIFEST_FILE="/etc/clawbox/root-exec.manifest"
 # line of this file can print it. Repeated as a literal in install.sh and
 # config/clawbox-root-step.sh, which are installed separately and cannot share a
 # constant; src/tests/unit/root-exec-manifest.test.ts pins them against this one.
+#
+# THIS STRING IS A WIRE FORMAT — never change it, only ever add a second
+# accepted value. install_root_libexec installs this helper unconditionally but
+# the dispatcher only if the manifest write succeeded, so the two ARE reachable
+# at different releases on the same box. A changed token would leave an older
+# dispatcher asking a newer helper: it gets exit 0 with a token it does not
+# recognise, which is neither the match nor the 64 an unknown verb returns, and
+# it would declare a perfectly healthy helper dead — every pinned root step
+# refused, on boxes that are fine, fleet-wide.
 SELFTEST_TOKEN="clawbox-root-manifest alive"
 
 # Everything the clawbox-root-update@ chain can end up running as root:
@@ -218,7 +228,7 @@ case "${1:-}" in
   --verify-file) verify_file "${2:-}" "${3:-}" ;;
   --selftest) printf '%s\n' "$SELFTEST_TOKEN" ;;
   *)
-    echo "usage: $0 --write|--verify|--verify-file <recorded path> <file>|--selftest" >&2
+    echo "usage: $0 --write | --verify | --verify-file <recorded path> <file> | --selftest" >&2
     exit 64
     ;;
 esac

--- a/config/clawbox-root-step.sh
+++ b/config/clawbox-root-step.sh
@@ -106,6 +106,13 @@ contains() {
 # bottom of the helper ran: the token from a helper that knows --selftest, or
 # exit 64 from an older one rejecting a verb it does not know. A stub does
 # neither: it prints nothing and exits 0.
+#
+# This file is the side of that comparison that can be OLDER than the helper:
+# install_root_libexec installs the helper unconditionally and this dispatcher
+# only if the manifest write succeeded. So the token below is a wire format —
+# see SELFTEST_TOKEN in clawbox-root-manifest.sh. Changing it there without
+# adding the old value as a second accepted answer here would make this refuse a
+# healthy helper, fleet-wide.
 manifest_helper_alive() {
   local out rc=0
   out="$("$MANIFEST_HELPER" --selftest 2>/dev/null)" || rc=$?

--- a/config/clawbox-root-step.sh
+++ b/config/clawbox-root-step.sh
@@ -93,6 +93,27 @@ contains() {
   return 1
 }
 
+# Does the manifest helper actually run, or is it only present?
+#
+# An empty or half-copied helper exits 0 for every verb without doing any of
+# them — see SELFTEST_TOKEN in clawbox-root-manifest.sh for how one gets there.
+# Reading that 0 turns this gate from fail-closed into fail-OPEN: the exec below
+# would run /home/clawbox/clawbox as root on the word of a program that hashed
+# nothing, and that tree is writable by the unprivileged user the web server
+# runs as. Which is the whole of TASK-445.
+#
+# Two answers count, and both prove the same thing — the verb dispatcher at the
+# bottom of the helper ran: the token from a helper that knows --selftest, or
+# exit 64 from an older one rejecting a verb it does not know. A stub does
+# neither: it prints nothing and exits 0.
+manifest_helper_alive() {
+  local out rc=0
+  out="$("$MANIFEST_HELPER" --selftest 2>/dev/null)" || rc=$?
+  [ "$out" = "clawbox-root-manifest alive" ] && return 0
+  [ "$rc" -eq 64 ] && return 0
+  return 1
+}
+
 if ! contains "$step" "$ALLOWED_STEPS"; then
   echo "clawbox-root-step: step not permitted: $step" >&2
   exit 64
@@ -135,6 +156,11 @@ else
   #     through sudo without moving the git work itself to the root side.
   if [ ! -x "$MANIFEST_HELPER" ]; then
     echo "clawbox-root-step: $MANIFEST_HELPER is missing — cannot tell what root is about to run" >&2
+    echo "clawbox-root-step: recover with: sudo bash $ENTRYPOINT --step systemd_services" >&2
+    exit 65
+  fi
+  if ! manifest_helper_alive; then
+    echo "clawbox-root-step: $MANIFEST_HELPER is installed but does nothing — it cannot tell what root is about to run" >&2
     echo "clawbox-root-step: recover with: sudo bash $ENTRYPOINT --step systemd_services" >&2
     exit 65
   fi

--- a/install.sh
+++ b/install.sh
@@ -102,24 +102,40 @@ if [ -z "${CLAWBOX_INSTALL_BOOTSTRAPPED:-}" ] \
       # literal because the constants block has not been parsed yet.
       #
       # A failure here is NOT a warning. The root dispatcher fails closed on a
-      # stale manifest, so every root step of this very update — and the owner's
+      # stale manifest, so every NON-UPDATE root step is then refused with exit
+      # 65 — openclaw_install, performance_mode, gateway_setup, and the owner's
       # password change, hostname change, hotspot restart and llama.cpp install
-      # afterwards — is refused with exit 65 until the record is written again
-      # (seen live: `--verify` returned 65 and every root step was refused).
-      # A single line on the stderr of an update nobody watches is how that
-      # became invisible. TASK-584.
+      # (the update family is deliberately exempt; see SELF_UPDATING_STEPS in
+      # config/clawbox-root-step.sh). Seen live: `--verify` returned 65 and every
+      # root step was refused, and a single line on the stderr of an update
+      # nobody watches was the whole trace. TASK-584.
       _mf=/usr/local/libexec/clawbox/clawbox-root-manifest.sh
+      # --write AND --verify, never --write alone: a truncated or empty helper
+      # exits 0 for both verbs without writing anything, so believing the write's
+      # own status is how this failure would go quiet again.
       if [ "$_b" = "/home/clawbox/clawbox" ] && [ -x "$_mf" ]; then
-        if ! "$_mf" --write; then
+        if ! { "$_mf" --write && "$_mf" --verify >/dev/null; }; then
           # Repair before reporting. The most likely reason the INSTALLED helper
           # failed is that it is the one from before this reset, so replace it
           # from the tree we just checked out and try once more. Best-effort:
           # this is the bootstrap of the boot path and it must never abort.
           echo "[bootstrap] WARN: could not re-record the root-exec manifest — refreshing the helper and retrying" >&2
           if [ -f "$_b/config/clawbox-root-manifest.sh" ]; then
-            install -o root -g root -m 0755 "$_b/config/clawbox-root-manifest.sh" "$_mf" 2>/dev/null || true
+            # Temp name + rename, NEVER a copy over the live file. `install`
+            # writes into the existing inode with O_TRUNC, so a copy that fails
+            # halfway (a full or read-only root filesystem — the same condition
+            # that most often fails the write above) would leave a 0-byte
+            # clawbox-root-manifest.sh behind. That is worse than the stale
+            # manifest: an empty helper exits 0 for --verify, which turns the
+            # root dispatcher from fail-closed into fail-open.
+            if install -o root -g root -m 0755 "$_b/config/clawbox-root-manifest.sh" "$_mf.new"; then
+              mv -f "$_mf.new" "$_mf" || echo "[bootstrap] WARN: could not replace $_mf" >&2
+            else
+              echo "[bootstrap] WARN: could not stage a fresh root-exec manifest helper" >&2
+              rm -f "$_mf.new" 2>/dev/null || true
+            fi
           fi
-          if ! "$_mf" --write; then
+          if ! { "$_mf" --write && "$_mf" --verify >/dev/null; }; then
             # Carried into the re-exec rather than acted on here: the process
             # that can record it against the run's verdict is the one about to
             # start. It re-checks before believing this.
@@ -180,10 +196,24 @@ clear_provision_failure() {
   PROVISION_FAILURES=("${kept[@]}")
 }
 
+# The step an operator should re-run to repair a recorded failure. Almost every
+# token IS its step, which is what both verdict printers assume — but
+# `root_exec_manifest` is recorded before any step runs and is not dispatchable,
+# so printing `--step root_exec_manifest` would hand the operator an "Unknown
+# step". `systemd_services` is the repair: it re-installs the helper AND the
+# dispatcher and re-records the manifest, which is also the hint
+# config/clawbox-root-step.sh gives when it refuses.
+provision_repair_step() {
+  case "$1" in
+    root_exec_manifest) printf 'systemd_services' ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
 # The bootstrap could not re-record the root-exec manifest before re-exec'ing
 # into this process (TASK-584). The dispatcher fails closed on a stale manifest,
-# so this update's own root steps — and the owner's password and hostname
-# changes after it — are being refused with exit 65.
+# so every NON-UPDATE root step — openclaw_install, gateway_setup, and the
+# owner's password and hostname changes — is being refused with exit 65.
 #
 # Verified rather than believed: the marker says the bootstrap's write failed,
 # not that the record is still wrong, and reporting a failure over a manifest
@@ -196,9 +226,9 @@ if [ "${CLAWBOX_ROOT_MANIFEST_STALE:-0}" = "1" ]; then
     record_provision_failure root_exec_manifest
     echo "  ############################################################" >&2
     echo "  # The root-exec manifest could not be re-recorded." >&2
-    echo "  # Root steps are being REFUSED (exit 65): password change," >&2
-    echo "  # hostname, hotspot restart and llama.cpp install included." >&2
-    echo "  # Repair:  sudo /usr/local/libexec/clawbox/clawbox-root-manifest.sh --write" >&2
+    echo "  # Non-update root steps are being REFUSED (exit 65): password" >&2
+    echo "  # change, hostname, hotspot restart, llama.cpp install." >&2
+    echo "  # Repair:  sudo bash $PROJECT_DIR/install.sh --step systemd_services" >&2
     echo "  ############################################################" >&2
   fi
 fi
@@ -3547,7 +3577,15 @@ write_root_exec_manifest() {
 # is current again.
 refresh_root_exec_manifest() {
   [ -x "$ROOT_EXEC_MANIFEST_HELPER" ] || return 0
-  write_root_exec_manifest || echo "  Warning: could not re-record the root-exec manifest; root steps will refuse until an operator runs 'sudo bash $PROJECT_DIR/install.sh --step systemd_services'" >&2
+  # RECORDED, not just warned. This is the second place install.sh re-records the
+  # manifest after a `git reset --hard` (sync_repo_to_update_target), and it had
+  # the same defect the bootstrap did: a failure here left the step exiting 0
+  # with a stale manifest, and the operator then met it as an opaque exit-65 on
+  # some later step instead. Non-fatal on purpose — the update should finish —
+  # but the run's verdict says so. TASK-584.
+  write_root_exec_manifest && return 0
+  echo "  Warning: could not re-record the root-exec manifest; root steps will refuse until an operator runs 'sudo bash $PROJECT_DIR/install.sh --step systemd_services'" >&2
+  record_provision_failure root_exec_manifest
 }
 
 install_root_libexec() {
@@ -6071,7 +6109,7 @@ if [ "${1:-}" = "--step" ]; then
       echo "  ############################################################"
       echo "  # PROVISIONING INCOMPLETE — step $local_step reported errors."
       echo "  # Steps that failed: ${PROVISION_FAILURES[*]}"
-      echo "  # Re-run:  sudo bash $PROJECT_DIR/install.sh --step ${PROVISION_FAILURES[0]}"
+      echo "  # Re-run:  sudo bash $PROJECT_DIR/install.sh --step $(provision_repair_step "${PROVISION_FAILURES[0]}")"
       echo "  ############################################################"
       write_provision_status incomplete "${PROVISION_FAILURES[*]}" || true
       # Same stdout contract as the full install: the flash host greps these
@@ -6287,7 +6325,7 @@ if [ "$FINAL_RC" -ne 0 ]; then
   echo "  # reported errors. Do NOT ship this box as healthy."
   if [ "${#PROVISION_FAILURES[@]}" -gt 0 ]; then
     echo "  # Steps that failed: ${PROVISION_FAILURES[*]}"
-    echo "  # Re-run:  sudo bash $PROJECT_DIR/install.sh --step ${PROVISION_FAILURES[0]}"
+    echo "  # Re-run:  sudo bash $PROJECT_DIR/install.sh --step $(provision_repair_step "${PROVISION_FAILURES[0]}")"
   fi
   if [ "${VALIDATE_RC:-0}" -ne 0 ]; then
     echo "  # Service validation FAILED (see the checks listed above)."

--- a/install.sh
+++ b/install.sh
@@ -190,10 +190,15 @@ record_provision_failure() {
 # half a minute later — a false failure over an install that is fine.
 clear_provision_failure() {
   local kept=() f
-  for f in "${PROVISION_FAILURES[@]}"; do
+  # `${a[@]+"${a[@]}"}` rather than `"${a[@]}"`: bash before 4.4 calls an empty
+  # array unbound under `set -u`, and both arrays here are empty on the common
+  # path (nothing recorded, or nothing kept). Aborting the installer inside the
+  # function whose whole job is to CLEAR a failure would report exactly the
+  # false failure it exists to remove.
+  for f in ${PROVISION_FAILURES[@]+"${PROVISION_FAILURES[@]}"}; do
     [ "$f" = "$1" ] || kept+=("$f")
   done
-  PROVISION_FAILURES=("${kept[@]}")
+  PROVISION_FAILURES=(${kept[@]+"${kept[@]}"})
 }
 
 # The step an operator should re-run to repair a recorded failure. Almost every

--- a/install.sh
+++ b/install.sh
@@ -100,12 +100,37 @@ if [ -z "${CLAWBOX_INSTALL_BOOTSTRAPPED:-}" ] \
       # manifest the root dispatcher checks is now stale by construction — and a
       # stale manifest fails every subsequent step of this very update. Paths are
       # literal because the constants block has not been parsed yet.
+      #
+      # A failure here is NOT a warning. The root dispatcher fails closed on a
+      # stale manifest, so every root step of this very update — and the owner's
+      # password change, hostname change, hotspot restart and llama.cpp install
+      # afterwards — is refused with exit 65 until the record is written again
+      # (seen live: `--verify` returned 65 and every root step was refused).
+      # A single line on the stderr of an update nobody watches is how that
+      # became invisible. TASK-584.
       _mf=/usr/local/libexec/clawbox/clawbox-root-manifest.sh
       if [ "$_b" = "/home/clawbox/clawbox" ] && [ -x "$_mf" ]; then
-        "$_mf" --write || echo "[bootstrap] WARN: could not re-record the root-exec manifest" >&2
+        if ! "$_mf" --write; then
+          # Repair before reporting. The most likely reason the INSTALLED helper
+          # failed is that it is the one from before this reset, so replace it
+          # from the tree we just checked out and try once more. Best-effort:
+          # this is the bootstrap of the boot path and it must never abort.
+          echo "[bootstrap] WARN: could not re-record the root-exec manifest — refreshing the helper and retrying" >&2
+          if [ -f "$_b/config/clawbox-root-manifest.sh" ]; then
+            install -o root -g root -m 0755 "$_b/config/clawbox-root-manifest.sh" "$_mf" 2>/dev/null || true
+          fi
+          if ! "$_mf" --write; then
+            # Carried into the re-exec rather than acted on here: the process
+            # that can record it against the run's verdict is the one about to
+            # start. It re-checks before believing this.
+            CLAWBOX_ROOT_MANIFEST_STALE=1
+          fi
+        fi
       fi
       echo "[bootstrap] Re-executing as $(git -C "$_b" -c safe.directory="$_b" rev-parse --short HEAD)..."
-      exec env CLAWBOX_INSTALL_BOOTSTRAPPED=1 bash "$_b/install.sh" "$@"
+      exec env CLAWBOX_INSTALL_BOOTSTRAPPED=1 \
+        CLAWBOX_ROOT_MANIFEST_STALE="${CLAWBOX_ROOT_MANIFEST_STALE:-0}" \
+        bash "$_b/install.sh" "$@"
     fi
     echo "[bootstrap] WARN: couldn't reset to origin/${_br}; continuing with on-disk copy."
   fi
@@ -143,6 +168,40 @@ PROVISION_STATUS_UNPUBLISHED=0
 record_provision_failure() {
   PROVISION_FAILURES+=("$1")
 }
+
+# Drop a recorded failure that a later step actually repaired. Without this the
+# root-exec manifest below would be reported at the end of a run that fixed it
+# half a minute later — a false failure over an install that is fine.
+clear_provision_failure() {
+  local kept=() f
+  for f in "${PROVISION_FAILURES[@]}"; do
+    [ "$f" = "$1" ] || kept+=("$f")
+  done
+  PROVISION_FAILURES=("${kept[@]}")
+}
+
+# The bootstrap could not re-record the root-exec manifest before re-exec'ing
+# into this process (TASK-584). The dispatcher fails closed on a stale manifest,
+# so this update's own root steps — and the owner's password and hostname
+# changes after it — are being refused with exit 65.
+#
+# Verified rather than believed: the marker says the bootstrap's write failed,
+# not that the record is still wrong, and reporting a failure over a manifest
+# that verifies would be the opposite defect. install_root_libexec re-records it
+# later in a full run and clears this again on success.
+if [ "${CLAWBOX_ROOT_MANIFEST_STALE:-0}" = "1" ]; then
+  if /usr/local/libexec/clawbox/clawbox-root-manifest.sh --verify >/dev/null 2>&1; then
+    echo "[bootstrap] the root-exec manifest verifies after all — continuing"
+  else
+    record_provision_failure root_exec_manifest
+    echo "  ############################################################" >&2
+    echo "  # The root-exec manifest could not be re-recorded." >&2
+    echo "  # Root steps are being REFUSED (exit 65): password change," >&2
+    echo "  # hostname, hotspot restart and llama.cpp install included." >&2
+    echo "  # Repair:  sudo /usr/local/libexec/clawbox/clawbox-root-manifest.sh --write" >&2
+    echo "  ############################################################" >&2
+  fi
+fi
 
 # ── The marker must never speak for a run other than this one ────────────────
 # The flash host reads $PROVISION_STATUS_FILE INSTEAD of parsing stdout, so the
@@ -3475,7 +3534,10 @@ ROOT_EXEC_MANIFEST_HELPER="$ROOT_LIBEXEC_DIR/clawbox-root-manifest.sh"
 # the record is NOT current, and the caller must treat that as a failure.
 write_root_exec_manifest() {
   [ -x "$ROOT_EXEC_MANIFEST_HELPER" ] || return 1
-  "$ROOT_EXEC_MANIFEST_HELPER" --write
+  "$ROOT_EXEC_MANIFEST_HELPER" --write || return 1
+  # This is exactly the repair for what the bootstrap could not do, so the run's
+  # verdict must stop reporting it. TASK-584.
+  clear_provision_failure root_exec_manifest
 }
 
 # Best-effort variant for the update paths that legitimately change the tree. A

--- a/install.sh
+++ b/install.sh
@@ -133,6 +133,13 @@ if [ -z "${CLAWBOX_INSTALL_BOOTSTRAPPED:-}" ] \
       # Temp name + rename, NEVER a copy over the live file: a copy that fails
       # halfway leaves behind exactly the stub described above.
       _mf_restage() {
+        # Once per run. Both call sites below are reachable in a single pass — a
+        # helper that was not answering is replaced, answers, and then fails
+        # --write — and staging the same bytes a second time cannot change that
+        # outcome. It only widens the window in which a file out of the
+        # clawbox-writable tree is being installed root-owned into libexec.
+        [ "${_mf_staged:-0}" = "0" ] || return 1
+        _mf_staged=1
         [ -f "$_mf_src" ] || return 1
         if ! install -o root -g root -m 0755 "$_mf_src" "$_mf.new"; then
           echo "[bootstrap] WARN: could not stage a fresh root-exec manifest helper" >&2
@@ -210,6 +217,16 @@ PROVISION_RUN_ID="$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo unknown)-$$"
 PROVISION_STATUS_UNPUBLISHED=0
 
 record_provision_failure() {
+  local f
+  # Idempotent. Three sites now record `root_exec_manifest` — the bootstrap's
+  # verdict block, refresh_root_exec_manifest and install_root_libexec — and two
+  # of them can fire in the same run, which put the token in the operator's
+  # "Steps that failed:" line twice and wrote it twice into the marker the flash
+  # host parses. `if`, not `[ … ] &&`: a for loop whose last command fails
+  # returns non-zero, and under `set -e` that would abort the installer here.
+  for f in ${PROVISION_FAILURES[@]+"${PROVISION_FAILURES[@]}"}; do
+    if [ "$f" = "$1" ]; then return 0; fi
+  done
   PROVISION_FAILURES+=("$1")
 }
 
@@ -3653,6 +3670,35 @@ refresh_root_exec_manifest() {
   record_provision_failure root_exec_manifest
 }
 
+# Install one root-owned file WITHOUT ever leaving a prefix of it behind.
+#
+# `install` writes into the destination inode with O_TRUNC, so a copy that dies
+# part way through — a full or read-only /usr — leaves an executable PREFIX of
+# the file at the destination. For every script this function installs that
+# prefix is silently PERMISSIVE rather than noisy, because each one's dispatch
+# is at the bottom: a truncated clawbox-root-manifest.sh exits 0 for --write and
+# --verify without looking at anything (TASK-584, which is why every caller now
+# probes it first), and a truncated clawbox-root-step.sh reaches EOF and exits 0
+# without exec'ing the step at all — which `Type=oneshot` reports to the updater
+# as a step that SUCCEEDED.
+#
+# So: temp name in the same directory, then rename. `rename(2)` within a
+# directory is atomic, so the live file is either the whole old one or the whole
+# new one and never a prefix of either — and a failed copy leaves the working
+# file it was replacing untouched. Same shape as the bootstrap's _mf_restage,
+# which had this and the path that runs on every install did not. TASK-584.
+install_root_file() {
+  local src="$1" dst="$2" mode="${3:-0755}"
+  if ! install -o root -g root -m "$mode" "$src" "$dst.new"; then
+    rm -f "$dst.new" 2>/dev/null || true
+    return 1
+  fi
+  if ! mv -f "$dst.new" "$dst"; then
+    rm -f "$dst.new" 2>/dev/null || true
+    return 1
+  fi
+}
+
 install_root_libexec() {
   install -d -o root -g root -m 0755 /usr/local/libexec
   install -d -o root -g root -m 0755 "$ROOT_LIBEXEC_DIR"
@@ -3661,7 +3707,7 @@ install_root_libexec() {
   # function refuses to run any step unless the manifest this writes verifies.
   for src in clawbox-root-manifest.sh clawbox-run-root-step.sh; do
     if [ -f "$PROJECT_DIR/config/$src" ]; then
-      install -o root -g root -m 0755 "$PROJECT_DIR/config/$src" "$ROOT_LIBEXEC_DIR/$src"
+      install_root_file "$PROJECT_DIR/config/$src" "$ROOT_LIBEXEC_DIR/$src"
     fi
   done
   # Everything the web server may invoke as root via a NOPASSWD grant. Same
@@ -3669,14 +3715,14 @@ install_root_libexec() {
   for src in optimize-ollama.sh clawbox-desktop-mode.sh clawbox-power-mode.sh \
              clawbox-resource-limits.sh; do
     if [ -f "$PROJECT_DIR/scripts/$src" ]; then
-      install -o root -g root -m 0755 "$PROJECT_DIR/scripts/$src" "$ROOT_LIBEXEC_DIR/$src"
+      install_root_file "$PROJECT_DIR/scripts/$src" "$ROOT_LIBEXEC_DIR/$src"
     fi
   done
   # The limits the scripts above read. Root-owned for the same reason they are.
   install -d -o root -g root -m 0755 /etc/clawbox
   if [ -f "$PROJECT_DIR/config/clawbox-resource-limits.env" ]; then
-    install -o root -g root -m 0644 "$PROJECT_DIR/config/clawbox-resource-limits.env" \
-      /etc/clawbox/resource-limits.env
+    install_root_file "$PROJECT_DIR/config/clawbox-resource-limits.env" \
+      /etc/clawbox/resource-limits.env 0644
   fi
 
   # Manifest, THEN dispatcher — never the other way round. The dispatcher fails
@@ -3688,7 +3734,7 @@ install_root_libexec() {
   # install_sudoers_dropin follows for the allow-list. TASK-445.
   if write_root_exec_manifest; then
     if [ -f "$PROJECT_DIR/config/clawbox-root-step.sh" ]; then
-      install -o root -g root -m 0755 "$PROJECT_DIR/config/clawbox-root-step.sh" \
+      install_root_file "$PROJECT_DIR/config/clawbox-root-step.sh" \
         "$ROOT_LIBEXEC_DIR/clawbox-root-step.sh"
     fi
   else
@@ -4483,8 +4529,8 @@ step_polkit_rules() {
   # it was how the unscoped .pkla ended up as the only authority.
   local POLKIT_RULES_DIR="/etc/polkit-1/rules.d"
   if [ -d "$POLKIT_RULES_DIR" ] && [ -f "$PROJECT_DIR/config/49-clawbox-updates.rules" ]; then
-    install -o root -g root -m 0644 "$PROJECT_DIR/config/49-clawbox-updates.rules" \
-      "$POLKIT_RULES_DIR/49-clawbox-updates.rules"
+    install_root_file "$PROJECT_DIR/config/49-clawbox-updates.rules" \
+      "$POLKIT_RULES_DIR/49-clawbox-updates.rules" 0644
   fi
   echo "  Polkit rules installed (NetworkManager only; root steps go through sudo)"
 }
@@ -4607,8 +4653,8 @@ step_resource_limits() {
   # clawbox-writable and this runs as root.
   install -d -o root -g root -m 0755 /etc/clawbox
   if [ -f "$PROJECT_DIR/config/clawbox-resource-limits.env" ]; then
-    install -o root -g root -m 0644 "$PROJECT_DIR/config/clawbox-resource-limits.env" \
-      /etc/clawbox/resource-limits.env
+    install_root_file "$PROJECT_DIR/config/clawbox-resource-limits.env" \
+      /etc/clawbox/resource-limits.env 0644
   fi
   install_root_libexec
   "$ROOT_LIBEXEC_DIR/clawbox-resource-limits.sh" --apply || \

--- a/install.sh
+++ b/install.sh
@@ -110,32 +110,60 @@ if [ -z "${CLAWBOX_INSTALL_BOOTSTRAPPED:-}" ] \
       # root step was refused, and a single line on the stderr of an update
       # nobody watches was the whole trace. TASK-584.
       _mf=/usr/local/libexec/clawbox/clawbox-root-manifest.sh
-      # --write AND --verify, never --write alone: a truncated or empty helper
-      # exits 0 for both verbs without writing anything, so believing the write's
-      # own status is how this failure would go quiet again.
+      _mf_src="$_b/config/clawbox-root-manifest.sh"
+      # Is the installed helper the whole program, or only the first part of it?
+      # Nothing below may read its exit status until this says yes: an empty or
+      # half-copied helper exits 0 for --write, for --verify AND for the
+      # --verify-file the root dispatcher asks about the file it is about to run
+      # as root (see SELFTEST_TOKEN in config/clawbox-root-manifest.sh).
+      # Believing that 0 is worse than the stale manifest this block exists to
+      # fix — it turns the dispatcher from fail-closed into fail-OPEN over a tree
+      # the clawbox user can rewrite. Inlined rather than shared with
+      # root_exec_manifest_helper_alive below, for the same reason the branch
+      # probes above are inlined: this block runs before that function is parsed.
+      _mf_alive() {
+        local out rc=0
+        [ -x "$_mf" ] || return 1
+        out="$("$_mf" --selftest 2>/dev/null)" || rc=$?
+        [ "$out" = "clawbox-root-manifest alive" ] && return 0
+        [ "$rc" -eq 64 ] && return 0
+        return 1
+      }
+      # Replace the installed helper with the one the reset just checked out.
+      # Temp name + rename, NEVER a copy over the live file: a copy that fails
+      # halfway leaves behind exactly the stub described above.
+      _mf_restage() {
+        [ -f "$_mf_src" ] || return 1
+        if ! install -o root -g root -m 0755 "$_mf_src" "$_mf.new"; then
+          echo "[bootstrap] WARN: could not stage a fresh root-exec manifest helper" >&2
+          rm -f "$_mf.new" 2>/dev/null || true
+          return 1
+        fi
+        mv -f "$_mf.new" "$_mf" || { echo "[bootstrap] WARN: could not replace $_mf" >&2; return 1; }
+      }
       if [ "$_b" = "/home/clawbox/clawbox" ] && [ -x "$_mf" ]; then
-        if ! { "$_mf" --write && "$_mf" --verify >/dev/null; }; then
+        # Best-effort throughout: this is the bootstrap of the boot path and it
+        # must never abort. A helper that cannot answer is replaced first, and
+        # only a helper that answers is asked to record anything.
+        _mf_ok=0
+        if _mf_alive; then
+          _mf_ok=1
+        else
+          echo "[bootstrap] WARN: the installed root-exec manifest helper is not answering — replacing it" >&2
+          if _mf_restage && _mf_alive; then _mf_ok=1; fi
+        fi
+        if [ "$_mf_ok" = "0" ]; then
+          echo "[bootstrap] WARN: no working root-exec manifest helper; root steps will refuse until an operator runs 'sudo bash $_b/install.sh --step systemd_services'" >&2
+          CLAWBOX_ROOT_MANIFEST_STALE=1
+        # --write AND --verify, never --write alone: the write's own status says
+        # the helper believes it recorded something, not that the record matches.
+        elif ! { "$_mf" --write && "$_mf" --verify >/dev/null; }; then
           # Repair before reporting. The most likely reason the INSTALLED helper
           # failed is that it is the one from before this reset, so replace it
-          # from the tree we just checked out and try once more. Best-effort:
-          # this is the bootstrap of the boot path and it must never abort.
+          # from the tree we just checked out and try once more.
           echo "[bootstrap] WARN: could not re-record the root-exec manifest — refreshing the helper and retrying" >&2
-          if [ -f "$_b/config/clawbox-root-manifest.sh" ]; then
-            # Temp name + rename, NEVER a copy over the live file. `install`
-            # writes into the existing inode with O_TRUNC, so a copy that fails
-            # halfway (a full or read-only root filesystem — the same condition
-            # that most often fails the write above) would leave a 0-byte
-            # clawbox-root-manifest.sh behind. That is worse than the stale
-            # manifest: an empty helper exits 0 for --verify, which turns the
-            # root dispatcher from fail-closed into fail-open.
-            if install -o root -g root -m 0755 "$_b/config/clawbox-root-manifest.sh" "$_mf.new"; then
-              mv -f "$_mf.new" "$_mf" || echo "[bootstrap] WARN: could not replace $_mf" >&2
-            else
-              echo "[bootstrap] WARN: could not stage a fresh root-exec manifest helper" >&2
-              rm -f "$_mf.new" 2>/dev/null || true
-            fi
-          fi
-          if ! { "$_mf" --write && "$_mf" --verify >/dev/null; }; then
+          _mf_restage || true
+          if ! { _mf_alive && "$_mf" --write && "$_mf" --verify >/dev/null; }; then
             # Carried into the re-exec rather than acted on here: the process
             # that can record it against the run's verdict is the one about to
             # start. It re-checks before believing this.
@@ -215,6 +243,29 @@ provision_repair_step() {
   esac
 }
 
+# Does the root-exec manifest helper at $1 actually run, or is it only present?
+#
+# An empty or half-copied helper exits 0 for every verb without doing any of
+# them (see SELFTEST_TOKEN in config/clawbox-root-manifest.sh), so reading that
+# 0 reports "the tree is recorded and matches" over a tree nobody hashed — and
+# config/clawbox-root-step.sh then execs that tree as root.
+#
+# Two answers count, and both prove the same thing — the verb dispatcher at the
+# bottom of the helper ran: the token from a helper that knows --selftest, or
+# exit 64 from an older one rejecting a verb it does not know. A stub does
+# neither: it prints nothing and exits 0.
+#
+# Takes the path as an argument because the block below runs long before
+# $ROOT_EXEC_MANIFEST_HELPER is defined.
+root_exec_manifest_helper_alive() {
+  local out rc=0
+  [ -x "$1" ] || return 1
+  out="$("$1" --selftest 2>/dev/null)" || rc=$?
+  [ "$out" = "clawbox-root-manifest alive" ] && return 0
+  [ "$rc" -eq 64 ] && return 0
+  return 1
+}
+
 # The bootstrap could not re-record the root-exec manifest before re-exec'ing
 # into this process (TASK-584). The dispatcher fails closed on a stale manifest,
 # so every NON-UPDATE root step — openclaw_install, gateway_setup, and the
@@ -225,7 +276,8 @@ provision_repair_step() {
 # that verifies would be the opposite defect. install_root_libexec re-records it
 # later in a full run and clears this again on success.
 if [ "${CLAWBOX_ROOT_MANIFEST_STALE:-0}" = "1" ]; then
-  if /usr/local/libexec/clawbox/clawbox-root-manifest.sh --verify >/dev/null 2>&1; then
+  if root_exec_manifest_helper_alive /usr/local/libexec/clawbox/clawbox-root-manifest.sh \
+     && /usr/local/libexec/clawbox/clawbox-root-manifest.sh --verify >/dev/null 2>&1; then
     echo "[bootstrap] the root-exec manifest verifies after all — continuing"
   else
     record_provision_failure root_exec_manifest
@@ -3568,8 +3620,16 @@ ROOT_EXEC_MANIFEST_HELPER="$ROOT_LIBEXEC_DIR/clawbox-root-manifest.sh"
 # Record the tree root is allowed to execute. Strict: a non-zero return means
 # the record is NOT current, and the caller must treat that as a failure.
 write_root_exec_manifest() {
-  [ -x "$ROOT_EXEC_MANIFEST_HELPER" ] || return 1
+  root_exec_manifest_helper_alive "$ROOT_EXEC_MANIFEST_HELPER" || return 1
   "$ROOT_EXEC_MANIFEST_HELPER" --write || return 1
+  # VERIFY, then clear — never the other way round. `--write` returning 0 says
+  # the helper believes it wrote a manifest, not that the record now matches the
+  # tree; a write that landed somewhere else, or a tree that moved while it ran,
+  # both end here. And this function's success is read as "the bootstrap's
+  # failure is repaired": install_root_libexec installs the root dispatcher on
+  # it, and that dispatcher refuses every pinned root step while the manifest
+  # does not verify. So prove the record before dropping the failure. TASK-584.
+  "$ROOT_EXEC_MANIFEST_HELPER" --verify >/dev/null || return 1
   # This is exactly the repair for what the bootstrap could not do, so the run's
   # verdict must stop reporting it. TASK-584.
   clear_provision_failure root_exec_manifest

--- a/src/tests/unit/desktop-power-wiring.test.ts
+++ b/src/tests/unit/desktop-power-wiring.test.ts
@@ -133,7 +133,12 @@ describe("install.sh", () => {
     ]) {
       expect(install, script).toContain(script);
     }
-    expect(install).toContain('install -o root -g root -m 0755 "$PROJECT_DIR/scripts/$src"');
+    // Root-owned and 0755 still, but through install_root_file, which stages
+    // under a temp name and renames rather than writing the live destination —
+    // an `install` killed part way through used to leave an executable PREFIX of
+    // a root-invoked script behind (TASK-584).
+    expect(install).toContain('install_root_file "$PROJECT_DIR/scripts/$src" "$ROOT_LIBEXEC_DIR/$src"');
+    expect(install).toContain('install -o root -g root -m "$mode" "$src" "$dst.new"');
   });
 
   it("re-applies the memory guards on update, not only on a fresh install", () => {

--- a/src/tests/unit/install-bootstrap-manifest.test.ts
+++ b/src/tests/unit/install-bootstrap-manifest.test.ts
@@ -43,11 +43,18 @@ const PROJECT_PATH = "/home/clawbox/clawbox";
 const canRun =
   process.platform !== "win32" && spawnSync("bash", ["-c", "true"], { stdio: "ignore" }).status === 0;
 
+/** A 0000 source is readable by root, so that one case would prove nothing there. */
+const isRoot = typeof process.getuid === "function" && process.getuid() === 0;
+
 let root: string;
 beforeEach(() => {
   root = mkdtempSync(path.join(tmpdir(), "clawbox-bootstrap-manifest-"));
 });
 afterEach(() => {
+  // The "unreadable source" case leaves a 0000 file behind.
+  try {
+    chmodSync(path.join(root, "project", "config", "clawbox-root-manifest.sh"), 0o755);
+  } catch { /* not every case writes one */ }
   rmSync(root, { recursive: true, force: true });
 });
 
@@ -88,13 +95,39 @@ interface Bootstrap {
   calls: string[];
   /** The value the bootstrap would hand to the re-exec. */
   marker: string;
+  /** The live helper's bytes as the run found them. */
+  helperBefore: string;
+  /** The live helper's bytes after the run — the thing a bad copy destroys. */
+  helperAfter: string;
+  /** Whether a staged `<helper>.new` was left behind in libexec. */
+  stagedLeft: boolean;
 }
 
 /**
  * Run the bootstrap's manifest arm with a helper stub whose `--write` fails
  * `failWrites` times before succeeding (Infinity = never succeeds).
  */
-function runBootstrap(opts: { failWrites: number; helperInTree?: boolean }): Bootstrap {
+function runBootstrap(opts: {
+  failWrites: number;
+  helperInTree?: boolean;
+  /**
+   * How the copy from the reset tree fails.
+   *
+   * "unreadable" — the source cannot be opened, so `install` fails before
+   * writing anything (a directory would not do: the shipped `[ -f ]` guard
+   * filters it out before `install` is ever reached, which is the
+   * `helperInTree: false` path). "truncates" — the source is larger than an
+   * RLIMIT_FSIZE the run is given, so `install` is killed by SIGXFSZ PART WAY
+   * THROUGH the copy.
+   * The second is the one that matters: `install` writes into the destination
+   * inode with O_TRUNC, so a copy straight over the live helper leaves a cut-off
+   * file behind — and a truncated helper exits 0 for `--verify`, which turns the
+   * root dispatcher from fail-closed into fail-open for every pinned step.
+   * Neither depends on the runner's privileges; a read-only mode is ignored by
+   * root.
+   */
+  stagingFails?: "unreadable" | "truncates";
+}): Bootstrap {
   const helper = path.join(root, "libexec", "clawbox-root-manifest.sh");
   const project = path.join(root, "project");
   const callLog = path.join(root, "helper-calls.log");
@@ -121,12 +154,13 @@ function runBootstrap(opts: { failWrites: number; helperInTree?: boolean }): Boo
 
   // The helper the reset just checked out. Present unless the test says the
   // fresh tree does not carry one.
+  const treeHelper = path.join(project, "config", "clawbox-root-manifest.sh");
   if (opts.helperInTree !== false) {
-    writeFileSync(
-      path.join(project, "config", "clawbox-root-manifest.sh"),
-      stub.replace("installed %s", "refreshed %s"),
-    );
-    chmodSync(path.join(project, "config", "clawbox-root-manifest.sh"), 0o755);
+    // Padded past the size limit the "truncates" run imposes, so the copy dies
+    // mid-write rather than before it starts.
+    const pad = opts.stagingFails === "truncates" ? `\n${"# pad\n".repeat(30_000)}` : "";
+    writeFileSync(treeHelper, stub.replace("installed %s", "refreshed %s") + pad);
+    chmodSync(treeHelper, opts.stagingFails === "unreadable" ? 0o000 : 0o755);
   }
 
   // The slice runs THROUGH the `exec`, into a stub install.sh that prints the
@@ -154,6 +188,8 @@ function runBootstrap(opts: { failWrites: number; helperInTree?: boolean }): Boo
   const program = [
     "#!/usr/bin/env bash",
     "set -euo pipefail",
+    // 8 blocks, and no core file: the copy below is killed part way through.
+    ...(opts.stagingFails === "truncates" ? ["ulimit -c 0", "ulimit -f 8"] : []),
     `_b=${JSON.stringify(project)}`,
     block,
     // Never reached: the block above ends in `exec`.
@@ -170,6 +206,9 @@ function runBootstrap(opts: { failWrites: number; helperInTree?: boolean }): Boo
     out,
     calls: existsSync(callLog) ? readFileSync(callLog, "utf-8").trim().split("\n").filter(Boolean) : [],
     marker: /MARKER=(\d)/.exec(run.stdout ?? "")?.[1] ?? "",
+    helperBefore: stub,
+    helperAfter: existsSync(helper) ? readFileSync(helper, "utf-8") : "",
+    stagedLeft: existsSync(`${helper}.new`),
   };
 }
 
@@ -279,6 +318,38 @@ describe.runIf(canRun)("the bootstrap's root-exec manifest re-record", () => {
     // reset to new code with nothing installed.
     const run = runBootstrap({ failWrites: Infinity, helperInTree: false });
     expect(run.status).toBe(0);
+    expect(run.out).toContain("REACHED_EXEC=1");
+    expect(run.marker).toBe("1");
+  });
+
+  it("leaves the live helper byte-identical when the copy dies mid-write", () => {
+    // The most dangerous line in this change, and nothing failed if it was
+    // reverted: the call sequence is identical whether the copy goes to
+    // "$_mf.new" and is renamed, or straight over "$_mf". `install` writes into
+    // the existing inode with O_TRUNC, so a copy killed part way through — a
+    // full or read-only root filesystem, which is the same condition that most
+    // often fails the write this repair is answering — leaves a cut-off helper
+    // behind. Measured both ways with an RLIMIT_FSIZE child: temp+rename keeps
+    // the live helper at its original bytes; installing over it leaves an
+    // 8192-byte survivor whose `--verify` still exits 0, which is worse than the
+    // stale manifest it was trying to fix — it turns the root dispatcher from
+    // fail-closed into fail-open for every pinned step.
+    const run = runBootstrap({ failWrites: Infinity, stagingFails: "truncates" });
+    expect(run.status).toBe(0);
+    expect(run.helperAfter, "the live helper was truncated by a failed copy").toBe(run.helperBefore);
+    expect(run.stagedLeft, "a half-written .new was left in libexec").toBe(false);
+    expect(run.out).toContain("REACHED_EXEC=1");
+    expect(run.marker).toBe("1");
+  });
+
+  it.skipIf(isRoot)("cleans up and carries on when the copy fails outright", () => {
+    // The other half: `install` that fails before writing anything must leave
+    // no staged file behind and must not abort the boot path.
+    const run = runBootstrap({ failWrites: Infinity, stagingFails: "unreadable" });
+    expect(run.status).toBe(0);
+    expect(run.out).toContain("could not stage a fresh root-exec manifest helper");
+    expect(run.helperAfter).toBe(run.helperBefore);
+    expect(run.stagedLeft).toBe(false);
     expect(run.out).toContain("REACHED_EXEC=1");
     expect(run.marker).toBe("1");
   });

--- a/src/tests/unit/install-bootstrap-manifest.test.ts
+++ b/src/tests/unit/install-bootstrap-manifest.test.ts
@@ -57,14 +57,21 @@ afterEach(() => {
  * adding an env seam: these paths select WHICH code root executes and must stay
  * literal in the shipped file.
  */
-function shipped(fromLine: string, toLine: string, paths: { helper: string; project: string }): string {
+function shipped(
+  fromLine: string,
+  toLine: string,
+  paths: { helper: string; project: string; inclusive?: boolean; must?: string },
+): string {
   const start = INSTALL_SH.indexOf(fromLine);
   if (start < 0) throw new Error(`bootstrap slice start not found: ${fromLine}`);
   const end = INSTALL_SH.indexOf(toLine, start);
   if (end < 0) throw new Error(`bootstrap slice end not found: ${toLine}`);
-  const text = INSTALL_SH.slice(start, end);
-  if (!text.includes(HELPER_PATH)) {
-    throw new Error("the slice no longer names the manifest helper — it was extracted wrong");
+  const text = INSTALL_SH.slice(start, paths.inclusive ? end + toLine.length : end);
+  // A slice that lost its subject would make every assertion over it pass for
+  // the wrong reason, so each caller names something its region must contain.
+  const must = paths.must ?? HELPER_PATH;
+  if (!text.includes(must)) {
+    throw new Error(`the slice no longer contains ${JSON.stringify(must)} — it was extracted wrong`);
   }
   return text
     .split(HELPER_PATH).join(paths.helper)
@@ -122,10 +129,26 @@ function runBootstrap(opts: { failWrites: number; helperInTree?: boolean }): Boo
     chmodSync(path.join(project, "config", "clawbox-root-manifest.sh"), 0o755);
   }
 
+  // The slice runs THROUGH the `exec`, into a stub install.sh that prints the
+  // environment it was handed. Asserting the exec line by substring instead
+  // would pass over a hard-coded 0 or a typo'd inner expansion — the marker
+  // surviving the re-exec is the single most important link in this chain.
+  writeFileSync(
+    path.join(project, "install.sh"),
+    [
+      "#!/usr/bin/env bash",
+      'echo "MARKER=${CLAWBOX_ROOT_MANIFEST_STALE:-unset}"',
+      'echo "BOOTSTRAPPED=${CLAWBOX_INSTALL_BOOTSTRAPPED:-unset}"',
+      'echo "REACHED_EXEC=1"',
+      "",
+    ].join("\n"),
+  );
+  chmodSync(path.join(project, "install.sh"), 0o755);
+
   const block = shipped(
     "      _mf=/usr/local/libexec/clawbox/clawbox-root-manifest.sh",
-    '      echo "[bootstrap] Re-executing as',
-    { helper, project },
+    'bash "$_b/install.sh" "$@"',
+    { helper, project, inclusive: true },
   );
 
   const program = [
@@ -133,9 +156,8 @@ function runBootstrap(opts: { failWrites: number; helperInTree?: boolean }): Boo
     "set -euo pipefail",
     `_b=${JSON.stringify(project)}`,
     block,
-    // What `exec env … CLAWBOX_ROOT_MANIFEST_STALE=…` would carry forward.
-    'echo "MARKER=${CLAWBOX_ROOT_MANIFEST_STALE:-0}"',
-    'echo "REACHED_EXEC=1"',
+    // Never reached: the block above ends in `exec`.
+    'echo "MARKER=exec-did-not-happen"',
     "",
   ].join("\n");
   const file = path.join(root, "bootstrap.sh");
@@ -155,7 +177,13 @@ function runBootstrap(opts: { failWrites: number; helperInTree?: boolean }): Boo
  * Run the verdict block — the marker check that decides whether this run
  * reports a failure — with a helper stub whose `--verify` answers `verifies`.
  */
-function runVerdict(opts: { marker: string; verifies: boolean; alsoWrite?: boolean }): {
+function runVerdict(opts: {
+  marker: string;
+  verifies: boolean;
+  alsoWrite?: boolean;
+  /** Also call refresh_root_exec_manifest, with a helper whose --write does this. */
+  refresh?: "works" | "fails";
+}): {
   status: number | null;
   out: string;
   failures: string;
@@ -164,21 +192,35 @@ function runVerdict(opts: { marker: string; verifies: boolean; alsoWrite?: boole
   mkdirSync(path.dirname(helper), { recursive: true });
   writeFileSync(
     helper,
-    ["#!/usr/bin/env bash", `[ "\${1:-}" = "--verify" ] && exit ${opts.verifies ? 0 : 65}`, "exit 0", ""].join("\n"),
+    [
+      "#!/usr/bin/env bash",
+      `[ "\${1:-}" = "--verify" ] && exit ${opts.verifies ? 0 : 65}`,
+      `[ "\${1:-}" = "--write" ] && exit ${opts.refresh === "fails" ? 1 : 0}`,
+      "exit 0",
+      "",
+    ].join("\n"),
   );
   chmodSync(helper, 0o755);
 
-  const block = shipped("record_provision_failure() {", "\n# ── The marker must never speak", {
+  const block = shipped(
+    "record_provision_failure() {",
+    'if [ "${CLAWBOX_ROOT_MANIFEST_STALE:-0}" = "1" ]; then',
+    { helper, project: path.join(root, "project"), must: "clear_provision_failure() {" },
+  ) + shipped('if [ "${CLAWBOX_ROOT_MANIFEST_STALE:-0}" = "1" ]; then', "\nfi", {
     helper,
     project: path.join(root, "project"),
+    inclusive: true,
   });
-  // The repair path: write_root_exec_manifest clears what it fixed.
-  const writer = (() => {
-    const start = INSTALL_SH.indexOf("write_root_exec_manifest() {");
-    if (start < 0) throw new Error("write_root_exec_manifest not found");
+  // The repair path: write_root_exec_manifest clears what it fixed, and
+  // refresh_root_exec_manifest records what it could not.
+  const fn = (name: string) => {
+    const start = INSTALL_SH.indexOf(`${name}() {`);
+    if (start < 0) throw new Error(`${name} not found`);
     const end = INSTALL_SH.indexOf("\n}", start);
+    if (end < 0) throw new Error(`${name} has no closing brace`);
     return INSTALL_SH.slice(start, end + 2);
-  })();
+  };
+  const writer = `${fn("write_root_exec_manifest")}\n${fn("refresh_root_exec_manifest")}`;
 
   const program = [
     "#!/usr/bin/env bash",
@@ -186,9 +228,11 @@ function runVerdict(opts: { marker: string; verifies: boolean; alsoWrite?: boole
     "PROVISION_FAILURES=()",
     `CLAWBOX_ROOT_MANIFEST_STALE=${JSON.stringify(opts.marker)}`,
     `ROOT_EXEC_MANIFEST_HELPER=${JSON.stringify(helper)}`,
+    `PROJECT_DIR=${JSON.stringify(path.join(root, "project"))}`,
     block,
     writer,
     opts.alsoWrite ? "write_root_exec_manifest" : "true",
+    opts.refresh ? "refresh_root_exec_manifest" : "true",
     'echo "FAILURES=${PROVISION_FAILURES[*]-}"',
     "",
   ].join("\n");
@@ -207,7 +251,8 @@ describe.runIf(canRun)("the bootstrap's root-exec manifest re-record", () => {
   it("re-records once and carries nothing forward when it works", () => {
     const run = runBootstrap({ failWrites: 0 });
     expect(run.status).toBe(0);
-    expect(run.calls).toEqual(["installed --write"]);
+    // --write AND --verify: a truncated helper exits 0 for the write alone.
+    expect(run.calls).toEqual(["installed --write", "installed --verify"]);
     expect(run.marker).toBe("0");
   });
 
@@ -217,8 +262,7 @@ describe.runIf(canRun)("the bootstrap's root-exec manifest re-record", () => {
     // before reporting anything.
     const run = runBootstrap({ failWrites: 1 });
     expect(run.status).toBe(0);
-    expect(run.calls).toHaveLength(2);
-    expect(run.calls[1]).toBe("refreshed --write");
+    expect(run.calls).toEqual(["installed --write", "refreshed --write", "refreshed --verify"]);
     expect(run.marker, "a manifest that was repaired must not be carried forward").toBe("0");
   });
 
@@ -239,11 +283,11 @@ describe.runIf(canRun)("the bootstrap's root-exec manifest re-record", () => {
     expect(run.marker).toBe("1");
   });
 
-  it("hands the marker to the re-exec'd process", () => {
-    // The block under test ends before the exec, so the exec line itself is
-    // pinned here: without this the marker is computed and thrown away.
-    const execLine = INSTALL_SH.slice(INSTALL_SH.indexOf('exec env CLAWBOX_INSTALL_BOOTSTRAPPED=1'));
-    expect(execLine.slice(0, 300)).toContain("CLAWBOX_ROOT_MANIFEST_STALE");
+  it("re-execs into the refreshed tree with the bootstrap flag set", () => {
+    // The other half of the exec's contract, executed rather than matched.
+    const run = runBootstrap({ failWrites: 0 });
+    expect(run.out).toContain("REACHED_EXEC=1");
+    expect(run.out).toContain("BOOTSTRAPPED=1");
   });
 });
 
@@ -253,9 +297,10 @@ describe.runIf(canRun)("a stale manifest is reported against the run's verdict",
     expect(run.status).toBe(0);
     expect(run.failures).toContain("root_exec_manifest");
     // The operator is told what is broken and how to repair it, not just that
-    // something failed.
+    // something failed — and the repair is a step that EXISTS and that
+    // re-installs the helper too, not the command that just failed twice.
     expect(run.out).toMatch(/REFUSED \(exit 65\)/);
-    expect(run.out).toContain("--write");
+    expect(run.out).toContain("--step systemd_services");
   });
 
   it("records nothing when the manifest verifies after all", () => {
@@ -268,6 +313,25 @@ describe.runIf(canRun)("a stale manifest is reported against the run's verdict",
 
   it("records nothing when the bootstrap never set the marker", () => {
     const run = runVerdict({ marker: "0", verifies: false });
+    expect(run.failures.trim()).toBe("");
+  });
+
+  it("records the OTHER re-record too — sync_repo_to_update_target's", () => {
+    // install.sh re-records the manifest after a hard reset in TWO places. The
+    // second, `refresh_root_exec_manifest` (reached from
+    // sync_repo_to_update_target), had the same `--write || echo WARN` shape: a
+    // failure there left the step exiting 0 with a stale manifest, and the
+    // operator met it as an opaque exit-65 on some later step instead. Without
+    // this the run's verdict is asymmetric — cleared by a success, never set by
+    // a failure.
+    const run = runVerdict({ marker: "0", verifies: false, refresh: "fails" });
+    expect(run.status).toBe(0);
+    expect(run.failures).toContain("root_exec_manifest");
+    expect(run.out).toMatch(/Warning: could not re-record/);
+  });
+
+  it("stays quiet when that re-record works", () => {
+    const run = runVerdict({ marker: "0", verifies: false, refresh: "works" });
     expect(run.failures.trim()).toBe("");
   });
 

--- a/src/tests/unit/install-bootstrap-manifest.test.ts
+++ b/src/tests/unit/install-bootstrap-manifest.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync, chmodSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/**
+ * The bootstrap re-records the root-exec manifest after it hard-resets the tree
+ * and before it re-execs into the new install.sh. It used to do that as
+ *
+ *     "$_mf" --write || echo "[bootstrap] WARN: could not re-record …" >&2
+ *
+ * and carry on (TASK-584). The comment directly above that line states the
+ * problem itself: the reset has just replaced install.sh, scripts/ and config/
+ * wholesale, so the manifest is stale by construction — and the root dispatcher
+ * fails CLOSED on a stale manifest. Every root step of that very update, and
+ * the owner's password change, hostname change, hotspot restart and llama.cpp
+ * install afterwards, is then refused with exit 65
+ * ("refusing '<step>' — /home/clawbox/clawbox does not match the root-exec
+ * manifest"). Observed live on a test box: `--verify` returned 65 and every
+ * root step was refused, with one warning line on the stderr of an update
+ * nobody was watching as the only trace.
+ *
+ * So a failed re-record now (a) repairs — the installed helper is the one from
+ * before the reset, so it is replaced from the fresh tree and retried — and
+ * (b) when that still fails, is carried into the re-exec and recorded against
+ * the run's verdict, which is what makes the update report failure instead of
+ * success. It is re-verified there rather than believed, and cleared again if a
+ * later step re-records the manifest successfully, so neither half can produce a
+ * false failure.
+ *
+ * These tests EXECUTE the shipped blocks out of install.sh under
+ * `set -euo pipefail`, with the hard-coded helper path retargeted onto a temp
+ * tree the way src/tests/unit/root-exec-manifest.test.ts retargets the shipped
+ * scripts' constants.
+ */
+
+const REPO = process.cwd();
+const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
+const HELPER_PATH = "/usr/local/libexec/clawbox/clawbox-root-manifest.sh";
+const PROJECT_PATH = "/home/clawbox/clawbox";
+
+const canRun =
+  process.platform !== "win32" && spawnSync("bash", ["-c", "true"], { stdio: "ignore" }).status === 0;
+
+let root: string;
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), "clawbox-bootstrap-manifest-"));
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+/**
+ * Slice a region out of install.sh by its first and last line, and retarget the
+ * two hard-coded absolute paths onto the temp tree. Retargeting rather than
+ * adding an env seam: these paths select WHICH code root executes and must stay
+ * literal in the shipped file.
+ */
+function shipped(fromLine: string, toLine: string, paths: { helper: string; project: string }): string {
+  const start = INSTALL_SH.indexOf(fromLine);
+  if (start < 0) throw new Error(`bootstrap slice start not found: ${fromLine}`);
+  const end = INSTALL_SH.indexOf(toLine, start);
+  if (end < 0) throw new Error(`bootstrap slice end not found: ${toLine}`);
+  const text = INSTALL_SH.slice(start, end);
+  if (!text.includes(HELPER_PATH)) {
+    throw new Error("the slice no longer names the manifest helper — it was extracted wrong");
+  }
+  return text
+    .split(HELPER_PATH).join(paths.helper)
+    .split(PROJECT_PATH).join(paths.project)
+    // `install -o root -g root` is EPERM for a test runner; the copy itself is
+    // what matters here and still happens.
+    .replace(/install -o root -g root /g, "install ");
+}
+
+interface Bootstrap {
+  status: number | null;
+  out: string;
+  /** One line per call the stub helper received. */
+  calls: string[];
+  /** The value the bootstrap would hand to the re-exec. */
+  marker: string;
+}
+
+/**
+ * Run the bootstrap's manifest arm with a helper stub whose `--write` fails
+ * `failWrites` times before succeeding (Infinity = never succeeds).
+ */
+function runBootstrap(opts: { failWrites: number; helperInTree?: boolean }): Bootstrap {
+  const helper = path.join(root, "libexec", "clawbox-root-manifest.sh");
+  const project = path.join(root, "project");
+  const callLog = path.join(root, "helper-calls.log");
+  const stateFile = path.join(root, "writes");
+  mkdirSync(path.dirname(helper), { recursive: true });
+  mkdirSync(path.join(project, "config"), { recursive: true });
+
+  // The INSTALLED helper: the one from before the reset. It counts its own
+  // --write calls so "retry once" is observable.
+  const stub = [
+    "#!/usr/bin/env bash",
+    `printf 'installed %s\\n' "$*" >> ${JSON.stringify(callLog)}`,
+    `n=$(cat ${JSON.stringify(stateFile)} 2>/dev/null || echo 0)`,
+    'if [ "${1:-}" = "--write" ]; then',
+    `  n=$((n + 1)); printf '%s' "$n" > ${JSON.stringify(stateFile)}`,
+    `  [ "$n" -gt ${opts.failWrites === Infinity ? 9999 : opts.failWrites} ] && exit 0`,
+    "  exit 1",
+    "fi",
+    "exit 0",
+    "",
+  ].join("\n");
+  writeFileSync(helper, stub);
+  chmodSync(helper, 0o755);
+
+  // The helper the reset just checked out. Present unless the test says the
+  // fresh tree does not carry one.
+  if (opts.helperInTree !== false) {
+    writeFileSync(
+      path.join(project, "config", "clawbox-root-manifest.sh"),
+      stub.replace("installed %s", "refreshed %s"),
+    );
+    chmodSync(path.join(project, "config", "clawbox-root-manifest.sh"), 0o755);
+  }
+
+  const block = shipped(
+    "      _mf=/usr/local/libexec/clawbox/clawbox-root-manifest.sh",
+    '      echo "[bootstrap] Re-executing as',
+    { helper, project },
+  );
+
+  const program = [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    `_b=${JSON.stringify(project)}`,
+    block,
+    // What `exec env … CLAWBOX_ROOT_MANIFEST_STALE=…` would carry forward.
+    'echo "MARKER=${CLAWBOX_ROOT_MANIFEST_STALE:-0}"',
+    'echo "REACHED_EXEC=1"',
+    "",
+  ].join("\n");
+  const file = path.join(root, "bootstrap.sh");
+  writeFileSync(file, program);
+  chmodSync(file, 0o755);
+  const run = spawnSync("bash", [file], { encoding: "utf-8", timeout: 30_000 });
+  const out = `${run.stdout ?? ""}${run.stderr ?? ""}`;
+  return {
+    status: run.status,
+    out,
+    calls: existsSync(callLog) ? readFileSync(callLog, "utf-8").trim().split("\n").filter(Boolean) : [],
+    marker: /MARKER=(\d)/.exec(run.stdout ?? "")?.[1] ?? "",
+  };
+}
+
+/**
+ * Run the verdict block — the marker check that decides whether this run
+ * reports a failure — with a helper stub whose `--verify` answers `verifies`.
+ */
+function runVerdict(opts: { marker: string; verifies: boolean; alsoWrite?: boolean }): {
+  status: number | null;
+  out: string;
+  failures: string;
+} {
+  const helper = path.join(root, "libexec", "clawbox-root-manifest.sh");
+  mkdirSync(path.dirname(helper), { recursive: true });
+  writeFileSync(
+    helper,
+    ["#!/usr/bin/env bash", `[ "\${1:-}" = "--verify" ] && exit ${opts.verifies ? 0 : 65}`, "exit 0", ""].join("\n"),
+  );
+  chmodSync(helper, 0o755);
+
+  const block = shipped("record_provision_failure() {", "\n# ── The marker must never speak", {
+    helper,
+    project: path.join(root, "project"),
+  });
+  // The repair path: write_root_exec_manifest clears what it fixed.
+  const writer = (() => {
+    const start = INSTALL_SH.indexOf("write_root_exec_manifest() {");
+    if (start < 0) throw new Error("write_root_exec_manifest not found");
+    const end = INSTALL_SH.indexOf("\n}", start);
+    return INSTALL_SH.slice(start, end + 2);
+  })();
+
+  const program = [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    "PROVISION_FAILURES=()",
+    `CLAWBOX_ROOT_MANIFEST_STALE=${JSON.stringify(opts.marker)}`,
+    `ROOT_EXEC_MANIFEST_HELPER=${JSON.stringify(helper)}`,
+    block,
+    writer,
+    opts.alsoWrite ? "write_root_exec_manifest" : "true",
+    'echo "FAILURES=${PROVISION_FAILURES[*]-}"',
+    "",
+  ].join("\n");
+  const file = path.join(root, "verdict.sh");
+  writeFileSync(file, program);
+  chmodSync(file, 0o755);
+  const run = spawnSync("bash", [file], { encoding: "utf-8", timeout: 30_000 });
+  return {
+    status: run.status,
+    out: `${run.stdout ?? ""}${run.stderr ?? ""}`,
+    failures: /FAILURES=(.*)/.exec(run.stdout ?? "")?.[1] ?? "",
+  };
+}
+
+describe.runIf(canRun)("the bootstrap's root-exec manifest re-record", () => {
+  it("re-records once and carries nothing forward when it works", () => {
+    const run = runBootstrap({ failWrites: 0 });
+    expect(run.status).toBe(0);
+    expect(run.calls).toEqual(["installed --write"]);
+    expect(run.marker).toBe("0");
+  });
+
+  it("refreshes the helper from the reset tree and retries before giving up", () => {
+    // The installed helper is the one from BEFORE the hard reset — the most
+    // likely reason it just failed — so replacing it is the repair to try
+    // before reporting anything.
+    const run = runBootstrap({ failWrites: 1 });
+    expect(run.status).toBe(0);
+    expect(run.calls).toHaveLength(2);
+    expect(run.calls[1]).toBe("refreshed --write");
+    expect(run.marker, "a manifest that was repaired must not be carried forward").toBe("0");
+  });
+
+  it("carries the failure into the re-exec when the retry fails too", () => {
+    // Today: one WARN line on stderr, nothing carried, and the update goes on
+    // into steps the dispatcher will refuse with exit 65.
+    const run = runBootstrap({ failWrites: Infinity });
+    expect(run.status).toBe(0);
+    expect(run.marker).toBe("1");
+  });
+
+  it("never aborts the bootstrap, even with no helper in the reset tree", () => {
+    // This is the boot path: an abort here leaves a box that has already been
+    // reset to new code with nothing installed.
+    const run = runBootstrap({ failWrites: Infinity, helperInTree: false });
+    expect(run.status).toBe(0);
+    expect(run.out).toContain("REACHED_EXEC=1");
+    expect(run.marker).toBe("1");
+  });
+
+  it("hands the marker to the re-exec'd process", () => {
+    // The block under test ends before the exec, so the exec line itself is
+    // pinned here: without this the marker is computed and thrown away.
+    const execLine = INSTALL_SH.slice(INSTALL_SH.indexOf('exec env CLAWBOX_INSTALL_BOOTSTRAPPED=1'));
+    expect(execLine.slice(0, 300)).toContain("CLAWBOX_ROOT_MANIFEST_STALE");
+  });
+});
+
+describe.runIf(canRun)("a stale manifest is reported against the run's verdict", () => {
+  it("records a provisioning failure, so the update cannot report success", () => {
+    const run = runVerdict({ marker: "1", verifies: false });
+    expect(run.status).toBe(0);
+    expect(run.failures).toContain("root_exec_manifest");
+    // The operator is told what is broken and how to repair it, not just that
+    // something failed.
+    expect(run.out).toMatch(/REFUSED \(exit 65\)/);
+    expect(run.out).toContain("--write");
+  });
+
+  it("records nothing when the manifest verifies after all", () => {
+    // The marker says the bootstrap's write failed, not that the record is
+    // still wrong — reporting a failure over a good manifest is the opposite
+    // defect.
+    const run = runVerdict({ marker: "1", verifies: true });
+    expect(run.failures.trim()).toBe("");
+  });
+
+  it("records nothing when the bootstrap never set the marker", () => {
+    const run = runVerdict({ marker: "0", verifies: false });
+    expect(run.failures.trim()).toBe("");
+  });
+
+  it("clears the recorded failure when a later step re-records the manifest", () => {
+    // install_root_libexec re-records it during a full run; that IS the repair,
+    // so the run must stop reporting it.
+    const run = runVerdict({ marker: "1", verifies: false, alsoWrite: true });
+    expect(run.failures.trim()).toBe("");
+  });
+});

--- a/src/tests/unit/install-bootstrap-manifest.test.ts
+++ b/src/tests/unit/install-bootstrap-manifest.test.ts
@@ -150,8 +150,14 @@ function runBootstrap(opts: {
    * because the exit status of such a helper is what the bootstrap here — and
    * the root dispatcher afterwards — would otherwise read as "the tree is
    * recorded and matches".
+   *
+   * "legacy" is the opposite risk, and the more likely one: the helper from
+   * BEFORE `--selftest` existed, which is what sits in libexec on every box
+   * updating across this release. It rejects the verb with 64 — from the very
+   * verb dispatcher a stub does not have — so it is live, and must be neither
+   * replaced nor reported.
    */
-  installed?: "healthy" | "empty" | "truncated";
+  installed?: "healthy" | "empty" | "truncated" | "legacy";
 }): Bootstrap {
   const helper = path.join(root, "libexec", "clawbox-root-manifest.sh");
   const project = path.join(root, "project");
@@ -165,9 +171,13 @@ function runBootstrap(opts: {
   const stub = [
     "#!/usr/bin/env bash",
     `printf 'installed %s\\n' "$*" >> ${JSON.stringify(callLog)}`,
-    // A stub stands in for a COMPLETE helper, so it answers the liveness verb.
-    // The "empty"/"truncated" modes install one that cannot.
-    `if [ "\${1:-}" = "--selftest" ]; then printf '%s\\n' ${JSON.stringify(SELFTEST_TOKEN)}; exit 0; fi`,
+    // A stub stands in for a COMPLETE helper, so it answers the liveness verb —
+    // as the token, or, in "legacy" mode, the way a release that predates the
+    // verb answers it: 64 from the same dispatcher. The "empty"/"truncated"
+    // modes install one that can do neither.
+    opts.installed === "legacy"
+      ? 'if [ "${1:-}" = "--selftest" ]; then echo "usage: ..." >&2; exit 64; fi'
+      : `if [ "\${1:-}" = "--selftest" ]; then printf '%s\\n' ${JSON.stringify(SELFTEST_TOKEN)}; exit 0; fi`,
     `n=$(cat ${JSON.stringify(stateFile)} 2>/dev/null || echo 0)`,
     'if [ "${1:-}" = "--write" ]; then',
     `  n=$((n + 1)); printf '%s' "$n" > ${JSON.stringify(stateFile)}`,
@@ -435,7 +445,6 @@ describe.runIf(canRun)("the bootstrap's root-exec manifest re-record", () => {
     expect(run.marker).toBe("1");
   });
 
-
   it("replaces a 0-byte helper instead of reading its exit status as an answer", () => {
     // The fail-OPEN this arm exists to close. An empty executable file runs to
     // EOF and exits 0 — for `--write`, for `--verify`, and for the
@@ -463,6 +472,22 @@ describe.runIf(canRun)("the bootstrap's root-exec manifest re-record", () => {
     expect(run.status).toBe(0);
     expect(run.helperAfter).toBe(run.helperInTree);
     expect(run.calls).toEqual(["refreshed --selftest", "refreshed --write", "refreshed --verify"]);
+    expect(run.marker).toBe("0");
+  });
+
+  it("leaves a helper from before --selftest alone, on its exit 64", () => {
+    // The false failure this probe must not become. Every box updating ACROSS
+    // this release runs this block with the PREVIOUS release's helper installed
+    // — that is the whole point of the block, it re-records before re-exec'ing
+    // into the new tree — and that helper rejects `--selftest` with 64. Reading
+    // 64 as "dead" would restage the helper on every box in the fleet, and on
+    // any box where the restage could not run it would record a provisioning
+    // failure over a manifest that was written and verified perfectly well.
+    const run = runBootstrap({ failWrites: 0, installed: "legacy" });
+    expect(run.status).toBe(0);
+    expect(run.helperAfter, "a live older helper was replaced anyway").toBe(run.helperBefore);
+    expect(run.out).not.toContain("is not answering");
+    expect(run.calls).toEqual(["installed --selftest", "installed --write", "installed --verify"]);
     expect(run.marker).toBe("0");
   });
 

--- a/src/tests/unit/install-bootstrap-manifest.test.ts
+++ b/src/tests/unit/install-bootstrap-manifest.test.ts
@@ -39,6 +39,14 @@ const REPO = process.cwd();
 const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
 const HELPER_PATH = "/usr/local/libexec/clawbox/clawbox-root-manifest.sh";
 const PROJECT_PATH = "/home/clawbox/clawbox";
+/**
+ * The liveness token config/clawbox-root-manifest.sh prints for `--selftest`.
+ * Repeated as a literal in install.sh and config/clawbox-root-step.sh because
+ * those are three separately installed root-owned files that cannot share a
+ * constant; root-exec-manifest.test.ts pins them against each other.
+ */
+const SELFTEST_TOKEN = "clawbox-root-manifest alive";
+const HELPER_SRC = readFileSync(path.join(REPO, "config", "clawbox-root-manifest.sh"), "utf-8");
 
 const canRun =
   process.platform !== "win32" && spawnSync("bash", ["-c", "true"], { stdio: "ignore" }).status === 0;
@@ -97,6 +105,8 @@ interface Bootstrap {
   marker: string;
   /** The live helper's bytes as the run found them. */
   helperBefore: string;
+  /** The helper the reset just checked out — what a repair must install. */
+  helperInTree: string;
   /** The live helper's bytes after the run — the thing a bad copy destroys. */
   helperAfter: string;
   /** Whether a staged `<helper>.new` was left behind in libexec. */
@@ -127,6 +137,21 @@ function runBootstrap(opts: {
    * root.
    */
   stagingFails?: "unreadable" | "truncates";
+  /**
+   * What is sitting at the installed helper path when the bootstrap starts.
+   *
+   * "empty" and "truncated" are the same defect from two directions: a copy
+   * that died part way through leaves a helper that RUNS and exits 0 for
+   * `--write`, `--verify` and `--verify-file` without doing any of them —
+   * `install` writes into the existing inode with O_TRUNC, and an interrupted
+   * in-place copy is how one gets there. "truncated" is the shipped helper cut
+   * where its verb dispatcher begins, so every function is defined and nothing
+   * dispatches; "empty" is the 0-byte case. Both must be detected and replaced,
+   * because the exit status of such a helper is what the bootstrap here — and
+   * the root dispatcher afterwards — would otherwise read as "the tree is
+   * recorded and matches".
+   */
+  installed?: "healthy" | "empty" | "truncated";
 }): Bootstrap {
   const helper = path.join(root, "libexec", "clawbox-root-manifest.sh");
   const project = path.join(root, "project");
@@ -140,6 +165,9 @@ function runBootstrap(opts: {
   const stub = [
     "#!/usr/bin/env bash",
     `printf 'installed %s\\n' "$*" >> ${JSON.stringify(callLog)}`,
+    // A stub stands in for a COMPLETE helper, so it answers the liveness verb.
+    // The "empty"/"truncated" modes install one that cannot.
+    `if [ "\${1:-}" = "--selftest" ]; then printf '%s\\n' ${JSON.stringify(SELFTEST_TOKEN)}; exit 0; fi`,
     `n=$(cat ${JSON.stringify(stateFile)} 2>/dev/null || echo 0)`,
     'if [ "${1:-}" = "--write" ]; then',
     `  n=$((n + 1)); printf '%s' "$n" > ${JSON.stringify(stateFile)}`,
@@ -149,17 +177,33 @@ function runBootstrap(opts: {
     "exit 0",
     "",
   ].join("\n");
-  writeFileSync(helper, stub);
+  // The bytes the bootstrap finds installed. A dead helper is executable and
+  // 0755 exactly like a live one — `install` sets the mode when it creates the
+  // file, so an interrupted copy leaves the mode intact and only the content
+  // short. Nothing about the file says it is a stub except that it does nothing.
+  const installedText =
+    opts.installed === "empty"
+      ? ""
+      : opts.installed === "truncated"
+        ? (() => {
+            const cut = HELPER_SRC.indexOf('case "${1:-}" in');
+            if (cut < 0) throw new Error("the shipped helper no longer ends in a verb dispatcher");
+            return HELPER_SRC.slice(0, cut);
+          })()
+        : stub;
+  writeFileSync(helper, installedText);
   chmodSync(helper, 0o755);
 
   // The helper the reset just checked out. Present unless the test says the
   // fresh tree does not carry one.
   const treeHelper = path.join(project, "config", "clawbox-root-manifest.sh");
+  let treeText = "";
   if (opts.helperInTree !== false) {
     // Padded past the size limit the "truncates" run imposes, so the copy dies
     // mid-write rather than before it starts.
     const pad = opts.stagingFails === "truncates" ? `\n${"# pad\n".repeat(30_000)}` : "";
-    writeFileSync(treeHelper, stub.replace("installed %s", "refreshed %s") + pad);
+    treeText = stub.replace("installed %s", "refreshed %s") + pad;
+    writeFileSync(treeHelper, treeText);
     chmodSync(treeHelper, opts.stagingFails === "unreadable" ? 0o000 : 0o755);
   }
 
@@ -206,7 +250,8 @@ function runBootstrap(opts: {
     out,
     calls: existsSync(callLog) ? readFileSync(callLog, "utf-8").trim().split("\n").filter(Boolean) : [],
     marker: /MARKER=(\d)/.exec(run.stdout ?? "")?.[1] ?? "",
-    helperBefore: stub,
+    helperBefore: installedText,
+    helperInTree: treeText,
     helperAfter: existsSync(helper) ? readFileSync(helper, "utf-8") : "",
     stagedLeft: existsSync(`${helper}.new`),
   };
@@ -218,7 +263,17 @@ function runBootstrap(opts: {
  */
 function runVerdict(opts: {
   marker: string;
+  /** What `--verify` answers BEFORE anything has written a manifest. */
   verifies: boolean;
+  /**
+   * What it answers AFTER a `--write` succeeded. Separate because that is the
+   * distinction write_root_exec_manifest turns on: a write can return 0 and
+   * leave a record that still does not verify, and the run must not report a
+   * repair on the strength of the write alone. Defaults to `verifies`.
+   */
+  writeVerifies?: boolean;
+  /** Install a 0-byte helper instead: it exits 0 for --verify without looking. */
+  deadHelper?: boolean;
   alsoWrite?: boolean;
   /** Also call refresh_root_exec_manifest, with a helper whose --write does this. */
   refresh?: "works" | "fails";
@@ -226,18 +281,31 @@ function runVerdict(opts: {
   status: number | null;
   out: string;
   failures: string;
+  /** "ok" / "failed" when alsoWrite ran, "" otherwise. */
+  write: string;
 } {
   const helper = path.join(root, "libexec", "clawbox-root-manifest.sh");
   mkdirSync(path.dirname(helper), { recursive: true });
+  const wrote = path.join(root, "wrote");
   writeFileSync(
     helper,
-    [
-      "#!/usr/bin/env bash",
-      `[ "\${1:-}" = "--verify" ] && exit ${opts.verifies ? 0 : 65}`,
-      `[ "\${1:-}" = "--write" ] && exit ${opts.refresh === "fails" ? 1 : 0}`,
-      "exit 0",
-      "",
-    ].join("\n"),
+    opts.deadHelper
+      ? ""
+      : [
+          "#!/usr/bin/env bash",
+          `[ "\${1:-}" = "--selftest" ] && { printf '%s\\n' ${JSON.stringify(SELFTEST_TOKEN)}; exit 0; }`,
+          'if [ "${1:-}" = "--write" ]; then',
+          ...(opts.refresh === "fails" ? ["  exit 1"] : []),
+          `  : > ${JSON.stringify(wrote)}`,
+          "  exit 0",
+          "fi",
+          'if [ "${1:-}" = "--verify" ]; then',
+          `  [ -e ${JSON.stringify(wrote)} ] && exit ${(opts.writeVerifies ?? opts.verifies) ? 0 : 65}`,
+          `  exit ${opts.verifies ? 0 : 65}`,
+          "fi",
+          "exit 0",
+          "",
+        ].join("\n"),
   );
   chmodSync(helper, 0o755);
 
@@ -270,7 +338,11 @@ function runVerdict(opts: {
     `PROJECT_DIR=${JSON.stringify(path.join(root, "project"))}`,
     block,
     writer,
-    opts.alsoWrite ? "write_root_exec_manifest" : "true",
+    // `if`, not a bare call: write_root_exec_manifest returns non-zero on a
+    // manifest that does not verify, and a bare call would take the whole
+    // script down with `set -e` before the line that reports what is left —
+    // which reads as an empty failure list, i.e. as a success.
+    opts.alsoWrite ? 'if write_root_exec_manifest; then echo "WRITE=ok"; else echo "WRITE=failed"; fi' : "true",
     opts.refresh ? "refresh_root_exec_manifest" : "true",
     'echo "FAILURES=${PROVISION_FAILURES[*]-}"',
     "",
@@ -283,6 +355,7 @@ function runVerdict(opts: {
     status: run.status,
     out: `${run.stdout ?? ""}${run.stderr ?? ""}`,
     failures: /FAILURES=(.*)/.exec(run.stdout ?? "")?.[1] ?? "",
+    write: /WRITE=(\w+)/.exec(run.stdout ?? "")?.[1] ?? "",
   };
 }
 
@@ -290,9 +363,11 @@ describe.runIf(canRun)("the bootstrap's root-exec manifest re-record", () => {
   it("re-records once and carries nothing forward when it works", () => {
     const run = runBootstrap({ failWrites: 0 });
     expect(run.status).toBe(0);
-    // --write AND --verify: a truncated helper exits 0 for the write alone.
-    expect(run.calls).toEqual(["installed --write", "installed --verify"]);
+    // --selftest FIRST, then --write AND --verify: the write's own status is
+    // only worth reading once the helper has proved it is the whole program.
+    expect(run.calls).toEqual(["installed --selftest", "installed --write", "installed --verify"]);
     expect(run.marker).toBe("0");
+    expect(run.helperAfter, "a healthy helper must not be re-staged").toBe(run.helperBefore);
   });
 
   it("refreshes the helper from the reset tree and retries before giving up", () => {
@@ -301,7 +376,13 @@ describe.runIf(canRun)("the bootstrap's root-exec manifest re-record", () => {
     // before reporting anything.
     const run = runBootstrap({ failWrites: 1 });
     expect(run.status).toBe(0);
-    expect(run.calls).toEqual(["installed --write", "refreshed --write", "refreshed --verify"]);
+    expect(run.calls).toEqual([
+      "installed --selftest",
+      "installed --write",
+      "refreshed --selftest",
+      "refreshed --write",
+      "refreshed --verify",
+    ]);
     expect(run.marker, "a manifest that was repaired must not be carried forward").toBe("0");
   });
 
@@ -354,6 +435,47 @@ describe.runIf(canRun)("the bootstrap's root-exec manifest re-record", () => {
     expect(run.marker).toBe("1");
   });
 
+
+  it("replaces a 0-byte helper instead of reading its exit status as an answer", () => {
+    // The fail-OPEN this arm exists to close. An empty executable file runs to
+    // EOF and exits 0 — for `--write`, for `--verify`, and for the
+    // `--verify-file` the root dispatcher asks about the copy it is about to
+    // execute as root. So `--write && --verify` returning 0 proves nothing
+    // here, and the same helper then tells the dispatcher that a tree it never
+    // hashed matches a manifest that may not exist.
+    const run = runBootstrap({ failWrites: 0, installed: "empty" });
+    expect(run.status).toBe(0);
+    expect(run.helperAfter, "the dead helper was left installed").toBe(run.helperInTree);
+    expect(run.out).toContain("[bootstrap] WARN: the installed root-exec manifest helper");
+    // Repaired, so nothing is carried into the re-exec: the replacement wrote
+    // and verified the record.
+    expect(run.calls).toEqual(["refreshed --selftest", "refreshed --write", "refreshed --verify"]);
+    expect(run.marker).toBe("0");
+    expect(run.stagedLeft).toBe(false);
+  });
+
+  it("replaces a helper truncated where a mid-write copy would cut it", () => {
+    // The shipped helper with its verb dispatcher gone: every function defined,
+    // `set -euo pipefail` honoured, and exit 0 for every verb. This is what a
+    // copy killed by a full disk actually leaves behind, and it is
+    // indistinguishable from a working helper by exit status alone.
+    const run = runBootstrap({ failWrites: 0, installed: "truncated" });
+    expect(run.status).toBe(0);
+    expect(run.helperAfter).toBe(run.helperInTree);
+    expect(run.calls).toEqual(["refreshed --selftest", "refreshed --write", "refreshed --verify"]);
+    expect(run.marker).toBe("0");
+  });
+
+  it("carries the failure forward when a dead helper cannot be replaced", () => {
+    // Nothing in the reset tree to repair with, so the run must not pretend the
+    // record is current — the dispatcher refuses every pinned step until it is.
+    const run = runBootstrap({ failWrites: 0, installed: "empty", helperInTree: false });
+    expect(run.status).toBe(0);
+    expect(run.out).toContain("REACHED_EXEC=1");
+    expect(run.marker).toBe("1");
+    expect(run.calls, "a helper that cannot answer must not be asked to record").toEqual([]);
+  });
+
   it("re-execs into the refreshed tree with the bootstrap flag set", () => {
     // The other half of the exec's contract, executed rather than matched.
     const run = runBootstrap({ failWrites: 0 });
@@ -372,6 +494,16 @@ describe.runIf(canRun)("a stale manifest is reported against the run's verdict",
     // re-installs the helper too, not the command that just failed twice.
     expect(run.out).toMatch(/REFUSED \(exit 65\)/);
     expect(run.out).toContain("--step systemd_services");
+  });
+
+  it("does not read a dead helper's 0 as 'it verifies after all'", () => {
+    // The marker is re-checked rather than believed, and the re-check runs the
+    // same helper the bootstrap just failed to use. If that helper is the empty
+    // one, its `--verify` exits 0 and the run clears a failure nobody repaired
+    // — the false success this whole chain is about, one step further along.
+    const run = runVerdict({ marker: "1", verifies: true, deadHelper: true });
+    expect(run.failures).toContain("root_exec_manifest");
+    expect(run.out).not.toContain("verifies after all");
   });
 
   it("records nothing when the manifest verifies after all", () => {
@@ -402,14 +534,34 @@ describe.runIf(canRun)("a stale manifest is reported against the run's verdict",
   });
 
   it("stays quiet when that re-record works", () => {
-    const run = runVerdict({ marker: "0", verifies: false, refresh: "works" });
+    // "Works" now means both halves: the write returned 0 AND the manifest it
+    // wrote verifies. Nothing may be cleared on the write alone.
+    const run = runVerdict({ marker: "0", verifies: false, writeVerifies: true, refresh: "works" });
     expect(run.failures.trim()).toBe("");
+  });
+
+  it("still reports the re-record that wrote a manifest which does not verify", () => {
+    // The write succeeded and the record is still not usable — every pinned
+    // root step keeps failing closed, so the run must keep saying so.
+    const run = runVerdict({ marker: "0", verifies: false, writeVerifies: false, refresh: "works" });
+    expect(run.failures).toContain("root_exec_manifest");
+    expect(run.out).toMatch(/Warning: could not re-record/);
   });
 
   it("clears the recorded failure when a later step re-records the manifest", () => {
     // install_root_libexec re-records it during a full run; that IS the repair,
     // so the run must stop reporting it.
-    const run = runVerdict({ marker: "1", verifies: false, alsoWrite: true });
+    const run = runVerdict({ marker: "1", verifies: false, writeVerifies: true, alsoWrite: true });
+    expect(run.write).toBe("ok");
     expect(run.failures.trim()).toBe("");
+  });
+
+  it("keeps reporting it when the re-record wrote a manifest that does not verify", () => {
+    // The write's own 0 is not the repair. Without this the run reports a
+    // recovery while the root dispatcher still refuses every pinned step —
+    // and install_root_libexec installs that dispatcher on the same answer.
+    const run = runVerdict({ marker: "1", verifies: false, writeVerifies: false, alsoWrite: true });
+    expect(run.write).toBe("failed");
+    expect(run.failures).toContain("root_exec_manifest");
   });
 });

--- a/src/tests/unit/install-sudoers-migration.test.ts
+++ b/src/tests/unit/install-sudoers-migration.test.ts
@@ -532,7 +532,23 @@ describe("the root-owned helper scripts the grants point at", () => {
 
   it("installs them root-owned at 0755 under a root-owned directory", () => {
     expect(libexec).toMatch(/install -d -o root -g root -m 0755 "\$ROOT_LIBEXEC_DIR"/);
-    expect(libexec).toMatch(/install -o root -g root -m 0755 "\$PROJECT_DIR\/scripts\/\$src"/);
+    // The copy goes through install_root_file, which is where the ownership and
+    // the mode now live — and which stages under a temp name and renames, so a
+    // copy killed part way through cannot leave an executable PREFIX of a root
+    // helper at the destination. Every script in here dispatches at the BOTTOM,
+    // so such a prefix is silently permissive: a truncated
+    // clawbox-root-manifest.sh exits 0 for --verify without looking, and a
+    // truncated clawbox-root-step.sh exits 0 without exec'ing the step at all.
+    // TASK-584.
+    expect(libexec).toMatch(/install_root_file "\$PROJECT_DIR\/scripts\/\$src" "\$ROOT_LIBEXEC_DIR\/\$src"/);
+    const installer = (() => {
+      const start = INSTALL_SH.indexOf("install_root_file() {");
+      expect(start, "install_root_file is gone from install.sh").toBeGreaterThan(-1);
+      return INSTALL_SH.slice(start, INSTALL_SH.indexOf("\n}", start));
+    })();
+    expect(installer).toMatch(/mode="\$\{3:-0755\}"/);
+    expect(installer).toMatch(/install -o root -g root -m "\$mode" "\$src" "\$dst\.new"/);
+    expect(installer).toMatch(/mv -f "\$dst\.new" "\$dst"/);
   });
 
   // Running the repo copy here would let a broken install_root_libexec pass

--- a/src/tests/unit/root-exec-manifest.test.ts
+++ b/src/tests/unit/root-exec-manifest.test.ts
@@ -27,6 +27,26 @@ const MANIFEST_SRC = path.join(REPO, "config", "clawbox-root-manifest.sh");
 const DISPATCHER_SRC = path.join(REPO, "config", "clawbox-root-step.sh");
 const INSTALL_SH = fs.readFileSync(path.join(REPO, "install.sh"), "utf-8");
 
+/**
+ * The liveness token --selftest prints. Three separately installed root-owned
+ * files carry it as a literal (the helper, the dispatcher, install.sh) because
+ * they cannot share a constant; the last test in this file pins them together.
+ */
+const SELFTEST_TOKEN = "clawbox-root-manifest alive";
+
+/**
+ * A helper cut off where a copy killed part way through would leave it: every
+ * function defined, the verb dispatcher at the bottom gone. It parses, runs to
+ * EOF under `set -euo pipefail` and exits 0 for `--write`, `--verify` and
+ * `--verify-file` alike, without doing any of them.
+ */
+function truncatedHelper(): string {
+  const text = fs.readFileSync(MANIFEST_SRC, "utf-8");
+  const cut = text.indexOf('case "${1:-}" in');
+  if (cut < 0) throw new Error("the shipped helper no longer ends in a verb dispatcher");
+  return text.slice(0, cut);
+}
+
 /** Lift one function out of install.sh, so the block under test runs the real one. */
 function shellFn(name: string): string {
   const start = INSTALL_SH.indexOf(`${name}() {`);
@@ -232,6 +252,25 @@ d("clawbox-root-manifest.sh", () => {
   it("rejects an unknown mode instead of doing something", () => {
     expect(sh(`"${helper}" --whatever`).status).toBe(64);
   });
+
+  it("proves it is the whole program, which is what its exit status cannot", () => {
+    // Every verb above answers with an exit status, and an exit status is
+    // exactly what a helper that lost its bottom half cannot be trusted for:
+    // it exits 0 for all of them. Only a copy that reaches the verb dispatcher
+    // can print this token.
+    const r = sh(`"${helper}" --selftest`);
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe(SELFTEST_TOKEN);
+
+    for (const [what, text] of [["a 0-byte", ""], ["a truncated", truncatedHelper()]] as const) {
+      fs.writeFileSync(helper, text, { mode: 0o755 });
+      const dead = sh(`"${helper}" --selftest`);
+      expect(dead.stdout.trim(), `${what} helper printed the token`).not.toBe(SELFTEST_TOKEN);
+      // ...while still answering every real verb with a clean success.
+      expect(sh(`"${helper}" --write`).status, `${what} helper refused --write`).toBe(0);
+      expect(sh(`"${helper}" --verify`).status, `${what} helper refused --verify`).toBe(0);
+    }
+  });
 });
 
 d("clawbox-root-step.sh — the gate in front of the exec", () => {
@@ -304,6 +343,32 @@ d("clawbox-root-step.sh — the gate in front of the exec", () => {
     }
   });
 
+  it("fails closed when the verifier is installed but does nothing", () => {
+    // A 0-byte or truncated helper is the missing-verifier case with a worse
+    // ending: it is present and executable, so the `-x` guard passes, and it
+    // answers `--verify` AND the `--verify-file` about the staged copy with 0.
+    // The dispatcher would then exec /home/clawbox/clawbox/install.sh as root
+    // on the word of a program that never hashed anything — and that tree is
+    // writable by the unprivileged user the web server runs as, which is the
+    // whole reason the manifest exists (TASK-445).
+    for (const [what, text] of [["0-byte", ""], ["truncated", truncatedHelper()]] as const) {
+      sh(`"${helper}" --write`);
+      fs.writeFileSync(helper, text, { mode: 0o755 });
+      const r = sh(`"${dispatcher}" chpasswd`);
+      expect(r.status, `a ${what} helper let the step through`).toBe(65);
+      expect(ran(), `a ${what} helper let root exec the tree`).toBe("");
+      // Loudly, and with a repair the operator can actually type: the step that
+      // re-installs the helper AND re-records the manifest.
+      expect(r.stderr).toMatch(/--step systemd_services/);
+      fs.rmSync(marker, { force: true });
+      retarget(MANIFEST_SRC, helper, [
+        [/^PROJECT_DIR=.*$/m, `PROJECT_DIR="${project}"`],
+        [/^MANIFEST_DIR=.*$/m, `MANIFEST_DIR="${etc}"`],
+        [/^MANIFEST_FILE=.*$/m, `MANIFEST_FILE="${manifest}"`],
+      ]);
+    }
+  });
+
   it("fails closed when the verifier itself is missing", () => {
     sh(`"${helper}" --write`);
     fs.rmSync(helper);
@@ -363,6 +428,9 @@ d("install.sh::install_root_libexec", () => {
       // reports what it actually removed.
       "PROVISION_FAILURES=(root_exec_manifest)",
       shellFn("clear_provision_failure"),
+      // write_root_exec_manifest refuses to read the exit status of a helper
+      // that has not proved it is complete, so the real probe is lifted too.
+      shellFn("root_exec_manifest_helper_alive"),
       block,
       extra,
       "install_root_libexec",
@@ -422,6 +490,42 @@ d("install.sh::install_root_libexec", () => {
     expect(r.stdout + r.stderr).toMatch(/remaining-failures:openclaw_tts hermes_edition/);
   });
 
+  it("does not clear the failure when the manifest does not verify after the write", () => {
+    // `--write` returning 0 says the helper believes it wrote something, not
+    // that the record now matches the tree. Clearing the recorded failure on
+    // the write alone reports a repair that has not been shown to have
+    // happened — and every pinned root step afterwards still fails closed.
+    fs.writeFileSync(
+      path.join(project, "config", "clawbox-root-manifest.sh"),
+      [
+        "#!/usr/bin/env bash",
+        `[ "\${1:-}" = "--selftest" ] && { printf '%s\\n' "${SELFTEST_TOKEN}"; exit 0; }`,
+        '[ "${1:-}" = "--write" ] && exit 0',
+        '[ "${1:-}" = "--verify" ] && exit 65',
+        "exit 64",
+        "",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(path.join(libexec, "clawbox-root-step.sh"), "#!/bin/sh\n# previous\n", { mode: 0o755 });
+    const r = runBlock();
+    expect(r.stdout + r.stderr).toMatch(/remaining-failures:root_exec_manifest/);
+    expect(r.stdout + r.stderr).toMatch(/leaving the existing root dispatcher in place/);
+    expect(fs.readFileSync(path.join(libexec, "clawbox-root-step.sh"), "utf-8")).toContain("# previous");
+  });
+
+  it("refuses to record anything through a helper that cannot prove it is live", () => {
+    // The same 0-byte helper, one layer up: it exits 0 for `--write`, so the
+    // run would install the dispatcher and clear the failure over a manifest
+    // that was never written. The dispatcher must stay where it is.
+    fs.writeFileSync(path.join(project, "config", "clawbox-root-manifest.sh"), "", { mode: 0o755 });
+    fs.writeFileSync(path.join(libexec, "clawbox-root-step.sh"), "#!/bin/sh\n# previous\n", { mode: 0o755 });
+    const r = runBlock();
+    expect(r.stdout + r.stderr).toMatch(/remaining-failures:root_exec_manifest/);
+    expect(fs.readFileSync(path.join(libexec, "clawbox-root-step.sh"), "utf-8")).toContain("# previous");
+    expect(fs.existsSync(manifest), "no manifest was written, yet one appeared").toBe(false);
+  });
+
   it("keeps the existing dispatcher when the manifest cannot be written", () => {
     // A dispatcher newer than its manifest refuses every root step: no password
     // change, no hostname change, no hotspot restart, on a box with no console.
@@ -431,5 +535,21 @@ d("install.sh::install_root_libexec", () => {
     expect(r.stdout + r.stderr).toMatch(/leaving the existing root dispatcher in place/);
     expect(r.stdout + r.stderr).toMatch(/provision-failure:root_exec_manifest/);
     expect(fs.readFileSync(path.join(libexec, "clawbox-root-step.sh"), "utf-8")).toContain("# previous");
+  });
+});
+
+d("the liveness token", () => {
+  it("is the same literal in every file that asks for it", () => {
+    // The helper, the root dispatcher and install.sh are three separately
+    // installed root-owned files, so the token cannot be a shared constant. A
+    // typo in one of them is silent in the direction that matters: the caller
+    // stops believing a healthy helper, or — worse — a caller that never got
+    // updated keeps believing a dead one.
+    const helperText = fs.readFileSync(MANIFEST_SRC, "utf-8");
+    expect(helperText).toContain(`SELFTEST_TOKEN="${SELFTEST_TOKEN}"`);
+    expect(fs.readFileSync(DISPATCHER_SRC, "utf-8")).toContain(SELFTEST_TOKEN);
+    // Twice in install.sh: the bootstrap block runs before any function it
+    // could share, so it carries its own copy of the probe.
+    expect(INSTALL_SH.split(SELFTEST_TOKEN).length - 1).toBeGreaterThanOrEqual(2);
   });
 });

--- a/src/tests/unit/root-exec-manifest.test.ts
+++ b/src/tests/unit/root-exec-manifest.test.ts
@@ -47,6 +47,19 @@ function truncatedHelper(): string {
   return text.slice(0, cut);
 }
 
+/**
+ * The same helper as it was before `--selftest` existed: the verb dispatcher
+ * intact, that one arm gone. This is what is INSTALLED on every box updating
+ * across this release — the copy in /usr/local/libexec is always the previous
+ * release's until a step re-installs it — so it is the shape a liveness probe
+ * must not mistake for a stub.
+ */
+function withoutSelftest(text: string): string {
+  const stripped = text.replace(/^ *--selftest\).*\n/m, "");
+  if (stripped === text) throw new Error("the shipped helper no longer has a --selftest arm");
+  return stripped;
+}
+
 /** Lift one function out of install.sh, so the block under test runs the real one. */
 function shellFn(name: string): string {
   const start = INSTALL_SH.indexOf(`${name}() {`);
@@ -367,6 +380,21 @@ d("clawbox-root-step.sh — the gate in front of the exec", () => {
         [/^MANIFEST_FILE=.*$/m, `MANIFEST_FILE="${manifest}"`],
       ]);
     }
+  });
+
+  it("still runs the step through a helper from before --selftest existed", () => {
+    // The false failure the probe must not become, and it would be a fleet-wide
+    // one: on EVERY box updating across this release the installed helper is the
+    // previous release's, which does not know `--selftest`. Its 64 is not a
+    // refusal to answer — it is the verb dispatcher at the bottom of the file
+    // running, which is the very thing being asked about, and which a stub
+    // cannot do. So an old helper is live and the step goes through.
+    sh(`"${helper}" --write`);
+    fs.writeFileSync(helper, withoutSelftest(fs.readFileSync(helper, "utf-8")), { mode: 0o755 });
+    expect(sh(`"${helper}" --selftest`).status, "the stand-in must answer 64, not 0").toBe(64);
+    const r = sh(`"${dispatcher}" chpasswd`);
+    expect(r.status, r.stderr).toBe(0);
+    expect(ran()).toContain("--step chpasswd");
   });
 
   it("fails closed when the verifier itself is missing", () => {

--- a/src/tests/unit/root-exec-manifest.test.ts
+++ b/src/tests/unit/root-exec-manifest.test.ts
@@ -571,6 +571,54 @@ d("install.sh::install_root_libexec", () => {
   });
 });
 
+d("install.sh::install_root_file", () => {
+  it("never leaves a prefix of a root helper where the live one was", () => {
+    // The stub factory, on the path that runs on EVERY install and every
+    // `--step systemd_services` — which is the remedy every refusal in this
+    // chain prints. `install` writes into the destination inode with O_TRUNC,
+    // so a copy killed part way through (a full or read-only /usr) left an
+    // executable PREFIX of the file behind. Every script install_root_libexec
+    // installs dispatches at the BOTTOM, so that prefix is silently PERMISSIVE:
+    // a truncated clawbox-root-manifest.sh exits 0 for --write and --verify
+    // without looking, and a truncated clawbox-root-step.sh reaches EOF and
+    // exits 0 without exec'ing the step at all — which `Type=oneshot` reports
+    // to the updater as a step that succeeded.
+    const dst = path.join(libexec, "victim.sh");
+    const live = "#!/bin/sh\n# the working copy\nexit 0\n";
+    fs.writeFileSync(dst, live, { mode: 0o755 });
+    const src = path.join(tmp, "big.sh");
+    fs.writeFileSync(src, `#!/bin/sh\n${"# pad\n".repeat(30_000)}exit 0\n`);
+
+    // RLIMIT_FSIZE 8 blocks = 4096 bytes, so the source cannot fit and the copy
+    // dies mid-write — the real shape of the failure, not a mocked one.
+    const r = sh(
+      [
+        "set -uo pipefail",
+        unroot(shellFn("install_root_file")),
+        "ulimit -f 8",
+        `if install_root_file "${src}" "${dst}"; then echo RC=ok; else echo RC=fail; fi`,
+        "",
+      ].join("\n"),
+    );
+    expect(r.stdout, r.stderr).toContain("RC=fail");
+    expect(fs.readFileSync(dst, "utf-8"), "a failed copy truncated the live file").toBe(live);
+    expect(fs.existsSync(`${dst}.new`), "a staged copy was left behind").toBe(false);
+  });
+
+  it("installs the whole file when the copy fits", () => {
+    const dst = path.join(libexec, "victim.sh");
+    const src = path.join(tmp, "small.sh");
+    fs.writeFileSync(src, "#!/bin/sh\nexit 7\n");
+    const r = sh(
+      ["set -euo pipefail", unroot(shellFn("install_root_file")), `install_root_file "${src}" "${dst}"`, ""].join("\n"),
+    );
+    expect(r.status, r.stderr).toBe(0);
+    expect(fs.readFileSync(dst, "utf-8")).toBe("#!/bin/sh\nexit 7\n");
+    expect(fs.statSync(dst).mode & 0o777).toBe(0o755);
+    expect(fs.existsSync(`${dst}.new`)).toBe(false);
+  });
+});
+
 d("the liveness token", () => {
   it("is the same literal in every file that asks for it", () => {
     // The helper, the root dispatcher and install.sh are three separately

--- a/src/tests/unit/root-exec-manifest.test.ts
+++ b/src/tests/unit/root-exec-manifest.test.ts
@@ -351,16 +351,22 @@ d("install.sh::install_root_libexec", () => {
     return sh([
       "set -uo pipefail",
       `PROJECT_DIR="${project}"`,
-      'record_provision_failure() { echo "provision-failure:$1"; }',
+      'record_provision_failure() { PROVISION_FAILURES+=("$1"); echo "provision-failure:$1"; }',
       // write_root_exec_manifest now CLEARS what it repaired (TASK-584): a
       // manifest the bootstrap could not write and a later step did is not a
       // failure of the run. The real helper is lifted out of install.sh rather
       // than stubbed, so this block exercises the clearing it actually does.
-      "PROVISION_FAILURES=()",
+      //
+      // Seeded, not empty. With an empty array and a record stub that only
+      // echoed, clear_provision_failure had nothing to remove: the lifted
+      // function proved only that the name resolves, while the line below
+      // reports what it actually removed.
+      "PROVISION_FAILURES=(root_exec_manifest)",
       shellFn("clear_provision_failure"),
       block,
       extra,
       "install_root_libexec",
+      'echo "remaining-failures:${PROVISION_FAILURES[*]-}"',
     ].join("\n"));
   }
 
@@ -398,6 +404,22 @@ d("install.sh::install_root_libexec", () => {
   it("records the tree it is about to authorise, so the new dispatcher verifies", () => {
     runBlock();
     expect(sh(`"${helper}" --verify`).status).toBe(0);
+  });
+
+  it("clears a bootstrap failure it has just repaired", () => {
+    // The bootstrap records root_exec_manifest when it cannot re-record the
+    // manifest after the hard reset. This step re-records it half a minute
+    // later, and a run that ends healthy must not still report that failure —
+    // that is a false failure over an install that is fine (TASK-584).
+    const r = runBlock();
+    expect(r.stdout + r.stderr).toMatch(/remaining-failures:\s*$/m);
+  });
+
+  it("clears only the token it repaired", () => {
+    // The control: without this, "clears" would pass over a function that
+    // emptied the whole array and lost every other step's failure.
+    const r = runBlock("PROVISION_FAILURES=(openclaw_tts root_exec_manifest hermes_edition)");
+    expect(r.stdout + r.stderr).toMatch(/remaining-failures:openclaw_tts hermes_edition/);
   });
 
   it("keeps the existing dispatcher when the manifest cannot be written", () => {

--- a/src/tests/unit/root-exec-manifest.test.ts
+++ b/src/tests/unit/root-exec-manifest.test.ts
@@ -370,9 +370,14 @@ d("clawbox-root-step.sh — the gate in front of the exec", () => {
       const r = sh(`"${dispatcher}" chpasswd`);
       expect(r.status, `a ${what} helper let the step through`).toBe(65);
       expect(ran(), `a ${what} helper let root exec the tree`).toBe("");
-      // Loudly, and with a repair the operator can actually type: the step that
-      // re-installs the helper AND re-records the manifest.
-      expect(r.stderr).toMatch(/--step systemd_services/);
+      // Loudly, and with a repair the operator can actually type — the whole
+      // command, not a fragment. `systemd_services` is the step that re-installs
+      // the helper AND re-records the manifest, and the path has to be the
+      // on-disk entrypoint: a few lines below this check the script repoints
+      // $ENTRYPOINT at a copy under /run that is deleted on reboot and that the
+      // operator cannot execute, so a probe moved after that point would print a
+      // remedy which cannot be run.
+      expect(r.stderr).toContain(`sudo bash ${path.join(project, "install.sh")} --step systemd_services`);
       fs.rmSync(marker, { force: true });
       retarget(MANIFEST_SRC, helper, [
         [/^PROJECT_DIR=.*$/m, `PROJECT_DIR="${project}"`],

--- a/src/tests/unit/root-exec-manifest.test.ts
+++ b/src/tests/unit/root-exec-manifest.test.ts
@@ -591,10 +591,15 @@ d("install.sh::install_root_file", () => {
 
     // RLIMIT_FSIZE 8 blocks = 4096 bytes, so the source cannot fit and the copy
     // dies mid-write — the real shape of the failure, not a mocked one.
+    // `ulimit -c 0` first: SIGXFSZ is a dumping signal, and `sh()` inherits the
+    // test runner's working directory, so on a host whose `core_pattern` names
+    // a plain file this would drop a `core` in the repo. Same guard as
+    // install-bootstrap-manifest.test.ts's copy of this setup.
     const r = sh(
       [
         "set -uo pipefail",
         unroot(shellFn("install_root_file")),
+        "ulimit -c 0",
         "ulimit -f 8",
         `if install_root_file "${src}" "${dst}"; then echo RC=ok; else echo RC=fail; fi`,
         "",

--- a/src/tests/unit/root-exec-manifest.test.ts
+++ b/src/tests/unit/root-exec-manifest.test.ts
@@ -27,6 +27,15 @@ const MANIFEST_SRC = path.join(REPO, "config", "clawbox-root-manifest.sh");
 const DISPATCHER_SRC = path.join(REPO, "config", "clawbox-root-step.sh");
 const INSTALL_SH = fs.readFileSync(path.join(REPO, "install.sh"), "utf-8");
 
+/** Lift one function out of install.sh, so the block under test runs the real one. */
+function shellFn(name: string): string {
+  const start = INSTALL_SH.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found in install.sh`);
+  const end = INSTALL_SH.indexOf("\n}", start);
+  if (end < 0) throw new Error(`${name} has no closing brace`);
+  return INSTALL_SH.slice(start, end + 2);
+}
+
 const CAN_RUN =
   process.platform !== "win32"
   && spawnSync("bash", ["-c", "true"], { stdio: "ignore" }).status === 0
@@ -343,6 +352,12 @@ d("install.sh::install_root_libexec", () => {
       "set -uo pipefail",
       `PROJECT_DIR="${project}"`,
       'record_provision_failure() { echo "provision-failure:$1"; }',
+      // write_root_exec_manifest now CLEARS what it repaired (TASK-584): a
+      // manifest the bootstrap could not write and a later step did is not a
+      // failure of the run. The real helper is lifted out of install.sh rather
+      // than stubbed, so this block exercises the clearing it actually does.
+      "PROVISION_FAILURES=()",
+      shellFn("clear_provision_failure"),
       block,
       extra,
       "install_root_libexec",

--- a/src/tests/unit/root-exec-manifest.test.ts
+++ b/src/tests/unit/root-exec-manifest.test.ts
@@ -519,8 +519,16 @@ d("install.sh::install_root_libexec", () => {
   it("clears only the token it repaired", () => {
     // The control: without this, "clears" would pass over a function that
     // emptied the whole array and lost every other step's failure.
+    //
+    // Anchored, like the sibling above it. Unanchored, the match only says the
+    // two survivors are adjacent somewhere in the line — which the ORDER
+    // already guarantees is false for a run that cleared nothing
+    // (`openclaw_tts root_exec_manifest hermes_edition`), but says nothing
+    // about a repair that removes the token and then puts it back at the end.
+    // `remaining-failures:openclaw_tts hermes_edition root_exec_manifest` is a
+    // false failure surviving its own repair, and it passed.
     const r = runBlock("PROVISION_FAILURES=(openclaw_tts root_exec_manifest hermes_edition)");
-    expect(r.stdout + r.stderr).toMatch(/remaining-failures:openclaw_tts hermes_edition/);
+    expect(r.stdout + r.stderr).toMatch(/remaining-failures:openclaw_tts hermes_edition\s*$/m);
   });
 
   it("does not clear the failure when the manifest does not verify after the write", () => {


### PR DESCRIPTION
**TASK-584** — a failed root-exec manifest re-record during bootstrap is
swallowed, and every root step afterwards is refused.

## Customer-visible symptom
The owner's password change, hostname change, hotspot restart and llama.cpp
install all stop working, silently. `clawbox-root-step.sh` refuses each one with

```
refusing '<step>' — /home/clawbox/clawbox does not match the root-exec manifest
```

and exit 65. Observed live on a test box: `--verify` returned 65 and every root
step was refused; the box was repaired by hand with
`clawbox-root-manifest.sh --write` (65 → 0).

## Cause
`install.sh:105`

```sh
"$_mf" --write || echo "[bootstrap] WARN: could not re-record the root-exec manifest" >&2
```

The comment directly above it states the problem: the bootstrap has just
replaced `install.sh`, `scripts/` and `config/` wholesale with a `git reset
--hard`, so the manifest the root dispatcher checks is stale **by construction**
— and the dispatcher fails CLOSED on a stale manifest. So a failed re-record
does not degrade one step; it refuses every root step of that very update, and
every root step the owner takes afterwards. One warning line on the stderr of an
update nobody watches was the entire trace. Same false-success family as
#504 / #519 / #552.

## Fix
Three parts, none of which can abort the boot path:

1. **Repair first.** The installed helper is the one from *before* the reset —
   the most likely reason it just failed — so it is re-installed from the freshly
   checked-out tree and `--write` retried once.
2. **Carry the failure forward.** If the retry fails too, the bootstrap sets
   `CLAWBOX_ROOT_MANIFEST_STALE=1` and passes it through the `exec`, because the
   process that can record it against the run's verdict is the one about to
   start.
3. **Record it, after re-checking.** The new process runs
   `clawbox-root-manifest.sh --verify` before believing the marker — reporting a
   failure over a manifest that turns out fine is the opposite defect — and on a
   genuine failure calls `record_provision_failure root_exec_manifest`, so the
   summary, the exit status and the `[provision-status]` marker all say the
   update did not succeed, and prints the repair command.

And the mirror of (3): `write_root_exec_manifest` now **clears** that record when
it succeeds. `install_root_libexec` re-records the manifest later in a full run,
and that is exactly the repair — without the clear, a run that fixed itself would
still report a failure at the end.

## Harness-first
Nothing in OpenClaw or Hermes owns this: the root-exec manifest is ClawBox's own
TASK-445 mechanism (`config/clawbox-root-manifest.sh`, `config/clawbox-root-step.sh`).
The in-repo owners are `write_root_exec_manifest` / `refresh_root_exec_manifest` /
`install_root_libexec`, and the change routes through them rather than adding a
fourth writer — the bootstrap block stays literal on purpose (the constants block
has not been parsed there yet, and these paths select which code root executes).

## RED (unmodified beta)
```
 × refreshes the helper from the reset tree and retries before giving up
 × carries the failure into the re-exec when the retry fails too
 × never aborts the bootstrap, even with no helper in the reset tree
 × hands the marker to the re-exec'd process
 × records a provisioning failure, so the update cannot report success
 × records nothing when the manifest verifies after all
 × records nothing when the bootstrap never set the marker
 × clears the recorded failure when a later step re-records the manifest

AssertionError: expected [ 'installed --write' ] to have a length of 2 but got 1
AssertionError: expected '0' to be '1'
Error: the slice no longer names the manifest helper — it was extracted wrong
      Tests  8 failed | 1 passed (9)
```

(The three `slice ... extracted wrong` errors are the verdict block: it does not
exist on beta at all.)

The tests execute the shipped blocks under `set -euo pipefail` with the two
hard-coded absolute paths retargeted onto a temp tree — the same technique
`src/tests/unit/root-exec-manifest.test.ts` already uses on these scripts, rather
than adding an environment seam to a path that decides what root executes.

## GREEN
```
 install-bootstrap-manifest, root-exec-manifest, root-steps,
 install-sudoers-migration, install-provision-status-marker,
 install-update-branch-pin, install-post-update-units      140 passed (7 files)
 all 23 src/tests/unit/install-*.test.ts                   546 passed
 bash -n install.sh                                        OK
```

## Sibling call sites
- `write_root_exec_manifest` (the strict writer) and `refresh_root_exec_manifest`
  (the best-effort one for update paths) — the first now clears the record it
  repairs; the second goes through it, so it clears too.
- `install_root_libexec` already refuses to install the dispatcher when the
  manifest write fails, and says so; unchanged, and it is what makes the "clear"
  half necessary.
- `src/tests/unit/root-exec-manifest.test.ts` lifts `install_root_libexec` out of
  install.sh and runs it standalone, so it now has to supply
  `clear_provision_failure` — lifted from install.sh rather than stubbed, so the
  clearing is exercised for real.
- Every consumer of `PROVISION_FAILURES` is a reader (the summary, the exit
  status, `write_provision_status`, and the `--step` dispatch trap
  `dispatch_provision_verdict`), so the record reaches all four paths in both
  install modes.
- The bootstrap runs on every edition; a box without the helper installed keeps
  the existing no-op (`[ -x "$_mf" ]`) and the marker is never set, so a Hermes
  box and a first-boot install cannot pick up a false failure.

## Device leg
Not run: proving this needs an update on hardware whose manifest re-record
fails, which means mutating a box, and this run is read-only on devices. The
tests execute the shipped blocks; the live half of the evidence is the original
incident on the card (`--verify` → 65, every root step refused).

## Review (one Opus `clawbox-review` pass: 3 high, 4 medium, 5 low)
Applied:
- **H1** — `refresh_root_exec_manifest` (the *other* re-record after a hard reset,
  reached from `sync_repo_to_update_target`) still read `--write || echo WARN` and
  returned 0. The PR had added a *clear* with no matching *record*, so the verdict
  was asymmetric and `--step bootstrap_updater` could still exit 0 with a stale
  manifest. It records now.
- **H2** — the repair copy used `install … "$_mf"`, which writes into the existing
  inode with `O_TRUNC`; a copy that fails halfway (a full or read-only rootfs —
  the same condition that most often fails the write it is repairing) left a
  0-byte helper. Reviewer reproduced it, and proved an empty helper exits **0**
  for `--verify`, which turns the dispatcher from fail-closed to fail-**open**.
  Now staged as `$_mf.new` and renamed.
- **M1** — both attempts are judged by `--write && --verify`, not by `--write`'s
  own exit code, for the same reason.
- **M2** — the printed repair command went through a new `provision_repair_step`
  mapper: `root_exec_manifest` is not a dispatchable step, so both verdict
  printers would have handed the operator "Unknown step".
- **M3** — the banner's repair is `--step systemd_services` (which re-installs the
  helper AND the dispatcher), not the command that just failed twice.
- **L1** — the comments no longer overstate: `SELF_UPDATING_STEPS` is exempt, so
  it is every *non-update* root step.
- **L4** — the copy no longer hides its own diagnostic.
- **L5 / I1** — the test now runs THROUGH the `exec` into a stub install.sh and
  asserts the value that arrives, instead of matching the exec line as a string
  (which passed with a hard-coded `0`); the verdict slice is anchored on the block
  itself rather than on a decorative comment banner.

**Not fixed here, recorded on the fixer queue (M4):** only a full install ever
writes `STATUS=ok`, so a dispatched step whose bootstrap marker fires stamps
`incomplete` into the marker file, and the repair — which happens in a later step,
in a *different process* — clears the in-memory record but cannot re-publish the
marker. A box that ends the update healthy keeps advertising `incomplete` until a
full re-install. Fixing it properly means changing who may publish `ok`, which is
a wider change than this card and risks deleting an `incomplete` that belongs to
someone else's failure.


## Final round (2026-09-04) — review M3 and three CodeRabbit threads

### M3 — the most dangerous line had no test that failed if it was reverted

The bootstrap stages to `$_mf.new` and renames, so a half-failed copy cannot
truncate the live root-integrity helper. The suite could not see that: the helper
call sequence (`installed --write`, `refreshed --write`, `refreshed --verify`) is
byte-identical whether the copy is staged or goes straight over `$_mf`.

A case now kills the copy **part way through** with `RLIMIT_FSIZE`
(`ulimit -c 0; ulimit -f 8`, source padded past the limit), which is what
distinguishes the two shapes — `install` writes into the existing inode with
`O_TRUNC`. Measured both ways:

```
[temp+rename]       helper: was 37 bytes, now 37 bytes     intact
[install over live] helper: was 37 bytes, now 8192 bytes   truncated
                    and that 8192-byte survivor: --verify -> 0
```

The last line is the point: a truncated helper exits 0 for `--verify`, turning
the root dispatcher from fail-closed into fail-open for every pinned step —
worse than the stale manifest the repair was answering.

The test asserts the live helper's bytes are unchanged, no `<helper>.new` is left
in libexec, the marker is `1` and the bootstrap still reaches the `exec`.
Reverting the guard locally makes it fail:

```
FAIL … > leaves the live helper byte-identical when the copy dies mid-write
  the live helper was truncated by a failed copy:
  expected '#!/usr/bin/env bash\nprintf 'refresh…' to be '#!/usr/bin/env bash\nprintf 'install…'
Tests  2 failed | 11 passed (13)
```

A second case covers the branch where `install` fails before writing anything
(an unreadable source; skipped under root, which reads it anyway): the
`could not stage` warning, no leftover `.new`, the helper untouched, marker `1`,
`exec` reached.

*Note on the mechanism CodeRabbit proposed:* a **directory** source does not
satisfy the shipped `[ -f … ]` guard, so `install` is never reached — that is the
`helperInTree: false` path, already covered, and it produces no warning at all.
Hence the RLIMIT_FSIZE child instead.

### CodeRabbit thread — `install.sh:196`, empty-array expansion under `set -u`

`clear_provision_failure` expanded `"${PROVISION_FAILURES[@]}"` and
`"${kept[@]}"`, both empty on the common path. On a bash that treats an empty
array as unbound, `set -u` would abort the installer inside the one function
whose job is to CLEAR a failure — reporting exactly the false failure it exists
to remove. Both now use `${a[@]+"${a[@]}"}`.

Swept the file for the same shape: every other `PROVISION_FAILURES` expansion is
a length (`:5976`, `:6183`, `:6191`), guarded by one of those length checks
(`:5979`, `:5980`, `:5982`, `:5985`, `:6192`, `:6193`), or carries a default
(`:6199`, `:6202`). Verified by execution: an empty clear returns cleanly, and
`(a root_exec_manifest b root_exec_manifest)` clears to `[a b]`.

### CodeRabbit thread — `root-exec-manifest.test.ts:360`, the clearing path

Also right: `record_provision_failure` was stubbed to echo only, so
`PROVISION_FAILURES` was always empty when `clear_provision_failure` ran and the
lifted function proved only that the name resolves. The stub now appends, the
array is seeded, and the block reports what survived — with a control, because
"empty afterwards" would equally pass over a function that wiped the array:

- `clears a bootstrap failure it has just repaired` — `remaining-failures:` empty.
- `clears only the token it repaired` — seeded
  `(openclaw_tts root_exec_manifest hermes_edition)`, result exactly
  `openclaw_tts hermes_edition`.

Both fail when `clear_provision_failure` is replaced with `:`, and nothing else
in the suite does.

### GREEN

`install-bootstrap-manifest` + `root-exec-manifest` + `install-sudoers-migration`
→ **81 passed**. `bash -n install.sh` clean; `tsc --noEmit` clean.
All three review threads answered in-thread and resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved installer reliability when refreshing and verifying root-execution components.
  - Added safer recovery for helper updates and manifest verification failures, including retries and clearer repair guidance.
  - Installer errors now identify the appropriate repair step.
  - Provisioning failures clear after successful repairs, preventing stale reports.
  - Root-owned scripts and policy files are installed through safer atomic updates.
  - Invalid or unavailable helpers now fail closed before protected steps run.
  - Added helper self-testing and compatibility with older helper versions.

- **Tests**
  - Expanded coverage for bootstrap recovery, persistent failures, manifest verification, and repair flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Round N+1 — the last review thread, and a rebase

**Applied** (`src/tests/unit/root-exec-manifest.test.ts:598`): the
`install_root_file` RLIMIT_FSIZE test now sets `ulimit -c 0` before
`ulimit -f 8`. `sh()` spawns bash with no `cwd`, so it inherits the vitest
worker's working directory — the repository root — and SIGXFSZ is a dumping
signal, so on a host whose `core_pattern` names a plain file the deliberately
killed copy would drop a `core` where nothing cleans it. The same setup in
`install-bootstrap-manifest.test.ts:246`, added in this PR, already carried the
guard; this copy had missed it.

No RED: whether a file lands is a property of the host, not the code. It needs
`core_pattern` to name a plain file *and* a non-zero inherited `RLIMIT_CORE`;
on the dev machine `core_pattern` pipes to a handler, and a scratch reproduction
under `ulimit -c unlimited` left no core behind. Hardening against a CI image we
do not control, stated as such.

## GREEN (on the rebased head)

```
root-exec-manifest + install-bootstrap-manifest + install-sudoers-migration
+ desktop-power-wiring   Test Files 4 passed (4)   Tests 117 passed (117)
bash -n   install.sh, config/clawbox-root-manifest.sh, config/clawbox-root-step.sh   clean
tsc --noEmit   exit 0
```

Rebased onto `origin/beta` `08e7057d`; `git diff --stat origin/beta...HEAD` lists
the same 7 files as before with no deletions.

**`e2e-install` must re-run on the rebased head before this merges** — the branch
changes `install.sh` and the root helpers.


**Follow-up on the rebased head** (`2ce0629f`): a late review thread on
`src/tests/unit/root-exec-manifest.test.ts:531` was valid and is applied. The
"clears only the token it repaired" control matched
`remaining-failures:openclaw_tts hermes_edition` unanchored. The input order
already ruled out a run that cleared nothing, but not a repair that removes the
token and re-appends it — `…openclaw_tts hermes_edition root_exec_manifest`, a
false failure surviving its own repair, passed. Now anchored `\s*$/m`, like the
sibling assertion four lines above it. The two remaining unanchored matches
(`:553`, `:565`) assert PRESENCE rather than completeness and are deliberately
left as they are. `root-exec-manifest` 35/35, four touched suites 117/117.
