### PR TITLE
test: give the tests that run real processes timeouts that survive CI

### DIFF
--- a/.github/workflows/pr-tests-coverage.yml
+++ b/.github/workflows/pr-tests-coverage.yml
@@ -11,9 +11,12 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    # Every other workflow here caps its job (codeql 30, e2e-tests 30,
-    # build-identity 20, e2e-install 90); this one ran to GitHub's six-hour
-    # default. It matters now: raising the per-test ceiling for the files that
+    # The four workflows that run real work cap their jobs (codeql 30,
+    # e2e-tests 30, build-identity 20, e2e-install 90); this one — the only job
+    # in the repo that runs the whole vitest suite — ran to GitHub's six-hour
+    # default. (The `comment` jobs here and in the e2e workflows, and
+    # docs-deploy / issue-triage / pr-review, are still uncapped; each is a
+    # short API call, and none of them was the one burning a runner.) It matters now: raising the per-test ceiling for the files that
     # start real processes makes a genuine hang that much more expensive to
     # surface, and this is the backstop that keeps "a hung test must not cost a
     # day" true without weakening the 5 s default everywhere else. TASK-702.

--- a/.github/workflows/pr-tests-coverage.yml
+++ b/.github/workflows/pr-tests-coverage.yml
@@ -11,6 +11,13 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Every other workflow here caps its job (codeql 30, e2e-tests 30,
+    # build-identity 20, e2e-install 90); this one ran to GitHub's six-hour
+    # default. It matters now: raising the per-test ceiling for the files that
+    # start real processes makes a genuine hang that much more expensive to
+    # surface, and this is the backstop that keeps "a hung test must not cost a
+    # day" true without weakening the 5 s default everywhere else. TASK-702.
+    timeout-minutes: 30
     outputs:
       found: ${{ steps.coverage.outputs.found }}
       statements: ${{ steps.coverage.outputs.statements }}

--- a/src/tests/components/chat-spoken-reply.test.tsx
+++ b/src/tests/components/chat-spoken-reply.test.tsx
@@ -8,7 +8,21 @@ import { resetHarnessCache } from "@/lib/client-harness";
 // a slice of the Jetson's six cores and the 5 s default started expiring on
 // whichever test mounted while the box was busiest (a different one each
 // run — solo runs never failed). The work is real, not hung: give it room.
-vi.setConfig({ testTimeout: 15000, hookTimeout: 15000 });
+//
+// 30 s, the same number as every other file that declares a ceiling. It stood
+// at 15 000 — exactly MIN_TIMEOUT_MS in
+// src/tests/unit/test-timeout-hygiene.test.ts, so it passed that guard with no
+// margin at all and would go red the day the floor moved by a millisecond. One
+// number across the fleet is also one number to reason about.
+//
+// The other ceiling on this file is Testing Library's `asyncUtilTimeout`
+// (src/tests/setup.ts), which bounds a SINGLE `findBy*` wait at 5 s and is not
+// what this raises. Deliberate: the failures recorded here were vitest's own
+// "Test timed out in 5000ms", i.e. several sub-5 s waits in series, and raising
+// asyncUtilTimeout to 15 s was tried on this branch and reverted — the same
+// cases still failed, one at 15.5 s and one on an outright assertion at 387 ms.
+// Whatever that is, it is not a wait that needed longer.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 /**
  * A spoken reply has to be something the user can play.

--- a/src/tests/components/chat-spoken-reply.test.tsx
+++ b/src/tests/components/chat-spoken-reply.test.tsx
@@ -8,7 +8,7 @@ import { resetHarnessCache } from "@/lib/client-harness";
 // a slice of the Jetson's six cores and the 5 s default started expiring on
 // whichever test mounted while the box was busiest (a different one each
 // run — solo runs never failed). The work is real, not hung: give it room.
-vi.setConfig({ testTimeout: 15000 });
+vi.setConfig({ testTimeout: 15000, hookTimeout: 15000 });
 
 /**
  * A spoken reply has to be something the user can play.

--- a/src/tests/components/chat-spoken-reply.test.tsx
+++ b/src/tests/components/chat-spoken-reply.test.tsx
@@ -9,11 +9,13 @@ import { resetHarnessCache } from "@/lib/client-harness";
 // whichever test mounted while the box was busiest (a different one each
 // run — solo runs never failed). The work is real, not hung: give it room.
 //
-// 30 s, the same number as every other file that declares a ceiling. It stood
-// at 15 000 — exactly MIN_TIMEOUT_MS in
+// 30 s, the standard value here — what almost every file that declares a
+// ceiling uses. Two sets of files do not: src/tests/unit/sudoers-coverage.test.ts
+// sits at 60 s, and a handful of settings component suites at 20 s. This one
+// stood at 15 000 — exactly MIN_TIMEOUT_MS in
 // src/tests/unit/test-timeout-hygiene.test.ts, so it passed that guard with no
-// margin at all and would go red the day the floor moved by a millisecond. One
-// number across the fleet is also one number to reason about.
+// margin at all and would go red the day the floor moved by a millisecond.
+// Taking the standard value is also one fewer number to reason about.
 //
 // The other ceiling on this file is Testing Library's `asyncUtilTimeout`
 // (src/tests/setup.ts), which bounds a SINGLE `findBy*` wait at 5 s and is not

--- a/src/tests/components/hermes-oauth-inline.test.tsx
+++ b/src/tests/components/hermes-oauth-inline.test.tsx
@@ -3,6 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
 import HermesProviderConfig from "@/components/HermesProviderConfig";
 
+// Long waits on a loaded CI runner: vitest's 5 s test and 10 s hook defaults
+// are not enough. See src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
 // The inline provider sign-in that replaced the jump to the Hermes dashboard's
 // :8090 proxy (unreachable through clawbox-tunnel / Cloudflare tunnels). The
 // whole flow must run inside this panel against same-origin /setup-api routes:

--- a/src/tests/routes/chat/capabilities-parallel.test.ts
+++ b/src/tests/routes/chat/capabilities-parallel.test.ts
@@ -21,6 +21,10 @@ import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vite
  * serial route needs the clock to move 1500 ms.
  */
 
+// Long waits on a loaded CI runner: vitest's 5 s test and 10 s hook defaults
+// are not enough. See src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
 vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn() }));
 vi.mock("@/lib/harness/credentials", () => ({ hasClawaiToken: vi.fn() }));
 vi.mock("@/lib/harness/clawai-images", () => ({ clawaiImageRouteReachable: vi.fn() }));

--- a/src/tests/routes/coding-agent/projects.test.ts
+++ b/src/tests/routes/coding-agent/projects.test.ts
@@ -18,6 +18,11 @@ import path from "path";
 import { saveEnv } from "@/tests/helpers/env";
 import { HARNESS_TEST_PROJECT_ID } from "@/lib/coding-agent";
 
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
 let GET: () => Promise<Response>;
 let base: string;
 let home: string;

--- a/src/tests/routes/hermes/skills-secrets.test.ts
+++ b/src/tests/routes/hermes/skills-secrets.test.ts
@@ -14,6 +14,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  * The contract these tests pin: the key goes in, and it never comes back out.
  */
 
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
 vi.mock("@/lib/harness", () => ({
   getActiveHarness: vi.fn(async () => "hermes"),
   HERMES_BIN: "/home/clawbox/.local/bin/hermes",

--- a/src/tests/unit/ap-watchdog-honours-disable.test.ts
+++ b/src/tests/unit/ap-watchdog-honours-disable.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
@@ -26,6 +26,11 @@ import path from "node:path";
  * The distinction under test is drop versus decision: healing an AP that fell
  * over is the reason this watchdog exists, and it must keep doing that.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = process.cwd();
 const WATCHDOG = path.join(REPO, "scripts", "ap-watchdog.sh");

--- a/src/tests/unit/app-version.test.ts
+++ b/src/tests/unit/app-version.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { spawnSync } from "child_process";
 import fs from "fs";
 import os from "os";
@@ -31,6 +31,11 @@ import path from "path";
  * read is null), and it has already drifted — v3.9.0 is not an ancestor of
  * beta, so a clean clone describes as v3.1.11-<n>-g<sha>. Out of scope here.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO_ROOT = path.resolve(__dirname, "../../..");
 

--- a/src/tests/unit/build-identity-hygiene.test.ts
+++ b/src/tests/unit/build-identity-hygiene.test.ts
@@ -20,6 +20,11 @@ import path from "path";
  * 4 and 5 are the same incident from both ends, so they are tested together.
  */
 
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
 const REPO_ROOT = path.resolve(__dirname, "../../..");
 const UPDATER_TS = fs.readFileSync(path.join(REPO_ROOT, "src/lib/updater.ts"), "utf-8");
 const INSTALL_SH = fs.readFileSync(path.join(REPO_ROOT, "install.sh"), "utf-8");

--- a/src/tests/unit/build-identity.test.ts
+++ b/src/tests/unit/build-identity.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { describe, expect, it, beforeAll, afterAll, vi } from "vitest";
 import { execFileSync } from "child_process";
 import fs from "fs";
 import os from "os";
@@ -12,6 +12,11 @@ import {
   type DriftInputs,
   type PinInfo,
 } from "@/lib/build-identity";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const A = "1b21187aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const B = "d285cfdbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";

--- a/src/tests/unit/claude-ds-wrapper.test.ts
+++ b/src/tests/unit/claude-ds-wrapper.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { execFileSync, spawnSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, statSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -26,6 +26,11 @@ import { CODING_HARNESS_COMMAND, CODING_HARNESS_WRAPPER_PATH } from "@/lib/codin
  *  - A box with no ClawBox AI login must say so in words its owner can act on,
  *    and must not start Claude Code at all.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = process.cwd();
 const WRAPPER = path.join(REPO, "scripts", "claude-ds");

--- a/src/tests/unit/clawbox-firewall-policy.test.ts
+++ b/src/tests/unit/clawbox-firewall-policy.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
 import {
   mkdtempSync,
   rmSync,
@@ -43,6 +43,11 @@ import path from "node:path";
  *     and nothing in this repo re-adds them, so the captive portal would go
  *     down mid-setup and stay down until a reboot.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = process.cwd();
 const FIREWALL = path.join(REPO, "scripts", "clawbox-firewall.sh");

--- a/src/tests/unit/clawbox-tts-email-directives.test.ts
+++ b/src/tests/unit/clawbox-tts-email-directives.test.ts
@@ -1,10 +1,15 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync, chmodSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { testEnv } from "@/tests/helpers/env";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // The on-device voice must not read an `EMAIL:<id>` directive out loud.
 //

--- a/src/tests/unit/clawbox-tts.test.ts
+++ b/src/tests/unit/clawbox-tts.test.ts
@@ -1,10 +1,15 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync, chmodSync } from "node:fs";
 import { spawnSync, spawn, type ChildProcess } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { testEnv } from "@/tests/helpers/env";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // These run the shipped scripts/openclaw/clawbox-tts.sh itself against a stub
 // `kokoro` executable on PATH — not a reimplementation of its logic in

--- a/src/tests/unit/clawkeep-memory.test.ts
+++ b/src/tests/unit/clawkeep-memory.test.ts
@@ -14,6 +14,11 @@ import path from "node:path";
  * changed its output, which is exactly the drift this panel exists to expose.
  */
 
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
 const REAL_STATUS = JSON.parse(
   await fs.readFile(new URL("../fixtures/openclaw-memory-status.json", import.meta.url), "utf8"),
 ) as unknown;

--- a/src/tests/unit/codex-auth-mirror.test.ts
+++ b/src/tests/unit/codex-auth-mirror.test.ts
@@ -1,9 +1,14 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, mkdirSync, readdirSync, writeFileSync, readFileSync, existsSync, statSync, symlinkSync, chmodSync } from "node:fs";
 import { execFileSync, spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import path from "node:path";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // vite cannot bundle the builtin; a test file is never bundled, so reaching it
 // lazily here is safe (same rule as openclaw-session-store.test.ts).

--- a/src/tests/unit/coding-agent-cleanup.test.ts
+++ b/src/tests/unit/coding-agent-cleanup.test.ts
@@ -24,6 +24,11 @@ import os from "os";
 import path from "path";
 import { saveEnv } from "@/tests/helpers/env";
 
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
 const announce = vi.hoisted(() => vi.fn<(run: unknown) => Promise<undefined>>(async () => undefined));
 vi.mock("@/lib/coding-agent-notify", () => ({ announceCodingAgent: announce }));
 

--- a/src/tests/unit/coding-agent-spawn-failure.test.ts
+++ b/src/tests/unit/coding-agent-spawn-failure.test.ts
@@ -21,6 +21,11 @@ import { execFileSync } from "child_process";
 import { saveEnv } from "@/tests/helpers/env";
 import { isPrPending, runBranchName } from "@/lib/coding-pr-state";
 
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
 const spawnMock = vi.hoisted(() => vi.fn());
 // Only spawn is the subject here. The rest of child_process stays real,
 // because modules further down the import graph (openclaw-config's execFile)

--- a/src/tests/unit/coding-agent.test.ts
+++ b/src/tests/unit/coding-agent.test.ts
@@ -20,6 +20,12 @@ import os from "os";
 import path from "path";
 import { saveEnv } from "@/tests/helpers/env";
 
+// Starts real processes through @/lib/coding-agent rather than importing
+// child_process itself, and CI has flaked on it both ways in one day — a
+// timed-out case, and a whole run exiting 1 on a teardown error from this
+// file with every test passing. See src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
 const announce = vi.hoisted(() => vi.fn<(run: unknown) => Promise<undefined>>(async () => undefined));
 vi.mock("@/lib/coding-agent-notify", () => ({ announceCodingAgent: announce }));
 // A roomy box unless a test says otherwise: the team's spawn slot reads it.

--- a/src/tests/unit/coding-git-changes.test.ts
+++ b/src/tests/unit/coding-git-changes.test.ts
@@ -8,12 +8,17 @@
  * what a run in flight has changed, what a finished run's commit changed, and
  * the diff of one file in either.
  */
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { execFileSync } from "child_process";
 import fs from "fs";
 import os from "os";
 import path from "path";
 import { gitChanges, gitFileDiff, gitLog, isSafeGitRef, safeProjectRelativePath } from "@/lib/coding-git";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 let root: string;
 let repo: string;

--- a/src/tests/unit/coding-git.test.ts
+++ b/src/tests/unit/coding-git.test.ts
@@ -8,12 +8,17 @@
  * ClawBox itself and land whatever else was staged. Everything below exists to
  * pin that this cannot happen.
  */
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { execFileSync } from "child_process";
 import fs from "fs";
 import os from "os";
 import path from "path";
 import { buildCommitMessage, commitRunWork } from "@/lib/coding-git";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 let root: string;
 

--- a/src/tests/unit/coding-run-preview.test.ts
+++ b/src/tests/unit/coding-run-preview.test.ts
@@ -10,11 +10,16 @@
  * not moving — and a thought that has words shows a line of them rather than
  * a bare "thinking…".
  */
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it, vi } from "vitest";
 import { spawn } from "child_process";
 import fs from "fs";
 import os from "os";
 import path from "path";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const SCRIPT = path.join(process.cwd(), "scripts", "coding-run-preview");
 const SESSION = "61400ab6-0da9-4feb-8ad5-b547239c1367";

--- a/src/tests/unit/coding-team-worktree.test.ts
+++ b/src/tests/unit/coding-team-worktree.test.ts
@@ -3,12 +3,17 @@
  * team branch, a worker's worktree and branch, the merge home, a conflict
  * aborted rather than guessed at, and the worktree's removal.
  */
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { execFileSync } from "child_process";
 import fs from "fs";
 import os from "os";
 import path from "path";
 import { addWorkerWorktree, changedFiles, ensureTeamBranch, mergeWorkerBranch, removeWorktree, teamBranchName, workerBranchName } from "@/lib/coding-team-worktree";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 let dir: string;
 const git = (cwd: string, ...args: string[]) => execFileSync("git", args, { cwd, encoding: "utf8", env: { ...process.env, GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@x", GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@x" } }).trim();

--- a/src/tests/unit/dual-license-issue.test.ts
+++ b/src/tests/unit/dual-license-issue.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { spawnSync } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
@@ -17,6 +17,11 @@ import { isLicensePayloadValid } from "@/lib/edition-license";
  * These pin both ends: the tool refuses the argument, and the verifier refuses
  * a payload whose `exp` is present but not a usable timestamp.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const SCRIPT = path.join(process.cwd(), "scripts", "issue-dual-license.mjs");
 

--- a/src/tests/unit/email-directive-parity.test.ts
+++ b/src/tests/unit/email-directive-parity.test.ts
@@ -1,10 +1,15 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { execFileSync, spawnSync } from "node:child_process";
 import path from "node:path";
 
 import { splitEmailRefs } from "@/lib/chat-email-refs";
 import { stripEmailDirectives } from "../../../scripts/openclaw-plugins/clawbox-email-directives/email-directives.mjs";
 import { EMAIL_DIRECTIVE_CASES } from "@/tests/fixtures/email-directive-cases";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // THE PIN. `EMAIL:<uid>` is understood in three places by three languages:
 //

--- a/src/tests/unit/embed-server-pin.test.ts
+++ b/src/tests/unit/embed-server-pin.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
@@ -23,6 +23,11 @@ import { DATA_DIR_PUBLIC_SUBTREES } from "@/lib/file-guard";
  * llama-server runs another. This reads them all as text and pins them to the
  * module, the way llamacpp-gguf-pin.test.ts does for Gemma.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const ROOT = process.cwd();
 const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), "utf-8");

