### PR TITLE
fix: declare the Hermes plugin's hook, and stop 11 hook(s) reading as 1

### DIFF
--- a/scripts/hermes-plugins/clawbox_email_directives/plugin.yaml
+++ b/scripts/hermes-plugins/clawbox_email_directives/plugin.yaml
@@ -3,3 +3,11 @@ version: 1.0.0
 description: "Strips ClawBox EMAIL: card directives from replies leaving the box for a channel, where no card can render."
 author: ID-Robots
 kind: standalone
+# Hermes' own manifest field (hermes_cli/plugins.py: allowed manifest keys,
+# `provides_hooks: List[str]`). `hermes plugins doctor` compares it against what
+# register() actually adds, in both directions, and without it every boot's
+# doctor line carried
+#   WARN: registration adds hook 'transform_llm_output' not listed in provides_hooks
+# beside its OK — a permanent warning about a plugin that is working.
+provides_hooks:
+  - transform_llm_output

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -679,12 +679,11 @@ fi
 #
 # `plugins doctor` is the honest one — it really imports the plugin in a
 # sandboxed temporary HERMES_HOME and prints what registered
-# (hermes_cli/plugin_dev.py:84-107). For this plugin the count line must read
-# exactly one hook; "0 hook(s)" means the file loaded but the hook did not
-# register, which is precisely the state nothing else on the box would report.
-# The match below anchors the number on both sides — `*"1 hook(s)"*` alone also
-# matched "11 hook(s)" — and reads an `ERROR:` verdict before it, because the
-# count line is printed whatever the doctor concluded.
+# (hermes_cli/plugin_dev.py:84-107). Three signals are read from it, in order:
+# the CLI's own `--ci` exit status (an error verdict), the `provides_hooks`
+# mismatch WARN (the only line that names a hook), and the count. "0 hook(s)"
+# means the file loaded but the hook did not register, which is precisely the
+# state nothing else on the box would report.
 #
 # EVERY BOOT, not once behind a marker — the same reasoning as the browser
 # toolset above. The state lives in Hermes' own tree, so a marker in ClawBox's
@@ -700,7 +699,19 @@ fi
 # refusing `hermes` would stop the boot here, over a DIAGNOSTIC.
 if [ "$EMAIL_HOOK_INSTALLED" = "1" ]; then
   EMAIL_HOOK_DOCTOR_RC=0
-  EMAIL_HOOK_DOCTOR="$(timeout -k 5 "$HERMES_CLI_TIMEOUT" "$HERMES_BIN" plugins doctor "$EMAIL_HOOK_PLUGIN" 2>&1)" \
+  # `--ci` is the harness's OWN verdict: cmd_plugin_doctor raises SystemExit(1)
+  # when the report carries an error, and stays 0 for warnings
+  # (hermes_cli/plugins_cmd.py). Measured on the Hermes box 2026-09-04: rc 0 on a
+  # healthy plugin that is still printing a WARN. Reading that status is what
+  # this block should do instead of grepping a human-readable stream for the
+  # word ERROR — the output is captured with 2>&1, and a Python `logging` line
+  # from the agent import ("ERROR:hermes_cli.x:...") is indistinguishable from
+  # the doctor's own "  ERROR: ..." to a substring match.
+  #
+  # A `hermes` too old for the flag exits non-zero without printing a report at
+  # all; the "did it really answer" gate below turns that into the same NOTE as
+  # any other unusable CLI, so the flag cannot manufacture a defect.
+  EMAIL_HOOK_DOCTOR="$(timeout -k 5 "$HERMES_CLI_TIMEOUT" "$HERMES_BIN" plugins doctor "$EMAIL_HOOK_PLUGIN" --ci 2>&1)" \
     || EMAIL_HOOK_DOCTOR_RC=$?
   # The doctor's own words, trimmed to one line: "no register() function",
   # "No __init__.py in ...", an import traceback's last line. Naming the plugin
@@ -709,6 +720,15 @@ if [ "$EMAIL_HOOK_INSTALLED" = "1" ]; then
   # boot, and under `pipefail` any stage of this is enough to do it.
   EMAIL_HOOK_DETAIL="$(printf '%s' "$EMAIL_HOOK_DOCTOR" | tr '\n' ' ' | cut -c1-300)" \
     || EMAIL_HOOK_DETAIL=""
+  # ...and, for the branches that fire ON a verdict line, the verdict lines
+  # themselves. The banner plus the manifest line is already ~110 characters on
+  # the real box, so a head-of-output window is where the reason that triggered
+  # the branch gets cut off — the branch would then report a defect and discard
+  # the one sentence that says what to fix. Falls back to the head when the
+  # doctor said nothing marked.
+  EMAIL_HOOK_REASON="$(printf '%s\n' "$EMAIL_HOOK_DOCTOR" | grep -E '^[[:space:]]*(ERROR|WARN):' | head -3 | tr '\n' ' ' | cut -c1-300)" \
+    || EMAIL_HOOK_REASON=""
+  [ -n "$EMAIL_HOOK_REASON" ] || EMAIL_HOOK_REASON="$EMAIL_HOOK_DETAIL"
   # The exit STATUS is read before the words. By the time `timeout` kills it the
   # doctor has usually printed its banner, and on the text alone that banner IS
   # the "ran and refused" branch below — so a wedged CLI would print a hard
@@ -736,42 +756,55 @@ if [ "$EMAIL_HOOK_INSTALLED" = "1" ]; then
     log "NOTE: 'hermes plugins doctor' answered $EMAIL_HOOK_DOCTOR_RC — the ${HERMES_CLI_TIMEOUT}s ceiling (SIGTERM, then SIGKILL 5s later), a kill from outside, or the CLI's own exit code — so $EMAIL_HOOK_PLUGIN is installed and enabled but whether its hook registered is unknown here. hermes had printed: $EMAIL_HOOK_DETAIL"
   else
     case "$EMAIL_HOOK_DOCTOR" in
-      *"ERROR:"*)
-        # The count line is printed WHATEVER the verdict — plugin_dev.py appends
-        # `registrations: N tool(s), M hook(s)` unconditionally, while its "OK:"
-        # line is conditional — so a doctor that REFUSED the hook (a callback
-        # without **kwargs is an error, not a warning) still says "1 hook(s)".
-        # Read the verdict before the count, or an error reads as a success.
-        log "WARNING: $EMAIL_HOOK_PLUGIN did not register its hook — EMAIL: directives will still reach channels. hermes plugins doctor said: $EMAIL_HOOK_DETAIL"
-        ;;
-      *"tool(s), 1 hook(s)"*)
-        # Anchored on both sides of the number. `*"1 hook(s)"*` also matched
-        # `11 hook(s)` — and `21`, and `31` — which is the same false-success
-        # class this block exists to catch: the count IS the evidence here.
-        #
-        # The count and not the hook NAME, unlike the OpenClaw twin
-        # (gateway-pre-start.sh parses the JSON and asks whether
-        # "reply_payload_sending" is in the names): Hermes' `plugins doctor` has
-        # no --json and its text output never names a registered hook
-        # (hermes_cli/plugin_dev.py renders counts only), so there is no name to
-        # read on this side. Verified read-only on the Hermes box, 2026-09-04.
-        log "$EMAIL_HOOK_PLUGIN loaded and registered its outbound hook"
-        ;;
-      *"hook(s)"*|*"Plugin Doctor"*|*"registration failed"*)
-        # The doctor RAN and did not report our hook: it imported and registered
-        # a count that is not one, or it refused to import at all. That IS the
-        # defect, and it is the one nothing else on the box reports — `plugins
-        # list` reads "enabled" straight back out of the config it was written
-        # into (hermes_cli/plugins_cmd.py:1931).
-        log "WARNING: $EMAIL_HOOK_PLUGIN did not register its hook — EMAIL: directives will still reach channels. hermes plugins doctor said: $EMAIL_HOOK_DETAIL"
+      *"registrations:"*|*"Plugin Doctor"*|*"registration failed"*)
+        # The doctor RAN. Everything below is about WHAT it said; a CLI that
+        # printed no report at all falls to the NOTE arm instead, which is what
+        # keeps an unknown-flag or a too-old `hermes` from reading as a defect.
+        if [ "$EMAIL_HOOK_DOCTOR_RC" != "0" ]; then
+          # The harness's own verdict, not a word this script looked for.
+          log "WARNING: the doctor REFUSED $EMAIL_HOOK_PLUGIN — EMAIL: directives will still reach channels. hermes plugins doctor said: $EMAIL_HOOK_REASON"
+        else
+          case "$EMAIL_HOOK_DOCTOR" in
+            *"provides_hooks"*)
+              # The one line in this output that names a HOOK. The doctor
+              # compares the manifest's `provides_hooks` against what register()
+              # actually added, in both directions, and warns by name on either
+              # mismatch — so this is the Hermes equivalent of the OpenClaw
+              # twin's `"reply_payload_sending" in names` check, and it catches
+              # what no count can: a register() that adds a DIFFERENT valid hook
+              # still says "1 hook(s)" with no error at all.
+              log "WARNING: $EMAIL_HOOK_PLUGIN registered hooks its manifest does not declare — EMAIL: directives may still reach channels. hermes plugins doctor said: $EMAIL_HOOK_REASON"
+              ;;
+            *[!0-9]"1 hook(s)"*)
+              # Anchored on the LEFT of the number and nothing else. `*"1
+              # hook(s)"*` also matched "11 hook(s)" — and 21, and 31 — which is
+              # the same false-success class this block exists to catch, since
+              # the count is the evidence. Borrowing the neighbouring "tool(s), "
+              # token would pin it too, but it couples the healthy match to a
+              # DIFFERENT number: this output goes through rich.Console, which
+              # wraps at 80 columns off a tty, and the WARN line visibly wrapped
+              # on the box. `*[!0-9]*` is this codebase's own idiom for the job
+              # (scripts/gateway-pre-start.sh).
+              log "$EMAIL_HOOK_PLUGIN loaded and registered its outbound hook"
+              ;;
+            *)
+              # The doctor ran, found no error, and still did not report our one
+              # hook: it registered a count that is not one. That IS the defect,
+              # and it is the one nothing else on the box reports — `plugins
+              # list` reads "enabled" straight back out of the config it was
+              # written into (hermes_cli/plugins_cmd.py:1931).
+              log "WARNING: $EMAIL_HOOK_PLUGIN did not register its hook — EMAIL: directives will still reach channels. hermes plugins doctor said: $EMAIL_HOOK_DETAIL"
+              ;;
+          esac
+        fi
         ;;
       *)
         # The doctor could not answer at all — a `hermes` too old for the
