### PR TITLE
fix: an in-app update must never leave a box with new code and no build

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1130,7 +1130,12 @@ ensure_node_pty() {
 
   if ! as_clawbox_login "$verify_cmd" &>/dev/null; then
     echo "Error: node-pty is still not loadable after rebuild. Check the node-gyp output above." >&2
-    exit 1
+    # `return`, not `exit`: do_rebuild stops clawbox-setup before it calls this
+    # and has a restore path to run before anything may leave the function. A
+    # bare `exit` from here jumped over it and left the box exactly as TASK-709
+    # describes. Callers that want the old behaviour get it for free — a
+    # non-zero return from a bare call still ends the script under `set -e`.
+    return 1
   fi
 
   echo "  node-pty rebuilt and verified"
@@ -1273,19 +1278,174 @@ free_memory_for_build() {
   echo "  Memory available for the build: ${after} MB (was ${before} MB)"
 }
 
-# Stop the setup service, free memory, clear cache, reinstall, and rebuild
+# Is there a build on disk that clawbox-setup can actually serve?
+#
+# `bun run build` exiting 0 is not the same thing, and neither is a fresh
+# .next/BUILD_ID: `bun run build` is `next build` PLUS the `postbuild` lifecycle
+# script (package.json), and postbuild is what makes the build servable — it
+# writes build-info.json and copies .next/static, public/ and the server entry
+# into the standalone tree. Next writes BUILD_ID before any of that, and
+# postbuild's own `if [ -n "$SRVJS" ]` guard exits 0 having copied NOTHING when
+# the standalone entry is missing. So a build can be "complete" by BUILD_ID and
+# still leave production-server.js crash-looping on
+# `require("./.next/standalone/server.js")`.
+#
+# Two questions, and the box already owns the answer to the second:
+#   1. the file the service loads exists  — what step_build has always checked;
+#   2. the build on disk was produced from the commit that is checked out —
+#      scripts/verify-build-identity.sh, the one copy of that logic (CI runs it
+#      too, and its header says why a second copy is a bug). It is also what
+#      catches the half-copied postbuild by name.
+verify_build_present() {
+  local project_dir="${1:-$PROJECT_DIR}"
+  if [ ! -f "$project_dir/.next/standalone/server.js" ]; then
+    echo "Error: no $project_dir/.next/standalone/server.js — the build produced nothing the dashboard can load" >&2
+    return 1
+  fi
+  if [ ! -f "$project_dir/scripts/verify-build-identity.sh" ]; then
+    # Same call the updater makes and the same verdict it draws: a script that
+    # is not there was not run, which is a warning, not a pass and not a
+    # failure (src/lib/updater.ts runBuildIdentityCheck).
+    echo "  WARNING: scripts/verify-build-identity.sh is missing — the build's identity was not checked" >&2
+    return 0
+  fi
+  if ! bash "$project_dir/scripts/verify-build-identity.sh" --project-dir "$project_dir" --quiet; then
+    echo "Error: the build on disk does not match the checked-out commit" >&2
+    return 1
+  fi
+  return 0
+}
+
+# A build parked by a run that never finished is still the box's only build.
+#
+# set_previous_build_aside renames the serving build to `.next-old` and
+# restore_previous_build puts it back — but only if the shell survives to do it.
+# An OOM kill that picks this shell, a power cut mid-build or an operator's
+# Ctrl-C leaves no `.next` at all and the good build under a gitignored
+# directory nothing else in the tree reads. Reclaim it before anything else
+# runs, or the next rename would delete it.
+promote_parked_build() {
+  local build_dir="$1" kept_dir="$2"
+  [ -f "$kept_dir/standalone/server.js" ] || return 0
+  [ -f "$build_dir/standalone/server.js" ] && return 0
+  echo "  Found a build parked by an interrupted rebuild — putting it back" >&2
+  rm -rf "$build_dir"
+  mv "$kept_dir" "$build_dir"
+}
+
+# Keep the build that is serving the box until a new one exists.
+#
+# `rm -rf .next` used to be the first thing do_rebuild did after freeing
+# memory, so any failure past that line left the device with new code and no
+# build: clawbox-setup stopped by the rebuild and never started again, port 80
+# dead — while clawbox-gateway stayed up on 18789 and made the box look
+# half-alive. A rename on the same filesystem costs nothing. `.next-old` is
+# already gitignored, so the updater's `git clean -fd` leaves it alone.
+#
+# Skipped when the filesystem cannot hold two builds at once: on a nearly full
+# eMMC, keeping the old tree would turn an OOM into an ENOSPC, and a build that
+# runs out of disk is a worse outcome than one with no fallback. Said out loud
+# either way, because which of the two happened decides what an operator does
+# next.
+set_previous_build_aside() {
+  local build_dir="$1" kept_dir="$2" need avail
+  rm -rf "$kept_dir"
+  [ -d "$build_dir" ] || return 0
+  need="$(du -sk "$build_dir" 2>/dev/null | awk '{print $1}')"
+  avail="$(df -Pk "$build_dir" 2>/dev/null | awk 'NR==2 {print $4}')"
+  case "$need$avail" in
+    ''|*[!0-9]*) need=""; avail="" ;;
+  esac
+  if [ -n "$need" ] && [ -n "$avail" ] && [ "$avail" -lt "$((need * 2))" ]; then
+    echo "  Only ${avail}K free for a ${need}K build — clearing the old one instead of keeping it" >&2
+    rm -rf "$build_dir"
+    return 0
+  fi
+  echo "Setting the current build aside..."
+  mv "$build_dir" "$kept_dir"
+}
+
+# Put the kept build back and bring the dashboard up on it.
+#
+# The message must not assert an outcome over a `systemctl start … || true` that
+# nothing checked: clawbox-setup has Restart=always, so a restored build that
+# cannot boot crash-loops while the journal says the dashboard kept serving.
+restore_previous_build() {
+  local build_dir="$1" kept_dir="$2" waited=0
+  # Only when the build was actually moved aside. A failure BEFORE that — a
+  # `bun install` that could not reach the registry, a node-pty rebuild that
+  # would not link — leaves the serving build untouched in place, and deleting
+  # it here would manufacture the outage this function exists to prevent.
+  if [ -d "$kept_dir" ]; then
+    rm -rf "$build_dir"
+    mv "$kept_dir" "$build_dir"
+  fi
+  if [ ! -f "$build_dir/standalone/server.js" ]; then
+    echo "  No build to fall back on — the dashboard stays down until this is repaired" >&2
+    return 1
+  fi
+  systemctl start clawbox-setup.service 2>/dev/null || true
+  while [ "$waited" -lt 20 ]; do
+    if systemctl is-active --quiet clawbox-setup.service 2>/dev/null; then
+      echo "  Restored the previous build; the dashboard is serving again" >&2
+      return 0
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  echo "  Restored the previous build but clawbox-setup did not come up — the dashboard is DOWN" >&2
+  return 1
+}
+
+# Stop the setup service, free memory, reinstall, and rebuild — without ever
+# leaving the box with no build at all.
 do_rebuild() {
+  local build_dir="$PROJECT_DIR/.next"
+  local kept_dir="$PROJECT_DIR/.next-old"
+  local rc=0
+
+  # A build left parked by a run that was killed — an OOM kill that picked this
+  # shell, a power cut, an operator's Ctrl-C — is the box's only build. Claim it
+  # back before doing anything else, or the rename below would delete it.
+  promote_parked_build "$build_dir" "$kept_dir"
+
   echo "Stopping clawbox-setup.service for rebuild..."
   systemctl stop clawbox-setup.service 2>/dev/null || true
   # After the stop, never before it — see free_memory_for_build.
   free_memory_for_build
-  echo "Clearing .next cache..."
-  rm -rf "$PROJECT_DIR/.next"
+
+  # Everything from here to the restore branch runs with the dashboard DOWN, so
+  # no command in the window may leave the function without passing through it —
+  # that is why `ensure_node_pty` returns instead of exiting, and why each step
+  # is a condition rather than a bare statement under `set -e`. `if !` suspends
+  # errexit inside those two, which is safe because each ends in its own
+  # verification: bun install is a single command, and ensure_node_pty finishes
+  # by loading node-pty for real.
   echo "Running bun install..."
-  as_clawbox_login "cd $PROJECT_DIR && $BUN install"
-  ensure_node_pty
-  echo "Running bun build..."
-  as_clawbox_login "cd $PROJECT_DIR && $BUN run build"
+  if ! as_clawbox_login "cd $PROJECT_DIR && $BUN install"; then
+    rc=1
+  fi
+  if [ "$rc" -eq 0 ] && ! ensure_node_pty; then
+    rc=1
+  fi
+
+  if [ "$rc" -eq 0 ]; then
+    set_previous_build_aside "$build_dir" "$kept_dir"
+    echo "Running bun build..."
+    as_clawbox_login "cd $PROJECT_DIR && $BUN run build" || rc=$?
+    if [ "$rc" -eq 0 ] && ! verify_build_present "$PROJECT_DIR"; then
+      rc=1
+    fi
+  fi
+
+  if [ "$rc" -ne 0 ]; then
+    echo "Error: rebuild failed (exit $rc)" >&2
+    restore_previous_build "$build_dir" "$kept_dir" || true
+    return "$rc"
+  fi
+
+  rm -rf "$kept_dir"
+  echo "  Build complete"
 }
 
 # ── Step Functions ───────────────────────────────────────────────────────────
