### PR TITLE
fix: let an entitled ClawBox AI Max model run instead of vetoing it on the device-tier badge (TASK-691)

### DIFF
--- a/src/app/setup-api/ai-models/status/route.ts
+++ b/src/app/setup-api/ai-models/status/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { readConfig } from "@/lib/openclaw-config";
 import { get as getConfigValue, set as setConfigValue } from "@/lib/config-store";
 import {
+  CLAWBOX_AI_FLASH_MODEL_ID,
+  CLAWBOX_AI_PRO_MODEL_ID,
   normalizeClawboxAiTier,
   type ClawboxAiTier,
 } from "@/lib/clawbox-ai-models";
@@ -33,6 +35,20 @@ const CLAWBOX_AI_TIER_CONFIG_KEY = "clawai_tier";
 // `applyClawaiToHermes` writes it here; the OpenClaw path reads the same token
 // from `models.providers.deepseek.apiKey` in openclaw.json instead.
 const CLAWBOX_AI_TOKEN_CONFIG_KEY = "clawai_token";
+
+/**
+ * The entitlement list a device-info answer without `allowedModels` implies:
+ * the old badge rule, written out. `"pro"` (the Max device tier) reaches both
+ * chat tiers, anything else reaches Flash — which every paid plan can run.
+ *
+ * Only the compatibility path uses this. A portal that publishes the real list
+ * always wins, and a portal that could not be reached gets no list at all.
+ */
+function allowedModelsForTier(tier: ClawboxAiTier | null): string[] {
+  return tier === "pro"
+    ? [CLAWBOX_AI_FLASH_MODEL_ID, CLAWBOX_AI_PRO_MODEL_ID]
+    : [CLAWBOX_AI_FLASH_MODEL_ID];
+}
 
 function normalizeProvider(provider: string | null): string | null {
   if (!provider) return null;
@@ -181,7 +197,13 @@ async function buildStatusResponse(state: ResolvedAiState): Promise<NextResponse
       const lookup = await fetchPortalTier(state.clawaiToken);
       if (lookup.source === "portal") {
         clawaiAccountTier = lookup.tier;
-        clawaiAllowedModels = lookup.allowedModels;
+        // A portal that answered but published no list is not "unknown": it is
+        // an older portal build, and there the badge IS all the entitlement
+        // there has ever been. Fill the list from it so nothing that used to
+        // be refused silently becomes allowed on such a deployment. Only the
+        // portal-ANSWERED branch does this — an unreachable portal stays null,
+        // which is the whole point of the change.
+        clawaiAllowedModels = lookup.allowedModels ?? allowedModelsForTier(lookup.tier);
         accountTierSource = "portal";
         // Persist the portal-confirmed tier so the portal-unreachable
         // fallback reflects the last *confirmed* tier, not a stale

--- a/src/app/setup-api/ai-models/status/route.ts
+++ b/src/app/setup-api/ai-models/status/route.ts
@@ -37,15 +37,27 @@ const CLAWBOX_AI_TIER_CONFIG_KEY = "clawai_tier";
 const CLAWBOX_AI_TOKEN_CONFIG_KEY = "clawai_token";
 
 /**
- * The entitlement list a device-info answer without `allowedModels` implies:
- * the old badge rule, written out. `"pro"` (the Max device tier) reaches both
- * chat tiers, anything else reaches Flash — which every paid plan can run.
+ * The entitlement list a device-info answer without `allowedModels` implies.
  *
  * Only the compatibility path uses this. A portal that publishes the real list
  * always wins, and a portal that could not be reached gets no list at all.
+ *
+ * It reaches the Max id when EITHER reading of the response does, and that
+ * "either" is load-bearing in both directions. The device stamp alone is what
+ * the old badge rule used, and deriving the list from it reproduced TASK-691
+ * through this very door: a Max subscriber whose box is stamped
+ * `deviceTier: "flash"` — a state `mapPortalTier` preserves on purpose — would
+ * get `["deepseek-v4-flash"]`, which the boot guard reads as a positive refusal
+ * and WRITES his primary model down on. The plan alone would be the mirror
+ * mistake: a box the portal stamped `"pro"` used to be allowed to run the Max
+ * model under the old rule, and a compatibility path must not start refusing
+ * something that used to work. So: the more permissive of the two.
  */
-function allowedModelsForTier(tier: ClawboxAiTier | null): string[] {
-  return tier === "pro"
+function allowedModelsForCompat(
+  deviceTier: ClawboxAiTier | null,
+  planTier: ClawboxAiTier | null,
+): string[] {
+  return deviceTier === "pro" || planTier === "pro"
     ? [CLAWBOX_AI_FLASH_MODEL_ID, CLAWBOX_AI_PRO_MODEL_ID]
     : [CLAWBOX_AI_FLASH_MODEL_ID];
 }
@@ -203,7 +215,8 @@ async function buildStatusResponse(state: ResolvedAiState): Promise<NextResponse
         // be refused silently becomes allowed on such a deployment. Only the
         // portal-ANSWERED branch does this — an unreachable portal stays null,
         // which is the whole point of the change.
-        clawaiAllowedModels = lookup.allowedModels ?? allowedModelsForTier(lookup.tier);
+        clawaiAllowedModels = lookup.allowedModels
+          ?? allowedModelsForCompat(lookup.tier, lookup.planTier);
         accountTierSource = "portal";
         // Persist the portal-confirmed tier so the portal-unreachable
         // fallback reflects the last *confirmed* tier, not a stale

--- a/src/app/setup-api/ai-models/status/route.ts
+++ b/src/app/setup-api/ai-models/status/route.ts
@@ -163,6 +163,13 @@ async function buildStatusResponse(state: ResolvedAiState): Promise<NextResponse
 
   let clawaiAccountTier: ClawboxAiTier | null = null;
   let accountTierSource: "portal" | "picker" = "picker";
+  // The portal's own list of model ids this token may run. NULL MEANS "NOT
+  // ANSWERED" — no token, portal unreachable, or a portal build that does not
+  // publish the field — and no caller may read that as a refusal. It is
+  // deliberately not backed by a local fallback the way the tier badge is: a
+  // remembered entitlement is a guess, and a guess is what locked a Max owner
+  // out of the model he pays for (TASK-691).
+  let clawaiAllowedModels: string[] | null = null;
   if (state.hasClawaiProfile) {
     clawaiAccountTier = localTier;
     // Ask the portal whenever a clawai token is paired, regardless
@@ -174,6 +181,7 @@ async function buildStatusResponse(state: ResolvedAiState): Promise<NextResponse
       const lookup = await fetchPortalTier(state.clawaiToken);
       if (lookup.source === "portal") {
         clawaiAccountTier = lookup.tier;
+        clawaiAllowedModels = lookup.allowedModels;
         accountTierSource = "portal";
         // Persist the portal-confirmed tier so the portal-unreachable
         // fallback reflects the last *confirmed* tier, not a stale
@@ -202,6 +210,9 @@ async function buildStatusResponse(state: ResolvedAiState): Promise<NextResponse
     model: state.model,
     clawaiTier,
     clawaiAccountTier,
+    // Model ids the portal says this account may run, or null when it did not
+    // say. The picker gates on this, never on the tier badge above.
+    clawaiAllowedModels,
     // Whether *any* clawai profile is configured. Distinguishes
     // "no ClawBox AI account at all" (false) from "Free user with
     // a paired clawai token" (true, clawaiAccountTier=null) — the
@@ -230,7 +241,8 @@ export async function GET() {
     return NextResponse.json(
       {
         connected: false, provider: null, providerLabel: null, mode: null, model: null,
-        clawaiTier: null, clawaiAccountTier: null, clawaiConfigured: false, tierSource: "picker",
+        clawaiTier: null, clawaiAccountTier: null, clawaiAllowedModels: null,
+        clawaiConfigured: false, tierSource: "picker",
       },
       {
         headers: {

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -273,7 +273,7 @@ import {
 } from '@/lib/hermes-reasoning'
 import { readHermesChatPrefs, writeHermesChatPrefs } from '@/lib/hermes-chat-prefs'
 import { useClawboxLogin } from '@/lib/use-clawbox-login'
-import { clawboxAiMaxPickUnconfirmed, isClawboxAiProModel, portalDeniesClawboxAiModel, CLAWBOX_AI_MODEL_BY_TIER } from '@/lib/clawbox-ai-models'
+import { isClawboxAiProModel, portalDeniesClawboxAiModel, CLAWBOX_AI_MODEL_BY_TIER } from '@/lib/clawbox-ai-models'
 import { PORTAL_DASHBOARD_URL } from '@/lib/max-subscription'
 import { HeaderDropdown } from '@/components/HeaderDropdown'
 import { buildDeviceConnectParams } from '@/lib/gateway-device-identity'
@@ -4177,25 +4177,6 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       }])
       return false
     }
-    // The Max model is also the one pick the portal may simply not have been
-    // asked about — it is unreachable, or it answers 401/403 to a revoked or
-    // migrated token, both of which arrive here as an unanswered list. This
-    // pick persists into `agents.defaults.model.primary`, which Telegram and
-    // the coding agent run too, so declining it while the answer is missing and
-    // the last confirmed badge is not Max costs the owner a retry, where
-    // letting it through costs every turn until the portal answers. The BOOT
-    // GUARD, which writes, keeps failing open on the same doubt — see
-    // `clawboxAiMaxPickUnconfirmed`.
-    if (!clawboxLogin.loading
-      && clawboxAiMaxPickUnconfirmed(target.model, clawboxLogin.allowedModels, clawboxLogin.tier)) {
-      setMessages(prev => [...prev, {
-        role: 'system',
-        text: `${target.label} could not be checked against your ClawBox AI plan — the ClawBox portal did not answer. Try again in a moment, or [check the plan in the portal](${PORTAL_DASHBOARD_URL}). Staying on the current model.`,
-        timestamp: Date.now(),
-        variant: 'error',
-      }])
-      return false
-    }
     setSwitchingModel(true)
     setErrorMsg('')
     try {
@@ -4249,7 +4230,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     } finally {
       setSwitchingModel(false)
     }
-  }, [chatModelState, connect, switchingModel, clawboxLogin.allowedModels, clawboxLogin.tier, clawboxLogin.loading])
+  }, [chatModelState, connect, switchingModel, clawboxLogin.allowedModels])
 
   // The dropdown gate above only catches picks the user *clicks*. An account
   // the portal refuses can also boot with the Max model already saved as the
@@ -4264,34 +4245,50 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   // the badge it fired for "tier unknown" too — a single failed status poll
   // was enough to rewrite a Max box's primary model to flash and tell its
   // owner to buy the subscription he already had (TASK-691).
-  const tierGuardRef = useRef(false)
+  //
+  // WHAT THE LATCH BELOW REMEMBERS, and why it is not a boolean. `switchChatModel`
+  // writes `switchingModel`, which is one of its own useCallback deps, so calling
+  // it changes its identity — and this effect depends on that identity. A boolean
+  // latch released on failure therefore re-armed the guard with nothing about the
+  // box changed, and any repeatable failure of `/setup-api/chat/model` (400
+  // "provider is not configured", 409, 500, a proxy's non-JSON body) became a POST
+  // loop against the box's own setup server with two system messages per turn of
+  // it. A boolean latch never released is the other error: `page.tsx` keeps this
+  // component mounted for the whole session and only toggles `isOpen`, so one
+  // failed attempt would leave the box on a refused model until a page reload —
+  // a capability probed once and treated as settled, which is the shape this
+  // codebase keeps producing.
+  //
+  // So it remembers the INPUTS the last attempt was made for. Re-entry on the
+  // same box state buys nothing; a changed active model or a changed entitlement
+  // list buys exactly one more attempt, and so does closing and re-opening the
+  // chat, which is the retry an owner reaches for. `allowedModels` keeps its
+  // array identity across polls that bring the same ids back (`sameIds` in
+  // use-clawbox-login.ts), so `===` here means "the answer has not changed".
+  const tierGuardAttemptRef = useRef<{ model: string; allowed: readonly string[] | null } | null>(null)
   useEffect(() => {
-    if (tierGuardRef.current || clawboxLogin.loading) return
+    if (!isOpen) {
+      tierGuardAttemptRef.current = null
+      return
+    }
+    if (clawboxLogin.loading) return
     const active = chatModelState?.activeModel
     // The Max tier and nothing else: it is the only ClawBox AI model with a
     // tier below it to fall back to, and the message below says so by name.
-    if (!isClawboxAiProModel(active)) return
+    if (!active || !isClawboxAiProModel(active)) return
     if (!portalDeniesClawboxAiModel(active, clawboxLogin.allowedModels)) return
     // The recovery is "drop to the Flash tier", so only run it when the portal
     // allows that one. Switching to a second refused model would move the
     // error rather than fix it.
     if (portalDeniesClawboxAiModel(CLAWBOX_AI_MODEL_BY_TIER.flash, clawboxLogin.allowedModels)) return
+    const attempted = tierGuardAttemptRef.current
+    if (attempted && attempted.model === active && attempted.allowed === clawboxLogin.allowedModels) return
     // `switchChatModel` early-returns without attempting anything while another
-    // switch is in flight, so wait rather than spend the latch on a call that
-    // cannot happen. `switchingModel` is a dep, so the effect comes back by
-    // itself when that other switch finishes. This is the ONLY reason the guard
-    // gets a second chance.
+    // switch is in flight, so wait rather than record an attempt that was never
+    // made. `switchingModel` is a dep, so the effect comes back by itself when
+    // that other switch finishes.
     if (switchingModel) return
-    // Latched for the life of the component, and deliberately NOT released when
-    // the switch fails. `switchChatModel` writes `switchingModel`, which is one
-    // of its own useCallback deps — calling it changes its identity, which
-    // re-runs this effect. Releasing the latch on a failure therefore re-armed
-    // the guard with nothing about the box changed, and any route failure that
-    // repeats (400 "provider is not configured", 409, 500, a proxy's non-JSON
-    // body) became a POST loop against the box's own setup server with two
-    // system messages per turn of it. One attempt; the error `switchChatModel`
-    // leaves in the transcript is the answer, and re-opening the chat retries.
-    tierGuardRef.current = true
+    tierGuardAttemptRef.current = { model: active, allowed: clawboxLogin.allowedModels }
     void switchChatModel({ model: CLAWBOX_AI_MODEL_BY_TIER.flash, label: 'Pro Tier' })
       .then(switched => {
         // Posted from the SUCCESS path only. This sentence says the box was
@@ -4306,7 +4303,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
           variant: 'error',
         }])
       })