-        # subcommand, one that is not there (127) or not executable (126).
-        # Reported as UNKNOWN rather than as a defect: saying "directives will
-        # still reach channels" about a box where the hook is registered and
-        # working is a false failure, and an operator who sees it every boot
-        # stops reading the line that matters.
+        # subcommand or for `--ci`, one that is not there (127) or not
+        # executable (126). Reported as UNKNOWN rather than as a defect: saying
+        # "directives will still reach channels" about a box where the hook is
+        # registered and working is a false failure, and an operator who sees it
+        # every boot stops reading the line that matters.
         log "NOTE: could not verify $EMAIL_HOOK_PLUGIN with 'hermes plugins doctor' — the plugin is installed and enabled, but whether its hook registered is unknown here. hermes said: $EMAIL_HOOK_DETAIL"
         ;;
     esac

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -679,9 +679,12 @@ fi
 #
 # `plugins doctor` is the honest one — it really imports the plugin in a
 # sandboxed temporary HERMES_HOME and prints what registered
-# (hermes_cli/plugin_dev.py:84-107). For this plugin the line must read
-# "1 hook(s)"; "0 hook(s)" means the file loaded but the hook did not register,
-# which is precisely the state nothing else on the box would report.
+# (hermes_cli/plugin_dev.py:84-107). For this plugin the count line must read
+# exactly one hook; "0 hook(s)" means the file loaded but the hook did not
+# register, which is precisely the state nothing else on the box would report.
+# The match below anchors the number on both sides — `*"1 hook(s)"*` alone also
+# matched "11 hook(s)" — and reads an `ERROR:` verdict before it, because the
+# count line is printed whatever the doctor concluded.
 #
 # EVERY BOOT, not once behind a marker — the same reasoning as the browser
 # toolset above. The state lives in Hermes' own tree, so a marker in ClawBox's
@@ -733,7 +736,25 @@ if [ "$EMAIL_HOOK_INSTALLED" = "1" ]; then
     log "NOTE: 'hermes plugins doctor' answered $EMAIL_HOOK_DOCTOR_RC — the ${HERMES_CLI_TIMEOUT}s ceiling (SIGTERM, then SIGKILL 5s later), a kill from outside, or the CLI's own exit code — so $EMAIL_HOOK_PLUGIN is installed and enabled but whether its hook registered is unknown here. hermes had printed: $EMAIL_HOOK_DETAIL"
   else
     case "$EMAIL_HOOK_DOCTOR" in
-      *"1 hook(s)"*)
+      *"ERROR:"*)
+        # The count line is printed WHATEVER the verdict — plugin_dev.py appends
+        # `registrations: N tool(s), M hook(s)` unconditionally, while its "OK:"
+        # line is conditional — so a doctor that REFUSED the hook (a callback
+        # without **kwargs is an error, not a warning) still says "1 hook(s)".
+        # Read the verdict before the count, or an error reads as a success.
+        log "WARNING: $EMAIL_HOOK_PLUGIN did not register its hook — EMAIL: directives will still reach channels. hermes plugins doctor said: $EMAIL_HOOK_DETAIL"
+        ;;
+      *"tool(s), 1 hook(s)"*)
+        # Anchored on both sides of the number. `*"1 hook(s)"*` also matched
+        # `11 hook(s)` — and `21`, and `31` — which is the same false-success
+        # class this block exists to catch: the count IS the evidence here.
+        #
+        # The count and not the hook NAME, unlike the OpenClaw twin
+        # (gateway-pre-start.sh parses the JSON and asks whether
+        # "reply_payload_sending" is in the names): Hermes' `plugins doctor` has
+        # no --json and its text output never names a registered hook
+        # (hermes_cli/plugin_dev.py renders counts only), so there is no name to
+        # read on this side. Verified read-only on the Hermes box, 2026-09-04.
         log "$EMAIL_HOOK_PLUGIN loaded and registered its outbound hook"
         ;;
       *"hook(s)"*|*"Plugin Doctor"*|*"registration failed"*)

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -739,10 +739,17 @@ if [ "$EMAIL_HOOK_INSTALLED" = "1" ]; then
   # REFUSED branch below fires on rc=1, which only an ERROR finding produces —
   # report order can put three WARNs ahead of it, and quoting those instead
   # drops the one sentence that says what to fix.
-  EMAIL_HOOK_REASON="$(printf '%s\n' "$EMAIL_HOOK_DOCTOR" | grep -m 3 -E '^[[:space:]]*ERROR:' | tr '\n' ' ' | cut -c1-300)" \
+  # INDENTED, both of them: the doctor prints its own findings as "  ERROR: …"
+  # and "  WARN: …", while the capture is 2>&1 and the doctor imports the whole
+  # agent in a blank sandboxed HERMES_HOME — where one missing optional
+  # dependency puts Python's default logging format on stderr FLUSH LEFT
+  # ("ERROR:hermes_cli.x:…"). With `*` that line wins the errors-first
+  # preference below and the boot log quotes a cause the branch did not fire
+  # on, dropping the sentence that names the hook.
+  EMAIL_HOOK_REASON="$(printf '%s\n' "$EMAIL_HOOK_DOCTOR" | grep -m 3 -E '^[[:space:]]+ERROR:' | tr '\n' ' ' | cut -c1-300)" \
     || EMAIL_HOOK_REASON=""
   [ -n "$EMAIL_HOOK_REASON" ] \
-    || EMAIL_HOOK_REASON="$(printf '%s\n' "$EMAIL_HOOK_DOCTOR" | grep -m 3 -E '^[[:space:]]*WARN:' | tr '\n' ' ' | cut -c1-300)" \
+    || EMAIL_HOOK_REASON="$(printf '%s\n' "$EMAIL_HOOK_DOCTOR" | grep -m 3 -E '^[[:space:]]+WARN:' | tr '\n' ' ' | cut -c1-300)" \
     || EMAIL_HOOK_REASON=""
   [ -n "$EMAIL_HOOK_REASON" ] || EMAIL_HOOK_REASON="$EMAIL_HOOK_DETAIL"
   # One flattened copy of the report, and every match below is against it.

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -223,6 +223,12 @@ chmod 600 "$MCP_TOKEN_FILE" 2>/dev/null || true
 # actually deliver it. The stale `__pycache__` goes with them, because Python
 # will happily import a `.pyc` whose source no longer exists.
 EMAIL_HOOK_PLUGIN="clawbox_email_directives"
+# The one hook this plugin registers, and — since the manifest now DECLARES it —
+# the name `hermes plugins doctor` compares against what register() actually
+# added. That comparison is the Hermes equivalent of the OpenClaw twin's
+# `"reply_payload_sending" in names` check (gateway-pre-start.sh), and it is why
+# the verdict below is a name test rather than a count.
+EMAIL_HOOK_NAME="transform_llm_output"
 EMAIL_HOOK_SRC="$PROJECT_DIR/scripts/hermes-plugins/$EMAIL_HOOK_PLUGIN"
 # `HERMES_HOME` first, exactly like Hermes' own `get_hermes_home()` and like
 # `hermesHome()` in src/lib/hermes-env.ts — NOT `dirname $HERMES_CONFIG`. With
