### PR TITLE
test: pin that a renamed box needs no Hermes allowed-origins update (TASK-553)

### DIFF
--- a/scripts/hermes-dashboard-proxy.js
+++ b/scripts/hermes-dashboard-proxy.js
@@ -157,8 +157,12 @@ const ALLOWED_HOSTS = new Set(
     .filter(Boolean),
 );
 
-// Single mDNS label — letters/digits/hyphens, no dots. Mirrors the same regex in
-// src/lib/gateway-proxy.ts so the two host checks can't drift apart.
+// Single mDNS label — letters/digits/hyphens, no dots. The REGEX is shared with
+// src/lib/gateway-proxy.ts (and with the rename route's own HOSTNAME_RE, so
+// every name a rename can produce is a label this accepts). The POLICY around
+// it deliberately is not the same: this proxy accepts any `<label>.local`
+// because nothing restarts it on a rename, while the gateway path reflects only
+// a configured or cached host. TASK-553.
 const MDNS_LABEL_RE = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 
 let cachedMdnsHost; // undefined = not computed yet, null = unusable hostname

--- a/src/app/setup-api/system/hostname/route.ts
+++ b/src/app/setup-api/system/hostname/route.ts
@@ -79,6 +79,21 @@ export async function POST(request: Request) {
   // unaffected either way, so this was never a false success — just litter,
   // and litter that makes `~/.openclaw` exist is the kind that misleads the
   // next person debugging an edition question.
+  //
+  // And Hermes needs no equivalent of its own — TASK-553 asked, and the answer
+  // is written down in src/tests/unit/hermes-dashboard-proxy-renamed-host.test.ts:
+  //   - Hermes 0.20.5 has no allowed-origins list to write. Its dashboard
+  //     guard (`_ws_host_origin_reason`, hermes_cli/web_server.py) compares
+  //     Host and Origin against `app.state.bound_host` and takes no
+  //     configuration. ClawBox binds the dashboard to 127.0.0.2 and
+  //     scripts/hermes-dashboard-proxy.js rewrites Host/Origin/Referer to that
+  //     authority, so the box's LAN name never reaches Hermes.
+  //   - The proxy's own DNS-rebind guard (`isAllowedHostname`) accepts any
+  //     well-formed `<label>.local` and any IP literal, so a renamed box works
+  //     the moment it is renamed — no list, no write, no restart.
+  // Measured read-only on the Hermes box at beta head: `Host: <newname>.local`
+  // answers 302 to the login page on the new name; `Host: evil.example.com`
+  // still answers 403.
   // Which half of the gateway leg failed, if either — the two need different
   // words, and one try around both would have blamed a gateway that was never
   // restarted for a failed origins write. `null` means nothing is outstanding:

--- a/src/app/setup-api/system/hostname/route.ts
+++ b/src/app/setup-api/system/hostname/route.ts
@@ -80,20 +80,11 @@ export async function POST(request: Request) {
   // and litter that makes `~/.openclaw` exist is the kind that misleads the
   // next person debugging an edition question.
   //
-  // And Hermes needs no equivalent of its own — TASK-553 asked, and the answer
-  // is written down in src/tests/unit/hermes-dashboard-proxy-renamed-host.test.ts:
-  //   - Hermes 0.20.5 has no allowed-origins list to write. Its dashboard
-  //     guard (`_ws_host_origin_reason`, hermes_cli/web_server.py) compares
-  //     Host and Origin against `app.state.bound_host` and takes no
-  //     configuration. ClawBox binds the dashboard to 127.0.0.2 and
-  //     scripts/hermes-dashboard-proxy.js rewrites Host/Origin/Referer to that
-  //     authority, so the box's LAN name never reaches Hermes.
-  //   - The proxy's own DNS-rebind guard (`isAllowedHostname`) accepts any
-  //     well-formed `<label>.local` and any IP literal, so a renamed box works
-  //     the moment it is renamed — no list, no write, no restart.
-  // Measured read-only on the Hermes box at beta head: `Host: <newname>.local`
-  // answers 302 to the login page on the new name; `Host: evil.example.com`
-  // still answers 403.
+  // Hermes needs no equivalent of its own either — TASK-553 asked, and the
+  // answer is no: neither Hermes nor its ClawBox proxy holds a list a rename
+  // could invalidate. The reasoning and the proof are in
+  // src/tests/unit/hermes-dashboard-proxy-renamed-host.test.ts.
+
   // Which half of the gateway leg failed, if either — the two need different
   // words, and one try around both would have blamed a gateway that was never
   // restarted for a failed origins write. `null` means nothing is outstanding:

--- a/src/tests/unit/hermes-dashboard-proxy-renamed-host.test.ts
+++ b/src/tests/unit/hermes-dashboard-proxy-renamed-host.test.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { createRequire } from "node:module";
 import http from "node:http";
 import net from "node:net";
+import type { Duplex } from "node:stream";
 import path from "node:path";
 import { createSessionCookie } from "@/lib/auth";
 
@@ -15,20 +16,33 @@ import { createSessionCookie } from "@/lib/auth";
  * equivalent runs on Hermes, and nothing needs to:
  *
  *   - Hermes 0.20.5 has no allowed-origins list to update. Its dashboard guard
- *     (`_ws_host_origin_reason` in hermes_cli/web_server.py) compares Host and
- *     Origin against `app.state.bound_host` — the address the dashboard was
- *     bound to — and takes no configuration. ClawBox binds it to 127.0.0.2 and
- *     the proxy rewrites Host/Origin/Referer to that authority, so the box's
- *     LAN name never reaches Hermes at all.
+ *     (`_ws_host_origin_reason` in hermes_cli/web_server.py, read on a v0.20.5
+ *     device 2026-09-04) compares Host and Origin against
+ *     `app.state.bound_host` — the address the dashboard was bound to — and
+ *     takes no configuration. ClawBox binds it to 127.0.0.2 and the proxy
+ *     rewrites Host/Origin/Referer to that authority, so the box's LAN name
+ *     never reaches Hermes at all.
  *   - The proxy's own guard (scripts/hermes-dashboard-proxy.js,
  *     `isAllowedHostname`) accepts ANY well-formed `<label>.local` and any raw
  *     IP literal, so it needs no list either — a renamed box is accepted the
- *     moment it is renamed, with no restart and no config write.
+ *     moment it is renamed, with no restart and no config write. That generic
+ *     rule also SUBSUMES the cached `systemMdnsHost()` branch above it: every
+ *     non-null value that branch can return is a `<label>.local` the generic
+ *     rule accepts anyway, so the process-lifetime cache decides no request and
+ *     cannot go stale into a lockout. The cache is not a fast path worth
+ *     keeping — deleting the generic rule and keeping it would break every
+ *     renamed box.
  *
  * What is pinned here is that second property, which nothing tested before:
  * `ALLOWED_HOSTS` below deliberately holds neither name used in the requests.
- * The same `checkRequestOrigin` runs on the WS-upgrade path, so tightening it
- * for one leg would break both.
+ * Both legs are covered — HTTP and the WS upgrade share `checkRequestOrigin`
+ * but own separate rejection paths, and the dashboard's live traffic is mostly
+ * WebSocket, so a renamed box could otherwise load and then sit dead.
+ *
+ * The scaffolding below (module-cache bust, env snapshot, session cookie) is
+ * the same shape as hermes-dashboard-proxy-timeouts.test.ts. Kept separate
+ * rather than folded in: that file is about upstream deadlines, this one about
+ * the host guard, and neither wants the other's fixtures.
  */
 
 const require_ = createRequire(import.meta.url);
@@ -95,6 +109,8 @@ let upstream: http.Server;
 let upstreamPort: number;
 let proxy: http.Server | undefined;
 let proxyPort: number;
+/** Upgrade sockets the fixture answered; destroyed in afterAll. */
+const upgraded: Duplex[] = [];
 
 const ENV_KEYS = ["SESSION_SECRET", "ALLOWED_HOSTS", "CLAWBOX_ROOT", "HERMES_DASH_HOST", "HERMES_PORT"] as const;
 const envBefore = new Map<string, string | undefined>();
@@ -105,6 +121,10 @@ beforeAll(async () => {
     res.writeHead(200, { "Content-Type": "text/plain" });
     res.end("dashboard ok");
   });
+  upstream.on("upgrade", (_req, socket) => {
+    upgraded.push(socket);
+    socket.write("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n");
+  });
   upstreamPort = await listen(upstream);
 });
 