-  }, [chatModelState?.activeModel, clawboxLogin.allowedModels, clawboxLogin.loading, switchChatModel, switchingModel])
+  }, [isOpen, chatModelState?.activeModel, clawboxLogin.allowedModels, clawboxLogin.loading, switchChatModel, switchingModel])
 
   const handleChatSourceChange = useCallback(async (optionId: string) => {
     const target = chatModelState?.options.find(option => option.id === optionId)

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -273,7 +273,7 @@ import {
 } from '@/lib/hermes-reasoning'
 import { readHermesChatPrefs, writeHermesChatPrefs } from '@/lib/hermes-chat-prefs'
 import { useClawboxLogin } from '@/lib/use-clawbox-login'
-import { isClawboxAiProModel, CLAWBOX_AI_MODEL_BY_TIER } from '@/lib/clawbox-ai-models'
+import { portalDeniesClawboxAiModel, CLAWBOX_AI_MODEL_BY_TIER } from '@/lib/clawbox-ai-models'
 import { PORTAL_DASHBOARD_URL } from '@/lib/max-subscription'
 import { HeaderDropdown } from '@/components/HeaderDropdown'
 import { buildDeviceConnectParams } from '@/lib/gateway-device-identity'
@@ -4149,15 +4149,20 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   // same reference, and the server cannot tell them apart from the model alone.
   const switchChatModel = useCallback(async (target: { model: string; label: string; provider?: string | null }) => {
     if (switchingModel || chatModelState?.activeModel === target.model) return
-    // Intercept clawai Pro picks from non-Max users. The portal's
-    // /api/ai gateway silently downgrades these requests to flash via
-    // its live-tier reconcile, which previously left the user staring
-    // at a "Switched chat to deepseek-v4-pro" success toast while every
-    // reply came from flash. Surface the gate here with an actionable
-    // upgrade prompt and skip the network call entirely. The portal URL
-    // is wrapped as `[text](url)` so chat-markdown renders it as a
-    // clickable link instead of a bare string.
-    if (isClawboxAiProModel(target.model) && clawboxLogin.tier !== 'pro') {
+    // Intercept clawai Pro picks the portal POSITIVELY refuses. Its /api/ai
+    // gateway silently downgrades an unentitled request to flash via its
+    // live-tier reconcile, which left the user staring at a "Switched chat to
+    // deepseek-v4-pro" success toast while every reply came from flash.
+    // Surface that with an actionable upgrade prompt and skip the network call.
+    // The portal URL is wrapped as `[text](url)` so chat-markdown renders it as
+    // a clickable link instead of a bare string.
+    //
+    // Gated on the portal's own entitlement list, never on the tier badge: the
+    // badge is the device-pair stamp, so a Max account paired while it was on
+    // the Pro plan reads "flash" and was refused the model it pays for. An
+    // unanswered entitlement (portal unreachable, poll failed) is not a
+    // refusal — the pick goes through and the proxy has the last word.
+    if (portalDeniesClawboxAiModel(target.model, clawboxLogin.allowedModels)) {
       setMessages(prev => [...prev, {
         role: 'system',
         text: `${target.label} requires a Max subscription. [Upgrade in the ClawBox portal](${PORTAL_DASHBOARD_URL}) to unlock it. Staying on the current model.`,
@@ -4217,19 +4222,30 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     } finally {
       setSwitchingModel(false)
     }
-  }, [chatModelState, connect, switchingModel, clawboxLogin.tier])
+  }, [chatModelState, connect, switchingModel, clawboxLogin.allowedModels])
 
-  // The dropdown gate above only catches Max-tier picks the user *clicks*. A
-  // non-Max account can also boot with the Max tier already saved as the
-  // default (picked during setup, or left over after a plan downgrade). The
-  // portal gateway then silently rejects every turn — the user only sees the
-  // opaque "[assistant turn failed]". Catch that on load: explain it with an
-  // upgrade link and drop to the Pro tier the plan supports so chat works.
+  // The dropdown gate above only catches picks the user *clicks*. An account
+  // the portal refuses can also boot with the Max model already saved as the
+  // default (picked during setup, chosen from the Telegram `/model` keyboard,
+  // or left over after a plan downgrade). The portal gateway then silently
+  // rejects every turn — the user only sees the opaque "[assistant turn
+  // failed]". Catch that on load: explain it with an upgrade link and drop to
+  // the Pro tier the plan supports so chat works.
+  //
+  // This one WRITES: it moves the box off the model the owner chose. So it
+  // fires only on a positive refusal from the portal's entitlement list. On
+  // the badge it fired for "tier unknown" too — a single failed status poll
+  // was enough to rewrite a Max box's primary model to flash and tell its
+  // owner to buy the subscription he already had (TASK-691).
   const tierGuardRef = useRef(false)
   useEffect(() => {
     if (tierGuardRef.current || clawboxLogin.loading) return
     const active = chatModelState?.activeModel
-    if (!active || !isClawboxAiProModel(active) || clawboxLogin.tier === 'pro') return
+    if (!portalDeniesClawboxAiModel(active, clawboxLogin.allowedModels)) return
+    // The recovery is "drop to the Flash tier", so only run it when the portal
+    // allows that one. Switching to a second refused model would move the
+    // error rather than fix it.
+    if (portalDeniesClawboxAiModel(CLAWBOX_AI_MODEL_BY_TIER.flash, clawboxLogin.allowedModels)) return
     tierGuardRef.current = true
     setMessages(prev => [...prev, {
       role: 'system',
@@ -4238,7 +4254,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       variant: 'error',
     }])
     void switchChatModel({ model: CLAWBOX_AI_MODEL_BY_TIER.flash, label: 'Pro Tier' })
-  }, [chatModelState?.activeModel, clawboxLogin.tier, clawboxLogin.loading, switchChatModel])
+  }, [chatModelState?.activeModel, clawboxLogin.allowedModels, clawboxLogin.loading, switchChatModel])
 
   const handleChatSourceChange = useCallback(async (optionId: string) => {
     const target = chatModelState?.options.find(option => option.id === optionId)

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -273,7 +273,7 @@ import {
 } from '@/lib/hermes-reasoning'
 import { readHermesChatPrefs, writeHermesChatPrefs } from '@/lib/hermes-chat-prefs'
 import { useClawboxLogin } from '@/lib/use-clawbox-login'
-import { portalDeniesClawboxAiModel, CLAWBOX_AI_MODEL_BY_TIER } from '@/lib/clawbox-ai-models'
+import { isClawboxAiProModel, portalDeniesClawboxAiModel, CLAWBOX_AI_MODEL_BY_TIER } from '@/lib/clawbox-ai-models'
 import { PORTAL_DASHBOARD_URL } from '@/lib/max-subscription'
 import { HeaderDropdown } from '@/components/HeaderDropdown'
 import { buildDeviceConnectParams } from '@/lib/gateway-device-identity'
@@ -1077,11 +1077,14 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       && !!chatModelState?.subscriptionProviders?.includes(headerProvider),
     [headerProvider, chatModelState],
   )
-  // Pull live tier so the chat-model picker can filter ClawBox AI options
-  // by entitlement. Without this, a Free user could pick deepseek-v4-pro,
-  // see a "Switched chat to deepseek/deepseek-v4-pro" success message,
-  // then watch every reply silently downgrade to flash because Mike's
-  // gateway gates by user.tier — UI says one thing, gateway does another.
+  // Pull the account state so the chat-model picker can refuse a ClawBox AI
+  // model the PORTAL says this account may not run. Without it a Free user
+  // could pick deepseek-v4-pro, see a "Switched chat to
+  // deepseek/deepseek-v4-pro" success message, and then get nothing but
+  // "[assistant turn failed]" — the proxy answers such a turn
+  // `400 "Model not allowed: …"` (measured 2026-09-04), which no chat surface
+  // can render as anything the owner could act on. `tier` is the device
+  // DEFAULT and never the gate; `allowedModels` is the gate.
   const clawboxLogin = useClawboxLogin()
 
   // ── Hermes header: provider-scoped model list ──
@@ -4147,29 +4150,32 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   // thing that can say a `openai/<id>` pick is the ChatGPT subscription rather
   // than the API key: on a box holding both credentials the two rows offer the
   // same reference, and the server cannot tell them apart from the model alone.
-  const switchChatModel = useCallback(async (target: { model: string; label: string; provider?: string | null }) => {
-    if (switchingModel || chatModelState?.activeModel === target.model) return
-    // Intercept clawai Pro picks the portal POSITIVELY refuses. Its /api/ai
-    // gateway silently downgrades an unentitled request to flash via its
-    // live-tier reconcile, which left the user staring at a "Switched chat to
-    // deepseek-v4-pro" success toast while every reply came from flash.
-    // Surface that with an actionable upgrade prompt and skip the network call.
-    // The portal URL is wrapped as `[text](url)` so chat-markdown renders it as
-    // a clickable link instead of a bare string.
+  const switchChatModel = useCallback(async (target: { model: string; label: string; provider?: string | null }): Promise<boolean> => {
+    if (switchingModel || chatModelState?.activeModel === target.model) return false
+    // Intercept a ClawBox AI pick the portal POSITIVELY refuses, and say so
+    // here rather than letting every turn on it come back as the opaque
+    // "[assistant turn failed]" — measured against the live proxy on
+    // 2026-09-04, an id outside the account's list answers
+    // `400 {"error":{"message":"Model not allowed: …"}}`. The portal URL is
+    // wrapped as `[text](url)` so chat-markdown renders it as a clickable link
+    // instead of a bare string.
     //
     // Gated on the portal's own entitlement list, never on the tier badge: the
-    // badge is the device-pair stamp, so a Max account paired while it was on
-    // the Pro plan reads "flash" and was refused the model it pays for. An
-    // unanswered entitlement (portal unreachable, poll failed) is not a
-    // refusal — the pick goes through and the proxy has the last word.
+    // badge follows the portal's `deviceTier`, which is a device DEFAULT — a
+    // Max subscriber may deliberately run Flash on this box — and a default is
+    // not something to veto an explicit pick with. An unanswered entitlement
+    // (portal unreachable, poll failed) is not a refusal either: the pick goes
+    // through and the proxy has the last word.
     if (portalDeniesClawboxAiModel(target.model, clawboxLogin.allowedModels)) {
       setMessages(prev => [...prev, {
         role: 'system',
-        text: `${target.label} requires a Max subscription. [Upgrade in the ClawBox portal](${PORTAL_DASHBOARD_URL}) to unlock it. Staying on the current model.`,
+        text: isClawboxAiProModel(target.model)
+          ? `${target.label} requires a Max subscription. [Upgrade in the ClawBox portal](${PORTAL_DASHBOARD_URL}) to unlock it. Staying on the current model.`
+          : `${target.label} is not included in your ClawBox AI plan. [Manage it in the ClawBox portal](${PORTAL_DASHBOARD_URL}). Staying on the current model.`,
         timestamp: Date.now(),
         variant: 'error',
       }])
-      return
+      return false
     }
     setSwitchingModel(true)
     setErrorMsg('')
@@ -4213,12 +4219,14 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
         try { wsRef.current.close() } catch { /* ignore */ }
       }
       connect()
+      return true
     } catch (err) {
       setMessages(prev => [...prev, {
         role: 'system',
         text: `Error: ${err instanceof Error ? err.message : 'Failed to switch chat model'}`,
         timestamp: Date.now(),
       }])
+      return false
     } finally {
       setSwitchingModel(false)
     }
@@ -4241,11 +4249,18 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   useEffect(() => {
     if (tierGuardRef.current || clawboxLogin.loading) return
     const active = chatModelState?.activeModel
+    // The Max tier and nothing else: it is the only ClawBox AI model with a
+    // tier below it to fall back to, and the message below says so by name.
+    if (!isClawboxAiProModel(active)) return
     if (!portalDeniesClawboxAiModel(active, clawboxLogin.allowedModels)) return
     // The recovery is "drop to the Flash tier", so only run it when the portal
     // allows that one. Switching to a second refused model would move the
     // error rather than fix it.
     if (portalDeniesClawboxAiModel(CLAWBOX_AI_MODEL_BY_TIER.flash, clawboxLogin.allowedModels)) return
+    // Latched before the call so the effect cannot re-enter while the switch
+    // is in flight, and released again if the switch did not happen — a box
+    // still on the refused model under a message saying it was moved is the
+    // false success this file has produced before.
     tierGuardRef.current = true
     setMessages(prev => [...prev, {
       role: 'system',
@@ -4254,6 +4269,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       variant: 'error',
     }])
     void switchChatModel({ model: CLAWBOX_AI_MODEL_BY_TIER.flash, label: 'Pro Tier' })
+      .then(switched => { if (!switched) tierGuardRef.current = false })
   }, [chatModelState?.activeModel, clawboxLogin.allowedModels, clawboxLogin.loading, switchChatModel])
 
   const handleChatSourceChange = useCallback(async (optionId: string) => {

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -273,7 +273,7 @@ import {
 } from '@/lib/hermes-reasoning'
 import { readHermesChatPrefs, writeHermesChatPrefs } from '@/lib/hermes-chat-prefs'
 import { useClawboxLogin } from '@/lib/use-clawbox-login'
-import { isClawboxAiProModel, portalDeniesClawboxAiModel, CLAWBOX_AI_MODEL_BY_TIER } from '@/lib/clawbox-ai-models'
+import { clawboxAiMaxPickUnconfirmed, isClawboxAiProModel, portalDeniesClawboxAiModel, CLAWBOX_AI_MODEL_BY_TIER } from '@/lib/clawbox-ai-models'
 import { PORTAL_DASHBOARD_URL } from '@/lib/max-subscription'
 import { HeaderDropdown } from '@/components/HeaderDropdown'
 import { buildDeviceConnectParams } from '@/lib/gateway-device-identity'
@@ -4177,6 +4177,25 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       }])
       return false
     }
+    // The Max model is also the one pick the portal may simply not have been
+    // asked about — it is unreachable, or it answers 401/403 to a revoked or
+    // migrated token, both of which arrive here as an unanswered list. This
+    // pick persists into `agents.defaults.model.primary`, which Telegram and
+    // the coding agent run too, so declining it while the answer is missing and
+    // the last confirmed badge is not Max costs the owner a retry, where
+    // letting it through costs every turn until the portal answers. The BOOT
+    // GUARD, which writes, keeps failing open on the same doubt — see
+    // `clawboxAiMaxPickUnconfirmed`.
+    if (!clawboxLogin.loading
+      && clawboxAiMaxPickUnconfirmed(target.model, clawboxLogin.allowedModels, clawboxLogin.tier)) {
+      setMessages(prev => [...prev, {
+        role: 'system',
+        text: `${target.label} could not be checked against your ClawBox AI plan — the ClawBox portal did not answer. Try again in a moment, or [check the plan in the portal](${PORTAL_DASHBOARD_URL}). Staying on the current model.`,
+        timestamp: Date.now(),
+        variant: 'error',
+      }])
+      return false
+    }
     setSwitchingModel(true)
     setErrorMsg('')
     try {
@@ -4230,7 +4249,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     } finally {
       setSwitchingModel(false)
     }
-  }, [chatModelState, connect, switchingModel, clawboxLogin.allowedModels])
+  }, [chatModelState, connect, switchingModel, clawboxLogin.allowedModels, clawboxLogin.tier, clawboxLogin.loading])
 
   // The dropdown gate above only catches picks the user *clicks*. An account
   // the portal refuses can also boot with the Max model already saved as the