@@ -680,10 +686,11 @@ fi
 # `plugins doctor` is the honest one — it really imports the plugin in a
 # sandboxed temporary HERMES_HOME and prints what registered
 # (hermes_cli/plugin_dev.py:84-107). Three signals are read from it, in order:
-# the CLI's own `--ci` exit status (an error verdict), the `provides_hooks`
-# mismatch WARN (the only line that names a hook), and the count. "0 hook(s)"
-# means the file loaded but the hook did not register, which is precisely the
-# state nothing else on the box would report.
+# the CLI's own `--ci` exit status (an error verdict); the doctor's own
+# declared-vs-registered comparison, which names OUR hook when registration did
+# not add it (hermes_cli/plugin_dev.py:342); and, for a box still carrying a
+# manifest that declares nothing, "0 hook(s)" — the file loaded and registered
+# nothing at all, which is precisely the state nothing else on the box reports.
 #
 # EVERY BOOT, not once behind a marker — the same reasoning as the browser
 # toolset above. The state lives in Hermes' own tree, so a marker in ClawBox's
@@ -726,9 +733,24 @@ if [ "$EMAIL_HOOK_INSTALLED" = "1" ]; then
   # the branch gets cut off — the branch would then report a defect and discard
   # the one sentence that says what to fix. Falls back to the head when the
   # doctor said nothing marked.
-  EMAIL_HOOK_REASON="$(printf '%s\n' "$EMAIL_HOOK_DOCTOR" | grep -E '^[[:space:]]*(ERROR|WARN):' | head -3 | tr '\n' ' ' | cut -c1-300)" \
+  # ERRORS FIRST, and `grep -m 3` rather than `| head -3`: under `pipefail` a
+  # `head` that closes the pipe early makes the whole pipeline 141, and the `||`
+  # then throws away the reason it had just computed. Errors first because the
+  # REFUSED branch below fires on rc=1, which only an ERROR finding produces —
+  # report order can put three WARNs ahead of it, and quoting those instead
+  # drops the one sentence that says what to fix.
+  EMAIL_HOOK_REASON="$(printf '%s\n' "$EMAIL_HOOK_DOCTOR" | grep -m 3 -E '^[[:space:]]*ERROR:' | tr '\n' ' ' | cut -c1-300)" \
+    || EMAIL_HOOK_REASON=""
+  [ -n "$EMAIL_HOOK_REASON" ] \
+    || EMAIL_HOOK_REASON="$(printf '%s\n' "$EMAIL_HOOK_DOCTOR" | grep -m 3 -E '^[[:space:]]*WARN:' | tr '\n' ' ' | cut -c1-300)" \
     || EMAIL_HOOK_REASON=""
   [ -n "$EMAIL_HOOK_REASON" ] || EMAIL_HOOK_REASON="$EMAIL_HOOK_DETAIL"
+  # One flattened copy of the report, and every match below is against it.
+  # `rich.Console` wraps at 80 columns off a tty, so any line — the count, or a
+  # finding sentence — can arrive split across two. Squeezing all whitespace to
+  # single spaces once heals every one of them, and matching the raw capture
+  # instead is how a reflow turns into a false verdict.
+  EMAIL_HOOK_FLAT="$(printf '%s' "$EMAIL_HOOK_DOCTOR" | tr -s '[:space:]' ' ')" || EMAIL_HOOK_FLAT=""
   # The exit STATUS is read before the words. By the time `timeout` kills it the
   # doctor has usually printed its banner, and on the text alone that banner IS
   # the "ran and refused" branch below — so a wedged CLI would print a hard
@@ -755,45 +777,72 @@ if [ "$EMAIL_HOOK_INSTALLED" = "1" ]; then
   if [ "$EMAIL_HOOK_DOCTOR_RC" = "124" ] || [ "$EMAIL_HOOK_DOCTOR_RC" = "137" ]; then
     log "NOTE: 'hermes plugins doctor' answered $EMAIL_HOOK_DOCTOR_RC — the ${HERMES_CLI_TIMEOUT}s ceiling (SIGTERM, then SIGKILL 5s later), a kill from outside, or the CLI's own exit code — so $EMAIL_HOOK_PLUGIN is installed and enabled but whether its hook registered is unknown here. hermes had printed: $EMAIL_HOOK_DETAIL"
   else
-    case "$EMAIL_HOOK_DOCTOR" in
+    case "$EMAIL_HOOK_FLAT" in
       *"registrations:"*|*"Plugin Doctor"*|*"registration failed"*)
         # The doctor RAN. Everything below is about WHAT it said; a CLI that
         # printed no report at all falls to the NOTE arm instead, which is what
         # keeps an unknown-flag or a too-old `hermes` from reading as a defect.
-        if [ "$EMAIL_HOOK_DOCTOR_RC" != "0" ]; then
-          # The harness's own verdict, not a word this script looked for.
+        if [ "$EMAIL_HOOK_DOCTOR_RC" = "1" ]; then
+          # The harness's own verdict, not a word this script looked for. ONE,
+          # not "any non-zero": `--ci` is documented as "exit non-zero when
+          # validation reports an error" and raises SystemExit(1) for exactly
+          # that (hermes_cli/plugins_cmd.py cmd_plugin_doctor). Another non-zero
+          # code from a run that still printed a healthy report — a
+          # BrokenPipeError at interpreter flush, a teardown raise on a loaded
+          # Jetson, a SIGINT during a restart — says nothing about the hook, and
+          # calling it a refusal would be a false failure on a working box.
           log "WARNING: the doctor REFUSED $EMAIL_HOOK_PLUGIN — EMAIL: directives will still reach channels. hermes plugins doctor said: $EMAIL_HOOK_REASON"
+        elif [ "$EMAIL_HOOK_DOCTOR_RC" != "0" ]; then
+          log "NOTE: 'hermes plugins doctor' printed a report for $EMAIL_HOOK_PLUGIN and then exited $EMAIL_HOOK_DOCTOR_RC — not the error verdict --ci defines, so whether its hook registered is unknown here. hermes had printed: $EMAIL_HOOK_REASON"
         else
-          case "$EMAIL_HOOK_DOCTOR" in
-            *"provides_hooks"*)
-              # The one line in this output that names a HOOK. The doctor
-              # compares the manifest's `provides_hooks` against what register()
-              # actually added, in both directions, and warns by name on either
-              # mismatch — so this is the Hermes equivalent of the OpenClaw
-              # twin's `"reply_payload_sending" in names` check, and it catches
-              # what no count can: a register() that adds a DIFFERENT valid hook
-              # still says "1 hook(s)" with no error at all.
-              log "WARNING: $EMAIL_HOOK_PLUGIN registered hooks its manifest does not declare — EMAIL: directives may still reach channels. hermes plugins doctor said: $EMAIL_HOOK_REASON"
+          case "$EMAIL_HOOK_FLAT" in
+            *"declares hook '$EMAIL_HOOK_NAME' but registration did not add it"*)
+              # THE name check, and the reason the manifest half of this change
+              # exists. Declaring `provides_hooks` makes the doctor compare what
+              # was declared against what register() actually added and warn BY
+              # NAME when ours is missing (hermes_cli/plugin_dev.py:342) — the
+              # Hermes equivalent of the OpenClaw twin's `"reply_payload_sending"
+              # in names`. It catches what no count can: a register() that adds a
+              # DIFFERENT valid hook still prints "1 hook(s)" with no error.
+              #
+              # This direction ONLY. The opposite finding at :343 ("registration
+              # adds hook X not listed in provides_hooks") means we registered
+              # something EXTRA, which says nothing about ours being missing —
+              # warning on it would put "directives may still reach channels" in
+              # the boot log of a box where they are being stripped correctly.
+              log "WARNING: $EMAIL_HOOK_PLUGIN did not register its hook — EMAIL: directives will still reach channels. hermes plugins doctor said: $EMAIL_HOOK_REASON"
               ;;