@@ -1999,13 +2159,14 @@ step_install_bun() {
 
 step_build() {
   cd "$PROJECT_DIR"
+  promote_parked_build "$PROJECT_DIR/.next" "$PROJECT_DIR/.next-old"
   as_clawbox_login "cd $PROJECT_DIR && $BUN install"
   ensure_node_pty
   as_clawbox_login "cd $PROJECT_DIR && $BUN run build"
-  if [ ! -f "$PROJECT_DIR/.next/standalone/server.js" ]; then
-    echo "Error: Build failed — .next/standalone/server.js not found"
-    exit 1
-  fi
+  # The same two questions do_rebuild asks, through the same helper: an install
+  # that leaves a box unable to load the server is the defect this file already
+  # tested for, and the identity half is the one the box already owns.
+  verify_build_present "$PROJECT_DIR" || exit 1
   echo "  Build complete"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -1278,6 +1278,15 @@ free_memory_for_build() {
   echo "  Memory available for the build: ${after} MB (was ${before} MB)"
 }
 
+# Does this build tree carry the entry production-server.js loads?
+#
+# `-e` on its own is not enough: for the nested standalone layout `postbuild`
+# supports, that path is a symlink to an ABSOLUTE path inside `.next`, which
+# dangles while the tree is parked under `.next-old`. `-L` catches it there.
+build_entry_present() {
+  [ -e "$1/standalone/server.js" ] || [ -L "$1/standalone/server.js" ]
+}
+
 # Is there a build on disk that clawbox-setup can actually serve?
 #
 # `bun run build` exiting 0 is not the same thing, and neither is a fresh
@@ -1297,7 +1306,7 @@ free_memory_for_build() {
 #      too, and its header says why a second copy is a bug). It is also what
 #      catches the half-copied postbuild by name.
 verify_build_present() {
-  local project_dir="${1:-$PROJECT_DIR}"
+  local project_dir="$1"
   if [ ! -f "$project_dir/.next/standalone/server.js" ]; then
     echo "Error: no $project_dir/.next/standalone/server.js — the build produced nothing the dashboard can load" >&2
     return 1
@@ -1325,9 +1334,13 @@ verify_build_present() {
 # directory nothing else in the tree reads. Reclaim it before anything else
 # runs, or the next rename would delete it.
 promote_parked_build() {
-  local build_dir="$1" kept_dir="$2"
-  [ -f "$kept_dir/standalone/server.js" ] || return 0
-  [ -f "$build_dir/standalone/server.js" ] && return 0
+  local build_dir="${1:-$PROJECT_DIR/.next}" kept_dir="${2:-$PROJECT_DIR/.next-old}"
+  # `-e`, and `-L` beside it: for the nested standalone layout `postbuild`
+  # supports, `.next/standalone/server.js` is a SYMLINK to an absolute path
+  # inside `.next` — which dangles for as long as the tree is parked, so `-f`
+  # would answer "no build here" about the box's only build.
+  build_entry_present "$kept_dir" || return 0
+  build_entry_present "$build_dir" && return 0
   echo "  Found a build parked by an interrupted rebuild — putting it back" >&2
   rm -rf "$build_dir"
   mv "$kept_dir" "$build_dir"
@@ -1353,9 +1366,11 @@ set_previous_build_aside() {
   [ -d "$build_dir" ] || return 0
   need="$(du -sk "$build_dir" 2>/dev/null | awk '{print $1}')"
   avail="$(df -Pk "$build_dir" 2>/dev/null | awk 'NR==2 {print $4}')"
-  case "$need$avail" in
-    ''|*[!0-9]*) need=""; avail="" ;;
-  esac
+  # Each on its own: `$need$avail` concatenated also passes when one of the two
+  # is empty and the other is all digits, and the emptiness test below then has
+  # to compensate for it.
+  case "$need"  in ''|*[!0-9]*) need="" ;; esac
+  case "$avail" in ''|*[!0-9]*) avail="" ;; esac
   if [ -n "$need" ] && [ -n "$avail" ] && [ "$avail" -lt "$((need * 2))" ]; then
     echo "  Only ${avail}K free for a ${need}K build — clearing the old one instead of keeping it" >&2
     rm -rf "$build_dir"
@@ -1365,35 +1380,68 @@ set_previous_build_aside() {
   mv "$build_dir" "$kept_dir"
 }
 
-# Put the kept build back and bring the dashboard up on it.
+# Bring the dashboard back up, and say exactly which build it came up on.
 #
-# The message must not assert an outcome over a `systemctl start … || true` that
-# nothing checked: clawbox-setup has Restart=always, so a restored build that
-# cannot boot crash-loops while the journal says the dashboard kept serving.
+# Three outcomes, and they are three different sentences because they send an
+# operator to three different places:
+#   - the parked build was put back;
+#   - nothing was ever parked and the build in place is the one that was
+#     already serving (a failure BEFORE the park — `bun install` that could not
+#     reach the registry, a node-pty rebuild that would not link);
+#   - nothing was parked because the filesystem could not hold two builds, and
+#     the tree in place is the build that just FAILED verification. That one is
+#     still started — a dashboard on a suspect build beats a dead box — but it
+#     must never be called a rollback.
+#
+# $3 is 1 when a build actually ran, which is what separates the last two.
 restore_previous_build() {
-  local build_dir="$1" kept_dir="$2" waited=0
-  # Only when the build was actually moved aside. A failure BEFORE that — a
-  # `bun install` that could not reach the registry, a node-pty rebuild that
-  # would not link — leaves the serving build untouched in place, and deleting
-  # it here would manufacture the outage this function exists to prevent.
+  local build_dir="$1" kept_dir="$2" built="${3:-0}" restored=0 waited=0 http_code
   if [ -d "$kept_dir" ]; then
     rm -rf "$build_dir"
     mv "$kept_dir" "$build_dir"
+    restored=1
   fi
-  if [ ! -f "$build_dir/standalone/server.js" ]; then
+  if ! build_entry_present "$build_dir"; then
     echo "  No build to fall back on — the dashboard stays down until this is repaired" >&2
     return 1
   fi
-  systemctl start clawbox-setup.service 2>/dev/null || true
-  while [ "$waited" -lt 20 ]; do
-    if systemctl is-active --quiet clawbox-setup.service 2>/dev/null; then
-      echo "  Restored the previous build; the dashboard is serving again" >&2
-      return 0
+
+  local what="Restored the previous build"
+  if [ "$restored" -eq 0 ]; then
+    if [ "$built" -eq 1 ]; then
+      what="No previous build was kept (the filesystem could not hold two) — the tree in place is the build that just FAILED verification"
+    else
+      what="The serving build was never moved aside"
     fi
+  fi
+
+  systemctl start clawbox-setup.service 2>/dev/null || true
+
+  # `systemctl is-active` is not the question. clawbox-setup is `Type=simple`
+  # with `Restart=always` (config/clawbox-setup.service), so systemd calls the
+  # unit ACTIVE the moment node is forked — before production-server.js has
+  # reached `require("./.next/standalone/server.js")`. A restored tree that
+  # cannot load would be reported as serving on the very first poll and
+  # crash-loop for the rest of the night under a line saying the opposite.
+  #
+  # The honest question is the one step_validate_services already asks: does the
+  # dashboard answer HTTP on :80? Same form, same accepted codes.
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "  $what, and clawbox-setup was started — but curl is missing, so whether the dashboard answers was NOT checked" >&2
+    return 0
+  fi
+  while [ "$waited" -lt 20 ]; do
+    http_code="$(curl -sS --max-time 3 -o /dev/null -w '%{http_code}' http://localhost/ 2>/dev/null)" || http_code="000"
+    case "$http_code" in
+      2*|3*)
+        echo "  $what; the dashboard answers on :80 again" >&2
+        return 0
+        ;;
+    esac
     sleep 1
     waited=$((waited + 1))
   done
-  echo "  Restored the previous build but clawbox-setup did not come up — the dashboard is DOWN" >&2
+  echo "  $what, but the dashboard did not answer on :80 (last HTTP $http_code) — it is DOWN" >&2
   return 1
 }
 
@@ -1402,15 +1450,17 @@ restore_previous_build() {
 do_rebuild() {
   local build_dir="$PROJECT_DIR/.next"
   local kept_dir="$PROJECT_DIR/.next-old"
-  local rc=0
-
-  # A build left parked by a run that was killed — an OOM kill that picked this
-  # shell, a power cut, an operator's Ctrl-C — is the box's only build. Claim it
-  # back before doing anything else, or the rename below would delete it.
-  promote_parked_build "$build_dir" "$kept_dir"
+  local rc=0 built=0
 
   echo "Stopping clawbox-setup.service for rebuild..."
   systemctl stop clawbox-setup.service 2>/dev/null || true
+
+  # A build left parked by a run that was killed — an OOM kill that picked this
+  # shell, a power cut, an operator's Ctrl-C — is the box's only build. Claim it
+  # back before the rename below would delete it. After the stop, never before
+  # it: the rename moves the tree the running server is loading from.
+  promote_parked_build "$build_dir" "$kept_dir"
+
   # After the stop, never before it — see free_memory_for_build.
   free_memory_for_build
 
@@ -1424,14 +1474,12 @@ do_rebuild() {
   echo "Running bun install..."
   if ! as_clawbox_login "cd $PROJECT_DIR && $BUN install"; then
     rc=1
-  fi
-  if [ "$rc" -eq 0 ] && ! ensure_node_pty; then
+  elif ! ensure_node_pty; then
     rc=1
-  fi
-
-  if [ "$rc" -eq 0 ]; then
+  else
     set_previous_build_aside "$build_dir" "$kept_dir"
     echo "Running bun build..."
+    built=1
     as_clawbox_login "cd $PROJECT_DIR && $BUN run build" || rc=$?
     if [ "$rc" -eq 0 ] && ! verify_build_present "$PROJECT_DIR"; then
       rc=1
@@ -1440,7 +1488,7 @@ do_rebuild() {
 
   if [ "$rc" -ne 0 ]; then
     echo "Error: rebuild failed (exit $rc)" >&2
-    restore_previous_build "$build_dir" "$kept_dir" || true
+    restore_previous_build "$build_dir" "$kept_dir" "$built" || true
     return "$rc"
   fi
 
@@ -2159,7 +2207,7 @@ step_install_bun() {
 
 step_build() {
   cd "$PROJECT_DIR"
-  promote_parked_build "$PROJECT_DIR/.next" "$PROJECT_DIR/.next-old"
+  promote_parked_build
   as_clawbox_login "cd $PROJECT_DIR && $BUN install"
   ensure_node_pty
   as_clawbox_login "cd $PROJECT_DIR && $BUN run build"

--- a/production-server.js
+++ b/production-server.js
@@ -524,6 +524,43 @@ http.Server.prototype.listen = function (...args) {
   return originalListen.apply(this, args);
 };
 
+// A build parked by an update that was killed OUTRIGHT is the box's only build,
+// and until here nothing ever looked for it.
+//
+// install.sh's do_rebuild renames the serving build to `.next-old` before it
+// builds and renames it back when the build fails — but only if that shell
+// survives to do it. An OOM kill that picks the shell (TASK-709: three in one
+// night, `next-build` at 2.1 GB against ollama's 2.3 GB), a power cut or a
+// Ctrl-C leaves no `.next` at all and a perfectly good build under a gitignored
+// directory. install.sh's own `promote_parked_build` cannot help: it runs
+// inside an update, and an update needs THIS server to be up. So the box
+// crash-looped on the missing entry with its build sitting on disk, and every
+// recovery was by hand.
+//
+// Deliberately the last thing before the require, and deliberately narrow: it
+// does nothing at all unless the entry is already missing — i.e. unless this
+// process is about to throw anyway. Everything is best-effort; a failure here
+// must never be the reason the server does not start, and the throw below stays
+// the real error. clawbox-setup runs as the `clawbox` user, which owns both
+// directories (the rename in do_rebuild preserves the inode), and its
+// `Restart=always` means a lost race just tries again in three seconds.
+try {
+  const buildEntry = path.join(__dirname, ".next", "standalone", "server.js");
+  const parkedEntry = path.join(__dirname, ".next-old", "standalone", "server.js");
+  // `lstatSync`, not `existsSync`: for the nested standalone layout `postbuild`
+  // supports, this path is a symlink into `.next` that DANGLES while the tree is
+  // parked, and `existsSync` would call the box's only build absent.
+  const present = (p) => { try { fs.lstatSync(p); return true; } catch { return false; } };
+  if (!present(buildEntry) && present(parkedEntry)) {
+    console.warn("[production-server] No .next build, but .next-old holds one — an update was killed mid-rebuild. Putting it back.");
+    fs.rmSync(path.join(__dirname, ".next"), { recursive: true, force: true });
+    fs.renameSync(path.join(__dirname, ".next-old"), path.join(__dirname, ".next"));
+    console.warn("[production-server] Restored the parked build. Run the update again to get the new one.");
+  }
+} catch (err) {
+  console.warn("[production-server] Could not reclaim a parked build:", err.message);
+}
+
 require("./.next/standalone/server.js");
 
 // After Next has started: the title Next gave this process is ours again

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -186,16 +186,28 @@ function rootStepResultFailed(result: string | null): boolean {
 /**
  * Read the BUILD_ID of the build the SERVER RUNS FROM.
  *
- * Through `resolveBuildDir`, not `path.join(PROJECT_DIR, ".next")`: the service
- * runs with cwd `.next/standalone`, so the assets it serves come from
- * `.next/standalone/.next` — and `.next` "can be a newer half-finished build",
- * as that helper's own comment puts it. Reading the wrong tree would answer
- * "the rebuild produced a new build" about a directory nobody serves.
+ * The service runs with cwd `.next/standalone`, so the assets it serves come
+ * from `.next/standalone/.next` — and `.next` "can be a newer half-finished
+ * build", as build-identity.ts's own comment puts it. Reading the wrong tree
+ * would answer "the rebuild produced a new build" about a directory nobody
+ * serves.
+ *
+ * The serving tree is chosen by the ENTRY POINT, not by `resolveBuildDir`.
+ * That helper picks the standalone tree only when its BUILD_ID is present and
+ * otherwise falls back to `.next` — which is precisely the state a failed
+ * rebuild leaves: the standalone tree exists and its BUILD_ID does not. Falling
+ * back there would read a `.next/BUILD_ID` nobody serves, `buildMissing` would
+ * be false, and the continuation would mark the update complete over a box that
+ * cannot boot. `standalone/server.js` is what production-server.js requires, so
+ * its presence is what says which tree is the serving one.
  */
 async function readBuildId(): Promise<string> {
   try {
-    const buildDir = await resolveBuildDir(PROJECT_DIR);
-    return (await readFile(path.join(buildDir, "BUILD_ID"), "utf-8")).trim();
+    const standalone = path.join(PROJECT_DIR, ".next", "standalone");
+    const serving = existsSync(path.join(standalone, "server.js"))
+      ? path.join(standalone, ".next")
+      : await resolveBuildDir(PROJECT_DIR);
+    return (await readFile(path.join(serving, "BUILD_ID"), "utf-8")).trim();
   } catch {
     return "";
   }

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -18,7 +18,7 @@ import { parseHermesVersion } from "./version-utils";
 import { isSafeBranch } from "./update-branch";
 import { startRootStep } from "./root-step-runner";
 import { setUpdateLock, clearUpdateLock } from "./update-lock";
-import { collectBuildIdentity } from "./build-identity";
+import { collectBuildIdentity, resolveBuildDir } from "./build-identity";
 import type { AuthProfileEntries } from "./subscription-surface";
 import {
   CHATGPT_AGENT_RUNTIME_ID,
@@ -183,10 +183,19 @@ function rootStepResultFailed(result: string | null): boolean {
   return result !== null && result !== "success";
 }
 
-/** Read .next/BUILD_ID — regenerated on every successful `next build`. */
+/**
+ * Read the BUILD_ID of the build the SERVER RUNS FROM.
+ *
+ * Through `resolveBuildDir`, not `path.join(PROJECT_DIR, ".next")`: the service
+ * runs with cwd `.next/standalone`, so the assets it serves come from
+ * `.next/standalone/.next` — and `.next` "can be a newer half-finished build",
+ * as that helper's own comment puts it. Reading the wrong tree would answer
+ * "the rebuild produced a new build" about a directory nobody serves.
+ */
 async function readBuildId(): Promise<string> {
   try {
-    return (await readFile(path.join(PROJECT_DIR, ".next", "BUILD_ID"), "utf-8")).trim();
+    const buildDir = await resolveBuildDir(PROJECT_DIR);
+    return (await readFile(path.join(buildDir, "BUILD_ID"), "utf-8")).trim();
   } catch {
     return "";
   }
@@ -1812,18 +1821,28 @@ async function resumeContinuation(): Promise<boolean> {
   // and restarted anything. Resuming blindly would stamp "Update complete"
   // on a box still running its old build. Demand evidence the rebuild
   // happened: the unit must not sit in `failed`, and the on-disk BUILD_ID
-  // must differ from the one recorded before the rebuild (systemd unit state
-  // resets across reboots, so the Result check alone can be erased by a
-  // power cycle; the BUILD_ID can't). Legacy boolean flags (written by the
-  // previous updater version) carry no build identity — for those only the
-  // unit check applies.
+  // must be present AND differ from the one recorded before the rebuild
+  // (systemd unit state resets across reboots, so the Result check alone can be
+  // erased by a power cycle; the BUILD_ID can't). Legacy boolean flags (written
+  // by the previous updater version) carry no build identity — for those the
+  // unit check and the "is there a build at all" check apply.
   const unitFailed = rootStepResultFailed(await getRootStepResult(REBUILD_ROOT_STEP));
   const recordedBuildId = typeof needsContinuation === "string" ? needsContinuation : null;
-  const buildUnchanged = recordedBuildId !== null && recordedBuildId === (await readBuildId());
-  if (unitFailed || buildUnchanged) {
+  const currentBuildId = await readBuildId();
+  const buildUnchanged = recordedBuildId !== null && recordedBuildId === currentBuildId;
+  // ...and NO build id is never evidence of a build. `do_rebuild` used to
+  // delete `.next` before building, so an OOM-killed build left the box with
+  // nothing — and an absent id compares UNEQUAL to the recorded one, which the
+  // check above read as "the build changed". A box with no dashboard at all
+  // then resumed and stamped itself complete. Measured on the OpenClaw dev box
+  // 2026-09-04, TASK-709.
+  const buildMissing = currentBuildId === "";
+  if (unitFailed || buildUnchanged || buildMissing) {
     const message = unitFailed
       ? (await readRootStepFailure(REBUILD_ROOT_STEP)) ?? "Rebuild failed before the restart"
-      : "The device restarted without producing a new build — see clawbox-root-update@rebuild_reboot logs";
+      : buildMissing
+        ? "The device restarted with no build at all (.next/BUILD_ID is missing) — see clawbox-root-update@rebuild_reboot logs"
+        : "The device restarted without producing a new build — see clawbox-root-update@rebuild_reboot logs";
     state = createInitialState(steps);
     state.warnings = await restoreWarnings();
     state.phase = "failed";

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,6 +1,6 @@
 import { exec as execCb, execFile as execFileCb } from "child_process";
 import { promisify } from "util";
-import { readFile, rm, writeFile } from "fs/promises";
+import { readFile, realpath, rm, writeFile } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
 import { get, set, setMany } from "./config-store";
@@ -200,12 +200,21 @@ function rootStepResultFailed(result: string | null): boolean {
  * be false, and the continuation would mark the update complete over a box that
  * cannot boot. `standalone/server.js` is what production-server.js requires, so
  * its presence is what says which tree is the serving one.
+ *
+ * …and the entry is followed through `realpath` rather than assumed to sit at
+ * `.next/standalone`. `postbuild` (package.json) SEARCHES for it — Next nests
+ * the standalone tree whenever `outputFileTracingRoot` resolves above the
+ * project — copies the assets and the identity stamp beside the real entry, and
+ * symlinks `.next/standalone/server.js` at it. On such a box
+ * `.next/standalone/.next/BUILD_ID` does not exist, so reading the literal path
+ * would answer "" and turn every successful update into "the device restarted
+ * with no build at all": a false failure over a rebuild that worked.
  */
 async function readBuildId(): Promise<string> {
   try {
-    const standalone = path.join(PROJECT_DIR, ".next", "standalone");
-    const serving = existsSync(path.join(standalone, "server.js"))
-      ? path.join(standalone, ".next")
+    const entry = path.join(PROJECT_DIR, ".next", "standalone", "server.js");
+    const serving = existsSync(entry)
+      ? path.join(path.dirname(await realpath(entry)), ".next")
       : await resolveBuildDir(PROJECT_DIR);
     return (await readFile(path.join(serving, "BUILD_ID"), "utf-8")).trim();
   } catch {

--- a/src/tests/unit/install-rebuild-build-verify.test.ts
+++ b/src/tests/unit/install-rebuild-build-verify.test.ts
@@ -40,10 +40,20 @@ import path from "node:path";
 const REPO = process.cwd();
 const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
 
-/** One shell function, verbatim, closing brace included; "" when there is none. */
+/**
+ * One shell function, verbatim, closing brace included; "" when there is none.
+ *
+ * Anchored at a LINE START. `indexOf(name + "() {")` also matches inside a
+ * longer identifier, so a future `pre_do_rebuild() {` above `do_rebuild` would
+ * hand back the tail of that definition — and the "extracted whole" guard,
+ * which checks the body STARTS with `name() {`, is satisfied by the suffix. The
+ * harness would then run the wrong body and the suite would pass for the wrong
+ * reason.
+ */
 function findShellFunction(name: string): string {
-  const start = INSTALL_SH.indexOf(name + "() {");
-  if (start < 0) return "";
+  const opener = new RegExp(`^${name}\\(\\) \\{$`, "m").exec(INSTALL_SH);
+  if (!opener) return "";
+  const start = opener.index;
   const end = INSTALL_SH.indexOf("\n}", start);
   if (end < 0) throw new Error(name + " has no closing brace");
   return INSTALL_SH.slice(start, end + 2);
@@ -405,9 +415,14 @@ describe("do_rebuild keeps the box serving when the build fails", () => {
   });
 
   it("does not touch a parked build when the current one is servable", () => {
-    const r = run({ build: "succeeds", previousBuild: "servable", parkedBuild: "servable" });
-    expect(r.status).toBe(0);
-    expect(r.buildId).toBe("new-build-id");
+    // A FAILING build, so the preserved identity is observable: with
+    // `succeeds` the build overwrites BUILD_ID either way, and removing the
+    // guard in promote_parked_build would leave every assertion holding.
+    // Failing, the box must end on its OWN previous build, not the parked one.
+    const r = run({ build: "oom-killed", previousBuild: "servable", parkedBuild: "servable" });
+
+    expect(r.status).not.toBe(0);
+    expect(r.buildId).toBe("old-build-id");
   });
 });
 

--- a/src/tests/unit/install-rebuild-build-verify.test.ts
+++ b/src/tests/unit/install-rebuild-build-verify.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 // not enough on a loaded CI runner. See src/tests/unit/test-timeout-hygiene.test.ts.
 vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync, existsSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -93,18 +93,34 @@ interface Scenario {
   identity?: "ok" | "drift" | "script-missing";
   /** Is there a servable build in `.next` before the rebuild? */
   previousBuild?: "servable" | "none";
-  /** Is there a build parked in `.next-old` by an earlier interrupted run? */
-  parkedBuild?: "servable" | "none";
+  /**
+   * Is there a build parked in `.next-old` by an earlier interrupted run?
+   *
+   * "nested-entry" is the layout `postbuild` supports when Next nests the
+   * standalone tree: `standalone/server.js` is a SYMLINK to an absolute path
+   * inside `.next`, which dangles for as long as the tree is parked.
+   */
+  parkedBuild?: "servable" | "nested-entry" | "none";
   /** Units `systemctl is-active --quiet` answers yes for at the start. */
   activeUnits?: string[];
   /**
-   * Does `systemctl start` actually bring the unit up?
+   * Does the dashboard actually answer on :80 after the start?
    *
-   * False models the crash-loop: the command succeeds, `Restart=always` keeps
-   * retrying, and the unit never becomes active — which is exactly the state
-   * the readiness poll exists to report.
+   * False models the REAL crash-loop, which is why the unit still goes active
+   * here: clawbox-setup is `Type=simple` with `Restart=always`, so systemd
+   * marks it active the instant node is forked — before production-server.js
+   * has required the build. `systemctl is-active` therefore says yes about a
+   * box whose port 80 is dead, and only an HTTP probe can tell them apart.
    */
   startWorks?: boolean;
+  /**
+   * Room on the filesystem for a second copy of the build.
+   *
+   * "tight" takes `set_previous_build_aside`'s no-fallback branch, where the
+   * old build is deleted rather than parked — the case in which a failed
+   * rebuild has nothing to roll back to.
+   */
+  diskHeadroom?: "ample" | "tight";
   bunInstall?: "succeeds" | "fails";
   nodePty?: "succeeds" | "fails";
   /** Which shipped function to run. */
@@ -139,6 +155,7 @@ function run(scenario: Scenario = {}): Run {
     parkedBuild = "none",
     activeUnits = ["ollama.service"],
     startWorks = true,
+    diskHeadroom = "ample",
     bunInstall = "succeeds",
     nodePty = "succeeds",
     entry = "do_rebuild",
@@ -147,6 +164,18 @@ function run(scenario: Scenario = {}): Run {
   mkdirSync(projectDir, { recursive: true });
   if (previousBuild === "servable") writeBuild(path.join(projectDir, ".next"), "old-build-id");
   if (parkedBuild === "servable") writeBuild(path.join(projectDir, ".next-old"), "parked-build-id");
+  if (parkedBuild === "nested-entry") {
+    const kept = path.join(projectDir, ".next-old");
+    writeBuild(kept, "parked-build-id", false);
+    mkdirSync(path.join(kept, "standalone", "nested"), { recursive: true });
+    writeFileSync(path.join(kept, "standalone", "nested", "server.js"), "// server\n", "utf-8");
+    // Exactly what postbuild writes: an ABSOLUTE path through `.next`, which
+    // does not exist while the tree is parked under `.next-old`.
+    symlinkSync(
+      path.join(projectDir, ".next", "standalone", "nested", "server.js"),
+      path.join(kept, "standalone", "server.js"),
+    );
+  }
 
   if (identity !== "script-missing") {
     mkdirSync(path.join(projectDir, "scripts"), { recursive: true });
@@ -179,6 +208,8 @@ function run(scenario: Scenario = {}): Run {
     "SYSTEMCTL_LOG=" + JSON.stringify(systemctlLog),
     'ACTIVE_UNITS="' + activeUnits.join(" ") + '"',
     'START_WORKS=' + (startWorks ? "1" : "0"),
+    "DASHBOARD_UP=0",
+    'DISK_HEADROOM=' + JSON.stringify(diskHeadroom),
     "",
     "is_test_mode() { return 1; }",
     "# The readiness poll waits a real second per attempt. The LOOP is the",
@@ -203,10 +234,13 @@ function run(scenario: Scenario = {}): Run {
     "",
     "systemctl() {",
     '  printf "%s\\n" "systemctl $*" >> "$SYSTEMCTL_LOG"',
-    "  # A real `start` makes the unit active, so the restore path's readiness",
-    "  # poll is answered by what it actually did rather than by a constant.",
+    "  # `Type=simple`: systemd marks the unit active as soon as ExecStart is",
+    "  # forked, whether or not the process can load the build. So `start`",
+    "  # ALWAYS makes is-active true here, and only the HTTP stub below knows",
+    "  # whether the dashboard came up.",
     '  if [ "$1" = "start" ] || [ "$1" = "restart" ]; then',
-    '    [ "$START_WORKS" = "1" ] && ACTIVE_UNITS="$ACTIVE_UNITS $2"',
+    '    ACTIVE_UNITS="$ACTIVE_UNITS $2"',
+    '    [ "$START_WORKS" = "1" ] && DASHBOARD_UP=1',
     "    return 0",
     "  fi",
     '  if [ "$1" = "stop" ]; then',
@@ -224,11 +258,31 @@ function run(scenario: Scenario = {}): Run {
     "  return 0",
     "}",
     "",
+    "# The dashboard's own answer, which is what restore_previous_build asks",
+    "# for. `command -v curl` finds a shell function, so the missing-curl arm",
+    "# stays unreached here and has its own case.",
+    "curl() {",
+    '  if [ "$DASHBOARD_UP" = "1" ]; then printf "200"; return 0; fi',
+    '  printf "000"',
+    "  return 7",
+    "}",
+    "",
+    "# Free space on the build's filesystem. `tight` reports less than twice the",
+    "# tree's size, which is set_previous_build_aside's no-fallback threshold.",
+    "df() {",
+    '  if [ "$DISK_HEADROOM" = "tight" ]; then',
+    '    printf "Filesystem 1024-blocks Used Available Capacity Mounted\\n/dev/x 100 99 1 99%% /\\n"',
+    "  else",
+    '    printf "Filesystem 1024-blocks Used Available Capacity Mounted\\n/dev/x 100 1 99999999 1%% /\\n"',
+    "  fi",
+    "}",
+    "",
     "# beta's own memory reclaim, which do_rebuild calls. Its behaviour has its",
     "# own suite; here it only has to be present and harmless.",
     "free_memory_for_build() { :; }",
     "",
     shellFunctions(
+      "build_entry_present",
       "verify_build_present",
       "promote_parked_build",
       "set_previous_build_aside",
@@ -258,8 +312,6 @@ function run(scenario: Scenario = {}): Run {
     parked: existsSync(path.join(projectDir, ".next-old")),
   };
 }
-
-const index = (r: Run, re: RegExp) => r.systemctl.findIndex((l) => re.test(l));
 
 beforeEach(() => {
   sandbox = mkdtempSync(path.join(tmpdir(), "clawbox-rebuild-"));
@@ -347,7 +399,7 @@ describe("do_rebuild keeps the box serving when the build fails", () => {
   it("starts clawbox-setup again after a failed build", () => {
     const r = run({ build: "oom-killed" });
     expect(restarted(r).length).toBeGreaterThan(0);
-    expect(r.stderr).toMatch(/dashboard is serving again/);
+    expect(r.stderr).toMatch(/Restored the previous build; the dashboard answers on :80 again/);
   });
 
   // The window the first version of this fix left open: `bun install` and
@@ -369,25 +421,51 @@ describe("do_rebuild keeps the box serving when the build fails", () => {
     expect(r.buildId).toBe("old-build-id");
   });
 
-  it("says the dashboard is down when the restored build will not start", () => {
-    // clawbox-setup has Restart=always, so a restore that crash-loops is
-    // invisible unless someone looks. `systemctl start … || true` under a
-    // message that asserts an outcome is the false-success shape — and an
-    // alternation over both messages would be satisfied by an implementation
-    // that skips the readiness poll entirely. This scenario's `start` is a
-    // no-op, so only the DOWN branch can produce a line.
+  it("says the dashboard is down when the restored build crash-loops", () => {
+    // The state a Type=simple unit with Restart=always really produces: the
+    // stub `systemctl start` makes the unit ACTIVE — as systemd does the
+    // instant node is forked — while nothing answers on :80. An
+    // implementation that polls `systemctl is-active` reports "serving again"
+    // here, on a box that will be dead all night. Only the HTTP probe can tell
+    // the two apart, which is why this case is the one that pins it.
     const r = run({ build: "oom-killed", startWorks: false });
 
     expect(r.status).not.toBe(0);
-    expect(r.stderr).toMatch(/dashboard is DOWN/);
-    expect(r.stderr).not.toMatch(/dashboard is serving again/);
+    expect(r.systemctl.some((l) => /^systemctl start clawbox-setup/.test(l))).toBe(true);
+    expect(r.stderr).toMatch(/it is DOWN/);
+    expect(r.stderr).not.toMatch(/answers on :80/);
   });
 
-  it("says the dashboard is serving when the restore really comes up", () => {
+  it("says the dashboard answers when the restore really comes up", () => {
     const r = run({ build: "oom-killed" });
 
-    expect(r.stderr).toMatch(/dashboard is serving again/);
-    expect(r.stderr).not.toMatch(/dashboard is DOWN/);
+    expect(r.stderr).toMatch(/answers on :80 again/);
+    expect(r.stderr).not.toMatch(/it is DOWN/);
+  });
+
+  it("does not call it a restore when nothing was ever moved aside", () => {
+    // `bun install` fails BEFORE the park, so the serving build was never
+    // touched. The outcome is right either way; the sentence is not, and this
+    // whole change is about not asserting things that did not happen.
+    const r = run({ bunInstall: "fails" });
+
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/The serving build was never moved aside/);
+    expect(r.stderr).not.toMatch(/Restored the previous build/);
+  });
+
+  it("names the build that failed verification when the disk could not hold two", () => {
+    // The no-fallback branch: `set_previous_build_aside` deleted the old build
+    // rather than parking it, the new one then failed identity, and what is on
+    // disk is that rejected build. Starting it beats a dead box — calling it a
+    // rollback does not.
+    const r = run({ build: "succeeds", identity: "drift", diskHeadroom: "tight" });
+
+    expect(r.status).not.toBe(0);
+    expect(r.parked).toBe(false);
+    expect(r.buildId).toBe("new-build-id");
+    expect(r.stderr).toMatch(/FAILED verification/);
+    expect(r.stderr).not.toMatch(/Restored the previous build/);
   });
 
   it("replaces the previous build only once the new one exists", () => {
@@ -412,6 +490,17 @@ describe("do_rebuild keeps the box serving when the build fails", () => {
     expect(r.status).not.toBe(0);
     expect(r.buildId).toBe("parked-build-id");
     expect(r.hasEntry).toBe(true);
+  });
+
+  it("reclaims a parked build whose entry is the nested layout's symlink", () => {
+    // `-f` resolves the link, and the link dangles while the tree is parked —
+    // so a `-f` guard answers "nothing parked here" about the box's only
+    // build and the rename below deletes it.
+    const r = run({ previousBuild: "none", parkedBuild: "nested-entry", build: "oom-killed" });
+
+    expect(r.stderr).toMatch(/parked by an interrupted rebuild/);
+    expect(r.buildId).toBe("parked-build-id");
+    expect(r.parked).toBe(false);
   });
 
   it("does not touch a parked build when the current one is servable", () => {

--- a/src/tests/unit/install-rebuild-build-verify.test.ts
+++ b/src/tests/unit/install-rebuild-build-verify.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// Runs real bash for every case: vitest's 5 s test and 10 s hook defaults are
+// not enough on a loaded CI runner. See src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -52,15 +56,15 @@ function shellFunction(name: string): string {
 }
 
 /**
- * The helpers this PR adds, or nothing.
+ * The helpers, all of them required.
  *
- * Deliberately tolerant, and only for these: on the code these tests were
- * written against there are no such functions, and their absence is the bug. A
- * hard failure here would make every case below fail with "not found in
- * install.sh", which proves nothing about what the old `do_rebuild` DID.
+ * They were optional while they did not exist yet; they ship now, and a
+ * tolerant lookup would be a hole: a renamed or deleted helper makes
+ * `do_rebuild` fail with command-not-found, and every case asserting
+ * `status).not.toBe(0)` would still pass — for the wrong reason.
  */
-function optionalShellFunctions(...names: string[]): string {
-  return names.map((n) => findShellFunction(n)).filter(Boolean).join("\n\n");
+function shellFunctions(...names: string[]): string {
+  return names.map((n) => shellFunction(n)).join("\n\n");
 }
 
 type BuildOutcome =
@@ -83,6 +87,14 @@ interface Scenario {
   parkedBuild?: "servable" | "none";
   /** Units `systemctl is-active --quiet` answers yes for at the start. */
   activeUnits?: string[];
+  /**
+   * Does `systemctl start` actually bring the unit up?
+   *
+   * False models the crash-loop: the command succeeds, `Restart=always` keeps
+   * retrying, and the unit never becomes active — which is exactly the state
+   * the readiness poll exists to report.
+   */
+  startWorks?: boolean;
   bunInstall?: "succeeds" | "fails";
   nodePty?: "succeeds" | "fails";
   /** Which shipped function to run. */
@@ -116,6 +128,7 @@ function run(scenario: Scenario = {}): Run {
     previousBuild = "servable",
     parkedBuild = "none",
     activeUnits = ["ollama.service"],
+    startWorks = true,
     bunInstall = "succeeds",
     nodePty = "succeeds",
     entry = "do_rebuild",
@@ -155,8 +168,13 @@ function run(scenario: Scenario = {}): Run {
     "FAKE_BUILD=" + JSON.stringify(fakeBuild),
     "SYSTEMCTL_LOG=" + JSON.stringify(systemctlLog),
     'ACTIVE_UNITS="' + activeUnits.join(" ") + '"',
+    'START_WORKS=' + (startWorks ? "1" : "0"),
     "",
     "is_test_mode() { return 1; }",
+    "# The readiness poll waits a real second per attempt. The LOOP is the",
+    "# subject, not the wall clock, so the wait is a no-op here and all twenty",
+    "# attempts run instantly.",
+    "sleep() { :; }",
     "ensure_node_pty() {",
     nodePty === "succeeds"
       ? "  echo '  node-pty is already loadable'"
@@ -178,7 +196,7 @@ function run(scenario: Scenario = {}): Run {
     "  # A real `start` makes the unit active, so the restore path's readiness",
     "  # poll is answered by what it actually did rather than by a constant.",
     '  if [ "$1" = "start" ] || [ "$1" = "restart" ]; then',
-    '    ACTIVE_UNITS="$ACTIVE_UNITS $2"',
+    '    [ "$START_WORKS" = "1" ] && ACTIVE_UNITS="$ACTIVE_UNITS $2"',
     "    return 0",
     "  fi",
     '  if [ "$1" = "stop" ]; then',
@@ -200,7 +218,7 @@ function run(scenario: Scenario = {}): Run {
     "# own suite; here it only has to be present and harmless.",
     "free_memory_for_build() { :; }",
     "",
-    optionalShellFunctions(
+    shellFunctions(
       "verify_build_present",
       "promote_parked_build",
       "set_previous_build_aside",
@@ -344,11 +362,22 @@ describe("do_rebuild keeps the box serving when the build fails", () => {
   it("says the dashboard is down when the restored build will not start", () => {
     // clawbox-setup has Restart=always, so a restore that crash-loops is
     // invisible unless someone looks. `systemctl start … || true` under a
-    // message that asserts an outcome is the false-success shape.
-    const r = run({ build: "oom-killed", activeUnits: [] });
-    // The stub only makes a unit active when `start` is called, and the
-    // scenario's start succeeds, so this asserts the poll ran at all.
-    expect(r.stderr).toMatch(/dashboard is serving again|dashboard is DOWN/);
+    // message that asserts an outcome is the false-success shape — and an
+    // alternation over both messages would be satisfied by an implementation
+    // that skips the readiness poll entirely. This scenario's `start` is a
+    // no-op, so only the DOWN branch can produce a line.
+    const r = run({ build: "oom-killed", startWorks: false });
+
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/dashboard is DOWN/);
+    expect(r.stderr).not.toMatch(/dashboard is serving again/);
+  });
+
+  it("says the dashboard is serving when the restore really comes up", () => {
+    const r = run({ build: "oom-killed" });
+
+    expect(r.stderr).toMatch(/dashboard is serving again/);
+    expect(r.stderr).not.toMatch(/dashboard is DOWN/);
   });
 
   it("replaces the previous build only once the new one exists", () => {

--- a/src/tests/unit/install-rebuild-build-verify.test.ts
+++ b/src/tests/unit/install-rebuild-build-verify.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/**
+ * `do_rebuild` is the build inside `install.sh --step rebuild_reboot` — the
+ * only thing that turns freshly pulled code into a dashboard. It had three
+ * defects, all measured on the OpenClaw dev box on 2026-09-04 (TASK-709).
+ *
+ *  1. It deleted `.next` BEFORE building. So any failure past that line left
+ *     the box with new code and NO build: `clawbox-setup` stopped by this same
+ *     function and never started again, port 80 dead — while `clawbox-gateway`
+ *     kept answering on 18789, so the box looked half-alive and the owner saw
+ *     "Failed to get gateway config" over a cached page.
+ *
+ *  2. It read `bun run build`'s exit status as the verdict and nothing else.
+ *     `bun run build` is `next build` PLUS the `postbuild` lifecycle script,
+ *     and postbuild is what makes a build servable — BUILD_ID is written
+ *     before any of it, and postbuild's own `if [ -n "$SRVJS" ]` guard exits 0
+ *     having copied nothing. So a "successful" build can still leave
+ *     production-server.js crash-looping on
+ *     `require("./.next/standalone/server.js")`.
+ *
+ * The memory half of the same incident — the build being OOM-killed with
+ * ollama, Kokoro and llama.cpp resident — was fixed on beta by
+ * `free_memory_for_build`, which `do_rebuild` calls after the clawbox-setup
+ * stop and which has its own suite (install-free-memory-before-build.test.ts).
+ * Nothing here duplicates it; the stub below simply lets it run.
+ *
+ * These run the SHIPPED function bodies out of install.sh against stubs, so an
+ * edit to install.sh is what the assertions see.
+ */
+
+const REPO = process.cwd();
+const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
+
+/** One shell function, verbatim, closing brace included; "" when there is none. */
+function findShellFunction(name: string): string {
+  const start = INSTALL_SH.indexOf(name + "() {");
+  if (start < 0) return "";
+  const end = INSTALL_SH.indexOf("\n}", start);
+  if (end < 0) throw new Error(name + " has no closing brace");
+  return INSTALL_SH.slice(start, end + 2);
+}
+
+function shellFunction(name: string): string {
+  const body = findShellFunction(name);
+  if (!body) throw new Error(name + " not found in install.sh");
+  return body;
+}
+
+/**
+ * The helpers this PR adds, or nothing.
+ *
+ * Deliberately tolerant, and only for these: on the code these tests were
+ * written against there are no such functions, and their absence is the bug. A
+ * hard failure here would make every case below fail with "not found in
+ * install.sh", which proves nothing about what the old `do_rebuild` DID.
+ */
+function optionalShellFunctions(...names: string[]): string {
+  return names.map((n) => findShellFunction(n)).filter(Boolean).join("\n\n");
+}
+
+type BuildOutcome =
+  /** BUILD_ID and a loadable standalone entry: a real build. */
+  | "succeeds"
+  /** SIGKILL from the global OOM killer: nothing written. */
+  | "oom-killed"
+  /** Exit 0, nothing written at all. */
+  | "exits-zero-without-output"
+  /** Exit 0 with BUILD_ID but no standalone entry: the half-run postbuild. */
+  | "no-standalone-entry";
+
+interface Scenario {
+  build?: BuildOutcome;
+  /** What `scripts/verify-build-identity.sh` answers, or that it is absent. */
+  identity?: "ok" | "drift" | "script-missing";
+  /** Is there a servable build in `.next` before the rebuild? */
+  previousBuild?: "servable" | "none";
+  /** Is there a build parked in `.next-old` by an earlier interrupted run? */
+  parkedBuild?: "servable" | "none";
+  /** Units `systemctl is-active --quiet` answers yes for at the start. */
+  activeUnits?: string[];
+  bunInstall?: "succeeds" | "fails";
+  nodePty?: "succeeds" | "fails";
+  /** Which shipped function to run. */
+  entry?: "do_rebuild" | "step_build";
+}
+
+interface Run {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  systemctl: string[];
+  buildId: string | null;
+  hasEntry: boolean;
+  parked: boolean;
+}
+
+let sandbox: string;
+let systemctlLog: string;
+let projectDir: string;
+
+function writeBuild(dir: string, buildId: string, withEntry = true): void {
+  mkdirSync(path.join(dir, "standalone"), { recursive: true });
+  writeFileSync(path.join(dir, "BUILD_ID"), buildId + "\n", "utf-8");
+  if (withEntry) writeFileSync(path.join(dir, "standalone", "server.js"), "// server\n", "utf-8");
+}
+
+function run(scenario: Scenario = {}): Run {
+  const {
+    build = "succeeds",
+    identity = "ok",
+    previousBuild = "servable",
+    parkedBuild = "none",
+    activeUnits = ["ollama.service"],
+    bunInstall = "succeeds",
+    nodePty = "succeeds",
+    entry = "do_rebuild",
+  } = scenario;
+
+  mkdirSync(projectDir, { recursive: true });
+  if (previousBuild === "servable") writeBuild(path.join(projectDir, ".next"), "old-build-id");
+  if (parkedBuild === "servable") writeBuild(path.join(projectDir, ".next-old"), "parked-build-id");
+
+  if (identity !== "script-missing") {
+    mkdirSync(path.join(projectDir, "scripts"), { recursive: true });
+    writeFileSync(
+      path.join(projectDir, "scripts", "verify-build-identity.sh"),
+      identity === "ok" ? "#!/usr/bin/env bash\nexit 0\n" : "#!/usr/bin/env bash\necho 'BUILD IDENTITY: FAIL' >&2\nexit 1\n",
+      "utf-8",
+    );
+  }
+
+  // Stands in for `bun run build`. The four outcomes are the four the box can
+  // produce, including the two that exit 0 without leaving a servable build.
+  const fakeBuild = path.join(sandbox, "fake-build.sh");
+  const bodies: Record<BuildOutcome, string> = {
+    succeeds: 'mkdir -p "$1/.next/standalone" && printf "new-build-id\\n" > "$1/.next/BUILD_ID" && printf "// server\\n" > "$1/.next/standalone/server.js" && exit 0',
+    "oom-killed": 'echo "Killed" >&2; exit 137',
+    "exits-zero-without-output": "exit 0",
+    "no-standalone-entry": 'mkdir -p "$1/.next" && printf "new-build-id\\n" > "$1/.next/BUILD_ID" && exit 0',
+  };
+  writeFileSync(fakeBuild, "#!/usr/bin/env bash\n" + bodies[build] + "\n", "utf-8");
+  spawnSync("chmod", ["+x", fakeBuild]);
+
+  const lines = [
+    "set -euo pipefail",
+    "",
+    "PROJECT_DIR=" + JSON.stringify(projectDir),
+    "CLAWBOX_USER=clawbox",
+    "BUN=/nonexistent/bun",
+    "FAKE_BUILD=" + JSON.stringify(fakeBuild),
+    "SYSTEMCTL_LOG=" + JSON.stringify(systemctlLog),
+    'ACTIVE_UNITS="' + activeUnits.join(" ") + '"',
+    "",
+    "is_test_mode() { return 1; }",
+    "ensure_node_pty() {",
+    nodePty === "succeeds"
+      ? "  echo '  node-pty is already loadable'"
+      : "  echo 'Error: node-pty is still not loadable' >&2; return 1",
+    "}",
+    "",
+    "# The build runs as the clawbox user through this one seam. `bun install`",
+    "# has an outcome of its own because it sits inside the window where the",
+    "# dashboard is down.",
+    "as_clawbox_login() {",
+    '  case "$*" in',
+    '    *"run build"*) "$FAKE_BUILD" "$PROJECT_DIR" ;;',
+    bunInstall === "succeeds" ? "    *) return 0 ;;" : '    *"install"*) return 1 ;;\n    *) return 0 ;;',
+    "  esac",
+    "}",
+    "",
+    "systemctl() {",
+    '  printf "%s\\n" "systemctl $*" >> "$SYSTEMCTL_LOG"',
+    "  # A real `start` makes the unit active, so the restore path's readiness",
+    "  # poll is answered by what it actually did rather than by a constant.",
+    '  if [ "$1" = "start" ] || [ "$1" = "restart" ]; then',
+    '    ACTIVE_UNITS="$ACTIVE_UNITS $2"',
+    "    return 0",
+    "  fi",
+    '  if [ "$1" = "stop" ]; then',
+    '    local kept="" u',
+    '    for u in $ACTIVE_UNITS; do [ "$u" = "$2" ] || kept="$kept $u"; done',
+    '    ACTIVE_UNITS="$kept"',
+    "    return 0",
+    "  fi",
+    '  if [ "$1" = "is-active" ]; then',
+    "    for u in $ACTIVE_UNITS; do",
+    '      for a in "$@"; do [ "$a" = "$u" ] && return 0; done',
+    "    done",
+    "    return 3",
+    "  fi",
+    "  return 0",
+    "}",
+    "",
+    "# beta's own memory reclaim, which do_rebuild calls. Its behaviour has its",
+    "# own suite; here it only has to be present and harmless.",
+    "free_memory_for_build() { :; }",
+    "",
+    optionalShellFunctions(
+      "verify_build_present",
+      "promote_parked_build",
+      "set_previous_build_aside",
+      "restore_previous_build",
+    ),
+    "",
+    shellFunction(entry),
+    "",
+    entry,
+    "",
+  ];
+
+  const scriptPath = path.join(sandbox, "run.sh");
+  writeFileSync(scriptPath, lines.join("\n"), "utf-8");
+  const result = spawnSync("bash", [scriptPath], { encoding: "utf-8", cwd: REPO });
+  const log = existsSync(systemctlLog)
+    ? readFileSync(systemctlLog, "utf-8").split("\n").filter(Boolean)
+    : [];
+  const buildIdPath = path.join(projectDir, ".next", "BUILD_ID");
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    systemctl: log,
+    buildId: existsSync(buildIdPath) ? readFileSync(buildIdPath, "utf-8").trim() : null,
+    hasEntry: existsSync(path.join(projectDir, ".next", "standalone", "server.js")),
+    parked: existsSync(path.join(projectDir, ".next-old")),
+  };
+}
+
+const index = (r: Run, re: RegExp) => r.systemctl.findIndex((l) => re.test(l));
+
+beforeEach(() => {
+  sandbox = mkdtempSync(path.join(tmpdir(), "clawbox-rebuild-"));
+  systemctlLog = path.join(sandbox, "systemctl.log");
+  projectDir = path.join(sandbox, "clawbox");
+});
+
+afterEach(() => {
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+describe("the shipped function bodies these tests run", () => {
+  // findShellFunction slices to the first line starting with `}`. That is true
+  // of every function it reads today, and silently wrong the day one grows a
+  // heredoc or an indented closing brace at column 0 — the tests would then
+  // assert against a fragment and pass for the wrong reason.
+  it.each(["do_rebuild", "step_build", "verify_build_present", "restore_previous_build"])(
+    "%s is extracted whole",
+    (name) => {
+      const body = shellFunction(name);
+      expect(body.startsWith(name + "() {")).toBe(true);
+      expect(body.endsWith("\n}")).toBe(true);
+      // A fragment would not carry the function's last statement; every one of
+      // these ends in a return, an echo or a cleanup, never mid-`if`.
+      expect(body).not.toMatch(/\n\s*(if|while|case)[^\n]*\n\}$/);
+    },
+  );
+});
+
+describe("do_rebuild verifies the build it produced", () => {
+  it("succeeds when the build writes a loadable standalone entry", () => {
+    const r = run({ build: "succeeds" });
+    expect(r.status).toBe(0);
+    expect(r.buildId).toBe("new-build-id");
+    expect(r.hasEntry).toBe(true);
+  });
+
+  it("fails when the build exits 0 without producing anything", () => {
+    const r = run({ build: "exits-zero-without-output" });
+    expect(r.status).not.toBe(0);
+  });
+
+  it("fails when the build is OOM-killed", () => {
+    expect(run({ build: "oom-killed" }).status).not.toBe(0);
+  });
+
+  // The false success the first version of this fix would still have had:
+  // BUILD_ID is written by `next build`, and `postbuild` — which copies the
+  // standalone entry, the static assets and the identity stamp — runs after it
+  // and can exit 0 having copied nothing. production-server.js does
+  // `require("./.next/standalone/server.js")`, so BUILD_ID alone green-lights a
+  // box that cannot boot.
+  it("fails when the build leaves no server entry for the dashboard to load", () => {
+    const r = run({ build: "no-standalone-entry" });
+    expect(r.status).not.toBe(0);
+    expect(r.stdout + r.stderr).toMatch(/standalone\/server\.js/);
+  });
+
+  it("fails when the build on disk is not the checked-out commit", () => {
+    // Asked through scripts/verify-build-identity.sh, the copy CI runs too —
+    // not a second implementation of the comparison.
+    const r = run({ build: "succeeds", identity: "drift" });
+    expect(r.status).not.toBe(0);
+    expect(r.buildId).toBe("old-build-id");
+  });
+
+  it("warns rather than failing when the identity script is not on disk", () => {
+    const r = run({ build: "succeeds", identity: "script-missing" });
+    expect(r.status).toBe(0);
+    expect(r.stderr).toMatch(/verify-build-identity\.sh is missing/);
+  });
+});
+
+describe("do_rebuild keeps the box serving when the build fails", () => {
+  const restarted = (r: Run) =>
+    r.systemctl.filter((l) => /^systemctl (start|restart) clawbox-setup\.service$/.test(l));
+
+  it("leaves the previous build in place after an OOM kill", () => {
+    const r = run({ build: "oom-killed" });
+    expect(r.status).not.toBe(0);
+    expect(r.buildId).toBe("old-build-id");
+    expect(r.hasEntry).toBe(true);
+  });
+
+  it("starts clawbox-setup again after a failed build", () => {
+    const r = run({ build: "oom-killed" });
+    expect(restarted(r).length).toBeGreaterThan(0);
+    expect(r.stderr).toMatch(/dashboard is serving again/);
+  });
+
+  // The window the first version of this fix left open: `bun install` and
+  // `ensure_node_pty` run AFTER clawbox-setup is stopped and BEFORE the restore
+  // branch, and `ensure_node_pty` used to `exit 1` outright — jumping over the
+  // recovery and leaving the box in exactly the state the card describes, this
+  // time with a perfectly good build untouched on disk.
+  it("starts clawbox-setup again when bun install fails", () => {
+    const r = run({ bunInstall: "fails" });
+    expect(r.status).not.toBe(0);
+    expect(restarted(r).length).toBeGreaterThan(0);
+    expect(r.buildId).toBe("old-build-id");
+  });
+
+  it("starts clawbox-setup again when node-pty cannot be rebuilt", () => {
+    const r = run({ nodePty: "fails" });
+    expect(r.status).not.toBe(0);
+    expect(restarted(r).length).toBeGreaterThan(0);
+    expect(r.buildId).toBe("old-build-id");
+  });
+
+  it("says the dashboard is down when the restored build will not start", () => {
+    // clawbox-setup has Restart=always, so a restore that crash-loops is
+    // invisible unless someone looks. `systemctl start … || true` under a
+    // message that asserts an outcome is the false-success shape.
+    const r = run({ build: "oom-killed", activeUnits: [] });
+    // The stub only makes a unit active when `start` is called, and the
+    // scenario's start succeeds, so this asserts the poll ran at all.
+    expect(r.stderr).toMatch(/dashboard is serving again|dashboard is DOWN/);
+  });
+
+  it("replaces the previous build only once the new one exists", () => {
+    const r = run({ build: "succeeds" });
+    expect(r.status).toBe(0);
+    expect(r.buildId).toBe("new-build-id");
+    expect(r.parked).toBe(false);
+  });
+
+  it("still fails, without a previous build to fall back on", () => {
+    const r = run({ build: "oom-killed", previousBuild: "none" });
+    expect(r.status).not.toBe(0);
+    expect(r.buildId).toBeNull();
+    expect(r.stderr).toMatch(/No build to fall back on/);
+  });
+
+  // A rebuild that is killed outright — the OOM killer picking this shell, a
+  // power cut, an operator's Ctrl-C — leaves the only good build parked under a
+  // gitignored directory that nothing else in the tree reads.
+  it("reclaims a build parked by an interrupted rebuild", () => {
+    const r = run({ build: "oom-killed", previousBuild: "none", parkedBuild: "servable" });
+    expect(r.status).not.toBe(0);
+    expect(r.buildId).toBe("parked-build-id");
+    expect(r.hasEntry).toBe(true);
+  });
+
+  it("does not touch a parked build when the current one is servable", () => {
+    const r = run({ build: "succeeds", previousBuild: "servable", parkedBuild: "servable" });
+    expect(r.status).toBe(0);
+    expect(r.buildId).toBe("new-build-id");
+  });
+});
+
+describe("step_build asks the same two questions", () => {
+  it("fails when the install path produces no server entry", () => {
+    const r = run({ entry: "step_build", build: "no-standalone-entry", previousBuild: "none" });
+    expect(r.status).not.toBe(0);
+  });
+
+  it("reclaims a parked build before rebuilding", () => {
+    const r = run({ entry: "step_build", build: "oom-killed", previousBuild: "none", parkedBuild: "servable" });
+    expect(r.status).not.toBe(0);
+    expect(r.buildId).toBe("parked-build-id");
+  });
+});

--- a/src/tests/unit/production-server-parked-build.test.ts
+++ b/src/tests/unit/production-server-parked-build.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync, existsSync, symlinkSync } from "node:fs";
+import * as realFs from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/**
+ * The half `install.sh` cannot reach: a build parked by an update that was
+ * killed OUTRIGHT.
+ *
+ * `do_rebuild` renames the serving build to `.next-old` before it builds and
+ * renames it back when the build fails — but only if that shell survives. An
+ * OOM kill that picks the shell (TASK-709: three in one night, `next-build` at
+ * 2.1 GB against ollama's 2.3 GB), a power cut or a Ctrl-C leaves no `.next` at
+ * all and a perfectly good build under a gitignored directory. `install.sh`'s
+ * own `promote_parked_build` is no help there: it runs inside an update, and an
+ * update needs the dashboard to be up. So the box crash-looped on the missing
+ * entry with its build on disk, and every recovery was by hand.
+ *
+ * production-server.js is the one process that runs in that state, so the
+ * reclaim lives immediately before its `require`. These cases run the SHIPPED
+ * block — extracted from the file by text — against a temp tree.
+ */
+
+const REPO = process.cwd();
+const SRC = readFileSync(path.join(REPO, "production-server.js"), "utf-8");
+const START = "// A build parked by an update that was killed OUTRIGHT";
+const END = 'require("./.next/standalone/server.js");';
+
+/** The shipped reclaim block, verbatim, or a failure that names why. */
+function reclaimBlock(): string {
+  const from = SRC.indexOf(START);
+  const to = SRC.indexOf(END);
+  if (from < 0) throw new Error("the parked-build reclaim block is gone from production-server.js");
+  if (to < from) throw new Error("the reclaim block no longer sits before the standalone require");
+  const block = SRC.slice(from, to).trim();
+  // A block that no longer mentions the parked directory would run happily and
+  // assert nothing — the shape this whole file exists to catch elsewhere.
+  if (!block.includes(".next-old")) throw new Error("the reclaim block no longer names .next-old");
+  return block;
+}
+
+interface Reclaim {
+  warnings: string[];
+  threw: unknown;
+}
+
+function runReclaim(dir: string, fsOverride: object = {}): Reclaim {
+  const warnings: string[] = [];
+  const fakeConsole = { warn: (...args: unknown[]) => warnings.push(args.join(" ")) };
+  const fs = { ...realFs, ...fsOverride };
+  let threw: unknown = null;
+  try {
+    new Function("fs", "path", "__dirname", "console", reclaimBlock())(fs, path, dir, fakeConsole);
+  } catch (err) {
+    threw = err;
+  }
+  return { warnings, threw };
+}
+
+function writeBuild(dir: string, buildId: string): void {
+  mkdirSync(path.join(dir, "standalone"), { recursive: true });
+  writeFileSync(path.join(dir, "BUILD_ID"), buildId + "\n", "utf-8");
+  writeFileSync(path.join(dir, "standalone", "server.js"), "// server\n", "utf-8");
+}
+
+const buildId = (dir: string): string | null => {
+  const p = path.join(dir, ".next", "BUILD_ID");
+  return existsSync(p) ? readFileSync(p, "utf-8").trim() : null;
+};
+
+let projectDir: string;
+
+beforeEach(() => {
+  projectDir = mkdtempSync(path.join(tmpdir(), "clawbox-parked-"));
+});
+
+afterEach(() => {
+  rmSync(projectDir, { recursive: true, force: true });
+});
+
+describe("production-server.js reclaims a parked build at boot", () => {
+  it("puts the parked build back when there is no build at all", () => {
+    writeBuild(path.join(projectDir, ".next-old"), "parked-build-id");
+
+    const r = runReclaim(projectDir);
+
+    expect(r.threw).toBeNull();
+    expect(buildId(projectDir)).toBe("parked-build-id");
+    expect(existsSync(path.join(projectDir, ".next-old"))).toBe(false);
+    expect(r.warnings.join(" ")).toMatch(/killed mid-rebuild/);
+  });
+
+  it("puts back a parked build whose entry is the nested layout's symlink", () => {
+    // `postbuild` links `.next/standalone/server.js` at an ABSOLUTE path inside
+    // `.next` when Next nests the standalone tree — and that link dangles for
+    // as long as the tree is parked. `existsSync` follows it and would call the
+    // box's only build absent.
+    const kept = path.join(projectDir, ".next-old");
+    mkdirSync(path.join(kept, "standalone", "nested"), { recursive: true });
+    writeFileSync(path.join(kept, "BUILD_ID"), "parked-build-id\n", "utf-8");
+    writeFileSync(path.join(kept, "standalone", "nested", "server.js"), "// server\n", "utf-8");
+    symlinkSync(
+      path.join(projectDir, ".next", "standalone", "nested", "server.js"),
+      path.join(kept, "standalone", "server.js"),
+    );
+
+    const r = runReclaim(projectDir);
+
+    expect(r.threw).toBeNull();
+    expect(buildId(projectDir)).toBe("parked-build-id");
+    // …and the link resolves again once the tree is back where it points.
+    expect(existsSync(path.join(projectDir, ".next", "standalone", "server.js"))).toBe(true);
+  });
+
+  it("does not touch a box that already has a build", () => {
+    // The narrowness IS the safety: this runs in the boot path of every box on
+    // every restart, and a build that is present must be left exactly alone —
+    // including a stale `.next-old` a previous run left behind.
+    writeBuild(path.join(projectDir, ".next"), "current-build-id");
+    writeBuild(path.join(projectDir, ".next-old"), "parked-build-id");
+
+    const r = runReclaim(projectDir);
+
+    expect(r.threw).toBeNull();
+    expect(buildId(projectDir)).toBe("current-build-id");
+    expect(existsSync(path.join(projectDir, ".next-old"))).toBe(true);
+    expect(r.warnings).toEqual([]);
+  });
+
+  it("says nothing and throws nothing when there is neither build", () => {
+    // A box that genuinely has no build must still reach the `require` below,
+    // so that ITS error is the one an operator reads.
+    const r = runReclaim(projectDir);
+
+    expect(r.threw).toBeNull();
+    expect(r.warnings).toEqual([]);
+    expect(existsSync(path.join(projectDir, ".next"))).toBe(false);
+  });
+
+  it("never lets its own failure stop the server from starting", () => {
+    // A read-only rootfs, a directory another process is holding, an ENOSPC on
+    // the rename: whatever it is, this block must swallow it. It runs in the
+    // boot path of every box on every restart, and the `require` below is what
+    // has to produce the real error — not a throw from the repair attempt.
+    writeBuild(path.join(projectDir, ".next-old"), "parked-build-id");
+
+    const r = runReclaim(projectDir, {
+      renameSync: () => {
+        throw Object.assign(new Error("EROFS: read-only file system"), { code: "EROFS" });
+      },
+    });
+
+    expect(r.threw).toBeNull();
+    expect(r.warnings.join(" ")).toMatch(/Could not reclaim a parked build/);
+  });
+});

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import * as childProcess from "child_process";
 import * as fs from "fs/promises";
+import { existsSync } from "fs";
 
 vi.mock("child_process", () => ({
   exec: vi.fn(),
@@ -10,6 +11,19 @@ vi.mock("child_process", () => ({
 vi.mock("fs/promises", () => ({
   readFile: vi.fn(),
 }));
+
+// `existsSync` is how readBuildId decides WHICH tree the server runs from — the
+// standalone entry point, not a BUILD_ID that a failed rebuild may have taken
+// with it. Partial, because `updater.ts` is not the only module in this graph
+// that touches `fs`.
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  // The REAL implementation by default — other code in this graph asks whether
+  // real files exist (the build-identity script, for one) and a blanket `false`
+  // would rewrite those tests' subject. Only the case that is about WHICH build
+  // tree the server runs from overrides it.
+  return { ...actual, existsSync: vi.fn(actual.existsSync) };
+});
 
 vi.mock("@/lib/config-store", () => ({
   get: vi.fn(),
@@ -42,6 +56,7 @@ const mockSetMany = vi.mocked(setMany);
 const mockExec = vi.mocked(childProcess.exec);
 const mockExecFile = vi.mocked(childProcess.execFile);
 const mockReadFile = vi.mocked(fs.readFile);
+const mockExists = vi.mocked(existsSync);
 const mockGatewayUp = vi.mocked(waitForPortOpen);
 
 /**
@@ -1104,6 +1119,28 @@ describe("updater", () => {
       const state = updater.getUpdateState();
       expect(state.phase).toBe("failed");
       expect(state.error).toContain("no build");
+    });
+
+    it("reports a failed update when the SERVING tree lost its build", async () => {
+      // The half a `resolveBuildDir` fallback would miss. A failed rebuild can
+      // leave `.next/standalone/server.js` in place — that is what the service
+      // loads — while the standalone BUILD_ID beside it is gone and a stale
+      // `.next/BUILD_ID` is still there. Reading the fallback tree would answer
+      // about a directory nobody serves, and the update would resume.
+      updater.resetUpdateState();
+      mockGet.mockResolvedValue("build-aaa");
+      mockExists.mockImplementation((file: unknown) => String(file).endsWith("standalone/server.js"));
+      mockReadFile.mockImplementation(async (file) => {
+        // Only the NON-serving tree still has one.
+        if (String(file).endsWith("standalone/.next/BUILD_ID")) {
+          throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+        }
+        if (String(file).endsWith("BUILD_ID")) return "build-bbb\n";
+        throw new Error("ENOENT");
+      });
+
+      expect(await updater.checkContinuation()).toBe(false);
+      expect(updater.getUpdateState().phase).toBe("failed");
     });
 
     it("reports a failed update when a box that had no build still has none", async () => {

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -8,8 +8,13 @@ vi.mock("child_process", () => ({
   execFile: vi.fn(),
 }));
 
+// `realpath` beside `readFile`: readBuildId follows `.next/standalone/server.js`
+// through the link `postbuild` writes for the NESTED standalone layout, so a
+// mock without it would make every case that reaches the entry throw inside
+// readBuildId's `try` and answer "" — i.e. pass for the wrong reason.
 vi.mock("fs/promises", () => ({
   readFile: vi.fn(),
+  realpath: vi.fn(),
 }));
 
 // `existsSync` is how readBuildId decides WHICH tree the server runs from — the
@@ -56,6 +61,7 @@ const mockSetMany = vi.mocked(setMany);
 const mockExec = vi.mocked(childProcess.exec);
 const mockExecFile = vi.mocked(childProcess.execFile);
 const mockReadFile = vi.mocked(fs.readFile);
+const mockRealpath = vi.mocked(fs.realpath);
 const mockExists = vi.mocked(existsSync);
 const mockGatewayUp = vi.mocked(waitForPortOpen);
 
@@ -202,6 +208,9 @@ describe("updater", () => {
       if (String(file).endsWith("BUILD_ID")) return "rebuilt-build-id\n";
       throw new Error("ENOENT");
     });
+    // The FLAT standalone layout — the entry is where it looks like it is.
+    // The nested one has a case of its own.
+    mockRealpath.mockImplementation((async (p: unknown) => String(p)) as never);
     mockGatewayUp.mockResolvedValue(true);
 
     setupExecMock({
@@ -1141,6 +1150,29 @@ describe("updater", () => {
 
       expect(await updater.checkContinuation()).toBe(false);
       expect(updater.getUpdateState().phase).toBe("failed");
+    });
+
+    it("reads the nested standalone layout's real build, not the path it links from", async () => {
+      // `postbuild` SEARCHES for the standalone entry (Next nests the tree when
+      // outputFileTracingRoot resolves above the project), copies the assets and
+      // the stamp beside the real one, and symlinks `.next/standalone/server.js`
+      // at it. On such a box `.next/standalone/.next/BUILD_ID` does not exist —
+      // so reading the literal path answers "" and turns a rebuild that WORKED
+      // into "the device restarted with no build at all".
+      updater.resetUpdateState();
+      mockGet.mockResolvedValue("build-aaa");
+      mockExists.mockImplementation((file: unknown) => String(file).endsWith("standalone/server.js"));
+      mockRealpath.mockImplementation((async (p: unknown) =>
+        String(p).replace("/standalone/server.js", "/standalone/nested/app/server.js")) as never);
+      mockReadFile.mockImplementation(async (file) => {
+        if (String(file).endsWith("standalone/nested/app/.next/BUILD_ID")) return "build-bbb\n";
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      });
+
+      // A new build id, read from the tree the service really loads: the
+      // continuation is allowed to run.
+      expect(await updater.checkContinuation()).toBe(true);
+      expect(updater.getUpdateState().phase).not.toBe("failed");
     });
 
     it("reports a failed update when a box that had no build still has none", async () => {

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -43,6 +43,22 @@ const mockExec = vi.mocked(childProcess.exec);
 const mockExecFile = vi.mocked(childProcess.execFile);
 const mockReadFile = vi.mocked(fs.readFile);
 const mockGatewayUp = vi.mocked(waitForPortOpen);
+
+/**
+ * A box whose rebuild produced a build, and no other readable file.
+ *
+ * These cases mean "there is nothing else on disk to read", and they used to
+ * say it with a blanket ENOENT. An absent `.next/BUILD_ID` is now a failed
+ * rebuild in its own right (TASK-709) — nothing is never evidence of a build —
+ * so the one file that decides whether the continuation may run has to be
+ * stated rather than left to the same rejection as everything else.
+ */
+function mockRebuiltBox(buildId = "rebuilt-build-id"): void {
+  mockReadFile.mockImplementation(async (file) => {
+    if (String(file).endsWith("BUILD_ID")) return `${buildId}\n`;
+    throw new Error("ENOENT");
+  });
+}
 let execFileFallbackResults: Record<string, { stdout: string; stderr: string } | Error> = {};
 
 function setupExecMock(results: Record<string, { stdout: string; stderr: string } | Error> = {}) {
@@ -163,7 +179,14 @@ describe("updater", () => {
     mockGet.mockResolvedValue(undefined);
     mockSet.mockResolvedValue();
     mockSetMany.mockResolvedValue();
-    mockReadFile.mockRejectedValue(new Error("ENOENT"));
+    // A box that got through the rebuild has a BUILD_ID; an absent one is now
+    // itself proof the rebuild failed (TASK-709), so the default fixture is a
+    // box that DID build and every case about a missing or unchanged build
+    // says so explicitly.
+    mockReadFile.mockImplementation(async (file) => {
+      if (String(file).endsWith("BUILD_ID")) return "rebuilt-build-id\n";
+      throw new Error("ENOENT");
+    });
     mockGatewayUp.mockResolvedValue(true);
 
     setupExecMock({
@@ -283,7 +306,7 @@ describe("updater", () => {
       mockGet.mockResolvedValue(undefined);
       mockSet.mockResolvedValue();
       mockSetMany.mockResolvedValue();
-      mockReadFile.mockRejectedValue(new Error("ENOENT"));
+      mockRebuiltBox();
       updater = await import("@/lib/updater");
 
       updater.resetUpdateState();
@@ -322,7 +345,7 @@ describe("updater", () => {
       mockGet.mockResolvedValue(undefined);
       mockSet.mockResolvedValue();
       mockSetMany.mockResolvedValue();
-      mockReadFile.mockRejectedValue(new Error("ENOENT"));
+      mockRebuiltBox();
       updater = await import("@/lib/updater");
 
       updater.resetUpdateState();
@@ -357,7 +380,7 @@ describe("updater", () => {
       mockGet.mockResolvedValue(undefined);
       mockSet.mockResolvedValue();
       mockSetMany.mockResolvedValue();
-      mockReadFile.mockRejectedValue(new Error("ENOENT"));
+      mockRebuiltBox();
       updater = await import("@/lib/updater");
 
       // Drive it through the post-restart continuation: resumes at post_update.
@@ -516,7 +539,7 @@ describe("updater", () => {
       mockGet.mockResolvedValue(true);
       mockSet.mockResolvedValue();
       mockSetMany.mockResolvedValue();
-      mockReadFile.mockRejectedValue(new Error("ENOENT"));
+      mockRebuiltBox();
       updater = await import("@/lib/updater");
 
       updater.resetUpdateState();
@@ -548,7 +571,7 @@ describe("updater", () => {
       mockGet.mockResolvedValue(true);
       mockSet.mockResolvedValue();
       mockSetMany.mockResolvedValue();
-      mockReadFile.mockRejectedValue(new Error("ENOENT"));
+      mockRebuiltBox();
       mockGatewayUp.mockResolvedValue(false);
       updater = await import("@/lib/updater");
 
@@ -583,7 +606,7 @@ describe("updater", () => {
       mockGet.mockResolvedValue(true);
       mockSet.mockResolvedValue();
       mockSetMany.mockResolvedValue();
-      mockReadFile.mockRejectedValue(new Error("ENOENT"));
+      mockRebuiltBox();
       // Health is impossible until BOTH explicit consent and the later system
       // restart occurred. Merely invoking pre-start must never make this green.
       mockGatewayUp.mockImplementation(async () => {
@@ -684,7 +707,7 @@ describe("updater", () => {
       mockGet.mockResolvedValue(true);
       mockSet.mockResolvedValue();
       mockSetMany.mockResolvedValue();
-      mockReadFile.mockRejectedValue(new Error("ENOENT"));
+      mockRebuiltBox();
       mockGatewayUp.mockImplementation(async () =>
         mockExecFile.mock.calls.some(([cmd, args]) =>
           cmd === "/usr/bin/sudo"
@@ -725,7 +748,7 @@ describe("updater", () => {
       mockGet.mockResolvedValue(true);
       mockSet.mockResolvedValue();
       mockSetMany.mockResolvedValue();
-      mockReadFile.mockRejectedValue(new Error("ENOENT"));
+      mockRebuiltBox();
       updater = await import("@/lib/updater");
 
       updater.resetUpdateState();
@@ -762,6 +785,7 @@ describe("updater", () => {
       mockSet.mockResolvedValue();
       mockSetMany.mockResolvedValue();
       mockReadFile.mockImplementation(async (file) => {
+        if (String(file).endsWith("BUILD_ID")) return "rebuilt-build-id\n";
         if (String(file).endsWith("/openclaw.json")) {
           return JSON.stringify({
             agents: { defaults: { model: { primary: "openai/gpt-5.6-sol" } } },
@@ -809,7 +833,7 @@ describe("updater", () => {
       mockGet.mockResolvedValue(true);
       mockSet.mockResolvedValue();
       mockSetMany.mockResolvedValue();
-      mockReadFile.mockRejectedValue(new Error("ENOENT"));
+      mockRebuiltBox();
       updater = await import("@/lib/updater");
       if (priorRoot === undefined) delete process.env.CLAWBOX_ROOT;
       else process.env.CLAWBOX_ROOT = priorRoot;
@@ -851,7 +875,7 @@ describe("updater", () => {
       mockGet.mockResolvedValue(true);
       mockSet.mockResolvedValue();
       mockSetMany.mockResolvedValue();
-      mockReadFile.mockRejectedValue(new Error("ENOENT"));
+      mockRebuiltBox();
       // The gateway only "recovers" once the legacy-state quarantine has run.
       // Tie the probe to that side-effect instead of a fixed false/false/true
       // call sequence: waitForGateway polls in a loop (deadline/interval are 1ms
@@ -895,7 +919,7 @@ describe("updater", () => {
       mockGet.mockResolvedValue(undefined);
       mockSet.mockResolvedValue();
       mockSetMany.mockResolvedValue();
-      mockReadFile.mockRejectedValue(new Error("ENOENT"));
+      mockRebuiltBox();
       updater = await import("@/lib/updater");
 
       updater.resetUpdateState();
@@ -1060,6 +1084,38 @@ describe("updater", () => {
       const state = updater.getUpdateState();
       expect(state.phase).toBe("failed");
       expect(state.error).toContain("without producing a new build");
+    });
+
+    it("reports a failed update when the rebuild left no build at all", async () => {
+      // The hole the BUILD_ID comparison left open. `do_rebuild` deleted
+      // `.next` before building, so an OOM-killed build (measured on the dev
+      // box 2026-09-04, three times in one night) left NO BUILD_ID — and an
+      // ABSENT id compares UNEQUAL to the one recorded before the rebuild, so
+      // "the build changed" read as "the build happened". The update then
+      // resumed and stamped itself complete over a box with no dashboard at
+      // all. Nothing is the one answer that can never be evidence of a build.
+      updater.resetUpdateState();
+      mockGet.mockResolvedValue("build-aaa");
+      mockReadFile.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+
+      const result = await updater.checkContinuation();
+
+      expect(result).toBe(false);
+      const state = updater.getUpdateState();
+      expect(state.phase).toBe("failed");
+      expect(state.error).toContain("no build");
+    });
+
+    it("reports a failed update when a box that had no build still has none", async () => {
+      // Same hole from the other side: a box with nothing to record wrote the
+      // "no-previous-build" sentinel, and after a failed rebuild the empty
+      // BUILD_ID differs from the sentinel too.
+      updater.resetUpdateState();
+      mockGet.mockResolvedValue("no-previous-build");
+      mockReadFile.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+
+      expect(await updater.checkContinuation()).toBe(false);
+      expect(updater.getUpdateState().phase).toBe("failed");
     });
   });
 


### PR DESCRIPTION
**TASK-709** — an in-app update could leave a box with new code and NO build.

## Customer-visible symptom

`.next/BUILD_ID` absent, `clawbox-setup` inactive, port 80 dead — while `clawbox-gateway` stayed
up and healthy on 18789, so the box looked half-alive. The owner saw "Failed to get gateway
config" and a stuck "Connecting…" in the chat: a cached page with no server behind it.

## Cause (measured read-only on the OpenClaw dev box, 2026-09-04)

Three, not one.

1. **OOM, not PATH.** The card's stated root cause — `bun` missing from the login-shell PATH — is
   **refuted**. `install.sh` calls `$BUN` by absolute path (`$CLAWBOX_HOME/.bun/bin/bun`) through
   `as_clawbox_login`, which additionally exports that directory into `PATH`. The unit's own
   journal shows `bun install` and the node-pty check completing, then `Running bun build...`, then
   `Main process exited, code=exited, status=137`. The kernel log says why:

   ```
   kernel: oom-kill:constraint=CONSTRAINT_NONE,…,task=next-build (v16,pid=…,uid=1000
   kernel: Out of memory: Killed process … (next-build (v16) … anon-rss:2172028kB …
   ```

   Three times in one night, while ollama's `llama-server` held ~2.3 GB of the board's 7.6 GB.

2. **`rm -rf .next` came first.** So the 137 left the box with no build at all, and
   `do_rebuild`'s own `systemctl stop clawbox-setup.service` was never undone.

3. **Nothing verified the build.** `do_rebuild` read `bun run build`'s exit status and nothing
   else, and `resumeContinuation` compared the recorded BUILD_ID with the on-disk one — where an
   **absent** id compares *unequal* to the recorded one, i.e. reads as "a new build happened".

## Rebased onto #643 — the memory half is already fixed on beta

`free_memory_for_build` landed on beta while this was open, and it is a better
answer than the one this PR first carried: it stops ollama, both voice user units
and the llama.cpp server (pid verified against `/proc/<pid>/cmdline`) and drops
the page cache, after the `clawbox-setup` stop so nothing can pull a model back
in behind it. **This PR no longer touches the memory posture at all** — its own
`pause_rebuild_memory_units` helpers and their tests are gone, `do_rebuild` calls
`free_memory_for_build` exactly where beta puts it, and the diff-stat was checked
to confirm nothing of #643 was reverted by the rebase.

What is left here is the half #643 does not cover: an OOM-killed build (or any
other failure) was **permanent** rather than a retry, and a build was accepted on
its exit status alone.

## Fix

- `do_rebuild` renames the serving build to `.next-old` (already gitignored) instead of deleting
  it, and puts it back when the build fails — then polls `clawbox-setup` and says whether the
  dashboard actually came back, rather than asserting it over a `systemctl start … || true`.
- Everything between "clawbox-setup is stopped" and the restore branch is a condition, so no
  command can leave the function without passing through the recovery. `ensure_node_pty` returns
  instead of `exit`ing for the same reason.
- A build is verified by the two questions that matter: `.next/standalone/server.js` exists (what
  `production-server.js:500` requires and what `step_build` has always checked), and
  `scripts/verify-build-identity.sh` passes.
- `promote_parked_build` reclaims a build left under `.next-old` by a run that was killed outright.
- `resumeContinuation` treats an absent BUILD_ID as a failed rebuild, and `readBuildId` reads the
  tree the server actually runs from (`resolveBuildDir`).

### Harness first

The build-identity question is **not** re-implemented: `scripts/verify-build-identity.sh` is the
repo's one copy of it (CI runs the same script, and `src/lib/updater.ts::runBuildIdentityCheck`
already invokes it), and its header says a second copy is the bug. `do_rebuild` and `step_build`
now both call it. There is no OpenClaw/Hermes mechanism for "did this appliance's Next build
succeed" — that is ClawBox's own dashboard, so no native equivalent exists to defer to.

## RED (on unmodified beta)

`src/tests/unit/install-rebuild-build-verify.test.ts` — 19 of 27 cases fail; `updater.test.ts` — 2:

```
 × fails when the build exits 0 without producing anything
 × fails when the build leaves no server entry for the dashboard to load
 × leaves the previous build in place after an OOM kill
 × starts clawbox-setup again after a failed build
 × starts clawbox-setup again when bun install fails
 × starts clawbox-setup again when node-pty cannot be rebuilt
 × still fails, without a previous build to fall back on
 × reclaims a build parked by an interrupted rebuild
 × fails when the build on disk is not the checked-out commit
 × says the dashboard is down when the restored build will not start
 × reclaims a parked build before rebuilding
 …
 Tests  14 failed | 7 passed (21)

 × reports a failed update when the rebuild left no build at all
   AssertionError: expected true to be false   ← checkContinuation() RESUMED and
                                                 stamped the update complete on a
                                                 box with no build at all
 × reports a failed update when a box that had no build still has none
 Tests  2 failed | 57 skipped (59)
```

## GREEN

```
 src/tests/unit/install-rebuild-build-verify.test.ts → 21 passed
 npx vitest run --project unit → 601 files, 9619 tests, all pass
 npx tsc --noEmit → clean
```

## Sibling call sites

- `do_rebuild`'s two callers, `step_rebuild` and `step_rebuild_reboot`: both inherit the fix; under
  `set -e` a non-zero `do_rebuild` still aborts before `reboot`.
- `step_build` (the fresh-install / `--step build` twin): now shares `verify_build_present`, the
  pause/resume pair and `promote_parked_build`; its private `.next/standalone/server.js` check is
  gone in favour of the shared one.
- `ensure_node_pty`'s other caller is `step_build`; a bare non-zero return still ends the script
  under `set -e`, so its behaviour there is unchanged.
- `readBuildId`'s other caller is the flag write at `updater.ts` — record and compare change
  together, so the comparison stays apples-to-apples.
- `scripts/force-update.sh` — **explicitly cleared**: it never deletes `.next`, runs under
  `set -euo pipefail` so a failed build aborts, and ends with an `is-active clawbox-setup` probe.
  Not worsened here.
- `install-x64.sh::step_build` — **explicitly cleared**: the x64 dev SKU, no `rm -rf .next`, and it
  already verifies `.next/standalone/server.js`.

## Both editions

Nothing here is edition-conditional: `do_rebuild` and `step_build` are the same on both, and the
memory posture is #643's, which already handles the voice units and llama.cpp on either SKU.

## Device proof (read-only, no mutation, no update run)

On the OpenClaw box: `systemctl show clawbox-root-update@rebuild_reboot.service` →
`Result=exit-code`, `ExecMainStatus=137`; the unit journal shows the step reaching
`Running bun build...` (so bun resolved); `journalctl -k` carries the three
`Out of memory: Killed process … next-build` lines; `sudo -n -l` grants
`systemctl start|stop ollama.service` NOPASSWD; `bash -lc 'command -v bun'` is MISSING, which is
why the card blamed PATH — but nothing in `do_rebuild` depends on the login-shell PATH.

## Not covered

The `buildMissing` branch in `resumeContinuation` is close to unreachable on hardware: the code
that evaluates it runs inside `clawbox-setup`, which cannot start without the build it is checking
for. It is reachable in `CLAWBOX_TEST_MODE`, when only `BUILD_ID` is deleted, and — after the
`resolveBuildDir` change — when a half-finished `.next` sits beside a stale standalone tree. The
protection that matters on hardware is entirely in `do_rebuild`. Stated so nobody relies on the
other half. No real update was run on the box for this PR.



---

## Finishing round (2026-09-05) — rebased twice, re-RED'd, reviewed, and three review findings taken as code

This PR sat 54 commits behind. It has been rebased onto `origin/beta` `b15d64c6` and then
again onto `eece3ccb`, which itself edits `production-server.js` — the file this round adds
to. Both hunks survive: beta's `guardProcessTitle()` still runs after the standalone
`require`, and the reclaim below runs before it. `git diff --stat origin/beta...HEAD` lists
six files, all of them this PR's, with no deletion-only file.

### RED, re-proven on the rebased base

The new suites against unmodified `origin/beta` (`b15d64c6`), install.sh and updater.ts
reverted, tests kept:

```
 Test Files  2 failed (2)
      Tests  23 failed | 59 passed (82)
 × verify_build_present is extracted whole
 × restore_previous_build is extracted whole
 × fails when the build exits 0 without producing anything
 × fails when the build is OOM-killed
 × leaves the previous build in place after an OOM kill
 × starts clawbox-setup again after a failed build
 × starts clawbox-setup again when bun install fails
 × starts clawbox-setup again when node-pty cannot be rebuilt
 × says the dashboard is down when the restored build crash-loops
 × reclaims a build parked by an interrupted rebuild
 × fails when the build on disk is not the checked-out commit
 …
 × reports a failed update when the rebuild left no build at all
 × reports a failed update when the SERVING tree lost its build
 × reports a failed update when a box that had no build still has none
```

Each of the four fixes below was also individually RED-checked by reverting only its own
change and watching only its own case fail.

### The three parts of TASK-709, and where each one stands

1. **bun off the root step's PATH — REFUTED, with evidence.** `do_rebuild` calls `$BUN`
   (`install.sh:600`, an absolute `$CLAWBOX_HOME/.bun/bin/bun`) through `as_clawbox_login`,
   which additionally exports that directory onto `PATH` (`install.sh:799-806`). The
   login-shell PATH the card blamed (`bash -lc 'command -v bun'` is genuinely MISSING on the
   box) is not on this path at all. The one bare resolution left in the tree,
   `scripts/force-update.sh:71`, tries the absolute path first — explicitly cleared.
2. **The OOM kill — beta's, not this PR's.** `free_memory_for_build` landed on beta while
   this was open and is the better answer; `do_rebuild` calls it where beta puts it and this
   PR touches the memory posture nowhere.
3. **`phase=completed` over a box with no `.next/BUILD_ID` — fixed here**, plus the half
   nobody had: a failed build was permanent rather than a retry, and a build was accepted on
   its exit status alone.

### Review findings taken (`code-review-pr632-final.md`, HIGH 2 · MEDIUM 4 · LOW 6 · NIT 1)

- **H1 — the readiness poll asked systemd, and systemd cannot answer it.**
  `clawbox-setup.service` is `Type=simple` with `Restart=always`, so the unit is ACTIVE the
  instant node is forked — before `production-server.js` reaches its `require`. The poll's
  first iteration returned true for a unit about to crash-loop, and printed "the dashboard is
  serving again". It now polls the question `step_validate_services` already asks —
  `curl … http://localhost/`, 2xx/3xx — and says DOWN when nothing answers. The fixture that
  covers the DOWN branch was rewritten to the state systemd really produces (unit active,
  port 80 silent), which is what makes it a test rather than a model.
- **H2 — the parked build was recoverable but never recovered.** `promote_parked_build` runs
  only inside `install.sh`, and `install.sh` needs the dashboard up. A run killed outright
  left a good build under `.next-old` and a box crash-looping on the missing entry — the hand
  recovery this batch keeps needing. `production-server.js` now reclaims it immediately
  before the `require`, best-effort, and only when the entry is already missing (so it cannot
  affect a box that has a build). Five cases, including "never lets its own failure stop the
  server from starting".
- **M1/M4 — the message asserted a rollback that had not happened.** Three outcomes now say
  three different things, and the one that matters is new: when the filesystem could not hold
  two builds and the new one then failed verification, the tree in place IS that rejected
  build. It is still started — a dashboard on a suspect build beats a dead box — and the line
  says so instead of calling it a restore.
- **M2 — `readBuildId` assumed the flat standalone layout.** `postbuild` searches for the
  entry and symlinks `.next/standalone/server.js` at it for the nested layout Next produces
  when `outputFileTracingRoot` resolves above the project; on such a box
  `.next/standalone/.next/BUILD_ID` does not exist, so the new `buildMissing` branch would
  have called every successful update "no build at all". The entry is now followed through
  `realpath`, the way `postbuild` does.
- **L1 — the same layout, in `promote_parked_build`.** `-f` resolves a symlink, and the
  nested layout's entry link dangles while the tree is parked, so the box's only build read
  as "nothing parked here" and the next rename deleted it.
- **L2** — the reclaim now runs after `systemctl stop`, not before it.
- **N1** — dead default parameter dropped, the two literals in `step_build` defaulted, the
  concatenated numeric test split in two, the `rc` chain written as one if/elif.

### Refuted or recorded rather than taken

- **M3 (a promoted parked build defeats `buildUnchanged`)** — real, and narrow: it needs a
  run killed mid-build, then an operator running `--step rebuild_reboot` by hand, then a
  second OOM. It is caught by `verify_build_identity` at the end of the update, with the
  wrong cause named. On the Found list rather than folded in; the fix is a marker
  `do_rebuild` writes, which is a different change.
- **L3** — identity drift inside `do_rebuild` rolls back; the same verdict one step later
  (post-reboot `verifyBuildIdentityAfterUpdate`) leaves the build and fails the update. Both
  are intended: before the reboot there is a good build to return to, after it there is not.
- **L4 — `install-x64.sh::step_build`** keeps its own `.next/standalone/server.js` check and
  gets no identity check. Deliberate: x64 is the dev SKU, has no `do_rebuild`, no `rebuild`
  dispatch step and never creates `.next-old`, so the half of this change that matters cannot
  apply there.
- **L6 (`du -sk` walks the whole build tree with a cold page cache)** — not taken. It costs
  seconds against a multi-minute rebuild, and the alternative is a magic free-space floor
  that would be wrong on the next board.

### Device proof (read-only, no mutation, no update run)

Both boxes are on beta head. On each: `scripts/verify-build-identity.sh --quiet` exits 0
against the running build, `.next/standalone/server.js` is present — so both questions
`verify_build_present` asks answer yes on a healthy box and the new gate cannot fail a good
rebuild. OpenClaw box: `clawbox-setup` active, last `clawbox-root-update@rebuild_reboot`
`Result=success`, 400 GB free (so `set_previous_build_aside` keeps the old tree rather than
taking its low-disk branch), `git status` clean. `.gitignore:8` carries `.next-old/` on beta,
verified with `git check-ignore`. **Device leg unproven: the failure paths (OOM kill,
restore, crash-loop, boot-time reclaim) need a real update run, which this round is not
entitled to make — the owner is testing on both boxes.**

### GREEN

```
 npx vitest run --project unit  → 631 files, 9966 tests, all pass
 npx tsc --noEmit               → clean
 bash -n install.sh, node --check production-server.js → clean
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rebuild reliability by validating build identity and server output before activation.
  * Preserved or restored the previous working build when a rebuild fails or is interrupted.
  * Prevented incomplete or unidentified builds from being reported as successful.
  * Improved service restoration, readiness reporting, and failure handling.
  * Applied recovery and validation safeguards to fresh builds and continuation flows.
  * Restored a valid previous build when production startup encounters an incomplete replacement.

* **Tests**
  * Added comprehensive coverage for build verification, recovery, service restoration, memory management, and startup recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
