### PR TITLE
fix: bring the backup_status tool description back inside the contract

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -197,6 +197,13 @@ pair: `backup_list` and `backup_now` are not registered there, and
 `backup_status` answers "not available on this edition" rather than a status
 object the agent reads as "not paired yet".
 
+Where ClawKeep does run, `backup_status` returns the shared `protection`
+verdict plus a `notes` array — the caveats that apply to *this* box (an
+unpaired box, a `lastHeartbeatStatus` that is not an outcome, a protected
+verdict with no schedule behind it). They are on the result rather than in the
+tool description because they are conditional, and because description text is
+paid for in the `tools/list` payload on every turn.
+
 `screen_capture` resolves the display from `CLAWBOX_VNC_DISPLAY`, then
 `~/.cache/clawbox/vnc-display.env`, then `:0` — the harness spawns this server
 with no `DISPLAY`, and the desktop is the VNC Xvfb, not `:0`.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -197,12 +197,13 @@ pair: `backup_list` and `backup_now` are not registered there, and
 `backup_status` answers "not available on this edition" rather than a status
 object the agent reads as "not paired yet".
 
-Where ClawKeep does run, `backup_status` returns the shared `protection`
-verdict plus a `notes` array — the caveats that apply to *this* box (an
-unpaired box, a `lastHeartbeatStatus` that is not an outcome, a protected
-verdict with no schedule behind it). They are on the result rather than in the
-tool description because they are conditional, and because description text is
-paid for in the `tools/list` payload on every turn.
+`backup_status` returns the shared `protection` verdict plus a `notes` array —
+the caveats that apply to *this* box (a `lastHeartbeatStatus` that is not the
+outcome by itself, a protected verdict with no schedule behind it). They are on
+the result rather than in the tool description because they are conditional,
+and because description text is paid for in the `tools/list` payload on every
+turn. An unpaired box gets `protection: null` and a note saying so, the same
+way the shelf shield publishes no verdict for one.
 
 `screen_capture` resolves the display from `CLAWBOX_VNC_DISPLAY`, then
 `~/.cache/clawbox/vnc-display.env`, then `:0` — the harness spawns this server

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -202,8 +202,11 @@ the caveats that apply to *this* box (a `lastHeartbeatStatus` that is not the
 outcome by itself, a protected verdict with no schedule behind it). They are on
 the result rather than in the tool description because they are conditional,
 and because description text is paid for in the `tools/list` payload on every
-turn. An unpaired box gets `protection: null` and a note saying so, the same
-way the shelf shield publishes no verdict for one.
+turn. The key is always present on a status result, and the array is often
+empty: a box no caveat applies to gets `notes: []`, never a missing field. An
+unpaired box gets `protection: null` and a note saying so, the same way the
+shelf shield publishes no verdict for one — and the edition that cannot run
+ClawKeep (above) answers in prose, with no `protection` and no `notes` at all.
 
 `screen_capture` resolves the display from `CLAWBOX_VNC_DISPLAY`, then
 `~/.cache/clawbox/vnc-display.env`, then `:0` — the harness spawns this server

--- a/mcp/tools/system.ts
+++ b/mcp/tools/system.ts
@@ -19,7 +19,7 @@ import { json, text, type Registrar, type ToolResult } from "../lib/register";
 import { zBool, zConfirm, zEnumOf, zInt, zText } from "../lib/schema";
 import type { McpContext } from "../lib/context";
 import { PREFERENCE_LANGUAGES, WALLPAPER_FITS } from "../../src/lib/preference-schema";
-import { deriveProtection, type ProtectionInput } from "../../src/lib/clawkeep-protection";
+import { deriveProtection, type Protection, type ProtectionInput } from "../../src/lib/clawkeep-protection";
 
 // Raw bytes whose base64 still fits under the 1 MiB image cap in
 // lib/register.ts (base64 is 4/3 of the input). Anything larger is dropped
