### PR TITLE
fix: label the Hermes skill documentation fetch while it runs

### DIFF
--- a/src/components/hermes-skills/SkillDetail.tsx
+++ b/src/components/hermes-skills/SkillDetail.tsx
@@ -11,7 +11,6 @@ import {
 } from '@/lib/hermes-skills';
 import { renderText } from '@/lib/chat-markdown';
 import { platformName, useCopy } from './copy';
-import type { DetailPhase } from './useSkillDetail';
 import {
   Alert,
   EmptyState,
@@ -83,24 +82,24 @@ function docsCollapsible(body: string): boolean {
  * outcome — body, or the `docs` failure note the panel already renders — is
  * what ends this.
  */
-function DocsPending({ phase, skillKey }: { phase: DetailPhase; skillKey: string }) {
+function DocsPending({ fetching }: { fetching: boolean }) {
   const COPY = useCopy();
-  const fetching = phase === 'docs';
   const [elapsed, setElapsed] = useState(0);
 
-  // Keyed on the identity the FETCH uses — `identifier || id` plus the tab the
-  // pick came from — not on `skill.id`: the same string is a lock name in the
-  // Installed tab and a registry identifier in Browse, and `onOpenSkill` can
-  // swap one for the other without unmounting this view.
+  // No reset here, and none needed: the caller keys this component on the
+  // identity the FETCH uses — `identifier || id` plus the tab the pick came
+  // from — and on whether the docs phase is running, so a new fetch is a new
+  // mount and `elapsed` starts at 0 by construction. Resetting it in the
+  // effect instead is a setState in an effect body, which cascades a render
+  // and which `react-hooks/set-state-in-effect` refuses.
   useEffect(() => {
-    setElapsed(0);
     if (!fetching) return;
     const startedAt = Date.now();
     const timer = setInterval(() => {
       setElapsed(Math.floor((Date.now() - startedAt) / 1000));
     }, 1000);
     return () => clearInterval(timer);
-  }, [skillKey, fetching]);
+  }, [fetching]);
 
   return (
     <div aria-hidden="true">
@@ -693,8 +692,17 @@ export function SkillDetail({
   const incompatible = detail?.incompatible ?? ('incompatible' in skill ? skill.incompatible : false);
 
   // The documentation is still on its way: no body yet, and the fetch that
-  // would bring one has not finished.
+  // would bring one has not finished. The SKELETON covers every pre-`done`
+  // phase, because during `meta` the panel has nothing else in it — every card
+  // below is gated on `detail` — and removing it would replace a placeholder
+  // with a blank body.
   const docsPending = phase !== 'done' && !detail?.body;
+  // What is ANNOUNCED, and what the stopwatch times, is narrower: only the
+  // phase that shells out to `hermes skills inspect`. Phase 1 never spawns the
+  // CLI, and `useSkillDetail` reports `meta` for a frame on every selection
+  // change, so saying "loading documentation" there would announce a fetch
+  // that has not started and time a request that is usually sub-second.
+  const docsFetching = phase === 'docs';
   // The identity `useSkillDetail` fetches and caches on — `detailKey()` there.
   const fetchKey = `${'origin' in skill ? 'i' : 'b'}:${
     ('identifier' in skill && skill.identifier) || skill.id
@@ -739,7 +747,7 @@ export function SkillDetail({
               is over. So it sits outside the branch below, which unmounts.
               (The same reasoning, and the same shape, as AiProviderList's.) */}
           <p className="sr-only" role="status" aria-live="polite">
-            {docsPending ? COPY.docsLoading : ''}
+            {docsFetching ? COPY.docsLoading : ''}
           </p>
           {/* Header */}
           <div className="flex gap-4 mb-5 flex-col @sm:flex-row">
@@ -826,7 +834,7 @@ export function SkillDetail({
 
               {docsPending && (
                 <Section title={COPY.sectionDocs}>
-                  <DocsPending phase={phase} skillKey={fetchKey} />
+                  <DocsPending key={`${fetchKey}:${docsFetching}`} fetching={docsFetching} />
                 </Section>
               )}
 

--- a/src/components/hermes-skills/SkillDetail.tsx
+++ b/src/components/hermes-skills/SkillDetail.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/lib/hermes-skills';
 import { renderText } from '@/lib/chat-markdown';
 import { platformName, useCopy } from './copy';
+import type { DetailPhase } from './useSkillDetail';
 import {
   Alert,
   EmptyState,
@@ -52,6 +53,67 @@ function hardenMarkdownLinks(markdown: string): string {
 /** Collapsed by default only for long documents — derived, never synced. */
 function docsCollapsible(body: string): boolean {
   return body.length > COLLAPSE_ABOVE;
+}
+
+/**
+ * The Documentation section while the phase-2 fetch is still running.
+ *
+ * Phase 2 shells out to `hermes skills inspect`, which takes 9.5-14.6 s on a
+ * Hermes box (measured read-only, 2026-09-04); the CLI cost is paid once per
+ * skill per store session, since `useSkillDetail` serves a reopen from its
+ * 50-entry cache and only a remount of the store pays it again. For all of
+ * that the section was five grey bars carrying `aria-hidden` with the only
+ * words in an `sr-only` paragraph: a sighted owner had nothing on screen to
+ * distinguish a slow fetch from a dead panel. Say what is being fetched, and
+ * count the seconds so a long wait reads as progressing rather than stuck.
+ *
+ * Entirely `aria-hidden`, and deliberately: `role="status"` is implicitly
+ * atomic, so a number ticking inside one makes a screen reader re-read the
+ * whole line every second for the length of the fetch — the same trap
+ * `ChatPopup`'s voice clock and `CodingAgentActivityPill` each had to close.
+ * What IS announced is the persistently-mounted region in `SkillDetail`, whose
+ * text changes at most twice per skill.
+ *
+ * The counter runs only in `docs`, the phase that shells out. Phase 1 never
+ * spawns the CLI, and `useSkillDetail` reports `meta` for a frame on every
+ * selection change, so counting there would put a stopwatch on a request that
+ * is usually sub-second and is not what the label names.
+ *
+ * The counter is not a timeout and never fails the section: the fetch's own
+ * outcome — body, or the `docs` failure note the panel already renders — is
+ * what ends this.
+ */
+function DocsPending({ phase, skillKey }: { phase: DetailPhase; skillKey: string }) {
+  const COPY = useCopy();
+  const fetching = phase === 'docs';
+  const [elapsed, setElapsed] = useState(0);
+
+  // Keyed on the identity the FETCH uses — `identifier || id` plus the tab the
+  // pick came from — not on `skill.id`: the same string is a lock name in the
+  // Installed tab and a registry identifier in Browse, and `onOpenSkill` can
+  // swap one for the other without unmounting this view.
+  useEffect(() => {
+    setElapsed(0);
+    if (!fetching) return;
+    const startedAt = Date.now();
+    const timer = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - startedAt) / 1000));
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [skillKey, fetching]);
+
+  return (
+    <div aria-hidden="true">
+      <p className="text-xs text-[var(--text-secondary)] mb-2">
+        {fetching && elapsed >= 2 ? COPY.docsLoadingElapsed(elapsed) : COPY.docsLoading}
+      </p>
+      <div className="space-y-2 motion-safe:animate-pulse">
+        {[...Array(5)].map((_, i) => (
+          <div key={i} className="h-3 rounded bg-[var(--surface-card)]" style={{ width: `${90 - i * 8}%` }} />
+        ))}
+      </div>
+    </div>
+  );
 }
 
 function DocumentBody({
@@ -630,6 +692,14 @@ export function SkillDetail({
   const platforms = detail?.platforms || ('platforms' in skill ? skill.platforms : undefined);
   const incompatible = detail?.incompatible ?? ('incompatible' in skill ? skill.incompatible : false);
 
+  // The documentation is still on its way: no body yet, and the fetch that
+  // would bring one has not finished.
+  const docsPending = phase !== 'done' && !detail?.body;
+  // The identity `useSkillDetail` fetches and caches on — `detailKey()` there.
+  const fetchKey = `${'origin' in skill ? 'i' : 'b'}:${
+    ('identifier' in skill && skill.identifier) || skill.id
+  }`;
+
   const copyId = async () => {
     try {
       await navigator.clipboard.writeText(identifier);
@@ -661,6 +731,16 @@ export function SkillDetail({
 
       <div className="flex-1 overflow-y-auto @container">
         <div className="p-6 max-w-3xl w-full mx-auto">
+          {/* MOUNTED IN EVERY STATE, empty when there is nothing to say. A live
+              region that appears together with its text announces a node
+              insertion, which assistive tech may drop; one that is already
+              there announces a text CHANGE, which it will not — and the same
+              applies on the way out, where the emptying is what says the wait
+              is over. So it sits outside the branch below, which unmounts.
+              (The same reasoning, and the same shape, as AiProviderList's.) */}
+          <p className="sr-only" role="status" aria-live="polite">
+            {docsPending ? COPY.docsLoading : ''}
+          </p>
           {/* Header */}
           <div className="flex gap-4 mb-5 flex-col @sm:flex-row">
             <SkillTile name={skill.name} category={detail?.category || skill.category} tags={tags} large />
@@ -744,18 +824,9 @@ export function SkillDetail({
                 />
               ) : null}
 
-              {phase !== 'done' && !detail?.body && (
+              {docsPending && (
                 <Section title={COPY.sectionDocs}>
-                  <div className="space-y-2 animate-pulse" aria-hidden="true">
-                    {[...Array(5)].map((_, i) => (
-                      <div
-                        key={i}
-                        className="h-3 rounded bg-[var(--surface-card)]"
-                        style={{ width: `${90 - i * 8}%` }}
-                      />
-                    ))}
-                  </div>
-                  <p className="sr-only">{COPY.docsLoading}</p>
+                  <DocsPending phase={phase} skillKey={fetchKey} />
                 </Section>
               )}
 

--- a/src/components/hermes-skills/copy.ts
+++ b/src/components/hermes-skills/copy.ts
@@ -152,6 +152,7 @@ export function useCopy() {
       docsFull: t('skills.docsFull'),
       docsPreview: t('skills.docsPreview'),
       docsLoading: t('skills.docsLoading'),
+      docsLoadingElapsed: (s: number) => t('skills.docsLoadingElapsed', { s }),
       docsUnavailable: t('skills.docsUnavailable'),
 
       reqCommands: t('skills.reqCommands'),

--- a/src/lib/hermes-translations/bg.ts
+++ b/src/lib/hermes-translations/bg.ts
@@ -288,6 +288,7 @@ export const bg: Record<string, string> = {
   "skills.docsFull": "Пълен SKILL.md",
   "skills.docsPreview": "Преглед на документацията — пълният текст е достъпен след инсталиране",
   "skills.docsLoading": "Зареждане на документацията…",
+  "skills.docsLoadingElapsed": "Зареждане на документацията… ({s} с)",
   "skills.docsUnavailable": "За това умение още няма документация.",
 
   // === Requirements card ===

--- a/src/lib/hermes-translations/de.ts
+++ b/src/lib/hermes-translations/de.ts
@@ -300,6 +300,7 @@ export const de: Record<string, string> = {
   "skills.docsFull": "Vollständige SKILL.md",
   "skills.docsPreview": "Vorschau der Dokumentation — der vollständige Text ist nach der Installation verfügbar",
   "skills.docsLoading": "Dokumentation wird geladen…",
+  "skills.docsLoadingElapsed": "Dokumentation wird geladen… ({s} s)",
   "skills.docsUnavailable": "Für diesen Skill gibt es noch keine Dokumentation.",
 
   // === Requirements card ===

--- a/src/lib/hermes-translations/en-skills.ts
+++ b/src/lib/hermes-translations/en-skills.ts
@@ -131,6 +131,7 @@ export const skillsEn: Record<string, string> = {
   "skills.docsFull": "Full SKILL.md",
   "skills.docsPreview": "Documentation preview — the full text is available after install",
   "skills.docsLoading": "Loading documentation…",
+  "skills.docsLoadingElapsed": "Loading documentation… ({s}s)",
   "skills.docsUnavailable": "No documentation available for this skill yet.",
 
   // === Requirements card ===

--- a/src/lib/hermes-translations/es.ts
+++ b/src/lib/hermes-translations/es.ts
@@ -296,6 +296,7 @@ export const es: Record<string, string> = {
   "skills.docsFull": "SKILL.md completo",
   "skills.docsPreview": "Vista previa de la documentación — el texto completo está disponible tras la instalación",
   "skills.docsLoading": "Cargando la documentación…",
+  "skills.docsLoadingElapsed": "Cargando la documentación… ({s} s)",
   "skills.docsUnavailable": "Todavía no hay documentación para esta habilidad.",
 
   // === Requirements card ===

--- a/src/lib/hermes-translations/fr.ts
+++ b/src/lib/hermes-translations/fr.ts
@@ -301,6 +301,7 @@ export const fr: Record<string, string> = {
   "skills.docsFull": "SKILL.md complet",
   "skills.docsPreview": "Aperçu de la documentation — le texte complet est disponible après l'installation",
   "skills.docsLoading": "Chargement de la documentation…",
+  "skills.docsLoadingElapsed": "Chargement de la documentation… ({s} s)",
   "skills.docsUnavailable": "Aucune documentation n'est encore disponible pour cette compétence.",
 
   // === Requirements card ===

--- a/src/lib/hermes-translations/it.ts
+++ b/src/lib/hermes-translations/it.ts
@@ -312,6 +312,7 @@ export const it: Record<string, string> = {
   "skills.docsFull": "SKILL.md completo",
   "skills.docsPreview": "Anteprima della documentazione — il testo completo è disponibile dopo l'installazione",
   "skills.docsLoading": "Caricamento della documentazione…",
+  "skills.docsLoadingElapsed": "Caricamento della documentazione… ({s} s)",
   "skills.docsUnavailable": "Per questa competenza non c'è ancora documentazione.",
 
   // === Requirements card ===

--- a/src/lib/hermes-translations/ja.ts
+++ b/src/lib/hermes-translations/ja.ts
@@ -303,6 +303,7 @@ export const ja: Record<string, string> = {
   "skills.docsFull": "SKILL.md 全文",
   "skills.docsPreview": "ドキュメントのプレビュー — 全文はインストール後に読めます",
   "skills.docsLoading": "ドキュメントを読み込み中…",
+  "skills.docsLoadingElapsed": "ドキュメントを読み込み中… ({s}秒)",
   "skills.docsUnavailable": "このスキルにはまだドキュメントがありません。",
 
   // === Requirements card ===

--- a/src/lib/hermes-translations/nl.ts
+++ b/src/lib/hermes-translations/nl.ts
@@ -301,6 +301,7 @@ export const nl: Record<string, string> = {
   "skills.docsFull": "Volledige SKILL.md",
   "skills.docsPreview": "Voorbeeld van de documentatie — de volledige tekst is beschikbaar na installatie",
   "skills.docsLoading": "Documentatie laden…",
+  "skills.docsLoadingElapsed": "Documentatie laden… ({s} s)",
   "skills.docsUnavailable": "Voor deze skill is nog geen documentatie beschikbaar.",
 
   // === Requirements card ===

--- a/src/lib/hermes-translations/sv.ts
+++ b/src/lib/hermes-translations/sv.ts
@@ -297,6 +297,7 @@ export const sv: Record<string, string> = {
   "skills.docsFull": "Fullständig SKILL.md",
   "skills.docsPreview": "Förhandsvisning av dokumentationen — hela texten finns efter installationen",
   "skills.docsLoading": "Laddar dokumentation…",
+  "skills.docsLoadingElapsed": "Laddar dokumentation… ({s} s)",
   "skills.docsUnavailable": "Det finns ingen dokumentation för den här skillen än.",
 
   // === Requirements card ===

--- a/src/lib/hermes-translations/zh.ts
+++ b/src/lib/hermes-translations/zh.ts
@@ -312,6 +312,7 @@ export const zh: Record<string, string> = {
   "skills.docsFull": "完整 SKILL.md",
   "skills.docsPreview": "文档预览 — 完整内容在安装后可见",
   "skills.docsLoading": "正在加载文档…",
+  "skills.docsLoadingElapsed": "正在加载文档…（{s} 秒）",
   "skills.docsUnavailable": "此技能暂无可用文档。",
 
   // === Requirements card ===

--- a/src/tests/components/hermes-skill-docs-loading.test.tsx
+++ b/src/tests/components/hermes-skill-docs-loading.test.tsx
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, act } from "@/tests/helpers/test-utils";
+import { SkillDetail } from "@/components/hermes-skills/SkillDetail";
+
+/**
+ * TASK-635, second half — the Documentation skeleton said nothing.
+ *
+ * The phase-2 documentation fetch shells out to `hermes skills inspect`. On a
+ * Hermes box it takes 9.5-14.6 s (measured read-only, 2026-09-04), and for that
+ * whole time the panel showed five grey bars and no words: the only label was
+ * `sr-only`, so a sighted owner could not tell a slow fetch from a dead panel.
+ *
+ * Two contracts, and the second is the one the first endangers:
+ *
+ *   The section must SAY it is fetching and count the seconds, on screen.
+ *
+ *   Nothing may put that ticking number inside a live region. `role="status"`
+ *   is implicitly atomic, so a per-second change there is a per-second
+ *   re-announcement of the whole line — the trap ChatPopup's voice clock and
+ *   CodingAgentActivityPill each had to close. What is announced is one
+ *   persistently-mounted region whose text changes at most twice per skill.
+ */
+
+vi.mock("@/lib/i18n", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/i18n")>();
+  const { skillsEn } = await import("@/lib/hermes-translations/en-skills");
+  return {
+    ...actual,
+    useT: () => ({
+      locale: "en" as const,
+      localeResolved: true,
+      setLocale: () => {},
+      t: (key: string, params?: Record<string, string | number>) =>
+        Object.entries(params ?? {}).reduce(
+          (out, [name, value]) => out.replaceAll(`{${name}}`, String(value)),
+          skillsEn[key] ?? key,
+        ),
+    }),
+  };
+});
+
+const SKILL = { id: "accelerated-computing-cudf", name: "cuDF", source: "github", trust: "trusted" };
+
+function renderDetail(phase: "meta" | "docs" | "done", body?: string) {
+  return render(
+    <SkillDetail
+      skill={SKILL}
+      detail={{ id: SKILL.id, name: SKILL.name, source: SKILL.source, ...(body ? { body } : {}) } as never}
+      phase={phase}
+      error={null}
+      ambiguous={null}
+      action={null}
+      breadcrumb="Installed"
+      installedNames={new Set([SKILL.id])}
+      onBack={() => {}}
+      onOpenSkill={() => {}}
+    />,
+  );
+}
+
+/** The one region that speaks: persistently mounted, `sr-only`. */
+function liveRegion(): HTMLElement {
+  return document.querySelector('p.sr-only[role="status"]') as HTMLElement;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("Documentation section while the phase-2 fetch runs", () => {
+  it("shows the label to a sighted owner, not only to a screen reader", () => {
+    renderDetail("docs");
+    const label = screen.getAllByText(/Loading documentation/).find((el) => !el.className.includes("sr-only"));
+    expect(label).toBeTruthy();
+  });
+
+  it("counts the seconds while the fetch runs", async () => {
+    renderDetail("docs");
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    expect(screen.getByText(/\b4s\b/)).toBeTruthy();
+  });
+
+  it("keeps the ticking number out of the accessibility tree", async () => {
+    renderDetail("docs");
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    const spoken = liveRegion();
+    const before = spoken.textContent;
+    expect(before).toBe("Loading documentation…");
+    // The number is on screen...
+    expect(screen.getByText(/\b3s\b/).closest('[aria-hidden="true"]')).toBeTruthy();
+    // ...and six more seconds change nothing that would be read out again.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6000);
+    });
+    expect(liveRegion().textContent).toBe(before);
+  });
+
+  it("keeps the region mounted once the documentation lands, and empties it", () => {
+    const { rerender } = renderDetail("docs");
+    expect(liveRegion().textContent).toBe("Loading documentation…");
+
+    rerender(
+      <SkillDetail
+        skill={SKILL}
+        detail={{ id: SKILL.id, name: SKILL.name, source: SKILL.source, body: "# cuDF\n\nDocs." } as never}
+        phase="done"
+        error={null}
+        ambiguous={null}
+        action={null}
+        breadcrumb="Installed"
+        installedNames={new Set([SKILL.id])}
+        onBack={() => {}}
+        onOpenSkill={() => {}}
+      />,
+    );
+
+    // Still there — the emptying is what says the wait is over.
+    expect(liveRegion()).toBeTruthy();
+    expect(liveRegion().textContent).toBe("");
+  });
+
+  it("does not put a stopwatch on phase 1, which never spawns the CLI", async () => {
+    renderDetail("meta");
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(screen.queryByText(/\b\ds\b/)).toBeNull();
+    // The label is still there — just without a stopwatch on it.
+    expect(screen.getAllByText("Loading documentation…").length).toBe(2);
+  });
+});

--- a/src/tests/components/hermes-skill-docs-loading.test.tsx
+++ b/src/tests/components/hermes-skill-docs-loading.test.tsx
@@ -127,13 +127,19 @@ describe("Documentation section while the phase-2 fetch runs", () => {
     expect(liveRegion().textContent).toBe("");
   });
 
-  it("does not put a stopwatch on phase 1, which never spawns the CLI", async () => {
+  it("does not put a stopwatch on phase 1, or announce a fetch that has not started", async () => {
+    // Phase 1 reads disk and never spawns the CLI, and `useSkillDetail` reports
+    // `meta` for a frame on every selection change. The placeholder stays —
+    // every card below it is gated on `detail`, so removing it would leave a
+    // blank body — but nothing times it and nothing is announced.
     renderDetail("meta");
     await act(async () => {
       await vi.advanceTimersByTimeAsync(5000);
     });
+
     expect(screen.queryByText(/\b\ds\b/)).toBeNull();
-    // The label is still there — just without a stopwatch on it.
-    expect(screen.getAllByText("Loading documentation…").length).toBe(2);
+    expect(liveRegion().textContent).toBe("");
+    // Still on screen, just silent: one occurrence, the visible one.
+    expect(screen.getAllByText("Loading documentation…").length).toBe(1);
   });
 });


### PR DESCRIPTION
**TASK-635** — Skills app: the Documentation section is an unlabelled skeleton for the length of a 9–15 s fetch.

## The card had two halves. One of them is refuted.

**REFUTED — "an Installed-tab search with no match renders a blank pane."** It does not, on
`origin/beta` 08e7057d, and it does not on the Hermes box running that exact commit. Verified
three ways, read-only:

* Live browser on the device, Skills app → Installed (89) → type `weather`:

  ```
  installed tab count 1 label Installed (89)
  BEFORE panel len 15775
  AFTER panel text >>> "search_off\n\nNo skills match “weather”"
  ```

* The same 89-row payload the device serves, replayed through the component in jsdom:
  panel text `"search_offNo skills match “weather”"`.

* The empty state's condition (`!installed.error && installed.skills.length > 0 &&
  installedFiltered.length === 0`, `HermesSkillsStore.tsx:1175`) has been in place since
  2026-08-10, well before the 2026-09-02 measurement.

The reported copy (`No installed skill matches "weather"`) is not what ships — the string is
`No skills match “weather”`, with curly quotes — which is the most likely reason a DOM scan for
the expected wording found nothing. No code change was made for this half.

**FIXED — the other half, which the triage kept: the Documentation section says nothing while it
loads.**

## Symptom

Open any skill whose documentation lives remotely. Five grey bars, no words, for 9.5–14.6 s.
The only label was `sr-only`, so a sighted owner had nothing to distinguish a slow fetch from a
dead panel.

## Cause

`SkillDetail.tsx` rendered the phase-2 skeleton with `aria-hidden` on the bars and
`<p className="sr-only">{COPY.docsLoading}</p>` beside them.

## Harness-first

Nothing native is re-implemented. `hermes skills inspect` prints Rich TUI panels, has no `--json`
and emits no progress stream, so there is no harness-side progress to surface — a client-side
elapsed counter is the only option. The two levers that do exist are already in place and are
left alone: the inspect route's 45 s `cli_timeout`, and `useSkillDetail`'s 50-entry detail cache,
which serves a reopen of the same skill without touching the CLI.

## Device evidence (read-only, Hermes box on beta 08e7057d)

```
inspect id=about                        pass=1 http=404 ms=14606
inspect id=about                        pass=2 http=404 ms=9503
inspect id=accelerated-computing-cudf   pass=1 http=200 ms=11114
inspect id=accelerated-computing-cudf   pass=2 http=200 ms=9573
```

## RED → GREEN

`src/tests/components/hermes-skill-docs-loading.test.tsx`, on unmodified beta 08e7057d:

```
 × shows the label to a sighted owner, not only to a screen reader
 × counts the seconds while the fetch runs
 × keeps the ticking number out of the accessibility tree
 × keeps the region mounted once the documentation lands, and empties it
 × does not put a stopwatch on phase 1, which never spawns the CLI
AssertionError: expected undefined to be truthy
TestingLibraryElementError: Unable to find an element with the text: /\b4s\b/
AssertionError: expected 1 to be 2
      Tests  5 failed (5)
```

On the branch: 5 passed. Neighbouring suites (5 hermes-skills component suites, both translation
parity suites, the skills-secrets route suite) 320 passed; `tsc --noEmit` clean.

## Accessibility, which the review pass caught

The first cut put the counter inside a `role="status"` node. That role is implicitly atomic, so
each tick re-announces the whole line — up to ~44 announcements on a `cli_timeout`. This repo has
closed the same trap twice (`ChatPopup`'s voice clock, `CodingAgentActivityPill`). The skeleton
is now entirely `aria-hidden`, and what speaks is a single `sr-only` region mounted for the life
of the panel, so the start and the finish are text changes rather than a node appearing and
disappearing — the shape `AiProviderList` documents. Both are pinned by tests.

## Both editions

Hermes-only surface: the Skills store is behind `hermesSkillsGuard`, and the whole component is
unreachable on an OpenClaw box. `skills.docsLoadingElapsed` carries its own copy in all ten
locales, so `hermes-translations.test.ts` parity holds.

## Not in this PR

The card's remaining ask — memoising the phase-2 docs server-side per skill id — is deliberately
left out: the triage line for TASK-639 says to land that card's shared timeout constant first,
and it touches the same inspect route.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved skill documentation loading feedback with animated placeholders, accessible status messages, and elapsed-time indicators.
  - Loading status resets appropriately when switching skills or loading phases.
  - Added translated loading-time messages across supported languages.

- **Bug Fixes**
  - Improved screen-reader announcements during documentation loading and completion.
  - Prevented unnecessary timer display during metadata loading.

- **Tests**
  - Added coverage for loading text, elapsed seconds, accessibility behavior, and status clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->