### PR TITLE
fix: top a guide up to every section the template has, not one named one

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -3225,12 +3225,93 @@ fi
 
 CLAWBOX_GUIDE_SRC="$CLAWBOX_ROOT/config/clawbox-workspace-guide.md"
 CLAWBOX_GUIDE_DST="$CLAWBOX_WORKSPACE/CLAWBOX.md"
-# The heading of the section an already-seeded CLAWBOX.md is topped up with,
-# and the marker that says it is already there. Matched with `grep -qF` and, in
-# the awk below, a WHOLE-LINE `==` against the heading — deliberately, for the
-# reason stated at that awk: a prefix match would let
-# `## System actions and restarts (advanced)` swallow every section after it.
-CLAWBOX_GUIDE_TOPUP="## System actions and restarts"
+# Topping an existing CLAWBOX.md up, section by section.
+#
+# Seeding is deliberately seed-if-MISSING, so an owner's or the agent's edits
+# survive a gateway start — and the cost of that was measured on the OpenClaw
+# dev box (2026-09-03, TASK-706): its CLAWBOX.md is dated Aug 13 and carries
+# five headings, so it has NEVER received "## Coding agent (delegate a whole
+# task)", which is how the agent learns that coding_agent_run /
+# coding_agent_status / coding_agent_stop exist and what to say when they are
+# not offered. Every box set up before that section landed is in the same state,
+# silently, and TASK-612's rule reached the field only because someone added a
+# marker for it BY HAND.
+#
+# One marker per section does not scale, so there is no marker list any more:
+# every `## ` heading in the shipped template that the box's file does not carry
+# is appended, in template order. The heading IS the marker, which is why every
+# comparison below is a WHOLE-LINE one (modulo a CR) rather than a substring —
+# a guide that says "## Skills and other things" must not satisfy "## Skills".
+#
+# The trade this takes, deliberately and per the card: an owner who DELETED a
+# section gets it back on the next gateway start. The alternative is what the
+# box has today — sections that never arrive at all, with nothing that says so.
+#
+# Values reach awk through the environment rather than `-v`, which runs them
+# through escape processing: a heading that ever grew a backslash would quietly
+# stop matching and the section would go missing with no warning.
+
+# Every `## ` heading in a markdown file, in order.
+#
+# Fenced blocks are skipped: this template is markdown that documents markdown
+# and shell, so a ``` fence containing a `## ` line is a live trap — it would be
+# enumerated as a phantom heading and its "section" extracted from inside the
+# fence to the next real heading, then appended to every box's guide. Harmless
+# while the old code named one heading by hand; not harmless now.
+#
+# Trailing whitespace is trimmed here and in the comparison below, together: a
+# heading that differs from the template's only by a trailing space would
+# otherwise be judged absent and the section appended a second time, permanently.
+clawbox_guide_headings() {
+  awk '
+    { line = $0; sub(/[ \t\r]+$/, "", line) }
+    line ~ /^(```|~~~)/ { fence = !fence; next }
+    !fence && line ~ /^## +[^ ]/ { print line }
+  ' "$1"
+}
+
+# Does this file already carry that heading, as a whole line?
+#
+# Three answers, not two: 0 present, 1 absent, 2 could not be read. `awk` returns
+# 2 for a file it cannot open, and reading that as "absent" is how an unreadable
+# destination gets appended to — the defect the readability guard above exists to
+# stop, through a door that guard cannot cover once the loop is running.
+clawbox_guide_has_heading() {
+  [ -r "$1" ] || return 2
+  heading="$2" awk '
+    { line = $0; sub(/[ \t\r]+$/, "", line) }
+    line == ENVIRON["heading"] { found = 1; exit }
+    END { exit(found ? 0 : 1) }
+  ' "$1"
+}
+
+# One section of the template: its heading line and everything up to the NEXT
+# `## ` heading.
+#
+# Bounded by the next heading rather than by the `---` rule that happens to sit
+# before it: a rule inside the section would have truncated it, and a CRLF
+# template (`---\r`) would have matched no terminator at all and dragged every
+# following section along. Trailing blank lines and that closing rule are then
+# dropped, because the append supplies its own separator and carrying the
+# template's too ends the topped-up guide on a dangling rule.
+clawbox_guide_section() {
+  heading="$2" awk '
+    { line = $0; sub(/[ \t\r]+$/, "", line) }
+    line ~ /^(```|~~~)/ { fence = !fence }
+    line == ENVIRON["heading"] && !fence { inside = 1; lines[++n] = $0; next }
+    inside && !fence && line ~ /^## / { exit }
+    inside { lines[++n] = $0 }
+    END {
+      while (n > 0) {
+        tail = lines[n]
+        sub(/\r$/, "", tail)
+        if (tail != "" && tail != "---") break
+        n--
+      }
+      for (i = 1; i <= n; i++) print lines[i]
+    }
+  ' "$1"
+}
 
 # Append to a file so that a write which stops PART WAY leaves nothing behind.
 #
@@ -3363,9 +3444,9 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
       echo "  Seeded CLAWBOX.md in OpenClaw workspace"
     else
       # The seed has the same partial-write problem as the appends, and it is
-      # WORSE: the fragment it leaves already contains the top-up marker, so the
-      # `grep -qF` below finds the heading on every later boot, appends nothing,
-      # and the box keeps a guide cut mid-sentence for good. The enclosing
+      # WORSE: the fragment it leaves already contains the headings that ARE the
+      # top-up markers, so the loop below finds them on every later boot, appends
+      # nothing, and the box keeps a guide cut mid-sentence for good. The enclosing
       # `elif [ ! -f "$CLAWBOX_GUIDE_DST" ]` proves the file did not exist before
       # this attempt, so removing it destroys nothing and the next boot re-seeds
       # from scratch.
@@ -3376,82 +3457,91 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
       # re-seed" step on such a box all land here.
       echo "  WARNING: could not seed CLAWBOX.md in the OpenClaw workspace" >&2
     fi
-  elif ! grep -qF "$CLAWBOX_GUIDE_TOPUP" "$CLAWBOX_GUIDE_DST"; then
-    # Seed-if-missing alone means a section ADDED to the template after a box
-    # was set up never reaches that box — every box in the field already has
-    # CLAWBOX.md, including the one whose agent queued an operator-approval
-    # proposal for a gateway restart (TASK-612). Shipping the rule to new
-    # boxes only would be a fix that reports success without arriving.
-    #
-    # So: append the one section, never overwrite the file. Personalizations
-    # survive, and the `grep -qF` above is the idempotence marker — a second
-    # gateway start finds the heading and appends nothing. The awk below is the
-    # section's only source, and it is bounded by the NEXT `## ` heading rather
-    # than by the `---` rule that happens to sit before it: a rule inside the
-    # section would have truncated it, and a CRLF template (`---\r`) would have
-    # matched no terminator at all and dragged every following section along.
-    # Trailing blank lines and that closing rule are then dropped, because the
-    # append supplies its own separator and carrying the template's too ends the
-    # topped-up guide on a dangling rule.
-    #
-    # The heading is matched as a WHOLE line (modulo a CR), not as a prefix: a
-    # later `## System actions and restarts (advanced)` would otherwise open the
-    # extraction and then fail to close it, swallowing every section after it.
-    #
-    # The heading reaches awk through the environment rather than `-v`, which
-    # runs its value through escape processing: a heading that ever grew a
-    # backslash would quietly stop matching and the section would go missing
-    # with no warning. Extraction and append are both guarded, under the
-    # invariant at the top of this block — neither may abort pre-start — and a
-    # renamed heading is reported apart from an unreadable template, because the
-    # two send an operator to different files.
-    CLAWBOX_GUIDE_SECTION=""
-    if CLAWBOX_GUIDE_SECTION="$(heading="$CLAWBOX_GUIDE_TOPUP" awk '
-      { line = $0; sub(/\r$/, "", line) }
-      line == ENVIRON["heading"] { inside = 1; lines[++n] = $0; next }
-      inside && /^## / { exit }
-      inside { lines[++n] = $0 }
-      END {
-        while (n > 0) {
-          tail = lines[n]
-          sub(/\r$/, "", tail)
-          if (tail != "" && tail != "---") break
-          n--
-        }
-        for (i = 1; i <= n; i++) print lines[i]
-      }
-    ' "$CLAWBOX_GUIDE_SRC")"; then
-      if [ -z "$CLAWBOX_GUIDE_SECTION" ]; then
-        # The heading was renamed in the template without this marker following
-        # it. Appending a separator alone would report a success that added
-        # nothing, and would do it again on every gateway start.
-        echo "  WARNING: the shipped guide no longer carries '$CLAWBOX_GUIDE_TOPUP'" >&2
-      else
+  elif [ ! -r "$CLAWBOX_GUIDE_DST" ]; then
+    # `grep` and `awk` answer exit 2 on a file they cannot read, which reads as
+    # "the heading is not there" — so a 0200 CLAWBOX.md was appended to on EVERY
+    # boot, growing without bound, while the file itself could never be checked.
+    # A file this block cannot read is a file it must not top up.
+    echo "  WARNING: could not read $CLAWBOX_GUIDE_DST; leaving it as it is" >&2
+  else
+    CLAWBOX_GUIDE_ADDED=""
+    CLAWBOX_GUIDE_HEADINGS=""
+    if ! CLAWBOX_GUIDE_HEADINGS="$(clawbox_guide_headings "$CLAWBOX_GUIDE_SRC")"; then
+      # An I/O fault on the template, not a renamed heading: the two send an
+      # operator to different files, so they are reported apart.
+      echo "  WARNING: could not read $CLAWBOX_GUIDE_SRC to top up CLAWBOX.md" >&2
+    elif [ -z "$CLAWBOX_GUIDE_HEADINGS" ]; then
+      # A readable template with no `## ` headings at all — a truncated or
+      # zero-byte file from a half-finished deploy. Silence here would be
+      # indistinguishable from "the guide is already complete", which is exactly
+      # the shape of the defect this card exists to fix: sections that never
+      # arrive, with nothing that says so. This replaces the old code's "the
+      # shipped guide no longer carries '<marker>'" warning, which fired on the
+      # same input.
+      echo "  WARNING: $CLAWBOX_GUIDE_SRC carries no '## ' headings; CLAWBOX.md not topped up" >&2
+    else
+      while IFS= read -r CLAWBOX_GUIDE_HEADING; do
+        [ -n "$CLAWBOX_GUIDE_HEADING" ] || continue
+        # `|| var=$?` and not a bare call: a non-zero status from a simple
+        # command is the whole shell's failure under `set -e`, and "the heading
+        # is absent" is the COMMON answer here, not an error.
+        CLAWBOX_GUIDE_SEEN=0
+        clawbox_guide_has_heading "$CLAWBOX_GUIDE_DST" "$CLAWBOX_GUIDE_HEADING" \
+          || CLAWBOX_GUIDE_SEEN=$?
+        case "$CLAWBOX_GUIDE_SEEN" in
+          0) continue ;;
+          1) ;;
+          *)
+            # The destination stopped being readable mid-loop: EIO on a failing
+            # eMMC, the path replaced by a directory, a symlink that went
+            # dangling. Judging every remaining section "missing" from that is
+            # the same false success the readability guard above prevents.
+            echo "  WARNING: could not read $CLAWBOX_GUIDE_DST while topping it up; stopping" >&2
+            break
+            ;;
+        esac
+        CLAWBOX_GUIDE_SECTION=""
+        if ! CLAWBOX_GUIDE_SECTION="$(clawbox_guide_section "$CLAWBOX_GUIDE_SRC" "$CLAWBOX_GUIDE_HEADING")"; then
+          echo "  WARNING: could not read $CLAWBOX_GUIDE_SRC to top up CLAWBOX.md" >&2
+          break
+        fi
+        if [ -z "$CLAWBOX_GUIDE_SECTION" ]; then
+          # The heading came out of this same template a moment ago, so an empty
+          # extraction is a bug in the extractor, not a renamed section.
+          # Appending a separator alone would report a success that added
+          # nothing, and would do it again on every gateway start.
+          echo "  WARNING: '$CLAWBOX_GUIDE_HEADING' extracted empty from $CLAWBOX_GUIDE_SRC" >&2
+          continue
+        fi
         # A file that does not end in a newline would otherwise have its last
-        # line joined to the separator, making it a setext heading.
+        # line joined to the separator, making it a setext heading. Re-tested per
+        # section, because the previous append in this loop changed the answer.
         CLAWBOX_GUIDE_LEAD=""
         if [ -s "$CLAWBOX_GUIDE_DST" ] && [ "$(tail -c1 "$CLAWBOX_GUIDE_DST")" != "" ]; then
           CLAWBOX_GUIDE_LEAD=$'\n'
         fi
         # Rendered whole first, then handed to the one writer that can undo a
-        # partial write. `printf -v` and not a command substitution: `$( )`
-        # strips trailing newlines, and the section's final newline is what
-        # keeps the next append off the last line of this one.
+        # partial write. `printf -v` and not a command substitution: `$( )` strips
+        # trailing newlines, and the section's final newline is what keeps the
+        # next append off the last line of this one.
+        #
+        # Undoing a partial write matters MORE here than it did for one section:
+        # a boot can now append up to seven of them, so a full disk is that many
+        # more chances to leave a heading sitting on a fragment.
         printf -v CLAWBOX_GUIDE_APPEND '%s\n---\n\n%s\n' "$CLAWBOX_GUIDE_LEAD" "$CLAWBOX_GUIDE_SECTION"
         if clawbox_append_or_rollback "$CLAWBOX_GUIDE_DST" "$CLAWBOX_GUIDE_APPEND"; then
-          echo "  Appended the system-actions section to CLAWBOX.md"
+          CLAWBOX_GUIDE_ADDED="$CLAWBOX_GUIDE_ADDED${CLAWBOX_GUIDE_ADDED:+, }${CLAWBOX_GUIDE_HEADING#\#\# }"
         else
           # The cause is on this shell's stderr already — the helper's failing
           # redirection prints it — so this line names the deliverable, not the
-          # errno.
-          echo "  WARNING: could not append the system-actions section to CLAWBOX.md" >&2
+          # errno. The loop carries on: one section that will not fit is no
+          # reason to withhold the rest.
+          echo "  WARNING: could not append '$CLAWBOX_GUIDE_HEADING' to CLAWBOX.md" >&2
         fi
+      done <<< "$CLAWBOX_GUIDE_HEADINGS"
+      if [ -n "$CLAWBOX_GUIDE_ADDED" ]; then
+        echo "  Appended to CLAWBOX.md: $CLAWBOX_GUIDE_ADDED"
       fi
-    else
-      # Separated from the empty-extraction case on purpose: an unreadable
-      # template is an I/O fault, not a renamed heading, and telling an
-      # operator the wrong one sends them to the wrong file.
-      echo "  WARNING: could not read $CLAWBOX_GUIDE_SRC to top up CLAWBOX.md" >&2
     fi
   fi
 
@@ -3470,7 +3560,16 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
   # and every box in the field already carries it verbatim (it has not changed
   # since it was introduced), so no box receives a second copy.
   CLAWBOX_AGENTS_POINTER="## ClawBox integration"
-  if [ -f "$CLAWBOX_AGENTS_MD" ] && ! grep -qF "$CLAWBOX_AGENTS_POINTER" "$CLAWBOX_AGENTS_MD"; then
+  # `-r` as well as `-f`, and `-qxF` rather than `-qF`: the same two corrections
+  # the CLAWBOX.md loop above needed, and they matter MORE here. `grep` answers
+  # exit 2 on a file it cannot read, which reads as "the marker is not there" —
+  # and mode 0200 denies the read while PERMITTING the write, so the append
+  # succeeded and the box grew AGENTS.md by ~1 KB on every single boot, each one
+  # reported as a success. AGENTS.md is the file the harness injects into every
+  # session, under a bootstrap character budget.
+  if [ -f "$CLAWBOX_AGENTS_MD" ] && [ ! -r "$CLAWBOX_AGENTS_MD" ]; then
+    echo "  WARNING: could not read $CLAWBOX_AGENTS_MD; leaving it as it is" >&2
+  elif [ -f "$CLAWBOX_AGENTS_MD" ] && ! grep -qxF "$CLAWBOX_AGENTS_POINTER" "$CLAWBOX_AGENTS_MD"; then
     # Guarded like the two appends below, and for the same reason: this one has
     # always been bare, so a read-only AGENTS.md aborted pre-start under
     # `set -euo pipefail` and the gateway never started — over a pointer
@@ -3498,7 +3597,10 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
   # already present on every box in the field, so anything guarded by it can
   # never be delivered again.
   CLAWBOX_AGENTS_RULE="## System actions on this ClawBox"
-  if [ -f "$CLAWBOX_AGENTS_MD" ] && ! grep -qF "$CLAWBOX_AGENTS_RULE" "$CLAWBOX_AGENTS_MD"; then
+  # Readability and whole-line, for the reason above. No second warning: the
+  # pointer block a few lines up has already printed one for the same file.
+  if [ -f "$CLAWBOX_AGENTS_MD" ] && [ -r "$CLAWBOX_AGENTS_MD" ] \
+    && ! grep -qxF "$CLAWBOX_AGENTS_RULE" "$CLAWBOX_AGENTS_MD"; then
     printf -v CLAWBOX_AGENTS_RULE_TEXT '\n\n%s\n\nRestarting the OpenClaw gateway is not yours to do from a chat turn: the gateway hosts this session, so the restart kills the reply before it lands. It is rarely needed either — saving a setting under Settings -> Providers, Voice or Channels restarts it. Say that, and name the setting.\n\nA device restart or shutdown IS yours when the owner asks in their own words: `system_power`, `confirm: true`, with their reason. Their own control is the power menu in the desktop tray, not Settings -> System.\n\nNever queue an `operator_approval` proposal for any of this. ClawBox renders no approval card, so a queued proposal is shown to nobody; a parked one is answered with `openclaw approvals pending` / `openclaw approvals resolve` from the Terminal app. `CLAWBOX.md` has the long form.\n' "$CLAWBOX_AGENTS_RULE"
     if clawbox_append_or_rollback "$CLAWBOX_AGENTS_MD" "$CLAWBOX_AGENTS_RULE_TEXT"; then
       echo "  Appended the system-actions rule to AGENTS.md"

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -3251,21 +3251,6 @@ CLAWBOX_GUIDE_DST="$CLAWBOX_WORKSPACE/CLAWBOX.md"
 # through escape processing: a heading that ever grew a backslash would quietly
 # stop matching and the section would go missing with no warning.
 
-# Does this file carry that line, whole, ignoring trailing whitespace and a CR?
-#
-# `grep -qxF` cannot do it: a CRLF file stores the marker as `## X\r`, which an
-# exact whole-line match misses — and the block then appends on EVERY boot and
-# the file grows without bound, which is the failure this whole-line matching
-# was introduced to prevent rather than to cause. One rule for both paths.
-clawbox_file_has_line() {
-  [ -r "$1" ] || return 2
-  wanted="$2" awk '
-    { line = $0; sub(/[ \t\r]+$/, "", line) }
-    line == ENVIRON["wanted"] { found = 1; exit }
-    END { exit(found ? 0 : 1) }
-  ' "$1"
-}
-
 # Every `## ` heading in a markdown file, in order.
 #
 # Fenced blocks are skipped: this template is markdown that documents markdown
@@ -3287,17 +3272,46 @@ clawbox_guide_headings() {
 
 # Does this file already carry that heading, as a whole line?
 #
+# One helper for BOTH destinations — CLAWBOX.md's sections and AGENTS.md's two
+# markers — so the two files cannot come to disagree about what "already there"
+# means. `grep -qxF`, which the AGENTS.md blocks used, cannot do the job: a CRLF
+# file stores the marker as `## X\r`, an exact whole-line match misses it, and
+# the block then appends on EVERY boot and the file grows without bound — the
+# failure whole-line matching exists to prevent rather than to cause.
+#
 # Three answers, not two: 0 present, 1 absent, 2 could not be read. `awk` returns
 # 2 for a file it cannot open, and reading that as "absent" is how an unreadable
 # destination gets appended to — the defect the readability guard above exists to
 # stop, through a door that guard cannot cover once the loop is running.
-clawbox_guide_has_heading() {
+#
+# Headings quoted inside a fence do not count — an owner or the agent pasting
+# an example of a heading is not carrying that section, and reading the quote as
+# the marker withholds the section for good.
+#
+# But ONLY when the fences balance, which is why this reads the whole file
+# instead of answering on the first match. These two files are the agent's and
+# the owner's to edit, and an odd number of ``` lines is ordinary damage. Track
+# it anyway and the region after the stray delimiter is judged fenced — so every
+# heading in it is "missing", the copy this block appends lands in it too, and
+# the file grows by those sections on EVERY boot. That is the unbounded growth
+# this whole block exists to stop, arriving through the fence rule instead of
+# through `grep`. Unbalanced fences are therefore read as prose: the worst that
+# costs is the behaviour this script had before fences were considered at all.
+clawbox_file_has_heading() {
   [ -r "$1" ] || return 2
   heading="$2" awk '
-    { line = $0; sub(/[ \t\r]+$/, "", line) }
-    line ~ /^(```|~~~)/ { fence = !fence; next }
-    !fence && line == ENVIRON["heading"] { found = 1; exit }
-    END { exit(found ? 0 : 1) }
+    {
+      line = $0; sub(/[ \t\r]+$/, "", line); text[NR] = line
+      if (line ~ /^(```|~~~)/) fence[++fences] = NR
+    }
+    END {
+      if (fences % 2 == 0)
+        for (i = 1; i < fences; i += 2)
+          for (j = fence[i]; j <= fence[i + 1]; j++) hidden[j] = 1
+      for (i = 1; i <= NR; i++)
+        if (!hidden[i] && text[i] == ENVIRON["heading"]) exit 0
+      exit 1
+    }
   ' "$1"
 }
 
@@ -3502,7 +3516,7 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
         # command is the whole shell's failure under `set -e`, and "the heading
         # is absent" is the COMMON answer here, not an error.
         CLAWBOX_GUIDE_SEEN=0
-        clawbox_guide_has_heading "$CLAWBOX_GUIDE_DST" "$CLAWBOX_GUIDE_HEADING" \
+        clawbox_file_has_heading "$CLAWBOX_GUIDE_DST" "$CLAWBOX_GUIDE_HEADING" \
           || CLAWBOX_GUIDE_SEEN=$?
         case "$CLAWBOX_GUIDE_SEEN" in
           0) continue ;;
