### PR TITLE
fix: stop chat/model answering for a store the box does not use

### DIFF
--- a/mcp/tools/orientation.ts
+++ b/mcp/tools/orientation.ts
@@ -136,11 +136,17 @@ interface ClawaiPayload {
  * `wrong_store` is the route's refusal (409) on a box whose harness keeps its
  * own model — the same code chat/history uses. It is read here so the two
  * halves of `ai` cannot contradict each other; see `limits` below.
+ *
+ * `activeModel` is `agents.defaults.model.primary` as the route reports it —
+ * the SAME key `readConfiguredModelLimits()` parses. Everything in `ai` is
+ * derived from it and nothing else: the payload's `primary` object is the
+ * "back to primary" TARGET, which on a box running its local model is a
+ * different row, and mixing the two produced a provider from one model beside
+ * the id and context window of another.
  */
 interface ChatModelPayload {
   activeModel?: string | null;
   activeLabel?: string | null;
-  primary?: { provider?: string | null; model?: string | null; label?: string | null } | null;
   code?: string;
 }
 
@@ -161,6 +167,13 @@ function bareModelId(ref: string | null | undefined): string | null {
   if (typeof ref !== "string" || !ref) return null;
   const slash = ref.indexOf("/");
   return slash > 0 && slash < ref.length - 1 ? ref.slice(slash + 1) : ref;
+}
+
+/** Its other half: `provider/modelId` -> the namespace the gateway routes through. */
+function providerOf(ref: string | null | undefined): string | null {
+  if (typeof ref !== "string" || !ref) return null;
+  const slash = ref.indexOf("/");
+  return slash > 0 && slash < ref.length - 1 ? ref.slice(0, slash) : null;
 }
 
 /** Keep only positive whole-token counts; invalid config stays visibly unknown. */
@@ -263,9 +276,14 @@ export function registerOrientationTools(reg: Registrar, ctx: McpContext): void 
                 : "unknown",
             }
           : {
+              // ONE source. Both halves and the limits below come from
+              // `agents.defaults.model.primary`, so the payload can only name a
+              // model the box is actually set to — or nothing, which is the
+              // truthful answer on a box with nothing pinned and the whole
+              // point of the route's own null guard.
               device_default: {
-                provider: reported(chatModel?.primary?.provider),
-                model: reported(bareModelId(chatModel?.activeModel ?? chatModel?.primary?.model)),
+                provider: reported(providerOf(chatModel?.activeModel)),
+                model: reported(bareModelId(chatModel?.activeModel)),
                 thinking: "unknown",
               },
               current_chat: ctx.install === "dual" ? UNCONFIRMED_EDITION_CHAT_NOTE : OPENCLAW_CURRENT_CHAT_NOTE,

--- a/mcp/tools/orientation.ts
+++ b/mcp/tools/orientation.ts
@@ -125,9 +125,23 @@ interface ClawaiPayload {
   model?: string;
 }
 
+/**
+ * The shape /setup-api/chat/model actually answers with.
+ *
+ * It never had `selected` or `current`: this tool read two keys the route has
+ * never returned, so `reported()` mapped both to "unknown" and every OpenClaw
+ * box reported `device_default: {provider:"unknown", model:"unknown"}`. The
+ * tests that should have caught it invented the payload themselves.
+ *
+ * `wrong_store` is the route's refusal (409) on a box whose harness keeps its
+ * own model — the same code chat/history uses. It is read here so the two
+ * halves of `ai` cannot contradict each other; see `limits` below.
+ */
 interface ChatModelPayload {
-  selected?: { model?: string | null; provider?: string | null; label?: string } | null;
-  current?: string | null;
+  activeModel?: string | null;
+  activeLabel?: string | null;
+  primary?: { provider?: string | null; model?: string | null; label?: string | null } | null;
+  code?: string;
 }
 
 interface ConfiguredModelLimits {
@@ -135,6 +149,18 @@ interface ConfiguredModelLimits {
   context_window_tokens: number | "unknown";
   max_output_tokens: number | "unknown";
   source: "openclaw_config";
+}
+
+/**
+ * `provider/modelId` -> the id half, so the OpenClaw leg reports the same shape
+ * the Hermes one does (`hermesDeviceDefault`): a bare model id beside a
+ * separate provider, not the qualified reference repeated in both fields.
+ * A reference with no namespace is passed through as-is.
+ */
+function bareModelId(ref: string | null | undefined): string | null {
+  if (typeof ref !== "string" || !ref) return null;
+  const slash = ref.indexOf("/");
+  return slash > 0 && slash < ref.length - 1 ? ref.slice(slash + 1) : ref;
 }
 
 /** Keep only positive whole-token counts; invalid config stays visibly unknown. */
@@ -238,12 +264,19 @@ export function registerOrientationTools(reg: Registrar, ctx: McpContext): void 
             }
           : {
               device_default: {
-                provider: reported(chatModel?.selected?.provider),
-                model: reported(chatModel?.selected?.model ?? chatModel?.current),
+                provider: reported(chatModel?.primary?.provider),
+                model: reported(bareModelId(chatModel?.activeModel ?? chatModel?.primary?.model)),
                 thinking: "unknown",
               },
               current_chat: ctx.install === "dual" ? UNCONFIRMED_EDITION_CHAT_NOTE : OPENCLAW_CURRENT_CHAT_NOTE,
-              limits: readConfiguredModelLimits(),
+              // Both halves answer from the SAME store or neither does. `ctx.edition`
+              // is resolved once at MCP startup and falls back to "openclaw" when the
+              // web app is not up yet, so on a dual box this branch can run while
+              // Hermes is active — and the route then 409s while this file happily
+              // parses openclaw.json. That produced one payload saying "I do not know
+              // my model" beside a named model with a context window, which the
+              // server's own instructions tell every model to read as authoritative.
+              limits: chatModel ? readConfiguredModelLimits() : "unknown",
             };
 
       return json({

--- a/src/app/setup-api/chat/history/route.ts
+++ b/src/app/setup-api/chat/history/route.ts
@@ -47,8 +47,12 @@ async function transcriptLivesHere(): Promise<boolean> {
   return !capabilitiesFor(harness, UNKNOWN_FACTS).hasLiveConnection;
 }
 
+// The same refusal chat/model makes about the chat's model, and it carries the
+// same `code`: two routes that say "you are asking the wrong store" must be one
+// thing a caller can switch on, not two shapes to string-match.
 const WRONG_STORE = {
   error: "This box's chat transcript is held by its agent gateway, not on disk. Ask the gateway.",
+  code: "wrong_store",
 } as const;
 
 const BAD_KEY = { error: "Invalid session key" } as const;

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from "next/server";
+import { getActiveHarness } from "@/lib/harness";
+import { UNKNOWN_FACTS, capabilitiesFor } from "@/lib/harness/capabilities";
 import { getAll } from "@/lib/config-store";
 import {
   GatewayNotReadyError,
@@ -716,10 +718,17 @@ async function loadChatModelState(preloaded?: OpenClawConfig) {
   // `openai` one first, and the header then rendered the API-key row — with
   // its catalogue — for a model the box routes through the subscription.
   const activeUiProvider = uiProviderForModel(activeModel);
-  const activeOption = options.find(
-    (option) => option.model === activeModel
-      && (!activeUiProvider || option.provider === activeUiProvider),
-  ) ?? options.find((option) => option.model === activeModel) ?? null;
+  // Only ever asked about a model that EXISTS. The Local-AI placeholder row
+  // carries `model: null` when no local model is configured, so a null
+  // activeModel — a box with nothing pinned yet — used to match it and be
+  // reported as the active chat model, complete with the "Local AI" label and
+  // an `available: false` beside it.
+  const activeOption = activeModel
+    ? options.find(
+        (option) => option.model === activeModel
+          && (!activeUiProvider || option.provider === activeUiProvider),
+      ) ?? options.find((option) => option.model === activeModel) ?? null
+    : null;
   const activeLabel = activeOption?.label ?? null;
 
   return {
@@ -770,7 +779,55 @@ function refuseDisabledProvider(
   );
 }
 
+/**
+ * Whether the chat's provider and model live in THIS route's store.
+ *
+ * Everything below reads and writes `agents.defaults.model.primary` in
+ * ~/.openclaw/openclaw.json. On the Hermes SKU that key is never written, and
+ * on the dual SKU `ai-models/configure` does keep it warm for the OpenClaw
+ * half — but while Hermes is the active harness it is not this box's chat
+ * model. That lives in `model.provider` / `model.default` in
+ * ~/.hermes/config.yaml, which the harness's own CLI owns and which
+ * /setup-api/hermes/models already serves — live catalogue, provider scope,
+ * pairing enforcement and all. Answering here from the OpenClaw config would
+ * be a second, thinner source of truth for the same question.
+ *
+ * Asked as a CAPABILITY, the way its sibling `chat/history` asks whether the
+ * transcript lives here: `modelStore` is the box's own statement about which
+ * store holds the answer, so the day a third harness arrives this route needs
+ * no edit — and the two "wrong store" refusals stay on one mechanism instead
+ * of each re-deciding from the harness id.
+ *
+ * Facts do not matter to it (no capability read here depends on a credential),
+ * so the cautious defaults are enough and this stays a cheap call.
+ */
+async function chatModelLivesHere(): Promise<boolean> {
+  const harness = await getActiveHarness();
+  return capabilitiesFor(harness, UNKNOWN_FACTS).modelStore === "openclaw-config";
+}
+
+/**
+ * Mirrors chat/history's refusal, for the same reason: a caller asking the
+ * wrong store is told so, rather than handed a confident answer about a store
+ * that does not hold its subject. Before this, a Hermes box answered
+ * `activeOptionId: "__setup_local__"` / `activeLabel: "Local AI"` — a row the
+ * same payload marks unavailable — while the chat was demonstrably running
+ * turns on a cloud provider.
+ *
+ * The sentence names no endpoint: `switchChatModel` renders a refusal's
+ * `error` straight into a chat bubble, and an internal path is not a sentence
+ * for a customer. The machine-readable half is the `code`, which chat/history
+ * carries too.
+ */
+const WRONG_STORE = {
+  error: "This box's chat provider and model are held by its agent harness, not by this store.",
+  code: "wrong_store",
+} as const;
+
 export async function GET() {
+  if (!(await chatModelLivesHere())) {
+    return NextResponse.json(WRONG_STORE, { status: 409, headers: { "Cache-Control": "no-store" } });
+  }
   try {
     const state = await loadChatModelState();
     return NextResponse.json(state, {
@@ -785,6 +842,11 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
+  // The write half of the same store. A switch here spends `openclaw config
+  // set` on a key the Hermes agent never reads, and answered 200 for it.
+  if (!(await chatModelLivesHere())) {
+    return NextResponse.json(WRONG_STORE, { status: 409 });
+  }
   try {
     let body: { source?: ChatModelSource; model?: string; provider?: string };
     try {

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -5896,16 +5896,21 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
             )
           ) : (<>
           {chatModelState && (() => {
-            // A primary the gateway IS running that matches no row is not the
-            // same as "nothing pinned yet". Defaulting to options[0] there
-            // named the first provider in the list — ClawBox AI on every
-            // paired box — while the box was actually running something else
-            // and every turn failed. It also made the owner's most natural
-            // recovery gesture a no-op: HeaderDropdown fires onChange only
-            // when the pick differs from `value`, so clicking the row the
-            // header was already showing did nothing. Empty `value` keeps
-            // that click live and the label honest.
-            const unselectableActive = !!chatModelState.activeModel && !chatModelState.activeOptionId
+            // No `activeOptionId` means no row on this list is what the box
+            // is running — whether because the primary matches none of them,
+            // or because nothing is pinned at all. Both used to default to
+            // options[0], which named the first provider in the list — ClawBox
+            // AI on every paired box — as the active one. It also made the
+            // owner's most natural recovery gesture a no-op: HeaderDropdown
+            // fires onChange only when the pick differs from `value`, so
+            // clicking the row the header was already showing did nothing.
+            // Empty `value` keeps that click live and the label honest.
+            //
+            // The `activeModel` half of this test was dropped when chat/model
+            // stopped resolving a null primary onto the Local-AI placeholder:
+            // that made "nothing pinned" a null/null state, which this
+            // predicate had been reading as "a row is active".
+            const unselectableActive = !chatModelState.activeOptionId
             const activeId = chatModelState.activeOptionId
               ?? (unselectableActive ? '' : (chatModelState.options[0]?.id ?? ''))
             const activeOption = chatModelState.options.find(o => o.id === activeId)

--- a/src/lib/harness/capabilities.ts
+++ b/src/lib/harness/capabilities.ts
@@ -132,6 +132,12 @@ export function capabilitiesFor(id: HarnessId, facts: HarnessFacts): HarnessCapa
       // `sessions.patch` is a gateway call. There is no session on the box to
       // patch — see `reasoningScope` for what Hermes has instead.
       canPatchSessionDefaults: false,
+      // The chat's provider and model are `model.provider` / `model.default` in
+      // ~/.hermes/config.yaml — the harness's own store, served by
+      // /setup-api/hermes/models. `agents.defaults.model.primary` is not this
+      // box's answer even on the dual SKU, where the OpenClaw half keeps it
+      // warm for the edition that is not running.
+      modelStore: "harness",
       reasoningScope: "per-turn",
       // BOTH halves, because a picture needs both to be answered about: a turn
       // that CARRIES it (`chat --image`) and something that LOOKS at it
@@ -247,6 +253,7 @@ export function capabilitiesFor(id: HarnessId, facts: HarnessFacts): HarnessCapa
     spokenReplyTrigger: "harness",
     canAbortTurn: true,
     hasLiveConnection: true,
+    modelStore: "openclaw-config",
   };
 }
 

--- a/src/lib/harness/transport.ts
+++ b/src/lib/harness/transport.ts
@@ -117,6 +117,23 @@ export interface HarnessCapabilities {
   readonly canAbortTurn: boolean;
   /** There is a socket that can be down — i.e. a connection banner is honest. */
   readonly hasLiveConnection: boolean;
+  /**
+   * WHERE this box's chat provider and model are configured:
+   *
+   *   `'openclaw-config'`  `agents.defaults.model.primary` in
+   *                        ~/.openclaw/openclaw.json, which
+   *                        /setup-api/chat/model reads and writes.
+   *   `'harness'`          the harness keeps its own — Hermes' `model.provider`
+   *                        / `model.default` in ~/.hermes/config.yaml, served
+   *                        by /setup-api/hermes/models.
+   *
+   * The sibling of `canListHistory`'s reasoning, and here for the same reason:
+   * a route whose whole subject lives in ONE harness's store has to be able to
+   * ask whether this is that harness, rather than each such route re-deciding
+   * from the harness id. chat/model answered a confident 200 about the
+   * OpenClaw config on every edition until it could ask this.
+   */
+  readonly modelStore: "openclaw-config" | "harness";
 }
 
 /**

--- a/src/tests/components/chat-header-mispinned-primary.test.tsx
+++ b/src/tests/components/chat-header-mispinned-primary.test.tsx
@@ -64,7 +64,23 @@ const RECOVERED = {
   activeLabel: "ClawBox AI",
 };
 
-function installFetch() {
+/**
+ * The other way to have no chat model: nothing is pinned at all.
+ *
+ * `agents.defaults.model.primary` is absent — a box with a credential the owner
+ * has not chosen a model on yet — so the route answers `activeModel: null` as
+ * well as `activeOptionId: null`. The header owes the same two things here as
+ * above, and for the same reason: no row is running, so naming one is a lie and
+ * clicking it must still post.
+ */
+const NOTHING_PINNED = {
+  ...MIS_PINNED,
+  activeOptionId: null,
+  activeModel: null,
+  activeSource: null,
+};
+
+function installFetch(state: object = MIS_PINNED) {
   vi.stubGlobal(
     "fetch",
     vi.fn(async (input: unknown, init?: RequestInit) => {
@@ -78,7 +94,7 @@ function installFetch() {
         // returned `{ success: true }` left `options` undefined and crashed
         // the header's `options.find` — the mock has to answer like the route.
         if (init?.method === "POST") return { ok: true, json: async () => RECOVERED };
-        return { ok: true, json: async () => MIS_PINNED };
+        return { ok: true, json: async () => state };
       }
       if (url.includes("/setup-api/chat/history")) {
         return { ok: true, json: async () => ({ messages: [] }) };
@@ -135,6 +151,39 @@ describe("the chat header on a box pinned to a model no row carries", () => {
     // owner's most natural recovery gesture — was swallowed and the box
     // stayed mute.
     installFetch();
+    render(<ChatPopup isOpen onClose={() => {}} />);
+
+    const trigger = await screen.findByRole("button", { name: /Chat provider/i });
+    fireEvent.click(trigger);
+    const rows = await screen.findAllByRole("option");
+    const clawai = rows.find((row) => (row.textContent ?? "").includes("ClawBox AI"));
+    expect(clawai).toBeDefined();
+    fireEvent.click(clawai!);
+
+    await waitFor(() => {
+      const posted = vi.mocked(fetch).mock.calls.some(([url, init]) =>
+        String(url).includes("/setup-api/chat/model")
+        && (init as RequestInit | undefined)?.method === "POST");
+      expect(posted).toBe(true);
+    });
+  });
+});
+
+describe("the chat header on a box with nothing pinned at all", () => {
+  it("does not claim the first provider in the list is the active one", async () => {
+    installFetch(NOTHING_PINNED);
+    render(<ChatPopup isOpen onClose={() => {}} />);
+
+    const trigger = await screen.findByRole("button", { name: /Chat provider/i });
+    await waitFor(() => {
+      expect(trigger.textContent).toContain(translations.en["chat.noChatModel"]);
+    });
+    expect(trigger.textContent).not.toContain("ClawBox");
+    expect(trigger.textContent).not.toContain("OpenAI");
+  });
+
+  it("posts when the owner picks a provider row, even the one shown", async () => {
+    installFetch(NOTHING_PINNED);
     render(<ChatPopup isOpen onClose={() => {}} />);
 
     const trigger = await screen.findByRole("button", { name: /Chat provider/i });

--- a/src/tests/helpers/hermes-chat-box.tsx
+++ b/src/tests/helpers/hermes-chat-box.tsx
@@ -169,7 +169,18 @@ export function installHermesBox(reply: (message: string) => string = () => "hel
         };
       }
       if (url.includes("/setup-api/chat/model")) {
-        return { ok: true, json: async () => ({ options: [], activeOptionId: "" }) };
+        // What the route really answers on a Hermes box: it reads the OpenClaw
+        // config, which is not this box's chat model, and says so. Stubbing a
+        // 200 here would keep a contract the server no longer offers alive in
+        // the only place 40-odd Hermes chat suites could notice.
+        return {
+          ok: false,
+          status: 409,
+          json: async () => ({
+            error: "This box's chat provider and model are held by its agent harness, not by this store.",
+            code: "wrong_store",
+          }),
+        };
       }
       if (url.includes("/setup-api/chat/spoken-history")) {
         return { ok: true, json: async () => ({ items: [] }) };

--- a/src/tests/routes/chat-model-harness.test.ts
+++ b/src/tests/routes/chat-model-harness.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * TASK-634 — /setup-api/chat/model names a model that is not serving.
+ *
+ * Two false successes, one root:
+ *
+ *   `options.find((o) => o.model === activeModel)` is asked with a NULL
+ *   activeModel, and the Local-AI placeholder row carries `model: null`, so
+ *   "nothing is pinned" resolves to "Local AI" — a row the same payload marks
+ *   `available: false`.
+ *
+ *   On Hermes `agents.defaults.model.primary` is always absent, because the
+ *   chat's provider and model live in ~/.hermes/config.yaml and are answered
+ *   by /setup-api/hermes/models. So the route confidently described a store
+ *   that does not own the answer: measured on the box, activeOptionId
+ *   "__setup_local__" / activeLabel "Local AI" while the chat had just run
+ *   turns on openai-codex and anthropic.
+ *
+ * Its sibling chat/history already refuses exactly this case; chat/model did
+ * not ask the question at all.
+ */
+
+vi.mock("child_process", () => ({ execFile: vi.fn() }));
+vi.mock("util", () => ({ promisify: vi.fn() }));
+vi.mock("@/lib/config-store", () => ({
+  DATA_DIR: "/home/clawbox/clawbox/data",
+  getAll: vi.fn(),
+}));
+vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
+  notifyProviderSetChanged: vi.fn(),
+  refreshInBackground: vi.fn(),
+}));
+vi.mock("@/lib/openclaw-config", () => ({
+  inferConfiguredLocalModel: vi.fn(),
+  findOpenclawBin: vi.fn(() => "/usr/local/bin/openclaw"),
+  readConfigStrict: vi.fn(async () => ({})),
+  readConfig: vi.fn(),
+  restartGateway: vi.fn(),
+  runOpenclawConfigSet: vi.fn(),
+  runOpenclawConfigSetBatch: vi.fn(),
+  runOpenclawConfigUnset: vi.fn(),
+  applyModelOverrideToAllAgentSessions: vi.fn(),
+  parseFullyQualifiedModel: vi.fn(),
+  setProviderPlugins: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/sqlite-store", () => ({ sqliteGet: vi.fn(), sqliteSet: vi.fn() }));
+
+let harness: "openclaw" | "hermes" = "openclaw";
+vi.mock("@/lib/harness", () => ({ getActiveHarness: async () => harness }));
+
+import { getAll } from "@/lib/config-store";
+import { inferConfiguredLocalModel, readConfig } from "@/lib/openclaw-config";
+import { sqliteGet, sqliteSet } from "@/lib/sqlite-store";
+import { promisify } from "util";
+
+/** An OpenClaw config with a credential but NO `agents.defaults.model.primary`. */
+const NO_PRIMARY = {
+  auth: { profiles: { "deepseek:default": { provider: "deepseek", mode: "api_key" } } },
+  models: {
+    mode: "merge",
+    providers: { deepseek: { models: [{ id: "deepseek-v4-flash", name: "ClawBox AI Flash" }] } },
+  },
+  agents: { defaults: {} },
+};
+
+describe("/setup-api/chat/model — who owns the answer", () => {
+  let GET: () => Promise<Response>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    harness = "openclaw";
+    vi.mocked(promisify).mockReturnValue(vi.fn().mockResolvedValue({ stdout: "", stderr: "" }) as never);
+    vi.mocked(getAll).mockResolvedValue({});
+    vi.mocked(readConfig).mockResolvedValue(NO_PRIMARY as never);
+    vi.mocked(inferConfiguredLocalModel).mockReturnValue(null);
+    vi.mocked(sqliteGet).mockResolvedValue(null);
+    vi.mocked(sqliteSet).mockResolvedValue();
+    GET = (await import("@/app/setup-api/chat/model/route")).GET;
+  });
+
+  it("does not name Local AI as active when nothing is pinned", async () => {
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.activeModel).toBeNull();
+    // The Local-AI placeholder carries `model: null`; it must not be matched by
+    // a null activeModel and reported as what the chat is running.
+    expect(body.activeOptionId).toBeNull();
+    expect(body.activeLabel).toBeNull();
+  });
+
+  it("refuses on a harness whose gateway owns the chat model", async () => {
+    harness = "hermes";
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(409);
+    // The machine-readable half — the same code chat/history's refusal carries,
+    // so one caller rule covers both. The sentence names no internal path: it
+    // is rendered into a chat bubble on the way past.
+    expect(body.code).toBe("wrong_store");
+    expect(String(body.error)).not.toMatch(/setup-api/);
+    expect(body.activeOptionId).toBeUndefined();
+  });
+});

--- a/src/tests/routes/chat-model-harness.test.ts
+++ b/src/tests/routes/chat-model-harness.test.ts
@@ -31,7 +31,12 @@ vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
   notifyProviderSetChanged: vi.fn(),
   refreshInBackground: vi.fn(),
 }));
-vi.mock("@/lib/openclaw-config", () => ({
+vi.mock("@/lib/openclaw-config", async (importOriginal) => ({
+  // The REAL class. A factory replaces the whole module, and the configure
+  // path narrows on `instanceof GatewayNotReadyError` — `instanceof undefined`
+  // throws a TypeError the first time a mocked restart rejects, which is what
+  // `openclaw-config-mock-completeness.test.ts` exists to stop shipping.
+  GatewayNotReadyError: (await importOriginal<typeof import("@/lib/openclaw-config")>()).GatewayNotReadyError,
   inferConfiguredLocalModel: vi.fn(),
   findOpenclawBin: vi.fn(() => "/usr/local/bin/openclaw"),
   readConfigStrict: vi.fn(async () => ({})),

--- a/src/tests/unit/mcp-served-model-honesty.test.ts
+++ b/src/tests/unit/mcp-served-model-honesty.test.ts
@@ -59,6 +59,25 @@ const ctx = (edition: "openclaw" | "hermes", install: McpContext["install"] = ed
 });
 
 const DEFAULT = { provider: "openai", current: "gpt-5.6-sol", reasoning: "medium" };
+
+/**
+ * The shape /setup-api/chat/model REALLY answers with.
+ *
+ * These two cases used to invent `{selected: {...}, current: ""}` — keys the
+ * route has never returned — and then assert `device_default` matched them, so
+ * they passed on their own fixture while every real box reported
+ * `{provider: "unknown", model: "unknown"}`. Restated from the route's own
+ * payload (`loadChatModelState`), which is what the tool now reads.
+ */
+const CHAT_MODEL_STATE = {
+  activeOptionId: "anthropic/claude-fable-5",
+  activeSource: "primary",
+  activeLabel: "Anthropic",
+  activeModel: "anthropic/claude-fable-5",
+  options: [],
+  primary: { available: true, label: "Anthropic", model: "anthropic/claude-fable-5", provider: "anthropic" },
+  local: { available: false, label: null, model: null },
+};
 const CATALOGUE = {
   ...DEFAULT,
   models: [{ id: "gpt-5.6-sol" }],
@@ -196,7 +215,7 @@ describe("device_status — the same honesty on the orientation tool", () => {
     // every agent session, and OpenClaw has neither the reply label nor the
     // Hermes instruction — so telling this edition "not visible" would turn a
     // right answer into a shrug.
-    routes({ "/setup-api/chat/model": { selected: { provider: "anthropic", model: "claude-fable-5" }, current: "" } });
+    routes({ "/setup-api/chat/model": CHAT_MODEL_STATE });
     const { ai: report } = (await parsed(status("openclaw"), "device_status")) as { ai: Record<string, unknown> };
 
     expect(report).not.toHaveProperty("model");
@@ -219,7 +238,7 @@ describe("device_status — the same honesty on the orientation tool", () => {
     // cannot be wrong; on dual it can, and the affirmative note would tell a
     // HERMES chat to answer "which model are you" from the device default,
     // which is the whole defect TASK-648 opened for.
-    routes({ "/setup-api/chat/model": { selected: { provider: "anthropic", model: "claude-fable-5" }, current: "" } });
+    routes({ "/setup-api/chat/model": CHAT_MODEL_STATE });
     const { ai: report } = (await parsed(status("openclaw", "dual"), "device_status")) as {
       ai: Record<string, unknown>;
     };

--- a/src/tests/unit/mcp-served-model-honesty.test.ts
+++ b/src/tests/unit/mcp-served-model-honesty.test.ts
@@ -78,6 +78,20 @@ const CHAT_MODEL_STATE = {
   primary: { available: true, label: "Anthropic", model: "anthropic/claude-fable-5", provider: "anthropic" },
   local: { available: false, label: null, model: null },
 };
+
+/**
+ * The box is running its LOCAL model; `primary` is the cloud row the "back to
+ * primary" gesture would return to. Two different models in one payload, and
+ * the tool must not compose an answer out of both.
+ */
+const ON_LOCAL_MODEL = {
+  ...CHAT_MODEL_STATE,
+  activeOptionId: "llamacpp/gemma4-e2b-it-q4_0",
+  activeSource: "local",
+  activeLabel: "Gemma 4 Local",
+  activeModel: "llamacpp/gemma4-e2b-it-q4_0",
+  local: { available: true, label: "Gemma 4 Local", model: "llamacpp/gemma4-e2b-it-q4_0" },
+};
 const CATALOGUE = {
   ...DEFAULT,
   models: [{ id: "gpt-5.6-sol" }],
@@ -222,6 +236,28 @@ describe("device_status — the same honesty on the orientation tool", () => {
     expect(report.device_default).toMatchObject({ provider: "anthropic", model: "claude-fable-5" });
     expect(String(report.current_chat)).toMatch(/what this chat runs/);
     expect(String(report.current_chat)).not.toMatch(/not visible/);
+  });
+
+  it("does not compose the default out of two different models", async () => {
+    // `device_default.provider` used to come from the payload's `primary` row
+    // while the model came from `activeModel`. On a box running its local model
+    // those are different models, so the answer named a cloud provider beside a
+    // local model id — and `ai.limits` describes `agents.defaults.model.primary`,
+    // which is the second of the two. One key, or nothing.
+    routes({ "/setup-api/chat/model": ON_LOCAL_MODEL });
+    const { ai: report } = (await parsed(status("openclaw"), "device_status")) as { ai: Record<string, unknown> };
+
+    expect(report.device_default).toMatchObject({
+      provider: "llamacpp",
+      model: "gemma4-e2b-it-q4_0",
+    });
+  });
+
+  it("says it does not know the default when nothing is pinned, rather than naming a fallback row", async () => {
+    routes({ "/setup-api/chat/model": { ...CHAT_MODEL_STATE, activeOptionId: null, activeModel: null } });
+    const { ai: report } = (await parsed(status("openclaw"), "device_status")) as { ai: Record<string, unknown> };
+
+    expect(report.device_default).toMatchObject({ provider: "unknown", model: "unknown" });
   });
 
   it("qualifies the default per edition in the description", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,6 +25,14 @@ export default defineConfig({
     // control; the individual edition tests override this with a real tmp file.
     env: {
       CLAWBOX_EDITION_FILE: "/nonexistent/clawbox-test-edition.env",
+      // ...and the ENV the lookup falls back to when that file is absent
+      // (edition-source.ts reads CLAWBOX_EDITION next). Pointing the file at
+      // nowhere only half-closed the hole: a shell on a Hermes box that
+      // exports CLAWBOX_EDITION still reached every route that asks which
+      // harness is active. Measured 2026-09-04: `CLAWBOX_EDITION=hermes`
+      // turned 76 chat-model assertions into 409s. Tests that mean to be on
+      // another edition set their own value or mock `@/lib/harness`.
+      CLAWBOX_EDITION: "openclaw",
       // The same hermetic principle for device STATE: config-store falls back
       // to the real /home/clawbox/clawbox when CLAWBOX_ROOT is unset, so a
       // test that imports the real modules without re-pointing the root reads


### PR DESCRIPTION
**TASK-634** — `/setup-api/chat/model` reports an active chat model that is not what is serving. False success.

## Symptom

On a Hermes box the route answers a confident `200` describing `agents.defaults.model.primary` in
`~/.openclaw/openclaw.json` — a key that SKU never writes. With nothing pinned there and no local
model configured it went further and named one: `activeOptionId: "__setup_local__"`,
`activeLabel: "Local AI"`, on a row the same payload marks `available: false`, while the chat had
demonstrably just run turns on a cloud provider.

## Cause

Two, one behind the other.

1. `options.find((o) => o.model === activeModel)` was asked with `activeModel === null`. The
   Local-AI placeholder row carries `model: null` when no local model is configured, so "nothing
   is pinned" matched it. This is edition-neutral — an OpenClaw box before its first model pick
   hits it too.

2. The route asked no harness question at all, unlike its sibling `chat/history`, which refuses
   precisely this case.

## Harness-first

Nothing is re-implemented. Hermes' own store answers this: `model.provider` / `model.default` in
`~/.hermes/config.yaml`, read through `hermes config get` and served by `/setup-api/hermes/models`
with the live catalogue, provider scope and pairing enforcement. Building a second, thinner view of
it inside `chat/model` would be the anti-pattern; the route refuses and says so instead.

The refusal is asked as a **capability**, not as `harness === "openclaw"`: `modelStore`
(`"openclaw-config" | "harness"`) joins the harness table beside `hasLiveConnection`, so this route
and `chat/history` share one mechanism and a third harness needs no edit here. Both now answer 409
with the same `wrong_store` code.

## Device evidence (read-only, Hermes box on beta 08e7057d)

```
=== box HEAD ===
08e7057d
=== GET /setup-api/chat/model ===
http=200
{ "activeOptionId": null, "activeSource": null, "activeLabel": null, "activeModel": null }
options: [('deepseek/deepseek-v4-flash', True), ('llamacpp/gemma4-e2b-it-q4_0', True)]
=== what Hermes itself says (native store) ===
clawlocal
gemma4-e2b-it-q4_0
```

Two stores, two answers, and the 200 is the one that is not this box's. The exact
`__setup_local__` / `"Local AI"` payload recorded on the card needs the box to have **no** local
model configured — its state on 2026-09-02, and any box's state before Local AI is set up. This box
has one now, which is why the placeholder no longer carries `model: null`. The unit test pins that
state directly.

## RED → GREEN

`src/tests/routes/chat-model-harness.test.ts` and the new cases in
`src/tests/components/chat-header-mispinned-primary.test.tsx`, on unmodified beta 08e7057d:

```
 × does not name Local AI as active when nothing is pinned
 × refuses on a harness whose gateway owns the chat model
 × does not claim the first provider in the list is the active one
 × posts when the owner picks a provider row, even the one shown
AssertionError: expected '__setup_local__' to be null
AssertionError: expected 200 to be 409
      Tests  4 failed | 2 passed (6)
```

The two that pass are the pre-existing mispinned-primary cases, which must keep passing.

On the branch: routes 187 files / 2272 tests, unit 377 files / 6496 tests, components 132 files /
1206 tests — all pass; `tsc --noEmit` clean.

## Sibling call sites

| site | verdict |
| --- | --- |
| `providers/default` (imports both handlers directly) | resolves `getActiveHarness()` and returns down the Hermes path before touching either — cannot meet the refusal |
| `ChatPopup` × 3 fetches | the picker is inside the non-Hermes branch; `refreshChatModelState` drops a non-ok answer, so `chatModelState` is null on Hermes instead of a bogus "Local AI" pill |
| `ChatPopup` header predicate | **was broken by this fix** — `unselectableActive` required a truthy `activeModel`, so null/null fell through to `options[0]`, naming the first provider active and swallowing the click on it. Fixed and pinned |
| `mcp/tools/orientation.ts` `device_status` | already asks `/setup-api/hermes/models` on Hermes. Two defects found and fixed: it read `selected`/`current`, keys this route has never returned (so `ai.device_default` was "unknown" on every OpenClaw box, with a test passing on its own fixture), and its `ai.limits` leg parses the same OpenClaw config directly — on a dual box, where `ctx.edition` is resolved once at startup and falls back to `openclaw`, that would have printed a named model with a context window beside a "I don't know my model" default |
| `chat/*` siblings (media, spoken-history, transcribe) | cleared: `media-root`, the ClawBox-owned spoken-history store and `harness/credentials` are all harness-aware already |
| `e2e/helpers/clawbox.ts` | its box is OpenClaw throughout (`harness/active` → `openclaw`), so the 200 stub is correct and stays |
| `src/tests/helpers/hermes-chat-box.tsx` | stubbed a 200 on an explicitly-Hermes box, which would have kept the old contract alive in the only place the 42 Hermes chat suites could notice it. Now returns the 409; all 132 component suites still pass |

## One test-harness fix that is not about this route

`vitest.config.ts` pinned `CLAWBOX_EDITION_FILE` at a nonexistent path for hermeticity, but the
edition lookup falls back to `process.env.CLAWBOX_EDITION` — so a shell that exports it reached
every route that asks which harness is active. Measured on this branch: `CLAWBOX_EDITION=hermes`
turned 76 chat-model assertions into 409s. The env is now pinned beside the file, which closes it
for every future guard as well.

## Both editions

The OpenClaw path is byte-identical apart from the null guard: on every non-dual SKU
`getActiveHarness()` short-circuits to a constant and cannot return `"hermes"`. On Hermes the UI
surface is not made worse — the model pills are already harness-branched, `chatModelState` is only
read inside the OpenClaw branch and by guards that no-op on null, and a harness switch reloads the
page. The cost is one 409 in the network log per chat open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chat model status now uses the correct active model information and removes provider namespaces from displayed model IDs.
  * Device status no longer shows model limits when model information is unavailable.
  * The model selector correctly displays a no-model state instead of selecting an unrelated default.
  * Model configuration requests now report when another system controls model settings.
  * Conflict responses include a stable error code for reliable integration handling.
  * Unconfigured models are now reported as unknown rather than incorrectly matching a local placeholder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->