--- a/src/tests/unit/ensure-local-embeddings.test.ts
+++ b/src/tests/unit/ensure-local-embeddings.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   mkdtempSync,
   rmSync,
@@ -13,6 +13,11 @@ import {
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // These run the shipped scripts/ensure-local-embeddings.sh itself — not a copy
 // of its logic — against stub `hf`, `curl` and `openclaw` binaries on PATH.

--- a/src/tests/unit/gateway-origins.test.ts
+++ b/src/tests/unit/gateway-origins.test.ts
@@ -1,8 +1,13 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { execFileSync, spawnSync } from "node:child_process";
 import path from "node:path";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // scripts/gateway_origins.py is the boot-path (Python) implementation of
 // trusted control-UI origin validation/loading — the counterpart to

--- a/src/tests/unit/gateway-pre-start-channel-security.test.ts
+++ b/src/tests/unit/gateway-pre-start-channel-security.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
 import { execFileSync, spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // gateway-pre-start.sh re-secures the messaging channels on EVERY gateway
 // start. Two independent jobs, both load-bearing:

--- a/src/tests/unit/gateway-pre-start-clawai-audio.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-audio.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
 import { execFileSync, spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // A voice note that arrives over a chat channel is transcribed through
 // OpenClaw's media-understanding surface, which is not a models[] row and

--- a/src/tests/unit/gateway-pre-start-clawai-images.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-images.test.ts
@@ -4,6 +4,11 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
 // `CLAWBOX_AI_IMAGE_MODEL_ID` resolves `process.env.CLAWBOX_AI_IMAGE_MODEL_ID`
 // at module load, and the .sh hardcodes the default because a shell migration
 // cannot import a TS constant. Read the constants through a plain `import` and

--- a/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
 import { execFileSync, spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // Cloud TTS shipped to production on 2026-08-22 (clawbox-website PR #523) and
 // the device was never told. `messages.tts.providers` on a paired box carried

--- a/src/tests/unit/gateway-pre-start-clawai-vision.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-vision.test.ts
@@ -4,6 +4,11 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
 // Same env-override dance as gateway-pre-start-clawai-images.test.ts:
 // `CLAWBOX_AI_VISION_MODEL_ID` resolves an env var at module load and the .sh
 // hardcodes the default, so a developer who happens to export that variable

--- a/src/tests/unit/gateway-pre-start-codex-runtime.test.ts
+++ b/src/tests/unit/gateway-pre-start-codex-runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   chmodSync,
   existsSync,
@@ -11,6 +11,11 @@ import {
 import { execFileSync, spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // `agents.defaults.models["codex/*"].agentRuntime = {"id":"codex"}` is what
 // routes a codex turn through the Codex app-server harness. WITHOUT it core

--- a/src/tests/unit/gateway-pre-start-corrupt-config.test.ts
+++ b/src/tests/unit/gateway-pre-start-corrupt-config.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { chmodSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { execFileSync, spawnSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // F-15, the boot-time sibling. gateway-pre-start.sh loads openclaw.json, edits
 // a few keys and writes the object back on every gateway start. A file that

--- a/src/tests/unit/gateway-pre-start-deepseek-plugin.test.ts
+++ b/src/tests/unit/gateway-pre-start-deepseek-plugin.test.ts
@@ -1,9 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { testEnv } from "@/tests/helpers/env";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // gateway-pre-start.sh installs @openclaw/deepseek-provider on a paired box
 // that lacks it, PINNED to the installed core. The day OpenClaw 2026.8.2

--- a/src/tests/unit/gateway-pre-start-email-hook.test.ts
+++ b/src/tests/unit/gateway-pre-start-email-hook.test.ts
@@ -1,10 +1,15 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, readdirSync, existsSync, mkdirSync, chmodSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { testEnv } from "@/tests/helpers/env";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // The gateway boot reconcile that installs ClawBox's outbound EMAIL:-directive
 // plugin into the OpenClaw core, enables it, and proves it loaded.

--- a/src/tests/unit/gateway-pre-start-llamacpp-provider.test.ts
+++ b/src/tests/unit/gateway-pre-start-llamacpp-provider.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from "node:fs";
 import { execFileSync, spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // A ClawBox whose `agents.defaults.model.primary` names `llamacpp/<model>` while
 // `models.providers` has no `llamacpp` entry cannot answer at all. OpenClaw

--- a/src/tests/unit/gateway-pre-start-token.test.ts
+++ b/src/tests/unit/gateway-pre-start-token.test.ts
@@ -1,7 +1,12 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { execFileSync, spawnSync } from "node:child_process";
 import path from "node:path";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // gateway-pre-start.sh decides whether to PRESERVE the on-disk gateway auth
 // token or rotate it to a fresh per-device random. That predicate + rotation

--- a/src/tests/unit/gateway-pre-start-v2-cleanup.test.ts
+++ b/src/tests/unit/gateway-pre-start-v2-cleanup.test.ts
@@ -6,7 +6,11 @@ import { describe, expect, it, vi } from "vitest";
 // Starts a real process (bash / python3 / node / git): vitest's 5 s test and
 // 10 s hook defaults are not enough on a loaded CI runner. See
 // src/tests/unit/test-timeout-hygiene.test.ts.
+//
+// It covers the tests and their hooks, not the `spawnSync` on the module line
+// below: that one runs during COLLECTION, which neither ceiling governs.
 vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
 const SCRIPT = path.resolve(process.cwd(), "scripts/gateway-pre-start.sh");
 const hasPython3 = spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
 

--- a/src/tests/unit/gateway-pre-start-v2-cleanup.test.ts
+++ b/src/tests/unit/gateway-pre-start-v2-cleanup.test.ts
@@ -1,8 +1,12 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 const SCRIPT = path.resolve(process.cwd(), "scripts/gateway-pre-start.sh");
 const hasPython3 = spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
 

--- a/src/tests/unit/gateway-pre-start-v4-context.test.ts
+++ b/src/tests/unit/gateway-pre-start-v4-context.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
 import { execFileSync, spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // A configured provider entry in openclaw.json overrides OpenClaw's bundled
 // model catalog outright. A V4 model that omits contextWindow therefore does

--- a/src/tests/unit/gateway-pre-start-version-probe.test.ts
+++ b/src/tests/unit/gateway-pre-start-version-probe.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   mkdtempSync,
   mkdirSync,
@@ -51,6 +51,11 @@ import path from "node:path";
  * either resolves, or says so and carries on, and none of them can take the
  * gateway down.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = process.cwd();
 const PRE_START = readFileSync(path.join(REPO, "scripts", "gateway-pre-start.sh"), "utf-8");

--- a/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
+++ b/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { spawnSync } from "node:child_process";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -20,6 +20,11 @@ import path from "node:path";
  * overwritten. These run the block out of the shipped `.sh` rather than a copy,
  * so the test fails if the real script drifts.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const SCRIPT = path.resolve(process.cwd(), "scripts/gateway-pre-start.sh");
 const TEMPLATE = path.resolve(process.cwd(), "config/clawbox-workspace-guide.md");

--- a/src/tests/unit/gateway-prestart-onboarding.test.ts
+++ b/src/tests/unit/gateway-prestart-onboarding.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
@@ -22,6 +22,11 @@ import { writeLanguagePersona } from "@/lib/language-persona";
  * extracting the shipped shell between its fence comments and running it under
  * real bash — a paraphrase in the test would prove the paraphrase.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = process.cwd();
 const SCRIPT = path.join(REPO, "scripts", "gateway-pre-start.sh");

--- a/src/tests/unit/hermes-config-lock.test.ts
+++ b/src/tests/unit/hermes-config-lock.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
@@ -17,6 +17,11 @@ import path from "node:path";
  * path so they always collide on one lock file. These pin the contract and the
  * runtime behaviour.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 const REPO = process.cwd();
 const AUTH = path.join(REPO, "scripts", "setup-hermes-dashboard-auth.sh");
 const REGISTER = path.join(REPO, "scripts", "register-mcp.sh");

--- a/src/tests/unit/hermes-dashboard-auth-yaml.test.ts
+++ b/src/tests/unit/hermes-dashboard-auth-yaml.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
@@ -14,6 +14,11 @@ import path from "node:path";
  * The username is the only field an operator supplies (HERMES_DASH_USERNAME).
  * These run the real script and read back what it wrote.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const SCRIPT = path.join(process.cwd(), "scripts", "setup-hermes-dashboard-auth.sh");
 const SCRIPT_SRC = fs.readFileSync(SCRIPT, "utf-8");

--- a/src/tests/unit/hermes-email-directive-plugin.test.ts
+++ b/src/tests/unit/hermes-email-directive-plugin.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { execFileSync, spawnSync } from "node:child_process";
 import path from "node:path";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // The Hermes half of TASK-697: the `transform_llm_output` plugin that takes
 // `EMAIL:<uid>` card directives out of a reply on its way to a channel.

--- a/src/tests/unit/hermes-env.test.ts
+++ b/src/tests/unit/hermes-env.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { execFileSync } from "child_process";
 import fs from "fs/promises";
 import os from "os";
@@ -18,6 +18,11 @@ import {
   setHermesEnvValues,
   removeEnvValues,
 } from "@/lib/hermes-env";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 describe("quoteEnvValue", () => {
   it("leaves plain values unquoted", () => {

--- a/src/tests/unit/hermes-skill-manifest.test.ts
+++ b/src/tests/unit/hermes-skill-manifest.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from 'child_process';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   diffManifest,
   fetchGithubBlob,
@@ -30,6 +30,11 @@ import {
  *   pdf              REFERENCE.md and FORMS.md named in running prose, plus
  *                    eight scripts/*.py → 1 of 12 files installed.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const ALGORITHMIC_ART_SKILL_MD = `---
 name: algorithmic-art

--- a/src/tests/unit/identity-sync.test.ts
+++ b/src/tests/unit/identity-sync.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { spawnSync } from "node:child_process";
 import fs, { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -16,6 +16,11 @@ import path from "node:path";
  * and exited 0 — and /setup-api/harness/select, which refuses to complete a
  * switch when this script fails, could never fire.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 /**
  * Each case spawns a real bash and two fake binaries. That is milliseconds on

--- a/src/tests/unit/install-bootstrap-manifest.test.ts
+++ b/src/tests/unit/install-bootstrap-manifest.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync, chmodSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
@@ -34,6 +34,11 @@ import path from "node:path";
  * tree the way src/tests/unit/root-exec-manifest.test.ts retargets the shipped
  * scripts' constants.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = process.cwd();
 const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");

--- a/src/tests/unit/install-chpasswd-validation.test.ts
+++ b/src/tests/unit/install-chpasswd-validation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { spawnSync } from "child_process";
 import fs from "fs";
 import os from "os";
@@ -22,6 +22,11 @@ import path from "path";
  * /usr/sbin/chpasswd redirected to a recorder, and assert what actually reaches
  * it.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = path.resolve(__dirname, "../../..");
 const INSTALL_SH = fs.readFileSync(path.join(REPO, "install.sh"), "utf-8");

--- a/src/tests/unit/install-coding-harness-repair.test.ts
+++ b/src/tests/unit/install-coding-harness-repair.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -31,6 +31,11 @@ import path from "node:path";
  * These run the SHIPPED function bodies out of install.sh against stubs, so an
  * edit to install.sh is what the assertions see.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = process.cwd();
 const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");

--- a/src/tests/unit/install-edition-switch-refusal.test.ts
+++ b/src/tests/unit/install-edition-switch-refusal.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { spawnSync } from "child_process";
 import fs from "fs";
 import os from "os";
 import path from "path";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // A device installed as one edition and then re-installed as another completed
 // all 26 steps and printed "All N checks healthy" — on a box that was broken.

--- a/src/tests/unit/install-ensure-local-embeddings.test.ts
+++ b/src/tests/unit/install-ensure-local-embeddings.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { execFileSync } from "node:child_process";
 import fs, { readFileSync } from "node:fs";
 import os from "node:os";
@@ -18,6 +18,12 @@ import path from "node:path";
  *  - the old embedder inside ollama is stopped afterwards, and the build frees
  *    the new unit's memory the way it frees ollama's.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
 const REPO = process.cwd();
 const INSTALL_SH_PATH = path.join(REPO, "install.sh");
 const INSTALL_SH = readFileSync(INSTALL_SH_PATH, "utf-8");

--- a/src/tests/unit/install-foreign-edition-teardown.test.ts
+++ b/src/tests/unit/install-foreign-edition-teardown.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { spawnSync } from "child_process";
 import fs from "fs";
 import os from "os";
 import path from "path";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // A device converted in place from hermes to openclaw came up with the OpenClaw
 // gateway healthy AND the whole Hermes stack still running — clawbox-gateway,

--- a/src/tests/unit/install-free-memory-before-build.test.ts
+++ b/src/tests/unit/install-free-memory-before-build.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { execFileSync, spawn } from "node:child_process";
 import fs, { readFileSync } from "node:fs";
 import os from "node:os";
@@ -27,6 +27,11 @@ import path from "node:path";
  *  - and it never signals a pid it has not identified, because it runs as root
  *    and pidfiles outlive the processes they name.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 const REPO = process.cwd();
 const INSTALL_SH_PATH = path.join(REPO, "install.sh");
 const INSTALL_SH = readFileSync(INSTALL_SH_PATH, "utf-8");

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { execFileSync } from "node:child_process";
 import fs, { readFileSync } from "node:fs";
 import os from "node:os";
@@ -32,6 +32,11 @@ import path from "node:path";
  *    the upstream installer refuses with "Directory exists but is not a git
  *    repository" and the box stays broken.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 const REPO = process.cwd();
 const INSTALL_SH_PATH = path.join(REPO, "install.sh");
 const INSTALL_SH = readFileSync(INSTALL_SH_PATH, "utf-8");

--- a/src/tests/unit/install-hermes-tts.test.ts
+++ b/src/tests/unit/install-hermes-tts.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
@@ -30,6 +30,11 @@ import path from "node:path";
  * the real scripts/openclaw/clawbox-tts.sh — against stubs for the two
  * harness CLIs, rather than grepping their text.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = process.cwd();
 const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");

--- a/src/tests/unit/install-kokoro-tts.test.ts
+++ b/src/tests/unit/install-kokoro-tts.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
@@ -22,6 +22,11 @@ import { testEnv } from "@/tests/helpers/env";
  * install.sh — against stubs for su/pip/uname/nvcc, rather than grepping their
  * text. A rewrite that keeps the words but drops the install fails them.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = process.cwd();
 const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");

--- a/src/tests/unit/install-llamacpp-prebuilt.test.ts
+++ b/src/tests/unit/install-llamacpp-prebuilt.test.ts
@@ -2,8 +2,7 @@ import { execFileSync } from "child_process";
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 /**
  * Building llama.cpp on the device costs 18m51s, measured on an Orin Nano, and
  * produces an identical result on every unit — so install.sh can accept a
@@ -15,6 +14,11 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
  * the prebuilt falls through to the source build, because a slow install beats
  * a device with no working inference binary.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 const INSTALL_SH = path.join(process.cwd(), "install.sh");
 
 /** Run install_prebuilt_llamacpp in isolation. Returns its exit code + output. */

--- a/src/tests/unit/install-provision-status-marker.test.ts
+++ b/src/tests/unit/install-provision-status-marker.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
@@ -25,6 +25,11 @@ import path from "node:path";
  * These run the real shell out of install.sh rather than a copy of it: the
  * helpers and the final-verdict block are extracted from the file and executed.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 const REPO = process.cwd();
 const INSTALL_SH = fs.readFileSync(path.join(REPO, "install.sh"), "utf-8");
 

--- a/src/tests/unit/install-step-counter.test.ts
+++ b/src/tests/unit/install-step-counter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
@@ -25,6 +25,11 @@ import path from "node:path";
  * covered here so the same drift — a step added without touching the constant —
  * cannot appear there unnoticed.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = process.cwd();
 

--- a/src/tests/unit/install-sudoers-migration.test.ts
+++ b/src/tests/unit/install-sudoers-migration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { spawnSync } from "child_process";
 import fs from "fs";
 import os from "os";
@@ -27,6 +27,11 @@ import path from "path";
  * These tests source the real functions out of install.sh (never a copy) and
  * run them against a temp /etc/sudoers.d with fake root-capable tools.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = path.resolve(__dirname, "../../..");
 const INSTALL_SH = fs.readFileSync(path.join(REPO, "install.sh"), "utf-8");

--- a/src/tests/unit/install-tts-mute-box-fails.test.ts
+++ b/src/tests/unit/install-tts-mute-box-fails.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
@@ -51,6 +51,11 @@ import path from "node:path";
  * verdict cannot be read, is not a mute box, and reporting it as one would be
  * the same class of untrue status line pointed the other way.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = process.cwd();
 const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");

--- a/src/tests/unit/install-tts-no-engine.test.ts
+++ b/src/tests/unit/install-tts-no-engine.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
@@ -55,6 +55,11 @@ import path from "node:path";
  * — against stubs. A rewrite that keeps the prose but drops the verdict fails
  * them.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = process.cwd();
 const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");

--- a/src/tests/unit/install-tts-provider-registry.test.ts
+++ b/src/tests/unit/install-tts-provider-registry.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
@@ -29,6 +29,11 @@ import path from "node:path";
  * verification is dropped — and so they cannot pass against a rewrite that
  * merely keeps the words.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = process.cwd();
 const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");

--- a/src/tests/unit/install-tts-survivor-verdict.test.ts
+++ b/src/tests/unit/install-tts-survivor-verdict.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
@@ -36,6 +36,11 @@ import path from "node:path";
  * sit next to. The mute box (exit 13, `skipped:*`, recorded and non-fatal) is
  * those suites' subject; this one stays on the survivor.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = process.cwd();
 const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");

--- a/src/tests/unit/install-tts-verdict-siblings.test.ts
+++ b/src/tests/unit/install-tts-verdict-siblings.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
@@ -44,6 +44,11 @@ import path from "node:path";
  * they sit next to. A rewrite that keeps the prose but drops the verdict fails
  * them.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = process.cwd();
 const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");

--- a/src/tests/unit/install-update-branch-pin.test.ts
+++ b/src/tests/unit/install-update-branch-pin.test.ts
@@ -1,10 +1,15 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { spawnSync } from "child_process";
 import fs from "fs";
 import os from "os";
 import path from "path";
 
 import { testEnv } from "@/tests/helpers/env";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // A device is flashed with CLAWBOX_VERSION=<branch>, which flash.sh hands to
 // install.sh as CLAWBOX_BRANCH. What the device later UPDATES to is decided

--- a/src/tests/unit/install-voice-espeak.test.ts
+++ b/src/tests/unit/install-voice-espeak.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync, chmodSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
@@ -38,6 +38,11 @@ import path from "node:path";
  * already has the Kokoro stack is exactly the box a broken wheel is found on,
  * and `--tts-only` runs on every in-app update.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = process.cwd();
 const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");

--- a/src/tests/unit/install-whisper-stt.test.ts
+++ b/src/tests/unit/install-whisper-stt.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { execFileSync } from "node:child_process";
 import fs, { readFileSync } from "node:fs";
 import os from "node:os";
@@ -18,6 +18,12 @@ import path from "node:path";
  * plus a 34 s clone on this Orin Nano (measured 2026-09-04, CTranslate2 4.8.2,
  * linking libcudnn.so.9 / libcublas.so.12, `cuobjdump` reporting sm_87 only).
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
 const REPO = process.cwd();
 const VOICE_SH_PATH = path.join(REPO, "scripts/install-voice.sh");
 const VOICE_SH = readFileSync(VOICE_SH_PATH, "utf-8");

--- a/src/tests/unit/install-x64.test.ts
+++ b/src/tests/unit/install-x64.test.ts
@@ -7,7 +7,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Starts a real process (bash / python3 / node / git): vitest's 5 s test and
 // 10 s hook defaults are not enough on a loaded CI runner. See
 // src/tests/unit/test-timeout-hygiene.test.ts.
+//
+// It covers the tests and their hooks, not the `spawnSync` on the module line
+// below: that one runs during COLLECTION, which neither ceiling governs.
 vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
 const INSTALLER = path.resolve(process.cwd(), "install-x64.sh");
 const SOURCE = readFileSync(INSTALLER, "utf8");
 const hasPython3 = spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;

--- a/src/tests/unit/install-x64.test.ts
+++ b/src/tests/unit/install-x64.test.ts
@@ -2,8 +2,12 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 const INSTALLER = path.resolve(process.cwd(), "install-x64.sh");
 const SOURCE = readFileSync(INSTALLER, "utf8");
 const hasPython3 = spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;

--- a/src/tests/unit/mcp-cli-app-gate.test.ts
+++ b/src/tests/unit/mcp-cli-app-gate.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
 import { spawn, spawnSync } from "child_process";
 import http from "http";
 import type { AddressInfo } from "net";
@@ -26,6 +26,11 @@ import { builtInApps, openedAppNotice } from "../../../mcp/lib/context";
  * The whole CLI had no test before this one; these run it as the agent does,
  * against a stub device.
  */
+
+// Starts real processes (bun running the CLI, and the `have()` probe): vitest's
+// 5 s test and 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = path.resolve(__dirname, "../../..");
 const CLI = path.join(REPO, "mcp", "clawbox-cli.ts");

--- a/src/tests/unit/migrate-auth-profiles.test.ts
+++ b/src/tests/unit/migrate-auth-profiles.test.ts
@@ -1,9 +1,14 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { DatabaseSync } from "node:sqlite";
 import { tmpdir } from "node:os";
 import path from "node:path";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // scripts/migrate-auth-profiles.js copies credentials out of the legacy
 // <agentDir>/auth-profiles.json into the sqlite auth_profile_store that core

--- a/src/tests/unit/postbuild-standalone-data.test.ts
+++ b/src/tests/unit/postbuild-standalone-data.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { spawnSync } from "child_process";
 import fs from "fs";
 import os from "os";
@@ -30,6 +30,11 @@ import path from "path";
  * These tests run the REAL postbuild script out of package.json against a
  * temp tree, so they cannot drift from what ships.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = path.resolve(__dirname, "../../..");
 const POSTBUILD: string = JSON.parse(

--- a/src/tests/unit/process-match.test.ts
+++ b/src/tests/unit/process-match.test.ts
@@ -15,7 +15,7 @@
  * match. The rest keep the matcher honest about real browsers.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { spawn } from "child_process";
 import {
   isBrowserExecutable,
@@ -24,6 +24,11 @@ import {
   findClawboxBrowserPids,
   parseProcCmdline,
 } from "@/lib/process-match";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const PROFILE_DIR = "/home/clawbox/.config/clawbox-browser";
 const CDP_PORT = 18800;

--- a/src/tests/unit/register-mcp-email-hook.test.ts
+++ b/src/tests/unit/register-mcp-email-hook.test.ts
@@ -1,10 +1,15 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { execFileSync, spawnSync } from "child_process";
 import fs from "fs";
 import os from "os";
 import path from "path";
 
 import { testEnv } from "@/tests/helpers/env";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // The boot reconcile that puts ClawBox's outbound `EMAIL:`-directive hook into
 // the Hermes agent, and then checks that it actually loaded.

--- a/src/tests/unit/register-mcp-hermes.test.ts
+++ b/src/tests/unit/register-mcp-hermes.test.ts
@@ -1,10 +1,15 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { execFileSync, spawnSync } from "child_process";
 import fs from "fs";
 import os from "os";
 import path from "path";
 
 import { testEnv } from "@/tests/helpers/env";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // scripts/register-mcp.sh is what puts the ClawBox MCP server into Hermes'
 // config. Before it existed, the only thing that ever registered the MCP was

--- a/src/tests/unit/root-exec-manifest.test.ts
+++ b/src/tests/unit/root-exec-manifest.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { spawnSync } from "child_process";
 import fs from "fs";
 import os from "os";
@@ -21,6 +21,11 @@ import path from "path";
  * the exec. These tests drive the real shipped scripts, with their constants
  * rewritten onto a temp tree — never a re-implementation of them.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = path.resolve(__dirname, "../../..");
 const MANIFEST_SRC = path.join(REPO, "config", "clawbox-root-manifest.sh");

--- a/src/tests/unit/root-step-launcher.test.ts
+++ b/src/tests/unit/root-step-launcher.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { spawnSync } from "child_process";
 import fs from "fs";
 import os from "os";
@@ -18,6 +18,11 @@ import path from "path";
  * refuses is the whole point. These tests run the real shipped script with
  * /usr/bin/systemctl redirected to a recorder.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = path.resolve(__dirname, "../../..");
 const LAUNCHER_SRC = path.join(REPO, "config", "clawbox-run-root-step.sh");

--- a/src/tests/unit/run-cannot-kill-the-box.test.ts
+++ b/src/tests/unit/run-cannot-kill-the-box.test.ts
@@ -9,12 +9,17 @@
  * the box's server takes a title of its own so a stray one cannot match it
  * anyway, checked here at runtime in a child process.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { execFileSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import { BASH_ALLOWLIST, BASH_KILL_DENYLIST } from "@/lib/coding-agent";
 import { WEBAPP_STORAGE_GUIDE } from "../../../mcp/tools/orientation";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 describe("the run's Bash rules", () => {
   it("deny every killer that matches by name, and a kill of every process", () => {

--- a/src/tests/unit/run-tunnel.test.ts
+++ b/src/tests/unit/run-tunnel.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { spawn } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import os from "node:os";
@@ -23,6 +23,11 @@ import path from "node:path";
  * SIGTERM goes to the whole process group, which is what systemd does with the
  * unit's default KillMode=control-group.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = process.cwd();
 const RUN_TUNNEL = path.join(REPO, "scripts/run-tunnel.sh");

--- a/src/tests/unit/stt-bench.test.ts
+++ b/src/tests/unit/stt-bench.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync, chmodSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // These run the shipped scripts/bench/stt-bench.py itself against a STUB
 // faster_whisper: a fake WhisperModel that sleeps a known time and returns a

--- a/src/tests/unit/sudoers-coverage.test.ts
+++ b/src/tests/unit/sudoers-coverage.test.ts
@@ -3,7 +3,8 @@ import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vite
 // Every test here spawns the real checker over the real src/ and mcp/ trees,
 // which takes ~5 s on a Jetson Orin Nano — right on the default 5 s test
 // timeout, so the suite failed on the device it protects while passing in CI.
-// The budget is per test; the checker's own OK line is still the assertion.
+// The budget is per test AND per hook; the checker's own OK line is still the
+// assertion.
 vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
 import { execFile, spawnSync } from "child_process";
 import fs from "fs";

--- a/src/tests/unit/sudoers-coverage.test.ts
+++ b/src/tests/unit/sudoers-coverage.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vite
 // which takes ~5 s on a Jetson Orin Nano — right on the default 5 s test
 // timeout, so the suite failed on the device it protects while passing in CI.
 // The budget is per test; the checker's own OK line is still the assertion.
-vi.setConfig({ testTimeout: 60_000 });
+vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
 import { execFile, spawnSync } from "child_process";
 import fs from "fs";
 import os from "os";

--- a/src/tests/unit/system-profile-scripts.test.ts
+++ b/src/tests/unit/system-profile-scripts.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { execFileSync } from "child_process";
 import fs from "fs";
 import os from "os";
@@ -17,6 +17,11 @@ import path from "path";
  * Everything is driven through the CLAWBOX_* overrides the scripts expose, so
  * nothing here reads or writes real system state.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = process.cwd();
 const DESKTOP = path.join(REPO, "scripts", "clawbox-desktop-mode.sh");

--- a/src/tests/unit/test-timeout-hygiene.test.ts
+++ b/src/tests/unit/test-timeout-hygiene.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Vitest's defaults are 5 000 ms per test and 10 000 ms per hook, and both are
+ * too tight for a test that runs REAL processes on a loaded CI runner.
+ *
+ * Measured (TASK-702): `startRunBranch` (src/lib/coding-pr.ts) runs six real
+ * `git`/`gh` processes in series inside one case. Locally the first case in the
+ * file takes ~470 ms; on a four-worker `ubuntu-latest` runner under v8 coverage
+ * it inflates past 1 500 ms and the series crosses 5 s. The failure lands on a
+ * file the PR did not touch — `coding-agent-spawn-failure.test.ts`,
+ * `hermes-oauth-inline.test.tsx`, `capabilities-parallel.test.ts` and
+ * `chat-spoken-reply.test.tsx` were all seen on 2026-09-03, and
+ * `hermes-config-lock.test.ts` + `hermes-dashboard-auth-yaml.test.ts` on
+ * 2026-09-04 — so it reads as an unrelated regression and costs a re-run.
+ *
+ * BOTH ceilings, not just the test one: `vi.setConfig({ testTimeout })` leaves
+ * `hookTimeout` at 10 s, and several of these files do their process work in a
+ * `beforeEach` — `updater-branch-resolution.test.ts` runs eleven real gits
+ * there before every case. Raising only the test ceiling would have left the
+ * dominant cost unguarded under a comment claiming it was fixed.
+ *
+ * The fix is NOT to widen the global defaults: 5 s is a useful guard against a
+ * unit test that has genuinely hung, and every file that keeps it keeps that
+ * guard. It is to declare the ceilings in the files that legitimately need
+ * them. Mocking `git`/`gh` is not the fix either — in these files the real
+ * process IS the thing under test.
+ *
+ * This is the guard that keeps it true for files added later.
+ */
+
+const REPO = path.resolve(__dirname, "../../..");
+const ROOT = path.join(REPO, "src", "tests");
+const rel = (p: string) => path.relative(REPO, p).split(path.sep).join("/");
+
+/**
+ * A real process is started only through a `child_process` import.
+ *
+ * Matching the bare call names would count `RE.exec(s)`, a local helper named
+ * `spawn`, and every `execFileSync` that is a mock's own type annotation. The
+ * import is the fact that decides it.
+ */
+const IMPORTS_CHILD_PROCESS =
+  /import\s+(?:\*\s+as\s+\w+|\{[^}]*\}|\w+)\s+from\s+["'](?:node:)?child_process["']|require\(\s*["'](?:node:)?child_process["']\s*\)/;
+/** …and one of its process starters is actually called. Async forms included:
+ * a test that spawns and awaits is in the same flake class as one that blocks —
+ * `run-tunnel.test.ts` polls for up to 5 000 ms on the wait alone. */
+const STARTS_A_PROCESS = /\b(spawnSync|execFileSync|execSync|spawn|execFile|fork|exec)\s*\(/;
+
+/**
+ * …unless the module is mocked WHOLLY, in which case nothing is spawned.
+ *
+ * A partial mock does not count, and that distinction is the whole point:
+ * `coding-agent-spawn-failure.test.ts` — the file CI flaked on first — mocks
+ * `spawn` alone and spreads `importOriginal()` for the rest, precisely so the
+ * modules further down the graph keep a real `child_process`. Its six real
+ * `git` calls go through the untouched `execFileSync`.
+ */
+function mocksChildProcessWholly(source: string): boolean {
+  const at = source.search(/vi\.mock\(\s*["'](?:node:)?child_process["']/);
+  if (at < 0) return false;
+  return !/importOriginal|importActual/.test(source.slice(at, at + 500));
+}
+
+/**
+ * Comments stripped before any pattern is read.
+ *
+ * Without this a file passes on a commented-out declaration — and the rule
+ * would have been satisfied by the prose in this very file.
+ */
+function code(source: string): string {
+  // Only comments that OWN their line, and that restraint is load-bearing: a
+  // blunt `/\*[\s\S]*?\*\//` eats from the `/*` inside a `"**/node_modules/**"`
+  // glob to the `*/` inside the next one and takes the whole file with it,
+  // which is how this helper first reported that vitest.config.ts had no
+  // projects at all. A commented-out declaration — the hole this exists to
+  // close — owns its line by convention.
+  return source
+    .replace(/^[ \t]*\/\*[\s\S]*?\*\/[ \t]*$/gm, "")
+    .replace(/^[ \t]*\/\/[^\n]*$/gm, "");
+}
+
+/** The house form: `vi.setConfig({ testTimeout: …, hookTimeout: … })` at file top. */
+function declared(source: string, key: "testTimeout" | "hookTimeout"): number | null {
+  const call = /^\s*vi\.setConfig\(\s*\{([\s\S]*?)\}\s*\)/m.exec(code(source));
+  if (!call) return null;
+  const match = new RegExp(`\\b${key}\\s*:\\s*([0-9_]+)`).exec(call[1]);
+  return match ? Number(match[1].replace(/_/g, "")) : null;
+}
+
+/**
+ * Six real processes in series, with the slowest measured at ~1.5 s each on a
+ * saturated runner, is ~9 s. 15 s is the floor that clears it with headroom and
+ * still fails a test that has actually hung.
+ */
+const MIN_TIMEOUT_MS = 15_000;
+
+/**
+ * Files that flake for a reason other than a subprocess, named from the CI runs
+ * above rather than detected: long `findBy*` waits against a jsdom tree, and a
+ * fake-timer probe fan-out whose module imports dominate under load. A pattern
+ * broad enough to catch these automatically would catch most of the component
+ * suite with it.
+ */
+const ALSO_REQUIRED = [
+  "src/tests/routes/chat/capabilities-parallel.test.ts",
+  "src/tests/components/hermes-oauth-inline.test.tsx",
+  "src/tests/components/chat-spoken-reply.test.tsx",
+];
+
+/**
+ * Files that carry a bigger budget on every case inline, so a file-level
+ * declaration would be a SECOND number disagreeing with the first.
+ * `build-typecheck.test.ts` runs `tsc --noEmit`, measured at ~28 s in CI
+ * (src/tests/helpers/slow-first-sequencer.ts), and says so with `}, 300_000)`.
+ * Listed rather than detected, and checked below so a stale entry fails.
+ */
+const INLINE_BUDGET: Record<string, number> = {
+  "src/tests/unit/build-typecheck.test.ts": 300_000,
+};
+
+function testFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...testFiles(full));
+    else if (/\.test\.tsx?$/.test(entry.name)) out.push(full);
+  }
+  return out.sort();
+}
+
+describe("test-timeout hygiene", () => {
+  const files = testFiles(ROOT).map((full) => ({
+    rel: rel(full),
+    source: fs.readFileSync(full, "utf-8"),
+  }));
+  const spawners = files.filter(
+    (f) =>
+      IMPORTS_CHILD_PROCESS.test(f.source)
+      && STARTS_A_PROCESS.test(f.source)
+      && !mocksChildProcessWholly(f.source),
+  );
+
+  it("finds the test tree at all", () => {
+    // A path that resolved to nothing would make every assertion below vacuous.
+    expect(files.length).toBeGreaterThan(300);
+    expect(spawners.length).toBeGreaterThan(50);
+  });
+
+  it("gives every test that starts a real process both ceilings", () => {
+    const offenders = spawners
+      .filter((f) => !(f.rel in INLINE_BUDGET))
+      .filter(
+        (f) =>
+          (declared(f.source, "testTimeout") ?? 0) < MIN_TIMEOUT_MS
+          || (declared(f.source, "hookTimeout") ?? 0) < MIN_TIMEOUT_MS,
+      )
+      .map((f) => f.rel);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("gives the files seen flaking on long waits both ceilings too", () => {
+    const byRel = new Map(files.map((f) => [f.rel, f.source]));
+    const offenders = ALSO_REQUIRED.filter((name) => {
+      const source = byRel.get(name);
+      // A file that has been renamed or deleted is a stale entry here, not a
+      // pass: the list would otherwise silently stop guarding anything.
+      if (source === undefined) return true;
+      return (
+        (declared(source, "testTimeout") ?? 0) < MIN_TIMEOUT_MS
+        || (declared(source, "hookTimeout") ?? 0) < MIN_TIMEOUT_MS
+      );
+    });
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("keeps the inline-budget exemptions honest", () => {
+    // An exemption that stops being true is a silent hole: the file would be
+    // skipped by the rule above while running on the default ceiling.
+    const byRel = new Map(files.map((f) => [f.rel, f.source]));
+    for (const [name, expected] of Object.entries(INLINE_BUDGET)) {
+      const source = byRel.get(name);
+      expect(source, `${name} is listed as inline-budgeted but does not exist`).toBeDefined();
+      const inline = [...code(source!).matchAll(/\}\s*,\s*([0-9_]+)\s*\)/g)]
+        .map((m) => Number(m[1].replace(/_/g, "")));
+      expect(inline.length, `${name} carries no inline timeout any more`).toBeGreaterThan(0);
+      expect(Math.min(...inline)).toBeGreaterThanOrEqual(expected);
+    }
+  });
+
+  it("excludes a file only when child_process is mocked whole", () => {
+    // The one SILENT exclusion in this guard: a file it drops leaves the check
+    // with nothing saying so. Pinned rather than trusted, so the day the set
+    // grows a human reads the name and decides whether it is really mocked.
+    const excluded = files
+      .filter((f) => IMPORTS_CHILD_PROCESS.test(f.source) && STARTS_A_PROCESS.test(f.source))
+      .filter((f) => mocksChildProcessWholly(f.source))
+      .map((f) => f.rel);
+
+    expect(excluded).toEqual(["src/tests/unit/system-password.test.ts"]);
+  });
+
+  it("does not simply raise the defaults for everything", () => {
+    // The other half of the ruling. Widening the defaults would hide a unit
+    // test that has genuinely hung, which is what they are for. Matched on a
+    // comment-stripped form, so the ruling can still be WRITTEN down where a
+    // reader would look for it.
+    const config = code(fs.readFileSync(path.join(REPO, "vitest.config.ts"), "utf-8"));
+    expect(config).not.toMatch(/^\s*(testTimeout|hookTimeout)\s*:/m);
+    // …and not through the back door either: a flag on the runner defeats the
+    // ruling without touching the config file.
+    const pkg = fs.readFileSync(path.join(REPO, "package.json"), "utf-8");
+    expect(pkg).not.toMatch(/--(test|hook)Timeout/);
+    const workflow = fs.readFileSync(
+      path.join(REPO, ".github", "workflows", "pr-tests-coverage.yml"),
+      "utf-8",
+    );
+    expect(workflow).not.toMatch(/--(test|hook)Timeout/);
+  });
+
+  it("caps the test job, so a genuine hang cannot burn a runner", () => {
+    // The cheap half of the same ruling. Raising 79 files' budget six-fold
+    // makes a real hang six times more expensive to surface, and this job was
+    // the only one in the repo with no ceiling at all — GitHub's default is
+    // six hours. Every other workflow here caps itself.
+    const workflow = fs.readFileSync(
+      path.join(REPO, ".github", "workflows", "pr-tests-coverage.yml"),
+      "utf-8",
+    );
+    expect(workflow).toMatch(/^\s*timeout-minutes:\s*\d+/m);
+  });
+});

--- a/src/tests/unit/test-timeout-hygiene.test.ts
+++ b/src/tests/unit/test-timeout-hygiene.test.ts
@@ -36,7 +36,25 @@ const ROOT = path.join(REPO, "src", "tests");
 const rel = (p: string) => path.relative(REPO, p).split(path.sep).join("/");
 
 /**
- * Comments blanked, length and newlines preserved. Strings are WALKED but kept.
+ * Where a `/` can begin a REGEX rather than a division.
+ *
+ * The walker has to know, and it is not decoration: a regex containing an odd
+ * number of quotes — `/["\']/`, which this very file writes — puts a quote-only
+ * walker into "inside a string" state and it stays desynced until the next
+ * matching quote, then desynced the OTHER way inside a real string. Both
+ * directions were reproduced and both are SILENT: a commented-out
+ * `vi.setConfig` is read as a declaration, and a real `execFileSync(` gets
+ * blanked as part of a "comment" the walker found inside `"https://…"`.
+ *
+ * The rule is the classic one every lexer uses: a `/` after a value (an
+ * identifier, a literal, a closing bracket) is division; after an operator,
+ * punctuation, the start of input, or one of these keywords, it opens a regex.
+ */
+const REGEX_MAY_FOLLOW = /(?:^|[^\w$)\]}'"`])(?:return|typeof|instanceof|in|of|new|delete|void|throw|case|do|else|yield|await)$|[(,=:[!&|?{};+\-*%~^<>]$|^$/;
+
+/**
+ * Comments blanked, length and newlines preserved. Strings and regexes are
+ * WALKED but kept.
  *
  * Every pattern below is read against this rather than the raw file: a
  * `vi.mock("child_process")` written inside a comment would otherwise EXCLUDE a
@@ -47,11 +65,13 @@ const rel = (p: string) => path.relative(REPO, p).split(path.sep).join("/");
  * Strings are kept because the facts this reads LIVE in them: the module
  * specifier of `from "child_process"` is a string, and blanking it would make
  * every file look like it starts no process at all. They are still walked, so a
- * `//` inside a URL cannot be mistaken for the start of a comment.
+ * `//` inside a URL cannot be mistaken for the start of a comment — and so is a
+ * regex literal, for the reason above it.
  */
 function code(source: string): string {
   const out = source.split("");
   let i = 0;
+  let prev = "";
   const blank = (from: number, to: number) => {
     for (let k = from; k < to && k < out.length; k++) if (out[k] !== "\n") out[k] = " ";
   };
@@ -70,7 +90,24 @@ function code(source: string): string {
       let j = i + 1;
       while (j < source.length && source[j] !== quote) j += source[j] === "\\" ? 2 : 1;
       i = j + 1;
+      prev = quote;
+    } else if (source[i] === "/" && REGEX_MAY_FOLLOW.test(prev)) {
+      // A regex body, character classes included: `/[/]/` is legal and the `/`
+      // inside the class does not close it.
+      let j = i + 1;
+      let inClass = false;
+      while (j < source.length && source[j] !== "\n") {
+        const c = source[j];
+        if (c === "\\") { j += 2; continue; }
+        if (c === "[") inClass = true;
+        else if (c === "]") inClass = false;
+        else if (c === "/" && !inClass) break;
+        j++;
+      }
+      i = j + 1;
+      prev = "/";
     } else {
+      if (!/\s/.test(source[i])) prev = (prev + source[i]).slice(-24);
       i++;
     }
   }
@@ -88,10 +125,18 @@ function code(source: string): string {
  */
 const CHILD_PROCESS_IMPORT = new RegExp(
   [
-    // ESM: `import * as cp from`, `import { a, b as c } from`, `import cp from`
-    String.raw`import\s+(?:\*\s+as\s+(?<esmNs>\w+)|\{(?<esmNamed>[^}]*)\}|(?<esmDefault>\w+))\s+from\s+["'](?:node:)?child_process["']`,
-    // CJS: `const { a, b: c } = require(...)`, `const cp = require(...)`
-    String.raw`(?:const|let|var)\s+(?:\{(?<cjsNamed>[^}]*)\}|(?<cjsNs>\w+))\s*=\s*require\(\s*["'](?:node:)?child_process["']\s*\)`,
+    // ESM: `import * as cp from`, `import { a, b as c } from`, `import cp from`,
+    // and `import cp, { a } from` — the last one bound nothing before, because
+    // the alternation had no branch for a default clause FOLLOWED by a named
+    // one, so a file writing the two together dropped out of the check.
+    String.raw`import\s+(?:\*\s+as\s+(?<esmNs>\w+)|(?:(?<esmDefaultNamed>\w+)\s*,\s*)?\{(?<esmNamed>[^}]*)\}|(?<esmDefault>\w+))\s+from\s+["'](?:node:)?child_process["']`,
+    // CJS and DYNAMIC: `const { a, b: c } = require(...)`, `const cp = require(...)`,
+    // `const { execFileSync } = await import("node:child_process")`. The dynamic
+    // form is not hypothetical — it is already the house style for a value
+    // import in this tree (`routes/hermes/oauth-wizard-handoff.test.ts`,
+    // `unit/instrumentation-terminal-server.test.ts`), and a new suite written
+    // that way with nothing mocked would have got no ceiling and no complaint.
+    String.raw`(?:const|let|var)\s+(?:\{(?<cjsNamed>[^}]*)\}|(?<cjsNs>\w+))\s*=\s*(?:await\s+)?(?:require|import)\(\s*["'](?:node:)?child_process["']\s*\)`,
   ].join("|"),
   "g",
 );
@@ -124,6 +169,9 @@ function processStarters(source: string): string[] {
     // out of the check — which is the direction that loses the guard.
     const g = m.groups ?? {};
     const namespace = g.esmNs || g.cjsNs || g.esmDefault;
+    // A default clause beside a named one binds the module object too, and its
+    // named specifiers are read below in the same pass.
+    if (g.esmDefaultNamed) for (const starter of STARTERS) names.push(`${g.esmDefaultNamed}.${starter}`);
     if (namespace) {
       // `import * as cp` / `const cp = require(...)` / a default import: any
       // starter reached off the module object.
@@ -161,14 +209,28 @@ function startsAProcess(source: string): boolean {
  * `git` calls go through the untouched `execFileSync`.
  */
 function mocksChildProcessWholly(source: string): boolean {
-  const at = source.search(/vi\.mock\(\s*["'](?:node:)?child_process["']/);
-  if (at < 0) return false;
-  return !/importOriginal|importActual/.test(source.slice(at, at + 500));
+  // The FACTORY'S SHAPE, not an identifier. Asking whether `importOriginal` or
+  // `importActual` appears nearby reads the author's choice of parameter name:
+  // `gateway-restart-hermes.test.ts` and `gateway-restart-readiness.test.ts`
+  // both write `async (orig) => ({ ...(await orig()), … })`, which spreads the
+  // real module and is emphatically not whole — and both were called whole.
+  // vitest 4's `vi.mock(path, { spy: true })` is the same trap with no factory
+  // function at all: the real implementations still run.
+  //
+  // So: whole ONLY when the call has no second argument. Anything else keeps
+  // some of the original as far as this guard is concerned, which errs toward
+  // counting a file as a spawner — the over-report direction, where the cost is
+  // a ceiling a file did not need and the alternative is a silent hole.
+  return new RegExp(String.raw`vi\.mock\(\s*["'](?:node:)?child_process["']\s*\)`).test(source);
 }
 
 /** The house form: `vi.setConfig({ testTimeout: …, hookTimeout: … })` at file top. */
-function declared(source: string, key: "testTimeout" | "hookTimeout"): number | null {
-  const call = /^\s*vi\.setConfig\(\s*\{([\s\S]*?)\}\s*\)/m.exec(code(source));
+function declared(stripped: string, key: "testTimeout" | "hookTimeout"): number | null {
+  // Takes the ALREADY-stripped form, like its two neighbours above. It used to
+  // take the raw source and re-run `code()` itself — a third convention one
+  // screenful from the other two, and passing `f.source` to `startsAProcess` by
+  // the same reflex silently over-reports.
+  const call = /^\s*vi\.setConfig\(\s*\{([\s\S]*?)\}\s*\)/m.exec(stripped);
   if (!call) return null;
   const match = new RegExp(`\\b${key}\\s*:\\s*([0-9_]+)`).exec(call[1]);
   return match ? Number(match[1].replace(/_/g, "")) : null;
@@ -187,6 +249,18 @@ const MIN_TIMEOUT_MS = 15_000;
  * fake-timer probe fan-out whose module imports dominate under load. A pattern
  * broad enough to catch these automatically would catch most of the component
  * suite with it.
+ */
+/**
+ * ...and the SIBLING ceiling, named so nobody has to rediscover it: Testing
+ * Library's `asyncUtilTimeout` (`src/tests/setup.ts`) bounds a SINGLE `findBy*`
+ * wait at 5 s, and nothing here raises it. That is deliberate rather than
+ * missed. The failures this file is about report vitest's own "Test timed out
+ * in 5000ms", which is several sub-5 s waits in series and is exactly what
+ * `testTimeout` governs; a single wait that needed longer would fail with
+ * "Unable to find an element…" instead. Raising `asyncUtilTimeout` to 15 s was
+ * tried on this branch and REVERTED — the same cases still failed, one at
+ * 15.5 s and one on an outright assertion at 387 ms — so under heavy parallel
+ * load something is not arriving at all, which no budget fixes. Its own card.
  */
 const ALSO_REQUIRED = [
   "src/tests/routes/chat/capabilities-parallel.test.ts",
@@ -256,13 +330,106 @@ describe("test-timeout hygiene", () => {
     expect(startsAProcess(code('const m = /x/; m.exec("s");'))).toBe(false);
   });
 
+  // Every fixture below joins the module specifier to the rest at RUNTIME.
+  // `code()` deliberately KEEPS strings, so a spelled-out
+  // `from "child_process"` anywhere in this file — inside a string literal
+  // included — would make the guard file itself a spawner and report itself as
+  // an offender. Which is the detector working, and a confusing way to find out.
+  const CP = '"node:child_process"';
+
+  it("is not thrown off by a regex literal containing a quote", () => {
+    // The walker knows strings and comments; a regex is neither, and
+    // `/["\']/` — which this very file writes — puts a quote-only walker into
+    // "inside a string" state until the next matching quote, then leaves it
+    // desynced the OTHER way inside a real string. Both directions are silent,
+    // which is why they get a case each.
+    const spawner = `import { execFileSync } from ${CP};`;
+    const quoteRegex = 'const QUOTED = /["\']/;';
+
+    // A: a commented-out declaration must not read as a declaration. This is
+    // the exact thing `code()`'s docblock says it exists to prevent.
+    const commentedOut = [
+      spawner,
+      quoteRegex,
+      "/*",
+      "vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });",
+      "*/",
+      'execFileSync("git", ["--version"]);',
+    ].join("\n");
+    expect(declared(code(commentedOut), "testTimeout")).toBeNull();
+    expect(startsAProcess(code(commentedOut))).toBe(true);
+
+    // B: a real call must not be blanked. Desynced into "code" state inside a
+    // string, the walker read the `//` of a URL as a comment and blanked the
+    // rest of the line — the spawner call with it.
+    const urlThenCall = [
+      spawner,
+      quoteRegex,
+      'const url = "https://example.com"; execFileSync("git", ["--version"]);',
+    ].join("\n");
+    expect(startsAProcess(code(urlThenCall))).toBe(true);
+  });
+
+  it("follows a dynamic import, and a default clause beside a named one", () => {
+    // `const { execFileSync } = await import(…)` is already the house form for a
+    // value import in this tree, and `import cp, { execFileSync } from …` had no
+    // branch in the alternation at all. A new suite in either style would have
+    // got no ceiling and no complaint.
+    const dynamic = [
+      `const { execFileSync } = await import(${CP});`,
+      'execFileSync("git", ["--version"]);',
+    ].join("\n");
+    expect(startsAProcess(code(dynamic))).toBe(true);
+
+    const dynamicNs = [
+      `const cp = await import(${CP});`,
+      'cp.execFileSync("git", ["--version"]);',
+    ].join("\n");
+    expect(startsAProcess(code(dynamicNs))).toBe(true);
+
+    const defaultAndNamed = [
+      `import cp, { execFileSync } from ${CP};`,
+      'execFileSync("git", ["--version"]);',
+    ].join("\n");
+    expect(startsAProcess(code(defaultAndNamed))).toBe(true);
+
+    // …and the default binding of that same import is followed too.
+    const defaultAndNamedNs = [
+      `import cp, { spawnSync } from ${CP};`,
+      'cp.execFileSync("git", ["--version"]);',
+    ].join("\n");
+    expect(startsAProcess(code(defaultAndNamedNs))).toBe(true);
+  });
+
+  it("calls a mock whole only when it replaces the module outright", () => {
+    // A factory that spreads the original leaves the real `execFileSync` in
+    // place, and two files in this tree write exactly that with the parameter
+    // named `orig` — so a check keyed on the words `importOriginal`/
+    // `importActual` called both of them whole. So does vitest 4's
+    // `vi.mock(path, { spy: true })`, which has no factory function at all.
+    const whole = `vi.mock(${CP});`;
+    expect(mocksChildProcessWholly(code(whole))).toBe(true);
+
+    for (const partial of [
+      `vi.mock(${CP}, async (orig) => ({ ...(await orig()), spawn: vi.fn() }));`,
+      `vi.mock(${CP}, async (importOriginal) => ({ ...(await importOriginal()) }));`,
+      `vi.mock(${CP}, { spy: true });`,
+      `vi.mock(${CP}, () => ({ spawn: vi.fn() }));`,
+    ]) {
+      expect(mocksChildProcessWholly(code(partial)), partial).toBe(false);
+    }
+
+    // …and a mock written inside a comment excludes nothing at all.
+    expect(mocksChildProcessWholly(code(`// vi.mock(${CP});`))).toBe(false);
+  });
+
   it("gives every test that starts a real process both ceilings", () => {
     const offenders = spawners
       .filter((f) => !(f.rel in INLINE_BUDGET))
       .filter(
         (f) =>
-          (declared(f.source, "testTimeout") ?? 0) < MIN_TIMEOUT_MS
-          || (declared(f.source, "hookTimeout") ?? 0) < MIN_TIMEOUT_MS,
+          (declared(f.code, "testTimeout") ?? 0) < MIN_TIMEOUT_MS
+          || (declared(f.code, "hookTimeout") ?? 0) < MIN_TIMEOUT_MS,
       )
       .map((f) => f.rel);
 
@@ -277,8 +444,8 @@ describe("test-timeout hygiene", () => {
       // pass: the list would otherwise silently stop guarding anything.
       if (source === undefined) return true;
       return (
-        (declared(source, "testTimeout") ?? 0) < MIN_TIMEOUT_MS
-        || (declared(source, "hookTimeout") ?? 0) < MIN_TIMEOUT_MS
+        (declared(code(source), "testTimeout") ?? 0) < MIN_TIMEOUT_MS
+        || (declared(code(source), "hookTimeout") ?? 0) < MIN_TIMEOUT_MS
       );
     });
 
@@ -292,10 +459,15 @@ describe("test-timeout hygiene", () => {
     for (const [name, expected] of Object.entries(INLINE_BUDGET)) {
       const source = byRel.get(name);
       expect(source, `${name} is listed as inline-budgeted but does not exist`).toBeDefined();
-      const inline = [...code(source!).matchAll(/\}\s*,\s*([0-9_]+)\s*\)/g)]
+      // Anchored to the END of a statement, which is where an `it(…, timeout)`
+      // budget sits — `/\}\s*,\s*(\d+)\s*\)/` alone also matches any helper
+      // called as `foo({…}, 5)`. And the MAXIMUM, not the minimum: the claim is
+      // "this file carries a bigger budget inline", and a second deliberately
+      // short case would otherwise turn a still-valid exemption red.
+      const inline = [...code(source!).matchAll(/\}\s*,\s*([0-9_]+)\s*\)\s*;?\s*$/gm)]
         .map((m) => Number(m[1].replace(/_/g, "")));
       expect(inline.length, `${name} carries no inline timeout any more`).toBeGreaterThan(0);
-      expect(Math.min(...inline)).toBeGreaterThanOrEqual(expected);
+      expect(Math.max(...inline)).toBeGreaterThanOrEqual(expected);
     }
   });
 
@@ -320,28 +492,46 @@ describe("test-timeout hygiene", () => {
     // test that has genuinely hung, which is what they are for. Matched on a
     // comment-stripped form, so the ruling can still be WRITTEN down where a
     // reader would look for it.
+    // No `^\s*` anchor: `test: { clearMocks: true, testTimeout: 30_000 }` on one
+    // line defeats a line-anchored pattern, and it is the same ruling broken.
+    const KEY_ANYWHERE = /[\s,{](testTimeout|hookTimeout)\s*:/;
     const config = code(fs.readFileSync(path.join(REPO, "vitest.config.ts"), "utf-8"));
-    expect(config).not.toMatch(/^\s*(testTimeout|hookTimeout)\s*:/m);
-    // …and not through the back door either: a flag on the runner defeats the
-    // ruling without touching the config file.
+    expect(config).not.toMatch(KEY_ANYWHERE);
+    // …and not through a SETUP FILE either. vitest's own runner comment names
+    // that as the place a user calls `vi.setConfig` globally, and this repo
+    // gives the `components` project one — a declaration there raises the
+    // ceiling for every component test with nothing else noticing.
+    for (const setup of [...config.matchAll(/["']([^"']*src\/tests\/[^"']*setup[^"']*)["']/g)].map((m) => m[1])) {
+      const file = path.join(REPO, setup);
+      if (!fs.existsSync(file)) continue;
+      expect(code(fs.readFileSync(file, "utf-8")), `${setup} raises a global ceiling`)
+        .not.toMatch(/vi\.setConfig\([\s\S]*?(testTimeout|hookTimeout)/);
+    }
+    // …and not through the runner's CLI either. cac camel-cases every parsed
+    // option, so `--test-timeout=30000` reaches vitest as `testTimeout` and a
+    // camelCase-only pattern waves it straight through.
+    const CLI_FLAG = /--(test|hook)-?[Tt]imeout/;
     const pkg = fs.readFileSync(path.join(REPO, "package.json"), "utf-8");
-    expect(pkg).not.toMatch(/--(test|hook)Timeout/);
+    expect(pkg).not.toMatch(CLI_FLAG);
     const workflow = fs.readFileSync(
       path.join(REPO, ".github", "workflows", "pr-tests-coverage.yml"),
       "utf-8",
     );
-    expect(workflow).not.toMatch(/--(test|hook)Timeout/);
+    expect(workflow).not.toMatch(CLI_FLAG);
   });
 
   it("caps the test job at thirty minutes, so a genuine hang cannot burn a runner", () => {
-    // The cheap half of the same ruling. Raising 79 files' budget six-fold
-    // makes a real hang six times more expensive to surface, and this job was
-    // the only one in the repo with no ceiling at all — GitHub's default is
-    // six hours. Every other workflow here caps itself.
+    // The cheap half of the same ruling. Raising eighty-odd files' budget
+    // six-fold makes a real hang six times more expensive to surface, and this
+    // job — the only one in the repo that runs the whole suite — had no ceiling
+    // at all, so GitHub's six-hour default applied.
     // The `test` job specifically, and the value specifically: `/timeout-minutes:
     // \d+/` anywhere in the file passes when the cap sits on another job, or
-    // when it is 360. The job is bounded by the next two-space key after
-    // `jobs:`, so a key under `on:` cannot be mistaken for one.
+    // when it is 360. The job is bounded by the NEXT two-space key after its
+    // own, so a key under `on:` cannot be mistaken for one — and the job is
+    // found BY NAME, because pinning it to the first position would fail this
+    // assertion, over a message about a timeout, the day someone adds a `lint:`
+    // job above it.
     const workflow = fs.readFileSync(
       path.join(REPO, ".github", "workflows", "pr-tests-coverage.yml"),
       "utf-8",
@@ -349,9 +539,11 @@ describe("test-timeout hygiene", () => {
     const jobsAt = workflow.indexOf("\njobs:\n");
     expect(jobsAt).toBeGreaterThan(-1);
     const headers = [...workflow.slice(jobsAt).matchAll(/^ {2}([\w-]+):$/gm)];
-    expect(headers[0]?.[1]).toBe("test");
-    const end = headers[1] ? jobsAt + headers[1].index! : workflow.length;
-    const testJob = workflow.slice(jobsAt, end);
+    const at = headers.findIndex((h) => h[1] === "test");
+    expect(at, "no `test` job in pr-tests-coverage.yml").toBeGreaterThan(-1);
+    const start = jobsAt + headers[at].index!;
+    const end = headers[at + 1] ? jobsAt + headers[at + 1].index! : workflow.length;
+    const testJob = workflow.slice(start, end);
     const cap = /^\s*timeout-minutes:\s*(\d+)\s*$/m.exec(testJob);
     expect(cap, "the test job has no timeout-minutes").not.toBeNull();
     expect(Number(cap![1])).toBe(30);

--- a/src/tests/unit/test-timeout-hygiene.test.ts
+++ b/src/tests/unit/test-timeout-hygiene.test.ts
@@ -36,18 +36,92 @@ const ROOT = path.join(REPO, "src", "tests");
 const rel = (p: string) => path.relative(REPO, p).split(path.sep).join("/");
 
 /**
+ * Comments blanked, length and newlines preserved. Strings are WALKED but kept.
+ *
+ * Every pattern below is read against this rather than the raw file: a
+ * `vi.mock("child_process")` written inside a comment would otherwise EXCLUDE a
+ * real-process test, and a commented-out `vi.setConfig` would satisfy the
+ * declaration rule — both the direction that loses the guard rather than the
+ * one that over-reports.
+ *
+ * Strings are kept because the facts this reads LIVE in them: the module
+ * specifier of `from "child_process"` is a string, and blanking it would make
+ * every file look like it starts no process at all. They are still walked, so a
+ * `//` inside a URL cannot be mistaken for the start of a comment.
+ */
+function code(source: string): string {
+  const out = source.split("");
+  let i = 0;
+  const blank = (from: number, to: number) => {
+    for (let k = from; k < to && k < out.length; k++) if (out[k] !== "\n") out[k] = " ";
+  };
+  while (i < source.length) {
+    const two = source.slice(i, i + 2);
+    if (two === "//") {
+      const end = source.indexOf("\n", i);
+      blank(i, end < 0 ? source.length : end);
+      i = end < 0 ? source.length : end;
+    } else if (two === "/*") {
+      const end = source.indexOf("*/", i + 2);
+      blank(i, end < 0 ? source.length : end + 2);
+      i = end < 0 ? source.length : end + 2;
+    } else if (source[i] === '"' || source[i] === "'" || source[i] === "`") {
+      const quote = source[i];
+      let j = i + 1;
+      while (j < source.length && source[j] !== quote) j += source[j] === "\\" ? 2 : 1;
+      i = j + 1;
+    } else {
+      i++;
+    }
+  }
+  return out.join("");
+}
+
+/**
  * A real process is started only through a `child_process` import.
  *
  * Matching the bare call names would count `RE.exec(s)`, a local helper named
  * `spawn`, and every `execFileSync` that is a mock's own type annotation. The
- * import is the fact that decides it.
+ * import is the fact that decides it — and the NAMES it binds are what the
+ * call has to use, so `import { execFileSync as run }` is followed through to
+ * `run(` rather than missed.
  */
-const IMPORTS_CHILD_PROCESS =
-  /import\s+(?:\*\s+as\s+\w+|\{[^}]*\}|\w+)\s+from\s+["'](?:node:)?child_process["']|require\(\s*["'](?:node:)?child_process["']\s*\)/;
-/** …and one of its process starters is actually called. Async forms included:
- * a test that spawns and awaits is in the same flake class as one that blocks —
+const CHILD_PROCESS_IMPORT =
+  /import\s+(\*\s+as\s+(\w+)|\{([^}]*)\}|(\w+))\s+from\s+["'](?:node:)?child_process["']|(?:const|let|var)\s+(?:\{([^}]*)\}|(\w+))\s*=\s*require\(\s*["'](?:node:)?child_process["']\s*\)/g;
+const STARTERS = ["spawnSync", "execFileSync", "execSync", "spawn", "execFile", "fork", "exec"];
+
+/** The local names this file can start a process through, or an empty list. */
+function processStarters(source: string): string[] {
+  const names: string[] = [];
+  for (const m of source.matchAll(CHILD_PROCESS_IMPORT)) {
+    const namespace = m[2] ?? m[7];
+    if (namespace) {
+      // `import * as cp` / `const cp = require(...)`: any starter off it.
+      for (const starter of STARTERS) names.push(`${namespace}.${starter}`);
+      continue;
+    }
+    const named = m[3] ?? m[6];
+    if (named) {
+      for (const spec of named.split(",")) {
+        const [original, alias] = spec.split(/\s+as\s+/).map((x) => x.trim());
+        if (STARTERS.includes(original)) names.push(alias || original);
+      }
+      continue;
+    }
+    // A default import of child_process binds the module object.
+    const dflt = m[4];
+    if (dflt) for (const starter of STARTERS) names.push(`${dflt}.${starter}`);
+  }
+  return names;
+}
+
+/** …and one of those bindings is actually called. Async forms included: a test
+ * that spawns and awaits is in the same flake class as one that blocks —
  * `run-tunnel.test.ts` polls for up to 5 000 ms on the wait alone. */
-const STARTS_A_PROCESS = /\b(spawnSync|execFileSync|execSync|spawn|execFile|fork|exec)\s*\(/;
+function startsAProcess(source: string): boolean {
+  return processStarters(source).some((name) =>
+    new RegExp(`(?<![\\w.])${name.replace(".", "\\.")}\\s*\\(`).test(source));
+}
 
 /**
  * …unless the module is mocked WHOLLY, in which case nothing is spawned.
@@ -62,24 +136,6 @@ function mocksChildProcessWholly(source: string): boolean {
   const at = source.search(/vi\.mock\(\s*["'](?:node:)?child_process["']/);
   if (at < 0) return false;
   return !/importOriginal|importActual/.test(source.slice(at, at + 500));
-}
-
-/**
- * Comments stripped before any pattern is read.
- *
- * Without this a file passes on a commented-out declaration — and the rule
- * would have been satisfied by the prose in this very file.
- */
-function code(source: string): string {
-  // Only comments that OWN their line, and that restraint is load-bearing: a
-  // blunt `/\*[\s\S]*?\*\//` eats from the `/*` inside a `"**/node_modules/**"`
-  // glob to the `*/` inside the next one and takes the whole file with it,
-  // which is how this helper first reported that vitest.config.ts had no
-  // projects at all. A commented-out declaration — the hole this exists to
-  // close — owns its line by convention.
-  return source
-    .replace(/^[ \t]*\/\*[\s\S]*?\*\/[ \t]*$/gm, "")
-    .replace(/^[ \t]*\/\/[^\n]*$/gm, "");
 }
 
 /** The house form: `vi.setConfig({ testTimeout: …, hookTimeout: … })` at file top. */
@@ -108,6 +164,12 @@ const ALSO_REQUIRED = [
   "src/tests/routes/chat/capabilities-parallel.test.ts",
   "src/tests/components/hermes-oauth-inline.test.tsx",
   "src/tests/components/chat-spoken-reply.test.tsx",
+  // Starts its processes through @/lib/coding-agent rather than importing
+  // child_process itself, so the rule above cannot see it — and CI has seen it
+  // both ways in one day: "pauses a live run…" timed out on one PR, and on
+  // another every one of 10 906 tests passed while the job exited 1 on an
+  // EnvironmentTeardownError originating in this file.
+  "src/tests/unit/coding-agent.test.ts",
 ];
 
 /**
@@ -132,15 +194,12 @@ function testFiles(dir: string): string[] {
 }
 
 describe("test-timeout hygiene", () => {
-  const files = testFiles(ROOT).map((full) => ({
-    rel: rel(full),
-    source: fs.readFileSync(full, "utf-8"),
-  }));
+  const files = testFiles(ROOT).map((full) => {
+    const source = fs.readFileSync(full, "utf-8");
+    return { rel: rel(full), source, code: code(source) };
+  });
   const spawners = files.filter(
-    (f) =>
-      IMPORTS_CHILD_PROCESS.test(f.source)
-      && STARTS_A_PROCESS.test(f.source)
-      && !mocksChildProcessWholly(f.source),
+    (f) => startsAProcess(f.code) && !mocksChildProcessWholly(f.code),
   );
 
   it("finds the test tree at all", () => {
@@ -197,11 +256,15 @@ describe("test-timeout hygiene", () => {
     // with nothing saying so. Pinned rather than trusted, so the day the set
     // grows a human reads the name and decides whether it is really mocked.
     const excluded = files
-      .filter((f) => IMPORTS_CHILD_PROCESS.test(f.source) && STARTS_A_PROCESS.test(f.source))
-      .filter((f) => mocksChildProcessWholly(f.source))
+      .filter((f) => startsAProcess(f.code))
+      .filter((f) => mocksChildProcessWholly(f.code))
       .map((f) => f.rel);
 
-    expect(excluded).toEqual(["src/tests/unit/system-password.test.ts"]);
+    // Empty today: the detection asks whether a child_process BINDING is
+    // called, and a file that mocks the module wholly and only reads the mock
+    // (system-password.test.ts) starts nothing to begin with, so it is not a
+    // spawner rather than an excluded one.
+    expect(excluded).toEqual([]);
   });
 
   it("does not simply raise the defaults for everything", () => {
@@ -222,15 +285,27 @@ describe("test-timeout hygiene", () => {
     expect(workflow).not.toMatch(/--(test|hook)Timeout/);
   });
 
-  it("caps the test job, so a genuine hang cannot burn a runner", () => {
+  it("caps the test job at thirty minutes, so a genuine hang cannot burn a runner", () => {
     // The cheap half of the same ruling. Raising 79 files' budget six-fold
     // makes a real hang six times more expensive to surface, and this job was
     // the only one in the repo with no ceiling at all — GitHub's default is
     // six hours. Every other workflow here caps itself.
+    // The `test` job specifically, and the value specifically: `/timeout-minutes:
+    // \d+/` anywhere in the file passes when the cap sits on another job, or
+    // when it is 360. The job is bounded by the next two-space key after
+    // `jobs:`, so a key under `on:` cannot be mistaken for one.
     const workflow = fs.readFileSync(
       path.join(REPO, ".github", "workflows", "pr-tests-coverage.yml"),
       "utf-8",
     );
-    expect(workflow).toMatch(/^\s*timeout-minutes:\s*\d+/m);
+    const jobsAt = workflow.indexOf("\njobs:\n");
+    expect(jobsAt).toBeGreaterThan(-1);
+    const headers = [...workflow.slice(jobsAt).matchAll(/^ {2}([\w-]+):$/gm)];
+    expect(headers[0]?.[1]).toBe("test");
+    const end = headers[1] ? jobsAt + headers[1].index! : workflow.length;
+    const testJob = workflow.slice(jobsAt, end);
+    const cap = /^\s*timeout-minutes:\s*(\d+)\s*$/m.exec(testJob);
+    expect(cap, "the test job has no timeout-minutes").not.toBeNull();
+    expect(Number(cap![1])).toBe(30);
   });
 });

--- a/src/tests/unit/test-timeout-hygiene.test.ts
+++ b/src/tests/unit/test-timeout-hygiene.test.ts
@@ -97,6 +97,24 @@ const CHILD_PROCESS_IMPORT = new RegExp(
 );
 const STARTERS = ["spawnSync", "execFileSync", "execSync", "spawn", "execFile", "fork", "exec"];
 
+/**
+ * …and the one form that binds no name at all:
+ * `require("child_process").execSync(…)`. `processStarters` has nothing to
+ * follow there, so this pattern decides on its own — it already contains the
+ * CALL, which is why it can afford to name the starters directly where the
+ * bare-name matching the rule above rejects (`RE.exec(s)`, a local helper
+ * called `spawn`, a mock's type annotation) cannot reach it.
+ *
+ * No file in the tree writes this form today, so the real-tree assertions
+ * below would pass whether or not it were detected. It is covered by a case of
+ * its own for exactly that reason.
+ */
+const CHILD_PROCESS_DIRECT_CALL = new RegExp(
+  String.raw`require\(\s*["'](?:node:)?child_process["']\s*\)\s*\.\s*(?:`
+    + STARTERS.join("|")
+    + String.raw`)\s*\(`,
+);
+
 /** The local names this file can start a process through, or an empty list. */
 function processStarters(source: string): string[] {
   const names: string[] = [];
@@ -128,6 +146,7 @@ function processStarters(source: string): string[] {
  * that spawns and awaits is in the same flake class as one that blocks —
  * `run-tunnel.test.ts` polls for up to 5 000 ms on the wait alone. */
 function startsAProcess(source: string): boolean {
+  if (CHILD_PROCESS_DIRECT_CALL.test(source)) return true;
   return processStarters(source).some((name) =>
     new RegExp(`(?<![\\w.])${name.replace(".", "\\.")}\\s*\\(`).test(source));
 }
@@ -215,6 +234,26 @@ describe("test-timeout hygiene", () => {
     // A path that resolved to nothing would make every assertion below vacuous.
     expect(files.length).toBeGreaterThan(300);
     expect(spawners.length).toBeGreaterThan(50);
+  });
+
+  it("counts a require(...) member call, which binds no name", () => {
+    // The one starter form processStarters cannot follow: there is no binding
+    // to look for, so the file would drop out of the rule below with nothing
+    // saying so. Nothing in the tree writes it today, which is precisely why
+    // the real-tree assertions cannot cover it — they would pass either way.
+    //
+    // The require and the member call are joined at RUNTIME on purpose: spelt
+    // out whole, this fixture would make THIS file a spawner and the rule
+    // below would report it. Which is itself the detector working.
+    const req = 'require("child_process")';
+    const nodeReq = 'require("node:child_process")';
+    expect(startsAProcess(code(`${nodeReq}.execSync("ls");`))).toBe(true);
+    expect(startsAProcess(code(`${req} . spawn ( "ls" );`))).toBe(true);
+    // A require with no call starts nothing…
+    expect(startsAProcess(code(`const cp = ${req};`))).toBe(false);
+    // …and a `.exec(` on something that is not child_process is not a starter,
+    // which is the false positive the import rule exists to avoid.
+    expect(startsAProcess(code('const m = /x/; m.exec("s");'))).toBe(false);
   });
 
   it("gives every test that starts a real process both ceilings", () => {

--- a/src/tests/unit/test-timeout-hygiene.test.ts
+++ b/src/tests/unit/test-timeout-hygiene.test.ts
@@ -86,31 +86,40 @@ function code(source: string): string {
  * call has to use, so `import { execFileSync as run }` is followed through to
  * `run(` rather than missed.
  */
-const CHILD_PROCESS_IMPORT =
-  /import\s+(\*\s+as\s+(\w+)|\{([^}]*)\}|(\w+))\s+from\s+["'](?:node:)?child_process["']|(?:const|let|var)\s+(?:\{([^}]*)\}|(\w+))\s*=\s*require\(\s*["'](?:node:)?child_process["']\s*\)/g;
+const CHILD_PROCESS_IMPORT = new RegExp(
+  [
+    // ESM: `import * as cp from`, `import { a, b as c } from`, `import cp from`
+    String.raw`import\s+(?:\*\s+as\s+(?<esmNs>\w+)|\{(?<esmNamed>[^}]*)\}|(?<esmDefault>\w+))\s+from\s+["'](?:node:)?child_process["']`,
+    // CJS: `const { a, b: c } = require(...)`, `const cp = require(...)`
+    String.raw`(?:const|let|var)\s+(?:\{(?<cjsNamed>[^}]*)\}|(?<cjsNs>\w+))\s*=\s*require\(\s*["'](?:node:)?child_process["']\s*\)`,
+  ].join("|"),
+  "g",
+);
 const STARTERS = ["spawnSync", "execFileSync", "execSync", "spawn", "execFile", "fork", "exec"];
 
 /** The local names this file can start a process through, or an empty list. */
 function processStarters(source: string): string[] {
   const names: string[] = [];
   for (const m of source.matchAll(CHILD_PROCESS_IMPORT)) {
-    const namespace = m[2] ?? m[7];
+    // NAMED groups, not indices: the two alternatives above number their
+    // captures differently, and reading the wrong one silently drops a file
+    // out of the check — which is the direction that loses the guard.
+    const g = m.groups ?? {};
+    const namespace = g.esmNs || g.cjsNs || g.esmDefault;
     if (namespace) {
-      // `import * as cp` / `const cp = require(...)`: any starter off it.
+      // `import * as cp` / `const cp = require(...)` / a default import: any
+      // starter reached off the module object.
       for (const starter of STARTERS) names.push(`${namespace}.${starter}`);
       continue;
     }
-    const named = m[3] ?? m[6];
+    const named = g.esmNamed || g.cjsNamed;
     if (named) {
       for (const spec of named.split(",")) {
-        const [original, alias] = spec.split(/\s+as\s+/).map((x) => x.trim());
+        // `execFileSync as run` in ESM, `execFileSync: run` in CJS.
+        const [original, alias] = spec.split(/\s+as\s+|:/).map((x) => x.trim());
         if (STARTERS.includes(original)) names.push(alias || original);
       }
-      continue;
     }
-    // A default import of child_process binds the module object.
-    const dflt = m[4];
-    if (dflt) for (const starter of STARTERS) names.push(`${dflt}.${starter}`);
   }
   return names;
 }

--- a/src/tests/unit/tts-bench.test.ts
+++ b/src/tests/unit/tts-bench.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync, chmodSync, readdirSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // These run the shipped scripts/bench/tts-bench.py itself against stub engines:
 // a fake `piper` binary that writes a WAV of a known length after a known

--- a/src/tests/unit/update-branch-validator.test.ts
+++ b/src/tests/unit/update-branch-validator.test.ts
@@ -1,9 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { spawnSync } from "child_process";
 import fs from "fs";
 import os from "os";
 import path from "path";
 import { isSafeBranch } from "@/lib/update-branch";
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 // Two validators decide what may sit in `.update-branch`: is_safe_git_ref in
 // install.sh (which WRITES the pin) and isSafeBranch in src/lib/update-branch.ts

--- a/src/tests/unit/updater-branch-resolution.test.ts
+++ b/src/tests/unit/updater-branch-resolution.test.ts
@@ -25,6 +25,11 @@ import path from "path";
  * both covered, because fixing only one of them fixes nothing.
  */
 
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
 const REPO_ROOT = path.resolve(__dirname, "../../..");
 const INSTALL_SH = fs.readFileSync(path.join(REPO_ROOT, "install.sh"), "utf-8");
 

--- a/src/tests/unit/updater-build-identity.test.ts
+++ b/src/tests/unit/updater-build-identity.test.ts
@@ -4,6 +4,11 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
 // The updater's step list is built from the running edition, and the module
 // probes the device at import time. Nothing below starts an update or touches
 // systemd: these tests exercise the three units of the WARN + AUTO-REPIN path

--- a/src/tests/unit/voice-catalog-contract.test.ts
+++ b/src/tests/unit/voice-catalog-contract.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { execFileSync } from "node:child_process";
 import path from "node:path";
 import { LANGUAGES } from "@/lib/i18n";
@@ -15,6 +15,11 @@ import { LOCAL_VOICES, VOICE_LANGUAGES, sampleSentence } from "@/lib/voice-catal
  * Neither can be enforced by types across a shell script and a "use client"
  * module, so this test is the contract.
  */
+
+// Starts a real process (bash / python3 / node / git): vitest's 5 s test and
+// 10 s hook defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const SCRIPT = path.resolve(__dirname, "../../../scripts/openclaw/clawbox-tts.sh");
 


### PR DESCRIPTION
**TASK-702** — the CI `test` job flakes with "Test timed out in 5000ms" on files the PR did not
touch.

## Customer-visible symptom (developer-visible, here)

A green change goes red on `coding-agent-spawn-failure.test.ts`, `hermes-oauth-inline.test.tsx`,
`capabilities-parallel.test.ts` or `chat-spoken-reply.test.tsx` — none of which it edited — and the
author re-runs the job. Measured again on 2026-09-04 while working this batch:
`hermes-config-lock.test.ts` and `hermes-dashboard-auth-yaml.test.ts` failed the same way under a
loaded four-worker `--project unit` run and **passed in isolation**.

## Cause

Vitest's defaults are 5 000 ms per test and 10 000 ms per hook. `startRunBranch`
(`src/lib/coding-pr.ts`) runs **six real `git`/`gh` processes in series** inside one case; locally
the first case in that file takes ~470 ms, and on a four-worker `ubuntu-latest` runner under v8
coverage it inflates past 1 500 ms and the series crosses 5 s.

## Fix

- The global defaults **stay put**. 5 s is a useful guard against a unit test that has genuinely
  hung, and every file that keeps it keeps that guard.
- Each file that starts a real process declares **both** ceilings —
  `vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 })`. Both, because `testTimeout` alone
  leaves hooks on 10 s and several of these files do their process work in a `beforeEach`:
  `updater-branch-resolution.test.ts` runs **eleven** real `git` processes there before every case.
  Raising only the test ceiling would have left the dominant cost unguarded, under a comment
  claiming it was fixed.
- `git`/`gh` are **not** mocked anywhere here — in these files the real process is the thing under
  test.
- A hygiene test keeps it true for files added later.
- `timeout-minutes: 30` on the `test` job. Every other workflow in the repo caps itself
  (codeql 30, e2e-tests 30, build-identity 20, e2e-install 90); this one ran to GitHub's six-hour
  default, and raising 79 files' budget six-fold is exactly what makes that matter — a genuine hang
  now costs six times longer to surface, and this is the backstop that keeps "a hung test must not
  cost a day" true without weakening the 5 s default everywhere else.

### What the guard actually checks

- "Starts a real process" is decided by a `child_process` **import** plus a call, so it covers the
  async `spawn`/`execFile`/`fork` forms and does not count `RE.exec(s)` or a local helper named
  `spawn`.
- A **partial** `child_process` mock counts as real. That distinction is the whole point:
  `coding-agent-spawn-failure.test.ts`, the file CI flaked on first, mocks `spawn` alone and spreads
  `importOriginal()` for the rest — its six `git` calls go through the untouched `execFileSync`.
- Comments are stripped before a declaration is read, so a commented-out one is not a pass. The
  stripper only removes comments that own their line, deliberately: a blunt block-comment regex eats
  from the `/*` inside a `"**/node_modules/**"` glob to the `*/` inside the next one and takes the
  whole file with it.
- Its two escape hatches are pinned, not trusted: the silent whole-mock exclusion set
  (`system-password.test.ts` today) and the one inline-budget exemption
  (`build-typecheck.test.ts`, whose `}, 300_000)` is the real budget — `tsc --noEmit` measures ~28 s
  in CI — so a file-level 30 s beside it would be a second number that disagrees).
- It refuses to pass vacuously: it asserts it found the tree (>300 files, >50 spawners) before
  asserting anything about it.

## RED (on unmodified beta)

```
 × gives every test that starts a real process both ceilings
   AssertionError: expected [ Array(79) ] to deeply equal []
 × gives the files seen flaking on long waits both ceilings too
   AssertionError: expected [ Array(3) ] to deeply equal []
 × caps the test job, so a genuine hang cannot burn a runner
   AssertionError: expected 'name: Tests…' to match /^\s*timeout-minutes:\s*\d+/m
```

The defect is a flake, so the guard test is the RED: it names every file running on a ceiling that
CI has been observed to exceed. It is not a synthetic assertion — an earlier revision of this branch
was caught by its own guard, which had missed `gateway-prestart-onboarding.test.ts`.

## GREEN

```
 npx vitest run --project unit → 594 files, 9535 tests, all pass
 npx tsc --noEmit → clean
```

## Sibling sweep

79 files edited plus the two already-declaring ones (`sudoers-coverage.test.ts`,
`chat-spoken-reply.test.tsx`), which had a `testTimeout` and no `hookTimeout`.

## Found while doing this, NOT fixed here

The **components** project has a second, different instability, and the obvious knob does not fix
it. On UNMODIFIED beta, `vitest run --project components` on a loaded four-worker machine failed six
cases at 5.0–8.6 s in `chat-spoken-reply.test.tsx` and `chat-email-refs-surfaces.test.tsx`; both
files pass alone and pass together. Raising Testing Library's `asyncUtilTimeout` from 5 s to 15 s
(with vitest's ceiling above it) was tried on this branch and **reverted**: the same cases still
failed, one at 15.5 s and one with an outright assertion at 387 ms. So they are not waiting for
something that arrives late — under heavy parallel load something does not arrive at all. That is
its own card, and it is recorded on the run's Found list so nobody spends a PR on the budget.



---

## Finishing round (2026-09-05) — rebased twice, CodeRabbit answered, and the guard given a lexer

Rebased onto `origin/beta` `b15d64c6` and then `eece3ccb`. Both rebases made the guard do its
job: six test files added on beta in between start real processes and had no ceilings, so the
suite went red and named them —

```
 × gives every test that starts a real process both ceilings
   + [ "coding-git-changes", "coding-team-worktree", "embed-server-pin",
       "install-ensure-local-embeddings", "install-whisper-stt" ]           (b15d64c6)
   + [ "run-cannot-kill-the-box" ]                                          (eece3ccb)
```

All six now declare both ceilings. That is the whole point of the guard, demonstrated twice
in one afternoon on code nobody in this PR wrote.

### Live evidence that the fix is the right one

Measured on the same loaded four-worker dev PC, same beta, within minutes of each other:

- `--project unit` in a worktree **without** this branch failed four files on
  "Test timed out in 5000ms" — `hermes-config-lock`, `hermes-dashboard-auth-yaml`,
  `ensure-local-embeddings`, `run-tunnel` — none of which that branch touches. All four pass
  when run alone.
- `--project unit` in **this** worktree, under the same load: 631 files, all pass. This
  branch gives all four the 30 s ceilings.

### CodeRabbit thread — addressed and resolved

The one open thread asked for `require("child_process").execSync(…)`, a call form that binds
no name and so dropped a file out of the check silently. `CHILD_PROCESS_DIRECT_CALL` handles
it, with a regression case whose fixtures are joined at runtime — spelled out whole, they
would make the guard file itself a spawner. Answered in-thread with the three further gaps
found while checking it.

### Review findings taken (`code-review-pr641-final.md`, HIGH 2 · MEDIUM 3 · LOW 8)

The review's first question is the one the working rules care about, and it clears the shape
of this fix: **`vi.setConfig({ testTimeout, hookTimeout })` IS vitest's native per-file
mechanism** (`RuntimeConfig` in `config.d.A1h_Y6Jt.d.ts:224`), and `vi.resetConfig()` runs
after every file (`base.B6Opl8PE.js:94-95`), so 85 per-file declarations cannot bleed into the
685 files that keep the 5 s default. `projects[].testTimeout` would need a hand-maintained
85-path include plus a matching exclude and would fragment the single coverage run;
`poolOptions` has no timeout key; `slowTestThreshold` is reporting only. Nothing re-invented.

Everything else was about the **guard**, and all of it is taken:

- **1 (HIGH) — `code()` mis-parsed a regex literal containing a quote**, and it was already
  happening in 31 files including this one: `/["']/` put the quote-only walker into
  "inside a string" state, and after the next quote it was desynced the other way inside a
  real string. Both directions are silent — a commented-out `vi.setConfig` read as a
  declaration, and a real `execFileSync(` blanked because the walker found a "comment" inside
  `"https://…"`. The walker now knows regex literals, using the classic previous-token rule,
  and the two scenarios are a test each. (The TypeScript scanner was considered and passed
  over: without a parser it has the same `/`-ambiguity, so it would have to carry the same
  rule anyway.)
- **2 (HIGH) — three import forms were invisible**: a dynamic
  `const { execFileSync } = await import("node:child_process")` — already the house form for
  a value import in `routes/hermes/oauth-wizard-handoff.test.ts` and
  `unit/instrumentation-terminal-server.test.ts` — the namespace variant of it, and
  `import cp, { execFileSync } from …`, for which the ESM alternation had no branch at all.
  All three covered.
- **3 (MEDIUM) — the "no back door either" check had two of its own and never read the setup
  file.** cac camel-cases every parsed option, so `--test-timeout=30000` reaches vitest as
  `testTimeout` and slipped past a camelCase-only pattern; the config check required the key
  to start a line, so `test: { clearMocks: true, testTimeout: 30_000 }` passed; and
  `setupFiles` — which vitest's own runner comment names as the place a user calls
  `vi.setConfig` globally — was not read. All three closed.
- **5 (MEDIUM) — "wholly mocked" was decided from two identifier spellings**, and this repo
  writes a third: `gateway-restart-hermes.test.ts` and `gateway-restart-readiness.test.ts`
  spread the real module with the parameter named `orig`, and both were called whole. So is
  vitest 4's `vi.mock(path, { spy: true })`, which has no factory function at all. It is now
  decided from the call's SHAPE — whole only when there is no second argument — which errs
  toward counting a file as a spawner, the over-report direction.
- **6, 7** — the workflow comment claimed every other workflow caps its job; three of eight
  do not, nor does the `comment` job in this same file. Reworded to what is true. "79 files"
  was stale after the rebase.
- **8** — the inline-budget check matched any `}, <number>)` and asserted the MINIMUM, so a
  second deliberately short case in `build-typecheck.test.ts`, or any helper called as
  `foo({…}, 5)`, would turn a still-valid exemption red. Anchored to the end of a statement,
  and asserts the maximum.
- **9** — the job-cap test required `test` to be the textually first job, so adding a `lint:`
  job above it would fail an assertion whose message is about a timeout. Found by name now.
- **10** — `declared()` takes the stripped form like its two neighbours instead of re-running
  `code()` internally.
- **4, 11, 12, 13** — the sibling ceiling is named where it belongs: Testing Library's
  `asyncUtilTimeout` (`src/tests/setup.ts`) bounds a single `findBy*` at 5 s and is
  deliberately not raised — the recorded failures are vitest's own "Test timed out in
  5000ms", i.e. several sub-5 s waits in series, and raising `asyncUtilTimeout` to 15 s was
  tried on this branch and reverted (the same cases still failed, one at 15.5 s and one on an
  outright assertion at 387 ms). `chat-spoken-reply.test.tsx` moved off the exact floor
  (15 000 == `MIN_TIMEOUT_MS`) to 30 000 like everything else; the two flush insertions got
  their blank line and a clause saying the ceilings do not govern the module-level
  `spawnSync` beneath them; `sudoers-coverage.test.ts`'s "per test" comment is now "per test
  and per hook", which is what it declares.

### GREEN

```
 npx vitest run --project unit → 631 files, all pass
 npx tsc --noEmit → clean
 npx eslint (every touched file) → clean
```

The `components` project's separate instability is unchanged and stays on the run's Found
list: on UNMODIFIED beta it fails a different file each run under load and every one passes
alone. No budget fixes that, and this PR does not pretend to.

### Also found while doing this, and NOT this PR's to fix

`npx vitest run --project unit` on `origin/beta` `eece3ccb` exits **1 over a fully green run** —
`Test Files 630 passed (630) / Tests 9944 passed (9944) / Errors 2` — with two
`Unhandled Rejection: ReferenceError: window is not defined` attributed to
`src/tests/unit/use-clawbox-login.test.ts`. The stack is `Timeout.tick → preserveOnTransient
(src/lib/use-clawbox-login.ts:95,141) → dispatchSetState`: a timer the hook armed fires after
jsdom is torn down and React reaches for `window`. Reproduced in three worktrees on three
different branches, none of which touches the file. `test:coverage:ci` exits 1 the same way,
so it will cost a rerun on whatever PR lands beside it. It is the same class as the
`catalog-sanitised-empty-cache` teardown error already on the run's Found list, and it is
recorded there rather than fixed here — the fix is in the hook's test cleanup, not in a
timeout budget.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Increased time allowances for process-heavy and integration-style tests, improving reliability on slower or busy CI runners.
  - Standardized test and setup/teardown timeouts across affected suites, with extended limits for specific coverage checks.
  - Added automated safeguards to verify timeout configuration and prevent regressions involving external processes and long-running operations.

- **Chores**
  - Extended the continuous integration test job timeout to prevent premature termination during lengthy test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