@@ -4257,20 +4276,37 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     // allows that one. Switching to a second refused model would move the
     // error rather than fix it.
     if (portalDeniesClawboxAiModel(CLAWBOX_AI_MODEL_BY_TIER.flash, clawboxLogin.allowedModels)) return
-    // Latched before the call so the effect cannot re-enter while the switch
-    // is in flight, and released again if the switch did not happen — a box
-    // still on the refused model under a message saying it was moved is the
-    // false success this file has produced before.
+    // `switchChatModel` early-returns without attempting anything while another
+    // switch is in flight, so wait rather than spend the latch on a call that
+    // cannot happen. `switchingModel` is a dep, so the effect comes back by
+    // itself when that other switch finishes. This is the ONLY reason the guard
+    // gets a second chance.
+    if (switchingModel) return
+    // Latched for the life of the component, and deliberately NOT released when
+    // the switch fails. `switchChatModel` writes `switchingModel`, which is one
+    // of its own useCallback deps — calling it changes its identity, which
+    // re-runs this effect. Releasing the latch on a failure therefore re-armed
+    // the guard with nothing about the box changed, and any route failure that
+    // repeats (400 "provider is not configured", 409, 500, a proxy's non-JSON
+    // body) became a POST loop against the box's own setup server with two
+    // system messages per turn of it. One attempt; the error `switchChatModel`
+    // leaves in the transcript is the answer, and re-opening the chat retries.
     tierGuardRef.current = true
-    setMessages(prev => [...prev, {
-      role: 'system',
-      text: `Max Tier needs a Max subscription. [Upgrade in the ClawBox portal](${PORTAL_DASHBOARD_URL}) to unlock it — switching you to Pro Tier so chat keeps working.`,
-      timestamp: Date.now(),
-      variant: 'error',
-    }])
     void switchChatModel({ model: CLAWBOX_AI_MODEL_BY_TIER.flash, label: 'Pro Tier' })