@@ -113,6 +133,9 @@ afterAll(async () => {
 });
 
 afterEach(async () => {
+  // An UPGRADED socket is detached from the server's connection tracking, so
+  // closeAllConnections() cannot reach it and close() would wait on it forever.
+  while (upgraded.length) upgraded.pop()!.destroy();
   await close(proxy);
   proxy = undefined;
   for (const [key, value] of envBefore) {
@@ -136,6 +159,43 @@ async function startProxy(): Promise<void> {
   const mod = require_(SCRIPT) as { createProxyServer: () => http.Server };
   proxy = mod.createProxyServer();
   proxyPort = await listen(proxy);
+}
+
+/** Drive a raw WebSocket upgrade through the proxy and collect what comes back. */
+function attemptUpgrade(host: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect(proxyPort, "127.0.0.1", () => {
+      socket.write(
+        [
+          "GET /ws HTTP/1.1",
+          `Host: ${host}`,
+          "Upgrade: websocket",
+          "Connection: Upgrade",
+          "Sec-WebSocket-Version: 13",
+          "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+          `Cookie: ${sessionCookie()}`,
+          "",
+          "",
+        ].join("\r\n"),
+      );
+    });
+    let text = "";
+    socket.on("data", (c) => {
+      text += c.toString();
+      // The proxy answers the handshake before any frame; that status line is
+      // all this asserts on, so stop as soon as the headers are complete.
+      if (text.includes("\r\n\r\n")) {
+        socket.destroy();
+        resolve(text);
+      }
+    });
+    socket.on("close", () => resolve(text));
+    socket.on("error", reject);
+    socket.setTimeout(5_000, () => {
+      socket.destroy();
+      reject(new Error("upgrade hung — proxy never answered or closed"));
+    });
+  });
 }
 
 describe("hermes dashboard proxy — a renamed box needs no allowed-origins update", () => {
@@ -177,6 +237,15 @@ describe("hermes dashboard proxy — a renamed box needs no allowed-origins upda
     await startProxy();
     const res = await request(proxyPort, { host: LAN_IP, cookie: sessionCookie() });
     expect(res.status).toBe(200);
+  });
+
+  it("accepts a WebSocket upgrade on the new name, and refuses a rebind name", async () => {
+    // The leg that matters most in service: the dashboard's live traffic is
+    // WebSocket, and handleUpgrade() owns its own 403 path, so an HTTP-only
+    // assertion would let a renamed box load and then sit dead.
+    await startProxy();
+    expect(await attemptUpgrade(RENAMED)).toContain("101 Switching Protocols");
+    expect(await attemptUpgrade("attacker.example.com")).toContain("403 Forbidden");
   });
 
   it("still refuses a DNS-rebind name, so the guard has not simply been opened", async () => {

--- a/src/tests/unit/hermes-dashboard-proxy-renamed-host.test.ts
+++ b/src/tests/unit/hermes-dashboard-proxy-renamed-host.test.ts
@@ -173,6 +173,10 @@ function attemptUpgrade(host: string): Promise<string> {
           "Connection: Upgrade",
           "Sec-WebSocket-Version: 13",
           "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+          // A browser always sends one on a WS handshake, and without it
+          // `checkRequestOrigin` takes its bare-navigation branch — so the
+          // upgrade would pass without the peer check ever running.
+          `Origin: http://${host}`,
           `Cookie: ${sessionCookie()}`,
           "",
           "",

--- a/src/tests/unit/hermes-dashboard-proxy-renamed-host.test.ts
+++ b/src/tests/unit/hermes-dashboard-proxy-renamed-host.test.ts
@@ -1,0 +1,188 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createRequire } from "node:module";
+import http from "node:http";
+import net from "node:net";
+import path from "node:path";
+import { createSessionCookie } from "@/lib/auth";
+
+/**
+ * TASK-553 — does the Hermes dashboard proxy need its own allowed-origins
+ * update after a hostname rename? No. This suite is the answer, written down
+ * as a test so it stays true.
+ *
+ * On OpenClaw a rename rewrites `gateway.controlUi.allowedOrigins` and
+ * restarts the gateway (src/app/setup-api/system/hostname/route.ts). Nothing
+ * equivalent runs on Hermes, and nothing needs to:
+ *
+ *   - Hermes 0.20.5 has no allowed-origins list to update. Its dashboard guard
+ *     (`_ws_host_origin_reason` in hermes_cli/web_server.py) compares Host and
+ *     Origin against `app.state.bound_host` — the address the dashboard was
+ *     bound to — and takes no configuration. ClawBox binds it to 127.0.0.2 and
+ *     the proxy rewrites Host/Origin/Referer to that authority, so the box's
+ *     LAN name never reaches Hermes at all.
+ *   - The proxy's own guard (scripts/hermes-dashboard-proxy.js,
+ *     `isAllowedHostname`) accepts ANY well-formed `<label>.local` and any raw
+ *     IP literal, so it needs no list either — a renamed box is accepted the
+ *     moment it is renamed, with no restart and no config write.
+ *
+ * What is pinned here is that second property, which nothing tested before:
+ * `ALLOWED_HOSTS` below deliberately holds neither name used in the requests.
+ * The same `checkRequestOrigin` runs on the WS-upgrade path, so tightening it
+ * for one leg would break both.
+ */
+
+const require_ = createRequire(import.meta.url);
+const SCRIPT = path.resolve(process.cwd(), "scripts/hermes-dashboard-proxy.js");
+
+const SESSION_SECRET = "test-session-secret-for-proxy-host-guard";
+/** The box after `Settings → System → rename`. Not in ALLOWED_HOSTS. */
+const RENAMED = "krasi-workshop.local";
+/** TEST-NET-1 (RFC 5737) — safe to write down in a public repo. */
+const LAN_IP = "192.0.2.10";
+
+/** A `clawbox_session` the proxy's HMAC gate accepts, on the pass-through path. */
+function sessionCookie(): string {
+  return `clawbox_session=${createSessionCookie(3600, SESSION_SECRET)}; hermes_session_at=stub`;
+}
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve((server.address() as net.AddressInfo).port));
+  });
+}
+
+function close(server?: http.Server): Promise<void> {
+  return new Promise((resolve) => {
+    if (!server) return resolve();
+    server.closeAllConnections();
+    server.close(() => resolve());
+  });
+}
+
+interface Reply {
+  status: number;
+  body: string;
+  location?: string;
+}
+
+function request(
+  port: number,
+  headers: Record<string, string>,
+  urlPath = "/",
+): Promise<Reply> {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: "127.0.0.1", port, path: urlPath, method: "GET", headers }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (c) => chunks.push(c));
+      res.on("end", () =>
+        resolve({
+          status: res.statusCode ?? 0,
+          body: Buffer.concat(chunks).toString(),
+          location: res.headers.location,
+        }),
+      );
+    });
+    req.setTimeout(5_000, () => {
+      req.destroy();
+      reject(new Error("proxy never responded"));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+let upstream: http.Server;
+let upstreamPort: number;
+let proxy: http.Server | undefined;
+let proxyPort: number;
+
+const ENV_KEYS = ["SESSION_SECRET", "ALLOWED_HOSTS", "CLAWBOX_ROOT", "HERMES_DASH_HOST", "HERMES_PORT"] as const;
+const envBefore = new Map<string, string | undefined>();
+
+beforeAll(async () => {
+  for (const key of ENV_KEYS) envBefore.set(key, process.env[key]);
+  upstream = http.createServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end("dashboard ok");
+  });
+  upstreamPort = await listen(upstream);
+});
+
+afterAll(async () => {
+  await close(upstream);
+});
+
+afterEach(async () => {
+  await close(proxy);
+  proxy = undefined;
+  for (const [key, value] of envBefore) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+async function startProxy(): Promise<void> {
+  Object.assign(process.env, {
+    SESSION_SECRET,
+    // Neither RENAMED nor LAN_IP is listed: the point is that the guard does
+    // not need them listed. `clawbox.local` is left out too, so a pass cannot
+    // come from the shipped default.
+    ALLOWED_HOSTS: "localhost",
+    CLAWBOX_ROOT: path.join(process.cwd(), "nonexistent-proxy-host-guard-root"),
+    HERMES_DASH_HOST: "127.0.0.1",
+    HERMES_PORT: String(upstreamPort),
+  });
+  delete require_.cache[require_.resolve(SCRIPT)];
+  const mod = require_(SCRIPT) as { createProxyServer: () => http.Server };
+  proxy = mod.createProxyServer();
+  proxyPort = await listen(proxy);
+}
+
+describe("hermes dashboard proxy — a renamed box needs no allowed-origins update", () => {
+  it("serves the dashboard under the new <name>.local with a valid session", async () => {
+    await startProxy();
+    const res = await request(proxyPort, { host: RENAMED, cookie: sessionCookie() });
+    expect(res.status).toBe(200);
+    expect(res.body).toBe("dashboard ok");
+  });
+
+  it("sends an unauthenticated visitor to the login page on the NEW name", async () => {
+    await startProxy();
+    const res = await request(proxyPort, { host: RENAMED });
+    // Not 403: the host guard passed. The login URL is derived from the
+    // request's own Host, so the redirect follows the rename too.
+    expect(res.status).toBe(302);
+    expect(res.location).toBe(`http://${RENAMED}/login`);
+  });
+
+  it("accepts an Origin on the new name, and refuses one on any other host", async () => {
+    await startProxy();
+    const same = await request(proxyPort, {
+      host: RENAMED,
+      origin: `http://${RENAMED}`,
+      cookie: sessionCookie(),
+    });
+    expect(same.status).toBe(200);
+
+    const other = await request(proxyPort, {
+      host: RENAMED,
+      origin: "http://someone-elses-box.local",
+      cookie: sessionCookie(),
+    });
+    expect(other.status).toBe(403);
+    expect(other.body).toContain("cross-origin origin");
+  });
+
+  it("accepts a raw LAN address, for a box reached before mDNS resolves", async () => {
+    await startProxy();
+    const res = await request(proxyPort, { host: LAN_IP, cookie: sessionCookie() });
+    expect(res.status).toBe(200);
+  });
+
+  it("still refuses a DNS-rebind name, so the guard has not simply been opened", async () => {
+    await startProxy();
+    const res = await request(proxyPort, { host: "attacker.example.com", cookie: sessionCookie() });
+    expect(res.status).toBe(403);
+    expect(res.body).toContain("bad Host header");
+  });
+});


### PR DESCRIPTION
**TASK-553** — Does the Hermes dashboard proxy need its own allowed-origins update after a hostname rename?

## The answer: no — and this writes it down

The card was filed as a question the author deliberately would not guess at: *"If it does not: nothing further is needed and this can be closed with a note saying so, which is worth having written down."* The owner's 2026-09-03 ruling ("yes, same trigger as the OpenClaw one") was taken on that card, i.e. before the code could answer it. It now can, and the answer is the other one. **No behaviour changes here.** What ships is the written-down answer where the question lives, plus the suite that keeps it true — and one corrected comment that said the opposite.

## Why nothing is needed

**Hermes has no allowed-origins list to write.** Read on the box, read-only: `hermes_cli/web_server.py:15898` `_ws_host_origin_reason` compares `Host` and `Origin` against `app.state.bound_host` — the address the dashboard was bound to — and takes no configuration at all. There is no equivalent of `gateway.controlUi.allowedOrigins` to update. ClawBox launches it `--host 127.0.0.2 --port 9119` (`config/clawbox-hermes-dashboard.service`) and `scripts/hermes-dashboard-proxy.js` rewrites Host/Origin/Referer to that authority on **both** legs (`:519-521` HTTP, `:783-792` upgrade), so the box's LAN name never reaches Hermes.

**The proxy needs no list either.** `isAllowedHostname` accepts any well-formed `<label>.local` and any IP literal, and the rename route's `HOSTNAME_RE` is the same regex — so every name a rename can produce is one the guard already takes, with no restart and no config write. That is what makes this card's answer "no".

## Harness-first

Named, as the rule asks: the native mechanism does not exist. Hermes 0.20.5 exposes no host or origin allowlist to configure, only a bound-host comparison. That absence is the finding, and the PR builds nothing in its place.

## Device proof — read-only, Hermes box on beta head

The proxy as it runs today, no mutation, no mutex taken:

```
proxy unit: active
renamed-probe.local      HTTP/1.1 302 Found  Location: http://renamed-probe.local/login
clawbox.local            HTTP/1.1 302 Found  Location: http://clawbox.local/login
evil.example.com         HTTP/1.1 403 Forbidden
```

A name the box has never been called is served, and the login redirect follows it. A rebind name is still refused.

## No RED, and why

There is no failing-on-beta output to paste: the claim is that beta is already correct. Two things stand in for it.

**The new suite bites.** Removing only the generic `.local` rule from a scratch copy of the proxy:

```
 × serves the dashboard under the new <name>.local with a valid session
 × sends an unauthenticated visitor to the login page on the NEW name
 × accepts an Origin on the new name, and refuses one on any other host
AssertionError: expected 403 to be 200
AssertionError: expected 403 to be 302
      Tests  3 failed | 3 passed (6)
```

**The claim was attacked and held.** The review pass tried seven falsifications — a rename producing a rejected name, the stale mDNS cache, the never-restarted proxy's frozen `ALLOWED_HOSTS`, the LAN name leaking to Hermes, a hardcoded dashboard link in the UI, the login redirect's target on `:80`, and a Hermes-side host config — and every one came back negative.

## GREEN

`hermes-dashboard-proxy-renamed-host` 6/6; with `hermes-dashboard-proxy-timeouts`, `gateway-proxy-origins` and `routes/system-hostname`, 4 files / 41 tests; `tsc --noEmit` clean; `eslint` clean on the changed files.

## Review findings applied (Opus pass)

- **MEDIUM** — the record was weaker than the truth. `systemMdnsHost()`'s process-lifetime cache does not merely happen to be harmless: every non-null value it can return is a `<label>.local` the generic rule three lines below accepts anyway, so it **decides no request at all** and cannot go stale into a lockout (proved by deleting the branch — all cases still pass). Written that way now, because "the cache is stale but the generic rule saves us" invites the next reader to keep the dead branch and drop the rule that carries it.
- **LOW** — the WS leg was claimed in prose and asserted nowhere. `handleUpgrade` shares `checkRequestOrigin` but owns a separate raw-socket 403, and the dashboard's live traffic is mostly WebSocket — a refactor guarding the legs differently would have left a renamed box loading and then sitting dead with every assertion green. One upgrade case each way.
- **LOW** — `scripts/hermes-dashboard-proxy.js:148` claimed the two host checks "can't drift apart", two lines above the rule whose whole point is that they differ. They have drifted twice (generic `.local`; `net.isIP` vs `net.isIPv4`), and this card turns on that difference. Corrected to say the regex is shared and the policies deliberately are not.
- **LOW/NIT** — the route comment restated the test's docblock almost verbatim, and dated its measurement to "beta head", a commit that changes several times a day. Trimmed to the answer and a pointer; the measurement is pinned to the Hermes version and a date in the test.

## Recorded, not fixed here

`src/lib/gateway-proxy.ts`'s `isReflectableHost` has the *same* cached-mDNS probe-once with **no** generic `.local` fallback, and `apply_hostname` restarts only `avahi-daemon`, never the web process. So a renamed **OpenClaw** box whose gateway is briefly down redirects to `http://clawbox.local/setup` — a name that no longer resolves. Narrow, pre-existing and OpenClaw-only, so it is not widened into a Hermes card; it is in the run's Found list, together with deleting the proxy's dead `systemMdnsHost()` branch.

## Both editions

The rename route's OpenClaw leg is untouched. The Hermes leg is the subject, and the conclusion is that it needs none — stated in the code rather than left as an open question.

## Overlap

Rebased onto `origin/beta` `e2aad622` after PR #613 landed in this same route; its `gatewayGap` split is preserved intact — this branch adds five comment lines there and nothing else.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added comprehensive coverage for dashboard proxy access after hostname changes, including authenticated and unauthenticated requests, origin matching, LAN IP access, WebSocket connections, and DNS-rebinding protection.
  - Added validation for accepted renamed-host connections, rejected mismatched hosts, and related session handling across HTTP and WebSocket requests.

- **Documentation**
  - Clarified hostname validation rules, including accepted local hostnames and rename behavior.
  - Clarified proxy behavior expectations during hostname changes, including origin-list handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->