-            *[!0-9]"1 hook(s)"*)
-              # Anchored on the LEFT of the number and nothing else. `*"1
-              # hook(s)"*` also matched "11 hook(s)" — and 21, and 31 — which is
-              # the same false-success class this block exists to catch, since
-              # the count is the evidence. Borrowing the neighbouring "tool(s), "
-              # token would pin it too, but it couples the healthy match to a
-              # DIFFERENT number: this output goes through rich.Console, which
-              # wraps at 80 columns off a tty, and the WARN line visibly wrapped
-              # on the box. `*[!0-9]*` is this codebase's own idiom for the job
-              # (scripts/gateway-pre-start.sh).
+            *" 0 hook(s)"*)
+              # The one thing the name check cannot see: a box still carrying a
+              # manifest that declares nothing — the boot before this change's
+              # plugin.yaml lands. Nothing declared means no comparison and no
+              # warning, so "it registered nothing at all" is the only evidence
+              # left. Left-anchored on the space, which is what keeps it off the
+              # "0" inside "10 hook(s)"; the flattened capture is what makes a
+              # wrapped count line one string again.
+              log "WARNING: $EMAIL_HOOK_PLUGIN did not register its hook — EMAIL: directives will still reach channels. hermes plugins doctor said: $EMAIL_HOOK_REASON"
+              ;;
+            *"registration failed"*)
+              # The doctor said so in as many words, without an error verdict
+              # to go with it. Kept as its own arm: it carries no `registrations:`
+              # line, so neither of the two checks above can see it.
+              log "WARNING: $EMAIL_HOOK_PLUGIN did not register its hook — EMAIL: directives will still reach channels. hermes plugins doctor said: $EMAIL_HOOK_REASON"
+              ;;
+            *"registrations:"*)
+              # No error verdict, and the doctor did not say our hook is
+              # missing — with the manifest declaring it, that IS the check.
+              # The count is deliberately not consulted here: a plugin that
+              # registers ours PLUS a second hook prints "2 hook(s)" and is
+              # perfectly healthy, and matching `1 hook(s)` called that a defect
+              # (while also reading "11 hook(s)" as a success — the bug this
+              # change was opened for; it is gone because the count is gone).
               log "$EMAIL_HOOK_PLUGIN loaded and registered its outbound hook"
               ;;
             *)
-              # The doctor ran, found no error, and still did not report our one
-              # hook: it registered a count that is not one. That IS the defect,
-              # and it is the one nothing else on the box reports — `plugins
-              # list` reads "enabled" straight back out of the config it was
-              # written into (hermes_cli/plugins_cmd.py:1931).
-              log "WARNING: $EMAIL_HOOK_PLUGIN did not register its hook — EMAIL: directives will still reach channels. hermes plugins doctor said: $EMAIL_HOOK_DETAIL"
+              # A report with no registration line at all. `format_text()` always
+              # prints one, so this is a shape this script does not understand —
+              # and an unread verdict is not a healthy one.
+              log "WARNING: $EMAIL_HOOK_PLUGIN did not register its hook — EMAIL: directives will still reach channels. hermes plugins doctor said: $EMAIL_HOOK_REASON"
               ;;
           esac
         fi

--- a/src/tests/unit/register-mcp-email-hook.test.ts
+++ b/src/tests/unit/register-mcp-email-hook.test.ts
@@ -146,6 +146,37 @@ d("register-mcp.sh — the outbound EMAIL: directive hook", () => {
     expect(installed).toContain("transform_llm_output");
   });
 
