### PR TITLE
fix: stop the MCP denying four apps the desktop shows (TASK-541)

### DIFF
--- a/config/clawbox-workspace-guide.md
+++ b/config/clawbox-workspace-guide.md
@@ -52,7 +52,7 @@ The Chromium window is visible on the ClawBox desktop (accessible via the VNC vi
 | Tool | Purpose |
 |---|---|
 | `ui_open_app` | Open a built-in ClawBox desktop app. Call `ui_list_apps` for the ids that exist on THIS device — the set differs by harness, and the chat window is `clawbox`, not `chat`. Two to know: `coding` is the Coding Agent app (see below), and `browser` is the Browser *Setup* panel — not for real web browsing, use the `browser_*` tools instead (see Browser section above) |
-| `ui_list_apps` | Enumerate installed desktop apps |
+| `ui_list_apps` | What is on THIS desktop: the built-in apps for this harness, the apps the user installed or you built (`installed-<id>`), and on Hermes the agent skills too |
 | `ui_notify` | Show a toast notification on the ClawBox desktop |
 | `app_search` | Search the ClawBox App Store |
 | `app_install` | Install a skill or webapp from the Store (see Skills section above) |

--- a/config/clawbox-workspace-guide.md
+++ b/config/clawbox-workspace-guide.md
@@ -51,7 +51,7 @@ The Chromium window is visible on the ClawBox desktop (accessible via the VNC vi
 
 | Tool | Purpose |
 |---|---|
-| `ui_open_app` | Open a built-in ClawBox desktop app. Known app IDs: `chat`, `files`, `settings`, `store`, `vnc`, `terminal`, `coding` (the Coding Agent app — see below), and `browser` (the Browser *Setup* panel — not for real web browsing; use `browser_*` tools instead, see Browser section above) |
+| `ui_open_app` | Open a built-in ClawBox desktop app. Call `ui_list_apps` for the ids that exist on THIS device — the set differs by harness, and the chat window is `clawbox`, not `chat`. Two to know: `coding` is the Coding Agent app (see below), and `browser` is the Browser *Setup* panel — not for real web browsing, use the `browser_*` tools instead (see Browser section above) |
 | `ui_list_apps` | Enumerate installed desktop apps |
 | `ui_notify` | Show a toast notification on the ClawBox desktop |
 | `app_search` | Search the ClawBox App Store |

--- a/e2e-install/35-mcp.spec.ts
+++ b/e2e-install/35-mcp.spec.ts
@@ -53,10 +53,14 @@ test.describe("clawbox-cli (MCP user-space wrapper)", () => {
       timeoutMs: 30_000,
     });
 
-    // Header carries the edition, so a reader knows which app set this is.
+    // Header carries the edition, so a reader knows which app set this is —
+    // and, when the two differ, the harness the apps belong to: on the premium
+    // `dual` SKU the list follows the ACTIVE harness, so the line reads
+    // "(dual edition, running hermes)".
     expect(out).toMatch(
-      new RegExp(`^Built-in apps \\(${edition} edition\\):`, "im"),
+      new RegExp(`^Built-in apps \\(${edition} edition[,)]`, "im"),
     );
+    const harness = /^Built-in apps \([^,)]+(?:, running (\w+))?\)/im.exec(out)?.[1] ?? edition;
 
     // Common apps — listed on every edition.
     for (const id of ["settings", "terminal", "files", "browser", "vnc"]) {
@@ -67,9 +71,10 @@ test.describe("clawbox-cli (MCP user-space wrapper)", () => {
 
     // Harness-specific apps. A Hermes box has the skills app and neither the
     // OpenClaw chat app nor the store; listing an app whose backend isn't
-    // installed would point the agent at a window that cannot open. The
-    // premium `dual` edition resolves to the OpenClaw set.
-    if (edition === "hermes") {
+    // installed would point the agent at a window that cannot open. Branch on
+    // the HARNESS the header reports rather than on the edition: a `dual` box
+    // follows whichever harness is running.
+    if (harness === "hermes") {
       expect(out).toMatch(/^\s+hermes-skills — /m);
       expect(out).not.toMatch(/^\s+openclaw — /m);
       expect(out).not.toMatch(/^\s+store — /m);

--- a/e2e-install/35-mcp.spec.ts
+++ b/e2e-install/35-mcp.spec.ts
@@ -60,7 +60,22 @@ test.describe("clawbox-cli (MCP user-space wrapper)", () => {
     expect(out).toMatch(
       new RegExp(`^Built-in apps \\(${edition} edition[,)]`, "im"),
     );
-    const harness = /^Built-in apps \([^,)]+(?:, running (\w+))?\)/im.exec(out)?.[1] ?? edition;
+    // The harness the header NAMED, or null when it named none. Not `?? edition`:
+    // on the `dual` SKU the edition is not a harness, so that fallback ran the
+    // OpenClaw assertions below over a header that had just said "harness
+    // undetermined" — asserting `openclaw —` and `store —` are listed on a box
+    // that could not say which harness it was running.
+    const harness = /^Built-in apps \([^,)]+(?:, running (\w+))?\)/im.exec(out)?.[1]
+      ?? (edition === "dual" ? null : edition);
+    // A dual box that cannot name its harness is a FAULT on an installed image,
+    // not a shape to branch on: /setup-api/harness/active is served by the same
+    // web server this CLI just reached, so a silence here means the box came up
+    // wrong. Fail with the header rather than picking an arm.
+    expect(
+      harness,
+      `a ${edition} box must name the harness its app list follows; header was: `
+      + `${/^Built-in apps \(.*\):/im.exec(out)?.[0] ?? "(no header)"}`,
+    ).not.toBeNull();
 
     // Common apps — listed on every edition.
     for (const id of ["settings", "terminal", "files", "browser", "vnc"]) {

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -47,13 +47,27 @@ To check a device: `hermes mcp list` (or `openclaw mcp status`) should name
 A ClawBox ships as an **OpenClaw** device or a **Hermes** device. They have
 different agents, different capability stores, and different backing routes.
 The edition is resolved **once at startup** from `readEdition()`
-(`src/lib/edition-source.ts` → the root-owned `/etc/clawbox/edition.env`);
-only the unlocked `dual` edition falls through to one
-`GET /setup-api/harness/active`. If the lock file **exists but cannot be read**,
-the MCP registers the *smaller* Hermes set and logs it: `readEdition()` defaults
-to `openclaw`, which is conservative for the app (the non-premium SKU) and the
-opposite here — `openclaw` is the only edition carrying `bash`, `write_file` and
-`grep`. An **absent** lock file is a different case (dev boxes, CI) and keeps the
+(`src/lib/edition-source.ts` → the root-owned `/etc/clawbox/edition.env`).
+`main()` makes **one** `GET /setup-api/harness/active` — for the unlocked `dual`
+edition, the only case where the device knows something the lock does not — and
+hands that answer to both questions it settles: `resolveAppHarness()` returns it
+as the APP harness, and `resolveEdition(appHarness)` is synchronous and cannot
+ask again. Two probes could disagree, and did.
+
+If the lock file **exists but cannot be read** the two questions part company,
+because their answers are shaped differently:
+
+* the **tool set** registers the *smaller* Hermes set and logs it. `readEdition()`
+  defaults to `openclaw`, which is conservative for the app (the non-premium SKU)
+  and the opposite here — `openclaw` is the only edition carrying `bash`,
+  `write_file` and `grep`. The two sets are nested, so a doubt has a safe side.
+* the **app harness** answers `null` and both harness-only sets are hidden, with
+  the reason said out loud (`UNKNOWN_HARNESS_NOTE`). The app sets are *not*
+  nested, so there is no safe side to fail onto. The device is not asked in this
+  state: `/setup-api/harness/active` resolves through `readEdition()` too, so it
+  can only echo the default this process already failed to read.
+
+An **absent** lock file is a different case (dev boxes, CI) and keeps the
 documented `CLAWBOX_EDITION` fallback.
 
 A tool that cannot work on the running edition **is not registered**. It is not
@@ -652,7 +666,7 @@ to the approved senders (`src/lib/coding-agent-notify.ts`).
 ## Layout
 
 ```
-mcp/clawbox-mcp.ts     entry: resolve edition → probe capabilities → register → connect
+mcp/clawbox-mcp.ts     entry: resolve app harness (one probe) → resolve edition → probe capabilities → register → connect
 mcp/check-tools.ts     surface check; run after any change here
 mcp/clawbox-cli.ts     shell-callable wrapper (clawbox webapp/app/notify/system/code/edition)
 mcp/lib/edition.ts     edition resolution (imports readEdition, never re-implements it)
@@ -672,7 +686,8 @@ mcp/tools/coding-agent.ts
 **Import rule for `mcp/**`:** a `src/lib` module may be imported only if its
 *entire transitive* import graph is relative paths + node builtins. Verified
 safe: `edition-source`, `file-guard` (→ `config-store`), `hermes-skills`,
-`hermes-reasoning`, `hermes-providers`. Anything using the `@/` alias is
+`hermes-reasoning`, `hermes-providers`, `local-model-profile`,
+`desktop-app-editions`. Anything using the `@/` alias is
 forbidden — bun resolves it inconsistently for files outside the root tsconfig,
 and it drags server-only Next.js code into this stdio process.
 `mcp/tsconfig.json` encodes exactly this list.

--- a/mcp/check-tools.ts
+++ b/mcp/check-tools.ts
@@ -58,7 +58,10 @@ async function main(): Promise<void> {
   const byEdition: Record<string, RegisteredToolInfo[]> = {};
 
   for (const edition of ["openclaw", "hermes"] as const) {
-    const { reg } = await buildServer(edition, "full");
+    // The app harness is the edition being simulated: this walks each
+    // edition's tool list, so an app gate resolving to anything else would
+    // describe a box that does not exist.
+    const { reg } = await buildServer(edition, "full", edition);
     const tools = reg.list();
     byEdition[edition] = tools;
     for (const tool of tools) problems.push(...contractViolations(tool), ...schemaShapeViolations(tool));

--- a/mcp/clawbox-cli.ts
+++ b/mcp/clawbox-cli.ts
@@ -189,6 +189,16 @@ async function main() {
       console.error("Usage: clawbox app open <appId>");
       process.exit(1);
     }
+    // Same gate ui_open_app applies. Without it this printed "Opening x" for a
+    // typo, for an installed id missing its `installed-` prefix, and for the
+    // other harness's apps — a false success on the CLI sibling of the list
+    // `app list` below prints from.
+    const openHarness = installEdition() === "hermes" ? "hermes" : "openclaw";
+    const openable = builtInApps(openHarness).map((a) => a.id);
+    if (!appId.startsWith("installed-") && !openable.includes(appId)) {
+      console.error(`No built-in app "${appId}" on this ClawBox. Try: ${openable.join(", ")}`);
+      process.exit(1);
+    }
     await apiPost("/setup-api/kv", {
       key: "ui:pending-action",
       value: JSON.stringify({ type: "open_app", appId, ts: Date.now() }),

--- a/mcp/clawbox-cli.ts
+++ b/mcp/clawbox-cli.ts
@@ -20,6 +20,7 @@ import { join } from "path";
 import { spawnSync } from "child_process";
 import { installEdition } from "./lib/edition";
 import { builtInApps } from "./lib/context";
+import { INSTALLED_APP_ID_RE } from "./lib/schema";
 
 const API_BASE = process.env.CLAWBOX_API_BASE || "http://127.0.0.1:80";
 const UI_PICKUP_DELAY_MS = 2500; // Time for the desktop UI to poll and pick up KV actions
@@ -200,7 +201,7 @@ async function main() {
       // The shape check, exactly where ui_open_app applies it: an installed id
       // is caller-supplied, and `installed-../etc` would otherwise be posted as
       // a pending action with a tick printed over it.
-      if (!/^installed-[a-z0-9][a-z0-9-]{0,63}$/.test(appId)) {
+      if (!INSTALLED_APP_ID_RE.test(appId)) {
         console.error(`"${appId}" is not a valid installed-app id.`);
         process.exit(1);
       }

--- a/mcp/clawbox-cli.ts
+++ b/mcp/clawbox-cli.ts
@@ -18,7 +18,7 @@
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 import { spawnSync } from "child_process";
-import { installEdition } from "./lib/edition";
+import { installEdition, resolveEdition, type Ed } from "./lib/edition";
 import { builtInApps } from "./lib/context";
 import { INSTALLED_APP_ID_RE } from "./lib/schema";
 
@@ -35,7 +35,7 @@ const UI_PICKUP_DELAY_MS = 2500; // Time for the desktop UI to poll and pick up 
 // gateway pre-start script wrote. Loaded lazily so token-free commands like
 // `app list` still work without it.
 let cachedToken: string | null = null;
-function getApiToken(): string {
+function findApiToken(): string | null {
   if (cachedToken) return cachedToken;
   const fromEnv = process.env.CLAWBOX_MCP_TOKEN;
   if (fromEnv && fromEnv.length >= 16) {
@@ -53,10 +53,37 @@ function getApiToken(): string {
       return raw;
     }
   } catch {
-    // fall through to the missing-token error
+    // No token file — the caller decides whether that is fatal.
   }
+  return null;
+}
+
+function getApiToken(): string {
+  const token = findApiToken();
+  if (token) return token;
   console.error("MCP token not found: set CLAWBOX_MCP_TOKEN or ensure data/.mcp-token exists (is the gateway pre-start script running?).");
   process.exit(1);
+}
+
+/**
+ * Which harness's built-in apps this box has.
+ *
+ * NOT `installEdition() === "hermes" ? … : "openclaw"`. That answer has THREE
+ * values — the premium `dual` SKU carries both harnesses — and folding `dual`
+ * into `openclaw` refused `clawbox app open hermes` on a dual box that is
+ * running Hermes, while the desktop opened that dashboard from the ACTIVE
+ * harness and `ui_open_app` allowed it from `resolveEdition`. One question,
+ * three surfaces, and the CLI was the one giving a different answer.
+ *
+ * `resolveEdition` is that same resolution: a locked edition decides on its
+ * own, and only `dual` asks the device which harness is active. The bearer is
+ * OPTIONAL here — `app list` has always worked without a token, and the only
+ * cost of not sending one is that a session-gated device answers the dual
+ * question with the default harness rather than the active one.
+ */
+function openHarness(): Promise<Ed> {
+  const token = findApiToken();
+  return resolveEdition(API_BASE, token ? `Bearer ${token}` : null);
 }
 
 async function api(path: string, options?: RequestInit) {
@@ -194,8 +221,7 @@ async function main() {
     // typo, for an installed id missing its `installed-` prefix, and for the
     // other harness's apps — a false success on the CLI sibling of the list
     // `app list` below prints from.
-    const openHarness = installEdition() === "hermes" ? "hermes" : "openclaw";
-    const openable = builtInApps(openHarness).map((a) => a.id);
+    const openable = builtInApps(await openHarness()).map((a) => a.id);
     const isInstalled = appId.startsWith("installed-");
     if (isInstalled) {
       // The shape check, exactly where ui_open_app applies it: an installed id
@@ -233,12 +259,17 @@ async function main() {
     console.log(`✅ Opening ${appId} on desktop.`);
 
   } else if (cmd === "app" && sub === "list") {
-    // The list is EDITION-dependent: a Hermes device has no OpenClaw chat app
+    // The list is HARNESS-dependent: a Hermes device has no OpenClaw chat app
     // and no app store, and printing them sends the user to a window that
-    // cannot open. Resolved from the root-owned edition lock, same as the app.
+    // cannot open. Same resolution as `app open` above, so the list and the
+    // gate can never name different apps.
     const edition = installEdition();
-    const harness = edition === "hermes" ? "hermes" : "openclaw";
-    console.log(`Built-in apps (${edition} edition):`);
+    const harness = await openHarness();
+    console.log(
+      edition === harness
+        ? `Built-in apps (${edition} edition):`
+        : `Built-in apps (${edition} edition, running ${harness}):`,
+    );
     for (const app of builtInApps(harness)) console.log(`  ${app.id} — ${app.name}`);
 
   } else if (cmd === "edition") {

--- a/mcp/clawbox-cli.ts
+++ b/mcp/clawbox-cli.ts
@@ -18,8 +18,9 @@
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 import { spawnSync } from "child_process";
-import { installEdition, resolveEdition, type Ed } from "./lib/edition";
+import { installEdition, resolveAppHarness, type Ed } from "./lib/edition";
 import { builtInApps } from "./lib/context";
+import { HARNESS_ONLY_APP_IDS, isInstalledAppVisible } from "../src/lib/desktop-app-editions";
 import { INSTALLED_APP_ID_RE } from "./lib/schema";
 
 const API_BASE = process.env.CLAWBOX_API_BASE || "http://127.0.0.1:80";
@@ -66,25 +67,33 @@ function getApiToken(): string {
 }
 
 /**
- * Which harness's built-in apps this box has.
+ * Which harness's built-in apps this box has — or null, when that could not be
+ * determined.
  *
  * NOT `installEdition() === "hermes" ? … : "openclaw"`. That answer has THREE
  * values — the premium `dual` SKU carries both harnesses — and folding `dual`
  * into `openclaw` refused `clawbox app open hermes` on a dual box that is
  * running Hermes, while the desktop opened that dashboard from the ACTIVE
- * harness and `ui_open_app` allowed it from `resolveEdition`. One question,
- * three surfaces, and the CLI was the one giving a different answer.
+ * harness and `ui_open_app` allowed it. One question, three surfaces, and the
+ * CLI was the one giving a different answer.
  *
- * `resolveEdition` is that same resolution: a locked edition decides on its
- * own, and only `dual` asks the device which harness is active. The bearer is
- * OPTIONAL here — `app list` has always worked without a token, and the only
- * cost of not sending one is that a session-gated device answers the dual
- * question with the default harness rather than the active one.
+ * `resolveAppHarness` is that same resolution: a locked edition decides on its
+ * own, only `dual` asks the device which harness is active, and an unreadable
+ * lock or a device that does not answer is NULL rather than a guess — see the
+ * note there on why an app gate cannot fail closed onto one harness. The
+ * bearer is OPTIONAL — `app list` has always worked without a token, and the
+ * cost is only that a session-gated device leaves the dual question
+ * unresolved rather than answering it.
  */
-function openHarness(): Promise<Ed> {
+function openHarness(): Promise<Ed | null> {
   const token = findApiToken();
-  return resolveEdition(API_BASE, token ? `Bearer ${token}` : null);
+  return resolveAppHarness(API_BASE, token ? `Bearer ${token}` : null);
 }
+
+/** Why an app that exists on ONE harness cannot be opened right now. */
+const UNKNOWN_HARNESS_NOTE =
+  "This ClawBox could not say which harness it is running, so apps that belong to only one of them"
+  + " are not offered. Check /etc/clawbox/edition.env and that the device's web server is up.";
 
 async function api(path: string, options?: RequestInit) {
   const headers = new Headers(options?.headers);
@@ -221,7 +230,8 @@ async function main() {
     // typo, for an installed id missing its `installed-` prefix, and for the
     // other harness's apps — a false success on the CLI sibling of the list
     // `app list` below prints from.
-    const openable = builtInApps(await openHarness()).map((a) => a.id);
+    const harness = await openHarness();
+    const openable = builtInApps(harness).map((a) => a.id);
     const isInstalled = appId.startsWith("installed-");
     if (isInstalled) {
       // The shape check, exactly where ui_open_app applies it: an installed id
@@ -235,21 +245,38 @@ async function main() {
       // id the device does not have is still a window that never opens, and
       // printing a tick over it is the same false success the built-in branch
       // below exists to stop.
-      const prefs = await api("/setup-api/preferences?keys=installed_apps") as {
+      //
+      // …and MEMBERSHIP IN WHAT THE DESKTOP WOULD OPEN, not merely in
+      // `installed_apps`: a store-installed OpenClaw skill is unusable on
+      // Hermes (its window shells out to the openclaw binary), so the desktop
+      // drops it and a tick here would be printed over a window that never
+      // appears. One predicate, shared with the desktop and with ui_open_app.
+      const prefs = await api("/setup-api/preferences?keys=installed_apps,installed_meta") as {
         installed_apps?: unknown;
+        installed_meta?: unknown;
       };
-      const installed = Array.isArray(prefs?.installed_apps)
+      const meta = (prefs?.installed_meta ?? {}) as Record<string, { webappUrl?: unknown } | undefined>;
+      const installed = (Array.isArray(prefs?.installed_apps)
         ? prefs.installed_apps.filter((v): v is string => typeof v === "string")
-        : [];
+        : []
+      ).filter((id) => isInstalledAppVisible(meta[id], harness));
       if (!installed.includes(appId.slice("installed-".length))) {
         console.error(
-          `No installed app "${appId.slice("installed-".length)}" on this ClawBox.`
+          `No installed app "${appId.slice("installed-".length)}" this ClawBox can open.`
           + (installed.length ? ` Installed: ${installed.join(", ")}` : " Nothing is installed."),
         );
         process.exit(1);
       }
     } else if (!openable.includes(appId)) {
-      console.error(`No built-in app "${appId}" on this ClawBox. Try: ${openable.join(", ")}`);
+      // An app the OTHER harness owns is "not here"; the same app while the
+      // harness is unknown is "could not be placed". Saying the first over the
+      // second tells the agent as a durable fact that a dual box has no
+      // dashboard, which is how it stops asking.
+      console.error(
+        harness === null && HARNESS_ONLY_APP_IDS.includes(appId)
+          ? `Cannot open "${appId}": ${UNKNOWN_HARNESS_NOTE}`
+          : `No built-in app "${appId}" on this ClawBox. Try: ${openable.join(", ")}`,
+      );
       process.exit(1);
     }
     await apiPost("/setup-api/kv", {
@@ -266,11 +293,14 @@ async function main() {
     const edition = installEdition();
     const harness = await openHarness();
     console.log(
-      edition === harness
-        ? `Built-in apps (${edition} edition):`
-        : `Built-in apps (${edition} edition, running ${harness}):`,
+      harness === null
+        ? `Built-in apps (${edition} edition, harness undetermined):`
+        : edition === harness
+          ? `Built-in apps (${edition} edition):`
+          : `Built-in apps (${edition} edition, running ${harness}):`,
     );
     for (const app of builtInApps(harness)) console.log(`  ${app.id} — ${app.name}`);
+    if (harness === null) console.log(`  (${UNKNOWN_HARNESS_NOTE})`);
 
   } else if (cmd === "edition") {
     console.log(installEdition());

--- a/mcp/clawbox-cli.ts
+++ b/mcp/clawbox-cli.ts
@@ -19,7 +19,7 @@ import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 import { spawnSync } from "child_process";
 import { installEdition, resolveAppHarness, type Ed } from "./lib/edition";
-import { builtInApps } from "./lib/context";
+import { builtInApps, openedAppNotice } from "./lib/context";
 import { HARNESS_ONLY_APP_IDS, isInstalledAppVisible } from "../src/lib/desktop-app-editions";
 import { INSTALLED_APP_ID_RE } from "./lib/schema";
 
@@ -78,12 +78,14 @@ function getApiToken(): string {
  * CLI was the one giving a different answer.
  *
  * `resolveAppHarness` is that same resolution: a locked edition decides on its
- * own, only `dual` asks the device which harness is active, and an unreadable
- * lock or a device that does not answer is NULL rather than a guess — see the
- * note there on why an app gate cannot fail closed onto one harness. The
- * bearer is OPTIONAL — `app list` has always worked without a token, and the
- * cost is only that a session-gated device leaves the dual question
- * unresolved rather than answering it.
+ * own, and `dual` — or a lock that cannot be read — asks the device which
+ * harness is active, because /setup-api/harness/active is the very route the
+ * desktop grid is built from and it always answers. Only a device that does
+ * NOT answer is NULL rather than a guess — see the note there on why an app
+ * gate cannot fail closed onto one harness. The bearer is OPTIONAL — `app
+ * list` has always worked without a token, and the cost is only that a
+ * session-gated device leaves the question unresolved rather than answering
+ * it.
  */
 function openHarness(): Promise<Ed | null> {
   const token = findApiToken();
@@ -231,7 +233,8 @@ async function main() {
     // other harness's apps — a false success on the CLI sibling of the list
     // `app list` below prints from.
     const harness = await openHarness();
-    const openable = builtInApps(harness).map((a) => a.id);
+    const builtIn = builtInApps(harness);
+    const openable = builtIn.map((a) => a.id);
     const isInstalled = appId.startsWith("installed-");
     if (isInstalled) {
       // The shape check, exactly where ui_open_app applies it: an installed id
@@ -283,7 +286,12 @@ async function main() {
       key: "ui:pending-action",
       value: JSON.stringify({ type: "open_app", appId, ts: Date.now() }),
     });
-    console.log(`✅ Opening ${appId} on desktop.`);
+    // The tick is a CLAIM, and for an `external` app it is not true: the
+    // desktop window.open()s that one from its poll, where a popup blocker
+    // drops it silently. `ui_open_app` hedges; this posts the same action to
+    // the same ring, so it says the same thing — from the same function.
+    const known = builtIn.find((a) => a.id === appId);
+    console.log(known?.external ? openedAppNotice(known, appId) : `✅ Opening ${appId} on desktop.`);
 
   } else if (cmd === "app" && sub === "list") {
     // The list is HARNESS-dependent: a Hermes device has no OpenClaw chat app

--- a/mcp/clawbox-cli.ts
+++ b/mcp/clawbox-cli.ts
@@ -195,7 +195,16 @@ async function main() {
     // `app list` below prints from.
     const openHarness = installEdition() === "hermes" ? "hermes" : "openclaw";
     const openable = builtInApps(openHarness).map((a) => a.id);
-    if (!appId.startsWith("installed-") && !openable.includes(appId)) {
+    const isInstalled = appId.startsWith("installed-");
+    if (isInstalled) {
+      // The shape check, exactly where ui_open_app applies it: an installed id
+      // is caller-supplied, and `installed-../etc` would otherwise be posted as
+      // a pending action with a tick printed over it.
+      if (!/^installed-[a-z0-9][a-z0-9-]{0,63}$/.test(appId)) {
+        console.error(`"${appId}" is not a valid installed-app id.`);
+        process.exit(1);
+      }
+    } else if (!openable.includes(appId)) {
       console.error(`No built-in app "${appId}" on this ClawBox. Try: ${openable.join(", ")}`);
       process.exit(1);
     }

--- a/mcp/clawbox-cli.ts
+++ b/mcp/clawbox-cli.ts
@@ -205,6 +205,23 @@ async function main() {
         console.error(`"${appId}" is not a valid installed-app id.`);
         process.exit(1);
       }
+      // …and then MEMBERSHIP, also where ui_open_app applies it. A well-formed
+      // id the device does not have is still a window that never opens, and
+      // printing a tick over it is the same false success the built-in branch
+      // below exists to stop.
+      const prefs = await api("/setup-api/preferences?keys=installed_apps") as {
+        installed_apps?: unknown;
+      };
+      const installed = Array.isArray(prefs?.installed_apps)
+        ? prefs.installed_apps.filter((v): v is string => typeof v === "string")
+        : [];
+      if (!installed.includes(appId.slice("installed-".length))) {
+        console.error(
+          `No installed app "${appId.slice("installed-".length)}" on this ClawBox.`
+          + (installed.length ? ` Installed: ${installed.join(", ")}` : " Nothing is installed."),
+        );
+        process.exit(1);
+      }
     } else if (!openable.includes(appId)) {
       console.error(`No built-in app "${appId}" on this ClawBox. Try: ${openable.join(", ")}`);
       process.exit(1);

--- a/mcp/clawbox-cli.ts
+++ b/mcp/clawbox-cli.ts
@@ -19,12 +19,15 @@ import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 import { spawnSync } from "child_process";
 import { installEdition, resolveAppHarness, type Ed } from "./lib/edition";
-import { builtInApps, openedAppNotice } from "./lib/context";
+import { builtInApps, openedAppLine, UNKNOWN_HARNESS_NOTE } from "./lib/context";
 import { HARNESS_ONLY_APP_IDS, isInstalledAppVisible } from "../src/lib/desktop-app-editions";
 import { INSTALLED_APP_ID_RE } from "./lib/schema";
 
 const API_BASE = process.env.CLAWBOX_API_BASE || "http://127.0.0.1:80";
 const UI_PICKUP_DELAY_MS = 2500; // Time for the desktop UI to poll and pick up KV actions
+// The ceiling on one /setup-api call. Generous — a cold Jetson answers some of
+// these in seconds — and finite, which is the whole point.
+const API_TIMEOUT_MS = 30_000;
 
 // MCP bearer token. /setup-api/* is session-gated by src/middleware.ts once
 // setup completes, but it also accepts this per-install bearer (see
@@ -92,17 +95,27 @@ function openHarness(): Promise<Ed | null> {
   return resolveAppHarness(API_BASE, token ? `Bearer ${token}` : null);
 }
 
-/** Why an app that exists on ONE harness cannot be opened right now. */
-const UNKNOWN_HARNESS_NOTE =
-  "This ClawBox could not say which harness it is running, so apps that belong to only one of them"
-  + " are not offered. Check /etc/clawbox/edition.env and that the device's web server is up.";
-
 async function api(path: string, options?: RequestInit) {
   const headers = new Headers(options?.headers);
   if (!headers.has("authorization")) {
     headers.set("authorization", `Bearer ${getApiToken()}`);
   }
-  const res = await fetch(`${API_BASE}${path}`, { ...options, headers, redirect: "manual" });
+  // A DEVICE THAT NEVER ANSWERS IS NOT A DEVICE THAT IS THINKING. Without a
+  // signal a wedged web server left `clawbox app open` hanging in the agent's
+  // shell forever with no output — `mcp/lib/api.ts` and `askActiveHarness` have
+  // always carried one, and this was the last client that did not.
+  let res: Response;
+  try {
+    res = await fetch(`${API_BASE}${path}`, {
+      ...options,
+      headers,
+      redirect: "manual",
+      signal: options?.signal ?? AbortSignal.timeout(API_TIMEOUT_MS),
+    });
+  } catch {
+    console.error(`The device did not answer within ${API_TIMEOUT_MS / 1000}s. Is its web server up?`);
+    process.exit(1);
+  }
   if (res.status >= 300 && res.status < 400) {
     console.error("The device rejected this request's token. Check data/.mcp-token, or restart the device.");
     process.exit(1);
@@ -289,9 +302,10 @@ async function main() {
     // The tick is a CLAIM, and for an `external` app it is not true: the
     // desktop window.open()s that one from its poll, where a popup blocker
     // drops it silently. `ui_open_app` hedges; this posts the same action to
-    // the same ring, so it says the same thing — from the same function.
-    const known = builtIn.find((a) => a.id === appId);
-    console.log(known?.external ? openedAppNotice(known, appId) : `✅ Opening ${appId} on desktop.`);
+    // the same ring, so it says the same sentence — from the same function, on
+    // BOTH branches, or the two surfaces drift again the next time one of them
+    // gains a reason to hedge.
+    console.log(openedAppLine(builtIn.find((a) => a.id === appId), appId));
 
   } else if (cmd === "app" && sub === "list") {
     // The list is HARNESS-dependent: a Hermes device has no OpenClaw chat app

--- a/mcp/clawbox-mcp.ts
+++ b/mcp/clawbox-mcp.ts
@@ -129,15 +129,13 @@ function instructionsFor(edition: Ed, profile: Profile): string {
  * Build a fully-registered server. Exported so mcp/check-tools.ts can build one
  * per edition and diff the tool lists without connecting a transport.
  */
-export async function buildServer(edition: Ed, profile: Profile) {
+export async function buildServer(edition: Ed, profile: Profile, appHarness: Ed | null) {
   // The app list is a different question from the tool set — see
-  // `resolveAppHarness`. Resolved here, once, beside the edition probe.
-  const ctx = await buildContext(
-    edition,
-    installEdition(),
-    profile,
-    await resolveAppHarness(API_BASE, authHeader()),
-  );
+  // `resolveAppHarness` — but it is answered by the SAME probe, taken once in
+  // `main()` and handed down. Asking again here made a dual box put two
+  // requests to /setup-api/harness/active at every startup, each with its own
+  // 3 s timeout, and let the two collapse a silence in opposite directions.
+  const ctx = await buildContext(edition, installEdition(), profile, appHarness);
   const server = new McpServer(
     { name: "clawbox", version: VERSION },
     { instructions: instructionsFor(edition, profile) },
@@ -168,9 +166,11 @@ export async function buildServer(edition: Ed, profile: Profile) {
 }
 
 async function main(): Promise<void> {
-  const edition = await resolveEdition(API_BASE, authHeader());
+  // ONE probe of /setup-api/harness/active, for both questions it settles.
+  const appHarness = await resolveAppHarness(API_BASE, authHeader());
+  const edition = resolveEdition(appHarness);
   const { profile, model } = await resolveProfile(edition);
-  const { server, reg, ctx } = await buildServer(edition, profile);
+  const { server, reg, ctx } = await buildServer(edition, profile, appHarness);
   const transport = new StdioServerTransport();
   await server.connect(transport);
   // The model is named because "why do I only have 16 tools?" is the first

--- a/mcp/clawbox-mcp.ts
+++ b/mcp/clawbox-mcp.ts
@@ -44,7 +44,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { API_BASE, authHeader } from "./lib/api";
 import { buildContext } from "./lib/context";
-import { installEdition, resolveEdition, type Ed } from "./lib/edition";
+import { installEdition, resolveAppHarness, resolveEdition, type Ed } from "./lib/edition";
 import { resolveProfile } from "./lib/profile";
 import { createRegistrar, type Profile } from "./lib/register";
 import { registerAiTools } from "./tools/ai";
@@ -130,7 +130,14 @@ function instructionsFor(edition: Ed, profile: Profile): string {
  * per edition and diff the tool lists without connecting a transport.
  */
 export async function buildServer(edition: Ed, profile: Profile) {
-  const ctx = await buildContext(edition, installEdition(), profile);
+  // The app list is a different question from the tool set — see
+  // `resolveAppHarness`. Resolved here, once, beside the edition probe.
+  const ctx = await buildContext(
+    edition,
+    installEdition(),
+    profile,
+    await resolveAppHarness(API_BASE, authHeader()),
+  );
   const server = new McpServer(
     { name: "clawbox", version: VERSION },
     { instructions: instructionsFor(edition, profile) },

--- a/mcp/lib/context.ts
+++ b/mcp/lib/context.ts
@@ -6,6 +6,7 @@
 // registered at all, rather than registered and failing.
 
 import { capabilitiesFor, type HarnessFacts } from "../../src/lib/harness/capabilities";
+import { appExistsOnEdition } from "../../src/lib/desktop-app-editions";
 import type { HarnessId } from "../../src/lib/harness/transport";
 import { hasBinary, spawnArgv } from "./guard";
 import { apiTry } from "./api";
@@ -17,29 +18,38 @@ export interface DesktopApp {
   description: string;
 }
 
-// Apps that exist on only one harness. Advertising the other harness's apps
-// would have the agent open a window onto a backend that isn't installed.
-const OPENCLAW_ONLY_APPS: DesktopApp[] = [
-  { id: "openclaw", name: "OpenClaw", description: "AI chat" },
-  { id: "store", name: "Store", description: "App store" },
-  // OpenClaw's memory index. Listed here and not in COMMON_APPS for the same
-  // reason the desktop hides it on Hermes: there is no index to show there.
-  { id: "memory-shard", name: "Memory Shard", description: "The memory index: embedding health, reindex, schedule" },
-];
-const HERMES_ONLY_APPS: DesktopApp[] = [
-  { id: "hermes-skills", name: "Hermes Skills", description: "Install skills for the agent" },
-];
-const COMMON_APPS: DesktopApp[] = [
-  { id: "settings", name: "Settings", description: "Device settings, AI provider, backup" },
-  { id: "terminal", name: "Terminal", description: "Shell" },
-  { id: "files", name: "Files", description: "File manager" },
-  { id: "browser", name: "Browser Setup", description: "Browser integration panel, not the browsing window" },
-  { id: "vnc", name: "Remote Desktop", description: "VNC viewer" },
-  { id: "coding", name: "Coding Agent", description: "The owner's switch for delegated coding runs, what a run needs, and recent runs" },
-];
+// Every built-in desktop app, in the order src/lib/desktop-apps.ts declares
+// them, with the sentence the agent needs to pick the right window. The
+// registry cannot be imported here — it reaches React through the `@/` alias,
+// which mcp/tsconfig.json exists to keep out of this stdio process — so
+// src/tests/unit/mcp-desktop-apps.test.ts holds this table against it: adding
+// an app to the desktop without a line here fails CI (TASK-541, where four
+// apps the desktop shows had gone missing from this list and `ui_open_app`
+// answered "there is no such app" for the box's own Hermes dashboard).
+//
+// The EDITION gate is not repeated here: src/lib/desktop-app-editions.ts is
+// the one copy, shared with the desktop grid and the standalone window.
+const APP_DESCRIPTIONS: Record<string, { name: string; description: string }> = {
+  settings: { name: "Settings", description: "Device settings, AI provider, backup" },
+  clawbox: { name: "Chat", description: "The ClawBox chat window on the desktop — this conversation, where the user can see it" },
+  openclaw: { name: "OpenClaw", description: "OpenClaw's own Control UI chat, in a browser tab" },
+  hermes: { name: "Hermes", description: "The Hermes dashboard, in a browser tab" },
+  "hermes-skills": { name: "Hermes Skills", description: "Install skills for the agent" },
+  terminal: { name: "Terminal", description: "Shell" },
+  coding: { name: "Coding Agent", description: "The owner's switch for delegated coding runs, what a run needs, and recent runs" },
+  files: { name: "Files", description: "File manager" },
+  clawkeep: { name: "ClawKeep", description: "Backups: what is protected, run one now, restore" },
+  "memory-shard": { name: "Memory Shard", description: "The memory index: embedding health, reindex, schedule" },
+  system_update: { name: "System Update", description: "The installed ClawBox version and the update button" },
+  store: { name: "Store", description: "App store" },
+  browser: { name: "Browser Setup", description: "Browser integration panel, not the browsing window" },
+  vnc: { name: "Remote Desktop", description: "VNC viewer" },
+};
 
 export function builtInApps(edition: Ed): DesktopApp[] {
-  return [...COMMON_APPS, ...(edition === "hermes" ? HERMES_ONLY_APPS : OPENCLAW_ONLY_APPS)];
+  return Object.entries(APP_DESCRIPTIONS)
+    .filter(([id]) => appExistsOnEdition(id, edition))
+    .map(([id, def]) => ({ id, ...def }));
 }
 
 export interface Capabilities {

--- a/mcp/lib/context.ts
+++ b/mcp/lib/context.ts
@@ -63,6 +63,30 @@ export function builtInApps(edition: Ed | null): DesktopApp[] {
     .map(([id, def]) => ({ id, ...def }));
 }
 
+/**
+ * What may honestly be said after the open action has been posted.
+ *
+ * ONE sentence for both surfaces. `ui_open_app` and `clawbox app open` push the
+ * same action into the same fire-and-forget ring (`ui:pending-actions`), which
+ * the desktop POLLS — so neither of them learns what became of it, and an
+ * `external` app is opened with `window.open()` from that poll rather than from
+ * a click, where a popup blocker can drop it silently. Claiming it appeared is
+ * a false success on the one path the agent cannot see; saying so is what lets
+ * the agent ask the owner to look. Kept here, beside the `external` flag, so
+ * the CLI and the tool cannot answer the same question two ways — which is the
+ * defect TASK-541 is about.
+ *
+ * @param app the built-in app, or undefined for an installed one (never
+ *            external: an installed app is FRAMED in the desktop).
+ * @param fallbackId what to call it when the registry has no row.
+ */
+export function openedAppNotice(app: DesktopApp | undefined, fallbackId: string): string {
+  return app?.external
+    ? `Asked the desktop to open ${app.name}. It opens in a new browser tab, so ask the user to`
+      + " look at the screen — and to allow the popup if their browser blocked it."
+    : `Opened ${app?.name ?? fallbackId} on the desktop.`;
+}
+
 export interface Capabilities {
   /** Binary that can grab display :0, or null when none is installed. */
   screenGrabber: string | null;

--- a/mcp/lib/context.ts
+++ b/mcp/lib/context.ts
@@ -53,7 +53,11 @@ const APP_DESCRIPTIONS: Record<string, Omit<DesktopApp, "id">> = {
   vnc: { name: "Remote Desktop", description: "VNC viewer" },
 };
 
-export function builtInApps(edition: Ed): DesktopApp[] {
+/**
+ * The built-in apps this harness has. `null` — the harness could not be
+ * determined — answers the apps that exist on BOTH, never one harness's guess.
+ */
+export function builtInApps(edition: Ed | null): DesktopApp[] {
   return Object.entries(APP_DESCRIPTIONS)
     .filter(([id]) => appExistsOnEdition(id, edition))
     .map(([id, def]) => ({ id, ...def }));
@@ -75,6 +79,17 @@ export interface McpContext {
   edition: Ed;
   /** The raw install edition — can be "dual", which `edition` resolves. */
   install: "openclaw" | "hermes" | "dual";
+  /**
+   * Whose built-in DESKTOP APPS this device shows, or null when that could not
+   * be determined — a different question from `edition`, which is a tool set
+   * and fails closed onto the smaller of two nested answers. See
+   * `resolveAppHarness`.
+   *
+   * A STARTUP SNAPSHOT, like everything else here: on the `dual` SKU a harness
+   * switch made after this child spawned is not seen until it restarts, which
+   * `mcp/tools/desktop.ts` says out loud where it matters.
+   */
+  appHarness: Ed | null;
   profile: Profile;
   capabilities: Capabilities;
   /**
@@ -196,6 +211,7 @@ export async function buildContext(
   edition: Ed,
   install: "openclaw" | "hermes" | "dual",
   profile: Profile,
+  appHarness: Ed | null = edition,
 ): Promise<McpContext> {
   let screenGrabber: string | null = null;
   for (const bin of SCREEN_GRABBERS) {
@@ -236,6 +252,7 @@ export async function buildContext(
   return {
     edition,
     install,
+    appHarness,
     profile,
     capabilities: { screenGrabber, imageConvert, journal, du },
     providers,

--- a/mcp/lib/context.ts
+++ b/mcp/lib/context.ts
@@ -64,6 +64,20 @@ export function builtInApps(edition: Ed | null): DesktopApp[] {
 }
 
 /**
+ * Why an app that exists on ONE harness cannot be offered right now.
+ *
+ * The wording matters, and the CLI has said it since this gate existed: an app
+ * the OTHER harness owns is "not here", while the SAME app on a box whose
+ * harness could not be determined is "could not be placed". Saying the first
+ * over the second tells the agent as a durable fact that the box has no
+ * dashboard, which is how it stops asking — so the MCP tool and the CLI say the
+ * same sentence, from here.
+ */
+export const UNKNOWN_HARNESS_NOTE =
+  "This ClawBox could not say which harness it is running, so apps that belong to only one of them"
+  + " are not offered. Check /etc/clawbox/edition.env and that the device's web server is up.";
+
+/**
  * What may honestly be said after the open action has been posted.
  *
  * ONE sentence for both surfaces. `ui_open_app` and `clawbox app open` push the
@@ -85,6 +99,19 @@ export function openedAppNotice(app: DesktopApp | undefined, fallbackId: string)
     ? `Asked the desktop to open ${app.name}. It opens in a new browser tab, so ask the user to`
       + " look at the screen — and to allow the popup if their browser blocked it."
     : `Opened ${app?.name ?? fallbackId} on the desktop.`;
+}
+
+/**
+ * The same notice for a human reading a shell, with the CLI's tick.
+ *
+ * The tick and the wording are separated deliberately: the SENTENCE is the
+ * claim, and it has to be the tool's, or a future change to one surface's
+ * hedging silently un-aligns them again — which is the drift `openedAppNotice`
+ * was added to prevent and, on its first outing, only half prevented. The glyph
+ * is presentation, and only where a person is reading.
+ */
+export function openedAppLine(app: DesktopApp | undefined, fallbackId: string): string {
+  return `${app?.external ? "" : "✅ "}${openedAppNotice(app, fallbackId)}`;
 }
 
 export interface Capabilities {
@@ -235,7 +262,13 @@ export async function buildContext(
   edition: Ed,
   install: "openclaw" | "hermes" | "dual",
   profile: Profile,
-  appHarness: Ed | null = edition,
+  // REQUIRED, with no default. `= edition` looked harmless because both
+  // production callers pass it, but it is the wrong answer by this module's own
+  // argument: with an unreadable lock `edition` is "hermes", and answering that
+  // for the APP question refuses three apps the box has and ticks off two it
+  // may not. A caller who omitted it would get exactly that, silently and
+  // without a type error — the conflation this pair of questions exists to end.
+  appHarness: Ed | null,
 ): Promise<McpContext> {
   let screenGrabber: string | null = null;
   for (const bin of SCREEN_GRABBERS) {

--- a/mcp/lib/context.ts
+++ b/mcp/lib/context.ts
@@ -16,6 +16,13 @@ export interface DesktopApp {
   id: string;
   name: string;
   description: string;
+  /**
+   * The desktop opens this one in a NEW BROWSER TAB (`window.open`), not in a
+   * desktop window — so the browser's popup blocker can drop it, and
+   * `ui_open_app` must not claim it appeared. Mirrors `type: "external"` in
+   * src/lib/desktop-apps.ts; the drift test holds the two together.
+   */
+  external?: boolean;
 }
 
 // Every built-in desktop app, in the order src/lib/desktop-apps.ts declares
@@ -29,11 +36,11 @@ export interface DesktopApp {
 //
 // The EDITION gate is not repeated here: src/lib/desktop-app-editions.ts is
 // the one copy, shared with the desktop grid and the standalone window.
-const APP_DESCRIPTIONS: Record<string, { name: string; description: string }> = {
+const APP_DESCRIPTIONS: Record<string, Omit<DesktopApp, "id">> = {
   settings: { name: "Settings", description: "Device settings, AI provider, backup" },
-  clawbox: { name: "Chat", description: "The ClawBox chat window on the desktop — this conversation, where the user can see it" },
-  openclaw: { name: "OpenClaw", description: "OpenClaw's own Control UI chat, in a browser tab" },
-  hermes: { name: "Hermes", description: "The Hermes dashboard, in a browser tab" },
+  clawbox: { name: "Chat", description: "The ClawBox chat window on the desktop — the device's MAIN conversation, which is not necessarily this one" },
+  openclaw: { name: "OpenClaw", description: "OpenClaw's own Control UI chat, in a browser tab", external: true },
+  hermes: { name: "Hermes", description: "The Hermes dashboard, in a browser tab", external: true },
   "hermes-skills": { name: "Hermes Skills", description: "Install skills for the agent" },
   terminal: { name: "Terminal", description: "Shell" },
   coding: { name: "Coding Agent", description: "The owner's switch for delegated coding runs, what a run needs, and recent runs" },

--- a/mcp/lib/edition.ts
+++ b/mcp/lib/edition.ts
@@ -72,7 +72,49 @@ export async function resolveEdition(apiBase: string, authHeader: string | null)
   }
   const installed = readEdition();
   if (installed === "openclaw" || installed === "hermes") return installed;
+  // Dual box whose API is not up yet — register the default harness's tools
+  // rather than an empty or half-wrong set.
+  return (await askActiveHarness(apiBase, authHeader)) ?? "openclaw";
+}
 
+/**
+ * Which harness's built-in APPS this device shows, or null when that cannot be
+ * determined.
+ *
+ * A SEPARATE QUESTION from `resolveEdition`, and the difference is the whole
+ * reason this exists. That one picks a TOOL SET, where the two answers are
+ * nested — hermes is openclaw minus the shell and file tools — so an
+ * undetermined edition can fail closed onto the smaller one. The app sets are
+ * not nested: `openclaw`/`store`/`memory-shard` against `hermes`/
+ * `hermes-skills`. Answering "hermes" for an unreadable lock would refuse
+ * three apps the box has AND tick off two it may not, which is the same false
+ * success the gate exists to stop.
+ *
+ * So this returns null instead, and every caller hides BOTH harness-only sets
+ * — the answer `hiddenAppIdsForHarness(null)` already gives the desktop while
+ * its own fetch is in flight.
+ *
+ * No console line: this is asked by the CLI as well as the MCP, and one
+ * invocation of `clawbox app list` registers no tools.
+ */
+export async function resolveAppHarness(
+  apiBase: string,
+  authHeader: string | null,
+): Promise<Ed | null> {
+  if (lockUnreadable()) return null;
+  const installed = readEdition();
+  if (installed === "openclaw" || installed === "hermes") return installed;
+  return askActiveHarness(apiBase, authHeader);
+}
+
+/**
+ * The harness the DEVICE says is active, or null when it did not say.
+ *
+ * Null rather than a default, because the two callers want opposite things
+ * from a silence: registration needs some tool set, an app gate must not claim
+ * a harness it never resolved.
+ */
+async function askActiveHarness(apiBase: string, authHeader: string | null): Promise<Ed | null> {
   try {
     const res = await fetch(`${apiBase}/setup-api/harness/active`, {
       headers: {
@@ -85,12 +127,13 @@ export async function resolveEdition(apiBase: string, authHeader: string | null)
     if (res.ok) {
       const body = (await res.json()) as { active?: unknown };
       if (body?.active === "hermes") return "hermes";
+      if (body?.active === "openclaw") return "openclaw";
     }
   } catch {
-    // Dual box whose API is not up yet — register the default harness's tools
-    // rather than an empty or half-wrong set.
+    // The device could not be reached, or answered something this build does
+    // not know. Either way nothing was resolved.
   }
-  return "openclaw";
+  return null;
 }
 
 /** The raw install edition, for reporting (can be "dual"). */

--- a/mcp/lib/edition.ts
+++ b/mcp/lib/edition.ts
@@ -71,11 +71,12 @@ function lockUnreadable(): boolean {
  */
 export function resolveEdition(appHarness: Ed | null): Ed {
   if (lockUnreadable()) {
-    // FAIL CLOSED, whatever the device answered. This is the one place the two
-    // questions genuinely differ: the app list may take the device's word here
-    // (the desktop's own route does), but OpenClaw is the larger tool surface
-    // and the only one carrying the shell and file tools, so an unreadable lock
-    // must not hand them out.
+    // FAIL CLOSED, whatever the device answered. This is where the two
+    // questions differ in DIRECTION: the tool sets are nested, so the smaller
+    // one is the safe answer to a doubt — OpenClaw is the larger surface and
+    // the only one carrying the shell and file tools, and an unreadable lock
+    // must not hand them out. The APP sets are not nested, so the same doubt
+    // there answers `null` and hides both (see `resolveAppHarness`).
     console.error(
       "[clawbox-mcp] /etc/clawbox/edition.env exists but no edition could be read from it. "
       + "Registering the SMALLER Hermes tool set: the shell and file tools stay off until the lock is readable.",
@@ -106,16 +107,22 @@ export function resolveEdition(appHarness: Ed | null): Ed {
  * — the answer `hiddenAppIdsForHarness(null)` already gives the desktop while
  * its own fetch is in flight.
  *
- * AN UNREADABLE LOCK IS ASKED ABOUT, not answered here. `/setup-api/harness/
- * active` always answers — `getActiveHarness()` falls through `lockedHarness()`
- * to `readEdition()`, whose default for an unreadable lock is "openclaw"
- * (src/lib/harness.ts) — so the desktop grid and `/app/<id>` show twelve apps
- * in that state while an early return of null told the agent three of them
- * could not be placed, with the owner looking at them on screen. The device's
- * own route is the oracle for the APP question exactly as it is for `dual`;
- * null is kept for the one case that establishes nothing, a device that did not
- * answer at all. (The TOOL SET still fails closed on that lock — see
- * `resolveEdition`.)
+ * AN UNREADABLE LOCK IS NOT ASKED ABOUT, because on that box the route has no
+ * independent answer to give. `/setup-api/harness/active` always answers, but
+ * traced out it is the SAME FILE this process just failed to read:
+ * `getActiveHarness()` -> `lockedHarness()` -> `isDualUnlocked()` is false
+ * because `readEdition()` fell back -> `getEdition()` -> `readEdition()` ->
+ * `"openclaw"`, its own default (src/lib/harness.ts:82-127,
+ * src/lib/edition-source.ts:65-77). So on an unreadable lock that route can
+ * only ever say "openclaw", on a Hermes box as readily as on an OpenClaw one —
+ * and taking it as the answer would register the Hermes TOOL SET beside an
+ * OpenClaw app list, deny the box its own `hermes-skills` with "there is no
+ * such app" (TASK-541's original symptom, verbatim) and tick off `openclaw` and
+ * `store` on a box that has neither.
+ *
+ * Asking is right for `dual`, where the route resolves a real runtime choice
+ * from the config store. It is not right here, and the difference is exactly
+ * whether the device knows something this process does not.
  *
  * No console line: this is asked by the CLI as well as the MCP, and one
  * invocation of `clawbox app list` registers no tools.
@@ -124,7 +131,8 @@ export async function resolveAppHarness(
   apiBase: string,
   authHeader: string | null,
 ): Promise<Ed | null> {
-  const installed = lockUnreadable() ? null : readEdition();
+  if (lockUnreadable()) return null;
+  const installed = readEdition();
   if (installed === "openclaw" || installed === "hermes") return installed;
   return askActiveHarness(apiBase, authHeader);
 }

--- a/mcp/lib/edition.ts
+++ b/mcp/lib/edition.ts
@@ -58,12 +58,24 @@ function lockUnreadable(): boolean {
  *
  * A locked edition ("openclaw" / "hermes") wins outright — that install only
  * has one harness on disk. Only the unlocked premium "dual" edition has a
- * runtime choice, and there the device's own /setup-api/harness/active is the
- * single source of truth; a failure there falls back to "openclaw", the default
- * harness src/lib/harness.ts also degrades to.
+ * runtime choice, and there `appHarness` — what the device itself said — is the
+ * single source of truth; a null falls back to "openclaw", the default harness
+ * src/lib/harness.ts also degrades to.
+ *
+ * ASKS THE DEVICE NOTHING. It takes the answer `resolveAppHarness` already got,
+ * so a startup makes ONE probe and the tool set and the app list cannot be
+ * built from two different replies — a dual box whose first probe said `hermes`
+ * and whose second timed out registered the Hermes tool set beside an app list
+ * that hid both dashboards, for the life of that stdio child. Synchronous now,
+ * which is what makes a second probe impossible rather than merely unlikely.
  */
-export async function resolveEdition(apiBase: string, authHeader: string | null): Promise<Ed> {
+export function resolveEdition(appHarness: Ed | null): Ed {
   if (lockUnreadable()) {
+    // FAIL CLOSED, whatever the device answered. This is the one place the two
+    // questions genuinely differ: the app list may take the device's word here
+    // (the desktop's own route does), but OpenClaw is the larger tool surface
+    // and the only one carrying the shell and file tools, so an unreadable lock
+    // must not hand them out.
     console.error(
       "[clawbox-mcp] /etc/clawbox/edition.env exists but no edition could be read from it. "
       + "Registering the SMALLER Hermes tool set: the shell and file tools stay off until the lock is readable.",
@@ -72,9 +84,9 @@ export async function resolveEdition(apiBase: string, authHeader: string | null)
   }
   const installed = readEdition();
   if (installed === "openclaw" || installed === "hermes") return installed;
-  // Dual box whose API is not up yet — register the default harness's tools
-  // rather than an empty or half-wrong set.
-  return (await askActiveHarness(apiBase, authHeader)) ?? "openclaw";
+  // Dual box whose API was not up — register the default harness's tools rather
+  // than an empty or half-wrong set.
+  return appHarness ?? "openclaw";
 }
 
 /**
@@ -94,6 +106,17 @@ export async function resolveEdition(apiBase: string, authHeader: string | null)
  * — the answer `hiddenAppIdsForHarness(null)` already gives the desktop while
  * its own fetch is in flight.
  *
+ * AN UNREADABLE LOCK IS ASKED ABOUT, not answered here. `/setup-api/harness/
+ * active` always answers — `getActiveHarness()` falls through `lockedHarness()`
+ * to `readEdition()`, whose default for an unreadable lock is "openclaw"
+ * (src/lib/harness.ts) — so the desktop grid and `/app/<id>` show twelve apps
+ * in that state while an early return of null told the agent three of them
+ * could not be placed, with the owner looking at them on screen. The device's
+ * own route is the oracle for the APP question exactly as it is for `dual`;
+ * null is kept for the one case that establishes nothing, a device that did not
+ * answer at all. (The TOOL SET still fails closed on that lock — see
+ * `resolveEdition`.)
+ *
  * No console line: this is asked by the CLI as well as the MCP, and one
  * invocation of `clawbox app list` registers no tools.
  */
@@ -101,8 +124,7 @@ export async function resolveAppHarness(
   apiBase: string,
   authHeader: string | null,
 ): Promise<Ed | null> {
-  if (lockUnreadable()) return null;
-  const installed = readEdition();
+  const installed = lockUnreadable() ? null : readEdition();
   if (installed === "openclaw" || installed === "hermes") return installed;
   return askActiveHarness(apiBase, authHeader);
 }

--- a/mcp/lib/schema.ts
+++ b/mcp/lib/schema.ts
@@ -76,8 +76,30 @@ export function zOptText(max: number, description: string) {
  * — an unbounded id in an injection check is not a guard — and no such app has
  * ever been installed, so the trade is a 65-character webapp nobody can open
  * from a tool against a rule that cannot be walked past.
+ *
+ * ONE ALPHABET, TWO SPELLINGS, built from the same source below: the surfaces
+ * that OPEN an app take the prefixed form, and the one that REMOVES it takes
+ * the bare id (`ui_list_apps` reports it without the prefix). Widening the one
+ * without the other left the agent able to create, list and open an app it
+ * could not delete.
  */
-export const INSTALLED_APP_ID_RE = /^installed-[A-Za-z0-9_][A-Za-z0-9_-]{0,63}$/;
+const INSTALLED_APP_ID_BODY = "[A-Za-z0-9_][A-Za-z0-9_-]{0,63}";
+
+export const INSTALLED_APP_ID_RE = new RegExp(`^installed-${INSTALLED_APP_ID_BODY}$`);
+
+/** The same id WITHOUT the `installed-` prefix, as `ui_list_apps` reports it. */
+export const RAW_INSTALLED_APP_ID_RE = new RegExp(`^${INSTALLED_APP_ID_BODY}$`);
+
+/** An installed-app id as a tool argument, in the producers' own alphabet. */
+export function zInstalledAppId(description: string) {
+  return z
+    .string()
+    .regex(
+      RAW_INSTALLED_APP_ID_RE,
+      "letters, digits, underscores and hyphens, not starting with a hyphen, at most 64 characters",
+    )
+    .describe(description);
+}
 
 export function zSlug(description: string) {
   return z.string().regex(/^[a-z0-9][a-z0-9-]{0,63}$/, "lowercase letters, digits and hyphens only").describe(description);

--- a/mcp/lib/schema.ts
+++ b/mcp/lib/schema.ts
@@ -67,8 +67,17 @@ export function zOptText(max: number, description: string) {
  *
  * Deliberately still a closed alphabet: no dots, no slashes, no whitespace, so
  * the value cannot become a path or a second field on its way to the desktop.
+ * The FIRST character carries the same alphabet bar the hyphen, because both
+ * producers accept a leading `_` (`_drafts`) and only the store's SLUG refuses
+ * a leading `-`.
+ *
+ * One shape the producers allow and this still refuses: an id longer than 64
+ * characters, which `SLUG` does not bound. That cap is the guard doing its job
+ * — an unbounded id in an injection check is not a guard — and no such app has
+ * ever been installed, so the trade is a 65-character webapp nobody can open
+ * from a tool against a rule that cannot be walked past.
  */
-export const INSTALLED_APP_ID_RE = /^installed-[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/;
+export const INSTALLED_APP_ID_RE = /^installed-[A-Za-z0-9_][A-Za-z0-9_-]{0,63}$/;
 
 export function zSlug(description: string) {
   return z.string().regex(/^[a-z0-9][a-z0-9-]{0,63}$/, "lowercase letters, digits and hyphens only").describe(description);

--- a/mcp/lib/schema.ts
+++ b/mcp/lib/schema.ts
@@ -53,6 +53,23 @@ export function zOptText(max: number, description: string) {
 }
 
 /** A lowercase id: app ids, project ids, webapp ids. */
+/**
+ * An `installed-<id>` the caller invented, gated on SHAPE only — membership is
+ * checked separately against what the device reports.
+ *
+ * The alphabet is the PRODUCERS', not this file's: `APP_ID_RE`
+ * (src/lib/code-projects.ts, the webapp routes) and the store's `SLUG`
+ * (setup-api/apps/install) both accept upper case and underscores, so a webapp
+ * legitimately called `Foo_Bar` exists on boxes today. Gating on `zSlug`'s
+ * narrower lowercase-and-hyphen rule refused to open it — a tool saying "that
+ * is not a valid app id" about an id the device created. Kept in step by
+ * src/tests/unit/mcp-desktop-apps.test.ts.
+ *
+ * Deliberately still a closed alphabet: no dots, no slashes, no whitespace, so
+ * the value cannot become a path or a second field on its way to the desktop.
+ */
+export const INSTALLED_APP_ID_RE = /^installed-[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/;
+
 export function zSlug(description: string) {
   return z.string().regex(/^[a-z0-9][a-z0-9-]{0,63}$/, "lowercase letters, digits and hyphens only").describe(description);
 }

--- a/mcp/lib/schema.ts
+++ b/mcp/lib/schema.ts
@@ -92,8 +92,12 @@ export const RAW_INSTALLED_APP_ID_RE = new RegExp(`^${INSTALLED_APP_ID_BODY}$`);
 
 /** An installed-app id as a tool argument, in the producers' own alphabet. */
 export function zInstalledAppId(description: string) {
+  // `.max(64)` alongside the pattern, which already bounds it: the emitted JSON
+  // Schema is what a 4-8B local model reads, and it reads `maxLength` far more
+  // reliably than a regex quantifier.
   return z
     .string()
+    .max(64)
     .regex(
       RAW_INSTALLED_APP_ID_RE,
       "letters, digits, underscores and hyphens, not starting with a hyphen, at most 64 characters",

--- a/mcp/tools/desktop.ts
+++ b/mcp/tools/desktop.ts
@@ -11,6 +11,7 @@ import { ApiError, ToolError, type ErrorRule } from "../lib/errors";
 import { json, text, type Registrar } from "../lib/register";
 import { INSTALLED_APP_ID_RE, zBool, zConfirm, zEnumOf, zInt, zOptText, zSlug, zText } from "../lib/schema";
 import { builtInApps, type McpContext } from "../lib/context";
+import { isInstalledAppVisible } from "../../src/lib/desktop-app-editions";
 import type { InstalledHermesSkill } from "../../src/lib/hermes-skills";
 
 const UI_PICKUP_DELAY_MS = 2_500;
@@ -42,14 +43,28 @@ interface PrefsBody {
   installed_meta?: unknown;
 }
 
-/** Webapps and store apps the user has installed, by id. */
-async function installedAppIds(): Promise<string[]> {
+/**
+ * Webapps and store apps the user has installed AND the desktop would open, by
+ * id.
+ *
+ * `installed_apps` alone is not that list. A store-installed OpenClaw skill is
+ * unusable on Hermes — its window shells out to the openclaw binary — so the
+ * desktop drops it from `getAllApps()` through `isInstalledAppVisible`, and a
+ * gate that checked only membership answered "Opened <name>" over a window
+ * that never appeared. Both facts come out of one preferences read.
+ *
+ * `harness: null` asks for the list UNFILTERED, which is what a REMOVAL wants:
+ * an app this harness cannot open is still the owner's to delete.
+ */
+async function installedAppIds(harness: string | null): Promise<string[]> {
   const prefs = await apiGet<PrefsBody>("/setup-api/preferences", {
-    query: { keys: "installed_apps" },
+    query: { keys: "installed_apps,installed_meta" },
     timeoutMs: 10_000,
   }).catch(() => null);
   const raw = prefs?.installed_apps;
-  return Array.isArray(raw) ? raw.filter((v): v is string => typeof v === "string") : [];
+  const meta = (prefs?.installed_meta ?? {}) as Record<string, { webappUrl?: unknown } | undefined>;
+  const ids = Array.isArray(raw) ? raw.filter((v): v is string => typeof v === "string") : [];
+  return ids.filter((id) => isInstalledAppVisible(meta[id], harness));
 }
 
 /**
@@ -100,7 +115,14 @@ const WEBAPP_RULES: ErrorRule[] = [
 ];
 
 export function registerDesktopTools(reg: Registrar, ctx: McpContext): void {
-  const apps = builtInApps(ctx.edition);
+  // The APP harness, not the tool-set edition: an unreadable edition lock
+  // resolves the tool set to hermes (the smaller, nested one) and must not
+  // therefore hide `store`/`openclaw`/`memory-shard` from a box that has them
+  // or advertise `hermes` on a box that may not. `null` shows what both
+  // harnesses have, the answer the desktop uses while its own fetch is in
+  // flight. A startup snapshot, like the registration itself — on the dual SKU
+  // a harness switched after this child spawned is seen at the next restart.
+  const apps = builtInApps(ctx.appHarness);
   const builtInIds = apps.map((a) => a.id);
   const appLine = apps.map((a) => a.id).join(", ");
 
@@ -131,11 +153,11 @@ export function registerDesktopTools(reg: Registrar, ctx: McpContext): void {
             "Call ui_list_apps and pass an id from its installed_apps list, unchanged.",
           );
         }
-        const ids = await installedAppIds();
+        const ids = await installedAppIds(ctx.appHarness);
         if (!ids.includes(app_id.slice("installed-".length))) {
           throw new ToolError(
             "NOT_FOUND",
-            "That installed app is not on this device.",
+            "That installed app is not on this device, or this harness cannot open it.",
             "Call ui_list_apps to see which installed apps exist, and use one of those ids.",
           );
         }
@@ -176,7 +198,7 @@ export function registerDesktopTools(reg: Registrar, ctx: McpContext): void {
     { editions: ["openclaw", "hermes"], readOnly: true, profile: "core", maxChars: 6_000 },
     async () => {
       const builtIn = apps.map((a) => ({ id: a.id, name: a.name, what: a.description }));
-      const installed = (await installedAppIds()).map((id) => ({ id: `installed-${id}`, name: id }));
+      const installed = (await installedAppIds(ctx.appHarness)).map((id) => ({ id: `installed-${id}`, name: id }));
       // On Hermes the agent's own capabilities come from the skills store, not
       // from ~/.openclaw/skills (which does not exist there — listing it was
       // why installed skills always showed up empty on a Hermes device).
@@ -291,7 +313,8 @@ export function registerDesktopTools(reg: Registrar, ctx: McpContext): void {
     { app_id: zSlug("App id, as ui_list_apps reports it without the installed- prefix") },
     { editions: ["openclaw", "hermes"], readOnly: false, destructive: true },
     async ({ app_id }: { app_id: string }) => {
-      const installed = await installedAppIds();
+      // Unfiltered: removing an app this harness cannot open is legitimate.
+      const installed = await installedAppIds(null);
       if (!installed.includes(app_id)) {
         throw new ToolError(
           "NOT_FOUND",

--- a/mcp/tools/desktop.ts
+++ b/mcp/tools/desktop.ts
@@ -10,8 +10,8 @@ import { apiGet, apiPost, CLAWBOX_ROOT } from "../lib/api";
 import { ApiError, ToolError, type ErrorRule } from "../lib/errors";
 import { json, text, type Registrar } from "../lib/register";
 import { INSTALLED_APP_ID_RE, zBool, zConfirm, zEnumOf, zInstalledAppId, zInt, zOptText, zSlug, zText } from "../lib/schema";
-import { builtInApps, openedAppNotice, type McpContext } from "../lib/context";
-import { isInstalledAppVisible } from "../../src/lib/desktop-app-editions";
+import { builtInApps, openedAppNotice, UNKNOWN_HARNESS_NOTE, type McpContext } from "../lib/context";
+import { HARNESS_ONLY_APP_IDS, isInstalledAppVisible } from "../../src/lib/desktop-app-editions";
 import type { InstalledHermesSkill } from "../../src/lib/hermes-skills";
 
 const UI_PICKUP_DELAY_MS = 2_500;
@@ -162,11 +162,23 @@ export function registerDesktopTools(reg: Registrar, ctx: McpContext): void {
           );
         }
       } else if (!builtInIds.includes(app_id)) {
-        throw new ToolError(
-          "NOT_FOUND",
-          "There is no such app on this ClawBox.",
-          `Call ui_list_apps to see what exists here. Built-in ids: ${appLine}.`,
-        );
+        // AN UNDETERMINED HARNESS IS NOT "NO SUCH APP". The box may well have
+        // this one — the harness simply could not be resolved — and saying it
+        // does not exist tells the agent as a durable fact that a dual box has
+        // no dashboard, which is how it stops asking. The CLI has drawn this
+        // distinction since the gate existed; the tool now says the same
+        // sentence, from the same constant.
+        throw ctx.appHarness === null && HARNESS_ONLY_APP_IDS.includes(app_id)
+          ? new ToolError(
+            "NOT_FOUND",
+            `Cannot open "${app_id}" right now. ${UNKNOWN_HARNESS_NOTE}`,
+            "Do not conclude the device lacks this app. Report the reason to the user and try again once the device can name its harness.",
+          )
+          : new ToolError(
+            "NOT_FOUND",
+            "There is no such app on this ClawBox.",
+            `Call ui_list_apps to see what exists here. Built-in ids: ${appLine}.`,
+          );
       }
       await pushUiAction({ type: "open_app", appId: app_id });
       if (app_id === "browser") {
@@ -211,6 +223,10 @@ export function registerDesktopTools(reg: Registrar, ctx: McpContext): void {
         built_in: builtIn,
         installed_apps: installed,
         ...(ctx.edition === "hermes" ? { agent_skills: skills } : {}),
+        // Said out loud rather than five apps quietly missing from the list:
+        // the agent cannot tell "this box has no dashboard" from "nobody could
+        // say" unless one of them is written down.
+        ...(ctx.appHarness === null ? { note: UNKNOWN_HARNESS_NOTE } : {}),
       });
     },
   );
@@ -366,7 +382,12 @@ export function registerDesktopTools(reg: Registrar, ctx: McpContext): void {
     "webapp_update",
     "Replace the HTML of a web app you created earlier with webapp_create. The whole document is replaced, so send the complete HTML, not just the changed part.",
     {
-      app_id: zSlug("The id you passed to webapp_create"),
+      // Widened for the same reason `app_uninstall` was: `APP_ID_RE` is what
+      // /setup-api/webapps enforces, and it mints ids with upper case and
+      // underscores. An app this family LISTS and OPENS must be one it can
+      // also act on. (`webapp_create` stays narrow — constraining what the
+      // agent MINTS is a choice; refusing what the device made is a defect.)
+      app_id: zInstalledAppId("The id you passed to webapp_create"),
       html: zText(400_000, "The complete replacement HTML"),
     },
     { editions: ["openclaw", "hermes"], readOnly: false },
@@ -447,7 +468,11 @@ export function registerDesktopTools(reg: Registrar, ctx: McpContext): void {
     "code_project_build",
     "Bundle a code project into a single page and install it on the ClawBox desktop. Call this after every set of edits — the desktop shows the last build, not the source files. The source files are the ones under the absolute path code_project_init and code_project_list report; edits written anywhere else are not part of the build.",
     {
-      project_id: zSlug("The project id from code_project_list"),
+      // From `code_project_list`, so it carries whatever alphabet
+      // /setup-api/code minted it with (`APP_ID_RE`: upper case and
+      // underscores included). Refusing it here made the tool reject an id
+      // its own sibling had just reported.
+      project_id: zInstalledAppId("The project id from code_project_list"),
       open_after_build: zBool(true, "Open it on the desktop after building."),
     },
     { editions: ["openclaw", "hermes"], readOnly: false },
@@ -479,7 +504,11 @@ export function registerDesktopTools(reg: Registrar, ctx: McpContext): void {
     "code_project_delete",
     "Delete a code project and all of its source files from the ClawBox. This cannot be undone. Ask the user to confirm before calling it.",
     {
-      project_id: zSlug("The project id from code_project_list"),
+      // From `code_project_list`, so it carries whatever alphabet
+      // /setup-api/code minted it with (`APP_ID_RE`: upper case and
+      // underscores included). Refusing it here made the tool reject an id
+      // its own sibling had just reported.
+      project_id: zInstalledAppId("The project id from code_project_list"),
       confirm: zConfirm("Must be true. Set it only when the user asked for this project to be deleted."),
     },
     { editions: ["openclaw", "hermes"], readOnly: false, destructive: true },

--- a/mcp/tools/desktop.ts
+++ b/mcp/tools/desktop.ts
@@ -112,25 +112,25 @@ export function registerDesktopTools(reg: Registrar, ctx: McpContext): void {
     },
     { editions: ["openclaw", "hermes"], readOnly: false, profile: "core" },
     async ({ app_id }: { app_id: string }) => {
-      if (!/^(installed-)?[a-z0-9][a-z0-9-]{0,63}$/.test(app_id)) {
-        throw new ToolError(
-          "BAD_ARGUMENT",
-          "That is not a valid app id.",
-          `Call ui_list_apps and pass an id from its list. Built-in ids: ${appLine}.`,
-        );
-      }
       // Order matters: check the app EXISTS on this edition before writing the
       // pending action. The previous version wrote first and then answered
       // "Opening X" for apps that are not installed on this harness at all.
+      //
+      // A built-in is gated on MEMBERSHIP, never on a slug shape. It used to be
+      // matched against a hyphen-only regex first, which rejected
+      // `system_update` — an id this tool's own description advertises — as
+      // "not a valid app id", and then told the agent to pass an id from that
+      // same list. The shape check survives only where it is the injection
+      // guard: an `installed-<id>` the caller invented.
       const isInstalled = app_id.startsWith("installed-");
-      if (!isInstalled && !builtInIds.includes(app_id)) {
-        throw new ToolError(
-          "NOT_FOUND",
-          "There is no such app on this ClawBox.",
-          `Call ui_list_apps to see what exists here. Built-in ids: ${appLine}.`,
-        );
-      }
       if (isInstalled) {
+        if (!/^installed-[a-z0-9][a-z0-9-]{0,63}$/.test(app_id)) {
+          throw new ToolError(
+            "BAD_ARGUMENT",
+            "That is not a valid installed-app id.",
+            "Call ui_list_apps and pass an id from its installed_apps list, unchanged.",
+          );
+        }
         const ids = await installedAppIds();
         if (!ids.includes(app_id.slice("installed-".length))) {
           throw new ToolError(
@@ -139,12 +139,27 @@ export function registerDesktopTools(reg: Registrar, ctx: McpContext): void {
             "Call ui_list_apps to see which installed apps exist, and use one of those ids.",
           );
         }
+      } else if (!builtInIds.includes(app_id)) {
+        throw new ToolError(
+          "NOT_FOUND",
+          "There is no such app on this ClawBox.",
+          `Call ui_list_apps to see what exists here. Built-in ids: ${appLine}.`,
+        );
       }
       await pushUiAction({ type: "open_app", appId: app_id });
       if (app_id === "browser") {
         return text("Opened the Browser Setup panel. That is the settings panel — to actually browse the web, use browser_open.");
       }
       const known = apps.find((a) => a.id === app_id);
+      // An `external` app is not a desktop window: the desktop calls
+      // window.open() for it, from a poll rather than a click, so the browser's
+      // popup blocker can drop it with nothing to report back here. Claiming it
+      // opened would be a false success on the one path the agent cannot see.
+      if (known?.external) {
+        return text(
+          `Asked the desktop to open ${known.name}. It opens in a new browser tab, so ask the user to look at the screen — and to allow the popup if their browser blocked it.`,
+        );
+      }
       return text(`Opened ${known?.name ?? app_id} on the desktop.`);
     },
   );

--- a/mcp/tools/desktop.ts
+++ b/mcp/tools/desktop.ts
@@ -9,8 +9,8 @@
 import { apiGet, apiPost, CLAWBOX_ROOT } from "../lib/api";
 import { ApiError, ToolError, type ErrorRule } from "../lib/errors";
 import { json, text, type Registrar } from "../lib/register";
-import { INSTALLED_APP_ID_RE, zBool, zConfirm, zEnumOf, zInt, zOptText, zSlug, zText } from "../lib/schema";
-import { builtInApps, type McpContext } from "../lib/context";
+import { INSTALLED_APP_ID_RE, zBool, zConfirm, zEnumOf, zInstalledAppId, zInt, zOptText, zSlug, zText } from "../lib/schema";
+import { builtInApps, openedAppNotice, type McpContext } from "../lib/context";
 import { isInstalledAppVisible } from "../../src/lib/desktop-app-editions";
 import type { InstalledHermesSkill } from "../../src/lib/hermes-skills";
 
@@ -172,17 +172,9 @@ export function registerDesktopTools(reg: Registrar, ctx: McpContext): void {
       if (app_id === "browser") {
         return text("Opened the Browser Setup panel. That is the settings panel — to actually browse the web, use browser_open.");
       }
-      const known = apps.find((a) => a.id === app_id);
-      // An `external` app is not a desktop window: the desktop calls
-      // window.open() for it, from a poll rather than a click, so the browser's
-      // popup blocker can drop it with nothing to report back here. Claiming it
-      // opened would be a false success on the one path the agent cannot see.
-      if (known?.external) {
-        return text(
-          `Asked the desktop to open ${known.name}. It opens in a new browser tab, so ask the user to look at the screen — and to allow the popup if their browser blocked it.`,
-        );
-      }
-      return text(`Opened ${known?.name ?? app_id} on the desktop.`);
+      // The same sentence `clawbox app open` prints, from one place — an
+      // `external` app is hedged about on both surfaces or on neither.
+      return text(openedAppNotice(apps.find((a) => a.id === app_id), app_id));
     },
   );
 
@@ -310,7 +302,12 @@ export function registerDesktopTools(reg: Registrar, ctx: McpContext): void {
     ctx.edition === "hermes"
       ? "Remove an app icon from the ClawBox desktop: a web app you built, or something the user installed. It does NOT remove one of your own skills — use skill_uninstall for those. Call ui_list_apps first to get the id, and ask the user to confirm."
       : "Remove an app the user installed from the ClawBox app store, or a web app you built, from the desktop. Call ui_list_apps first to get the id, and ask the user to confirm.",
-    { app_id: zSlug("App id, as ui_list_apps reports it without the installed- prefix") },
+    // The producers' alphabet, not zSlug's: `ui_open_app` and `clawbox app
+    // open` accept `Foo_Bar` and `_drafts`, so removal must too — an app the
+    // agent can create and open and cannot delete is the worse half of the
+    // defect this file's widening fixed. The membership check below is
+    // deliberately unfiltered for the same reason.
+    { app_id: zInstalledAppId("App id, as ui_list_apps reports it without the installed- prefix") },
     { editions: ["openclaw", "hermes"], readOnly: false, destructive: true },
     async ({ app_id }: { app_id: string }) => {
       // Unfiltered: removing an app this harness cannot open is legitimate.

--- a/mcp/tools/desktop.ts
+++ b/mcp/tools/desktop.ts
@@ -9,7 +9,7 @@
 import { apiGet, apiPost, CLAWBOX_ROOT } from "../lib/api";
 import { ApiError, ToolError, type ErrorRule } from "../lib/errors";
 import { json, text, type Registrar } from "../lib/register";
-import { zBool, zConfirm, zEnumOf, zInt, zOptText, zSlug, zText } from "../lib/schema";
+import { INSTALLED_APP_ID_RE, zBool, zConfirm, zEnumOf, zInt, zOptText, zSlug, zText } from "../lib/schema";
 import { builtInApps, type McpContext } from "../lib/context";
 import type { InstalledHermesSkill } from "../../src/lib/hermes-skills";
 
@@ -124,7 +124,7 @@ export function registerDesktopTools(reg: Registrar, ctx: McpContext): void {
       // guard: an `installed-<id>` the caller invented.
       const isInstalled = app_id.startsWith("installed-");
       if (isInstalled) {
-        if (!/^installed-[a-z0-9][a-z0-9-]{0,63}$/.test(app_id)) {
+        if (!INSTALLED_APP_ID_RE.test(app_id)) {
           throw new ToolError(
             "BAD_ARGUMENT",
             "That is not a valid installed-app id.",

--- a/mcp/tools/orientation.ts
+++ b/mcp/tools/orientation.ts
@@ -21,9 +21,10 @@ const FIELD_GUIDE_PATH = join(DEFAULT_CWD, "Clawbox.md");
 const OPENCLAW_CURRENT_CHAT_NOTE =
   "the device default above: on this edition the chat header writes it to the box and repoints every session, so it is what this chat runs.";
 
-// …but only where the edition is CERTAIN. `resolveEdition` asks
-// /setup-api/harness/active with a 3 s timeout and answers "openclaw" on any
-// failure, and this server is spawned at harness start — exactly when the web
+// …but only where the edition is CERTAIN. `resolveAppHarness` asks
+// /setup-api/harness/active with a 3 s timeout and hands the answer to
+// `resolveEdition`, which takes "openclaw" for a `dual` box that did not
+// answer — and this server is spawned at harness start, exactly when the web
 // app may not be up yet. On a locked SKU that fallback cannot be wrong; on
 // DUAL it can, and an affirmative "the default is what this chat runs" handed
 // to a Hermes chat reinstates the whole defect this note exists to remove

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -14,6 +14,7 @@
     "../src/lib/edition-source.ts",
     "../src/lib/file-guard.ts",
     "../src/lib/config-store.ts",
+    "../src/lib/desktop-app-editions.ts",
     "../src/lib/hermes-skills.ts",
     "../src/lib/hermes-reasoning.ts",
     "../src/lib/local-model-profile.ts",

--- a/src/app/app/[id]/page.tsx
+++ b/src/app/app/[id]/page.tsx
@@ -12,6 +12,11 @@ import { handoffSettingsSection, STANDALONE_SETTINGS_SECTION_PARAM } from "@/lib
 import { WEBAPP_IFRAME_SANDBOX } from "@/lib/webapp-sandbox";
 import { attachWebappKvBridge } from "@/lib/webapp-kv-bridge";
 import type { InstalledMeta } from "@/lib/store-categories";
+import {
+  hiddenAppIdsForHarness,
+  HERMES_ONLY_APP_IDS,
+  OPENCLAW_ONLY_APP_IDS,
+} from "@/lib/desktop-app-editions";
 import type { StoreApp } from "@/components/AppStore";
 import InstalledAppIcon from "@/components/InstalledAppIcon";
 
@@ -32,9 +37,9 @@ const MemoryShardApp = dynamic(() => import("@/components/MemoryShardApp"), { ss
 
 // Apps that exist on only ONE harness. This page is reachable directly
 // ("Open in new tab"), so without the same gate the desktop applies, /app/store
-// would render the whole OpenClaw App Store on a Hermes device.
-const OPENCLAW_ONLY_APP_IDS = ["store", "openclaw", "memory-shard"];
-const HERMES_ONLY_APP_IDS = ["hermes", "hermes-skills"];
+// would render the whole OpenClaw App Store on a Hermes device. The lists are
+// the desktop's own (src/lib/desktop-app-editions.ts), not a second copy.
+const HARNESS_ONLY_APP_IDS: readonly string[] = [...OPENCLAW_ONLY_APP_IDS, ...HERMES_ONLY_APP_IDS];
 
 // This window is the same app the desktop shows, so its title comes from the
 // SAME registry rather than a second table of names — which is what it used to
@@ -177,16 +182,10 @@ export default function StandaloneAppPage() {
 
   const renderApp = () => {
     const appId = id ?? "";
-    if (OPENCLAW_ONLY_APP_IDS.includes(appId) || HERMES_ONLY_APP_IDS.includes(appId)) {
+    if (HARNESS_ONLY_APP_IDS.includes(appId)) {
       if (!harness) return loading;
       // An unknown harness hides BOTH sets — fail closed.
-      const hidden =
-        harness === "hermes"
-          ? OPENCLAW_ONLY_APP_IDS
-          : harness === "openclaw"
-            ? HERMES_ONLY_APP_IDS
-            : [...OPENCLAW_ONLY_APP_IDS, ...HERMES_ONLY_APP_IDS];
-      if (hidden.includes(appId)) {
+      if (hiddenAppIdsForHarness(harness).includes(appId)) {
         return (
           <div className="h-full flex items-center justify-center text-white/50 text-sm">
             App not found: {appId}

--- a/src/app/app/[id]/page.tsx
+++ b/src/app/app/[id]/page.tsx
@@ -12,11 +12,7 @@ import { handoffSettingsSection, STANDALONE_SETTINGS_SECTION_PARAM } from "@/lib
 import { WEBAPP_IFRAME_SANDBOX } from "@/lib/webapp-sandbox";
 import { attachWebappKvBridge } from "@/lib/webapp-kv-bridge";
 import type { InstalledMeta } from "@/lib/store-categories";
-import {
-  hiddenAppIdsForHarness,
-  HERMES_ONLY_APP_IDS,
-  OPENCLAW_ONLY_APP_IDS,
-} from "@/lib/desktop-app-editions";
+import { HARNESS_ONLY_APP_IDS, hiddenAppIdsForHarness } from "@/lib/desktop-app-editions";
 import type { StoreApp } from "@/components/AppStore";
 import InstalledAppIcon from "@/components/InstalledAppIcon";
 
@@ -35,11 +31,6 @@ const AppStore = dynamic(() => import("@/components/AppStore"), { ssr: false });
 const HermesSkillsStore = dynamic(() => import("@/components/HermesSkillsStore"), { ssr: false });
 const MemoryShardApp = dynamic(() => import("@/components/MemoryShardApp"), { ssr: false });
 
-// Apps that exist on only ONE harness. This page is reachable directly
-// ("Open in new tab"), so without the same gate the desktop applies, /app/store
-// would render the whole OpenClaw App Store on a Hermes device. The lists are
-// the desktop's own (src/lib/desktop-app-editions.ts), not a second copy.
-const HARNESS_ONLY_APP_IDS: readonly string[] = [...OPENCLAW_ONLY_APP_IDS, ...HERMES_ONLY_APP_IDS];
 
 // This window is the same app the desktop shows, so its title comes from the
 // SAME registry rather than a second table of names — which is what it used to
@@ -182,6 +173,11 @@ export default function StandaloneAppPage() {
 
   const renderApp = () => {
     const appId = id ?? "";
+    // Apps that exist on only ONE harness. This page is reachable directly
+    // ("Open in new tab"), so without the same gate the desktop applies,
+    // /app/store would render the whole OpenClaw App Store on a Hermes device.
+    // Only these ids wait on the harness fetch; `settings` and `files` render
+    // straight away.
     if (HARNESS_ONLY_APP_IDS.includes(appId)) {
       if (!harness) return loading;
       // An unknown harness hides BOTH sets — fail closed.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,6 +42,7 @@ import { fetchHarness } from "@/lib/client-harness";
 import { samePairingToken } from "@/lib/telegram-pairing-token";
 import type { InstalledMeta } from "@/lib/store-categories";
 import { apps, type AppDef } from "@/lib/desktop-apps";
+import { hiddenAppIdsForHarness } from "@/lib/desktop-app-editions";
 import {
   layoutIcons,
   layoutsEqual,
@@ -92,21 +93,6 @@ const TASKBAR_RESERVE = 72; // px kept clear at the bottom for the taskbar
 function canonicalIconOrder(installedAppIds: readonly string[]): string[] {
   return [...installedAppIds, ...BUILT_IN_APP_IDS.map((id) => `desktop-${id}`)];
 }
-
-// Apps that only make sense on ONE harness. The other harness's backend isn't
-// installed, so its app would open onto errors:
-//   - "openclaw" is the OpenClaw gateway Control UI.
-//   - "store" is the OpenClaw App Store — it installs OpenClaw desktop apps via
-//     the openclaw binary and reloads the OpenClaw gateway. On Hermes the Skills
-//     app ("hermes-skills") is the equivalent surface.
-//   - "memory-shard" is OpenClaw's memory index (`openclaw memory status`);
-//     Hermes has no equivalent, and ClawKeep hid the same panel on that box.
-//   - "hermes" / "hermes-skills" are the Hermes dashboard and skills store.
-// BOTH the icon-layout filter (harnessHiddenAppIds) and getAllApps read THESE
-// lists — keep them the single source of the policy so a hidden app can never be
-// visible in one surface and hidden in another.
-const OPENCLAW_ONLY_APP_IDS = ["openclaw", "store", "memory-shard"] as const;
-const HERMES_ONLY_APP_IDS = ["hermes", "hermes-skills"] as const;
 
 /**
  * Should an app the user installed from the OpenClaw store still be shown?
@@ -405,15 +391,12 @@ function ChromeDesktopInner() {
 
   // The harness-specific apps hidden on this edition (OpenClaw Control-UI +
   // App Store on Hermes; the Hermes dashboard + Hermes Skills Store on
-  // OpenClaw). See OPENCLAW_ONLY_APP_IDS / HERMES_ONLY_APP_IDS. Until the
+  // OpenClaw). The policy lives in src/lib/desktop-app-editions.ts, which the
+  // standalone /app/<id> window and the MCP server read too — so a hidden app
+  // can never be visible in one surface and hidden in another. Until the
   // harness is known BOTH sets are hidden — fail closed.
   const harnessHiddenAppIds = useMemo<string[]>(
-    () =>
-      activeHarness === "hermes"
-        ? [...OPENCLAW_ONLY_APP_IDS]
-        : activeHarness === "openclaw"
-          ? [...HERMES_ONLY_APP_IDS]
-          : [...OPENCLAW_ONLY_APP_IDS, ...HERMES_ONLY_APP_IDS],
+    () => hiddenAppIdsForHarness(activeHarness),
     [activeHarness],
   );
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,7 +42,7 @@ import { fetchHarness } from "@/lib/client-harness";
 import { samePairingToken } from "@/lib/telegram-pairing-token";
 import type { InstalledMeta } from "@/lib/store-categories";
 import { apps, type AppDef } from "@/lib/desktop-apps";
-import { hiddenAppIdsForHarness } from "@/lib/desktop-app-editions";
+import { hiddenAppIdsForHarness, isInstalledAppVisible } from "@/lib/desktop-app-editions";
 import {
   layoutIcons,
   layoutsEqual,
@@ -94,28 +94,11 @@ function canonicalIconOrder(installedAppIds: readonly string[]): string[] {
   return [...installedAppIds, ...BUILT_IN_APP_IDS.map((id) => `desktop-${id}`)];
 }
 
-/**
- * Should an app the user installed from the OpenClaw store still be shown?
- *
- * An `installed` app IS an OpenClaw skill: its window (InstalledAppSettings)
- * calls /setup-api/apps/settings + /apps/skill-info, both of which shell out to
- * the openclaw binary, and its uninstall reloads the OpenClaw gateway. None of
- * that exists on a Hermes device, so the window would open onto errors — hide
- * it. A WEBAPP (meta.webappUrl) is different: those are ClawBox code-assistant
- * builds served by /setup-api/webapps, harness-independent, and frequently the
- * Hermes agent's OWN output — hiding them would be the regression, not the fix.
- *
- * This filters what is RENDERED only. The persisted installedApps list is never
- * mutated, so a dual box that switches back finds its layout intact.
- *
- * While the harness is still unresolved (null) these stay VISIBLE, unlike the
- * built-in harness apps: they are the majority case on an OpenClaw box, they
- * are not the surface goal B forbids, and hiding then re-showing them would
- * flash the whole desktop on every load.
- */
-function isInstalledAppVisible(meta: InstalledMeta | undefined, harness: string | null): boolean {
-  return harness !== "hermes" || !!meta?.webappUrl;
-}
+// `isInstalledAppVisible` lives in src/lib/desktop-app-editions.ts beside the
+// built-in harness gate, so the desktop and the two agent-facing gates answer
+// it from one copy. It filters what is RENDERED only: the persisted
+// installedApps list is never mutated, so a dual box that switches back finds
+// its layout intact.
 
 // LAN port of the auth-gated Hermes dashboard proxy (scripts/hermes-dashboard-proxy.js).
 const HERMES_DASH_PROXY_PORT = 8090;

--- a/src/lib/desktop-app-editions.ts
+++ b/src/lib/desktop-app-editions.ts
@@ -58,7 +58,43 @@ export function hiddenAppIdsForHarness(harness: string | null): string[] {
   return [...hiddenFor(harness)];
 }
 
-/** Whether a built-in app id exists on this (resolved) edition at all. */
-export function appExistsOnEdition(id: string, edition: AppEdition): boolean {
+/**
+ * Whether a built-in app id exists on this harness at all.
+ *
+ * `null` is "which harness this is could not be determined" — an unreadable
+ * edition lock, a `dual` box whose device did not answer — and it hides BOTH
+ * harness-only sets, exactly as the desktop does while its own fetch is in
+ * flight. There is no smaller-of-the-two to fail closed onto here: the two app
+ * sets are different, not nested, so picking one would BOTH hide apps the box
+ * has and offer apps it does not.
+ */
+export function appExistsOnEdition(id: string, edition: AppEdition | null): boolean {
   return !hiddenFor(edition).includes(id);
+}
+
+/**
+ * Should an app the user INSTALLED still be shown on this harness?
+ *
+ * An `installed` app is normally an OpenClaw skill: its window calls
+ * /setup-api/apps/settings + /apps/skill-info, both of which shell out to the
+ * openclaw binary, and its uninstall reloads the OpenClaw gateway. None of that
+ * exists on a Hermes device, so the window would open onto errors. A WEBAPP
+ * (`webappUrl`) is different: harness-independent, served by
+ * /setup-api/webapps, and frequently the Hermes agent's OWN output.
+ *
+ * Takes the meta ROW rather than the id, because "is it a webapp" is the whole
+ * question and only the row knows. Lives here, beside the built-in gate, so the
+ * desktop grid and the two agent-facing gates (`ui_open_app`, `clawbox app
+ * open`) cannot answer it differently — the drift this module exists to end.
+ *
+ * `null` (the harness is not resolved yet, or could not be) keeps them VISIBLE,
+ * unlike the built-in harness apps: they are the majority case on an OpenClaw
+ * box, and hiding then re-showing them would flash the whole desktop on every
+ * load.
+ */
+export function isInstalledAppVisible(
+  meta: { webappUrl?: unknown } | undefined,
+  harness: string | null,
+): boolean {
+  return harness !== "hermes" || !!meta?.webappUrl;
 }

--- a/src/lib/desktop-app-editions.ts
+++ b/src/lib/desktop-app-editions.ts
@@ -11,7 +11,11 @@
 // whose import graph is relative paths and node builtins — the `@/` alias, and
 // anything React, would drag the Next.js runtime into that stdio process.
 
-/** The harness whose app set applies. `dual` resolves to `openclaw`. */
+/**
+ * A RESOLVED harness: the premium `dual` install has already become
+ * `openclaw` by the time an edition reaches here. Not the same value as the
+ * `harness` string the browser holds — see `hiddenAppIdsForHarness`.
+ */
 export type AppEdition = "openclaw" | "hermes";
 
 // Apps that only make sense on ONE harness. The other harness's backend isn't
@@ -26,22 +30,35 @@ export type AppEdition = "openclaw" | "hermes";
 export const OPENCLAW_ONLY_APP_IDS = ["openclaw", "store", "memory-shard"] as const;
 export const HERMES_ONLY_APP_IDS = ["hermes", "hermes-skills"] as const;
 
-/**
- * Built-in ids to hide for a harness that is not resolved yet.
- *
- * `null` — the harness is still being fetched — hides BOTH sets: showing an app
- * and then taking it away is the surface flash the desktop is built to avoid,
- * and a wrong app is worse than a late one.
- */
-export function hiddenAppIdsForHarness(harness: string | null): string[] {
-  if (harness === "hermes") return [...OPENCLAW_ONLY_APP_IDS];
-  if (harness === "openclaw") return [...HERMES_ONLY_APP_IDS];
-  return [...OPENCLAW_ONLY_APP_IDS, ...HERMES_ONLY_APP_IDS];
+/** Every id that is gated on a harness at all — the two lists above, joined. */
+export const HARNESS_ONLY_APP_IDS: readonly string[] = [
+  ...OPENCLAW_ONLY_APP_IDS,
+  ...HERMES_ONLY_APP_IDS,
+];
+
+function hiddenFor(harness: string | null): readonly string[] {
+  if (harness === "hermes") return OPENCLAW_ONLY_APP_IDS;
+  if (harness === "openclaw") return HERMES_ONLY_APP_IDS;
+  // Fail closed. `null` is "still fetching"; anything else — `"dual"`, a value
+  // from a newer release — is a harness this build cannot reason about, and a
+  // wrong app is worse than a late one.
+  return HARNESS_ONLY_APP_IDS;
 }
 
-/** Whether a built-in app id exists on this edition at all. */
+/**
+ * Built-in ids hidden on this harness — the whole per-harness policy, read by
+ * the desktop grid, the icon layout, the launcher menu and the standalone
+ * window.
+ *
+ * Takes the ACTIVE harness the browser resolved, which is `null` while the
+ * fetch is in flight and can be any string the device reports. Both hide BOTH
+ * sets.
+ */
+export function hiddenAppIdsForHarness(harness: string | null): string[] {
+  return [...hiddenFor(harness)];
+}
+
+/** Whether a built-in app id exists on this (resolved) edition at all. */
 export function appExistsOnEdition(id: string, edition: AppEdition): boolean {
-  const hidden: readonly string[] =
-    edition === "hermes" ? OPENCLAW_ONLY_APP_IDS : HERMES_ONLY_APP_IDS;
-  return !hidden.includes(id);
+  return !hiddenFor(edition).includes(id);
 }

--- a/src/lib/desktop-app-editions.ts
+++ b/src/lib/desktop-app-editions.ts
@@ -1,0 +1,47 @@
+// Which built-in desktop apps exist on which harness — and nothing else.
+//
+// This used to be copied into three places: the desktop grid (src/app/page.tsx),
+// the standalone `/app/<id>` window (src/app/app/[id]/page.tsx) and the MCP
+// server's own app list (mcp/lib/context.ts). The MCP copy had drifted: it
+// listed neither the Hermes dashboard nor chat, ClawKeep or System Update, so
+// `ui_open_app("hermes")` told the agent its own dashboard does not exist on a
+// box whose desktop pins it (TASK-541).
+//
+// Deliberately dependency-free. mcp/tsconfig.json admits only src/lib modules
+// whose import graph is relative paths and node builtins — the `@/` alias, and
+// anything React, would drag the Next.js runtime into that stdio process.
+
+/** The harness whose app set applies. `dual` resolves to `openclaw`. */
+export type AppEdition = "openclaw" | "hermes";
+
+// Apps that only make sense on ONE harness. The other harness's backend isn't
+// installed, so its app would open onto errors:
+//   - "openclaw" is the OpenClaw gateway Control UI.
+//   - "store" is the OpenClaw App Store — it installs OpenClaw desktop apps via
+//     the openclaw binary and reloads the OpenClaw gateway. On Hermes the Skills
+//     app ("hermes-skills") is the equivalent surface.
+//   - "memory-shard" is OpenClaw's memory index (`openclaw memory status`);
+//     Hermes has no equivalent, and ClawKeep hid the same panel on that box.
+//   - "hermes" / "hermes-skills" are the Hermes dashboard and skills store.
+export const OPENCLAW_ONLY_APP_IDS = ["openclaw", "store", "memory-shard"] as const;
+export const HERMES_ONLY_APP_IDS = ["hermes", "hermes-skills"] as const;
+
+/**
+ * Built-in ids to hide for a harness that is not resolved yet.
+ *
+ * `null` — the harness is still being fetched — hides BOTH sets: showing an app
+ * and then taking it away is the surface flash the desktop is built to avoid,
+ * and a wrong app is worse than a late one.
+ */
+export function hiddenAppIdsForHarness(harness: string | null): string[] {
+  if (harness === "hermes") return [...OPENCLAW_ONLY_APP_IDS];
+  if (harness === "openclaw") return [...HERMES_ONLY_APP_IDS];
+  return [...OPENCLAW_ONLY_APP_IDS, ...HERMES_ONLY_APP_IDS];
+}
+
+/** Whether a built-in app id exists on this edition at all. */
+export function appExistsOnEdition(id: string, edition: AppEdition): boolean {
+  const hidden: readonly string[] =
+    edition === "hermes" ? OPENCLAW_ONLY_APP_IDS : HERMES_ONLY_APP_IDS;
+  return !hidden.includes(id);
+}

--- a/src/lib/desktop-apps.ts
+++ b/src/lib/desktop-apps.ts
@@ -32,8 +32,8 @@ export const apps: AppDef[] = [
   // Hermes dashboard — only shown on the Hermes edition. Opened via the
   // auth-gated dashboard proxy (url computed at click time from the host).
   { id: "hermes", name: "Hermes", color: "#1a1230", type: "external", url: "hermes-dashboard", pinned: true },
-  // Hermes Skills Store — only shown on the Hermes edition (gated below via
-  // HERMES_ONLY_APP_IDS / harnessHiddenAppIds, same mechanism as `hermes`).
+  // Hermes Skills Store — only shown on the Hermes edition (gated via
+  // HERMES_ONLY_APP_IDS in desktop-app-editions.ts, same mechanism as `hermes`).
   { id: "hermes-skills", name: "app.skills", color: "#1a1230", type: "hermes_skills", pinned: true, defaultWidth: 900, defaultHeight: 600 },
   { id: "terminal", name: "app.terminal", color: "#1a1a2e", type: "terminal" as const, pinned: false, defaultWidth: 900, defaultHeight: 600 },
   // The coding agent: the owner's switch for letting the assistant delegate a

--- a/src/lib/openclaw-apps-server.ts
+++ b/src/lib/openclaw-apps-server.ts
@@ -3,8 +3,8 @@
 // The store installs OPENCLAW desktop apps: /setup-api/apps/install and
 // /apps/settings and /apps/skill-info all shell out to the openclaw binary and
 // reload the OpenClaw gateway. On a Hermes device neither exists, so the store
-// is hidden from every UI surface (see OPENCLAW_ONLY_APP_IDS in src/app/page.tsx
-// and the harness gate in src/app/app/[id]/page.tsx). This is the HTTP mirror of
+// is hidden from every UI surface (see OPENCLAW_ONLY_APP_IDS in
+// src/lib/desktop-app-editions.ts, which every surface reads). This is the HTTP mirror of
 // that decision — the same reasoning as hermesSkillsGuard, which refuses the
 // skills routes when the active harness isn't Hermes.
 //

--- a/src/tests/unit/mcp-cli-app-gate.test.ts
+++ b/src/tests/unit/mcp-cli-app-gate.test.ts
@@ -7,6 +7,7 @@ import os from "os";
 import path from "path";
 
 import { testEnv } from "@/tests/helpers/env";
+import { builtInApps, openedAppNotice } from "../../../mcp/lib/context";
 
 /**
  * `clawbox app open` / `app list` on the DUAL SKU.
@@ -118,6 +119,20 @@ beforeEach(() => {
 const CLI_TIMEOUT_MS = 4_000;
 
 /**
+ * A test budget derived from what the test SPAWNS.
+ *
+ * vitest's 5 s default covers one `bun` start, not five: a multi-spawn test
+ * would hit the framework's timeout first, and per the note on `cli()` that
+ * neither cancels the promise nor kills the child — exactly the failure this
+ * file's timer exists to remove. So every test that spawns more than once says
+ * how many, and `CLI_TIMEOUT_MS` stays the thing that fires first on ONE hung
+ * child.
+ */
+function budget(spawns: number): { timeout: number } {
+  return { timeout: spawns * CLI_TIMEOUT_MS + 10_000 };
+}
+
+/**
  * Run the CLI against the stub device.
  *
  * ASYNC, never `spawnSync`: the stub server lives in THIS process, so blocking
@@ -187,20 +202,20 @@ d("clawbox app open — the edition gate", () => {
     expect(posted).toContainEqual(expect.objectContaining({ type: "open_app", appId: "store" }));
   });
 
-  it("still refuses the other harness's app on a single-harness box", async () => {
+  it("still refuses the other harness's app on a single-harness box", budget(3), async () => {
     const r = await cli(["app", "open", "hermes"], "openclaw");
     expect(r.status).toBe(1);
     expect(r.stderr).toContain("No built-in app");
     expect(posted).toEqual([]);
   });
 
-  it("still refuses an id no app claims", async () => {
+  it("still refuses an id no app claims", budget(3), async () => {
     const r = await cli(["app", "open", "not-an-app"], "hermes");
     expect(r.status).toBe(1);
     expect(posted).toEqual([]);
   });
 
-  it("opens an app the device really installed, and refuses one it did not", async () => {
+  it("opens an app the device really installed, and refuses one it did not", budget(2), async () => {
     installedApps = ["notes"];
     expect((await cli(["app", "open", "installed-notes"], "openclaw")).status).toBe(0);
     expect(posted).toContainEqual(
@@ -211,7 +226,7 @@ d("clawbox app open — the edition gate", () => {
     expect(missing.stderr).toContain("No installed app");
   });
 
-  it("refuses a store-installed skill on Hermes, and opens a web app", async () => {
+  it("refuses a store-installed skill on Hermes, and opens a web app", budget(2), async () => {
     // An installed STORE app is an OpenClaw skill: its window shells out to the
     // openclaw binary, so the Hermes desktop drops it from `getAllApps()` and a
     // tick here would be printed over a window that never appears. A ClawBox
@@ -237,13 +252,16 @@ d("clawbox app open — when the harness cannot be determined", () => {
   // A lock file that EXISTS and carries no edition: a truncated write, a
   // permission change, a partial reflash. The MCP resolves that to the smaller
   // TOOL SET on purpose — an unreadable lock must not hand a device the shell
-  // and file tools. The APP question is a different one, and it has an oracle:
-  // /setup-api/harness/active always answers (getActiveHarness() falls through
-  // readEdition(), whose default is "openclaw"), and it is the same route the
-  // desktop grid and /app/<id> are built from. So the lock's state is not what
-  // decides here — the DEVICE'S SILENCE is, and only then are both harness-only
-  // sets hidden, the way the desktop hides them while its own fetch is in
-  // flight.
+  // and file tools. The APP sets are not nested, so the same doubt cannot fail
+  // closed onto one harness: answering "hermes" hides `store`, `openclaw` and
+  // `memory-shard` from a box that has them, and answering "openclaw" ticks off
+  // apps a Hermes box does not have. Both sets are hidden and the reason said.
+  //
+  // The device is NOT asked here, and that is deliberate:
+  // /setup-api/harness/active resolves through `readEdition()` — the same file
+  // this process just failed to read — so on an unreadable lock it can only
+  // echo "openclaw", on a Hermes box as readily as on an OpenClaw one. See
+  // mcp/lib/edition.ts.
   const NO_EDITION = "# ClawBox edition lock\n# (truncated)\n";
 
   it("keeps offering the apps that exist on either harness", async () => {
@@ -252,35 +270,14 @@ d("clawbox app open — when the harness cannot be determined", () => {
     expect(posted).toContainEqual(expect.objectContaining({ appId: "settings" }));
   });
 
-  it("asks the device rather than hiding apps the box is showing", async () => {
-    // The unreadable lock alone is NOT "undetermined". The desktop renders
-    // twelve apps in this state, and telling the agent that three of them
-    // cannot be placed — while the owner is looking at them — is the two
-    // surfaces disagreeing, which is the defect this whole change is about.
+  it("refuses BOTH harnesses' own apps rather than guessing one", budget(5), async () => {
+    // The stub device WOULD answer "openclaw" here — that is the point. Taking
+    // it would tick off `store` and `openclaw` on a box whose lock nobody could
+    // read, and deny a Hermes box its own dashboard.
     activeHarness = "openclaw";
-    for (const appId of ["store", "openclaw", "memory-shard"]) {
-      posted = [];
-      const r = await cli(["app", "open", appId], "openclaw", { lockBody: NO_EDITION });
-      expect(r.status, `${appId} must open: ${r.stderr}`).toBe(0);
-      expect(posted).toContainEqual(expect.objectContaining({ appId }));
-    }
-    // …and the other harness's are still refused, because the device named one.
-    const other = await cli(["app", "open", "hermes"], "openclaw", { lockBody: NO_EDITION });
-    expect(other.status).toBe(1);
-
-    const list = await cli(["app", "list"], "openclaw", { lockBody: NO_EDITION });
-    expect(list.stdout).toContain("store —");
-    expect(list.stdout).not.toContain("hermes —");
-  });
-
-  it("refuses BOTH harnesses' own apps when the device cannot answer", async () => {
-    // A dual box mid-update: the web server is restarting, so
-    // /setup-api/harness/active does not answer. Defaulting to one harness
-    // would tell the agent as a durable fact that the box has no dashboard.
-    const dead = "http://127.0.0.1:9";
     for (const appId of ["hermes", "hermes-skills", "store", "openclaw", "memory-shard"]) {
       posted = [];
-      const r = await cli(["app", "open", appId], "dual", { apiBase: dead });
+      const r = await cli(["app", "open", appId], "openclaw", { lockBody: NO_EDITION });
       expect(r.status, `${appId} must be refused`).toBe(1);
       // Not "there is no such app": the device may well have it. Ticking off an
       // open the desktop then drops is the false success this gate exists for.
@@ -289,14 +286,31 @@ d("clawbox app open — when the harness cannot be determined", () => {
     }
   });
 
-  it("lists neither harness's own apps when the device cannot answer, and says why", async () => {
-    const list = await cli(["app", "list"], "dual", { apiBase: "http://127.0.0.1:9" });
-    expect(list.status, list.stderr).toBe(0);
-    expect(list.stdout).toContain("settings —");
+  it("lists neither harness's own apps, and says why", async () => {
+    const r = await cli(["app", "list"], "openclaw", { lockBody: NO_EDITION });
+    expect(r.status, r.stderr).toBe(0);
+    expect(r.stdout).toContain("settings —");
     for (const appId of ["hermes —", "store —", "openclaw —", "memory-shard —"]) {
-      expect(list.stdout).not.toContain(appId);
+      expect(r.stdout).not.toContain(appId);
     }
-    expect(list.stdout).toMatch(/harness/i);
+    expect(r.stdout).toMatch(/harness/i);
+  });
+
+  it("refuses them on a dual box the device cannot answer for either", budget(3), async () => {
+    // A dual box mid-update: the web server is restarting, so
+    // /setup-api/harness/active does not answer. Defaulting to one harness
+    // would tell the agent as a durable fact that the box has no dashboard.
+    const dead = "http://127.0.0.1:9";
+    for (const appId of ["hermes", "store"]) {
+      posted = [];
+      const r = await cli(["app", "open", appId], "dual", { apiBase: dead });
+      expect(r.status, `${appId} must be refused`).toBe(1);
+      expect(r.stderr).toMatch(/which harness/i);
+      expect(posted).toEqual([]);
+    }
+    const list = await cli(["app", "list"], "dual", { apiBase: dead });
+    expect(list.stdout).not.toContain("hermes —");
+    expect(list.stdout).not.toContain("store —");
   });
 
   it("prints nothing about registering a tool set", async () => {
@@ -330,8 +344,21 @@ d("clawbox app open — what it may claim happened", () => {
     // over every app would make the honest note meaningless.
     const r = await cli(["app", "open", "terminal"], "openclaw");
     expect(r.status, r.stderr).toBe(0);
-    expect(r.stdout).toMatch(/✅ Opening terminal/);
     expect(r.stdout).not.toMatch(/popup/i);
+    expect(r.stdout).toContain("✅ ");
+  });
+
+  it("says the SAME SENTENCE ui_open_app says, on both branches", budget(2), async () => {
+    // The invariant `openedAppNotice` exists for. Consulted only on the
+    // external branch it was half dead, and the ordinary wording was free to
+    // drift from the tool's — which is the defect, one surface over.
+    for (const [appId, edition] of [["terminal", "openclaw"], ["hermes", "hermes"]] as const) {
+      const r = await cli(["app", "open", appId], edition);
+      expect(r.status, r.stderr).toBe(0);
+      const app = builtInApps(edition).find((a) => a.id === appId);
+      expect(app, `${appId} must exist on ${edition}`).toBeTruthy();
+      expect(r.stdout).toContain(openedAppNotice(app, appId));
+    }
   });
 
   it("reports an installed web app as opened", async () => {
@@ -341,7 +368,8 @@ d("clawbox app open — what it may claim happened", () => {
     installedMeta = { notes: { webappUrl: "/setup-api/webapps?app=notes" } };
     const r = await cli(["app", "open", "installed-notes"], "openclaw");
     expect(r.status, r.stderr).toBe(0);
-    expect(r.stdout).toMatch(/✅ Opening installed-notes/);
+    expect(r.stdout).toContain("✅ ");
+    expect(r.stdout).toContain("installed-notes");
   });
 });
 
@@ -366,7 +394,7 @@ d("clawbox app list — the same answer as the gate", () => {
   // paying bun's own start. That is well past vitest's 5 s default, and a
   // ceiling derived from the work (rather than inherited) is what keeps the
   // failure honest: `CLI_TIMEOUT_MS` still fails a single hung child first.
-  it("names every app it would open, and no app it would refuse", { timeout: 60_000 }, async () => {
+  it("names every app it would open, and no app it would refuse", budget(12), async () => {
     // The two commands are one gate: a list that offers what `open` refuses is
     // the false success this pair exists to prevent.
     activeHarness = "hermes";

--- a/src/tests/unit/mcp-cli-app-gate.test.ts
+++ b/src/tests/unit/mcp-cli-app-gate.test.ts
@@ -111,11 +111,26 @@ beforeEach(() => {
 });
 
 /**
+ * The ceiling on ONE `bun` spawn, comfortably under vitest's own per-test
+ * default so this file's failure is "the CLI hung" rather than "the test timed
+ * out". See `cli()`.
+ */
+const CLI_TIMEOUT_MS = 4_000;
+
+/**
  * Run the CLI against the stub device.
  *
  * ASYNC, never `spawnSync`: the stub server lives in THIS process, so blocking
  * the event loop until the child exits would leave the child's own request
  * unanswered forever — the two would wait for each other.
+ *
+ * KILLED ON ITS OWN CLOCK. `mcp/clawbox-cli.ts`'s `api()` calls fetch with no
+ * `signal`, so a device that accepts the connection and never answers blocks
+ * the child indefinitely. Resolving only on `close` then hands the timeout to
+ * vitest, which fails the test WITHOUT cancelling this promise or killing
+ * `bun` — the worker keeps the child through teardown and the run reports a
+ * generic timeout over a hung CLI. This is the only test of the CLI gate, so
+ * it must not be the thing that hangs.
  */
 function cli(
   args: string[],
@@ -138,10 +153,22 @@ function cli(
     });
     let stdout = "";
     let stderr = "";
+    // SIGKILL, not SIGTERM: the point is that the child is wedged, and a
+    // handler that never runs would leave it alive exactly as before.
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(
+        `clawbox ${args.join(" ")} did not exit within ${CLI_TIMEOUT_MS}ms; killed.`
+        + ` stdout: ${stdout.trim() || "(none)"} stderr: ${stderr.trim() || "(none)"}`,
+      ));
+    }, CLI_TIMEOUT_MS);
     child.stdout.on("data", (c: Buffer) => { stdout += c.toString(); });
     child.stderr.on("data", (c: Buffer) => { stderr += c.toString(); });
-    child.on("error", reject);
-    child.on("close", (code) => resolve({ status: code ?? -1, stdout, stderr }));
+    child.on("error", (err) => { clearTimeout(timer); reject(err); });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ status: code ?? -1, stdout, stderr });
+    });
   });
 }
 
@@ -210,10 +237,13 @@ d("clawbox app open — when the harness cannot be determined", () => {
   // A lock file that EXISTS and carries no edition: a truncated write, a
   // permission change, a partial reflash. The MCP resolves that to the smaller
   // TOOL SET on purpose — an unreadable lock must not hand a device the shell
-  // and file tools. Apps are not a subset of one another, though: answering
-  // "hermes" there hides `store`, `openclaw` and `memory-shard` from a box
-  // that has them and ticks off `hermes` on a box that may not. The desktop's
-  // own rule for an unknown harness is to hide BOTH sets and say so.
+  // and file tools. The APP question is a different one, and it has an oracle:
+  // /setup-api/harness/active always answers (getActiveHarness() falls through
+  // readEdition(), whose default is "openclaw"), and it is the same route the
+  // desktop grid and /app/<id> are built from. So the lock's state is not what
+  // decides here — the DEVICE'S SILENCE is, and only then are both harness-only
+  // sets hidden, the way the desktop hides them while its own fetch is in
+  // flight.
   const NO_EDITION = "# ClawBox edition lock\n# (truncated)\n";
 
   it("keeps offering the apps that exist on either harness", async () => {
@@ -222,10 +252,35 @@ d("clawbox app open — when the harness cannot be determined", () => {
     expect(posted).toContainEqual(expect.objectContaining({ appId: "settings" }));
   });
 
-  it("refuses BOTH harnesses' own apps rather than guessing one", async () => {
-    for (const appId of ["hermes", "hermes-skills", "store", "openclaw", "memory-shard"]) {
+  it("asks the device rather than hiding apps the box is showing", async () => {
+    // The unreadable lock alone is NOT "undetermined". The desktop renders
+    // twelve apps in this state, and telling the agent that three of them
+    // cannot be placed — while the owner is looking at them — is the two
+    // surfaces disagreeing, which is the defect this whole change is about.
+    activeHarness = "openclaw";
+    for (const appId of ["store", "openclaw", "memory-shard"]) {
       posted = [];
       const r = await cli(["app", "open", appId], "openclaw", { lockBody: NO_EDITION });
+      expect(r.status, `${appId} must open: ${r.stderr}`).toBe(0);
+      expect(posted).toContainEqual(expect.objectContaining({ appId }));
+    }
+    // …and the other harness's are still refused, because the device named one.
+    const other = await cli(["app", "open", "hermes"], "openclaw", { lockBody: NO_EDITION });
+    expect(other.status).toBe(1);
+
+    const list = await cli(["app", "list"], "openclaw", { lockBody: NO_EDITION });
+    expect(list.stdout).toContain("store —");
+    expect(list.stdout).not.toContain("hermes —");
+  });
+
+  it("refuses BOTH harnesses' own apps when the device cannot answer", async () => {
+    // A dual box mid-update: the web server is restarting, so
+    // /setup-api/harness/active does not answer. Defaulting to one harness
+    // would tell the agent as a durable fact that the box has no dashboard.
+    const dead = "http://127.0.0.1:9";
+    for (const appId of ["hermes", "hermes-skills", "store", "openclaw", "memory-shard"]) {
+      posted = [];
+      const r = await cli(["app", "open", appId], "dual", { apiBase: dead });
       expect(r.status, `${appId} must be refused`).toBe(1);
       // Not "there is no such app": the device may well have it. Ticking off an
       // open the desktop then drops is the false success this gate exists for.
@@ -234,27 +289,14 @@ d("clawbox app open — when the harness cannot be determined", () => {
     }
   });
 
-  it("lists neither harness's own apps, and says why", async () => {
-    const r = await cli(["app", "list"], "openclaw", { lockBody: NO_EDITION });
-    expect(r.status, r.stderr).toBe(0);
-    expect(r.stdout).toContain("settings —");
+  it("lists neither harness's own apps when the device cannot answer, and says why", async () => {
+    const list = await cli(["app", "list"], "dual", { apiBase: "http://127.0.0.1:9" });
+    expect(list.status, list.stderr).toBe(0);
+    expect(list.stdout).toContain("settings —");
     for (const appId of ["hermes —", "store —", "openclaw —", "memory-shard —"]) {
-      expect(r.stdout).not.toContain(appId);
+      expect(list.stdout).not.toContain(appId);
     }
-    expect(r.stdout).toMatch(/harness/i);
-  });
-
-  it("does not report a harness it never resolved when the device cannot answer", async () => {
-    // A dual box mid-update: the web server is restarting, so
-    // /setup-api/harness/active does not answer. Defaulting to one harness
-    // would tell the agent as a durable fact that the box has no dashboard.
-    const dead = "http://127.0.0.1:9";
-    const open = await cli(["app", "open", "hermes"], "dual", { apiBase: dead });
-    expect(open.status).toBe(1);
-    expect(open.stderr).toMatch(/which harness/i);
-    const list = await cli(["app", "list"], "dual", { apiBase: dead });
-    expect(list.stdout).not.toContain("hermes —");
-    expect(list.stdout).not.toContain("store —");
+    expect(list.stdout).toMatch(/harness/i);
   });
 
   it("prints nothing about registering a tool set", async () => {
@@ -263,6 +305,43 @@ d("clawbox app open — when the harness cannot be determined", () => {
     // this run may not even be reading.
     const r = await cli(["app", "list"], "openclaw", { lockBody: NO_EDITION });
     expect(`${r.stdout}${r.stderr}`).not.toMatch(/tool set|clawbox-mcp/i);
+  });
+});
+
+d("clawbox app open — what it may claim happened", () => {
+  it("does not report an EXTERNAL app as opened", async () => {
+    // `openclaw` and `hermes` are `external: true`: the desktop opens them with
+    // window.open() from a POLL rather than a click, so a popup blocker drops
+    // the tab with nothing to report back. `ui_open_app` hedges for exactly
+    // that reason; the CLI posts the same action to the same ring, so a tick
+    // here is the same false success on the one path the agent cannot see —
+    // and "one question, three surfaces" is this whole file's subject.
+    activeHarness = "hermes";
+    const r = await cli(["app", "open", "hermes"], "dual");
+    expect(r.status, r.stderr).toBe(0);
+    expect(posted.at(-1)).toMatchObject({ type: "open_app", appId: "hermes" });
+    expect(r.stdout).not.toMatch(/✅ Opening/);
+    expect(r.stdout).toMatch(/new browser tab/);
+    expect(r.stdout).toMatch(/popup/i);
+  });
+
+  it("still reports an ordinary desktop window as opened", async () => {
+    // The counterweight: a real window IS placed by the desktop, and hedging
+    // over every app would make the honest note meaningless.
+    const r = await cli(["app", "open", "terminal"], "openclaw");
+    expect(r.status, r.stderr).toBe(0);
+    expect(r.stdout).toMatch(/✅ Opening terminal/);
+    expect(r.stdout).not.toMatch(/popup/i);
+  });
+
+  it("reports an installed web app as opened", async () => {
+    // An installed app is framed IN the desktop, not window.open()ed, so it is
+    // not external and the tick is true.
+    installedApps = ["notes"];
+    installedMeta = { notes: { webappUrl: "/setup-api/webapps?app=notes" } };
+    const r = await cli(["app", "open", "installed-notes"], "openclaw");
+    expect(r.status, r.stderr).toBe(0);
+    expect(r.stdout).toMatch(/✅ Opening installed-notes/);
   });
 });
 
@@ -283,7 +362,11 @@ d("clawbox app list — the same answer as the gate", () => {
     expect(r.stdout).not.toContain("hermes —");
   });
 
-  it("names every app it would open, and no app it would refuse", async () => {
+  // One `bun` spawn per listed id, in series — eleven on a Hermes box, each
+  // paying bun's own start. That is well past vitest's 5 s default, and a
+  // ceiling derived from the work (rather than inherited) is what keeps the
+  // failure honest: `CLI_TIMEOUT_MS` still fails a single hung child first.
+  it("names every app it would open, and no app it would refuse", { timeout: 60_000 }, async () => {
     // The two commands are one gate: a list that offers what `open` refuses is
     // the false success this pair exists to prevent.
     activeHarness = "hermes";

--- a/src/tests/unit/mcp-cli-app-gate.test.ts
+++ b/src/tests/unit/mcp-cli-app-gate.test.ts
@@ -38,6 +38,16 @@ function have(bin: string, args: string[]): boolean {
 const CAN_RUN = process.platform !== "win32" && have("bun", ["--version"]);
 const d = CAN_RUN ? describe : describe.skip;
 
+// A skipped file reports green while asserting nothing, and this is the ONLY
+// test of the CLI's gate. CI installs bun (pr-tests-coverage.yml,
+// oven-sh/setup-bun), so if it ever stops resolving there, say so out loud
+// rather than going quiet.
+describe("the CLI can be run at all", () => {
+  it.skipIf(!process.env.CI)("has bun on PATH in CI", () => {
+    expect(CAN_RUN).toBe(true);
+  });
+});
+
 let server: http.Server;
 let base: string;
 let home: string;
@@ -45,6 +55,8 @@ let lockPath: string;
 /** What the device would answer for `/setup-api/harness/active`. */
 let activeHarness: string;
 let installedApps: string[];
+/** `installed_meta` rows, by raw id — a `webappUrl` marks a ClawBox web app. */
+let installedMeta: Record<string, { webappUrl?: string }>;
 /** Every `ui:pending-action` the CLI posted, newest last. */
 let posted: Array<Record<string, unknown>>;
 
@@ -60,7 +72,7 @@ beforeAll(async () => {
       return;
     }
     if (req.method === "GET" && url.pathname === "/setup-api/preferences") {
-      json({ installed_apps: installedApps });
+      json({ installed_apps: installedApps, installed_meta: installedMeta });
       return;
     }
     if (req.method === "POST" && url.pathname === "/setup-api/kv") {
@@ -94,6 +106,7 @@ afterAll(async () => {
 beforeEach(() => {
   activeHarness = "openclaw";
   installedApps = [];
+  installedMeta = {};
   posted = [];
 });
 
@@ -104,14 +117,18 @@ beforeEach(() => {
  * the event loop until the child exits would leave the child's own request
  * unanswered forever — the two would wait for each other.
  */
-function cli(args: string[], edition: string): Promise<{ status: number; stdout: string; stderr: string }> {
-  fs.writeFileSync(lockPath, `CLAWBOX_EDITION=${edition}\n`);
+function cli(
+  args: string[],
+  edition: string,
+  opts: { lockBody?: string; apiBase?: string } = {},
+): Promise<{ status: number; stdout: string; stderr: string }> {
+  fs.writeFileSync(lockPath, opts.lockBody ?? `CLAWBOX_EDITION=${edition}\n`);
   return new Promise((resolve, reject) => {
     const child = spawn("bun", [CLI, ...args], {
       env: testEnv({
         PATH: process.env.PATH ?? "",
         HOME: home,
-        CLAWBOX_API_BASE: base,
+        CLAWBOX_API_BASE: opts.apiBase ?? base,
         CLAWBOX_EDITION_FILE: lockPath,
         // Long enough to pass the CLI's own length check; the stub device does
         // not look at it.
@@ -158,13 +175,94 @@ d("clawbox app open — the edition gate", () => {
 
   it("opens an app the device really installed, and refuses one it did not", async () => {
     installedApps = ["notes"];
-    expect((await cli(["app", "open", "installed-notes"], "hermes")).status).toBe(0);
+    expect((await cli(["app", "open", "installed-notes"], "openclaw")).status).toBe(0);
     expect(posted).toContainEqual(
       expect.objectContaining({ type: "open_app", appId: "installed-notes" }),
     );
-    const missing = await cli(["app", "open", "installed-ledger"], "hermes");
+    const missing = await cli(["app", "open", "installed-ledger"], "openclaw");
     expect(missing.status).toBe(1);
     expect(missing.stderr).toContain("No installed app");
+  });
+
+  it("refuses a store-installed skill on Hermes, and opens a web app", async () => {
+    // An installed STORE app is an OpenClaw skill: its window shells out to the
+    // openclaw binary, so the Hermes desktop drops it from `getAllApps()` and a
+    // tick here would be printed over a window that never appears. A ClawBox
+    // web app is harness-independent — often the Hermes agent's own output.
+    installedApps = ["weather-skill", "notes"];
+    installedMeta = { notes: { webappUrl: "/setup-api/webapps?app=notes" } };
+
+    const skill = await cli(["app", "open", "installed-weather-skill"], "hermes");
+    expect(skill.status).toBe(1);
+    expect(posted).toEqual([]);
+
+    const webapp = await cli(["app", "open", "installed-notes"], "hermes");
+    expect(webapp.status, webapp.stderr).toBe(0);
+    expect(posted).toContainEqual(expect.objectContaining({ appId: "installed-notes" }));
+
+    // …and on OpenClaw the same skill opens.
+    posted = [];
+    expect((await cli(["app", "open", "installed-weather-skill"], "openclaw")).status).toBe(0);
+  });
+});
+
+d("clawbox app open — when the harness cannot be determined", () => {
+  // A lock file that EXISTS and carries no edition: a truncated write, a
+  // permission change, a partial reflash. The MCP resolves that to the smaller
+  // TOOL SET on purpose — an unreadable lock must not hand a device the shell
+  // and file tools. Apps are not a subset of one another, though: answering
+  // "hermes" there hides `store`, `openclaw` and `memory-shard` from a box
+  // that has them and ticks off `hermes` on a box that may not. The desktop's
+  // own rule for an unknown harness is to hide BOTH sets and say so.
+  const NO_EDITION = "# ClawBox edition lock\n# (truncated)\n";
+
+  it("keeps offering the apps that exist on either harness", async () => {
+    const r = await cli(["app", "open", "settings"], "openclaw", { lockBody: NO_EDITION });
+    expect(r.status, r.stderr).toBe(0);
+    expect(posted).toContainEqual(expect.objectContaining({ appId: "settings" }));
+  });
+
+  it("refuses BOTH harnesses' own apps rather than guessing one", async () => {
+    for (const appId of ["hermes", "hermes-skills", "store", "openclaw", "memory-shard"]) {
+      posted = [];
+      const r = await cli(["app", "open", appId], "openclaw", { lockBody: NO_EDITION });
+      expect(r.status, `${appId} must be refused`).toBe(1);
+      // Not "there is no such app": the device may well have it. Ticking off an
+      // open the desktop then drops is the false success this gate exists for.
+      expect(r.stderr).toMatch(/which harness/i);
+      expect(posted).toEqual([]);
+    }
+  });
+
+  it("lists neither harness's own apps, and says why", async () => {
+    const r = await cli(["app", "list"], "openclaw", { lockBody: NO_EDITION });
+    expect(r.status, r.stderr).toBe(0);
+    expect(r.stdout).toContain("settings —");
+    for (const appId of ["hermes —", "store —", "openclaw —", "memory-shard —"]) {
+      expect(r.stdout).not.toContain(appId);
+    }
+    expect(r.stdout).toMatch(/harness/i);
+  });
+
+  it("does not report a harness it never resolved when the device cannot answer", async () => {
+    // A dual box mid-update: the web server is restarting, so
+    // /setup-api/harness/active does not answer. Defaulting to one harness
+    // would tell the agent as a durable fact that the box has no dashboard.
+    const dead = "http://127.0.0.1:9";
+    const open = await cli(["app", "open", "hermes"], "dual", { apiBase: dead });
+    expect(open.status).toBe(1);
+    expect(open.stderr).toMatch(/which harness/i);
+    const list = await cli(["app", "list"], "dual", { apiBase: dead });
+    expect(list.stdout).not.toContain("hermes —");
+    expect(list.stdout).not.toContain("store —");
+  });
+
+  it("prints nothing about registering a tool set", async () => {
+    // The MCP's fail-closed notice is about tools/list on a long-lived stdio
+    // server. A CLI invocation registers nothing, and the line names a path
+    // this run may not even be reading.
+    const r = await cli(["app", "list"], "openclaw", { lockBody: NO_EDITION });
+    expect(`${r.stdout}${r.stderr}`).not.toMatch(/tool set|clawbox-mcp/i);
   });
 });
 

--- a/src/tests/unit/mcp-cli-app-gate.test.ts
+++ b/src/tests/unit/mcp-cli-app-gate.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { spawn, spawnSync } from "child_process";
+import http from "http";
+import type { AddressInfo } from "net";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+import { testEnv } from "@/tests/helpers/env";
+
+/**
+ * `clawbox app open` / `app list` on the DUAL SKU.
+ *
+ * The CLI is the agent's fallback when MCP tool calling is not available, and
+ * it applies the same gate `ui_open_app` does — so it has to answer the same
+ * question the same way. `installEdition()` returns THREE values (`openclaw`,
+ * `hermes`, `dual`: the premium SKU carries both harnesses), and a two-way
+ * branch on it folds `dual` into `openclaw`, which hides `hermes` and
+ * `hermes-skills` from a box whose ACTIVE harness is Hermes. The desktop opens
+ * that dashboard happily (`src/app/page.tsx` builds its grid from the active
+ * harness) and so does the MCP tool (`mcp/lib/edition.ts` resolves `dual`
+ * through `/setup-api/harness/active`) — the CLI was the one surface that
+ * refused it, which is TASK-541's own symptom one surface over.
+ *
+ * The whole CLI had no test before this one; these run it as the agent does,
+ * against a stub device.
+ */
+
+const REPO = path.resolve(__dirname, "../../..");
+const CLI = path.join(REPO, "mcp", "clawbox-cli.ts");
+
+function have(bin: string, args: string[]): boolean {
+  return spawnSync(bin, args, { stdio: "ignore" }).status === 0;
+}
+
+// The CLI's shebang is bun, and the device runs it with bun; there is no other
+// runtime here that takes the TypeScript source unbuilt.
+const CAN_RUN = process.platform !== "win32" && have("bun", ["--version"]);
+const d = CAN_RUN ? describe : describe.skip;
+
+let server: http.Server;
+let base: string;
+let home: string;
+let lockPath: string;
+/** What the device would answer for `/setup-api/harness/active`. */
+let activeHarness: string;
+let installedApps: string[];
+/** Every `ui:pending-action` the CLI posted, newest last. */
+let posted: Array<Record<string, unknown>>;
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    const json = (body: unknown) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(body));
+    };
+    if (req.method === "GET" && url.pathname === "/setup-api/harness/active") {
+      json({ active: activeHarness });
+      return;
+    }
+    if (req.method === "GET" && url.pathname === "/setup-api/preferences") {
+      json({ installed_apps: installedApps });
+      return;
+    }
+    if (req.method === "POST" && url.pathname === "/setup-api/kv") {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        try {
+          const body = JSON.parse(Buffer.concat(chunks).toString("utf-8")) as { value?: string };
+          posted.push(JSON.parse(String(body.value ?? "{}")));
+        } catch {
+          posted.push({});
+        }
+        json({ ok: true });
+      });
+      return;
+    }
+    res.writeHead(404, { "content-type": "application/json" });
+    res.end("{}");
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-cli-home-"));
+  lockPath = path.join(home, "edition.env");
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  activeHarness = "openclaw";
+  installedApps = [];
+  posted = [];
+});
+
+/**
+ * Run the CLI against the stub device.
+ *
+ * ASYNC, never `spawnSync`: the stub server lives in THIS process, so blocking
+ * the event loop until the child exits would leave the child's own request
+ * unanswered forever — the two would wait for each other.
+ */
+function cli(args: string[], edition: string): Promise<{ status: number; stdout: string; stderr: string }> {
+  fs.writeFileSync(lockPath, `CLAWBOX_EDITION=${edition}\n`);
+  return new Promise((resolve, reject) => {
+    const child = spawn("bun", [CLI, ...args], {
+      env: testEnv({
+        PATH: process.env.PATH ?? "",
+        HOME: home,
+        CLAWBOX_API_BASE: base,
+        CLAWBOX_EDITION_FILE: lockPath,
+        // Long enough to pass the CLI's own length check; the stub device does
+        // not look at it.
+        CLAWBOX_MCP_TOKEN: "0".repeat(32),
+      }),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (c: Buffer) => { stdout += c.toString(); });
+    child.stderr.on("data", (c: Buffer) => { stderr += c.toString(); });
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ status: code ?? -1, stdout, stderr }));
+  });
+}
+
+d("clawbox app open — the edition gate", () => {
+  it("opens the Hermes dashboard on a dual box that is running Hermes", async () => {
+    activeHarness = "hermes";
+    const r = await cli(["app", "open", "hermes"], "dual");
+    expect(r.status, r.stderr).toBe(0);
+    expect(posted).toContainEqual(expect.objectContaining({ type: "open_app", appId: "hermes" }));
+  });
+
+  it("opens an OpenClaw-only app on a dual box that is running OpenClaw", async () => {
+    activeHarness = "openclaw";
+    const r = await cli(["app", "open", "store"], "dual");
+    expect(r.status, r.stderr).toBe(0);
+    expect(posted).toContainEqual(expect.objectContaining({ type: "open_app", appId: "store" }));
+  });
+
+  it("still refuses the other harness's app on a single-harness box", async () => {
+    const r = await cli(["app", "open", "hermes"], "openclaw");
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("No built-in app");
+    expect(posted).toEqual([]);
+  });
+
+  it("still refuses an id no app claims", async () => {
+    const r = await cli(["app", "open", "not-an-app"], "hermes");
+    expect(r.status).toBe(1);
+    expect(posted).toEqual([]);
+  });
+
+  it("opens an app the device really installed, and refuses one it did not", async () => {
+    installedApps = ["notes"];
+    expect((await cli(["app", "open", "installed-notes"], "hermes")).status).toBe(0);
+    expect(posted).toContainEqual(
+      expect.objectContaining({ type: "open_app", appId: "installed-notes" }),
+    );
+    const missing = await cli(["app", "open", "installed-ledger"], "hermes");
+    expect(missing.status).toBe(1);
+    expect(missing.stderr).toContain("No installed app");
+  });
+});
+
+d("clawbox app list — the same answer as the gate", () => {
+  it("lists the Hermes apps on a dual box that is running Hermes", async () => {
+    activeHarness = "hermes";
+    const r = await cli(["app", "list"], "dual");
+    expect(r.status, r.stderr).toBe(0);
+    expect(r.stdout).toContain("hermes —");
+    expect(r.stdout).not.toContain("store —");
+  });
+
+  it("lists the OpenClaw apps on a dual box that is running OpenClaw", async () => {
+    activeHarness = "openclaw";
+    const r = await cli(["app", "list"], "dual");
+    expect(r.status, r.stderr).toBe(0);
+    expect(r.stdout).toContain("store —");
+    expect(r.stdout).not.toContain("hermes —");
+  });
+
+  it("names every app it would open, and no app it would refuse", async () => {
+    // The two commands are one gate: a list that offers what `open` refuses is
+    // the false success this pair exists to prevent.
+    activeHarness = "hermes";
+    const listed = (await cli(["app", "list"], "dual")).stdout
+      .split("\n")
+      .map((line) => /^ {2}(\S+) —/.exec(line)?.[1])
+      .filter((id): id is string => Boolean(id));
+    expect(listed.length).toBeGreaterThan(0);
+    for (const id of listed) {
+      expect((await cli(["app", "open", id], "dual")).status, `app open ${id}`).toBe(0);
+    }
+  });
+});

--- a/src/tests/unit/mcp-code-project-paths.test.ts
+++ b/src/tests/unit/mcp-code-project-paths.test.ts
@@ -59,6 +59,7 @@ import type { McpContext } from "../../../mcp/lib/context";
 const ctx = (edition: "openclaw" | "hermes"): McpContext => ({
   edition,
   install: edition,
+  appHarness: edition,
   profile: "full",
   capabilities: { screenGrabber: null, imageConvert: false, journal: false, du: false },
   providers: [],

--- a/src/tests/unit/mcp-desktop-apps.test.ts
+++ b/src/tests/unit/mcp-desktop-apps.test.ts
@@ -17,6 +17,7 @@ import { INSTALLED_APP_ID_RE } from "../../../mcp/lib/schema";
 import { APP_ID_RE } from "@/lib/code-projects";
 import { captureRegistrar } from "../helpers/mcp-registrar";
 import { registerDesktopTools } from "../../../mcp/tools/desktop";
+import { UNKNOWN_HARNESS_NOTE } from "../../../mcp/lib/context";
 import {
   HARNESS_ONLY_APP_IDS,
   hiddenAppIdsForHarness,
@@ -184,6 +185,33 @@ describe("ui_open_app accepts every id it advertises", () => {
       expect(appId.safeParse(id).success, `${id} must be refused`).toBe(false);
     }
   });
+
+  it("lets an id it can LIST also be UPDATED, BUILT and DELETED", async () => {
+    // The same rule one family over. `APP_ID_RE` (src/lib/code-projects.ts) is
+    // what /setup-api/code and /setup-api/webapps enforce, and it takes upper
+    // case and underscores — so `clawbox code init Weather_App` succeeds and
+    // `code_project_list` reports that id "with the id each one is built and
+    // deleted by", while a narrower schema refused the build and the delete
+    // before the handler ran. An id the device mints and the tools list must be
+    // an id the tools can act on.
+    const h = captureRegistrar("openclaw");
+    registerDesktopTools(h.reg, ctx("openclaw"));
+    const actOn: Array<[string, string]> = [
+      ["webapp_update", "app_id"],
+      ["code_project_build", "project_id"],
+      ["code_project_delete", "project_id"],
+    ];
+    for (const [tool, field] of actOn) {
+      const schema = h.get(tool).shape[field];
+      for (const id of ["Weather_App", "Foo_Bar", "weather", "_drafts"]) {
+        expect(APP_ID_RE.test(id), `${id} must be creatable`).toBe(true);
+        expect(schema.safeParse(id).success, `${tool} must accept ${id}`).toBe(true);
+      }
+      for (const id of ["../etc", "a/b", "a b", "a.b", "", "-lead", "x".repeat(65)]) {
+        expect(schema.safeParse(id).success, `${tool} must refuse ${id}`).toBe(false);
+      }
+    }
+  });
 });
 
 describe("an installed app the desktop would not open", () => {
@@ -229,6 +257,38 @@ describe("when the harness could not be determined", () => {
     }
     const shared = await h.call("ui_open_app", { app_id: "settings" });
     expect(shared.isError).toBe(false);
+  });
+
+  it("says the harness is UNDETERMINED, not that the app does not exist", async () => {
+    // The CLI has always drawn this distinction, and its own comment says why:
+    // "an app the OTHER harness owns is 'not here'; the same app while the
+    // harness is unknown is 'could not be placed'. Saying the first over the
+    // second tells the agent as a durable fact that a dual box has no
+    // dashboard, which is how it stops asking." The tool said the first.
+    const h = captureRegistrar("hermes");
+    registerDesktopTools(h.reg, unknown);
+    for (const id of HARNESS_ONLY_APP_IDS) {
+      const outcome = await h.call("ui_open_app", { app_id: id });
+      expect(outcome.isError).toBe(true);
+      if (!outcome.isError) continue;
+      const said = `${outcome.error.message} ${outcome.error.next ?? ""}`;
+      expect(said, `${id} must not be reported as non-existent`)
+        .not.toMatch(/no such app/i);
+      expect(said, `${id} must name the undetermined harness`).toContain(UNKNOWN_HARNESS_NOTE);
+    }
+    // An id that exists on NEITHER harness is still an honest "no such app".
+    const nonsense = await h.call("ui_open_app", { app_id: "nope" });
+    expect(nonsense.isError).toBe(true);
+    if (nonsense.isError) expect(nonsense.error.message).toMatch(/no such app/i);
+  });
+
+  it("says so in ui_list_apps too, rather than silently dropping five apps", async () => {
+    const h = captureRegistrar("hermes");
+    registerDesktopTools(h.reg, unknown);
+    const outcome = await h.call("ui_list_apps");
+    expect(outcome.isError).toBe(false);
+    if (outcome.isError) return;
+    expect(outcome.text).toContain(UNKNOWN_HARNESS_NOTE);
   });
 
   it("does not name an app in its own description that it would refuse", async () => {

--- a/src/tests/unit/mcp-desktop-apps.test.ts
+++ b/src/tests/unit/mcp-desktop-apps.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { builtInApps } from "../../../mcp/lib/context";
+import {
+  hiddenAppIdsForHarness,
+  HERMES_ONLY_APP_IDS,
+  OPENCLAW_ONLY_APP_IDS,
+} from "@/lib/desktop-app-editions";
+import { apps } from "@/lib/desktop-apps";
+
+/**
+ * TASK-541 — `ui_open_app` / `ui_list_apps` denied four apps the desktop shows.
+ *
+ * `mcp/lib/context.ts` kept its own hand-written copy of the built-in app list,
+ * and it had drifted from the desktop registry (`src/lib/desktop-apps.ts`):
+ * `clawbox` (the chat app), `clawkeep`, `system_update` and — on Hermes — the
+ * `hermes` dashboard itself were missing. `mcp/tools/desktop.ts` gates
+ * `ui_open_app` on exactly that list, so the agent was told its own dashboard
+ * "does not exist on this ClawBox" while `src/app/page.tsx` pins it on the
+ * shelf and opens it happily.
+ *
+ * The property pinned here is the one that makes the bug unrepeatable: the two
+ * surfaces read the SAME registry and the SAME edition gate.
+ */
+
+function idsFor(edition: "openclaw" | "hermes"): string[] {
+  return builtInApps(edition).map((a) => a.id);
+}
+
+describe("MCP built-in apps match the desktop registry", () => {
+  it("offers the Hermes dashboard, chat, ClawKeep and System Update on Hermes", () => {
+    const ids = idsFor("hermes");
+    for (const id of ["hermes", "clawbox", "clawkeep", "system_update"]) {
+      expect(ids, `ui_open_app must accept "${id}" on Hermes`).toContain(id);
+    }
+  });
+
+  it("offers chat, ClawKeep and System Update on OpenClaw", () => {
+    const ids = idsFor("openclaw");
+    for (const id of ["clawbox", "clawkeep", "system_update"]) {
+      expect(ids, `ui_open_app must accept "${id}" on OpenClaw`).toContain(id);
+    }
+  });
+
+  it("hides only the other harness's apps", () => {
+    expect(idsFor("hermes")).not.toContain("openclaw");
+    expect(idsFor("hermes")).not.toContain("store");
+    expect(idsFor("hermes")).not.toContain("memory-shard");
+    expect(idsFor("openclaw")).not.toContain("hermes");
+    expect(idsFor("openclaw")).not.toContain("hermes-skills");
+  });
+
+  it("lists exactly the desktop registry, edition-gated, in registry order", () => {
+    const registry = apps.map((a) => a.id);
+    const hermesOnly: readonly string[] = HERMES_ONLY_APP_IDS;
+    const openclawOnly: readonly string[] = OPENCLAW_ONLY_APP_IDS;
+    expect(idsFor("hermes")).toEqual(registry.filter((id) => !openclawOnly.includes(id)));
+    expect(idsFor("openclaw")).toEqual(registry.filter((id) => !hermesOnly.includes(id)));
+  });
+
+  it("gives every app a name and a description for the agent", () => {
+    for (const edition of ["openclaw", "hermes"] as const) {
+      for (const app of builtInApps(edition)) {
+        expect(app.name, `${app.id} name`).toBeTruthy();
+        expect(app.description, `${app.id} description`).toBeTruthy();
+      }
+    }
+  });
+});
+
+describe("the edition gate has one copy", () => {
+  it("hides the other harness's apps, and both sets while the harness is unknown", () => {
+    expect(hiddenAppIdsForHarness("hermes")).toEqual([...OPENCLAW_ONLY_APP_IDS]);
+    expect(hiddenAppIdsForHarness("openclaw")).toEqual([...HERMES_ONLY_APP_IDS]);
+    // null (still fetching) and "dual" both fail closed, as the desktop did
+    // before the lists moved out of src/app/page.tsx.
+    for (const harness of [null, "dual"]) {
+      expect(hiddenAppIdsForHarness(harness)).toEqual([
+        ...OPENCLAW_ONLY_APP_IDS,
+        ...HERMES_ONLY_APP_IDS,
+      ]);
+    }
+  });
+
+  it("names only ids the desktop registry actually declares", () => {
+    const registry = apps.map((a) => a.id);
+    for (const id of [...OPENCLAW_ONLY_APP_IDS, ...HERMES_ONLY_APP_IDS]) {
+      expect(registry, `${id} is gated but not declared`).toContain(id);
+    }
+  });
+});

--- a/src/tests/unit/mcp-desktop-apps.test.ts
+++ b/src/tests/unit/mcp-desktop-apps.test.ts
@@ -153,7 +153,7 @@ describe("ui_open_app accepts every id it advertises", () => {
     // store's SLUG both take upper case and underscores, so a webapp called
     // `Foo_Bar` exists on boxes today. Refusing it would be the tool calling an
     // id the device itself minted invalid.
-    for (const id of ["Foo_Bar", "weather", "a", "A1_b-c", "x".repeat(64)]) {
+    for (const id of ["Foo_Bar", "weather", "a", "A1_b-c", "_drafts", "x".repeat(64)]) {
       expect(APP_ID_RE.test(id), `${id} must be creatable`).toBe(true);
       expect(INSTALLED_APP_ID_RE.test(`installed-${id}`), `${id} must be openable`).toBe(true);
     }

--- a/src/tests/unit/mcp-desktop-apps.test.ts
+++ b/src/tests/unit/mcp-desktop-apps.test.ts
@@ -163,6 +163,27 @@ describe("ui_open_app accepts every id it advertises", () => {
       expect(INSTALLED_APP_ID_RE.test(`installed-${id}`), `${id} must be refused`).toBe(false);
     }
   });
+
+  it("lets an id it can OPEN also be REMOVED", async () => {
+    // Widening what can be listed and opened without widening what can be
+    // removed leaves the owner with an app the agent created, shows and opens
+    // and cannot delete — `app_uninstall`'s own membership check is
+    // deliberately unfiltered so that removal always works, and a narrower
+    // schema in front of it refuses the call before the handler ever runs.
+    const h = captureRegistrar("hermes");
+    registerDesktopTools(h.reg, ctx("hermes"));
+    const appId = h.get("app_uninstall").shape.app_id;
+    for (const id of ["Foo_Bar", "weather", "A1_b-c", "_drafts"]) {
+      expect(appId.safeParse(id).success, `${id} must be removable`).toBe(true);
+      // The same alphabet on both surfaces, stated as the invariant rather than
+      // as two lists that happen to agree today.
+      expect(INSTALLED_APP_ID_RE.test(`installed-${id}`), `${id} must be openable`).toBe(true);
+    }
+    // Still a closed alphabet: the value reaches /setup-api/apps/uninstall.
+    for (const id of ["../etc", "a/b", "a b", "a.b", "", "-lead", "x".repeat(65)]) {
+      expect(appId.safeParse(id).success, `${id} must be refused`).toBe(false);
+    }
+  });
 });
 
 describe("an installed app the desktop would not open", () => {

--- a/src/tests/unit/mcp-desktop-apps.test.ts
+++ b/src/tests/unit/mcp-desktop-apps.test.ts
@@ -13,6 +13,8 @@ vi.mock("../../../mcp/lib/api", () => ({
 }));
 
 import { builtInApps, type McpContext } from "../../../mcp/lib/context";
+import { INSTALLED_APP_ID_RE } from "../../../mcp/lib/schema";
+import { APP_ID_RE } from "@/lib/code-projects";
 import { captureRegistrar } from "../helpers/mcp-registrar";
 import { registerDesktopTools } from "../../../mcp/tools/desktop";
 import {
@@ -144,6 +146,21 @@ describe("ui_open_app accepts every id it advertises", () => {
     const malformed = await h.call("ui_open_app", { app_id: "installed-../etc" });
     expect(malformed.isError).toBe(true);
     if (malformed.isError) expect(malformed.error.code).toBe("BAD_ARGUMENT");
+  });
+
+  it("accepts every installed id the device is able to create", async () => {
+    // The producers' alphabet is wider than `zSlug`'s: `APP_ID_RE` and the
+    // store's SLUG both take upper case and underscores, so a webapp called
+    // `Foo_Bar` exists on boxes today. Refusing it would be the tool calling an
+    // id the device itself minted invalid.
+    for (const id of ["Foo_Bar", "weather", "a", "A1_b-c", "x".repeat(64)]) {
+      expect(APP_ID_RE.test(id), `${id} must be creatable`).toBe(true);
+      expect(INSTALLED_APP_ID_RE.test(`installed-${id}`), `${id} must be openable`).toBe(true);
+    }
+    // …and no wider: nothing that could become a path or a second field.
+    for (const id of ["../etc", "a/b", "a b", "a.b", "", "-lead"]) {
+      expect(INSTALLED_APP_ID_RE.test(`installed-${id}`), `${id} must be refused`).toBe(false);
+    }
   });
 });
 

--- a/src/tests/unit/mcp-desktop-apps.test.ts
+++ b/src/tests/unit/mcp-desktop-apps.test.ts
@@ -1,7 +1,22 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { builtInApps } from "../../../mcp/lib/context";
+const { apiGet, apiPost } = vi.hoisted(() => ({ apiGet: vi.fn(), apiPost: vi.fn() }));
+
+// Registration and the ui_open_app handler are what this file exercises; the
+// device calls behind them (the KV write, the installed-apps read) are stubbed.
+vi.mock("../../../mcp/lib/api", () => ({
+  apiGet,
+  apiPost,
+  apiTry: async () => null,
+  API_BASE: "http://127.0.0.1:80",
+  CLAWBOX_ROOT: "/home/clawbox/clawbox",
+}));
+
+import { builtInApps, type McpContext } from "../../../mcp/lib/context";
+import { captureRegistrar } from "../helpers/mcp-registrar";
+import { registerDesktopTools } from "../../../mcp/tools/desktop";
 import {
+  HARNESS_ONLY_APP_IDS,
   hiddenAppIdsForHarness,
   HERMES_ONLY_APP_IDS,
   OPENCLAW_ONLY_APP_IDS,
@@ -26,6 +41,22 @@ import { apps } from "@/lib/desktop-apps";
 function idsFor(edition: "openclaw" | "hermes"): string[] {
   return builtInApps(edition).map((a) => a.id);
 }
+
+const ctx = (edition: "openclaw" | "hermes"): McpContext => ({
+  edition,
+  install: edition,
+  profile: "full",
+  capabilities: { screenGrabber: null, imageConvert: false, journal: false, du: false },
+  providers: [],
+  emailCanRead: false,
+  codingAgent: false,
+  canGenerateImages: false,
+});
+
+beforeEach(() => {
+  apiPost.mockResolvedValue({});
+  apiGet.mockResolvedValue({ installed_apps: [] });
+});
 
 describe("MCP built-in apps match the desktop registry", () => {
   it("offers the Hermes dashboard, chat, ClawKeep and System Update on Hermes", () => {
@@ -66,6 +97,54 @@ describe("MCP built-in apps match the desktop registry", () => {
       }
     }
   });
+
+  it("marks exactly the apps the desktop opens in a browser tab", () => {
+    // `external` decides whether ui_open_app claims the window appeared, so it
+    // has to follow the registry rather than a second opinion.
+    const externalInRegistry = apps.filter((a) => a.type === "external").map((a) => a.id).sort();
+    const externalInMcp = [
+      ...new Set(
+        (["openclaw", "hermes"] as const).flatMap((edition) =>
+          builtInApps(edition).filter((a) => a.external).map((a) => a.id),
+        ),
+      ),
+    ].sort();
+    expect(externalInMcp).toEqual(externalInRegistry);
+  });
+});
+
+describe("ui_open_app accepts every id it advertises", () => {
+  // The bug this closes: `system_update` was advertised in the tool's own
+  // description and in ui_list_apps, then refused by an id validator that
+  // allowed no underscore — with a remedy naming the id that had just failed.
+  for (const edition of ["openclaw", "hermes"] as const) {
+    it(`opens each built-in on ${edition} instead of rejecting the id`, async () => {
+      const h = captureRegistrar(edition);
+      registerDesktopTools(h.reg, ctx(edition));
+      for (const app of builtInApps(edition)) {
+        const outcome = await h.call("ui_open_app", { app_id: app.id });
+        expect(outcome.isError, `${app.id}: ${JSON.stringify(outcome)}`).toBe(false);
+      }
+    });
+  }
+
+  it("still refuses an id no app claims, and a malformed installed id", async () => {
+    const h = captureRegistrar("hermes");
+    registerDesktopTools(h.reg, ctx("hermes"));
+
+    const unknown = await h.call("ui_open_app", { app_id: "not-an-app" });
+    expect(unknown.isError).toBe(true);
+    if (unknown.isError) expect(unknown.error.code).toBe("NOT_FOUND");
+
+    // The other harness's app is still hidden, not merely unlisted.
+    const otherHarness = await h.call("ui_open_app", { app_id: "store" });
+    expect(otherHarness.isError).toBe(true);
+    if (otherHarness.isError) expect(otherHarness.error.code).toBe("NOT_FOUND");
+
+    const malformed = await h.call("ui_open_app", { app_id: "installed-../etc" });
+    expect(malformed.isError).toBe(true);
+    if (malformed.isError) expect(malformed.error.code).toBe("BAD_ARGUMENT");
+  });
 });
 
 describe("the edition gate has one copy", () => {
@@ -84,8 +163,15 @@ describe("the edition gate has one copy", () => {
 
   it("names only ids the desktop registry actually declares", () => {
     const registry = apps.map((a) => a.id);
-    for (const id of [...OPENCLAW_ONLY_APP_IDS, ...HERMES_ONLY_APP_IDS]) {
+    for (const id of HARNESS_ONLY_APP_IDS) {
       expect(registry, `${id} is gated but not declared`).toContain(id);
     }
+  });
+
+  it("joins the two lists into the set the standalone window waits on", () => {
+    expect([...HARNESS_ONLY_APP_IDS]).toEqual([
+      ...OPENCLAW_ONLY_APP_IDS,
+      ...HERMES_ONLY_APP_IDS,
+    ]);
   });
 });

--- a/src/tests/unit/mcp-desktop-apps.test.ts
+++ b/src/tests/unit/mcp-desktop-apps.test.ts
@@ -47,6 +47,7 @@ function idsFor(edition: "openclaw" | "hermes"): string[] {
 const ctx = (edition: "openclaw" | "hermes"): McpContext => ({
   edition,
   install: edition,
+  appHarness: edition,
   profile: "full",
   capabilities: { screenGrabber: null, imageConvert: false, journal: false, du: false },
   providers: [],
@@ -161,6 +162,59 @@ describe("ui_open_app accepts every id it advertises", () => {
     for (const id of ["../etc", "a/b", "a b", "a.b", "", "-lead"]) {
       expect(INSTALLED_APP_ID_RE.test(`installed-${id}`), `${id} must be refused`).toBe(false);
     }
+  });
+});
+
+describe("an installed app the desktop would not open", () => {
+  it("is refused on Hermes when it is a store skill, and opened when it is a web app", async () => {
+    // The desktop drops a store-installed OpenClaw skill on Hermes — its window
+    // shells out to the openclaw binary — so answering "Opened <name>" for one
+    // is a tick over a window that never appears. Both gates read the rule from
+    // src/lib/desktop-app-editions.ts.
+    apiGet.mockResolvedValue({
+      installed_apps: ["weather-skill", "notes"],
+      installed_meta: { notes: { webappUrl: "/setup-api/webapps?app=notes" } },
+    });
+    const h = captureRegistrar("hermes");
+    registerDesktopTools(h.reg, ctx("hermes"));
+
+    const skill = await h.call("ui_open_app", { app_id: "installed-weather-skill" });
+    expect(skill.isError).toBe(true);
+    if (skill.isError) expect(skill.error.code).toBe("NOT_FOUND");
+
+    const webapp = await h.call("ui_open_app", { app_id: "installed-notes" });
+    expect(webapp.isError, JSON.stringify(webapp)).toBe(false);
+
+    // …and it is still the owner's to REMOVE, on either harness.
+    const removed = await h.call("app_uninstall", { app_id: "weather-skill", confirm: true });
+    expect(removed.isError, JSON.stringify(removed)).toBe(false);
+  });
+});
+
+describe("when the harness could not be determined", () => {
+  // The MCP resolves its TOOL SET closed onto hermes when the edition lock is
+  // unreadable, because those two answers are nested — hermes is openclaw
+  // without the shell and file tools. The APP sets are not nested, so the same
+  // answer would refuse `store` on a box that has it and tick off `hermes` on
+  // a box that does not. `appHarness: null` is the third answer.
+  const unknown: McpContext = { ...ctx("hermes"), appHarness: null };
+
+  it("advertises and opens only what both harnesses have", async () => {
+    const h = captureRegistrar("hermes");
+    registerDesktopTools(h.reg, unknown);
+    for (const id of HARNESS_ONLY_APP_IDS) {
+      const outcome = await h.call("ui_open_app", { app_id: id });
+      expect(outcome.isError, `${id} must not be opened on an undetermined harness`).toBe(true);
+    }
+    const shared = await h.call("ui_open_app", { app_id: "settings" });
+    expect(shared.isError).toBe(false);
+  });
+
+  it("does not name an app in its own description that it would refuse", async () => {
+    const h = captureRegistrar("hermes");
+    registerDesktopTools(h.reg, unknown);
+    const described = h.tools.get("ui_open_app")?.description ?? "";
+    for (const id of HARNESS_ONLY_APP_IDS) expect(described).not.toContain(id);
   });
 });
 

--- a/src/tests/unit/mcp-edition.test.ts
+++ b/src/tests/unit/mcp-edition.test.ts
@@ -173,27 +173,38 @@ describe("resolveEdition — it never asks the device itself", () => {
   });
 });
 
-describe("resolveAppHarness — an unreadable lock still asks the device", () => {
-  it("takes the device's answer rather than hiding apps the box has", async () => {
-    // /setup-api/harness/active ALWAYS answers: getActiveHarness() falls back
-    // through readEdition(), whose default for an unreadable lock is
-    // "openclaw". So the desktop grid shows twelve apps while this returned
-    // null and the agent was told three of them could not be placed — the two
-    // surfaces disagreeing in exactly the state this PR is about.
+describe("resolveAppHarness — an unreadable lock does NOT ask the device", () => {
+  it("answers null without a request, because the route would only echo the default", async () => {
+    // /setup-api/harness/active always answers, but on an unreadable lock it is
+    // the SAME FILE this process just failed to read: getActiveHarness() ->
+    // lockedHarness() -> getEdition() -> readEdition() -> "openclaw", its own
+    // default. Taking that as the answer would register the Hermes TOOL SET
+    // (resolveEdition fails closed) beside an OpenClaw APP list — denying a
+    // Hermes box its own `hermes-skills` with "there is no such app", which is
+    // TASK-541's original symptom, and ticking off `openclaw` and `store` on a
+    // box that has neither.
     writeLock("GARBAGE\n");
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+    const fetchSpy = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ active: "openclaw" }),
-    }));
-    const { resolveAppHarness } = await loadEdition();
-    await expect(resolveAppHarness("http://127.0.0.1:80", null)).resolves.toBe("openclaw");
-  });
-
-  it("is null only when the device does not answer either", async () => {
-    writeLock("GARBAGE\n");
-    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("connection refused")));
+    });
+    vi.stubGlobal("fetch", fetchSpy);
     const { resolveAppHarness } = await loadEdition();
     await expect(resolveAppHarness("http://127.0.0.1:80", null)).resolves.toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("still asks on the unlocked dual SKU, where the device knows something we do not", async () => {
+    // The contrast that makes the rule above a rule and not a refusal to ask:
+    // on `dual` the route resolves a real runtime choice from the config store,
+    // which no file this process reads can answer.
+    writeLock("CLAWBOX_EDITION=dual\n");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ active: "hermes" }),
+    }));
+    const { resolveAppHarness } = await loadEdition();
+    await expect(resolveAppHarness("http://127.0.0.1:80", null)).resolves.toBe("hermes");
   });
 });
 

--- a/src/tests/unit/mcp-edition.test.ts
+++ b/src/tests/unit/mcp-edition.test.ts
@@ -46,28 +46,30 @@ describe("resolveEdition — the lock file is the authority", () => {
     writeLock("CLAWBOX_EDITION=hermes\n");
     process.env.CLAWBOX_EDITION = "openclaw";
     const { resolveEdition } = await loadEdition();
-    await expect(resolveEdition("http://127.0.0.1:80", null)).resolves.toBe("hermes");
+    expect(resolveEdition(null)).toBe("hermes");
   });
 
   it("reports openclaw from the lock even when the environment says hermes", async () => {
     writeLock("CLAWBOX_EDITION=openclaw\n");
     process.env.CLAWBOX_EDITION = "hermes";
     const { resolveEdition } = await loadEdition();
-    await expect(resolveEdition("http://127.0.0.1:80", null)).resolves.toBe("openclaw");
+    expect(resolveEdition(null)).toBe("openclaw");
   });
 
   it("reads the lock through comments and surrounding quotes", async () => {
     writeLock("# ClawBox edition lock\n\nexport CLAWBOX_EDITION=\"hermes\"\n");
     const { resolveEdition } = await loadEdition();
-    await expect(resolveEdition("http://127.0.0.1:80", null)).resolves.toBe("hermes");
+    expect(resolveEdition(null)).toBe("hermes");
   });
 
   it("never asks the API when the edition is locked", async () => {
+    // `resolveAppHarness` is the one that may ask; a locked edition settles it
+    // from the file and the device is left alone.
     writeLock("CLAWBOX_EDITION=hermes\n");
     const fetchSpy = vi.fn();
     vi.stubGlobal("fetch", fetchSpy);
-    const { resolveEdition } = await loadEdition();
-    await resolveEdition("http://127.0.0.1:80", null);
+    const { resolveAppHarness } = await loadEdition();
+    await expect(resolveAppHarness("http://127.0.0.1:80", null)).resolves.toBe("hermes");
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 });
@@ -76,12 +78,12 @@ describe("resolveEdition — no lock file", () => {
   it("falls back to the environment, for dev machines and CI", async () => {
     process.env.CLAWBOX_EDITION = "hermes";
     const { resolveEdition } = await loadEdition();
-    await expect(resolveEdition("http://127.0.0.1:80", null)).resolves.toBe("hermes");
+    expect(resolveEdition(null)).toBe("hermes");
   });
 
   it("defaults to openclaw when there is neither a lock nor an environment value", async () => {
     const { resolveEdition } = await loadEdition();
-    await expect(resolveEdition("http://127.0.0.1:80", null)).resolves.toBe("openclaw");
+    expect(resolveEdition(null)).toBe("openclaw");
   });
 });
 
@@ -89,49 +91,109 @@ describe("resolveEdition — an unreadable lock fails closed", () => {
   it("registers the smaller Hermes set when the lock carries no edition", async () => {
     writeLock("# nothing useful in here\n");
     const { resolveEdition } = await loadEdition();
-    await expect(resolveEdition("http://127.0.0.1:80", null)).resolves.toBe("hermes");
+    expect(resolveEdition(null)).toBe("hermes");
   });
 
   it("ignores the environment when the lock exists but cannot be parsed", async () => {
     writeLock("GARBAGE\n");
     process.env.CLAWBOX_EDITION = "openclaw";
     const { resolveEdition } = await loadEdition();
-    await expect(resolveEdition("http://127.0.0.1:80", null)).resolves.toBe("hermes");
+    expect(resolveEdition(null)).toBe("hermes");
   });
 
   it("does not treat an empty lock file as openclaw", async () => {
     writeLock("");
     const { resolveEdition } = await loadEdition();
-    await expect(resolveEdition("http://127.0.0.1:80", null)).resolves.toBe("hermes");
+    expect(resolveEdition(null)).toBe("hermes");
   });
 });
 
-describe("resolveEdition — the unlocked dual SKU", () => {
-  it("asks the device which harness is active", async () => {
+describe("the unlocked dual SKU — one probe, two answers", () => {
+  it("asks the device which harness is active, and the tool set follows it", async () => {
     writeLock("CLAWBOX_EDITION=dual\n");
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+    const fetchSpy = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ active: "hermes" }),
-    }));
-    const { resolveEdition } = await loadEdition();
-    await expect(resolveEdition("http://127.0.0.1:80", null)).resolves.toBe("hermes");
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+    const { resolveAppHarness, resolveEdition } = await loadEdition();
+    const appHarness = await resolveAppHarness("http://127.0.0.1:80", null);
+    expect(appHarness).toBe("hermes");
+    expect(resolveEdition(appHarness)).toBe("hermes");
+    // ONE request for both facts — the whole point of handing the answer on.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   it("uses the default harness when the device cannot answer", async () => {
     writeLock("CLAWBOX_EDITION=dual\n");
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("connection refused")));
-    const { resolveEdition } = await loadEdition();
-    await expect(resolveEdition("http://127.0.0.1:80", null)).resolves.toBe("openclaw");
+    const { resolveAppHarness, resolveEdition } = await loadEdition();
+    const appHarness = await resolveAppHarness("http://127.0.0.1:80", null);
+    // The app list makes no claim; the tool set still needs one, and takes the
+    // default. Two different right answers to a silence, from one probe.
+    expect(appHarness).toBeNull();
+    expect(resolveEdition(appHarness)).toBe("openclaw");
   });
 
   it("sends the bearer so a session-gated device can answer", async () => {
     writeLock("CLAWBOX_EDITION=dual\n");
     const fetchSpy = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ active: "openclaw" }) });
     vi.stubGlobal("fetch", fetchSpy);
-    const { resolveEdition } = await loadEdition();
-    await resolveEdition("http://127.0.0.1:80", "Bearer secret");
+    const { resolveAppHarness } = await loadEdition();
+    await resolveAppHarness("http://127.0.0.1:80", "Bearer secret");
     const init = fetchSpy.mock.calls[0][1] as { headers: Record<string, string> };
     expect(init.headers.authorization).toBe("Bearer secret");
+  });
+});
+
+describe("resolveEdition — it never asks the device itself", () => {
+  it("makes no request even on the unlocked dual SKU", async () => {
+    // ONE PROBE PER STARTUP. `main()` resolves the APP harness (which does ask)
+    // and hands the answer here, so the tool set and the app list cannot come
+    // from two different replies: a dual box whose first probe said `hermes`
+    // and whose second timed out registered the Hermes tool set beside an app
+    // list that hid both dashboards, for the life of that stdio child.
+    writeLock("CLAWBOX_EDITION=dual\n");
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    const { resolveEdition } = await loadEdition();
+    expect(resolveEdition("hermes")).toBe("hermes");
+    expect(resolveEdition(null)).toBe("openclaw");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("still fails CLOSED on an unreadable lock, whatever the device said", async () => {
+    // The two questions differ HERE, which is why they are two functions: the
+    // app list may take the device's word for an unreadable lock (the desktop
+    // does), but the TOOL SET must not — OpenClaw is the larger surface and
+    // carries the shell and file tools.
+    writeLock("GARBAGE\n");
+    const { resolveEdition } = await loadEdition();
+    expect(resolveEdition("openclaw")).toBe("hermes");
+  });
+});
+
+describe("resolveAppHarness — an unreadable lock still asks the device", () => {
+  it("takes the device's answer rather than hiding apps the box has", async () => {
+    // /setup-api/harness/active ALWAYS answers: getActiveHarness() falls back
+    // through readEdition(), whose default for an unreadable lock is
+    // "openclaw". So the desktop grid shows twelve apps while this returned
+    // null and the agent was told three of them could not be placed — the two
+    // surfaces disagreeing in exactly the state this PR is about.
+    writeLock("GARBAGE\n");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ active: "openclaw" }),
+    }));
+    const { resolveAppHarness } = await loadEdition();
+    await expect(resolveAppHarness("http://127.0.0.1:80", null)).resolves.toBe("openclaw");
+  });
+
+  it("is null only when the device does not answer either", async () => {
+    writeLock("GARBAGE\n");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("connection refused")));
+    const { resolveAppHarness } = await loadEdition();
+    await expect(resolveAppHarness("http://127.0.0.1:80", null)).resolves.toBeNull();
   });
 });
 

--- a/src/tests/unit/mcp-served-model-honesty.test.ts
+++ b/src/tests/unit/mcp-served-model-honesty.test.ts
@@ -50,6 +50,7 @@ import { registerOrientationTools } from "../../../mcp/tools/orientation";
 const ctx = (edition: "openclaw" | "hermes", install: McpContext["install"] = edition): McpContext => ({
   edition,
   install,
+  appHarness: edition,
   profile: "full",
   capabilities: { screenGrabber: null, imageConvert: false, journal: false, du: false },
   providers: ["clawai", "openai"],

--- a/src/tests/unit/mcp-served-model-honesty.test.ts
+++ b/src/tests/unit/mcp-served-model-honesty.test.ts
@@ -269,9 +269,10 @@ describe("device_status — the same honesty on the orientation tool", () => {
   });
 
   it("does not claim the default is this chat's model on a DUAL box, where the edition may be a fallback", async () => {
-    // `resolveEdition` asks /setup-api/harness/active with a 3 s timeout and
-    // answers "openclaw" on any failure — and this server starts with the
-    // harness, exactly when the web app may not be up. On a locked SKU that
+    // `resolveAppHarness` asks /setup-api/harness/active with a 3 s timeout and
+    // hands the answer to `resolveEdition`, which takes "openclaw" for a `dual`
+    // box that did not answer — and this server starts with the harness,
+    // exactly when the web app may not be up. On a locked SKU that
     // cannot be wrong; on dual it can, and the affirmative note would tell a
     // HERMES chat to answer "which model are you" from the device default,
     // which is the whole defect TASK-648 opened for.

--- a/src/tests/unit/mcp-skills-edition-guard.test.ts
+++ b/src/tests/unit/mcp-skills-edition-guard.test.ts
@@ -124,6 +124,7 @@ describe("the edition guards — a refusal has to be tellable from a missing id"
 const ctx = (edition: "openclaw" | "hermes"): McpContext => ({
   edition,
   install: edition,
+  appHarness: edition,
   profile: "full",
   capabilities: { screenGrabber: null, imageConvert: false, journal: false, du: false },
   providers: [],

--- a/src/tests/unit/mcp-skills-lock-id.test.ts
+++ b/src/tests/unit/mcp-skills-lock-id.test.ts
@@ -92,6 +92,7 @@ const BUILTIN: Row = { id: "pdf", name: "pdf", origin: "builtin", category: "doc
 const ctx = (edition: "openclaw" | "hermes"): McpContext => ({
   edition,
   install: edition,
+  appHarness: edition,
   profile: "full",
   capabilities: { screenGrabber: null, imageConvert: false, journal: false, du: false },
   providers: [],

--- a/src/tests/unit/mcp-tool-honesty.test.ts
+++ b/src/tests/unit/mcp-tool-honesty.test.ts
@@ -78,6 +78,7 @@ const ctx = (
 ): McpContext => ({
   edition,
   install: edition,
+  appHarness: edition,
   profile: "full",
   capabilities: { screenGrabber: null, imageConvert: false, journal: false, du: false },
   providers,

--- a/src/tests/unit/mcp-tool-honesty.test.ts
+++ b/src/tests/unit/mcp-tool-honesty.test.ts
@@ -875,7 +875,7 @@ describe("ai_set_provider is not a one-way door", () => {
       providers: [{ id: "zai", authenticated: true }, { id: "openai", authenticated: false }],
     });
 
-    const built = await buildContext("hermes", "hermes", "full");
+    const built = await buildContext("hermes", "hermes", "full", "hermes");
     expect(built.providers).toContain("auto");
     expect(built.providers).toContain("zai");
     expect(built.providers).not.toContain("openai");
@@ -889,7 +889,7 @@ describe("ai_set_provider is not a one-way door", () => {
       providers: [{ id: "clawlocal", authenticated: true }],
     });
 
-    const built = await buildContext("hermes", "hermes", "full");
+    const built = await buildContext("hermes", "hermes", "full", "hermes");
     expect(built.providers).toEqual(["clawlocal"]);
   });
 });

--- a/src/tests/unit/mcp-wifi-status.test.ts
+++ b/src/tests/unit/mcp-wifi-status.test.ts
@@ -35,6 +35,7 @@ const ETH_DOWN = { connected: false, cable: false, iface: null };
 const CTX = {
   edition: "openclaw",
   install: "openclaw",
+  appHarness: "openclaw",
   profile: "full",
   capabilities: { screenGrabber: null, imageConvert: false, journal: false, du: true },
   providers: [],


### PR DESCRIPTION
**TASK-541** — Hermes: `ui_open_app` and `ui_list_apps` deny four apps that exist on the desktop.

## Customer-visible symptom

On a Hermes box the agent is told its own dashboard does not exist. `ui_open_app("hermes")` answers `NOT_FOUND` — *"There is no such app on this ClawBox"* — for the window `src/app/page.tsx` declares and pins on the shelf. Same for the chat window (`clawbox`), ClawKeep and System Update, on **both** editions. `ui_list_apps` never mentions them either, so a small model has no way to recover: it asks for the list, the list is short, and the app the owner is looking at is not in it.

## Cause

`mcp/lib/context.ts` kept a hand-written copy of the built-in app list (`COMMON_APPS` / `OPENCLAW_ONLY_APPS` / `HERMES_ONLY_APPS`) and it had drifted from the desktop registry `src/lib/desktop-apps.ts`. `mcp/tools/desktop.ts` gates `ui_open_app` on exactly that list. The per-edition gate was written out a **third** and **fourth** time as well — `src/app/page.tsx:104-105` and `src/app/app/[id]/page.tsx:36-37`, the latter in a different order — which is what let one surface hide an app another shows.

## Harness-first

Nothing here belongs to OpenClaw or Hermes: the desktop app registry is ClawBox's own (`src/lib/desktop-apps.ts`), and it already existed. The fix reads it instead of re-declaring it. The one thing that could not be reused directly is the registry module itself — it reaches React through the `@/` alias, which `mcp/tsconfig.json` exists to keep out of the MCP's stdio process — so the edition gate moved to a new dependency-free `src/lib/desktop-app-editions.ts` that all four surfaces import, and the MCP's per-app description table is held against the registry by a unit test. Adding a desktop app without a line in that table now fails CI.

## RED (on unmodified beta, `08e7057d`)

```
 FAIL  |unit| src/tests/unit/mcp-desktop-apps.test.ts > offers the Hermes dashboard, chat, ClawKeep and System Update on Hermes
AssertionError: ui_open_app must accept "hermes" on Hermes: expected [ 'settings', 'terminal', …(5) ] to include 'hermes'

 FAIL  |unit| src/tests/unit/mcp-desktop-apps.test.ts > offers chat, ClawKeep and System Update on OpenClaw
AssertionError: ui_open_app must accept "clawbox" on OpenClaw: expected [ 'settings', 'terminal', …(7) ] to include 'clawbox'

 FAIL  |unit| src/tests/unit/mcp-desktop-apps.test.ts > lists exactly the desktop registry, edition-gated, in registry order
- Expected
+ Received
  [ "settings", - "clawbox", - "hermes", - "hermes-skills", "terminal", - "coding",
    "files", - "clawkeep", - "system_update", "browser", "vnc", + "coding", + "hermes-skills" ]

 Test Files  1 failed (1)
      Tests  3 failed | 2 passed (5)
```

## Device proof (read-only, Hermes box on beta head `08e7057d`)

The box's own CLI, which reads the same `builtInApps()`:

```
Built-in apps (hermes edition):
  settings — Settings
  terminal — Terminal
  files — Files
  browser — Browser Setup
  vnc — Remote Desktop
  coding — Coding Agent
  hermes-skills — Hermes Skills
```

Seven rows. `hermes`, `clawbox`, `clawkeep` and `system_update` are the four missing ones. No box was mutated.

## GREEN

`src/tests/unit/mcp-desktop-apps.test.ts` 12/12; `--project unit` 567 files / 8956 tests; `--project components` 132 files / 1204 tests (three files flake under a loaded full-project run on the dev PC — `app-store-errors`, `chat-email-refs-surfaces`, `chat-attachment-staging`, plus `chat-spoken-reply` on an earlier run — all 16/16 when run together on their own, none touching this diff); `tsc --noEmit` clean; `eslint` clean on the changed files. `typecheck:mcp` reports the same 3 pre-existing errors as beta (`chat-history-cache.ts:72,74`, `harness/transport.ts:26` — DOM globals absent from that project), none from this branch.

## Review findings applied (Opus pass)

- **HIGH** — `system_update` was the one advertised id the tool's own validator refused: `/^(installed-)?[a-z0-9][a-z0-9-]{0,63}$/` allows no underscore, so `ui_open_app("system_update")` answered `BAD_ARGUMENT` *"that is not a valid app id"* and pointed the agent back at the list the id came from. The TASK-541 defect one layer down. Built-ins are gated on **membership** now; the shape check survives only as the injection guard on an `installed-<id>` the caller invented. The test walks every id `builtInApps()` returns through the handler, which is the assertion that makes it unrepeatable.
- **MEDIUM** — `hermes` and `openclaw` are `type: "external"`: the desktop opens them with `window.open()` from a KV **poll**, with no user gesture, so a popup blocker drops them silently. `ui_open_app` no longer claims they opened — it says it asked and to look at the screen. The flag mirrors the registry and the test holds the two together.
- **MEDIUM** — the `clawbox` description said "this conversation". `ChatApp` binds the device's MAIN session key, so an agent reached over Telegram would have told the owner their thread was on screen. Reworded.
- **MEDIUM** — `config/clawbox-workspace-guide.md` (seeded into the agent's own `CLAWBOX.md`) listed `chat`, an id that does not exist, and none of the apps this PR adds. It now sends the agent to `ui_list_apps`, which after this PR is edition-accurate. **Overlaps PR #612**, which also edits this file — this branch is based on fresh `origin/beta` and touches one table row.
- **LOW** — sibling call site: `clawbox app open <id>` wrote the pending action for any string and printed a tick — a false success for a typo, for an installed id missing its prefix, and for the other harness's apps. Same gate applied.
- **LOW** — `hiddenAppIdsForHarness` (active harness, may be `null` or `"dual"`, both fail closed) and `appExistsOnEdition` (already-resolved edition) now share one ternary and say which is which; `HARNESS_ONLY_APP_IDS` is exported instead of rebuilt in the page.

## Not done, and why

The reviewer asked for `ui_open_app("hermes")` to be raised on the monitor of a real box before merge. That writes a pending action and opens a browser tab on the box the owner is actively using, so it is a mutation and I did not run it — the fix here is to stop claiming success on that path, which needs no such proof. **Popup-blocker behaviour unproven on hardware.**

Both editions: the app set is per-edition throughout, and the same test walks both.



---

# Finishing round (2026-09-04)

The gate cleared `b31e2b16` as MERGE-OK but named a NEW false failure this branch had
introduced, and a second pass on the fix found one more. Findings:
`code-review-pr627-final.md` (1 MEDIUM, 2 LOW) and `code-review-pr627-final2.md`
(1 MEDIUM, 4 LOW, 4 INFO).

## R1 (MEDIUM) — `clawbox app open hermes` was refused on a dual box running Hermes

`installEdition()` answers **three** values — the premium `dual` SKU carries both harnesses —
and the new CLI gate branched two ways, so `dual` fell into the `openclaw` arm. On beta that
command wrote the KV action and the desktop opened the dashboard; on `b31e2b16` it exited 1 with
*"No built-in app "hermes" on this ClawBox"* and a remedy list that omits it — TASK-541's own
symptom, one surface over, while the MCP tool on the same box resolved `dual` correctly.

**RED** (baseline is the branch head `b31e2b16`, not beta — the defect is the branch's own; the
new test drives the real CLI against a stub device):

```
 ❯ src/tests/unit/mcp-cli-app-gate.test.ts (8 tests | 2 failed)
     × opens the Hermes dashboard on a dual box that is running Hermes
     × lists the Hermes apps on a dual box that is running Hermes

AssertionError: No built-in app "hermes" on this ClawBox. Try: settings, clawbox, openclaw,
terminal, coding, files, clawkeep, memory-shard, system_update, store, browser, vnc
: expected 1 to be +0
AssertionError: expected 'Built-in apps (dual edition):\n  sett…' to contain 'hermes —'
```

## …and the fix's own regression, found by the second pass

Routing the CLI through `resolveEdition()` imported an answer it did not have before.
`resolveEdition` resolves an unreadable `/etc/clawbox/edition.env` to **hermes**, and that is
correct for a TOOL SET: hermes is openclaw minus the shell and file tools, so an unreadable lock
must not widen the surface. **App sets are not nested.** On a box with a degraded lock the gate
then refused `store`, `openclaw` and `memory-shard` — apps the box has — *and* printed a tick
over `hermes`, which the desktop drops. A `dual` box whose web server was restarting got the
mirror image: told as a durable fact that it has no dashboard, on a default that was never
verified.

`resolveAppHarness()` is that question asked separately: a locked edition decides on its own,
only `dual` asks the device, and anything undetermined is **null**. Null hides BOTH harness-only
sets — the answer `hiddenAppIdsForHarness(null)` already gives the desktop while its own fetch is
in flight — and both surfaces say which harness could not be determined instead of "there is no
such app". `ui_open_app` reads the same answer, so it no longer advertises in its own description
an app it would refuse. The MCP's tool-registration notice stays where it belongs: a
`clawbox app list` registers nothing and no longer prints it.

**RED** for that half, same file:

```
     × refuses BOTH harnesses' own apps rather than guessing one
     × lists neither harness's own apps, and says why
     × does not report a harness it never resolved when the device cannot answer
     × prints nothing about registering a tool set
```

## R2 (LOW) — the CLI had no test at all

`grep -rn "clawbox-cli" src/tests/` returned nothing before this round: 37 new lines of gate, and
the whole file, unverified. `src/tests/unit/mcp-cli-app-gate.test.ts` runs the real binary the way
the agent does — an in-process stub device on port 0, its own edition lock and token, async spawn
(a `spawnSync` version deadlocked against its own server) — and pins the pair: *a list that offers
what `open` refuses is the false success the gate exists for*. It skips where `bun` does not
resolve, and says so out loud in CI rather than going quiet.

## R3 (LOW) — `INSTALLED_APP_ID_RE`

Widened to accept a leading `_`, which both producers create. The remaining difference — an id
over 64 characters, which the store's `SLUG` does not bound — is the cap doing its job, and the
docstring now says which shapes it still refuses and why.

## R5 (LOW) — an installed app the desktop would not open still got a tick

Both gates checked `installed_apps` alone, while the desktop admits an installed app only when
`isInstalledAppVisible(meta, activeHarness)` — a store-installed OpenClaw skill is unusable on
Hermes, its window shells out to the openclaw binary. So `ui_open_app("installed-<skill>")` on a
Hermes box answered *"Opened <name> on the desktop"* over a window that never appeared. That
predicate moves next to the harness gate in `src/lib/desktop-app-editions.ts` and all three
surfaces read the one copy; both gates now read `installed_meta` in the same preferences call.
Removing such an app is still allowed — that is the owner's to do on either harness.

## R3 of the second pass (LOW) — the e2e was the sibling call site

`e2e-install/35-mcp.spec.ts` anchored on `^Built-in apps \(<edition> edition\):` and branched its
app assertions on `clawbox edition`. Neither is right for `dual`, where the header now carries the
running harness. Not a live break — `e2e-install` builds an openclaw image — but the comment
taught the rule this round removed.

## Sibling sweep — every two-way branch on a three-valued edition

- `mcp/clawbox-cli.ts` `clawbox update` — `installEdition() === "hermes"` refuses. **Correct for
  dual**: that SKU has the OpenClaw gateway, and `install.sh` reads the RECORDED edition when
  `CLAWBOX_EDITION` is unset (`install.sh:455`), so re-running it on a dual box installs dual.
- `mcp/clawbox-mcp.ts:133` / `clawbox edition` — pass the raw three-valued answer through. Correct.
- `readEdition()`'s consumers — `middleware.ts`, `openclaw-config.ts`, `setup/reset`,
  `[...gateway]` — all ask "is OpenClaw absent", which is `hermes` only. Correct for dual.
- `updater.ts`, `pets/route.ts` — use `hasHermesHarness()` (hermes **or** dual). Correct.

No other surface gives `dual` the wrong arm.

## GREEN (rebased head)

`--project unit` **603 files / 9641 tests** (1 skipped: the CI-only bun guard);
`--project components` 135 files / 1270 tests; `tsc --noEmit` clean; `tsc -p mcp/tsconfig.json`
reports only the 3 errors it reported before this branch, in two files it does not touch;
`eslint` 0 errors. Rebased on `origin/beta` `a3faafc4`; `git diff --stat origin/beta...HEAD`
lists the 22 intended files and `--diff-filter=DR` is empty.

## Follow-up, not taken here

On the `dual` SKU the MCP resolves the app harness once when its child spawns, while the CLI
resolves it per invocation — so a harness switched mid-session (which deliberately does not bounce
the other gateway) leaves `ui_open_app` on the old answer until the next restart. Pre-existing and
now stated in `mcp/lib/context.ts` and `mcp/tools/desktop.ts`; closing it means re-resolving inside
the handler on dual, which wants its own card and a dual-box device test.

## Unproven

No device leg: this change is CLI and MCP surface only, and both are exercised end to end by the
new unit test against a stub device plus `e2e-install`'s own `clawbox app list` check. Nothing was
mutated on a box.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App availability now adapts to the active desktop edition, hiding incompatible apps.
  * Installed web apps remain discoverable where supported, while incompatible installed skills are hidden.
  * Browser-based apps indicate that they open in a new tab and may be affected by popup blocking.
  * App listings and opening now account for dual-edition installations and active harness status.

* **Bug Fixes**
  * Invalid, unavailable, cross-edition, or malformed app IDs now return an error.
  * Built-in apps with underscore-based IDs can now be opened correctly.

* **Documentation**
  * Updated app-opening guidance covering discovery, availability, chat access, and browser setup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Rounds 4 and 5 — the six review threads, and the one my own fix created

All six CodeRabbit threads are answered in-thread and resolved. Three were real defects,
three were robustness; and a review round then found that one of my answers was itself
wrong, which is the most important item here.

### One question must not have three answers — including the sentence

`clawbox app open hermes` printed `✅ Opening hermes on desktop.` for an app the desktop
opens with `window.open()` from its POLL of `ui:pending-actions` — where a popup blocker
drops the tab with nothing to report back — while `ui_open_app` had just been taught to
hedge about exactly that. A false success on the one path the agent cannot see.

The sentence now lives in `openedAppNotice` (`mcp/lib/context.ts`), beside the `external`
flag it depends on. The first pass wired it on the external branch only, so half the
function that exists to stop drift was dead and the ordinary wording could still diverge;
both branches go through it now, with the tick as presentation (`openedAppLine`), pinned
by a test that compares the two surfaces string for string.

### What can be OPENED must be REMOVABLE — and BUILT, and DELETED

`app_uninstall` still took `zSlug` while this branch widened opening to the producers'
alphabet, so an id the device mints (`Foo_Bar`, `_drafts`) could be created, listed and
opened but not deleted — the schema refused the call before `installedAppIds(null)`, which
this same branch made deliberately unfiltered *so that removal always works*, could run.

`mcp/lib/schema.ts` builds both spellings from one source string. The review then found
the same gap one family over: `webapp_update`, `code_project_build` and
`code_project_delete` refused an id their own routes mint under `APP_ID_RE` and
`code_project_list` reports "with the id each one is built and deleted by". Those three
are widened too. `webapp_create` / `code_project_init` stay narrow: constraining what the
agent MINTS is a choice; refusing what the device already made is a defect.

### One probe, two answers

A dual box put **two** requests to `/setup-api/harness/active` at every MCP startup, each
with its own 3 s timeout, and the two collapse a silence in opposite directions by design.
Probe 1 saying `hermes` and probe 2 timing out registered the Hermes tool set beside an
app list that hid both dashboards, for the life of that stdio child.

`main()` probes once and hands the answer down; `resolveEdition` is **synchronous** and
takes the resolved harness, which is what makes a second probe impossible rather than
merely unlikely.

### The one I got wrong, and how

CodeRabbit's LOW on the unreadable edition lock said the app gate answered "could not say
which harness" while the desktop asked the device and got an answer. I fixed it by asking
the device too. **That was wrong**, and the next review round traced why:

```
GET /setup-api/harness/active
  -> getActiveHarness()   (src/lib/harness.ts:117)
  -> lockedHarness()      (:82)   isDualUnlocked() false, because readEdition() fell back
  -> getEdition() -> readEdition()  (src/lib/edition-source.ts:65)
  -> "openclaw"           its own default
```

On an unreadable lock that route is **not an independent oracle** — it is the same file
this process just failed to read, and it can only ever answer `openclaw`, on a Hermes box
as readily as on an OpenClaw one. Taking it would have registered the Hermes TOOL SET
(fail-closed, correctly) beside an OpenClaw APP list: `ui_open_app("hermes-skills")` →
*"There is no such app on this ClawBox"* — TASK-541's original symptom, verbatim — and
`openclaw` and `store` ticked off on a box that has neither.

Reverted, with the trace written into the code, and the two tests restored to the
invariant they were pinning: **never advertise a harness-only app whose harness was not
established**. Asking is right for `dual`, where the device resolves a real runtime choice
from the config store; it is wrong here, and the difference is exactly whether the device
knows something this process does not.

The desktop grid *does* show twelve apps in that state, which is its own pre-existing
over-confidence rather than a reason for the agent to copy it. **Not fixed here** — it
wants the route to report whether the harness is actually known (a `source`/`locked`
field), which is a route + desktop change and a separate PR.

What the revert leaves is the honest wording, which was the other half of the same
finding: `ui_open_app` said *"there is no such app"* where the CLI says *"could not say
which harness"* — and the CLI's own comment says why that matters: it tells the agent as a
durable fact that the box has no dashboard, which is how it stops asking. Both surfaces
say the same sentence from one constant now, and `ui_list_apps` carries it too instead of
silently dropping five apps.

### The two robustness threads, and the product defect behind them

The spawn helper could not time out, so a wedged child outlived the run it failed: fixed
with a per-spawn `SIGKILL` timer, and every multi-spawn test now derives its budget from
its spawn count (a 4 s per-child ceiling under a 5 s framework default only ever protected
a single-spawn test). More to the point, fixing it only in the harness left the real defect
standing: `mcp/clawbox-cli.ts`'s `api()` had **no fetch timeout at all**, so on a device
with a wedged web server `clawbox app open` hangs forever in the agent's shell with no
output, while every other client already carried an `AbortSignal.timeout`. The CLI has one
now.

### Harness-first

Nothing here re-implements a harness mechanism. The active harness is read from the
device's own `/setup-api/harness/active`, the built-in app list from
`src/lib/desktop-apps.ts` rather than a second copy, and the edition from the root-owned
lock through `readEdition()`. The finding above is the inverse problem — *over*-trusting a
native route that had no independent answer to give.

### RED → GREEN

Every behavioural change was run against the unmodified previous head. Seven fail there
and pass here:

```
 × answers null without a request, because the route would only echo the default
 × lets an id it can LIST also be UPDATED, BUILT and DELETED
 × says the harness is UNDETERMINED, not that the app does not exist
 × says so in ui_list_apps too, rather than silently dropping five apps
 × refuses BOTH harnesses' own apps rather than guessing one
 × lists neither harness's own apps, and says why
 × says the SAME SENTENCE ui_open_app says, on both branches
 Test Files  3 failed (3)
      Tests  7 failed | 50 passed | 1 skipped (58)
```

GREEN on this head:

```
npx vitest run --project unit mcp-cli-app-gate mcp-desktop-apps mcp-tool-honesty \
  mcp-skills-edition-guard mcp-code-project-paths mcp-served-model-honesty \
  mcp-skills-lock-id mcp-wifi-status mcp-edition
 Test Files  9 passed (9)
      Tests  198 passed | 1 skipped (199)

npx tsc --noEmit                        # clean
npx tsc -p mcp/tsconfig.json --noEmit   # the 3 known pre-existing errors only
```

Full unit project: **630 files / 9969 passed**, 1 skipped (the CI-only bun guard).

### Sibling call sites

Every `buildServer` caller passes the new third argument (`mcp/check-tools.ts` passes the
edition it is walking). `buildContext`'s `appHarness` is **required** now — the `= edition`
default was the wrong answer by this module's own argument and would have been silent.
Every `resolveEdition` / `resolveAppHarness` caller is on the new form;
`src/lib/client-harness.ts`'s same-named browser-side function is unrelated and untouched.
`INSTALLED_APP_ID_RE` and `RAW_INSTALLED_APP_ID_RE` come from one source string. Every
`zSlug` that guards an id a *route* mints is widened; the ones that guard an id the agent
mints through the same tool are deliberately left. `mcp/README.md`, the two comments naming
`resolveEdition` as the asker, and the "verified safe" import list are corrected.

### Device leg

**Unproven on hardware.** This change is MCP/CLI-side and fully exercised by CI (the CLI
gate suite spawns the real binary against a stub device, and `e2e-install` walks
`clawbox app list` on a built image). No box was touched — the owner is testing on both.