-      .then(switched => { if (!switched) tierGuardRef.current = false })
-  }, [chatModelState?.activeModel, clawboxLogin.allowedModels, clawboxLogin.loading, switchChatModel])
+      .then(switched => {
+        // Posted from the SUCCESS path only. This sentence says the box was
+        // moved, and until the POST comes back that is not known — announcing
+        // it first left a failed switch under a message claiming it had
+        // happened, above the `Error:` line saying it had not.
+        if (!switched) return
+        setMessages(prev => [...prev, {
+          role: 'system',
+          text: `Max Tier needs a Max subscription. [Upgrade in the ClawBox portal](${PORTAL_DASHBOARD_URL}) to unlock it — switched you to Pro Tier so chat keeps working.`,
+          timestamp: Date.now(),
+          variant: 'error',
+        }])
+      })
+  }, [chatModelState?.activeModel, clawboxLogin.allowedModels, clawboxLogin.loading, switchChatModel, switchingModel])
 
   const handleChatSourceChange = useCallback(async (optionId: string) => {
     const target = chatModelState?.options.find(option => option.id === optionId)

--- a/src/lib/clawbox-ai-models.ts
+++ b/src/lib/clawbox-ai-models.ts
@@ -94,7 +94,7 @@ export function normalizeClawboxAiTier(value: unknown): ClawboxAiTier | null {
  * Says WHICH model this is, and nothing about who may run it — that
  * question is answered by {@link portalDeniesClawboxAiModel} from the
  * portal's own entitlement list. The two used to be one check keyed on
- * the device-tier badge, and the badge is not an entitlement.
+ * the device-tier badge, which is a device DEFAULT, not an entitlement.
  */
 export function isClawboxAiProModel(model: string | null | undefined): boolean {
   if (typeof model !== "string") return false;
@@ -104,6 +104,24 @@ export function isClawboxAiProModel(model: string | null | undefined): boolean {
   const modelId = model.slice(idx + 1);
   if (modelId !== CLAWBOX_AI_PRO_MODEL_ID) return false;
   return provider === CLAWBOX_AI_PROVIDER || provider === "clawai";
+}
+
+/**
+ * The entitlement list out of whatever the portal (or our own status route)
+ * put in that field: a non-empty list of trimmed ids, or null.
+ *
+ * ONE normaliser, called by the server that reads the portal and by the client
+ * that reads the server, because an empty list and a null mean the same thing
+ * downstream ("not answered") and two spellings of that rule is how this
+ * codebase drifts.
+ */
+export function normalizeAllowedModelIds(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  const ids = value
+    .filter((id): id is string => typeof id === "string")
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0);
+  return ids.length > 0 ? ids : null;
 }
 
 /** Bare id of a model ref: `deepseek/deepseek-v4-pro` → `deepseek-v4-pro`. */
@@ -140,22 +158,33 @@ function isClawboxAiModelRef(ref: string): boolean {
  *    "allowedModels":["deepseek-v4-flash","deepseek-v4-pro",…],
  *    "defaultModel":"deepseek-v4-pro", …}
  *
- * WHY NOT THE TIER BADGE. `deviceTier` is the tier the device was STAMPED
- * with, not what the plan entitles: a Max account whose box was paired while
- * it was on the Pro plan is stamped `flash`, and `mapPortalTier` prefers the
- * stamp. Gating the Pro model on that badge locked a paying Max owner out of
- * the model he had just picked in Telegram, and told him to buy the plan he
- * already had.
+ * WHY NOT THE TIER BADGE. The badge (`clawai_tier`) comes from
+ * `mapPortalTier`, which prefers the portal's `deviceTier` stamp — and that
+ * stamp is deliberately a DEVICE DEFAULT: "a Max subscriber who runs Flash on
+ * this device" is a state the configure route documents and keeps (TASK-481).
+ * A default is the right thing to write as the primary model. It is the wrong
+ * thing to VETO with: the old gate refused the Pro model, and rewrote the
+ * box's primary back to Flash, whenever the badge was not exactly `"pro"` —
+ * including when the status poll had simply not answered and the badge was
+ * `null`. That undid an explicit pick (from this picker or from the Telegram
+ * `/model` keyboard) on a Max box and told its owner to buy the plan he
+ * already had. A default may be overridden by a pick; an entitlement may not,
+ * and only the portal knows which is which.
  *
  * ONLY ClawBox AI refs are judged (`clawai/…`, `deepseek/…`). The list says
  * nothing about a provider the owner brought their own key for.
  *
  * FALSE ON ANY DOUBT, deliberately. An absent, non-array or empty list is "I
- * don't know" — an unreachable portal, an older portal build, a failed status
- * poll — and an unanswered question must never read as a refusal: that is how
- * the box came to rewrite its own model on a network blip. The proxy still
- * gates every turn on the far side, so a genuinely unentitled pick surfaces as
- * a visible error instead of a silent downgrade.
+ * don't know" — an unreachable portal, a failed status poll — and an
+ * unanswered question must never read as a refusal: that is how the box came
+ * to rewrite its own model on a network blip. (A portal that answers the tier
+ * but publishes no list is NOT one of those cases: the status route fills the
+ * list from the badge there, so nothing that used to be refused becomes
+ * allowed on an older portal.) The proxy is the last word either way, and it
+ * speaks plainly — measured 2026-09-04 against the live proxy with a paired
+ * token: an id outside the account's list answers
+ * `400 {"error":{"message":"Model not allowed: …","code":"model_not_allowed"}}`,
+ * not a silent downgrade.
  */
 export function portalDeniesClawboxAiModel(
   model: string | null | undefined,

--- a/src/lib/clawbox-ai-models.ts
+++ b/src/lib/clawbox-ai-models.ts
@@ -199,6 +199,40 @@ export function portalDeniesClawboxAiModel(
   );
 }
 
+/**
+ * Is `model` the ClawBox AI Max model on a device whose entitlement the portal
+ * has never confirmed?
+ *
+ * True only when all three hold: the pick IS the Max model; `allowedModels` is
+ * unanswered (the portal could not be reached, or answered 401/403 to a revoked
+ * or migrated token, which `fetchPortalTier` maps to `unreachable` on purpose);
+ * and the last portal-confirmed badge is not the Max device tier.
+ *
+ * ONLY THE CLICK GATE MAY READ THIS — never the boot guard, which WRITES.
+ * Declining a click changes nothing and the owner can pick again a moment
+ * later; a write moves the box off a model that may be working perfectly, and
+ * a guess must not drive that. {@link portalDeniesClawboxAiModel} stays false
+ * on any doubt for exactly that reason.
+ *
+ * The badge is a WORSE answer than the list, and this is the one gate where it
+ * is still better than none. Worse: a Max subscriber who deliberately runs
+ * Flash on this box carries a `"flash"` badge (TASK-481) and is declined here
+ * while the portal is down — a state no measured device-info response has ever
+ * shown, and one a retry fixes. Better than none: without it a revoked token
+ * writes the Max model into `agents.defaults.model.primary` — which Telegram
+ * and the coding-agent wrapper run too — and every turn afterwards comes back
+ * as the opaque "[assistant turn failed]" until the portal answers again.
+ */
+export function clawboxAiMaxPickUnconfirmed(
+  model: string | null | undefined,
+  allowedModels: readonly string[] | null | undefined,
+  tier: string | null | undefined,
+): boolean {
+  if (!isClawboxAiProModel(model)) return false;
+  if (Array.isArray(allowedModels) && allowedModels.length > 0) return false;
+  return tier !== "pro";
+}
+
 /* ---------------------------------------------------------------------------
  * ClawBox AI image generation
  * ------------------------------------------------------------------------ */

--- a/src/lib/clawbox-ai-models.ts
+++ b/src/lib/clawbox-ai-models.ts
@@ -91,12 +91,10 @@ export function normalizeClawboxAiTier(value: unknown): ClawboxAiTier | null {
  * True if `model` is a fully-qualified ClawBox AI Pro slug
  * (`clawai/deepseek-v4-pro` or `deepseek/deepseek-v4-pro`).
  *
- * The Pro device-tier maps to the V4 Pro frontier weights, which the
- * portal gateway gates to Max subscribers (`user.tier === "max"`,
- * `deviceTier === "pro"`). Non-Max users picking it would silently
- * have their requests downgraded to flash by the gateway's live-tier
- * reconcile, so the device-side picker uses this helper to surface
- * an upgrade prompt instead.
+ * Says WHICH model this is, and nothing about who may run it — that
+ * question is answered by {@link portalDeniesClawboxAiModel} from the
+ * portal's own entitlement list. The two used to be one check keyed on
+ * the device-tier badge, and the badge is not an entitlement.
  */
 export function isClawboxAiProModel(model: string | null | undefined): boolean {
   if (typeof model !== "string") return false;
@@ -106,6 +104,70 @@ export function isClawboxAiProModel(model: string | null | undefined): boolean {
   const modelId = model.slice(idx + 1);
   if (modelId !== CLAWBOX_AI_PRO_MODEL_ID) return false;
   return provider === CLAWBOX_AI_PROVIDER || provider === "clawai";
+}
+
+/** Bare id of a model ref: `deepseek/deepseek-v4-pro` → `deepseek-v4-pro`. */
+function bareModelId(ref: string): string {
+  const slash = ref.lastIndexOf("/");
+  return (slash >= 0 ? ref.slice(slash + 1) : ref).trim().toLowerCase();
+}
+
+/**
+ * Is `ref` a fully-qualified model of the ClawBox AI proxy
+ * (`clawai/…` or `deepseek/…`)?
+ *
+ * The prefix is required. A bare id says nothing about whose model it is, and
+ * the portal's entitlement list governs ONLY ClawBox AI: matching an
+ * `anthropic/claude-opus-5` primary against it would refuse every model the
+ * owner brought their own key for.
+ */
+function isClawboxAiModelRef(ref: string): boolean {
+  const idx = ref.indexOf("/");
+  if (idx <= 0) return false;
+  const provider = ref.slice(0, idx).trim().toLowerCase();
+  return provider === CLAWBOX_AI_PROVIDER || provider === "clawai";
+}
+
+/**
+ * Does the portal POSITIVELY refuse `model` for this device's account?
+ *
+ * `allowedModels` is the list `GET /api/clawbox-ai/device-info` publishes for
+ * the paired `claw_*` token — the portal's own answer to "what may this device
+ * run", carried in the same response the tier badge is read from. Measured on
+ * a Max box (2026-09-04):
+ *
+ *   {"tier":"max","deviceTier":"pro",
+ *    "allowedModels":["deepseek-v4-flash","deepseek-v4-pro",…],
+ *    "defaultModel":"deepseek-v4-pro", …}
+ *
+ * WHY NOT THE TIER BADGE. `deviceTier` is the tier the device was STAMPED
+ * with, not what the plan entitles: a Max account whose box was paired while
+ * it was on the Pro plan is stamped `flash`, and `mapPortalTier` prefers the
+ * stamp. Gating the Pro model on that badge locked a paying Max owner out of
+ * the model he had just picked in Telegram, and told him to buy the plan he
+ * already had.
+ *
+ * ONLY ClawBox AI refs are judged (`clawai/…`, `deepseek/…`). The list says
+ * nothing about a provider the owner brought their own key for.
+ *
+ * FALSE ON ANY DOUBT, deliberately. An absent, non-array or empty list is "I
+ * don't know" — an unreachable portal, an older portal build, a failed status
+ * poll — and an unanswered question must never read as a refusal: that is how
+ * the box came to rewrite its own model on a network blip. The proxy still
+ * gates every turn on the far side, so a genuinely unentitled pick surfaces as
+ * a visible error instead of a silent downgrade.
+ */
+export function portalDeniesClawboxAiModel(
+  model: string | null | undefined,
+  allowedModels: readonly string[] | null | undefined,
+): boolean {
+  if (typeof model !== "string" || !isClawboxAiModelRef(model)) return false;
+  if (!Array.isArray(allowedModels) || allowedModels.length === 0) return false;
+  const wanted = bareModelId(model);
+  if (!wanted) return false;
+  return !allowedModels.some(
+    (entry) => typeof entry === "string" && bareModelId(entry) === wanted,
+  );
 }
 
 /* ---------------------------------------------------------------------------

--- a/src/lib/clawbox-ai-models.ts
+++ b/src/lib/clawbox-ai-models.ts
@@ -199,40 +199,6 @@ export function portalDeniesClawboxAiModel(
   );
 }
 
-/**
- * Is `model` the ClawBox AI Max model on a device whose entitlement the portal
- * has never confirmed?
- *
- * True only when all three hold: the pick IS the Max model; `allowedModels` is
- * unanswered (the portal could not be reached, or answered 401/403 to a revoked
- * or migrated token, which `fetchPortalTier` maps to `unreachable` on purpose);
- * and the last portal-confirmed badge is not the Max device tier.
- *
- * ONLY THE CLICK GATE MAY READ THIS — never the boot guard, which WRITES.
- * Declining a click changes nothing and the owner can pick again a moment
- * later; a write moves the box off a model that may be working perfectly, and
- * a guess must not drive that. {@link portalDeniesClawboxAiModel} stays false
- * on any doubt for exactly that reason.
- *
- * The badge is a WORSE answer than the list, and this is the one gate where it
- * is still better than none. Worse: a Max subscriber who deliberately runs
- * Flash on this box carries a `"flash"` badge (TASK-481) and is declined here
- * while the portal is down — a state no measured device-info response has ever
- * shown, and one a retry fixes. Better than none: without it a revoked token
- * writes the Max model into `agents.defaults.model.primary` — which Telegram
- * and the coding-agent wrapper run too — and every turn afterwards comes back
- * as the opaque "[assistant turn failed]" until the portal answers again.
- */
-export function clawboxAiMaxPickUnconfirmed(
-  model: string | null | undefined,
-  allowedModels: readonly string[] | null | undefined,
-  tier: string | null | undefined,
-): boolean {
-  if (!isClawboxAiProModel(model)) return false;
-  if (Array.isArray(allowedModels) && allowedModels.length > 0) return false;
-  return tier !== "pro";
-}
-
 /* ---------------------------------------------------------------------------
  * ClawBox AI image generation
  * ------------------------------------------------------------------------ */

--- a/src/lib/clawbox-ai-portal-tier.ts
+++ b/src/lib/clawbox-ai-portal-tier.ts
@@ -54,17 +54,28 @@ const PORTAL_UNREACHABLE_TTL_MS = 30_000;
 export interface DeviceInfoResponse {
   tier?: string;
   deviceTier?: string | null;
+  /**
+   * Model ids this token may run, as the portal publishes them (bare ids,
+   * e.g. `["deepseek-v4-flash","deepseek-v4-pro",…]`). The portal's own
+   * answer to "what is this account entitled to" — see
+   * `portalDeniesClawboxAiModel`, which is the only thing allowed to read it
+   * as a refusal. Absent on older portal builds.
+   */
+  allowedModels?: unknown;
 }
 
 export type PortalLookup =
   | {
       source: "portal";
       tier: ClawboxAiTier | null;
+      /** Entitled model ids, or null when the portal published none. */
+      allowedModels: string[] | null;
     }
   | { source: "unreachable" };
 
 interface PortalCacheEntry {
   tier: ClawboxAiTier | null;
+  allowedModels: string[] | null;
   expiresAt: number;
 }
 
@@ -89,6 +100,7 @@ const inFlightPortalLookups = new Map<string, Promise<PortalLookup>>();
 function rememberTier(
   token: string,
   tier: ClawboxAiTier | null,
+  allowedModels: string[] | null,
   now: number,
 ) {
   for (const [key, entry] of portalTierCache) {
@@ -101,8 +113,26 @@ function rememberTier(
   }
   portalTierCache.set(token, {
     tier,
+    allowedModels,
     expiresAt: now + PORTAL_TIER_CACHE_TTL_MS,
   });
+}
+
+/**
+ * The entitlement list out of a device-info body, or null when the portal
+ * published none.
+ *
+ * Null and an empty list mean the same thing downstream — "not answered" —
+ * so an all-blank list is normalised to null here rather than travelling as
+ * a list that refuses everything.
+ */
+export function mapPortalAllowedModels(body: DeviceInfoResponse): string[] | null {
+  if (!Array.isArray(body.allowedModels)) return null;
+  const ids = body.allowedModels
+    .filter((id): id is string => typeof id === "string")
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0);
+  return ids.length > 0 ? ids : null;
 }
 
 /**
@@ -155,6 +185,7 @@ export async function fetchPortalTier(token: string): Promise<PortalLookup> {
     return {
       source: "portal",
       tier: cached.tier,
+      allowedModels: cached.allowedModels,
     };
   }
 
@@ -179,9 +210,10 @@ export async function fetchPortalTier(token: string): Promise<PortalLookup> {
       if (res.ok) {
         const body = await res.json() as DeviceInfoResponse;
         const tier = mapPortalTier(body);
-        rememberTier(token, tier, now);
+        const allowedModels = mapPortalAllowedModels(body);
+        rememberTier(token, tier, allowedModels, now);
         portalUnreachableCache.delete(token);
-        return { source: "portal", tier };
+        return { source: "portal", tier, allowedModels };
       }
       // 401/403 is ambiguous: it can mean genuinely Free OR token
       // revoked / migrated / corrupted on a still-paid account. We

--- a/src/lib/clawbox-ai-portal-tier.ts
+++ b/src/lib/clawbox-ai-portal-tier.ts
@@ -1,4 +1,5 @@
 import {
+  normalizeAllowedModelIds,
   normalizeClawboxAiTier,
   type ClawboxAiTier,
 } from "@/lib/clawbox-ai-models";
@@ -120,19 +121,11 @@ function rememberTier(
 
 /**
  * The entitlement list out of a device-info body, or null when the portal
- * published none.
- *
- * Null and an empty list mean the same thing downstream — "not answered" —
- * so an all-blank list is normalised to null here rather than travelling as
- * a list that refuses everything.
+ * published none. Normalised through the one shared rule so the server and
+ * the client cannot disagree about what an empty list means.
  */
 export function mapPortalAllowedModels(body: DeviceInfoResponse): string[] | null {
-  if (!Array.isArray(body.allowedModels)) return null;
-  const ids = body.allowedModels
-    .filter((id): id is string => typeof id === "string")
-    .map((id) => id.trim())
-    .filter((id) => id.length > 0);
-  return ids.length > 0 ? ids : null;
+  return normalizeAllowedModelIds(body.allowedModels);
 }
 
 /**

--- a/src/lib/clawbox-ai-portal-tier.ts
+++ b/src/lib/clawbox-ai-portal-tier.ts
@@ -69,6 +69,16 @@ export type PortalLookup =
   | {
       source: "portal";
       tier: ClawboxAiTier | null;
+      /**
+       * The PLAN, read WITHOUT the device stamp — see `mapPortalPlanTier`.
+       *
+       * `tier` above prefers `deviceTier`, so it answers "what does this box
+       * default to", not "what does this account pay for". Anything deciding
+       * ENTITLEMENT needs the second question, and collapsing the two into one
+       * field is how a Max subscriber's box came to refuse the model he pays
+       * for (TASK-691).
+       */
+      planTier: ClawboxAiTier | null;
       /** Entitled model ids, or null when the portal published none. */
       allowedModels: string[] | null;
     }
@@ -76,6 +86,7 @@ export type PortalLookup =
 
 interface PortalCacheEntry {
   tier: ClawboxAiTier | null;
+  planTier: ClawboxAiTier | null;
   allowedModels: string[] | null;
   expiresAt: number;
 }
@@ -101,6 +112,7 @@ const inFlightPortalLookups = new Map<string, Promise<PortalLookup>>();
 function rememberTier(
   token: string,
   tier: ClawboxAiTier | null,
+  planTier: ClawboxAiTier | null,
   allowedModels: string[] | null,
   now: number,
 ) {
@@ -114,6 +126,7 @@ function rememberTier(
   }
   portalTierCache.set(token, {
     tier,
+    planTier,
     allowedModels,
     expiresAt: now + PORTAL_TIER_CACHE_TTL_MS,
   });
@@ -152,6 +165,25 @@ export function mapPortalTier(body: DeviceInfoResponse): ClawboxAiTier | null {
 }
 
 /**
+ * The subscription PLAN, mapped to the same two-value enum and ignoring the
+ * device stamp entirely: Max plan -> `"pro"`, Pro plan -> `"flash"`, anything
+ * unpaid -> `null`.
+ *
+ * The sibling of {@link mapPortalTier}, and the difference between them is the
+ * whole of TASK-691. `mapPortalTier` prefers `deviceTier` on purpose, because
+ * it answers "what should this BOX default to" and a Max subscriber is allowed
+ * to run Flash here. This one answers "what does this ACCOUNT pay for", which
+ * is the only question an entitlement may be derived from. Read the first for a
+ * default to write; read this one before refusing anything.
+ */
+export function mapPortalPlanTier(body: DeviceInfoResponse): ClawboxAiTier | null {
+  const plan = (body.tier ?? "").trim().toLowerCase();
+  if (plan === "max") return "pro";
+  if (plan === "pro") return "flash";
+  return null;
+}
+
+/**
  * Resolves a `claw_*` token's current tier against the portal, with
  * a short in-memory cache and concurrent-request de-duplication.
  *
@@ -178,6 +210,7 @@ export async function fetchPortalTier(token: string): Promise<PortalLookup> {
     return {
       source: "portal",
       tier: cached.tier,
+      planTier: cached.planTier,
       allowedModels: cached.allowedModels,
     };
   }
@@ -203,10 +236,11 @@ export async function fetchPortalTier(token: string): Promise<PortalLookup> {
       if (res.ok) {
         const body = await res.json() as DeviceInfoResponse;
         const tier = mapPortalTier(body);
+        const planTier = mapPortalPlanTier(body);
         const allowedModels = mapPortalAllowedModels(body);
-        rememberTier(token, tier, allowedModels, now);
+        rememberTier(token, tier, planTier, allowedModels, now);
         portalUnreachableCache.delete(token);
-        return { source: "portal", tier, allowedModels };
+        return { source: "portal", tier, planTier, allowedModels };
       }
       // 401/403 is ambiguous: it can mean genuinely Free OR token
       // revoked / migrated / corrupted on a still-paid account. We

--- a/src/lib/use-clawbox-login.ts
+++ b/src/lib/use-clawbox-login.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { normalizeAllowedModelIds } from "@/lib/clawbox-ai-models";
 
 // Lightweight client hook for "is the device signed in to a ClawBox AI
 // account, and what does that account entitle?". Backed by
@@ -122,11 +123,9 @@ export function useClawboxLogin(intervalMs: number = DEFAULT_INTERVAL_MS): Clawb
         // Older responses without `clawaiConfigured` fall back to the
         // pre-rollout `provider === "clawai"` heuristic.
         const loggedIn = data.clawaiConfigured ?? (data.provider === "clawai");
-        // Anything that is not a non-empty list of strings is "not answered".
-        const parsed = Array.isArray(data.clawaiAllowedModels)
-          ? data.clawaiAllowedModels.filter((id): id is string => typeof id === "string")
-          : [];
-        const allowedModels = parsed.length > 0 ? parsed : null;
+        // One normaliser, shared with the server that produced the field, so
+        // the two cannot disagree about what an empty list means.
+        const allowedModels = normalizeAllowedModelIds(data.clawaiAllowedModels);
         // Keep the previous array when the poll brought the same ids back.
         // A fresh array every 30 s would be a new identity for every consumer
         // that memoises on it — see the same-ref rule in preserveOnTransient.

--- a/src/lib/use-clawbox-login.ts
+++ b/src/lib/use-clawbox-login.ts
@@ -30,6 +30,14 @@ export type ClawboxAiTier = "flash" | "pro" | string;
 export interface ClawboxLoginState {
   loggedIn: boolean;
   tier: ClawboxAiTier | null;
+  /**
+   * Model ids the portal says this account may run, or null when the question
+   * has not been answered (no token, portal unreachable, poll failed, older
+   * portal build). Null is NOT "nothing is allowed" — see
+   * `portalDeniesClawboxAiModel`, the only reader permitted to turn this into
+   * a refusal.
+   */
+  allowedModels: string[] | null;
   loading: boolean;
 }
 
@@ -42,6 +50,9 @@ interface AiStatusResponse {
   // for chat. Falls back to `clawaiTier` when missing so older
   // callers (and pre-rollout responses) keep working.
   clawaiAccountTier?: ClawboxAiTier | null;
+  // The portal's entitlement list for the paired token. Absent on a
+  // pre-rollout server, which reads as "not answered", not as "empty".
+  clawaiAllowedModels?: string[] | null;
   // True when any clawai profile is configured. Distinguishes
   // "no ClawBox AI account" (false) from "Free user paired"
   // (true, clawaiAccountTier=null).
@@ -50,10 +61,18 @@ interface AiStatusResponse {
 
 const DEFAULT_INTERVAL_MS = 30_000;
 
+/** Same ids in the same order — or both unanswered. */
+function sameIds(a: string[] | null, b: string[] | null): boolean {
+  if (a === b) return true;
+  if (!a || !b || a.length !== b.length) return false;
+  return a.every((id, i) => id === b[i]);
+}
+
 export function useClawboxLogin(intervalMs: number = DEFAULT_INTERVAL_MS): ClawboxLoginState {
   const [state, setState] = useState<ClawboxLoginState>({
     loggedIn: false,
     tier: null,
+    allowedModels: null,
     loading: true,
   });
 
@@ -74,7 +93,12 @@ export function useClawboxLogin(intervalMs: number = DEFAULT_INTERVAL_MS): Clawb
       // out and downstream consumers don't re-render on every failed poll.
       setState((prev) => (
         prev.loading
-          ? { loggedIn: prev.loggedIn, tier: prev.tier, loading: false }
+          ? {
+              loggedIn: prev.loggedIn,
+              tier: prev.tier,
+              allowedModels: prev.allowedModels,
+              loading: false,
+            }
           : prev
       ));
     };
@@ -98,11 +122,22 @@ export function useClawboxLogin(intervalMs: number = DEFAULT_INTERVAL_MS): Clawb
         // Older responses without `clawaiConfigured` fall back to the
         // pre-rollout `provider === "clawai"` heuristic.
         const loggedIn = data.clawaiConfigured ?? (data.provider === "clawai");
-        setState({
-          loggedIn,
-          tier,
-          loading: false,
-        });
+        // Anything that is not a non-empty list of strings is "not answered".
+        const parsed = Array.isArray(data.clawaiAllowedModels)
+          ? data.clawaiAllowedModels.filter((id): id is string => typeof id === "string")
+          : [];
+        const allowedModels = parsed.length > 0 ? parsed : null;
+        // Keep the previous array when the poll brought the same ids back.
+        // A fresh array every 30 s would be a new identity for every consumer
+        // that memoises on it — see the same-ref rule in preserveOnTransient.
+        setState((prev) => (
+          !prev.loading
+            && prev.loggedIn === loggedIn
+            && prev.tier === tier
+            && sameIds(prev.allowedModels, allowedModels)
+            ? prev
+            : { loggedIn, tier, allowedModels, loading: false }
+        ));
       } catch {
         preserveOnTransient();
       } finally {

--- a/src/tests/components/chat-clawai-pro-entitlement.test.tsx
+++ b/src/tests/components/chat-clawai-pro-entitlement.test.tsx
@@ -278,4 +278,31 @@ describe("the boot guard when the switch it asks for fails", () => {
     // …and nothing claims the box was moved off the model it is still on.
     expect(document.body.textContent).not.toMatch(/needs a Max subscription/i);
   });
+
+  it("tries again when the chat is closed and re-opened", async () => {
+    // The other half of the same latch. Never releasing it is the mirror
+    // defect: `page.tsx` keeps ChatPopup mounted for the whole session and only
+    // toggles `isOpen`, so one failed attempt would leave the box on a refused
+    // model until a page reload — a capability probed once and treated as
+    // settled. The latch therefore remembers the INPUTS it tried, and closing
+    // the chat forgets them, which is the retry an owner reaches for.
+    const calls = installFetch(
+      async () => ({ ok: true, json: async () => REFUSED_STATUS }),
+      async () => ({
+        ok: false,
+        status: 500,
+        json: async () => ({ error: "Selected AI provider is not configured" }),
+      }),
+    );
+    const { rerender } = render(<ChatPopup isOpen onClose={() => {}} />);
+    await settle(calls);
+    expect(modelWrites(calls)).toHaveLength(1);
+
+    rerender(<ChatPopup isOpen={false} onClose={() => {}} />);
+    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 10)); });
+    rerender(<ChatPopup isOpen onClose={() => {}} />);
+    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 50)); });
+
+    expect(modelWrites(calls)).toHaveLength(2);
+  });
 });