@@ -183,6 +183,45 @@ interface BackupStatusBody extends Partial<ProtectionInput> {
 /** What every backup tool says on an edition that cannot run ClawKeep. */
 const NOT_ON_THIS_EDITION =
   "Cloud backup (ClawKeep) is not available on this edition of ClawBox. There is nothing to pair and nothing to restore from. Tell the user that, and do not call any backup tool again this session.";
+
+/**
+ * The caveats a `backup_status` reader has to apply, as data on the result
+ * rather than prose in the tool description.
+ *
+ * They were in the description, which pushed it to 1002 chars — over the
+ * MAX_DESCRIPTION_CHARS contract in mcp/lib/register.ts. Description text is
+ * also the wrong place for them twice over: every tool description is spliced
+ * into the tools/list payload on EVERY turn, which is the budget that matters
+ * on a device running a 4-8B local model, and a general rule stated there
+ * leaves the model to decide whether it applies to the box in front of it.
+ * Emitted here, only the caveats that are true of THIS box are paid for, and
+ * only when the tool is actually called.
+ */
+function backupNotes(body: BackupStatusBody, protection: Protection): string[] {
+  const notes: string[] = [];
+  if (body.paired === false) {
+    notes.push(
+      "This ClawBox is not paired with cloud backup. Tell the user to set it up in Settings -> Backup; no tool here can pair it.",
+    );
+  }
+  // Unconditional while the field is present: the whole point is that it can
+  // read "ok" on a box whose backups died weeks ago, so the agent must never
+  // meet it without the warning attached.
+  if (body.lastHeartbeatStatus) {
+    notes.push(
+      `lastHeartbeatStatus is "${body.lastHeartbeatStatus}" — the last thing the daemon published, not an outcome. `
+      + "The failures that keep a box unprotected longest write no heartbeat at all, so this field can read \"ok\" on a box "
+      + "that has not backed up for weeks. Answer from protection, not from this.",
+    );
+  }
+  if (protection.state === "protected" && body.schedule?.enabled === false) {
+    notes.push(
+      "schedule.enabled is false, so this verdict says only that the last backup is recent enough for a box with no "
+      + "schedule: nothing is scheduled to make a newer one. Say that, rather than \"you're protected\".",
+    );
+  }
+  return notes;
+}
 
 // ── Screen ───────────────────────────────────────────────────────────────────
 
@@ -532,7 +571,7 @@ export function registerSystemTools(reg: Registrar, ctx: McpContext): void {
 
   reg.tool(
     "backup_status",
-    "Report whether this ClawBox is protected by cloud backup. `protection` is the answer: {state: protected|lapsed|unprotected, reason: ok|error|blocked|stale|never} — the same verdict the ClawKeep shield and the desktop shelf draw. `lastHeartbeatStatus` is the last thing the daemon published, NOT an outcome: the failures that keep a box unprotected longest write no heartbeat at all, so it can read \"ok\" on a box that has not backed up for weeks. reason=stale means no recent backup; error means a run failed; blocked means backups refuse to start until this box has an encryption passphrase (Settings -> Backup); never means it has never backed up. A {state: protected, reason: ok} verdict on a box whose `schedule.enabled` is false says only that the last backup is recent enough for a box with no schedule: nothing is scheduled to make a newer one, so say that rather than \"you're protected\". If backup is not paired, tell the user to set it up in Settings -> Backup — there is no tool that pairs it.",
+    "Report whether this ClawBox is protected by cloud backup. Answer from `protection`, never from the raw fields: {state: protected|lapsed|unprotected, reason: ok|error|blocked|stale|never} — the same verdict the ClawKeep shield and the desktop shelf draw. reason=ok means a recent backup succeeded; stale means no recent backup; error means a run failed; blocked means no backup can run until this box has an encryption passphrase (Settings -> Backup); never means it has never backed up. The result's `notes` are the caveats that apply to THIS box — read them out rather than drawing your own conclusion from the other fields.",
     {},
     { editions: ["openclaw", "hermes"], readOnly: true, maxChars: 4_000 },
     async () => {
@@ -549,16 +588,14 @@ export function registerSystemTools(reg: Registrar, ctx: McpContext): void {
       // that stop backups longest write no heartbeat, so a box whose backups
       // died days ago still reports `lastHeartbeatStatus: "ok"` — read
       // literally, the agent tells the owner the last run succeeded. Attach
-      // the same verdict the two shields draw, and say in the description which
-      // of the two fields is the answer: leaving the misleading one in the body
-      // with nothing to rank them keeps that read one plausible step away.
-      return json({
-        ...body,
-        protection: deriveProtection(
-          { ...body, lastBackupAtMs: body.lastBackupAtMs ?? 0 },
-          Date.now(),
-        ),
-      });
+      // the same verdict the two shields draw, plus the notes that rank the
+      // fields for this box: leaving the misleading one in the body with
+      // nothing to rank them keeps that read one plausible step away.
+      const protection = deriveProtection(
+        { ...body, lastBackupAtMs: body.lastBackupAtMs ?? 0 },
+        Date.now(),
+      );
+      return json({ ...body, protection, notes: backupNotes(body, protection) });
     },
   );
 

--- a/mcp/tools/system.ts
+++ b/mcp/tools/system.ts
@@ -197,27 +197,34 @@ const NOT_ON_THIS_EDITION =
  * Emitted here, only the caveats that are true of THIS box are paid for, and
  * only when the tool is actually called.
  */
-function backupNotes(body: BackupStatusBody, protection: Protection): string[] {
+function backupNotes(body: BackupStatusBody, protection: Protection | null): string[] {
   const notes: string[] = [];
   if (body.paired === false) {
     notes.push(
-      "This ClawBox is not paired with cloud backup. Tell the user to set it up in Settings -> Backup; no tool here can pair it.",
+      "This ClawBox is not paired with cloud backup, so no backup can run and there is no verdict to report. "
+      + "Tell the user to set it up in Settings -> Backup; no tool here can pair it.",
     );
   }
-  // Unconditional while the field is present: the whole point is that it can
-  // read "ok" on a box whose backups died weeks ago, so the agent must never
-  // meet it without the warning attached.
+  // Not gated on the value: "error" and "needs-passphrase" ARE outcomes
+  // deriveProtection() acts on, so the note says the field is not the answer
+  // BY ITSELF rather than that it is never an outcome. The value is not
+  // interpolated — it is already in the body, and result text is screened by
+  // neither the length cap nor BANNED_DESCRIPTION_RE.
   if (body.lastHeartbeatStatus) {
     notes.push(
-      `lastHeartbeatStatus is "${body.lastHeartbeatStatus}" — the last thing the daemon published, not an outcome. `
-      + "The failures that keep a box unprotected longest write no heartbeat at all, so this field can read \"ok\" on a box "
-      + "that has not backed up for weeks. Answer from protection, not from this.",
+      "lastHeartbeatStatus is the last thing the daemon published, not the outcome by itself. "
+      + "The failures that keep a box unprotected longest write no heartbeat at all, so it can still "
+      + "read \"ok\" on a box that has not backed up for weeks. Answer from protection.",
     );
   }
-  if (protection.state === "protected" && body.schedule?.enabled === false) {
+  // `!enabled`, not `=== false`: a null or absent schedule takes the same
+  // lenient no-schedule window in expectedBackupWindowMs(), and the ClawKeep
+  // card switches its copy on exactly this predicate (ClawKeepApp.tsx).
+  if (protection?.state === "protected" && !body.schedule?.enabled) {
     notes.push(
-      "schedule.enabled is false, so this verdict says only that the last backup is recent enough for a box with no "
-      + "schedule: nothing is scheduled to make a newer one. Say that, rather than \"you're protected\".",
+      "No backup schedule is armed (schedule.enabled), so this verdict says only that the last backup is recent "
+      + "enough for a box with no schedule: nothing is scheduled to make a newer one. Say that, rather than "
+      + "\"you're protected\".",
     );
   }
   return notes;
@@ -571,7 +578,7 @@ export function registerSystemTools(reg: Registrar, ctx: McpContext): void {
 
   reg.tool(
     "backup_status",
-    "Report whether this ClawBox is protected by cloud backup. Answer from `protection`, never from the raw fields: {state: protected|lapsed|unprotected, reason: ok|error|blocked|stale|never} — the same verdict the ClawKeep shield and the desktop shelf draw. reason=ok means a recent backup succeeded; stale means no recent backup; error means a run failed; blocked means no backup can run until this box has an encryption passphrase (Settings -> Backup); never means it has never backed up. The result's `notes` are the caveats that apply to THIS box — read them out rather than drawing your own conclusion from the other fields.",
+    "Report whether this ClawBox is protected by cloud backup. `protection` is the answer — {state: protected|lapsed|unprotected, reason: ok|error|blocked|stale|never}, the same verdict the ClawKeep shield and the desktop shelf draw. It is null when the box is not paired, which is not a verdict but the answer itself. reason=stale means no recent backup; error means a run failed; blocked means no backup can run until this box has an encryption passphrase (Settings -> Backup); never means it has never backed up. Read the result's `notes` out too: they are the caveats that apply to THIS box, and they qualify the verdict.",
     {},
     { editions: ["openclaw", "hermes"], readOnly: true, maxChars: 4_000 },
     async () => {
@@ -591,10 +598,17 @@ export function registerSystemTools(reg: Registrar, ctx: McpContext): void {
       // the same verdict the two shields draw, plus the notes that rank the
       // fields for this box: leaving the misleading one in the body with
       // nothing to rank them keeps that read one plausible step away.
-      const protection = deriveProtection(
-        { ...body, lastBackupAtMs: body.lastBackupAtMs ?? 0 },
-        Date.now(),
-      );
+      // An unpaired box publishes NO verdict, exactly as the shelf shield does
+      // (`useClawkeepShieldStatus.ts`: "paired: false is the opt-in that has
+      // not happened"). deriveProtection() judges lastBackupAtMs alone and
+      // never sees `paired`, and unpairLocal() deliberately KEEPS the last
+      // successful stats — so deriving one here answered {protected, ok} for a
+      // box that had just been unpaired and can never back up again, while the
+      // shelf two inches away drew the calm setup shield. The three surfaces
+      // are required not to disagree (src/lib/clawkeep-protection.ts).
+      const protection = body.paired === false
+        ? null
+        : deriveProtection({ ...body, lastBackupAtMs: body.lastBackupAtMs ?? 0 }, Date.now());
       return json({ ...body, protection, notes: backupNotes(body, protection) });
     },
   );

--- a/src/tests/unit/mcp-tool-honesty.test.ts
+++ b/src/tests/unit/mcp-tool-honesty.test.ts
@@ -62,7 +62,7 @@ vi.mock("../../../mcp/lib/guard", async (importOriginal) => {
 import { ApiError, classifyError } from "../../../mcp/lib/errors";
 import type { McpContext } from "../../../mcp/lib/context";
 import { captureRegistrar } from "../helpers/mcp-registrar";
-import { MAX_DESCRIPTION_CHARS } from "../../../mcp/lib/register";
+import { contractViolations } from "../../../mcp/lib/register";
 import { registerAiTools } from "../../../mcp/tools/ai";
 import { registerBrowserTools } from "../../../mcp/tools/browser";
 import { registerSkillTools } from "../../../mcp/tools/skills";
@@ -571,14 +571,21 @@ describe("ClawKeep is gated on the edition that can actually run it", () => {
     expect(h.has("backup_status")).toBe(true);
   });
 
-  it("keeps the backup_status description inside the tool contract", () => {
-    // It was 1002 chars on beta — over MAX_DESCRIPTION_CHARS, which
-    // `npm run check:mcp-tools` fails on. Nothing in CI ran that checker
-    // (TASK-708), so this is the guard on the one description that broke it.
-    const desc = system("openclaw").get("backup_status").description;
-    expect(desc.length).toBeLessThanOrEqual(MAX_DESCRIPTION_CHARS);
+  it("keeps every system tool inside the contract check:mcp-tools enforces", () => {
+    // backup_status shipped at 1002 chars on beta — over MAX_DESCRIPTION_CHARS,
+    // which `npm run check:mcp-tools` fails on. No CI job runs that checker
+    // (TASK-708 covers adding it) and the registrar logs a violation without
+    // failing, by design, so nothing caught it. Assert the repo's own contract
+    // function over the whole file rather than one tool's length: the next
+    // description to grow is not going to be this one.
+    for (const edition of ["openclaw", "hermes"] as const) {
+      for (const tool of system(edition).reg.list()) {
+        expect({ [tool.name]: contractViolations(tool) }).toEqual({ [tool.name]: [] });
+      }
+    }
     // What the length budget must never cost: the verdict vocabulary the
     // agent answers from.
+    const desc = system("openclaw").get("backup_status").description;
     expect(desc).toMatch(/protected\|lapsed\|unprotected/);
     expect(desc).toMatch(/ok\|error\|blocked\|stale\|never/);
   });
@@ -608,8 +615,30 @@ describe("ClawKeep is gated on the edition that can actually run it", () => {
     const body = JSON.parse(out.text);
     expect(body.protection).toEqual({ state: "protected", reason: "ok" });
     const notes = (body.notes as string[]).join("\n");
-    expect(notes).toMatch(/schedule\.enabled is false/);
+    expect(notes).toMatch(/No backup schedule is armed/);
     expect(notes).toMatch(/nothing is scheduled to make a newer one/i);
+  });
+
+  it("caveats a missing schedule the same as a disabled one", async () => {
+    // expectedBackupWindowMs() widens to the no-schedule week on
+    // `!schedule?.enabled` — false OR null OR absent — and the ClawKeep card
+    // switches its copy on the same predicate. A note gated on `=== false`
+    // would let a null schedule take the lenient window with no caveat.
+    apiGet.mockResolvedValue({
+      paired: true,
+      configured: true,
+      supportedOnEdition: true,
+      encryptionConfigured: true,
+      lastBackupAtMs: Date.now() - 6 * 24 * 60 * 60 * 1000,
+      lastHeartbeatStatus: "ok",
+      schedule: null,
+    });
+
+    const out = await system("openclaw").call("backup_status", {});
+    if (out.isError) throw new Error("backup_status failed");
+    const body = JSON.parse(out.text);
+    expect(body.protection).toEqual({ state: "protected", reason: "ok" });
+    expect((body.notes as string[]).join("\n")).toMatch(/nothing is scheduled to make a newer one/i);
   });
 
   it("never hands the agent lastHeartbeatStatus without saying it is not an outcome", async () => {
@@ -631,16 +660,37 @@ describe("ClawKeep is gated on the edition that can actually run it", () => {
     const body = JSON.parse(out.text);
     expect(body.protection.state).not.toBe("protected");
     const notes = (body.notes as string[]).join("\n");
-    expect(notes).toMatch(/not an outcome/i);
+    expect(notes).toMatch(/not the outcome by itself/i);
     expect(notes).toMatch(/Answer from protection/i);
+    // The value itself is never interpolated into the note: it is already in
+    // the body, and result text is screened by neither the description length
+    // cap nor BANNED_DESCRIPTION_RE.
+    expect(notes).not.toMatch(/lastHeartbeatStatus is "/);
   });
 
-  it("tells the agent an unpaired box cannot be paired from a tool", async () => {
-    apiGet.mockResolvedValue({ paired: false, configured: false, supportedOnEdition: true });
+  it("publishes no verdict for an unpaired box, the way the shelf shield does not", async () => {
+    // unpairLocal() deliberately KEEPS the last successful stats, and
+    // deriveProtection() judges lastBackupAtMs alone — it never sees `paired`.
+    // So a box unpaired one minute ago still has a fresh lastBackupAtMs, and
+    // deriving a verdict from it answered "you're protected" over a box that
+    // can never back up again, while the shelf drew the calm setup shield.
+    // `useClawkeepShieldStatus` publishes protection: null there; so does this.
+    apiGet.mockResolvedValue({
+      paired: false,
+      configured: false,
+      supportedOnEdition: true,
+      encryptionConfigured: true,
+      lastBackupAtMs: Date.now() - 60 * 1000,
+      lastHeartbeatStatus: "ok",
+      schedule: { enabled: true, frequency: "daily" },
+    });
 
     const out = await system("openclaw").call("backup_status", {});
     if (out.isError) throw new Error("backup_status failed");
-    const notes = (JSON.parse(out.text).notes as string[]).join("\n");
+    const body = JSON.parse(out.text);
+    expect(body.protection).toBeNull();
+    const notes = (body.notes as string[]).join("\n");
+    expect(notes).toMatch(/not paired/i);
     expect(notes).toMatch(/Settings -> Backup/);
     expect(notes).toMatch(/no tool here can pair it/i);
   });

--- a/src/tests/unit/mcp-tool-honesty.test.ts
+++ b/src/tests/unit/mcp-tool-honesty.test.ts
@@ -617,11 +617,18 @@ describe("ClawKeep is gated on the edition that can actually run it", () => {
 
   it("says a protected verdict with the schedule off is not a promise of a newer backup", async () => {
     // Turning auto-backup off widens the tolerated backup age to the
-    // no-schedule week, so a five-day-stale nightly box answers
+    // no-schedule week, so a six-day-stale nightly box answers
     // {protected, ok} on one click. The ClawKeep card says so in prose; the
     // agent reading this tool has only the verdict unless something ranks it,
     // and "you're protected" over a box nothing will back up again is the same
     // false success the rest of this tool exists to stop.
+    //
+    // Six days is chosen, not rounded: it brackets the only two windows the
+    // verdict could be judged against — 36 h (DAY_MS + BACKUP_GRACE_MS, the
+    // armed-daily window) < 6 d < 7 d (UNSCHEDULED_MAX_AGE_MS). Anything under
+    // 36 h reads {protected, ok} whether or not expectedBackupWindowMs()
+    // honours `enabled: false`, so it would prove nothing about the widening
+    // this test is named for.
     //
     // The caveat rides on the RESULT, not the description: it is true of some
     // boxes and not others, and description text is paid for on every turn.
@@ -630,7 +637,7 @@ describe("ClawKeep is gated on the edition that can actually run it", () => {
       configured: true,
       supportedOnEdition: true,
       encryptionConfigured: true,
-      lastBackupAtMs: Date.now() - 24 * 60 * 60 * 1000,
+      lastBackupAtMs: Date.now() - 6 * 24 * 60 * 60 * 1000,
       lastHeartbeatStatus: "ok",
       schedule: { enabled: false, frequency: "daily" },
     });
@@ -648,37 +655,43 @@ describe("ClawKeep is gated on the edition that can actually run it", () => {
     // expectedBackupWindowMs() widens to the no-schedule week on
     // `!schedule?.enabled` — false OR null OR absent — and the ClawKeep card
     // switches its copy on the same predicate. A note gated on `=== false`
-    // would let a null schedule take the lenient window with no caveat.
-    apiGet.mockResolvedValue({
-      paired: true,
-      configured: true,
-      supportedOnEdition: true,
-      encryptionConfigured: true,
-      lastBackupAtMs: Date.now() - 6 * 24 * 60 * 60 * 1000,
-      lastHeartbeatStatus: "ok",
-      schedule: null,
-    });
+    // would let a null schedule take the lenient window with no caveat, so the
+    // two shapes that are not `false` are both walked here. Six days again,
+    // for the reason spelled out above: under 36 h neither shape would prove
+    // the widened window was the one taken.
+    for (const [shape, schedule] of [["null", { schedule: null }], ["omitted", {}]] as const) {
+      apiGet.mockResolvedValue({
+        paired: true,
+        configured: true,
+        supportedOnEdition: true,
+        encryptionConfigured: true,
+        lastBackupAtMs: Date.now() - 6 * 24 * 60 * 60 * 1000,
+        lastHeartbeatStatus: "ok",
+        ...schedule,
+      });
 
-    const out = await system("openclaw").call("backup_status", {});
-    if (out.isError) throw new Error("backup_status failed");
-    const body = JSON.parse(out.text);
-    expect(body.protection).toEqual({ state: "protected", reason: "ok" });
-    expect((body.notes as string[]).join("\n")).toMatch(/nothing is scheduled to make a newer one/i);
+      const out = await system("openclaw").call("backup_status", {});
+      if (out.isError) throw new Error("backup_status failed");
+      const body = JSON.parse(out.text);
+      expect(body.protection, `schedule ${shape}`).toEqual({ state: "protected", reason: "ok" });
+      expect((body.notes as string[]).join("\n"), `schedule ${shape}`)
+        .toMatch(/nothing is scheduled to make a newer one/i);
+    }
   });
 
   it("never hands the agent lastHeartbeatStatus without saying it is not an outcome", async () => {
     // The exact live failure: backups died days ago, the daemon never wrote a
     // heartbeat about it, so the last one still reads "ok". Read literally the
     // agent tells the owner the last run succeeded.
-    apiGet.mockResolvedValue({
+    const staleBox = {
       paired: true,
       configured: true,
       supportedOnEdition: true,
       encryptionConfigured: true,
       lastBackupAtMs: Date.now() - 30 * 24 * 60 * 60 * 1000,
-      lastHeartbeatStatus: "ok",
       schedule: { enabled: true, frequency: "daily" },
-    });
+    };
+    apiGet.mockResolvedValue({ ...staleBox, lastHeartbeatStatus: "ok" });
 
     const out = await system("openclaw").call("backup_status", {});
     if (out.isError) throw new Error("backup_status failed");
@@ -687,10 +700,24 @@ describe("ClawKeep is gated on the edition that can actually run it", () => {
     const notes = (body.notes as string[]).join("\n");
     expect(notes).toMatch(/not the outcome by itself/i);
     expect(notes).toMatch(/Answer from protection/i);
+
     // The value itself is never interpolated into the note: it is already in
     // the body, and result text is screened by neither the description length
-    // cap nor BANNED_DESCRIPTION_RE.
-    expect(notes).not.toMatch(/lastHeartbeatStatus is "/);
+    // cap nor BANNED_DESCRIPTION_RE. "ok" cannot show that — the note quotes
+    // the word as its own literal example ('can still read "ok"'), so an
+    // absence check on it would read a coincidence as a passing contract. Ask
+    // again with a value nothing but an interpolation could have put there.
+    const sentinel = "zzz-heartbeat-sentinel-622";
+    apiGet.mockResolvedValue({ ...staleBox, lastHeartbeatStatus: sentinel });
+    const probe = await system("openclaw").call("backup_status", {});
+    if (probe.isError) throw new Error("backup_status failed");
+    const probeBody = JSON.parse(probe.text);
+    // The fixture did arrive — otherwise the sentinel's absence from the notes
+    // below would only be saying the mock never landed.
+    expect(probeBody.lastHeartbeatStatus).toBe(sentinel);
+    const probeNotes = (probeBody.notes as string[]).join("\n");
+    expect(probeNotes).toMatch(/not the outcome by itself/i);
+    expect(probeNotes).not.toContain(sentinel);
   });
 
   it("publishes no verdict for an unpaired box, the way the shelf shield does not", async () => {

--- a/src/tests/unit/mcp-tool-honesty.test.ts
+++ b/src/tests/unit/mcp-tool-honesty.test.ts
@@ -68,6 +68,7 @@ import { registerBrowserTools } from "../../../mcp/tools/browser";
 import { registerSkillTools } from "../../../mcp/tools/skills";
 import { buildContext } from "../../../mcp/lib/context";
 import { registerOrientationTools } from "../../../mcp/tools/orientation";
+import { registerDesktopTools } from "../../../mcp/tools/desktop";
 import { desktopDisplay, registerSystemTools } from "../../../mcp/tools/system";
 
 const ctx = (
@@ -571,17 +572,41 @@ describe("ClawKeep is gated on the edition that can actually run it", () => {
     expect(h.has("backup_status")).toBe(true);
   });
 
-  it("keeps every system tool inside the contract check:mcp-tools enforces", () => {
+  it("keeps every system and desktop tool inside the contract check:mcp-tools enforces", () => {
     // backup_status shipped at 1002 chars on beta — over MAX_DESCRIPTION_CHARS,
     // which `npm run check:mcp-tools` fails on. No CI job runs that checker
     // (TASK-708 covers adding it) and the registrar logs a violation without
     // failing, by design, so nothing caught it. Assert the repo's own contract
     // function over the whole file rather than one tool's length: the next
     // description to grow is not going to be this one.
+    //
+    // Both capability postures, because four system tools register only when a
+    // probe says yes — disk_usage/disk_cleanup on `du`, logs_tail on `journal`,
+    // screen_capture on a grabber — and ctx()'s defaults have every probe off.
+    // A guard that skips whatever a device happens to have is a guard that
+    // green-lights the description it exists to catch. registerDesktopTools
+    // rides along for app_uninstall, the one description written per edition.
+    const postures: Partial<McpContext>[] = [
+      {}, // ctx()'s own defaults: every probe off
+      { capabilities: { screenGrabber: "scrot", imageConvert: true, journal: true, du: true } },
+    ];
+    const checked = new Set<string>();
     for (const edition of ["openclaw", "hermes"] as const) {
-      for (const tool of system(edition).reg.list()) {
-        expect({ [tool.name]: contractViolations(tool) }).toEqual({ [tool.name]: [] });
+      for (const overrides of postures) {
+        const h = captureRegistrar(edition);
+        registerSystemTools(h.reg, ctx(edition, [], overrides));
+        registerDesktopTools(h.reg, ctx(edition, [], overrides));
+        for (const tool of h.reg.list()) {
+          checked.add(tool.name);
+          expect({ [tool.name]: contractViolations(tool) }).toEqual({ [tool.name]: [] });
+        }
       }
+    }
+    // Name the probe-gated four: a gate rewritten so its tool no longer
+    // registers would otherwise shrink this loop back to what it used to cover,
+    // silently and while staying green.
+    for (const name of ["disk_usage", "disk_cleanup", "logs_tail", "screen_capture", "app_uninstall"]) {
+      expect([...checked]).toContain(name);
     }
     // What the length budget must never cost: the verdict vocabulary the
     // agent answers from.

--- a/src/tests/unit/mcp-tool-honesty.test.ts
+++ b/src/tests/unit/mcp-tool-honesty.test.ts
@@ -62,6 +62,7 @@ vi.mock("../../../mcp/lib/guard", async (importOriginal) => {
 import { ApiError, classifyError } from "../../../mcp/lib/errors";
 import type { McpContext } from "../../../mcp/lib/context";
 import { captureRegistrar } from "../helpers/mcp-registrar";
+import { MAX_DESCRIPTION_CHARS } from "../../../mcp/lib/register";
 import { registerAiTools } from "../../../mcp/tools/ai";
 import { registerBrowserTools } from "../../../mcp/tools/browser";
 import { registerSkillTools } from "../../../mcp/tools/skills";
@@ -570,16 +571,78 @@ describe("ClawKeep is gated on the edition that can actually run it", () => {
     expect(h.has("backup_status")).toBe(true);
   });
 
-  it("says a protected verdict with the schedule off is not a promise of a newer backup", () => {
+  it("keeps the backup_status description inside the tool contract", () => {
+    // It was 1002 chars on beta — over MAX_DESCRIPTION_CHARS, which
+    // `npm run check:mcp-tools` fails on. Nothing in CI ran that checker
+    // (TASK-708), so this is the guard on the one description that broke it.
+    const desc = system("openclaw").get("backup_status").description;
+    expect(desc.length).toBeLessThanOrEqual(MAX_DESCRIPTION_CHARS);
+    // What the length budget must never cost: the verdict vocabulary the
+    // agent answers from.
+    expect(desc).toMatch(/protected\|lapsed\|unprotected/);
+    expect(desc).toMatch(/ok\|error\|blocked\|stale\|never/);
+  });
+
+  it("says a protected verdict with the schedule off is not a promise of a newer backup", async () => {
     // Turning auto-backup off widens the tolerated backup age to the
     // no-schedule week, so a five-day-stale nightly box answers
     // {protected, ok} on one click. The ClawKeep card says so in prose; the
-    // agent reading this tool has only the verdict unless the description
-    // ranks it, and "you're protected" over a box nothing will back up again
-    // is the same false success the rest of this description exists to stop.
-    const desc = system("openclaw").get("backup_status").description;
-    expect(desc).toMatch(/schedule\.enabled/);
-    expect(desc).toMatch(/nothing is scheduled to make a newer one/i);
+    // agent reading this tool has only the verdict unless something ranks it,
+    // and "you're protected" over a box nothing will back up again is the same
+    // false success the rest of this tool exists to stop.
+    //
+    // The caveat rides on the RESULT, not the description: it is true of some
+    // boxes and not others, and description text is paid for on every turn.
+    apiGet.mockResolvedValue({
+      paired: true,
+      configured: true,
+      supportedOnEdition: true,
+      encryptionConfigured: true,
+      lastBackupAtMs: Date.now() - 24 * 60 * 60 * 1000,
+      lastHeartbeatStatus: "ok",
+      schedule: { enabled: false, frequency: "daily" },
+    });
+
+    const out = await system("openclaw").call("backup_status", {});
+    if (out.isError) throw new Error("backup_status failed");
+    const body = JSON.parse(out.text);
+    expect(body.protection).toEqual({ state: "protected", reason: "ok" });
+    const notes = (body.notes as string[]).join("\n");
+    expect(notes).toMatch(/schedule\.enabled is false/);
+    expect(notes).toMatch(/nothing is scheduled to make a newer one/i);
+  });
+
+  it("never hands the agent lastHeartbeatStatus without saying it is not an outcome", async () => {
+    // The exact live failure: backups died days ago, the daemon never wrote a
+    // heartbeat about it, so the last one still reads "ok". Read literally the
+    // agent tells the owner the last run succeeded.
+    apiGet.mockResolvedValue({
+      paired: true,
+      configured: true,
+      supportedOnEdition: true,
+      encryptionConfigured: true,
+      lastBackupAtMs: Date.now() - 30 * 24 * 60 * 60 * 1000,
+      lastHeartbeatStatus: "ok",
+      schedule: { enabled: true, frequency: "daily" },
+    });
+
+    const out = await system("openclaw").call("backup_status", {});
+    if (out.isError) throw new Error("backup_status failed");
+    const body = JSON.parse(out.text);
+    expect(body.protection.state).not.toBe("protected");
+    const notes = (body.notes as string[]).join("\n");
+    expect(notes).toMatch(/not an outcome/i);
+    expect(notes).toMatch(/Answer from protection/i);
+  });
+
+  it("tells the agent an unpaired box cannot be paired from a tool", async () => {
+    apiGet.mockResolvedValue({ paired: false, configured: false, supportedOnEdition: true });
+
+    const out = await system("openclaw").call("backup_status", {});
+    if (out.isError) throw new Error("backup_status failed");
+    const notes = (JSON.parse(out.text).notes as string[]).join("\n");
+    expect(notes).toMatch(/Settings -> Backup/);
+    expect(notes).toMatch(/no tool here can pair it/i);
   });
 
   it("answers backup_status honestly when the edition cannot run ClawKeep", async () => {


### PR DESCRIPTION
**Finding:** `npm run check:mcp-tools` fails on unmodified `origin/beta` (`0547c0bb`).

## Customer-visible symptom

`backup_status` is the tool the on-device agent answers "is my ClawBox backed up?" from. Its description is spliced into the `tools/list` payload the model reads on **every turn** — the budget that matters on a box running a 4-8B local model. PR #608 (`39dcbdc1`, "rank the schedule switch in what backup_status tells the agent") grew it to **1002 characters**, two over the `MAX_DESCRIPTION_CHARS = 1000` contract in `mcp/lib/register.ts`.

The registrar deliberately does not fail closed on a contract violation — it logs and carries on, so a customer device keeps its tool surface — which means the only thing that catches this is the checker, and the checker is not in CI (see below). The repo's own tool contract has therefore been red on `beta` since #608 merged.

## Cause

The description had grown to carry four separate pieces of guidance, three of which are **conditional** — true of some boxes and not others:

- an unpaired box must be sent to Settings -> Backup;
- `lastHeartbeatStatus` is not an outcome;
- a `{protected, ok}` verdict with `schedule.enabled === false` is not a promise of a newer backup.

Description text is the wrong place for a conditional rule twice over: it is paid for on every turn whether or not the tool is called, and it leaves the model to decide whether the rule applies to the box in front of it.

## Fix

The conditional caveats move onto the tool's **structured result** as a `notes` array, emitted only when they are true of this box. The description keeps exactly what the agent answers *from* — the `protection` state and reason vocabulary, and what each reason means.

- `backup_status` description: **1002 -> 625 chars** (375 margin, 37.5%).
- `tools/list` payload: 35.0 -> 34.6 KB (openclaw), 25.0 -> 24.6 KB (hermes).
- Worst-case result with all three notes present: 1588 chars against the tool's `maxChars: 4_000` cap.

Nothing the old description said is lost: every clause is either still in the description or emitted as a note. The unit test that pinned the schedule caveat to the description now pins it to the result, and three further tests pin the heartbeat, unpaired and missing-schedule cases.

### Second commit — what the review caught

Moving an unconditional warning behind a condition is only safe if the condition is as wide as the state the warning covered. On the first pass two of the three were narrower, which is the same false-success class the tool exists to prevent:

- **An unpaired box was still handed a verdict.** `deriveProtection()` judges `lastBackupAtMs` alone and never sees `paired`, and `unpairLocal()` keeps the last successful stats *by design* (`src/lib/clawkeep.ts`, "so the user doesn't lose the 'you're protected' history"). So a box unpaired one minute ago answered `{protected, ok}`. Both UI surfaces deliberately refuse to publish a verdict there — `useClawkeepShieldStatus.ts` sets `protection: null` with the comment *"paired: false is the opt-in that has not happened"*, and `ClawKeepApp.tsx` renders the verdict card only under `status.paired`. `src/lib/clawkeep-protection.ts` states the invariant outright: the shield, the shelf and this tool *"cannot disagree about whether the box is protected"*. **The tool now publishes `protection: null` for an unpaired box**, matching the shield.
- **The schedule caveat was gated on `schedule.enabled === false`**, but the lenient 7-day no-schedule window is taken on `!schedule?.enabled` — false *or* null *or* absent — and the ClawKeep card switches its copy on exactly that predicate. A null schedule got the wider window with no caveat. Now the same predicate, with a fixture for the null case.
- **"reason=ok means a recent backup succeeded" was a clause I added, and it is false.** Under the arm grace (`deriveProtection` anchors on `max(lastBackupAtMs, armGrace)`) a box whose newest backup is five days old reads `{protected, ok}` — behaviour that is intentional and separately tested. Dropped; beta never claimed it.
- The heartbeat note no longer interpolates the daemon's own `state.json` string into text the agent is told to read out — result text is screened by neither the length cap nor `BANNED_DESCRIPTION_RE`, so moving prose from description to result moves it outside the contract. It also no longer says the field is *never* an outcome, which is false for `error` and `needs-passphrase`, the two values `deriveProtection()` treats as authoritative.

**Harness note.** There is no OpenClaw/Hermes-native description-length rule to defer to — the MCP spec sets no limit. The contract is this repo's own (`MAX_DESCRIPTION_CHARS` + `contractViolations()` in `mcp/lib/register.ts`, enforced by `mcp/check-tools.ts`), so the repo's existing checker is the mechanism used here as the RED, rather than a new bespoke assertion.

## RED (unmodified beta, `0547c0bb`)

`npm run check:mcp-tools` — run with `bun` and the worktree's own `node_modules`:

```
[clawbox-mcp] TOOL CONTRACT: backup_status: description is 1002 chars (max 1000)
[clawbox-mcp] TOOL CONTRACT: backup_status: description is 1002 chars (max 1000)

openclaw: 52 tools, 35.0 KB of tools/list payload
hermes: 39 tools, 25.0 KB of tools/list payload

2 problem(s):
  - backup_status: description is 1002 chars (max 1000)
  - backup_status: description is 1002 chars (max 1000)
```

exit 1. (Reported once per edition — the checker builds the server for both.)

The new unit tests against beta's `mcp/tools/system.ts`:

```
 × keeps the backup_status description inside the tool contract
 × says a protected verdict with the schedule off is not a promise of a newer backup
 × never hands the agent lastHeartbeatStatus without saying it is not an outcome
 × tells the agent an unpaired box cannot be paired from a tool
AssertionError: expected 1002 to be less than or equal to 1000
 Tests  4 failed | 67 passed (71)
```

## GREEN

```
openclaw: 52 tools, 34.6 KB of tools/list payload
hermes: 39 tools, 24.6 KB of tools/list payload

Tool contract OK.
```

exit 0.

- `npx vitest run` over the MCP + ClawKeep unit suites: **35 files, 561 tests passed**.
- `npx tsc -p mcp/tsconfig.json`: the same **3 pre-existing** errors as `origin/beta` (`chat-history-cache.ts` x2, `harness/transport.ts`), **0 new** — verified by running the same command against beta's `mcp/tools/system.ts` in the same tree.
- `npx eslint` clean on both changed source files.

## Every other tool description swept against the same limit

All 70 `reg.tool()` sites in `mcp/tools/*.ts`, by AST rather than by runtime registration — so tools gated off on the dev machine are included (the runtime sweep alone misses `coding_agent_*`, which need the coding agent enabled).

`backup_status` was the only one over. The three longest that remain:

| tool | chars | margin |
|---|---|---|
| `coding_agent_run` | 995 | **5 (0.5%)** |
| `coding_agent_status` | 618 | 382 (38.2%) |
| `backup_status` (after this PR) | 625 | 375 (37.5%) |
| `bash` | 528 | 472 (47.2%) |

**Flagged, not fixed here:** `coding_agent_run` at 995 chars has 5 characters of headroom. It is *not* currently in violation and it is the one long description that CI already guards — `src/tests/unit/mcp-coding-agent-tools.test.ts` asserts every coding-agent description against `MAX_DESCRIPTION_CHARS`, and that suite does run in CI. So the next edit to it fails a CI job rather than silently shipping. Left alone deliberately: rewriting a description nobody has complained about, in the same PR that fixes a different one, is how the margin gets spent twice.

The seven descriptions built by concatenation or template rather than a plain literal were resolved at runtime and are all comfortably clear: `device_status` 437, `ui_open_app` 352, `ai_set_provider` 348, `ai_set_model` 306, `skill_list` 292, `skill_uninstall` 267, `app_uninstall` 241.

## Regression guard

Rather than assert one description's length, the test now runs the repo's own `contractViolations()` over **every tool `registerSystemTools` registers, on both editions** — the same function `check:mcp-tools` calls, so the unit suite and the checker cannot disagree about the rule. `src/tests/unit/mcp-coding-agent-tools.test.ts` already does this for its own tool set; this follows that precedent.

## Sibling call sites

- `deriveProtection` — behaviour and signature untouched; the call was only hoisted into a local so the notes can be derived from the same verdict. The other consumers (`ClawKeepApp.tsx`, `useClawkeepShieldStatus.ts`, `setup-api/clawkeep/schedule/route.ts` and their suites) are unaffected.
- `BackupStatusBody` / `NOT_ON_THIS_EDITION` — used only in `mcp/tools/system.ts`.
- `MAX_DESCRIPTION_CHARS` — the constant is unchanged; the other consumer (`mcp-coding-agent-tools.test.ts`) still passes.
- The `supportedOnEdition === false` path returns before the notes are built, so the Hermes "not available on this edition" answer is byte-identical.
- `mcp/README.md` documents this tool's behaviour, so the `notes` field and the unpaired `protection: null` are documented there.
- `useClawkeepShieldStatus.ts` and `ClawKeepApp.tsx` are the two surfaces this tool is required to agree with; the unpaired change brings it back into line with both rather than away from them. Neither needed editing, and their suites pass.

## Known-flaky, unrelated

A full `--project components` run failed `src/tests/components/chat-spoken-reply.test.tsx`; it passes alone (18/18), no component test imports `mcp/` (the two that mention it do so in comments), and this exact file under full parallelism is already on the run's residual list. Not from this change.

## CI gap

**No CI job runs `check:mcp-tools`.** `.github/workflows/pr-tests-coverage.yml` runs `check:sudoers` and `test:coverage:ci` only, and `typecheck:mcp` is not run either — which is why a red tool contract sat on `beta`. **TASK-708** covers adding it. The unit test added here runs in CI and guards this specific description in the meantime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `backup_status` now reports a clear protection verdict for paired devices.
  - Device-specific notes highlight backup schedule, heartbeat, and unpaired-device caveats.
  - Unpaired devices now show that protection status is unavailable.
  - Unsupported editions continue to receive status guidance without protection or note fields.

- **Documentation**
  - Updated backup status documentation to explain protection results and conditional notes.

- **Tests**
  - Expanded validation for system tool responses and backup status scenarios, including stale heartbeats and scheduling caveats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->