### PR TITLE
refactor: name the coding family's edition list for what it holds (TASK-549)

### DIFF
--- a/mcp/tools/coding.ts
+++ b/mcp/tools/coding.ts
@@ -198,12 +198,9 @@ async function readCapped(res: Response, maxBytes: number): Promise<string> {
 }
 
 export function registerCodingTools(reg: Registrar): void {
-  // The editions this family registers on: OpenClaw ONLY, for the three
-  // reasons at the top of this file. CLAWBOX_MCP_CODING_TOOLS=1 widens it to
-  // Hermes for debugging and is set nowhere in the repo — no unit, no install
-  // step, no package script — so every shipped device takes the first branch.
-  // It used to be called `both`, which read as "both editions" at all twelve
-  // registration sites while meaning the opposite (TASK-549).
+  // OpenClaw only — the three reasons are at the top of this file.
+  // CLAWBOX_MCP_CODING_TOOLS=1 widens it to Hermes for debugging, and is set on
+  // no shipped device.
   const codingEditions: ("openclaw" | "hermes")[] =
     process.env.CLAWBOX_MCP_CODING_TOOLS === "1" ? ["openclaw", "hermes"] : ["openclaw"];
 

--- a/mcp/tools/coding.ts
+++ b/mcp/tools/coding.ts
@@ -198,7 +198,13 @@ async function readCapped(res: Response, maxBytes: number): Promise<string> {
 }
 
 export function registerCodingTools(reg: Registrar): void {
-  const both: ("openclaw" | "hermes")[] =
+  // The editions this family registers on: OpenClaw ONLY, for the three
+  // reasons at the top of this file. CLAWBOX_MCP_CODING_TOOLS=1 widens it to
+  // Hermes for debugging and is set nowhere in the repo — no unit, no install
+  // step, no package script — so every shipped device takes the first branch.
+  // It used to be called `both`, which read as "both editions" at all twelve
+  // registration sites while meaning the opposite (TASK-549).
+  const codingEditions: ("openclaw" | "hermes")[] =
     process.env.CLAWBOX_MCP_CODING_TOOLS === "1" ? ["openclaw", "hermes"] : ["openclaw"];
 
   // ── bash ─────────────────────────────────────────────────────────────────
@@ -214,7 +220,7 @@ export function registerCodingTools(reg: Registrar): void {
       cwd: zOptText(300, "Folder to run in. Defaults to the ClawBox home folder."),
       allow_dangerous: zBool(false, "Override the block on destructive commands. Only set it when the user asked for exactly this."),
     },
-    { editions: both, readOnly: false, destructive: true, maxChars: BIG_OUTPUT },
+    { editions: codingEditions, readOnly: false, destructive: true, maxChars: BIG_OUTPUT },
     async ({
       command,
       description,
@@ -282,7 +288,7 @@ export function registerCodingTools(reg: Registrar): void {
       // Floor 1: "just show me the last line" must not be a schema rejection.
       tail: zInt(1, 500, 100, "How many of the most recent output lines to return."),
     },
-    { editions: both, readOnly: true, maxChars: BIG_OUTPUT },
+    { editions: codingEditions, readOnly: true, maxChars: BIG_OUTPUT },
     async ({ job_id, tail }: { job_id: string; tail: number }) => {
       const job = getJob(job_id);
       if (!job) {
@@ -307,7 +313,7 @@ export function registerCodingTools(reg: Registrar): void {
     "job_stop",
     "Stop a background job that bash started and that is still running. Its output up to that point stays readable with job_status.",
     { job_id: zText(40, "The job id bash returned, e.g. \"job-1\".") },
-    { editions: both, readOnly: false },
+    { editions: codingEditions, readOnly: false },
     async ({ job_id }: { job_id: string }) => {
       const job = getJob(job_id);
       if (!job) {
@@ -332,7 +338,7 @@ export function registerCodingTools(reg: Registrar): void {
       offset: zInt(0, 1_000_000, 0, "First line to return, counting from 0."),
       limit: zInt(1, 5_000, 2_000, "How many lines to return."),
     },
-    { editions: both, readOnly: true, maxChars: BIG_OUTPUT },
+    { editions: codingEditions, readOnly: true, maxChars: BIG_OUTPUT },
     async ({ file_path, offset, limit }: { file_path: string; offset: number; limit: number }) => {
       const abs = resolveUserPath(file_path);
       assertPathAllowed(abs);
@@ -435,7 +441,7 @@ export function registerCodingTools(reg: Registrar): void {
       file_path: zText(4_000, "Path to the file. Absolute, starting with ~, or relative to the ClawBox project folder."),
       content: zText(2_000_000, "The complete new contents of the file."),
     },
-    { editions: both, readOnly: false, destructive: true },
+    { editions: codingEditions, readOnly: false, destructive: true },
     async ({ file_path, content }: { file_path: string; content: string }) => {
       const abs = resolveUserPath(file_path);
       assertPathAllowed(abs);
@@ -480,7 +486,7 @@ export function registerCodingTools(reg: Registrar): void {
       new_text: zMaybeEmptyText(100_000, "The replacement text. Use an empty string to delete the old text."),
       replace_all: zBool(false, "Replace every occurrence instead of requiring exactly one."),
     },
-    { editions: both, readOnly: false },
+    { editions: codingEditions, readOnly: false },
     async ({
       file_path,
       old_text,
@@ -542,7 +548,7 @@ export function registerCodingTools(reg: Registrar): void {
     "list_directory",
     "List what is inside a folder on the ClawBox: folders first, then files. Use glob when you are looking for files by name across many folders. Folders holding device credentials are not listed.",
     { path: zOptText(4_000, "Folder to list. Defaults to the ClawBox project folder.") },
-    { editions: both, readOnly: true, maxChars: 8_000 },
+    { editions: codingEditions, readOnly: true, maxChars: 8_000 },
     async ({ path }: { path?: string }) => {
       const abs = path ? resolveUserPath(path) : DEFAULT_CWD;
       assertPathAllowed(abs);
@@ -570,7 +576,7 @@ export function registerCodingTools(reg: Registrar): void {
       pattern: zText(200, "Name pattern, e.g. \"**/*.ts\"."),
       path: zOptText(4_000, "Folder to search under. Defaults to the ClawBox project folder."),
     },
-    { editions: both, readOnly: true, maxChars: 8_000 },
+    { editions: codingEditions, readOnly: true, maxChars: 8_000 },
     async ({ pattern, path }: { pattern: string; path?: string }) => {
       const dir = path ? resolveUserPath(path) : DEFAULT_CWD;
       assertPathAllowed(dir);
@@ -613,7 +619,7 @@ export function registerCodingTools(reg: Registrar): void {
       max_results: zInt(1, 500, GREP_LIMIT, "Most output lines to return."),
       offset: zInt(0, 10_000, 0, "Skip this many results before returning any."),
     },
-    { editions: both, readOnly: true, maxChars: BIG_OUTPUT },
+    { editions: codingEditions, readOnly: true, maxChars: BIG_OUTPUT },
     async ({
       pattern,
       path,
@@ -716,7 +722,7 @@ export function registerCodingTools(reg: Registrar): void {
       new_source: zOptText(200_000, "The new cell contents. Required for replace and insert."),
       cell_type: zEnumOf(["code", "markdown"], "Type of the cell to insert.").default("code"),
     },
-    { editions: both, readOnly: false },
+    { editions: codingEditions, readOnly: false },
     async ({
       notebook_path,
       cell_index,
@@ -786,7 +792,7 @@ export function registerCodingTools(reg: Registrar): void {
       accept: zOptText(200, "Optional Accept header, e.g. \"application/json\"."),
       accept_language: zOptText(100, "Optional Accept-Language header, e.g. \"en\"."),
     },
-    { editions: both, readOnly: true, openWorld: true, maxChars: BIG_OUTPUT },
+    { editions: codingEditions, readOnly: true, openWorld: true, maxChars: BIG_OUTPUT },
     async ({
       url,
       max_length,
@@ -855,7 +861,7 @@ export function registerCodingTools(reg: Registrar): void {
       max_results: zInt(1, 20, 10, "How many results to return."),
       allowed_domains: zOptText(300, "Comma-separated list of domains to restrict results to, e.g. \"github.com,python.org\"."),
     },
-    { editions: both, readOnly: true, openWorld: true, maxChars: 8_000 },
+    { editions: codingEditions, readOnly: true, openWorld: true, maxChars: 8_000 },
     async ({ query, max_results, allowed_domains }: { query: string; max_results: number; allowed_domains?: string }) => {
       let res: Response;
       try {

--- a/src/tests/unit/mcp-coding-family-editions.test.ts
+++ b/src/tests/unit/mcp-coding-family-editions.test.ts
@@ -1,0 +1,63 @@
+/**
+ * TASK-549 — the coding family's edition gate says what it means.
+ *
+ * `mcp/tools/coding.ts` computed its edition list into a local called `both`,
+ * and twelve registrations then read `{ editions: both }` — so the code said
+ * "both editions" at every site while the value is OpenClaw-only on every
+ * shipped device. The rename is cosmetic; what was NOT pinned anywhere in the
+ * unit suite is the behaviour behind it, which is why a rename could have
+ * changed it silently. `mcp/check-tools.ts` asserts a handful of these names
+ * are absent on Hermes, but that checker runs off no CI job (TASK-708) and
+ * needs a real device to probe.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { captureRegistrar } from "../helpers/mcp-registrar";
+import { registerCodingTools } from "../../../mcp/tools/coding";
+
+const CODING_TOOLS = [
+  "bash",
+  "job_status",
+  "job_stop",
+  "read_file",
+  "write_file",
+  "edit_file",
+  "list_directory",
+  "glob",
+  "grep",
+  "notebook_edit",
+  "web_fetch",
+  "web_search",
+];
+
+function namesOn(edition: "openclaw" | "hermes"): string[] {
+  const h = captureRegistrar(edition);
+  registerCodingTools(h.reg);
+  return h.names();
+}
+
+beforeEach(() => {
+  delete process.env.CLAWBOX_MCP_CODING_TOOLS;
+});
+
+describe("the coding family is OpenClaw-only", () => {
+  it("registers every tool on OpenClaw", () => {
+    expect(namesOn("openclaw").sort()).toEqual([...CODING_TOOLS].sort());
+  });
+
+  it("registers none of them on Hermes", () => {
+    expect(namesOn("hermes")).toEqual([]);
+  });
+
+  it("widens to Hermes only under the debugging override", () => {
+    process.env.CLAWBOX_MCP_CODING_TOOLS = "1";
+    expect(namesOn("hermes").sort()).toEqual([...CODING_TOOLS].sort());
+  });
+
+  it("treats any other value of the override as off", () => {
+    for (const value of ["", "0", "true", "yes"]) {
+      process.env.CLAWBOX_MCP_CODING_TOOLS = value;
+      expect(namesOn("hermes"), `CLAWBOX_MCP_CODING_TOOLS=${JSON.stringify(value)}`).toEqual([]);
+    }
+  });
+});

--- a/src/tests/unit/mcp-coding-family-editions.test.ts
+++ b/src/tests/unit/mcp-coding-family-editions.test.ts
@@ -6,12 +6,17 @@
  * "both editions" at every site while the value is OpenClaw-only on every
  * shipped device. The rename is cosmetic; what was NOT pinned anywhere in the
  * unit suite is the behaviour behind it, which is why a rename could have
- * changed it silently. `mcp/check-tools.ts` asserts a handful of these names
- * are absent on Hermes, but that checker runs off no CI job (TASK-708) and
- * needs a real device to probe.
+ * changed it silently.
+ *
+ * `mcp/check-tools.ts` does cover it — `OPENCLAW_ONLY` there lists all twelve
+ * and asserts both directions — but no CI workflow runs `check:mcp-tools`
+ * (TASK-708) and the checker needs a real device to probe. The twelve names
+ * below are therefore a deliberate second copy: keep them in step with
+ * `mcp/check-tools.ts` when a coding tool is added.
  */
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { saveEnv } from "../helpers/env";
 import { captureRegistrar } from "../helpers/mcp-registrar";
 import { registerCodingTools } from "../../../mcp/tools/coding";
 
@@ -36,11 +41,19 @@ function namesOn(edition: "openclaw" | "hermes"): string[] {
   return h.names();
 }
 
+let restoreEnv: () => void;
+
 beforeEach(() => {
+  restoreEnv = saveEnv("CLAWBOX_MCP_CODING_TOOLS");
   delete process.env.CLAWBOX_MCP_CODING_TOOLS;
 });
 
+afterEach(() => restoreEnv());
+
 describe("the coding family is OpenClaw-only", () => {
+  // The `full` profile throughout: none of the twelve declares a profile, so
+  // `CLAWBOX_MCP_PROFILE=core` drops them on OpenClaw too. captureRegistrar
+  // models the edition axis only, which is the axis this card is about.
   it("registers every tool on OpenClaw", () => {
     expect(namesOn("openclaw").sort()).toEqual([...CODING_TOOLS].sort());
   });


### PR DESCRIPTION
**TASK-549** — Cleanup: `mcp/tools/coding.ts` `both` is named the opposite of its default.

## Customer-visible symptom

None, and the card says so: *"Behaviour is correct — trivial rename."* This is a readability card the owner ruled to clear. What ships is a name that stops lying and the coverage that keeps the behaviour behind it from moving silently.

## Cause

`mcp/tools/coding.ts` computed its edition list into a local called `both`:

```ts
const both: ("openclaw" | "hermes")[] =
  process.env.CLAWBOX_MCP_CODING_TOOLS === "1" ? ["openclaw", "hermes"] : ["openclaw"];
```

Twelve registrations then read `{ editions: both }`, so every one of them says *"both editions"* while the value is `["openclaw"]` on every shipped device — `CLAWBOX_MCP_CODING_TOOLS` is a documented debugging override that no install step, unit, package script or `.env` sets. Renamed to `codingEditions`, all twelve sites, with the reason at the declaration.

## Harness-first

Nothing here is the harness's. The edition split is ClawBox's own, and the mechanism that already owns this contract is `mcp/check-tools.ts` — its `OPENCLAW_ONLY` list carries all twelve names and asserts both directions (absent on Hermes, present on OpenClaw). It is not re-implemented here; the new unit test exists because **no CI workflow runs `check:mcp-tools`** (TASK-708) and the checker needs a real device to probe, so nothing in CI held this gate. The twelve names in the test are a deliberate second copy of that list and the docblock says so.

## No RED, deliberately

There is no failing-on-beta output to paste and none should be claimed: the behaviour is already correct, which is exactly what the card reports. Verified rather than assumed — the new test file was run against unmodified `origin/beta` in a detached worktree:

```
 RUN  v4.1.11 …/red549
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

So the suite is a characterization test: it fails only if a future edit moves the gate. That is what a rename card can honestly deliver.

## GREEN

`src/tests/unit/mcp-coding-family-editions.test.ts` 4/4; all 27 `mcp-*` unit suites 446/446; `tsc --noEmit` clean; `eslint` clean. `typecheck:mcp` reports the same 3 pre-existing errors as beta, none from this branch.

## Sibling sweep

`grep` for the idiom across `mcp/` and `src/`: the only surviving `const both` in the repo is in `src/tests/unit/voice-output.test.ts` (TTS engines, unrelated). All four callers of `registerCodingTools` were checked — none passes or inspects the edition list. No other tool family computed its `editions` into a local.

## Review findings applied (Opus pass)

- **MEDIUM** — the first draft of the new comment named a branch position above a ternary and named the wrong one, reintroducing the inverted reading two lines below the sentence complaining about it. Removed; the comment says what the value *is*.
- **LOW** — it also claimed the override is "set nowhere in the repo — no unit, no install step, no package script", in the same commit that adds a test setting it three times. A comment one grep disproves decays exactly like the name this card removes. Trimmed to the durable claim.
- **LOW** — the test deleted `CLAWBOX_MCP_CODING_TOOLS` in `beforeEach` with no restore, and its last case left it set to `"yes"` for every file after it in that vitest worker. Now uses the repo's own `saveEnv` helper, which exists for this hazard.
- **LOW** — docblock corrected: `check-tools.ts` covers all twelve in both directions, not "a handful"; and the OpenClaw cases hold at the `full` profile (none of the twelve declares a profile, so `CLAWBOX_MCP_PROFILE=core` drops them there too).

## Also noted on the card, and REFUTED

The card adds: *"`src/components/ChatApp.tsx` is a full second chat implementation … It is imported nowhere, so it is dead today."* That is no longer true, and it matters. `src/app/app/[id]/page.tsx:19,199` renders it for `/app/clawbox` — the standalone chat window reached from "Open in new tab" — and two component suites cover it (`chat-inter-session-envelope`, `chat-email-refs-surfaces`). The card's second half of the claim survives: it talks straight to the OpenClaw gateway (`/setup-api/gateway/ws-config` → gateway WebSocket) with no `useHarnessAdapter`, and `clawbox` is not harness-gated, so `/app/clawbox` on a **Hermes** box renders a chat with no gateway behind it. That is a live defect rather than dead code, out of scope here, and recorded in the run's Found list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Coding tools are now available by default in the OpenClaw edition.
  - Coding tools can be enabled in the Hermes edition with the `CLAWBOX_MCP_CODING_TOOLS=1` setting.
  - Other setting values leave these tools disabled in Hermes.

- **Tests**
  - Added coverage to verify coding tool availability across editions and configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->