### PR TITLE
fix: never let a failed version probe abort the gateway pre-start (TASK-657)

### DIFF
--- a/install-x64.sh
+++ b/install-x64.sh
@@ -448,7 +448,7 @@ step_openclaw_install() {
     # An unknown pin is already a defined state -- the fallback on the next line
     # -- and an aborted install is not. TASK-657, the third copy of the read
     # install.sh:2245 and gateway-pre-start.sh:45 already guard.
-    TARGET=$(head -1 "$PIN_FILE" | awk '{print $1}' || true)
+    TARGET=$(head -1 "$PIN_FILE" 2>/dev/null | awk '{print $1}' || true)
     if [ -z "$TARGET" ]; then
       # Say it: the fallback is silently a DIFFERENT core version from the one
       # the repo pinned, and external plugins are locked to whatever wins here.

--- a/install-x64.sh
+++ b/install-x64.sh
@@ -440,7 +440,20 @@ step_openclaw_install() {
   local PIN_FILE="$PROJECT_DIR/config/openclaw-target.txt"
   local TARGET="${OPENCLAW_PIN_VERSION:-}"
   if [ -z "$TARGET" ] && [ -f "$PIN_FILE" ]; then
-    TARGET=$(head -1 "$PIN_FILE" | awk '{print $1}')
+    # `|| true`: step_openclaw_install is called plainly from
+    # step_openclaw_setup, which is itself called in plain command position, so
+    # errexit is NOT suppressed here. Under `set -euo pipefail` (:16) an
+    # unreadable pin file (permissions, a truncated mount) makes `head` fail,
+    # pipefail carries it into the assignment, and the whole installer aborts.
+    # An unknown pin is already a defined state -- the fallback on the next line
+    # -- and an aborted install is not. TASK-657, the third copy of the read
+    # install.sh:2245 and gateway-pre-start.sh:45 already guard.
+    TARGET=$(head -1 "$PIN_FILE" | awk '{print $1}' || true)
+    if [ -z "$TARGET" ]; then
+      # Say it: the fallback is silently a DIFFERENT core version from the one
+      # the repo pinned, and external plugins are locked to whatever wins here.
+      echo "  WARN: $PIN_FILE is empty or could not be read — falling back to hardcoded $OPENCLAW_VERSION" >&2
+    fi
   fi
   TARGET="${TARGET:-$OPENCLAW_VERSION}"
   OPENCLAW_TARGET="$TARGET"

--- a/install.sh
+++ b/install.sh
@@ -2242,7 +2242,7 @@ step_openclaw_install() {
     # installer here. The `else` branch below already reports an unknown pin and
     # falls back to the hardcoded version — that is the defined answer, and an
     # aborted update is not. TASK-657, same shape as gateway-pre-start.sh:45.
-    PINNED=$(head -1 "$PIN_FILE" | awk '{print $1}' || true)
+    PINNED=$(head -1 "$PIN_FILE" 2>/dev/null | awk '{print $1}' || true)
     if [ -n "$PINNED" ]; then
       echo "  Pinned OpenClaw target from $PIN_FILE: $PINNED"
     else

--- a/install.sh
+++ b/install.sh
@@ -2237,7 +2237,12 @@ step_openclaw_install() {
     # would concat tokens on a hypothetical multi-field line — keeping the
     # two parsers identical avoids subtle UI ↔ install.sh desync if the file
     # format ever grows.
-    PINNED=$(head -1 "$PIN_FILE" | awk '{print $1}')
+    # `|| true`: this step is dispatched with errexit deliberately ON, so an
+    # unreadable pin file (permissions, a truncated mount) would abort the
+    # installer here. The `else` branch below already reports an unknown pin and
+    # falls back to the hardcoded version — that is the defined answer, and an
+    # aborted update is not. TASK-657, same shape as gateway-pre-start.sh:45.
+    PINNED=$(head -1 "$PIN_FILE" | awk '{print $1}' || true)
     echo "  Pinned OpenClaw target from $PIN_FILE: $PINNED"
   else
     echo "  WARN: $PIN_FILE not found — falling back to hardcoded $OPENCLAW_VERSION" >&2

--- a/install.sh
+++ b/install.sh
@@ -2246,12 +2246,14 @@ step_openclaw_install() {
     if [ -n "$PINNED" ]; then
       echo "  Pinned OpenClaw target from $PIN_FILE: $PINNED"
     else
-      # The `|| true` above turns an unreadable or empty pin file into an empty
-      # PINNED, and the fallback below is then correct -- but the unconditional
-      # line printed "Pinned OpenClaw target from ...: " and asserted a pin had
-      # been read when none had. The `else` branch's WARN is not reached from
-      # here, so say it here.
-      echo "  WARN: $PIN_FILE could not be read — falling back to hardcoded $OPENCLAW_VERSION" >&2
+      # The `|| true` above turns an unreadable pin file into an empty PINNED,
+      # and a file that is empty (or whose first line is blank) gets there with
+      # `head` and `awk` both SUCCEEDING -- so this arm cannot claim the file
+      # could not be read. The fallback below is correct either way, but the
+      # unconditional line printed "Pinned OpenClaw target from ...: " and
+      # asserted a pin had been read when none had. The `else` branch's WARN is
+      # not reached from here, so say it here.
+      echo "  WARN: $PIN_FILE is empty or could not be read — falling back to hardcoded $OPENCLAW_VERSION" >&2
     fi
   else
     echo "  WARN: $PIN_FILE not found — falling back to hardcoded $OPENCLAW_VERSION" >&2

--- a/install.sh
+++ b/install.sh
@@ -2243,7 +2243,16 @@ step_openclaw_install() {
     # falls back to the hardcoded version — that is the defined answer, and an
     # aborted update is not. TASK-657, same shape as gateway-pre-start.sh:45.
     PINNED=$(head -1 "$PIN_FILE" | awk '{print $1}' || true)
-    echo "  Pinned OpenClaw target from $PIN_FILE: $PINNED"
+    if [ -n "$PINNED" ]; then
+      echo "  Pinned OpenClaw target from $PIN_FILE: $PINNED"
+    else
+      # The `|| true` above turns an unreadable or empty pin file into an empty
+      # PINNED, and the fallback below is then correct -- but the unconditional
+      # line printed "Pinned OpenClaw target from ...: " and asserted a pin had
+      # been read when none had. The `else` branch's WARN is not reached from
+      # here, so say it here.
+      echo "  WARN: $PIN_FILE could not be read — falling back to hardcoded $OPENCLAW_VERSION" >&2
+    fi
   else
     echo "  WARN: $PIN_FILE not found — falling back to hardcoded $OPENCLAW_VERSION" >&2
   fi

--- a/production-server.js
+++ b/production-server.js
@@ -167,26 +167,19 @@ try {
   // that drifted to broader perms via manual edit) would otherwise
   // stay readable to other local users. The bearer is the sole
   // /setup-api/* credential, so don't trust a reused file's perms.
-  // The MODE is the outcome, not chmod's exit code — the same rule
-  // scripts/gateway-pre-start.sh grades on — so report what the file
-  // is actually left at rather than that a call failed.
+  // In its own try, because it is the one step here that may fail
+  // without costing anything already achieved. The message states the
+  // STATE and never a cause: chmod fails with EPERM (another uid owns
+  // it), EROFS or EACCES (data/ read-only, or a path component), and
+  // no code here can tell which — the same correction the shell copy
+  // in scripts/gateway-pre-start.sh got.
   try {
     fs.chmodSync(MCP_TOKEN_PATH, 0o600);
-  } catch {
-    let mode = null;
-    try {
-      mode = fs.statSync(MCP_TOKEN_PATH).mode & 0o777;
-    } catch {}
-    if (mode === null) {
-      console.warn(`[production-server] Could not re-harden ${MCP_TOKEN_PATH}, and its mode could not be read.`);
-    } else if (mode & 0o077) {
-      console.warn(
-        `[production-server] ${MCP_TOKEN_PATH} is mode ${mode.toString(8)}, which other local users can read, `
-          + "and it could not be re-hardened (it belongs to another user). The MCP bearer for /setup-api/* is exposed on this box.",
-      );
-    }
-    // A mode with no group/other bits is exposed to nobody; the failed chmod
-    // had nothing to fix and is not worth a line.
+  } catch (err) {
+    console.warn(
+      `[production-server] Could not re-harden ${MCP_TOKEN_PATH} (${err.code || err.message}); `
+        + "if other local users can read it, the MCP bearer for /setup-api/* is exposed on this box.",
+    );
   }
 } catch (err) {
   console.warn("[production-server] Failed to set up MCP token:", err.message);

--- a/production-server.js
+++ b/production-server.js
@@ -153,13 +153,41 @@ try {
     fs.mkdirSync(path.dirname(MCP_TOKEN_PATH), { recursive: true });
     fs.writeFileSync(MCP_TOKEN_PATH, mcpToken, { mode: 0o600 });
   }
+  // Publish the value FIRST. The re-harden below is a separate concern and it
+  // can fail on its own (a root-owned token, a read-only data/); with it inside
+  // this try and above this line, an EPERM threw past the assignment and
+  // CLAWBOX_MCP_TOKEN was never set — so a permissions hiccup discarded a token
+  // that had just been read successfully, and middleware.ts lost the very
+  // first-request resolution this block exists to provide. On the Hermes SKU
+  // clawbox-gateway.service is masked, so gateway-pre-start.sh's replacement
+  // never runs and nothing else repairs it. TASK-657.
+  process.env.CLAWBOX_MCP_TOKEN = mcpToken;
   // Re-harden mode on every boot. fs.writeFileSync only applies mode
   // when creating; an existing file from an older install (or one
   // that drifted to broader perms via manual edit) would otherwise
   // stay readable to other local users. The bearer is the sole
   // /setup-api/* credential, so don't trust a reused file's perms.
-  fs.chmodSync(MCP_TOKEN_PATH, 0o600);
-  process.env.CLAWBOX_MCP_TOKEN = mcpToken;
+  // The MODE is the outcome, not chmod's exit code — the same rule
+  // scripts/gateway-pre-start.sh grades on — so report what the file
+  // is actually left at rather than that a call failed.
+  try {
+    fs.chmodSync(MCP_TOKEN_PATH, 0o600);
+  } catch {
+    let mode = null;
+    try {
+      mode = fs.statSync(MCP_TOKEN_PATH).mode & 0o777;
+    } catch {}
+    if (mode === null) {
+      console.warn(`[production-server] Could not re-harden ${MCP_TOKEN_PATH}, and its mode could not be read.`);
+    } else if (mode & 0o077) {
+      console.warn(
+        `[production-server] ${MCP_TOKEN_PATH} is mode ${mode.toString(8)}, which other local users can read, `
+          + "and it could not be re-hardened (it belongs to another user). The MCP bearer for /setup-api/* is exposed on this box.",
+      );
+    }
+    // A mode with no group/other bits is exposed to nobody; the failed chmod
+    // had nothing to fix and is not worth a line.
+  }
 } catch (err) {
   console.warn("[production-server] Failed to set up MCP token:", err.message);
 }

--- a/scripts/ensure-local-embeddings.sh
+++ b/scripts/ensure-local-embeddings.sh
@@ -55,6 +55,16 @@ if [ -z "${CLAWBOX_OPENCLAW_V2:-}" ]; then
   CLAWBOX_OPENCLAW_V2=0
   OPENCLAW_PKG="$(dirname "$OPENCLAW_BIN")/../lib/node_modules/openclaw/package.json"
   INSTALLED_VERSION="$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1])).get("version") or "")' "$OPENCLAW_PKG" 2>/dev/null || true)"
+  # Shape-checked, the same way scripts/gateway-pre-start.sh grades this exact
+  # file: a version that is not a date says nothing about the generation. The
+  # bare `sort -V` below reads a non-date as NEWER than 2026.8 -- `next` and
+  # `dev` both grade v2 -- so a dev build, a fork or a vendor rebuild picked
+  # memory.search on a core that may be v1. Anchored to the whole string because
+  # this is a version FIELD, and a suffix is kept by the extraction
+  # (2026.8.1-rc.2 -> 2026.8.1), so only a genuinely undatable core falls out.
+  # Falling out is the safe direction here: it lands on the same legacy names a
+  # box with no core at all already takes, and that write fails soft. TASK-657.
+  INSTALLED_VERSION="$(printf '%s' "$INSTALLED_VERSION" | grep -oE '^20[0-9]{2}\.[0-9]+\.[0-9]+' || true)"
   if [ -n "$INSTALLED_VERSION" ] && [ "$(printf '%s\n' 2026.8 "$INSTALLED_VERSION" | sort -V | head -1)" = "2026.8" ]; then
     CLAWBOX_OPENCLAW_V2=1
   fi

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -369,11 +369,17 @@ except OSError as err:
     # also does NOT re-apply the gateway auth token, the messaging-channel
     # security pass, the gateway.controlUi.allowedOrigins rebuild (a changed LAN
     # IP is not picked up), the model catalog or the provider blocks.
+    #
+    # The MCP registration reconcile is named too, and it is the one that is
+    # SILENT rather than skipped: the shell carries on past this program and runs
+    # it, but that block's own `except (OSError, json.JSONDecodeError)` exits 0
+    # on the same unreadable file, so its `if !` guard prints nothing and the
+    # registration no-ops without a word. Say it here, where the cause is known.
     print(
         "  WARN: this boot therefore does NOT re-apply the gateway auth token, "
         "the messaging-channel security pass, the gateway.controlUi.allowedOrigins "
-        "rebuild (a changed LAN IP is not picked up), the model catalog or the "
-        "provider blocks.",
+        "rebuild (a changed LAN IP is not picked up), the model catalog, the "
+        "provider blocks or the MCP server registration.",
         file=sys.stderr,
     )
     raise SystemExit(0)
@@ -2411,14 +2417,32 @@ fi
 # skip the openclaw.json reconcile — leaving the MCP subprocess
 # with a stale or missing CLAWBOX_MCP_TOKEN and every tool call
 # 307'd to /login again.
+#
+# WARN and skip, never `exit 1`. This was the last unguarded step in the block,
+# and it made every guard above it decorative: when the seeding AND the
+# replacement both fail -- `data/` not writable, or ENOSPC on a box whose token
+# was never seeded -- control fell out of the "left exactly as it stands" WARN
+# straight into an `exit 1` here. `ExecStartPre=` carries no `-` prefix
+# (config/clawbox-gateway.service), so that fails the unit, and Restart=always
+# then spends StartLimitBurst: no gateway and no chat, on every boot. It is not
+# even privileged: `data/` is clawbox-owned at 0755, so any process running as
+# clawbox -- a coding-agent run, the in-UI terminal, an ssh session -- reaches it
+# by removing the token and chmod-ing the directory. TASK-657, and the same
+# outcome the block was rewritten to remove.
+#
+# A missing bearer costs this boot its MCP tools, exactly like a failed
+# registration write below, which has always been a WARN. It must not also cost
+# the box its gateway, its chat, the CLAWBOX.md seeding or the deepseek catalog
+# pass that follow. The empty value is carried deliberately: the reconcile's
+# python `sys.exit(0)`s on it, so openclaw.json keeps whatever it already had.
+CLAWBOX_MCP_TOKEN_VAL=""
 if [ ! -r "$MCP_TOKEN_FILE" ]; then
-  echo "  ERROR: MCP token file is not readable: $MCP_TOKEN_FILE" >&2
-  exit 1
-fi
-CLAWBOX_MCP_TOKEN_VAL="$(cat "$MCP_TOKEN_FILE")"
-if [ -z "$CLAWBOX_MCP_TOKEN_VAL" ]; then
-  echo "  ERROR: MCP token file is empty: $MCP_TOKEN_FILE" >&2
-  exit 1
+  echo "  WARN: MCP token file is not readable ($MCP_TOKEN_FILE); skipping the MCP server registration — the ClawBox MCP tools are unavailable this boot" >&2
+else
+  CLAWBOX_MCP_TOKEN_VAL="$(cat "$MCP_TOKEN_FILE" 2>/dev/null || true)"
+  if [ -z "$CLAWBOX_MCP_TOKEN_VAL" ]; then
+    echo "  WARN: MCP token file is empty ($MCP_TOKEN_FILE); skipping the MCP server registration — the ClawBox MCP tools are unavailable this boot" >&2
+  fi
 fi
 export CLAWBOX_MCP_TOKEN_VAL
 export CLAWBOX_BUN_BIN="${CLAWBOX_BUN_BIN:-$CLAWBOX_HOME_DIR/.bun/bin/bun}"

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -57,29 +57,59 @@ fi
 # v2 also REFUSES a config carrying the legacy keys once its own loader
 # migration has produced the new ones, so writing the old names against a
 # v2 gateway does not degrade politely — it kept this gateway from ever
-# reporting ready. Decided from the pinned target (the fleet's source of
-# truth), falling back to the installed binary when the pin is unknown.
-# The INSTALLED binary is the authority: it is the process that will parse
-# what this script writes. A partially failed update (repo synced, npm
-# install not yet done) leaves pin=2026.8.1 with a 2026.7 binary — deciding
-# from the pin there would write v2 keys a v1 gateway refuses AND delete the
-# controlUi auth switches v1 still needs. The pin only fills in when the
-# binary cannot be asked.
+# reporting ready. The INSTALLED core is the authority and the ONLY source:
+# it is the process that will parse what this script writes. The pinned
+# target is deliberately NOT a fallback — a partially failed update (repo
+# synced, npm install not yet done) leaves pin=2026.8.1 with a 2026.7 core,
+# and that is exactly the state in which the core cannot be read, so a pin
+# fallback would fire precisely when it is wrong: v2 keys a v1 gateway
+# refuses, and the controlUi auth switches v1 still needs deleted.
 #
-# `|| true` and an explicit empty result. This pipeline FAILS whenever the CLI
-# cannot answer -- `grep -oE` exits 1 on no match, a crashed binary or a node
-# engine mismatch exits non-zero, and `pipefail` carries either into the
-# assignment, which under `set -e` aborted the WHOLE pre-start. This script is
-# the gateway unit's ExecStartPre, so such a box got no gateway and no chat at
-# all, with the only trace in the unit's failure -- while the paragraph above
-# was already written as though the empty result it now really produces was
-# what happened. A missing binary is handled a few lines up (exit 0). TASK-657.
-CLAWBOX_OPENCLAW_EFFECTIVE="$("$OPENCLAW_BIN" --version 2>/dev/null | grep -oE '20[0-9]{2}\.[0-9]+\.[0-9]+' | head -1 || true)"
+# Read from the core's own package.json -- the file the binary IS -- rather than
+# by RUNNING it. Two reasons, and the second is TASK-657:
+#
+#   1. `openclaw --version` costs ~10 s on a Jetson (measured on a shipped Orin:
+#      7904 ms and 8044 ms; the package.json read is 53 ms) and this is a
+#      BLOCKING ExecStartPre. Both siblings that ask this same question already
+#      refuse the CLI for exactly that reason and say so in writing --
+#      scripts/ensure-local-embeddings.sh and src/lib/memory-shard.ts.
+#   2. The old pipeline FAILED whenever the CLI could not answer: `grep -oE`
+#      exits 1 on no match, a crashed binary or a node engine mismatch exits
+#      non-zero, and `pipefail` carried either into the assignment, which under
+#      `set -e` aborted the WHOLE pre-start. That box got no gateway and no chat
+#      at all, with the only trace in the unit's failure -- while the paragraph
+#      above was already written as though an empty result was what happened.
+CLAWBOX_OPENCLAW_PKG="$(dirname "$OPENCLAW_BIN")/../lib/node_modules/openclaw/package.json"
+CLAWBOX_OPENCLAW_EFFECTIVE="$(python3 - "$CLAWBOX_OPENCLAW_PKG" <<'PY' 2>/dev/null || true
+import json, sys
+try:
+    v = json.load(open(sys.argv[1])).get("version")
+except Exception:
+    v = None
+print(v if isinstance(v, str) else "")
+PY
+)"
+# Second source, and time-boxed. `|| true` only rescues a CLI that RETURNS: a
+# wedged `--version` (an import that never resolves, an fs stall, a SQLite lock)
+# would hold ExecStartPre until TimeoutStartSec killed the unit, and
+# Restart=always would then spend StartLimitBurst on a box that never comes up.
 if [ -z "$CLAWBOX_OPENCLAW_EFFECTIVE" ]; then
-  # Said out loud: the fallback changes which config dialect this script writes,
-  # and a box guessing its own core's generation is worth a line in the journal.
-  echo "  WARN: $OPENCLAW_BIN did not print a version — assuming the pinned target ${OPENCLAW_TARGET:-<unknown>}" >&2
-  CLAWBOX_OPENCLAW_EFFECTIVE="${OPENCLAW_TARGET}"
+  CLAWBOX_OPENCLAW_EFFECTIVE="$(timeout 20 "$OPENCLAW_BIN" --version 2>/dev/null | grep -oE '20[0-9]{2}\.[0-9]+\.[0-9]+' | head -1 || true)"
+fi
+# And if the installed core cannot be identified at all, WRITE NOTHING. The pin
+# is deliberately not a fallback here: a partially failed update (repo synced,
+# npm install unfinished) is precisely the state in which the core cannot answer,
+# and it is also the state in which the pin is ahead of the binary -- so guessing
+# from it would write v2 keys a v1 gateway refuses AND permanently delete
+# commands.ownerDisplay, gateway.tailscale.resetOnExit and
+# agents.defaults.compaction.reserveTokensFloor, which nothing on the boot path
+# re-adds. The config on disk booted this box before; leaving it alone is the
+# only option here that cannot make a working box stop working. A box with no
+# core at all already exited 0 a few lines above.
+if [ -z "$CLAWBOX_OPENCLAW_EFFECTIVE" ]; then
+  echo "  WARN: cannot tell which OpenClaw generation is installed ($CLAWBOX_OPENCLAW_PKG unreadable and $OPENCLAW_BIN did not answer)." >&2
+  echo "  WARN: leaving openclaw.json exactly as it is and starting the gateway on it." >&2
+  exit 0
 fi
 # An explicit CLAWBOX_OPENCLAW_V2 in the environment wins — the unit tests
 # pin BOTH generations of this script against fixture configs, and they must
@@ -105,6 +135,12 @@ if [ -f "$HOSTNAME_ENV" ]; then
   _h="${_h%\'}"; _h="${_h#\'}"
   if [[ "$_h" =~ ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$ ]]; then
     CONFIGURED_HOSTNAME="$_h"
+  else
+    # Not silent: this name feeds gateway.controlUi.allowedOrigins below, so a
+    # boot that falls back here rebuilds that list around "clawbox.local" and
+    # drops the configured one — which is the "origin not allowed" failure the
+    # comment further down exists to prevent.
+    echo "  WARN: no usable HOSTNAME in $HOSTNAME_ENV — using the default mDNS name \"clawbox\"" >&2
   fi
 fi
 
@@ -2156,18 +2192,27 @@ fi
 # if it comes up before clawbox-setup on a fresh boot.
 MCP_TOKEN_FILE="$CLAWBOX_ROOT/data/.mcp-token"
 if [ ! -s "$MCP_TOKEN_FILE" ] || [ "$(wc -c < "$MCP_TOKEN_FILE" 2>/dev/null || echo 0)" -lt 32 ]; then
-  mkdir -p "$(dirname "$MCP_TOKEN_FILE")"
+  # Every write here is guarded so a full or read-only filesystem cannot abort
+  # the boot. Nothing is lost by falling through: the token's readability and
+  # length are checked below, and that check is the deliberate hard failure.
+  mkdir -p "$(dirname "$MCP_TOKEN_FILE")" 2>/dev/null || true
   if command -v openssl >/dev/null 2>&1; then
-    openssl rand -hex 32 > "$MCP_TOKEN_FILE"
+    openssl rand -hex 32 > "$MCP_TOKEN_FILE" || true
   else
-    head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n' > "$MCP_TOKEN_FILE"
+    head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n' > "$MCP_TOKEN_FILE" || true
   fi
 fi
 # Re-harden mode unconditionally: chmod only ran on the regeneration
 # path before, so a file with drifted permissions (manual edit, upgrade
 # from a pre-0600 build) would keep being trusted as-is. The bearer
 # is the sole /setup-api/* credential.
-chmod 600 "$MCP_TOKEN_FILE"
+# Guarded: this runs on EVERY boot, and the file is also seeded by
+# production-server.js. One created under another uid (a root update step, a
+# manual repair) makes chmod return EPERM, and an unguarded failure here cost
+# the box its gateway on every boot from then on. The token's own state is
+# checked below, which is where a real problem is reported. TASK-657.
+chmod 600 "$MCP_TOKEN_FILE" 2>/dev/null \
+  || echo "  WARN: could not re-harden $MCP_TOKEN_FILE to 0600" >&2
 
 # Always reconcile the MCP server registration in openclaw.json with
 # the current token. Done in Python so the atomic-rename pattern used

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -89,12 +89,24 @@ except Exception:
 print(v if isinstance(v, str) else "")
 PY
 )"
+# Both sources validate the SAME way. The manifest read accepted any non-empty
+# string while the fallback below applied this regex, so the stricter of the two
+# was the one almost never reached: a core whose version is not 20YY.M.P -- a
+# dev or nightly build, a fork, an `npm i -g <git url>` install, a vendor
+# rebuild -- yielded a non-empty value that sailed past the "write nothing"
+# guard and picked v1 semantics for a core that may well be v2, whose loader
+# then refuses the legacy names this script would write. A version that is not a
+# date says nothing about the generation, so it must read as "unknown".
+CLAWBOX_OPENCLAW_EFFECTIVE="$(printf '%s' "$CLAWBOX_OPENCLAW_EFFECTIVE" | grep -oE '^20[0-9]{2}\.[0-9]+\.[0-9]+' || true)"
 # Second source, and time-boxed. `|| true` only rescues a CLI that RETURNS: a
 # wedged `--version` (an import that never resolves, an fs stall, a SQLite lock)
 # would hold ExecStartPre until TimeoutStartSec killed the unit, and
 # Restart=always would then spend StartLimitBurst on a box that never comes up.
+# 45 s, matching the CLI call PR #614 added to this same script: the measured
+# cost is 7.9-8.0 s on an Orin, a cold first boot is the slow case, and running
+# out of time here now means skipping the whole pre-start (below), not aborting.
 if [ -z "$CLAWBOX_OPENCLAW_EFFECTIVE" ]; then
-  CLAWBOX_OPENCLAW_EFFECTIVE="$(timeout 20 "$OPENCLAW_BIN" --version 2>/dev/null | grep -oE '20[0-9]{2}\.[0-9]+\.[0-9]+' | head -1 || true)"
+  CLAWBOX_OPENCLAW_EFFECTIVE="$(timeout 45 "$OPENCLAW_BIN" --version 2>/dev/null | grep -oE '20[0-9]{2}\.[0-9]+\.[0-9]+' | head -1 || true)"
 fi
 # And if the installed core cannot be identified at all, WRITE NOTHING. The pin
 # is deliberately not a fallback here: a partially failed update (repo synced,
@@ -106,17 +118,24 @@ fi
 # re-adds. The config on disk booted this box before; leaving it alone is the
 # only option here that cannot make a working box stop working. A box with no
 # core at all already exited 0 a few lines above.
-if [ -z "$CLAWBOX_OPENCLAW_EFFECTIVE" ]; then
-  echo "  WARN: cannot tell which OpenClaw generation is installed ($CLAWBOX_OPENCLAW_PKG unreadable and $OPENCLAW_BIN did not answer)." >&2
-  echo "  WARN: leaving openclaw.json exactly as it is and starting the gateway on it." >&2
-  exit 0
-fi
 # An explicit CLAWBOX_OPENCLAW_V2 in the environment wins — the unit tests
 # pin BOTH generations of this script against fixture configs, and they must
-# not follow whatever the box's own pin file happens to say.
+# not follow whatever the box's own pin file happens to say. It has to be
+# checked BEFORE the give-up below, not after: with the `exit 0` above it, a
+# pinned generation became a silent no-op on any box whose core could not be
+# identified, while the comment here still said it wins.
 if [ -z "${CLAWBOX_OPENCLAW_V2:-}" ]; then
+  if [ -z "$CLAWBOX_OPENCLAW_EFFECTIVE" ]; then
+    # Not a small skip. Everything below this line is skipped, and most of it is
+    # not generation-sensitive at all, so the WARN has to name what this boot
+    # does NOT re-apply rather than sound like "one rewrite was left out".
+    echo "  WARN: cannot tell which OpenClaw generation is installed ($CLAWBOX_OPENCLAW_PKG carries no usable version and $OPENCLAW_BIN did not answer)." >&2
+    echo "  WARN: leaving openclaw.json exactly as it is and starting the gateway on it." >&2
+    echo "  WARN: this boot therefore does NOT re-apply the gateway auth token, the messaging-channel security pass, the gateway.controlUi.allowedOrigins rebuild (a changed LAN IP is not picked up), the MCP token seeding or the MCP registration reconcile." >&2
+    exit 0
+  fi
   CLAWBOX_OPENCLAW_V2=0
-  if [ -n "$CLAWBOX_OPENCLAW_EFFECTIVE" ] && [ "$(printf '%s\n' 2026.8 "$CLAWBOX_OPENCLAW_EFFECTIVE" | sort -V | head -1)" = "2026.8" ]; then
+  if [ "$(printf '%s\n' 2026.8 "$CLAWBOX_OPENCLAW_EFFECTIVE" | sort -V | head -1)" = "2026.8" ]; then
     CLAWBOX_OPENCLAW_V2=1
   fi
 fi
@@ -298,6 +317,23 @@ try:
         cfg = json.load(f)
 except FileNotFoundError:
     cfg = {}
+except OSError as err:
+    # The file EXISTS and could not be opened (a mode, an ACL, an I/O error).
+    # Neither of the two obvious answers is safe here. Letting it escape aborts
+    # this ExecStartPre under `set -e`, so the box gets no gateway at all, on
+    # every boot, until someone with shell access fixes the mode -- and
+    # openclaw.json is clawbox-owned, so an agent can reach that from a chat
+    # turn. Answering {} is worse: that object is written back below, and a
+    # config that merely could not be READ would lose every provider, auth
+    # profile and channel. PermissionError is not a FileNotFoundError, so the
+    # arm above never covered this. Leave the file alone and boot on it, the
+    # same policy the generation probe settles on further up.
+    print(
+        f"  WARN: {os.path.basename(cfg_path)} could not be read ({err}); "
+        f"leaving it exactly as it is and starting the gateway on it",
+        file=sys.stderr,
+    )
+    raise SystemExit(0)
 except json.JSONDecodeError as err:
     # Corrupt file — start from an empty object and let the gateway re-seed on
     # first write; the alternative is refusing to boot. But that {} is written
@@ -1768,7 +1804,11 @@ if [ ! -f "$DEEPSEEK_PLUGIN_JSON" ]; then
   DEEPSEEK_PLUGIN_JSON="$(dirname "$OPENCLAW_CONFIG")/extensions/deepseek/openclaw.plugin.json"
 fi
 if [ -f "$DEEPSEEK_PLUGIN_JSON" ]; then
-  python3 - "$DEEPSEEK_PLUGIN_JSON" <<'PY'
+  # Guarded, like the guide seeding further down and for the same reason: this
+  # is a bare top-level command in a script under `set -e`, its write `raise`s
+  # on failure, and a read-only rootfs or a full disk would turn a cosmetic
+  # "declare xhigh reasoning effort" patch into a box with no gateway.
+  if ! python3 - "$DEEPSEEK_PLUGIN_JSON" <<'PY'
 import json, os, sys, tempfile
 
 path = sys.argv[1]
@@ -1776,7 +1816,7 @@ target = ["off", "high", "xhigh"]
 try:
     with open(path) as f:
         cfg = json.load(f)
-except (FileNotFoundError, json.JSONDecodeError):
+except (OSError, json.JSONDecodeError):
     sys.exit(0)
 
 models = cfg.get("modelCatalog", {}).get("providers", {}).get("deepseek", {}).get("models", [])
@@ -1807,6 +1847,9 @@ if changed:
 else:
     print("  Deepseek plugin JSON already declares xhigh, skipping write")
 PY
+  then
+    echo "  WARN: could not patch the deepseek plugin JSON with xhigh reasoning effort; the gateway starts without it" >&2
+  fi
 fi
 
 # One-time config migration for devices updating from OpenClaw <=2026.5.x:
@@ -1829,7 +1872,7 @@ LEGACY_CODEX_PRIMARY="$(python3 - "$OPENCLAW_CONFIG" <<'PY'
 import json, sys
 try:
     cfg = json.load(open(sys.argv[1]))
-except (FileNotFoundError, json.JSONDecodeError):
+except (OSError, json.JSONDecodeError):
     print(""); sys.exit(0)
 primary = (((cfg.get("agents") or {}).get("defaults") or {}).get("model") or {}).get("primary") or ""
 print(primary if isinstance(primary, str) and primary.lower().startswith("openai-codex/") else "")
@@ -1944,7 +1987,7 @@ import json, sys
 try:
     with open(sys.argv[1]) as f:
         cfg = json.load(f)
-except (FileNotFoundError, json.JSONDecodeError):
+except (OSError, json.JSONDecodeError):
     print("0"); sys.exit(0)
 agents = cfg.get("agents")
 defaults = agents.get("defaults", {}) if isinstance(agents, dict) else {}
@@ -1988,7 +2031,7 @@ import json, sys
 try:
     with open(sys.argv[1]) as f:
         cfg = json.load(f)
-except (FileNotFoundError, json.JSONDecodeError):
+except (OSError, json.JSONDecodeError):
     print("1"); sys.exit(0)
 plugins = cfg.get("plugins")
 entries = plugins.get("entries", {}) if isinstance(plugins, dict) else {}
@@ -2241,7 +2284,10 @@ export CLAWBOX_MCP_TOKEN_VAL
 export CLAWBOX_BUN_BIN="${CLAWBOX_BUN_BIN:-$CLAWBOX_HOME_DIR/.bun/bin/bun}"
 export CLAWBOX_MCP_ENTRY="${CLAWBOX_MCP_ENTRY:-$CLAWBOX_ROOT/mcp/clawbox-mcp.ts}"
 export CLAWBOX_API_BASE="${CLAWBOX_API_BASE:-http://127.0.0.1:$CLAWBOX_PORT}"
-python3 - "$OPENCLAW_CONFIG" <<'PY'
+# Guarded for the same reason as the deepseek patch above: a bare heredoc whose
+# write `raise`s, in a script under `set -e`. A full disk must cost this boot
+# its MCP registration, never its gateway.
+if ! python3 - "$OPENCLAW_CONFIG" <<'PY'
 import json, os, sys, tempfile
 
 cfg_path = sys.argv[1]
@@ -2251,7 +2297,7 @@ if not token:
 try:
     with open(cfg_path) as f:
         cfg = json.load(f)
-except (FileNotFoundError, json.JSONDecodeError):
+except (OSError, json.JSONDecodeError):
     sys.exit(0)
 
 desired = {
@@ -2280,6 +2326,9 @@ except Exception:
     raise
 print("  Updated MCP server registration with bearer token")
 PY
+then
+  echo "  WARN: could not write the MCP server registration; the ClawBox MCP tools are unavailable this boot" >&2
+fi
 unset CLAWBOX_MCP_TOKEN_VAL
 
 # Seed CLAWBOX.md in the OpenClaw workspace so the agent's session-start
@@ -2310,7 +2359,7 @@ if [ "$CLAWBOX_OPENCLAW_V2" = "1" ] && [ ! -f "$OPENCLAW_HOME_DIR/extensions/dee
 import json, sys
 try:
     cfg = json.load(open(sys.argv[1]))
-except (FileNotFoundError, json.JSONDecodeError):
+except (OSError, json.JSONDecodeError):
     print("0"); sys.exit(0)
 providers = ((cfg.get("models") or {}).get("providers") or {})
 deepseek = providers.get("deepseek")
@@ -2357,7 +2406,7 @@ try:
     with open(sys.argv[1]) as f:
         cfg = json.load(f)
     ws = cfg.get("agents", {}).get("defaults", {}).get("workspace")
-except (FileNotFoundError, json.JSONDecodeError, KeyError):
+except (OSError, json.JSONDecodeError, KeyError):
     ws = None
 if isinstance(ws, str) and ws.strip():
     ws = os.path.expanduser(ws.strip())

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -1804,18 +1804,40 @@ if isinstance(ds_models, list):
 if changed:
     # Atomic write so a crash mid-rewrite can't leave a half-written
     # file where the gateway would refuse to boot.
-    tmp_fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(cfg_path), prefix=".openclaw.", suffix=".tmp")
+    #
+    # WARN and carry on, never raise. This heredoc is invoked bare, and the
+    # script runs under `set -euo pipefail` as the gateway unit's
+    # ExecStartPre= with no `-` prefix (config/clawbox-gateway.service) -- so
+    # an exception here fails the unit, and Restart=always then spends
+    # StartLimitBurst: no gateway and no chat, on every boot. An unwritable
+    # ~/.openclaw or a full disk must cost this boot its config migration, not
+    # the box its gateway; the gateway starts on the config already on disk,
+    # which is the state it was in a moment ago. Same call as the deepseek
+    # plugin patch and the MCP registration further down, both already guarded
+    # this way. TASK-657.
+    #
+    # `mkstemp` is INSIDE the guard, and that is the half that was missing: it
+    # is the call that raises PermissionError on a directory this uid cannot
+    # write and OSError on ENOSPC, and it sat outside the `try` that existed
+    # to contain exactly those.
+    tmp_path = None
     try:
+        tmp_fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(cfg_path), prefix=".openclaw.", suffix=".tmp")
         with os.fdopen(tmp_fd, "w") as f:
             json.dump(cfg, f, indent=2)
         os.replace(tmp_path, cfg_path)
-    except Exception:
-        try:
-            os.unlink(tmp_path)
-        except Exception:
-            pass
-        raise
-    print("  Updated gateway config")
+        print("  Updated gateway config")
+    except Exception as exc:
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except Exception:
+                pass
+        print(
+            "  WARN: could not write the gateway config (%s: %s); the gateway starts on the config already on disk"
+            % (type(exc).__name__, exc),
+            file=sys.stderr,
+        )
 else:
     print("  Gateway config already correct, skipping write")
 PY
@@ -2442,6 +2464,29 @@ else
   CLAWBOX_MCP_TOKEN_VAL="$(cat "$MCP_TOKEN_FILE" 2>/dev/null || true)"
   if [ -z "$CLAWBOX_MCP_TOKEN_VAL" ]; then
     echo "  WARN: MCP token file is empty ($MCP_TOKEN_FILE); skipping the MCP server registration — the ClawBox MCP tools are unavailable this boot" >&2
+  elif [ "${#CLAWBOX_MCP_TOKEN_VAL}" -lt 32 ]; then
+    # The same threshold the seeding gate above uses, and for the same reason.
+    # That gate re-seeds anything under 32 bytes, so a shorter file can only be
+    # one whose write did not finish -- an ENOSPC part way through `openssl rand
+    # -hex 32 > "$1"`, on the boot where the seed itself failed and `|| true`
+    # swallowed it. The length check ran BEFORE that write, so nothing between
+    # there and here looks at the value again, and a truncated bearer would be
+    # published to openclaw.json as if it were a token this box generated.
+    #
+    # Refusing it costs the same as an empty one: the MCP tools, for this boot,
+    # and the file is re-seeded on the next. Keeping it costs more than it
+    # looks. Under 16 characters src/lib/mcp-token.ts's readTokenFile() rejects
+    # it outright, the verifier mints its own value instead, and every tool call
+    # 307s to /login with nothing in the journal to say why. Between 16 and 31
+    # it WORKS -- and that is the bad case, because the box then runs on a
+    # bearer with a fraction of the intended entropy and nothing ever says so.
+    #
+    # 32 rather than a 64-hex literal on purpose: three writers seed this file
+    # (mcp_write_token's two branches and production-server.js) and all three
+    # produce 64 hex characters today, but the gate above is the one that
+    # decides what counts as seeded, and the two must not be able to disagree.
+    echo "  WARN: MCP token file holds only ${#CLAWBOX_MCP_TOKEN_VAL} characters ($MCP_TOKEN_FILE), too short to be a token this box wrote; skipping the MCP server registration — the ClawBox MCP tools are unavailable this boot" >&2
+    CLAWBOX_MCP_TOKEN_VAL=""
   fi
 fi
 export CLAWBOX_MCP_TOKEN_VAL

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -37,7 +37,12 @@ OPENCLAW_PIN_FILE="${OPENCLAW_PIN_FILE:-$CLAWBOX_ROOT/config/openclaw-target.txt
 if [ -n "${OPENCLAW_PIN_VERSION:-}" ]; then
   OPENCLAW_TARGET="${OPENCLAW_PIN_VERSION}"
 elif [ -f "$OPENCLAW_PIN_FILE" ]; then
-  OPENCLAW_TARGET=$(head -1 "$OPENCLAW_PIN_FILE" | awk '{print $1}')
+  # `|| true`: the file exists, but a read can still fail (permissions, a
+  # truncated mount), and under `set -euo pipefail` a failed pipeline in an
+  # assignment aborts this ExecStartPre — which means no gateway at all. An
+  # empty target is already a defined state here (see above); an aborted boot
+  # is not. TASK-657.
+  OPENCLAW_TARGET=$(head -1 "$OPENCLAW_PIN_FILE" | awk '{print $1}' || true)
 fi
 
 if [ ! -x "$OPENCLAW_BIN" ]; then
@@ -60,8 +65,20 @@ fi
 # from the pin there would write v2 keys a v1 gateway refuses AND delete the
 # controlUi auth switches v1 still needs. The pin only fills in when the
 # binary cannot be asked.
-CLAWBOX_OPENCLAW_EFFECTIVE="$("$OPENCLAW_BIN" --version 2>/dev/null | grep -oE '20[0-9]{2}\.[0-9]+\.[0-9]+' | head -1)"
+#
+# `|| true` and an explicit empty result. This pipeline FAILS whenever the CLI
+# cannot answer -- `grep -oE` exits 1 on no match, a crashed binary or a node
+# engine mismatch exits non-zero, and `pipefail` carries either into the
+# assignment, which under `set -e` aborted the WHOLE pre-start. This script is
+# the gateway unit's ExecStartPre, so such a box got no gateway and no chat at
+# all, with the only trace in the unit's failure -- while the paragraph above
+# was already written as though the empty result it now really produces was
+# what happened. A missing binary is handled a few lines up (exit 0). TASK-657.
+CLAWBOX_OPENCLAW_EFFECTIVE="$("$OPENCLAW_BIN" --version 2>/dev/null | grep -oE '20[0-9]{2}\.[0-9]+\.[0-9]+' | head -1 || true)"
 if [ -z "$CLAWBOX_OPENCLAW_EFFECTIVE" ]; then
+  # Said out loud: the fallback changes which config dialect this script writes,
+  # and a box guessing its own core's generation is worth a line in the journal.
+  echo "  WARN: $OPENCLAW_BIN did not print a version — assuming the pinned target ${OPENCLAW_TARGET:-<unknown>}" >&2
   CLAWBOX_OPENCLAW_EFFECTIVE="${OPENCLAW_TARGET}"
 fi
 # An explicit CLAWBOX_OPENCLAW_V2 in the environment wins — the unit tests
@@ -79,7 +96,11 @@ export CLAWBOX_OPENCLAW_V2
 CONFIGURED_HOSTNAME="clawbox"
 if [ -f "$HOSTNAME_ENV" ]; then
   # Parse HOSTNAME=... without executing the file (avoid arbitrary code execution).
-  _h=$(sed -n 's/^[[:space:]]*HOSTNAME[[:space:]]*=[[:space:]]*//p' "$HOSTNAME_ENV" | head -n1)
+  # `|| true` for the same reason as the pin read above: `sed` exits non-zero on
+  # a file it cannot open, and an unreadable hostname file must cost this box its
+  # configured mDNS name, never its gateway. The regex below already rejects the
+  # empty result and keeps the "clawbox" default. TASK-657.
+  _h=$(sed -n 's/^[[:space:]]*HOSTNAME[[:space:]]*=[[:space:]]*//p' "$HOSTNAME_ENV" | head -n1 || true)
   _h="${_h%\"}"; _h="${_h#\"}"
   _h="${_h%\'}"; _h="${_h#\'}"
   if [[ "$_h" =~ ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$ ]]; then

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -102,11 +102,17 @@ CLAWBOX_OPENCLAW_EFFECTIVE="$(printf '%s' "$CLAWBOX_OPENCLAW_EFFECTIVE" | grep -
 # wedged `--version` (an import that never resolves, an fs stall, a SQLite lock)
 # would hold ExecStartPre until TimeoutStartSec killed the unit, and
 # Restart=always would then spend StartLimitBurst on a box that never comes up.
-# 45 s, matching the CLI call PR #614 added to this same script: the measured
-# cost is 7.9-8.0 s on an Orin, a cold first boot is the slow case, and running
-# out of time here now means skipping the whole pre-start (below), not aborting.
+# 45 s, justified on this call's OWN measurement rather than on any precedent:
+# `openclaw --version` costs 7.9-8.0 s on a shipped Orin, a cold first boot is
+# the slow case, so the bound has to leave several multiples of that as headroom
+# or it cuts off a HEALTHY core and makes the fallback useless exactly when it is
+# needed. It also has to stay far inside the unit's own TimeoutStartSec=600, and
+# running out of time here means skipping the whole pre-start (below), not
+# aborting. `-k 5` because plain `timeout` sends SIGTERM only: a `--version` that
+# ignores it would hold this ExecStartPre for the unit's entire start budget,
+# which is precisely the outcome the bound exists to prevent.
 if [ -z "$CLAWBOX_OPENCLAW_EFFECTIVE" ]; then
-  CLAWBOX_OPENCLAW_EFFECTIVE="$(timeout 45 "$OPENCLAW_BIN" --version 2>/dev/null | grep -oE '20[0-9]{2}\.[0-9]+\.[0-9]+' | head -1 || true)"
+  CLAWBOX_OPENCLAW_EFFECTIVE="$(timeout -k 5 45 "$OPENCLAW_BIN" --version 2>/dev/null | grep -oE '20[0-9]{2}\.[0-9]+\.[0-9]+' | head -1 || true)"
 fi
 # And if the installed core cannot be identified at all, WRITE NOTHING. The pin
 # is deliberately not a fallback here: a partially failed update (repo synced,
@@ -328,9 +334,24 @@ except OSError as err:
     # profile and channel. PermissionError is not a FileNotFoundError, so the
     # arm above never covered this. Leave the file alone and boot on it, the
     # same policy the generation probe settles on further up.
+    # `err.strerror` rather than `err`: str(OSError) carries the full path, which
+    # the basename above was chosen to keep out of the line.
     print(
-        f"  WARN: {os.path.basename(cfg_path)} could not be read ({err}); "
-        f"leaving it exactly as it is and starting the gateway on it",
+        f"  WARN: {os.path.basename(cfg_path)} could not be read "
+        f"({err.strerror or type(err).__name__}); leaving it exactly as it is "
+        f"and starting the gateway on it",
+        file=sys.stderr,
+    )
+    # Not a small skip, and the same understatement the generation give-up was
+    # corrected for further up: SystemExit ends this whole program, so this boot
+    # also does NOT re-apply the gateway auth token, the messaging-channel
+    # security pass, the gateway.controlUi.allowedOrigins rebuild (a changed LAN
+    # IP is not picked up), the model catalog or the provider blocks.
+    print(
+        "  WARN: this boot therefore does NOT re-apply the gateway auth token, "
+        "the messaging-channel security pass, the gateway.controlUi.allowedOrigins "
+        "rebuild (a changed LAN IP is not picked up), the model catalog or the "
+        "provider blocks.",
         file=sys.stderr,
     )
     raise SystemExit(0)
@@ -2245,7 +2266,12 @@ mcp_write_token() {
     ( umask 077; head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n' > "$1" ) 2>/dev/null
   fi
 }
-if [ ! -s "$MCP_TOKEN_FILE" ] || [ "$(wc -c < "$MCP_TOKEN_FILE" 2>/dev/null || echo 0)" -lt 32 ]; then
+# `{ ...; } 2>/dev/null` rather than `wc ... 2>/dev/null`: a failed INPUT
+# redirect is reported by the shell, not by wc, so the narrower form printed a
+# bare "Permission denied" into the journal for a token this uid cannot read --
+# a line that reads like the boot failing, immediately before the block below
+# repairs it.
+if [ ! -s "$MCP_TOKEN_FILE" ] || [ "$( { wc -c < "$MCP_TOKEN_FILE"; } 2>/dev/null || echo 0 )" -lt 32 ]; then
   # Every write here is guarded so a full or read-only filesystem cannot abort
   # the boot. Nothing is lost by falling through: the token's readability and
   # length are checked below, and that check is the deliberate hard failure.
@@ -2261,38 +2287,67 @@ fi
 # manual repair) makes chmod return EPERM, and an unguarded failure here cost
 # the box its gateway on every boot from then on. TASK-657.
 chmod 600 "$MCP_TOKEN_FILE" 2>/dev/null || true
-# But the MODE is the outcome, not chmod's exit code, and grading the call was
-# wrong in both directions: it warned over a root-owned file that was ALREADY
-# 0600, and it stayed quiet about the case that matters -- a file this uid
-# cannot chmod whose mode is 0644, which is what root's umask gives
-# `openssl rand > file`. The bearer then reaches every local user on the box.
+# But the MODE is the outcome, not chmod's exit code -- and the outcome has two
+# halves, both of which grading the literal string "600" got wrong:
+#
+#   * can anyone ELSE read it? A file this uid cannot chmod whose mode carries
+#     group/other bits hands the sole /setup-api/* credential to every local
+#     user on the box. 0644 is what root's umask gives a bare
+#     `openssl rand > file`.
+#   * can THIS uid read it? Every shipped writer that can create the file as
+#     root leaves it 0600 -- scripts/register-mcp.sh mints under `umask 077`,
+#     production-server.js writes `{ mode: 0o600 }` -- so root:root 0600 is the
+#     state the fleet actually produces, and it is unreadable to
+#     User=clawbox. A `case` keyed on "600"
+#     declined to touch exactly that file, and the `[ ! -r ]` check below then
+#     exited 1: ExecStartPre fails, no gateway, on every boot.
+#
+# So grade on `-r` plus the permission bits, never on a literal. The corollary
+# matters as much: a mode with no group/other bits that this uid CAN read (0400,
+# 0600) is exposed to nobody, and rotating it would be pure cost -- see the
+# second WARN below for what a rotation costs.
 #
 # Replacing it is the only remedy available here that is neither exposure nor a
 # brick. The DIRECTORY is clawbox's own (install.sh chowns $PROJECT_DIR/data),
 # and a rename is governed by the directory, not by the file's owner -- so a
-# file this uid cannot chmod can still be swapped for one it owns at 0600. That
-# rotates the token, which the reconcile immediately below already handles: it
-# rewrites openclaw.json from whatever the file now holds, exactly as it does
-# for the seeding path above. One boot rotates; every boot after it the file is
-# ours and chmod succeeds.
+# file this uid can neither chmod nor read can still be swapped for one it owns
+# at 0600. One boot rotates; every boot after it the file is ours and chmod
+# succeeds.
 MCP_TOKEN_MODE="$(stat -c '%a' "$MCP_TOKEN_FILE" 2>/dev/null || echo unknown)"
-case "$MCP_TOKEN_MODE" in
-  600|unknown)
-    # 0600, or a box that cannot report a mode at all -- for the latter the
-    # readability and length checks below stay the backstop. Neither is a
-    # reason to rotate a working token.
-    ;;
-  *)
-    MCP_TOKEN_TMP="$(mktemp "$(dirname "$MCP_TOKEN_FILE")/.mcp-token.XXXXXX" 2>/dev/null || true)"
-    if [ -n "$MCP_TOKEN_TMP" ] && mcp_write_token "$MCP_TOKEN_TMP" \
-      && mv -f "$MCP_TOKEN_TMP" "$MCP_TOKEN_FILE" 2>/dev/null; then
-      echo "  WARN: $MCP_TOKEN_FILE was mode $MCP_TOKEN_MODE and could not be re-hardened (it belongs to another user); replaced it with a fresh 0600 token this boot owns" >&2
-    else
-      if [ -n "$MCP_TOKEN_TMP" ]; then rm -f "$MCP_TOKEN_TMP" 2>/dev/null || true; fi
-      echo "  WARN: $MCP_TOKEN_FILE is mode $MCP_TOKEN_MODE and could be neither re-hardened nor replaced — the MCP bearer for /setup-api/* is readable by other local users on this box" >&2
-    fi
-    ;;
-esac
+# `stat -c %a` prints three or four octal digits (setuid/setgid/sticky make it
+# four). Anything else is a box that cannot report a mode at all -- not a reason
+# to rotate a working token on its own, and `-r` above stays the backstop.
+mcp_mode_is_exposed() {
+  case "${1:-}" in
+    ''|*[!0-7]*) return 1 ;;
+  esac
+  [ "$(( 8#$1 & 8#077 ))" -ne 0 ]
+}
+if [ ! -r "$MCP_TOKEN_FILE" ] || mcp_mode_is_exposed "$MCP_TOKEN_MODE"; then
+  if [ ! -r "$MCP_TOKEN_FILE" ]; then
+    MCP_TOKEN_WHY="is mode $MCP_TOKEN_MODE and unreadable to this gateway (it belongs to another user)"
+  else
+    MCP_TOKEN_WHY="was mode $MCP_TOKEN_MODE and could not be re-hardened (it belongs to another user)"
+  fi
+  MCP_TOKEN_TMP="$(mktemp "$(dirname "$MCP_TOKEN_FILE")/.mcp-token.XXXXXX" 2>/dev/null || true)"
+  if [ -n "$MCP_TOKEN_TMP" ] && mcp_write_token "$MCP_TOKEN_TMP" \
+    && mv -f "$MCP_TOKEN_TMP" "$MCP_TOKEN_FILE" 2>/dev/null; then
+    echo "  WARN: $MCP_TOKEN_FILE $MCP_TOKEN_WHY; replaced it with a fresh 0600 token this boot owns." >&2
+    # What a rotation costs, and who pays it. The reconcile below republishes
+    # the new bearer to the MCP SUBPROCESS only -- it rewrites openclaw.json
+    # from whatever the file now holds. It does NOT reach the VERIFIER:
+    # src/lib/mcp-token.ts caches in module state and production-server.js pins
+    # the value into CLAWBOX_MCP_TOKEN at Next.js boot, and nothing orders
+    # clawbox-setup.service against this unit. The verifier now re-reads the
+    # file when a bearer check fails, so this heals itself on the next call --
+    # but say it, because a device tool that 401s once after a rotation should
+    # have a line in the journal explaining itself.
+    echo "  WARN: the web server re-reads the rotated bearer on its next /setup-api/* check; restart clawbox-setup.service if device tools keep answering 401." >&2
+  else
+    if [ -n "$MCP_TOKEN_TMP" ]; then rm -f "$MCP_TOKEN_TMP" 2>/dev/null || true; fi
+    echo "  WARN: $MCP_TOKEN_FILE $MCP_TOKEN_WHY, and could be neither re-hardened nor replaced (is $(dirname "$MCP_TOKEN_FILE") writable?) — the MCP bearer for /setup-api/* is left exactly as it stands" >&2
+  fi
+fi
 
 # Always reconcile the MCP server registration in openclaw.json with
 # the current token. Done in Python so the atomic-rename pattern used

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -42,7 +42,17 @@ elif [ -f "$OPENCLAW_PIN_FILE" ]; then
   # assignment aborts this ExecStartPre — which means no gateway at all. An
   # empty target is already a defined state here (see above); an aborted boot
   # is not. TASK-657.
-  OPENCLAW_TARGET=$(head -1 "$OPENCLAW_PIN_FILE" | awk '{print $1}' || true)
+  OPENCLAW_TARGET=$(head -1 "$OPENCLAW_PIN_FILE" 2>/dev/null | awk '{print $1}' || true)
+  if [ -z "$OPENCLAW_TARGET" ]; then
+    # Say it, for the same reason the two installer copies of this read do — and
+    # here the empty value is not merely a missing pin. It also switches OFF the
+    # codex version-skew guard below and turns CODEX_SPEC into the bare `codex`
+    # alias, which this file's own comment says makes every Codex chat crash
+    # with `createDiagnosticTraceContextFromActiveScope is not a function`.
+    # Reaching a defined-but-costly state through a NEW silent route is what
+    # needs the line.
+    echo "  WARN: $OPENCLAW_PIN_FILE is empty or could not be read — continuing with no pinned OpenClaw target" >&2
+  fi
 fi
 
 if [ ! -x "$OPENCLAW_BIN" ]; then
@@ -89,14 +99,26 @@ except Exception:
 print(v if isinstance(v, str) else "")
 PY
 )"
-# Both sources validate the SAME way. The manifest read accepted any non-empty
-# string while the fallback below applied this regex, so the stricter of the two
-# was the one almost never reached: a core whose version is not 20YY.M.P -- a
-# dev or nightly build, a fork, an `npm i -g <git url>` install, a vendor
-# rebuild -- yielded a non-empty value that sailed past the "write nothing"
-# guard and picked v1 semantics for a core that may well be v2, whose loader
-# then refuses the legacy names this script would write. A version that is not a
-# date says nothing about the generation, so it must read as "unknown".
+# The manifest read accepted any non-empty string while the fallback below
+# applied this regex, so the stricter of the two was the one almost never
+# reached: a core whose version is not 20YY.M.P -- a dev or nightly build, a
+# fork, an `npm i -g <git url>` install, a vendor rebuild -- yielded a non-empty
+# value that sailed past the "write nothing" guard and picked v1 semantics for a
+# core that may well be v2, whose loader then refuses the legacy names this
+# script would write. A version that is not a date says nothing about the
+# generation, so it must read as "unknown".
+#
+# ANCHORED, and the two sources are deliberately NOT graded alike. This one is
+# a version FIELD, so the whole string has to be the version. The CLI fallback
+# below reads a BANNER, where the version is one token among words this script
+# does not control, so it can only extract -- which means a `--version` that
+# happens to mention any other 20YY.M.P (a "built from" note, a schema warning
+# on its own line) is taken at face value there. Tightening that arm needs the
+# real banner of a shipped core measured on a box, not a guess: an anchor that
+# is wrong by one space turns every healthy fallback into "cannot identify the
+# core" and skips the whole pre-start fleet-wide, which is worse than the state
+# it would close. Recorded rather than guessed at; the manifest is the source
+# that answers on every ordinary box, and it is the one that is strict.
 CLAWBOX_OPENCLAW_EFFECTIVE="$(printf '%s' "$CLAWBOX_OPENCLAW_EFFECTIVE" | grep -oE '^20[0-9]{2}\.[0-9]+\.[0-9]+' || true)"
 # Second source, and time-boxed. `|| true` only rescues a CLI that RETURNS: a
 # wedged `--version` (an import that never resolves, an fs stall, a SQLite lock)
@@ -137,7 +159,7 @@ if [ -z "${CLAWBOX_OPENCLAW_V2:-}" ]; then
     # does NOT re-apply rather than sound like "one rewrite was left out".
     echo "  WARN: cannot tell which OpenClaw generation is installed ($CLAWBOX_OPENCLAW_PKG carries no usable version and $OPENCLAW_BIN did not answer)." >&2
     echo "  WARN: leaving openclaw.json exactly as it is and starting the gateway on it." >&2
-    echo "  WARN: this boot therefore does NOT re-apply the gateway auth token, the messaging-channel security pass, the gateway.controlUi.allowedOrigins rebuild (a changed LAN IP is not picked up), the MCP token seeding or the MCP registration reconcile." >&2
+    echo "  WARN: this boot therefore does NOT re-apply the gateway auth token, the messaging-channel security pass, the gateway.controlUi.allowedOrigins rebuild (a changed LAN IP is not picked up), the @openclaw/codex plugin install and repair, the deepseek catalog patch, the CLAWBOX.md workspace guide, the MCP token seeding or the MCP registration reconcile." >&2
     exit 0
   fi
   CLAWBOX_OPENCLAW_V2=0
@@ -355,7 +377,17 @@ except OSError as err:
         file=sys.stderr,
     )
     raise SystemExit(0)
