### PR TITLE
fix: a partial append must not leave the idempotence marker on a fragment

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -3290,10 +3290,14 @@ clawbox_append_or_rollback() {
   if [ -n "$after" ] && [ "$after" = "$before" ]; then
     return 1
   fi
-  # `truncate` is coreutils, which is essential on both rootfs images; the `dd`
-  # form is the busybox fallback and costs nothing to carry.
+  # `truncate` is coreutils, which is essential on both rootfs images; python3
+  # is the fallback, and it is python rather than `dd` deliberately —
+  # `dd of=… seek=N count=0` truncates at the seek offset on GNU coreutils but
+  # is not guaranteed to elsewhere, and the one implementation that gets it
+  # wrong empties the file this function exists to preserve. `os.truncate` says
+  # exactly what is meant, and this script already depends on python3 throughout.
   if ! truncate -s "$before" "$dest" 2>/dev/null \
-    && ! dd of="$dest" bs=1 seek="$before" count=0 2>/dev/null; then
+    && ! python3 -c 'import os,sys; os.truncate(sys.argv[1], int(sys.argv[2]))' "$dest" "$before" 2>/dev/null; then
     echo "  WARNING: could not roll $dest back after a failed append; it may be cut mid-section" >&2
   fi
   return 1

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -3192,6 +3192,18 @@ if [ -r "$CLAWBOX_BOOTSTRAP_SRC" ] \
     && install -m 644 "$CLAWBOX_BOOTSTRAP_SRC" "$CLAWBOX_BOOTSTRAP_DST"; then
     echo "  Seeded ClawBox's BOOTSTRAP.md into a fresh OpenClaw workspace"
   else
+    # The same partial-write hole the CLAWBOX.md seed below closes, in the same
+    # verb, and its consequence is worse. `install` that stops part way — ENOSPC
+    # on a full eMMC, the first-boot and post-factory-reset path — leaves a
+    # fragment, and the guard above is `[ ! -e ]`, which a fragment satisfies
+    # FOREVER. The script's own rule is that a BOOTSTRAP.md already on disk is
+    # adopted verbatim, so OpenClaw would run the birth sequence against a ritual
+    # cut off mid-sentence, delete the file when it thinks it is done, and stamp
+    # the workspace complete: the owner is never asked their name, permanently,
+    # with no second chance. The enclosing `[ ! -e "$CLAWBOX_BOOTSTRAP_DST" ]`
+    # proves the file did not exist before this attempt, so removing it destroys
+    # nothing and the next boot re-seeds from scratch.
+    rm -f "$CLAWBOX_BOOTSTRAP_DST" 2>/dev/null || true
     # Not fatal, and not silent: OpenClaw still runs its own introduction, it
     # just will not ask the owner their name.
     echo "  WARNING: could not seed BOOTSTRAP.md; OpenClaw will use its own ritual" >&2
@@ -3214,8 +3226,10 @@ fi
 CLAWBOX_GUIDE_SRC="$CLAWBOX_ROOT/config/clawbox-workspace-guide.md"
 CLAWBOX_GUIDE_DST="$CLAWBOX_WORKSPACE/CLAWBOX.md"
 # The heading of the section an already-seeded CLAWBOX.md is topped up with,
-# and the marker that says it is already there. Matched with `grep -qF` and
-# `index(...) == 1`, so it must be the literal start of the heading line.
+# and the marker that says it is already there. Matched with `grep -qF` and, in
+# the awk below, a WHOLE-LINE `==` against the heading — deliberately, for the
+# reason stated at that awk: a prefix match would let
+# `## System actions and restarts (advanced)` swallow every section after it.
 CLAWBOX_GUIDE_TOPUP="## System actions and restarts"
 
 # Append to a file so that a write which stops PART WAY leaves nothing behind.
@@ -3244,10 +3258,38 @@ CLAWBOX_GUIDE_TOPUP="## System actions and restarts"
 # the option that closes it, at the cost of a full copy at peak on the one
 # occasion there is no room for one.
 #
-# The destination must already exist; all three callers guarantee it (the seed
-# branch runs only when it does not, and the AGENTS.md blocks test `-f` first).
-# A missing file is still handled rather than assumed: there is nothing to
-# measure, so the rollback is a removal.
+# The destination must already exist, and that is the CONTRACT rather than a
+# case to handle: the seed branch runs only when it does not, and the two
+# AGENTS.md blocks test `-f` first. An "it was absent, so remove it" branch was
+# tried and removed — it is unreachable from every caller, and the one line in
+# it that could run is the only line here able to delete a file the helper did
+# not create (`[ -e ]` is false for a DANGLING SYMLINK, `printf >>` follows the
+# link and creates its target, and the removal would then take the link and
+# orphan the fragment: the opposite of a rollback).
+#
+# Single-writer, and that is a precondition, not a coincidence: `truncate -s`
+# restores a length measured before the write, so anything a second writer
+# appended in that window is discarded. Safe here because this runs in
+# `ExecStartPre` with the gateway — and therefore the agent and its file tools —
+# stopped. A caller that runs while the agent is live must not use it.
+# The size of a file in bytes, or "" when it cannot be read.
+#
+# Two syscall paths, because the number decides whether a rollback happens at
+# all: `wc -c` opens and reads, `stat` does not, so a file that is present but
+# unopenable (mode 0222) still answers. Note the redirection ORDER — bash
+# applies them left to right, so `< "$f" 2>/dev/null` opens BEFORE stderr is
+# silenced and a "Permission denied" line reaches the gateway journal on a boot
+# where nothing went wrong.
+clawbox_file_size() {
+  local size=""
+  [ -e "$1" ] || return 0
+  size="$(wc -c 2>/dev/null < "$1" || true)"
+  size="${size//[![:digit:]]/}"
+  [ -n "$size" ] || size="$(stat -c %s "$1" 2>/dev/null || true)"
+  size="${size//[![:digit:]]/}"
+  printf '%s' "$size"
+}
+
 clawbox_append_or_rollback() {
   local dest="$1" payload="$2" before="" after=""
   # A no-op append that reports success is the failure mode this whole block
@@ -3260,24 +3302,13 @@ clawbox_append_or_rollback() {
   fi
   # Measured BEFORE the write, and a length that could not be read is a length
   # this must never truncate to: with no number the only safe outcome is to
-  # leave the file as the failed write left it and say so.
-  if [ -e "$dest" ]; then
-    before="$(wc -c < "$dest" 2>/dev/null || true)"
-    before="${before//[![:digit:]]/}"
-  else
-    before="absent"
-  fi
+  # leave the file as the failed write left it and say what to do about it.
+  before="$(clawbox_file_size "$dest")"
   if printf '%s' "$payload" >> "$dest"; then
     return 0
   fi
   if [ -z "$before" ]; then
-    echo "  WARNING: could not measure $dest before a failed append; a partial write may remain" >&2
-    return 1
-  fi
-  if [ "$before" = "absent" ]; then
-    # Nothing to roll back TO. The file is either absent (the open failed) or a
-    # fragment this call created; either way removing it is the rollback.
-    rm -f "$dest" 2>/dev/null || true
+    echo "  WARNING: could not measure $dest before a failed append. Check it for a truncated '${payload%%$'\n'*}' section; deleting the file lets the next gateway start rebuild it." >&2
     return 1
   fi
   # A write that failed at OPEN — EACCES on a 0444 file, EROFS on a rootfs
@@ -3285,8 +3316,7 @@ clawbox_append_or_rollback() {
   # the same reason. Warning about a file that is byte-identical to what it was
   # sends an operator triaging a real disk fault to inspect a guide that is
   # fine, on every boot. Ask the file before saying anything about it.
-  after="$(wc -c < "$dest" 2>/dev/null || true)"
-  after="${after//[![:digit:]]/}"
+  after="$(clawbox_file_size "$dest")"
   if [ -n "$after" ] && [ "$after" = "$before" ]; then
     return 1
   fi
@@ -3303,7 +3333,8 @@ clawbox_append_or_rollback() {
   return 1
 }
 # EVERY write in this block — the appends through the helper above included —
-# is guarded, and that is a boot requirement rather than a matter of taste: config/clawbox-gateway.service runs this script as
+# is guarded, and that is a boot requirement rather than a matter of taste:
+# config/clawbox-gateway.service runs this script as an
 # `ExecStartPre=` with no leading `-`, so under `set -euo pipefail` a failing
 # write here is the unit's failure. With Restart=always and RestartSec=5 the
 # gateway would burn StartLimitBurst=20 in about a hundred seconds and then sit

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -3217,8 +3217,89 @@ CLAWBOX_GUIDE_DST="$CLAWBOX_WORKSPACE/CLAWBOX.md"
 # and the marker that says it is already there. Matched with `grep -qF` and
 # `index(...) == 1`, so it must be the literal start of the heading line.
 CLAWBOX_GUIDE_TOPUP="## System actions and restarts"
-# EVERY write below is guarded, and that is a boot requirement rather than a
-# matter of taste: config/clawbox-gateway.service runs this script as
+
+# Append to a file so that a write which stops PART WAY leaves nothing behind.
+#
+# Every append below writes its HEADING first, and that heading is also the
+# marker the next boot greps for to decide whether the append already happened.
+# A write that stops half-way — ENOSPC on a full Jetson eMMC is the realistic
+# shape — therefore leaves the marker sitting on a fragment: every later gateway
+# start finds the heading, appends nothing, and the file stays cut mid-sentence
+# FOREVER, while the only warning is a journal line from a boot nobody is
+# watching. What is lost is the tail of the section, which is where TASK-612's
+# deliverable ("never queue an operator_approval proposal") lives.
+#
+# Rolling the file back to the length it had removes the fragment AND the
+# marker, so the next boot retries. Rollback rather than build-a-copy-and-
+# rename: these are owner-personalised files with their own mode and owner, and
+# the case this exists for is a FULL disk, where a second full copy is the least
+# affordable thing to ask for.
+#
+# NAMED FOR WHAT IT IS, not "atomic", because it is not: it undoes a write that
+# FAILED, and nothing it can do covers a shell that DIES between the partial
+# write and the rollback — a SIGTERM from `systemctl restart` landing in
+# ExecStartPre, an OOM kill, a power cut on the very box whose disk is full.
+# That residual window is the price of not writing a second copy of the file,
+# and it is a much smaller target than the whole build: temp-file + rename is
+# the option that closes it, at the cost of a full copy at peak on the one
+# occasion there is no room for one.
+#
+# The destination must already exist; all three callers guarantee it (the seed
+# branch runs only when it does not, and the AGENTS.md blocks test `-f` first).
+# A missing file is still handled rather than assumed: there is nothing to
+# measure, so the rollback is a removal.
+clawbox_append_or_rollback() {
+  local dest="$1" payload="$2" before="" after=""
+  # A no-op append that reports success is the failure mode this whole block
+  # goes to lengths to avoid elsewhere ("appending a separator alone would
+  # report a success that added nothing, and would do it again on every gateway
+  # start"). Refuse it here so no future caller has to remember.
+  if [ -z "$payload" ]; then
+    echo "  WARNING: refusing to append an empty payload to $dest" >&2
+    return 1
+  fi
+  # Measured BEFORE the write, and a length that could not be read is a length
+  # this must never truncate to: with no number the only safe outcome is to
+  # leave the file as the failed write left it and say so.
+  if [ -e "$dest" ]; then
+    before="$(wc -c < "$dest" 2>/dev/null || true)"
+    before="${before//[![:digit:]]/}"
+  else
+    before="absent"
+  fi
+  if printf '%s' "$payload" >> "$dest"; then
+    return 0
+  fi
+  if [ -z "$before" ]; then
+    echo "  WARNING: could not measure $dest before a failed append; a partial write may remain" >&2
+    return 1
+  fi
+  if [ "$before" = "absent" ]; then
+    # Nothing to roll back TO. The file is either absent (the open failed) or a
+    # fragment this call created; either way removing it is the rollback.
+    rm -f "$dest" 2>/dev/null || true
+    return 1
+  fi
+  # A write that failed at OPEN — EACCES on a 0444 file, EROFS on a rootfs
+  # remounted read-only — wrote nothing at all, and truncating then fails for
+  # the same reason. Warning about a file that is byte-identical to what it was
+  # sends an operator triaging a real disk fault to inspect a guide that is
+  # fine, on every boot. Ask the file before saying anything about it.
+  after="$(wc -c < "$dest" 2>/dev/null || true)"
+  after="${after//[![:digit:]]/}"
+  if [ -n "$after" ] && [ "$after" = "$before" ]; then
+    return 1
+  fi
+  # `truncate` is coreutils, which is essential on both rootfs images; the `dd`
+  # form is the busybox fallback and costs nothing to carry.
+  if ! truncate -s "$before" "$dest" 2>/dev/null \
+    && ! dd of="$dest" bs=1 seek="$before" count=0 2>/dev/null; then
+    echo "  WARNING: could not roll $dest back after a failed append; it may be cut mid-section" >&2
+  fi
+  return 1
+}
+# EVERY write in this block — the appends through the helper above included —
+# is guarded, and that is a boot requirement rather than a matter of taste: config/clawbox-gateway.service runs this script as
 # `ExecStartPre=` with no leading `-`, so under `set -euo pipefail` a failing
 # write here is the unit's failure. With Restart=always and RestartSec=5 the
 # gateway would burn StartLimitBurst=20 in about a hundred seconds and then sit
@@ -3246,6 +3327,14 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
     if install -m 644 "$CLAWBOX_GUIDE_SRC" "$CLAWBOX_GUIDE_DST"; then
       echo "  Seeded CLAWBOX.md in OpenClaw workspace"
     else
+      # The seed has the same partial-write problem as the appends, and it is
+      # WORSE: the fragment it leaves already contains the top-up marker, so the
+      # `grep -qF` below finds the heading on every later boot, appends nothing,
+      # and the box keeps a guide cut mid-sentence for good. The enclosing
+      # `elif [ ! -f "$CLAWBOX_GUIDE_DST" ]` proves the file did not exist before
+      # this attempt, so removing it destroys nothing and the next boot re-seeds
+      # from scratch.
+      rm -f "$CLAWBOX_GUIDE_DST" 2>/dev/null || true
       # The first-boot and post-factory-reset path, and the one write in this
       # block that used to be bare: a full rootfs, a filesystem remounted
       # read-only after errors, or the documented "delete CLAWBOX.md to
@@ -3302,15 +3391,26 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
         # it. Appending a separator alone would report a success that added
         # nothing, and would do it again on every gateway start.
         echo "  WARNING: the shipped guide no longer carries '$CLAWBOX_GUIDE_TOPUP'" >&2
-      # A file that does not end in a newline would otherwise have its last
-      # line joined to the separator, making it a setext heading.
-      elif { [ -s "$CLAWBOX_GUIDE_DST" ] && [ "$(tail -c1 "$CLAWBOX_GUIDE_DST")" != "" ] && printf '\n'; \
-             printf '\n---\n\n%s\n' "$CLAWBOX_GUIDE_SECTION"; } >> "$CLAWBOX_GUIDE_DST"; then
-        echo "  Appended the system-actions section to CLAWBOX.md"
       else
-        # Its cause is on this shell's stderr already; do not hide it behind a
-        # 2>/dev/null that the failing redirection never reaches anyway.
-        echo "  WARNING: could not append the system-actions section to CLAWBOX.md" >&2
+        # A file that does not end in a newline would otherwise have its last
+        # line joined to the separator, making it a setext heading.
+        CLAWBOX_GUIDE_LEAD=""
+        if [ -s "$CLAWBOX_GUIDE_DST" ] && [ "$(tail -c1 "$CLAWBOX_GUIDE_DST")" != "" ]; then
+          CLAWBOX_GUIDE_LEAD=$'\n'
+        fi
+        # Rendered whole first, then handed to the one writer that can undo a
+        # partial write. `printf -v` and not a command substitution: `$( )`
+        # strips trailing newlines, and the section's final newline is what
+        # keeps the next append off the last line of this one.
+        printf -v CLAWBOX_GUIDE_APPEND '%s\n---\n\n%s\n' "$CLAWBOX_GUIDE_LEAD" "$CLAWBOX_GUIDE_SECTION"
+        if clawbox_append_or_rollback "$CLAWBOX_GUIDE_DST" "$CLAWBOX_GUIDE_APPEND"; then
+          echo "  Appended the system-actions section to CLAWBOX.md"
+        else
+          # The cause is on this shell's stderr already — the helper's failing
+          # redirection prints it — so this line names the deliverable, not the
+          # errno.
+          echo "  WARNING: could not append the system-actions section to CLAWBOX.md" >&2
+        fi
       fi
     else
       # Separated from the empty-extraction case on purpose: an unreadable
@@ -3340,7 +3440,8 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
     # always been bare, so a read-only AGENTS.md aborted pre-start under
     # `set -euo pipefail` and the gateway never started — over a pointer
     # sentence. Reachable whenever the file exists without the marker.
-    if printf '\n\n%s\n\nSee `CLAWBOX.md` for device-specific conventions: where user-installed skills live, how to control the desktop Chromium via `browser_*` tools, how to install/uninstall skills through the App Store, and which system actions are the owner'"'"'s.\n' "$CLAWBOX_AGENTS_POINTER" >> "$CLAWBOX_AGENTS_MD"; then
+    printf -v CLAWBOX_AGENTS_POINTER_TEXT '\n\n%s\n\nSee `CLAWBOX.md` for device-specific conventions: where user-installed skills live, how to control the desktop Chromium via `browser_*` tools, how to install/uninstall skills through the App Store, and which system actions are the owner'"'"'s.\n' "$CLAWBOX_AGENTS_POINTER"
+    if clawbox_append_or_rollback "$CLAWBOX_AGENTS_MD" "$CLAWBOX_AGENTS_POINTER_TEXT"; then
       echo "  Appended CLAWBOX.md reference to AGENTS.md"
     else
       echo "  WARNING: could not append the CLAWBOX.md reference to AGENTS.md" >&2
@@ -3363,7 +3464,8 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
   # never be delivered again.
   CLAWBOX_AGENTS_RULE="## System actions on this ClawBox"
   if [ -f "$CLAWBOX_AGENTS_MD" ] && ! grep -qF "$CLAWBOX_AGENTS_RULE" "$CLAWBOX_AGENTS_MD"; then
-    if printf '\n\n%s\n\nRestarting the OpenClaw gateway is not yours to do from a chat turn: the gateway hosts this session, so the restart kills the reply before it lands. It is rarely needed either — saving a setting under Settings -> Providers, Voice or Channels restarts it. Say that, and name the setting.\n\nA device restart or shutdown IS yours when the owner asks in their own words: `system_power`, `confirm: true`, with their reason. Their own control is the power menu in the desktop tray, not Settings -> System.\n\nNever queue an `operator_approval` proposal for any of this. ClawBox renders no approval card, so a queued proposal is shown to nobody; a parked one is answered with `openclaw approvals pending` / `openclaw approvals resolve` from the Terminal app. `CLAWBOX.md` has the long form.\n' "$CLAWBOX_AGENTS_RULE" >> "$CLAWBOX_AGENTS_MD"; then
+    printf -v CLAWBOX_AGENTS_RULE_TEXT '\n\n%s\n\nRestarting the OpenClaw gateway is not yours to do from a chat turn: the gateway hosts this session, so the restart kills the reply before it lands. It is rarely needed either — saving a setting under Settings -> Providers, Voice or Channels restarts it. Say that, and name the setting.\n\nA device restart or shutdown IS yours when the owner asks in their own words: `system_power`, `confirm: true`, with their reason. Their own control is the power menu in the desktop tray, not Settings -> System.\n\nNever queue an `operator_approval` proposal for any of this. ClawBox renders no approval card, so a queued proposal is shown to nobody; a parked one is answered with `openclaw approvals pending` / `openclaw approvals resolve` from the Terminal app. `CLAWBOX.md` has the long form.\n' "$CLAWBOX_AGENTS_RULE"
+    if clawbox_append_or_rollback "$CLAWBOX_AGENTS_MD" "$CLAWBOX_AGENTS_RULE_TEXT"; then
       echo "  Appended the system-actions rule to AGENTS.md"
     else
       # Advisory text must never hold up the gateway; the next start retries.

--- a/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
+++ b/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
@@ -194,6 +194,11 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
     // write, so the call form — a quoted destination — is what is matched).
     const writes = lines.filter((line) =>
       /^(if |elif )?(install|cp|mv|tee|truncate|rm)\b/.test(line)
+      // The rollback is two commands on two lines — `if ! truncate …` and the
+      // continued `&& ! dd of=…` — and without this the six-line minimum would
+      // still be met with BOTH of them deleted.
+      || /^(if\s+)?!\s*truncate\b/.test(line)
+      || /^&&\s*!\s*dd\b/.test(line)
       || />>/.test(line)
       // The helper's CALL, not its definition line. Matched on the name alone
       // so an unquoted first argument cannot slip past the filter — which is
@@ -205,13 +210,19 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
     const unguarded = writes.filter((line) =>
       !/^(if|elif)\b/.test(line)
       && !/;\s*then$/.test(line)
-      // A rollback that cannot roll back must not take the boot down either.
-      && !/\|\|\s*true$/.test(line));
+      // A rollback that cannot roll back must not take the boot down either —
+      // but the exception is `rm`'s alone. `printf … >> "$f" || true` would
+      // otherwise pass this audit while printing a success line over a failed
+      // write, which is the class the audit exists to catch.
+      && !/^rm\b.*\|\|\s*true$/.test(line));
 
     // Sanity: the filter has to be finding this block's write sites — the seed,
     // the three appends, the helper's own redirection and its two rollback
     // verbs — or an empty `unguarded` would prove nothing.
     expect(writes.length).toBeGreaterThanOrEqual(6);
+    // Both rollback verbs, by name: a six-line count can be met without them.
+    expect(writes.join("\n")).toMatch(/truncate -s/);
+    expect(writes.join("\n")).toMatch(/dd of=/);
     expect(unguarded).toEqual([]);
   });
 

--- a/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
+++ b/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
@@ -210,8 +210,8 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
     const writes = lines.filter((line) =>
       /^(if |elif )?(install|cp|mv|tee|truncate|rm)\b/.test(line)
       // The rollback is two commands on two lines — `if ! truncate …` and the
-      // continued `&& ! dd of=…` — and without this the six-line minimum would
-      // still be met with BOTH of them deleted.
+      // continued `&& ! python3 -c '… os.truncate …'` — and without this the
+      // write-count floor would still be met with BOTH of them deleted.
       || /^(if\s+)?!\s*truncate\b/.test(line)
       || /^&&\s*!\s*python3\b/.test(line)
       || />>/.test(line)
@@ -233,14 +233,14 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
 
     // Sanity: the filter has to be finding this block's write sites, or an
     // empty `unguarded` would prove nothing. The floor is the REAL count, not a
-    // token one — at six, three of these could have been deleted outright and
-    // this test would still have passed. They are, today:
+    // token one. The eight write sites are, today:
     //   1 the helper's own `printf >>`
     //   2 `truncate -s`, 3 the `python3 os.truncate` fallback
     //   4 the `install` seed, 5 its failure-branch `rm -f`
     //   6-8 the three `clawbox_append_or_rollback` calls
     expect(writes.length).toBeGreaterThanOrEqual(8);
-    // Both rollback verbs, by name: a six-line count can be met without them.
+    // Both rollback verbs, by name: the write-count floor can be met
+    // without them.
     expect(writes.join("\n")).toMatch(/truncate -s/);
     expect(writes.join("\n")).toMatch(/os\.truncate/);
     expect(unguarded).toEqual([]);

--- a/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
+++ b/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
@@ -110,7 +110,7 @@ function run(template = TEMPLATE): { stdout: string; stderr: string } {
 function runCapped(
   bytes: number,
   template = TEMPLATE,
-  opts: { hideTruncate?: boolean } = {},
+  opts: { hideTruncate?: boolean; hidePython?: boolean } = {},
 ): { status: number | null; stdout: string; stderr: string } {
   const root = mkdtempSync(path.join(dir, "root-"));
   mkdirSync(path.join(root, "config"), { recursive: true });
@@ -122,6 +122,14 @@ function runCapped(
     // A rootfs without coreutils' `truncate`: the shell function shadows the
     // binary, so the helper falls through to its python3 fallback.
     ...(opts.hideTruncate ? ["truncate() { return 127; }"] : []),
+    // …and both of them gone, which is the only way to reach the helper's
+    // "could not roll it back" warning. Two divergences from a real ENOSPC are
+    // worth knowing when reading these fixtures: the shipped script sets no
+    // XFSZ trap (correct — ENOSPC raises no signal, only `ulimit -f` does), and
+    // under the cap the rollback verbs themselves always succeed, which is why
+    // the failed-rollback branch needs a shadow of its own rather than falling
+    // out of any capped run.
+    ...(opts.hidePython ? ["python3() { return 127; }"] : []),
     `ulimit -f ${blocks}`,
     `CLAWBOX_ROOT=${JSON.stringify(root)}`,
     `CLAWBOX_WORKSPACE=${JSON.stringify(workspace)}`,
@@ -221,12 +229,17 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
       // but the exception is `rm`'s alone. `printf … >> "$f" || true` would
       // otherwise pass this audit while printing a success line over a failed
       // write, which is the class the audit exists to catch.
-      && !/^rm\b.*\|\|\s*true$/.test(line));
+      && !/^rm -f "\$[A-Za-z_][A-Za-z0-9_]*" 2>\/dev\/null \|\| true$/.test(line));
 
-    // Sanity: the filter has to be finding this block's write sites — the seed,
-    // the three appends, the helper's own redirection and its two rollback
-    // verbs — or an empty `unguarded` would prove nothing.
-    expect(writes.length).toBeGreaterThanOrEqual(6);
+    // Sanity: the filter has to be finding this block's write sites, or an
+    // empty `unguarded` would prove nothing. The floor is the REAL count, not a
+    // token one — at six, three of these could have been deleted outright and
+    // this test would still have passed. They are, today:
+    //   1 the helper's own `printf >>`
+    //   2 `truncate -s`, 3 the `python3 os.truncate` fallback
+    //   4 the `install` seed, 5 its failure-branch `rm -f`
+    //   6-8 the three `clawbox_append_or_rollback` calls
+    expect(writes.length).toBeGreaterThanOrEqual(8);
     // Both rollback verbs, by name: a six-line count can be met without them.
     expect(writes.join("\n")).toMatch(/truncate -s/);
     expect(writes.join("\n")).toMatch(/os\.truncate/);
@@ -404,6 +417,64 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
     expect(res.stderr).toContain("could not append");
     expect(res.stderr).not.toContain("could not roll");
     expect(readFileSync(guide, "utf-8")).toBe(older);
+  });
+
+  it.skipIf(process.getuid?.() === 0)("measures a destination it cannot open, and says nothing about it", () => {
+    // Two things at once, both in the false-failure class.
+    //
+    // The number decides whether a rollback happens at all, and `wc -c` needs
+    // to OPEN the file: on a present-but-unopenable destination the helper had
+    // no length and left the fragment. `stat` does not open, so it still
+    // answers.
+    //
+    // And the redirection ORDER: bash applies them left to right, so
+    // `wc -c < "$f" 2>/dev/null` opens BEFORE stderr is silenced and a
+    // "Permission denied" line reached the gateway journal on a boot where
+    // nothing had gone wrong — in the file an operator triaging a real disk
+    // fault is reading.
+    const target = path.join(dir, "unopenable.md");
+    writeFileSync(target, "0123456789");
+    chmodSync(target, 0o222);
+
+    const script = [
+      "set -euo pipefail",
+      `CLAWBOX_ROOT=${JSON.stringify(dir)}`,
+      // A workspace that does not exist, so the block defines its helpers and
+      // runs none of its own writes.
+      `CLAWBOX_WORKSPACE=${JSON.stringify(path.join(dir, "nowhere"))}`,
+      seedingBlock(),
+      `clawbox_file_size ${JSON.stringify(target)}`,
+    ].join("\n");
+    const res = spawnSync("bash", ["-c", script], { encoding: "utf-8" });
+
+    expect(res.status).toBe(0);
+    expect(res.stdout).toBe("10");
+    expect(res.stderr).toBe("");
+  });
+
+  it("says the fragment is still there when NEITHER rollback verb can run", () => {
+    // The one operator-facing line in the helper that no other case reaches:
+    // both verbs shadowed, so the rollback itself fails. Without a fixture of
+    // its own the message could be malformed, or the `if ! … && ! …` chain
+    // inverted, and every other case would stay green.
+    //
+    // The three things that matter here are the three the helper promises: the
+    // boot survives, the failure is NOT reported as a success, and the file is
+    // named as suspect rather than claimed clean.
+    const older = padToJustUnderABlock(readFileSync(TEMPLATE, "utf-8").split(`\n---\n\n${HEADING}`)[0]);
+    writeFileSync(guide, older);
+
+    const res = runCapped(Buffer.byteLength(older) + 64, TEMPLATE, {
+      hideTruncate: true,
+      hidePython: true,
+    });
+
+    expect(res.status).toBe(0);
+    expect(res.stderr).toContain("could not roll");
+    expect(res.stderr).toContain(guide);
+    expect(res.stdout).not.toContain("Appended the system-actions section");
+    // …and it really is still cut: the warning is not itself a false failure.
+    expect(readFileSync(guide, "utf-8").length).toBeGreaterThan(older.length);
   });
 
   it("appends the whole section on the next boot after a part-way write", () => {

--- a/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
+++ b/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -42,6 +42,25 @@ function seedingBlock(): string {
   return src.slice(start, end);
 }
 
+/**
+ * Pad `body` so it ends `slack` bytes below a 1024-byte boundary.
+ *
+ * The cap `runCapped` sets can only land on a block boundary, so without this
+ * the room left for the append is whatever the template's length happens to
+ * leave — measured at 1242 bytes for today's guide, which is most of the way to
+ * the 1761-byte section. The case would still fail loudly the day the section
+ * is trimmed, but with a message about the wrong thing.
+ */
+function padToJustUnderABlock(body: string, slack = 64): string {
+  const filler = "Owner note: the printer is on the shelf.\n";
+  let out = body;
+  while ((Buffer.byteLength(out) + slack) % 1024 !== 0) {
+    const gap = (1024 - ((Buffer.byteLength(out) + slack) % 1024) + 1024) % 1024;
+    out += gap >= filler.length ? filler : "x".repeat(gap);
+  }
+  return out;
+}
+
 let dir: string;
 let workspace: string;
 let guide: string;
@@ -70,6 +89,39 @@ function run(template = TEMPLATE): { stdout: string; stderr: string } {
     throw new Error(`pre-start block exited ${res.status}\n${res.stdout}\n${res.stderr}`);
   }
   return { stdout: res.stdout, stderr: res.stderr };
+}
+
+/**
+ * The same run under a file-size limit, so an append stops PART WAY through.
+ *
+ * A full Jetson eMMC is the realistic shape and ENOSPC cannot be produced in a
+ * unit test; `ulimit -f` produces the same partial write with the same
+ * non-zero return. `trap "" XFSZ` is what makes it a return value rather than a
+ * signal — without it the kernel kills the shell and nothing in the block ever
+ * gets to see the failure it is supposed to handle.
+ *
+ * `bytes` is rounded up to the 1024-byte blocks bash's `ulimit -f` counts in
+ * (bash scales -f by 1024, not by the POSIX 512 — getting that wrong makes the
+ * cap twice as generous as intended and the append simply succeeds). Because
+ * the cap can only move in whole blocks, callers pad their fixture so the
+ * headroom is a fixed small number rather than "up to 1023 bytes, depending on
+ * how long the shipped template happens to be" — see `padToJustUnderABlock`.
+ */
+function runCapped(bytes: number, template = TEMPLATE): { status: number | null; stdout: string; stderr: string } {
+  const root = mkdtempSync(path.join(dir, "root-"));
+  mkdirSync(path.join(root, "config"), { recursive: true });
+  writeFileSync(path.join(root, "config/clawbox-workspace-guide.md"), readFileSync(template, "utf-8"));
+  const blocks = Math.max(1, Math.ceil(bytes / 1024));
+  const script = [
+    "set -euo pipefail",
+    'trap "" XFSZ',
+    `ulimit -f ${blocks}`,
+    `CLAWBOX_ROOT=${JSON.stringify(root)}`,
+    `CLAWBOX_WORKSPACE=${JSON.stringify(workspace)}`,
+    seedingBlock(),
+  ].join("\n");
+  const res = spawnSync("bash", ["-c", script], { encoding: "utf-8" });
+  return { status: res.status, stdout: res.stdout, stderr: res.stderr };
 }
 
 beforeEach(() => {
@@ -125,26 +177,41 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
     // where both `skipIf` cases skip and nothing else covers the appends.
     //
     // A write that OPENS a statement runs with `set -e` armed, and its failure is
-    // the whole unit's failure. Both sanctioned forms put the write in a
-    // condition instead — `if printf … >> f; then` or `elif { …; } >> f; then` —
-    // where `set -e` is suspended and an else branch can warn. `… || true` is
-    // deliberately NOT sanctioned here: it keeps the boot alive but lets the
-    // success line print over a write that failed, which is the false-success
-    // class this block exists to avoid.
+    // the whole unit's failure. The sanctioned form puts the write in a
+    // condition instead — `if install …; then`, or `if clawbox_append_or_rollback
+    // …; then` — where `set -e` is suspended and an else branch can warn.
+    // `… || true` is deliberately NOT sanctioned here: it keeps the boot alive
+    // but lets the success line print over a write that failed, which is the
+    // false-success class this block exists to avoid. (`rm -f … || true` on a
+    // recovery path is the one exception, and it is matched below as a write so
+    // it stays visible; it undoes rather than produces.)
     const lines = seedingBlock()
       .split("\n")
       .map((line) => line.trim())
       .filter((line) => line && !line.startsWith("#"));
-    // Every line that writes: a copy verb, or an append redirection.
-    const writes = lines.filter((line) => /^(if |elif )?(install|cp|mv|tee)\b/.test(line) || />>/.test(line));
+    // Every line that writes: a copy verb, an append redirection, or a call to
+    // the one helper that owns the appends (its own definition line is not a
+    // write, so the call form — a quoted destination — is what is matched).
+    const writes = lines.filter((line) =>
+      /^(if |elif )?(install|cp|mv|tee|truncate|rm)\b/.test(line)
+      || />>/.test(line)
+      // The helper's CALL, not its definition line. Matched on the name alone
+      // so an unquoted first argument cannot slip past the filter — which is
+      // exactly the shape this test exists to catch.
+      || (/^(if |elif )?clawbox_append_or_rollback\b/.test(line) && !/\(\)\s*\{/.test(line)));
     // Guarded means the write sits in a condition — the line opens with
     // `if`/`elif`, or it closes a brace group the condition consumes
     // (`…; } >> file; then`). Anything else runs with `set -e` armed.
-    const unguarded = writes.filter((line) => !/^(if|elif)\b/.test(line) && !/;\s*then$/.test(line));
+    const unguarded = writes.filter((line) =>
+      !/^(if|elif)\b/.test(line)
+      && !/;\s*then$/.test(line)
+      // A rollback that cannot roll back must not take the boot down either.
+      && !/\|\|\s*true$/.test(line));
 
-    // Sanity: the filter has to be finding this block's four writes (the seed
-    // and the three appends), or an empty `unguarded` would prove nothing.
-    expect(writes.length).toBeGreaterThanOrEqual(4);
+    // Sanity: the filter has to be finding this block's write sites — the seed,
+    // the three appends, the helper's own redirection and its two rollback
+    // verbs — or an empty `unguarded` would prove nothing.
+    expect(writes.length).toBeGreaterThanOrEqual(6);
     expect(unguarded).toEqual([]);
   });
 
@@ -228,6 +295,11 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
 
     expect(stdout).not.toContain("Appended the system-actions section");
     expect(stderr).toContain("could not append");
+    // ...and nothing about a rollback. A write that failed at OPEN wrote
+    // nothing, so warning that the file "may be cut mid-section" sends an
+    // operator triaging a real disk fault to inspect a guide that is fine —
+    // every boot, in the journal they are actually reading.
+    expect(stderr).not.toContain("could not roll");
     expect(readFileSync(guide, "utf-8")).toBe(older);
   });
 
@@ -255,6 +327,67 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
 
     const after = readFileSync(guide, "utf-8");
     expect(after.indexOf(HEADING)).toBeGreaterThan(after.indexOf("## Owner's notes"));
+  });
+
+  // Every append in this block writes its HEADING first, and the heading is
+  // also the `grep -qF` idempotence marker. A write that stops part way — a
+  // full eMMC on a Jetson is the realistic shape — therefore leaves the marker
+  // sitting on a fragment: every later gateway start finds the heading,
+  // appends nothing, and the guide stays cut mid-sentence forever. The one
+  // warning went to the journal at boot and is never seen again. What is lost
+  // is exactly TASK-612's deliverable, the "never queue an operator_approval"
+  // paragraph, which is the last thing the section says.
+  // The seed is the same defect one branch up, and worse: the fragment it leaves
+  // already contains the top-up marker, so the `grep -qF` guard finds the
+  // heading on every later boot, appends nothing, and the box keeps a guide cut
+  // mid-sentence for good. First boot and post-factory-reset is exactly where a
+  // full eMMC bites.
+  it("leaves no fragment when the first seed stops part way", () => {
+    const res = runCapped(4096);
+
+    expect(res.status).toBe(0);
+    expect(res.stderr).toContain("could not seed CLAWBOX.md");
+    expect(existsSync(guide)).toBe(false);
+  });
+
+  it("seeds the whole template on the next boot after a part-way seed", () => {
+    runCapped(4096);
+    const { stdout } = run();
+
+    expect(stdout).toContain("Seeded CLAWBOX.md");
+    expect(readFileSync(guide, "utf-8")).toBe(readFileSync(TEMPLATE, "utf-8"));
+  });
+
+  it("leaves nothing behind when the append stops part way", () => {
+    const older = padToJustUnderABlock(readFileSync(TEMPLATE, "utf-8").split(`\n---\n\n${HEADING}`)[0]);
+    writeFileSync(guide, older);
+
+    // Exactly 64 bytes of room for a section that is well over a kilobyte.
+    const res = runCapped(Buffer.byteLength(older) + 64);
+
+    // Boot safety first: pre-start must still exit 0 (config/clawbox-gateway.service
+    // runs it as ExecStartPre with no leading `-`).
+    expect(res.status).toBe(0);
+    expect(res.stderr).toContain("could not append");
+    expect(res.stdout).not.toContain("Appended the system-actions section");
+    // ...and the file is back to what it was, marker and fragment both gone.
+    expect(readFileSync(guide, "utf-8")).toBe(older);
+  });
+
+  it("appends the whole section on the next boot after a part-way write", () => {
+    const older = padToJustUnderABlock(readFileSync(TEMPLATE, "utf-8").split(`\n---\n\n${HEADING}`)[0]);
+    writeFileSync(guide, older);
+
+    runCapped(Buffer.byteLength(older) + 64);
+    const second = run();
+
+    expect(second.stdout).toContain("Appended the system-actions section");
+    const after = readFileSync(guide, "utf-8");
+    expect(after.startsWith(older)).toBe(true);
+    // The paragraph that used to be the casualty.
+    expect(after).toContain("operator_approval");
+    // And exactly one copy of the heading, not a fragment plus a full one.
+    expect(after.split(HEADING)).toHaveLength(2);
   });
 
   it("leaves a guide that already carries the section untouched", () => {
@@ -390,6 +523,33 @@ describe("gateway-pre-start puts the rule where the harness loads it", () => {
     expect(after.split(RULE)).toHaveLength(2);
   });
 
+  it("leaves no fragment in AGENTS.md when an append stops part way", () => {
+    // The same shape as the guide top-up, in the file the harness actually
+    // injects: a half-written rule keeps its heading, so the rule the model
+    // reads is a sentence that stops mid-word and no later boot repairs it.
+    // Padded past a 1024-byte boundary on purpose: the cap can only be set in
+    // whole blocks, so a short file would let the whole rule fit inside the
+    // first block and the write would simply succeed, testing nothing.
+    const existing = "# AGENTS\n\nBe helpful.\n\n## ClawBox integration\n\nSee `CLAWBOX.md`.\n"
+      + "Owner note: the printer is on the shelf.\n".repeat(45);
+    writeFileSync(agents, existing);
+
+    const res = runCapped(Buffer.byteLength(existing) + 128);
+
+    expect(res.status).toBe(0);
+    // Proof the append really did stop part way — without this the case
+    // degenerates into "the write succeeded" the day the rule text shrinks.
+    expect(res.stderr).toContain("could not append the system-actions rule");
+    expect(readFileSync(agents, "utf-8")).toBe(existing);
+
+    const second = run();
+    expect(second.stdout).toContain("Appended the system-actions rule to AGENTS.md");
+    const after = readFileSync(agents, "utf-8");
+    expect(after).toContain(RULE);
+    expect(after).toContain("operator_approval");
+    expect(after.split(RULE)).toHaveLength(2);
+  });
+
   it.skipIf(process.getuid?.() === 0)("does not stop the gateway when AGENTS.md cannot be written", () => {
     writeFileSync(agents, "# AGENTS\n");
     chmodSync(agents, 0o444);
@@ -398,6 +558,7 @@ describe("gateway-pre-start puts the rule where the harness loads it", () => {
     const { stderr } = run();
 
     expect(stderr).toContain("could not append the system-actions rule");
+    expect(stderr).not.toContain("could not roll");
     expect(readFileSync(agents, "utf-8")).toBe("# AGENTS\n");
   });
 });

--- a/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
+++ b/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
@@ -107,7 +107,11 @@ function run(template = TEMPLATE): { stdout: string; stderr: string } {
  * headroom is a fixed small number rather than "up to 1023 bytes, depending on
  * how long the shipped template happens to be" — see `padToJustUnderABlock`.
  */
-function runCapped(bytes: number, template = TEMPLATE): { status: number | null; stdout: string; stderr: string } {
+function runCapped(
+  bytes: number,
+  template = TEMPLATE,
+  opts: { hideTruncate?: boolean } = {},
+): { status: number | null; stdout: string; stderr: string } {
   const root = mkdtempSync(path.join(dir, "root-"));
   mkdirSync(path.join(root, "config"), { recursive: true });
   writeFileSync(path.join(root, "config/clawbox-workspace-guide.md"), readFileSync(template, "utf-8"));
@@ -115,6 +119,9 @@ function runCapped(bytes: number, template = TEMPLATE): { status: number | null;
   const script = [
     "set -euo pipefail",
     'trap "" XFSZ',
+    // A rootfs without coreutils' `truncate`: the shell function shadows the
+    // binary, so the helper falls through to its python3 fallback.
+    ...(opts.hideTruncate ? ["truncate() { return 127; }"] : []),
     `ulimit -f ${blocks}`,
     `CLAWBOX_ROOT=${JSON.stringify(root)}`,
     `CLAWBOX_WORKSPACE=${JSON.stringify(workspace)}`,
@@ -198,7 +205,7 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
       // continued `&& ! dd of=…` — and without this the six-line minimum would
       // still be met with BOTH of them deleted.
       || /^(if\s+)?!\s*truncate\b/.test(line)
-      || /^&&\s*!\s*dd\b/.test(line)
+      || /^&&\s*!\s*python3\b/.test(line)
       || />>/.test(line)
       // The helper's CALL, not its definition line. Matched on the name alone
       // so an unquoted first argument cannot slip past the filter — which is
@@ -222,7 +229,7 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
     expect(writes.length).toBeGreaterThanOrEqual(6);
     // Both rollback verbs, by name: a six-line count can be met without them.
     expect(writes.join("\n")).toMatch(/truncate -s/);
-    expect(writes.join("\n")).toMatch(/dd of=/);
+    expect(writes.join("\n")).toMatch(/os\.truncate/);
     expect(unguarded).toEqual([]);
   });
 
@@ -382,6 +389,20 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
     expect(res.stderr).toContain("could not append");
     expect(res.stdout).not.toContain("Appended the system-actions section");
     // ...and the file is back to what it was, marker and fragment both gone.
+    expect(readFileSync(guide, "utf-8")).toBe(older);
+  });
+
+  it("rolls back without truncate on the PATH", () => {
+    // The fallback, exercised rather than assumed: a rootfs without coreutils'
+    // `truncate` must still remove the fragment, not empty the file.
+    const older = padToJustUnderABlock(readFileSync(TEMPLATE, "utf-8").split(`\n---\n\n${HEADING}`)[0]);
+    writeFileSync(guide, older);
+
+    const res = runCapped(Buffer.byteLength(older) + 64, TEMPLATE, { hideTruncate: true });
+
+    expect(res.status).toBe(0);
+    expect(res.stderr).toContain("could not append");
+    expect(res.stderr).not.toContain("could not roll");
     expect(readFileSync(guide, "utf-8")).toBe(older);
   });
 

--- a/src/tests/unit/gateway-prestart-onboarding.test.ts
+++ b/src/tests/unit/gateway-prestart-onboarding.test.ts
@@ -65,6 +65,30 @@ function runBlock(name: string, env: Record<string, string>) {
   return { status: res.status, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
 }
 
+/**
+ * The same block under a file-size cap, so `install` stops PART WAY.
+ *
+ * A full Jetson eMMC is the realistic shape and ENOSPC cannot be produced in a
+ * unit test; `ulimit -f` produces the same partial write with the same non-zero
+ * return. `trap "" XFSZ` is what makes it a return value rather than a signal —
+ * without it the kernel kills the shell and the block never sees the failure it
+ * is supposed to handle. Bash scales `-f` by 1024, not the POSIX 512.
+ */
+function runBlockCapped(name: string, env: Record<string, string>, blocks: number) {
+  const script = path.join(dir, "block-capped.sh");
+  fs.writeFileSync(
+    script,
+    `set -euo pipefail\ntrap "" XFSZ\nulimit -f ${blocks}\n${block(name)}\n`,
+    "utf-8",
+  );
+  const res = spawnSync("bash", [script], {
+    encoding: "utf-8",
+    cwd: REPO,
+    env: { ...process.env, ...env } as NodeJS.ProcessEnv,
+  });
+  return { status: res.status, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+}
+
 const read = (f: string) => (fs.existsSync(f) ? fs.readFileSync(f, "utf-8") : null);
 
 // ── The ritual ClawBox ships ─────────────────────────────────────────────────
@@ -175,6 +199,33 @@ describe("gateway-pre-start: the bootstrap seed", () => {
     const run = runBlock("clawbox bootstrap seed", { CLAWBOX_ROOT: path.join(dir, "nowhere"), CLAWBOX_WORKSPACE: ws() });
     expect(run.status).toBe(0);
     expect(fs.existsSync(bootstrap())).toBe(false);
+  }, SHELL_TIMEOUT_MS);
+
+  it("leaves no fragment when the seed stops part way", () => {
+    // The same partial-write hole the CLAWBOX.md seed closes, in the same verb,
+    // and worse here: the guard is `[ ! -e ]`, which a fragment satisfies
+    // FOREVER. The block's own rule is that a BOOTSTRAP.md already on disk is
+    // adopted verbatim, so a truncated ritual would be run once, deleted by the
+    // agent when it thought it was done, and the owner would never be asked
+    // their name — permanently, on the first-boot and post-factory-reset path
+    // where a full eMMC actually bites.
+    fs.mkdirSync(ws());
+    const run = runBlockCapped("clawbox bootstrap seed", { CLAWBOX_ROOT: REPO, CLAWBOX_WORKSPACE: ws() }, 1);
+
+    expect(run.status).toBe(0);
+    expect(run.stderr).toMatch(/could not seed BOOTSTRAP\.md/);
+    expect(fs.existsSync(bootstrap())).toBe(false);
+  }, SHELL_TIMEOUT_MS);
+
+  it("seeds the whole ritual on the next boot after a part-way seed", () => {
+    // The half that makes the removal worth anything: the retry must land.
+    fs.mkdirSync(ws());
+    runBlockCapped("clawbox bootstrap seed", { CLAWBOX_ROOT: REPO, CLAWBOX_WORKSPACE: ws() }, 1);
+
+    const run = seed();
+
+    expect(run.status).toBe(0);
+    expect(read(bootstrap())).toBe(fs.readFileSync(TEMPLATE, "utf-8"));
   }, SHELL_TIMEOUT_MS);
 
   it("does not fail when the workspace cannot be created", () => {


### PR DESCRIPTION
**TASK-707** — a partial append left the idempotence marker on a fragment, so the guide stayed
truncated forever.

## Customer-visible symptom

`<workspace>/CLAWBOX.md` (and `AGENTS.md`) cut mid-sentence, permanently. Every append in
`gateway-pre-start.sh`'s guide block writes its **heading first**, and the heading is also the
`grep -qF` marker the next boot reads to decide whether the append already happened. A write that
stops half-way — ENOSPC on a full Jetson eMMC is the realistic shape — leaves the marker on the
fragment; every later gateway start finds the heading, appends nothing, and nothing ever repairs
it. What is lost is exactly TASK-612's deliverable: "Never queue an `operator_approval` proposal
for any of this…" is the last paragraph of the section. The one warning went to the journal at boot
and is never seen again.

## Cause

The marker and the payload are the same bytes, and the write was not undoable.

## Fix

- One helper, `clawbox_append_or_rollback`, owns the three appends. On a failed write it rolls the
  file back to the length it had, so the fragment **and** its marker are gone and the next boot
  retries.
- **Rollback, not temp-file + rename.** These are owner-personalised files with their own mode and
  owner, and the case this exists for is a *full disk*, where a second full copy is the least
  affordable thing to ask for. What that trades away is named in the helper's comment rather than
  implied: a shell **killed** between the partial write and the rollback (a SIGTERM in
  `ExecStartPre`, an OOM kill, a power cut) still leaves the fragment. That window is far smaller
  than the write itself, and closing it costs the copy the full-disk case cannot afford.
- The **seed** is the same defect one branch up and worse — the fragment it leaves already contains
  the top-up marker, so the guard locks it in on the very first boot. It is removed on failure,
  which destroys nothing: the branch only runs when the file was absent.
- The helper refuses an empty payload (the "reported a success that added nothing" shape this block
  already guards against elsewhere), handles a destination that does not exist, falls back to `dd`
  where `truncate` is absent, and — the false failure the first version of this fix introduced —
  says nothing about a rollback when the write failed at **open** and the file is byte-identical to
  what it was. Warning that an intact file "may be cut mid-section" on every boot of a read-only
  rootfs is noise in the journal an operator is reading while triaging the real fault.

### Harness first

There is no OpenClaw/Hermes primitive for this: the harness owns the *injection* of AGENTS.md at
session start (its workspace file map, cited in the block), not the writing of it. A local helper is
the right shape. The tree does already carry a second idiom —
`scripts/setup-hermes-dashboard-auth.sh` writes a temp file and renames — and this call site
deliberately diverges from it for the full-disk reason above.

## RED (on unmodified beta)

```
 × leaves no fragment when the first seed stops part way
 × seeds the whole template on the next boot after a part-way seed
 × leaves nothing behind when the append stops part way
 × appends the whole section on the next boot after a part-way write
 × leaves no fragment in AGENTS.md when an append stops part way
 × leaves no write in the seeding block unguarded, whatever the uid
 Tests  6 failed | 17 passed (23)
```

The partial write is produced with `ulimit -f` plus `trap "" XFSZ` (so `write()` returns EFBIG
rather than the signal killing the shell) — ENOSPC cannot be produced in a unit test, and this is
the same partial write with the same non-zero return. The fixtures are padded to a fixed 64 bytes
below a block boundary so the headroom does not drift with the template's length. The last failure
is the structural test's write-site count, which the new helper changes — a filter adjustment, not
a defect proof.

## GREEN

```
 gateway-pre-start-workspace-guide.test.ts → 23 passed
 npx vitest run --project unit → 579 files, 9299 tests, all pass
 npx tsc --noEmit → clean
```

## Sibling call sites

Converted: all three appends in the block, plus the seed.

**Explicitly NOT converted, and each one is the same class** — every one is in a different script
with its own boot path and needs its own RED, so they are recorded on the run's Found list rather
than folded in here:

- `scripts/install-voice.sh` — the marker is *inside* the `LD_LIBRARY_PATH` line, so a partial write
  leaves a broken `export` with an unterminated `${…}` in the clawbox user's `.bashrc` (which breaks
  every interactive shell) and the guard matches it forever.
- `scripts/setup-optimizations.sh` — the marker is written by the 3rd of 6 separate `echo >>`, so a
  failure after #3 leaves MKL/NUMEXPR/VECLIB permanently missing with the guard satisfied.
- `install.sh` / `install-x64.sh` (`GOOGLE_OAUTH_CLIENT_ID=`) — a partial write leaves a **truncated
  OAuth client id or secret** that satisfies the guard forever: a silently wrong credential, never
  repaired. Worth its own card.
- `install.sh` / `install-x64.sh` `.bashrc` PATH heredocs — same shape, milder consequence.

## Both editions

This hardens a delivery path that exists on **one** edition. `gateway-pre-start.sh` writes
`~/.openclaw/workspace/{CLAWBOX.md,AGENTS.md}`; `scripts/setup-shared-identity.sh` links only
`SOUL.md` and the memories for Hermes, so on a Hermes-only or dual box the TASK-612 rule reaches the
Hermes agent through nothing at all. Pre-existing and outside this diff — recorded on the Found list
under the standing both-editions rule.

## Device proof

None run for this PR, and it is not skipped silently: the change is inside the ExecStartPre that
brings the gateway up, the failure it fixes needs a genuinely full filesystem to reproduce, and the
box is one the owner is using. The boot-safety invariant it must not break — every write guarded,
the block always exits 0 — is asserted structurally and in five behavioural cases, including the
read-only and capped-write ones. **Device leg unproven: the partial-write path needs a full-disk
box, and no update or disk-filling was run on hardware.**



---

## Finishing round (2026-09-05) — rebased twice, reviewed, and the SIBLING seed fixed

Rebased onto `origin/beta` `b15d64c6` and then `eece3ccb`. `scripts/gateway-pre-start.sh` was
edited on beta in between (the llama.cpp / local-embeddings memory-search switch, `5af60fad`
/ `779a469c` / `9aa2fd50`); that work is present and untouched, and
`git diff origin/beta...HEAD -- scripts/gateway-pre-start.sh` contains only the append
machinery. `git diff --stat origin/beta...HEAD` lists three files, no deletion-only file.

### The blocking finding: the same defect, one verb over

`code-review-pr639-final.md` (HIGH 1 · MEDIUM 3 · LOW 7) found the second call site of the
exact thing this PR fixes, 140 lines above it and untouched: the **BOOTSTRAP.md seed**
(`install -m 644 "$CLAWBOX_BOOTSTRAP_SRC" "$CLAWBOX_BOOTSTRAP_DST"`). Its guard is
`[ ! -e "$CLAWBOX_BOOTSTRAP_DST" ]`, which a fragment satisfies forever, and the consequence
is worse than the guide's: the block's own rule is that a BOOTSTRAP.md already on disk is
adopted verbatim, so OpenClaw would run the birth sequence against a ritual cut off
mid-sentence, delete the file when it thought it was done, and stamp the workspace complete.
**The owner is never asked their name — permanently, with no second chance** — and this is
the first-boot and post-factory-reset path, which is where a full eMMC bites.

Fixed with the same one-line rollback, and two cases in
`src/tests/unit/gateway-prestart-onboarding.test.ts` under the same `ulimit -f` + `trap ""
XFSZ` shape:

```
 × leaves no fragment when the seed stops part way
 × seeds the whole ritual on the next boot after a part-way seed
```

Both fail with the `rm -f` removed and pass with it.

### Other findings taken

- **H4 + L1 — the rollback was conditional on `wc -c` succeeding, and leaked when it did
  not.** With no length the helper warned and left the fragment, so the guarantee was really
  "no marker on a fragment *if the length could be read*". A new `clawbox_file_size` asks
  twice — `wc -c`, then `stat -c %s`, which does not open the file — so a
  present-but-unopenable destination still answers. And the redirection order is fixed:
  bash applies them left to right, so `wc -c < "$f" 2>/dev/null` opened before stderr was
  silenced and put a "Permission denied" line in the gateway journal on a boot where the
  append succeeded. Both directions covered by
  `measures a destination it cannot open, and says nothing about it`, which fails on the old
  helper.
- **L2 — the unreachable `before="absent"` branch is gone.** It could not be reached from any
  caller, and the one line in it that could run was the only line in the diff able to delete
  a file the helper did not create: `[ -e ]` is false for a dangling symlink, `printf >>`
  follows it and creates the target, and the removal would take the *link* and orphan the
  fragment. "The destination exists" is now stated as the contract it always was.
- **L3** — the single-writer precondition is written down: `truncate -s` restores a length
  measured before the write, which is safe only because this runs in `ExecStartPre` with the
  gateway (and so the agent and its file tools) stopped.
- **L5 — the audit's floor was three write sites below reality** (6 against 8) and its new
  `rm` exemption accepted any `rm … || true`, so a future `rm -rf "$CLAWBOX_WORKSPACE" ||
  true` would have passed the very audit that exists to catch it. Floor raised to the real
  count with all eight named, exemption narrowed to `rm -f "$VAR" 2>/dev/null || true`.
- **L6 — the "could not roll it back" branch had never run.** No fixture made *both* verbs
  fail, so the operator-facing output of a failed rollback was unexercised. `runCapped` can
  now shadow `python3` as well as `truncate`, and the new case asserts the three things the
  helper promises there: the boot survives, the failure is not reported as a success, and the
  file is named as suspect rather than claimed clean. The two divergences from a real ENOSPC
  are written into `runCapped`'s doc comment.
- **L4** — the 126-character comment line re-wrapped. **L7** — the stale comment above the
  block said the marker is matched with `index(...) == 1` when the awk does a whole-line `==`;
  corrected (pre-existing on beta, one line while the file was open).

### Harness first — the PR body's earlier claim was wrong, corrected here

This PR said no OpenClaw/Hermes primitive owns this. That is right about *making an append
undoable*, and wrong about the block being protected. OpenClaw 2026.8.1 — the version
`config/openclaw-target.txt` pins — ships an `agent:bootstrap` hook whose
`event.context.bootstrapFiles` array is explicitly mutable
(`dist/bootstrap-files-HonSr_Jo.js:18-31`; `docs/automation/hooks.md:207` calls it "the
explicit mutable exception"), **and** a bundled `bootstrap-extra-files` hook configured
declaratively through `hooks.internal.entries.bootstrap-extra-files.paths` whose stated job
is loading additional bootstrap files into Project Context. The caveat, verified in the same
package: `dist/workspace-B5FP2og5.js:920` passes `acceptedBasenames:
WORKSPACE_BOOTSTRAP_FILENAMES` = AGENTS.md / SOUL.md / IDENTITY.md / USER.md / BOOTSTRAP.md /
MEMORY.md, so a file named `CLAWBOX.md` cannot be injected that way — but a ClawBox-owned
`<workspace>/clawbox/AGENTS.md` can, and that path is ours rather than owner-personalised, so
it could be written with a plain overwrite-on-every-boot `install` and need no marker, no
append and no rollback at all. **The helper is a separate concern and stays; the BLOCK is the
re-implementation.** On the run's Found list, not expanded here.

### Recorded rather than taken

- **H2 — this is preventive only.** The idempotence test still asks whether the section
  *started*, so a box a pre-fix build already left cut mid-section keeps its marker and is
  never healed: `[ -f DST ]` skips the seed, `grep -qF` skips the top-up. Healing it means
  proving the section is *complete* (its final line present) and stripping from the heading
  with awk before re-appending — a change to the marker contract that deserves its own RED.
  Stated so nobody reads "forever" as fixed for a box that already has it.
- The four other "marker inside the guarded append" sites (`install-voice.sh`,
  `setup-optimizations.sh`, the two `GOOGLE_OAUTH_CLIENT_ID` writes, the `.bashrc` PATH
  heredocs) stay on the Found list: each is a different script with its own boot path and
  needs its own RED.

### GREEN

```
 gateway-pre-start-workspace-guide.test.ts + gateway-prestart-onboarding.test.ts → 53 passed
 npx vitest run --project unit → 630 files, all pass
 npx tsc --noEmit → clean;  bash -n scripts/gateway-pre-start.sh → clean
```

**Device leg unproven, unchanged from the original body:** the partial-write path needs a
genuinely full filesystem, and no update or disk-filling was run on hardware. What the change
must not break — every write guarded, the block always exits 0 — is asserted structurally and
in nine behavioural cases, including the read-only, capped-write and both-verbs-missing ones.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace file initialization to safely handle partial or failed writes.
  * Preserved newline boundaries when appending generated content.
  * Gateway startup now continues after write failures while reporting warnings.
  * Failed initial file creation is cleaned up before retrying.
  * Subsequent runs can successfully complete previously interrupted setup.

* **Tests**
  * Added coverage for partial writes, append failures, rollback behavior, retry success, and file access failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