@@ -3576,16 +3590,17 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
   # and every box in the field already carries it verbatim (it has not changed
   # since it was introduced), so no box receives a second copy.
   CLAWBOX_AGENTS_POINTER="## ClawBox integration"
-  # `-r` as well as `-f`, and `-qxF` rather than `-qF`: the same two corrections
-  # the CLAWBOX.md loop above needed, and they matter MORE here. `grep` answers
-  # exit 2 on a file it cannot read, which reads as "the marker is not there" —
+  # `-r` as well as `-f`, and the whole-line helper rather than a `grep -qF`
+  # substring: the same two corrections the CLAWBOX.md loop above needed, and
+  # they matter MORE here. `grep` answers exit 2 on a file it cannot read, which
+  # reads as "the marker is not there" —
   # and mode 0200 denies the read while PERMITTING the write, so the append
   # succeeded and the box grew AGENTS.md by ~1 KB on every single boot, each one
   # reported as a success. AGENTS.md is the file the harness injects into every
   # session, under a bootstrap character budget.
   if [ -f "$CLAWBOX_AGENTS_MD" ] && [ ! -r "$CLAWBOX_AGENTS_MD" ]; then
     echo "  WARNING: could not read $CLAWBOX_AGENTS_MD; leaving it as it is" >&2
-  elif [ -f "$CLAWBOX_AGENTS_MD" ] && ! clawbox_file_has_line "$CLAWBOX_AGENTS_MD" "$CLAWBOX_AGENTS_POINTER"; then
+  elif [ -f "$CLAWBOX_AGENTS_MD" ] && ! clawbox_file_has_heading "$CLAWBOX_AGENTS_MD" "$CLAWBOX_AGENTS_POINTER"; then
     # Guarded like the two appends below, and for the same reason: this one has
     # always been bare, so a read-only AGENTS.md aborted pre-start under
     # `set -euo pipefail` and the gateway never started — over a pointer
@@ -3616,7 +3631,7 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
   # Readability and whole-line, for the reason above. No second warning: the
   # pointer block a few lines up has already printed one for the same file.
   if [ -f "$CLAWBOX_AGENTS_MD" ] && [ -r "$CLAWBOX_AGENTS_MD" ] \
-    && ! clawbox_file_has_line "$CLAWBOX_AGENTS_MD" "$CLAWBOX_AGENTS_RULE"; then
+    && ! clawbox_file_has_heading "$CLAWBOX_AGENTS_MD" "$CLAWBOX_AGENTS_RULE"; then
     printf -v CLAWBOX_AGENTS_RULE_TEXT '\n\n%s\n\nRestarting the OpenClaw gateway is not yours to do from a chat turn: the gateway hosts this session, so the restart kills the reply before it lands. It is rarely needed either — saving a setting under Settings -> Providers, Voice or Channels restarts it. Say that, and name the setting.\n\nA device restart or shutdown IS yours when the owner asks in their own words: `system_power`, `confirm: true`, with their reason. Their own control is the power menu in the desktop tray, not Settings -> System.\n\nNever queue an `operator_approval` proposal for any of this. ClawBox renders no approval card, so a queued proposal is shown to nobody; a parked one is answered with `openclaw approvals pending` / `openclaw approvals resolve` from the Terminal app. `CLAWBOX.md` has the long form.\n' "$CLAWBOX_AGENTS_RULE"
     if clawbox_append_or_rollback "$CLAWBOX_AGENTS_MD" "$CLAWBOX_AGENTS_RULE_TEXT"; then
       echo "  Appended the system-actions rule to AGENTS.md"

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -3273,18 +3273,28 @@ CLAWBOX_GUIDE_DST="$CLAWBOX_WORKSPACE/CLAWBOX.md"
 # section on the source side, and read as the section already being present on
 # the destination side.
 #