-except json.JSONDecodeError as err:
+except (json.JSONDecodeError, UnicodeDecodeError) as err:
+    # UnicodeDecodeError is a ValueError, NOT a JSONDecodeError and NOT an
+    # OSError, so a config holding bytes that are not valid UTF-8 escaped all
+    # three arms and took the ExecStartPre down with a traceback -- on every
+    # boot, until someone with shell access fixed the file. That is the same
+    # class as the arm above, one exception type over, and it is reached by the
+    # same event this backup exists for: a power loss mid-write on a Jetson
+    # leaves arbitrary bytes here, not a truncated but decodable string.
+    # "Corrupt" is the right verdict for both, and the .corrupt-<utc> copy below
+    # preserves the bytes either way.
+    #
     # Corrupt file — start from an empty object and let the gateway re-seed on
     # first write; the alternative is refusing to boot. But that {} is written
     # back below, and until it was copied first the write replaced every
@@ -2316,18 +2348,34 @@ chmod 600 "$MCP_TOKEN_FILE" 2>/dev/null || true
 MCP_TOKEN_MODE="$(stat -c '%a' "$MCP_TOKEN_FILE" 2>/dev/null || echo unknown)"
 # `stat -c %a` prints three or four octal digits (setuid/setgid/sticky make it
 # four). Anything else is a box that cannot report a mode at all -- not a reason