+  it("declares in the manifest exactly the hooks it registers", () => {
+    // Measured on the Hermes box, read-only, 2026-09-04: with no
+    // `provides_hooks` the shipped plugin.yaml makes `hermes plugins doctor`
+    // print, on every web-server boot,
+    //   WARN: registration adds hook 'transform_llm_output' not listed in provides_hooks
+    // beside its OK line — a permanent warning about a plugin that is working,
+    // in the log where the line that matters has to be readable. The key is the
+    // harness's own manifest field (hermes_cli/plugins.py: the allowed-key list
+    // and `provides_hooks: List[str]`, read at manifest parse), and
+    // `transform_llm_output` is in its VALID_HOOKS, so declaring it cannot turn
+    // the warning into an error.
+    //
+    // Pinned against `register()` rather than restated: the doctor compares the
+    // two sets in both directions (plugin_dev.py warns for a declared hook that
+    // is not registered as well as for a registered one that is not declared),
+    // so a manifest that names the wrong hook is the same defect with the
+    // opposite sign.
+    const dir = path.join(REPO, "scripts/hermes-plugins", PLUGIN);
+    const manifest = execFileSync(
+      "python3",
+      ["-c", "import json,sys,yaml; print(json.dumps(yaml.safe_load(open(sys.argv[1])) or {}))", path.join(dir, "plugin.yaml")],
+      { encoding: "utf-8" },
+    );
+    const declared = (JSON.parse(manifest) as { provides_hooks?: unknown }).provides_hooks;
+    const source = fs.readFileSync(path.join(dir, "__init__.py"), "utf-8");
+    const registered = [...source.matchAll(/register_hook\(\s*["']([a-z_]+)["']/g)].map((m) => m[1]);
+
+    expect(registered.length).toBeGreaterThan(0);
+    expect(declared).toEqual(registered);
+  });
+
   it("MERGES into plugins.enabled — the ClawAI image backend must survive", () => {
     // The same list gates image generation. Writing ours over it would take the
     // customer's picture-drawing away as a side effect of a directive strip.
@@ -290,6 +321,61 @@ d("register-mcp.sh — the outbound EMAIL: directive hook", () => {
     expect(r.status).toBe(0);
     expect(r.stdout).toMatch(/WARNING.*did not register its hook/);
     expect(r.stdout).toContain("0 hook(s)");
+  });
+
+  it("does not read 11 hook(s) as the one hook it asked for", () => {
+    // `*"1 hook(s)"*` is a substring match, and "11 hook(s)" contains it. The
+    // count IS the evidence here — Hermes' doctor prints counts and never the
+    // hook NAMES (hermes_cli/plugin_dev.py renders "registrations: N tool(s),
+    // M hook(s)"), which is why the OpenClaw twin's name check has no
+    // equivalent on this side — so a pattern that does not pin the number is
+    // the same false success the block exists to catch. Unreachable while the
+    // plugin registers exactly one hook; reachable the moment it registers
+    // eleven, or twenty-one.
+    doctorOutput = "  OK: registration passed\n  registrations: 0 tool(s), 11 hook(s)\n";
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/WARNING.*did not register its hook/);
+    expect(r.stdout).not.toMatch(/loaded and registered its outbound hook/);
+  });
+
+  it("does not call a doctor that reported an ERROR a success", () => {
+    // `registrations:` is printed whatever the verdict — the count line is
+    // unconditional in plugin_dev.py, while the "OK:" line is not. So a plugin
+    // whose hook callback the doctor REFUSES ("must accept **kwargs for forward
+    // compatibility" is an error, not a warning) still prints "1 hook(s)", and
+    // the boot log used to call that a healthy registration.
+    doctorOutput = [
+      "Plugin Doctor: /home/x/.hermes/plugins/clawbox_email_directives",
+      "  ERROR: hook callback 'transform_llm_output' for 'transform_llm_output' must accept **kwargs for forward compatibility",
+      "  registrations: 0 tool(s), 1 hook(s)",
+      "",
+    ].join("\n");
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/WARNING.*did not register its hook/);
+    expect(r.stdout).toContain("must accept **kwargs");
+  });
+
+  it("still calls a clean one-hook registration a success", () => {
+    // The other half: the healthy shape must keep reading as healthy, with and
+    // without the manifest WARN that the provides_hooks fix removes.
+    for (const output of [
+      "  OK: registration passed\n  registrations: 0 tool(s), 1 hook(s)\n",
+      [
+        "Plugin Doctor: /home/x/.hermes/plugins/clawbox_email_directives",
+        "  manifest: clawbox_email_directives 1.0.0 (standalone)",
+        "  OK: runtime discovery, manifest parsing, import, and registration passed",
+        "  registrations: 0 tool(s), 1 hook(s)",
+        "",
+      ].join("\n"),
+    ]) {
+      doctorOutput = output;
+      const r = run();
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain("loaded and registered its outbound hook");
+      expect(r.stdout).not.toMatch(/WARNING/);
+    }
   });
 
   it("says so when the doctor cannot load the plugin at all, and carries the reason", () => {

--- a/src/tests/unit/register-mcp-email-hook.test.ts
+++ b/src/tests/unit/register-mcp-email-hook.test.ts
@@ -183,19 +183,23 @@ d("register-mcp.sh — the outbound EMAIL: directive hook", () => {
       ["-c", "import json,sys,yaml; print(json.dumps(yaml.safe_load(open(sys.argv[1])) or {}))", path.join(dir, "plugin.yaml")],
       { encoding: "utf-8" },
     );
-    const declared = ((JSON.parse(manifest) as { provides_hooks?: string[] }).provides_hooks ?? [])
-      .slice()
-      .sort();
+    // De-duplicated on both sides. The scan is a regex over the module TEXT —
+    // docstrings and comments included, and this package documents itself — so
+    // an example call in a docstring, or a hook registered on two code paths,
+    // would otherwise fail the pin on a plugin that is perfectly correct.
+    const unique = (names: string[]) => [...new Set(names)].sort();
+    const declared = unique((JSON.parse(manifest) as { provides_hooks?: string[] }).provides_hooks ?? []);
     // Every module in the package, not just __init__.py: a hook registered from
     // a sibling would otherwise be invisible to the pin while the "found at
     // least one" guard below still passed on the one it did see.
-    const registered = fs.readdirSync(dir)
-      .filter((f) => f.endsWith(".py"))
-      .flatMap((f) => [
-        ...fs.readFileSync(path.join(dir, f), "utf-8")
-          .matchAll(/register_hook\(\s*["']([a-z0-9_]+)["']/g),
-      ].map((m) => m[1]))
-      .sort();
+    const registered = unique(
+      fs.readdirSync(dir)
+        .filter((f) => f.endsWith(".py"))
+        .flatMap((f) => [
+          ...fs.readFileSync(path.join(dir, f), "utf-8")
+            .matchAll(/register_hook\(\s*["']([a-z0-9_]+)["']/g),
+        ].map((m) => m[1])),
+    );
 
     expect(registered.length).toBeGreaterThan(0);
     expect(declared).toEqual(registered);
@@ -328,12 +332,36 @@ d("register-mcp.sh — the outbound EMAIL: directive hook", () => {
   it("verifies the plugin LOADED on every boot, not once at install", () => {
     run();
     const calls = fs.readFileSync(path.join(home, "calls.log"), "utf-8");
-    expect(calls).toContain(`plugins doctor ${PLUGIN}`);
+    // `--ci` INCLUDED in the assertion, not just the subcommand: the whole
+    // verdict below is the CLI's own exit status, and without the flag the
+    // doctor exits 0 over an error report. A substring match on
+    // `plugins doctor <id>` is satisfied by a call that never asks for it.
+    expect(calls).toContain(`plugins doctor ${PLUGIN} --ci`);
 
     // Second boot, nothing to write — the check still runs.
     fs.writeFileSync(path.join(home, "calls.log"), "");
     run();
-    expect(fs.readFileSync(path.join(home, "calls.log"), "utf-8")).toContain(`plugins doctor ${PLUGIN}`);
+    expect(fs.readFileSync(path.join(home, "calls.log"), "utf-8")).toContain(
+      `plugins doctor ${PLUGIN} --ci`,
+    );
+  });
+
+  it("treats a hermes too old for --ci as unknown, not as a defect", () => {
+    // argparse's shape for an unrecognised flag: usage on stderr, exit 2, and
+    // no report at all. It must reach the NOTE arm — saying "directives will
+    // still reach channels" about a box whose hook is registered and working is
+    // the false failure this block's own comment forbids.
+    doctorRc = 2;
+    doctorOutput = "";
+    doctorStderr = [
+      "usage: hermes plugins doctor [-h] [target]",
+      "hermes plugins doctor: error: unrecognized arguments: --ci",
+      "",
+    ].join("\n");
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/NOTE.*could not verify/);
+    expect(r.stdout).not.toMatch(/WARNING/);
   });
 
   it("says so when the plugin registered no hook", () => {
@@ -345,22 +373,6 @@ d("register-mcp.sh — the outbound EMAIL: directive hook", () => {
     expect(r.status).toBe(0);
     expect(r.stdout).toMatch(/WARNING.*did not register its hook/);
     expect(r.stdout).toContain("0 hook(s)");
-  });
-
-  it("does not read 11 hook(s) as the one hook it asked for", () => {
-    // `*"1 hook(s)"*` is a substring match, and "11 hook(s)" contains it. The
-    // count IS the evidence here — Hermes' doctor prints counts and never the
-    // hook NAMES (hermes_cli/plugin_dev.py renders "registrations: N tool(s),
-    // M hook(s)"), which is why the OpenClaw twin's name check has no
-    // equivalent on this side — so a pattern that does not pin the number is
-    // the same false success the block exists to catch. Unreachable while the
-    // plugin registers exactly one hook; reachable the moment it registers
-    // eleven, or twenty-one.
-    doctorOutput = "  OK: registration passed\n  registrations: 0 tool(s), 11 hook(s)\n";
-    const r = run();
-    expect(r.status).toBe(0);
-    expect(r.stdout).toMatch(/WARNING.*did not register its hook/);
-    expect(r.stdout).not.toMatch(/loaded and registered its outbound hook/);
   });
 
   it("does not call a doctor that REFUSED the plugin a success", () => {
@@ -403,18 +415,36 @@ d("register-mcp.sh — the outbound EMAIL: directive hook", () => {
     expect(r.stdout).not.toMatch(/WARNING/);
   });
 
+  it("does not call an EXTRA hook a missing one", () => {
+    // The count was never the question, and reading it as one cuts both ways:
+    // `*"1 hook(s)"*` also matched "11 hook(s)" (a false SUCCESS), and pinning
+    // the number made a plugin that registers ours plus a second hook read as a
+    // failed registration (a false FAILURE, on a box where the directives are
+    // being stripped correctly). With the manifest declaring our hook, the
+    // doctor answers the real question by name and the count is not consulted.
+    doctorOutput = [
+      "Plugin Doctor: /home/x/.hermes/plugins/clawbox_email_directives",
+      "  WARN: registration adds hook 'telemetry_x' not listed in provides_hooks",
+      "  OK: runtime discovery, manifest parsing, import, and registration passed",
+      "  registrations: 0 tool(s), 2 hook(s)",
+      "",
+    ].join("\n");
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("loaded and registered its outbound hook");
+    expect(r.stdout).not.toMatch(/WARNING/);
+  });
+
   it("does not read 11 hook(s) as the one hook it asked for", () => {
-    // `*"1 hook(s)"*` is a substring match, and "11 hook(s)" contains it. The
-    // count IS the evidence here — Hermes' doctor prints counts, and the only
-    // line that ever names a hook is the provides_hooks mismatch WARN below —
-    // so a pattern that does not pin the number is the same false success the
-    // block exists to catch. Unreachable while the plugin registers exactly one
-    // hook; reachable the moment it registers eleven, or twenty-one.
+    // The original finding, kept as its own case: eleven hooks and no
+    // "declares … did not add it" line means ours IS among them, so this is a
+    // healthy box — and beta called it healthy too, for the wrong reason (the
+    // substring). What must never happen is the count deciding anything.
     doctorOutput = "  OK: registration passed\n  registrations: 0 tool(s), 11 hook(s)\n";
     const r = run();
     expect(r.status).toBe(0);
-    expect(r.stdout).toMatch(/WARNING.*did not register its hook/);
-    expect(r.stdout).not.toMatch(/loaded and registered its outbound hook/);
+    expect(r.stdout).toContain("loaded and registered its outbound hook");
+    expect(r.stdout).not.toMatch(/WARNING/);
   });
 
   it("still matches the one hook when the count line is wrapped or reordered", () => {
@@ -433,12 +463,20 @@ d("register-mcp.sh — the outbound EMAIL: directive hook", () => {
     }
   });
 
-  it("reads the one line that names a hook as the name check it is", () => {
+  it("reads the one line that names OUR hook as the name check it is", () => {
     // The Hermes equivalent of the OpenClaw twin's `"reply_payload_sending" in
-    // names`: the doctor compares provides_hooks against what register() added,
-    // in both directions, and warns BY NAME on either mismatch. It catches what
-    // no count can — a register() that adds a different valid hook still prints
-    // "1 hook(s)" with no error at all, and the directives reach channels.
+    // names`. The doctor warns in BOTH directions and only one of them means
+    // anything here: `manifest declares hook 'transform_llm_output' but
+    // registration did not add it` (plugin_dev.py:342) says ours is missing.
+    // The other — `registration adds hook X not listed in provides_hooks`
+    // (:343) — says we registered something EXTRA, which is not a defect at
+    // all. Note that only the :343 text contains the string `provides_hooks`,
+    // so a branch keyed on that word sees exactly the harmless direction and
+    // never the harmful one.
+    //
+    // This catches what no count can: a register() that adds a DIFFERENT valid
+    // hook still prints "1 hook(s)" with no error, and the directives reach
+    // channels.
     doctorOutput = [
       "Plugin Doctor: /home/x/.hermes/plugins/clawbox_email_directives",
       "  WARN: registration adds hook 'reply_payload_sending' not listed in provides_hooks",
@@ -449,8 +487,65 @@ d("register-mcp.sh — the outbound EMAIL: directive hook", () => {
     ].join("\n");
     const r = run();
     expect(r.status).toBe(0);
-    expect(r.stdout).toMatch(/WARNING.*manifest does not declare/);
+    expect(r.stdout).toMatch(/WARNING.*did not register its hook/);
     expect(r.stdout).toContain("transform_llm_output");
+    expect(r.stdout).not.toContain("loaded and registered its outbound hook");
+  });
+
+  it("still reads it when rich wraps the sentence across two lines", () => {
+    // `rich.Console` wraps at 80 columns off a tty, and the manifest WARN
+    // visibly wrapped on the box — so the sentence the verdict depends on
+    // arrives in two pieces. Matching the raw capture is how a reflow becomes a
+    // false verdict; the whole report is flattened to single spaces first.
+    doctorOutput = [
+      "Plugin Doctor: /home/x/.hermes/plugins/clawbox_email_directives",
+      "  WARN: manifest declares hook 'transform_llm_output' but registration",
+      "did not add it",
+      "  registrations: 0 tool(s), 1 hook(s)",
+      "",
+    ].join("\n");
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/WARNING.*did not register its hook/);
+  });
+
+  it("does not call a healthy report a refusal over an unrelated exit code", () => {
+    // `--ci` is documented as "exit non-zero when validation reports an error"
+    // and raises SystemExit(1) for exactly that. Another non-zero code over a
+    // report that says the plugin is fine — a BrokenPipeError at interpreter
+    // flush, a teardown raise on a loaded Jetson, a SIGINT during a restart —
+    // says nothing about the hook, and beta logged success for this same input.
+    doctorRc = 120;
+    doctorOutput = [
+      "Plugin Doctor: /home/x/.hermes/plugins/clawbox_email_directives",
+      "  OK: runtime discovery, manifest parsing, import, and registration passed",
+      "  registrations: 0 tool(s), 1 hook(s)",
+      "",
+    ].join("\n");
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/NOTE.*unknown here/);
+    expect(r.stdout).not.toMatch(/WARNING/);
+  });
+
+  it("quotes the ERROR that produced the refusal, not the warnings ahead of it", () => {
+    // Report order can put several WARN findings before the ERROR that makes
+    // `--ci` exit 1, and quoting those instead drops the one sentence that says
+    // what to fix — in the branch that needs it most.
+    doctorRc = 1;
+    doctorOutput = [
+      "Plugin Doctor: /home/x/.hermes/plugins/clawbox_email_directives",
+      "  WARN: registration adds hook 'a' not listed in provides_hooks",
+      "  WARN: registration adds hook 'b' not listed in provides_hooks",
+      "  WARN: registration adds hook 'c' not listed in provides_hooks",
+      "  ERROR: registered unknown hook 'not_a_real_hook'",
+      "  registrations: 0 tool(s), 4 hook(s)",
+      "",
+    ].join("\n");
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/WARNING.*REFUSED/);
+    expect(r.stdout).toContain("registered unknown hook");
   });
 
   it("still calls a clean one-hook registration a success", () => {

--- a/src/tests/unit/register-mcp-email-hook.test.ts
+++ b/src/tests/unit/register-mcp-email-hook.test.ts
@@ -49,6 +49,10 @@ let editionFile: string;
 let hermesBin: string;
 /** What the fake `hermes plugins doctor` prints; the reconcile reads it back. */
 let doctorOutput: string;
+/** …and what it prints on stderr, which the capture folds in with 2>&1. */
+let doctorStderr: string;
+/** …and its exit status, which is what `--ci` turns into the verdict. */
+let doctorRc: number;
 
 /**
  * A `hermes` that records its calls and answers `plugins doctor` with whatever
@@ -63,7 +67,12 @@ function writeHermesStub() {
       'printf "%s\\n" "$*" >> "$HERMES_CALLS"',
       'if [ "$1" = "plugins" ] && [ "$2" = "doctor" ]; then',
       '  cat "$HERMES_DOCTOR_OUT"',
-      "  exit 0",
+      // The reconcile captures with 2>&1, so stderr is part of what the arms
+      // read. Without a way to stage it, every fixture is tidy verdict-shaped
+      // stdout and a suite can go green over an arm that cannot tell the
+      // doctor's own "  ERROR: …" from a Python logging line.
+      '  [ -s "$HERMES_DOCTOR_ERR" ] && cat "$HERMES_DOCTOR_ERR" >&2',
+      '  exit "${HERMES_DOCTOR_RC:-0}"',
       "fi",
       "exit 0",
     ].join("\n"),
@@ -73,6 +82,7 @@ function writeHermesStub() {
 
 function run(extra: Record<string, string> = {}, root = REPO) {
   fs.writeFileSync(path.join(home, "doctor-out"), doctorOutput);
+  fs.writeFileSync(path.join(home, "doctor-err"), doctorStderr);
   const r = spawnSync("bash", [SCRIPT], {
     encoding: "utf-8",
     env: testEnv({
@@ -85,6 +95,8 @@ function run(extra: Record<string, string> = {}, root = REPO) {
       CLAWBOX_EDITION_FILE: editionFile,
       HERMES_CALLS: path.join(home, "calls.log"),
       HERMES_DOCTOR_OUT: path.join(home, "doctor-out"),
+      HERMES_DOCTOR_ERR: path.join(home, "doctor-err"),
+      HERMES_DOCTOR_RC: String(doctorRc),
       ...extra,
     }),
   });
@@ -117,6 +129,8 @@ beforeEach(() => {
   editionFile = path.join(home, "edition.env");
   hermesBin = path.join(home, "fake-hermes");
   doctorOutput = "  OK: registration passed\n  registrations: 0 tool(s), 1 hook(s)\n";
+  doctorStderr = "";
+  doctorRc = 0;
 
   fs.mkdirSync(path.join(home, ".hermes"), { recursive: true });
   fs.writeFileSync(editionFile, "CLAWBOX_EDITION=hermes\n");
@@ -169,9 +183,19 @@ d("register-mcp.sh — the outbound EMAIL: directive hook", () => {
       ["-c", "import json,sys,yaml; print(json.dumps(yaml.safe_load(open(sys.argv[1])) or {}))", path.join(dir, "plugin.yaml")],
       { encoding: "utf-8" },
     );
-    const declared = (JSON.parse(manifest) as { provides_hooks?: unknown }).provides_hooks;
-    const source = fs.readFileSync(path.join(dir, "__init__.py"), "utf-8");
-    const registered = [...source.matchAll(/register_hook\(\s*["']([a-z_]+)["']/g)].map((m) => m[1]);
+    const declared = ((JSON.parse(manifest) as { provides_hooks?: string[] }).provides_hooks ?? [])
+      .slice()
+      .sort();
+    // Every module in the package, not just __init__.py: a hook registered from
+    // a sibling would otherwise be invisible to the pin while the "found at
+    // least one" guard below still passed on the one it did see.
+    const registered = fs.readdirSync(dir)
+      .filter((f) => f.endsWith(".py"))
+      .flatMap((f) => [
+        ...fs.readFileSync(path.join(dir, f), "utf-8")
+          .matchAll(/register_hook\(\s*["']([a-z0-9_]+)["']/g),
+      ].map((m) => m[1]))
+      .sort();
 
     expect(registered.length).toBeGreaterThan(0);
     expect(declared).toEqual(registered);
@@ -339,12 +363,15 @@ d("register-mcp.sh — the outbound EMAIL: directive hook", () => {
     expect(r.stdout).not.toMatch(/loaded and registered its outbound hook/);
   });
 
-  it("does not call a doctor that reported an ERROR a success", () => {
+  it("does not call a doctor that REFUSED the plugin a success", () => {
     // `registrations:` is printed whatever the verdict — the count line is
     // unconditional in plugin_dev.py, while the "OK:" line is not. So a plugin
-    // whose hook callback the doctor REFUSES ("must accept **kwargs for forward
+    // whose hook callback the doctor refuses ("must accept **kwargs for forward
     // compatibility" is an error, not a warning) still prints "1 hook(s)", and
-    // the boot log used to call that a healthy registration.
+    // the boot log used to call that a healthy registration. The verdict comes
+    // from the CLI's own `--ci` exit status, not from a word grepped out of its
+    // prose.
+    doctorRc = 1;
     doctorOutput = [
       "Plugin Doctor: /home/x/.hermes/plugins/clawbox_email_directives",
       "  ERROR: hook callback 'transform_llm_output' for 'transform_llm_output' must accept **kwargs for forward compatibility",
@@ -353,13 +380,84 @@ d("register-mcp.sh — the outbound EMAIL: directive hook", () => {
     ].join("\n");
     const r = run();
     expect(r.status).toBe(0);
-    expect(r.stdout).toMatch(/WARNING.*did not register its hook/);
+    expect(r.stdout).toMatch(/WARNING.*REFUSED/);
+    // The reason that triggered the branch survives into the line. The banner
+    // plus the manifest line is ~110 characters before any verdict, so a
+    // head-of-output window would have cut exactly this off.
     expect(r.stdout).toContain("must accept **kwargs");
   });
 
+  it("asks the CLI for its verdict instead of grepping its prose for ERROR", () => {
+    // The doctor imports the whole agent in a blank sandboxed HERMES_HOME, and
+    // the capture is 2>&1. Python's logging default format is
+    // `%(levelname)s:%(name)s:%(message)s`, so one missing optional dependency
+    // in that empty home puts a literal `ERROR:` on stderr. A substring match
+    // would turn a healthy, registered hook into a per-boot "EMAIL: directives
+    // will still reach channels" — the false failure the NOTE arm below exists
+    // to avoid.
+    doctorRc = 0;
+    doctorStderr = "ERROR:hermes_cli.telemetry:could not reach the catalog index\n";
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("loaded and registered its outbound hook");
+    expect(r.stdout).not.toMatch(/WARNING/);
+  });
+
+  it("does not read 11 hook(s) as the one hook it asked for", () => {
+    // `*"1 hook(s)"*` is a substring match, and "11 hook(s)" contains it. The
+    // count IS the evidence here — Hermes' doctor prints counts, and the only
+    // line that ever names a hook is the provides_hooks mismatch WARN below —
+    // so a pattern that does not pin the number is the same false success the
+    // block exists to catch. Unreachable while the plugin registers exactly one
+    // hook; reachable the moment it registers eleven, or twenty-one.
+    doctorOutput = "  OK: registration passed\n  registrations: 0 tool(s), 11 hook(s)\n";
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/WARNING.*did not register its hook/);
+    expect(r.stdout).not.toMatch(/loaded and registered its outbound hook/);
+  });
+
+  it("still matches the one hook when the count line is wrapped or reordered", () => {
+    // This output goes through rich.Console, which wraps at 80 columns off a
+    // tty — and the manifest WARN visibly wrapped on the box. Anchoring the
+    // healthy match on the neighbouring "tool(s), " token would make a reflow
+    // read as a failed registration.
+    for (const line of [
+      "  registrations: 0 tool(s),\n1 hook(s)",
+      "  registrations: 1 hook(s), 0 tool(s)",
+    ]) {
+      doctorOutput = `  OK: registration passed\n${line}\n`;
+      const r = run();
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain("loaded and registered its outbound hook");
+    }
+  });
+
+  it("reads the one line that names a hook as the name check it is", () => {
+    // The Hermes equivalent of the OpenClaw twin's `"reply_payload_sending" in
+    // names`: the doctor compares provides_hooks against what register() added,
+    // in both directions, and warns BY NAME on either mismatch. It catches what
+    // no count can — a register() that adds a different valid hook still prints
+    // "1 hook(s)" with no error at all, and the directives reach channels.
+    doctorOutput = [
+      "Plugin Doctor: /home/x/.hermes/plugins/clawbox_email_directives",
+      "  WARN: registration adds hook 'reply_payload_sending' not listed in provides_hooks",
+      "  WARN: manifest declares hook 'transform_llm_output' but registration did not add it",
+      "  OK: runtime discovery, manifest parsing, import, and registration passed",
+      "  registrations: 0 tool(s), 1 hook(s)",
+      "",
+    ].join("\n");
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/WARNING.*manifest does not declare/);
+    expect(r.stdout).toContain("transform_llm_output");
+  });
+
   it("still calls a clean one-hook registration a success", () => {
-    // The other half: the healthy shape must keep reading as healthy, with and
-    // without the manifest WARN that the provides_hooks fix removes.
+    // The healthy shapes, including the five-line one measured on the box
+    // BEFORE this PR — every already-deployed box prints that until the new
+    // manifest lands, and it must not read as a defect on the boot that
+    // installs it.
     for (const output of [
       "  OK: registration passed\n  registrations: 0 tool(s), 1 hook(s)\n",
       [

--- a/src/tests/unit/register-mcp-email-hook.test.ts
+++ b/src/tests/unit/register-mcp-email-hook.test.ts
@@ -492,6 +492,33 @@ d("register-mcp.sh — the outbound EMAIL: directive hook", () => {
     expect(r.stdout).not.toContain("loaded and registered its outbound hook");
   });
 
+  it("quotes the doctor's own finding, not a flush-left logging line", () => {
+    // The capture is 2>&1 and the doctor imports the whole agent in a blank
+    // sandboxed HERMES_HOME, so one missing optional dependency puts Python's
+    // default `%(levelname)s:%(name)s:%(message)s` on stderr FLUSH LEFT. The
+    // doctor prints its OWN findings indented two spaces ("  WARN: …",
+    // "  ERROR: …"), so requiring at least one leading space is what keeps the
+    // ERRORS-first preference on verdict lines.
+    //
+    // Unanchored, the logging line wins that preference and the boot log hands
+    // the operator a cause the branch did not fire on — while dropping the one
+    // sentence that names the hook. That is the same "names the wrong cause"
+    // shape the rest of this change exists to end.
+    doctorRc = 0;
+    doctorStderr = "ERROR:hermes_cli.telemetry:could not reach the catalog index\n";
+    doctorOutput = [
+      "Plugin Doctor: /home/x/.hermes/plugins/clawbox_email_directives",
+      "  WARN: manifest declares hook 'transform_llm_output' but registration did not add it",
+      "  registrations: 0 tool(s), 0 hook(s)",
+      "",
+    ].join("\n");
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/WARNING.*did not register its hook/);
+    expect(r.stdout).toContain("transform_llm_output");
+    expect(r.stdout).not.toContain("hermes_cli.telemetry");
+  });
+
   it("still reads it when rich wraps the sentence across two lines", () => {
     // `rich.Console` wraps at 80 columns off a tty, and the manifest WARN
     // visibly wrapped on the box — so the sentence the verdict depends on


### PR DESCRIPTION
Two findings from the **#614 device proof** (TASK-697), both measured read-only on the Hermes box
(beta `e2aad622`, Hermes 0.20.5). Neither is a functional failure of #614; both are the boot log
lying, in opposite directions.

## 1. A permanent WARNING about a plugin that is working

`scripts/hermes-plugins/clawbox_email_directives/plugin.yaml` declared no `provides_hooks`, so
`hermes plugins doctor` — which `register-mcp.sh` runs on **every web-server boot** — printed:

```
Plugin Doctor: /home/clawbox/.hermes/plugins/clawbox_email_directives
  manifest: clawbox_email_directives 1.0.0 (standalone)
  WARN: registration adds hook 'transform_llm_output' not listed in provides_hooks
  OK: runtime discovery, manifest parsing, import, and registration passed
  registrations: 0 tool(s), 1 hook(s)
```

That is exactly what `register-mcp.sh`'s own comment warns against: "an operator who sees it every
boot stops reading the line that matters."

**Harness first.** `provides_hooks` is Hermes' own manifest field, not something invented here:
`hermes_cli/plugins.py` carries it in `_KNOWN_MANIFEST_FIELDS` (in the **v1** group), declares it
`provides_hooks: List[str]` on `PluginManifest`, and reads it at manifest parse.
`transform_llm_output` is in that module's `VALID_HOOKS`, so declaring it cannot turn the warning
into an error. And the compatibility question the change raises is answered by the parser's own
comment: unknown manifest keys are *forward-compat surface* — "warn … and continue loading" — so an
older Hermes that did not know the key would not refuse the manifest. It has not been unknown since
v1 in any case.

## 2. `11 hook(s)` read as `1 hook(s)`

`scripts/register-mcp.sh` matched `*"1 hook(s)"*`, which also matches `11 hook(s)` — and 21, and 31.
Unreachable while the plugin registers exactly one hook, and it did not affect the #614 proof, but
the count **is** the evidence here and the pattern did not pin it: the same false-success class the
block exists to catch.

## What the fix does, after the review pass

- **The verdict comes from the CLI, not from its prose.** `plugins doctor --ci` raises
  `SystemExit(1)` on an error report and stays 0 for warnings (`hermes_cli/plugins_cmd.py`);
  measured on the box, rc **0** while the WARN above was still printing. The first version of this
  PR grepped the capture for `ERROR:` instead — and the capture is `2>&1`, while the doctor imports
  the whole agent in a blank sandboxed `HERMES_HOME`, where Python's default logging format puts a
  literal `ERROR:hermes_cli.…:` on stderr. One missing optional dependency there and a healthy hook
  would have logged "EMAIL: directives will still reach channels" on every boot. A `hermes` too old
  for the flag prints no report at all and falls to the same NOTE as any other unusable CLI, so the
  flag cannot manufacture a defect.
- **The count is anchored on the left of the number only** — `*[!0-9]"1 hook(s)"*`, the idiom the
  OpenClaw twin's script already uses. Borrowing the neighbouring `tool(s), ` token would pin the
  number too, but it couples the healthy match to a *different* count: this output goes through
  `rich.Console`, which wraps at 80 columns off a tty, and the WARN line visibly wrapped on the box.
- **The name check the OpenClaw twin has, which Hermes did not.** Declaring `provides_hooks` makes
  the doctor compare declared against registered in both directions and warn **by name** on either
  mismatch — so the second half of this PR creates the signal the first half needed. It is read now.
  That closes the residual no count can: a `register()` that adds a *different valid* hook still
  prints `1 hook(s)` with no error, and the directives reach channels.
- The reason logged with a WARNING is built from the verdict lines rather than the head of the
  output (banner + manifest line is ~110 characters before any verdict, so the sentence that
  triggered the branch was being cut off); the "refused" and "wrong count" cases no longer log the
  identical sentence.

## RED (on unmodified beta)

```
 × declares in the manifest exactly the hooks it registers
     AssertionError: expected undefined to deeply equal [ 'transform_llm_output' ]
 × does not read 11 hook(s) as the one hook it asked for
 × does not call a doctor that REFUSED the plugin a success
 × reads the one line that names a hook as the name check it is
 Tests  5 failed | 28 passed (33)
```

## GREEN

```
 src/tests/unit/register-mcp-email-hook.test.ts → 33 passed
 npx vitest run --project unit → 579 files, 9302 tests, all pass
```

The test stub can now stage stderr and an exit status. Without that every fixture was tidy,
verdict-shaped stdout — which is why the first version's `ERROR:` bug was invisible to a green
suite. The suite is gated on `python3 -c "import yaml"`; `ubuntu-latest` ships PyYAML, so these
cases run rather than skip, but the gate is worth knowing about.

## Sibling call sites

- `scripts/hermes-plugins/image_gen/clawai/plugin.yaml` — **explicitly cleared**: it registers an
  image-gen provider (`register_image_gen_provider`), no hooks and no tools, so it has nothing to
  under-declare.
- This is the only place in the tree that scrapes a count out of a CLI's human-readable output; the
  OpenClaw twin (`gateway-pre-start.sh`) parses JSON and asks for the hook by name, which is right
  and unchanged.
- The plugin directory is `cp -f`'d unconditionally on every boot, so no marker or version gate
  stands between the new manifest and an already-deployed box — the fix reaches the field on update.

## Device proof (read-only, no mutation)

On the Hermes box: the doctor transcript above; `hermes_cli/plugins.py` and
`hermes_cli/plugin_dev.py` for the manifest field, `VALID_HOOKS`, the unknown-key policy and the
both-directions comparison; `plugins doctor … --ci` → rc 0 with the WARN present. Nothing was
written to the box.



---

## Finishing round (2026-09-05) — rebased twice, and the hook check re-pointed at the right mismatch

Rebased onto `origin/beta` `b15d64c6` and then `eece3ccb`; beta's own last change to
`scripts/register-mcp.sh` (`5190411e`, the gateway version probe) does not touch this block,
so there is no semantic conflict. `git diff --stat origin/beta...HEAD` lists three files.

### H1 — `--ci` is really on the parser, and here is the citation

The review was right to refuse `cmd_plugin_doctor(target, *, ci=False)` as evidence: that is
the implementation, and a flag missing from the subparser would have turned this whole check
into a permanent silent NOTE on every box. Read read-only from the installed 0.20.5 package
on the Hermes box:

```
hermes_cli/subcommands/plugins.py:161  plugins_doctor = plugins_subparsers.add_parser("doctor", …)
hermes_cli/subcommands/plugins.py:171      plugins_doctor.add_argument("--ci", action="store_true",
                                               help="Exit non-zero when validation reports an error")
hermes_cli/plugins_cmd.py:3164-3165   elif action == "doctor": cmd_plugin_doctor(args.target, ci=getattr(args, "ci", False))
hermes_cli/plugins_cmd.py:3051-3059   report = doctor_plugin(target); Console().print(report.format_text())
                                      if ci and not report.ok: raise SystemExit(1)
                                      # report.ok == not any(finding.level == "error")
```

So `--ci` exits 1 on an ERROR finding and 0 for warnings — exactly what this block reads. And
a `hermes` too old for the flag now has a fixture of its own (argparse usage on stderr, exit
2, no report) proving it reaches the NOTE arm rather than manufacturing a defect.

### H2 — the branch was pointed at the harmless direction

The doctor warns in **both** directions and only one of them means anything here:

- `plugin_dev.py:342` — `manifest declares hook 'transform_llm_output' but registration did
  not add it` → **ours is missing**. Contains no `provides_hooks`.
- `plugin_dev.py:343` — `registration adds hook 'X' not listed in provides_hooks` → **we
  registered something extra**. Contains it.

So a branch keyed on the word `provides_hooks` saw only the harmless one, and logged
"registered hooks its manifest does not declare — EMAIL: directives may still reach channels"
on a box where they were being stripped correctly — a false failure on every boot — while the
direction that means the hook is gone could never enter it.

**Rewritten as the name check it was meant to be.** The verdict now reads `:342` naming
`$EMAIL_HOOK_NAME`, which is the Hermes equivalent of the OpenClaw twin's
`"reply_payload_sending" in names`, and catches what no count can: a `register()` that adds a
*different* valid hook still prints `1 hook(s)` with no error at all.

With the name as the evidence the count stops deciding anything, and L7's whole glob-ladder
problem goes with it: `2 hook(s)` is healthy (ours plus another), `11 hook(s)` is healthy,
and the `11`-reads-as-`1` bug this PR was opened for is gone because there is no longer a
`1 hook(s)` match to fool. Two count-independent arms remain: `registration failed` in as
many words, and `" 0 hook(s)"` — nothing registered at all, which is the only evidence left
on a box still carrying a manifest that declares nothing (the boot before this change's
`plugin.yaml` lands).

The whole report is flattened to single spaces once (`tr -s '[:space:]' ' '`) before any
match, because `rich.Console` wraps at 80 columns off a tty and can split the count line *or*
a finding sentence — both wrap positions are now fixtures.

### Other findings taken

- **M3 — only rc 1 means REFUSED.** Any other non-zero over a report that says the plugin is
  fine (a `BrokenPipeError` at interpreter flush, a teardown raise on a loaded Jetson, a
  SIGINT during a restart) said "the doctor REFUSED it" on a healthy box. It is a NOTE now.
  Beta logged *success* for that same input, so this is the false-success direction closed
  too.
- **M4 — the tests could not see `--ci` at all.** They asserted `plugins doctor <id>`, a
  substring of both the old and the new call, so the flag could have been deleted with the
  suite green. Now asserted exactly, plus the argparse-refusal fixture.
- **M5** — the byte-identical duplicate `it()` deleted.
- **L8/L9** — `grep -m 3` instead of `| head -3` (under `pipefail` a `head` that closes the
  pipe makes the pipeline 141 and the `||` then discards the reason it had just computed),
  and **errors before warnings**, because the REFUSED branch fires on an ERROR that report
  order can put behind three WARNs.
- **L11** — the count-defect arm quotes the verdict lines rather than the head of the output.
- **L12** — both stale comments corrected (the `*[!0-9]*` "house idiom" citation is gone with
  the glob it justified; the "only line that names a hook" claim was H2's own misreading).
- **L13** — the manifest pin de-duplicates both sides, so a `register_hook(…)` shown in a
  docstring, or a hook registered on two code paths, cannot fail the test on a correct plugin.

### Harness first — Hermes has no machine-readable hook surface, and that is the finding

The standing rule asks for the native mechanism or a statement that there is none. Read
read-only from the installed package: `hermes plugins list --json` exists
(`subcommands/plugins.py:118`) and its payload is `name`, `status`, `version`, `description`,
`source` — **no hooks, no tools** (`plugins_cmd.py cmd_list`). `plugins doctor` has no
`--json`. `plugins show` advertises "including emits/listens" and has no `--json` either.
There is no `hermes plugins inspect`. So the doctor's text report is the only place a
registered hook name appears on this side, which is why this block reads prose at all — the
OpenClaw twin asks `plugins inspect --runtime --json` and gets a list. Recorded on the run's
Found list as an upstream gap.

### RED (on unmodified `origin/beta`, with the new tests)

```
 × declares in the manifest exactly the hooks it registers
 × verifies the plugin LOADED on every boot, not once at install      (--ci not passed)
 × does not call a doctor that REFUSED the plugin a success
 × does not call an EXTRA hook a missing one                          (beta: false failure)
 × reads the one line that names OUR hook as the name check it is     (beta: false success)
 × still reads it when rich wraps the sentence across two lines
 × does not call a healthy report a refusal over an unrelated exit code (beta: false success)
 × quotes the ERROR that produced the refusal, not the warnings ahead of it
 Tests  8 failed | 29 passed (37)
```

### GREEN

```
 register-mcp-email-hook.test.ts + clawbox-mcp-browser-guidance.test.ts → 44 passed
 npx vitest run --project unit → 630 files, all pass
 npx tsc --noEmit → clean;  bash -n scripts/register-mcp.sh → clean
```

**Device leg:** read-only only, on the Hermes box — the installed `hermes_cli` sources cited
above (parser, `--ci` contract, `DoctorReport.format_text()`, `VALID_HOOKS`, the
declared-vs-registered comparison at `:342`/`:343`) and the plugin surfaces that do not carry
hook names. Nothing was written to any box. **Unproven: the doctor was not re-run on the box
against the NEW manifest** — the owner is testing on both boxes, and running it is a
mutation of the sandbox it builds. What the source settles instead is the thing that
mattered: the substring `provides_hooks` appears in the report ONLY inside a mismatch
finding, so on a correctly-declaring manifest neither warning fires and the healthy path
cannot log a warning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved email hook setup verification with more reliable plugin registration checks.
  - Added clearer diagnostics for timeouts, registration mismatches, unexpected hook counts, and command failures.
  - Prevented misleading matches when interpreting hook-count results.
  - Ensured the email plugin’s declared hook is checked against its actual registration.

- **Tests**
  - Expanded automated coverage for successful registrations, manifest mismatches, error output, nonzero results, and legacy or updated diagnostic formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
