### PR TITLE
fix: stop the Hermes finish notice being gated on a credential it cannot use

### DIFF
--- a/src/app/setup-api/telegram/pairing/route.ts
+++ b/src/app/setup-api/telegram/pairing/route.ts
@@ -15,7 +15,11 @@ import {
   notifyHermesTelegramUser,
   type HermesPairingRequest,
 } from "@/lib/hermes-telegram";
+import { hermesSecretsPresent } from "@/lib/hermes-skill-secrets";
 import { PAIRING_TOKEN_RE, normalizePairingToken, samePairingToken } from "@/lib/telegram-pairing-token";
+
+/** Where Hermes keeps its own bot token — `hermes config set` writes this key. */
+const HERMES_TELEGRAM_TOKEN_KEY = "TELEGRAM_BOT_TOKEN";
 
 export const dynamic = "force-dynamic";
 
@@ -29,7 +33,30 @@ const APPROVED_NAMES_KEY = "telegram_approved_names";
 // it with `hermes send`.
 const APPROVED_NOTICE = "You're approved — send me a message and I'll answer.";
 
-async function isConfigured(): Promise<boolean> {
+/**
+ * Does this box have a Telegram bot at all?
+ *
+ * Asked per edition, because the two keep the credential in different places.
+ * On OpenClaw ClawBox holds it and `telegram_bot_token` IS the answer. On
+ * Hermes the harness holds its own in ~/.hermes/.env — `hermes config set
+ * TELEGRAM_BOT_TOKEN` writes there and `hermes send` reads from there — and
+ * ClawBox's copy is written only as a side effect of
+ * /setup-api/telegram/configure. Asking for it on a box paired with `hermes
+ * config set`, or restored without config.json, answered `configured: false`
+ * for a working bot, and this route's GET returns an empty pairing state on
+ * that answer: page.tsx polls it every 20 s for the "someone wants to talk to
+ * your bot" popup, so a new household member's request was never shown to
+ * anyone.
+ *
+ * Presence only, and never the value — `hermesSecretsPresent` is the same
+ * write-only reader the skills store uses. A plain file read, no CLI: this
+ * route is on a 20 s desktop poll, which is why its Hermes paths are
+ * deliberately CLI-free.
+ */
+async function isConfigured(harness: Harness): Promise<boolean> {
+  if (harness === "hermes") {
+    return (await hermesSecretsPresent([HERMES_TELEGRAM_TOKEN_KEY]))[HERMES_TELEGRAM_TOKEN_KEY] === true;
+  }
   const token = await get("telegram_bot_token");
   return typeof token === "string" && token.length > 0;
 }
@@ -68,13 +95,13 @@ async function buildApproved(
 // status refresh.
 export async function GET(request: Request) {
   try {
-    if (!(await isConfigured())) {
+    const harness = await getActiveHarness();
+    if (!(await isConfigured(harness))) {
       return NextResponse.json(
         { configured: false, approved: [], pending: [] },
         { headers: { "Cache-Control": "no-store" } },
       );
     }
-    const harness = await getActiveHarness();
     const params = new URL(request.url).searchParams;
     const approved = await buildApproved(harness);
     // `?poll=1` reads the pairing store directly — the state database, or the

--- a/src/lib/coding-agent-notify.ts
+++ b/src/lib/coding-agent-notify.ts
@@ -13,6 +13,11 @@
  *      has no CLI send path, so it calls the Bot API directly with the stored
  *      token — the same token telegram/status already uses for `getMe`.
  *
+ *      The two editions therefore have DIFFERENT credentials, and the check
+ *      has to sit on the edition's own side of the branch: Hermes' bot token
+ *      lives in ~/.hermes/.env and is never read here, so ClawBox's copy of a
+ *      token says nothing about whether that box can send.
+ *
  * WHAT THE MESSAGE SAYS, AND WHAT IT DELIBERATELY DOES NOT
  *
  * The text is a fixed template: status, run id, a few counts. It never
@@ -129,23 +134,28 @@ async function sendTelegramDirect(token: string, chatId: string, text: string): 
 }
 
 async function notifyTelegram(message: string): Promise<void> {
-  const token = await configGet("telegram_bot_token");
-  if (typeof token !== "string") return;
-  // Rebuild the token from the match rather than testing and reusing the
-  // original. Same value either way, but the one that reaches the URL is now
-  // constructed here out of characters the pattern allows, which is what lets
-  // CodeQL see the check as a sanitizer instead of an unrelated branch.
-  const matched = BOT_TOKEN_RE.exec(token.trim());
-  if (!matched) {
-    if (token.trim()) console.error("[coding-agent] telegram bot token is not a valid token; notice not sent");
-    return;
-  }
-  const botToken = `${matched[1]}:${matched[2]}`;
   const text = message.slice(0, MAX_TELEGRAM_CHARS);
-
+  // WHICH EDITION FIRST, because the two have different credentials — and the
+  // credential is the whole reason this branch exists.
   const harness = await getActiveHarness();
+
   if (harness === "hermes") {
+    // The bot is the HARNESS's. `hermes send` reads its own token from
+    // ~/.hermes/.env and the approved senders come from Hermes' pairing store;
+    // nothing on this path can use ClawBox's `telegram_bot_token`, which is
+    // written only as a side effect of /setup-api/telegram/configure.
+    //
+    // Gating on it anyway — which is what this function did, above the harness
+    // branch — silenced the notice on every Hermes box paired another way:
+    // `hermes config set`, or a restore that brought back ~/.hermes without
+    // ClawBox's config.json. A working bot, approved users, and no notice.
     const users = (await readHermesApprovedUsers()).slice(0, MAX_TELEGRAM_RECIPIENTS);
+    if (users.length === 0) {
+      // "No notice arrived" and "no notice was sent" are different problems.
+      // A silent return made them the same one to whoever went looking.
+      console.info("[coding-agent] no approved Telegram users on this device; notice not sent");
+      return;
+    }
     for (const user of users) {
       const ok = await notifyHermesTelegramUser(user.id, text);
       if (!ok) console.error(`[coding-agent] telegram notice to ${user.id} was not delivered`);
@@ -153,9 +163,32 @@ async function notifyTelegram(message: string): Promise<void> {
     return;
   }
 
+  // OpenClaw: the web server has no CLI send path, so it calls the Bot API
+  // itself and the stored token IS the credential — no token, nothing to send
+  // with.
+  const token = await configGet("telegram_bot_token");
+  if (typeof token !== "string" || !token.trim()) {
+    console.info("[coding-agent] no Telegram bot is configured on this device; notice not sent");
+    return;
+  }
+  // Rebuild the token from the match rather than testing and reusing the
+  // original. Same value either way, but the one that reaches the URL is now
+  // constructed here out of characters the pattern allows, which is what lets
+  // CodeQL see the check as a sanitizer instead of an unrelated branch.
+  const matched = BOT_TOKEN_RE.exec(token.trim());
+  if (!matched) {
+    console.error("[coding-agent] telegram bot token is not a valid token; notice not sent");
+    return;
+  }
+  const botToken = `${matched[1]}:${matched[2]}`;
+
   const ids = (await readTelegramAllowFrom())
     .filter((id) => CHAT_ID_RE.test(id))
     .slice(0, MAX_TELEGRAM_RECIPIENTS);
+  if (ids.length === 0) {
+    console.info("[coding-agent] no approved Telegram senders on this device; notice not sent");
+    return;
+  }
   for (const id of ids) {
     const ok = await sendTelegramDirect(botToken, id, text);
     if (!ok) console.error(`[coding-agent] telegram notice to ${id} was not delivered`);

--- a/src/lib/coding-agent-notify.ts
+++ b/src/lib/coding-agent-notify.ts
@@ -149,7 +149,14 @@ async function notifyTelegram(message: string): Promise<void> {
     // branch — silenced the notice on every Hermes box paired another way:
     // `hermes config set`, or a restore that brought back ~/.hermes without
     // ClawBox's config.json. A working bot, approved users, and no notice.
-    const users = (await readHermesApprovedUsers()).slice(0, MAX_TELEGRAM_RECIPIENTS);
+    // Shape-checked before they are counted, the way the OpenClaw leg filters
+    // its ids below. Hermes' store tolerates a legacy layout and merges two
+    // directories, so a key that cannot address anyone is possible — counting
+    // it would report five delivery FAILURES for messages nothing attempted,
+    // which is the ambiguity the log line right below exists to remove.
+    const users = (await readHermesApprovedUsers())
+      .filter((user) => CHAT_ID_RE.test(user.id))
+      .slice(0, MAX_TELEGRAM_RECIPIENTS);
     if (users.length === 0) {
       // "No notice arrived" and "no notice was sent" are different problems.
       // A silent return made them the same one to whoever went looking.

--- a/src/tests/routes/telegram/pairing-hermes.test.ts
+++ b/src/tests/routes/telegram/pairing-hermes.test.ts
@@ -15,6 +15,9 @@ vi.mock("@/lib/openclaw-config", () => ({
   readTelegramPairingRequests: vi.fn(),
   approveTelegramPairing: vi.fn(),
 }));
+// Hermes keeps its own bot token in ~/.hermes/.env; the route asks for its
+// PRESENCE, never its value.
+vi.mock("@/lib/hermes-skill-secrets", () => ({ hermesSecretsPresent: vi.fn() }));
 vi.mock("@/lib/hermes-telegram", () => ({
   approveHermesPairing: vi.fn(),
   listHermesPairing: vi.fn(),
@@ -31,6 +34,7 @@ import {
   readTelegramPairingRequests,
   approveTelegramPairing,
 } from "@/lib/openclaw-config";
+import { hermesSecretsPresent } from "@/lib/hermes-skill-secrets";
 import {
   approveHermesPairing,
   listHermesPairing,
@@ -51,6 +55,7 @@ const mockHermesList = vi.mocked(listHermesPairing);
 const mockHermesApproved = vi.mocked(readHermesApprovedUsers);
 const mockHermesRead = vi.mocked(readHermesPairingRequests);
 const mockNotify = vi.mocked(notifyHermesTelegramUser);
+const mockSecrets = vi.mocked(hermesSecretsPresent);
 
 const REQUEST_ID = "a1b2c3d4e5f60718";
 
@@ -89,6 +94,7 @@ describe("/setup-api/telegram/pairing on Hermes", () => {
     });
     mockHermesApprove.mockResolvedValue({ userId: "123456789", userName: "Krasimir Kralev" });
     mockNotify.mockResolvedValue(true);
+    mockSecrets.mockResolvedValue({ TELEGRAM_BOT_TOKEN: true });
 
     const mod = await import("@/app/setup-api/telegram/pairing/route");
     GET = mod.GET;
@@ -104,6 +110,31 @@ describe("/setup-api/telegram/pairing on Hermes", () => {
     ]);
     expect(mockHermesRead).toHaveBeenCalled();
     expect(mockOpenclawRead).not.toHaveBeenCalled();
+  });
+
+  it("answers for a bot ClawBox has no token for — the harness holds its own", async () => {
+    // `hermes config set TELEGRAM_BOT_TOKEN` writes ~/.hermes/.env and nothing
+    // else; ClawBox'"'"'s copy is a side effect of /setup-api/telegram/configure.
+    // Asking for that copy answered `configured: false` for a working bot, and
+    // this GET returns an empty pairing state on that answer — so the desktop
+    // poll that raises the "someone wants to talk to your bot" popup was told
+    // there was nothing to show.
+    mockGet.mockResolvedValue(undefined);
+
+    const body = await (await GET(new Request(`${url}?poll=1`))).json();
+
+    expect(body.configured).toBe(true);
+    expect(body.pending).toHaveLength(1);
+  });
+
+  it("still says not configured when the harness has no bot either", async () => {
+    mockGet.mockResolvedValue(undefined);
+    mockSecrets.mockResolvedValue({ TELEGRAM_BOT_TOKEN: false });
+
+    const body = await (await GET(new Request(`${url}?poll=1`))).json();
+
+    expect(body.configured).toBe(false);
+    expect(body.pending).toEqual([]);
   });
 
   it("uses the authoritative CLI for the Settings check", async () => {

--- a/src/tests/unit/coding-agent-notify.test.ts
+++ b/src/tests/unit/coding-agent-notify.test.ts
@@ -167,14 +167,19 @@ describe("the desktop leg", () => {
 
 describe("the Telegram leg", () => {
   it("does nothing without a bot token — on OpenClaw, where the token IS the credential", async () => {
-    // The default harness in this suite is openclaw. On that edition the web
-    // server calls the Bot API itself, so no token means nothing can be sent.
-    // Hermes is the opposite case and has its own tests below.
+    // Set here, not inherited from beforeEach: with the harness left implicit
+    // this case passes on hermes too (an empty approved list sends nothing),
+    // so it would keep passing with the OpenClaw token gate deleted.
+    getActiveHarness.mockResolvedValue("openclaw");
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
+
     await announceCodingAgent(run());
+
     expect(fetchMock).not.toHaveBeenCalled();
     expect(notifyHermesTelegramUser).not.toHaveBeenCalled();
+    expect(info).toHaveBeenCalledWith(expect.stringContaining("no Telegram bot"));
   });
 
   it("refuses a token that could reshape the request path", async () => {
@@ -258,22 +263,50 @@ describe("the Telegram leg", () => {
     expect(notifyHermesTelegramUser).toHaveBeenCalledWith("42", buildAnnouncement(run()));
   });
 
-  it("says in the log when there was nobody to send to, on either edition", async () => {
+  it("says in the log when there was nobody to send to, on each edition and for each reason", async () => {
     // "No notice arrived" and "no notice was sent" are different problems, and
-    // a silent return made them the same one to whoever went looking.
+    // a silent return made them the same one to whoever went looking. Three
+    // branches, three distinguishable lines — matched on the word that tells
+    // them apart, not on a prefix they share.
     const info = vi.spyOn(console, "info").mockImplementation(() => {});
 
     getActiveHarness.mockResolvedValue("hermes");
     configGet.mockResolvedValue(undefined);
     readHermesApprovedUsers.mockResolvedValue([]);
     await announceCodingAgent(run());
-    expect(info).toHaveBeenCalledWith(expect.stringMatching(/no approved Telegram/i));
+    expect(info).toHaveBeenCalledWith(expect.stringContaining("no approved Telegram users"));
 
     info.mockClear();
     getActiveHarness.mockResolvedValue("openclaw");
     await announceCodingAgent(run());
-    expect(info).toHaveBeenCalledWith(expect.stringMatching(/no Telegram bot/i));
-    info.mockRestore();
+    expect(info).toHaveBeenCalledWith(expect.stringContaining("no Telegram bot is configured"));
+
+    // The one a real OpenClaw box hits most: a working bot and nobody approved.
+    info.mockClear();
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    configGet.mockImplementation(async (key: string) => (key === "telegram_bot_token" ? "123:abc" : undefined));
+    readTelegramAllowFrom.mockResolvedValue([]);
+    await announceCodingAgent(run());
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(info).toHaveBeenCalledWith(expect.stringContaining("no approved Telegram senders"));
+  });
+
+  it("counts only recipients it can actually address", async () => {
+    // Hermes' pairing store tolerates a legacy layout and merges two
+    // directories, so a key that addresses nobody is possible. Counting it
+    // logged up to five delivery FAILURES for messages nothing attempted.
+    getActiveHarness.mockResolvedValue("hermes");
+    configGet.mockResolvedValue(undefined);
+    readHermesApprovedUsers.mockResolvedValue([{ id: "not-an-id" }, { id: "legacy:42" }]);
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await announceCodingAgent(run());
+
+    expect(notifyHermesTelegramUser).not.toHaveBeenCalled();
+    expect(info).toHaveBeenCalledWith(expect.stringContaining("no approved Telegram users"));
+    expect(error).not.toHaveBeenCalled();
   });
 
   it("on Hermes goes through the hermes send path for each approved user", async () => {

--- a/src/tests/unit/coding-agent-notify.test.ts
+++ b/src/tests/unit/coding-agent-notify.test.ts
@@ -166,7 +166,10 @@ describe("the desktop leg", () => {
 });
 
 describe("the Telegram leg", () => {
-  it("does nothing without a bot token", async () => {
+  it("does nothing without a bot token — on OpenClaw, where the token IS the credential", async () => {
+    // The default harness in this suite is openclaw. On that edition the web
+    // server calls the Bot API itself, so no token means nothing can be sent.
+    // Hermes is the opposite case and has its own tests below.
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
     await announceCodingAgent(run());
@@ -221,6 +224,56 @@ describe("the Telegram leg", () => {
     expect(body.text).toBe(buildAnnouncement(run()));
     expect(body.parse_mode).toBeUndefined();
     expect(body.text).not.toContain("DO-NOT-LEAK");
+  });
+
+  it("on Hermes sends even with no ClawBox-side bot token — the harness owns the credential", async () => {
+    // `hermes send` reads its own token from ~/.hermes/.env and the approved
+    // senders come from Hermes' pairing store. ClawBox's `telegram_bot_token`
+    // is written only as a side effect of /setup-api/telegram/configure, so a
+    // box paired with `hermes config set` — or restored without config.json —
+    // has a working bot, approved users, and no ClawBox token. Gating on that
+    // token silenced the notice on every one of them, without a log line.
+    getActiveHarness.mockResolvedValue("hermes");
+    configGet.mockResolvedValue(undefined);
+    readHermesApprovedUsers.mockResolvedValue([{ id: "42", name: "Maya" }]);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await announceCodingAgent(run());
+
+    expect(notifyHermesTelegramUser).toHaveBeenCalledWith("42", buildAnnouncement(run()));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("on Hermes a malformed ClawBox-side token does not silence it either", async () => {
+    // A partial restore can leave a truncated value in config.json. It is not
+    // the credential this path uses, so it has no business deciding anything.
+    getActiveHarness.mockResolvedValue("hermes");
+    configGet.mockImplementation(async (key: string) =>
+      key === "telegram_bot_token" ? "not-a-token" : undefined);
+    readHermesApprovedUsers.mockResolvedValue([{ id: "42" }]);
+
+    await announceCodingAgent(run());
+
+    expect(notifyHermesTelegramUser).toHaveBeenCalledWith("42", buildAnnouncement(run()));
+  });
+
+  it("says in the log when there was nobody to send to, on either edition", async () => {
+    // "No notice arrived" and "no notice was sent" are different problems, and
+    // a silent return made them the same one to whoever went looking.
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    getActiveHarness.mockResolvedValue("hermes");
+    configGet.mockResolvedValue(undefined);
+    readHermesApprovedUsers.mockResolvedValue([]);
+    await announceCodingAgent(run());
+    expect(info).toHaveBeenCalledWith(expect.stringMatching(/no approved Telegram/i));
+
+    info.mockClear();
+    getActiveHarness.mockResolvedValue("openclaw");
+    await announceCodingAgent(run());
+    expect(info).toHaveBeenCalledWith(expect.stringMatching(/no Telegram bot/i));
+    info.mockRestore();
   });
 
   it("on Hermes goes through the hermes send path for each approved user", async () => {


### PR DESCRIPTION
**TASK-650** — the Hermes coding-agent finish notice is gated on the OpenClaw Telegram token and never sends. False failure.

## Symptom

On a Hermes box whose bot was set up outside `/setup-api/telegram/configure`, a coding run finishes,
the desktop card lands, and Telegram gets nothing — with no log line, so "no notice arrived" and "no
notice was sent" looked identical to anyone who went looking.

## Cause

`notifyTelegram()` read ClawBox's `telegram_bot_token` and returned **before** the harness branch
when it was absent or malformed. On Hermes that token is never used: `hermes send` reads its own
from `~/.hermes/.env` and the approved senders come from Hermes' own pairing store. ClawBox's copy is
written only as a side effect of `/setup-api/telegram/configure`, so a box paired with `hermes config
set` — or restored with `~/.hermes` but without `config.json` — had a working bot, approved users,
and a credential check standing in front of a path that cannot use it.

The desktop leg is untouched; it was already proved working on the box.

## Harness-first

The send path already uses the native mechanism (`hermes send --to telegram:<id>`, and Hermes' own
pairing store for who to tell) — nothing is re-implemented. The authoritative Hermes answer to "is
Telegram usable here" is `hermesTelegramRegistered()` (`hermes send --list telegram --json`,
tri-state), and it is deliberately **not** used for the notice: the notice needs to know *who to
tell*, not whether a credential exists, and the pairing store answers that with a file read rather
than a CLI spawn per finished run.

For the pairing route (below) the native answer is Hermes' own `TELEGRAM_BOT_TOKEN` in
`~/.hermes/.env` — the key `hermes config set` writes — read for **presence only**, never its value,
through `hermesSecretsPresent`, the same write-only reader the skills store uses. `hermesTelegramRegistered()`
was rejected there too: that GET is on a 20 s desktop poll and its Hermes paths are CLI-free by design.

## Device evidence (read-only, Hermes box on beta; presence and counts only — no values)

```
clawbox config.json telegram_bot_token present: True
hermes .env telegram token line present:        True
hermes approved users:                          1  in telegram-approved.json

hermes send --list telegram --json
  platforms: ['telegram']
    telegram: 1 target(s) [ids redacted]
```

Both credentials exist on this box because the in-product path wrote both — which is exactly the
card's reachability statement — and the listing proves the harness's own credential and target list
are independent of ClawBox's copy. The defect state is out-of-band setup or a partial restore, and
the unit tests pin it directly; the delivery itself was not exercised (no reachable bot, and pairing
is out of bounds for this run).

## RED → GREEN

On unmodified beta: **6 failed | 9 passed** across `coding-agent-notify.test.ts` and
`pairing-hermes.test.ts`.

```
 × does nothing without a bot token — on OpenClaw, where the token IS the credential
 × on Hermes sends even with no ClawBox-side bot token — the harness owns the credential
 × on Hermes a malformed ClawBox-side token does not silence it either
 × says in the log when there was nobody to send to, on each edition and for each reason
 × counts only recipients it can actually address
 × answers for a bot ClawBox has no token for — the harness holds its own
```

On the branch: routes + unit 9090 tests pass; `tsc --noEmit` clean; `eslint` 0 errors on both files.

## Siblings — four other readers of `telegram_bot_token` that ask the same question

Findings applied from `/tmp/claude-1000/-home-krasi/07313fbb-d607-4f0f-9568-6763a2c88253/scratchpad/code-review-650.md`
(2 High, 1 Medium, 4 Low — all applied or recorded).

| site | verdict |
| --- | --- |
| `telegram/pairing/route.ts:32` | **Fixed here.** Same wrong question, and the blast radius is the pairing popup: `page.tsx` polls this GET every 20 s and gates on `configured`, so on an out-of-band-paired box a new member's request was never shown and the approved list came back empty. CLI-free to fix, same function shape, same population of boxes. |
| `telegram/status/route.ts:126` | **Residual.** The route already asks Hermes at :131, but the token read four lines earlier returns `configured:false` first, so that branch is unreachable on exactly the boxes it was written for. The fix reaches `hermesTelegramRegistered()` (~1.7 s, memoised 15 s) and needs `registered ?? Boolean(token)` rather than `?? true`, or a false negative becomes a false positive. Its own change. |
| `email/chat-approval/route.ts:101` | **Residual, and the one with teeth.** The same-bot guard compares the approval bot to ClawBox's copy of the main token; with no copy it fails open, and the owner can point the approval bot at the one Hermes is already long-polling — duplicate `getUpdates`, and their normal Telegram chat drops messages. Fixing it means reading Hermes' own token to compare, which is a credential decision, not a rider on this PR. |
| `setup/status/route.ts:70` | **Residual.** `telegram_configured` is the same flag; an out-of-band-paired Hermes box re-entering the wizard is shown the Telegram step for a bot that already works. Mild, and that route is deliberately public and polled on a 3 s tray loop, so no probe belongs there. |

All four are recorded in the run queue's "Found" list with this reasoning.

## Both editions

The OpenClaw path is behaviour-identical apart from the log lines: same token pattern, same
`CHAT_ID_RE` filter, same recipient cap, same request order. The malformed-token `console.error` is
kept exactly as it was; only the silence became an info line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Telegram pairing now correctly detects configuration for each supported harness.
  - Hermes installations with credentials stored in environment settings are no longer incorrectly reported as unconfigured.
  - Telegram notifications now use the appropriate credentials for Hermes and OpenClaw independently.
  - Invalid or unreachable notification recipients are excluded, with clearer diagnostics when configuration or recipients are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->