-# to rotate a working token on its own, and `-r` above stays the backstop.
+# to rotate a working token on its own. `-r` backstops the UNREADABLE half of
+# that state; there is no backstop for the exposed half, so say so rather than
+# be silent about a bearer nothing could grade.
 mcp_mode_is_exposed() {
   case "${1:-}" in
     ''|*[!0-7]*) return 1 ;;
   esac
   [ "$(( 8#$1 & 8#077 ))" -ne 0 ]
 }
+# `unknown` is never "exposed", so this needs no second call to say so: a mode
+# that could not be read on a file that CAN be read is the one state nothing
+# below grades, and it passes through silently unless it is said here.
+if [ "$MCP_TOKEN_MODE" = unknown ] && [ -r "$MCP_TOKEN_FILE" ]; then
+  echo "  WARN: could not read the mode of $MCP_TOKEN_FILE; using it as it stands without checking whether other local users can read it" >&2
+fi
 if [ ! -r "$MCP_TOKEN_FILE" ] || mcp_mode_is_exposed "$MCP_TOKEN_MODE"; then
-  if [ ! -r "$MCP_TOKEN_FILE" ]; then
-    MCP_TOKEN_WHY="is mode $MCP_TOKEN_MODE and unreadable to this gateway (it belongs to another user)"
+  # State the STATE, never a cause this shell cannot establish. The earlier
+  # wording asserted "it belongs to another user" for a file that does not exist
+  # (the seeding above could not create it, because data/ is not writable) and
+  # for a 0644 file this uid owns perfectly well -- the same "a message
+  # asserting a cause it cannot know" the pin WARN was corrected for. The
+  # outcome sentences below carry the verbs; this carries the fact.
+  if [ ! -e "$MCP_TOKEN_FILE" ]; then
+    MCP_TOKEN_WHY="does not exist and could not be created"
+  elif [ ! -r "$MCP_TOKEN_FILE" ]; then
+    MCP_TOKEN_WHY="is mode $MCP_TOKEN_MODE, which this gateway cannot read"
   else
-    MCP_TOKEN_WHY="was mode $MCP_TOKEN_MODE and could not be re-hardened (it belongs to another user)"
+    MCP_TOKEN_WHY="is mode $MCP_TOKEN_MODE, which other local users can read"
   fi
   MCP_TOKEN_TMP="$(mktemp "$(dirname "$MCP_TOKEN_FILE")/.mcp-token.XXXXXX" 2>/dev/null || true)"
   if [ -n "$MCP_TOKEN_TMP" ] && mcp_write_token "$MCP_TOKEN_TMP" \

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -2234,16 +2234,23 @@ fi
 # we mirror that here so the gateway can register the MCP server even
 # if it comes up before clawbox-setup on a fresh boot.
 MCP_TOKEN_FILE="$CLAWBOX_ROOT/data/.mcp-token"