-# But a fence hides only what it CLOSES, and that is the whole reason these read
-# the file twice instead of toggling as they go. An odd number of column-0
-# delimiters is ordinary damage — an indented closing fence is valid CommonMark
-# and does not match at column 0 — and a naive toggle makes it catastrophic in
-# BOTH directions: on the destination every heading after the stray delimiter is
-# "missing", the copy this block appends lands in the fenced region too, and the
-# file grows by those sections on EVERY boot; on the template the headings
-# simply stop being enumerated, and the box is told nothing while section after
-# section fails to arrive — this card's own defect, on the source side, with the
-# "no '## ' headings at all" warning firing only if the count reaches zero.
-# Unbalanced fences are therefore read as prose, which is what this script did
-# before fences were considered at all.
+# A delimiter is a ``` or ~~~ line indented by AT MOST THREE spaces, which is
+# how CommonMark defines one — an opener and a closer alike. Matching only at
+# column 0 is not a stricter rule, it is a WRONG one: an indented closing fence
+# then goes unseen, the next opener is paired with the previous opener, and the
+# prose between two examples is marked as fenced. Measured on this template with
+# two two-space-indented closers — which render correctly on GitHub and are
+# invisible in review — `## Browser (real Chromium on the device)` and
+# `## Apps and UI` were enumerated by nothing and delivered to no box, exit 0,
+# not one word on stderr. The interval form `{0,3}` is not available: mawk 1.3.4
+# does not merely reject it, it aborts with `REcompile() - panic`.
+#
+# And a fence hides only what it CLOSES, which is the whole reason these read
+# the file twice instead of toggling as they go. An odd delimiter count is
+# ordinary damage in a file the owner and the agent both edit, and a naive
+# toggle makes it catastrophic in BOTH directions: on the destination every
+# heading after the stray delimiter is "missing", the copy this block appends
+# lands in the fenced region too, and the file grows by those sections on EVERY
+# boot; on the template the headings simply stop being enumerated. Unbalanced
+# fences are therefore read as prose, which is what this script did before
+# fences were considered at all — and the two blocks below SAY SO rather than
+# leaving it silent, because "read as prose" on the destination means a heading
+# quoted inside a fence counts as present and its section is withheld.
 CLAWBOX_FENCE_AWK='
   function clawbox_fences(   i, j) {
     if (fences % 2) return
@@ -3294,9 +3304,20 @@ CLAWBOX_FENCE_AWK='
   {
     raw[NR] = $0
     line = $0; sub(/[ \t\r]+$/, "", line); text[NR] = line
-    if (line ~ /^(```|~~~)/) fence[++fences] = NR
+    if (line ~ /^ *(```|~~~)/ && match(line, /^ */) && RLENGTH < 4) fence[++fences] = NR
   }
 '
+
+# Do this file'"'"'s fences balance? 0 yes, 1 no, 2 could not be read.
+#
+# Asked once per file rather than folded into the helpers, because the answer is
+# a fact about the FILE and the helpers are called once per heading.
+clawbox_fences_balanced() {
+  [ -r "$1" ] || return 2
+  awk "$CLAWBOX_FENCE_AWK"'
+    END { exit(fences % 2 ? 1 : 0) }
+  ' "$1"
+}
 
 # Every `## ` heading in a markdown file, in order.
 clawbox_guide_headings() {
@@ -3493,9 +3514,13 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
     # `-f` alone says "seed it" about a DIRECTORY, and `install SRC DIR` copies
     # INTO it: two boots, two "Seeded CLAWBOX.md" success lines, a
     # CLAWBOX.md/clawbox-workspace-guide.md nobody reads, and no guide on the
-    # box ever — a success printed on every boot, forever. A socket or a
-    # dangling symlink is the same shape. Nothing here can fix that path, so it
-    # says so instead of reporting work it did not do.
+    # box ever — a success printed on every boot, forever. A socket and a FIFO
+    # are the same shape (verified: the FIFO does not hang here either).
+    # NOT a dangling symlink: `-e` follows the link and is false, so that case
+    # goes to the seed below, where `install` replaces the link with the guide —
+    # which is the right outcome and is why this is `-e` rather than `-h`.
+    # Nothing here can fix a directory, so it says so instead of reporting work
+    # it did not do.
     echo "  WARNING: $CLAWBOX_GUIDE_DST exists and is not a regular file; leaving it as it is" >&2
   elif [ ! -f "$CLAWBOX_GUIDE_DST" ]; then
     if install -m 644 "$CLAWBOX_GUIDE_SRC" "$CLAWBOX_GUIDE_DST"; then
@@ -3524,7 +3549,31 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
   else
     CLAWBOX_GUIDE_ADDED=""
     CLAWBOX_GUIDE_HEADINGS=""
-    if ! CLAWBOX_GUIDE_HEADINGS="$(clawbox_guide_headings "$CLAWBOX_GUIDE_SRC")"; then
+    # A file whose fences do not balance is read as prose (see the fence rule
+    # above), and on each side that costs something different, so each side says
+    # so in its own words.
+    #
+    # The TEMPLATE is ours and a template we cannot parse must not be merged
+    # from: every `## ` line quoted inside its examples would be enumerated as a
+    # section, extracted from inside the fence to the next such line — so the
+    # real section above it is truncated AND a phantom one is appended, to every
+    # box, permanently. Refusing is the same call the "no headings at all" arm
+    # below already makes about the same kind of half-deployed file.
+    CLAWBOX_GUIDE_FENCES=0
+    clawbox_fences_balanced "$CLAWBOX_GUIDE_SRC" || CLAWBOX_GUIDE_FENCES=$?
+    # The DESTINATION is the owner's and the agent's, so it is not refused —
+    # only reported. Reading its fences as prose means a heading quoted inside
+    # one counts as present and that section is withheld, which is this card's
+    # own defect; there is no second guard that would catch it, so the operator
+    # gets the sentence instead of silence.
+    CLAWBOX_DST_FENCES=0
+    clawbox_fences_balanced "$CLAWBOX_GUIDE_DST" || CLAWBOX_DST_FENCES=$?
+    if [ "$CLAWBOX_DST_FENCES" = 1 ]; then
+      echo "  WARNING: the \`\`\` fences in $CLAWBOX_GUIDE_DST do not balance; a heading quoted inside one will be read as present and its section withheld" >&2
+    fi
+    if [ "$CLAWBOX_GUIDE_FENCES" = 1 ]; then
+      echo "  WARNING: the \`\`\` fences in $CLAWBOX_GUIDE_SRC do not balance; CLAWBOX.md not topped up (a quoted heading would be appended as a section)" >&2
+    elif ! CLAWBOX_GUIDE_HEADINGS="$(clawbox_guide_headings "$CLAWBOX_GUIDE_SRC")"; then
       # An I/O fault on the template, not a renamed heading: the two send an
       # operator to different files, so they are reported apart.
       echo "  WARNING: could not read $CLAWBOX_GUIDE_SRC to top up CLAWBOX.md" >&2
@@ -3630,7 +3679,9 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
   # CLAWBOX.md loop above already does. AGENTS.md is the file the harness
   # injects into every session, under a bootstrap character budget.
   clawbox_agents_append() {
-    CLAWBOX_AGENTS_SEEN=0
+    # `local`, or the boot-time value leaks into the second marker's call and a
+    # `case` that never ran reads the first one's answer.
+    local CLAWBOX_AGENTS_SEEN=0
     clawbox_file_has_heading "$CLAWBOX_AGENTS_MD" "$1" || CLAWBOX_AGENTS_SEEN=$?
     case "$CLAWBOX_AGENTS_SEEN" in
       0) return 0 ;;

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -3246,27 +3246,66 @@ CLAWBOX_GUIDE_DST="$CLAWBOX_WORKSPACE/CLAWBOX.md"
 # The trade this takes, deliberately and per the card: an owner who DELETED a
 # section gets it back on the next gateway start. The alternative is what the
 # box has today — sections that never arrive at all, with nothing that says so.
+# Whole-line matching cuts the same way in both directions, and both are the
+# trade: `## Skills and other things` no longer satisfies `## Skills` (the old
+# substring match said it did, and would have withheld that section forever),
+# and a heading the agent DEMOTED to `### Skills` no longer satisfies it either,
+# so such a box gets one copy of the section back — once, because the appended
+# copy is found on the next boot.
 #
 # Values reach awk through the environment rather than `-v`, which runs them
 # through escape processing: a heading that ever grew a backslash would quietly
 # stop matching and the section would go missing with no warning.
 
+# ONE fence rule, shared by the three helpers below.
+#
+# Prepended to each awk program, so `text[i]` is every line with trailing
+# whitespace and a CR trimmed, `raw[i]` is the line as it stands, and
+# `clawbox_fences()` marks in `hidden[i]` the lines a fence encloses. Trailing
+# whitespace is trimmed in one place for all three: a heading that differs from
+# the template's only by a trailing space would otherwise be judged absent by
+# one helper and found by another, and the section appended a second time,
+# permanently.
+#
+# Fenced `## ` lines do not count. This template is markdown that documents
+# markdown and shell, and the destinations are the owner's and the agent's to
+# edit: a ``` block quoting a heading would otherwise be enumerated as a phantom
+# section on the source side, and read as the section already being present on
+# the destination side.
+#
+# But a fence hides only what it CLOSES, and that is the whole reason these read
+# the file twice instead of toggling as they go. An odd number of column-0
+# delimiters is ordinary damage — an indented closing fence is valid CommonMark
+# and does not match at column 0 — and a naive toggle makes it catastrophic in
+# BOTH directions: on the destination every heading after the stray delimiter is
+# "missing", the copy this block appends lands in the fenced region too, and the
+# file grows by those sections on EVERY boot; on the template the headings
+# simply stop being enumerated, and the box is told nothing while section after
+# section fails to arrive — this card's own defect, on the source side, with the
+# "no '## ' headings at all" warning firing only if the count reaches zero.
+# Unbalanced fences are therefore read as prose, which is what this script did
+# before fences were considered at all.
+CLAWBOX_FENCE_AWK='
+  function clawbox_fences(   i, j) {
+    if (fences % 2) return
+    for (i = 1; i < fences; i += 2)
+      for (j = fence[i]; j <= fence[i + 1]; j++) hidden[j] = 1
+  }
+  {
+    raw[NR] = $0
+    line = $0; sub(/[ \t\r]+$/, "", line); text[NR] = line
+    if (line ~ /^(```|~~~)/) fence[++fences] = NR
+  }
+'
+
 # Every `## ` heading in a markdown file, in order.
-#
-# Fenced blocks are skipped: this template is markdown that documents markdown
-# and shell, so a ``` fence containing a `## ` line is a live trap — it would be
-# enumerated as a phantom heading and its "section" extracted from inside the
-# fence to the next real heading, then appended to every box's guide. Harmless
-# while the old code named one heading by hand; not harmless now.
-#
-# Trailing whitespace is trimmed here and in the comparison below, together: a
-# heading that differs from the template's only by a trailing space would
-# otherwise be judged absent and the section appended a second time, permanently.
 clawbox_guide_headings() {
-  awk '
-    { line = $0; sub(/[ \t\r]+$/, "", line) }
-    line ~ /^(```|~~~)/ { fence = !fence; next }
-    !fence && line ~ /^## +[^ ]/ { print line }
+  awk "$CLAWBOX_FENCE_AWK"'
+    END {
+      clawbox_fences()
+      for (i = 1; i <= NR; i++)
+        if (!hidden[i] && text[i] ~ /^## +[^ ]/) print text[i]
+    }
   ' "$1"
 }
 
@@ -3274,40 +3313,24 @@ clawbox_guide_headings() {
 #
 # One helper for BOTH destinations — CLAWBOX.md's sections and AGENTS.md's two
 # markers — so the two files cannot come to disagree about what "already there"
-# means. `grep -qxF`, which the AGENTS.md blocks used, cannot do the job: a CRLF
-# file stores the marker as `## X\r`, an exact whole-line match misses it, and
-# the block then appends on EVERY boot and the file grows without bound — the
-# failure whole-line matching exists to prevent rather than to cause.
+# means. The AGENTS.md blocks used `grep -qF`, a SUBSTRING match, which read
+# `### ClawBox integration notes` as the marker and withheld the pointer for
+# good; whole-line is the correction. And whole-line is exactly what a bare
+# `grep -qxF` cannot do here, because a CRLF file stores the marker as
+# `## X\r`: an exact match misses it, the block appends on EVERY boot and the
+# file grows without bound — so the CR is normalised on both sides, in one
+# place, for both files.
 #
 # Three answers, not two: 0 present, 1 absent, 2 could not be read. `awk` returns
 # 2 for a file it cannot open, and reading that as "absent" is how an unreadable
 # destination gets appended to — the defect the readability guard above exists to
 # stop, through a door that guard cannot cover once the loop is running.
 #
-# Headings quoted inside a fence do not count — an owner or the agent pasting
-# an example of a heading is not carrying that section, and reading the quote as
-# the marker withholds the section for good.
-#
-# But ONLY when the fences balance, which is why this reads the whole file
-# instead of answering on the first match. These two files are the agent's and
-# the owner's to edit, and an odd number of ``` lines is ordinary damage. Track
-# it anyway and the region after the stray delimiter is judged fenced — so every
-# heading in it is "missing", the copy this block appends lands in it too, and
-# the file grows by those sections on EVERY boot. That is the unbounded growth
-# this whole block exists to stop, arriving through the fence rule instead of
-# through `grep`. Unbalanced fences are therefore read as prose: the worst that
-# costs is the behaviour this script had before fences were considered at all.
 clawbox_file_has_heading() {
   [ -r "$1" ] || return 2
-  heading="$2" awk '
-    {
-      line = $0; sub(/[ \t\r]+$/, "", line); text[NR] = line
-      if (line ~ /^(```|~~~)/) fence[++fences] = NR
-    }
+  heading="$2" awk "$CLAWBOX_FENCE_AWK"'
     END {
-      if (fences % 2 == 0)
-        for (i = 1; i < fences; i += 2)
-          for (j = fence[i]; j <= fence[i + 1]; j++) hidden[j] = 1
+      clawbox_fences()
       for (i = 1; i <= NR; i++)
         if (!hidden[i] && text[i] == ENVIRON["heading"]) exit 0
       exit 1
@@ -3325,20 +3348,17 @@ clawbox_file_has_heading() {
 # dropped, because the append supplies its own separator and carrying the
 # template's too ends the topped-up guide on a dangling rule.
 clawbox_guide_section() {
-  heading="$2" awk '
-    { line = $0; sub(/[ \t\r]+$/, "", line) }
-    line ~ /^(```|~~~)/ { fence = !fence }
-    line == ENVIRON["heading"] && !fence { inside = 1; lines[++n] = $0; next }
-    inside && !fence && line ~ /^## / { exit }
-    inside { lines[++n] = $0 }
+  heading="$2" awk "$CLAWBOX_FENCE_AWK"'
     END {
-      while (n > 0) {
-        tail = lines[n]
-        sub(/\r$/, "", tail)
-        if (tail != "" && tail != "---") break
-        n--
-      }
-      for (i = 1; i <= n; i++) print lines[i]
+      clawbox_fences()
+      for (i = 1; i <= NR && !start; i++)
+        if (!hidden[i] && text[i] == ENVIRON["heading"]) start = i
+      if (!start) exit 0
+      last = NR
+      for (i = start + 1; i <= NR && last == NR; i++)
+        if (!hidden[i] && text[i] ~ /^## /) last = i - 1
+      while (last > start && (text[last] == "" || text[last] == "---")) last--
+      for (i = start; i <= last; i++) print raw[i]
     }
   ' "$1"
 }
@@ -3469,6 +3489,14 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
   # prevented, with no warning at all.
   if [ ! -r "$CLAWBOX_GUIDE_SRC" ]; then
     echo "  WARNING: could not read $CLAWBOX_GUIDE_SRC; leaving CLAWBOX.md as it is" >&2
+  elif [ -e "$CLAWBOX_GUIDE_DST" ] && [ ! -f "$CLAWBOX_GUIDE_DST" ]; then
+    # `-f` alone says "seed it" about a DIRECTORY, and `install SRC DIR` copies
+    # INTO it: two boots, two "Seeded CLAWBOX.md" success lines, a
+    # CLAWBOX.md/clawbox-workspace-guide.md nobody reads, and no guide on the
+    # box ever — a success printed on every boot, forever. A socket or a
+    # dangling symlink is the same shape. Nothing here can fix that path, so it
+    # says so instead of reporting work it did not do.
+    echo "  WARNING: $CLAWBOX_GUIDE_DST exists and is not a regular file; leaving it as it is" >&2
   elif [ ! -f "$CLAWBOX_GUIDE_DST" ]; then
     if install -m 644 "$CLAWBOX_GUIDE_SRC" "$CLAWBOX_GUIDE_DST"; then
       echo "  Seeded CLAWBOX.md in OpenClaw workspace"
@@ -3488,7 +3516,7 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
       echo "  WARNING: could not seed CLAWBOX.md in the OpenClaw workspace" >&2
     fi
   elif [ ! -r "$CLAWBOX_GUIDE_DST" ]; then
-    # `grep` and `awk` answer exit 2 on a file they cannot read, which reads as
+    # `awk` answers exit 2 on a file it cannot read, which reads as
     # "the heading is not there" — so a 0200 CLAWBOX.md was appended to on EVERY
     # boot, growing without bound, while the file itself could never be checked.
     # A file this block cannot read is a file it must not top up.
@@ -3590,55 +3618,65 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
   # and every box in the field already carries it verbatim (it has not changed
   # since it was introduced), so no box receives a second copy.
   CLAWBOX_AGENTS_POINTER="## ClawBox integration"
-  # `-r` as well as `-f`, and the whole-line helper rather than a `grep -qF`
-  # substring: the same two corrections the CLAWBOX.md loop above needed, and
-  # they matter MORE here. `grep` answers exit 2 on a file it cannot read, which
-  # reads as "the marker is not there" —
-  # and mode 0200 denies the read while PERMITTING the write, so the append
-  # succeeded and the box grew AGENTS.md by ~1 KB on every single boot, each one
-  # reported as a success. AGENTS.md is the file the harness injects into every
-  # session, under a bootstrap character budget.
+  # One readability test for both blocks, and one `case` over the helper's THREE
+  # answers.
+  #
+  # `! clawbox_file_has_heading …` would collapse them to two, and reading
+  # "could not be read" as "the marker is absent" is how this file grew by ~1 KB
+  # on every single boot, each one printed as a success — mode 0200 denies the
+  # read while PERMITTING the write. `-r` closes that measured door; the `case`
+  # closes the rest of them (an EIO on a failing eMMC, `awk` missing from a
+  # stripped rootfs, the file losing readability after the test), the way the
+  # CLAWBOX.md loop above already does. AGENTS.md is the file the harness
+  # injects into every session, under a bootstrap character budget.
+  clawbox_agents_append() {
+    CLAWBOX_AGENTS_SEEN=0
+    clawbox_file_has_heading "$CLAWBOX_AGENTS_MD" "$1" || CLAWBOX_AGENTS_SEEN=$?
+    case "$CLAWBOX_AGENTS_SEEN" in
+      0) return 0 ;;
+      1) ;;
+      *)
+        echo "  WARNING: could not read $CLAWBOX_AGENTS_MD while looking for '$1'; leaving it as it is" >&2
+        return 0
+        ;;
+    esac
+    # Guarded, and not a bare append: a read-only AGENTS.md used to abort
+    # pre-start under `set -euo pipefail` and the gateway never started — over a
+    # pointer sentence. Advisory text must never hold up the gateway; the next
+    # start retries.
+    if clawbox_append_or_rollback "$CLAWBOX_AGENTS_MD" "$2"; then
+      echo "  $3"
+    else
+      echo "  WARNING: $4" >&2
+    fi
+  }
   if [ -f "$CLAWBOX_AGENTS_MD" ] && [ ! -r "$CLAWBOX_AGENTS_MD" ]; then
     echo "  WARNING: could not read $CLAWBOX_AGENTS_MD; leaving it as it is" >&2
-  elif [ -f "$CLAWBOX_AGENTS_MD" ] && ! clawbox_file_has_heading "$CLAWBOX_AGENTS_MD" "$CLAWBOX_AGENTS_POINTER"; then
-    # Guarded like the two appends below, and for the same reason: this one has
-    # always been bare, so a read-only AGENTS.md aborted pre-start under
-    # `set -euo pipefail` and the gateway never started — over a pointer
-    # sentence. Reachable whenever the file exists without the marker.
+  elif [ -f "$CLAWBOX_AGENTS_MD" ]; then
     printf -v CLAWBOX_AGENTS_POINTER_TEXT '\n\n%s\n\nSee `CLAWBOX.md` for device-specific conventions: where user-installed skills live, how to control the desktop Chromium via `browser_*` tools, how to install/uninstall skills through the App Store, and which system actions are the owner'"'"'s.\n' "$CLAWBOX_AGENTS_POINTER"
-    if clawbox_append_or_rollback "$CLAWBOX_AGENTS_MD" "$CLAWBOX_AGENTS_POINTER_TEXT"; then
-      echo "  Appended CLAWBOX.md reference to AGENTS.md"
-    else
-      echo "  WARNING: could not append the CLAWBOX.md reference to AGENTS.md" >&2
-    fi
-  fi
+    clawbox_agents_append "$CLAWBOX_AGENTS_POINTER" "$CLAWBOX_AGENTS_POINTER_TEXT" \
+      "Appended CLAWBOX.md reference to AGENTS.md" \
+      "could not append the CLAWBOX.md reference to AGENTS.md"
 
-  # THE RULE ITSELF GOES IN AGENTS.md, not only in CLAWBOX.md.
-  #
-  # OpenClaw's workspace file map (docs/concepts/agent-workspace.md, verified in
-  # the pinned 2026.8.1 package) injects AGENTS.md, SOUL.md, USER.md,
-  # IDENTITY.md, BOOT.md, BOOTSTRAP.md and memory/ at the start of every
-  # session — and describes AGENTS.md as "operating instructions ... good place
-  # for rules". CLAWBOX.md is NOT in that set: it is read only if the agent
-  # chooses to open it, prompted by the pointer above. A behavioural
-  # prohibition that the model may never load is not a prohibition, which is
-  # how TASK-612 could otherwise have shipped green and reproduced unchanged.
-  #
-  # Its own marker, deliberately not the "CLAWBOX.md" one: that pointer is
-  # already present on every box in the field, so anything guarded by it can
-  # never be delivered again.
-  CLAWBOX_AGENTS_RULE="## System actions on this ClawBox"
-  # Readability and whole-line, for the reason above. No second warning: the
-  # pointer block a few lines up has already printed one for the same file.
-  if [ -f "$CLAWBOX_AGENTS_MD" ] && [ -r "$CLAWBOX_AGENTS_MD" ] \
-    && ! clawbox_file_has_heading "$CLAWBOX_AGENTS_MD" "$CLAWBOX_AGENTS_RULE"; then
+    # THE RULE ITSELF GOES IN AGENTS.md, not only in CLAWBOX.md.
+    #
+    # OpenClaw's workspace file map (docs/concepts/agent-workspace.md, verified
+    # in the pinned 2026.8.1 package) injects AGENTS.md, SOUL.md, USER.md,
+    # IDENTITY.md, BOOT.md, BOOTSTRAP.md and memory/ at the start of every
+    # session — and describes AGENTS.md as "operating instructions ... good
+    # place for rules". CLAWBOX.md is NOT in that set: it is read only if the
+    # agent chooses to open it, prompted by the pointer above. A behavioural
+    # prohibition that the model may never load is not a prohibition, which is
+    # how TASK-612 could otherwise have shipped green and reproduced unchanged.
+    #
+    # Its own marker, deliberately not the "CLAWBOX.md" one: that pointer is
+    # already present on every box in the field, so anything guarded by it can
+    # never be delivered again.
+    CLAWBOX_AGENTS_RULE="## System actions on this ClawBox"
     printf -v CLAWBOX_AGENTS_RULE_TEXT '\n\n%s\n\nRestarting the OpenClaw gateway is not yours to do from a chat turn: the gateway hosts this session, so the restart kills the reply before it lands. It is rarely needed either — saving a setting under Settings -> Providers, Voice or Channels restarts it. Say that, and name the setting.\n\nA device restart or shutdown IS yours when the owner asks in their own words: `system_power`, `confirm: true`, with their reason. Their own control is the power menu in the desktop tray, not Settings -> System.\n\nNever queue an `operator_approval` proposal for any of this. ClawBox renders no approval card, so a queued proposal is shown to nobody; a parked one is answered with `openclaw approvals pending` / `openclaw approvals resolve` from the Terminal app. `CLAWBOX.md` has the long form.\n' "$CLAWBOX_AGENTS_RULE"
-    if clawbox_append_or_rollback "$CLAWBOX_AGENTS_MD" "$CLAWBOX_AGENTS_RULE_TEXT"; then
-      echo "  Appended the system-actions rule to AGENTS.md"
-    else
-      # Advisory text must never hold up the gateway; the next start retries.
-      echo "  WARNING: could not append the system-actions rule to AGENTS.md" >&2
-    fi
+    clawbox_agents_append "$CLAWBOX_AGENTS_RULE" "$CLAWBOX_AGENTS_RULE_TEXT" \
+      "Appended the system-actions rule to AGENTS.md" \
+      "could not append the system-actions rule to AGENTS.md"
   fi
 
   # --- clawbox language re-apply ---

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -3260,8 +3260,8 @@ CLAWBOX_GUIDE_DST="$CLAWBOX_WORKSPACE/CLAWBOX.md"
 # ONE fence rule, shared by the three helpers below.
 #
 # Prepended to each awk program, so `text[i]` is every line with trailing
-# whitespace and a CR trimmed, `raw[i]` is the line as it stands, and
-# `clawbox_fences()` marks in `hidden[i]` the lines a fence encloses. Trailing
+# whitespace and a CR trimmed and `clawbox_fences()` marks in `hidden[i]` the
+# lines a fence encloses, and sets `unbalanced` when one never closed. Trailing
 # whitespace is trimmed in one place for all three: a heading that differs from
 # the template's only by a trailing space would otherwise be judged absent by
 # one helper and found by another, and the section appended a second time,
@@ -3284,38 +3284,72 @@ CLAWBOX_GUIDE_DST="$CLAWBOX_WORKSPACE/CLAWBOX.md"
 # not one word on stderr. The interval form `{0,3}` is not available: mawk 1.3.4
 # does not merely reject it, it aborts with `REcompile() - panic`.
 #
+# A delimiter also closes only a fence opened with the SAME character, and only
+# with a run at least as long — CommonMark again, and the same mis-pairing as
+# above one delimiter character over. These files document markdown, so a ```
+# block quoting a ~~~ example is an ordinary edit; with both characters in one
+# list the ``` opener pairs with the quoted ~~~, the lines between the two
+# quoted delimiters fall outside every pair, and a heading the template only
+# QUOTES is appended to every box as a section of its own. The run-length half
+# is what lets a ```` block quote a ``` one, which is how this template shows
+# markdown inside markdown.
+#
+# CommonMark's third closer rule — that a closer carries no info string, so
+# "```markdown" cannot close "```text" — is deliberately NOT applied. It is the
+# one rule of the three that can only ever turn "unbalanced" into "balanced",
+# and balanced is the answer that HIDES lines. Measured: with it, a guide
+# carrying one stray ``` had the sections appended below it swallowed by that
+# stray on the next boot and appended again, and again — the unbounded growth
+# this whole block exists to stop. The other two rules lean the other way, and
+# leaning toward "read it as prose" is the whole design.
+#
 # And a fence hides only what it CLOSES, which is the whole reason these read
-# the file twice instead of toggling as they go. An odd delimiter count is
+# the file twice instead of toggling as they go. An opener with no closer is
 # ordinary damage in a file the owner and the agent both edit, and a naive
 # toggle makes it catastrophic in BOTH directions: on the destination every
 # heading after the stray delimiter is "missing", the copy this block appends
 # lands in the fenced region too, and the file grows by those sections on EVERY
-# boot; on the template the headings simply stop being enumerated. Unbalanced
-# fences are therefore read as prose, which is what this script did before
-# fences were considered at all — and the two blocks below SAY SO rather than
-# leaving it silent, because "read as prose" on the destination means a heading
-# quoted inside a fence counts as present and its section is withheld.
+# boot; on the template the headings simply stop being enumerated. Such a file
+# is therefore read as prose — nothing is hidden at all, which is what this
+# script did before fences were considered — and the two blocks below SAY SO
+# rather than leaving it silent, because "read as prose" on the destination
+# means a heading quoted inside a fence counts as present and its section is
+# withheld.
 CLAWBOX_FENCE_AWK='
-  function clawbox_fences(   i, j) {
-    if (fences % 2) return
-    for (i = 1; i < fences; i += 2)
-      for (j = fence[i]; j <= fence[i + 1]; j++) hidden[j] = 1
+  function clawbox_fences(   i, j, k, open, pairs, from, to) {
+    open = 0; pairs = 0
+    for (i = 1; i <= fences; i++) {
+      if (!open) { open = i; continue }
+      if (fchar[i] != fchar[open] || flen[i] < flen[open]) continue
+      pairs++; from[pairs] = fence[open]; to[pairs] = fence[i]; open = 0
+    }
+    unbalanced = (open != 0)
+    if (unbalanced) return
+    for (k = 1; k <= pairs; k++)
+      for (j = from[k]; j <= to[k]; j++) hidden[j] = 1
   }
   {
-    raw[NR] = $0
     line = $0; sub(/[ \t\r]+$/, "", line); text[NR] = line
-    if (line ~ /^ *(```|~~~)/ && match(line, /^ */) && RLENGTH < 4) fence[++fences] = NR
+    if (line ~ /^ *(```|~~~)/ && match(line, /^ */) && RLENGTH < 4) {
+      mark = substr(line, RLENGTH + 1)
+      char = substr(mark, 1, 1)
+      run = 1
+      while (substr(mark, run + 1, 1) == char) run++
+      fences++
+      fence[fences] = NR; fchar[fences] = char; flen[fences] = run
+    }
   }
 '
 
 # Do this file'"'"'s fences balance? 0 yes, 1 no, 2 could not be read.
 #
 # Asked once per file rather than folded into the helpers, because the answer is
-# a fact about the FILE and the helpers are called once per heading.
+# a fact about the FILE and the helpers are called once per heading. It is the
+# same pairing the helpers use, not a second rule that could drift from it.
 clawbox_fences_balanced() {
   [ -r "$1" ] || return 2
   awk "$CLAWBOX_FENCE_AWK"'
-    END { exit(fences % 2 ? 1 : 0) }
+    END { clawbox_fences(); exit(unbalanced ? 1 : 0) }
   ' "$1"
 }
 
@@ -3370,6 +3404,11 @@ clawbox_file_has_heading() {
 # template's too ends the topped-up guide on a dangling rule.
 clawbox_guide_section() {
   heading="$2" awk "$CLAWBOX_FENCE_AWK"'
+    # The only helper that reproduces lines rather than matching them, so it is
+    # the only one that keeps a second copy of the file in memory. The shared
+    # prologue builds `text[]`, which is trimmed; a section must be appended to
+    # the box exactly as it is shipped.
+    { raw[NR] = $0 }
     END {
       clawbox_fences()
       for (i = 1; i <= NR && !start; i++)
@@ -3678,16 +3717,28 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
   # stripped rootfs, the file losing readability after the test), the way the
   # CLAWBOX.md loop above already does. AGENTS.md is the file the harness
   # injects into every session, under a bootstrap character budget.
+  #
+  # One warning per fault, not one per marker: both calls below ask about the
+  # SAME file for the same reason, so an unreadable AGENTS.md would otherwise
+  # put two lines in the journal, and a duplicate reads as two faults to whoever
+  # is triaging a failing eMMC. The old code had this property and the hoist
+  # into a shared wrapper dropped it.
+  CLAWBOX_AGENTS_UNREADABLE=0
   clawbox_agents_append() {
-    # `local`, or the boot-time value leaks into the second marker's call and a
-    # `case` that never ran reads the first one's answer.
+    # `local` for namespace hygiene beside `clawbox_append_or_rollback`, which
+    # declares its own: the value is assigned on every call, so nothing leaks
+    # between them, but a name this file uses nowhere else should not become a
+    # global that a later block could read.
     local CLAWBOX_AGENTS_SEEN=0
     clawbox_file_has_heading "$CLAWBOX_AGENTS_MD" "$1" || CLAWBOX_AGENTS_SEEN=$?
     case "$CLAWBOX_AGENTS_SEEN" in
       0) return 0 ;;
       1) ;;
       *)
-        echo "  WARNING: could not read $CLAWBOX_AGENTS_MD while looking for '$1'; leaving it as it is" >&2
+        if [ "$CLAWBOX_AGENTS_UNREADABLE" = 0 ]; then
+          CLAWBOX_AGENTS_UNREADABLE=1
+          echo "  WARNING: could not read $CLAWBOX_AGENTS_MD while looking for its markers; leaving it as it is" >&2
+        fi
         return 0
         ;;
     esac

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -3277,11 +3277,14 @@ CLAWBOX_GUIDE_DST="$CLAWBOX_WORKSPACE/CLAWBOX.md"
 # how CommonMark defines one — an opener and a closer alike. Matching only at
 # column 0 is not a stricter rule, it is a WRONG one: an indented closing fence
 # then goes unseen, the next opener is paired with the previous opener, and the
-# prose between two examples is marked as fenced. Measured on this template with
-# two two-space-indented closers — which render correctly on GitHub and are
-# invisible in review — `## Browser (real Chromium on the device)` and
-# `## Apps and UI` were enumerated by nothing and delivered to no box, exit 0,
-# not one word on stderr. The interval form `{0,3}` is not available: mawk 1.3.4
+# prose between two examples is marked as fenced. Measured on a COPY of this
+# template carrying two two-space-indented closers — which render correctly on
+# GitHub and are invisible in review — `## Browser (real Chromium on the
+# device)` and `## Apps and UI` were enumerated by nothing and delivered to no
+# box, exit 0, not one word on stderr. (A copy: the shipped file has exactly one
+# fenced block and it is in the LAST section, so its own closers cannot reach
+# those two headings. The shape is what matters, and the day an example lands
+# above them it would.) The interval form `{0,3}` is not available: mawk 1.3.4
 # does not merely reject it, it aborts with `REcompile() - panic`.
 #
 # A delimiter also closes only a fence opened with the SAME character, and only
@@ -3294,14 +3297,32 @@ CLAWBOX_GUIDE_DST="$CLAWBOX_WORKSPACE/CLAWBOX.md"
 # is what lets a ```` block quote a ``` one, which is how this template shows
 # markdown inside markdown.
 #
-# CommonMark's third closer rule — that a closer carries no info string, so
-# "```markdown" cannot close "```text" — is deliberately NOT applied. It is the
-# one rule of the three that can only ever turn "unbalanced" into "balanced",
-# and balanced is the answer that HIDES lines. Measured: with it, a guide
-# carrying one stray ``` had the sections appended below it swallowed by that
-# stray on the next boot and appended again, and again — the unbounded growth
-# this whole block exists to stop. The other two rules lean the other way, and
-# leaning toward "read it as prose" is the whole design.
+# CommonMark's THIRD closer rule — that a closer carries no info string, so
+# "```md" cannot close "```text" — is applied to the TEMPLATE and not to the
+# destinations, and that asymmetry is the point rather than an oversight. It
+# changes which delimiter becomes the closer, so it moves the answer in BOTH
+# directions depending on the file, and the two files want opposite things:
+#
+#   The template is OURS — shipped, reviewed, and pinned by a unit test that
+#   compares this enumerator against a fence-blind list of every `## ` line. It
+#   should be parsed by the book, and anything the book cannot parse cleanly
+#   should be REFUSED out loud. Without the rule it is not: a `` ```text ``
+#   example closed by a `` ```md `` line (a copy-paste slip that renders
+#   correctly on GitHub) pairs opener-with-content, the pairing still comes out
+#   even, and `## Real Heading` below it is enumerated by nothing. Measured on
+#   exactly that shape: `Appended to CLAWBOX.md: First`, exit 0, not one word on
+#   stderr, and the section never reaches a box. That is this card's own defect.
+#
+#   A destination is the OWNER's and the agent's, edited by hand and by a model,
+#   and there the unaffordable outcome is not a wrong parse but an UNBOUNDED
+#   one: a heading wrongly hidden is judged missing and re-appended on every
+#   boot. Measured with the rule applied there too: a CLAWBOX.md carrying one
+#   stray ``` grew 8793 -> 11731 bytes over two boots, because the rule stopped
+#   the appended section's own `` ```text `` from closing the stray and let a
+#   later bare ``` close it instead — swallowing everything appended in between.
+#   Lenient, the same file is unbalanced, read as prose, and stable from boot 1.
+#
+# So: strict on the file we control, lenient on the files we do not.
 #
 # And a fence hides only what it CLOSES, which is the whole reason these read
 # the file twice instead of toggling as they go. An opener with no closer is
@@ -3321,6 +3342,7 @@ CLAWBOX_FENCE_AWK='
     for (i = 1; i <= fences; i++) {
       if (!open) { open = i; continue }
       if (fchar[i] != fchar[open] || flen[i] < flen[open]) continue
+      if (strict && finfo[i]) continue
       pairs++; from[pairs] = fence[open]; to[pairs] = fence[i]; open = 0
     }
     unbalanced = (open != 0)
@@ -3337,6 +3359,10 @@ CLAWBOX_FENCE_AWK='
       while (substr(mark, run + 1, 1) == char) run++
       fences++
       fence[fences] = NR; fchar[fences] = char; flen[fences] = run
+      # An info string ("```text"), which an opener may carry and a closer may
+      # not. `mark` has already had its trailing whitespace trimmed, so anything
+      # past the delimiter run is real text.
+      finfo[fences] = (length(mark) > run)
     }
   }
 '
@@ -3344,18 +3370,20 @@ CLAWBOX_FENCE_AWK='
 # Do this file'"'"'s fences balance? 0 yes, 1 no, 2 could not be read.
 #
 # Asked once per file rather than folded into the helpers, because the answer is
-# a fact about the FILE and the helpers are called once per heading. It is the
-# same pairing the helpers use, not a second rule that could drift from it.
+# a fact about the FILE and the helpers are called once per heading. `$2`
+# non-empty asks the STRICT reading, and every caller passes what the helpers
+# that go on to read the same file use — the answer must come from the same
+# pairing those helpers apply, not a second rule that could drift from it.
 clawbox_fences_balanced() {
   [ -r "$1" ] || return 2
-  awk "$CLAWBOX_FENCE_AWK"'
+  awk -v strict="${2-}" "$CLAWBOX_FENCE_AWK"'
     END { clawbox_fences(); exit(unbalanced ? 1 : 0) }
   ' "$1"
 }
 
-# Every `## ` heading in a markdown file, in order.
+# Every `## ` heading in a markdown file, in order. Template-side, so strict.
 clawbox_guide_headings() {
-  awk "$CLAWBOX_FENCE_AWK"'
+  awk -v strict=1 "$CLAWBOX_FENCE_AWK"'
     END {
       clawbox_fences()
       for (i = 1; i <= NR; i++)
@@ -3368,7 +3396,10 @@ clawbox_guide_headings() {
 #
 # One helper for BOTH destinations — CLAWBOX.md's sections and AGENTS.md's two
 # markers — so the two files cannot come to disagree about what "already there"
-# means. The AGENTS.md blocks used `grep -qF`, a SUBSTRING match, which read
+# means. No `strict`, deliberately: these are the owner's and the agent's files,
+# where the lenient closer is the reading that leans toward "unbalanced, so read
+# it as prose and hide nothing", and hiding nothing is the only answer that
+# cannot make a section be re-appended on every boot. See the rule above. The AGENTS.md blocks used `grep -qF`, a SUBSTRING match, which read
 # `### ClawBox integration notes` as the marker and withheld the pointer for
 # good; whole-line is the correction. And whole-line is exactly what a bare
 # `grep -qxF` cannot do here, because a CRLF file stores the marker as
@@ -3403,7 +3434,7 @@ clawbox_file_has_heading() {
 # dropped, because the append supplies its own separator and carrying the
 # template's too ends the topped-up guide on a dangling rule.
 clawbox_guide_section() {
-  heading="$2" awk "$CLAWBOX_FENCE_AWK"'
+  heading="$2" awk -v strict=1 "$CLAWBOX_FENCE_AWK"'
     # The only helper that reproduces lines rather than matching them, so it is
     # the only one that keeps a second copy of the file in memory. The shared
     # prologue builds `text[]`, which is trimmed; a section must be appended to
@@ -3599,7 +3630,7 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
     # box, permanently. Refusing is the same call the "no headings at all" arm
     # below already makes about the same kind of half-deployed file.
     CLAWBOX_GUIDE_FENCES=0
-    clawbox_fences_balanced "$CLAWBOX_GUIDE_SRC" || CLAWBOX_GUIDE_FENCES=$?
+    clawbox_fences_balanced "$CLAWBOX_GUIDE_SRC" strict || CLAWBOX_GUIDE_FENCES=$?
     # The DESTINATION is the owner's and the agent's, so it is not refused —
     # only reported. Reading its fences as prose means a heading quoted inside
     # one counts as present and that section is withheld, which is this card's
@@ -3608,7 +3639,7 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
     CLAWBOX_DST_FENCES=0
     clawbox_fences_balanced "$CLAWBOX_GUIDE_DST" || CLAWBOX_DST_FENCES=$?
     if [ "$CLAWBOX_DST_FENCES" = 1 ]; then
-      echo "  WARNING: the \`\`\` fences in $CLAWBOX_GUIDE_DST do not balance; a heading quoted inside one will be read as present and its section withheld" >&2
+      echo "  WARNING: the \`\`\` fences in $CLAWBOX_GUIDE_DST do not balance; a heading quoted inside one will be read as present and its section withheld. Close the fence, or delete the file and the next gateway start re-seeds it" >&2
     fi
     if [ "$CLAWBOX_GUIDE_FENCES" = 1 ]; then
       echo "  WARNING: the \`\`\` fences in $CLAWBOX_GUIDE_SRC do not balance; CLAWBOX.md not topped up (a quoted heading would be appended as a section)" >&2
@@ -3752,9 +3783,30 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
       echo "  WARNING: $4" >&2
     fi
   }
-  if [ -f "$CLAWBOX_AGENTS_MD" ] && [ ! -r "$CLAWBOX_AGENTS_MD" ]; then
+  # The same two sentences CLAWBOX.md gets above, because this is the file the
+  # harness injects into EVERY session and a withheld rule here is TASK-612's
+  # failure mode returning.
+  #
+  # Nothing here creates AGENTS.md — the harness owns that — so there is no seed
+  # arm and no dangling-symlink case to answer: `-e` is false for a dangling
+  # link, which lands on "no AGENTS.md yet", which is correct.
+  if [ -e "$CLAWBOX_AGENTS_MD" ] && [ ! -f "$CLAWBOX_AGENTS_MD" ]; then
+    # A directory, socket or FIFO in AGENTS.md's place: `-f` alone reads that as
+    # "there is no AGENTS.md" and both blocks below are skipped in silence, boot
+    # after boot, with the pointer and the rule never delivered.
+    echo "  WARNING: $CLAWBOX_AGENTS_MD exists and is not a regular file; leaving it as it is" >&2
+  elif [ -f "$CLAWBOX_AGENTS_MD" ] && [ ! -r "$CLAWBOX_AGENTS_MD" ]; then
     echo "  WARNING: could not read $CLAWBOX_AGENTS_MD; leaving it as it is" >&2
   elif [ -f "$CLAWBOX_AGENTS_MD" ]; then
+    # An AGENTS.md whose own fences do not balance is read as prose, so a marker
+    # QUOTED inside a fence — the agent showing the owner what ClawBox appends —
+    # counts as present and its block is withheld for good. Nothing else here
+    # would catch it, so the operator gets the sentence instead of silence.
+    CLAWBOX_AGENTS_FENCES=0
+    clawbox_fences_balanced "$CLAWBOX_AGENTS_MD" || CLAWBOX_AGENTS_FENCES=$?
+    if [ "$CLAWBOX_AGENTS_FENCES" = 1 ]; then
+      echo "  WARNING: the \`\`\` fences in $CLAWBOX_AGENTS_MD do not balance; a marker quoted inside one will be read as present and its block withheld. Close the fence" >&2
+    fi
     printf -v CLAWBOX_AGENTS_POINTER_TEXT '\n\n%s\n\nSee `CLAWBOX.md` for device-specific conventions: where user-installed skills live, how to control the desktop Chromium via `browser_*` tools, how to install/uninstall skills through the App Store, and which system actions are the owner'"'"'s.\n' "$CLAWBOX_AGENTS_POINTER"
     clawbox_agents_append "$CLAWBOX_AGENTS_POINTER" "$CLAWBOX_AGENTS_POINTER_TEXT" \
       "Appended CLAWBOX.md reference to AGENTS.md" \

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -3251,6 +3251,21 @@ CLAWBOX_GUIDE_DST="$CLAWBOX_WORKSPACE/CLAWBOX.md"
 # through escape processing: a heading that ever grew a backslash would quietly
 # stop matching and the section would go missing with no warning.
 
+# Does this file carry that line, whole, ignoring trailing whitespace and a CR?
+#
+# `grep -qxF` cannot do it: a CRLF file stores the marker as `## X\r`, which an
+# exact whole-line match misses — and the block then appends on EVERY boot and
+# the file grows without bound, which is the failure this whole-line matching
+# was introduced to prevent rather than to cause. One rule for both paths.
+clawbox_file_has_line() {
+  [ -r "$1" ] || return 2
+  wanted="$2" awk '
+    { line = $0; sub(/[ \t\r]+$/, "", line) }
+    line == ENVIRON["wanted"] { found = 1; exit }
+    END { exit(found ? 0 : 1) }
+  ' "$1"
+}
+
 # Every `## ` heading in a markdown file, in order.
 #
 # Fenced blocks are skipped: this template is markdown that documents markdown
@@ -3280,7 +3295,8 @@ clawbox_guide_has_heading() {
   [ -r "$1" ] || return 2
   heading="$2" awk '
     { line = $0; sub(/[ \t\r]+$/, "", line) }
-    line == ENVIRON["heading"] { found = 1; exit }
+    line ~ /^(```|~~~)/ { fence = !fence; next }
+    !fence && line == ENVIRON["heading"] { found = 1; exit }
     END { exit(found ? 0 : 1) }
   ' "$1"
 }
@@ -3569,7 +3585,7 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
   # session, under a bootstrap character budget.
   if [ -f "$CLAWBOX_AGENTS_MD" ] && [ ! -r "$CLAWBOX_AGENTS_MD" ]; then
     echo "  WARNING: could not read $CLAWBOX_AGENTS_MD; leaving it as it is" >&2
-  elif [ -f "$CLAWBOX_AGENTS_MD" ] && ! grep -qxF "$CLAWBOX_AGENTS_POINTER" "$CLAWBOX_AGENTS_MD"; then
+  elif [ -f "$CLAWBOX_AGENTS_MD" ] && ! clawbox_file_has_line "$CLAWBOX_AGENTS_MD" "$CLAWBOX_AGENTS_POINTER"; then
     # Guarded like the two appends below, and for the same reason: this one has
     # always been bare, so a read-only AGENTS.md aborted pre-start under
     # `set -euo pipefail` and the gateway never started — over a pointer
@@ -3600,7 +3616,7 @@ if [ -d "$CLAWBOX_WORKSPACE" ]; then
   # Readability and whole-line, for the reason above. No second warning: the
   # pointer block a few lines up has already printed one for the same file.
   if [ -f "$CLAWBOX_AGENTS_MD" ] && [ -r "$CLAWBOX_AGENTS_MD" ] \
-    && ! grep -qxF "$CLAWBOX_AGENTS_RULE" "$CLAWBOX_AGENTS_MD"; then
+    && ! clawbox_file_has_line "$CLAWBOX_AGENTS_MD" "$CLAWBOX_AGENTS_RULE"; then
     printf -v CLAWBOX_AGENTS_RULE_TEXT '\n\n%s\n\nRestarting the OpenClaw gateway is not yours to do from a chat turn: the gateway hosts this session, so the restart kills the reply before it lands. It is rarely needed either — saving a setting under Settings -> Providers, Voice or Channels restarts it. Say that, and name the setting.\n\nA device restart or shutdown IS yours when the owner asks in their own words: `system_power`, `confirm: true`, with their reason. Their own control is the power menu in the desktop tray, not Settings -> System.\n\nNever queue an `operator_approval` proposal for any of this. ClawBox renders no approval card, so a queued proposal is shown to nobody; a parked one is answered with `openclaw approvals pending` / `openclaw approvals resolve` from the Terminal app. `CLAWBOX.md` has the long form.\n' "$CLAWBOX_AGENTS_RULE"
     if clawbox_append_or_rollback "$CLAWBOX_AGENTS_MD" "$CLAWBOX_AGENTS_RULE_TEXT"; then
       echo "  Appended the system-actions rule to AGENTS.md"

--- a/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
+++ b/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
@@ -708,6 +708,27 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
       expect(readFileSync(guide, "utf-8").match(/^## Skills *$/gm)).toHaveLength(2);
     });
 
+    it("does not top a guide up again and again below a stray fence", () => {
+      // A guide whose ``` lines do not balance — ordinary damage in a file the
+      // owner and the agent both edit. Track the fences anyway and everything
+      // after the stray delimiter is judged fenced, so the sections are
+      // "missing", the copies appended land after it too, and the guide grows
+      // by them on every boot. That is this block's own defect, arriving
+      // through the fence rule. Second boot appends nothing: that is the whole
+      // assertion.
+      const current = readFileSync(TEMPLATE, "utf-8");
+      const cut = current.indexOf("\n## Coding agent");
+      expect(cut).toBeGreaterThan(0);
+      writeFileSync(guide, `${current.slice(0, cut)}\n\n\`\`\`\n`);
+
+      const first = run();
+      const second = run();
+
+      expect(first.stdout).toMatch(/Appended to CLAWBOX\.md:.*Coding agent/);
+      expect(second.stdout).not.toMatch(/Appended/);
+      expect(readFileSync(guide, "utf-8").match(/^## Coding agent/gm)).toHaveLength(1);
+    });
+
     it("does not add a second copy of a section whose heading has trailing whitespace", () => {
       // What a markdown hard line break, a prettier pass or a hand edit leaves.
       // The old substring match tolerated it; a whole-line match must normalise
@@ -915,6 +936,28 @@ describe("gateway-pre-start puts the rule where the harness loads it", () => {
 
     expect(stdout).not.toMatch(/Appended/);
     expect(readFileSync(agents, "utf-8")).toBe(existing);
+  });
+
+  it("does not take a marker quoted inside a fence as the marker", () => {
+    // The destination-side fence rule, on the file the harness injects into
+    // every session. An AGENTS.md that quotes the pointer inside a ``` block —
+    // the agent showing the owner what ClawBox writes — is not carrying it, and
+    // reading the quote as the marker withholds the pointer for good.
+    writeFileSync(
+      agents,
+      "# AGENTS\n\n```markdown\n## ClawBox integration\n```\n\n"
+        + "## System actions on this ClawBox\n\nMine.\n",
+    );
+
+    const first = run();
+    const second = run();
+
+    expect(first.stdout).toContain("Appended CLAWBOX.md reference to AGENTS.md");
+    expect(first.stdout).not.toContain("Appended the system-actions rule");
+    // Once, and only once however many times the gateway starts: the quoted one
+    // stays where it was and the real one is found on the next boot.
+    expect(second.stdout).not.toMatch(/Appended/);
+    expect(readFileSync(agents, "utf-8").match(/^## ClawBox integration$/gm)).toHaveLength(2);
   });
 
   it("does not take a longer heading of the owner's as its own marker", () => {

--- a/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
+++ b/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
@@ -271,12 +271,15 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
 
     // Sanity: the filter has to be finding this block's write sites, or an
     // empty `unguarded` would prove nothing. The floor is the REAL count, not a
-    // token one. The eight write sites are, today:
+    // token one. The seven write sites are, today:
     //   1 the helper's own `printf >>`
     //   2 `truncate -s`, 3 the `python3 os.truncate` fallback
     //   4 the `install` seed, 5 its failure-branch `rm -f`
-    //   6-8 the three `clawbox_append_or_rollback` calls
-    expect(writes.length).toBeGreaterThanOrEqual(8);
+    //   6 the guide loop's `clawbox_append_or_rollback`, once for every missing
+    //     section, and 7 the one inside `clawbox_agents_append`, which both
+    //     AGENTS.md markers go through. Seven rather than eight because this
+    //     change replaced two hand-named appends with those two loops.
+    expect(writes.length).toBeGreaterThanOrEqual(7);
     // Both rollback verbs, by name: the write-count floor can be met
     // without them.
     expect(writes.join("\n")).toMatch(/truncate -s/);

--- a/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
+++ b/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
@@ -516,11 +516,19 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
   // that section landed is in the same state, silently. So the top-up appends
   // EVERY `## ` section the file is missing, not one named one.
   describe("tops a guide up to every section the template has", () => {
-    const headings = () =>
-      readFileSync(TEMPLATE, "utf-8")
-        .split("\n")
-        .map((l) => l.replace(/\r$/, ""))
-        .filter((l) => l.startsWith("## "));
+    // Fenced lines excluded, exactly as the script excludes them: the template
+    // documents markdown, so a ``` block containing a `## ` line would make
+    // these cases demand a section the script correctly refuses to enumerate.
+    const headings = () => {
+      const out: string[] = [];
+      let fenced = false;
+      for (const raw of readFileSync(TEMPLATE, "utf-8").split("\n")) {
+        const line = raw.replace(/[ \t\r]+$/, "");
+        if (/^(```|~~~)/.test(line)) { fenced = !fenced; continue; }
+        if (!fenced && /^## +[^ ]/.test(line)) out.push(line);
+      }
+      return out;
+    };
 
     it("gives an old guide every heading the shipped template carries", () => {
       // A real pre-TASK-612 guide: the sections that box was seeded with, and
@@ -692,7 +700,10 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
       const { stdout } = run();
 
       expect(stdout).not.toMatch(/Appended/);
-      expect(readFileSync(guide, "utf-8").match(/^## Skills */gm)).toHaveLength(1);
+      // End-anchored: `/^## Skills */gm` also matches the prefix of
+      // `## Skills and other things`, which is the very heading this case is
+      // about.
+      expect(readFileSync(guide, "utf-8").match(/^## Skills *$/gm)).toHaveLength(1);
     });
   });
 
@@ -826,11 +837,12 @@ describe("gateway-pre-start puts the rule where the harness loads it", () => {
     // Padded past a 1024-byte boundary on purpose: the cap can only be set in
     // whole blocks, so a short file would let the whole rule fit inside the
     // first block and the write would simply succeed, testing nothing.
-    const existing = "# AGENTS\n\nBe helpful.\n\n## ClawBox integration\n\nSee `CLAWBOX.md`.\n"
-      + "Owner note: the printer is on the shelf.\n".repeat(45);
+    const existing = padToJustUnderABlock(
+      "# AGENTS\n\nBe helpful.\n\n## ClawBox integration\n\nSee `CLAWBOX.md`.\n",
+    );
     writeFileSync(agents, existing);
 
-    const res = runCapped(Buffer.byteLength(existing) + 128);
+    const res = runCapped(Buffer.byteLength(existing) + 64);
 
     expect(res.status).toBe(0);
     // Proof the append really did stop part way — without this the case

--- a/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
+++ b/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
@@ -16,9 +16,11 @@ import path from "node:path";
  * shipped to new boxes only — including not to the box whose agent produced the
  * incident.
  *
- * So an existing file is TOPPED UP with the one missing section, and never
- * overwritten. These run the block out of the shipped `.sh` rather than a copy,
- * so the test fails if the real script drifts.
+ * So an existing file is TOPPED UP with EVERY section it is missing, and never
+ * overwritten — one hand-added marker per section did not scale, and the box
+ * that proved it had never received the Coding agent section at all (TASK-706).
+ * These run the block out of the shipped `.sh` rather than a copy, so the test
+ * fails if the real script drifts.
  */
 
 // Starts a real process (bash / python3 / node / git): vitest's 5 s test and
@@ -259,7 +261,7 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
 
     const { stdout } = run();
 
-    expect(stdout).toContain("Appended the system-actions section");
+    expect(stdout).toMatch(/Appended to CLAWBOX\.md:.*System actions and restarts/);
     const after = readFileSync(guide, "utf-8");
     // The rule arrived...
     expect(after).toContain(HEADING);
@@ -278,43 +280,50 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
     const afterFirst = readFileSync(guide, "utf-8");
     const second = run();
 
-    expect(second.stdout).not.toContain("Appended the system-actions section");
+    expect(second.stdout).not.toMatch(/Appended to CLAWBOX\.md/);
     expect(readFileSync(guide, "utf-8")).toBe(afterFirst);
     expect(afterFirst.split(HEADING)).toHaveLength(2);
   });
 
-  it("takes only that section, not the ones that follow it in the template", () => {
+  it("appends each section on its own, bounded by the next heading", () => {
+    // The extraction is bounded by the NEXT `## ` heading, so every missing
+    // section arrives as its own block behind its own separator — never one
+    // heading carrying the body of the ones after it. With a multi-section
+    // top-up that invariant is what keeps the file readable rather than one
+    // run-on tail.
     const older = readFileSync(TEMPLATE, "utf-8").split(`\n---\n\n${HEADING}`)[0];
     writeFileSync(guide, older);
 
     run();
 
     const appended = readFileSync(guide, "utf-8").slice(older.length);
-    expect(appended).toContain(HEADING);
-    // The template's next heading must not have been dragged along.
-    expect(appended).not.toContain("## Coding agent");
-    expect(appended).not.toContain("## Remember the user's name");
-    // Nor the `---` rule that closes the section in the template: the append
-    // supplies its own leading separator, so carrying that one too ends the
+    for (const heading of ["## System actions and restarts", "## Coding agent (delegate a whole task)"]) {
+      expect(appended).toContain(`\n---\n\n${heading}\n`);
+    }
+    // And the template's own closing rule is not carried with them: the append
+    // supplies its own leading separator, so carrying that one too would end the
     // topped-up guide on a dangling horizontal rule.
     expect(appended.trimEnd().endsWith("---")).toBe(false);
   });
 
-  it("warns instead of appending an empty section when the template loses the heading", () => {
-    // The marker and the heading are two strings that have to stay in step. If
-    // the heading is renamed and the marker is not, the extraction comes back
-    // empty — appending the separator alone would report a success that added
-    // nothing, and would do it again on every gateway start.
+  it("follows a heading the template renames, instead of losing the section", () => {
+    // The old top-up matched ONE marker string that had to stay in step with the
+    // template's heading; a rename in the template silently stopped delivering
+    // the section, with a warning nobody sees. The headings now come out of the
+    // template itself, so a rename is simply a different heading to deliver —
+    // and the old name, which no template carries any more, is not invented.
     const older = readFileSync(TEMPLATE, "utf-8").split(`\n---\n\n${HEADING}`)[0];
     writeFileSync(guide, older);
     const renamed = path.join(dir, "renamed-template.md");
     writeFileSync(renamed, readFileSync(TEMPLATE, "utf-8").replace(HEADING, "## Restarts, renamed"));
 
-    const { stdout, stderr } = run(renamed);
+    const { stdout } = run(renamed);
 
-    expect(stdout).not.toContain("Appended the system-actions section");
-    expect(stderr).toContain("no longer carries");
-    expect(readFileSync(guide, "utf-8")).toBe(older);
+    const after = readFileSync(guide, "utf-8");
+    expect(stdout).toMatch(/Appended to CLAWBOX\.md:.*Restarts, renamed/);
+    expect(after).toContain("## Restarts, renamed");
+    expect(after).toContain("operator_approval");
+    expect(after).not.toContain(HEADING);
   });
 
   // `skipIf`, not an early return: a root container would otherwise report this
@@ -329,7 +338,7 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
     // that pre-start survived.
     const { stdout, stderr } = run();
 
-    expect(stdout).not.toContain("Appended the system-actions section");
+    expect(stdout).not.toMatch(/Appended to CLAWBOX\.md/);
     expect(stderr).toContain("could not append");
     // ...and nothing about a rollback. A write that failed at OPEN wrote
     // nothing, so warning that the file "may be cut mid-section" sends an
@@ -405,7 +414,7 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
     // runs it as ExecStartPre with no leading `-`).
     expect(res.status).toBe(0);
     expect(res.stderr).toContain("could not append");
-    expect(res.stdout).not.toContain("Appended the system-actions section");
+    expect(res.stdout).not.toMatch(/Appended to CLAWBOX\.md/);
     // ...and the file is back to what it was, marker and fragment both gone.
     expect(readFileSync(guide, "utf-8")).toBe(older);
   });
@@ -489,7 +498,7 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
     runCapped(Buffer.byteLength(older) + 64);
     const second = run();
 
-    expect(second.stdout).toContain("Appended the system-actions section");
+    expect(second.stdout).toMatch(/Appended to CLAWBOX\.md:.*System actions and restarts/);
     const after = readFileSync(guide, "utf-8");
     expect(after.startsWith(older)).toBe(true);
     // The paragraph that used to be the casualty.
@@ -498,16 +507,195 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
     expect(after.split(HEADING)).toHaveLength(2);
   });
 
-  it("leaves a guide that already carries the section untouched", () => {
-    const current = readFileSync(TEMPLATE, "utf-8");
-    writeFileSync(guide, current);
+  // TASK-706. Seed-if-missing plus one hand-added marker per section does not
+  // scale, and the cost was measured: the OpenClaw dev box's CLAWBOX.md is
+  // dated Aug 13 and carries five headings, so it has NEVER received the
+  // "## Coding agent (delegate a whole task)" section — which is how the agent
+  // learns that coding_agent_run / coding_agent_status / coding_agent_stop
+  // exist and what to say when they are not offered. Every box set up before
+  // that section landed is in the same state, silently. So the top-up appends
+  // EVERY `## ` section the file is missing, not one named one.
+  describe("tops a guide up to every section the template has", () => {
+    const headings = () =>
+      readFileSync(TEMPLATE, "utf-8")
+        .split("\n")
+        .map((l) => l.replace(/\r$/, ""))
+        .filter((l) => l.startsWith("## "));
 
-    const { stdout } = run();
+    it("gives an old guide every heading the shipped template carries", () => {
+      // A real pre-TASK-612 guide: the sections that box was seeded with, and
+      // nothing added since.
+      const older = readFileSync(TEMPLATE, "utf-8").split(`\n---\n\n${HEADING}`)[0];
+      writeFileSync(guide, older);
 
-    expect(stdout).not.toContain("Appended the system-actions section");
-    expect(stdout).not.toContain("Seeded CLAWBOX.md");
-    expect(readFileSync(guide, "utf-8")).toBe(current);
+      run();
+
+      const after = readFileSync(guide, "utf-8")
+        .split("\n")
+        .map((l) => l.replace(/\r$/, ""));
+      for (const heading of headings()) {
+        expect(after).toContain(heading);
+      }
+    });
+
+    it("names the Coding agent section specifically", () => {
+      // The one the measurement was about, and the one a per-section marker
+      // would still be missing today.
+      const older = readFileSync(TEMPLATE, "utf-8").split(`\n---\n\n${HEADING}`)[0];
+      writeFileSync(guide, older);
+
+      const { stdout } = run();
+
+      const after = readFileSync(guide, "utf-8");
+      expect(after).toContain("## Coding agent");
+      expect(after).toContain("coding_agent_run");
+      expect(stdout).toMatch(/Coding agent/);
+    });
+
+    it("adds each missing section exactly once, however many times the gateway starts", () => {
+      const older = readFileSync(TEMPLATE, "utf-8").split(`\n---\n\n${HEADING}`)[0];
+      writeFileSync(guide, older);
+
+      run();
+      const afterFirst = readFileSync(guide, "utf-8");
+      const second = run();
+
+      expect(readFileSync(guide, "utf-8")).toBe(afterFirst);
+      expect(second.stdout).not.toMatch(/Appended/);
+      for (const heading of headings()) {
+        expect(afterFirst.split(heading)).toHaveLength(2);
+      }
+    });
+
+    it("keeps the owner's own sections and their text", () => {
+      const older = readFileSync(TEMPLATE, "utf-8").split(`\n---\n\n${HEADING}`)[0];
+      writeFileSync(guide, `${older}\n\n## Owner's notes\n\nThe printer is on the shelf.\n`);
+
+      run();
+
+      const after = readFileSync(guide, "utf-8");
+      expect(after).toContain("The printer is on the shelf.");
+      expect(after).toContain("## Owner's notes");
+      expect(after.startsWith(older)).toBe(true);
+    });
+
+    it("does not accept a longer heading of the owner's as the template's section", () => {
+      // The marker is a WHOLE line, not a prefix. The discriminating fixture
+      // REPLACES the template's `## Skills` with a longer heading of the
+      // owner's: a substring match would call the section present and the box
+      // would never receive it. Adding the longer heading BESIDE the real one
+      // proves nothing — `## Skills` is a whole line either way.
+      const current = readFileSync(TEMPLATE, "utf-8");
+      writeFileSync(guide, current.replace("\n## Skills\n", "\n## Skills and other things\n"));
+
+      const { stdout } = run();
+
+      expect(stdout).toMatch(/Appended to CLAWBOX\.md:.*Skills/);
+      const after = readFileSync(guide, "utf-8");
+      expect(after).toContain("## Skills and other things");
+      expect(after.match(/^## Skills$/gm)).toHaveLength(1);
+    });
+
+    it("leaves a guide that already carries every section alone", () => {
+      const current = readFileSync(TEMPLATE, "utf-8");
+      writeFileSync(guide, `${current}\n\n## Skills and other things\n\nMine.\n`);
+
+      const { stdout } = run();
+
+      expect(stdout).not.toMatch(/Appended/);
+      expect(readFileSync(guide, "utf-8").match(/^## Skills$/gm)).toHaveLength(1);
+    });
+
+    it("says nothing about a guide that is already complete", () => {
+      const current = readFileSync(TEMPLATE, "utf-8");
+      writeFileSync(guide, current);
+
+      const { stdout } = run();
+
+      expect(stdout).not.toMatch(/Appended/);
+      // Nor re-seeded: a complete guide takes neither path.
+      expect(stdout).not.toContain("Seeded CLAWBOX.md");
+      expect(readFileSync(guide, "utf-8")).toBe(current);
+    });
+
+    // `skipIf`, like every other chmod case in this file: root ignores the mode
+    // bits, so `[ -r ]` is true, the file reads fine and there is nothing to
+    // assert. A root container would otherwise report this as a pass.
+    it.skipIf(process.getuid?.() === 0)("warns and changes nothing when the guide cannot be read", () => {
+      // `grep`/`awk` answer exit 2 on an unreadable file, which reads as
+      // "the heading is not there" — so a 0200 CLAWBOX.md was re-appended to on
+      // EVERY boot, growing without bound, while the file itself could never be
+      // checked. A file this block cannot read is a file it must not top up.
+      const older = readFileSync(TEMPLATE, "utf-8").split(`\n---\n\n${HEADING}`)[0];
+      writeFileSync(guide, older);
+      chmodSync(guide, 0o200);
+      let res: { status: number | null; stdout: string; stderr: string };
+      try {
+        res = runRaw();
+      } finally {
+        chmodSync(guide, 0o644);
+      }
+      expect(res.status).toBe(0);
+      // Anchored on the DESTINATION: `/could not read/` alone also matches the
+      // warning about an unreadable TEMPLATE, which is a different fault.
+      expect(res.stderr).toMatch(/could not read .*CLAWBOX\.md/);
+      expect(res.stdout).not.toMatch(/Appended/);
+      // The point of the guard: the file is untouched, not merely unreported.
+      expect(readFileSync(guide, "utf-8")).toBe(older);
+    });
+
+    it("says so when the shipped template carries no sections at all", () => {
+      // A truncated or zero-byte template from a half-finished deploy is
+      // readable, so the guard above passes and the loop runs zero times.
+      // Silence there is indistinguishable from "already complete" — the same
+      // shape as the defect this card exists to fix.
+      const older = readFileSync(TEMPLATE, "utf-8").split(`\n---\n\n${HEADING}`)[0];
+      writeFileSync(guide, older);
+      const empty = path.join(dir, "empty-template.md");
+      writeFileSync(empty, "# ClawBox Integration Guide\n\nNo sections here.\n");
+
+      const res = runRaw(empty);
+
+      expect(res.status).toBe(0);
+      expect(res.stderr).toMatch(/carries no '## ' headings/);
+      expect(res.stdout).not.toMatch(/Appended/);
+      expect(readFileSync(guide, "utf-8")).toBe(older);
+    });
+
+    it("does not enumerate a heading that lives inside a fenced block", () => {
+      // The template is markdown that documents markdown and shell. A `## ` line
+      // inside a ``` fence was harmless while one heading was named by hand;
+      // enumerated, it would become a phantom section appended to every box.
+      const fenced = path.join(dir, "fenced-template.md");
+      writeFileSync(
+        fenced,
+        [
+          "# Guide", "", "## Real section", "", "Body.", "",
+          "```markdown", "## Not a heading", "```", "",
+        ].join("\n"),
+      );
+      writeFileSync(guide, "# Guide\n\n## Real section\n\nBody.\n");
+
+      const { stdout } = runRaw(fenced);
+
+      expect(stdout).not.toMatch(/Appended/);
+      expect(readFileSync(guide, "utf-8")).not.toContain("Not a heading");
+    });
+
+    it("does not add a second copy of a section whose heading has trailing whitespace", () => {
+      // What a markdown hard line break, a prettier pass or a hand edit leaves.
+      // The old substring match tolerated it; a whole-line match must normalise
+      // what it now compares, or the box gains a permanent duplicate.
+      const current = readFileSync(TEMPLATE, "utf-8");
+      writeFileSync(guide, current.replace("\n## Skills\n", "\n## Skills \n"));
+
+      const { stdout } = run();
+
+      expect(stdout).not.toMatch(/Appended/);
+      expect(readFileSync(guide, "utf-8").match(/^## Skills */gm)).toHaveLength(1);
+    });
   });
+
 });
 
 /**
@@ -656,6 +844,48 @@ describe("gateway-pre-start puts the rule where the harness loads it", () => {
     expect(after).toContain(RULE);
     expect(after).toContain("operator_approval");
     expect(after.split(RULE)).toHaveLength(2);
+  });
+
+  it.skipIf(process.getuid?.() === 0)("does not grow an AGENTS.md it cannot read", () => {
+    // The same exit-2 conflation the CLAWBOX.md loop guards against, and worse
+    // here: mode 0200 denies the READ while permitting the WRITE, so `grep`
+    // answered "marker absent", both appends succeeded, and the file grew by
+    // ~1 KB on every boot — each one reported on stdout as a success. AGENTS.md
+    // is what the harness injects into every session, under a bootstrap
+    // character budget.
+    const existing = "# AGENTS\n\nBe helpful.\n";
+    writeFileSync(agents, existing);
+    chmodSync(agents, 0o200);
+    let first: { status: number | null; stdout: string; stderr: string };
+    let second: { status: number | null; stdout: string; stderr: string };
+    try {
+      first = runRaw();
+      second = runRaw();
+    } finally {
+      chmodSync(agents, 0o644);
+    }
+
+    expect(first.status).toBe(0);
+    expect(second.status).toBe(0);
+    expect(first.stdout).not.toMatch(/Appended/);
+    expect(second.stdout).not.toMatch(/Appended/);
+    expect(first.stderr).toMatch(/could not read .*AGENTS\.md/);
+    expect(readFileSync(agents, "utf-8")).toBe(existing);
+  });
+
+  it("does not take a longer heading of the owner's as its own marker", () => {
+    // Whole-line, not substring: an AGENTS.md that says "## ClawBox integration
+    // notes" is not carrying ClawBox's pointer, and a substring guard would
+    // withhold it forever.
+    const existing = "# AGENTS\n\n## ClawBox integration notes\n\nMine.\n";
+    writeFileSync(agents, existing);
+
+    const { stdout } = run();
+
+    expect(stdout).toContain("Appended CLAWBOX.md reference to AGENTS.md");
+    const after = readFileSync(agents, "utf-8");
+    expect(after.startsWith(existing)).toBe(true);
+    expect(after.match(/^## ClawBox integration$/gm)).toHaveLength(1);
   });
 
   it.skipIf(process.getuid?.() === 0)("does not stop the gateway when AGENTS.md cannot be written", () => {

--- a/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
+++ b/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
@@ -120,6 +120,18 @@ function runHelper(fn: string, file: string): string[] {
   return res.stdout.split("\n").filter((l) => l !== "");
 }
 
+/** The same call, for the helpers whose ANSWER is their exit status. */
+function helperStatus(fn: string, file: string): number | null {
+  const script = [
+    "set -euo pipefail",
+    `CLAWBOX_ROOT=${JSON.stringify(dir)}`,
+    `CLAWBOX_WORKSPACE=${JSON.stringify(path.join(dir, "no-such-workspace"))}`,
+    seedingBlock(),
+    `${fn} ${JSON.stringify(file)} || exit $?`,
+  ].join("\n");
+  return spawnSync("bash", ["-c", script], { encoding: "utf-8" }).status;
+}
+
 /** The same run, asserting the exit code the systemd unit demands. */
 function run(template = TEMPLATE, opts: { prelude?: string[] } = {}): { stdout: string; stderr: string } {
   const res = runRaw(template, opts);
@@ -588,6 +600,14 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
 
       expect(enumerated).toEqual(headings());
       expect(enumerated.length).toBeGreaterThanOrEqual(7);
+
+      // …and the equality above has to be earned, not reached by giving up. An
+      // enumerator whose fences do not balance hides nothing and returns every
+      // `## ` line — which is exactly `headings()`, so this case would go green
+      // over a template the block then REFUSES to top up from: no section
+      // reaches any box again, on every boot, with a journal line for a signal.
+      // Balance is what makes the agreement above mean anything.
+      expect(helperStatus("clawbox_fences_balanced", TEMPLATE)).toBe(0);
     });
 
     it("gives an old guide every heading the shipped template carries", () => {
@@ -744,10 +764,47 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
       );
       writeFileSync(guide, "# Guide\n\n## Real section\n\nBody.\n");
 
-      const { stdout } = runRaw(fenced);
+      // `run`, not `runRaw`: with no exit-status check a block that failed
+      // outright would print no `Appended` line and touch no file, and both
+      // assertions below would pass over it.
+      const { stdout } = run(fenced);
 
       expect(stdout).not.toMatch(/Appended/);
       expect(readFileSync(guide, "utf-8")).not.toContain("Not a heading");
+    });
+
+    it("does not pair a fence with a delimiter of the other character", () => {
+      // ``` and ~~~ open different fences, and a delimiter closes only one of
+      // its own character. Kept in a single list they pair by position, so a
+      // ``` block that QUOTES a ~~~ example has its opener paired with the
+      // quoted ~~~ — and the lines between the two quoted delimiters fall
+      // outside every pair. A heading the template only quotes is then
+      // enumerated as a real section and appended to every box, permanently,
+      // and the example above it is cut in half by the separator. Measured on
+      // the fixture below: "Appended to CLAWBOX.md: First, Not a heading,
+      // Second", exit 0, nothing on stderr. This is the D-H1 mis-pairing one
+      // delimiter character over.
+      const mixed = path.join(dir, "mixed-fence-template.md");
+      writeFileSync(
+        mixed,
+        [
+          "# Guide", "",
+          "## First", "", "Body.", "",
+          "```markdown", "~~~", "## Not a heading", "~~~", "```", "",
+          "## Second", "", "Body two.", "",
+        ].join("\n"),
+      );
+      writeFileSync(guide, "# Guide\n");
+
+      const { stdout, stderr } = run(mixed);
+
+      expect(stdout).toMatch(/Appended to CLAWBOX\.md: First, Second$/m);
+      expect(stderr).not.toMatch(/WARNING/);
+      // The quoted block arrives whole, inside `## First`, rather than split
+      // across a separator the phantom section introduced.
+      expect(readFileSync(guide, "utf-8")).toContain(
+        "```markdown\n~~~\n## Not a heading\n~~~\n```\n",
+      );
     });
 
     it("delivers a section the guide only mentions inside a fenced block", () => {
@@ -795,7 +852,14 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
 
       expect(stdout).toMatch(/Appended to CLAWBOX\.md:.*First.*Second.*Third/);
       expect(stderr).not.toMatch(/WARNING/);
-      expect(readFileSync(guide, "utf-8").match(/^## (First|Second|Third)$/gm)).toHaveLength(3);
+      // As three SECTIONS, each behind its own separator — not three heading
+      // lines. Counting headings alone passes on the pre-fix block: it delivers
+      // "First, Third", and `## Second` still turns up in the file because
+      // `## First`'s extraction over-ran to the next heading it could see and
+      // dragged it along. The separator is what says it arrived as itself.
+      for (const heading of ["First", "Second", "Third"]) {
+        expect(readFileSync(guide, "utf-8")).toContain(`\n---\n\n## ${heading}\n`);
+      }
     });
 
     it("refuses to top up from a template whose fences do not balance", () => {
@@ -1097,6 +1161,11 @@ describe("gateway-pre-start puts the rule where the harness loads it", () => {
     expect(first.stdout).not.toMatch(/Appended/);
     expect(second.stdout).not.toMatch(/Appended/);
     expect(first.stderr).toMatch(/could not read .*AGENTS\.md while looking for/);
+    // ONE line, not one per marker. Both calls ask about the same file for the
+    // same reason, and a duplicate reads as two faults to an operator triaging
+    // a failing eMMC by its journal. The old per-marker blocks had this
+    // property and hoisting them into a shared wrapper dropped it.
+    expect(first.stderr.match(/could not read .*AGENTS\.md while looking for/g)).toHaveLength(1);
     expect(readFileSync(agents, "utf-8")).toBe(existing);
   });
 

--- a/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
+++ b/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
@@ -690,6 +690,24 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
       expect(readFileSync(guide, "utf-8")).not.toContain("Not a heading");
     });
 
+    it("delivers a section the guide only mentions inside a fenced block", () => {
+      // The destination side of the same rule. A guide that quotes a heading
+      // inside a ``` fence — an owner pasting an example, or the guide
+      // documenting itself — does not CARRY that section, and reading the
+      // fenced line as the marker would withhold it for good.
+      const current = readFileSync(TEMPLATE, "utf-8");
+      writeFileSync(
+        guide,
+        current.replace("\n## Skills\n", "\n```markdown\n## Skills\n```\n"),
+      );
+
+      const { stdout } = run();
+
+      expect(stdout).toMatch(/Appended to CLAWBOX\.md:.*Skills/);
+      // The real one arrives; the quoted one is left where it was.
+      expect(readFileSync(guide, "utf-8").match(/^## Skills *$/gm)).toHaveLength(2);
+    });
+
     it("does not add a second copy of a section whose heading has trailing whitespace", () => {
       // What a markdown hard line break, a prettier pass or a hand edit leaves.
       // The old substring match tolerated it; a whole-line match must normalise
@@ -882,6 +900,20 @@ describe("gateway-pre-start puts the rule where the harness loads it", () => {
     expect(first.stdout).not.toMatch(/Appended/);
     expect(second.stdout).not.toMatch(/Appended/);
     expect(first.stderr).toMatch(/could not read .*AGENTS\.md/);
+    expect(readFileSync(agents, "utf-8")).toBe(existing);
+  });
+
+  it("does not re-append to a CRLF AGENTS.md on every boot", () => {
+    // A whole-line match that is byte-exact misses `## ClawBox integration\r`,
+    // so a CRLF file was appended to on EVERY boot and grew without bound —
+    // the failure whole-line matching was introduced to prevent, not cause.
+    const existing = "# AGENTS\r\n\r\n## ClawBox integration\r\n\r\nSee `CLAWBOX.md`.\r\n"
+      + "## System actions on this ClawBox\r\n\r\nMine.\r\n";
+    writeFileSync(agents, existing);
+
+    const { stdout } = run();
+
+    expect(stdout).not.toMatch(/Appended/);
     expect(readFileSync(agents, "utf-8")).toBe(existing);
   });
 

--- a/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
+++ b/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
@@ -100,6 +100,26 @@ function runRaw(
   return { status: res.status, stdout: res.stdout, stderr: res.stderr };
 }
 
+/**
+ * Call ONE function out of the shipped block and return its stdout lines.
+ *
+ * The block is sourced, not re-implemented: these cases are about what the real
+ * `.sh` does, and a copy of an awk program in TypeScript can only ever agree
+ * with itself.
+ */
+function runHelper(fn: string, file: string): string[] {
+  const script = [
+    "set -euo pipefail",
+    `CLAWBOX_ROOT=${JSON.stringify(dir)}`,
+    `CLAWBOX_WORKSPACE=${JSON.stringify(path.join(dir, "no-such-workspace"))}`,
+    seedingBlock(),
+    `${fn} ${JSON.stringify(file)}`,
+  ].join("\n");
+  const res = spawnSync("bash", ["-c", script], { encoding: "utf-8" });
+  if (res.status !== 0) throw new Error(`${fn} exited ${res.status}\n${res.stderr}`);
+  return res.stdout.split("\n").filter((l) => l !== "");
+}
+
 /** The same run, asserting the exit code the systemd unit demands. */
 function run(template = TEMPLATE, opts: { prelude?: string[] } = {}): { stdout: string; stderr: string } {
   const res = runRaw(template, opts);
@@ -262,6 +282,17 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
     expect(writes.join("\n")).toMatch(/truncate -s/);
     expect(writes.join("\n")).toMatch(/os\.truncate/);
     expect(unguarded).toEqual([]);
+
+    // The AGENTS.md wrapper is called BARE, twice, at the top level of a block
+    // running under `set -euo pipefail` — so its contract is "never fatal", and
+    // the only thing holding that is what it returns. Mutation-proved: a
+    // `return 7` inside it takes pre-start down with exit 7, over an advisory
+    // sentence, and nothing else in this file would notice.
+    const helper = seedingBlock().slice(seedingBlock().indexOf("clawbox_agents_append() {"));
+    const body = helper.slice(0, helper.indexOf("\n  }\n"));
+    const returns = [...body.matchAll(/^\s*return\b.*$/gm)].map((m) => m[0].trim());
+    expect(returns.length).toBeGreaterThan(0);
+    expect(returns.filter((r) => r !== "return 0")).toEqual([]);
   });
 
   it("appends the system-actions section to a guide written before it existed", () => {
@@ -527,19 +558,34 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
   // that section landed is in the same state, silently. So the top-up appends
   // EVERY `## ` section the file is missing, not one named one.
   describe("tops a guide up to every section the template has", () => {
-    // Fenced lines excluded, exactly as the script excludes them: the template
-    // documents markdown, so a ``` block containing a `## ` line would make
-    // these cases demand a section the script correctly refuses to enumerate.
-    const headings = () => {
-      const out: string[] = [];
-      let fenced = false;
-      for (const raw of readFileSync(TEMPLATE, "utf-8").split("\n")) {
-        const line = raw.replace(/[ \t\r]+$/, "");
-        if (/^(```|~~~)/.test(line)) { fenced = !fenced; continue; }
-        if (!fenced && /^## +[^ ]/.test(line)) out.push(line);
-      }
-      return out;
-    };
+    /**
+     * Every `## ` line in the shipped template, INDEPENDENTLY of the script.
+     *
+     * Deliberately no fence logic: a helper that re-implemented the script's
+     * rule would agree with it whatever it did, which is how a fence bug on the
+     * source side stayed invisible through a whole review round. The case below
+     * asserts that the shipped enumerator answers exactly this, so the two
+     * derivations have to agree — and if the template ever does quote a `## `
+     * line inside a fence, that case fails and is the place to decide about it.
+     */
+    const headings = () => readFileSync(TEMPLATE, "utf-8")
+      .split("\n")
+      .map((raw) => raw.replace(/[ \t\r]+$/, ""))
+      .filter((line) => /^## +[^ ]/.test(line));
+
+    it("enumerates exactly the sections the shipped template declares", () => {
+      // The assertion the fence rule has to survive. A closing fence indented
+      // by up to three spaces is valid CommonMark and renders correctly on
+      // GitHub; matched only at column 0 it goes unseen, the next opener pairs
+      // with the previous one, and the prose between two examples — headings
+      // and all — is treated as fenced and enumerated by nothing. Measured on
+      // this template with two such closers: two real sections were delivered
+      // to no box, exit 0, nothing on stderr.
+      const enumerated = runHelper("clawbox_guide_headings", TEMPLATE);
+
+      expect(enumerated).toEqual(headings());
+      expect(enumerated.length).toBeGreaterThanOrEqual(7);
+    });
 
     it("gives an old guide every heading the shipped template carries", () => {
       // A real pre-TASK-612 guide: the sections that box was seeded with, and
@@ -719,32 +765,69 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
       expect(readFileSync(guide, "utf-8").match(/^## Skills *$/gm)).toHaveLength(2);
     });
 
-    it("still delivers every section when the template's fences do not balance", () => {
-      // An indented closing fence is valid CommonMark — it is what a fence
-      // inside a list item looks like — and it does not match at column 0. A
-      // fence rule that toggled as it went would leave the rest of the template
-      // "fenced": section after section would fail to arrive, exit 0, and not
-      // one word about it, which is this card's own defect on the SOURCE side.
-      // The "no '## ' headings at all" warning cannot catch it either; it fires
-      // only when the count reaches zero.
-      const odd = path.join(dir, "odd-fence-template.md");
+    it("pairs an indented closing fence instead of swallowing the sections after it", () => {
+      // CommonMark lets a closing fence be indented up to three spaces, and it
+      // renders correctly on GitHub — so it is invisible in review. Matched at
+      // column 0 only, the closer goes unseen, the NEXT opener pairs with the
+      // previous opener, and everything between two examples is treated as
+      // fenced. The headings in that region are then enumerated by nothing and
+      // delivered to no box, with exit 0 and nothing on stderr: this card's own
+      // defect, on the source side, arriving through the rule written to
+      // prevent it.
+      const odd = path.join(dir, "indented-fence-template.md");
       writeFileSync(
         odd,
         [
-          "# Guide", "", "## First", "", "Body.", "",
-          "```text", "example", "  ```", "",
+          "# Guide", "",
+          "## First", "", "Body.", "",
+          "```text", "example one", "  ```", "",
           "## Second", "", "Body two.", "",
+          "```text", "example two", "  ```", "",
+          "## Third", "", "Body three.", "",
         ].join("\n"),
       );
       writeFileSync(guide, "# Guide\n");
 
       const { stdout, stderr } = run(odd);
 
-      expect(stdout).toMatch(/Appended to CLAWBOX\.md:.*First.*Second/);
+      expect(stdout).toMatch(/Appended to CLAWBOX\.md:.*First.*Second.*Third/);
       expect(stderr).not.toMatch(/WARNING/);
-      const after = readFileSync(guide, "utf-8");
-      expect(after).toContain("Body two.");
-      expect(after.match(/^## (First|Second)$/gm)).toHaveLength(2);
+      expect(readFileSync(guide, "utf-8").match(/^## (First|Second|Third)$/gm)).toHaveLength(3);
+    });
+
+    it("refuses to top up from a template whose fences do not balance", () => {
+      // A template we cannot parse must not be merged from: every `## ` line
+      // quoted inside its examples would be enumerated as a section and
+      // extracted from inside the fence to the next such line, so the real
+      // section above it is truncated AND a phantom one is appended — to every
+      // box, permanently. Refusing is the same call the "no headings at all"
+      // arm makes about the same kind of half-deployed file.
+      const broken = path.join(dir, "unbalanced-template.md");
+      writeFileSync(
+        broken,
+        ["# Guide", "", "## First", "", "```text", "## Not a heading", "", "## Second", "", "Body.", ""].join("\n"),
+      );
+      writeFileSync(guide, "# Guide\n");
+
+      const { stdout, stderr } = run(broken);
+
+      expect(stdout).not.toMatch(/Appended/);
+      expect(stderr).toMatch(/fences in .* do not balance/);
+      expect(readFileSync(guide, "utf-8")).toBe("# Guide\n");
+    });
+
+    it("says so when the guide's own fences do not balance", () => {
+      // Read as prose, which on the DESTINATION means a heading quoted inside
+      // one counts as present and that section is withheld — silently, with no
+      // other guard that would catch it. The operator gets the sentence.
+      const current = readFileSync(TEMPLATE, "utf-8");
+      const cut = current.indexOf("\n## Coding agent");
+      writeFileSync(guide, `${current.slice(0, cut)}\n\n\`\`\`\n`);
+
+      const { stderr } = run();
+
+      expect(stderr).toMatch(/fences in .*CLAWBOX\.md do not balance/);
+      expect(stderr).toMatch(/read as present and its section withheld/);
     });
 
     it("says so when CLAWBOX.md is a directory, instead of seeding into it", () => {

--- a/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
+++ b/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { spawnSync } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -78,20 +78,31 @@ let guide: string;
  * of these tests is what those options do to a failure.
  *
  * `template` overrides the guide the block copies from, for the case where the
- * template no longer carries the section the marker names.
+ * template no longer carries the section the marker names. `prelude` puts lines
+ * in front of the block — shell functions that shadow a binary, for the cases
+ * where what fails is the tool the block reaches for.
  */
-function runRaw(template = TEMPLATE): { status: number | null; stdout: string; stderr: string } {
+function runRaw(
+  template = TEMPLATE,
+  opts: { prelude?: string[] } = {},
+): { status: number | null; stdout: string; stderr: string } {
   const root = mkdtempSync(path.join(dir, "root-"));
   mkdirSync(path.join(root, "config"), { recursive: true });
   writeFileSync(path.join(root, "config/clawbox-workspace-guide.md"), readFileSync(template, "utf-8"));
-  const script = `set -euo pipefail\nCLAWBOX_ROOT=${JSON.stringify(root)}\nCLAWBOX_WORKSPACE=${JSON.stringify(workspace)}\n${seedingBlock()}`;
+  const script = [
+    "set -euo pipefail",
+    ...(opts.prelude ?? []),
+    `CLAWBOX_ROOT=${JSON.stringify(root)}`,
+    `CLAWBOX_WORKSPACE=${JSON.stringify(workspace)}`,
+    seedingBlock(),
+  ].join("\n");
   const res = spawnSync("bash", ["-c", script], { encoding: "utf-8" });
   return { status: res.status, stdout: res.stdout, stderr: res.stderr };
 }
 
 /** The same run, asserting the exit code the systemd unit demands. */
-function run(template = TEMPLATE): { stdout: string; stderr: string } {
-  const res = runRaw(template);
+function run(template = TEMPLATE, opts: { prelude?: string[] } = {}): { stdout: string; stderr: string } {
+  const res = runRaw(template, opts);
   if (res.status !== 0) {
     throw new Error(`pre-start block exited ${res.status}\n${res.stdout}\n${res.stderr}`);
   }
@@ -630,7 +641,7 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
     // bits, so `[ -r ]` is true, the file reads fine and there is nothing to
     // assert. A root container would otherwise report this as a pass.
     it.skipIf(process.getuid?.() === 0)("warns and changes nothing when the guide cannot be read", () => {
-      // `grep`/`awk` answer exit 2 on an unreadable file, which reads as
+      // `awk` answers exit 2 on an unreadable file, which reads as
       // "the heading is not there" — so a 0200 CLAWBOX.md was re-appended to on
       // EVERY boot, growing without bound, while the file itself could never be
       // checked. A file this block cannot read is a file it must not top up.
@@ -706,6 +717,49 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
       expect(stdout).toMatch(/Appended to CLAWBOX\.md:.*Skills/);
       // The real one arrives; the quoted one is left where it was.
       expect(readFileSync(guide, "utf-8").match(/^## Skills *$/gm)).toHaveLength(2);
+    });
+
+    it("still delivers every section when the template's fences do not balance", () => {
+      // An indented closing fence is valid CommonMark — it is what a fence
+      // inside a list item looks like — and it does not match at column 0. A
+      // fence rule that toggled as it went would leave the rest of the template
+      // "fenced": section after section would fail to arrive, exit 0, and not
+      // one word about it, which is this card's own defect on the SOURCE side.
+      // The "no '## ' headings at all" warning cannot catch it either; it fires
+      // only when the count reaches zero.
+      const odd = path.join(dir, "odd-fence-template.md");
+      writeFileSync(
+        odd,
+        [
+          "# Guide", "", "## First", "", "Body.", "",
+          "```text", "example", "  ```", "",
+          "## Second", "", "Body two.", "",
+        ].join("\n"),
+      );
+      writeFileSync(guide, "# Guide\n");
+
+      const { stdout, stderr } = run(odd);
+
+      expect(stdout).toMatch(/Appended to CLAWBOX\.md:.*First.*Second/);
+      expect(stderr).not.toMatch(/WARNING/);
+      const after = readFileSync(guide, "utf-8");
+      expect(after).toContain("Body two.");
+      expect(after.match(/^## (First|Second)$/gm)).toHaveLength(2);
+    });
+
+    it("says so when CLAWBOX.md is a directory, instead of seeding into it", () => {
+      // `-f` alone answers "seed it" about a directory and `install SRC DIR`
+      // copies INTO it: a "Seeded CLAWBOX.md" success line on every boot,
+      // forever, with no guide on the box at all.
+      mkdirSync(guide, { recursive: true });
+
+      const first = run();
+      const second = run();
+
+      expect(first.stdout).not.toMatch(/Seeded|Appended/);
+      expect(second.stdout).not.toMatch(/Seeded|Appended/);
+      expect(first.stderr).toMatch(/exists and is not a regular file/);
+      expect(readdirSync(guide)).toEqual([]);
     });
 
     it("does not top a guide up again and again below a stray fence", () => {
@@ -935,6 +989,28 @@ describe("gateway-pre-start puts the rule where the harness loads it", () => {
     const { stdout } = run();
 
     expect(stdout).not.toMatch(/Appended/);
+    expect(readFileSync(agents, "utf-8")).toBe(existing);
+  });
+
+  it("does not grow an AGENTS.md whose marker check could not run", () => {
+    // The helper answers 0 present / 1 absent / 2 could not be read, and `!`
+    // collapses that to two: everything non-zero becomes "absent" and the block
+    // appends. `-r` closes only the measured mode-0200 door — an EIO on a
+    // failing eMMC, or `awk` missing from a stripped rootfs, walks straight
+    // past it and adds ~1 KB per boot to the file the harness injects into
+    // every session, each one printed as a success.
+    const existing = "# AGENTS\n\nBe helpful.\n";
+    writeFileSync(agents, existing);
+
+    const first = runRaw(TEMPLATE, { prelude: ["awk() { return 2; }"] });
+    const second = runRaw(TEMPLATE, { prelude: ["awk() { return 2; }"] });
+
+    // Boot safety first: this runs as ExecStartPre with no leading `-`.
+    expect(first.status).toBe(0);
+    expect(second.status).toBe(0);
+    expect(first.stdout).not.toMatch(/Appended/);
+    expect(second.stdout).not.toMatch(/Appended/);
+    expect(first.stderr).toMatch(/could not read .*AGENTS\.md while looking for/);
     expect(readFileSync(agents, "utf-8")).toBe(existing);
   });
 

--- a/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
+++ b/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
@@ -121,13 +121,14 @@ function runHelper(fn: string, file: string): string[] {
 }
 
 /** The same call, for the helpers whose ANSWER is their exit status. */
-function helperStatus(fn: string, file: string): number | null {
+function helperStatus(fn: string, file: string, ...args: string[]): number | null {
+  const call = [fn, file, ...args].map((a) => JSON.stringify(a)).join(" ");
   const script = [
     "set -euo pipefail",
     `CLAWBOX_ROOT=${JSON.stringify(dir)}`,
     `CLAWBOX_WORKSPACE=${JSON.stringify(path.join(dir, "no-such-workspace"))}`,
     seedingBlock(),
-    `${fn} ${JSON.stringify(file)} || exit $?`,
+    `${call} || exit $?`,
   ].join("\n");
   return spawnSync("bash", ["-c", script], { encoding: "utf-8" }).status;
 }
@@ -606,8 +607,10 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
       // `## ` line — which is exactly `headings()`, so this case would go green
       // over a template the block then REFUSES to top up from: no section
       // reaches any box again, on every boot, with a journal line for a signal.
-      // Balance is what makes the agreement above mean anything.
-      expect(helperStatus("clawbox_fences_balanced", TEMPLATE)).toBe(0);
+      // Balance is what makes the agreement above mean anything, and it is
+      // asked the way the top-up asks it about the template: `strict`, the
+      // reading `clawbox_guide_headings` itself uses.
+      expect(helperStatus("clawbox_fences_balanced", TEMPLATE, "strict")).toBe(0);
     });
 
     it("gives an old guide every heading the shipped template carries", () => {
@@ -860,6 +863,45 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
       for (const heading of ["First", "Second", "Third"]) {
         expect(readFileSync(guide, "utf-8")).toContain(`\n---\n\n## ${heading}\n`);
       }
+    });
+
+    it("delivers the section below an example closed by an info-string delimiter", () => {
+      // CommonMark's third closer rule: a CLOSING fence may not carry an info
+      // string, so "```md" inside a "```text" example is content, not the end
+      // of it. Without the rule the opener pairs with that quoted line, the
+      // pairing still comes out even — so nothing warns — and the heading below
+      // is enumerated by nothing. Measured on this fixture before the rule:
+      //
+      //   Appended to CLAWBOX.md: First          ← exit 0, nothing on stderr
+      //
+      // `## Real Heading` reaching no box, silently, which is this card's own
+      // defect arriving through the fence rule written to prevent it. The rule
+      // is applied to the TEMPLATE only — on the owner's own files the lenient
+      // reading is the one that cannot re-append a section on every boot, which
+      // the stray-fence case below pins.
+      const info = path.join(dir, "info-closer-template.md");
+      writeFileSync(
+        info,
+        [
+          "# Guide", "",
+          "## First", "", "Body one.", "",
+          "```text", "example", "```md", "still inside the example", "```", "",
+          "## Real Heading", "", "Body two.", "",
+          "```py", "code", "```js", "still inside the example", "```", "",
+        ].join("\n"),
+      );
+      writeFileSync(guide, "# Guide\n");
+
+      const { stdout, stderr } = run(info);
+
+      expect(stdout).toMatch(/Appended to CLAWBOX\.md: First, Real Heading$/m);
+      expect(stderr).not.toMatch(/WARNING/);
+      expect(readFileSync(guide, "utf-8")).toContain("\n---\n\n## Real Heading\n");
+      // …and the example it sits below arrived whole, rather than cut where the
+      // mis-paired closer put a separator.
+      expect(readFileSync(guide, "utf-8")).toContain(
+        "```text\nexample\n```md\nstill inside the example\n```\n",
+      );
     });
 
     it("refuses to top up from a template whose fences do not balance", () => {
@@ -1126,6 +1168,38 @@ describe("gateway-pre-start puts the rule where the harness loads it", () => {
     expect(second.stdout).not.toMatch(/Appended/);
     expect(first.stderr).toMatch(/could not read .*AGENTS\.md/);
     expect(readFileSync(agents, "utf-8")).toBe(existing);
+  });
+
+  it("says so when AGENTS.md is not a regular file, instead of skipping it in silence", () => {
+    // `-f` alone reads a DIRECTORY in AGENTS.md's place as "there is no
+    // AGENTS.md", so both blocks were skipped with exit 0 and no output at all,
+    // boot after boot, and the pointer and the rule never reached the file the
+    // harness injects into every session. The CLAWBOX.md sibling was made loud
+    // about the same shape; this is that guard's other half.
+    mkdirSync(agents, { recursive: true });
+
+    const first = run();
+    const second = run();
+
+    expect(first.stdout).not.toMatch(/Appended/);
+    expect(second.stdout).not.toMatch(/Appended/);
+    expect(first.stderr).toMatch(/AGENTS\.md exists and is not a regular file/);
+    // Nothing was written INTO the directory either.
+    expect(readdirSync(agents)).toEqual([]);
+  });
+
+  it("says so when AGENTS.md's own fences do not balance", () => {
+    // Read as prose, a marker quoted inside a fence counts as present and its
+    // block is withheld — for good, on the one file the harness loads every
+    // session. Nothing else here would catch it, so the operator gets the
+    // sentence rather than silence. The block is still delivered, because the
+    // markers are genuinely absent from this file.
+    writeFileSync(agents, "# AGENTS\n\nBe helpful.\n\n```\n");
+
+    const { stderr } = run();
+
+    expect(stderr).toMatch(/fences in .*AGENTS\.md do not balance/);
+    expect(stderr).toMatch(/read as present and its block withheld/);
   });
 
   it("does not re-append to a CRLF AGENTS.md on every boot", () => {


### PR DESCRIPTION
**TASK-706** — a box's CLAWBOX.md is frozen at the sections it was seeded with; the Coding agent
section has never reached a single live box.

> **#639 (TASK-707) has merged** (beta `1eaac8bb`) and this branch is rebased on top of it: the
> stale three-commit copy of it dropped out as already-applied and the eight commits here are this
> card's alone. #639's rollback helper is what makes a seven-section boot safe — a full disk is that
> many more chances to leave a heading on a fragment — and the reconciliation of the two is written
> up under *Second finishing round* below.

## Customer-visible symptom

The agent does not know it can delegate. `## Coding agent (delegate a whole task)` is what tells it
`coding_agent_run` / `coding_agent_status` / `coding_agent_stop` exist and what to say when they are
not offered. Measured read-only on the OpenClaw dev box (2026-09-03): its CLAWBOX.md is dated
**Aug 13, 5411 bytes, five headings** — Skills, Browser, Apps and UI, File-system and network,
Remember the user's name. The shipped template has seven. Every box set up before a section landed
is in the same state, silently.

## Cause

`gateway-pre-start.sh` seeds the template only when the file is absent — deliberately, so an
owner's or the agent's edits survive a gateway start — and then topped an existing file up with
**one hand-named section** behind a `grep -qF` marker. TASK-612's rule reached the field only
because somebody added a marker for it by hand. One marker per section does not scale, and nothing
reported the sections that never arrived.

## Fix — option (b) from the card

Every `## ` heading in the shipped template that the box's file does not carry is appended, in
template order, each behind its own separator and bounded by the next heading. There is no marker
list any more: **the heading is the marker**.

- The comparison is **whole-line**, with trailing whitespace and CR normalised on both sides. A
  guide that says `## Skills and other things` is not carrying `## Skills` (the old substring match
  said it was, and would have withheld the section forever); a guide that says `## Skills ` is, and
  does not get a permanent duplicate.
- **One fence rule, one prologue, all four helpers.** `## ` lines inside a fenced block are not
  headings — not when the template is enumerated, not when the destination is searched, not when a
  section is extracted. A delimiter is a ``` or ~~~ run indented by at most three spaces, and it
  closes only a fence opened with the same character by a run at least as long; a fence hides only
  what it **closes**, so a file with an opener that never closes is read as prose rather than
  tracked, and said so about. These are files the owner and the agent both edit, and both directions
  of getting it wrong are this card's own defect — on the destination every heading after a stray
  delimiter is "missing", the copy appended lands in the fenced region too, and the file grows on
  **every boot**; on the template the headings simply stop being enumerated and the box is told
  nothing. The one deliberate asymmetry — CommonMark's "a closer carries no info string", applied to
  our template and not to the owner's files — is measured and argued under *A third review pass*.
- The destination helper answers **three** things, not two: present, absent, and *could not be
  read* — and every call site branches on all three. `awk` answers 2 for a file it cannot open, and
  reading that as "absent" is how an unreadable file gets appended to.
- A template that is readable but carries **no headings at all** — truncated or zero-byte from a
  half-finished deploy — says so.
- A destination that stops being readable **mid-loop** stops the loop instead of judging every
  remaining section missing.
- A `CLAWBOX.md` that exists and is **not a regular file** says so instead of being seeded into.
  `[ ! -f ]` is true of a directory and `install SRC DIR` copies *into* it: two boots, two
  "Seeded CLAWBOX.md" success lines, and no guide on the box, forever.

### The trade, stated

An owner who deliberately **deleted** a section gets it back on the next gateway start. The card
names this and chooses it: the alternative is what the field has today — sections that never arrive
at all, with nothing that says so. Whole-line matching cuts both ways and both are the trade:
`## Skills and other things` no longer satisfies `## Skills`, and a heading the agent **demoted** to
`### Skills` no longer satisfies it either, so such a box gets one copy of the section back — once,
because the appended copy is found on the next boot.

## Sibling call sites

The two AGENTS.md blocks in the same body had the identical defect **and worse**. `grep` answers
exit 2 on a file it cannot read, which reads as "the marker is absent" — and mode 0200 denies the
read while *permitting* the write. Simulated, three boots on a 0200 AGENTS.md:

```
--- boot 1 ---  AGENTS.md 1107 bytes, pointer ×1, rule ×1   (both reported as successes)
--- boot 2 ---  AGENTS.md 2193 bytes, pointer ×2, rule ×2
--- boot 3 ---  AGENTS.md 3279 bytes, pointer ×3, rule ×3
```

1086 bytes per boot, forever, in the file the harness injects into **every** session under
`agents.defaults.bootstrapTotalMaxChars`. Both blocks now sit behind one `[ -f ] && [ -r ]` test and
one `case` over the helper's three answers, and both match their marker whole-line through the same
helper the guide loop uses.

## Harness first

Checked the pinned core (2026.8.1). What the harness **does** own:

- `agent:bootstrap`, with a mutable `bootstrapFiles` array whose records carry an optional
  `content` (`docs/automation/hooks.md`) — the native way to put a file in front of the model at
  every session start, without writing to an owner-personalised file at all.
- Declarative delivery: `workspace.bootstrapFiles` / `workspace.files` in a claw package
  (`docs/cli/claws.md`), and `openclaw setup --workspace <path>`, which recreates *missing* defaults
  without overwriting existing files (`docs/concepts/agent-workspace.md`).

What it does **not** own is **section-level merge into an already-edited markdown file**, which is
what this card asks for — so this loop is not a re-implementation. But **both** AGENTS.md blocks are
a hand-rolled `agent:bootstrap`, and retiring them in favour of the hook would delete the marker
matching, the readability guards *and* the rollback helper outright. Recorded on the run's Found
list rather than folded in here.

## RED

This branch's test file, run against unmodified `origin/beta` (`81c58a01`, which carries #639):

```
 × leaves no write in the seeding block unguarded, whatever the uid
 × appends the system-actions section to a guide written before it existed
 × appends each section on its own, bounded by the next heading
 × follows a heading the template renames, instead of losing the section
 × appends the whole section on the next boot after a part-way write
 × enumerates exactly the sections the shipped template declares
 × gives an old guide every heading the shipped template carries
 × names the Coding agent section specifically
 × adds each missing section exactly once, however many times the gateway starts
 × does not accept a longer heading of the owner's as the template's section
 × warns and changes nothing when the guide cannot be read
 × says so when the shipped template carries no sections at all
 × delivers a section the guide only mentions inside a fenced block
 × pairs an indented closing fence instead of swallowing the sections after it
 × does not pair a fence with a delimiter of the other character
 × refuses to top up from a template whose fences do not balance
 × says so when the guide's own fences do not balance
 × says so when CLAWBOX.md is a directory, instead of seeding into it
 × does not top a guide up again and again below a stray fence
 × does not grow an AGENTS.md it cannot read
 × does not grow an AGENTS.md whose marker check could not run
 × does not take a marker quoted inside a fence as the marker
 × does not take a longer heading of the owner's as its own marker

 Tests  22 failed | 26 passed (48)
```

One of them in full, since it is the finding this round turned on:

```
 FAIL  … > pairs an indented closing fence instead of swallowing the sections after it
 AssertionError: expected '' to match /Appended to CLAWBOX\.md:.*First.*Seco…/
 - Expected: /Appended to CLAWBOX\.md:.*First.*Second.*Third/
 + Received: ""
```

## GREEN

```
 gateway-pre-start-workspace-guide.test.ts
   + gateway-prestart-onboarding.test.ts
   + clawbox-workspace-guide.test.ts                             → 91 passed / 3 files
 npx vitest run --project unit src/tests/unit/gateway-pre-start
   + clawbox-workspace-guide.test.ts                             → 17 files, 367 passed
 npx tsc --noEmit                                                → exit 0
 npx eslint <the changed test file>                              → exit 0
```

## Finishing round (2026-09-05)

Rebased onto fresh `origin/beta` (54 commits of drift; no overlap with the workspace-guide block).
The three CodeRabbit threads were addressed, and a second Opus review pass found two HIGHs in the
first revision of that fix — both are closed here, each proved by executing the shipped block:

- **The fence rule was applied on the discovery side only.** CodeRabbit's finding, and the fix went
  further than the thread: rather than a second copy of the rule in the destination helper, all
  three helpers now share one `CLAWBOX_FENCE_AWK` prologue. The review found the *source* side had
  the mirror defect — a naive `fence = !fence` toggle, so one indented closing fence in the template
  (valid CommonMark) left `fence` on for the rest of the file: exit 0, no warning, and not one
  missing section delivered, including `## Coding agent`. Pinned by
  *"still delivers every section when the template's fences do not balance"*.
- **The two AGENTS.md sites threw away the helper's third answer.** They called it inside `! …`,
  which collapses 0/1/2 to two and appends on anything non-zero. Reproduced over three boots with
  `awk` answering 2 — and again with `awk` absent from `PATH` — 1095 → 2181 → 3267 bytes, each boot
  printing a success. `-r` closes only the measured mode-0200 door. Pinned by *"does not grow an
  AGENTS.md whose marker check could not run"*.
- **Directory destination** (above), pinned by *"says so when CLAWBOX.md is a directory"*.

Each of the three is mutation-proved: with the parity guard removed, with the fence rule removed,
with the AGENTS.md `case` falling through, and with the markers back on `grep -qxF`, exactly the
matching case fails and the other 42 pass.

### A second delta pass, and the finding that mattered most

The review round above was itself reviewed, and it found that the fence fix had closed only half
its own root cause. `clawbox_file_has_heading` matched a delimiter **at column 0 only** — yet
CommonMark allows an opening *and a closing* fence to be indented up to three spaces, and such a
closer renders correctly on GitHub, so it is invisible in review. With one of those in the template
the closer goes unseen, the **next opener pairs with the previous opener**, and the prose between
two examples is marked fenced. Measured on this very template with two two-space-indented closers:

```
  Appended to CLAWBOX.md: System actions and restarts, Coding agent (delegate a whole task),
                          File-system and network, Remember the user's name
exit=0   ... boot 2: silence ...   grep -c 'browser_' CLAWBOX.md → 0
```

`## Browser (real Chromium on the device)` and `## Apps and UI` delivered **to no box, ever**, exit
0, nothing on stderr — this card's own defect, on the source side, arriving through the rule written
to prevent it. A delimiter is now any ``` or ~~~ line indented by at most three spaces (spelled with
`match(line, /^ */) && RLENGTH < 4`, because mawk 1.3.4 does not merely reject the interval form
`{0,3}` — it aborts with `REcompile() - panic`).

Two more from the same pass, both about the silence rather than the growth:

- **A template whose fences do not balance is no longer merged from.** Read as prose, every `## `
  line quoted in its examples is enumerated as a section and extracted from inside the fence to the
  next such line — so the real section above it is truncated *and* a phantom appended, to every box,
  permanently. It now warns and tops nothing up, the same call the "no headings at all" arm already
  makes about the same kind of half-deployed file.
- **A guide whose own fences do not balance says so.** There the same rule inverts into a false
  positive — a heading quoted inside a fence counts as present and its section is withheld — and
  nothing else would catch it, so the operator gets the sentence instead of silence.

Three more, small: the AGENTS.md wrapper's `CLAWBOX_AGENTS_SEEN` is `local` (without it the first
marker's answer leaks into the second's `case`); the audit now asserts the wrapper returns only 0,
because it is called bare at the top level of a `set -euo pipefail` block and a `return 7` inside it
takes the gateway down over an advisory sentence; and the test's `headings()` helper no longer
mirrors the script's fence rule — it lists every `## ` line and a new case asserts the shipped
`clawbox_guide_headings` answers exactly that, which is the assertion that would have caught the
defect above in the first round.

Each is mutation-proved: restore the column-0 match and only the indented-fence case fails; remove
the template balance check and only the refusal case fails.

**Not taken, and why:** the remaining findings from that round — `truncate -s` creating the
destination as NUL bytes, and a long comment line — are inside code **#639** owns and has since
merged; they are on the run's Found list against that file rather than re-opened here. The 0/1/2
contract is also mawk-specific (busybox awk answers 1, i.e. "absent", for a file it cannot open) —
the images carry mawk and the shell's own `[ -r ]` is the primary guard, so it is recorded rather
than worked around.

## Second finishing round (2026-09-05) — the rebase onto merged #639, and the review's findings

### The stack, resolved

#639 merged at beta `1eaac8bb` in a **five**-commit form; this branch carried a **three**-commit
copy of it. `git rebase origin/beta` dropped all three as already-applied (identical patch-ids to
`aaadeb04`, `07f56144`, `a2f1a0f6`), so the branch now carries only this card's work and beta's own
`d1ff5bab` (the BOOTSTRAP.md seed's partial-write `rm -f`, `clawbox_file_size`, the removal of
`clawbox_append_or_rollback`'s "it was absent, so remove it" branch) and `85e63235` survive
untouched. One conflict, in the one place both heads edit:

- **`scripts/gateway-pre-start.sh`** — beta reworded the comment above `CLAWBOX_GUIDE_TOPUP`; this
  card deletes that variable outright (the heading *is* the marker now). Resolved to this card's
  side: a comment about a variable that no longer exists.
- **`…workspace-guide.test.ts`, the write-audit block** — #639 raised the floor to eight write
  sites, listing "6-8 the three `clawbox_append_or_rollback` calls". This change replaces those
  three hand-named appends with **two loops** (the guide's, once per missing section, and the one
  inside `clawbox_agents_append` that both AGENTS.md markers go through), so the real count is
  seven. Reconciled to seven with the list rewritten, keeping #639's own rule that the floor is the
  measured count and not a token one — at eight the audit failed over a correct block, at six three
  writes could be deleted unnoticed.

`git diff --stat origin/beta...HEAD` is the two intended files and nothing else, with no deletions
or renames.

### CodeRabbit, both open threads applied

- **`gateway-pre-start.sh` — pair a fence delimiter only with the same character.** Valid, and the
  same mis-pairing as the indented closer one delimiter over. ``` and ~~~ went into one list and
  paired by position, so a ``` block quoting a ~~~ example paired its opener with the quoted ~~~ and
  the lines between the two quoted delimiters fell outside every pair. Measured on a fixture of
  exactly that shape (a `## ` line quoted inside a `~~~` example inside a ```` ``` ```` block):

  ```
  before:  Appended to CLAWBOX.md: First, Not a heading, Second   ← phantom section, exit 0, silent
  after :  Appended to CLAWBOX.md: First, Second
  ```

  A closer must now carry the same character with a run **at least as long** — the run-length half
  is also what lets a ```` ```` ```` block quote a ```` ``` ```` one, which is how a guide documents
  markdown. Pinned by *"does not pair a fence with a delimiter of the other character"*.

  **CommonMark's third closer rule — that a closer carries no info string — is deliberately not
  implemented, and that is the interesting part.** It is the only one of the three closer rules that
  can turn *unbalanced* into *balanced*, and balanced is the answer that HIDES lines. Implemented,
  a guide carrying one stray ``` had the sections appended below it swallowed by that stray on the
  next boot and appended again, and again: the unbounded growth this whole block exists to stop.
  The existing case *"does not top a guide up again and again below a stray fence"* went red on it,
  which is how it was caught. The other two rules lean the other way, and leaning toward "read it as
  prose" is the design.

- **`…test.ts` — assert the exit status of this run.** Valid: `runRaw(fenced)` was the one of ten
  call sites with no `expect(res.status).toBe(0)`, so a block that exited non-zero would have printed
  no `Appended` line, touched no file, and passed both assertions. Now `run(fenced)`.

### The review pass's other findings

- **The enumerator guard could go green over a template the block then refuses.** It asserted the
  shipped `clawbox_guide_headings` answers exactly a naive `^## ` list — and an enumerator whose
  fences do not balance satisfies that by hiding nothing, over a template the top-up then declines
  to merge from (no section reaches any box again, on every boot, with a journal line for a signal).
  The case now also asserts `clawbox_fences_balanced(TEMPLATE)` is 0, so the agreement is earned.
- **The indented-fence case's content assertion passed on pre-fix code.** It counted `^## ` lines,
  and the pre-fix block produces three of them too: it delivers "First, Third", and `## Second`
  turns up anyway because `## First`'s extraction over-ran to the next heading it could see and
  dragged it along. It now asserts each section arrived behind its **own** `---` separator.
- **Two warnings for one unreadable AGENTS.md.** Both calls ask about the same file for the same
  reason; the per-marker blocks warned once and hoisting them into a shared wrapper dropped that.
  One warning per fault now, pinned by a count assertion on the existing case.
- **`raw[]` was built by every caller and read by one.** `{ raw[NR] = $0 }` moved out of the shared
  prologue into `clawbox_guide_section`, the only helper that reproduces lines rather than matching
  them; the other three no longer keep a second copy of the file.
- **A `local` with the wrong reason on it.** The comment claimed the boot-time value would leak into
  the second marker's call; it is assigned on entry to every call, so it never could. The real
  reason is namespace hygiene beside `clawbox_append_or_rollback`, and that is what it says.

**Not taken:** the balance check costs two more `awk` passes per boot (one on the template, one on
CLAWBOX.md) on top of the ~10 the helpers make. Kept: the question is a fact about the FILE and is
asked once per file rather than once per heading, and the alternative it buys — a phantom section
appended to every box from an unparseable template, permanently — is the defect this card is about.
Two passes is the price of the refusal.

### A third review pass, and the one that changed the code

The rebased head was reviewed again on Opus (1 Medium, 5 Low, 1 Info). The Medium is worth reading
in full because it overturned a decision recorded above.

**The comment justifying the omitted CommonMark rule was false, and the omission cost a section.**
The paragraph above says the closer info-string rule "can only ever turn unbalanced into balanced".
It does not: it changes which delimiter becomes the closer, so it moves the answer in both
directions. Without it, a template whose ```` ```text ```` example is closed by a ```` ```md ````
line — a copy-paste slip that renders correctly on GitHub — pairs the opener with that quoted line,
the pairing still comes out even so **nothing warns**, and the heading below it is enumerated by
nothing:

```
before:  Appended to CLAWBOX.md: First                  <- exit 0, stderr empty
after :  Appended to CLAWBOX.md: First, Real Heading
```

`## Real Heading` reaching no box, silently — this card's own defect, arriving through the rule
written to prevent it. The reviewer fuzzed it: of 105 templates the block called *balanced*, 4
silently dropped a real heading and 44 enumerated a phantom one.

**The fix is the asymmetry, not the rule.** The rule is applied to the **template** and not to the
**destinations**, because the two files want opposite things and the reviewer measured both:

- The template is ours — shipped, reviewed, and pinned by a unit test that compares the enumerator
  against a fence-blind list of every `## ` line. It should be read by the book, and refused out
  loud when it cannot be.
- A destination is the owner's and the agent's, and there the unaffordable outcome is not a wrong
  parse but an unbounded one. With the rule applied there too, a CLAWBOX.md carrying one stray ```
  grew **8793 -> 11731 bytes over two boots**: the rule stopped the appended section's own
  ```` ```text ```` from closing the stray and let a later bare ``` close it instead, swallowing
  everything appended in between. Lenient, the same file is read as prose and is stable from boot 1.

Pinned by *"delivers the section below an example closed by an info-string delimiter"* on one side
and the existing *"does not top a guide up again and again below a stray fence"* on the other, both
on mawk and busybox awk.

**The AGENTS.md sibling was missing the two sentences CLAWBOX.md had just been given** — the exact
"the fix was right but a second call site was left unguarded" shape. Both applied and
mutation-proved (silence before, the sentence after):

```
AGENTS.md is a directory      before: (nothing said about AGENTS.md)
                              after :  WARNING: ... exists and is not a regular file
AGENTS.md fences unbalanced   before: (nothing said)
                              after :  WARNING: the ``` fences in ... do not balance;
                                       a marker quoted inside one will be read as present
```

**The destination fence warning names a remedy now.** It repeats for the life of the fault, which is
right for a fault that withholds a section, but a sentence with no action in it is what makes that
noise rather than signal.

**"Measured on this template" overstated what was measured.** The shipped file has exactly one fenced
block and it is in the LAST section, so its own closers cannot reach the two headings the paragraph
names; the measurement was on a copy carrying two indented closers. The comment says "a copy" now,
and says why the shape still matters.

**Recorded, not fixed:**

- *The 0/1/2 helper contract is mawk-specific* — already disclosed above, and the review confirmed a
  second consequence: on busybox awk (which answers 1, "absent", for a file it cannot open) the
  `case *)` arm can never fire, and `clawbox_fences_balanced` would report "the ``` fences do not
  balance" over an I/O fault, sending an operator to the wrong file. The images carry mawk and
  `[ -r ]` is the primary guard. A real fix is to grade on a sentinel the awk program prints rather
  than on its exit status, which is a change to three helpers' contract and belongs on its own card.
- *The balance check costs two more `awk` passes per boot.* Kept: it is a fact about the FILE, asked
  once per file rather than once per heading, and what it buys is the refusal above.

### Harness first, restated honestly

The review checked the claims against the pinned core (2026.8.1) and confirmed them: `agent:bootstrap`
(`docs/automation/hooks.md`) hands a handler a mutable `bootstrapFiles` array whose records carry an
optional `content`; `workspace.bootstrapFiles` / `workspace.files` exist in a claw package
(`docs/cli/claws.md`); `openclaw setup --workspace` seeds missing files
(`docs/concepts/agent-workspace.md`). None of them merges sections into an already-edited markdown
file, which is what this card asks for, so the CLAWBOX.md loop is not a re-implementation.

But the reason this PR gave for not retiring the two **AGENTS.md** writes onto `agent:bootstrap` was
circular — "it would delete the marker matching, the readability guards and the rollback" is a
description of the change, not an argument against it — and the plumbing is not the obstacle either:
this same script already installs, enables and runtime-checks an OpenClaw hook plugin
(`scripts/openclaw-plugins/clawbox-email-directives`, wired at `scripts/gateway-pre-start.sh:2600`).

The real reason is scope and proof. Moving the pointer and the rule onto the hook stops writing into
the owner's AGENTS.md at all — which is better — but it changes what reaches the agent at the start of
**every session on every box**, and a hook that fails to load leaves the agent with no rule at all,
where a file on disk survives a gateway restart. That needs a device leg this PR cannot run. It is on
the run's Found list as its own card; this PR does not add those two writes, it only routes two
existing ones through one helper.

### Portability, re-measured

`awk` on this machine is **mawk 1.3.4**; the shipped seeding block was executed out of the real
`.sh` under both it and `busybox awk 1.36.1`, on the pre-fix commit and on this head:

```
indented-fence fixture   before (both awks):  Appended to CLAWBOX.md: First, Third
                         after  (both awks):  Appended to CLAWBOX.md: First, Second, Third
mixed-delimiter fixture  before (both awks):  Appended to CLAWBOX.md: First, Not a heading, Second
                         after  (both awks):  Appended to CLAWBOX.md: First, Second
shipped template         after  (both awks):  all 7 sections, exit 0, nothing on stderr
```

The interval form `{0,3}` is still avoided (mawk aborts with `REcompile() - panic`);
`match(line, /^ */) && RLENGTH < 4` and the `substr`/`while` run-length count behave on both.

## Both editions

Unchanged by this PR and worth repeating: the Hermes edition receives **neither** CLAWBOX.md nor
AGENTS.md — `setup-shared-identity.sh` links only `SOUL.md`, `MEMORY.md` and `USER.md` — so
TASK-612's rule reaches the Hermes agent through nothing at all. On the run's Found list; this PR
does not make it worse.

## Device proof

None run. The change is inside the ExecStartPre that brings the gateway up, on a box the owner is
using, and every case here is driven against the shipped block extracted from the real `.sh`.
**Device leg unproven: no gateway restart was performed on hardware.** The measurement that
motivated the card (the box's five-heading, Aug-13 CLAWBOX.md) was taken read-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workspace guide setup to add all missing sections reliably.
  - Prevented headings inside fenced code blocks from being treated as guide sections.
  - Added validation for unreadable, empty, malformed, or renamed templates.
  - Prevented incomplete guide or `AGENTS.md` content from remaining after interrupted writes.
  - Improved exact marker matching and repeat-run behavior to avoid duplicate sections.
  - Added safer handling for non-regular files and line-ending variations.

- **Tests**
  - Expanded coverage for guide updates, marker matching, invalid files, and recovery from partial writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
