### PR TITLE
fix: prove plugins.enabled landed as a list before claiming the box can draw (TASK-701)

### DIFF
--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -532,6 +532,16 @@ def config_name_list(value):
     None, never []: a shape nobody understands is not consent. Read as empty,
     an unparseable `enabled` would be overwritten and an unparseable `disabled`
     would be taken for "nothing is denied".
+
+    DELIBERATELY STRICTER THAN HERMES ON `disabled`. `_get_disabled_set()` is
+    `set(disabled) if isinstance(disabled, list) else set()`, so hermes reads a
+    JSON-string or bare-scalar deny-list as denying NOTHING, while this reader
+    recovers its names and the re-arm below then declines. That asymmetry is
+    safe HERE and only here: the cost is that a boot does not re-arm and the
+    owner's next Settings -> AI Models save does it instead. The same reading
+    in src/lib/hermes-clawai.ts would WITHDRAW `image_gen.provider` from a box
+    that draws today, which is why that reader answers the empty set for a
+    residue.
     """
     if value is None:
         return []

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -535,8 +535,9 @@ def config_name_list(value):
 
     DELIBERATELY STRICTER THAN HERMES ON `disabled`. `_get_disabled_set()` is
     `set(disabled) if isinstance(disabled, list) else set()`, so hermes reads a
-    JSON-string or bare-scalar deny-list as denying NOTHING, while this reader
-    recovers its names and the re-arm below then declines. That asymmetry is
+    JSON-string, a bare scalar or any other NON-LIST deny-list as denying
+    NOTHING, while this reader either recovers names from it or answers None,
+    and the re-arm below then declines either way. That asymmetry is
     safe HERE and only here: the cost is that a boot does not re-arm and the
     owner's next Settings -> AI Models save does it instead. The same reading
     in src/lib/hermes-clawai.ts would WITHDRAW `image_gen.provider` from a box

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -304,6 +304,11 @@ export CLAWBOX_MCP_API_BASE="$API_BASE"
 # false success this whole step exists to avoid.
 export CLAWBOX_EMAIL_HOOK_PLUGIN=""
 [ "$EMAIL_HOOK_INSTALLED" = "1" ] && export CLAWBOX_EMAIL_HOOK_PLUGIN="$EMAIL_HOOK_PLUGIN"
+# The ClawAI image backend, for the re-arm below. Its files are written by the
+# LINK path (src/lib/hermes-image-plugin.ts), not by this script — this is only
+# where they would be if the box has ever been linked.
+export CLAWBOX_IMAGE_PLUGIN="clawai"
+export CLAWBOX_IMAGE_PLUGIN_ENTRY="$HERMES_PLUGINS_DIR/image_gen/clawai/__init__.py"
 
 python3 - <<'PY'
 import ast, json, os, sys, tempfile
@@ -527,6 +532,10 @@ else:
 # string is exactly the box that loads no plugins at all with nothing else on
 # it to put the type back. TASK-701.
 hook_plugin = os.environ.get("CLAWBOX_EMAIL_HOOK_PLUGIN") or ""
+# Set only where a STRING became a real list — the state a withdrawn image
+# claim is paired with. See the re-arm below.
+repaired_enabled = False
+names = None
 plugins_cfg = cfg.get("plugins")
 if plugins_cfg is None and hook_plugin:
     # Created only when there is a name to write into it; an absent key with
@@ -534,8 +543,8 @@ if plugins_cfg is None and hook_plugin:
     plugins_cfg = {}
     cfg["plugins"] = plugins_cfg
 if plugins_cfg is not None and not isinstance(plugins_cfg, dict):
-    print("[register-mcp] WARNING: plugins is not a mapping; leaving plugins.enabled alone "
-          "and the EMAIL: directive hook disabled.", file=sys.stderr)
+    print("[register-mcp] WARNING: plugins is not a mapping; leaving plugins.enabled alone."
+          + (" The EMAIL: directive hook stays disabled." if hook_plugin else ""), file=sys.stderr)
 elif isinstance(plugins_cfg, dict):
     raw_enabled = plugins_cfg.get("enabled")
     if isinstance(raw_enabled, str):
@@ -564,7 +573,9 @@ elif isinstance(plugins_cfg, dict):
                 # prevent, caused by the code preventing it.
                 names = None
                 print("[register-mcp] WARNING: plugins.enabled is a list this script cannot parse; "
-                      "leaving it untouched.", file=sys.stderr)
+                      "leaving it untouched."
+                      + (" The EMAIL: directive hook stays disabled." if hook_plugin else ""),
+                      file=sys.stderr)
         else:
             names = [raw_enabled] if raw_enabled else []
     elif isinstance(raw_enabled, (list, tuple)):
@@ -574,10 +585,16 @@ elif isinstance(plugins_cfg, dict):
     else:
         names = None
         print("[register-mcp] WARNING: plugins.enabled is not a list or a string; "
-              "leaving it untouched.", file=sys.stderr)
+              "leaving it untouched."
+              + (" The EMAIL: directive hook stays disabled." if hook_plugin else ""),
+              file=sys.stderr)
     if names is not None and hook_plugin and hook_plugin not in names:
-        plugins_cfg["enabled"] = names + [hook_plugin]
+        names = names + [hook_plugin]
+        plugins_cfg["enabled"] = names
         changed = True
+        # A string that had a name to append was normalised too — the write
+        # below is `yaml.safe_dump` of a real sequence either way.
+        repaired_enabled = isinstance(raw_enabled, str)
         print("[register-mcp] enabled the " + hook_plugin
               + " plugin — EMAIL: card directives are stripped on the way to a channel")
     elif names is not None and isinstance(raw_enabled, str):
@@ -591,8 +608,47 @@ elif isinstance(plugins_cfg, dict):
         # `yaml.safe_dump` writes it back as a real sequence. TASK-701.
         plugins_cfg["enabled"] = names
         changed = True
+        repaired_enabled = True
         print("[register-mcp] rewrote plugins.enabled as a list — it was stored as text, "
               "which loads no plugins at all")
+
+# ── Re-arm the ClawAI image backend the repair above just made loadable. ────
+# `enableHermesImageGeneration` (src/lib/hermes-clawai.ts) unsets
+# `image_gen.provider` when Hermes has ANSWERED that it will not load our
+# plugin — the honest thing to do at that moment — and it runs only when the
+# owner presses Save in Settings → AI Models. So without this, the repair above
+# would leave a box whose plugin loads again still reporting that it cannot
+# draw, until someone happened to open that page. A claim taken away by a proof
+# is put back by the opposite proof.
+#
+# ALL THREE CONDITIONS, or nothing is written:
+#   1. we JUST turned a string into a list, and that list names the backend —
+#      so this can only fire on the box the withdrawal was made on;
+#   2. the backend's files are really on disk (the link path put them there),
+#      because "named in config, nothing to load" is the false success this
+#      whole script keeps guarding against;
+#   3. `image_gen.provider` is UNSET. Never over a backend the customer chose
+#      by hand, and never as a first-time opt-in on a box nobody has linked.
+image_plugin = os.environ.get("CLAWBOX_IMAGE_PLUGIN") or ""
+image_entry = os.environ.get("CLAWBOX_IMAGE_PLUGIN_ENTRY") or ""
+if repaired_enabled and image_plugin and image_plugin in (names or []):
+    image_cfg = cfg.get("image_gen")
+    if image_cfg is None:
+        image_cfg = {}
+    if not isinstance(image_cfg, dict):
+        print("[register-mcp] WARNING: image_gen is not a mapping; leaving the image backend alone.",
+              file=sys.stderr)
+    elif image_cfg.get("provider") is not None:
+        pass  # somebody's choice, ours or theirs — not this script's to move
+    elif not (image_entry and os.path.isfile(image_entry)):
+        print("[register-mcp] the ClawAI image backend is not installed; "
+              "leaving image_gen.provider unset")
+    else:
+        image_cfg["provider"] = image_plugin
+        cfg["image_gen"] = image_cfg
+        changed = True
+        print("[register-mcp] re-armed image_gen.provider — the plugin list was repaired "
+              "and the ClawBox AI backend is installed")
 
 if not changed:
     print("[register-mcp] Hermes MCP registration already current, skipping write")

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -511,6 +511,44 @@ else:
     print("[register-mcp] WARNING: agent is not a mapping; "
           "leaving the clarify timeout at hermes' own default.", file=sys.stderr)
 
+def config_name_list(value):
+    """The plugin names in a hermes config list value, or None for a shape this
+    script cannot read.
+
+    ONE reader for both `plugins.enabled` and `plugins.disabled`, because the
+    re-arm below has to weigh them against each other and a second parse that
+    disagreed by a corner case would arm the backend over its own deny-list.
+    Three forms reach these keys: a real sequence, hermes' own JSON-string form
+    ('["a","b"]', how `hermes config set` stores a list whose coercion missed),
+    and a bare scalar meaning one name.
+
+    None, never []: a shape nobody understands is not consent. Read as empty,
+    an unparseable `enabled` would be overwritten and an unparseable `disabled`
+    would be taken for "nothing is denied".
+    """
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return [str(item) for item in value]
+    if not isinstance(value, str):
+        return None
+    if not value.strip().startswith("["):
+        return [value] if value else []
+    # `hermes config set` stores a list as a JSON string, and
+    # src/lib/hermes-clawai.ts writes this very key that way with
+    # JSON.stringify — so JSON first, and the Python literal form only as a
+    # fallback for anything hand-written.
+    parsed = None
+    try:
+        parsed = json.loads(value)
+    except ValueError:
+        try:
+            parsed = ast.literal_eval(value)
+        except (ValueError, SyntaxError):
+            parsed = None
+    return [str(item) for item in parsed] if isinstance(parsed, list) else None
+
+
 # ── Enable the outbound EMAIL:-directive hook plugin. ───────────────────────
 # `plugins.enabled` is opt-in for every user plugin on the box
 # (hermes_cli/plugins.py:4000 skips anything not listed), and it is the SAME
@@ -547,45 +585,17 @@ if plugins_cfg is not None and not isinstance(plugins_cfg, dict):
           + (" The EMAIL: directive hook stays disabled." if hook_plugin else ""), file=sys.stderr)
 elif isinstance(plugins_cfg, dict):
     raw_enabled = plugins_cfg.get("enabled")
-    if isinstance(raw_enabled, str):
-        text = raw_enabled.strip()
-        if text.startswith("["):
-            # `hermes config set` stores a list as a JSON string, and
-            # src/lib/hermes-clawai.ts writes this very key that way with
-            # JSON.stringify — so JSON first, and the Python literal form
-            # only as a fallback for anything hand-written.
-            parsed = None
-            try:
-                parsed = json.loads(text)
-            except ValueError:
-                try:
-                    parsed = ast.literal_eval(text)
-                except (ValueError, SyntaxError):
-                    parsed = None
-            if isinstance(parsed, list):
-                names = [str(item) for item in parsed]
-            else:
-                # A list we cannot read is left ALONE. Falling back to
-                # "the whole string is one plugin name" would write
-                # `['["clawai", …', 'clawbox_email_directives']` and the
-                # customer's image backend would stop loading on the next
-                # boot — the exact failure the merge above exists to
-                # prevent, caused by the code preventing it.
-                names = None
-                print("[register-mcp] WARNING: plugins.enabled is a list this script cannot parse; "
-                      "leaving it untouched."
-                      + (" The EMAIL: directive hook stays disabled." if hook_plugin else ""),
-                      file=sys.stderr)
-        else:
-            names = [raw_enabled] if raw_enabled else []
-    elif isinstance(raw_enabled, (list, tuple)):
-        names = [str(item) for item in raw_enabled]
-    elif raw_enabled is None:
-        names = []
-    else:
-        names = None
-        print("[register-mcp] WARNING: plugins.enabled is not a list or a string; "
-              "leaving it untouched."
+    names = config_name_list(raw_enabled)
+    if names is None:
+        # LEFT ALONE, whichever shape it is. Falling back to "the whole string
+        # is one plugin name" would write `['["clawai", …', 'clawbox_…']` and
+        # the customer's image backend would stop loading on the next boot —
+        # the exact failure the merge below exists to prevent, caused by the
+        # code preventing it.
+        print("[register-mcp] WARNING: plugins.enabled is "
+              + ("a list this script cannot parse" if isinstance(raw_enabled, str)
+                 else "not a list or a string")
+              + "; leaving it untouched."
               + (" The EMAIL: directive hook stays disabled." if hook_plugin else ""),
               file=sys.stderr)
     if names is not None and hook_plugin and hook_plugin not in names:
@@ -612,7 +622,7 @@ elif isinstance(plugins_cfg, dict):
         print("[register-mcp] rewrote plugins.enabled as a list — it was stored as text, "
               "which loads no plugins at all")
 
-# ── Re-arm the ClawAI image backend the repair above just made loadable. ────
+# ── Re-arm the ClawAI image backend the repair above made loadable. ─────────
 # `enableHermesImageGeneration` (src/lib/hermes-clawai.ts) unsets
 # `image_gen.provider` when Hermes has ANSWERED that it will not load our
 # plugin — the honest thing to do at that moment — and it runs only when the
@@ -621,7 +631,17 @@ elif isinstance(plugins_cfg, dict):
 # draw, until someone happened to open that page. A claim taken away by a proof
 # is put back by the opposite proof.
 #
-# ALL THREE CONDITIONS, or nothing is written:
+# AT THE AGENT'S NEXT START, not at this moment. Like the MCP registration this
+# script exists for, the repair and the re-arm are writes to config.yaml: the
+# Hermes agent already running discovered its plugins at ITS start and holds
+# that answer, and this script — which runs as `clawbox`, not root, and has
+# never restarted a unit — does not disturb it. So on the boot that repairs a
+# residue the claim can be true of the config and not yet of the running agent,
+# for one dashboard lifetime. Strictly better than the state before, which was
+# permanent, and the reason the line below reports what it WROTE rather than
+# claiming the plugin is loaded.
+#
+# ALL FOUR CONDITIONS, or nothing is written:
 #   1. we JUST turned a string into a list, and that list names the backend —
 #      so this can only fire on the box the withdrawal was made on;
 #   2. the backend's files are really on disk (the link path put them there),
@@ -629,9 +649,26 @@ elif isinstance(plugins_cfg, dict):
 #      whole script keeps guarding against;
 #   3. `image_gen.provider` is UNSET. Never over a backend the customer chose
 #      by hand, and never as a first-time opt-in on a box nobody has linked.
+#      KNOWN LIMIT: unset is read as "nobody has chosen", and it cannot tell
+#      that from an owner who cleared the key BY HAND to stop the agent drawing
+#      — nothing in ClawBox distinguishes the two, since only the link path and
+#      this block ever write it. The supported way to say no is Hermes' own
+#      `hermes plugins disable clawai`, which condition 4 honours and which the
+#      link path reads back as proof; a real ClawBox switch for it belongs on
+#      the AI Models page, not in a boot script's inference.
+#   4. `plugins.disabled` does NOT name the backend. The deny-list WINS over
+#      `plugins.enabled` (`_plugin_status`, hermes_cli/plugins_cmd.py:1930-1936),
+#      so a name in it is loadable by every reading of the allow-list and loaded
+#      by none — and it is one of the two answers the link path withdraws the
+#      claim FOR. Repairing a type does not lift a denial, so re-arming without
+#      asking it would put back, unattended, the very claim a proof had just
+#      taken away. Weighed through the same reader as the allow-list, and a
+#      deny-list this script cannot read declines the re-arm rather than
+#      guessing: the cost is one Settings → Save, which asks Hermes itself.
 image_plugin = os.environ.get("CLAWBOX_IMAGE_PLUGIN") or ""
 image_entry = os.environ.get("CLAWBOX_IMAGE_PLUGIN_ENTRY") or ""
 if repaired_enabled and image_plugin and image_plugin in (names or []):
+    denied = config_name_list(plugins_cfg.get("disabled"))
     image_cfg = cfg.get("image_gen")
     if image_cfg is None:
         image_cfg = {}
@@ -640,6 +677,12 @@ if repaired_enabled and image_plugin and image_plugin in (names or []):
               file=sys.stderr)
     elif image_cfg.get("provider") is not None:
         pass  # somebody's choice, ours or theirs — not this script's to move
+    elif denied is None:
+        print("[register-mcp] WARNING: plugins.disabled is a shape this script cannot read; "
+              "leaving image_gen.provider unset.", file=sys.stderr)
+    elif image_plugin in denied:
+        print("[register-mcp] plugins.disabled names the ClawAI image backend, so hermes "
+              "loads it from no list; leaving image_gen.provider unset")
     elif not (image_entry and os.path.isfile(image_entry)):
         print("[register-mcp] the ClawAI image backend is not installed; "
               "leaving image_gen.provider unset")
@@ -648,7 +691,7 @@ if repaired_enabled and image_plugin and image_plugin in (names or []):
         cfg["image_gen"] = image_cfg
         changed = True
         print("[register-mcp] re-armed image_gen.provider — the plugin list was repaired "
-              "and the ClawBox AI backend is installed")
+              "and the ClawBox AI backend is installed; hermes loads it at its next start")
 
 if not changed:
     print("[register-mcp] Hermes MCP registration already current, skipping write")

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -518,72 +518,81 @@ else:
 # `hermes config set` stores lists as a JSON string ('["a","b"]'), which
 # `parse_config_string_list` reads, and the same two forms the skills block
 # below handles turn up here.
+#
+# THE TYPE REPAIR IS NOT GATED ON THE HOOK. Reading the key, normalising a
+# string back into a sequence and appending the hook are three separate
+# questions, and only the last one needs a hook to append: `hook_plugin` is
+# empty whenever the plugin's files did not land (see EMAIL_HOOK_INSTALLED
+# above), and a box whose install failed AND whose `plugins.enabled` is a
+# string is exactly the box that loads no plugins at all with nothing else on
+# it to put the type back. TASK-701.
 hook_plugin = os.environ.get("CLAWBOX_EMAIL_HOOK_PLUGIN") or ""
-if hook_plugin:
-    plugins_cfg = cfg.get("plugins")
-    if plugins_cfg is None:
-        plugins_cfg = {}
-        cfg["plugins"] = plugins_cfg
-    if isinstance(plugins_cfg, dict):
-        raw_enabled = plugins_cfg.get("enabled")
-        if isinstance(raw_enabled, str):
-            text = raw_enabled.strip()
-            if text.startswith("["):
-                # `hermes config set` stores a list as a JSON string, and
-                # src/lib/hermes-clawai.ts writes this very key that way with
-                # JSON.stringify — so JSON first, and the Python literal form
-                # only as a fallback for anything hand-written.
-                parsed = None
+plugins_cfg = cfg.get("plugins")
+if plugins_cfg is None and hook_plugin:
+    # Created only when there is a name to write into it; an absent key with
+    # nothing to add is not a repair, it is a needless config rewrite.
+    plugins_cfg = {}
+    cfg["plugins"] = plugins_cfg
+if plugins_cfg is not None and not isinstance(plugins_cfg, dict):
+    print("[register-mcp] WARNING: plugins is not a mapping; leaving plugins.enabled alone "
+          "and the EMAIL: directive hook disabled.", file=sys.stderr)
+elif isinstance(plugins_cfg, dict):
+    raw_enabled = plugins_cfg.get("enabled")
+    if isinstance(raw_enabled, str):
+        text = raw_enabled.strip()
+        if text.startswith("["):
+            # `hermes config set` stores a list as a JSON string, and
+            # src/lib/hermes-clawai.ts writes this very key that way with
+            # JSON.stringify — so JSON first, and the Python literal form
+            # only as a fallback for anything hand-written.
+            parsed = None
+            try:
+                parsed = json.loads(text)
+            except ValueError:
                 try:
-                    parsed = json.loads(text)
-                except ValueError:
-                    try:
-                        parsed = ast.literal_eval(text)
-                    except (ValueError, SyntaxError):
-                        parsed = None
-                if isinstance(parsed, list):
-                    names = [str(item) for item in parsed]
-                else:
-                    # A list we cannot read is left ALONE. Falling back to
-                    # "the whole string is one plugin name" would write
-                    # `['["clawai", …', 'clawbox_email_directives']` and the
-                    # customer's image backend would stop loading on the next
-                    # boot — the exact failure the merge above exists to
-                    # prevent, caused by the code preventing it.
-                    names = None
-                    print("[register-mcp] WARNING: plugins.enabled is a list this script cannot parse; "
-                          "leaving it untouched and the EMAIL: directive hook disabled.", file=sys.stderr)
+                    parsed = ast.literal_eval(text)
+                except (ValueError, SyntaxError):
+                    parsed = None
+            if isinstance(parsed, list):
+                names = [str(item) for item in parsed]
             else:
-                names = [raw_enabled] if raw_enabled else []
-        elif isinstance(raw_enabled, (list, tuple)):
-            names = [str(item) for item in raw_enabled]
-        elif raw_enabled is None:
-            names = []
+                # A list we cannot read is left ALONE. Falling back to
+                # "the whole string is one plugin name" would write
+                # `['["clawai", …', 'clawbox_email_directives']` and the
+                # customer's image backend would stop loading on the next
+                # boot — the exact failure the merge above exists to
+                # prevent, caused by the code preventing it.
+                names = None
+                print("[register-mcp] WARNING: plugins.enabled is a list this script cannot parse; "
+                      "leaving it untouched.", file=sys.stderr)
         else:
-            names = None
-            print("[register-mcp] WARNING: plugins.enabled is not a list or a string; "
-                  "leaving the EMAIL: directive hook disabled.", file=sys.stderr)
-        if names is not None and hook_plugin not in names:
-            plugins_cfg["enabled"] = names + [hook_plugin]
-            changed = True
-            print("[register-mcp] enabled the " + hook_plugin
-                  + " plugin — EMAIL: card directives are stripped on the way to a channel")
-        elif names is not None and isinstance(raw_enabled, str):
-            # NORMALISE THE TYPE even when there is no name to add. A string
-            # here is the residue of a `hermes config set` that exited 0 and
-            # stored its literal as text; `_get_enabled_set` reads a non-list
-            # as EMPTY, so the box loads NO user plugin at all — ours, the
-            # customer's and this hook included. The branch above healed it
-            # only as a side effect of having a name to append, so a box whose
-            # residue already spelled the hook stayed broken indefinitely.
-            # `yaml.safe_dump` writes it back as a real sequence. TASK-701.
-            plugins_cfg["enabled"] = names
-            changed = True
-            print("[register-mcp] rewrote plugins.enabled as a list — it was stored as text, "
-                  "which loads no plugins at all")
+            names = [raw_enabled] if raw_enabled else []
+    elif isinstance(raw_enabled, (list, tuple)):
+        names = [str(item) for item in raw_enabled]
+    elif raw_enabled is None:
+        names = []
     else:
-        print("[register-mcp] WARNING: plugins is not a mapping; "
-              "leaving the EMAIL: directive hook disabled.", file=sys.stderr)
+        names = None
+        print("[register-mcp] WARNING: plugins.enabled is not a list or a string; "
+              "leaving it untouched.", file=sys.stderr)
+    if names is not None and hook_plugin and hook_plugin not in names:
+        plugins_cfg["enabled"] = names + [hook_plugin]
+        changed = True
+        print("[register-mcp] enabled the " + hook_plugin
+              + " plugin — EMAIL: card directives are stripped on the way to a channel")
+    elif names is not None and isinstance(raw_enabled, str):
+        # NORMALISE THE TYPE even when there is no name to add. A string here
+        # is the residue of a `hermes config set` that exited 0 and stored its
+        # literal as text; `_get_enabled_set` reads a non-list as EMPTY, so the
+        # box loads NO user plugin at all — ours, the customer's and this hook
+        # included. The branch above healed it only as a side effect of having
+        # a name to append, so a box whose residue already spelled the hook —
+        # or one with no hook to append at all — stayed broken indefinitely.
+        # `yaml.safe_dump` writes it back as a real sequence. TASK-701.
+        plugins_cfg["enabled"] = names
+        changed = True
+        print("[register-mcp] rewrote plugins.enabled as a list — it was stored as text, "
+              "which loads no plugins at all")
 
 if not changed:
     print("[register-mcp] Hermes MCP registration already current, skipping write")

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -568,6 +568,19 @@ if hook_plugin:
             changed = True
             print("[register-mcp] enabled the " + hook_plugin
                   + " plugin — EMAIL: card directives are stripped on the way to a channel")
+        elif names is not None and isinstance(raw_enabled, str):
+            # NORMALISE THE TYPE even when there is no name to add. A string
+            # here is the residue of a `hermes config set` that exited 0 and
+            # stored its literal as text; `_get_enabled_set` reads a non-list
+            # as EMPTY, so the box loads NO user plugin at all — ours, the
+            # customer's and this hook included. The branch above healed it
+            # only as a side effect of having a name to append, so a box whose
+            # residue already spelled the hook stayed broken indefinitely.
+            # `yaml.safe_dump` writes it back as a real sequence. TASK-701.
+            plugins_cfg["enabled"] = names
+            changed = True
+            print("[register-mcp] rewrote plugins.enabled as a list — it was stored as text, "
+                  "which loads no plugins at all")
     else:
         print("[register-mcp] WARNING: plugins is not a mapping; "
               "leaving the EMAIL: directive hook disabled.", file=sys.stderr)

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -308,6 +308,13 @@ export CLAWBOX_EMAIL_HOOK_PLUGIN=""
 # LINK path (src/lib/hermes-image-plugin.ts), not by this script — this is only
 # where they would be if the box has ever been linked.
 export CLAWBOX_IMAGE_PLUGIN="clawai"
+# The plugin's CANONICAL registry key — its second spelling, and the one
+# `hermes plugins disable clawai` writes into `plugins.disabled`
+# (`cmd_disable` -> `_resolve_plugin_key`, hermes_cli/plugins_cmd.py:1710-1739
+# and :1337-1362, read on the pinned 0.20.5 build). Hermes' own
+# `_plugin_status` tests both spellings; so must the re-arm's deny-list check.
+# Mirrors HERMES_IMAGE_PLUGIN_KEY in src/lib/hermes-image-plugin.ts.
+export CLAWBOX_IMAGE_PLUGIN_KEY="image_gen/clawai"
 export CLAWBOX_IMAGE_PLUGIN_ENTRY="$HERMES_PLUGINS_DIR/image_gen/clawai/__init__.py"
 
 python3 - <<'PY'
@@ -656,16 +663,24 @@ elif isinstance(plugins_cfg, dict):
 #      `hermes plugins disable clawai`, which condition 4 honours and which the
 #      link path reads back as proof; a real ClawBox switch for it belongs on
 #      the AI Models page, not in a boot script's inference.
-#   4. `plugins.disabled` does NOT name the backend. The deny-list WINS over
-#      `plugins.enabled` (`_plugin_status`, hermes_cli/plugins_cmd.py:1930-1936),
-#      so a name in it is loadable by every reading of the allow-list and loaded
-#      by none — and it is one of the two answers the link path withdraws the
-#      claim FOR. Repairing a type does not lift a denial, so re-arming without
-#      asking it would put back, unattended, the very claim a proof had just
-#      taken away. Weighed through the same reader as the allow-list, and a
+#   4. `plugins.disabled` does NOT name the backend, IN EITHER SPELLING. The
+#      deny-list WINS over `plugins.enabled` (`_plugin_status`,
+#      hermes_cli/plugins_cmd.py:1931-1937), so a name in it is loadable by
+#      every reading of the allow-list and loaded by none — and it is one of the
+#      two answers the link path withdraws the claim FOR. Repairing a type does
+#      not lift a denial, so re-arming without asking it would put back,
+#      unattended, the very claim a proof had just taken away. BOTH spellings
+#      because `hermes plugins disable clawai` stores the RESOLVED key
+#      `image_gen/clawai` (`cmd_disable` -> `_resolve_plugin_key`, :1710-1739
+#      and :1337-1362, read on the pinned 0.20.5 build) while the loader's
+#      allow-list carries the bare name — hermes' own `_plugin_status` tests
+#      both, and a check that knew only one would miss the deny-list in the one
+#      state the harness's own command produces. Weighed through the same
+#      reader as the allow-list, and a
 #      deny-list this script cannot read declines the re-arm rather than
 #      guessing: the cost is one Settings → Save, which asks Hermes itself.
 image_plugin = os.environ.get("CLAWBOX_IMAGE_PLUGIN") or ""
+image_plugin_key = os.environ.get("CLAWBOX_IMAGE_PLUGIN_KEY") or ""
 image_entry = os.environ.get("CLAWBOX_IMAGE_PLUGIN_ENTRY") or ""
 if repaired_enabled and image_plugin and image_plugin in (names or []):
     denied = config_name_list(plugins_cfg.get("disabled"))
@@ -680,7 +695,9 @@ if repaired_enabled and image_plugin and image_plugin in (names or []):
     elif denied is None:
         print("[register-mcp] WARNING: plugins.disabled is a shape this script cannot read; "
               "leaving image_gen.provider unset.", file=sys.stderr)
-    elif image_plugin in denied:
+    elif image_plugin in denied or (image_plugin_key and image_plugin_key in denied):
+        # BOTH spellings: `hermes plugins disable clawai` stores the resolved
+        # key, and hermes' own `_plugin_status` matches either.
         print("[register-mcp] plugins.disabled names the ClawAI image backend, so hermes "
               "loads it from no list; leaving image_gen.provider unset")
     elif not (image_entry and os.path.isfile(image_entry)):

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -1057,7 +1057,16 @@ async function enableHermesImageGeneration(token: string): Promise<void> {
       );
     }
     const merged = mergePluginsEnabled(state);
-    loadable = merged ? await writePluginsEnabled(merged, typed) : true;
+    // NULL IS "NOTHING TO WRITE", NEVER "NOTHING TO ASK". The key already names
+    // us in a real list — the state of every healthy linked box — so the write
+    // is skipped; but the allow-list is not the only thing Hermes gates on, and
+    // deriving "loadable" from it here would be the same inference this whole
+    // path exists to stop making. `plugins.disabled` names us and every type
+    // check on `plugins.enabled` still says yes. So the prover runs on both
+    // paths: the write path asks it after the write, this one asks it directly.
+    loadable = merged
+      ? await writePluginsEnabled(merged, typed)
+      : await hermesConfirmsPluginLoadable(typed);
   } catch (err) {
     if (err instanceof PluginsEnabledDisproved) await withdrawImageProviderClaim();
     throw err;
@@ -1075,12 +1084,11 @@ async function enableHermesImageGeneration(token: string): Promise<void> {
   ];
   for (const args of describes) await runOrThrow(args);
   if (!loadable) {
-    // The write exited 0 and the CLI never answered the question that would
-    // prove it. Not a failure worth throwing over, and not proof either — so
-    // no new claim is made, no old one is taken away, and the next link asks
-    // again.
+    // Hermes never answered the question that would prove it loads the plugin.
+    // Not a failure worth throwing over, and not proof either — so no new claim
+    // is made, no old one is taken away, and the next link asks again.
     console.warn(
-      "[hermes/clawai] plugins.enabled could not be proved to hold a list — image generation left as it was",
+      "[hermes/clawai] hermes did not confirm the plugin is loadable — image generation left as it was",
     );
     return;
   }
@@ -1147,6 +1155,17 @@ async function readPluginsEnabledFromCli(): Promise<{ state: PluginsEnabledState
     "[hermes/clawai] this hermes does not answer `config get --json`;"
     + " plugins.enabled is merged from the plain rendering and its type is not proved",
   );
+  // The SIBLING of the silence rule in `decodePluginsEnabledJson`, and it
+  // matters just as much here: this build cannot be asked the typed question,
+  // so `writePluginsEnabled` arms the backend without a listing to prove it,
+  // and the merge that runs first would write `["clawai"]` over whatever the
+  // key really holds. An exit 0 that printed NOTHING is not "the list is
+  // empty"; the unset key arrives on the branch above, as a non-zero exit
+  // saying "Config key not set" (or those words in the rendering), and only
+  // that is read as an empty list.
+  if (plainRead.code === 0 && !plainRead.stdout?.trim()) {
+    return { state: { kind: "unreadable" }, typed: false };
+  }
   return {
     state: decodePluginsEnabledPlain(plainRead.code === 0 ? plainRead.stdout : ""),
     typed: false,
@@ -1245,28 +1264,58 @@ async function writePluginsEnabled(names: string[], typed: boolean): Promise<boo
       "hermes stored plugins.enabled as text, so no plugin would load — image generation left off",
     );
   }
-  // ASK HERMES, do not re-derive its answer. `hermes plugins list --json` runs
-  // `_get_enabled_set()` itself — the very function the loader uses — so its
-  // verdict cannot disagree with what will actually load, the way a type
-  // inference over `config get` can.
+  return hermesConfirmsPluginLoadable(typed);
+}
+
+/**
+ * Will Hermes LOAD our plugin? The one prover, for both paths.
+ *
+ * ASK HERMES, do not re-derive its answer. `hermes plugins list --json` runs
+ * `_get_enabled_set()` itself — the very function the loader uses — so its
+ * verdict cannot disagree with what will actually load, the way a type
+ * inference over `config get` can. And it is the ONLY thing that catches
+ * `plugins.disabled`, a deny-list that wins over `plugins.enabled` and leaves
+ * every reading of the allow-list saying "loadable" over a plugin Hermes
+ * refuses. That is why the caller asks this even when it wrote nothing: an
+ * allow-list that already names us is a reason to skip the WRITE, never a
+ * reason to skip the QUESTION.
+ *
+ * @param typed whether this build answered `config get --json` at all.
+ * @returns true when Hermes reports the plugin enabled — false when the
+ *          question could not be put on a build that can otherwise be asked
+ *          machine-readable questions. Throws `PluginsEnabledDisproved` when
+ *          Hermes answers that it will not load it.
+ */
+async function hermesConfirmsPluginLoadable(typed: boolean): Promise<boolean> {
   const verdict = await hermesReportsPluginEnabled(HERMES_IMAGE_PLUGIN_NAME);
   if (verdict === "enabled") return true;
   if (verdict === "not-enabled") {
     // ANSWERED, and the answer is no: the value stored is not a list Hermes
     // can load us from, or `plugins.disabled` names us. This is the proof.
     throw new PluginsEnabledDisproved(
-      "hermes does not report the plugin as enabled after the write",
+      "hermes does not report the plugin as enabled",
     );
+  }
+  if (verdict === "no-such-question") {
+    // This build HAS no listing to ask, so no link of it will ever prove
+    // anything — and refusing the feature on that would take image generation
+    // away from a first link for good, where beta gave it unconditionally.
+    // Exempted exactly as a build without `config get --json` is.
+    console.warn(
+      "[hermes/clawai] this hermes does not answer `plugins list --json`;"
+      + " image generation is armed without that proof",
+    );
+    return true;
   }
   // A QUESTION THAT COULD NOT BE ASKED IS NOT A WRITE THAT FAILED. 126, 127 and
   // a signalled `null` are the shell's codes for the `hermes` shim while
   // `step_hermes_install` rebuilds the venv under it — nothing was parsed, and
-  // the write above still exited 0 with no coercion warning. Suppressing image
+  // any write above still exited 0 with no coercion warning. Suppressing image
   // generation for the whole link over that is the false-failure shape; the
   // sibling repair answers `unverified` and tries again for the same reason.
   console.warn(
     "[hermes/clawai] hermes could not be asked whether the plugin is enabled;"
-    + " the write exited 0 and is left as written, unproved",
+    + " what is on disk is left exactly as it is, unproved",
   );
   // A build that answers NEITHER machine-readable question cannot be asked at
   // all — a permanent property rather than a moment — and refusing the feature
@@ -1276,8 +1325,14 @@ async function writePluginsEnabled(names: string[], typed: boolean): Promise<boo
   return !typed;
 }
 
-/** What Hermes itself says about a plugin, or that it could not be asked. */
-type HermesPluginVerdict = "enabled" | "not-enabled" | "cannot-ask";
+/**
+ * What Hermes itself says about a plugin, or why it could not be asked.
+ *
+ * `cannot-ask` and `no-such-question` are kept apart because they are a moment
+ * and a permanent property of the build: a shim exiting 127 will answer at the
+ * next link, a subcommand flag that does not exist never will.
+ */
+type HermesPluginVerdict = "enabled" | "not-enabled" | "cannot-ask" | "no-such-question";
 
 /**
  * Would Hermes load this plugin? ASKED, not inferred.
@@ -1302,7 +1357,16 @@ type HermesPluginVerdict = "enabled" | "not-enabled" | "cannot-ask";
  */
 async function hermesReportsPluginEnabled(name: string): Promise<HermesPluginVerdict> {
   const listed = await runHermesCli(["plugins", "list", "--json"], { timeoutMs: 15_000 });
-  if (!hermesCliAnswered(listed) || listed.code !== 0) return "cannot-ask";
+  if (!hermesCliAnswered(listed) || listed.code !== 0) {
+    // A build without this flag can never answer, however often it is asked —
+    // the same permanent property `config get --json` is exempted for, matched
+    // on the same wording. Told apart from a transient failure because the
+    // caller owes those two different things.
+    return hermesCliAnswered(listed)
+      && UNSUPPORTED_OPTION_RE.test(`${listed.stdout ?? ""}\n${listed.stderr ?? ""}`)
+      ? "no-such-question"
+      : "cannot-ask";
+  }
   let rows: unknown;
   try {
     rows = JSON.parse(listed.stdout);

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -1006,9 +1006,8 @@ async function enableHermesImageGeneration(token: string): Promise<void> {
   // any other reason (a locked config, a timeout) knows NOTHING about what is
   // in that list — treating it as empty would write `["clawai"]` over the
   // customer's own enabled plugins and silently unload every one of them. So
-  // only the "not set" wording proceeds; anything else stops here, and the
-  // capability probe reports a box that cannot draw through its agent, which
-  // is the truth.
+  // only the "not set" wording proceeds; anything else stops here, with what
+  // the box already holds left exactly as it is.
   //
   // `--json` IS LOAD-BEARING. In the plain rendering a stored LIST and a stored
   // STRING that spells one are the same characters, and `hermes config set`
@@ -1027,8 +1026,10 @@ async function enableHermesImageGeneration(token: string): Promise<void> {
   // Hermes does not load.
   //
   // But only such an answer. This function runs on every AI-Models save and
-  // every re-link, it has no periodic or boot-time caller, and it is the only
-  // writer of `image_gen.provider` in the repo — so a withdrawal made over a
+  // every re-link and has no periodic caller, and the only unattended writer of
+  // `image_gen.provider` is the boot repair in `scripts/register-mcp.sh`, which
+  // puts it back solely where it has just repaired the plugin list that made it
+  // unloadable — so a withdrawal made over a
   // held config lock, a timeout, a shim exiting 127 or a rendering that is not
   // machine-readable is not caution: it is image generation gone from a
   // working box until the owner happens to save Settings again. Those failures
@@ -1044,12 +1045,35 @@ async function enableHermesImageGeneration(token: string): Promise<void> {
         "plugins.enabled holds a value this build cannot read — left alone, image generation not re-armed",
       );
     }
+    if (state.kind === "residue" && !state.names.length) {
+      // The one place "MERGED, NEVER REPLACED" gives way: a residue no name
+      // could be recovered from is overwritten, because leaving it would leave
+      // the box loading no plugin at all. Said out loud before it happens, and
+      // said HERE rather than in the decoder, which also runs as the prover —
+      // where nothing is replaced and the same line would be a false report.
+      console.warn(
+        `[hermes/clawai] plugins.enabled holds ${state.shape}, which names no plugin;`
+        + " replacing it rather than merging into it",
+      );
+    }
     const merged = mergePluginsEnabled(state);
     loadable = merged ? await writePluginsEnabled(merged, typed) : true;
   } catch (err) {
     if (err instanceof PluginsEnabledDisproved) await withdrawImageProviderClaim();
     throw err;
   }
+  // WHAT THE BACKEND IS, before the proof — it turns nothing on. These three
+  // name the model and the address this device's own plugin posts to, and
+  // `image_gen.clawai.base_url` is the key a re-link exists to repair when
+  // `CLAWBOX_AI_PROXY_URL` moves in a release. Held behind the proof they were
+  // skipped by a shim exiting 127 mid-update, leaving a box that still claims
+  // `clawai` posting to the address of the release before.
+  const describes: string[][] = [
+    ["config", "set", "image_gen.model", CLAWBOX_AI_IMAGE_MODEL_ID],
+    ["config", "set", `image_gen.${HERMES_IMAGE_PLUGIN_NAME}.model`, CLAWBOX_AI_IMAGE_MODEL_ID],
+    ["config", "set", `image_gen.${HERMES_IMAGE_PLUGIN_NAME}.base_url`, CLAWBOX_AI_PROXY_URL],
+  ];
+  for (const args of describes) await runOrThrow(args);
   if (!loadable) {
     // The write exited 0 and the CLI never answered the question that would
     // prove it. Not a failure worth throwing over, and not proof either — so
@@ -1066,20 +1090,18 @@ async function enableHermesImageGeneration(token: string): Promise<void> {
   // claiming it can draw through a backend that has nowhere to send the
   // request; written last, a failure anywhere above means the claim was never
   // made and the composer button stays.
-  const steps: string[][] = [
-    ["config", "set", "image_gen.model", CLAWBOX_AI_IMAGE_MODEL_ID],
-    ["config", "set", `image_gen.${HERMES_IMAGE_PLUGIN_NAME}.model`, CLAWBOX_AI_IMAGE_MODEL_ID],
-    ["config", "set", `image_gen.${HERMES_IMAGE_PLUGIN_NAME}.base_url`, CLAWBOX_AI_PROXY_URL],
-    ["config", "set", "image_gen.provider", HERMES_IMAGE_PLUGIN_NAME],
-  ];
-  for (const args of steps) {
-    const r = await runHermesCli(args, { timeoutMs: 15_000 });
-    if (r.code !== 0) {
-      // Thrown, not swallowed: the caller logs it and the link still succeeds.
-      // Half-written image config is exactly what the capability probe is for.
-      throw new Error(r.stderr?.trim() || `hermes ${args.join(" ")} failed`);
-    }
-  }
+  await runOrThrow(["config", "set", "image_gen.provider", HERMES_IMAGE_PLUGIN_NAME]);
+}
+
+/**
+ * One `hermes config set` that has to land.
+ *
+ * Thrown, not swallowed: the caller logs it and the link still succeeds.
+ * Half-written image config is exactly what the capability probe is for.
+ */
+async function runOrThrow(args: string[]): Promise<void> {
+  const r = await runHermesCli(args, { timeoutMs: 15_000 });
+  if (r.code !== 0) throw new Error(r.stderr?.trim() || `hermes ${args.join(" ")} failed`);
 }
 
 /**
@@ -1135,9 +1157,11 @@ async function readPluginsEnabledFromCli(): Promise<{ state: PluginsEnabledState
  * Stop claiming the agent can draw.
  *
  * `hermesAgentDrawsImages` reads `image_gen.provider` and nothing else, and
- * this function is its only writer — so on a box linked once before, declining
- * to re-write the key leaves the old claim standing. Only OUR selection is
- * withdrawn: a customer who chose FAL by hand keeps it (the "known and accepted
+ * nothing else on the device writes it while the owner is away except the
+ * boot repair in `scripts/register-mcp.sh`, which puts the claim back only
+ * where it has just made the plugin loadable again — so on a box linked once
+ * before, declining to re-write the key leaves the old claim standing. Only
+ * OUR selection is withdrawn: a customer who chose FAL by hand keeps it (the "known and accepted
  * false positive" hermes-features.ts documents is their choice, not ours).
  *
  * Best effort, and never throws: it runs on the way out of a failure that is
@@ -1169,20 +1193,20 @@ const UNSUPPORTED_OPTION_RE =
   /unrecogni[sz]ed arguments?:|no such option|unknown option|invalid choice|got unexpected extra argument/i;
 
 /**
- * The stored value was ASKED ABOUT AND ANSWERED, and the answer establishes
- * that no plugin can load from it: the CLI's own "storing as string", or a
- * strict read-back that is not the list just written.
+ * Hermes was ASKED AND ANSWERED, and the answer establishes that it will not
+ * load our plugin: the CLI's own "storing as string" on the write, or
+ * `hermes plugins list` reporting the plugin as anything but enabled.
  *
  * The one error that withdraws `image_gen.provider`. Everything else that can
  * go wrong around this key — a held config lock, a timeout, 126/127 from the
- * shim, stdout that is not JSON, a write that never landed — leaves the box
+ * shim, a listing that is not JSON, a write that never landed — leaves the box
  * holding whatever it held, because none of it says the plugin is absent and
  * nothing on the device would put the claim back (see the caller).
  */
 class PluginsEnabledDisproved extends Error {}
 
 /**
- * Write `plugins.enabled` and PROVE it landed as a list.
+ * Write `plugins.enabled` and PROVE Hermes will load us from it.
  *
  * AN EXIT CODE IS NOT AN OUTCOME — the same rule `reconcileClawaiModelsWithHermes`
  * follows for `providers.clawai.models`, and it matters more here. That key
@@ -1199,8 +1223,8 @@ class PluginsEnabledDisproved extends Error {}
  * while the link itself still succeeds.
  *
  * @returns true when the plugin is loadable as far as this build can be asked —
- *          false when the write exited 0 and the read-back that would prove it
- *          could not be run. Throws when the write could not be made (a plain
+ *          false when the write exited 0 and the question that would prove it
+ *          could not be put. Throws when the write could not be made (a plain
  *          Error: nothing was established, and the box is no worse off than
  *          before the save) and `PluginsEnabledDisproved` when the CLI's answer
  *          establishes that no plugin can load from what is stored.
@@ -1221,47 +1245,75 @@ async function writePluginsEnabled(names: string[], typed: boolean): Promise<boo
       "hermes stored plugins.enabled as text, so no plugin would load — image generation left off",
     );
   }
-  // The type cannot be proved on THIS BUILD at all (see the read above), which
-  // is a permanent property rather than a moment. Refusing the feature on those
-  // boxes would take away something that works today.
-  if (!typed) return true;
-  const read = await runHermesCli(
-    ["config", "get", "plugins.enabled", "--json"],
-    { timeoutMs: 15_000 },
-  );
+  // ASK HERMES, do not re-derive its answer. `hermes plugins list --json` runs
+  // `_get_enabled_set()` itself — the very function the loader uses — so its
+  // verdict cannot disagree with what will actually load, the way a type
+  // inference over `config get` can.
+  const verdict = await hermesReportsPluginEnabled(HERMES_IMAGE_PLUGIN_NAME);
+  if (verdict === "enabled") return true;
+  if (verdict === "not-enabled") {
+    // ANSWERED, and the answer is no: the value stored is not a list Hermes
+    // can load us from, or `plugins.disabled` names us. This is the proof.
+    throw new PluginsEnabledDisproved(
+      "hermes does not report the plugin as enabled after the write",
+    );
+  }
   // A QUESTION THAT COULD NOT BE ASKED IS NOT A WRITE THAT FAILED. 126, 127 and
   // a signalled `null` are the shell's codes for the `hermes` shim while
   // `step_hermes_install` rebuilds the venv under it — nothing was parsed, and
   // the write above still exited 0 with no coercion warning. Suppressing image
   // generation for the whole link over that is the false-failure shape; the
   // sibling repair answers `unverified` and tries again for the same reason.
-  if (!hermesCliAnswered(read)) {
-    console.warn(
-      "[hermes/clawai] could not read plugins.enabled back (the CLI did not answer);"
-      + " the write exited 0 and is left as written, unproved",
-    );
-    return false;
+  console.warn(
+    "[hermes/clawai] hermes could not be asked whether the plugin is enabled;"
+    + " the write exited 0 and is left as written, unproved",
+  );
+  // A build that answers NEITHER machine-readable question cannot be asked at
+  // all — a permanent property rather than a moment — and refusing the feature
+  // on those boxes would take away something that works today. Where the build
+  // does answer `config get --json` (so the ambiguity this whole path exists
+  // for was resolvable) a silent listing is a moment, and no claim is made.
+  return !typed;
+}
+
+/** What Hermes itself says about a plugin, or that it could not be asked. */
+type HermesPluginVerdict = "enabled" | "not-enabled" | "cannot-ask";
+
+/**
+ * Would Hermes load this plugin? ASKED, not inferred.
+ *
+ * HARNESS-FIRST, READ ON THE BOX (0.20.5 = 2026.8.19, the pinned build,
+ * read-only, 2026-09-04). `hermes plugins list --json` prints one row per
+ * discovered plugin as `{name, status, version, description, source}`
+ * (`hermes_cli/plugins_cmd.py:1969-1980`), and `status` comes from
+ * `_plugin_status(name, enabled, disabled, key)` (`:1930-1936`) over
+ * `_get_enabled_set()` (`:1309-1324`) — the SAME function the loader gates on,
+ * `set(enabled) if isinstance(enabled, list) else set()`. So a residue stored
+ * as text reads back "not enabled" from Hermes' own mouth, and a name in
+ * `plugins.disabled` reads "disabled" — a state a type check on
+ * `plugins.enabled` calls loadable and Hermes never loads. Measured: the
+ * command answers in ~1 s and reports our plugin `{"status": "enabled",
+ * "source": "user"}` on a linked box.
+ *
+ * A MISSING ROW IS NOT A NO. The rows come from `_discover_all_plugins()`, so
+ * an absent one means discovery did not see the directory — which says nothing
+ * about the allow-list this function was asked about. Reported as "cannot ask"
+ * so it makes no claim and withdraws none.
+ */
+async function hermesReportsPluginEnabled(name: string): Promise<HermesPluginVerdict> {
+  const listed = await runHermesCli(["plugins", "list", "--json"], { timeoutMs: 15_000 });
+  if (!hermesCliAnswered(listed) || listed.code !== 0) return "cannot-ask";
+  let rows: unknown;
+  try {
+    rows = JSON.parse(listed.stdout);
+  } catch {
+    return "cannot-ask";
   }
-  if (read.code !== 0) {
-    // The CLI ran and refused the question — a held lock, a usage error. That
-    // is a proof that could not be obtained, not a proof of the negative.
-    throw new Error(`could not read plugins.enabled back (exit ${read.code})`);
-  }
-  // STRICT: `decodePluginsEnabledJson` never falls back to a text parse. A
-  // prover that accepts the ambiguous plain rendering would re-open the exact
-  // hole this function closes.
-  const state = decodePluginsEnabledJson(read.stdout);
-  if (state.kind === "unreadable") {
-    // `--json` answered with something that is not JSON: the RENDERING is
-    // unreadable, which says nothing about the stored type.
-    throw new Error("plugins.enabled did not read back as JSON, so the write is unproved");
-  }
-  if (state.kind !== "list" || !names.every((name) => state.names.includes(name))) {
-    // ANSWERED, and the answer is the residue (or a list without us). This is
-    // the proof, and the only shape of it the read-back can produce.
-    throw new PluginsEnabledDisproved(
-      "plugins.enabled did not read back as the list that was written",
-    );
-  }
-  return true;
+  if (!Array.isArray(rows)) return "cannot-ask";
+  const row = rows.find(
+    (r): r is { name: string; status?: unknown } =>
+      !!r && typeof r === "object" && (r as { name?: unknown }).name === name,
+  );
+  if (!row) return "cannot-ask";
+  return row.status === "enabled" ? "enabled" : "not-enabled";
 }

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -9,6 +9,7 @@ import { invalidateModelOptions } from "@/lib/hermes-model-options";
 import { readUsableProviderIds, refreshProviderToolsIfSetChanged } from "@/lib/provider-mcp-refresh";
 import { setHermesEnvValues } from "@/lib/hermes-env";
 import {
+  HERMES_IMAGE_PLUGIN_KEY,
   HERMES_IMAGE_PLUGIN_NAME,
   HERMES_IMAGE_TOKEN_ENV,
   installHermesImagePlugin,
@@ -1039,10 +1040,14 @@ async function enableHermesImageGeneration(token: string): Promise<void> {
   try {
     const { state, typed } = await readPluginsEnabledFromCli();
     if (state.kind === "unreadable") {
-      // Not a proof of anything: a build that takes `--json` without honouring
-      // it renders the same ambiguous text here as a healthy list would.
+      // Not a proof of anything, and the two reasons are said apart: a build
+      // that takes `--json` without honouring it renders the same ambiguous
+      // text here as a healthy list would, while a command that printed nothing
+      // read no value at all and must not be reported as if it had.
       throw new Error(
-        "plugins.enabled holds a value this build cannot read — left alone, image generation not re-armed",
+        state.reason === "silent"
+          ? "hermes answered nothing for plugins.enabled — left alone, image generation not re-armed"
+          : "plugins.enabled holds a value this build cannot read — left alone, image generation not re-armed",
       );
     }
     if (state.kind === "residue" && !state.names.length) {
@@ -1071,14 +1076,15 @@ async function enableHermesImageGeneration(token: string): Promise<void> {
     if (err instanceof PluginsEnabledDisproved) await withdrawImageProviderClaim();
     throw err;
   }
-  // WHAT THE BACKEND IS, before the proof — it turns nothing on. These three
-  // name the model and the address this device's own plugin posts to, and
+  // WHAT OUR BACKEND IS, before the proof — it turns nothing on. These name the
+  // model and the address this device's own plugin posts to, and
   // `image_gen.clawai.base_url` is the key a re-link exists to repair when
-  // `CLAWBOX_AI_PROXY_URL` moves in a release. Held behind the proof they were
-  // skipped by a shim exiting 127 mid-update, leaving a box that still claims
-  // `clawai` posting to the address of the release before.
+  // `CLAWBOX_AI_PROXY_URL` moves in a release. Written ahead of the proof
+  // because held behind it they were skipped whenever the listing could not be
+  // asked, leaving a box that still claims `clawai` posting to the address of
+  // the release before. (They are still skipped when the READ above throws —
+  // nothing here runs then — which is the honest limit of the hoist.)
   const describes: string[][] = [
-    ["config", "set", "image_gen.model", CLAWBOX_AI_IMAGE_MODEL_ID],
     ["config", "set", `image_gen.${HERMES_IMAGE_PLUGIN_NAME}.model`, CLAWBOX_AI_IMAGE_MODEL_ID],
     ["config", "set", `image_gen.${HERMES_IMAGE_PLUGIN_NAME}.base_url`, CLAWBOX_AI_PROXY_URL],
   ];
@@ -1098,6 +1104,15 @@ async function enableHermesImageGeneration(token: string): Promise<void> {
   // claiming it can draw through a backend that has nowhere to send the
   // request; written last, a failure anywhere above means the claim was never
   // made and the composer button stays.
+  // The GLOBAL `image_gen.model` belongs with the provider, not with the
+  // describing writes above: whichever backend is SELECTED reads it (our own
+  // plugin reads `image_gen.clawai.model`), so it is ours to name only when we
+  // are about to become that backend. Written unconditionally it replaced a
+  // customer's chosen model on every AI-Models save — including on the paths
+  // that then make no claim at all — which is the mirror of the care
+  // `withdrawImageProviderClaim` takes not to remove somebody else's provider.
+  // Before `image_gen.provider`, so the ordering rule below still holds.
+  await runOrThrow(["config", "set", "image_gen.model", CLAWBOX_AI_IMAGE_MODEL_ID]);
   await runOrThrow(["config", "set", "image_gen.provider", HERMES_IMAGE_PLUGIN_NAME]);
 }
 
@@ -1164,7 +1179,7 @@ async function readPluginsEnabledFromCli(): Promise<{ state: PluginsEnabledState
   // saying "Config key not set" (or those words in the rendering), and only
   // that is read as an empty list.
   if (plainRead.code === 0 && !plainRead.stdout?.trim()) {
-    return { state: { kind: "unreadable" }, typed: false };
+    return { state: { kind: "unreadable", reason: "silent" }, typed: false };
   }
   return {
     state: decodePluginsEnabledPlain(plainRead.code === 0 ? plainRead.stdout : ""),
@@ -1296,16 +1311,19 @@ async function hermesConfirmsPluginLoadable(typed: boolean): Promise<boolean> {
       "hermes does not report the plugin as enabled",
     );
   }
-  if (verdict === "no-such-question") {
-    // This build HAS no listing to ask, so no link of it will ever prove
-    // anything — and refusing the feature on that would take image generation
-    // away from a first link for good, where beta gave it unconditionally.
-    // Exempted exactly as a build without `config get --json` is.
+  if (verdict === "no-such-question" && typed) {
+    // This build HAS no listing to ask, so no link of it will ever get THAT
+    // proof, and refusing the feature over it would take image generation away
+    // from a first link for good. But it is not a build that can be asked
+    // NOTHING: it answers `config get --json`, so the two keys Hermes actually
+    // gates on can still be read machine-readably. Ask those instead of arming
+    // on an exit code — a build without the listing is not a licence to make
+    // the claim TASK-701 exists to stop making.
     console.warn(
       "[hermes/clawai] this hermes does not answer `plugins list --json`;"
-      + " image generation is armed without that proof",
+      + " proving the plugin from plugins.enabled and plugins.disabled instead",
     );
-    return true;
+    return hermesKeysConfirmPluginLoadable();
   }
   // A QUESTION THAT COULD NOT BE ASKED IS NOT A WRITE THAT FAILED. 126, 127 and
   // a signalled `null` are the shell's codes for the `hermes` shim while
@@ -1379,5 +1397,82 @@ async function hermesReportsPluginEnabled(name: string): Promise<HermesPluginVer
       !!r && typeof r === "object" && (r as { name?: unknown }).name === name,
   );
   if (!row) return "cannot-ask";
-  return row.status === "enabled" ? "enabled" : "not-enabled";
+  if (row.status === "enabled") return "enabled";
+  // THE NEGATIVE IS A CLOSED LIST, not "anything that is not `enabled`".
+  // `not-enabled` is the one verdict that WITHDRAWS a working box's claim, and
+  // this file already argues (see UNSUPPORTED_OPTION_RE) that CLI wording
+  // differs on builds moved off the pin by a hand-run `hermes update`. An
+  // unrecognised status — a renamed field, an "enabled (user)" — would then
+  // take image generation away from a box where Hermes was loading the plugin
+  // all along, on every Save, with nothing to put it back. A wrong
+  // `cannot-ask` hides nothing; a wrong `not-enabled` is an apology.
+  //
+  // The list is what `_plugin_status` can return, read on the pinned 0.20.5
+  // build (`hermes_cli/plugins_cmd.py:1931-1937`): exactly `disabled`,
+  // `enabled` and `not enabled`.
+  return typeof row.status === "string" && HERMES_NOT_LOADED_STATUSES.has(row.status.toLowerCase())
+    ? "not-enabled"
+    : "cannot-ask";
+}
+
+/** The statuses that PROVE Hermes will not load the plugin. See above. */
+const HERMES_NOT_LOADED_STATUSES = new Set(["disabled", "not enabled", "not-enabled"]);
+
+/**
+ * The proof a build WITHOUT `plugins list --json` can still give.
+ *
+ * Hermes gates a user plugin on exactly two keys, and this reads both the way
+ * the loader does rather than inferring either:
+ *   `plugins.enabled`  — `_get_enabled_set()` is
+ *      `set(enabled) if isinstance(enabled, list) else set()`, so anything that
+ *      is not a LIST naming us means no load. That is a fact about what is
+ *      stored, so it PROVES the negative.
+ *   `plugins.disabled` — `_plugin_status` gives it precedence, in either
+ *      spelling (`clawai` and the resolved `image_gen/clawai`).
+ *
+ * A question that could not be PUT — an unreadable rendering, a read that
+ * failed — establishes nothing and answers false: no claim made, none taken
+ * away, and the next Save asks again. Only an ANSWER that names the negative
+ * throws, exactly as the listing's does.
+ */
+async function hermesKeysConfirmPluginLoadable(): Promise<boolean> {
+  const { state, typed } = await readPluginsEnabledFromCli();
+  if (!typed || state.kind === "unreadable") return false;
+  if (state.kind === "residue" || !state.names.includes(HERMES_IMAGE_PLUGIN_NAME)) {
+    throw new PluginsEnabledDisproved(
+      "plugins.enabled does not read back as a list naming the plugin",
+    );
+  }
+  const denied = await readPluginsDisabledFromCli();
+  if (!denied) return false;
+  if (denied.has(HERMES_IMAGE_PLUGIN_NAME) || denied.has(HERMES_IMAGE_PLUGIN_KEY)) {
+    throw new PluginsEnabledDisproved("plugins.disabled names the plugin");
+  }
+  return true;
+}
+
+/**
+ * `plugins.disabled` as a set of names, or null when it could not be read.
+ *
+ * Null rather than an empty set for every doubt: an empty set here reads as
+ * "nothing is denied", which is precisely the claim this function must not
+ * invent. Only the CLI's own "Config key not set" — the key having never been
+ * written — is an honest empty.
+ */
+async function readPluginsDisabledFromCli(): Promise<Set<string> | null> {
+  const read = await runHermesCli(
+    ["config", "get", "plugins.disabled", "--json"],
+    { timeoutMs: 15_000 },
+  );
+  const listing = `${read.stdout ?? ""}\n${read.stderr ?? ""}`;
+  if (read.code !== 0) {
+    return /config key not set/i.test(listing) ? new Set() : null;
+  }
+  const state = decodePluginsEnabledJson(read.stdout);
+  // The same decoder, and the same reading of silence: a command that printed
+  // nothing has not said the deny-list is empty. A `residue` is a value Hermes
+  // itself reads as no deny-list at all (`isinstance(disabled, list)`), so it
+  // is an honest empty here.
+  if (state.kind === "unreadable") return null;
+  return new Set(state.names);
 }

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -13,6 +13,7 @@ import {
   HERMES_IMAGE_TOKEN_ENV,
   installHermesImagePlugin,
   mergePluginsEnabled,
+  readPluginsEnabled,
 } from "@/lib/hermes-image-plugin";
 import {
   CLAWBOX_AI_CHAT_MODEL_IDS,
@@ -1006,12 +1007,26 @@ async function enableHermesImageGeneration(token: string): Promise<void> {
   // only the "not set" wording proceeds; anything else stops here, and the
   // capability probe reports a box that cannot draw through its agent, which
   // is the truth.
-  const current = await runHermesCli(["config", "get", "plugins.enabled"], { timeoutMs: 15_000 });
+  //
+  // `--json` IS LOAD-BEARING. In the plain rendering a stored LIST and a stored
+  // STRING that spells one are the same characters, and `hermes config set`
+  // stores the literal as TEXT whenever its coercion misses
+  // (hermes_cli/config.py:5514-5527, exit 0 either way). Hermes then loads NO
+  // user plugin at all — `_get_enabled_set` answers `set(enabled) if
+  // isinstance(enabled, list) else set()` — while ClawBox read the residue back
+  // as a real list and concluded there was nothing to do. TASK-701.
+  const current = await runHermesCli(
+    ["config", "get", "plugins.enabled", "--json"],
+    { timeoutMs: 15_000 },
+  );
   const listing = `${current.stdout ?? ""}\n${current.stderr ?? ""}`;
   if (current.code !== 0 && !/config key not set/i.test(listing)) {
     throw new Error(current.stderr?.trim() || "hermes config get plugins.enabled failed");
   }
-  const merged = mergePluginsEnabled(current.code === 0 ? current.stdout : "");
+  const merged = mergePluginsEnabled(
+    readPluginsEnabled(current.code === 0 ? current.stdout : ""),
+  );
+  if (merged) await writePluginsEnabled(merged);
   // `image_gen.provider` LAST, because it is the key `hermesAgentDrawsImages`
   // reads and therefore the key that turns the agent's picture ability on. A
   // provider written first and then a failed `base_url` would leave a box
@@ -1019,7 +1034,6 @@ async function enableHermesImageGeneration(token: string): Promise<void> {
   // request; written last, a failure anywhere above means the claim was never
   // made and the composer button stays.
   const steps: string[][] = [
-    ...(merged ? [["config", "set", "plugins.enabled", JSON.stringify(merged)]] : []),
     ["config", "set", "image_gen.model", CLAWBOX_AI_IMAGE_MODEL_ID],
     ["config", "set", `image_gen.${HERMES_IMAGE_PLUGIN_NAME}.model`, CLAWBOX_AI_IMAGE_MODEL_ID],
     ["config", "set", `image_gen.${HERMES_IMAGE_PLUGIN_NAME}.base_url`, CLAWBOX_AI_PROXY_URL],
@@ -1032,5 +1046,53 @@ async function enableHermesImageGeneration(token: string): Promise<void> {
       // Half-written image config is exactly what the capability probe is for.
       throw new Error(r.stderr?.trim() || `hermes ${args.join(" ")} failed`);
     }
+  }
+}
+
+/**
+ * Write `plugins.enabled` and PROVE it landed as a list.
+ *
+ * AN EXIT CODE IS NOT AN OUTCOME — the same rule `reconcileClawaiModelsWithHermes`
+ * follows for `providers.clawai.models`, and it matters more here. That key
+ * degrades one picker; this one is the opt-in allow-list for every user plugin
+ * on the box, and a value Hermes cannot read as a list disables all of them.
+ *
+ * It THROWS rather than returning a verdict, and the caller's ordering is what
+ * makes that the right shape: `image_gen.provider` — the key
+ * `hermesAgentDrawsImages` reads, and therefore the key that turns the agent's
+ * picture ability on — is written after this. So a plugin that did not land
+ * means the box never claims it can draw. A wrong `false` only hides an
+ * ability; a wrong `true` is an apology.
+ *
+ * Fails closed when the read-back cannot be RUN, for the same reason. There is
+ * no retry loop: this runs once, at link time, and the caller logs the throw
+ * while the link itself still succeeds.
+ */
+async function writePluginsEnabled(names: string[]): Promise<void> {
+  const written = await runHermesCli(
+    ["config", "set", "plugins.enabled", JSON.stringify(names)],
+    { timeoutMs: 15_000 },
+  );
+  if (written.code !== 0) {
+    throw new Error(written.stderr?.trim() || "hermes config set plugins.enabled failed");
+  }
+  // The CLI's own warning when its coercion did not yield a structure. Cheap,
+  // and it names the cause; the read-back below is what covers a build too old
+  // to print it, where the same literal is stored as text with a clean stderr.
+  if (/storing as string/i.test(written.stderr ?? "")) {
+    throw new Error(
+      "hermes stored plugins.enabled as text, so no plugin would load — image generation left off",
+    );
+  }
+  const read = await runHermesCli(
+    ["config", "get", "plugins.enabled", "--json"],
+    { timeoutMs: 15_000 },
+  );
+  if (read.code !== 0) {
+    throw new Error(`could not read plugins.enabled back (exit ${read.code})`);
+  }
+  const state = readPluginsEnabled(read.stdout);
+  if (state.residue || !names.every((name) => state.names.includes(name))) {
+    throw new Error("plugins.enabled did not read back as the list that was written");
   }
 }

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -2,7 +2,7 @@ import { setMany } from "@/lib/config-store";
 import { refreshCodingAgentToolsIfReadinessChanged } from "@/lib/coding-agent-mcp-refresh";
 import { hermesAgentDrawsImages } from "@/lib/harness/hermes-features";
 import { runHermesCli, type HermesCliResult } from "@/lib/hermes-cli";
-import { hermesCliAnswered } from "@/lib/hermes-cli-answered";
+import { hermesCliAnswered, hermesStoredValueAsText } from "@/lib/hermes-cli-answered";
 import { redactKey, safeHermesFailureMessage } from "@/lib/hermes-cli-message";
 import { refreshHermesImageTools } from "@/lib/hermes-image-refresh";
 import { invalidateModelOptions } from "@/lib/hermes-model-options";
@@ -511,7 +511,7 @@ export async function reconcileClawaiModelsWithHermes(): Promise<void> {
     // this repair would have latched "done" over it. Not reachable on the build
     // `HERMES_PIN_COMMIT` installs — the coercion chain there yields a real
     // list — which is exactly why it is worth a guard rather than a comment.
-    const storedAsText = /storing as string/i.test(written.stderr ?? "");
+    const storedAsText = hermesStoredValueAsText(written);
     // AND NEITHER IS A CLEAN STDERR. That warning only exists on a CLI whose
     // coercion block prints it, so it cannot speak for one old enough to lack
     // the block — where the same literal is stored as text with an EMPTY stderr
@@ -1018,34 +1018,45 @@ async function enableHermesImageGeneration(token: string): Promise<void> {
   // isinstance(enabled, list) else set()` — while ClawBox read the residue back
   // as a real list and concluded there was nothing to do. TASK-701.
   //
-  // WITHDRAW THE CLAIM on every exit that is not "the plugin is loadable",
-  // don't merely decline to re-make it. Every box that can be in the residue
-  // state has been linked once already, so `image_gen.provider` is on disk
-  // naming us — and that single key is what `hermesAgentDrawsImages` reads.
-  // Skipping the writes below would leave the composer button and the
-  // capability both saying yes over a plugin Hermes does not load.
+  // WITHDRAW THE CLAIM ON AN ANSWER, NEVER ON A FAILED QUESTION. Every box
+  // that can be in the residue state has been linked once already, so
+  // `image_gen.provider` is on disk naming us — and that single key is what
+  // `hermesAgentDrawsImages` reads — so an answer that PROVES the plugin
+  // cannot load has to take it back down; declining to re-make the claim would
+  // leave the composer button and the capability both saying yes over a plugin
+  // Hermes does not load.
+  //
+  // But only such an answer. This function runs on every AI-Models save and
+  // every re-link, it has no periodic or boot-time caller, and it is the only
+  // writer of `image_gen.provider` in the repo — so a withdrawal made over a
+  // held config lock, a timeout, a shim exiting 127 or a rendering that is not
+  // machine-readable is not caution: it is image generation gone from a
+  // working box until the owner happens to save Settings again. Those failures
+  // establish NOTHING about what is on disk; they are reported, and what the
+  // box holds is left exactly as it was (which is what beta did).
   let loadable: boolean;
   try {
     const { state, typed } = await readPluginsEnabledFromCli();
     if (state.kind === "unreadable") {
+      // Not a proof of anything: a build that takes `--json` without honouring
+      // it renders the same ambiguous text here as a healthy list would.
       throw new Error(
-        "plugins.enabled holds a value this build cannot read — left alone, image generation off",
+        "plugins.enabled holds a value this build cannot read — left alone, image generation not re-armed",
       );
     }
     const merged = mergePluginsEnabled(state);
     loadable = merged ? await writePluginsEnabled(merged, typed) : true;
   } catch (err) {
-    await withdrawImageProviderClaim();
+    if (err instanceof PluginsEnabledDisproved) await withdrawImageProviderClaim();
     throw err;
   }
   if (!loadable) {
     // The write exited 0 and the CLI never answered the question that would
-    // prove it. Not a failure worth throwing over — but not a licence to claim
-    // the agent can draw either, so the claim is withdrawn and the image keys
-    // below are left unwritten. The next link asks again.
-    await withdrawImageProviderClaim();
+    // prove it. Not a failure worth throwing over, and not proof either — so
+    // no new claim is made, no old one is taken away, and the next link asks
+    // again.
     console.warn(
-      "[hermes/clawai] plugins.enabled could not be proved to hold a list — image generation left off",
+      "[hermes/clawai] plugins.enabled could not be proved to hold a list — image generation left as it was",
     );
     return;
   }
@@ -1146,10 +1157,29 @@ async function withdrawImageProviderClaim(): Promise<void> {
 }
 
 /**
- * Argparse's answers for an option a build does not have. Matched on the
- * WORDING because the exit code (2) is shared with every other usage error.
+ * Argparse's (and Click's) answers for an option a build does not have.
+ * Matched on the WORDING because the exit code (2) is shared with every other
+ * usage error. Both spellings of "unrecognised" are listed: the population this
+ * fallback exists for is boxes moved off `HERMES_PIN_COMMIT` by a hand-run
+ * `hermes update`, which is precisely where the wording can differ. A miss only
+ * costs the plain fallback — the type is then simply not proved, and nothing is
+ * withdrawn over it.
  */
-const UNSUPPORTED_OPTION_RE = /unrecognized arguments?:|no such option|unknown option|invalid choice/i;
+const UNSUPPORTED_OPTION_RE =
+  /unrecogni[sz]ed arguments?:|no such option|unknown option|invalid choice|got unexpected extra argument/i;
+
+/**
+ * The stored value was ASKED ABOUT AND ANSWERED, and the answer establishes
+ * that no plugin can load from it: the CLI's own "storing as string", or a
+ * strict read-back that is not the list just written.
+ *
+ * The one error that withdraws `image_gen.provider`. Everything else that can
+ * go wrong around this key — a held config lock, a timeout, 126/127 from the
+ * shim, stdout that is not JSON, a write that never landed — leaves the box
+ * holding whatever it held, because none of it says the plugin is absent and
+ * nothing on the device would put the claim back (see the caller).
+ */
+class PluginsEnabledDisproved extends Error {}
 
 /**
  * Write `plugins.enabled` and PROVE it landed as a list.
@@ -1170,7 +1200,10 @@ const UNSUPPORTED_OPTION_RE = /unrecognized arguments?:|no such option|unknown o
  *
  * @returns true when the plugin is loadable as far as this build can be asked —
  *          false when the write exited 0 and the read-back that would prove it
- *          could not be run. Throws when the write, or the proof, said no.
+ *          could not be run. Throws when the write could not be made (a plain
+ *          Error: nothing was established, and the box is no worse off than
+ *          before the save) and `PluginsEnabledDisproved` when the CLI's answer
+ *          establishes that no plugin can load from what is stored.
  */
 async function writePluginsEnabled(names: string[], typed: boolean): Promise<boolean> {
   const written = await runHermesCli(
@@ -1183,8 +1216,8 @@ async function writePluginsEnabled(names: string[], typed: boolean): Promise<boo
   // The CLI's own warning when its coercion did not yield a structure. Cheap,
   // and it names the cause; the read-back below is what covers a build too old
   // to print it, where the same literal is stored as text with a clean stderr.
-  if (/storing as string/i.test(written.stderr ?? "")) {
-    throw new Error(
+  if (hermesStoredValueAsText(written)) {
+    throw new PluginsEnabledDisproved(
       "hermes stored plugins.enabled as text, so no plugin would load — image generation left off",
     );
   }
@@ -1210,14 +1243,25 @@ async function writePluginsEnabled(names: string[], typed: boolean): Promise<boo
     return false;
   }
   if (read.code !== 0) {
+    // The CLI ran and refused the question — a held lock, a usage error. That
+    // is a proof that could not be obtained, not a proof of the negative.
     throw new Error(`could not read plugins.enabled back (exit ${read.code})`);
   }
   // STRICT: `decodePluginsEnabledJson` never falls back to a text parse. A
   // prover that accepts the ambiguous plain rendering would re-open the exact
   // hole this function closes.
   const state = decodePluginsEnabledJson(read.stdout);
+  if (state.kind === "unreadable") {
+    // `--json` answered with something that is not JSON: the RENDERING is
+    // unreadable, which says nothing about the stored type.
+    throw new Error("plugins.enabled did not read back as JSON, so the write is unproved");
+  }
   if (state.kind !== "list" || !names.every((name) => state.names.includes(name))) {
-    throw new Error("plugins.enabled did not read back as the list that was written");
+    // ANSWERED, and the answer is the residue (or a list without us). This is
+    // the proof, and the only shape of it the read-back can produce.
+    throw new PluginsEnabledDisproved(
+      "plugins.enabled did not read back as the list that was written",
+    );
   }
   return true;
 }

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -1455,10 +1455,12 @@ async function hermesKeysConfirmPluginLoadable(): Promise<boolean> {
 /**
  * `plugins.disabled` as a set of names, or null when it could not be read.
  *
- * Null rather than an empty set for every doubt: an empty set here reads as
- * "nothing is denied", which is precisely the claim this function must not
- * invent. Only the CLI's own "Config key not set" — the key having never been
- * written — is an honest empty.
+ * Null rather than an empty set for every DOUBT — a read that failed, a
+ * rendering that could not be parsed — because an empty set here reads as
+ * "nothing is denied" and that is not a claim to invent. Two things ARE an
+ * honest empty, because both are ANSWERS: the CLI's own "Config key not set",
+ * and a value that is not a LIST — `_get_disabled_set()` reads that as denying
+ * nothing, so it denies nothing here too.
  */
 async function readPluginsDisabledFromCli(): Promise<Set<string> | null> {
   const read = await runHermesCli(

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -1017,24 +1017,37 @@ async function enableHermesImageGeneration(token: string): Promise<void> {
   // user plugin at all — `_get_enabled_set` answers `set(enabled) if
   // isinstance(enabled, list) else set()` — while ClawBox read the residue back
   // as a real list and concluded there was nothing to do. TASK-701.
-  const { state, typed } = await readPluginsEnabledFromCli();
-  if (state.kind === "unreadable") {
-    throw new Error(
-      "plugins.enabled holds a value this build cannot read — left alone, image generation off",
-    );
-  }
-  const merged = mergePluginsEnabled(state);
+  //
+  // WITHDRAW THE CLAIM on every exit that is not "the plugin is loadable",
+  // don't merely decline to re-make it. Every box that can be in the residue
+  // state has been linked once already, so `image_gen.provider` is on disk
+  // naming us — and that single key is what `hermesAgentDrawsImages` reads.
+  // Skipping the writes below would leave the composer button and the
+  // capability both saying yes over a plugin Hermes does not load.
+  let loadable: boolean;
   try {
-    if (merged) await writePluginsEnabled(merged, typed);
+    const { state, typed } = await readPluginsEnabledFromCli();
+    if (state.kind === "unreadable") {
+      throw new Error(
+        "plugins.enabled holds a value this build cannot read — left alone, image generation off",
+      );
+    }
+    const merged = mergePluginsEnabled(state);
+    loadable = merged ? await writePluginsEnabled(merged, typed) : true;
   } catch (err) {
-    // WITHDRAW THE CLAIM, don't merely decline to re-make it. Every box that
-    // can be in the residue state has been linked once already, so
-    // `image_gen.provider` is on disk naming us — and that single key is what
-    // `hermesAgentDrawsImages` reads. Skipping the writes below would leave the
-    // composer button and the capability both saying yes over a plugin Hermes
-    // does not load.
     await withdrawImageProviderClaim();
     throw err;
+  }
+  if (!loadable) {
+    // The write exited 0 and the CLI never answered the question that would
+    // prove it. Not a failure worth throwing over — but not a licence to claim
+    // the agent can draw either, so the claim is withdrawn and the image keys
+    // below are left unwritten. The next link asks again.
+    await withdrawImageProviderClaim();
+    console.warn(
+      "[hermes/clawai] plugins.enabled could not be proved to hold a list — image generation left off",
+    );
+    return;
   }
   // `image_gen.provider` LAST, because it is the key `hermesAgentDrawsImages`
   // reads and therefore the key that turns the agent's picture ability on. A
@@ -1092,6 +1105,16 @@ async function readPluginsEnabledFromCli(): Promise<{ state: PluginsEnabledState
   // that cannot answer that question has told us nothing about whether the
   // stored value is residue. Losing image generation there would be a false
   // failure, not a conservative one — these boxes draw today.
+  //
+  // ONLY for that answer, though. Any other failure — a held config lock, a
+  // timeout, a wedged shim — must propagate: falling back to the ambiguous
+  // rendering there is how a stored `["clawai"]` string gets read as a list
+  // again, which is the whole defect this function exists to remove.
+  if (!UNSUPPORTED_OPTION_RE.test(`${typedRead.stdout ?? ""}\n${typedRead.stderr ?? ""}`)) {
+    throw new Error(
+      typedRead.stderr?.trim() || `hermes config get plugins.enabled --json failed (exit ${typedRead.code})`,
+    );
+  }
   const plainRead = await runHermesCli(["config", "get", "plugins.enabled"], { timeoutMs: 15_000 });
   const listing = `${plainRead.stdout ?? ""}\n${plainRead.stderr ?? ""}`;
   if (plainRead.code !== 0 && !/config key not set/i.test(listing)) {
@@ -1132,7 +1155,18 @@ async function withdrawImageProviderClaim(): Promise<void> {
   }
 }
 
-async function writePluginsEnabled(names: string[], typed: boolean): Promise<void> {
+/**
+ * Argparse's answers for an option a build does not have. Matched on the
+ * WORDING because the exit code (2) is shared with every other usage error.
+ */
+const UNSUPPORTED_OPTION_RE = /unrecognized arguments?:|no such option|unknown option|invalid choice/i;
+
+/**
+ * @returns true when the plugin is loadable as far as this build can be asked —
+ *          false when the write exited 0 and the read-back that would prove it
+ *          could not be run. Throws when the write, or the proof, said no.
+ */
+async function writePluginsEnabled(names: string[], typed: boolean): Promise<boolean> {
   const written = await runHermesCli(
     ["config", "set", "plugins.enabled", JSON.stringify(names)],
     { timeoutMs: 15_000 },
@@ -1148,7 +1182,10 @@ async function writePluginsEnabled(names: string[], typed: boolean): Promise<voi
       "hermes stored plugins.enabled as text, so no plugin would load — image generation left off",
     );
   }
-  if (!typed) return; // the type cannot be proved on this build; see the read above.
+  // The type cannot be proved on THIS BUILD at all (see the read above), which
+  // is a permanent property rather than a moment. Refusing the feature on those
+  // boxes would take away something that works today.
+  if (!typed) return true;
   const read = await runHermesCli(
     ["config", "get", "plugins.enabled", "--json"],
     { timeoutMs: 15_000 },
@@ -1162,9 +1199,9 @@ async function writePluginsEnabled(names: string[], typed: boolean): Promise<voi
   if (!hermesCliAnswered(read)) {
     console.warn(
       "[hermes/clawai] could not read plugins.enabled back (the CLI did not answer);"
-      + " the write exited 0 and is left as written",
+      + " the write exited 0 and is left as written, unproved",
     );
-    return;
+    return false;
   }
   if (read.code !== 0) {
     throw new Error(`could not read plugins.enabled back (exit ${read.code})`);
@@ -1176,4 +1213,5 @@ async function writePluginsEnabled(names: string[], typed: boolean): Promise<voi
   if (state.kind !== "list" || !names.every((name) => state.names.includes(name))) {
     throw new Error("plugins.enabled did not read back as the list that was written");
   }
+  return true;
 }

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -1082,8 +1082,9 @@ async function enableHermesImageGeneration(token: string): Promise<void> {
   // `CLAWBOX_AI_PROXY_URL` moves in a release. Written ahead of the proof
   // because held behind it they were skipped whenever the listing could not be
   // asked, leaving a box that still claims `clawai` posting to the address of
-  // the release before. (They are still skipped when the READ above throws —
-  // nothing here runs then — which is the honest limit of the hoist.)
+  // the release before. (They are still skipped whenever the read OR the proof
+  // throws — nothing below the block above runs then — which is the honest
+  // limit of the hoist.)
   const describes: string[][] = [
     ["config", "set", `image_gen.${HERMES_IMAGE_PLUGIN_NAME}.model`, CLAWBOX_AI_IMAGE_MODEL_ID],
     ["config", "set", `image_gen.${HERMES_IMAGE_PLUGIN_NAME}.base_url`, CLAWBOX_AI_PROXY_URL],
@@ -1470,9 +1471,15 @@ async function readPluginsDisabledFromCli(): Promise<Set<string> | null> {
   }
   const state = decodePluginsEnabledJson(read.stdout);
   // The same decoder, and the same reading of silence: a command that printed
-  // nothing has not said the deny-list is empty. A `residue` is a value Hermes
-  // itself reads as no deny-list at all (`isinstance(disabled, list)`), so it
-  // is an honest empty here.
+  // nothing has not said the deny-list is empty.
   if (state.kind === "unreadable") return null;
-  return new Set(state.names);
+  // A RESIDUE DENIES NOTHING, so its recovered names are not a deny-list.
+  // `_get_disabled_set()` gates on the same type as the allow-list —
+  // `set(disabled) if isinstance(disabled, list) else set()`
+  // (hermes_cli/plugins_cmd.py:1257-1269, read on the pinned 0.20.5 build) —
+  // so a `plugins.disabled` stored as a STRING is a value Hermes loads the
+  // plugin over. Returning the names recovered out of it would withdraw
+  // `image_gen.provider` from a box that is drawing today; the honest empty is
+  // the only reading that matches what Hermes does.
+  return state.kind === "residue" ? new Set() : new Set(state.names);
 }

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -1072,23 +1072,13 @@ async function enableHermesImageGeneration(token: string): Promise<void> {
 }
 
 /**
- * Write `plugins.enabled` and PROVE it landed as a list.
+ * Read `plugins.enabled` as Hermes would, and say whether the TYPE could be
+ * asked about at all.
  *
- * AN EXIT CODE IS NOT AN OUTCOME — the same rule `reconcileClawaiModelsWithHermes`
- * follows for `providers.clawai.models`, and it matters more here. That key
- * degrades one picker; this one is the opt-in allow-list for every user plugin
- * on the box, and a value Hermes cannot read as a list disables all of them.
- *
- * It THROWS rather than returning a verdict, and the caller's ordering is what
- * makes that the right shape: `image_gen.provider` — the key
- * `hermesAgentDrawsImages` reads, and therefore the key that turns the agent's
- * picture ability on — is written after this. So a plugin that did not land
- * means the box never claims it can draw. A wrong `false` only hides an
- * ability; a wrong `true` is an apology.
- *
- * Fails closed when the read-back cannot be RUN, for the same reason. There is
- * no retry loop: this runs once, at link time, and the caller logs the throw
- * while the link itself still succeeds.
+ * `typed` is the second half of the answer: false means this build cannot
+ * render the key machine-readably, so a list and a string that spells one are
+ * indistinguishable here and no proof is possible on this box — a permanent
+ * property, not a moment, which is why the caller keeps its claim there.
  */
 async function readPluginsEnabledFromCli(): Promise<{ state: PluginsEnabledState; typed: boolean }> {
   const typedRead = await runHermesCli(
@@ -1162,6 +1152,22 @@ async function withdrawImageProviderClaim(): Promise<void> {
 const UNSUPPORTED_OPTION_RE = /unrecognized arguments?:|no such option|unknown option|invalid choice/i;
 
 /**
+ * Write `plugins.enabled` and PROVE it landed as a list.
+ *
+ * AN EXIT CODE IS NOT AN OUTCOME — the same rule `reconcileClawaiModelsWithHermes`
+ * follows for `providers.clawai.models`, and it matters more here. That key
+ * degrades one picker; this one is the opt-in allow-list for every user plugin
+ * on the box, and a value Hermes cannot read as a list disables all of them.
+ *
+ * The caller's ordering is what turns the answer into behaviour:
+ * `image_gen.provider` — the key `hermesAgentDrawsImages` reads, and therefore
+ * the key that turns the agent's picture ability on — is written after this. So
+ * anything short of proof means the box does not claim it can draw. A wrong
+ * `false` only hides an ability; a wrong `true` is an apology.
+ *
+ * There is no retry loop: this runs once, at link time, and the caller logs
+ * while the link itself still succeeds.
+ *
  * @returns true when the plugin is loadable as far as this build can be asked —
  *          false when the write exited 0 and the read-back that would prove it
  *          could not be run. Throws when the write, or the proof, said no.

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -13,7 +13,9 @@ import {
   HERMES_IMAGE_TOKEN_ENV,
   installHermesImagePlugin,
   mergePluginsEnabled,
-  readPluginsEnabled,
+  decodePluginsEnabledJson,
+  decodePluginsEnabledPlain,
+  type PluginsEnabledState,
 } from "@/lib/hermes-image-plugin";
 import {
   CLAWBOX_AI_CHAT_MODEL_IDS,
@@ -1015,18 +1017,25 @@ async function enableHermesImageGeneration(token: string): Promise<void> {
   // user plugin at all — `_get_enabled_set` answers `set(enabled) if
   // isinstance(enabled, list) else set()` — while ClawBox read the residue back
   // as a real list and concluded there was nothing to do. TASK-701.
-  const current = await runHermesCli(
-    ["config", "get", "plugins.enabled", "--json"],
-    { timeoutMs: 15_000 },
-  );
-  const listing = `${current.stdout ?? ""}\n${current.stderr ?? ""}`;
-  if (current.code !== 0 && !/config key not set/i.test(listing)) {
-    throw new Error(current.stderr?.trim() || "hermes config get plugins.enabled failed");
+  const { state, typed } = await readPluginsEnabledFromCli();
+  if (state.kind === "unreadable") {
+    throw new Error(
+      "plugins.enabled holds a value this build cannot read — left alone, image generation off",
+    );
   }
-  const merged = mergePluginsEnabled(
-    readPluginsEnabled(current.code === 0 ? current.stdout : ""),
-  );
-  if (merged) await writePluginsEnabled(merged);
+  const merged = mergePluginsEnabled(state);
+  try {
+    if (merged) await writePluginsEnabled(merged, typed);
+  } catch (err) {
+    // WITHDRAW THE CLAIM, don't merely decline to re-make it. Every box that
+    // can be in the residue state has been linked once already, so
+    // `image_gen.provider` is on disk naming us — and that single key is what
+    // `hermesAgentDrawsImages` reads. Skipping the writes below would leave the
+    // composer button and the capability both saying yes over a plugin Hermes
+    // does not load.
+    await withdrawImageProviderClaim();
+    throw err;
+  }
   // `image_gen.provider` LAST, because it is the key `hermesAgentDrawsImages`
   // reads and therefore the key that turns the agent's picture ability on. A
   // provider written first and then a failed `base_url` would leave a box
@@ -1068,7 +1077,62 @@ async function enableHermesImageGeneration(token: string): Promise<void> {
  * no retry loop: this runs once, at link time, and the caller logs the throw
  * while the link itself still succeeds.
  */
-async function writePluginsEnabled(names: string[]): Promise<void> {
+async function readPluginsEnabledFromCli(): Promise<{ state: PluginsEnabledState; typed: boolean }> {
+  const typedRead = await runHermesCli(
+    ["config", "get", "plugins.enabled", "--json"],
+    { timeoutMs: 15_000 },
+  );
+  if (typedRead.code === 0) return { state: decodePluginsEnabledJson(typedRead.stdout), typed: true };
+  if (/config key not set/i.test(`${typedRead.stdout ?? ""}\n${typedRead.stderr ?? ""}`)) {
+    return { state: { kind: "list", names: [] }, typed: true };
+  }
+  // A CLI whose `config get` does not take the flag answers argparse's
+  // "unrecognized arguments: --json". Ask again PLAINLY rather than refusing
+  // the feature: `--json` is only what lets the type be PROVED, and a build
+  // that cannot answer that question has told us nothing about whether the
+  // stored value is residue. Losing image generation there would be a false
+  // failure, not a conservative one — these boxes draw today.
+  const plainRead = await runHermesCli(["config", "get", "plugins.enabled"], { timeoutMs: 15_000 });
+  const listing = `${plainRead.stdout ?? ""}\n${plainRead.stderr ?? ""}`;
+  if (plainRead.code !== 0 && !/config key not set/i.test(listing)) {
+    throw new Error(plainRead.stderr?.trim() || "hermes config get plugins.enabled failed");
+  }
+  console.warn(
+    "[hermes/clawai] this hermes does not answer `config get --json`;"
+    + " plugins.enabled is merged from the plain rendering and its type is not proved",
+  );
+  return {
+    state: decodePluginsEnabledPlain(plainRead.code === 0 ? plainRead.stdout : ""),
+    typed: false,
+  };
+}
+
+/**
+ * Stop claiming the agent can draw.
+ *
+ * `hermesAgentDrawsImages` reads `image_gen.provider` and nothing else, and
+ * this function is its only writer — so on a box linked once before, declining
+ * to re-write the key leaves the old claim standing. Only OUR selection is
+ * withdrawn: a customer who chose FAL by hand keeps it (the "known and accepted
+ * false positive" hermes-features.ts documents is their choice, not ours).
+ *
+ * Best effort, and never throws: it runs on the way out of a failure that is
+ * already being reported, and a second error here would replace the first.
+ */
+async function withdrawImageProviderClaim(): Promise<void> {
+  try {
+    const read = await runHermesCli(["config", "get", "image_gen.provider"], { timeoutMs: 15_000 });
+    if (read.code !== 0 || read.stdout.trim() !== HERMES_IMAGE_PLUGIN_NAME) return;
+    await runHermesCli(["config", "unset", "image_gen.provider"], { timeoutMs: 15_000 });
+    console.warn(
+      "[hermes/clawai] withdrew image_gen.provider — the ClawBox AI backend is not loadable here",
+    );
+  } catch {
+    // Nothing to add: the caller is already reporting why we got here.
+  }
+}
+
+async function writePluginsEnabled(names: string[], typed: boolean): Promise<void> {
   const written = await runHermesCli(
     ["config", "set", "plugins.enabled", JSON.stringify(names)],
     { timeoutMs: 15_000 },
@@ -1084,15 +1148,32 @@ async function writePluginsEnabled(names: string[]): Promise<void> {
       "hermes stored plugins.enabled as text, so no plugin would load — image generation left off",
     );
   }
+  if (!typed) return; // the type cannot be proved on this build; see the read above.
   const read = await runHermesCli(
     ["config", "get", "plugins.enabled", "--json"],
     { timeoutMs: 15_000 },
   );
+  // A QUESTION THAT COULD NOT BE ASKED IS NOT A WRITE THAT FAILED. 126, 127 and
+  // a signalled `null` are the shell's codes for the `hermes` shim while
+  // `step_hermes_install` rebuilds the venv under it — nothing was parsed, and
+  // the write above still exited 0 with no coercion warning. Suppressing image
+  // generation for the whole link over that is the false-failure shape; the
+  // sibling repair answers `unverified` and tries again for the same reason.
+  if (!hermesCliAnswered(read)) {
+    console.warn(
+      "[hermes/clawai] could not read plugins.enabled back (the CLI did not answer);"
+      + " the write exited 0 and is left as written",
+    );
+    return;
+  }
   if (read.code !== 0) {
     throw new Error(`could not read plugins.enabled back (exit ${read.code})`);
   }
-  const state = readPluginsEnabled(read.stdout);
-  if (state.residue || !names.every((name) => state.names.includes(name))) {
+  // STRICT: `decodePluginsEnabledJson` never falls back to a text parse. A
+  // prover that accepts the ambiguous plain rendering would re-open the exact
+  // hole this function closes.
+  const state = decodePluginsEnabledJson(read.stdout);
+  if (state.kind !== "list" || !names.every((name) => state.names.includes(name))) {
     throw new Error("plugins.enabled did not read back as the list that was written");
   }
 }

--- a/src/lib/hermes-cli-answered.ts
+++ b/src/lib/hermes-cli-answered.ts
@@ -22,3 +22,23 @@ import type { HermesCliResult } from "@/lib/hermes-cli";
 export function hermesCliAnswered(result: Pick<HermesCliResult, "code">): boolean {
   return typeof result.code === "number" && result.code !== 126 && result.code !== 127;
 }
+
+/**
+ * Did `hermes config set` say its own coercion missed and it stored the value
+ * as TEXT?
+ *
+ * `hermes config set k '["a","b"]'` exits 0 either way; when the structured
+ * parse does not yield a list it prints "…storing as string." to stderr and
+ * saves the literal (hermes_cli/config.py:5514-5527 on the pinned 0.20.5).
+ * Every key this repo writes as a JSON literal has to read that line, because
+ * an exit code is not an outcome — `providers.clawai.models` degrades to a
+ * one-id allowlist and `plugins.enabled` disables every user plugin on the box.
+ *
+ * One function rather than the regex written out at each site: the two callers
+ * that had their own copy also grew their own idea of what the answer MEANT,
+ * which is how a proved "stored as text" and an unanswerable question came to
+ * be handled alike in one of them.
+ */
+export function hermesStoredValueAsText(result: Pick<HermesCliResult, "stderr">): boolean {
+  return /storing as string/i.test(result.stderr ?? "");
+}

--- a/src/lib/hermes-image-plugin.ts
+++ b/src/lib/hermes-image-plugin.ts
@@ -113,9 +113,57 @@ export async function hermesImagePluginInstalled(): Promise<boolean> {
   }
 }
 
+/** What `plugins.enabled` currently holds, as Hermes would read it. */
+export interface PluginsEnabledState {
+  /** The names Hermes will actually load. Empty unless the key holds a LIST. */
+  names: string[];
+  /**
+   * The key holds something that is not a list — in practice the residue of a
+   * `hermes config set` whose coercion failed and stored our own JSON literal
+   * as text. `_get_enabled_set` (hermes_cli/plugins_cmd.py:1309-1324) answers
+   * `set(enabled) if isinstance(enabled, list) else set()`, so on such a box NO
+   * user plugin loads at all — the customer's included.
+   */
+  residue: boolean;
+}
+
 /**
- * The `plugins.enabled` list with our backend added, or null when it is already
- * there.
+ * Decode what `hermes config get plugins.enabled --json` printed.
+ *
+ * `--json` IS LOAD-BEARING, and it is the whole reason this function exists
+ * rather than the YAML-text parser it replaced. In the plain rendering a stored
+ * LIST and a stored STRING that spells one are the same characters, so the
+ * residue above read back as a real one-element list, the merge answered
+ * "already there, nothing to do", and a box that was loading no plugins at all
+ * could never heal itself (TASK-701).
+ *
+ * The YAML fallback is kept for the plain rendering — a CLI old enough to
+ * reject `--json`, and the block/flow shapes both observed on the live box.
+ * It cannot tell the two apart, which is why the caller asks for `--json`.
+ */
+export function readPluginsEnabled(stdout: string): PluginsEnabledState {
+  const text = (stdout || "").trim();
+  if (!text || /^config key not set/i.test(text)) return { names: [], residue: false };
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    return { names: parseYamlList(text), residue: false };
+  }
+  if (Array.isArray(value)) {
+    return { names: value.filter((v): v is string => typeof v === "string"), residue: false };
+  }
+  // A STRING is the residue case. Its content is our own literal, so the names
+  // in it are recoverable and the customer's plugins survive the repair — but
+  // the key is still wrong, and `mergePluginsEnabled` must not read this as
+  // "already correct".
+  if (typeof value === "string") return { names: parseYamlList(value), residue: true };
+  return { names: [], residue: true };
+}
+
+/**
+ * The `plugins.enabled` list with our backend added, or null when there is
+ * nothing to write.
  *
  * MERGED, NEVER REPLACED, and that is the whole reason this is a function with
  * a test rather than a literal in the caller. `plugins.enabled` is opt-in for
@@ -126,16 +174,15 @@ export async function hermesImagePluginInstalled(): Promise<boolean> {
  *
  * Null on "nothing to do" so the caller can skip the write entirely: `hermes
  * config set` rewrites config.yaml, which invalidates the mtime-keyed config
- * memo every chat open reads through.
- *
- * @param current what `hermes config get plugins.enabled` printed — a YAML
- *                list, an empty string on an unset key, or the CLI's
- *                "Config key not set: …" line.
+ * memo every chat open reads through. A `residue` state is never "nothing to
+ * do", however complete its names look: the TYPE is what Hermes gates on.
  */
-export function mergePluginsEnabled(current: string): string[] | null {
-  const existing = parseYamlList(current);
-  if (existing.includes(HERMES_IMAGE_PLUGIN_NAME)) return null;
-  return [...existing, HERMES_IMAGE_PLUGIN_NAME];
+export function mergePluginsEnabled(state: PluginsEnabledState): string[] | null {
+  const withOurs = state.names.includes(HERMES_IMAGE_PLUGIN_NAME)
+    ? [...state.names]
+    : [...state.names, HERMES_IMAGE_PLUGIN_NAME];
+  if (state.residue) return withOurs;
+  return state.names.includes(HERMES_IMAGE_PLUGIN_NAME) ? null : withOurs;
 }
 
 /**

--- a/src/lib/hermes-image-plugin.ts
+++ b/src/lib/hermes-image-plugin.ts
@@ -133,7 +133,10 @@ export async function hermesImagePluginInstalled(): Promise<boolean> {
  *                answers `set(enabled) if isinstance(enabled, list) else
  *                set()`, so on such a box NO user plugin loads at all — the
  *                customer's included. `names` is what could be recovered from
- *                it, which is what keeps the repair from destroying their list.
+ *                it, which is what keeps the repair from destroying their list,
+ *                and `shape` is what it looked like — for the caller's journal
+ *                line on the one path where nothing could be recovered and the
+ *                value is replaced rather than merged into.
  *   unreadable — a shape nothing here can take names out of. Left ALONE:
  *                replacing it would discard the only record of what the
  *                customer had enabled, the same way `scripts/register-mcp.sh`
@@ -141,7 +144,7 @@ export async function hermesImagePluginInstalled(): Promise<boolean> {
  */
 export type PluginsEnabledState =
   | { kind: "list"; names: string[] }
-  | { kind: "residue"; names: string[] }
+  | { kind: "residue"; names: string[]; shape: string }
   | { kind: "unreadable" };
 
 /**
@@ -153,8 +156,10 @@ export type PluginsEnabledState =
  * and a box loading no plugins at all could never heal itself (TASK-701).
  *
  * Strict on purpose — stdout that is not JSON is `unreadable`, never a lenient
- * text parse. This function is what PROVES a write landed as a list, and a
- * prover that accepts the ambiguous rendering re-opens the hole it closes.
+ * text parse. This decides whether the value is REPAIRED, and a decoder that
+ * accepts the ambiguous rendering leaves the residue in place. (What Hermes
+ * will actually LOAD is asked of Hermes, not derived here — see
+ * `hermesReportsPluginEnabled` in hermes-clawai.ts.)
  */
 export function decodePluginsEnabledJson(stdout: string): PluginsEnabledState {
   const text = (stdout || "").trim();
@@ -170,7 +175,7 @@ export function decodePluginsEnabledJson(stdout: string): PluginsEnabledState {
     // than carried — but the drop is deliberate, not incidental.
     return { kind: "list", names: value.filter((v): v is string => typeof v === "string") };
   }
-  return { kind: "residue", names: recoverNames(value) };
+  return { kind: "residue", names: recoverNames(value), shape: describeShape(value) };
 }
 
 /**
@@ -187,30 +192,8 @@ export function decodePluginsEnabledPlain(stdout: string): PluginsEnabledState {
   return { kind: "list", names: parseYamlList(stdout) };
 }
 
-/**
- * Names out of a value that is not a list, or [] when there are none.
- *
- * A residue nothing can be recovered from is still REPLACED by the caller —
- * leaving the box loading no plugins at all would be worse — but it is the one
- * place the "merged, never replaced" invariant gives way, so what is being
- * discarded is written to the journal first. `scripts/register-mcp.sh` prints
- * the same kind of line before it declines a list it cannot parse.
- */
+/** Names out of a value that is not a list, or [] when there are none. */
 function recoverNames(value: unknown): string[] {
-  const names = recoverNamesFrom(value);
-  if (!names.length) {
-    // Plugin names only — this key holds no credential — and truncated anyway,
-    // since a hand-edited config can hold anything.
-    const shape = typeof value === "string" ? JSON.stringify(value.slice(0, 120)) : typeof value;
-    console.warn(
-      `[hermes/clawai] plugins.enabled holds ${shape}, which names no plugin;`
-      + " it is being replaced rather than merged into",
-    );
-  }
-  return names;
-}
-
-function recoverNamesFrom(value: unknown): string[] {
   // Our own literal, handed back as text. Its content is the customer's list.
   if (typeof value === "string") {
     const names = parseYamlList(value);
@@ -220,9 +203,29 @@ function recoverNamesFrom(value: unknown): string[] {
     return bare && !bare.startsWith("[") && !bare.includes("\n") ? [bare] : [];
   }
   // A hand-edited mapping (`enabled: {weather: true}`) is a plausible YAML
-  // mistake, and its KEYS are perfectly good plugin names.
-  if (value && typeof value === "object" && !Array.isArray(value)) return Object.keys(value);
+  // mistake, and its KEYS are perfectly good plugin names — but a mapping is
+  // how someone writes an ON/OFF table, so when every value is a boolean the
+  // FALSE ones are a decision, not a name. Turning `weather: false` into a
+  // listed (and therefore loaded) plugin would enable something the owner had
+  // just switched off, as a side effect of repairing a type.
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const entries = Object.entries(value as Record<string, unknown>);
+    return entries.every(([, v]) => typeof v === "boolean")
+      ? entries.filter(([, v]) => v).map(([name]) => name)
+      : entries.map(([name]) => name);
+  }
   return [];
+}
+
+/**
+ * What the value LOOKED like, for the journal line the caller prints before it
+ * replaces a residue no name could be recovered from.
+ *
+ * Plugin names only — this key holds no credential — and truncated anyway,
+ * since a hand-edited config can hold anything.
+ */
+function describeShape(value: unknown): string {
+  return typeof value === "string" ? JSON.stringify(value.slice(0, 120)) : typeof value;
 }
 
 /**

--- a/src/lib/hermes-image-plugin.ts
+++ b/src/lib/hermes-image-plugin.ts
@@ -7,6 +7,16 @@ import { hermesHome } from "@/lib/hermes-env";
  *
  * SERVER ONLY.
  *
+ * HARNESS-FIRST, READ ON THE BOX (0.20.5, read-only, 2026-09-04). Hermes owns
+ * `hermes plugins enable <name>`, which does the read-modify-write itself and
+ * cannot store a string. ClawBox does not use it, and the reason is a fact
+ * rather than a preference: `_resolve_plugin_key("clawai")` answers
+ * `image_gen/clawai`, so that command would write a SECOND spelling into
+ * `plugins.enabled` beside the bare `clawai` the loader already accepts on
+ * every field box (`hermes plugins list` reports our plugin as `enabled` from
+ * that bare name today). Swapping them is a link-path change that wants a
+ * device test with a mutation, not a unit one — see TASK-701.
+ *
  * WHY A PLUGIN AND NOT A CONFIG LINE. Hermes' image generation is a tool the
  * AGENT reaches for (`image_generate`), serviced by whichever backend
  * `image_gen.provider` names, and every backend is a plugin. Upstream ships
@@ -113,52 +123,84 @@ export async function hermesImagePluginInstalled(): Promise<boolean> {
   }
 }
 
-/** What `plugins.enabled` currently holds, as Hermes would read it. */
-export interface PluginsEnabledState {
-  /** The names Hermes will actually load. Empty unless the key holds a LIST. */
-  names: string[];
-  /**
-   * The key holds something that is not a list — in practice the residue of a
-   * `hermes config set` whose coercion failed and stored our own JSON literal
-   * as text. `_get_enabled_set` (hermes_cli/plugins_cmd.py:1309-1324) answers
-   * `set(enabled) if isinstance(enabled, list) else set()`, so on such a box NO
-   * user plugin loads at all — the customer's included.
-   */
-  residue: boolean;
-}
+/**
+ * What `plugins.enabled` currently holds, as Hermes would read it.
+ *
+ *   list       — a real sequence. `_get_enabled_set` loads exactly these names.
+ *   residue    — NOT a sequence: in practice our own JSON literal stored as
+ *                text by a `hermes config set` whose coercion missed.
+ *                `_get_enabled_set` (hermes_cli/plugins_cmd.py:1309-1324)
+ *                answers `set(enabled) if isinstance(enabled, list) else
+ *                set()`, so on such a box NO user plugin loads at all — the
+ *                customer's included. `names` is what could be recovered from
+ *                it, which is what keeps the repair from destroying their list.
+ *   unreadable — a shape nothing here can take names out of. Left ALONE:
+ *                replacing it would discard the only record of what the
+ *                customer had enabled, the same way `scripts/register-mcp.sh`
+ *                declines a list it cannot parse.
+ */
+export type PluginsEnabledState =
+  | { kind: "list"; names: string[] }
+  | { kind: "residue"; names: string[] }
+  | { kind: "unreadable" };
 
 /**
- * Decode what `hermes config get plugins.enabled --json` printed.
+ * Decode `hermes config get plugins.enabled --json`, STRICTLY.
  *
- * `--json` IS LOAD-BEARING, and it is the whole reason this function exists
- * rather than the YAML-text parser it replaced. In the plain rendering a stored
- * LIST and a stored STRING that spells one are the same characters, so the
- * residue above read back as a real one-element list, the merge answered
- * "already there, nothing to do", and a box that was loading no plugins at all
- * could never heal itself (TASK-701).
+ * `--json` is what tells a stored list from a stored string: in the plain
+ * rendering they are the same characters, which is how the residue read back as
+ * a real one-element list, the merge answered "already there, nothing to do",
+ * and a box loading no plugins at all could never heal itself (TASK-701).
  *
- * The YAML fallback is kept for the plain rendering — a CLI old enough to
- * reject `--json`, and the block/flow shapes both observed on the live box.
- * It cannot tell the two apart, which is why the caller asks for `--json`.
+ * Strict on purpose — stdout that is not JSON is `unreadable`, never a lenient
+ * text parse. This function is what PROVES a write landed as a list, and a
+ * prover that accepts the ambiguous rendering re-opens the hole it closes.
  */
-export function readPluginsEnabled(stdout: string): PluginsEnabledState {
+export function decodePluginsEnabledJson(stdout: string): PluginsEnabledState {
   const text = (stdout || "").trim();
-  if (!text || /^config key not set/i.test(text)) return { names: [], residue: false };
+  if (!text || /^config key not set/i.test(text)) return { kind: "list", names: [] };
   let value: unknown;
   try {
     value = JSON.parse(text);
   } catch {
-    return { names: parseYamlList(text), residue: false };
+    return { kind: "unreadable" };
   }
   if (Array.isArray(value)) {
-    return { names: value.filter((v): v is string => typeof v === "string"), residue: false };
+    // A non-string member can never match a plugin key, so it is dropped rather
+    // than carried — but the drop is deliberate, not incidental.
+    return { kind: "list", names: value.filter((v): v is string => typeof v === "string") };
   }
-  // A STRING is the residue case. Its content is our own literal, so the names
-  // in it are recoverable and the customer's plugins survive the repair — but
-  // the key is still wrong, and `mergePluginsEnabled` must not read this as
-  // "already correct".
-  if (typeof value === "string") return { names: parseYamlList(value), residue: true };
-  return { names: [], residue: true };
+  return { kind: "residue", names: recoverNames(value) };
+}
+
+/**
+ * Decode a PLAIN `hermes config get plugins.enabled`, for a CLI that rejects
+ * `--json`.
+ *
+ * It cannot tell a list from a string — that is the whole reason the caller
+ * asks for `--json` first — so everything it can read is reported as a list and
+ * the type is simply not proved on such a build. Reading it as a list is what
+ * those boxes did before this key was ever verified, and losing image
+ * generation on them would be a false failure rather than a tightened claim.
+ */
+export function decodePluginsEnabledPlain(stdout: string): PluginsEnabledState {
+  return { kind: "list", names: parseYamlList(stdout) };
+}
+
+/** Names out of a value that is not a list, or [] when there are none. */
+function recoverNames(value: unknown): string[] {
+  // Our own literal, handed back as text. Its content is the customer's list.
+  if (typeof value === "string") {
+    const names = parseYamlList(value);
+    if (names.length) return names;
+    // A bare scalar — `plugins.enabled: weather` — is one name, not nothing.
+    const bare = value.trim();
+    return bare && !bare.startsWith("[") && !bare.includes("\n") ? [bare] : [];
+  }
+  // A hand-edited mapping (`enabled: {weather: true}`) is a plausible YAML
+  // mistake, and its KEYS are perfectly good plugin names.
+  if (value && typeof value === "object" && !Array.isArray(value)) return Object.keys(value);
+  return [];
 }
 
 /**
@@ -174,15 +216,16 @@ export function readPluginsEnabled(stdout: string): PluginsEnabledState {
  *
  * Null on "nothing to do" so the caller can skip the write entirely: `hermes
  * config set` rewrites config.yaml, which invalidates the mtime-keyed config
- * memo every chat open reads through. A `residue` state is never "nothing to
- * do", however complete its names look: the TYPE is what Hermes gates on.
+ * memo every chat open reads through. A `residue` is never nothing-to-do,
+ * however complete its names look: the TYPE is what Hermes gates on. An
+ * `unreadable` value is not this function's to touch — the caller decides, and
+ * it must not go on to claim the plugin is loaded.
  */
 export function mergePluginsEnabled(state: PluginsEnabledState): string[] | null {
-  const withOurs = state.names.includes(HERMES_IMAGE_PLUGIN_NAME)
-    ? [...state.names]
-    : [...state.names, HERMES_IMAGE_PLUGIN_NAME];
-  if (state.residue) return withOurs;
-  return state.names.includes(HERMES_IMAGE_PLUGIN_NAME) ? null : withOurs;
+  if (state.kind === "unreadable") return null;
+  const has = state.names.includes(HERMES_IMAGE_PLUGIN_NAME);
+  if (has && state.kind === "list") return null;
+  return has ? [...state.names] : [...state.names, HERMES_IMAGE_PLUGIN_NAME];
 }
 
 /**
@@ -190,10 +233,7 @@ export function mergePluginsEnabled(state: PluginsEnabledState): string[] | null
  *
  * Two shapes, both observed on the live box: a block list (`- clawai` per line)
  * and a flow list (`['clawai']`). Anything else — including the CLI's
- * "Config key not set: plugins.enabled" — parses to nothing, which is the safe
- * answer: it means we add ours to an empty list, and a `set` that turns out to
- * be wrong is visible in the file rather than silently dropping names we could
- * not read.
+ * "Config key not set: plugins.enabled" — parses to nothing.
  */
 function parseYamlList(raw: string): string[] {
   const text = (raw || "").trim();

--- a/src/lib/hermes-image-plugin.ts
+++ b/src/lib/hermes-image-plugin.ts
@@ -187,8 +187,30 @@ export function decodePluginsEnabledPlain(stdout: string): PluginsEnabledState {
   return { kind: "list", names: parseYamlList(stdout) };
 }
 
-/** Names out of a value that is not a list, or [] when there are none. */
+/**
+ * Names out of a value that is not a list, or [] when there are none.
+ *
+ * A residue nothing can be recovered from is still REPLACED by the caller —
+ * leaving the box loading no plugins at all would be worse — but it is the one
+ * place the "merged, never replaced" invariant gives way, so what is being
+ * discarded is written to the journal first. `scripts/register-mcp.sh` prints
+ * the same kind of line before it declines a list it cannot parse.
+ */
 function recoverNames(value: unknown): string[] {
+  const names = recoverNamesFrom(value);
+  if (!names.length) {
+    // Plugin names only — this key holds no credential — and truncated anyway,
+    // since a hand-edited config can hold anything.
+    const shape = typeof value === "string" ? JSON.stringify(value.slice(0, 120)) : typeof value;
+    console.warn(
+      `[hermes/clawai] plugins.enabled holds ${shape}, which names no plugin;`
+      + " it is being replaced rather than merged into",
+    );
+  }
+  return names;
+}
+
+function recoverNamesFrom(value: unknown): string[] {
   // Our own literal, handed back as text. Its content is the customer's list.
   if (typeof value === "string") {
     const names = parseYamlList(value);

--- a/src/lib/hermes-image-plugin.ts
+++ b/src/lib/hermes-image-plugin.ts
@@ -54,8 +54,26 @@ import { hermesHome } from "@/lib/hermes-env";
  * 1024×1024, with `gpt-image-1-mini` — the id every plan is entitled to.
  */
 
-/** The plugin's name, which is also its directory and its registry key. */
+/** The plugin's name, which is also its directory and the loader's allow-list entry. */
 export const HERMES_IMAGE_PLUGIN_NAME = "clawai";
+
+/**
+ * The plugin's CANONICAL registry key — the second spelling of the same plugin.
+ *
+ * READ ON THE PINNED BUILD (0.20.5, Hermes box, read-only, 2026-09-05):
+ * `_resolve_plugin_key("clawai")` answers `image_gen/clawai`
+ * (`hermes_cli/plugins_cmd.py:1337-1362` — the category directory joined to the
+ * name), and `cmd_disable` (`:1710-1739`) writes THAT key into
+ * `plugins.disabled`, not the bare name. Hermes' own `_plugin_status`
+ * (`:1931-1937`) then tests BOTH — `if name in disabled or key in disabled` —
+ * which is why anything that asks Hermes is immune and anything that reads the
+ * key itself has to test both too.
+ *
+ * Exported because two readers need it and a second literal would drift:
+ * `hermes-clawai.ts`'s deny-list fallback, and `scripts/register-mcp.sh`'s boot
+ * re-arm through `CLAWBOX_IMAGE_PLUGIN_KEY`.
+ */
+export const HERMES_IMAGE_PLUGIN_KEY = `image_gen/${HERMES_IMAGE_PLUGIN_NAME}`;
 
 /** The two files that make a Hermes directory plugin: manifest and entry point. */
 const PLUGIN_FILES = ["plugin.yaml", "__init__.py"] as const;
@@ -145,7 +163,23 @@ export async function hermesImagePluginInstalled(): Promise<boolean> {
 export type PluginsEnabledState =
   | { kind: "list"; names: string[] }
   | { kind: "residue"; names: string[]; shape: string }
-  | { kind: "unreadable" };
+  | { kind: "unreadable"; reason: UnreadableReason };
+
+/**
+ * WHY nothing could be taken out of the value — two different facts that the
+ * operator's journal must not word as one.
+ *
+ *   silent      — the command exited 0 and printed NOTHING. Nothing was read,
+ *                 so naming a stored "value this build cannot read" would be a
+ *                 report of something that never happened.
+ *   unparsable  — stdout was there and was not JSON: a build that takes
+ *                 `--json` without honouring it, which really is a value this
+ *                 build cannot read.
+ *
+ * Both are left ALONE by every caller; they are kept apart so the case is
+ * greppable if it turns up in the field.
+ */
+export type UnreadableReason = "silent" | "unparsable";
 
 /**
  * Decode `hermes config get plugins.enabled --json`, STRICTLY.
@@ -170,12 +204,12 @@ export function decodePluginsEnabledJson(stdout: string): PluginsEnabledState {
   // writes it over whatever is really stored, unloading every plugin the
   // customer installed. That is `unreadable`, which the caller leaves alone.
   if (/^config key not set/i.test(text)) return { kind: "list", names: [] };
-  if (!text) return { kind: "unreadable" };
+  if (!text) return { kind: "unreadable", reason: "silent" };
   let value: unknown;
   try {
     value = JSON.parse(text);
   } catch {
-    return { kind: "unreadable" };
+    return { kind: "unreadable", reason: "unparsable" };
   }
   if (Array.isArray(value)) {
     // A non-string member can never match a plugin key, so it is dropped rather

--- a/src/lib/hermes-image-plugin.ts
+++ b/src/lib/hermes-image-plugin.ts
@@ -163,7 +163,14 @@ export type PluginsEnabledState =
  */
 export function decodePluginsEnabledJson(stdout: string): PluginsEnabledState {
   const text = (stdout || "").trim();
-  if (!text || /^config key not set/i.test(text)) return { kind: "list", names: [] };
+  // AN UNSET KEY AND A SILENT COMMAND ARE NOT THE SAME ANSWER. The CLI's own
+  // "Config key not set" says what the key holds — nothing — and a list may be
+  // started from it. An exit 0 with EMPTY stdout says only that the command
+  // printed nothing; read as `[]` the merge answers `["clawai"]` and the caller
+  // writes it over whatever is really stored, unloading every plugin the
+  // customer installed. That is `unreadable`, which the caller leaves alone.
+  if (/^config key not set/i.test(text)) return { kind: "list", names: [] };
+  if (!text) return { kind: "unreadable" };
   let value: unknown;
   try {
     value = JSON.parse(text);

--- a/src/tests/unit/hermes-clawai-images.test.ts
+++ b/src/tests/unit/hermes-clawai-images.test.ts
@@ -51,6 +51,38 @@ import { CLAWBOX_AI_PROXY_URL, applyClawaiToHermes } from "@/lib/hermes-clawai";
 import { CLAWBOX_AI_IMAGE_MODEL_ID } from "@/lib/clawbox-ai-models";
 import { HERMES_IMAGE_PLUGIN_NAME, HERMES_IMAGE_TOKEN_ENV } from "@/lib/hermes-image-plugin";
 
+const OK = { code: 0, stdout: "", stderr: "" };
+
+/**
+ * A `hermes` that actually STORES what it is told for `plugins.enabled`.
+ *
+ * That write is verified with a `config get --json` read-back now (TASK-701),
+ * so a stub answering "" to every read reports a key that did not land — and
+ * the link then correctly refuses to claim the box can draw, which would end
+ * every case here in the same place. Modelling the store keeps each case about
+ * what it is about. `override` wins where a case needs a specific failure.
+ */
+function hermesFake(
+  override: (args: string[]) => { code: number; stdout: string; stderr: string } | undefined = () => undefined,
+  seed?: unknown,
+): void {
+  let stored = seed;
+  cliMock.mockImplementation(async (args: string[]) => {
+    const forced = override(args);
+    if (forced) return forced;
+    if (args[1] === "set" && args[2] === "plugins.enabled") {
+      stored = JSON.parse(args[3]);
+      return OK;
+    }
+    if (args[1] === "get" && args[2] === "plugins.enabled") {
+      return stored === undefined
+        ? { code: 1, stdout: "", stderr: "Config key not set: plugins.enabled" }
+        : { code: 0, stdout: JSON.stringify(stored), stderr: "" };
+    }
+    return OK;
+  });
+}
+
 /** Every `config set`, as "key=value", in the order they were issued. */
 function sets(): string[] {
   return cliMock.mock.calls
@@ -66,7 +98,7 @@ describe("enabling image generation when ClawBox AI is linked", () => {
     installMock.mockReset();
     drawsMock.mockReset();
     refreshMock.mockReset();
-    cliMock.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+    hermesFake();
     // Called twice per link: once before the writes, once after. The default is
     // the ordinary case — a box that could not draw, and now can.
     drawsMock.mockResolvedValueOnce(false).mockResolvedValue(true);
@@ -110,11 +142,7 @@ describe("enabling image generation when ClawBox AI is linked", () => {
   });
 
   it("adds itself to plugins.enabled without dropping the customer's plugins", async () => {
-    cliMock.mockImplementation(async (args: string[]) =>
-      args[1] === "get" && args[2] === "plugins.enabled"
-        ? { code: 0, stdout: "- weather\n- spotify\n", stderr: "" }
-        : { code: 0, stdout: "", stderr: "" },
-    );
+    hermesFake(() => undefined, ["weather", "spotify"]);
     await applyClawaiToHermes("claw_token_abc", "flash");
     expect(sets()).toContain(
       `plugins.enabled=${JSON.stringify(["weather", "spotify", HERMES_IMAGE_PLUGIN_NAME])}`,
@@ -122,11 +150,7 @@ describe("enabling image generation when ClawBox AI is linked", () => {
   });
 
   it("leaves plugins.enabled alone when it already lists us", async () => {
-    cliMock.mockImplementation(async (args: string[]) =>
-      args[1] === "get" && args[2] === "plugins.enabled"
-        ? { code: 0, stdout: `- ${HERMES_IMAGE_PLUGIN_NAME}\n`, stderr: "" }
-        : { code: 0, stdout: "", stderr: "" },
-    );
+    hermesFake(() => undefined, [HERMES_IMAGE_PLUGIN_NAME]);
     await applyClawaiToHermes("claw_token_abc", "flash");
     expect(sets().some((s) => s.startsWith("plugins.enabled="))).toBe(false);
   });
@@ -135,11 +159,7 @@ describe("enabling image generation when ClawBox AI is linked", () => {
     // `hermes config get` exits NON-ZERO for an absent key, with this wording.
     // It is not a failed read: there is genuinely nothing to preserve, so the
     // list is created with ours in it.
-    cliMock.mockImplementation(async (args: string[]) =>
-      args[1] === "get" && args[2] === "plugins.enabled"
-        ? { code: 1, stdout: "", stderr: "Config key not set: plugins.enabled" }
-        : { code: 0, stdout: "", stderr: "" },
-    );
+    hermesFake();
     await applyClawaiToHermes("claw_token_abc", "flash");
     expect(sets()).toContain(`plugins.enabled=${JSON.stringify([HERMES_IMAGE_PLUGIN_NAME])}`);
   });
@@ -149,10 +169,10 @@ describe("enabling image generation when ClawBox AI is linked", () => {
     // list. Reading that as "empty" and writing ours over it would unload every
     // plugin the customer had enabled — the one destructive thing this whole
     // function can do.
-    cliMock.mockImplementation(async (args: string[]) =>
+    hermesFake((args) =>
       args[1] === "get" && args[2] === "plugins.enabled"
         ? { code: 1, stdout: "", stderr: "could not acquire config lock" }
-        : { code: 0, stdout: "", stderr: "" },
+        : undefined,
     );
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     await applyClawaiToHermes("claw_token_abc", "flash");
@@ -167,10 +187,10 @@ describe("enabling image generation when ClawBox AI is linked", () => {
     // before the base URL, a failed base URL would leave a box advertising a
     // backend with nowhere to send the request: no composer button, and every
     // request for a picture dying inside the agent.
-    cliMock.mockImplementation(async (args: string[]) =>
+    hermesFake((args) =>
       args[2] === `image_gen.${HERMES_IMAGE_PLUGIN_NAME}.base_url`
         ? { code: 1, stdout: "", stderr: "nope" }
-        : { code: 0, stdout: "", stderr: "" },
+        : undefined,
     );
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     await applyClawaiToHermes("claw_token_abc", "flash");
@@ -209,10 +229,8 @@ describe("enabling image generation when ClawBox AI is linked", () => {
   });
 
   it("does not stop the link when a config write for images fails", async () => {
-    cliMock.mockImplementation(async (args: string[]) =>
-      args[2]?.startsWith("image_gen")
-        ? { code: 1, stdout: "", stderr: "nope" }
-        : { code: 0, stdout: "", stderr: "" },
+    hermesFake((args) =>
+      args[2]?.startsWith("image_gen") ? { code: 1, stdout: "", stderr: "nope" } : undefined,
     );
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     await expect(applyClawaiToHermes("claw_token_abc", "flash")).resolves.toMatchObject({

--- a/src/tests/unit/hermes-clawai-images.test.ts
+++ b/src/tests/unit/hermes-clawai-images.test.ts
@@ -54,13 +54,16 @@ import { HERMES_IMAGE_PLUGIN_NAME, HERMES_IMAGE_TOKEN_ENV } from "@/lib/hermes-i
 const OK = { code: 0, stdout: "", stderr: "" };
 
 /**
- * A `hermes` that actually STORES what it is told for `plugins.enabled`.
+ * A `hermes` that actually STORES what it is told for `plugins.enabled`, and
+ * REPORTS what it would load from it.
  *
- * That write is verified with a `config get --json` read-back now (TASK-701),
- * so a stub answering "" to every read reports a key that did not land — and
- * the link then correctly refuses to claim the box can draw, which would end
- * every case here in the same place. Modelling the store keeps each case about
- * what it is about. `override` wins where a case needs a specific failure.
+ * The write is proved by asking Hermes now (TASK-701): `plugins list --json`,
+ * whose `status` comes from the loader's own `_get_enabled_set`. A stub
+ * answering "" to every call therefore reports a plugin that is not enabled,
+ * and the link then correctly refuses to claim the box can draw — which would
+ * end every case here in the same place. Modelling the store keeps each case
+ * about what it is about. `override` wins where a case needs a specific
+ * failure.
  */
 function hermesFake(
   override: (args: string[]) => { code: number; stdout: string; stderr: string } | undefined = () => undefined,
@@ -70,6 +73,18 @@ function hermesFake(
   cliMock.mockImplementation(async (args: string[]) => {
     const forced = override(args);
     if (forced) return forced;
+    if (args[0] === "plugins" && args[1] === "list") {
+      // `set(enabled) if isinstance(enabled, list) else set()` — the rule the
+      // real one applies (hermes_cli/plugins_cmd.py:1309-1324).
+      const enabled = Array.isArray(stored) && stored.includes(HERMES_IMAGE_PLUGIN_NAME);
+      return {
+        code: 0,
+        stdout: JSON.stringify([
+          { name: HERMES_IMAGE_PLUGIN_NAME, status: enabled ? "enabled" : "not enabled", version: "1.0.0", description: "", source: "user" },
+        ]),
+        stderr: "",
+      };
+    }
     if (args[1] === "set" && args[2] === "plugins.enabled") {
       stored = JSON.parse(args[3]);
       return OK;

--- a/src/tests/unit/hermes-image-plugin.test.ts
+++ b/src/tests/unit/hermes-image-plugin.test.ts
@@ -188,8 +188,10 @@ describe("plugins.enabled", () => {
   });
 
   it("leaves a shape it cannot read names out of alone", () => {
-    // A JSON value that is not a list names no plugin, so there is nothing to
-    // preserve: it is REPLACED, and the caller journals the old shape first.
+    // A JSON value NO NAME CAN BE RECOVERED FROM names no plugin, so there is
+    // nothing to preserve: it is REPLACED, and the caller journals the old
+    // shape first. Not every non-list is: a bare scalar and a JSON-string
+    // spelling a list both name plugins, and those are kept (see above).
     for (const stored of [7, null, true]) {
       expect(asJson(stored).kind, JSON.stringify(stored)).toBe("residue");
       expect(mergePluginsEnabled(asJson(stored))).toEqual([HERMES_IMAGE_PLUGIN_NAME]);

--- a/src/tests/unit/hermes-image-plugin.test.ts
+++ b/src/tests/unit/hermes-image-plugin.test.ts
@@ -188,12 +188,15 @@ describe("plugins.enabled", () => {
   });
 
   it("leaves a shape it cannot read names out of alone", () => {
-    // Not repaired and not replaced: the caller refuses the feature instead,
-    // the same call `scripts/register-mcp.sh` makes on a list it cannot parse.
+    // A JSON value that is not a list names no plugin, so there is nothing to
+    // preserve: it is REPLACED, and the caller journals the old shape first.
     for (const stored of [7, null, true]) {
       expect(asJson(stored).kind, JSON.stringify(stored)).toBe("residue");
       expect(mergePluginsEnabled(asJson(stored))).toEqual([HERMES_IMAGE_PLUGIN_NAME]);
     }
+    // Stdout that is not JSON is different: nothing was read, so nothing is
+    // repaired and nothing is replaced — the same call
+    // `scripts/register-mcp.sh` makes on a list it cannot parse.
     expect(decodePluginsEnabledJson("not json at all").kind).toBe("unreadable");
     expect(mergePluginsEnabled(decodePluginsEnabledJson("not json at all"))).toBeNull();
   });

--- a/src/tests/unit/hermes-image-plugin.test.ts
+++ b/src/tests/unit/hermes-image-plugin.test.ts
@@ -156,6 +156,24 @@ describe("plugins.enabled", () => {
     expect(mergePluginsEnabled(asJson("weather"))).toEqual(["weather", HERMES_IMAGE_PLUGIN_NAME]);
   });
 
+  it("keeps a mapping's OFF entries off when it repairs the type", () => {
+    // `enabled: {clawai: true, weather: false}` is how a person writes a
+    // switch table. Taking every key would list `weather` as a real list entry
+    // and start loading, on the next boot, a plugin the owner had switched off
+    // — enabling something as a side effect of repairing a type.
+    expect(mergePluginsEnabled(asJson({ weather: false, spotify: true }))).toEqual([
+      "spotify",
+      HERMES_IMAGE_PLUGIN_NAME,
+    ]);
+    // Only when the mapping really is a switch table, though: mixed values are
+    // not a decision about anything, so every key is still a name.
+    expect(mergePluginsEnabled(asJson({ weather: null, spotify: true }))).toEqual([
+      "weather",
+      "spotify",
+      HERMES_IMAGE_PLUGIN_NAME,
+    ]);
+  });
+
   it("leaves a shape it cannot read names out of alone", () => {
     // Not repaired and not replaced: the caller refuses the feature instead,
     // the same call `scripts/register-mcp.sh` makes on a list it cannot parse.

--- a/src/tests/unit/hermes-image-plugin.test.ts
+++ b/src/tests/unit/hermes-image-plugin.test.ts
@@ -10,6 +10,7 @@ import {
   hermesImagePluginInstalled,
   installHermesImagePlugin,
   mergePluginsEnabled,
+  readPluginsEnabled,
 } from "@/lib/hermes-image-plugin";
 
 /**
@@ -91,35 +92,61 @@ describe("installing the ClawBox AI image backend", () => {
 });
 
 describe("plugins.enabled", () => {
+  /** What `hermes config get plugins.enabled --json` prints for a stored value. */
+  const asJson = (value: unknown) => readPluginsEnabled(JSON.stringify(value));
+
   it("adds ours to a list the customer already has", () => {
     // The list gates EVERY user plugin on the box, so replacing it would
     // unload whatever else is installed — a feature landing by breaking one.
-    expect(mergePluginsEnabled("- weather\n- spotify\n")).toEqual([
+    expect(mergePluginsEnabled(asJson(["weather", "spotify"]))).toEqual([
       "weather",
       "spotify",
       HERMES_IMAGE_PLUGIN_NAME,
     ]);
   });
 
-  it("reads the flow spelling of the same list", () => {
-    expect(mergePluginsEnabled("['weather', \"spotify\"]")).toEqual([
-      "weather",
-      "spotify",
-      HERMES_IMAGE_PLUGIN_NAME,
-    ]);
+  it("reads the YAML spellings too, for a plain `config get`", () => {
+    // Block and flow, both observed on the live box. Kept because a CLI old
+    // enough to reject `--json` still has to be understood.
+    for (const rendering of ["- weather\n- spotify\n", "['weather', \"spotify\"]"]) {
+      expect(mergePluginsEnabled(readPluginsEnabled(rendering))).toEqual([
+        "weather",
+        "spotify",
+        HERMES_IMAGE_PLUGIN_NAME,
+      ]);
+    }
   });
 
   it("starts a list when the key has never been set", () => {
     // What the CLI prints for an unset key, verbatim.
-    expect(mergePluginsEnabled("Config key not set: plugins.enabled")).toEqual([
+    expect(mergePluginsEnabled(readPluginsEnabled("Config key not set: plugins.enabled"))).toEqual([
       HERMES_IMAGE_PLUGIN_NAME,
     ]);
-    expect(mergePluginsEnabled("")).toEqual([HERMES_IMAGE_PLUGIN_NAME]);
+    expect(mergePluginsEnabled(readPluginsEnabled(""))).toEqual([HERMES_IMAGE_PLUGIN_NAME]);
   });
 
   it("writes nothing when ours is already listed", () => {
     // Null, not the same list again: `hermes config set` rewrites config.yaml,
     // and that invalidates the mtime-keyed memo every chat open reads through.
-    expect(mergePluginsEnabled("- clawai\n")).toBeNull();
+    expect(mergePluginsEnabled(asJson([HERMES_IMAGE_PLUGIN_NAME]))).toBeNull();
+  });
+
+  it("treats a value that is not a list as something to repair", () => {
+    // The residue of a `config set` whose coercion missed: our own literal,
+    // stored as TEXT. `_get_enabled_set` reads a non-list as EMPTY, so this box
+    // is loading no plugin at all — and through the plain rendering it looked
+    // like a list that already contained us, which is why it never healed.
+    const residue = asJson(`["weather", "${HERMES_IMAGE_PLUGIN_NAME}"]`);
+    expect(residue.residue).toBe(true);
+    // The names inside it are still recoverable, so the repair keeps them.
+    expect(mergePluginsEnabled(residue)).toEqual(["weather", HERMES_IMAGE_PLUGIN_NAME]);
+  });
+
+  it("repairs a value it cannot read names out of, without inventing any", () => {
+    for (const stored of [{ clawai: true }, 7, null]) {
+      const state = asJson(stored);
+      expect(state.residue, JSON.stringify(stored)).toBe(true);
+      expect(mergePluginsEnabled(state)).toEqual([HERMES_IMAGE_PLUGIN_NAME]);
+    }
   });
 });

--- a/src/tests/unit/hermes-image-plugin.test.ts
+++ b/src/tests/unit/hermes-image-plugin.test.ts
@@ -10,7 +10,8 @@ import {
   hermesImagePluginInstalled,
   installHermesImagePlugin,
   mergePluginsEnabled,
-  readPluginsEnabled,
+  decodePluginsEnabledJson,
+  decodePluginsEnabledPlain,
 } from "@/lib/hermes-image-plugin";
 
 /**
@@ -93,7 +94,7 @@ describe("installing the ClawBox AI image backend", () => {
 
 describe("plugins.enabled", () => {
   /** What `hermes config get plugins.enabled --json` prints for a stored value. */
-  const asJson = (value: unknown) => readPluginsEnabled(JSON.stringify(value));
+  const asJson = (value: unknown) => decodePluginsEnabledJson(JSON.stringify(value));
 
   it("adds ours to a list the customer already has", () => {
     // The list gates EVERY user plugin on the box, so replacing it would
@@ -109,7 +110,7 @@ describe("plugins.enabled", () => {
     // Block and flow, both observed on the live box. Kept because a CLI old
     // enough to reject `--json` still has to be understood.
     for (const rendering of ["- weather\n- spotify\n", "['weather', \"spotify\"]"]) {
-      expect(mergePluginsEnabled(readPluginsEnabled(rendering))).toEqual([
+      expect(mergePluginsEnabled(decodePluginsEnabledPlain(rendering))).toEqual([
         "weather",
         "spotify",
         HERMES_IMAGE_PLUGIN_NAME,
@@ -119,10 +120,10 @@ describe("plugins.enabled", () => {
 
   it("starts a list when the key has never been set", () => {
     // What the CLI prints for an unset key, verbatim.
-    expect(mergePluginsEnabled(readPluginsEnabled("Config key not set: plugins.enabled"))).toEqual([
+    expect(mergePluginsEnabled(decodePluginsEnabledJson("Config key not set: plugins.enabled"))).toEqual([
       HERMES_IMAGE_PLUGIN_NAME,
     ]);
-    expect(mergePluginsEnabled(readPluginsEnabled(""))).toEqual([HERMES_IMAGE_PLUGIN_NAME]);
+    expect(mergePluginsEnabled(decodePluginsEnabledJson(""))).toEqual([HERMES_IMAGE_PLUGIN_NAME]);
   });
 
   it("writes nothing when ours is already listed", () => {
@@ -137,16 +138,32 @@ describe("plugins.enabled", () => {
     // is loading no plugin at all — and through the plain rendering it looked
     // like a list that already contained us, which is why it never healed.
     const residue = asJson(`["weather", "${HERMES_IMAGE_PLUGIN_NAME}"]`);
-    expect(residue.residue).toBe(true);
+    expect(residue.kind).toBe("residue");
     // The names inside it are still recoverable, so the repair keeps them.
     expect(mergePluginsEnabled(residue)).toEqual(["weather", HERMES_IMAGE_PLUGIN_NAME]);
   });
 
-  it("repairs a value it cannot read names out of, without inventing any", () => {
-    for (const stored of [{ clawai: true }, 7, null]) {
-      const state = asJson(stored);
-      expect(state.residue, JSON.stringify(stored)).toBe(true);
-      expect(mergePluginsEnabled(state)).toEqual([HERMES_IMAGE_PLUGIN_NAME]);
+  it("recovers a customer's names out of a residue it did not write", () => {
+    // A hand-edited mapping is a plausible YAML mistake and its KEYS are good
+    // plugin names; a bare scalar is one name. Both were loading nothing, and
+    // replacing them with `["clawai"]` would have destroyed the only record of
+    // what the owner had enabled.
+    expect(mergePluginsEnabled(asJson({ weather: true, spotify: true }))).toEqual([
+      "weather",
+      "spotify",
+      HERMES_IMAGE_PLUGIN_NAME,
+    ]);
+    expect(mergePluginsEnabled(asJson("weather"))).toEqual(["weather", HERMES_IMAGE_PLUGIN_NAME]);
+  });
+
+  it("leaves a shape it cannot read names out of alone", () => {
+    // Not repaired and not replaced: the caller refuses the feature instead,
+    // the same call `scripts/register-mcp.sh` makes on a list it cannot parse.
+    for (const stored of [7, null, true]) {
+      expect(asJson(stored).kind, JSON.stringify(stored)).toBe("residue");
+      expect(mergePluginsEnabled(asJson(stored))).toEqual([HERMES_IMAGE_PLUGIN_NAME]);
     }
+    expect(decodePluginsEnabledJson("not json at all").kind).toBe("unreadable");
+    expect(mergePluginsEnabled(decodePluginsEnabledJson("not json at all"))).toBeNull();
   });
 });

--- a/src/tests/unit/hermes-image-plugin.test.ts
+++ b/src/tests/unit/hermes-image-plugin.test.ts
@@ -119,11 +119,24 @@ describe("plugins.enabled", () => {
   });
 
   it("starts a list when the key has never been set", () => {
-    // What the CLI prints for an unset key, verbatim.
+    // What the CLI prints for an unset key, verbatim. THAT is an empty list:
+    // the CLI said what it holds, and it holds nothing.
     expect(mergePluginsEnabled(decodePluginsEnabledJson("Config key not set: plugins.enabled"))).toEqual([
       HERMES_IMAGE_PLUGIN_NAME,
     ]);
-    expect(mergePluginsEnabled(decodePluginsEnabledJson(""))).toEqual([HERMES_IMAGE_PLUGIN_NAME]);
+  });
+
+  it("does not read an exit-0 SILENCE as an empty list", () => {
+    // A command that printed NOTHING has not said the key is empty, and this
+    // decoder is the one that decides whether the value gets REPLACED: read as
+    // `[]` the merge answers `["clawai"]`, which is then written over whatever
+    // the key really held — silently unloading every plugin the customer
+    // installed, the exact outcome `enableHermesImageGeneration` says it must
+    // never cause. "Could not ask" is the only honest reading of silence, and
+    // an `unreadable` is left strictly alone.
+    expect(decodePluginsEnabledJson("").kind).toBe("unreadable");
+    expect(decodePluginsEnabledJson("   \n").kind).toBe("unreadable");
+    expect(mergePluginsEnabled(decodePluginsEnabledJson(""))).toBeNull();
   });
 
   it("writes nothing when ours is already listed", () => {

--- a/src/tests/unit/hermes-plugins-enabled-readback.test.ts
+++ b/src/tests/unit/hermes-plugins-enabled-readback.test.ts
@@ -550,12 +550,17 @@ describe("a failure that establishes nothing takes nothing away", () => {
     expect(unsets()).not.toContain("image_gen.provider");
   });
 
-  it("believes hermes over the list when the plugin is explicitly disabled", async () => {
-    // `plugins.disabled` is a deny-list that wins over `plugins.enabled`
-    // (`_plugin_status`, hermes_cli/plugins_cmd.py:1930-1936). The allow-list
-    // here is a perfectly good list naming us, so every type check ClawBox
-    // could make on it says "loadable" — and Hermes still loads nothing. This
-    // is why the proof is Hermes' own answer rather than our reading of a key.
+  /**
+   * A box whose `plugins.enabled` holds `stored` and whose `plugins.disabled`
+   * names our plugin, so Hermes' own listing reports it `disabled`.
+   *
+   * `plugins.disabled` is a deny-list that WINS over `plugins.enabled`
+   * (`_plugin_status`, hermes_cli/plugins_cmd.py:1930-1936), so every type check
+   * ClawBox could make on the allow-list says "loadable" and Hermes still loads
+   * nothing. That is why the proof is Hermes' own answer rather than our reading
+   * of a key — and why it has to be asked on BOTH paths below.
+   */
+  function boxWithUsDenied(stored: string[]): void {
     boxThatDraws(async (args) => {
       if (isPluginsListing(args)) {
         return {
@@ -568,8 +573,75 @@ describe("a failure that establishes nothing takes nothing away", () => {
       }
       if (args[1] === "get" && args[2] === "plugins.enabled") {
         return args.includes("--json")
-          ? { code: 0, stdout: JSON.stringify(["weather"]), stderr: "" }
-          : { code: 0, stdout: "- weather\n", stderr: "" };
+          ? { code: 0, stdout: JSON.stringify(stored), stderr: "" }
+          : { code: 0, stdout: stored.map((v) => `- ${v}`).join("\n") + "\n", stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+  }
+
+  it("believes hermes over the list when the plugin is explicitly disabled", async () => {
+    // The allow-list does not name us yet, so a WRITE is needed and the listing
+    // is consulted on the way out of it.
+    boxWithUsDenied(["weather"]);
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(claimedItCanDraw()).toBe(false);
+    expect(unsets()).toContain("image_gen.provider");
+  });
+
+  it("believes hermes over the list on a box that needs no write at all", async () => {
+    // THE FIELD STATE, and the one this whole round exists for: a healthy
+    // linked box already names us in a real list, so `mergePluginsEnabled`
+    // answers null and there is nothing to write. That must not be read as
+    // "loadable" — nothing has been asked yet. The deny-list is the case where
+    // the difference is visible: with no write there is no `writePluginsEnabled`
+    // to consult the listing, and the claim would be made over a plugin Hermes
+    // refuses to load, which is TASK-701's exact symptom.
+    boxWithUsDenied([HERMES_IMAGE_PLUGIN_NAME, "clawbox_email_directives"]);
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(wrotePluginsEnabled(), "the list already names us: nothing to write").toBe(false);
+    expect(claimedItCanDraw()).toBe(false);
+    expect(unsets()).toContain("image_gen.provider");
+  });
+
+  it("asks hermes on the no-write path even when the answer is yes", async () => {
+    // The counterweight: the same no-write path on a box where the plugin IS
+    // enabled must still reach `image_gen.provider`. A guard that answered
+    // "unproved" for every healthy box would take image generation away from
+    // the whole fleet.
+    boxThatDraws(async (args) => {
+      if (isPluginsListing(args)) return pluginsListing([HERMES_IMAGE_PLUGIN_NAME]);
+      if (args[1] === "get" && args[2] === "plugins.enabled") {
+        return args.includes("--json")
+          ? { code: 0, stdout: JSON.stringify([HERMES_IMAGE_PLUGIN_NAME]), stderr: "" }
+          : { code: 0, stdout: `- ${HERMES_IMAGE_PLUGIN_NAME}\n`, stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(wrotePluginsEnabled()).toBe(false);
+    expect(claimedItCanDraw()).toBe(true);
+    expect(unsets()).not.toContain("image_gen.provider");
+  });
+
+  it("keeps drawing on the no-write path when hermes cannot be asked", async () => {
+    // 127: the `hermes` shim while `step_hermes_install` rebuilds the venv under
+    // it. Nothing was established, so the claim standing on disk is neither
+    // re-made nor taken away — the same rule the write path follows.
+    boxThatDraws(async (args) => {
+      if (isPluginsListing(args)) {
+        return { code: 127, stdout: "", stderr: "hermes: command not found" };
+      }
+      if (args[1] === "get" && args[2] === "plugins.enabled") {
+        return args.includes("--json")
+          ? { code: 0, stdout: JSON.stringify([HERMES_IMAGE_PLUGIN_NAME]), stderr: "" }
+          : { code: 0, stdout: `- ${HERMES_IMAGE_PLUGIN_NAME}\n`, stderr: "" };
       }
       return { code: 0, stdout: "", stderr: "" };
     });
@@ -577,7 +649,55 @@ describe("a failure that establishes nothing takes nothing away", () => {
     await applyClawaiToHermes("claw_token_abc", "flash");
 
     expect(claimedItCanDraw()).toBe(false);
-    expect(unsets()).toContain("image_gen.provider");
+    expect(unsets()).not.toContain("image_gen.provider");
+  });
+
+  it("does not overwrite the customer's plugins over a silent plain read", async () => {
+    // The `--json`-less build, where nothing can prove the type and the write
+    // is therefore made unproved: a `config get` that exits 0 and prints
+    // NOTHING must not be read as an empty list, or the merge writes
+    // `["clawai"]` over whatever the key holds and unloads every plugin the
+    // customer installed.
+    boxThatDraws(async (args) => {
+      if (args[1] === "get" && args[2] === "plugins.enabled") {
+        return args.includes("--json")
+          ? { code: 2, stdout: "", stderr: "Error: no such option: --json" }
+          : { code: 0, stdout: "", stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(wrotePluginsEnabled()).toBe(false);
+    expect(unsets()).not.toContain("image_gen.provider");
+  });
+
+  it("still links a FIRST box whose hermes has no `plugins list --json`", async () => {
+    // The feature now rests on one subcommand flag, and a build that lacks it
+    // could be asked nothing — so a box being linked for the FIRST time would
+    // silently never gain image generation, where beta gave it unconditionally.
+    // A flag that does not exist is a PERMANENT property of the build, not a
+    // moment, and it is the same exemption `config get --json` already gets:
+    // where no machine-readable question can be put, the box keeps the feature
+    // it would have had. (A box linked before keeps its claim either way —
+    // nothing here withdraws.)
+    cliMock.mockImplementation(async (args: string[]) => {
+      if (isPluginsListing(args)) {
+        return { code: 2, stdout: "", stderr: "Error: no such option: --json" };
+      }
+      if (args[1] === "get" && args[2] === "plugins.enabled") {
+        return args.includes("--json")
+          ? { code: 0, stdout: JSON.stringify([HERMES_IMAGE_PLUGIN_NAME]), stderr: "" }
+          : { code: 0, stdout: `- ${HERMES_IMAGE_PLUGIN_NAME}\n`, stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(claimedItCanDraw()).toBe(true);
+    expect(unsets()).not.toContain("image_gen.provider");
   });
 
   it("still withdraws on the one answer that establishes the plugin cannot load", async () => {

--- a/src/tests/unit/hermes-plugins-enabled-readback.test.ts
+++ b/src/tests/unit/hermes-plugins-enabled-readback.test.ts
@@ -298,11 +298,11 @@ describe("the proof does not accept the ambiguous rendering", () => {
     expect(claimedItCanDraw()).toBe(false);
   });
 
-  it("does not punish a read-back the CLI never answered", async () => {
+  it("makes no claim on a read-back the CLI never answered, and withdraws the old one", async () => {
     // 127 is the shell's code for the `hermes` shim while the venv under it is
-    // being rebuilt: nothing was parsed, and the write above still exited 0
-    // with no coercion warning. Abandoning the feature for the whole link over
-    // that is the false-failure shape.
+    // being rebuilt: nothing was parsed, and the write above still exited 0. So
+    // this is not worth failing the link over — but it is not proof either, and
+    // a box linked once before is still holding the claim from that link.
     let written = false;
     cliMock.mockImplementation(async (args: string[]) => {
       if (args[1] === "set" && args[2] === "plugins.enabled") {
@@ -313,12 +313,59 @@ describe("the proof does not accept the ambiguous rendering", () => {
         if (!written) return { code: 1, stdout: "", stderr: "Config key not set: plugins.enabled" };
         return { code: 127, stdout: "", stderr: "hermes: command not found" };
       }
+      if (args[1] === "get" && args[2] === "image_gen.provider") {
+        return { code: 0, stdout: `${HERMES_IMAGE_PLUGIN_NAME}\n`, stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    const result = await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(result.provider).toBe("clawai"); // the link itself still succeeds
+    expect(claimedItCanDraw()).toBe(false);
+    expect(unsets()).toContain("image_gen.provider");
+  });
+
+  it("withdraws the claim when the key holds a shape it cannot read at all", async () => {
+    cliMock.mockImplementation(async (args: string[]) => {
+      if (args[1] === "get" && args[2] === "plugins.enabled") {
+        return { code: 0, stdout: "not json and not a list", stderr: "" };
+      }
+      if (args[1] === "get" && args[2] === "image_gen.provider") {
+        return { code: 0, stdout: `${HERMES_IMAGE_PLUGIN_NAME}\n`, stderr: "" };
+      }
       return { code: 0, stdout: "", stderr: "" };
     });
 
     await applyClawaiToHermes("claw_token_abc", "flash");
 
-    expect(claimedItCanDraw()).toBe(true);
-    expect(unsets()).not.toContain("image_gen.provider");
+    expect(wrotePluginsEnabled()).toBe(false); // left alone, not replaced
+    expect(claimedItCanDraw()).toBe(false);
+    expect(unsets()).toContain("image_gen.provider");
+  });
+});
+
+describe("the plain fallback is for one answer only", () => {
+  it("does not downgrade to the ambiguous rendering on a transient typed-read failure", async () => {
+    // A held config lock is not "this build has no --json". Falling back there
+    // would read the residue `["clawai"]` out of the plain rendering as a real
+    // list, conclude there is nothing to do, and go on to claim the box can
+    // draw — the exact defect this file exists to remove.
+    cliMock.mockImplementation(async (args: string[]) => {
+      if (args[1] === "get" && args[2] === "plugins.enabled") {
+        return args.includes("--json")
+          ? { code: 1, stdout: "", stderr: "could not acquire config lock" }
+          : { code: 0, stdout: `["${HERMES_IMAGE_PLUGIN_NAME}"]`, stderr: "" };
+      }
+      if (args[1] === "get" && args[2] === "image_gen.provider") {
+        return { code: 0, stdout: `${HERMES_IMAGE_PLUGIN_NAME}\n`, stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(claimedItCanDraw()).toBe(false);
+    expect(unsets()).toContain("image_gen.provider");
   });
 });

--- a/src/tests/unit/hermes-plugins-enabled-readback.test.ts
+++ b/src/tests/unit/hermes-plugins-enabled-readback.test.ts
@@ -90,6 +90,38 @@ const STORING_AS_STRING =
 
 interface Reply { code: number; stdout: string; stderr: string }
 
+/**
+ * What `hermes plugins list --json` prints, derived the way Hermes derives it.
+ *
+ * `_plugin_status` reads `_get_enabled_set()`, which is
+ * `set(enabled) if isinstance(enabled, list) else set()`
+ * (hermes_cli/plugins_cmd.py:1309-1324, read on the pinned 0.20.5 build) — so
+ * a value that is not a LIST reports "not enabled" however it is spelled, and
+ * that is the whole reason this listing is the proof rather than a type check
+ * of our own.
+ */
+function pluginsListing(stored: unknown): Reply {
+  const enabled = Array.isArray(stored) && stored.includes(HERMES_IMAGE_PLUGIN_NAME);
+  return {
+    code: 0,
+    stdout: JSON.stringify([
+      {
+        name: HERMES_IMAGE_PLUGIN_NAME,
+        status: enabled ? "enabled" : "not enabled",
+        version: "1.0.0",
+        description: "ClawBox AI image generation backend.",
+        source: "user",
+      },
+    ]),
+    stderr: "",
+  };
+}
+
+/** Is this argv the plugin listing? */
+function isPluginsListing(args: string[]): boolean {
+  return args[0] === "plugins" && args[1] === "list";
+}
+
 /** `hermes config get <key>` with no flag: a YAML block list, or raw text. */
 function renderPlain(value: unknown): string {
   return Array.isArray(value) ? value.map((v) => `- ${v}`).join("\n") + "\n" : String(value);
@@ -111,6 +143,7 @@ function box(opts: { value: unknown; onSet?: Reply }): void {
   // exercises the mismatch branch — the tests would pass for the wrong reason.
   let stored = opts.value;
   cliMock.mockImplementation(async (args: string[]) => {
+    if (isPluginsListing(args)) return pluginsListing(stored);
     if (args[1] === "get" && args[2] === "plugins.enabled") {
       if (stored === undefined) {
         return { code: 1, stdout: "", stderr: "Config key not set: plugins.enabled" };
@@ -181,13 +214,16 @@ describe("plugins.enabled is written on a read-back, not on an exit code", () =>
     // read-back is the only witness. It answers with the string it stored.
     let written = false;
     cliMock.mockImplementation(async (args: string[]) => {
+      const residue = `["${HERMES_IMAGE_PLUGIN_NAME}"]`;
+      // A STRING, so `_get_enabled_set` answers empty and Hermes reports the
+      // plugin as not enabled — however that string is spelled.
+      if (isPluginsListing(args)) return pluginsListing(written ? residue : undefined);
       if (args[1] === "set" && args[2] === "plugins.enabled") {
         written = true;
         return { code: 0, stdout: "", stderr: "" };
       }
       if (args[1] === "get" && args[2] === "plugins.enabled") {
         if (!written) return { code: 1, stdout: "", stderr: "Config key not set: plugins.enabled" };
-        const residue = `["${HERMES_IMAGE_PLUGIN_NAME}"]`;
         return args.includes("--json")
           ? { code: 0, stdout: JSON.stringify(residue), stderr: "" }
           : { code: 0, stdout: residue, stderr: "" };
@@ -223,6 +259,20 @@ describe("plugins.enabled is written on a read-back, not on an exit code", () =>
     // Nothing to report: assert on the recorded arguments, not on a matcher
     // pair that could never line up with a one-argument console.warn.
     expect(warn.mock.calls.flat().join(" ")).not.toContain("plugins.enabled");
+  });
+
+  it("says what it discarded when a residue names no plugin, and says it once", async () => {
+    // The one place "merged, never replaced" gives way. It is announced at the
+    // moment of the decision — not from inside the decoder, which also runs as
+    // the prover, where nothing is replaced and the same line would report an
+    // overwrite that never happened.
+    box({ value: 7 });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    const journal = warn.mock.calls.flat().join("\n");
+    expect(journal).toContain("names no plugin");
+    expect(journal.match(/names no plugin/g)).toHaveLength(1);
   });
 
   it("keeps the customer's plugins when it adds itself", async () => {
@@ -288,6 +338,11 @@ describe("a hermes whose config get does not take --json", () => {
     // that question has said nothing about whether the value is residue, so
     // withdrawing the feature would be a false failure — these boxes draw today.
     cliMock.mockImplementation(async (args: string[]) => {
+      // A build old enough to lack `--json` on `config get` lacks it on
+      // `plugins list` too, so NEITHER question can be put here.
+      if (isPluginsListing(args)) {
+        return { code: 2, stdout: "", stderr: "usage: hermes plugins list\nunrecognized arguments: --json" };
+      }
       if (args[1] === "get" && args[2] === "plugins.enabled") {
         return args.includes("--json")
           ? { code: 2, stdout: "", stderr: "usage: hermes config get\nunrecognized arguments: --json" }
@@ -307,10 +362,11 @@ describe("a hermes whose config get does not take --json", () => {
 });
 
 describe("the proof does not accept the ambiguous rendering", () => {
-  it("refuses a read-back that is not JSON, even though it spells the right list", async () => {
+  it("refuses a `--json` answer that is not JSON, even though it spells the right list", async () => {
     // A build that takes `--json` but does not honour it in the formatter, or
-    // anything that re-renders on the way back. `- clawai` through a lenient
-    // text parse would have proved nothing and been called landed.
+    // anything that re-renders on the way out. `- clawai` through a lenient
+    // text parse would have looked like a list already holding us and left the
+    // residue in place.
     cliMock.mockImplementation(async (args: string[]) => {
       if (args[1] === "get" && args[2] === "plugins.enabled") {
         return args.includes("--json")
@@ -325,22 +381,17 @@ describe("the proof does not accept the ambiguous rendering", () => {
     expect(claimedItCanDraw()).toBe(false);
   });
 
-  it("makes no claim on a read-back the CLI never answered, and leaves the old one standing", async () => {
+  it("makes no claim when the CLI never answered, and leaves the old one standing", async () => {
     // 127 is the shell's code for the `hermes` shim while the venv under it is
     // being rebuilt: nothing was parsed, and the write above still exited 0.
     // NOTHING WAS ESTABLISHED, so nothing is withdrawn either: unsetting
     // `image_gen.provider` here would take drawing away from a box that has it,
     // and no code path on the device puts it back — this function has no
     // periodic caller and is the only writer of that key.
-    let written = false;
     cliMock.mockImplementation(async (args: string[]) => {
-      if (args[1] === "set" && args[2] === "plugins.enabled") {
-        written = true;
-        return { code: 0, stdout: "", stderr: "" };
-      }
+      if (isPluginsListing(args)) return { code: 127, stdout: "", stderr: "hermes: command not found" };
       if (args[1] === "get" && args[2] === "plugins.enabled") {
-        if (!written) return { code: 1, stdout: "", stderr: "Config key not set: plugins.enabled" };
-        return { code: 127, stdout: "", stderr: "hermes: command not found" };
+        return { code: 1, stdout: "", stderr: "Config key not set: plugins.enabled" };
       }
       if (args[1] === "get" && args[2] === "image_gen.provider") {
         return { code: 0, stdout: `${HERMES_IMAGE_PLUGIN_NAME}\n`, stderr: "" };
@@ -481,20 +532,72 @@ describe("a failure that establishes nothing takes nothing away", () => {
     expect(unsets()).not.toContain("image_gen.provider");
   });
 
+  it("keeps drawing when hermes' own listing says nothing at all", async () => {
+    // Exit 0 and an empty stdout from `plugins list --json`. A command that
+    // printed nothing has not reported that a plugin is absent, and reading it
+    // as one would take a working box's claim away over silence.
+    boxThatDraws(async (args) => {
+      if (isPluginsListing(args)) return { code: 0, stdout: "", stderr: "" };
+      if (args[1] === "get" && args[2] === "plugins.enabled") {
+        return { code: 1, stdout: "", stderr: "Config key not set: plugins.enabled" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(claimedItCanDraw()).toBe(false);
+    expect(unsets()).not.toContain("image_gen.provider");
+  });
+
+  it("believes hermes over the list when the plugin is explicitly disabled", async () => {
+    // `plugins.disabled` is a deny-list that wins over `plugins.enabled`
+    // (`_plugin_status`, hermes_cli/plugins_cmd.py:1930-1936). The allow-list
+    // here is a perfectly good list naming us, so every type check ClawBox
+    // could make on it says "loadable" — and Hermes still loads nothing. This
+    // is why the proof is Hermes' own answer rather than our reading of a key.
+    boxThatDraws(async (args) => {
+      if (isPluginsListing(args)) {
+        return {
+          code: 0,
+          stdout: JSON.stringify([
+            { name: HERMES_IMAGE_PLUGIN_NAME, status: "disabled", version: "1.0.0", description: "", source: "user" },
+          ]),
+          stderr: "",
+        };
+      }
+      if (args[1] === "get" && args[2] === "plugins.enabled") {
+        return args.includes("--json")
+          ? { code: 0, stdout: JSON.stringify(["weather"]), stderr: "" }
+          : { code: 0, stdout: "- weather\n", stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(claimedItCanDraw()).toBe(false);
+    expect(unsets()).toContain("image_gen.provider");
+  });
+
   it("still withdraws on the one answer that establishes the plugin cannot load", async () => {
     // The counterweight, kept in the same block as the cases above so the rule
     // reads as one: a read-back that ANSWERED and did not spell the list is
     // proof, and proof still takes the claim away.
     let written = false;
     boxThatDraws(async (args) => {
+      // The write landed AS TEXT with a clean stderr — an older CLI stores the
+      // literal silently — so Hermes' own listing is the only witness, and it
+      // reports the plugin not enabled because a string is not a list.
+      if (isPluginsListing(args)) {
+        return pluginsListing(written ? `["${HERMES_IMAGE_PLUGIN_NAME}"]` : undefined);
+      }
       if (args[1] === "set" && args[2] === "plugins.enabled") {
         written = true;
         return { code: 0, stdout: "", stderr: "" };
       }
       if (args[1] === "get" && args[2] === "plugins.enabled") {
-        if (!written) return { code: 1, stdout: "", stderr: "Config key not set: plugins.enabled" };
-        // The literal, stored as text: JSON of a STRING, not of a list.
-        return { code: 0, stdout: JSON.stringify(`["${HERMES_IMAGE_PLUGIN_NAME}"]`), stderr: "" };
+        return { code: 1, stdout: "", stderr: "Config key not set: plugins.enabled" };
       }
       return { code: 0, stdout: "", stderr: "" };
     });

--- a/src/tests/unit/hermes-plugins-enabled-readback.test.ts
+++ b/src/tests/unit/hermes-plugins-enabled-readback.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * TASK-701 — `plugins.enabled` was written on an exit code and read back never.
+ *
+ * `hermes config set k '["a"]'` exits 0 whether or not its coercion yielded a
+ * list. When it does not, it prints "…storing as string." to stderr and stores
+ * the LITERAL TEXT (hermes_cli/config.py:5514-5527, read on the pinned 0.20.5
+ * build). What that costs here is not one plugin:
+ *
+ *     _get_enabled_set()  ->  set(enabled) if isinstance(enabled, list) else set()
+ *     (hermes_cli/plugins_cmd.py:1309-1324)
+ *
+ * A string is not a list, so the allow-list reads EMPTY and Hermes loads NO
+ * user plugin at all — the customer's included. And the box could not heal
+ * itself, because ClawBox read the key back through a YAML-text parser that
+ * decodes the residue `["clawai"]` as a real one-element list: the merge then
+ * answered "already there, nothing to do" for a key that was disabling
+ * everything. Meanwhile `image_gen.provider` was written regardless, so
+ * `/setup-api/chat/capabilities` reported a box that can draw through a plugin
+ * Hermes never loaded.
+ *
+ * Harness-first note for the reader: Hermes owns `hermes plugins enable <name>`,
+ * which does this read-modify-write itself and cannot store a string. It is not
+ * used here — see the PR body — because `_resolve_plugin_key("clawai")` answers
+ * `image_gen/clawai` on the pinned build, a different string from the one the
+ * loader already accepts on every field box, and swapping them is a link-path
+ * change that wants a device test rather than a unit one.
+ */
+
+const cliMock = vi.hoisted(() => vi.fn());
+const envMock = vi.hoisted(() => vi.fn());
+const installMock = vi.hoisted(() => vi.fn());
+const drawsMock = vi.hoisted(() => vi.fn());
+const refreshMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
+vi.mock("@/lib/harness/hermes-features", () => ({ hermesAgentDrawsImages: drawsMock }));
+vi.mock("@/lib/hermes-image-refresh", () => ({ refreshHermesImageTools: refreshMock }));
+vi.mock("@/lib/coding-agent", () => ({ getCodingAgentStatus: vi.fn(async () => ({ ready: false })) }));
+vi.mock("@/lib/coding-agent-mcp-refresh", () => ({
+  refreshCodingAgentToolsIfReadinessChanged: vi.fn(),
+}));
+vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
+vi.mock("@/lib/config-store", () => ({ setMany: vi.fn() }));
+vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: envMock }));
+vi.mock("@/lib/hermes-image-plugin", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/hermes-image-plugin")>()),
+  installHermesImagePlugin: installMock,
+}));
+
+import { applyClawaiToHermes } from "@/lib/hermes-clawai";
+import { HERMES_IMAGE_PLUGIN_NAME } from "@/lib/hermes-image-plugin";
+
+/** Every `config set`, as "key=value", in the order they were issued. */
+function sets(): string[] {
+  return cliMock.mock.calls
+    .map((c) => c[0] as string[])
+    .filter((a) => a[1] === "set")
+    .map((a) => `${a[2]}=${a[3]}`);
+}
+
+function wrotePluginsEnabled(): boolean {
+  return sets().some((s) => s.startsWith("plugins.enabled="));
+}
+
+function claimedItCanDraw(): boolean {
+  return sets().some((s) => s.startsWith("image_gen.provider="));
+}
+
+/** The CLI's own warning when a JSON literal did not coerce to a structure. */
+const STORING_AS_STRING =
+  "Warning: value for 'plugins.enabled' looks like a list/mapping but parsed as str; storing as string.";
+
+interface Reply { code: number; stdout: string; stderr: string }
+
+/** `hermes config get <key>` with no flag: a YAML block list, or raw text. */
+function renderPlain(value: unknown): string {
+  return Array.isArray(value) ? value.map((v) => `- ${v}`).join("\n") + "\n" : String(value);
+}
+
+/**
+ * A box whose `plugins.enabled` HOLDS `value`, rendered the way the CLI renders
+ * it: `--json` prints `json.dumps(value)` (hermes_cli/config.py:5769), a plain
+ * get prints YAML. That difference is the whole subject of this file — a stored
+ * STRING and a stored LIST are the same characters in the plain rendering — so
+ * the stub has to reproduce it rather than answer one shape to both.
+ *
+ * `value: undefined` is an unset key, which the CLI reports as a non-zero exit.
+ */
+function box(opts: { value: unknown; onSet?: Reply }): void {
+  cliMock.mockImplementation(async (args: string[]) => {
+    if (args[1] === "get" && args[2] === "plugins.enabled") {
+      if (opts.value === undefined) {
+        return { code: 1, stdout: "", stderr: "Config key not set: plugins.enabled" };
+      }
+      return args.includes("--json")
+        ? { code: 0, stdout: JSON.stringify(opts.value), stderr: "" }
+        : { code: 0, stdout: renderPlain(opts.value), stderr: "" };
+    }
+    if (args[1] === "set" && args[2] === "plugins.enabled") {
+      return opts.onSet ?? { code: 0, stdout: "", stderr: "" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+}
+
+let warn: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  cliMock.mockReset();
+  envMock.mockReset();
+  installMock.mockReset();
+  drawsMock.mockReset();
+  refreshMock.mockReset();
+  cliMock.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+  drawsMock.mockResolvedValueOnce(false).mockResolvedValue(true);
+  warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+describe("plugins.enabled is written on a read-back, not on an exit code", () => {
+  it("repairs a key whose previous write was stored as text", async () => {
+    // The residue of an earlier `config set`: a STRING that happens to spell a
+    // list. Hermes loads nothing at all from it. Read through YAML this looks
+    // like a one-element list already containing us, which is why the box could
+    // never heal itself.
+    box({ value: `["${HERMES_IMAGE_PLUGIN_NAME}"]` });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(wrotePluginsEnabled(), "a string residue must be rewritten as a list").toBe(true);
+  });
+
+  it("does not claim the agent can draw when the CLI stored the list as text", async () => {
+    box({ value: undefined, onSet: { code: 0, stdout: "", stderr: STORING_AS_STRING } });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    // The write exited 0. Nothing else about it was true.
+    expect(claimedItCanDraw()).toBe(false);
+  });
+
+  it("does not claim the agent can draw when the key reads back as something else", async () => {
+    // No warning on stderr — an older CLI stores the literal silently — so the
+    // read-back is the only witness. It answers with the string it stored.
+    let written = false;
+    cliMock.mockImplementation(async (args: string[]) => {
+      if (args[1] === "set" && args[2] === "plugins.enabled") {
+        written = true;
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (args[1] === "get" && args[2] === "plugins.enabled") {
+        if (!written) return { code: 1, stdout: "", stderr: "Config key not set: plugins.enabled" };
+        const residue = `["${HERMES_IMAGE_PLUGIN_NAME}"]`;
+        return args.includes("--json")
+          ? { code: 0, stdout: JSON.stringify(residue), stderr: "" }
+          : { code: 0, stdout: residue, stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(claimedItCanDraw()).toBe(false);
+  });
+
+  it("asks for the machine-readable rendering, so a string is not read as a list", async () => {
+    box({ value: [HERMES_IMAGE_PLUGIN_NAME] });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    const reads = cliMock.mock.calls
+      .map((c) => c[0] as string[])
+      .filter((a) => a[1] === "get" && a[2] === "plugins.enabled");
+    expect(reads.length).toBeGreaterThan(0);
+    for (const args of reads) expect(args).toContain("--json");
+  });
+
+  it("still links, and still draws, on a box where the key lands as a list", async () => {
+    box({ value: ["weather", HERMES_IMAGE_PLUGIN_NAME] });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    // Already listed as a real list: nothing to write, and the backend is named.
+    expect(wrotePluginsEnabled()).toBe(false);
+    expect(claimedItCanDraw()).toBe(true);
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("plugins.enabled"),
+      expect.anything(),
+    );
+  });
+
+  it("keeps the customer's plugins when it adds itself", async () => {
+    box({ value: ["weather", "spotify"] });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(sets()).toContain(
+      `plugins.enabled=${JSON.stringify(["weather", "spotify", HERMES_IMAGE_PLUGIN_NAME])}`,
+    );
+  });
+});

--- a/src/tests/unit/hermes-plugins-enabled-readback.test.ts
+++ b/src/tests/unit/hermes-plugins-enabled-readback.test.ts
@@ -117,9 +117,16 @@ function pluginsListing(stored: unknown): Reply {
   };
 }
 
-/** Is this argv the plugin listing? */
+/**
+ * Is this argv the plugin listing — asked MACHINE-READABLY?
+ *
+ * `--json` is asserted rather than ignored: without it the real CLI prints a
+ * rich table, which `hermesReportsPluginEnabled` reads as `cannot-ask`. A stub
+ * that answered JSON to both would keep every test in this file green while the
+ * flag was dropped from the call.
+ */
 function isPluginsListing(args: string[]): boolean {
-  return args[0] === "plugins" && args[1] === "list";
+  return args[0] === "plugins" && args[1] === "list" && args.includes("--json");
 }
 
 /** `hermes config get <key>` with no flag: a YAML block list, or raw text. */
@@ -144,6 +151,12 @@ function box(opts: { value: unknown; onSet?: Reply }): void {
   let stored = opts.value;
   cliMock.mockImplementation(async (args: string[]) => {
     if (isPluginsListing(args)) return pluginsListing(stored);
+    // No deny-list on this box, reported the way the CLI reports an unset key.
+    // Not an exit-0 silence: that is "the command said nothing", which no
+    // reader here may take for "nothing is denied".
+    if (args[1] === "get" && args[2] === "plugins.disabled") {
+      return { code: 1, stdout: "", stderr: "Config key not set: plugins.disabled" };
+    }
     if (args[1] === "get" && args[2] === "plugins.enabled") {
       if (stored === undefined) {
         return { code: 1, stdout: "", stderr: "Config key not set: plugins.enabled" };
@@ -608,6 +621,43 @@ describe("a failure that establishes nothing takes nothing away", () => {
     expect(unsets()).toContain("image_gen.provider");
   });
 
+  it("does not rewrite image_gen.model when it makes no claim", async () => {
+    // `image_gen.model` is the GLOBAL key, read by whichever backend is
+    // SELECTED; our own plugin reads `image_gen.clawai.model`. Written with the
+    // describing keys it was replaced on every AI-Models save — including here,
+    // where the listing answered nothing, no claim is made and the box keeps
+    // whatever provider it had. A customer on another backend lost their model
+    // to a link that concluded it could not turn ours on. It belongs with
+    // `image_gen.provider`: ours to name only when we become the backend.
+    boxThatDraws(async (args) => {
+      if (isPluginsListing(args)) return { code: 0, stdout: "", stderr: "" };
+      if (args[1] === "get" && args[2] === "plugins.enabled") {
+        return { code: 0, stdout: JSON.stringify([HERMES_IMAGE_PLUGIN_NAME]), stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(claimedItCanDraw()).toBe(false);
+    expect(unsets()).not.toContain("image_gen.provider");
+    expect(sets().some((v) => v.startsWith("image_gen.model="))).toBe(false);
+    // Our OWN backend is still described — that is ours either way, and it is
+    // what a re-link exists to repair when the proxy address moves.
+    expect(sets().some((v) => v.startsWith(`image_gen.${HERMES_IMAGE_PLUGIN_NAME}.base_url=`))).toBe(true);
+  });
+
+  it("writes image_gen.model when it does claim the backend", async () => {
+    // The counterweight: once we ARE the provider that key is ours to name, and
+    // a provider set without its model would point at whatever came before.
+    box({ value: [HERMES_IMAGE_PLUGIN_NAME] });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(claimedItCanDraw()).toBe(true);
+    expect(sets().some((s) => s.startsWith("image_gen.model="))).toBe(true);
+  });
+
   it("asks hermes on the no-write path even when the answer is yes", async () => {
     // The counterweight: the same no-write path on a box where the plugin IS
     // enabled must still reach `image_gen.provider`. A guard that answered
@@ -674,30 +724,117 @@ describe("a failure that establishes nothing takes nothing away", () => {
   });
 
   it("still links a FIRST box whose hermes has no `plugins list --json`", async () => {
-    // The feature now rests on one subcommand flag, and a build that lacks it
-    // could be asked nothing — so a box being linked for the FIRST time would
-    // silently never gain image generation, where beta gave it unconditionally.
-    // A flag that does not exist is a PERMANENT property of the build, not a
-    // moment, and it is the same exemption `config get --json` already gets:
-    // where no machine-readable question can be put, the box keeps the feature
-    // it would have had. (A box linked before keeps its claim either way —
-    // nothing here withdraws.)
+    // A build that answers `config get --json` but not `plugins list --json`.
+    // The key is UNSET — a genuine first link — so a write happens and the
+    // prover runs; without a fallback the listing answers nothing, the write
+    // path returns `!typed` = false, and the box silently never gains image
+    // generation, where beta gave it unconditionally.
+    //
+    // The proof it CAN still give is the typed read-back of the two keys
+    // Hermes gates on. `box()` is stateful, so after the write those answer
+    // the list just written and an unset deny-list.
+    box({ value: undefined });
+    const stored = cliMock.getMockImplementation()!;
     cliMock.mockImplementation(async (args: string[]) => {
       if (isPluginsListing(args)) {
         return { code: 2, stdout: "", stderr: "Error: no such option: --json" };
       }
-      if (args[1] === "get" && args[2] === "plugins.enabled") {
-        return args.includes("--json")
-          ? { code: 0, stdout: JSON.stringify([HERMES_IMAGE_PLUGIN_NAME]), stderr: "" }
-          : { code: 0, stdout: `- ${HERMES_IMAGE_PLUGIN_NAME}\n`, stderr: "" };
-      }
-      return { code: 0, stdout: "", stderr: "" };
+      return stored(args);
     });
 
     await applyClawaiToHermes("claw_token_abc", "flash");
 
+    expect(wrotePluginsEnabled(), "an unset key must be written").toBe(true);
     expect(claimedItCanDraw()).toBe(true);
     expect(unsets()).not.toContain("image_gen.provider");
+  });
+
+  it("does not arm a build with no listing when the write landed as TEXT", async () => {
+    // The other half of the same exemption, and the reason it cannot be an
+    // unconditional yes: this build can still be asked the typed questions, and
+    // a `plugins.enabled` that reads back as a STRING is Hermes loading no user
+    // plugin at all. Arming on an exit code here would re-open TASK-701's own
+    // symptom for one build class.
+    box({
+      value: undefined,
+      onSet: { code: 0, stdout: "", stderr: STORING_AS_STRING },
+    });
+    const stored = cliMock.getMockImplementation()!;
+    cliMock.mockImplementation(async (args: string[]) => {
+      if (isPluginsListing(args)) {
+        return { code: 2, stdout: "", stderr: "Error: no such option: --json" };
+      }
+      return stored(args);
+    });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(claimedItCanDraw()).toBe(false);
+  });
+
+  it("does not arm a build with no listing while plugins.disabled names us", async () => {
+    // `plugins.disabled` is the deny-list the listing would have caught. On a
+    // build that cannot be asked for the listing it is read directly, in BOTH
+    // spellings hermes writes — `hermes plugins disable clawai` stores the
+    // resolved key `image_gen/clawai` (cmd_disable -> _resolve_plugin_key,
+    // read on the pinned 0.20.5 build).
+    for (const spelling of [HERMES_IMAGE_PLUGIN_NAME, `image_gen/${HERMES_IMAGE_PLUGIN_NAME}`]) {
+      cliMock.mockReset();
+      drawsMock.mockResolvedValueOnce(false).mockResolvedValue(true);
+      boxThatDraws(async (args) => {
+        if (isPluginsListing(args)) {
+          return { code: 2, stdout: "", stderr: "Error: no such option: --json" };
+        }
+        if (args[1] === "get" && args[2] === "plugins.enabled") {
+          return { code: 0, stdout: JSON.stringify([HERMES_IMAGE_PLUGIN_NAME]), stderr: "" };
+        }
+        if (args[1] === "get" && args[2] === "plugins.disabled") {
+          return { code: 0, stdout: JSON.stringify([spelling]), stderr: "" };
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      });
+
+      await applyClawaiToHermes("claw_token_abc", "flash");
+
+      expect(claimedItCanDraw(), `${spelling} must deny the claim`).toBe(false);
+      expect(unsets(), `${spelling} must withdraw`).toContain("image_gen.provider");
+    }
+  });
+
+  it("does not read an unfamiliar status as a NO", async () => {
+    // `not-enabled` is the one verdict that takes a working box's claim away,
+    // so it is a CLOSED list — `disabled`, `not enabled`, `not-enabled`, what
+    // `_plugin_status` can return on the pinned 0.20.5 build
+    // (hermes_cli/plugins_cmd.py:1931-1937). This file already argues that CLI
+    // wording differs on builds moved off the pin by a hand-run `hermes
+    // update`; that applies to a status string as much as to argparse's errors.
+    // A wrong "cannot ask" hides nothing. A wrong "no" unsets image generation
+    // on a box where Hermes was loading the plugin all along, on every Save,
+    // with nothing on the device to put it back.
+    for (const status of ["enabled (user)", "active", "", undefined]) {
+      cliMock.mockReset();
+      drawsMock.mockResolvedValueOnce(false).mockResolvedValue(true);
+      boxThatDraws(async (args) => {
+        if (isPluginsListing(args)) {
+          return {
+            code: 0,
+            stdout: JSON.stringify([
+              { name: HERMES_IMAGE_PLUGIN_NAME, status, version: "1.0.0", description: "", source: "user" },
+            ]),
+            stderr: "",
+          };
+        }
+        if (args[1] === "get" && args[2] === "plugins.enabled") {
+          return { code: 0, stdout: JSON.stringify([HERMES_IMAGE_PLUGIN_NAME]), stderr: "" };
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      });
+
+      await applyClawaiToHermes("claw_token_abc", "flash");
+
+      expect(unsets(), `status ${JSON.stringify(status)} must not withdraw`)
+        .not.toContain("image_gen.provider");
+    }
   });
 
   it("still withdraws on the one answer that establishes the plugin cannot load", async () => {

--- a/src/tests/unit/hermes-plugins-enabled-readback.test.ts
+++ b/src/tests/unit/hermes-plugins-enabled-readback.test.ts
@@ -33,6 +33,7 @@ const envMock = vi.hoisted(() => vi.fn());
 const installMock = vi.hoisted(() => vi.fn());
 const drawsMock = vi.hoisted(() => vi.fn());
 const refreshMock = vi.hoisted(() => vi.fn());
+const resolveVisionMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
 vi.mock("@/lib/harness/hermes-features", () => ({ hermesAgentDrawsImages: drawsMock }));
@@ -44,6 +45,12 @@ vi.mock("@/lib/coding-agent-mcp-refresh", () => ({
 vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
 vi.mock("@/lib/config-store", () => ({ setMany: vi.fn() }));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: envMock }));
+// The vision probe reaches the proxy over the network and waits seconds for it.
+// Nothing in this file is about vision; stubbing it keeps the suite hermetic.
+vi.mock("@/lib/clawbox-ai-vision", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/clawbox-ai-vision")>()),
+  resolveVisionModelId: resolveVisionMock,
+}));
 vi.mock("@/lib/hermes-image-plugin", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/hermes-image-plugin")>()),
   installHermesImagePlugin: installMock,
@@ -97,17 +104,28 @@ function renderPlain(value: unknown): string {
  * `value: undefined` is an unset key, which the CLI reports as a non-zero exit.
  */
 function box(opts: { value: unknown; onSet?: Reply }): void {
+  // STATEFUL: a `config set` changes what the next `config get` answers, unless
+  // the case says the write fails. Without that the read-back compares the
+  // written names against the PRE-write value and every success path really
+  // exercises the mismatch branch — the tests would pass for the wrong reason.
+  let stored = opts.value;
   cliMock.mockImplementation(async (args: string[]) => {
     if (args[1] === "get" && args[2] === "plugins.enabled") {
-      if (opts.value === undefined) {
+      if (stored === undefined) {
         return { code: 1, stdout: "", stderr: "Config key not set: plugins.enabled" };
       }
       return args.includes("--json")
-        ? { code: 0, stdout: JSON.stringify(opts.value), stderr: "" }
-        : { code: 0, stdout: renderPlain(opts.value), stderr: "" };
+        ? { code: 0, stdout: JSON.stringify(stored), stderr: "" }
+        : { code: 0, stdout: renderPlain(stored), stderr: "" };
     }
     if (args[1] === "set" && args[2] === "plugins.enabled") {
-      return opts.onSet ?? { code: 0, stdout: "", stderr: "" };
+      const reply = opts.onSet ?? { code: 0, stdout: "", stderr: "" };
+      // A write the case made fail leaves the old value; the CLI's own
+      // "storing as string" is a write that landed AS TEXT.
+      if (reply.code === 0) {
+        stored = /storing as string/i.test(reply.stderr) ? args[3] : JSON.parse(args[3]);
+      }
+      return reply;
     }
     return { code: 0, stdout: "", stderr: "" };
   });
@@ -123,6 +141,7 @@ beforeEach(() => {
   refreshMock.mockReset();
   cliMock.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
   drawsMock.mockResolvedValueOnce(false).mockResolvedValue(true);
+  resolveVisionMock.mockResolvedValue({ model: "", reason: "probe stubbed" });
   warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 });
 
@@ -192,10 +211,9 @@ describe("plugins.enabled is written on a read-back, not on an exit code", () =>
     // Already listed as a real list: nothing to write, and the backend is named.
     expect(wrotePluginsEnabled()).toBe(false);
     expect(claimedItCanDraw()).toBe(true);
-    expect(warn).not.toHaveBeenCalledWith(
-      expect.stringContaining("plugins.enabled"),
-      expect.anything(),
-    );
+    // Nothing to report: assert on the recorded arguments, not on a matcher
+    // pair that could never line up with a one-argument console.warn.
+    expect(warn.mock.calls.flat().join(" ")).not.toContain("plugins.enabled");
   });
 
   it("keeps the customer's plugins when it adds itself", async () => {

--- a/src/tests/unit/hermes-plugins-enabled-readback.test.ts
+++ b/src/tests/unit/hermes-plugins-enabled-readback.test.ts
@@ -816,6 +816,42 @@ describe("a failure that establishes nothing takes nothing away", () => {
     }
   });
 
+  it("keeps drawing when plugins.disabled holds a residue hermes ignores", async () => {
+    // The mirror of the case above, in the direction that costs a customer
+    // their pictures. `_get_disabled_set()` gates on the SAME type as the
+    // allow-list — `set(disabled) if isinstance(disabled, list) else set()`
+    // (hermes_cli/plugins_cmd.py:1257-1269, read on the pinned 0.20.5 build) —
+    // so a deny-list stored as a STRING denies nothing and Hermes loads the
+    // plugin. Reading the names recovered out of that residue as a real denial
+    // would withdraw `image_gen.provider` from a box that is drawing today, on
+    // every Save, with nothing on the device to put it back: the false failure
+    // this block forbids, arriving through a misread ANSWER rather than a
+    // failed question.
+    for (const residue of [`["${HERMES_IMAGE_PLUGIN_NAME}"]`, HERMES_IMAGE_PLUGIN_NAME]) {
+      cliMock.mockReset();
+      drawsMock.mockResolvedValueOnce(false).mockResolvedValue(true);
+      boxThatDraws(async (args) => {
+        if (isPluginsListing(args)) {
+          return { code: 2, stdout: "", stderr: "Error: no such option: --json" };
+        }
+        if (args[1] === "get" && args[2] === "plugins.enabled") {
+          return { code: 0, stdout: JSON.stringify([HERMES_IMAGE_PLUGIN_NAME]), stderr: "" };
+        }
+        if (args[1] === "get" && args[2] === "plugins.disabled") {
+          // A `hermes config set plugins.disabled '["clawai"]'` whose coercion
+          // missed, or `disabled: clawai` hand-edited into config.yaml.
+          return { code: 0, stdout: JSON.stringify(residue), stderr: "" };
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      });
+
+      await applyClawaiToHermes("claw_token_abc", "flash");
+
+      expect(unsets(), `${residue} must not withdraw`).not.toContain("image_gen.provider");
+      expect(claimedItCanDraw(), `${residue} must keep the claim`).toBe(true);
+    }
+  });
+
   it("does not read an unfamiliar status as a NO", async () => {
     // `not-enabled` is the one verdict that takes a working box's claim away,
     // so it is a CLOSED list — `disabled`, `not enabled`, `not-enabled`, what

--- a/src/tests/unit/hermes-plugins-enabled-readback.test.ts
+++ b/src/tests/unit/hermes-plugins-enabled-readback.test.ts
@@ -68,6 +68,14 @@ function claimedItCanDraw(): boolean {
   return sets().some((s) => s.startsWith("image_gen.provider="));
 }
 
+/** Every `config unset`, by key. */
+function unsets(): string[] {
+  return cliMock.mock.calls
+    .map((c) => c[0] as string[])
+    .filter((a) => a[1] === "unset")
+    .map((a) => a[2]);
+}
+
 /** The CLI's own warning when a JSON literal did not coerce to a structure. */
 const STORING_AS_STRING =
   "Warning: value for 'plugins.enabled' looks like a list/mapping but parsed as str; storing as string.";
@@ -198,5 +206,119 @@ describe("plugins.enabled is written on a read-back, not on an exit code", () =>
     expect(sets()).toContain(
       `plugins.enabled=${JSON.stringify(["weather", "spotify", HERMES_IMAGE_PLUGIN_NAME])}`,
     );
+  });
+});
+
+describe("a box that was linked before the guard existed", () => {
+  it("withdraws the claim it can draw, rather than leaving the old one standing", async () => {
+    // Every box that CAN be in the residue state has been linked once already,
+    // so `image_gen.provider` is on disk naming us — and that one key is what
+    // `hermesAgentDrawsImages` reads. Declining to re-write it would leave the
+    // composer button and the capability both saying yes over a plugin Hermes
+    // does not load: the same false success, one link later.
+    cliMock.mockImplementation(async (args: string[]) => {
+      if (args[1] === "set" && args[2] === "plugins.enabled") {
+        return { code: 0, stdout: "", stderr: STORING_AS_STRING };
+      }
+      if (args[1] === "get" && args[2] === "plugins.enabled") {
+        return { code: 1, stdout: "", stderr: "Config key not set: plugins.enabled" };
+      }
+      if (args[1] === "get" && args[2] === "image_gen.provider") {
+        return { code: 0, stdout: `${HERMES_IMAGE_PLUGIN_NAME}\n`, stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(unsets()).toContain("image_gen.provider");
+  });
+
+  it("leaves a backend the customer chose by hand alone", async () => {
+    // The "known and accepted false positive" is their choice, not ours.
+    cliMock.mockImplementation(async (args: string[]) => {
+      if (args[1] === "set" && args[2] === "plugins.enabled") {
+        return { code: 0, stdout: "", stderr: STORING_AS_STRING };
+      }
+      if (args[1] === "get" && args[2] === "plugins.enabled") {
+        return { code: 1, stdout: "", stderr: "Config key not set: plugins.enabled" };
+      }
+      if (args[1] === "get" && args[2] === "image_gen.provider") {
+        return { code: 0, stdout: "fal\n", stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(unsets()).not.toContain("image_gen.provider");
+  });
+});
+
+describe("a hermes whose config get does not take --json", () => {
+  it("keeps drawing, merging from the plain rendering instead of refusing", async () => {
+    // `--json` is only what lets the TYPE be proved. A build that cannot answer
+    // that question has said nothing about whether the value is residue, so
+    // withdrawing the feature would be a false failure — these boxes draw today.
+    cliMock.mockImplementation(async (args: string[]) => {
+      if (args[1] === "get" && args[2] === "plugins.enabled") {
+        return args.includes("--json")
+          ? { code: 2, stdout: "", stderr: "usage: hermes config get\nunrecognized arguments: --json" }
+          : { code: 0, stdout: "- weather\n", stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(sets()).toContain(
+      `plugins.enabled=${JSON.stringify(["weather", HERMES_IMAGE_PLUGIN_NAME])}`,
+    );
+    expect(claimedItCanDraw()).toBe(true);
+    expect(unsets()).not.toContain("image_gen.provider");
+  });
+});
+
+describe("the proof does not accept the ambiguous rendering", () => {
+  it("refuses a read-back that is not JSON, even though it spells the right list", async () => {
+    // A build that takes `--json` but does not honour it in the formatter, or
+    // anything that re-renders on the way back. `- clawai` through a lenient
+    // text parse would have proved nothing and been called landed.
+    cliMock.mockImplementation(async (args: string[]) => {
+      if (args[1] === "get" && args[2] === "plugins.enabled") {
+        return args.includes("--json")
+          ? { code: 0, stdout: `- ${HERMES_IMAGE_PLUGIN_NAME}\n`, stderr: "" }
+          : { code: 1, stdout: "", stderr: "Config key not set: plugins.enabled" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(claimedItCanDraw()).toBe(false);
+  });
+
+  it("does not punish a read-back the CLI never answered", async () => {
+    // 127 is the shell's code for the `hermes` shim while the venv under it is
+    // being rebuilt: nothing was parsed, and the write above still exited 0
+    // with no coercion warning. Abandoning the feature for the whole link over
+    // that is the false-failure shape.
+    let written = false;
+    cliMock.mockImplementation(async (args: string[]) => {
+      if (args[1] === "set" && args[2] === "plugins.enabled") {
+        written = true;
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (args[1] === "get" && args[2] === "plugins.enabled") {
+        if (!written) return { code: 1, stdout: "", stderr: "Config key not set: plugins.enabled" };
+        return { code: 127, stdout: "", stderr: "hermes: command not found" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(claimedItCanDraw()).toBe(true);
+    expect(unsets()).not.toContain("image_gen.provider");
   });
 });

--- a/src/tests/unit/hermes-plugins-enabled-readback.test.ts
+++ b/src/tests/unit/hermes-plugins-enabled-readback.test.ts
@@ -56,6 +56,7 @@ vi.mock("@/lib/hermes-image-plugin", async (importOriginal) => ({
   installHermesImagePlugin: installMock,
 }));
 
+import { CLAWBOX_AI_VISION_MODEL_ID } from "@/lib/clawbox-ai-models";
 import { applyClawaiToHermes } from "@/lib/hermes-clawai";
 import { HERMES_IMAGE_PLUGIN_NAME } from "@/lib/hermes-image-plugin";
 
@@ -141,7 +142,15 @@ beforeEach(() => {
   refreshMock.mockReset();
   cliMock.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
   drawsMock.mockResolvedValueOnce(false).mockResolvedValue(true);
-  resolveVisionMock.mockResolvedValue({ model: "", reason: "probe stubbed" });
+  // The resolver's own shape (`id`, not `model`), so the vision write below it
+  // is issued with a real id rather than `undefined`: a stub whose field name
+  // is wrong makes every case in this file exercise a path the file is not
+  // about. Same value the vision suite stubs with.
+  resolveVisionMock.mockResolvedValue({
+    id: CLAWBOX_AI_VISION_MODEL_ID,
+    verified: true,
+    reason: "proxy-allows",
+  });
   warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 });
 
@@ -316,11 +325,13 @@ describe("the proof does not accept the ambiguous rendering", () => {
     expect(claimedItCanDraw()).toBe(false);
   });
 
-  it("makes no claim on a read-back the CLI never answered, and withdraws the old one", async () => {
+  it("makes no claim on a read-back the CLI never answered, and leaves the old one standing", async () => {
     // 127 is the shell's code for the `hermes` shim while the venv under it is
-    // being rebuilt: nothing was parsed, and the write above still exited 0. So
-    // this is not worth failing the link over — but it is not proof either, and
-    // a box linked once before is still holding the claim from that link.
+    // being rebuilt: nothing was parsed, and the write above still exited 0.
+    // NOTHING WAS ESTABLISHED, so nothing is withdrawn either: unsetting
+    // `image_gen.provider` here would take drawing away from a box that has it,
+    // and no code path on the device puts it back — this function has no
+    // periodic caller and is the only writer of that key.
     let written = false;
     cliMock.mockImplementation(async (args: string[]) => {
       if (args[1] === "set" && args[2] === "plugins.enabled") {
@@ -341,10 +352,15 @@ describe("the proof does not accept the ambiguous rendering", () => {
 
     expect(result.provider).toBe("clawai"); // the link itself still succeeds
     expect(claimedItCanDraw()).toBe(false);
-    expect(unsets()).toContain("image_gen.provider");
+    expect(unsets()).not.toContain("image_gen.provider");
   });
 
-  it("withdraws the claim when the key holds a shape it cannot read at all", async () => {
+  it("makes no claim on a shape it cannot read, and leaves the old one standing", async () => {
+    // Stdout that is not JSON from a read that exited 0 says the RENDERING was
+    // not machine-readable — a build that takes `--json` without honouring it,
+    // a wrapper that re-renders, a deprecation line ahead of the value. It says
+    // nothing about the stored type, so it is not a licence to make the claim
+    // and not grounds to take an existing one away.
     cliMock.mockImplementation(async (args: string[]) => {
       if (args[1] === "get" && args[2] === "plugins.enabled") {
         return { code: 0, stdout: "not json and not a list", stderr: "" };
@@ -359,7 +375,7 @@ describe("the proof does not accept the ambiguous rendering", () => {
 
     expect(wrotePluginsEnabled()).toBe(false); // left alone, not replaced
     expect(claimedItCanDraw()).toBe(false);
-    expect(unsets()).toContain("image_gen.provider");
+    expect(unsets()).not.toContain("image_gen.provider");
   });
 });
 
@@ -377,6 +393,108 @@ describe("the plain fallback is for one answer only", () => {
       }
       if (args[1] === "get" && args[2] === "image_gen.provider") {
         return { code: 0, stdout: `${HERMES_IMAGE_PLUGIN_NAME}\n`, stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(claimedItCanDraw()).toBe(false);
+    expect(unsets()).not.toContain("image_gen.provider");
+  });
+});
+
+describe("a failure that establishes nothing takes nothing away", () => {
+  /**
+   * The other half of the withdrawal rule, and the one that decides what a
+   * WORKING box does on a bad day.
+   *
+   * `enableHermesImageGeneration` runs on every AI-Models save and every
+   * re-link, it is the only writer of `image_gen.provider`, and nothing on the
+   * device re-runs it on its own. So a withdrawal made on a failure that
+   * proved nothing is not a moment of caution — it is image generation gone
+   * from a customer's box until they happen to open Settings and save again.
+   * Only an ANSWER that establishes the plugin cannot load may withdraw the
+   * claim: the CLI's own "storing as string", or a strict read-back that is
+   * not the list that was just written.
+   */
+  function boxThatDraws(reply: (args: string[]) => Promise<Reply>): void {
+    cliMock.mockImplementation(async (args: string[]) => {
+      if (args[1] === "get" && args[2] === "image_gen.provider") {
+        return { code: 0, stdout: `${HERMES_IMAGE_PLUGIN_NAME}\n`, stderr: "" };
+      }
+      return reply(args);
+    });
+  }
+
+  it("keeps drawing when the typed read cannot be run at all", async () => {
+    // `runHermesCli` REJECTS for a missing binary, a timeout and its own
+    // SIGKILL. A 15 s timeout on one `config get` is not evidence about
+    // anything on disk.
+    boxThatDraws(async (args) => {
+      if (args[1] === "get" && args[2] === "plugins.enabled") {
+        throw new Error("hermes config get plugins.enabled --json timed out after 15000ms");
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    const result = await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(result.provider).toBe("clawai"); // the link itself still succeeds
+    expect(unsets()).not.toContain("image_gen.provider");
+  });
+
+  it("keeps drawing when the config lock is held", async () => {
+    // The scenario the fleet actually meets: a second `hermes` holding the
+    // config lock while the owner saves Settings → AI Models.
+    boxThatDraws(async (args) => {
+      if (args[1] === "get" && args[2] === "plugins.enabled") {
+        return { code: 1, stdout: "", stderr: "could not acquire config lock" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(unsets()).not.toContain("image_gen.provider");
+  });
+
+  it("keeps drawing when the write itself could not be made", async () => {
+    // The read answered and the list needs us added; the WRITE is what failed.
+    // The box is no worse off than before the save, and what it holds now is
+    // what it held then.
+    boxThatDraws(async (args) => {
+      if (args[1] === "get" && args[2] === "plugins.enabled") {
+        return args.includes("--json")
+          ? { code: 0, stdout: JSON.stringify(["weather"]), stderr: "" }
+          : { code: 0, stdout: "- weather\n", stderr: "" };
+      }
+      if (args[1] === "set" && args[2] === "plugins.enabled") {
+        return { code: 1, stdout: "", stderr: "could not acquire config lock" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(claimedItCanDraw()).toBe(false);
+    expect(unsets()).not.toContain("image_gen.provider");
+  });
+
+  it("still withdraws on the one answer that establishes the plugin cannot load", async () => {
+    // The counterweight, kept in the same block as the cases above so the rule
+    // reads as one: a read-back that ANSWERED and did not spell the list is
+    // proof, and proof still takes the claim away.
+    let written = false;
+    boxThatDraws(async (args) => {
+      if (args[1] === "set" && args[2] === "plugins.enabled") {
+        written = true;
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (args[1] === "get" && args[2] === "plugins.enabled") {
+        if (!written) return { code: 1, stdout: "", stderr: "Config key not set: plugins.enabled" };
+        // The literal, stored as text: JSON of a STRING, not of a list.
+        return { code: 0, stdout: JSON.stringify(`["${HERMES_IMAGE_PLUGIN_NAME}"]`), stderr: "" };
       }
       return { code: 0, stdout: "", stderr: "" };
     });

--- a/src/tests/unit/hermes-plugins-enabled-readback.test.ts
+++ b/src/tests/unit/hermes-plugins-enabled-readback.test.ts
@@ -753,23 +753,38 @@ describe("a failure that establishes nothing takes nothing away", () => {
     // The other half of the same exemption, and the reason it cannot be an
     // unconditional yes: this build can still be asked the typed questions, and
     // a `plugins.enabled` that reads back as a STRING is Hermes loading no user
-    // plugin at all. Arming on an exit code here would re-open TASK-701's own
-    // symptom for one build class.
-    box({
-      value: undefined,
-      onSet: { code: 0, stdout: "", stderr: STORING_AS_STRING },
-    });
-    const stored = cliMock.getMockImplementation()!;
-    cliMock.mockImplementation(async (args: string[]) => {
+    // plugin at all.
+    //
+    // The write lands as text SILENTLY — exit 0, clean stderr, the older CLI
+    // with no coercion warning — so `hermesStoredValueAsText` sees nothing and
+    // the typed read-back is the only witness left. Arming on the exit code
+    // here is TASK-701's own symptom, re-opened for one build class.
+    let written = false;
+    boxThatDraws(async (args) => {
+      const residue = `["${HERMES_IMAGE_PLUGIN_NAME}"]`;
       if (isPluginsListing(args)) {
         return { code: 2, stdout: "", stderr: "Error: no such option: --json" };
       }
-      return stored(args);
+      if (args[1] === "set" && args[2] === "plugins.enabled") {
+        written = true;
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (args[1] === "get" && args[2] === "plugins.enabled") {
+        if (!written) return { code: 1, stdout: "", stderr: "Config key not set: plugins.enabled" };
+        // A STRING that spells a list: `_get_enabled_set` reads it as empty.
+        return { code: 0, stdout: JSON.stringify(residue), stderr: "" };
+      }
+      if (args[1] === "get" && args[2] === "plugins.disabled") {
+        return { code: 1, stdout: "", stderr: "Config key not set: plugins.disabled" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
     });
 
     await applyClawaiToHermes("claw_token_abc", "flash");
 
     expect(claimedItCanDraw()).toBe(false);
+    // The residue is an ANSWER, so the stale claim goes too.
+    expect(unsets()).toContain("image_gen.provider");
   });
 
   it("does not arm a build with no listing while plugins.disabled names us", async () => {

--- a/src/tests/unit/register-mcp-email-hook.test.ts
+++ b/src/tests/unit/register-mcp-email-hook.test.ts
@@ -549,6 +549,50 @@ d("register-mcp.sh — the outbound EMAIL: directive hook", () => {
     expect(imageProvider()).toBe("fal");
   });
 
+  it("arms nothing while plugins.disabled names the backend", () => {
+    // The deny-list WINS over the allow-list (`_plugin_status`,
+    // hermes_cli/plugins_cmd.py:1930-1936) — it is the very state the link
+    // path's withdrawal exists for, and the type repair does not change it.
+    // Re-arming here would put back, unattended, exactly the claim a proof had
+    // just taken away, on a box where Hermes still loads nothing.
+    fs.writeFileSync(
+      configPath,
+      `plugins:\n  enabled: '["clawai"]'\n  disabled:\n    - clawai\n`,
+    );
+    installImageBackend();
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(enabledPlugins()).toEqual(["clawai", PLUGIN]); // the type repair still happens
+    expect(imageProvider()).toBeUndefined();
+    expect(r.stdout).toMatch(/disabled/);
+  });
+
+  it("arms nothing when plugins.disabled is a shape it cannot read", () => {
+    // Declining costs one Settings → Save, which re-asks Hermes directly.
+    // Re-arming over a deny-list nobody could read would be a claim made on a
+    // guess, and this key is the one that turns the composer button on.
+    fs.writeFileSync(
+      configPath,
+      `plugins:\n  enabled: '["clawai"]'\n  disabled: 7\n`,
+    );
+    installImageBackend();
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(imageProvider()).toBeUndefined();
+  });
+
+  it("still arms when plugins.disabled names somebody else", () => {
+    // The counterweight: a deny-list that is not about us must not cost the
+    // repair its re-arm.
+    fs.writeFileSync(
+      configPath,
+      `plugins:\n  enabled: '["clawai"]'\n  disabled: '["weather"]'\n`,
+    );
+    installImageBackend();
+    run();
+    expect(imageProvider()).toBe("clawai");
+  });
+
   it("arms nothing when the backend's files are not on the box", () => {
     // "named in config, nothing to load" is the false success this script
     // guards against everywhere else.

--- a/src/tests/unit/register-mcp-email-hook.test.ts
+++ b/src/tests/unit/register-mcp-email-hook.test.ts
@@ -105,6 +105,19 @@ function enabledPlugins(): unknown {
   return plugins?.enabled;
 }
 
+/** What `image_gen.provider` holds, if anything. */
+function imageProvider(): unknown {
+  const imageGen = readConfig().image_gen as Record<string, unknown> | undefined;
+  return imageGen?.provider;
+}
+
+/** The ClawAI image backend on disk, where the LINK path would have put it. */
+function installImageBackend(): void {
+  const dir = path.join(pluginsDir, "image_gen", "clawai");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "__init__.py"), "# stand-in for the shipped backend\n");
+}
+
 function installedFiles(): string[] {
   const dir = path.join(pluginsDir, PLUGIN);
   return fs.existsSync(dir) ? fs.readdirSync(dir).sort() : [];
@@ -511,6 +524,46 @@ d("register-mcp.sh — the outbound EMAIL: directive hook", () => {
     } finally {
       fs.rmSync(bareRoot, { recursive: true, force: true });
     }
+  });
+
+  it("re-arms the image backend the repair just made loadable", () => {
+    // The link path withdraws `image_gen.provider` when Hermes answers that it
+    // will not load the plugin, and it is only reached from Settings → Save.
+    // Repairing the list without putting the claim back would leave a box that
+    // CAN draw reporting that it cannot until somebody opened that page.
+    fs.writeFileSync(configPath, `plugins:\n  enabled: '["clawai"]'\n`);
+    installImageBackend();
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(enabledPlugins()).toEqual(["clawai", PLUGIN]);
+    expect(imageProvider()).toBe("clawai");
+  });
+
+  it("never writes over a backend the customer chose", () => {
+    fs.writeFileSync(
+      configPath,
+      `plugins:\n  enabled: '["clawai"]'\nimage_gen:\n  provider: fal\n`,
+    );
+    installImageBackend();
+    run();
+    expect(imageProvider()).toBe("fal");
+  });
+
+  it("arms nothing when the backend's files are not on the box", () => {
+    // "named in config, nothing to load" is the false success this script
+    // guards against everywhere else.
+    fs.writeFileSync(configPath, `plugins:\n  enabled: '["clawai"]'\n`);
+    run();
+    expect(imageProvider()).toBeUndefined();
+  });
+
+  it("arms nothing on a box whose list needed no repair", () => {
+    // A real list is not the state a withdrawal is paired with, so there is
+    // nothing here to put back — and a first-time opt-in is not this script's.
+    fs.writeFileSync(configPath, "plugins:\n  enabled:\n    - clawai\n");
+    installImageBackend();
+    run();
+    expect(imageProvider()).toBeUndefined();
   });
 
   it("does nothing at all on an OpenClaw box", () => {

--- a/src/tests/unit/register-mcp-email-hook.test.ts
+++ b/src/tests/unit/register-mcp-email-hook.test.ts
@@ -492,6 +492,27 @@ d("register-mcp.sh — the outbound EMAIL: directive hook", () => {
     expect(enabledPlugins()).toEqual(["clawai", "other", PLUGIN]);
   });
 
+  it("normalises a stored-as-text plugins.enabled even when this hook is NOT installed", () => {
+    // The repair has to be independent of the EMAIL: hook, because the box that
+    // most needs it is the one where the hook could not be installed: a string
+    // here makes `_get_enabled_set` answer EMPTY, so Hermes loads no user
+    // plugin at all — the customer's image backend included — and nothing else
+    // on the box rewrites the type. Gating the repair on `hook_plugin` skipped
+    // exactly that box.
+    fs.writeFileSync(configPath, `plugins:\n  enabled: '["clawai"]'\n`);
+    const bareRoot = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-bare-root-"));
+    try {
+      fs.mkdirSync(path.join(bareRoot, "mcp"), { recursive: true });
+      fs.writeFileSync(path.join(bareRoot, "mcp", "clawbox-mcp.ts"), "// stand-in\n");
+      const r = run({}, bareRoot);
+      expect(r.status).toBe(0);
+      expect(installedFiles()).toEqual([]); // the hook really is not there
+      expect(enabledPlugins()).toEqual(["clawai"]); // and the type is a list again
+    } finally {
+      fs.rmSync(bareRoot, { recursive: true, force: true });
+    }
+  });
+
   it("does nothing at all on an OpenClaw box", () => {
     // gateway-pre-start.sh owns that edition; this script exits before it
     // touches anything.

--- a/src/tests/unit/register-mcp-email-hook.test.ts
+++ b/src/tests/unit/register-mcp-email-hook.test.ts
@@ -567,6 +567,25 @@ d("register-mcp.sh — the outbound EMAIL: directive hook", () => {
     expect(r.stdout).toMatch(/disabled/);
   });
 
+  it("arms nothing while plugins.disabled names the backend by its RESOLVED key", () => {
+    // The spelling `hermes plugins disable clawai` actually writes. Read on the
+    // pinned 0.20.5 build: `cmd_disable` (hermes_cli/plugins_cmd.py:1710-1739)
+    // stores `_resolve_plugin_key(name)`, which answers `image_gen/clawai` —
+    // the category directory joined to the name — and Hermes' own
+    // `_plugin_status` (:1931-1937) then tests BOTH spellings. A check that
+    // knew only the bare name would miss the deny-list in the one state an
+    // owner can actually produce with the harness's own command.
+    fs.writeFileSync(
+      configPath,
+      `plugins:\n  enabled: '["clawai"]'\n  disabled:\n    - image_gen/clawai\n`,
+    );
+    installImageBackend();
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(enabledPlugins()).toEqual(["clawai", PLUGIN]); // the type repair still happens
+    expect(imageProvider()).toBeUndefined();
+  });
+
   it("arms nothing when plugins.disabled is a shape it cannot read", () => {
     // Declining costs one Settings → Save, which re-asks Hermes directly.
     // Re-arming over a deny-list nobody could read would be a claim made on a


### PR DESCRIPTION
**TASK-701** — Hermes image generation: `plugins.enabled` false success.

## Customer-visible symptom

The box says it can draw and cannot. `/setup-api/chat/capabilities` answers `hermesAgentDrawsImages: true`, the composer button is there, and the customer's request for a picture dies inside the agent because Hermes never loaded the backend. Worse than one feature: `plugins.enabled` is the opt-in allow-list for **every** user plugin on the box, so in the state this fixes the customer's own plugins are not loading either.

## Cause, and the harness fact behind it

`hermes config set plugins.enabled '["clawai"]'` exits 0 whether or not its coercion yielded a list. When it does not, it prints `…storing as string.` to stderr and stores the literal text — `hermes_cli/config.py:5514-5527`, read read-only on the pinned 0.20.5 build. And a stored string is not merely one wrong name:

```python
# hermes_cli/plugins_cmd.py:1309-1324
enabled = plugins_cfg.get("enabled", [])
return set(enabled) if isinstance(enabled, list) else set()
```

An empty set. Nothing loads.

ClawBox wrote that key on the exit code and read it back through a YAML-text parser, where the residue `["clawai"]` decodes as a real one-element list — so the merge answered "already there, nothing to do" for a key that was disabling everything, and the box could never heal itself. Meanwhile `image_gen.provider`, the one key the capability probe reads, was written regardless.

## Harness-first

Hermes owns `hermes plugins enable <name>`, which does this read-modify-write itself and cannot store a string. **It is not used here, and the reason is a measurement rather than a preference.** Read read-only on the box: `_resolve_plugin_key("clawai")` answers `image_gen/clawai`, so that command would write a *second* spelling into `plugins.enabled` beside the bare `clawai` the loader already accepts — `hermes plugins list` reports our plugin as `enabled` from that bare name on the live box today. Swapping them is a link-path behaviour change that wants a device test with a mutation, not a unit one. Recorded in the header of `src/lib/hermes-image-plugin.ts` beside the write it explains, and in the run's Found list as the follow-up.

The other half of the harness answer is what this PR *does* use: `hermes config get <key> --json` (`config.py:5769`, prints `json.dumps(value)`) is the CLI's own machine-readable mode, and it is the only thing that tells a stored list from a stored string. Same mechanism PR #600 established for `providers.clawai.models`.

## RED (on `origin/beta`, with a CLI stub that renders `--json` and plain the way Hermes does)

```
 × repairs a key whose previous write was stored as text
     a string residue must be rewritten as a list: expected false to be true
 × does not claim the agent can draw when the CLI stored the list as text
     expected true to be false
 × does not claim the agent can draw when the key reads back as something else
     expected true to be false
 × asks for the machine-readable rendering, so a string is not read as a list
     expected [ 'config', 'get', 'plugins.enabled' ] to include '--json'
      Tests  4 failed | 2 passed (6)
```

## Device proof (read-only, Hermes box, beta head)

```
hermes config get plugins.enabled --json   ->  ["clawai", "clawbox_email_directives"]   (exit 0)
hermes plugins list                        ->  clawai │ enabled │ 1.0.0 │ user
```

A real JSON list: **no box is in the residue state today**, exactly as #600 found for the sibling key. What ships is the guard that stops one being created silently, the repair if one ever is, and the boot-time normalisation for a box that already has one. No box was mutated; no mutex taken.

## GREEN

`--project unit` 580 files / 9308 tests; the six affected suites 132/132; `tsc --noEmit` clean; `eslint` clean on the changed files (one pre-existing unused-import warning in `hermes-clawai.ts`, untouched).

## Sibling sweep — every `hermes config set` of a list or object, and every writer of this key

- `hermes-clawai.ts:501` — `providers.clawai.models` in `reconcileClawaiModelsWithHermes`: **guarded** (#600), and the model this change follows.
- `hermes-clawai.ts:192` — the same key on the link path: **not guarded here, deliberately.** `clawaiCatalogueVerdict` detects exactly this residue (`typeof row.models === "string" && looksLikeStructuredText(...)` → `action: "write"`) and rewrites it on the next `GET /setup-api/hermes/models`. Self-healing, unlike `plugins.enabled`, whose merge could never heal.
- `scripts/register-mcp.sh` — the only other writer of `plugins.enabled`. It parses a residue string rather than trusting it, but it only WROTE when it had a hook name to append, so a box whose residue already spelled the hook stayed broken. It normalises the type on its own now, on every boot — which is what gives a field box in that state a repair that does not need a re-link.
- Every other `hermes config set` in the repo writes a scalar. The OpenClaw side takes a typed `config set … --json`; the asymmetry is Hermes'.

## Review findings applied (Opus pass) — `/home/krasi/clawbox-run-scratch-2026-09-03/review-701.md`

- **HIGH F1** — declining to re-write `image_gen.provider` is not withdrawing it. Every affected box has been linked once, so the key is already on disk naming us and the stale claim survived the guard. Our selection is unset on failure now, and only ours.
- **HIGH F2** — making `--json` a precondition lost image generation entirely on a CLI that rejects the flag, where it works today. The read falls back to the plain rendering, merges, writes, and skips only the proof, with a journal line. `--json` is what proves a type; a build that cannot answer has said nothing about the value.
- **MEDIUM F4** — the prover shared the tolerant reader, so a non-JSON read-back that spelled the right list was accepted. The decoder is strict now; the sibling verifier already worked this way.
- **MEDIUM F5** — a mapping or a bare scalar was flattened to nothing and replaced, destroying the only record of what the customer had enabled. Keys and bare names are recovered now. A shape NO name can be recovered from (`7`, `null`, `true`) is still replaced — leaving it would leave the box loading no plugin at all — but the journal line says what it held first. Only stdout that could not be read at all is left alone, and there the feature is refused. (Corrected in round 6: this bullet used to claim the unrecoverable shape was left alone, which is the `unreadable` branch, not the residue one.)
- **MEDIUM F6** — the residue was detected but never repaired on a box nobody re-links. Covered by the register-mcp normalisation above.
- **LOW F7** — 126/127 and a signalled child are a question that could not be asked, not a write that failed. Separated, the way `verifyClawaiCatalogue` does it.
- **LOW F3/F8/F9/F10** — the YAML fallback's stated reason is now true (F2 made it reachable); the double membership test collapsed; the harness-first answer moved out of a test docstring into the module header.

## Both editions

Hermes-only by construction: `plugins.enabled` is a Hermes key and image generation there is a plugin. OpenClaw's equivalent is `agents.defaults.imageModel` through a typed `openclaw config set --json`, which cannot silently store a list as text — stated rather than assumed, and nothing on that edition changes here.



---

# Finishing round (2026-09-04) — the review's BLOCK, applied

The gate reviewed `f8fdf556` and blocked it: the branch withdrew the drawing claim on **every**
failure path, including ones that establish nothing. Findings file:
`code-review-pr638-final.md` (1 HIGH, 2 MEDIUM, 4 LOW), then a second pass on the fix:
`code-review-pr638-final2.md` (0 HIGH, 2 MEDIUM, 6 LOW).

## HARNESS-FIRST, and this round is where it bit

The card's harness-first note only covered the WRITE (`hermes plugins enable clawai` writes a
second spelling, `image_gen/clawai`, beside the bare name the loader accepts — measured, still
deferred). Nobody had asked how Hermes answers the READ, and the branch was re-deriving it:
ClawBox read `plugins.enabled` back and decided for itself whether the value was a list Hermes
would load from.

**Measured on the pinned build (0.20.5 = 2026.8.19), read-only, no mutex, nothing mutated:**

```
$ hermes plugins list --json        # ~1.0 s, 57 rows
[ { "name": "clawai", "status": "enabled", "version": "1.0.0", "source": "user" }, … ]
```

and, from the installed package on the same box:

- `cmd_list` prints that payload — `hermes_cli/plugins_cmd.py:1969-1980`
- `status` is `_plugin_status(name, enabled, disabled, key)` — `:1930-1936`
- `enabled` is `_get_enabled_set()` — `:1309-1324`,
  `set(enabled) if isinstance(enabled, list) else set()`, **the loader's own predicate**
- `disabled` is `_get_disabled_set()` — an explicit deny-list that WINS over `plugins.enabled`

So the proof is now `hermes plugins list --json`, not a type check of ours. Two things that
buys beyond tidiness:

- a box that names `clawai` in a perfectly good list **and** carries it in `plugins.disabled`
  read as loadable and loaded nothing. Every type check ClawBox could make on `plugins.enabled`
  says yes there; Hermes says `disabled`. Pinned by a test.
- an empty or unparsable answer is now "could not ask" rather than an empty list read as proof
  of absence.

## R1 (HIGH) — the claim is withdrawn on an ANSWER, never on a failed question

`withdrawImageProviderClaim()` fired from both arms of the try/catch, so a held config lock, a
15 s timeout, a shim exiting 127 mid-update or a rendering that is not machine-readable all
unset `image_gen.provider`. That key is the only thing `hermesAgentDrawsImages` reads;
`enableHermesImageGeneration` runs on every AI-Models save and has no periodic caller. One
transient CLI failure took image generation off a working box until the owner happened to save
again.

Withdrawal is now gated on a single error type, `PluginsEnabledDisproved`, thrown at exactly
four sites and every one of them an ANSWER: the CLI's own `storing as string` on the write, a
strict read-back that is not the list just written, Hermes reporting the plugin as anything but
enabled, and — on a build with no listing — `plugins.enabled` failing the type check or
`plugins.disabled` naming us in a real list. Everything else is reported and leaves the key
exactly as it was, which is what beta did. (Round 6 corrected the count: this paragraph said
"two sites" while the later commits added the other two.)

**RED** (the baseline is the branch head `f8fdf556`, not beta: the defect is the branch's own):

```
 ❯ src/tests/unit/hermes-plugins-enabled-readback.test.ts (17 tests | 6 failed)
     × makes no claim on a read-back the CLI never answered, and leaves the old one standing
     × makes no claim on a shape it cannot read, and leaves the old one standing
     × does not downgrade to the ambiguous rendering on a transient typed-read failure
     × keeps drawing when the typed read cannot be run at all
     × keeps drawing when the config lock is held
     × keeps drawing when the write itself could not be made
 ❯ src/tests/unit/register-mcp-email-hook.test.ts (26 tests | 1 failed)
     × normalises a stored-as-text plugins.enabled even when this hook is NOT installed

AssertionError: expected [ 'model.base_url', …(2) ] to not include 'image_gen.provider'
AssertionError: expected '["clawai"]' to deeply equal [ 'clawai' ]

 Test Files  2 failed (2)
      Tests  7 failed | 36 passed (43)
```

The two tests that asserted the old behaviour (a held lock at `:367`, exit 127 at `:319`) are
inverted, and the third — an unreadable rendering — with them.

## R2 (MEDIUM) — the boot repair is out of `if hook_plugin:`

Chosen over correcting the claim, because the box that most needs the repair is the one where
the email-hook install failed: `CLAWBOX_EMAIL_HOOK_PLUGIN` is empty there, so the whole block
was skipped on a box loading no user plugin at all. Reading the key, normalising the type and
appending the hook are three questions now, and only the last needs a hook. RED above; the new
test proves the hook really is absent (`installedFiles()` empty) while the type is normalised.

## R3 (MEDIUM) — `UNSUPPORTED_OPTION_RE` widened

`unrecognised` and Click's `Got unexpected extra argument` added. With R1 fixed a miss now costs
only the plain fallback rather than a withdrawal, which the docblock says.

## R4 — CodeRabbit thread `PRRT_kwDORKkVuM6fQAD7`, answered in-thread

Valid: the stub returned `{model}` where `resolveVisionModelId` answers `{id}`, so every case in
the file issued `config set auxiliary.vision.model undefined`. Fixed with the resolver's real
shape (`{ id, verified, reason }`), the same value the vision suite stubs with.

## Second pass on the fix (`code-review-pr638-final2.md`)

- **S1 (MEDIUM) — the withdrawal was one-way.** This PR's own boot repair makes the plugin load
  again while nothing put `image_gen.provider` back, so a box that would have self-healed needed
  an owner save. `register-mcp.sh` now re-arms the key on all three conditions or not at all: it
  has just turned a string into a list that names the backend, the backend's files are on disk,
  and the key is unset. Never over a backend the customer chose, never as a first-time opt-in.
- **S2 (MEDIUM) — harness-first.** The measurement above; the proof is Hermes' answer now.
- **S3** a mapping residue's `false` entries are no longer enabled by the type repair.
- **S4** the "replacing it" journal line moved to the decision site — the decoder also runs as the
  prover, where nothing is replaced and the line would have reported an overwrite that never
  happened.
- **S5** an empty read-back was decoded as an empty list and withdrew a working claim over
  silence. Gone with the read-back; "could not ask" covers it.
- **S6** the stale paragraph that still described beta's behaviour is corrected.
- **S7** `image_gen.model`, `image_gen.clawai.model` and `image_gen.clawai.base_url` are written
  before the proof — they turn nothing on, and holding `base_url` behind it meant one shim
  flicker left a box claiming `clawai` and posting to the proxy address of the release before.
  Only `image_gen.provider` stays behind the proof.
- **S8** the repair's log lines no longer name the EMAIL: hook on a box that has none.

## Two claims in the body above, corrected

- *"the repair if one ever is"* — the repair reaches a `--json`-less build only through the boot
  normalisation, not through the link path, where a plain rendering cannot tell a residue from a
  list. That population now heals at the next boot (R2), which is why R2 matters more than its
  severity suggests.
- *"LOW F3/F8/F9/F10"* — **F9 was not done** in the first round. This round takes the half that
  removes the divergence risk: the `storing as string` regex is one function
  (`hermesStoredValueAsText`), and the two verifiers no longer share a shape to drift apart in.
  The full hoist of "write → check → classify" into one helper is not done; the two paths verify
  different keys with different outcome types, and merging them is a refactor with no defect
  behind it.

## GREEN (rebased head)

`--project unit` **602 files / 9640 tests**, twice; `tsc --noEmit` clean; the eight affected
suites green on their own. Rebased on `origin/beta` `a3faafc4`;
`git diff --stat origin/beta...HEAD` lists the 8 intended files and
`--diff-filter=DR` is empty.

## Unproven

The device leg is READ-ONLY: the harness-first measurement above (`plugins list --json`, the
installed package's source, and the box's current `plugins.enabled` / `image_gen.provider`). The
new write paths — the withdrawal, the re-arm, the type repair — are proved by the unit and shell
suites against the real `register-mcp.sh`, not on hardware: each one mutates `~/.hermes/config.yaml`
on a box the owner is using, which this round did not do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hermes plugin configuration handling for serialized, malformed, disabled, or unreadable settings.
  * Preserved existing customer-selected plugins and providers while recovering recognizable plugin entries.
  * Prevented inaccurate image capability claims when plugin configuration cannot be read, written, or verified.
  * Added compatibility for Hermes versions without structured JSON output.
  * Ensured stale provider selections are safely removed when ClawBox cannot confirm its plugin configuration.
  * Repaired plugin settings without requiring the email hook and restored the image provider only when the backend is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Rounds 4 and 5 — the proof is asked on every path, not only where a write happened

### The block: the deny-list case was never asked on a healthy box (HIGH)

`mergePluginsEnabled` answers `null` whenever `plugins.enabled` is already a real list
naming us — the state of **every healthy linked box** — and the caller read that `null` as
"loadable":

```ts
loadable = merged ? await writePluginsEnabled(merged, typed) : true;   // ← the bug
```

So the listing this round exists for was consulted **only when a WRITE was needed**.
`plugins.disabled` wins over `plugins.enabled` (`_plugin_status`,
`hermes_cli/plugins_cmd.py:1931-1937`), so an owner who ran the harness's own
`hermes plugins disable clawai` passed every check ClawBox could make on the allow-list
and had `image_gen.provider` written over a plugin Hermes refuses to load — TASK-701's own
customer-visible symptom, on the path 100% of linked boxes take.

The test that "pinned" this passed only because its fixture seeded `["weather"]`, forcing
a write.

**Fix.** The prover is one function, `hermesConfirmsPluginLoadable`, asked on **both**
paths. `null` means "nothing to write", never "nothing to ask".

RED on the previous head:

```
 × believes hermes over the list on a box that needs no write at all
AssertionError: expected true to be false
 ❯ src/tests/unit/hermes-plugins-enabled-readback.test.ts:607:32
     605|     expect(wrotePluginsEnabled(), "the list already names us: nothing …
     606|     expect(claimedItCanDraw()).toBe(false);
```

### The boot re-arm put back what the withdrawal removed (MEDIUM)

`scripts/register-mcp.sh`'s re-arm consulted no deny-list, so on the next boot it wrote
`image_gen.provider` back over a plugin a proof had just disproved — unattended, with no
way for the owner to notice. It now weighs `plugins.disabled` through the **same reader**
as `plugins.enabled` (`config_name_list`, one parser for both keys), and declines rather
than guessing when that key is a shape it cannot read.

### Round 5 — what the round-4 review found in round 4's own work

- **The `plugins list --json` exemption was too wide.** A build without that flag was
  armed unconditionally. It is not a build that can be asked *nothing* — it answers
  `config get --json`, so the two keys Hermes gates on can still be read machine-readably.
  It now proves the plugin from `plugins.enabled` (a list naming us) and `plugins.disabled`
  (not naming us) instead of writing the claim on an exit code, which was TASK-701's
  symptom re-opened for one build class.
- **A test passed for a fixture reason.** The case named "a FIRST box" seeded a key that
  was *already listed*, so no write happened and the parent's short-circuit gave the
  identical result. The fixture is an unset key now, so it genuinely exercises the write
  path, and a second case (the residue stored silently) covers what the exemption must
  refuse. **It is still GREEN on its own parent** and is NOT one of that round's five RED
  cases: it is the counterweight that pins the fallback still arming a genuine first link.
  Commit `1bdf416a` overstates it as a regression test; the five listed under RED are the
  whole RED set for that round.
- **The deny-list check knew only one spelling.** `hermes plugins disable clawai` stores
  the **resolved** key `image_gen/clawai`, not the bare name. Both spellings now, from one
  exported constant, exactly as Hermes' own `_plugin_status` tests both.
- **Any status but the literal `enabled` was read as PROOF** the plugin will not load — the
  one verdict that withdraws a working box's claim. The negative is a closed list now; an
  unfamiliar wording is "could not ask". A wrong "cannot ask" hides nothing; a wrong "no"
  takes a working ability away on every Save.
- **The global `image_gen.model`** was written with the describing keys, so a customer on
  another backend lost their chosen model to a link that then concluded it could not turn
  ours on. It moves beside `image_gen.provider`: ours to name only when we become the
  backend.
- An exit-0 **silence** and an unparsable rendering are told apart, so the journal says
  "hermes answered nothing" rather than naming a value nothing read.
- The listing stub now asserts `--json`, which it did not — dropping the flag would have
  left every test in the file green.

### Harness-first, read on the pinned build (0.20.5, read-only, 2026-09-05)

The proof is Hermes' own `hermes plugins list --json`, which runs `_get_enabled_set()` —
the very function the loader gates on — so its verdict cannot disagree with what will
actually load. Three facts were read off the box rather than assumed:

- `_resolve_plugin_key("clawai")` → `image_gen/clawai` (`plugins_cmd.py:1337-1362`);
- `cmd_disable` (`:1710-1739`) writes **that** key into `plugins.disabled`;
- `_plugin_status` (`:1931-1937`) returns exactly `disabled` / `enabled` / `not enabled`,
  and tests both spellings — which is why anything that *asks* Hermes is immune and
  anything that reads the key itself has to test both too.

The native writer that cannot produce this residue at all — `hermes plugins enable` — is
still not used, and the reason remains a measured fact rather than a preference: it would
write the second spelling into `plugins.enabled` beside the bare name the loader already
accepts on every field box. Swapping them is a link-path change that wants a device test
with a mutation. **Follow-up, not fixed here.**

### RED → GREEN

Every behavioural case was run against the unmodified previous head. Five fail there and
pass here:

```
 × does not rewrite image_gen.model when it makes no claim
 × does not arm a build with no listing when the write landed as TEXT
 × does not arm a build with no listing while plugins.disabled names us
 × does not read an unfamiliar status as a NO
 × arms nothing while plugins.disabled names the backend by its RESOLVED key
 Test Files  2 failed (2)
      Tests  5 failed | 59 passed (64)
```

GREEN on this head:

```
npx vitest run --project unit hermes-plugins-enabled-readback hermes-image-plugin \
  hermes-clawai-images register-mcp-email-hook register-mcp-hermes hermes-clawai-vision \
  hermes-config-lock
 Test Files  7 passed (7)
      Tests  144 passed (144)

npx tsc --noEmit    # clean
```

Full unit project: 629 files / 9971 passed. (`run-tunnel.test.ts` flakes intermittently
under full parallel load on this dev PC — it passes in isolation on every run, it is not
in this branch's diff, and no file this PR touches is involved.)

### Sibling call sites

`mergePluginsEnabled` has no callers outside `hermes-clawai.ts` and its tests.
`image_gen.provider` has exactly two writers (`hermes-clawai.ts` and `register-mcp.sh`)
and one reader (`harness/hermes-features.ts`). `decodePluginsEnabledJson` has one
production caller; its sibling `decodePluginsEnabledPlain` reached the same
"silence read as an empty list" hole from the untyped path, and that is closed in the
caller. `config_name_list` replaced the inline `plugins.enabled` parser and reproduces
both of its warnings verbatim. `HERMES_IMAGE_PLUGIN_KEY` and the shell's
`CLAWBOX_IMAGE_PLUGIN_KEY` are the two readers of the resolved key, kept as one fact.

Hermes-only by construction: `register-mcp.sh` exits before this block on an OpenClaw box,
and the dual SKU reaches it only through the Hermes half. Nothing on the OpenClaw edition
changes.

### Device leg

Read-only, through the `clawbox-box` skill: the three `plugins_cmd.py` facts above were
read off the Hermes box's installed 0.20.5 package. **No box was mutated** — the owner is
testing on both boxes. The link path itself (a Settings → AI Models save) is therefore
**unproven on hardware in this round**; the unit suite covers every branch of it.

---

## Round 6 — the closing round

`readPluginsDisabledFromCli` did the opposite of what its own comment promised: it returned
the names recovered out of a `plugins.disabled` RESIDUE instead of the empty set, so a
deny-list Hermes itself ignores was read as a real denial.

**Customer-visible symptom.** A Hermes box moved off `HERMES_PIN_COMMIT` by a hand-run
`hermes update`, so that `config get` takes `--json` and `plugins list` does not — exactly the
population the `no-such-question` fallback exists for — whose `plugins.disabled` holds a
STRING: `disabled: clawai` hand-edited into `config.yaml`, or a
`hermes config set plugins.disabled '["clawai"]'` whose coercion missed, which is the same
residue class this whole PR is about. Hermes loads the plugin and the box draws today. The
owner opens Settings → AI Models and presses Save: the listing cannot be asked, the key
fallback reads `Set{"clawai"}`, `PluginsEnabledDisproved` is thrown, `image_gen.provider` is
unset, the composer button disappears and `refreshHermesImageTools` takes `image_generate`
off the running agent. Nothing on the device puts it back, and the next Save withdraws it
again. That is the false-failure class, produced by the branch whose headline rule is
"withdraw on an ANSWER, never on a failed question" — here the answer was misread.

**Cause and fix.** Harness-first, re-read read-only on the Hermes box this round:
`_get_disabled_set()` is `set(disabled) if isinstance(disabled, list) else set()`
(`hermes_cli/plugins_cmd.py:1257-1269`, installed 0.20.5) — the same type gate as
`_get_enabled_set()` (`:1309-1323`). A `plugins.disabled` that is not a LIST denies nothing.
The reader now answers the empty set for a residue, one line, and the code finally says what
the comment above it already claimed.

The asymmetry with `plugins.enabled` is deliberate and is exactly what those two Hermes
functions do: a residue in the ALLOW-list proves the negative (Hermes loads no user plugin at
all), a residue in the DENY-list proves nothing at all.

### RED → GREEN, round 6

RED on the previous head `f5634c67`, the new case run against it unmodified:

```
 FAIL  src/tests/unit/hermes-plugins-enabled-readback.test.ts >
       a failure that establishes nothing takes nothing away >
       keeps drawing when plugins.disabled holds a residue hermes ignores
AssertionError: ["clawai"] must not withdraw:
  expected [ 'model.base_url', …(2) ] to not include 'image_gen.provider'
 ❯ src/tests/unit/hermes-plugins-enabled-readback.test.ts:850:60

 Test Files  1 failed (1)
      Tests  1 failed | 30 skipped (31)
```

GREEN on this head:

```
npx vitest run --project unit hermes-plugins-enabled-readback hermes-image-plugin \
  hermes-clawai-images register-mcp-email-hook
 Test Files  4 passed (4)
      Tests  90 passed (90)

npx tsc --noEmit    # clean
bash -n scripts/register-mcp.sh + ast.parse of its embedded python    # clean
```

The case loops both spellings a residue reaches this key in — the JSON-string
`"[\"clawai\"]"` and the bare scalar `"clawai"` — because `recoverNames` is generous with
both and either one alone would leave half the hole open.

### Round-5 review items

- **M1** — fixed above. Sibling check: `readPluginsDisabledFromCli` has exactly one caller
  (`hermesKeysConfirmPluginLoadable`); `decodePluginsEnabledJson`'s other production caller
  reads `plugins.enabled`, where a residue must still prove the negative and is unchanged.
- **M2** — CodeRabbit `…6fjN5S`: the comment described the `unreadable` branch while the loop
  beneath it asserts the `residue` branch REPLACES the stored value. The assertions were
  right; CodeRabbit's own comment split is applied verbatim and answered in-thread.
- **L1** — the hoist comment named only the read as its limit. The `describes` writes sit
  after the whole try/catch, so they are skipped whenever the read OR the proof throws —
  including the common `PluginsEnabledDisproved`. Sentence corrected; no behaviour change.
- **L2** — `config_name_list` in `register-mcp.sh` reads a residue deny-list the strict way
  too, and it stays that way ON PURPOSE. There the cost of the disagreement is that one boot
  does not re-arm and the owner's next Save does it instead; in `hermes-clawai.ts` the same
  reading withdraws image generation from a box that draws. The docstring now states the
  asymmetry and why it is safe there and not here. Shell behaviour unchanged.
- **L3** — no code change, and the RED claim is corrected here instead: "still links a FIRST
  box whose hermes has no `plugins list --json`" is GREEN on its own parent and is NOT one of
  the five RED cases. It is the counterweight to the two red cases beside it — it pins that
  the fallback still arms a genuine first link — and commit `489f71be`'s message overstates
  it as a regression test (`1bdf416a` after the rebase). The five listed under that round's RED
  are the whole RED set for it; this round adds the sixth, above.
- **I1** — on a loadable box the link path still writes `image_gen.provider` over a
  customer-chosen backend, while `withdrawImageProviderClaim` is careful to remove only our
  own name. Pre-existing in beta and out of this PR's scope; recorded as a follow-up on
  TASK-701 rather than widened into a seventh round.
- **I2** — the native writer (`hermes plugins enable`) follow-up stands as recorded above:
  not adopted here because `_resolve_plugin_key("clawai")` answers `image_gen/clawai`, a
  different string from the bare name every field box's loader already accepts, and swapping
  them is a link-path change that wants a device test with a mutation.

### Round-6 review (Opus, one agent, delta only)

`f5634c67..HEAD` reviewed on its own: **APPROVE, 0 blockers** — 0 high, 1 medium (process:
"push it and answer the thread", done here), 3 low, 4 nits. The reviewer answered the two
questions this fix had to survive:

- **Does the empty set trade a false failure for a false SUCCESS?** No, and the argument closes:
  `residue` and "hermes denies nothing" are the same predicate read from opposite ends. `config
  get --json` prints `json.dumps`, so a Python list always serialises to a JSON array; `residue`
  therefore means the stored value is not a list, which is exactly the input `_get_disabled_set()`
  reduces to the empty set. And `hermesKeysConfirmPluginLoadable` has already proved
  `plugins.enabled` is a real list naming us before it asks, so `_plugin_status()` falls to its
  `enabled` branch. Tabulated over all five deny-list spellings: two arm where they used to
  withdraw and hermes agrees; the two real lists still withdraw; the unreadable rendering still
  makes no claim either way.
- **Does the new test pass for the right reason?** Verified by running it against a full revert
  and against BOTH half-fixes (only the JSON-string spelling fixed, then only the bare scalar).
  It fails in all three and is the only failing test in its file each time.

Applied from it: the `readPluginsDisabledFromCli` DOCBLOCK still asserted the invariant this
round widened — an IDE shows it at the call site, so it told the next maintainer to restore the
withdrawal; CodeRabbit's borrowed sentence "a JSON value that is not a list names no plugin" is
refuted by the assertion 30 lines above it (a bare scalar and a JSON-string spelling a list both
name plugins and are KEPT — the property that makes `7`/`null`/`true` replaceable is that no name
could be recovered); and `register-mcp.sh`'s docstring undersold its own strictness, which also
declines on a mapping, a number and a boolean.

Refused, with the reason: **NIT-1**, the hoist comment names two of three throw classes — the
clause "nothing below the block above runs then" already states the general rule, and it is round
5's own fix direction verbatim. **NIT-3**, the shell case the new docstring is about
(`disabled: '["clawai"]'`) has no test — the divergence it would catch is the SAFE direction (a
boot that does not re-arm), so a silent alignment with hermes later would fix behaviour rather
than break it; not worth a seventh round. **NIT-4**, the new test's two loop members exercise the
same `kind === "residue"` decision — true, and they earn their place by foreclosing a
spelling-specific fix, which is what the two half-fix runs above demonstrate.

Findings file (local, not in the repo): `code-review-pr638-final6.md`.

### Device leg, round 6

Read-only through the `clawbox-box` skill: `_get_disabled_set`, `_get_enabled_set` and
`_plugin_status` were re-read off the Hermes box's installed 0.20.5 package to confirm the
type gate this fix rests on. **No box was mutated.** The Settings → AI Models save itself is
still **unproven on hardware** — the owner validates on the boxes — and the unit suite covers
every branch of it.