+# One writer, used by the seed below and by the re-harden beneath it, so the two
+# cannot drift on entropy source or on mode. `umask 077` rather than a chmod
+# afterwards: the file must never exist readable, and on the re-harden path
+# chmod is precisely what has just failed.
+mcp_write_token() {
+  if command -v openssl >/dev/null 2>&1; then
+    ( umask 077; openssl rand -hex 32 > "$1" ) 2>/dev/null
+  else
+    ( umask 077; head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n' > "$1" ) 2>/dev/null
+  fi
+}
 if [ ! -s "$MCP_TOKEN_FILE" ] || [ "$(wc -c < "$MCP_TOKEN_FILE" 2>/dev/null || echo 0)" -lt 32 ]; then
   # Every write here is guarded so a full or read-only filesystem cannot abort
   # the boot. Nothing is lost by falling through: the token's readability and
   # length are checked below, and that check is the deliberate hard failure.
   mkdir -p "$(dirname "$MCP_TOKEN_FILE")" 2>/dev/null || true
-  if command -v openssl >/dev/null 2>&1; then
-    openssl rand -hex 32 > "$MCP_TOKEN_FILE" || true
-  else
-    head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n' > "$MCP_TOKEN_FILE" || true
-  fi
+  mcp_write_token "$MCP_TOKEN_FILE" || true
 fi
 # Re-harden mode unconditionally: chmod only ran on the regeneration
 # path before, so a file with drifted permissions (manual edit, upgrade
@@ -2252,10 +2259,40 @@ fi
 # Guarded: this runs on EVERY boot, and the file is also seeded by
 # production-server.js. One created under another uid (a root update step, a
 # manual repair) makes chmod return EPERM, and an unguarded failure here cost
-# the box its gateway on every boot from then on. The token's own state is
-# checked below, which is where a real problem is reported. TASK-657.
-chmod 600 "$MCP_TOKEN_FILE" 2>/dev/null \
-  || echo "  WARN: could not re-harden $MCP_TOKEN_FILE to 0600" >&2
+# the box its gateway on every boot from then on. TASK-657.
+chmod 600 "$MCP_TOKEN_FILE" 2>/dev/null || true
+# But the MODE is the outcome, not chmod's exit code, and grading the call was
+# wrong in both directions: it warned over a root-owned file that was ALREADY
+# 0600, and it stayed quiet about the case that matters -- a file this uid
+# cannot chmod whose mode is 0644, which is what root's umask gives
+# `openssl rand > file`. The bearer then reaches every local user on the box.
+#
+# Replacing it is the only remedy available here that is neither exposure nor a
+# brick. The DIRECTORY is clawbox's own (install.sh chowns $PROJECT_DIR/data),
+# and a rename is governed by the directory, not by the file's owner -- so a
+# file this uid cannot chmod can still be swapped for one it owns at 0600. That
+# rotates the token, which the reconcile immediately below already handles: it
+# rewrites openclaw.json from whatever the file now holds, exactly as it does
+# for the seeding path above. One boot rotates; every boot after it the file is
+# ours and chmod succeeds.
+MCP_TOKEN_MODE="$(stat -c '%a' "$MCP_TOKEN_FILE" 2>/dev/null || echo unknown)"
+case "$MCP_TOKEN_MODE" in
+  600|unknown)
+    # 0600, or a box that cannot report a mode at all -- for the latter the
+    # readability and length checks below stay the backstop. Neither is a
+    # reason to rotate a working token.
+    ;;
+  *)
+    MCP_TOKEN_TMP="$(mktemp "$(dirname "$MCP_TOKEN_FILE")/.mcp-token.XXXXXX" 2>/dev/null || true)"
+    if [ -n "$MCP_TOKEN_TMP" ] && mcp_write_token "$MCP_TOKEN_TMP" \
+      && mv -f "$MCP_TOKEN_TMP" "$MCP_TOKEN_FILE" 2>/dev/null; then
+      echo "  WARN: $MCP_TOKEN_FILE was mode $MCP_TOKEN_MODE and could not be re-hardened (it belongs to another user); replaced it with a fresh 0600 token this boot owns" >&2
+    else
+      if [ -n "$MCP_TOKEN_TMP" ]; then rm -f "$MCP_TOKEN_TMP" 2>/dev/null || true; fi
+      echo "  WARN: $MCP_TOKEN_FILE is mode $MCP_TOKEN_MODE and could be neither re-hardened nor replaced — the MCP bearer for /setup-api/* is readable by other local users on this box" >&2
+    fi
+    ;;
+esac
 
 # Always reconcile the MCP server registration in openclaw.json with
 # the current token. Done in Python so the atomic-rename pattern used

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -131,12 +131,25 @@ if [ ! -s "$MCP_TOKEN_FILE" ] || [ "$( { wc -c < "$MCP_TOKEN_FILE"; } 2>/dev/nul
   # It also cannot close it at all when the chmod fails (a file this uid does
   # not own), which is the state gateway-pre-start.sh's `mcp_write_token` was
   # written for. TASK-657.
+  # Guarded, because REGISTERING the MCP server is this script's job and minting
+  # the bearer is a convenience it does on the way past. In plain command
+  # position a failed redirect (a root-owned token, a read-only data/) exits the
+  # subshell 1 and `set -e` kills the run — and on the hermes SKU nothing else
+  # writes mcp_servers.clawbox, so `hermes mcp list` stays "No MCP servers
+  # configured" and the agent has NO device tools at all, on every web-server
+  # boot. The token is not lost by carrying on: production-server.js seeds the
+  # same file at every clawbox-setup boot, and mcp/lib/api.ts reads it directly.
+  # TASK-657.
   if command -v openssl >/dev/null 2>&1; then
-    ( umask 077; openssl rand -hex 32 > "$MCP_TOKEN_FILE" )
+    ( umask 077; openssl rand -hex 32 > "$MCP_TOKEN_FILE" ) 2>/dev/null || MCP_TOKEN_MINTED=no
   else
-    ( umask 077; head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n' > "$MCP_TOKEN_FILE" )
+    ( umask 077; head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n' > "$MCP_TOKEN_FILE" ) 2>/dev/null || MCP_TOKEN_MINTED=no
   fi
-  log "minted $MCP_TOKEN_FILE"
+  if [ "${MCP_TOKEN_MINTED:-yes}" = no ]; then
+    log "WARN: could not write $MCP_TOKEN_FILE — registering the MCP server anyway; the bearer is seeded again at every clawbox-setup boot"
+  else
+    log "minted $MCP_TOKEN_FILE"
+  fi
 fi
 chmod 600 "$MCP_TOKEN_FILE" 2>/dev/null || true
 
@@ -209,7 +222,10 @@ except OSError as err:
     # mcp_servers over a config whose contents we never saw. Same verdict as
     # invalid YAML below — refuse, and say why, instead of the traceback this
     # top-level `python3` under `set -euo pipefail` produced. TASK-657.
-    print(f"[register-mcp] ERROR: {os.path.basename(cfg_path)} could not be read "
+    # The full path, matching the YAML arm two lines down rather than the
+    # basename: there is no secret in a config path and the operator has to know
+    # WHICH file to fix.
+    print(f"[register-mcp] ERROR: {cfg_path} could not be read "
           f"({err.strerror or type(err).__name__}); refusing to overwrite it.", file=sys.stderr)
     sys.exit(1)
 except yaml.YAMLError as exc:

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -124,7 +124,12 @@ fi
 # bare "Permission denied" for a token this uid cannot read. Same correction as
 # gateway-pre-start.sh's copy of this line.
 if [ ! -s "$MCP_TOKEN_FILE" ] || [ "$( { wc -c < "$MCP_TOKEN_FILE"; } 2>/dev/null || echo 0 )" -lt 32 ]; then
-  mkdir -p "$(dirname "$MCP_TOKEN_FILE")"
+  # Guarded like its sibling in gateway-pre-start.sh: in plain command position a
+  # `data/` that cannot be CREATED (a read-only $PROJECT_DIR, ENOSPC) exits
+  # non-zero and `set -e` kills the run before the reconcile — which is the same
+  # "no device tools at all on the hermes SKU" outcome the mint guard below
+  # exists to prevent, one line earlier. TASK-657.
+  mkdir -p "$(dirname "$MCP_TOKEN_FILE")" 2>/dev/null || true
   # `umask 077` in the subshell, not a chmod afterwards: a bare redirect creates
   # the file at the umask's mode — 0644 under root's — and the chmod below only
   # closes that window AFTER the secret is already on disk and world-readable.
@@ -146,7 +151,13 @@ if [ ! -s "$MCP_TOKEN_FILE" ] || [ "$( { wc -c < "$MCP_TOKEN_FILE"; } 2>/dev/nul
     ( umask 077; head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n' > "$MCP_TOKEN_FILE" ) 2>/dev/null || MCP_TOKEN_MINTED=no
   fi
   if [ "${MCP_TOKEN_MINTED:-yes}" = no ]; then
-    log "WARN: could not write $MCP_TOKEN_FILE — registering the MCP server anyway; the bearer is seeded again at every clawbox-setup boot"
+    # State what is true, not a repair that cannot happen. production-server.js
+    # seeds the same path as the same uid, so every state that fails this mint
+    # fails that one too, and on the hermes SKU clawbox-gateway.service is masked
+    # so gateway-pre-start.sh's replacement never runs either. The registration
+    # is still worth writing — it is what puts the tools in `hermes mcp list` —
+    # but they will 401 until the directory is writable.
+    log "WARN: could not write $MCP_TOKEN_FILE — registering the MCP server anyway, but it has no bearer: /setup-api/* tool calls will answer 401 until $(dirname "$MCP_TOKEN_FILE") is writable"
   else
     log "minted $MCP_TOKEN_FILE"
   fi

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -119,12 +119,22 @@ fi
 # Same file, same semantics as src/lib/mcp-token.ts and gateway-pre-start.sh.
 # Minted here too so a Hermes box — which has no gateway pre-start hook — is
 # never left without one.
-if [ ! -s "$MCP_TOKEN_FILE" ] || [ "$(wc -c < "$MCP_TOKEN_FILE" 2>/dev/null || echo 0)" -lt 32 ]; then
+# `{ ...; } 2>/dev/null` rather than `wc ... 2>/dev/null`: a failed INPUT
+# redirect is reported by the shell, not by wc, so the narrower form prints a
+# bare "Permission denied" for a token this uid cannot read. Same correction as
+# gateway-pre-start.sh's copy of this line.
+if [ ! -s "$MCP_TOKEN_FILE" ] || [ "$( { wc -c < "$MCP_TOKEN_FILE"; } 2>/dev/null || echo 0 )" -lt 32 ]; then
   mkdir -p "$(dirname "$MCP_TOKEN_FILE")"
+  # `umask 077` in the subshell, not a chmod afterwards: a bare redirect creates
+  # the file at the umask's mode — 0644 under root's — and the chmod below only
+  # closes that window AFTER the secret is already on disk and world-readable.
+  # It also cannot close it at all when the chmod fails (a file this uid does
+  # not own), which is the state gateway-pre-start.sh's `mcp_write_token` was
+  # written for. TASK-657.
   if command -v openssl >/dev/null 2>&1; then
-    openssl rand -hex 32 > "$MCP_TOKEN_FILE"
+    ( umask 077; openssl rand -hex 32 > "$MCP_TOKEN_FILE" )
   else
-    head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n' > "$MCP_TOKEN_FILE"
+    ( umask 077; head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n' > "$MCP_TOKEN_FILE" )
   fi
   log "minted $MCP_TOKEN_FILE"
 fi
@@ -192,6 +202,16 @@ except FileNotFoundError:
     # valid — Hermes merges its own defaults over it — so register now rather
     # than leave the device tool-less until someone finishes onboarding.
     cfg = {}
+except OSError as err:
+    # The file is THERE and cannot be read (permissions, a truncated mount).
+    # Deliberately NOT the `cfg = {}` above: that arm's premise is "no config
+    # exists yet", and taking it here would write a file holding only
+    # mcp_servers over a config whose contents we never saw. Same verdict as
+    # invalid YAML below — refuse, and say why, instead of the traceback this
+    # top-level `python3` under `set -euo pipefail` produced. TASK-657.
+    print(f"[register-mcp] ERROR: {os.path.basename(cfg_path)} could not be read "
+          f"({err.strerror or type(err).__name__}); refusing to overwrite it.", file=sys.stderr)
+    sys.exit(1)
 except yaml.YAMLError as exc:
     print(f"[register-mcp] ERROR: {cfg_path} is not valid YAML ({type(exc).__name__}); "
           "refusing to overwrite it.", file=sys.stderr)

--- a/src/lib/mcp-token.ts
+++ b/src/lib/mcp-token.ts
@@ -31,17 +31,31 @@ const DATA_ROOT = process.env.CLAWBOX_ROOT
 const TOKEN_PATH = path.join(DATA_ROOT, "data", ".mcp-token");
 
 let cached: string | null = null;
+/** Epoch ms of the last disk re-read triggered by a FAILED bearer check. */
+let lastRecheck = 0;
+/**
+ * The failure path is the one an unauthenticated caller controls, so the
+ * re-read below is rate-limited: a bad-bearer flood must not become one disk
+ * read per request. A second is well under a restart and well over a flood.
+ */
+const RECHECK_INTERVAL_MS = 1000;
+
+function readTokenFile(): string | null {
+  try {
+    const raw = fs.readFileSync(TOKEN_PATH, "utf-8").trim();
+    if (raw && raw.length >= 16) return raw;
+  } catch {
+    // absent, or unreadable to this uid
+  }
+  return null;
+}
 
 function readOrCreateToken(): string {
   const fromEnv = process.env.CLAWBOX_MCP_TOKEN;
   if (fromEnv && fromEnv.length >= 16) return fromEnv;
 
-  try {
-    const raw = fs.readFileSync(TOKEN_PATH, "utf-8").trim();
-    if (raw && raw.length >= 16) return raw;
-  } catch {
-    // fall through to mint a fresh token
-  }
+  const onDisk = readTokenFile();
+  if (onDisk) return onDisk;
 
   const fresh = crypto.randomBytes(32).toString("hex");
   try {
@@ -61,14 +75,7 @@ export function getMcpToken(): string {
   return cached;
 }
 
-export function verifyMcpBearer(headerValue: string | null): boolean {
-  if (!headerValue) return false;
-  const match = headerValue.match(/^Bearer\s+(.+)$/i);
-  if (!match) return false;
-  const presented = match[1].trim();
-  if (!presented) return false;
-
-  const expected = getMcpToken();
+function matches(presented: string, expected: string): boolean {
   const presentedBuf = Buffer.from(presented);
   const expectedBuf = Buffer.from(expected);
   return (
@@ -77,6 +84,45 @@ export function verifyMcpBearer(headerValue: string | null): boolean {
   );
 }
 
+export function verifyMcpBearer(headerValue: string | null): boolean {
+  if (!headerValue) return false;
+  const match = headerValue.match(/^Bearer\s+(.+)$/i);
+  if (!match) return false;
+  const presented = match[1].trim();
+  if (!presented) return false;
+
+  if (matches(presented, getMcpToken())) return true;
+
+  // The token on disk can be ROTATED under a running web server:
+  // scripts/gateway-pre-start.sh replaces it when the gateway can neither read
+  // nor re-harden it, and the reconcile it runs afterwards reaches the MCP
+  // subprocess only. This process is the verifier, and it holds its own copy —
+  // `cached` above, seeded from CLAWBOX_MCP_TOKEN which production-server.js
+  // pins at Next.js boot. Nothing orders clawbox-setup.service against
+  // clawbox-gateway.service, so a gateway restart mid-uptime (a model/config
+  // change, or Restart=always after a crash) used to 401 every /setup-api/*
+  // call from the agent's device tools until clawbox-setup happened to restart.
+  //
+  // Re-read the file once, rate-limited, and only on a check that already
+  // failed. This widens nothing: data/.mcp-token is 0600 under a directory this
+  // uid owns and it is the source `cached` was read from in the first place —
+  // the stale value is what has no authority, not the file. TASK-657.
+  const now = Date.now();
+  if (now - lastRecheck < RECHECK_INTERVAL_MS) return false;
+  lastRecheck = now;
+
+  const onDisk = readTokenFile();
+  if (!onDisk || onDisk === cached) return false;
+  if (!matches(presented, onDisk)) return false;
+
+  // Adopt it, so the superseded value stops being accepted and the MCP
+  // subprocess's env copy agrees with ours.
+  cached = onDisk;
+  process.env.CLAWBOX_MCP_TOKEN = onDisk;
+  return true;
+}
+
 export function _resetMcpTokenCacheForTests(): void {
   cached = null;
+  lastRecheck = 0;
 }

--- a/src/lib/mcp-token.ts
+++ b/src/lib/mcp-token.ts
@@ -31,7 +31,7 @@ import crypto from "crypto";
  * that fails against it: that check re-reads the file and adopts what
  * it finds, whether or not anything rotated, and the env value stops
  * being accepted from then on. Said plainly because it is easy to read
- * the rate limit as "only on a rotation" — `lastReadMtimeMs` starts
+ * the rate limit as "only on a rotation" — `lastReadFileId` starts
  * null, so the first failed check of the process always reads.
  *
  * In production that is inert: the only setter of the variable is
@@ -49,18 +49,30 @@ const TOKEN_PATH = path.join(DATA_ROOT, "data", ".mcp-token");
 
 let cached: string | null = null;
 /**
- * `mtimeMs` of the token file the last time a FAILED bearer check re-read it.
+ * Identity of the token file the last time a FAILED bearer check re-read it:
+ * `dev:ino:mtimeMs`.
  *
  * The failure path is the one an unauthenticated caller controls, so the
  * re-read has to be bounded — but NOT by a wall clock. A time slot is a shared
  * resource an attacker can consume: at more than one bad bearer per interval,
  * the flood takes every slot and the legitimate rotated bearer keeps being
  * rejected, which re-opens the very defect the re-read closes. Gating on the
- * file's mtime instead makes the bound exact: a rotation always changes it, so
- * the file is read at most ONCE per rotation no matter how many checks fail,
- * and a flood costs one `statSync` per request rather than one read.
+ * file itself makes the bound exact: the file is read at most ONCE per
+ * rotation no matter how many checks fail, and a flood costs one `statSync`
+ * per request rather than one read.
+ *
+ * `mtimeMs` alone is not that identity, and the two rotation shapes are why
+ * both halves are needed. `scripts/gateway-pre-start.sh` REPLACES the file
+ * (`mv` over it), so the inode changes and the timestamp need not: `mtimeMs`
+ * resolution is the filesystem's, and two replacements inside one tick report
+ * the same value — the second is then never read, and the bearer the MCP
+ * subprocess is now sending stays rejected until something rotates the file a
+ * third time. `production-server.js` and `readOrCreateToken` below instead
+ * rewrite it IN PLACE, keeping the inode and moving the mtime. Neither field
+ * covers both, and together they cost nothing: the `statSync` was already
+ * being made.
  */
-let lastReadMtimeMs: number | null = null;
+let lastReadFileId: string | null = null;
 
 function readTokenFile(): string | null {
   try {
@@ -129,14 +141,15 @@ export function verifyMcpBearer(headerValue: string | null): boolean {
   // failed. This widens nothing: data/.mcp-token is 0600 under a directory this
   // uid owns and it is the source `cached` was read from in the first place —
   // the stale value is what has no authority, not the file. TASK-657.
-  let mtimeMs: number;
+  let fileId: string;
   try {
-    mtimeMs = fs.statSync(TOKEN_PATH).mtimeMs;
+    const st = fs.statSync(TOKEN_PATH);
+    fileId = `${st.dev}:${st.ino}:${st.mtimeMs}`;
   } catch {
     // No file to reconcile against; the cached value is all there is.
     return false;
   }
-  if (mtimeMs === lastReadMtimeMs) return false;
+  if (fileId === lastReadFileId) return false;
 
   const onDisk = readTokenFile();
   // Spend the rotation's one allowed read only on a read that RETURNED. Stamping
@@ -147,7 +160,7 @@ export function verifyMcpBearer(headerValue: string | null): boolean {
   // one unlucky syscall. A file that is genuinely unreadable now costs one failed
   // `open()` per bad bearer, the same order as the `statSync` above it.
   if (!onDisk) return false;
-  lastReadMtimeMs = mtimeMs;
+  lastReadFileId = fileId;
   if (onDisk === cached) return false;
 
   // Adopt on the ROTATION, not on a caller presenting the new value. Making the
@@ -169,5 +182,5 @@ export function verifyMcpBearer(headerValue: string | null): boolean {
 
 export function _resetMcpTokenCacheForTests(): void {
   cached = null;
-  lastReadMtimeMs = null;
+  lastReadFileId = null;
 }

--- a/src/lib/mcp-token.ts
+++ b/src/lib/mcp-token.ts
@@ -27,12 +27,17 @@ import crypto from "crypto";
  * and what lets `production-server.js` seed it before the first
  * request. But the FILE is the rotation's authority: it is what
  * `mcp/lib/api.ts` presents and what `scripts/gateway-pre-start.sh`
- * rewrites, so once the file changes under this process the next
- * failed bearer check adopts its contents and the earlier value stops
- * being accepted. An env pin therefore holds only until the file is
- * rotated, never after — which costs nothing in production, where the
- * only setter of the variable is `production-server.js` and it sets it
- * to that same file's contents.
+ * rewrites. So the env value holds only until the FIRST bearer check
+ * that fails against it: that check re-reads the file and adopts what
+ * it finds, whether or not anything rotated, and the env value stops
+ * being accepted from then on. Said plainly because it is easy to read
+ * the rate limit as "only on a rotation" — `lastReadMtimeMs` starts
+ * null, so the first failed check of the process always reads.
+ *
+ * In production that is inert: the only setter of the variable is
+ * `production-server.js`, and it sets it to this same file's contents,
+ * so the adoption is a no-op until a real rotation. An operator who
+ * pins the variable to something else should expect the file to win.
  *
  * Verification is constant-time via `crypto.timingSafeEqual` to keep
  * the bearer check robust against timing oracles.
@@ -132,10 +137,18 @@ export function verifyMcpBearer(headerValue: string | null): boolean {
     return false;
   }
   if (mtimeMs === lastReadMtimeMs) return false;
-  lastReadMtimeMs = mtimeMs;
 
   const onDisk = readTokenFile();
-  if (!onDisk || onDisk === cached) return false;
+  // Spend the rotation's one allowed read only on a read that RETURNED. Stamping
+  // the mtime on the attempt let a single transient failure — an EMFILE or ENOMEM
+  // on a loaded server, a momentary EACCES inside the rotation window — record
+  // this mtime forever, so the rotated token was never adopted until the file
+  // changed AGAIN: the 401s this re-read exists to end, re-opened permanently by
+  // one unlucky syscall. A file that is genuinely unreadable now costs one failed
+  // `open()` per bad bearer, the same order as the `statSync` above it.
+  if (!onDisk) return false;
+  lastReadMtimeMs = mtimeMs;
+  if (onDisk === cached) return false;
 
   // Adopt on the ROTATION, not on a caller presenting the new value. Making the
   // adoption conditional on `matches(presented, onDisk)` reintroduces the

--- a/src/lib/mcp-token.ts
+++ b/src/lib/mcp-token.ts
@@ -22,6 +22,18 @@ import crypto from "crypto";
  * legacy sentinels — this is a fresh capability with no upgrade
  * compatibility window to maintain.
  *
+ * PRECEDENCE, and it is not symmetric. `CLAWBOX_MCP_TOKEN` wins when
+ * the value is first resolved — that is what makes it a test override
+ * and what lets `production-server.js` seed it before the first
+ * request. But the FILE is the rotation's authority: it is what
+ * `mcp/lib/api.ts` presents and what `scripts/gateway-pre-start.sh`
+ * rewrites, so once the file changes under this process the next
+ * failed bearer check adopts its contents and the earlier value stops
+ * being accepted. An env pin therefore holds only until the file is
+ * rotated, never after — which costs nothing in production, where the
+ * only setter of the variable is `production-server.js` and it sets it
+ * to that same file's contents.
+ *
  * Verification is constant-time via `crypto.timingSafeEqual` to keep
  * the bearer check robust against timing oracles.
  */
@@ -31,14 +43,19 @@ const DATA_ROOT = process.env.CLAWBOX_ROOT
 const TOKEN_PATH = path.join(DATA_ROOT, "data", ".mcp-token");
 
 let cached: string | null = null;
-/** Epoch ms of the last disk re-read triggered by a FAILED bearer check. */
-let lastRecheck = 0;
 /**
+ * `mtimeMs` of the token file the last time a FAILED bearer check re-read it.
+ *
  * The failure path is the one an unauthenticated caller controls, so the
- * re-read below is rate-limited: a bad-bearer flood must not become one disk
- * read per request. A second is well under a restart and well over a flood.
+ * re-read has to be bounded — but NOT by a wall clock. A time slot is a shared
+ * resource an attacker can consume: at more than one bad bearer per interval,
+ * the flood takes every slot and the legitimate rotated bearer keeps being
+ * rejected, which re-opens the very defect the re-read closes. Gating on the
+ * file's mtime instead makes the bound exact: a rotation always changes it, so
+ * the file is read at most ONCE per rotation no matter how many checks fail,
+ * and a flood costs one `statSync` per request rather than one read.
  */
-const RECHECK_INTERVAL_MS = 1000;
+let lastReadMtimeMs: number | null = null;
 
 function readTokenFile(): string | null {
   try {
@@ -103,26 +120,41 @@ export function verifyMcpBearer(headerValue: string | null): boolean {
   // change, or Restart=always after a crash) used to 401 every /setup-api/*
   // call from the agent's device tools until clawbox-setup happened to restart.
   //
-  // Re-read the file once, rate-limited, and only on a check that already
+  // Re-read the file, once per rotation, and only on a check that already
   // failed. This widens nothing: data/.mcp-token is 0600 under a directory this
   // uid owns and it is the source `cached` was read from in the first place —
   // the stale value is what has no authority, not the file. TASK-657.
-  const now = Date.now();
-  if (now - lastRecheck < RECHECK_INTERVAL_MS) return false;
-  lastRecheck = now;
+  let mtimeMs: number;
+  try {
+    mtimeMs = fs.statSync(TOKEN_PATH).mtimeMs;
+  } catch {
+    // No file to reconcile against; the cached value is all there is.
+    return false;
+  }
+  if (mtimeMs === lastReadMtimeMs) return false;
+  lastReadMtimeMs = mtimeMs;
 
   const onDisk = readTokenFile();
   if (!onDisk || onDisk === cached) return false;
-  if (!matches(presented, onDisk)) return false;
 
-  // Adopt it, so the superseded value stops being accepted and the MCP
-  // subprocess's env copy agrees with ours.
+  // Adopt on the ROTATION, not on a caller presenting the new value. Making the
+  // adoption conditional on `matches(presented, onDisk)` reintroduces the
+  // starvation this mtime bound exists to remove: the first failed check after
+  // a rotation consumes the one read that mtime allows, and if that check came
+  // from a bad bearer the new value is never adopted, so the legitimate one
+  // keeps failing until the file is rotated AGAIN. Reading the file is what
+  // settles the question — whoever wrote it already holds the credential, and
+  // `getMcpToken` would return exactly this value in a process that started now.
+  //
+  // Only `cached` is written: `process.env.CLAWBOX_MCP_TOKEN` is the value this
+  // process STARTED from, and overwriting it would leave a rotated secret in the
+  // environment of everything spawned afterwards for no gain — `getMcpToken`
+  // consults the env only while `cached` is null.
   cached = onDisk;
-  process.env.CLAWBOX_MCP_TOKEN = onDisk;
-  return true;
+  return matches(presented, onDisk);
 }
 
 export function _resetMcpTokenCacheForTests(): void {
   cached = null;
-  lastRecheck = 0;
+  lastReadMtimeMs = null;
 }

--- a/src/tests/unit/ensure-local-embeddings.test.ts
+++ b/src/tests/unit/ensure-local-embeddings.test.ts
@@ -463,6 +463,32 @@ describe.skipIf(!canRun)("ensure-local-embeddings.sh on OpenClaw 2", () => {
     expect(r.search).toEqual({});
   });
 
+  for (const version of ["next", "dev", "0.0.0-dev"]) {
+    it(`refuses to read a core v2 on a version that is not a date (${version})`, () => {
+      // `sort -V` reads a non-date as NEWER than 2026.8 — `next` and `dev` both
+      // graded v2 — so a dev build, a fork, an `npm i -g <git url>` install or a
+      // vendor rebuild picked memory.search on a core that may well be v1, whose
+      // CLI then refuses the key. gateway-pre-start.sh got this shape check for
+      // exactly that reason; this file reads the SAME package.json by the same
+      // derivation and was left behind. Unknown falls to the legacy names, which
+      // is where a box with no core at all already lands and where the write
+      // fails soft. TASK-657.
+      const r = run({ installedVersion: version, stubV2: false, present: true });
+      expect(r.status).toBe(0);
+      expect(configSets(r.calls)).toEqual([
+        `openclaw config set agents.defaults.memorySearch.model ${MODEL}`,
+        "openclaw config set agents.defaults.memorySearch.provider ollama",
+      ]);
+    });
+  }
+
+  it("still reads a real date version, suffix and all", () => {
+    // The control: the shape check must not reject the versions the fleet runs.
+    const r = run({ installedVersion: "2026.8.1-rc.2", stubV2: true, present: true });
+    expect(r.status).toBe(0);
+    expect(configSets(r.calls)[0]).toBe(`openclaw config set memory.search.model ${MODEL}`);
+  });
+
   it("lets the generation gateway-pre-start.sh exported win over the package on disk", () => {
     // Pre-start asked the binary itself; a package.json that disagrees is the
     // mid-update case, and the binary is the process that parses the write.

--- a/src/tests/unit/gateway-pre-start-corrupt-config.test.ts
+++ b/src/tests/unit/gateway-pre-start-corrupt-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { execFileSync, spawnSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
@@ -17,6 +17,12 @@ const SCRIPT = path.resolve(process.cwd(), "scripts/gateway-pre-start.sh");
 
 const hasPython3 =
   spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
+
+/**
+ * 0000 is a no-op for root, which reads anything — the unreadable case would
+ * take the happy path and prove nothing. CI is non-root.
+ */
+const isRoot = typeof process.getuid === "function" && process.getuid() === 0;
 
 function extractLoader(): string {
   const src = readFileSync(SCRIPT, "utf-8");
@@ -43,6 +49,20 @@ function load(cfgPath: string): { result: unknown; stderr: string } {
   );
   if (proc.status !== 0) throw new Error(`loader exited ${proc.status}: ${proc.stderr}`);
   return { result: JSON.parse(proc.stdout.trim()), stderr: proc.stderr };
+}
+
+/** The same run, but reporting a non-zero exit instead of throwing on it. */
+function loadRaw(cfgPath: string): { status: number | null; stdout: string; stderr: string } {
+  const proc = spawnSync(
+    "python3",
+    [
+      "-c",
+      `import json, os, sys, shutil, time\ncfg_path = sys.argv[1]${LOADER}\nprint(json.dumps(cfg))`,
+      cfgPath,
+    ],
+    { encoding: "utf-8" },
+  );
+  return { status: proc.status, stdout: proc.stdout ?? "", stderr: proc.stderr ?? "" };
 }
 
 describe.skipIf(!hasPython3)("gateway-pre-start.sh config load block", () => {
@@ -84,6 +104,34 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh config load block", () => {
     expect(readFileSync(cfgPath, "utf-8")).toBe(torn);
     expect(stderr).toMatch(/WARN: openclaw\.json is not valid JSON/);
     expect(stderr).toContain(backups[0]);
+  });
+
+  it.skipIf(isRoot)("does not take the boot down on a file it cannot read, and does not answer {}", () => {
+    // `PermissionError` is not a subclass of `FileNotFoundError`, so it escaped
+    // the one arm that was caught. This heredoc is a bare top-level command in
+    // a script under `set -euo pipefail`, so the raise killed the whole
+    // ExecStartPre: no gateway, on every boot, until someone with shell access
+    // fixed the mode. openclaw.json is clawbox-owned and therefore writable
+    // from a chat turn, which makes that an agent-reachable boot DoS — the same
+    // class this change already closed for data/hostname.env and .mcp-token,
+    // moved to the more central file, the one this script exists to edit.
+    //
+    // And answering `{}` is not the fix either: that object is written back a
+    // few hundred lines below, so a config that merely could not be OPENED
+    // would lose every provider, auth profile and channel.
+    writeFileSync(cfgPath, JSON.stringify({ gateway: { port: 18789 }, models: { providers: { openai: {} } } }));
+    chmodSync(cfgPath, 0o000);
+    try {
+      const r = loadRaw(cfgPath);
+      expect(r.status, `the loader aborted the pre-start:\n${r.stderr}`).toBe(0);
+      expect(r.stdout.trim(), "it answered {} for a file it could not read").toBe("");
+      expect(r.stderr).toMatch(/could not be read/i);
+      expect(r.stderr).toMatch(/leaving it exactly as it is/i);
+      // Nothing beside it: this is not the corrupt-file path.
+      expect(readdirSync(dir)).toEqual(["openclaw.json"]);
+    } finally {
+      chmodSync(cfgPath, 0o644);
+    }
   });
 
   // The block runs with the script's own imports; a change there must move here.

--- a/src/tests/unit/gateway-pre-start-corrupt-config.test.ts
+++ b/src/tests/unit/gateway-pre-start-corrupt-config.test.ts
@@ -167,3 +167,100 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh config load block", () => {
     expect(src).toMatch(/^import json, os, sys, tempfile, secrets, shutil, time$/m);
   });
 });
+
+/**
+ * The other half of the same file, and the one that can still fail the unit.
+ * The loader above was made unable to take the boot down; the WRITE it feeds
+ * was not. `tempfile.mkstemp` sat OUTSIDE the `try` that existed to contain a
+ * failed write, so a `~/.openclaw` this uid cannot write — or a full disk —
+ * raised PermissionError/OSError straight out of a bare top-level heredoc in a
+ * script under `set -euo pipefail`. `ExecStartPre=` carries no `-` prefix
+ * (config/clawbox-gateway.service), so that fails the unit and Restart=always
+ * spends StartLimitBurst: no gateway and no chat, on every boot.
+ *
+ * A config migration that cannot be written costs this boot the migration. The
+ * gateway then starts on the config already on disk — the state it was in a
+ * moment earlier — exactly as the deepseek plugin patch and the MCP
+ * registration in the same script already do.
+ */
+function extractWriter(): string {
+  const src = readFileSync(SCRIPT, "utf-8");
+  const head = "\nif changed:\n    # Atomic write";
+  const tail = '\n    print("  Gateway config already correct, skipping write")\n';
+  const start = src.indexOf(head);
+  const end = src.indexOf(tail, start);
+  if (start < 0 || end < 0) {
+    throw new Error("config write block not found in gateway-pre-start.sh");
+  }
+  return src.slice(start, end + tail.length);
+}
+
+const WRITER = hasPython3 ? extractWriter() : "";
+
+/** Run the write block over `cfgPath` with `cfg` as the object to persist. */
+function write(cfgPath: string, cfg: unknown): { status: number | null; stdout: string; stderr: string } {
+  const proc = spawnSync(
+    "python3",
+    [
+      "-c",
+      "import json, os, sys, tempfile, secrets, shutil, time\n"
+        + "cfg_path = sys.argv[1]\ncfg = json.loads(sys.argv[2])\nchanged = True"
+        + WRITER,
+      cfgPath,
+      JSON.stringify(cfg),
+    ],
+    { encoding: "utf-8" },
+  );
+  return { status: proc.status, stdout: proc.stdout ?? "", stderr: proc.stderr ?? "" };
+}
+
+describe.skipIf(!hasPython3)("gateway-pre-start.sh config write block", () => {
+  let dir: string;
+  let cfgPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), "clawbox-prestart-write-"));
+    cfgPath = path.join(dir, "openclaw.json");
+  });
+
+  afterEach(() => {
+    try {
+      chmodSync(dir, 0o755);
+    } catch { /* the unwritable-dir case is the only one that changes it */ }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes the migrated config and says so", () => {
+    writeFileSync(cfgPath, JSON.stringify({ gateway: { port: 1 } }));
+
+    const r = write(cfgPath, { gateway: { port: 18789 } });
+
+    expect(r.status, r.stderr).toBe(0);
+    expect(r.stdout).toMatch(/Updated gateway config/);
+    expect(JSON.parse(readFileSync(cfgPath, "utf-8"))).toEqual({ gateway: { port: 18789 } });
+    // Nothing staged left behind.
+    expect(readdirSync(dir)).toEqual(["openclaw.json"]);
+  });
+
+  it.skipIf(isRoot)("does not fail the unit when the config directory cannot be written", () => {
+    // The reproduction is `mkstemp`, not the write: on a directory this uid
+    // cannot write it raises PermissionError before the `try` was ever entered.
+    // ENOSPC reaches the same call the same way.
+    const original = JSON.stringify({ gateway: { port: 18789 }, models: { providers: { openai: {} } } });
+    writeFileSync(cfgPath, original);
+    chmodSync(dir, 0o500);
+
+    const r = write(cfgPath, { gateway: { port: 18789 }, migrated: true });
+
+    expect(r.status, `the pre-start aborted, so the box gets no gateway:\n${r.stderr}`).toBe(0);
+    // Said as what it costs, not as an error, and not silently.
+    expect(r.stderr).toMatch(/WARN: could not write the gateway config/);
+    expect(r.stderr).toMatch(/PermissionError/);
+    expect(r.stderr).toMatch(/starts on the config already on disk/);
+    expect(r.stderr).not.toMatch(/Traceback/);
+    // And the config it starts on is the one that was already there, untouched.
+    chmodSync(dir, 0o755);
+    expect(readFileSync(cfgPath, "utf-8")).toBe(original);
+    expect(readdirSync(dir)).toEqual(["openclaw.json"]);
+  });
+});

--- a/src/tests/unit/gateway-pre-start-corrupt-config.test.ts
+++ b/src/tests/unit/gateway-pre-start-corrupt-config.test.ts
@@ -106,6 +106,33 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh config load block", () => {
     expect(stderr).toContain(backups[0]);
   });
 
+  it("treats bytes that are not UTF-8 as corrupt, rather than tracing back", () => {
+    // `json.load` raises UnicodeDecodeError — a ValueError, NOT a
+    // JSONDecodeError and NOT an OSError — so a config holding arbitrary bytes
+    // escaped all three arms and killed this bare top-level heredoc under
+    // `set -euo pipefail`: no gateway, on every boot, until someone with shell
+    // access fixed the file. The event that produces it is the SAME one the
+    // .corrupt-<utc> copy exists for — a power loss mid-write on a Jetson
+    // leaves arbitrary bytes, not a truncated but decodable string — so the
+    // fixture that pinned the corrupt path (`'{not json'`, valid UTF-8) could
+    // not see it. TASK-657.
+    const torn = Buffer.concat([
+      Buffer.from('{"gateway":{"port":18789},"models":'),
+      Buffer.from([0xe9, 0xff, 0xfe]),
+    ]);
+    writeFileSync(cfgPath, torn);
+
+    const { result, stderr } = load(cfgPath);
+
+    expect(result).toEqual({});
+    // The bytes are preserved exactly, which is the whole point of the copy.
+    const backups = readdirSync(dir).filter((f) => f.startsWith("openclaw.json.corrupt-"));
+    expect(backups).toHaveLength(1);
+    expect(readFileSync(path.join(dir, backups[0]))).toEqual(torn);
+    expect(readFileSync(cfgPath)).toEqual(torn);
+    expect(stderr).toMatch(/WARN: openclaw\.json is not valid JSON/);
+  });
+
   it.skipIf(isRoot)("does not take the boot down on a file it cannot read, and does not answer {}", () => {
     // `PermissionError` is not a subclass of `FileNotFoundError`, so it escaped
     // the one arm that was caught. This heredoc is a bare top-level command in

--- a/src/tests/unit/gateway-pre-start-version-probe.test.ts
+++ b/src/tests/unit/gateway-pre-start-version-probe.test.ts
@@ -88,9 +88,11 @@ function run(program: string): { status: number | null; out: string; stderr: str
   chmodSync(file, 0o755);
   // `spawnSync` inherits process.env, and an explicit CLAWBOX_OPENCLAW_V2 WINS
   // over everything the probe derives — by design, and the shipped script says
-  // so. A runner (or a shell on a box) that exports it would make every derived
-  // generation here read back as the override instead, so the tests that pin
-  // v1 and the ones that pin "wrote nothing" would pass on any script at all.
+  // so. Nothing in this repo exports it today, so this is future-proofing
+  // against a runner (or a shell on a box) that does, and it is not symmetric:
+  // an ambient `=0` makes the v1-pinning assertions pass against ANY block,
+  // including beta's, which is the case that would hide a regression; an
+  // ambient `=1` makes the "writes NOTHING" case fail loudly instead.
   // Deleted rather than emptied: "unset" is the state a device is in.
   const env = { ...process.env };
   delete env.CLAWBOX_OPENCLAW_V2;
@@ -168,11 +170,16 @@ function probe(opts: {
 describe.runIf(canRun)("gateway-pre-start's OpenClaw generation probe", () => {
   it("reads the installed core's own manifest, without running it", () => {
     // ~10 s on a Jetson vs 53 ms for the manifest, in a BLOCKING ExecStartPre.
-    const r = probe({ cli: 'echo "openclaw 2026.9.9"; echo RAN >&2', pkg: "2026.8.1" });
+    // The stub leaves a FILE behind rather than a line on a stream: the shipped
+    // call is `--version 2>/dev/null` and the command substitution swallows its
+    // stdout, so neither stream can carry the marker out and an assertion on
+    // `r.out` would pass against a block that ran the CLI every time.
+    const ranMarker = path.join(root, "cli-was-run");
+    const r = probe({ cli: `: > ${JSON.stringify(ranMarker)}\necho "openclaw 2026.9.9"`, pkg: "2026.8.1" });
     expect(r.status).toBe(0);
     expect(r.effective).toBe("2026.8.1");
     expect(r.v2).toBe("1");
-    expect(r.out, "the CLI was run even though the manifest answered").not.toContain("RAN");
+    expect(existsSync(ranMarker), "the CLI was run even though the manifest answered").toBe(false);
   });
 
   it("asks the binary when there is no manifest to read", () => {
@@ -182,23 +189,45 @@ describe.runIf(canRun)("gateway-pre-start's OpenClaw generation probe", () => {
     expect(r.v2).toBe("1");
   });
 
+  /**
+   * What `openclaw --version` costs on a HEALTHY shipped Orin, measured on a
+   * box: 7.9-8.0 s, and a cold first boot is the slow case. Rounded up, and
+   * stated here rather than in a bare number below, because both bounds are
+   * derived from it.
+   */
+  const MEASURED_VERSION_SECONDS = 8;
+
   it("time-boxes that call with a value the boot can actually afford", () => {
-    const m = /timeout (\d+) "\$OPENCLAW_BIN" --version/.exec(block('OPENCLAW_TARGET=""', "export CLAWBOX_OPENCLAW_V2"));
+    const probeBlock = block('OPENCLAW_TARGET=""', "export CLAWBOX_OPENCLAW_V2");
+    const m = /timeout (?:-k (\d+) )?(\d+) "\$OPENCLAW_BIN" --version/.exec(probeBlock);
     expect(m, "the version probe is no longer time-boxed at all").not.toBeNull();
-    const seconds = Number(m![1]);
-    // 45, matching the other bounded `openclaw` CLI call this script makes.
-    // `\d+` alone accepted `timeout 1` — which cuts off the healthy 7.9-8.0 s
-    // this call measures on a shipped Orin, making the fallback useless exactly
-    // when it is needed — and `timeout 600`, which would spend the unit's whole
-    // start budget inside one optional probe.
-    expect(seconds).toBe(45);
-    // And it has to stay inside the unit's own ceiling, read from the shipped
-    // unit rather than repeated here: ExecStartPre running out of time is a
-    // gateway that never starts, so a lowered TimeoutStartSec has to fail here.
+    // Plain `timeout` sends SIGTERM only. A `--version` that ignores it would
+    // hold this ExecStartPre for the unit's whole start budget — precisely the
+    // outcome the bound exists to prevent — so the SIGKILL escalation is part
+    // of the behaviour, not a stylistic choice.
+    expect(m![1], "the bound sends SIGTERM only, so a wedged --version outlives it").toBeDefined();
+    expect(Number(m![1])).toBeGreaterThan(0);
+    const seconds = Number(m![2]);
+    // The bound is asserted against what it has to survive and what it has to
+    // stay inside, not against a literal: a number pinned to a precedent goes
+    // stale the moment the precedent moves.
+    //
+    // Floor — it must leave several multiples of the measured healthy cost as
+    // headroom, or it cuts off a WORKING core and makes the fallback fire
+    // exactly when it is not needed. `\d+` alone accepted `timeout 1`.
+    expect(
+      seconds,
+      `a healthy --version measures ~${MEASURED_VERSION_SECONDS}s on a shipped Orin; this bound cuts it off`,
+    ).toBeGreaterThanOrEqual(3 * MEASURED_VERSION_SECONDS);
+    // Ceiling — it has to stay well inside the unit's own budget, read from the
+    // shipped unit rather than repeated here: ExecStartPre running out of time
+    // is a gateway that never starts, so a lowered TimeoutStartSec has to fail
+    // here. Half the budget, not merely under it: this is one OPTIONAL probe
+    // and the rest of the pre-start still has to run after it.
     const unit = readFileSync(path.join(REPO, "config", "clawbox-gateway.service"), "utf-8");
     const budget = Number(/^TimeoutStartSec=(\d+)$/m.exec(unit)?.[1]);
     expect(budget, "clawbox-gateway.service no longer states TimeoutStartSec in seconds").toBeGreaterThan(0);
-    expect(seconds).toBeLessThan(budget);
+    expect(seconds, "one optional probe may not claim half the unit's start budget").toBeLessThanOrEqual(budget / 2);
   });
 
   it("still calls a v1 core v1, whatever the pin says", () => {
@@ -385,7 +414,13 @@ describe.runIf(canRun)("gateway-pre-start's MCP token hardening", () => {
   /** 64 hex chars: long enough that the seeding branch above leaves it alone. */
   const EXISTING = "a".repeat(64);
 
-  function token(opts: { contents?: string; mode?: number; chmodFails?: boolean }): {
+  function token(opts: {
+    contents?: string;
+    mode?: number;
+    chmodFails?: boolean;
+    /** What a stubbed `stat -c %a` reports, for a mode this uid cannot produce. */
+    statSays?: string;
+  }): {
     status: number | null;
     out: string;
     /** The file's permission bits after the block ran, or null if it is gone. */
@@ -412,6 +447,13 @@ describe.runIf(canRun)("gateway-pre-start's MCP token hardening", () => {
       writeFileSync(stub, "#!/bin/sh\necho \"chmod: changing permissions: Operation not permitted\" >&2\nexit 1\n");
       chmodSync(stub, 0o755);
     }
+    // The one mode this uid cannot actually create: another user's 0600, which
+    // `stat` reports as 600 while every read of it is denied.
+    if (opts.statSays !== undefined) {
+      const stub = path.join(stubBin, "stat");
+      writeFileSync(stub, `#!/bin/sh\necho ${opts.statSays}\n`);
+      chmodSync(stub, 0o755);
+    }
     const r = run(
       [
         `CLAWBOX_ROOT=${JSON.stringify(clawboxRoot)}`,
@@ -421,10 +463,19 @@ describe.runIf(canRun)("gateway-pre-start's MCP token hardening", () => {
         'echo "REACHED_END=1"',
       ].join("\n"),
     );
+    const mode = existsSync(file) ? statSync(file).mode & 0o777 : null;
+    // A case that leaves the token unreadable to this uid must still be
+    // reportable: the mode is already captured, so open it up for the
+    // contents read and for the tmpdir cleanup.
+    try {
+      chmodSync(file, 0o600);
+    } catch {
+      /* the block may have removed it */
+    }
     return {
       status: r.status,
       out: r.out,
-      mode: existsSync(file) ? statSync(file).mode & 0o777 : null,
+      mode,
       contents: existsSync(file) ? readFileSync(file, "utf-8") : null,
       exported: /EXPORTED=(.*)/.exec(r.out)?.[1] ?? null,
     };
@@ -466,6 +517,35 @@ describe.runIf(canRun)("gateway-pre-start's MCP token hardening", () => {
     expect(r.mode).toBe(0o600);
     expect(r.contents).toBe(EXISTING);
     expect(r.out).not.toMatch(/WARN/);
+  });
+
+  it.skipIf(isRoot)("replaces a token this gateway cannot read, instead of refusing to boot", () => {
+    // The state the fleet's writers ACTUALLY produce when they run as root is
+    // root:root 0600, not 0644: scripts/register-mcp.sh chmods 600 on the line
+    // after its redirect, and production-server.js writes { mode: 0o600 }. That
+    // file is unreadable to User=clawbox and unchmoddable by it — and grading
+    // the mode on the literal string "600" declined to touch it, so the
+    // `[ ! -r "$MCP_TOKEN_FILE" ] → exit 1` three lines below fired: ExecStartPre
+    // fails, no gateway, on every boot until someone with shell access fixes
+    // the mode. That is TASK-657's own headline defect, standing inside the one
+    // block that carries the remedy for it.
+    //
+    // Reproduced without being two users: the file is 0000 (every read denied,
+    // exactly as another user's 0600 is), `chmod` fails the way it does on
+    // another user's file, and `stat` reports the 600 those writers leave.
+    const r = token({ contents: EXISTING, mode: 0o000, chmodFails: true, statSays: "600" });
+    expect(r.status, `the pre-start aborted, so the box gets no gateway:\n${r.out}`).toBe(0);
+    expect(r.out).toContain("REACHED_END=1");
+    // Replaced, and the replacement is this uid's own 0600 token.
+    expect(r.mode! & 0o077).toBe(0);
+    expect(r.exported).toHaveLength(64);
+    expect(r.exported).not.toBe(EXISTING);
+    expect(r.out).toMatch(/WARN/);
+    // A rotation reaches the MCP subprocess (the reconcile below rewrites
+    // openclaw.json) but NOT the verifier in the web server, which holds its
+    // own copy — so the WARN has to name the unit that must pick the new
+    // bearer up. See src/lib/mcp-token.ts.
+    expect(r.out).toMatch(/clawbox-setup/);
   });
 
   it("seeds a missing token at 0600 without a chmod to do it", () => {

--- a/src/tests/unit/gateway-pre-start-version-probe.test.ts
+++ b/src/tests/unit/gateway-pre-start-version-probe.test.ts
@@ -101,9 +101,14 @@ function run(program: string): { status: number | null; out: string; stderr: str
 }
 
 /**
- * The 0000 cases are a no-op for root, which reads anything: they would pass by
- * taking the happy path and prove nothing. CI is non-root; a `sudo npm test` on
- * a box is not.
+ * Skip ONLY where root's extra privilege changes which branch the shipped block
+ * takes, and the rule is narrow: `[ -r "$f" ]` and `[ -w "$dir" ]` answer
+ * differently for root, so a 0000 file (or a 0555 directory) is a no-op for it
+ * and the case would pass by taking the happy path and prove nothing. Nothing
+ * else here is uid-dependent — the mode grading reads `stat -c %a`, the `chmod`
+ * stub fails for every user alike, and `umask 077` yields 0600 for root too —
+ * so a case whose branch turns on the MODE runs everywhere, and skipping it
+ * would only cost coverage on a box (CI is non-root; a `sudo npm test` is not).
  */
 const isRoot = typeof process.getuid === "function" && process.getuid() === 0;
 
@@ -509,7 +514,7 @@ describe.runIf(canRun)("gateway-pre-start's MCP token hardening", () => {
     expect(r.exported).toBe(EXISTING);
   });
 
-  it.skipIf(isRoot)("never exports a token other local users can read", () => {
+  it("never exports a token other local users can read", () => {
     // The file root created at 0644 and clawbox cannot chmod. Warning and
     // carrying on hands the only /setup-api/* credential to every local user.
     const r = token({ contents: EXISTING, mode: 0o644, chmodFails: true });
@@ -528,7 +533,7 @@ describe.runIf(canRun)("gateway-pre-start's MCP token hardening", () => {
     expect(r.out).toContain("REACHED_END=1");
   });
 
-  it.skipIf(isRoot)("does not rotate, or warn, over a file that is already 0600", () => {
+  it("does not rotate, or warn, over a file that is already 0600", () => {
     // chmod on a root-owned file fails whatever its mode is. The old warning
     // fired here too, over a box with nothing wrong with it.
     const r = token({ contents: EXISTING, mode: 0o600, chmodFails: true });
@@ -567,7 +572,7 @@ describe.runIf(canRun)("gateway-pre-start's MCP token hardening", () => {
     expect(r.out).toMatch(/clawbox-setup/);
   });
 
-  it.skipIf(isRoot)("leaves a readable token no other user can read exactly as it is", () => {
+  it("leaves a readable token no other user can read exactly as it is", () => {
     // 0400 and 0000-that-this-uid-owns are exposed to NOBODY. Grading the mode
     // on the literal "600" rotated both of them, and rotating a credential that
     // was never exposed is pure cost: it invalidates the bearer the web server

--- a/src/tests/unit/gateway-pre-start-version-probe.test.ts
+++ b/src/tests/unit/gateway-pre-start-version-probe.test.ts
@@ -73,17 +73,26 @@ function block(fromLine: string, toLine: string): string {
   return PRE_START.slice(start, end + toLine.length);
 }
 
-function run(program: string): { status: number | null; out: string } {
+function run(program: string): { status: number | null; out: string; stderr: string } {
   const file = path.join(root, "block.sh");
   writeFileSync(file, `#!/usr/bin/env bash\nset -euo pipefail\n${program}\n`);
   chmodSync(file, 0o755);
   const r = spawnSync("bash", [file], { encoding: "utf-8", timeout: 30_000 });
-  return { status: r.status, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+  return { status: r.status, out: `${r.stdout ?? ""}${r.stderr ?? ""}`, stderr: r.stderr ?? "" };
 }
+
+/**
+ * The 0000 cases are a no-op for root, which reads anything: they would pass by
+ * taking the happy path and prove nothing. CI is non-root; a `sudo npm test` on
+ * a box is not.
+ */
+const isRoot = typeof process.getuid === "function" && process.getuid() === 0;
 
 interface Probe {
   status: number | null;
   out: string;
+  /** Only what went to fd 2 — the stream the WARNs promise. */
+  stderr: string;
   /** The version the block settled on, or null when it never got that far. */
   effective: string | null;
   /** The generation it exported, or null when it never got that far. */
@@ -133,6 +142,7 @@ function probe(opts: {
   return {
     status: r.status,
     out: r.out,
+    stderr: r.stderr,
     effective: /EFFECTIVE=(.*)/.exec(r.out)?.[1] ?? null,
     v2: /V2=(.*)/.exec(r.out)?.[1] ?? null,
   };
@@ -196,8 +206,95 @@ describe.runIf(canRun)("gateway-pre-start's OpenClaw generation probe", () => {
     const r = probe({ cli: "exit 1", pkg: null, pin: "2026.8.1\n" });
     expect(r.status, `the pre-start aborted:\n${r.out}`).toBe(0);
     expect(r.out, "it decided a generation it could not know").not.toContain("REACHED_END=1");
-    expect(r.out).toMatch(/cannot tell which OpenClaw generation/);
-    expect(r.out).toMatch(/leaving openclaw.json exactly as it is/);
+    expect(r.stderr).toMatch(/cannot tell which OpenClaw generation/);
+    expect(r.stderr).toMatch(/leaving openclaw.json exactly as it is/);
+    // The skipped pre-start is not only the generation-sensitive rewrites, so
+    // the WARN must name what this boot does NOT re-apply.
+    expect(r.stderr).toMatch(/auth token/i);
+    expect(r.stderr).toMatch(/allowedOrigins/);
+  });
+
+  for (const version of ["0.0.0-dev", "1.2.3", "next", "2026.8"] as const) {
+    it(`refuses to call a core v1 on a version it cannot read as a date (${version})`, () => {
+      // The manifest read accepted ANY non-empty string, while the CLI
+      // fallback right beneath it applied `grep -oE '20[0-9]{4}...'`. So the
+      // two sources validated differently and the stricter one was the one
+      // almost never reached: a dev/nightly build, a fork, an
+      // `npm i -g <git url>` install or a vendor rebuild sailed past the
+      // "write nothing" guard as a non-empty value and selected v1 semantics
+      // on a core that may well be v2 — which then refuses the legacy
+      // messages.tts / imageGenerationModel / allowInsecureAuth names this
+      // script would write, and never reports ready. Exactly the outcome this
+      // change exists to make impossible, through a different door.
+      const r = probe({ cli: "exit 1", pkg: version, pin: "2026.8.1\n" });
+      expect(r.status, `the pre-start aborted:\n${r.out}`).toBe(0);
+      expect(r.out, "it decided a generation it could not know").not.toContain("REACHED_END=1");
+      expect(r.stderr).toMatch(/cannot tell which OpenClaw generation/);
+    });
+  }
+
+  it("still reads a real date version, suffix and all", () => {
+    // The control for the four above: the shape check must not reject the
+    // versions the fleet actually runs.
+    const r = probe({ cli: "exit 1", pkg: "2026.8.1-rc.2" });
+    expect(r.status).toBe(0);
+    expect(r.effective).toBe("2026.8.1");
+    expect(r.v2).toBe("1");
+  });
+
+  for (const [name, pkg] of [
+    ["is not valid JSON", "@@corrupt@@"],
+    ["is empty", ""],
+    ["carries no version at all", "{}"],
+    ["carries a non-string version", '{"version":{"major":2026}}'],
+  ] as const) {
+    it(`falls through to the CLI when the manifest ${name}`, () => {
+      const pkgDir = path.join(root, "lib", "node_modules", "openclaw");
+      mkdirSync(pkgDir, { recursive: true });
+      writeFileSync(path.join(pkgDir, "package.json"), pkg);
+      const r = probe({ cli: 'echo "openclaw 2026.8.1"', pkg: null });
+      expect(r.status, `the pre-start aborted:\n${r.out}`).toBe(0);
+      expect(r.effective).toBe("2026.8.1");
+    });
+  }
+
+  it.skipIf(isRoot)("falls through to the CLI when the manifest cannot be read", () => {
+    const pkgDir = path.join(root, "lib", "node_modules", "openclaw");
+    mkdirSync(pkgDir, { recursive: true });
+    const manifest = path.join(pkgDir, "package.json");
+    writeFileSync(manifest, JSON.stringify({ version: "2026.8.1" }));
+    chmodSync(manifest, 0o000);
+    try {
+      const r = probe({ cli: 'echo "openclaw 2026.7.4"', pkg: null });
+      expect(r.status, `the pre-start aborted:\n${r.out}`).toBe(0);
+      expect(r.effective).toBe("2026.7.4");
+    } finally {
+      chmodSync(manifest, 0o644);
+    }
+  });
+
+  it("lets an explicit generation win over a core it cannot identify", () => {
+    // The comment above this check says an explicit CLAWBOX_OPENCLAW_V2 "wins".
+    // With the write-nothing exit 0 placed above it, a pinned generation became
+    // a silent no-op instead — and every sibling suite pins BOTH generations
+    // of this script that way.
+    const bin = path.join(root, "bin", "openclaw");
+    mkdirSync(path.dirname(bin), { recursive: true });
+    writeFileSync(bin, "#!/usr/bin/env bash\nexit 1\n");
+    chmodSync(bin, 0o755);
+    const r = run(
+      [
+        "CLAWBOX_OPENCLAW_V2=1",
+        `OPENCLAW_BIN=${JSON.stringify(bin)}`,
+        `OPENCLAW_PIN_FILE=${JSON.stringify(path.join(root, "absent.txt"))}`,
+        block('OPENCLAW_TARGET=""', "export CLAWBOX_OPENCLAW_V2"),
+        'echo "V2=${CLAWBOX_OPENCLAW_V2}"',
+        'echo "REACHED_END=1"',
+      ].join("\n"),
+    );
+    expect(r.status, `the pre-start aborted:\n${r.out}`).toBe(0);
+    expect(r.out).toContain("REACHED_END=1");
+    expect(r.out).toContain("V2=1");
   });
 
   it("carries on when the pin file exists but cannot be read", () => {
@@ -233,6 +330,7 @@ describe.runIf(canRun)("gateway-pre-start's mDNS hostname read", () => {
   it("falls back to clawbox when the file cannot be read, instead of aborting", () => {
     // `sed` exits 2 on a file it cannot open, pipefail carries it, and the
     // gateway never starts — the same defect as the version probe.
+    if (isRoot) return; // 0000 is a no-op for root; the case would prove nothing
     const r = hostname({ unreadable: true });
     expect(r.status, `the pre-start aborted:\n${r.out}`).toBe(0);
     expect(r.name).toBe("clawbox");

--- a/src/tests/unit/gateway-pre-start-version-probe.test.ts
+++ b/src/tests/unit/gateway-pre-start-version-probe.test.ts
@@ -450,6 +450,13 @@ describe.runIf(canRun)("gateway-pre-start's MCP token hardening", () => {
      * both fail, and nothing downstream may turn that into a failed unit.
      */
     dataMode?: number;
+    /**
+     * What a stubbed `openssl rand -hex 32` writes. The seeding branch's own
+     * length check runs BEFORE the write, so a write that returns 0 having
+     * emitted only part of the token is the one way a short file survives to
+     * the registration below.
+     */
+    opensslWrites?: string;
   }): {
     status: number | null;
     out: string;
@@ -482,6 +489,14 @@ describe.runIf(canRun)("gateway-pre-start's MCP token hardening", () => {
     if (opts.statSays !== undefined) {
       const stub = path.join(stubBin, "stat");
       writeFileSync(stub, `#!/bin/sh\necho ${opts.statSays}\n`);
+      chmodSync(stub, 0o755);
+    }
+    // A truncated write that reports success: `openssl` exits 0 having emitted
+    // less than the token it was asked for, which is what an ENOSPC part way
+    // through the redirect leaves behind.
+    if (opts.opensslWrites !== undefined) {
+      const stub = path.join(stubBin, "openssl");
+      writeFileSync(stub, `#!/bin/sh\nprintf %s ${JSON.stringify(opts.opensslWrites)}\n`);
       chmodSync(stub, 0o755);
     }
     if (opts.dataMode !== undefined) chmodSync(path.join(clawboxRoot, "data"), opts.dataMode);
@@ -617,6 +632,31 @@ describe.runIf(canRun)("gateway-pre-start's MCP token hardening", () => {
     // openclaw.json keeps whatever it already had rather than being rewritten
     // with a token this boot never read.
     expect(r.exported).toBe("");
+  });
+
+  it("does not register a bearer a truncated write left too short to be one", () => {
+    // The seeding gate re-seeds anything under 32 bytes, so a shorter file can
+    // only be one whose own write did not finish — ENOSPC part way through
+    // `openssl rand -hex 32 > "$1"`, on the boot where the seed failed and
+    // `|| true` swallowed it. That length check ran BEFORE the write, and
+    // nothing between it and the registration looked at the value again: the
+    // block exported a truncated bearer and the reconcile published it to
+    // openclaw.json as if the box had generated it.
+    //
+    // The window that matters is 16–31 characters, because it WORKS:
+    // src/lib/mcp-token.ts's readTokenFile() accepts 16 and up, so the box runs
+    // on a bearer with a fraction of the intended entropy and nothing says so.
+    // (Under 16 the verifier mints its own value instead and every tool call
+    // 307s to /login — broken, but at least loudly.)
+    const r = token({ opensslWrites: "a".repeat(20) });
+    expect(r.status, `the pre-start aborted, so the box gets no gateway:\n${r.out}`).toBe(0);
+    expect(r.out).toContain("REACHED_END=1");
+    expect(r.contents, "the fixture never produced a short token").toBe("a".repeat(20));
+    // Refused, and said as what it costs — the same shape as the empty case.
+    expect(r.exported).toBe("");
+    expect(r.out).toMatch(/WARN: MCP token file holds only 20 characters/);
+    expect(r.out).toMatch(/MCP tools are unavailable this boot/);
+    expect(r.out).not.toMatch(/ERROR/);
   });
 
   it("seeds a missing token at 0600 without a chmod to do it", () => {

--- a/src/tests/unit/gateway-pre-start-version-probe.test.ts
+++ b/src/tests/unit/gateway-pre-start-version-probe.test.ts
@@ -292,6 +292,25 @@ describe.runIf(canRun)("gateway-pre-start's OpenClaw generation probe", () => {
     });
   }
 
+  it("takes a date out of the CLI banner even when the manifest was rejected", () => {
+    // The two sources are graded DIFFERENTLY on purpose, and the difference is
+    // only visible when both arms run — every case above pairs a rejected
+    // manifest with a CLI that cannot answer, so none of them sees it. The
+    // manifest holds a version FIELD, so the whole string must be the version
+    // (`^20…`). The CLI prints a BANNER, where the version is one token among
+    // words this script does not control, so that arm can only EXTRACT — which
+    // means a banner mentioning any other date-shaped number is taken at face
+    // value. Pinned rather than tightened: an anchor that is wrong by one space
+    // turns every healthy fallback into "cannot identify the core" and skips
+    // the whole pre-start fleet-wide, and the real banner of a shipped core has
+    // not been measured. If this assertion ever has to change, that measurement
+    // is the thing to take first.
+    const r = probe({ cli: 'echo "openclaw 0.0.0-dev (built from 2026.8.1)"', pkg: "0.0.0-dev" });
+    expect(r.status, `the pre-start aborted:\n${r.out}`).toBe(0);
+    expect(r.effective).toBe("2026.8.1");
+    expect(r.v2).toBe("1");
+  });
+
   it("still reads a real date version, suffix and all", () => {
     // The control for the four above: the shape check must not reject the
     // versions the fleet actually runs.
@@ -546,6 +565,19 @@ describe.runIf(canRun)("gateway-pre-start's MCP token hardening", () => {
     // own copy — so the WARN has to name the unit that must pick the new
     // bearer up. See src/lib/mcp-token.ts.
     expect(r.out).toMatch(/clawbox-setup/);
+  });
+
+  it.skipIf(isRoot)("leaves a readable token no other user can read exactly as it is", () => {
+    // 0400 and 0000-that-this-uid-owns are exposed to NOBODY. Grading the mode
+    // on the literal "600" rotated both of them, and rotating a credential that
+    // was never exposed is pure cost: it invalidates the bearer the web server
+    // is holding for no benefit at all. The `& 077` grading is what makes this
+    // case a no-op, and nothing else in this block pins it.
+    const r = token({ contents: EXISTING, mode: 0o400, chmodFails: true });
+    expect(r.status, `the pre-start aborted:\n${r.out}`).toBe(0);
+    expect(r.contents, "a token no other user can read was rotated anyway").toBe(EXISTING);
+    expect(r.exported).toBe(EXISTING);
+    expect(r.out).not.toMatch(/WARN/);
   });
 
   it("seeds a missing token at 0600 without a chmod to do it", () => {

--- a/src/tests/unit/gateway-pre-start-version-probe.test.ts
+++ b/src/tests/unit/gateway-pre-start-version-probe.test.ts
@@ -444,6 +444,12 @@ describe.runIf(canRun)("gateway-pre-start's MCP token hardening", () => {
     chmodFails?: boolean;
     /** What a stubbed `stat -c %a` reports, for a mode this uid cannot produce. */
     statSays?: string;
+    /**
+     * Permission bits to leave on `data/` itself. 0500 is the state where the
+     * block can neither seed a token nor replace one: `mktemp` and the redirect
+     * both fail, and nothing downstream may turn that into a failed unit.
+     */
+    dataMode?: number;
   }): {
     status: number | null;
     out: string;
@@ -478,6 +484,7 @@ describe.runIf(canRun)("gateway-pre-start's MCP token hardening", () => {
       writeFileSync(stub, `#!/bin/sh\necho ${opts.statSays}\n`);
       chmodSync(stub, 0o755);
     }
+    if (opts.dataMode !== undefined) chmodSync(path.join(clawboxRoot, "data"), opts.dataMode);
     const r = run(
       [
         `CLAWBOX_ROOT=${JSON.stringify(clawboxRoot)}`,
@@ -487,6 +494,9 @@ describe.runIf(canRun)("gateway-pre-start's MCP token hardening", () => {
         'echo "REACHED_END=1"',
       ].join("\n"),
     );
+    // Put the directory back before anything reads through it, including the
+    // afterEach cleanup.
+    if (opts.dataMode !== undefined) chmodSync(path.join(clawboxRoot, "data"), 0o755);
     const mode = existsSync(file) ? statSync(file).mode & 0o777 : null;
     // A case that leaves the token unreadable to this uid must still be
     // reportable: the mode is already captured, so open it up for the
@@ -583,6 +593,30 @@ describe.runIf(canRun)("gateway-pre-start's MCP token hardening", () => {
     expect(r.contents, "a token no other user can read was rotated anyway").toBe(EXISTING);
     expect(r.exported).toBe(EXISTING);
     expect(r.out).not.toMatch(/WARN/);
+  });
+
+  it.skipIf(isRoot)("boots without a bearer it can neither seed nor replace, instead of failing the unit", () => {
+    // The last unguarded step in the block, and it made every guard above it
+    // decorative: when the seeding AND the replacement both fail — `data/` not
+    // writable — control fell out of the "left exactly as it stands" WARN
+    // straight into `ERROR: MCP token file is not readable → exit 1`.
+    // `ExecStartPre=` carries no `-` prefix, so that fails the unit and
+    // Restart=always spends StartLimitBurst: no gateway and no chat, on every
+    // boot. Not privileged, either — `data/` is clawbox-owned at 0755, so any
+    // process running as clawbox reaches it with `rm .mcp-token; chmod 500 .`.
+    // A missing bearer costs this boot its MCP tools, exactly like the failed
+    // registration write below it, which has always been a WARN. TASK-657.
+    const r = token({ dataMode: 0o500 });
+    expect(r.status, `the pre-start aborted, so the box gets no gateway:\n${r.out}`).toBe(0);
+    expect(r.out).toContain("REACHED_END=1");
+    // Said, and said as what it costs — not as an error, and not silently.
+    expect(r.out).toMatch(/WARN: MCP token file is not readable/);
+    expect(r.out).toMatch(/MCP tools are unavailable this boot/);
+    expect(r.out).not.toMatch(/ERROR/);
+    // Empty, deliberately: the reconcile's python sys.exit(0)s on it, so
+    // openclaw.json keeps whatever it already had rather than being rewritten
+    // with a token this boot never read.
+    expect(r.exported).toBe("");
   });
 
   it("seeds a missing token at 0600 without a chmod to do it", () => {

--- a/src/tests/unit/gateway-pre-start-version-probe.test.ts
+++ b/src/tests/unit/gateway-pre-start-version-probe.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, chmodSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/**
+ * `scripts/gateway-pre-start.sh` runs under `set -euo pipefail` as the
+ * gateway unit's `ExecStartPre`. Its generation probe is
+ *
+ *     CLAWBOX_OPENCLAW_EFFECTIVE="$("$OPENCLAW_BIN" --version 2>/dev/null \
+ *       | grep -oE '20[0-9]{2}\.[0-9]+\.[0-9]+' | head -1)"
+ *
+ * and the comment beneath it assumes an empty result when the CLI cannot
+ * answer ("The pin only fills in when the binary cannot be asked"). It does not
+ * get one. `grep -oE` exits 1 when it matches nothing, `pipefail` carries that
+ * to the pipeline, and an assignment whose command substitution failed aborts
+ * the script under `set -e`. A box whose `openclaw` binary exists but cannot
+ * print its version — a crash, a node engine mismatch, a hang the CLI answers
+ * with a non-zero status, a banner the regex does not match — therefore gets
+ * NO gateway and no chat at all, with the only trace in the unit's
+ * ExecStartPre failure (TASK-657). A missing binary is already handled: the
+ * script exits 0 a few lines above.
+ *
+ * These tests EXECUTE the shipped blocks under `set -euo pipefail` against
+ * stubs. The rule they pin is the one the boot path needs: every probe here
+ * warns and carries on with its stated fallback, and none of them can take the
+ * gateway down.
+ */
+
+const REPO = process.cwd();
+const PRE_START = readFileSync(path.join(REPO, "scripts", "gateway-pre-start.sh"), "utf-8");
+
+const canRun =
+  process.platform !== "win32" && spawnSync("bash", ["-c", "true"], { stdio: "ignore" }).status === 0;
+
+let root: string;
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), "clawbox-version-probe-"));
+});
+afterEach(() => {
+  // The unreadable-file cases leave a 0000 file behind.
+  try {
+    chmodSync(path.join(root, "pin.txt"), 0o644);
+  } catch { /* not every case writes one */ }
+  try {
+    chmodSync(path.join(root, "hostname.env"), 0o644);
+  } catch { /* not every case writes one */ }
+  rmSync(root, { recursive: true, force: true });
+});
+
+/** Slice a region of the shipped script by its first and last line. */
+function block(fromLine: string, toLine: string): string {
+  const start = PRE_START.indexOf(fromLine);
+  if (start < 0) throw new Error(`slice start not found: ${fromLine}`);
+  const end = PRE_START.indexOf(toLine, start);
+  if (end < 0) throw new Error(`slice end not found: ${toLine}`);
+  return PRE_START.slice(start, end + toLine.length);
+}
+
+function run(program: string): { status: number | null; out: string } {
+  const file = path.join(root, "block.sh");
+  writeFileSync(file, `#!/usr/bin/env bash\nset -euo pipefail\n${program}\n`);
+  chmodSync(file, 0o755);
+  const r = spawnSync("bash", [file], { encoding: "utf-8", timeout: 30_000 });
+  return { status: r.status, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+
+interface Probe {
+  status: number | null;
+  out: string;
+  /** The version the block settled on, or null when it never got that far. */
+  effective: string | null;
+  /** The generation it exported, or null when it never got that far. */
+  v2: string | null;
+}
+
+/**
+ * Run the pin + generation probe with a scripted `openclaw` stub.
+ *
+ * `cli` is the stub's body. `pin` is the contents of the pin file, or null for
+ * no pin file at all; `pinUnreadable` makes the file exist but deny reads.
+ */
+function probe(opts: { cli: string; pin?: string | null; pinUnreadable?: boolean }): Probe {
+  const bin = path.join(root, "openclaw");
+  writeFileSync(bin, `#!/usr/bin/env bash\n${opts.cli}\n`);
+  chmodSync(bin, 0o755);
+  const pinFile = path.join(root, "pin.txt");
+  if (opts.pin !== null) {
+    writeFileSync(pinFile, opts.pin ?? "2026.8.1\n");
+    if (opts.pinUnreadable) chmodSync(pinFile, 0o000);
+  }
+
+  const r = run(
+    [
+      `OPENCLAW_BIN=${JSON.stringify(bin)}`,
+      `OPENCLAW_PIN_FILE=${JSON.stringify(pinFile)}`,
+      block('OPENCLAW_TARGET=""', "export CLAWBOX_OPENCLAW_V2"),
+      'echo "EFFECTIVE=${CLAWBOX_OPENCLAW_EFFECTIVE}"',
+      'echo "V2=${CLAWBOX_OPENCLAW_V2}"',
+    ].join("\n"),
+  );
+  return {
+    status: r.status,
+    out: r.out,
+    effective: /EFFECTIVE=(.*)/.exec(r.out)?.[1] ?? null,
+    v2: /V2=(.*)/.exec(r.out)?.[1] ?? null,
+  };
+}
+
+describe.runIf(canRun)("gateway-pre-start's OpenClaw generation probe", () => {
+  it("reads the version the installed binary prints", () => {
+    const r = probe({ cli: 'echo "openclaw 2026.8.1"' });
+    expect(r.status).toBe(0);
+    expect(r.effective).toBe("2026.8.1");
+    expect(r.v2).toBe("1");
+  });
+
+  it("still calls a v1 binary v1, whatever the pin says", () => {
+    // The comment's whole point: the INSTALLED binary is the authority, because
+    // it is the process that parses what this script writes.
+    const r = probe({ cli: 'echo "openclaw 2026.7.4"', pin: "2026.8.1\n" });
+    expect(r.status).toBe(0);
+    expect(r.effective).toBe("2026.7.4");
+    expect(r.v2).toBe("0");
+  });
+
+  for (const [name, cli] of [
+    ["exits non-zero saying nothing", "exit 1"],
+    ["crashes with a stack trace on stderr", 'echo "Error: bad engine" >&2; exit 7'],
+    ["prints a banner the regex does not match", 'echo "openclaw (development build)"'],
+    ["prints nothing at all and succeeds", "exit 0"],
+  ] as const) {
+    it(`falls back to the pin when the CLI ${name}, instead of taking the gateway down`, () => {
+      // Today: the pipeline fails, `set -e` aborts the whole pre-start, and the
+      // unit never starts the gateway.
+      const r = probe({ cli, pin: "2026.8.1\n" });
+      expect(r.status, `the pre-start aborted:\n${r.out}`).toBe(0);
+      expect(r.effective).toBe("2026.8.1");
+      expect(r.v2).toBe("1");
+      // Silence is what made this invisible for a release: the box booted with
+      // no gateway and nothing said why.
+      expect(r.out).toMatch(/WARN/);
+    });
+  }
+
+  it("carries on with no version at all when there is no pin either", () => {
+    // Nothing can be inferred here, and the legacy names are the safe default —
+    // but the gateway must still start.
+    const r = probe({ cli: "exit 1", pin: null });
+    expect(r.status).toBe(0);
+    expect(r.effective).toBe("");
+    expect(r.v2).toBe("0");
+  });
+
+  it("carries on when the pin file exists but cannot be read", () => {
+    // Same class, same script, one screen up: `head` on an unreadable file
+    // exits non-zero and pipefail carries it into the assignment.
+    const r = probe({ cli: 'echo "openclaw 2026.8.1"', pin: "2026.8.1\n", pinUnreadable: true });
+    expect(r.status, `the pre-start aborted:\n${r.out}`).toBe(0);
+    expect(r.effective).toBe("2026.8.1");
+  });
+});
+
+describe.runIf(canRun)("gateway-pre-start's mDNS hostname read", () => {
+  function hostname(opts: { contents?: string; unreadable?: boolean }): { status: number | null; name: string | null; out: string } {
+    const env = path.join(root, "hostname.env");
+    writeFileSync(env, opts.contents ?? "HOSTNAME=someboxname\n");
+    if (opts.unreadable) chmodSync(env, 0o000);
+    const r = run(
+      [
+        `HOSTNAME_ENV=${JSON.stringify(env)}`,
+        block('CONFIGURED_HOSTNAME="clawbox"', "\nfi"),
+        'echo "NAME=${CONFIGURED_HOSTNAME}"',
+      ].join("\n"),
+    );
+    return { status: r.status, name: /NAME=(.*)/.exec(r.out)?.[1] ?? null, out: r.out };
+  }
+
+  it("reads the configured hostname", () => {
+    const r = hostname({});
+    expect(r.status).toBe(0);
+    expect(r.name).toBe("someboxname");
+  });
+
+  it("falls back to clawbox when the file cannot be read, instead of aborting", () => {
+    // `sed` exits 2 on a file it cannot open, pipefail carries it, and the
+    // gateway never starts — the same defect as the version probe.
+    const r = hostname({ unreadable: true });
+    expect(r.status, `the pre-start aborted:\n${r.out}`).toBe(0);
+    expect(r.name).toBe("clawbox");
+  });
+});

--- a/src/tests/unit/gateway-pre-start-version-probe.test.ts
+++ b/src/tests/unit/gateway-pre-start-version-probe.test.ts
@@ -6,25 +6,40 @@ import path from "node:path";
 
 /**
  * `scripts/gateway-pre-start.sh` runs under `set -euo pipefail` as the
- * gateway unit's `ExecStartPre`. Its generation probe is
+ * gateway unit's `ExecStartPre`. Its generation probe was
  *
  *     CLAWBOX_OPENCLAW_EFFECTIVE="$("$OPENCLAW_BIN" --version 2>/dev/null \
  *       | grep -oE '20[0-9]{2}\.[0-9]+\.[0-9]+' | head -1)"
  *
- * and the comment beneath it assumes an empty result when the CLI cannot
- * answer ("The pin only fills in when the binary cannot be asked"). It does not
- * get one. `grep -oE` exits 1 when it matches nothing, `pipefail` carries that
- * to the pipeline, and an assignment whose command substitution failed aborts
- * the script under `set -e`. A box whose `openclaw` binary exists but cannot
- * print its version — a crash, a node engine mismatch, a hang the CLI answers
- * with a non-zero status, a banner the regex does not match — therefore gets
- * NO gateway and no chat at all, with the only trace in the unit's
- * ExecStartPre failure (TASK-657). A missing binary is already handled: the
- * script exits 0 a few lines above.
+ * and the comment beneath it assumed an empty result when the CLI cannot
+ * answer. It did not get one. `grep -oE` exits 1 when it matches nothing,
+ * `pipefail` carries that to the pipeline, and an assignment whose command
+ * substitution failed aborts the script under `set -e`. A box whose `openclaw`
+ * binary exists but cannot print its version — a crash, a node engine
+ * mismatch, a banner the regex does not match — therefore got NO gateway and
+ * no chat at all, with the only trace in the unit's ExecStartPre failure
+ * (TASK-657). A missing binary is already handled: the script exits 0 a few
+ * lines above.
+ *
+ * The generation now comes from the installed core's own `package.json` — the
+ * file the binary IS — with a time-boxed `--version` behind it. That is the
+ * source `scripts/ensure-local-embeddings.sh` and `src/lib/memory-shard.ts`
+ * already use, in both cases with a written "never `openclaw --version`, it
+ * costs ~10 s on a Jetson" rationale; measured on a shipped Orin, the CLI takes
+ * 7.9 s and the manifest 53 ms, inside a BLOCKING ExecStartPre.
+ *
+ * And when the core cannot be identified at all, the script writes NOTHING and
+ * boots on the config already on disk. The pin is deliberately not a fallback:
+ * a partially failed update is exactly the state where the core cannot answer
+ * AND the pin is ahead of it, so a pin fallback would fire precisely when it is
+ * wrong — writing v2 keys a v1 gateway refuses and permanently deleting
+ * `commands.ownerDisplay`, `gateway.tailscale.resetOnExit` and
+ * `agents.defaults.compaction.reserveTokensFloor`, which nothing on the boot
+ * path re-adds.
  *
  * These tests EXECUTE the shipped blocks under `set -euo pipefail` against
- * stubs. The rule they pin is the one the boot path needs: every probe here
- * warns and carries on with its stated fallback, and none of them can take the
+ * stubs. The rule they pin is the one the boot path needs: every read here
+ * either resolves, or says so and carries on, and none of them can take the
  * gateway down.
  */
 
@@ -81,10 +96,24 @@ interface Probe {
  * `cli` is the stub's body. `pin` is the contents of the pin file, or null for
  * no pin file at all; `pinUnreadable` makes the file exist but deny reads.
  */
-function probe(opts: { cli: string; pin?: string | null; pinUnreadable?: boolean }): Probe {
-  const bin = path.join(root, "openclaw");
+function probe(opts: {
+  cli: string;
+  pin?: string | null;
+  pinUnreadable?: boolean;
+  /** The version in the installed core's package.json, or null for no manifest. */
+  pkg?: string | null;
+}): Probe {
+  // The binary and its manifest, laid out the way npm does it: <prefix>/bin/openclaw
+  // beside <prefix>/lib/node_modules/openclaw/package.json.
+  const bin = path.join(root, "bin", "openclaw");
+  mkdirSync(path.dirname(bin), { recursive: true });
   writeFileSync(bin, `#!/usr/bin/env bash\n${opts.cli}\n`);
   chmodSync(bin, 0o755);
+  if (opts.pkg !== null && opts.pkg !== undefined) {
+    const pkgDir = path.join(root, "lib", "node_modules", "openclaw");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(path.join(pkgDir, "package.json"), JSON.stringify({ version: opts.pkg }));
+  }
   const pinFile = path.join(root, "pin.txt");
   if (opts.pin !== null) {
     writeFileSync(pinFile, opts.pin ?? "2026.8.1\n");
@@ -98,6 +127,7 @@ function probe(opts: { cli: string; pin?: string | null; pinUnreadable?: boolean
       block('OPENCLAW_TARGET=""', "export CLAWBOX_OPENCLAW_V2"),
       'echo "EFFECTIVE=${CLAWBOX_OPENCLAW_EFFECTIVE}"',
       'echo "V2=${CLAWBOX_OPENCLAW_V2}"',
+      'echo "REACHED_END=1"',
     ].join("\n"),
   );
   return {
@@ -109,17 +139,32 @@ function probe(opts: { cli: string; pin?: string | null; pinUnreadable?: boolean
 }
 
 describe.runIf(canRun)("gateway-pre-start's OpenClaw generation probe", () => {
-  it("reads the version the installed binary prints", () => {
-    const r = probe({ cli: 'echo "openclaw 2026.8.1"' });
+  it("reads the installed core's own manifest, without running it", () => {
+    // ~10 s on a Jetson vs 53 ms for the manifest, in a BLOCKING ExecStartPre.
+    const r = probe({ cli: 'echo "openclaw 2026.9.9"; echo RAN >&2', pkg: "2026.8.1" });
+    expect(r.status).toBe(0);
+    expect(r.effective).toBe("2026.8.1");
+    expect(r.v2).toBe("1");
+    expect(r.out, "the CLI was run even though the manifest answered").not.toContain("RAN");
+  });
+
+  it("asks the binary when there is no manifest to read", () => {
+    const r = probe({ cli: 'echo "openclaw 2026.8.1"', pkg: null });
     expect(r.status).toBe(0);
     expect(r.effective).toBe("2026.8.1");
     expect(r.v2).toBe("1");
   });
 
-  it("still calls a v1 binary v1, whatever the pin says", () => {
-    // The comment's whole point: the INSTALLED binary is the authority, because
-    // it is the process that parses what this script writes.
-    const r = probe({ cli: 'echo "openclaw 2026.7.4"', pin: "2026.8.1\n" });
+  it("time-boxes that call, so a wedged CLI cannot hold the boot", () => {
+    expect(block('OPENCLAW_TARGET=""', "export CLAWBOX_OPENCLAW_V2")).toMatch(
+      /timeout \d+ "\$OPENCLAW_BIN" --version/,
+    );
+  });
+
+  it("still calls a v1 core v1, whatever the pin says", () => {
+    // The INSTALLED core is the authority, because it is the process that
+    // parses what this script writes.
+    const r = probe({ cli: "exit 1", pkg: "2026.7.4", pin: "2026.8.1\n" });
     expect(r.status).toBe(0);
     expect(r.effective).toBe("2026.7.4");
     expect(r.v2).toBe("0");
@@ -131,32 +176,34 @@ describe.runIf(canRun)("gateway-pre-start's OpenClaw generation probe", () => {
     ["prints a banner the regex does not match", 'echo "openclaw (development build)"'],
     ["prints nothing at all and succeeds", "exit 0"],
   ] as const) {
-    it(`falls back to the pin when the CLI ${name}, instead of taking the gateway down`, () => {
-      // Today: the pipeline fails, `set -e` aborts the whole pre-start, and the
-      // unit never starts the gateway.
-      const r = probe({ cli, pin: "2026.8.1\n" });
+    it(`reads the manifest when the CLI ${name}, instead of taking the gateway down`, () => {
+      // Before TASK-657: the pipeline failed, `set -e` aborted the whole
+      // pre-start, and the unit never started the gateway.
+      const r = probe({ cli, pkg: "2026.8.1", pin: "2026.7.0\n" });
       expect(r.status, `the pre-start aborted:\n${r.out}`).toBe(0);
       expect(r.effective).toBe("2026.8.1");
       expect(r.v2).toBe("1");
-      // Silence is what made this invisible for a release: the box booted with
-      // no gateway and nothing said why.
-      expect(r.out).toMatch(/WARN/);
+      expect(r.out).toContain("REACHED_END=1");
     });
   }
 
-  it("carries on with no version at all when there is no pin either", () => {
-    // Nothing can be inferred here, and the legacy names are the safe default —
-    // but the gateway must still start.
-    const r = probe({ cli: "exit 1", pin: null });
-    expect(r.status).toBe(0);
-    expect(r.effective).toBe("");
-    expect(r.v2).toBe("0");
+  it("writes NOTHING when the installed core cannot be identified at all", () => {
+    // The pin is deliberately not a fallback: a partially failed update is
+    // exactly the state where the core cannot answer AND the pin is ahead of
+    // it, so guessing from it would write v2 keys a v1 gateway refuses and
+    // permanently delete keys nothing on the boot path re-adds. Boot on the
+    // config that already worked.
+    const r = probe({ cli: "exit 1", pkg: null, pin: "2026.8.1\n" });
+    expect(r.status, `the pre-start aborted:\n${r.out}`).toBe(0);
+    expect(r.out, "it decided a generation it could not know").not.toContain("REACHED_END=1");
+    expect(r.out).toMatch(/cannot tell which OpenClaw generation/);
+    expect(r.out).toMatch(/leaving openclaw.json exactly as it is/);
   });
 
   it("carries on when the pin file exists but cannot be read", () => {
     // Same class, same script, one screen up: `head` on an unreadable file
     // exits non-zero and pipefail carries it into the assignment.
-    const r = probe({ cli: 'echo "openclaw 2026.8.1"', pin: "2026.8.1\n", pinUnreadable: true });
+    const r = probe({ cli: "exit 1", pkg: "2026.8.1", pin: "2026.8.1\n", pinUnreadable: true });
     expect(r.status, `the pre-start aborted:\n${r.out}`).toBe(0);
     expect(r.effective).toBe("2026.8.1");
   });
@@ -170,7 +217,7 @@ describe.runIf(canRun)("gateway-pre-start's mDNS hostname read", () => {
     const r = run(
       [
         `HOSTNAME_ENV=${JSON.stringify(env)}`,
-        block('CONFIGURED_HOSTNAME="clawbox"', "\nfi"),
+        block('CONFIGURED_HOSTNAME="clawbox"', "\n# Build the dynamic part of the allowedOrigins list"),
         'echo "NAME=${CONFIGURED_HOSTNAME}"',
       ].join("\n"),
     );
@@ -189,5 +236,9 @@ describe.runIf(canRun)("gateway-pre-start's mDNS hostname read", () => {
     const r = hostname({ unreadable: true });
     expect(r.status, `the pre-start aborted:\n${r.out}`).toBe(0);
     expect(r.name).toBe("clawbox");
+    // Not silent: this name rebuilds gateway.controlUi.allowedOrigins, so a
+    // fallback drops the configured origin and the Control UI stops being
+    // reachable by the name the owner uses.
+    expect(r.out).toMatch(/WARN/);
   });
 });

--- a/src/tests/unit/gateway-pre-start-version-probe.test.ts
+++ b/src/tests/unit/gateway-pre-start-version-probe.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, chmodSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  chmodSync,
+  existsSync,
+  statSync,
+} from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -77,7 +86,15 @@ function run(program: string): { status: number | null; out: string; stderr: str
   const file = path.join(root, "block.sh");
   writeFileSync(file, `#!/usr/bin/env bash\nset -euo pipefail\n${program}\n`);
   chmodSync(file, 0o755);
-  const r = spawnSync("bash", [file], { encoding: "utf-8", timeout: 30_000 });
+  // `spawnSync` inherits process.env, and an explicit CLAWBOX_OPENCLAW_V2 WINS
+  // over everything the probe derives — by design, and the shipped script says
+  // so. A runner (or a shell on a box) that exports it would make every derived
+  // generation here read back as the override instead, so the tests that pin
+  // v1 and the ones that pin "wrote nothing" would pass on any script at all.
+  // Deleted rather than emptied: "unset" is the state a device is in.
+  const env = { ...process.env };
+  delete env.CLAWBOX_OPENCLAW_V2;
+  const r = spawnSync("bash", [file], { encoding: "utf-8", timeout: 30_000, env });
   return { status: r.status, out: `${r.stdout ?? ""}${r.stderr ?? ""}`, stderr: r.stderr ?? "" };
 }
 
@@ -165,10 +182,23 @@ describe.runIf(canRun)("gateway-pre-start's OpenClaw generation probe", () => {
     expect(r.v2).toBe("1");
   });
 
-  it("time-boxes that call, so a wedged CLI cannot hold the boot", () => {
-    expect(block('OPENCLAW_TARGET=""', "export CLAWBOX_OPENCLAW_V2")).toMatch(
-      /timeout \d+ "\$OPENCLAW_BIN" --version/,
-    );
+  it("time-boxes that call with a value the boot can actually afford", () => {
+    const m = /timeout (\d+) "\$OPENCLAW_BIN" --version/.exec(block('OPENCLAW_TARGET=""', "export CLAWBOX_OPENCLAW_V2"));
+    expect(m, "the version probe is no longer time-boxed at all").not.toBeNull();
+    const seconds = Number(m![1]);
+    // 45, matching the other bounded `openclaw` CLI call this script makes.
+    // `\d+` alone accepted `timeout 1` — which cuts off the healthy 7.9-8.0 s
+    // this call measures on a shipped Orin, making the fallback useless exactly
+    // when it is needed — and `timeout 600`, which would spend the unit's whole
+    // start budget inside one optional probe.
+    expect(seconds).toBe(45);
+    // And it has to stay inside the unit's own ceiling, read from the shipped
+    // unit rather than repeated here: ExecStartPre running out of time is a
+    // gateway that never starts, so a lowered TimeoutStartSec has to fail here.
+    const unit = readFileSync(path.join(REPO, "config", "clawbox-gateway.service"), "utf-8");
+    const budget = Number(/^TimeoutStartSec=(\d+)$/m.exec(unit)?.[1]);
+    expect(budget, "clawbox-gateway.service no longer states TimeoutStartSec in seconds").toBeGreaterThan(0);
+    expect(seconds).toBeLessThan(budget);
   });
 
   it("still calls a v1 core v1, whatever the pin says", () => {
@@ -338,5 +368,110 @@ describe.runIf(canRun)("gateway-pre-start's mDNS hostname read", () => {
     // fallback drops the configured origin and the Control UI stops being
     // reachable by the name the owner uses.
     expect(r.out).toMatch(/WARN/);
+  });
+});
+
+// The MCP token is the SOLE credential for `/setup-api/*`: `mcp/lib/api.ts`
+// sends it as a bearer and `src/middleware.ts` accepts it. Its `chmod 600` used
+// to run unguarded under `set -euo pipefail`, so a token file another uid owns
+// — a root update step, a manual repair — returned EPERM and cost the box its
+// gateway on EVERY boot from then on (TASK-657). Guarding it turned that into a
+// warning, which is the opposite failure: the unit runs as User=clawbox
+// (config/clawbox-gateway.service), root's umask gives `openssl rand > file`
+// mode 0644, and the block below then read that file and exported it.
+//
+// So the outcome that matters is the MODE, not the chmod's exit code.
+describe.runIf(canRun)("gateway-pre-start's MCP token hardening", () => {
+  /** 64 hex chars: long enough that the seeding branch above leaves it alone. */
+  const EXISTING = "a".repeat(64);
+
+  function token(opts: { contents?: string; mode?: number; chmodFails?: boolean }): {
+    status: number | null;
+    out: string;
+    /** The file's permission bits after the block ran, or null if it is gone. */
+    mode: number | null;
+    /** Its contents after the block ran. */
+    contents: string | null;
+    /** What the block exported, which is what reaches the MCP subprocess. */
+    exported: string | null;
+  } {
+    const clawboxRoot = path.join(root, "clawbox");
+    mkdirSync(path.join(clawboxRoot, "data"), { recursive: true });
+    const file = path.join(clawboxRoot, "data", ".mcp-token");
+    if (opts.contents !== undefined) {
+      writeFileSync(file, opts.contents);
+      chmodSync(file, opts.mode ?? 0o600);
+    }
+    // A `chmod` that fails is the only way to reproduce EPERM without being two
+    // different users; everything else on PATH stays real, because the recovery
+    // has to work with the chmod that just failed.
+    const stubBin = path.join(root, "stub-bin");
+    mkdirSync(stubBin, { recursive: true });
+    if (opts.chmodFails) {
+      const stub = path.join(stubBin, "chmod");
+      writeFileSync(stub, "#!/bin/sh\necho \"chmod: changing permissions: Operation not permitted\" >&2\nexit 1\n");
+      chmodSync(stub, 0o755);
+    }
+    const r = run(
+      [
+        `CLAWBOX_ROOT=${JSON.stringify(clawboxRoot)}`,
+        `PATH=${JSON.stringify(stubBin)}:$PATH`,
+        block('MCP_TOKEN_FILE="$CLAWBOX_ROOT/data/.mcp-token"', "export CLAWBOX_MCP_TOKEN_VAL"),
+        'echo "EXPORTED=${CLAWBOX_MCP_TOKEN_VAL}"',
+        'echo "REACHED_END=1"',
+      ].join("\n"),
+    );
+    return {
+      status: r.status,
+      out: r.out,
+      mode: existsSync(file) ? statSync(file).mode & 0o777 : null,
+      contents: existsSync(file) ? readFileSync(file, "utf-8") : null,
+      exported: /EXPORTED=(.*)/.exec(r.out)?.[1] ?? null,
+    };
+  }
+
+  it("hardens an existing token and leaves it exactly as it was", () => {
+    const r = token({ contents: EXISTING, mode: 0o644 });
+    expect(r.status).toBe(0);
+    expect(r.mode).toBe(0o600);
+    // The control for the rotation below: a chmod that WORKS must not rotate.
+    expect(r.contents).toBe(EXISTING);
+    expect(r.exported).toBe(EXISTING);
+  });
+
+  it.skipIf(isRoot)("never exports a token other local users can read", () => {
+    // The file root created at 0644 and clawbox cannot chmod. Warning and
+    // carrying on hands the only /setup-api/* credential to every local user.
+    const r = token({ contents: EXISTING, mode: 0o644, chmodFails: true });
+    expect(r.status, `the pre-start aborted:\n${r.out}`).toBe(0);
+    expect(r.mode, "the token was left readable by group/other").not.toBeNull();
+    expect(r.mode! & 0o077, `token left at mode ${r.mode!.toString(8)}`).toBe(0);
+    // Not silently: the operator has a root-owned file to clean up.
+    expect(r.out).toMatch(/WARN/);
+    // And the box still has a working MCP token — the alternative to exposure
+    // is not a gateway that never starts.
+    expect(r.exported).toHaveLength(64);
+    // What the file holds is what reaches the MCP subprocess (`openssl rand`
+    // leaves a trailing newline; `$(cat …)` strips it).
+    expect(r.exported).toBe(r.contents!.trim());
+    expect(r.exported).not.toBe(EXISTING);
+    expect(r.out).toContain("REACHED_END=1");
+  });
+
+  it.skipIf(isRoot)("does not rotate, or warn, over a file that is already 0600", () => {
+    // chmod on a root-owned file fails whatever its mode is. The old warning
+    // fired here too, over a box with nothing wrong with it.
+    const r = token({ contents: EXISTING, mode: 0o600, chmodFails: true });
+    expect(r.status).toBe(0);
+    expect(r.mode).toBe(0o600);
+    expect(r.contents).toBe(EXISTING);
+    expect(r.out).not.toMatch(/WARN/);
+  });
+
+  it("seeds a missing token at 0600 without a chmod to do it", () => {
+    const r = token({ chmodFails: true });
+    expect(r.status, `the pre-start aborted:\n${r.out}`).toBe(0);
+    expect(r.mode! & 0o077).toBe(0);
+    expect(r.exported).toHaveLength(64);
   });
 });

--- a/src/tests/unit/install-x64.test.ts
+++ b/src/tests/unit/install-x64.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -13,6 +13,19 @@ function v2SeedProgram(): string {
   const end = SOURCE.indexOf("\nPY", start);
   if (start < 0 || end < 0) throw new Error("OpenClaw 2 seed block not found");
   return SOURCE.slice(start, end);
+}
+
+/**
+ * `step_openclaw_install`'s pin read, from its `local PIN_FILE=` line down to
+ * the fallback that defines the empty case. Sliced rather than retyped so the
+ * test cannot drift from the shipped line.
+ */
+function pinReadBlock(): string {
+  const start = SOURCE.indexOf('  local PIN_FILE="$PROJECT_DIR/config/openclaw-target.txt"');
+  const marker = 'TARGET="${TARGET:-$OPENCLAW_VERSION}"';
+  const end = SOURCE.indexOf(marker, start);
+  if (start < 0 || end < 0) throw new Error("OpenClaw pin read not found");
+  return SOURCE.slice(start, end + marker.length);
 }
 
 function openclawPatchFunction(): string {
@@ -78,6 +91,81 @@ describe("install-x64.sh safety contracts", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe("install-x64.sh pinned-target read", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "clawbox-x64-pin-"));
+  });
+  afterEach(() => {
+    try {
+      chmodSync(path.join(root, "config", "openclaw-target.txt"), 0o644);
+    } catch {
+      /* not every case writes one */
+    }
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  /** Run the shipped slice under the installer's own `set -euo pipefail`. */
+  function readPin(): { status: number | null; out: string } {
+    const file = path.join(root, "pin-block.sh");
+    writeFileSync(
+      file,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "step_openclaw_install() {",
+        pinReadBlock(),
+        '  echo "TARGET=$TARGET"',
+        "}",
+        "step_openclaw_install",
+        'echo "REACHED_END=1"',
+      ].join("\n"),
+    );
+    const r = spawnSync("bash", [file], {
+      encoding: "utf-8",
+      timeout: 30_000,
+      env: {
+        ...process.env,
+        PROJECT_DIR: root,
+        OPENCLAW_VERSION: "2026.8.1",
+        OPENCLAW_PIN_VERSION: "",
+      },
+    });
+    return { status: r.status, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+  }
+
+  const isRoot = typeof process.getuid === "function" && process.getuid() === 0;
+
+  it("reads the pin when it can", () => {
+    mkdirSync(path.join(root, "config"), { recursive: true });
+    writeFileSync(path.join(root, "config", "openclaw-target.txt"), "2026.7.4\n");
+    const r = readPin();
+    expect(r.status, r.out).toBe(0);
+    expect(r.out).toContain("TARGET=2026.7.4");
+  });
+
+  it.skipIf(isRoot)("carries on when the pin file exists but cannot be read", () => {
+    // The third copy of the read `install.sh:2245` and `gateway-pre-start.sh:45`
+    // both guard. Under `set -euo pipefail` (install-x64.sh:16) an unreadable
+    // pin file makes `head` fail, pipefail carries it into the assignment, and
+    // the installer aborts — from `step_openclaw_setup`, which is called in
+    // plain command position, so errexit is NOT suppressed. An unknown pin is
+    // already a defined state here (the fallback on the next line); an aborted
+    // install is not.
+    mkdirSync(path.join(root, "config"), { recursive: true });
+    const pin = path.join(root, "config", "openclaw-target.txt");
+    writeFileSync(pin, "2026.7.4\n");
+    chmodSync(pin, 0o000);
+    const r = readPin();
+    expect(r.status, `the installer aborted:\n${r.out}`).toBe(0);
+    expect(r.out).toContain("REACHED_END=1");
+    // And it falls back to the hardcoded version rather than an empty target.
+    expect(r.out).toContain("TARGET=2026.8.1");
+    // Not silently: the operator is told the pin did not apply.
+    expect(r.out).toMatch(/WARN/);
   });
 });
 

--- a/src/tests/unit/mcp-token.test.ts
+++ b/src/tests/unit/mcp-token.test.ts
@@ -158,11 +158,11 @@ describe("mcp-token", () => {
     });
 
     it("does not let one transient read error consume the rotation's re-read", async () => {
-      // The mtime is the budget for the re-read, so it must be spent on a read
-      // that RETURNED. Stamped on the ATTEMPT, a single transient failure — an
-      // EMFILE or ENOMEM on a loaded server, a momentary EACCES inside the
-      // rotation window — recorded that mtime forever: every later check saw
-      // `mtimeMs === lastReadMtimeMs` and returned early, so the rotated token
+      // The file's identity is the budget for the re-read, so it must be spent
+      // on a read that RETURNED. Stamped on the ATTEMPT, a single transient
+      // failure — an EMFILE or ENOMEM on a loaded server, a momentary EACCES
+      // inside the rotation window — recorded that identity forever: every later
+      // check saw `fileId === lastReadFileId` and returned early, so the rotated
       // was never adopted until the file changed AGAIN. One unlucky syscall
       // re-opened the 401s this re-read exists to end, permanently.
       const { getMcpToken, verifyMcpBearer } = await loadModule(tmpDir);
@@ -194,6 +194,48 @@ describe("mcp-token", () => {
       // The rotation is still picked up on the next call, with no further write
       // to the file — the transient did not spend its budget.
       expect(verifyMcpBearer(`Bearer ${rotated}`)).toBe(true);
+    });
+
+    it("adopts a second rotation that reports the same mtime as the first", async () => {
+      // The re-read is bounded by the file's identity so a bad-bearer flood
+      // costs one `statSync` rather than one read per request. `mtimeMs` alone
+      // is not that identity. `scripts/gateway-pre-start.sh` rotates by
+      // REPLACING the file (`mv` over it), and `mtimeMs` resolution belongs to
+      // the filesystem — so two replacements landing inside one timestamp tick
+      // report the same value, the second is never read, and the bearer the MCP
+      // subprocess is now sending is rejected until something rotates the file a
+      // THIRD time. That is the permanent 401 this whole re-read exists to end,
+      // reached through a different door.
+      const { getMcpToken, verifyMcpBearer } = await loadModule(tmpDir);
+      const tokenPath = path.join(tmpDir, "data", ".mcp-token");
+      const before = getMcpToken();
+      expect(verifyMcpBearer(`Bearer ${before}`)).toBe(true);
+
+      // One fixed timestamp on every rotation: what a coarse-granularity
+      // filesystem reports for replacements inside a single tick.
+      const pinned = new Date(1_700_000_000_000);
+      const rotate = (value: string) => {
+        // Staged and renamed, the way the shipped script does it, so each
+        // rotation is a new inode rather than a rewrite in place.
+        const staged = path.join(tmpDir, "data", ".mcp-token.new");
+        fs.writeFileSync(staged, `${value}\n`, { mode: 0o600 });
+        fs.renameSync(staged, tokenPath);
+        fs.utimesSync(tokenPath, pinned, pinned);
+      };
+
+      const first = "b".repeat(64);
+      rotate(first);
+      expect(verifyMcpBearer(`Bearer ${first}`)).toBe(true);
+
+      const second = "c".repeat(64);
+      rotate(second);
+      expect(
+        fs.statSync(tokenPath).mtimeMs,
+        "both rotations must report one mtime or this test proves nothing",
+      ).toBe(pinned.getTime());
+
+      expect(verifyMcpBearer(`Bearer ${second}`)).toBe(true);
+      expect(verifyMcpBearer(`Bearer ${first}`)).toBe(false);
     });
 
     it("rejects a token that's a prefix of the real one", async () => {

--- a/src/tests/unit/mcp-token.test.ts
+++ b/src/tests/unit/mcp-token.test.ts
@@ -88,6 +88,52 @@ describe("mcp-token", () => {
       expect(verifyMcpBearer("Bearer wrong-token-value-here-do-not-match")).toBe(false);
     });
 
+    it("picks up a token rotated on disk under a running web server", async () => {
+      // gateway-pre-start.sh replaces the token file whenever this uid cannot
+      // read it or other local users can, and only the MCP SUBPROCESS gets the
+      // new value (the reconcile rewrites openclaw.json). The verifier lives
+      // here, caches in module state and prefers CLAWBOX_MCP_TOKEN, which
+      // production-server.js pins at Next boot — and nothing orders
+      // clawbox-setup.service against clawbox-gateway.service. So a gateway
+      // restart mid-uptime (a model/config change, or Restart=always after a
+      // crash) left every /setup-api/* call from the agent's device tools
+      // 401'ing until clawbox-setup happened to restart. TASK-657.
+      const { getMcpToken, verifyMcpBearer } = await loadModule(tmpDir);
+      const before = getMcpToken();
+      expect(verifyMcpBearer(`Bearer ${before}`)).toBe(true);
+
+      const rotated = "b".repeat(64);
+      fs.writeFileSync(path.join(tmpDir, "data", ".mcp-token"), `${rotated}\n`, { mode: 0o600 });
+
+      expect(verifyMcpBearer(`Bearer ${rotated}`)).toBe(true);
+      // And the superseded one stops working, rather than both being valid for
+      // the life of the process.
+      expect(verifyMcpBearer(`Bearer ${before}`)).toBe(false);
+    });
+
+    it("does not re-read the file for every rejected bearer", async () => {
+      // The re-read above is on the failure path, which is the path an
+      // unauthenticated caller controls. Rate-limited so a bad-bearer flood
+      // cannot turn into one disk read per request.
+      const { getMcpToken, verifyMcpBearer } = await loadModule(tmpDir);
+      getMcpToken();
+      const tokenPath = path.join(tmpDir, "data", ".mcp-token");
+      let reads = 0;
+      const realRead = fs.readFileSync;
+      const spy = vi.spyOn(fs, "readFileSync").mockImplementation(((f: never, ...rest: never[]) => {
+        if (f === tokenPath) reads += 1;
+        return (realRead as never as (...a: never[]) => never)(f, ...rest);
+      }) as never);
+      try {
+        for (let i = 0; i < 50; i += 1) {
+          expect(verifyMcpBearer(`Bearer ${"c".repeat(64)}`)).toBe(false);
+        }
+      } finally {
+        spy.mockRestore();
+      }
+      expect(reads).toBeLessThanOrEqual(1);
+    });
+
     it("rejects a token that's a prefix of the real one", async () => {
       // Guard against any accidental startsWith comparison — timingSafeEqual
       // requires equal lengths so this should be a fast reject.

--- a/src/tests/unit/mcp-token.test.ts
+++ b/src/tests/unit/mcp-token.test.ts
@@ -113,8 +113,8 @@ describe("mcp-token", () => {
 
     it("does not re-read the file for every rejected bearer", async () => {
       // The re-read above is on the failure path, which is the path an
-      // unauthenticated caller controls. Rate-limited so a bad-bearer flood
-      // cannot turn into one disk read per request.
+      // unauthenticated caller controls. Bounded by the file's mtime so a
+      // bad-bearer flood cannot turn into one disk read per request.
       const { getMcpToken, verifyMcpBearer } = await loadModule(tmpDir);
       getMcpToken();
       const tokenPath = path.join(tmpDir, "data", ".mcp-token");
@@ -132,6 +132,29 @@ describe("mcp-token", () => {
         spy.mockRestore();
       }
       expect(reads).toBeLessThanOrEqual(1);
+    });
+
+    it("a bad-bearer flood cannot stop the rotated token from being picked up", async () => {
+      // The bound on the re-read has to be a property of the FILE, not a slot
+      // on a wall clock. A slot is a shared resource an unauthenticated caller
+      // can consume: at more than one bad bearer per interval the flood takes
+      // every window, the legitimate rotated bearer keeps landing inside a
+      // spent one, and the 401s this re-read exists to end carry on for as long
+      // as the flood does — the defect back through its own remedy.
+      const { getMcpToken, verifyMcpBearer } = await loadModule(tmpDir);
+      const before = getMcpToken();
+      expect(verifyMcpBearer(`Bearer ${before}`)).toBe(true);
+
+      const rotated = "d".repeat(64);
+      fs.writeFileSync(path.join(tmpDir, "data", ".mcp-token"), `${rotated}\n`, { mode: 0o600 });
+
+      // The flood arrives first and keeps arriving, all within one second.
+      for (let i = 0; i < 50; i += 1) {
+        expect(verifyMcpBearer(`Bearer ${"e".repeat(64)}`)).toBe(false);
+      }
+      // The real caller still gets in, on its first attempt, with no wait.
+      expect(verifyMcpBearer(`Bearer ${rotated}`)).toBe(true);
+      expect(verifyMcpBearer(`Bearer ${before}`)).toBe(false);
     });
 
     it("rejects a token that's a prefix of the real one", async () => {

--- a/src/tests/unit/mcp-token.test.ts
+++ b/src/tests/unit/mcp-token.test.ts
@@ -157,6 +157,45 @@ describe("mcp-token", () => {
       expect(verifyMcpBearer(`Bearer ${before}`)).toBe(false);
     });
 
+    it("does not let one transient read error consume the rotation's re-read", async () => {
+      // The mtime is the budget for the re-read, so it must be spent on a read
+      // that RETURNED. Stamped on the ATTEMPT, a single transient failure — an
+      // EMFILE or ENOMEM on a loaded server, a momentary EACCES inside the
+      // rotation window — recorded that mtime forever: every later check saw
+      // `mtimeMs === lastReadMtimeMs` and returned early, so the rotated token
+      // was never adopted until the file changed AGAIN. One unlucky syscall
+      // re-opened the 401s this re-read exists to end, permanently.
+      const { getMcpToken, verifyMcpBearer } = await loadModule(tmpDir);
+      getMcpToken();
+      const tokenPath = path.join(tmpDir, "data", ".mcp-token");
+
+      const rotated = "f".repeat(64);
+      fs.writeFileSync(tokenPath, `${rotated}\n`, { mode: 0o600 });
+
+      // Exactly one read fails, on the first check after the rotation.
+      const realRead = fs.readFileSync;
+      let thrown = false;
+      const spy = vi.spyOn(fs, "readFileSync").mockImplementation(((f: never, ...rest: never[]) => {
+        if (f === tokenPath && !thrown) {
+          thrown = true;
+          const err = new Error("EMFILE: too many open files") as Error & { code: string };
+          err.code = "EMFILE";
+          throw err;
+        }
+        return (realRead as never as (...a: never[]) => never)(f, ...rest);
+      }) as never);
+      try {
+        expect(verifyMcpBearer(`Bearer ${rotated}`)).toBe(false);
+        expect(thrown, "the fixture never exercised the failing read").toBe(true);
+      } finally {
+        spy.mockRestore();
+      }
+
+      // The rotation is still picked up on the next call, with no further write
+      // to the file — the transient did not spend its budget.
+      expect(verifyMcpBearer(`Bearer ${rotated}`)).toBe(true);
+    });
+
     it("rejects a token that's a prefix of the real one", async () => {
       // Guard against any accidental startsWith comparison — timingSafeEqual
       // requires equal lengths so this should be a fast reject.

--- a/src/tests/unit/register-mcp-hermes.test.ts
+++ b/src/tests/unit/register-mcp-hermes.test.ts
@@ -192,6 +192,38 @@ d("register-mcp.sh — registering on Hermes", () => {
     expect(fs.statSync(tokenPath).mode & 0o077, "the bearer was left readable by other local users").toBe(0);
   });
 
+  it.skipIf(isRoot)("still registers the MCP server when the bearer cannot be written", () => {
+    // REGISTERING is this script's job; minting the bearer is a convenience it
+    // does on the way past. The mint was a bare subshell in plain command
+    // position, so under `set -euo pipefail` (:36) a failed redirect — a
+    // root-owned token, a read-only data/ — exited the subshell 1 and killed
+    // the run before it reached the reconcile. On the hermes SKU nothing else
+    // writes mcp_servers.clawbox (there is no gateway pre-start), so
+    // `hermes mcp list` stayed "No MCP servers configured" and the agent had NO
+    // device tools at all, on every web-server boot. Nothing is lost by
+    // carrying on: production-server.js seeds the same file at every
+    // clawbox-setup boot and mcp/lib/api.ts reads it directly. TASK-657.
+    fs.writeFileSync(configPath, "model:\n  default: x\n");
+    const dataDir = path.join(root, "data");
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.chmodSync(dataDir, 0o555);
+
+    let r;
+    try {
+      r = run();
+    } finally {
+      fs.chmodSync(dataDir, 0o755);
+    }
+
+    expect(r.status, `the registration aborted:\n${r.stdout}${r.stderr}`).toBe(0);
+    // The whole point: the device tools exist even though the bearer does not.
+    expect(clawboxEntry().command).toBe(path.join(home, "fake-bun"));
+    // And it says so, rather than failing silently or claiming it minted one.
+    expect(r.stdout).toMatch(/WARN: could not write .*\.mcp-token/);
+    expect(r.stdout).not.toMatch(/minted/);
+    expect(fs.existsSync(path.join(dataDir, ".mcp-token"))).toBe(false);
+  });
+
   it("does not disturb a bearer token that already exists", () => {
     fs.mkdirSync(path.join(root, "data"), { recursive: true });
     const tokenPath = path.join(root, "data", ".mcp-token");

--- a/src/tests/unit/register-mcp-hermes.test.ts
+++ b/src/tests/unit/register-mcp-hermes.test.ts
@@ -34,6 +34,13 @@ const CAN_RUN =
 
 const d = CAN_RUN ? describe : describe.skip;
 
+/**
+ * The unreadable-file and failing-chmod cases prove nothing under root, which
+ * reads and chmods anything: they would pass by taking the happy path. CI is
+ * non-root; a `sudo npm test` on a box is not.
+ */
+const isRoot = typeof process.getuid === "function" && process.getuid() === 0;
+
 let home: string;
 let root: string;
 let configPath: string;
@@ -164,6 +171,27 @@ d("register-mcp.sh — registering on Hermes", () => {
     expect(fs.statSync(tokenPath).mode & 0o777).toBe(0o600);
   });
 
+  it.skipIf(isRoot)("mints the token owner-only without leaning on the chmod that follows", () => {
+    // A bare `openssl rand -hex 32 > file` creates the file at the umask's
+    // mode — 0644 under root's — so the secret is on disk world-readable for
+    // the window before the chmod, and STAYS there when the chmod cannot run
+    // (a file this uid does not own). `umask 077` in the minting subshell is
+    // what makes the mode a property of the creation instead. Stubbing `chmod`
+    // to fail is how that window is made visible without being two users.
+    fs.writeFileSync(configPath, "model:\n  default: x\n");
+    const stubBin = path.join(home, "stub-bin");
+    fs.mkdirSync(stubBin, { recursive: true });
+    const stub = path.join(stubBin, "chmod");
+    fs.writeFileSync(stub, "#!/bin/sh\nexit 1\n");
+    fs.chmodSync(stub, 0o755);
+
+    const r = run({ PATH: `${stubBin}:${process.env.PATH ?? ""}` });
+    expect(r.status).toBe(0);
+    const tokenPath = path.join(root, "data", ".mcp-token");
+    expect(fs.readFileSync(tokenPath, "utf-8").trim().length).toBeGreaterThanOrEqual(32);
+    expect(fs.statSync(tokenPath).mode & 0o077, "the bearer was left readable by other local users").toBe(0);
+  });
+
   it("does not disturb a bearer token that already exists", () => {
     fs.mkdirSync(path.join(root, "data"), { recursive: true });
     const tokenPath = path.join(root, "data", ".mcp-token");
@@ -235,6 +263,27 @@ d("register-mcp.sh — refuses rather than clobbers", () => {
     const r = run();
     expect(r.status).not.toBe(0);
     expect(fs.readFileSync(configPath, "utf-8")).toBe(broken);
+  });
+
+  it.skipIf(isRoot)("says why, rather than tracing back, when the config cannot be read", () => {
+    // The file is THERE and unreadable — permissions, a truncated mount. The
+    // `except FileNotFoundError: cfg = {}` arm beside this one is for "Hermes
+    // has not been onboarded yet", and taking it here would write a config
+    // holding only `mcp_servers` over one whose contents were never seen. The
+    // reader had no arm for it at all, so a bare `python3` heredoc under
+    // `set -euo pipefail` ended the run with a PermissionError traceback.
+    // TASK-657.
+    const kept = "model:\n  default: deepseek-v4-pro\n";
+    fs.writeFileSync(configPath, kept);
+    fs.chmodSync(configPath, 0o000);
+    const r = run();
+    fs.chmodSync(configPath, 0o600);
+    expect(r.status).not.toBe(0);
+    // Diagnosed, not traced back.
+    expect(r.stderr).toMatch(/could not be read/);
+    expect(r.stderr).not.toMatch(/Traceback/);
+    // And the file it could not read is exactly as it was.
+    expect(fs.readFileSync(configPath, "utf-8")).toBe(kept);
   });
 
   it("fails when the MCP entry point is missing", () => {

--- a/src/tests/unit/register-mcp-hermes.test.ts
+++ b/src/tests/unit/register-mcp-hermes.test.ts
@@ -223,7 +223,39 @@ d("register-mcp.sh — registering on Hermes", () => {
     // And it says so, rather than failing silently or claiming it minted one.
     expect(r.stdout).toMatch(/WARN: could not write .*\.mcp-token/);
     expect(r.stdout).not.toMatch(/minted/);
+    // The remedy it names has to be one that can actually happen.
+    // production-server.js seeds the same path as the same uid, so "seeded
+    // again at every clawbox-setup boot" was false in every state that reaches
+    // this line — and on the hermes SKU clawbox-gateway.service is masked, so
+    // gateway-pre-start.sh's replacement never runs either.
+    expect(r.stdout).toMatch(/401/);
+    expect(r.stdout).not.toMatch(/seeded again/);
     expect(fs.existsSync(path.join(dataDir, ".mcp-token"))).toBe(false);
+  });
+
+  it.skipIf(isRoot)("still registers the MCP server when data/ cannot even be created", () => {
+    // One line earlier than the mint: `mkdir -p "$(dirname "$MCP_TOKEN_FILE")"`
+    // was the last write in this block left in plain command position, so a
+    // $PROJECT_DIR that cannot be written — a read-only mount, ENOSPC — exited
+    // non-zero and `set -e` killed the run before the reconcile, which is the
+    // same "no device tools at all on the hermes SKU" outcome the mint guard
+    // below it exists to prevent. The sibling case above cannot see it: it
+    // creates data/ first and only then chmods it, so the mkdir is always a
+    // no-op on a directory that already exists. TASK-657.
+    fs.writeFileSync(configPath, "model:\n  default: x\n");
+    expect(fs.existsSync(path.join(root, "data"))).toBe(false);
+    fs.chmodSync(root, 0o555);
+
+    let r;
+    try {
+      r = run();
+    } finally {
+      fs.chmodSync(root, 0o755);
+    }
+
+    expect(r.status, `the registration aborted:\n${r.stdout}${r.stderr}`).toBe(0);
+    expect(clawboxEntry().command).toBe(path.join(home, "fake-bun"));
+    expect(fs.existsSync(path.join(root, "data"))).toBe(false);
   });
 
   it("does not disturb a bearer token that already exists", () => {

--- a/src/tests/unit/register-mcp-hermes.test.ts
+++ b/src/tests/unit/register-mcp-hermes.test.ts
@@ -35,9 +35,11 @@ const CAN_RUN =
 const d = CAN_RUN ? describe : describe.skip;
 
 /**
- * The unreadable-file and failing-chmod cases prove nothing under root, which
- * reads and chmods anything: they would pass by taking the happy path. CI is
- * non-root; a `sudo npm test` on a box is not.
+ * Skip ONLY where root's extra privilege changes which branch the script takes:
+ * it reads a 0000 file and writes into a 0555 directory, so those cases would
+ * pass by taking the happy path and prove nothing. A stubbed `chmod` is NOT
+ * such a case — the stub exits 1 for every user — so the cases that turn on the
+ * minting umask run everywhere. CI is non-root; a `sudo npm test` on a box is not.
  */
 const isRoot = typeof process.getuid === "function" && process.getuid() === 0;
 
@@ -171,7 +173,7 @@ d("register-mcp.sh — registering on Hermes", () => {
     expect(fs.statSync(tokenPath).mode & 0o777).toBe(0o600);
   });
 
-  it.skipIf(isRoot)("mints the token owner-only without leaning on the chmod that follows", () => {
+  it("mints the token owner-only without leaning on the chmod that follows", () => {
     // A bare `openssl rand -hex 32 > file` creates the file at the umask's
     // mode — 0644 under root's — so the secret is on disk world-readable for
     // the window before the chmod, and STAYS there when the chmod cannot run


### PR DESCRIPTION
**TASK-657** — `gateway-pre-start.sh` aborts, leaving no gateway, when the
`openclaw --version` probe fails at boot.

## Customer-visible symptom
A box whose `openclaw` binary exists but cannot print its version — it crashes,
it hits a node engine mismatch, it answers non-zero, or it prints a banner the
regex does not match — comes up with **no gateway and no chat at all**. The only
trace is the unit's `ExecStartPre` failure in the journal.

## Cause
The script is the gateway unit's `ExecStartPre` and runs under
`set -euo pipefail`. The probe was

```sh
CLAWBOX_OPENCLAW_EFFECTIVE="$("$OPENCLAW_BIN" --version 2>/dev/null \
  | grep -oE '20[0-9]{2}\.[0-9]+\.[0-9]+' | head -1)"
```

`grep -oE` exits 1 when it matches nothing, `pipefail` makes that the pipeline's
status, and an assignment whose command substitution failed aborts the script
under `set -e`. The paragraph above it was already written as though an empty
result were what happened. It never was. A *missing* binary is fine: the script
exits 0 a few lines up.

Confirmed read-only against the shipped script on a live box, reproducing the
abort with that box's own bash:

```
63:CLAWBOX_OPENCLAW_EFFECTIVE="$("$OPENCLAW_BIN" --version 2>/dev/null | grep -oE '20[0-9]{2}\.[0-9]+\.[0-9]+' | head -1)"
19:set -euo pipefail
rc=1 (no REACHED above == aborts)
```

## Harness-first — and this is what the fix turned out to be
`|| true` alone would have been wrong, and the review is what caught it: the
fallback then went to the **pin**, which this block's own comment forbids in
exactly the state that makes the CLI unable to answer. A partially failed update
(repo synced, `npm install` unfinished) leaves `pin=2026.8.1` beside a 2026.7
core — so the pin fallback would fire precisely when it is wrong, writing v2 keys
a v1 gateway refuses and **permanently** deleting `commands.ownerDisplay`,
`gateway.tailscale.resetOnExit` and
`agents.defaults.compaction.reserveTokensFloor`, none of which anything on the
boot path re-adds.

The native source is the installed core's own `package.json` — the file the
binary *is*, readable even when the binary cannot run. This repo has already
decided that twice, in writing, for this exact reason:
`scripts/ensure-local-embeddings.sh:50-52` and `src/lib/memory-shard.ts:91-95`
both refuse `openclaw --version` because it costs ~10 s on a Jetson. Measured
read-only on a shipped Orin:

```
openclaw --version   rc=0  7904 ms / 8044 ms
package.json read    version=2026.8.1  53 ms
```

So the probe is now **manifest → time-boxed `--version` → nothing**:

1. read `<prefix>/lib/node_modules/openclaw/package.json` (free, no process);
2. else `timeout -k 5 45 openclaw --version` — `|| true` only rescues a CLI that
   *returns*, and a wedged one would hold ExecStartPre until `TimeoutStartSec`
   killed the unit, with `Restart=always` then spending `StartLimitBurst` on a
   box that never comes up. This was the only un-time-boxed `openclaw` call left
   in the file, and the first one, before every guard;
3. else **write nothing** — WARN loudly and `exit 0`, leaving `openclaw.json`
   exactly as it is. The config on disk booted this box before; writing a guessed
   dialect is the only option here that can make a working box stop working.

*(Corrected in the final round: an earlier draft of this section claimed the
guessed value would also have reached `ensure-local-embeddings.sh` through an
exported `CLAWBOX_OPENCLAW_V2`. It would not — this script never spawns that one
(`grep`: the only mention is a comment), and an `export` in an `ExecStartPre`
does not reach `ExecStart`. The two scripts are independent readers of the same
manifest, which is why the shape check had to be applied to both; see 621T-L5.)*

## RED (unmodified beta)
```
 × reads the installed core's own manifest, without running it
 × time-boxes that call, so a wedged CLI cannot hold the boot
 × still calls a v1 core v1, whatever the pin says
 × reads the manifest when the CLI exits non-zero saying nothing, instead of taking the gateway down
 × reads the manifest when the CLI crashes with a stack trace on stderr, instead of taking the gateway down
 × reads the manifest when the CLI prints a banner the regex does not match, instead of taking the gateway down
 × reads the manifest when the CLI prints nothing at all and succeeds, instead of taking the gateway down
 × writes NOTHING when the installed core cannot be identified at all
 × carries on when the pin file exists but cannot be read
 × falls back to clawbox when the file cannot be read, instead of aborting

AssertionError: the pre-start aborted:
AssertionError: expected '2026.9.9' to be '2026.8.1'
      Tests  10 failed | 2 passed (12)
```

The tests execute the shipped blocks under `set -euo pipefail` against a stubbed
core laid out the way npm lays it out, and assert the manifest is preferred (the
stub CLI prints `RAN` to prove it was never invoked).

## GREEN
```
 gateway-pre-start-version-probe                       12 passed
 all 15 gateway-pre-start-*.test.ts + ensure-local-embeddings
   + install-update-branch-pin + mcp-token               328 passed (18 files)
 all 22 src/tests/unit/install-*.test.ts                 537 passed
 bash -n scripts/gateway-pre-start.sh && bash -n install.sh   OK
```

## Sibling call sites
Swept the script for the same pattern — a command whose failure aborts the boot —
and fixed the ones on the same path:

- `:45` the pin read (`head | awk`) — guarded by `[ -f ]`, but a file that exists
  and cannot be READ takes the gateway with it.
- `:96-109` the mDNS hostname read (`sed | head`) — same shape, and now it also
  WARNs: that name rebuilds `gateway.controlUi.allowedOrigins`, so a silent
  fallback drops the configured origin and the Control UI stops being reachable
  by the name the owner uses. (This guard also closes a small agent-reachable
  DoS: `data/hostname.env` is agent-writable, so making it unreadable used to
  wedge the gateway from a chat turn.)
- `:2159-2170` the MCP token block — `chmod 600` runs on **every** boot and the
  file is also seeded by `production-server.js`; one created under another uid
  makes it EPERM and cost the box its gateway on every boot from then on. The two
  token writes fall through to the existing readability/length check, which is
  the deliberate hard failure here.
- `install.sh:2240` — the identical `head -1 "$PIN_FILE" | awk` read, and
  `step_openclaw_install` is dispatched with errexit deliberately ON, so an
  unreadable pin aborts the installer. Guarded; the `else` branch already
  reported an unknown pin.
- Cleared explicitly: `:1677`, `:1822`, `:1991` already carry `|| true` /
  `|| echo ""`; `install-x64.sh:187` and `install.sh:openclaw_is_v2` are the same
  pipeline in *condition* context, where errexit is suspended.

## Deliberately NOT in this PR — *both were later folded in; see the note*
> **Superseded.** Both items below were deferred at the time for conflict reasons
> and have since been **applied in this PR** (the `except (OSError, …)` sweep and
> the heredoc guard on the deepseek catalog patch). Kept for the record of why
> they were deferred first. Nothing in this section is still outstanding.

Two sibling classes the review found, deferred with a reason rather than folded
in — both sit in the plugin/codex/deepseek region of this file, which **PR #614
(TASK-697) is editing**, and taking them here would create the conflict this
batch was told to avoid:

- every python `open()` in the script catches `FileNotFoundError` /
  `JSONDecodeError` but lets `PermissionError` escape (`:260`, `:1740`, `:1794`,
  `:1908`, `:1952`, `:2206`, `:2266`, `:2311`) — an unreadable `openclaw.json`
  aborts the boot, which is this PR's own sentence applied to a more central
  file. Fix is `except (OSError, json.JSONDecodeError)` at each site.
- `:1735-1773`, the deepseek catalog patch, `raise`s on any write failure, so a
  read-only rootfs turns a cosmetic patch into a box with no gateway.

Both are on the fixer queue.

## Device leg
Read-only only: the defect is confirmed against the script as shipped on a live
box, and both measurements the fix rests on (`--version` at 7.9 s, the manifest at
53 ms, and that the manifest exists and reads `2026.8.1`) were taken on that box.
The fix itself is **not** proven on hardware — that means deploying an unmerged
branch to a box, which this run does not do.

## Conflict note
PR #614 (TASK-697) also edits `scripts/gateway-pre-start.sh`, inserting near
line 2216. These hunks are at `:45`, `:63-95`, `:96-109` and `:2159-2170`; the
last is the only one anywhere near it and is 50 lines above, in the MCP-token
block rather than the plugin block. A rebase should be textually clean.


## Final review round (2026-09-04) — M1 and M4 fixed

### M1 — the version string was never shape-checked

The `package.json` read accepted **any** non-empty string, while the `--version`
fallback one line below applied `grep -oE '20[0-9]{2}\.[0-9]+\.[0-9]+'`. The two
sources validated differently and the stricter one was the one almost never
reached, so a core whose version is not `20YY.M.P` — a dev/nightly build, a fork,
an `npm i -g <git url>` install, a vendor rebuild — produced a non-empty value
that bypassed the "write nothing" guard and selected a generation from a string
that says nothing about one. Both sources now validate the same way.

### M4 — the boot DoS was closed for two files, not for the class

`PermissionError` is not a subclass of `FileNotFoundError`, so an unreadable
`~/.openclaw/openclaw.json` escaped the one arm that was caught. The heredoc at
`:233` is a bare top-level command in a script under `set -euo pipefail`, so the
raise killed the whole ExecStartPre: no gateway, on every boot, until someone
with shell access fixed the mode — on the file this script exists to edit, which
is clawbox-owned and therefore writable from a chat turn.

Widening that arm to `cfg = {}` would have been **worse**: that object is written
back a few hundred lines below, so a config that merely could not be *opened*
would lose every provider, auth profile and channel. It now warns and boots on
the config as it stands — the same policy the generation probe settles on. The
seven read-only siblings (`:1815 :1868 :1983 :2027 :2290 :2349 :2396`) catch
`OSError` instead of `FileNotFoundError`, each keeping its own existing fallback,
none of which writes anything.

### RED (against this PR's own previous head, `ac764c5d`)

```
FAIL  … > refuses to call a core v1 on a version it cannot read as a date (0.0.0-dev)
      expected 'EFFECTIVE=0.0.0-dev\nV2=0\nREACHED_END=1' not to contain 'REACHED_END=1'
FAIL  …                                                     (1.2.3)
      expected 'EFFECTIVE=1.2.3\nV2=0\nREACHED_END=1\n'     not to contain 'REACHED_END=1'
FAIL  …                                                     (next)
      expected 'EFFECTIVE=next\nV2=1\nREACHED_END=1\n'      not to contain 'REACHED_END=1'
FAIL  …                                                     (2026.8)
      expected 'EFFECTIVE=2026.8\nV2=1\nREACHED_END=1'      not to contain 'REACHED_END=1'
FAIL  … > lets an explicit generation win over a core it cannot identify
FAIL  … > writes NOTHING … (the WARN did not name the skipped hardening)

FAIL  … config load block > does not take the boot down on a file it cannot read,
                            and does not answer {}
      AssertionError: the loader aborted the pre-start:
      PermissionError: [Errno 13] Permission denied: '…/openclaw.json'

Tests  7 failed | 16 passed (23)   +   1 failed | 4 passed (5)
```

`next` is worth pausing on: it sorted **above** `2026.8` under `sort -V`, so a core
called "next" was declared **v2**. The controls (`still reads a real date version,
suffix and all` → `2026.8.1-rc.2` still resolves to `2026.8.1`) keep the shape
check from simply rejecting the fleet.

### GREEN

All 16 `gateway-pre-start-*` suites plus `install-update-branch-pin` → **295
passed**. `bash -n` clean on `scripts/gateway-pre-start.sh` and `install.sh`;
`tsc --noEmit` clean. The pin fallback is **not** reintroduced.

### Also applied

- **M2** — the give-up WARN now names what this boot does **not** re-apply: the
  gateway auth token, the messaging-channel security pass, the
  `gateway.controlUi.allowedOrigins` rebuild (a changed LAN IP is not picked up),
  the MCP token seeding and the MCP registration reconcile. Pinned by assertions
  on **stderr** specifically.
- **M3** — an explicit `CLAWBOX_OPENCLAW_V2` is now honoured *before* the give-up,
  so a pinned generation is no longer a silent no-op and the comment claiming it
  "wins" is true again. Kept as one `export` at the end so the block slice every
  sibling suite relies on still terminates where it did.
- **M5** — the deepseek catalog patch and the MCP registration reconcile are
  wrapped in `if ! python3 - … ; then WARN; fi`. A read-only rootfs or a full disk
  no longer turns a cosmetic "declare xhigh reasoning effort" patch into a box
  with no gateway.
- **LOW-1** — `install.sh` no longer prints `Pinned OpenClaw target from …: `
  (empty) and assert a pin was read when the read failed; the fallback itself was
  already correct.
- **LOW-2** — `timeout 45`. *(Superseded in the final round: this originally read
  "matching the CLI call PR #614 added to this same script". PR #614 is still open
  and its `timeout 45` lives only on that branch, so the shipped tree contradicted
  the claim. The bound now argues from this call's own measured evidence — 7.9-8.0 s
  healthy on a shipped Orin — and from `TimeoutStartSec` read out of the shipped
  unit. See 621-L2/L3 below.)*
- **LOW-4** — the manifest cases are pinned: corrupt JSON, empty, `{}`, a
  non-string version, an unreadable file, plus the four non-date versions of M1.
- **LOW-5** — `stdout` and `stderr` are separated, so the WARN assertions pin the
  stream the `>&2` contract promises; the `chmod 0o000` cases now skip under root
  instead of silently degrading to the happy path.

### Declined, with reasons

- **LOW-3** (bare `echo … >&2` returns EBADF with fd 2 closed, and `set -e` then
  kills the script) — declined. It is unreachable under systemd, which always
  provides fd 2, and it is the shape of the ~6 pre-existing `echo >&2` calls in
  this file; changing only the new ones would leave the file inconsistent for no
  behavioural gain. Worth a sweep of the whole script if it is ever worth doing.
- **LOW-6** (the hostname WARN might fire on every boot of a box that never set a
  name) — checked read-only on a shipped openclaw box rather than argued:
  `data/hostname.env` exists and carries a usable `HOSTNAME=` line, so the WARN
  does not fire in the default state. No change; no log noise.

### Residual noted — *WITHDRAWN, the reasoning was wrong; now fixed*

> **Superseded.** This paragraph claimed the `exit 1` was "not agent-reachable"
> because "the unconditional `chmod 600` above it succeeds for any clawbox-owned
> file". Both halves are false, and the round-3 review reproduced it: the token
> need not exist at all (a `chmod` on an absent file changes nothing), and `data/`
> is clawbox-owned at 0755, so **any** process running as `clawbox` reaches it with
> `rm data/.mcp-token; chmod 500 data`. It is **fixed in this PR** — see 621T-M1
> below. Kept visible because it is exactly the kind of cleared-on-paper reasoning
> this PR exists to distrust.

### Review round 2 (CodeRabbit threads, 2 applied / 1 part-applied / 1 refuted)

One of these changed behaviour on the boot path, and it is the important one:

- **Guarding the MCP token's `chmod` traded a brick for an exposure.** The unit is
  `User=clawbox` (`config/clawbox-gateway.service:18`), so a token file root
  created — a root update step, a manual repair — returns EPERM to `chmod` and
  keeps the **0644** root's umask gives `openssl rand -hex 32 > file`. The guarded
  version warned and exported it anyway, and that value is the sole `/setup-api/*`
  bearer (`mcp/lib/api.ts` sends it, `src/middleware.ts` accepts it). The same
  warning also fired over a root-owned file that was already 0600 — a box with
  nothing wrong with it.

  `gateway-pre-start.sh:2264-2296` now grades the **mode**, not the chmod's exit
  code. Anything that is not `600` is replaced with a fresh token this uid owns,
  written under `umask 077` rather than chmod'ed (chmod is what just failed). That
  works because a rename is governed by the DIRECTORY — `$PROJECT_DIR/data` is
  chowned to clawbox (`install.sh:1104`, `:3353`) — not by the file's owner. The
  rotation is absorbed by the reconcile immediately below, which rewrites
  `openclaw.json` from whatever the file then holds, exactly as it already does for
  the seeding path. One boot rotates; every boot after it the file is ours.
  Failing closed as suggested was declined: `exit 1` in `ExecStartPre` is the brick
  this branch exists to remove, and it would not close the hole anyway (the
  reconcile has already put the token in `openclaw.json`).

  The seed and the re-harden now share one writer, which also fixed a third case:
  a freshly seeded token was landing at 0644 whenever chmod failed.

Test-side:

- The suite inherited `CLAWBOX_OPENCLAW_V2` from the runner, and an explicit one
  wins over everything the probe derives — with it exported, **six** tests passed
  against any script at all. `run()` now deletes it (unset is the state a device is
  in, and cannot be confused with a deliberate empty override).
- The `timeout` assertion took any number: `timeout 1` and `timeout 600` both
  passed it. It now pins 45 and cross-checks `TimeoutStartSec` read from the
  shipped unit, so a lowered boot budget fails the test instead of silently
  shrinking the margin.

Refuted: lowering `timeout 45` to 20. There is no 20 s contract. *(The original
refutation leaned on PR #614's copy of `timeout 45`; that PR has not landed, so the
argument now stands on its own evidence, which was always the stronger half:*
`TimeoutStartSec=600` makes 45 s 7.5% of the ceiling, the measured healthy cost is
7.9-8.0 s, and cutting to 20 would time out exactly the cold-boot box this fallback
exists for.*)*

Sibling checked and cleared: `production-server.js:161` does the same re-harden in
JS; after this change the file is clawbox-owned on any box whose gateway has booted
once, so that `chmodSync` succeeds. Its separate ordering quirk (a throw there skips
the `process.env.CLAWBOX_MCP_TOKEN` assignment below it) is not this PR's and is
recorded as a residual.

**RED → GREEN:** all four cases failed on `49622dcd` (`token left at mode 644`, a
WARN over an already-0600 file, a seeded token at 0644, and the six generation
tests under an exported override). After the fix: 27/27 in
`gateway-pre-start-version-probe.test.ts`, 922/922 across the 40 suites touching
`gateway-pre-start.sh` or the MCP token, `tsc --noEmit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Installers now continue when OpenClaw pin files are empty, unreadable, or malformed, using the default version.
  - Gateway startup is more resilient to corrupt, unreadable, or invalid configuration and support files.
  - Improved OpenClaw version detection prevents unsupported builds from receiving incompatible settings.
  - MCP registration and token handling now recover more safely from permission, creation, rotation, and read failures.
  - Codex discovery and optional setup steps continue with warnings when recovery is not possible.

- **Tests**
  - Expanded coverage for startup recovery, version detection, configuration corruption, token security, rotation, and MCP registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Round N+1 — the three open review threads, one folded-in MEDIUM, and a rebase

### Applied

**The main `openclaw.json` write could still fail the unit** (the MEDIUM the last
review left open). `tempfile.mkstemp` sat OUTSIDE the `try` that existed to
contain a failed write, inside a bare top-level heredoc in a script running under
`set -euo pipefail` as the gateway's `ExecStartPre=` — which carries no `-`
prefix, so `Restart=always` then spends `StartLimitBurst`: no gateway and no
chat, on every boot, on an unwritable `~/.openclaw` or ENOSPC. It now warns and
boots on the config already on disk, exactly as the deepseek plugin patch and the
MCP registration in the same script already do. RED
(`src/tests/unit/gateway-pre-start-corrupt-config.test.ts:255`):

```
AssertionError: the pre-start aborted, so the box gets no gateway:
PermissionError: [Errno 13] Permission denied: '…/.openclaw.uquz8son.tmp'
: expected 1 to be +0
```

Sibling sweep: the script's two other `tempfile.mkstemp` sites (the deepseek
plugin JSON, `:1916`; the MCP registration, `:2525`) are both invoked as
`if ! python3 … ; then WARN; fi`, so a raise there is already non-fatal and
leaves no staged file. Cleared, not changed.

**A truncated MCP bearer could be published.** The registration accepted any
non-empty token file, while the seeding gate above it re-seeds anything under 32
bytes — and that check runs BEFORE the write, so a write that did not finish
produced a short token nothing looked at again. Between 16 and 31 characters it
even works (`src/lib/mcp-token.ts:80` accepts 16 and up), so the box would run on
a fraction of the intended entropy silently. Now gated at the same 32 the two
seeding gates and `production-server.js:151` already use — not on a 64-hex
literal, so the gate that decides what counts as seeded and the gate that
publishes cannot drift. RED:

```
AssertionError: expected 'aaaaaaaaaaaaaaaaaaaa' to be ''
 ❯ src/tests/unit/gateway-pre-start-version-probe.test.ts:656:24
```

**The verifier's re-read budget keyed on `mtimeMs` alone.** The rotation replaces
the file with `mv`, and `mtimeMs` resolution belongs to the filesystem, so two
replacements inside one tick reported the same value: the second was never read
and the bearer the MCP subprocess was sending stayed rejected until a third
rotation — the same permanent 401 the re-read exists to end. The identity is now
`dev:ino:mtimeMs`, which covers replacement and rewrite-in-place both, on a
`statSync` already being made. RED:

```
FAIL  mcp-token > verifyMcpBearer > adopts a second rotation that reports the same mtime as the first
AssertionError: expected false to be true
 ❯ src/tests/unit/mcp-token.test.ts:237:51
```

### Refuted

**"Skip MCP registration when token hardening fails."** In that state the bearer
is already in a world-readable file, and the reconcile writes `openclaw.json`
through `mkstemp` + `os.replace`, so the token lands at 0600 — registering it
publishes it to nobody who could not already read it. Skipping would leave the
exposure exactly as it is and additionally cost the box every `/setup-api/*` tool
call, which is the failure this branch exists to remove. The state already has a
journal line naming it, and the box heals on the first boot where `data/` is
writable.

## GREEN (on the rebased head)

```
mcp-token + gateway-pre-start-version-probe + gateway-pre-start-corrupt-config
+ register-mcp-hermes + install-x64 + ensure-local-embeddings
                    Test Files 6 passed (6)   Tests 149 passed (149)
tsc --noEmit        exit 0
bash -n             gateway-pre-start.sh, register-mcp.sh,
                    ensure-local-embeddings.sh, install.sh, install-x64.sh   clean
```

Rebased onto `origin/beta` `08e7057d`; `git diff --stat origin/beta...HEAD` lists
the same 13 files as before with no deletions.

**`e2e-install` must re-run on the rebased head before this merges** — the branch
changes the gateway boot path and the installer.

### Left for the queue, deliberately not in this PR

- Five read-only heredocs in `gateway-pre-start.sh` (`:1952`, `:2066`, `:2110`,
  `:2567`, `:2611`) catch `(OSError, json.JSONDecodeError)` and so still let a
  `UnicodeDecodeError` through — the same gap this PR closed in the main loader,
  in bare command substitutions under `set -e`. Pre-existing and unchanged by
  this diff.
- The reader-side token floor is 16 (`mcp/lib/api.ts:20`, `mcp/clawbox-cli.ts:40`,
  `src/lib/mcp-token.ts:80`, `src/lib/local-ai-token.ts:58`) while every writer
  uses 32. Raising it would reject an operator-pinned `CLAWBOX_MCP_TOKEN`, which
  is a behaviour change with no reproduced harm behind it.