--- a/src/tests/components/chat-clawai-pro-entitlement.test.tsx
+++ b/src/tests/components/chat-clawai-pro-entitlement.test.tsx
@@ -1,0 +1,192 @@
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@/tests/helpers/test-utils";
+import ChatPopup from "@/components/ChatPopup";
+import { resetHarnessCache } from "@/lib/client-harness";
+import { translations } from "@/lib/translations";
+
+vi.mock("@/lib/i18n", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/i18n")>();
+  return {
+    ...actual,
+    useT: () => ({ t: (key: string) => translations.en[key] ?? key }),
+    I18nProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  };
+});
+
+/**
+ * A box running the ClawBox AI Max model, picked from the Telegram `/model`
+ * keyboard. `activeModel` is what the gateway is really on; the chat header
+ * only reads it.
+ */
+const ON_PRO = {
+  activeOptionId: "clawai",
+  activeModel: "deepseek/deepseek-v4-pro",
+  activeSource: "primary",
+  activeLabel: "ClawBox AI",
+  options: [
+    {
+      id: "clawai",
+      label: "ClawBox AI",
+      model: "deepseek/deepseek-v4-pro",
+      provider: "clawai",
+      available: true,
+      settingsSection: "ai",
+      isLocal: false,
+    },
+    {
+      id: "openai/gpt-5.4",
+      label: "OpenAI GPT",
+      model: "openai/gpt-5.4",
+      provider: "openai",
+      available: true,
+      settingsSection: "ai",
+      isLocal: false,
+    },
+  ],
+  primary: { available: true, label: "ClawBox AI", model: "deepseek/deepseek-v4-pro" },
+  local: { available: false, label: null, model: null },
+  subscriptionProviders: [],
+};
+
+/**
+ * The portal's answer for the paired token, as `/api/clawbox-ai/device-info`
+ * really serves it (measured on a Max box, 2026-09-04):
+ *   {"tier":"max","deviceTier":"pro",
+ *    "allowedModels":["deepseek-v4-flash","deepseek-v4-pro",…],
+ *    "defaultModel":"deepseek-v4-pro", …}
+ *
+ * `deviceTier` is the model the device currently defaults to, NOT what the
+ * plan entitles — a Max account whose box was paired while it was on the Pro
+ * plan is still stamped `flash`, so the badge tier reads "flash" while the
+ * entitlement list still carries the Pro id.
+ */
+const ENTITLED_STATUS = {
+  connected: true,
+  provider: "clawai",
+  providerLabel: "ClawBox AI",
+  mode: "api_key",
+  model: "deepseek/deepseek-v4-pro",
+  clawaiTier: "flash",
+  clawaiAccountTier: "flash",
+  clawaiAllowedModels: ["deepseek-v4-flash", "deepseek-v4-pro"],
+  clawaiConfigured: true,
+  tierSource: "portal",
+};
+
+type FetchCall = { url: string; init?: RequestInit };
+
+function installFetch(statusResponder: () => Promise<unknown>) {
+  const calls: FetchCall[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: unknown, init?: RequestInit) => {
+      const url = String(input);
+      calls.push({ url, init });
+      if (url.includes("/setup-api/harness/active")) {
+        return { ok: true, json: async () => ({ active: "openclaw", edition: "openclaw" }) };
+      }
+      if (url.includes("/setup-api/ai-models/status")) {
+        return statusResponder();
+      }
+      if (url.includes("/setup-api/chat/model")) {
+        return { ok: true, json: async () => ON_PRO };
+      }
+      if (url.includes("/setup-api/chat/history")) {
+        return { ok: true, json: async () => ({ messages: [] }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    }),
+  );
+  return calls;
+}
+
+function modelWrites(calls: FetchCall[]): string[] {
+  return calls
+    .filter((call) => call.url.includes("/setup-api/chat/model") && call.init?.method === "POST")
+    .map((call) => String(call.init?.body ?? ""));
+}
+
+/** Let every effect chain the status poll can start run to completion. */
+async function settle(calls: FetchCall[]) {
+  await waitFor(() => {
+    expect(calls.some((call) => call.url.includes("/setup-api/ai-models/status"))).toBe(true);
+  });
+  await waitFor(() => {
+    expect(calls.some((call) => call.url.includes("/setup-api/chat/model"))).toBe(true);
+  });
+  // Two macrotask turns: the guard's own effect, then the POST it would fire.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+beforeEach(() => {
+  resetHarnessCache();
+  window.localStorage.clear();
+  Element.prototype.scrollIntoView = vi.fn();
+  vi.stubGlobal(
+    "WebSocket",
+    class {
+      close() {}
+      send() {}
+      addEventListener() {}
+      removeEventListener() {}
+    },
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetHarnessCache();
+});
+
+describe("a ClawBox AI Pro model the account is entitled to", () => {
+  it("is left running when the portal lists it, whatever the device-tier badge says", async () => {
+    // The badge tier is the device-pair stamp, not the entitlement. Reading it
+    // as one told a paying Max owner he needed a Max subscription and moved
+    // his box off the model he had just picked in Telegram.
+    const calls = installFetch(async () => ({ ok: true, json: async () => ENTITLED_STATUS }));
+    render(<ChatPopup isOpen onClose={() => {}} />);
+    await settle(calls);
+
+    expect(modelWrites(calls)).toEqual([]);
+    expect(document.body.textContent).not.toMatch(/Max subscription/i);
+  });
+
+  it("still drops to Flash when the portal really does refuse it", async () => {
+    // The protection this replaces is real: an unentitled Pro pick is
+    // downgraded to flash by the proxy's live-tier reconcile, so every reply
+    // comes from a model the header does not name. A NAMED refusal keeps the
+    // upgrade prompt and the switch.
+    const calls = installFetch(async () => ({
+      ok: true,
+      json: async () => ({
+        ...ENTITLED_STATUS,
+        clawaiAllowedModels: ["deepseek-v4-flash"],
+      }),
+    }));
+    render(<ChatPopup isOpen onClose={() => {}} />);
+    await settle(calls);
+
+    // The switch itself is the assertion: the upgrade message is posted into
+    // the transcript, which the "Switching AI provider…" overlay covers for
+    // the whole of the switch it just started.
+    await waitFor(() => {
+      expect(modelWrites(calls)).toEqual(['{"model":"deepseek/deepseek-v4-flash"}']);
+    });
+  });
+
+  it("is left running when the entitlement could not be read at all", async () => {
+    // A failed status poll is "I don't know", not "you are not entitled" —
+    // and the box's model is not something to rewrite on a question that
+    // never got an answer.
+    const calls = installFetch(async () => {
+      throw new Error("network down");
+    });
+    render(<ChatPopup isOpen onClose={() => {}} />);
+    await settle(calls);
+
+    expect(modelWrites(calls)).toEqual([]);
+    expect(document.body.textContent).not.toMatch(/Max subscription/i);
+  });
+});

--- a/src/tests/components/chat-clawai-pro-entitlement.test.tsx
+++ b/src/tests/components/chat-clawai-pro-entitlement.test.tsx
@@ -76,9 +76,26 @@ const ENTITLED_STATUS = {
   tierSource: "portal",
 };
 
+/** What the route answers once the box has been moved to the Flash tier. */
+const ON_FLASH = {
+  ...ON_PRO,
+  activeModel: "deepseek/deepseek-v4-flash",
+  primary: { available: true, label: "ClawBox AI", model: "deepseek/deepseek-v4-flash" },
+};
+
+/** The same account, on a portal whose list POSITIVELY excludes the Max id. */
+const REFUSED_STATUS = {
+  ...ENTITLED_STATUS,
+  clawaiAllowedModels: ["deepseek-v4-flash"],
+};
+
 type FetchCall = { url: string; init?: RequestInit };
 
-function installFetch(statusResponder: () => Promise<unknown>) {
+function installFetch(
+  statusResponder: () => Promise<unknown>,
+  /** Answer for the model WRITE only; the GET always reports `ON_PRO`. */
+  modelPostResponder?: () => Promise<unknown>,
+) {
   const calls: FetchCall[] = [];
   vi.stubGlobal(
     "fetch",
@@ -92,6 +109,7 @@ function installFetch(statusResponder: () => Promise<unknown>) {
         return statusResponder();
       }
       if (url.includes("/setup-api/chat/model")) {
+        if (init?.method === "POST" && modelPostResponder) return modelPostResponder();
         return { ok: true, json: async () => ON_PRO };
       }
       if (url.includes("/setup-api/chat/history")) {
@@ -107,6 +125,11 @@ function modelWrites(calls: FetchCall[]): string[] {
   return calls
     .filter((call) => call.url.includes("/setup-api/chat/model") && call.init?.method === "POST")
     .map((call) => String(call.init?.body ?? ""));
+}
+
+/** How many times `needle` appears in the rendered transcript. */
+function occurrences(needle: string): number {
+  return (document.body.textContent ?? "").split(needle).length - 1;
 }
 
 /**
@@ -170,13 +193,7 @@ describe("a ClawBox AI Pro model the account is entitled to", () => {
     // answers every turn `400 "Model not allowed: …"` (measured 2026-09-04),
     // which the chat can only render as the opaque "[assistant turn failed]".
     // A NAMED refusal keeps the upgrade prompt and the drop to Flash.
-    const calls = installFetch(async () => ({
-      ok: true,
-      json: async () => ({
-        ...ENTITLED_STATUS,
-        clawaiAllowedModels: ["deepseek-v4-flash"],
-      }),
-    }));
+    const calls = installFetch(async () => ({ ok: true, json: async () => REFUSED_STATUS }));
     render(<ChatPopup isOpen onClose={() => {}} />);
     await settle(calls);
 
@@ -199,5 +216,66 @@ describe("a ClawBox AI Pro model the account is entitled to", () => {
 
     expect(modelWrites(calls)).toEqual([]);
     expect(document.body.textContent).not.toMatch(/Max subscription/i);
+  });
+});
+
+describe("the boot guard when the switch it asks for fails", () => {
+  it("POSTs once, says only what happened, and does not re-arm", async () => {
+    // TWO defects in one path, both of them the guard's failure leg.
+    //
+    // Re-entry: `switchChatModel` writes `switchingModel`, which is one of its
+    // OWN useCallback deps, so calling it changes its identity — and this
+    // effect depends on that identity. The once-only latch is what stops the
+    // guard re-entering; releasing it because the switch FAILED re-arms it
+    // with nothing about the box changed. Every deterministic failure of
+    // `/setup-api/chat/model` (400 "provider is not configured", 400 "invalid
+    // model identifier", 409, 500, a proxy's non-JSON body) then loops: POST,
+    // fail, release, re-enter — hundreds of writes against the box's own setup
+    // server and two system messages per turn of it, for as long as the chat
+    // window is open.
+    //
+    // False success: "switching you to Pro Tier so chat keeps working" was
+    // posted BEFORE the switch was attempted, so a failed one left the
+    // transcript claiming the box had been moved, directly above the `Error:`
+    // line saying it had not, with the box still on the refused model.
+    let release: () => void = () => {};
+    const held = new Promise<void>((resolve) => { release = resolve; });
+    let writes = 0;
+    const calls = installFetch(
+      async () => ({ ok: true, json: async () => REFUSED_STATUS }),
+      async () => {
+        writes += 1;
+        if (writes > 1) {
+          // Reached only by a re-armed guard. Answering the SECOND write
+          // successfully is what lets this test fail with an assertion rather
+          // than a five-second timeout: two failures in a row loop past 250
+          // writes in 200 ms and the renderer never catches up.
+          return { ok: true, json: async () => ON_FLASH };
+        }
+        // The first write is HELD until the test lets it go, and that is what
+        // makes the mock faithful rather than slow. A real POST takes long
+        // enough for React to commit the `switchingModel = true` render (the
+        // one that raises the "Switching AI provider…" overlay); a mock that
+        // settles inside the same microtask never commits it, so the callback
+        // identity never changes and the re-entry above stays invisible.
+        await held;
+        return {
+          ok: false,
+          status: 500,
+          json: async () => ({ error: "Selected AI provider is not configured" }),
+        };
+      },
+    );
+    render(<ChatPopup isOpen onClose={() => {}} />);
+    await waitFor(() => { expect(modelWrites(calls)).toHaveLength(1); });
+    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 50)); });
+    release();
+    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 50)); });
+
+    expect(modelWrites(calls)).toEqual(['{"model":"deepseek/deepseek-v4-flash"}']);
+    // The failure is reported once, as itself…
+    expect(occurrences("Selected AI provider is not configured")).toBe(1);
+    // …and nothing claims the box was moved off the model it is still on.
+    expect(document.body.textContent).not.toMatch(/needs a Max subscription/i);
   });
 });

--- a/src/tests/components/chat-clawai-pro-entitlement.test.tsx
+++ b/src/tests/components/chat-clawai-pro-entitlement.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, waitFor } from "@/tests/helpers/test-utils";
+import { act, render, waitFor } from "@/tests/helpers/test-utils";
 import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 import { translations } from "@/lib/translations";
@@ -50,16 +50,18 @@ const ON_PRO = {
 };
 
 /**
- * The portal's answer for the paired token, as `/api/clawbox-ai/device-info`
- * really serves it (measured on a Max box, 2026-09-04):
+ * A status answer whose BADGE and ENTITLEMENT disagree.
+ *
+ * CONSTRUCTED, and say so: the only device-info response measured on hardware
+ * (2026-09-04, Max box) has them agreeing —
  *   {"tier":"max","deviceTier":"pro",
  *    "allowedModels":["deepseek-v4-flash","deepseek-v4-pro",…],
  *    "defaultModel":"deepseek-v4-pro", …}
- *
- * `deviceTier` is the model the device currently defaults to, NOT what the
- * plan entitles — a Max account whose box was paired while it was on the Pro
- * plan is still stamped `flash`, so the badge tier reads "flash" while the
- * entitlement list still carries the Pro id.
+ * The disagreement is what the gate exists to get right: `deviceTier` is the
+ * tier this DEVICE defaults to (the configure route keeps "a Max subscriber
+ * who runs Flash on this box" working on purpose, TASK-481), so a badge of
+ * "flash" beside an entitlement list carrying the Pro id is a device default
+ * next to an account permission — and only the second one may refuse a pick.
  */
 const ENTITLED_STATUS = {
   connected: true,
@@ -107,7 +109,15 @@ function modelWrites(calls: FetchCall[]): string[] {
     .map((call) => String(call.init?.body ?? ""));
 }
 
-/** Let every effect chain the status poll can start run to completion. */
+/**
+ * Wait until the guard has had its chance.
+ *
+ * A "no POST happened" assertion is only worth anything against a window a
+ * POST demonstrably fits inside — so the refusal case below asserts its POST
+ * has ALREADY landed after this same helper, with no waitFor of its own. That
+ * is the positive control: one settle, one POST when the portal refuses, none
+ * when it does not.
+ */
 async function settle(calls: FetchCall[]) {
   await waitFor(() => {
     expect(calls.some((call) => call.url.includes("/setup-api/ai-models/status"))).toBe(true);
@@ -115,9 +125,11 @@ async function settle(calls: FetchCall[]) {
   await waitFor(() => {
     expect(calls.some((call) => call.url.includes("/setup-api/chat/model"))).toBe(true);
   });
-  // Two macrotask turns: the guard's own effect, then the POST it would fire.
-  await new Promise((resolve) => setTimeout(resolve, 0));
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  // Generous next to the guard's chain (one effect turn, then the fetch): the
+  // point of the window is that it cannot be the reason a POST is missing.
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  });
 }
 
 beforeEach(() => {
@@ -142,9 +154,9 @@ afterEach(() => {
 
 describe("a ClawBox AI Pro model the account is entitled to", () => {
   it("is left running when the portal lists it, whatever the device-tier badge says", async () => {
-    // The badge tier is the device-pair stamp, not the entitlement. Reading it
-    // as one told a paying Max owner he needed a Max subscription and moved
-    // his box off the model he had just picked in Telegram.
+    // Reading the device default as an entitlement told a paying Max owner he
+    // needed a Max subscription and moved his box off the model he had just
+    // picked in Telegram.
     const calls = installFetch(async () => ({ ok: true, json: async () => ENTITLED_STATUS }));
     render(<ChatPopup isOpen onClose={() => {}} />);
     await settle(calls);
@@ -154,10 +166,10 @@ describe("a ClawBox AI Pro model the account is entitled to", () => {
   });
 
   it("still drops to Flash when the portal really does refuse it", async () => {
-    // The protection this replaces is real: an unentitled Pro pick is
-    // downgraded to flash by the proxy's live-tier reconcile, so every reply
-    // comes from a model the header does not name. A NAMED refusal keeps the
-    // upgrade prompt and the switch.
+    // The protection this replaces is real: on an unentitled account the proxy
+    // answers every turn `400 "Model not allowed: …"` (measured 2026-09-04),
+    // which the chat can only render as the opaque "[assistant turn failed]".
+    // A NAMED refusal keeps the upgrade prompt and the drop to Flash.
     const calls = installFetch(async () => ({
       ok: true,
       json: async () => ({
@@ -168,12 +180,11 @@ describe("a ClawBox AI Pro model the account is entitled to", () => {
     render(<ChatPopup isOpen onClose={() => {}} />);
     await settle(calls);
 
-    // The switch itself is the assertion: the upgrade message is posted into
-    // the transcript, which the "Switching AI provider…" overlay covers for
-    // the whole of the switch it just started.
-    await waitFor(() => {
-      expect(modelWrites(calls)).toEqual(['{"model":"deepseek/deepseek-v4-flash"}']);
-    });
+    // No waitFor: this is the positive control for the two negative tests —
+    // the POST is already there after the same settle() they assert emptiness
+    // after. (The upgrade message itself goes into the transcript, which the
+    // "Switching AI provider…" overlay covers for the whole of the switch.)
+    expect(modelWrites(calls)).toEqual(['{"model":"deepseek/deepseek-v4-flash"}']);
   });
 
   it("is left running when the entitlement could not be read at all", async () => {

--- a/src/tests/components/chat-thinking-default.test.tsx
+++ b/src/tests/components/chat-thinking-default.test.tsx
@@ -88,7 +88,17 @@ function installFetch(model: string) {
       return { ok: true, json: async () => ({ harness: "openclaw", facts: { hasClawaiToken: true, hermesSupportsImages: false } }) };
     }
     if (url.includes("/setup-api/ai-models/status")) {
-      return { ok: true, json: async () => ({ clawaiAccountTier: "pro", clawaiTier: "pro", clawaiLoggedIn: true }) };
+      // `clawaiAllowedModels` is what the entitlement guard reads — without it
+      // the guard is quiet because the question was unanswered, not because
+      // this account is entitled, and the fixture would stop meaning what its
+      // comment says.
+      return { ok: true, json: async () => ({
+        clawaiAccountTier: "pro",
+        clawaiTier: "pro",
+        clawaiAllowedModels: ["deepseek-v4-flash", "deepseek-v4-pro"],
+        clawaiConfigured: true,
+        clawaiLoggedIn: true,
+      }) };
     }
     if (url.includes("/setup-api/chat/model")) {
       return {

--- a/src/tests/routes/ai-models/status.test.ts
+++ b/src/tests/routes/ai-models/status.test.ts
@@ -301,6 +301,40 @@ describe("/setup-api/ai-models/status", () => {
       expect(body.tierSource).toBe("picker");
     });
 
+    it("surfaces the portal's entitlement list beside the badge", async () => {
+      // The badge is the device-pair stamp; the list is what the account may
+      // actually run. A Max account paired while it was on the Pro plan reads
+      // "flash" and still carries the Pro id — the picker gates on the list.
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue("flash");
+      fetchSpy.mockResolvedValue(new Response(
+        JSON.stringify({
+          tier: "max",
+          deviceTier: "flash",
+          allowedModels: ["deepseek-v4-flash", "deepseek-v4-pro"],
+        }),
+        { status: 200 },
+      ));
+
+      const body = await (await GET()).json();
+
+      expect(body.clawaiAccountTier).toBe("flash");
+      expect(body.clawaiAllowedModels).toEqual(["deepseek-v4-flash", "deepseek-v4-pro"]);
+    });
+
+    it("says null — not an empty list — when the portal could not be asked", async () => {
+      // Null is "not answered". An empty list would read as "nothing is
+      // allowed" and lock the box out of its own models.
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue("pro");
+      fetchSpy.mockRejectedValue(new Error("ETIMEDOUT"));
+
+      const body = await (await GET()).json();
+
+      expect(body.clawaiTier).toBe("pro");
+      expect(body.clawaiAllowedModels).toBeNull();
+    });
+
     it("negative-caches an unreachable verdict so back-to-back polls don't hammer the portal", async () => {
       mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
       mockGetConfigValue.mockResolvedValue("pro");

--- a/src/tests/routes/ai-models/status.test.ts
+++ b/src/tests/routes/ai-models/status.test.ts
@@ -339,6 +339,27 @@ describe("/setup-api/ai-models/status", () => {
       expect(body.clawaiAllowedModels).toEqual(["deepseek-v4-flash"]);
     });
 
+    it("keeps the Max id in that fallback when the PLAN is Max and only the device stamp is Flash", async () => {
+      // TASK-691, reached through the compatibility door. `mapPortalTier`
+      // prefers `deviceTier` on purpose, so deriving the fallback list from the
+      // badge alone gave a Max subscriber `["deepseek-v4-flash"]` — which the
+      // boot guard reads as a POSITIVE refusal and writes his primary model
+      // down on, under a message telling him to buy the plan he already has.
+      // The plan is what an entitlement may be read from.
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue("flash");
+      fetchSpy.mockResolvedValue(new Response(
+        JSON.stringify({ tier: "max", deviceTier: "flash" }),
+        { status: 200 },
+      ));
+
+      const body = await (await GET()).json();
+
+      // The BADGE still follows the device stamp — that is its job.
+      expect(body.clawaiAccountTier).toBe("flash");
+      expect(body.clawaiAllowedModels).toEqual(["deepseek-v4-flash", "deepseek-v4-pro"]);
+    });
+
     it("says null — not an empty list — when the portal could not be asked", async () => {
       // Null is "not answered". An empty list would read as "nothing is
       // allowed" and lock the box out of its own models.

--- a/src/tests/routes/ai-models/status.test.ts
+++ b/src/tests/routes/ai-models/status.test.ts
@@ -322,6 +322,23 @@ describe("/setup-api/ai-models/status", () => {
       expect(body.clawaiAllowedModels).toEqual(["deepseek-v4-flash", "deepseek-v4-pro"]);
     });
 
+    it("fills the list from the badge when the portal answered without one", async () => {
+      // An older portal build publishes no `allowedModels`. There the badge is
+      // all the entitlement there has ever been, so nothing that used to be
+      // refused may quietly become allowed — but this is the ANSWERED branch
+      // only; an unreachable portal still yields null.
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue("flash");
+      fetchSpy.mockResolvedValue(new Response(
+        JSON.stringify({ tier: "pro", deviceTier: "flash" }),
+        { status: 200 },
+      ));
+
+      const body = await (await GET()).json();
+
+      expect(body.clawaiAllowedModels).toEqual(["deepseek-v4-flash"]);
+    });
+
     it("says null — not an empty list — when the portal could not be asked", async () => {
       // Null is "not answered". An empty list would read as "nothing is
       // allowed" and lock the box out of its own models.

--- a/src/tests/unit/clawbox-ai-entitlement.test.ts
+++ b/src/tests/unit/clawbox-ai-entitlement.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   CLAWBOX_AI_MODEL_BY_TIER,
+  normalizeAllowedModelIds,
   portalDeniesClawboxAiModel,
 } from "@/lib/clawbox-ai-models";
 
@@ -40,5 +41,24 @@ describe("portalDeniesClawboxAiModel", () => {
     expect(portalDeniesClawboxAiModel("clawai/DeepSeek-V4-Pro", PORTAL_MAX)).toBe(false);
     expect(portalDeniesClawboxAiModel("deepseek/deepseek-v4-pro", ["deepseek/deepseek-v4-pro"]))
       .toBe(false);
+  });
+});
+
+describe("normalizeAllowedModelIds", () => {
+  it("keeps a real list, trimmed", () => {
+    expect(normalizeAllowedModelIds([" deepseek-v4-pro ", "deepseek-v4-flash"]))
+      .toEqual(["deepseek-v4-pro", "deepseek-v4-flash"]);
+  });
+
+  it("answers null for everything that is not one", () => {
+    // null and [] are the same answer downstream — "not answered" — and this
+    // is the one place that rule is written, for the server and the client.
+    for (const value of [undefined, null, [], ["", "  "], "deepseek-v4-pro", 7, {}]) {
+      expect(normalizeAllowedModelIds(value)).toBeNull();
+    }
+  });
+
+  it("drops non-string entries rather than the whole list", () => {
+    expect(normalizeAllowedModelIds(["deepseek-v4-pro", 1, null])).toEqual(["deepseek-v4-pro"]);
   });
 });

--- a/src/tests/unit/clawbox-ai-entitlement.test.ts
+++ b/src/tests/unit/clawbox-ai-entitlement.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLAWBOX_AI_MODEL_BY_TIER,
+  portalDeniesClawboxAiModel,
+} from "@/lib/clawbox-ai-models";
+
+const PORTAL_MAX = ["deepseek-v4-flash", "deepseek-v4-pro", "gpt-5.6-luna"];
+const PORTAL_PRO = ["deepseek-v4-flash", "gpt-5.6-luna"];
+
+describe("portalDeniesClawboxAiModel", () => {
+  it("refuses a ClawBox AI model the portal left off the list", () => {
+    expect(portalDeniesClawboxAiModel(CLAWBOX_AI_MODEL_BY_TIER.pro, PORTAL_PRO)).toBe(true);
+  });
+
+  it("allows a model the portal lists, under either provider spelling", () => {
+    expect(portalDeniesClawboxAiModel("deepseek/deepseek-v4-pro", PORTAL_MAX)).toBe(false);
+    expect(portalDeniesClawboxAiModel("clawai/deepseek-v4-pro", PORTAL_MAX)).toBe(false);
+  });
+
+  it("treats an unanswered entitlement as no refusal", () => {
+    // The whole point: a portal that did not answer must never move a box off
+    // the model its owner chose.
+    for (const unknown of [null, undefined, [], "deepseek-v4-flash" as unknown as string[]]) {
+      expect(portalDeniesClawboxAiModel(CLAWBOX_AI_MODEL_BY_TIER.pro, unknown)).toBe(false);
+    }
+  });
+
+  it("never judges a provider the list does not describe", () => {
+    // The list is ClawBox AI's. Matching another provider's model against it
+    // would refuse every model the owner brought their own key for.
+    expect(portalDeniesClawboxAiModel("anthropic/claude-opus-5", PORTAL_PRO)).toBe(false);
+    expect(portalDeniesClawboxAiModel("openai/gpt-5.4", PORTAL_PRO)).toBe(false);
+  });
+
+  it("ignores a bare id, which names no provider", () => {
+    expect(portalDeniesClawboxAiModel("deepseek-v4-pro", PORTAL_PRO)).toBe(false);
+  });
+
+  it("compares the bare id, whatever prefix or case either side carries", () => {
+    expect(portalDeniesClawboxAiModel("clawai/DeepSeek-V4-Pro", PORTAL_MAX)).toBe(false);
+    expect(portalDeniesClawboxAiModel("deepseek/deepseek-v4-pro", ["deepseek/deepseek-v4-pro"]))
+      .toBe(false);
+  });
+});

--- a/src/tests/unit/clawbox-ai-entitlement.test.ts
+++ b/src/tests/unit/clawbox-ai-entitlement.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   CLAWBOX_AI_MODEL_BY_TIER,
+  clawboxAiMaxPickUnconfirmed,
   normalizeAllowedModelIds,
   portalDeniesClawboxAiModel,
 } from "@/lib/clawbox-ai-models";
@@ -41,6 +42,43 @@ describe("portalDeniesClawboxAiModel", () => {
     expect(portalDeniesClawboxAiModel("clawai/DeepSeek-V4-Pro", PORTAL_MAX)).toBe(false);
     expect(portalDeniesClawboxAiModel("deepseek/deepseek-v4-pro", ["deepseek/deepseek-v4-pro"]))
       .toBe(false);
+  });
+});
+
+describe("clawboxAiMaxPickUnconfirmed", () => {
+  it("declines the Max pick when nobody answered and the badge is not Max", () => {
+    // Portal unreachable, or a token it answers 401/403 to. Letting this
+    // through writes the Max model into the box's primary — Telegram and the
+    // coding agent run it too — and every turn afterwards fails opaquely.
+    for (const unanswered of [null, undefined, []]) {
+      expect(clawboxAiMaxPickUnconfirmed(CLAWBOX_AI_MODEL_BY_TIER.pro, unanswered, "flash"))
+        .toBe(true);
+      expect(clawboxAiMaxPickUnconfirmed(CLAWBOX_AI_MODEL_BY_TIER.pro, unanswered, null))
+        .toBe(true);
+    }
+  });
+
+  it("lets it through the moment either half of the question is answered", () => {
+    // A list that names the model is the real answer; the last portal-confirmed
+    // Max badge is a weaker one, and both beat declining a paying owner's pick.
+    expect(clawboxAiMaxPickUnconfirmed(CLAWBOX_AI_MODEL_BY_TIER.pro, PORTAL_MAX, "flash"))
+      .toBe(false);
+    expect(clawboxAiMaxPickUnconfirmed(CLAWBOX_AI_MODEL_BY_TIER.pro, null, "pro")).toBe(false);
+  });
+
+  it("says nothing about any other model", () => {
+    // It is the Max pick alone: the Flash tier and every bring-your-own-key
+    // provider are unaffected by a portal that did not answer.
+    expect(clawboxAiMaxPickUnconfirmed(CLAWBOX_AI_MODEL_BY_TIER.flash, null, "flash")).toBe(false);
+    expect(clawboxAiMaxPickUnconfirmed("anthropic/claude-opus-5", null, "flash")).toBe(false);
+    expect(clawboxAiMaxPickUnconfirmed("deepseek-v4-pro", null, "flash")).toBe(false);
+  });
+
+  it("is not the refusal the write guard reads", () => {
+    // The two predicates deliberately disagree on the unanswered case: the
+    // click declines, the boot guard (which WRITES) does not.
+    expect(portalDeniesClawboxAiModel(CLAWBOX_AI_MODEL_BY_TIER.pro, null)).toBe(false);
+    expect(clawboxAiMaxPickUnconfirmed(CLAWBOX_AI_MODEL_BY_TIER.pro, null, "flash")).toBe(true);
   });
 });
 

--- a/src/tests/unit/clawbox-ai-entitlement.test.ts
+++ b/src/tests/unit/clawbox-ai-entitlement.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
   CLAWBOX_AI_MODEL_BY_TIER,
-  clawboxAiMaxPickUnconfirmed,
   normalizeAllowedModelIds,
   portalDeniesClawboxAiModel,
 } from "@/lib/clawbox-ai-models";
@@ -42,43 +41,6 @@ describe("portalDeniesClawboxAiModel", () => {
     expect(portalDeniesClawboxAiModel("clawai/DeepSeek-V4-Pro", PORTAL_MAX)).toBe(false);
     expect(portalDeniesClawboxAiModel("deepseek/deepseek-v4-pro", ["deepseek/deepseek-v4-pro"]))
       .toBe(false);
-  });
-});
-
-describe("clawboxAiMaxPickUnconfirmed", () => {
-  it("declines the Max pick when nobody answered and the badge is not Max", () => {
-    // Portal unreachable, or a token it answers 401/403 to. Letting this
-    // through writes the Max model into the box's primary — Telegram and the
-    // coding agent run it too — and every turn afterwards fails opaquely.
-    for (const unanswered of [null, undefined, []]) {
-      expect(clawboxAiMaxPickUnconfirmed(CLAWBOX_AI_MODEL_BY_TIER.pro, unanswered, "flash"))
-        .toBe(true);
-      expect(clawboxAiMaxPickUnconfirmed(CLAWBOX_AI_MODEL_BY_TIER.pro, unanswered, null))
-        .toBe(true);
-    }
-  });
-
-  it("lets it through the moment either half of the question is answered", () => {
-    // A list that names the model is the real answer; the last portal-confirmed
-    // Max badge is a weaker one, and both beat declining a paying owner's pick.
-    expect(clawboxAiMaxPickUnconfirmed(CLAWBOX_AI_MODEL_BY_TIER.pro, PORTAL_MAX, "flash"))
-      .toBe(false);
-    expect(clawboxAiMaxPickUnconfirmed(CLAWBOX_AI_MODEL_BY_TIER.pro, null, "pro")).toBe(false);
-  });
-
-  it("says nothing about any other model", () => {
-    // It is the Max pick alone: the Flash tier and every bring-your-own-key
-    // provider are unaffected by a portal that did not answer.
-    expect(clawboxAiMaxPickUnconfirmed(CLAWBOX_AI_MODEL_BY_TIER.flash, null, "flash")).toBe(false);
-    expect(clawboxAiMaxPickUnconfirmed("anthropic/claude-opus-5", null, "flash")).toBe(false);
-    expect(clawboxAiMaxPickUnconfirmed("deepseek-v4-pro", null, "flash")).toBe(false);
-  });
-
-  it("is not the refusal the write guard reads", () => {
-    // The two predicates deliberately disagree on the unanswered case: the
-    // click declines, the boot guard (which WRITES) does not.
-    expect(portalDeniesClawboxAiModel(CLAWBOX_AI_MODEL_BY_TIER.pro, null)).toBe(false);
-    expect(clawboxAiMaxPickUnconfirmed(CLAWBOX_AI_MODEL_BY_TIER.pro, null, "flash")).toBe(true);
   });
 });
 

--- a/src/tests/unit/use-clawbox-login.test.ts
+++ b/src/tests/unit/use-clawbox-login.test.ts
@@ -216,4 +216,38 @@ describe("useClawboxLogin", () => {
       .filter((msg) => /unmounted|cancelled/i.test(msg));
     expect(warnings).toEqual([]);
   });
+  it("reports an empty entitlement list as unanswered, not as 'nothing allowed'", async () => {
+    // An empty list read as a refusal would lock the box out of every model
+    // it has — the whole reason null and [] mean the same thing here.
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({
+      provider: "clawai",
+      clawaiConfigured: true,
+      clawaiAccountTier: "pro",
+      clawaiAllowedModels: [],
+    })) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useClawboxLogin());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.allowedModels).toBeNull();
+  });
+
+  it("keeps the same array across polls that bring the same ids back", async () => {
+    // A fresh array every 30 s is a fresh identity for every consumer that
+    // memoises on it — ChatPopup rebuilds its switch callback from this.
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({
+      provider: "clawai",
+      clawaiConfigured: true,
+      clawaiAccountTier: "pro",
+      clawaiAllowedModels: ["deepseek-v4-flash", "deepseek-v4-pro"],
+    })) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useClawboxLogin(10));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const first = result.current.allowedModels;
+    expect(first).toEqual(["deepseek-v4-flash", "deepseek-v4-pro"]);
+
+    await waitFor(() => expect(vi.mocked(globalThis.fetch).mock.calls.length).toBeGreaterThan(2));
+    expect(result.current.allowedModels).toBe(first);
+  });
 });


### PR DESCRIPTION
**TASK-691** — owner ruling 2026-09-04: "WE have it DeepSeek Pro. Fix it and make it work." The earlier "hide the Pro id below the Max plan" line is revoked; a Pro turn picked from the Telegram `/model` keyboard, and from the ClawBox chat picker, has to actually run.

## Customer-visible symptom

A ClawBox AI **Max** owner picks the Max model (`deepseek-v4-pro`) — in the Telegram `/model` keyboard, or in the chat header. He then opens the dashboard chat and is told

> Max Tier needs a Max subscription. Upgrade in the ClawBox portal to unlock it — switching you to Pro Tier so chat keeps working.

…and the box is moved off the model he chose: the picker POSTs `deepseek/deepseek-v4-flash` as the new primary. He is being sold the subscription he already pays for, and the Max model he picked is gone.

## Cause

`ChatPopup` decided **entitlement** from the two-value device-tier badge (`clawboxLogin.tier === 'pro'`), in two places: the pick-time refusal, and a boot guard that *writes* — it rewrites `agents.defaults.model.primary` back to Flash.

The badge is a device **default**, not an entitlement. `mapPortalTier()` prefers the portal's `deviceTier`, and the configure route documents that on purpose: "a Max subscriber who deliberately runs Flash on this device" is a supported state (TASK-481). A default is the right thing to *write* as the primary model. It is the wrong thing to *veto* an explicit pick with — and the old condition vetoed on two values that are not refusals:

* **`null` because nobody answered.** Portal unreachable, or a failed `/setup-api/ai-models/status` poll: `useClawboxLogin`'s transient handler leaves `tier: null, loading: false`, and `null !== 'pro'` fired the guard. **One failed poll rewrote a Max box's primary model to Flash.** That is the *false failure* class, with a destructive write behind it, and it is what the RED below reproduces.
* **`"flash"` because the device default is Flash** while the account may run Pro — the case the gate now gets right.

## Harness/portal-first: the mechanism already exists

The portal already publishes the answer, in the very response `fetchPortalTier()` fetches for the badge. Measured read-only on the box (2026-09-04):

```
GET https://clawbox.com/api/clawbox-ai/device-info   →  200
{"tier":"max","deviceTier":"pro",
 "allowedModels":["deepseek-v4-flash","deepseek-v4-pro","deepseek-v4-flash-vision-exp","gpt-5.6-luna","gpt-5-nano"],
 "defaultModel":"deepseek-v4-pro", …}
```

ClawBox was throwing `allowedModels` away and re-deriving entitlement from a badge. No new list, no new probe, no extra request: the fix carries the portal's own list through `fetchPortalTier` (same cache, same round trip), surfaces it as `clawaiAllowedModels` on `/setup-api/ai-models/status`, and gates on it.

## The rule now

`portalDeniesClawboxAiModel(model, allowedModels)` is **false on any doubt**:

* refuses only when the portal named a list and that list excludes the model's bare id;
* an absent / non-array / empty list is "not answered" and never a refusal;
* only ClawBox AI refs (`clawai/…`, `deepseek/…`) are judged — the list says nothing about a provider the owner brought their own key for;
* the boot guard — the one that writes — additionally requires the refused model to be the **Max tier** (the only one with a tier below it to fall back on, which is what its message says) and requires Flash itself to be allowed, so it can never switch to a second refused model;
* it latches only on a switch that happened; a failed one releases the latch instead of leaving the box on a refused model under a message saying it moved.

**Nothing that used to be refused becomes allowed on an older portal.** A portal that ANSWERS but publishes no `allowedModels` is not "unknown" — there the badge is all the entitlement there has ever been, so the status route fills the list from it (`allowedModelsForTier`). Only an unreachable portal yields `null`. This repo's own pre-existing test fixture for a Free device-info body already carries `allowedModels: ["deepseek-v4-flash"]` (`src/tests/routes/ai-models/status.test.ts` on `beta`), i.e. the field is published on unpaid plans too — recorded there before this PR, not measured by me.

A genuinely unentitled pick keeps the upgrade prompt and the drop to Flash — that protection is unchanged and pinned by a test.

## Device evidence (read-only, OpenClaw box, beta `08e7057d`)

* portal: `tier=max`, `deviceTier=pro`, `allowedModels` contains `deepseek-v4-pro` (same answer on the Hermes box).
* `agents.defaults.model.primary` = `deepseek/deepseek-v4-pro`; one turn, no override:
  `executionTrace: {winnerProvider:"deepseek", winnerModel:"deepseek-v4-pro", result:"success", fallbackUsed:false}`.
* **What the proxy does with a model outside the list** — it refuses in the open, it does not silently downgrade. `POST <proxy>/chat/completions {"model":"gpt-5.5"}` with the paired token:
  `400 {"error":{"message":"Model not allowed: gpt-5.5","type":"invalid_request_error","code":"model_not_allowed"}}`, while `deepseek-v4-pro` on the same token answers `200` with `model: "deepseek-v4-pro"`. Three comments in this tree claimed a silent live-tier downgrade; they are corrected to the measured contract.

So the proxy serves Pro for this plan — the model the picker was refusing runs. No mutex taken, nothing on the box changed, no message sent.

## RED → GREEN

`src/tests/components/chat-clawai-pro-entitlement.test.tsx`, on unmodified `beta`:

```
FAIL  a ClawBox AI Pro model the account is entitled to
      > is left running when the portal lists it, whatever the device-tier badge says
AssertionError: expected [ Array(1) ] to deeply equal []
- []
+ [ "{\"model\":\"deepseek/deepseek-v4-flash\"}" ]

FAIL  a ClawBox AI Pro model the account is entitled to
      > is left running when the entitlement could not be read at all
AssertionError: expected [ Array(1) ] to deeply equal []
- []
+ [ "{\"model\":\"deepseek/deepseek-v4-flash\"}" ]

Test Files  1 failed (1)   Tests  2 failed (2)
```

i.e. beta rewrites the box's primary model to Flash in both cases. After the fix, with the third case (a portal that really does refuse the id, which must still downgrade):

```
Test Files  1 passed (1)   Tests  3 passed (3)
components suite:  133 files, 1207 tests passed
unit suite:        567 files, 8958 tests passed
tsc --noEmit: clean   eslint on the changed files: clean (no new warnings)
```

## Sibling call sites

* **`ChatPopup` is the shared chat on BOTH editions** — one component, one fix. On Hermes the model pill (`changeHermesModel`) is a per-provider preference and never carried a tier gate, and `/setup-api/chat/model` is OpenClaw-shaped, so the Hermes Telegram pick was never undone by the picker; the change strictly narrows what can refuse on either edition.
* `src/lib/chat-reasoning.ts:114` — `isClawboxAiProModel` there selects reasoning levels, not entitlement. Left alone.
* `SettingsApp.tsx`, `TierUpgradeCelebration.tsx`, `page.tsx` — read the badge for paid-feature gating and the plan badge, which is what the badge is for. Unchanged.
* `scripts/claude-ds:117-123` picks the coding-agent model from the stored badge, `src/app/setup-api/ai-models/configure/route.ts:1950` writes the primary from it, and `src/lib/hermes-clawai.ts:56,121` writes Hermes' `model.default` from it. All three set a **default**, which is what the badge is for and what TASK-481 decided; none of them vetoes a pick. Left alone deliberately — changing what the device *defaults* to is a product decision, not this defect.
* `src/lib/hermes-tts.ts:478` and `scripts/gateway-pre-start.sh:1454` gate whether cloud VOICE runs on `clawai_tier === "pro"` — that one is an entitlement decision taken from the badge, the same class one surface over. This PR cannot fix it: the portal's `allowedModels` carries chat and vision ids only (measured above), no speech id. Recorded as a gap.

## Review

One Opus `clawbox-review` pass: 4 high, 5 medium, 5 low. Applied: the "older portal answers without a list" compatibility leg (the pass was right that the first cut turned a fail-closed gate into a fail-open one for anyone the portal answers differently), the write-guard re-narrowed to the Max tier, message accuracy, the latch-on-success, one shared normaliser, the corrected proxy comments, and every test finding (constructed fixtures now say so, the negative assertions sit behind the same window the positive control lands in, the hook's parsing and same-array promise are covered, and a sibling fixture that had stopped meaning what its comment said). Refuted with the reason in the thread above: the three "still derives the model from the badge" findings (S2/S3/S4) — those are defaults, not vetoes, and TASK-481 decided them.

## Declared gaps

* **Device leg unproven for the UI change.** The ClawBox web server is down on both dev boxes right now (`clawbox-setup.service` inactive; `clawbox-root-update@rebuild_reboot` failed on the OpenClaw box and activating on the Hermes box — an update someone else is running), so the fixed picker and route were not exercised on hardware. The portal input the fix reads was verified read-only on both boxes. After this merges and deploys: open the chat on a Max box whose primary is `deepseek/deepseek-v4-pro` — no "needs a Max subscription" message, and the model stays Pro.
* **Not fixed here, and it is the other half of the card's title:** the OpenClaw box carries an orphaned `agents.defaults.modelPolicy.allow = ["openai/gpt-5.5"]` that ClawBox never writes, reads or surfaces. Measured today: `--model deepseek/deepseek-v4-pro` (== the primary) serves, while `--model deepseek/deepseek-v4-flash` and `--model anthropic/claude-opus-5` are refused by that list; in the installed core 2026.8.1 `dist/apply-session-model-selection-*.js` refuses a picker selection through the same policy and the Telegram ingress drain is one of its callers. That is TASK-654 D-08/D-09, an owner decision with its own branch.

---

## Finishing round

Two review passes were owed on this branch: the one that BLOCKED it (1 high, 2 medium, 3 low) and a fresh Opus pass over the result, which found two more HIGHs the earlier rounds had missed. Both are applied. One of the mediums is **refuted with evidence** rather than applied — see below.

### 1. The blocker: the guard retried a failed switch, forever

`switchChatModel` is a `useCallback` whose deps include `switchingModel` — state it writes itself — and the boot guard is a `useEffect` that depends on that callback. A switch that FAILED flipped `switchingModel` true→false, gave the callback a new identity, and re-ran the very effect whose `.then(switched => { if (!switched) tierGuardRef.current = false })` had just cleared the latch. Nothing about the box had changed, so the guard fired again. On any repeatable failure of `/setup-api/chat/model` — 400 "Selected AI provider is not configured", 400 "Invalid model identifier", 409, 500, or a proxy answering non-JSON into the same catch — a box whose primary is `deepseek/deepseek-v4-pro` hammered its own setup server and filled its own transcript for as long as the chat window was open.

**It does not reproduce with an ordinary mock, and that is the part worth keeping.** A `fetch` stub that settles inside the same microtask never lets React commit the `switchingModel = true` render (the one that raises the "Switching AI provider…" overlay), so the callback identity never changes and the loop is invisible — the first version of this test passed on the broken head. Holding the POST open until that render commits, the way a real round trip does, gives **251–475 POSTs in a 200 ms window**, measured across four runs.

**Never releasing the latch is the mirror defect, and the second pass caught it.** `src/app/page.tsx:2401` keeps `ChatPopup` mounted for the whole session and only toggles `isOpen` (the component's own comment at `:2843` says so), so a boolean latch that is never released leaves a box on a refused model until a page reload — probe-once, one of the three classes this codebase keeps producing.

So the latch is no longer a boolean: **it remembers the inputs the last attempt was made for** (`{ model, allowed }`). Re-entry on unchanged box state buys nothing — no loop. A changed active model or a changed entitlement list buys exactly one more attempt, and so does closing and re-opening the chat, which is the retry an owner actually reaches for. `allowedModels` keeps its array identity across polls that bring the same ids back (`sameIds` in `use-clawbox-login.ts`), so `===` is a sound "the answer has not changed" test. The guard also waits rather than recording an attempt while another switch is in flight, since `switchChatModel` early-returns there without doing anything.

The **"switched you to Pro Tier" message moved to the success path** with it: a failed switch now leaves only the error, which is true.

### 2. Second HIGH: the compatibility list was built from the device badge and handed to the guard that WRITES

Found by the second pass, in the compatibility leg the *first* pass asked for. `allowedModelsForTier(lookup.tier)` derived the fallback entitlement from `mapPortalTier`'s output — which prefers the portal's `deviceTier` **stamp**, not the plan. On a portal that answers without `allowedModels`, a Max subscriber whose box is stamped `deviceTier: "flash"` (the TASK-481 state this PR exists to respect) got `["deepseek-v4-flash"]`, which the boot guard reads as a positive refusal and writes his primary model down on, under a message telling him to buy the plan he already has. **TASK-691 verbatim, through the compatibility door.**

Root cause: `PortalLookup` collapsed the PLAN (`body.tier`) and the DEVICE DEFAULT (`body.deviceTier`) into one field, so by the time the compat path ran the plan had been thrown away. `PortalLookup` now carries both — `mapPortalPlanTier` is the sibling of `mapPortalTier` that reads the plan and ignores the stamp — and the fallback list reaches the Max id when **either** reading does. The "either" is load-bearing in both directions: the plan alone would start refusing a box the portal stamped `"pro"`, which used to work, and a compatibility path must not narrow what it was added to preserve.

### 3. Refuted, not applied: the click-time decline (`M2`)

The blocking review's second medium asked the click gate to refuse the Max pick while the portal is unreachable and the badge is not Max. I implemented it, the second pass argued it should be dropped, and on checking the code it is right. Three findings from the tree, not opinions:

* **It fires on exactly the state this PR exists to fix.** A Max subscriber whose box is stamped `deviceTier: "flash"` — preserved on purpose by `mapPortalTier` (`clawbox-ai-portal-tier.ts:142-151`) — is declined the Max pick whenever the portal is silent. Same customer, same refusal, same ticket.
* **It does not cover the case its own docstring justified it with.** The harm named was a revoked token writing the Max model into `agents.defaults.model.primary`. A box that was *on* the Max default carries `deviceTier: "pro"`, so the persisted badge is `"pro"`, the condition is false, and the pick goes through and writes the primary anyway.
* **Its third argument is not the fact the doc claimed.** `clawai_tier` is not "the last portal-confirmed badge": `configure/route.ts:1907-1911` resolves `portalConfirmedTier ?? requestedClawboxAiTier ?? stored ?? default` and writes the result at `:2524`/`:2558`, so on any configure where the portal probe failed the stored badge is the **wizard plan picker's** value. The gate is satisfied by anyone who once clicked "Max" offline, and fires on the genuine Max owner.

The blast-radius concern behind it is real — the Max pick does persist into `agents.defaults.model.primary`, which Telegram and the coding-agent wrapper also run. But the remedy has to be *asking the authority*, not inferring from the one field this PR just finished proving is not an entitlement. The repo already has that pattern: `src/lib/clawbox-ai-vision.ts:50-80` sends one `max_tokens: 1` completion and reads `400 model_not_allowed` as a measured refusal while treating auth failures, timeouts and 5xx as "the question failed". That is the right shape and it is a change of its own, not a line in this PR.

### RED → GREEN

The blocker, on the blocked head `9df09a29`:

```
FAIL  src/tests/components/chat-clawai-pro-entitlement.test.tsx
      > POSTs once, says only what happened, and does not re-arm
AssertionError: expected [ …(2) ] to deeply equal [ Array(1) ]
  [
    "{\"model\":\"deepseek/deepseek-v4-flash\"}",
+   "{\"model\":\"deepseek/deepseek-v4-flash\"}",
  ]
```

An earlier form of the same test, asserting only the false-success half, on the same head:

```
AssertionError: expected '…' not to match /switching you to Pro Tier/i
+ Received: "…Max Tier needs a Max subscription. Upgrade in the ClawBox portal to
unlock it — switching you to Pro Tier so chat keeps working.Error: Selected AI
provider is not configured…"
```

The two defects the second pass added, both RED on the intermediate head `0040e3fd` (checked in a throwaway worktree at that commit):

```
FAIL  chat-clawai-pro-entitlement.test.tsx > tries again when the chat is closed and re-opened
AssertionError: expected [ Array(1) ] to have a length of 2 but got 1
- 2
+ 1

FAIL  status.test.ts > keeps the Max id in that fallback when the PLAN is Max and only
                       the device stamp is Flash
AssertionError: expected [ 'deepseek-v4-flash' ] to deeply equal [ 'deepseek-v4-flash', …(1) ]
  [
    "deepseek-v4-flash",
-   "deepseek-v4-pro",
  ]
```

GREEN:

```
npx vitest run src/tests/components/chat-clawai-pro-entitlement.test.tsx \
  src/tests/components/chat-thinking-default.test.tsx \
  src/tests/routes/ai-models/status.test.ts \
  src/tests/unit/clawbox-ai-entitlement.test.ts \
  src/tests/unit/use-clawbox-login.test.ts
→ Test Files 5 passed (5)   Tests 61 passed (61)

npx tsc --noEmit → clean

npx vitest run --project components → Test Files 138 passed (138)   Tests 1291 passed (1291)
npx vitest run --project unit       → Test Files 597 passed (597)   Tests 9576 passed (9576)
```

Both full suites are green on this head, run one at a time. Recorded because the first attempt was not: running the two projects and `tsc` concurrently on one machine produced a scatter of 5-second timeouts (`chat-spoken-reply`, `chat-email-refs-surfaces`, `chat-header-seed-race`, `run-tunnel`, …). They were checked rather than waved through — each passed alone, and `chat-spoken-reply` failed *worse* on the untouched base head `9df09a29` in a throwaway worktree — and then they all passed in the sequential runs above. Contention, not flake, and not this diff.

### Sibling sweep: every effect that depends on a callback and writes through it

Swept all **67** `useEffect` (and zero `useLayoutEffect`) in `ChatPopup.tsx` against every `useCallback`/`useMemo` in the file. **`switchChatModel` is the only one with the full shape** — the only non-stable callback an effect both depends on and calls, where the call writes one of that callback's own deps. It writes *two* of them: `switchingModel`, and `chatModelState` via `setChatModelState` on success, so even a *successful* switch changes the identity and re-runs the effect. Every other callback appearing in an effect dep array bottoms out in `useCallback([])` (`connect`, `refreshChatModelState`, `scrollToBottom`, `failPending`, `dispatchTurn` and its whole dep chain, `startRun`, `endImageWait`, `stopRecording`, `abandonRecording`, `seedHermesHeader`, …); `adapter`, `caps` and `clawboxLogin.allowedModels` are identity-stable by construction.

Six effects write a dep of *themselves* without a callback in between; each was checked rather than assumed, and all are bounded. The nearest miss is the thinking-level effect (`:1602`), which releases its own latch on failure exactly the way this one did and is held only by a `prev === suggested` React bail-out.

**One defect of the same class found while sweeping, deliberately not fixed here:** the `new WebSocket(wsUrl)` catch (`ChatPopup.tsx:2308-2314`) sets `status: 'error'` without `tearDownReloadOverlay()`, unlike the three other terminal paths. The retry effect at `:4666` therefore stays armed and resets `retryCountRef.current = 0` every 3 s, so the reconnect ladder can never exhaust on a malformed `wsUrl`. Separate path, separate defect — **TASK-712**.

### Declared, and not resolvable from this repo

* **The premise is not measured.** The only `device-info` response anyone has seen is `{"tier":"max","deviceTier":"pro","allowedModels":[…]}`, where badge and entitlement agree — so it cannot discriminate between the portal computing `allowedModels` from the PLAN (what this PR needs) and from the DEVICE STAMP. The discriminating measurement is a Max-plan token whose device is stamped `deviceTier: "flash"`, and it needs the portal plus a specially stamped box. **What can be said without it:** if the list turns out to be stamp-derived, this PR is still never worse than `beta` — `beta` vetoed on the badge, which is the same stamp, and additionally vetoed when nothing answered at all. It would then be an incomplete fix rather than a regression, and the remaining half would be a portal change.
* **Device leg unproven.** The ClawBox web server was down on both dev boxes throughout this work (`clawbox-setup.service` inactive, a root update in flight), so the fixed picker and guard were never exercised on hardware. Nothing in the delta touches the updater, gateway, systemd units, device paths or the edition lock — it is browser-side chat logic CI exercises — but the guard's failure path is exactly what a box run surfaces. After merge and deploy: open the chat on a Max box whose primary is `deepseek/deepseek-v4-pro` (no "needs a Max subscription", model stays Pro), then again with the gateway stopped so the write fails (exactly one error line, no repeat), then close and re-open the chat (exactly one more attempt).
* **Edition scope, and how it composes with #626.** The gate covers the OpenClaw chat path. On Hermes the model pill (`changeHermesModel`) is a per-provider localStorage preference that never calls `switchChatModel` and never carried a tier gate, before or after this PR — so nothing is lost there, but nothing is gained either, and `allowedModels` now makes that half cheap. Follow-up, not a regression.

  Rebased onto `538274b3`, which includes **#626** (`/setup-api/chat/model` is now harness-aware). Checked for semantic conflict, not just textual: on Hermes that route answers `409 WRONG_STORE` to **both** verbs, so `refreshChatModelState` bails on `!res.ok`, `chatModelState` stays null, and this boot guard — which reads `chatModelState?.activeModel` — cannot fire on that edition at all. It can no longer write into a store Hermes does not use, which is the safest possible resolution of the edition question above. #626 also made "nothing pinned" a null/null state; the guard's `if (!active || …) return` reads that as "no guard", which is correct. #626's own ChatPopup hunk (`unselectableActive`, ~`:6077`) and its route changes are present and untouched on this head.
* Other follow-ups recorded from the review rounds: **TASK-713** (should a re-pair rewrite the primary from the badge over an explicit pick — the one path where this PR's invariant does not hold, TASK-481's decided behaviour), the `speechEntitledTier` badge-as-entitlement sibling in `hermes-tts.ts:530-539` + `gateway-pre-start.sh` (must move together), and the `allowedModels: []` contract with the portal (today `[]` reads as "not answered" on both sides, which is the safe default but is asserted nowhere the portal can see it).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - ClawBox AI model availability now reflects portal entitlements rather than relying solely on device tier.
  - Users are notified when a selected model is unavailable, with guidance for subscription or portal settings.
  - Unsupported active Pro models automatically switch to Flash when permitted.

- **Bug Fixes**
  - Preserves model access when entitlement information is missing or temporarily unavailable.
  - Correctly handles provider prefixes, capitalization, and invalid entitlement entries.
  - Reports portal-provided model availability and sensible tier-based fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
