### PR TITLE
fix: append an interrupted turn outside the state updater, on both chats

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -583,8 +583,9 @@ function ChromeDesktopInner() {
       // shape TASK-703 removes from the chat surfaces. Idempotent today, which
       // is exactly why it would go unnoticed.
       const next = [...customWallpapersRef.current, dataUrl];
-      // The ref is advanced HERE, not by the mirroring effect: two uploads (or
-      // an upload and a delete) can both run before React commits, and both
+      // `applyCustomWallpapers` advances the ref synchronously with the write,
+      // rather than a mirroring effect doing it after the commit: two uploads
+      // (or an upload and a delete) can both run before React commits, and both
       // would otherwise read the same list and the second would discard the
       // first — from the state AND from localStorage.
       applyCustomWallpapers(next);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -539,6 +539,11 @@ function ChromeDesktopInner() {
     : { backgroundSize: "auto", backgroundPosition: "center", backgroundRepeat: "no-repeat" };
   const CUSTOM_WPS_KEY = "clawbox-custom-wallpapers";
   const [customWallpapers, setCustomWallpapers] = useState<string[]>([]);
+  // Mirrored so the two writers below can compute the next list without a
+  // functional updater. Both used to do their localStorage write and their
+  // sibling `setWallpaperId` from INSIDE one, which React may run twice.
+  const customWallpapersRef = useRef<string[]>([]);
+  useEffect(() => { customWallpapersRef.current = customWallpapers; }, [customWallpapers]);
   // Wallpapers are large base64 blobs — keep in localStorage to avoid
   // bloating the KV JSON file that gets read/written on every state save.
   useEffect(() => {
@@ -554,13 +559,16 @@ function ChromeDesktopInner() {
     const reader = new FileReader();
     reader.onload = () => {
       const dataUrl = reader.result as string;
-      setCustomWallpapers(prev => {
-        const next = [...prev, dataUrl];
-        try { localStorage.setItem(CUSTOM_WPS_KEY, JSON.stringify(next)); } catch {}
-        setWallpaperId(`custom-${next.length - 1}`);
-        setWpOpacity(100);
-        return next;
-      });
+      // Computed from the ref, not from inside a `setCustomWallpapers` updater.
+      // React may run an updater twice, and this one wrote localStorage and
+      // called two other setters from inside it — the side-effect-in-an-updater
+      // shape TASK-703 removes from the chat surfaces. Idempotent today, which
+      // is exactly why it would go unnoticed.
+      const next = [...customWallpapersRef.current, dataUrl];
+      try { localStorage.setItem(CUSTOM_WPS_KEY, JSON.stringify(next)); } catch {}
+      setCustomWallpapers(next);
+      setWallpaperId(`custom-${next.length - 1}`);
+      setWpOpacity(100);
     };
     reader.readAsDataURL(file);
     e.target.value = "";
@@ -1753,12 +1761,12 @@ function ChromeDesktopInner() {
               onMascotToggle: setMascotHidden,
               onWallpaperUpload: () => wallpaperInputRef.current?.click(),
               onCustomWallpaperDelete: (idx: number) => {
-                setCustomWallpapers(prev => {
-                  const next = prev.filter((_, i) => i !== idx);
-                  try { localStorage.setItem("clawbox-custom-wallpapers", JSON.stringify(next)); } catch {}
-                  if (wallpaperId === `custom-${idx}`) setWallpaperId("clawbox");
-                  return next;
-                });
+                // Same as the upload above: outside the updater, and off the
+                // ref rather than off `prev`.
+                const next = customWallpapersRef.current.filter((_, i) => i !== idx);
+                try { localStorage.setItem("clawbox-custom-wallpapers", JSON.stringify(next)); } catch {}
+                setCustomWallpapers(next);
+                if (wallpaperId === `custom-${idx}`) setWallpaperId("clawbox");
               },
             }} />
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -542,6 +542,10 @@ function ChromeDesktopInner() {
   // Mirrored so the two writers below can compute the next list without a
   // functional updater. Both used to do their localStorage write and their
   // sibling `setWallpaperId` from INSIDE one, which React may run twice.
+  //
+  // Each writer advances the ref itself before its state update, so two
+  // callbacks that run before React commits do not both read the same list; the
+  // effect only re-syncs it against whatever state actually settled.
   const customWallpapersRef = useRef<string[]>([]);
   useEffect(() => { customWallpapersRef.current = customWallpapers; }, [customWallpapers]);
   // Wallpapers are large base64 blobs — keep in localStorage to avoid
@@ -565,6 +569,11 @@ function ChromeDesktopInner() {
       // shape TASK-703 removes from the chat surfaces. Idempotent today, which
       // is exactly why it would go unnoticed.
       const next = [...customWallpapersRef.current, dataUrl];
+      // The ref is advanced HERE, not by the mirroring effect: two uploads (or
+      // an upload and a delete) can both run before React commits, and both
+      // would otherwise read the same list and the second would discard the
+      // first — from the state AND from localStorage.
+      customWallpapersRef.current = next;
       try { localStorage.setItem(CUSTOM_WPS_KEY, JSON.stringify(next)); } catch {}
       setCustomWallpapers(next);
       setWallpaperId(`custom-${next.length - 1}`);
@@ -1764,6 +1773,7 @@ function ChromeDesktopInner() {
                 // Same as the upload above: outside the updater, and off the
                 // ref rather than off `prev`.
                 const next = customWallpapersRef.current.filter((_, i) => i !== idx);
+                customWallpapersRef.current = next;
                 try { localStorage.setItem("clawbox-custom-wallpapers", JSON.stringify(next)); } catch {}
                 setCustomWallpapers(next);
                 if (wallpaperId === `custom-${idx}`) setWallpaperId("clawbox");

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -539,21 +539,26 @@ function ChromeDesktopInner() {
     : { backgroundSize: "auto", backgroundPosition: "center", backgroundRepeat: "no-repeat" };
   const CUSTOM_WPS_KEY = "clawbox-custom-wallpapers";
   const [customWallpapers, setCustomWallpapers] = useState<string[]>([]);
-  // Mirrored so the two writers below can compute the next list without a
-  // functional updater. Both used to do their localStorage write and their
-  // sibling `setWallpaperId` from INSIDE one, which React may run twice.
+  // Mirrored so the writers below can compute the next list without a
+  // functional updater. The upload and the delete used to do their localStorage
+  // write and their sibling `setWallpaperId` from INSIDE one, which React may
+  // run twice.
   //
-  // Each writer advances the ref itself before its state update, so two
-  // callbacks that run before React commits do not both read the same list; the
-  // effect only re-syncs it against whatever state actually settled.
+  // EVERY writer advances the ref itself, before its state update — including
+  // the loader below, which is why there is no mirroring effect. An effect
+  // would have left a window one paint wide between the load committing and the
+  // ref catching up, and a delete dispatched inside it would compute
+  // `[].filter(…)` and write an empty list over every saved wallpaper.
   const customWallpapersRef = useRef<string[]>([]);
-  useEffect(() => { customWallpapersRef.current = customWallpapers; }, [customWallpapers]);
   // Wallpapers are large base64 blobs — keep in localStorage to avoid
   // bloating the KV JSON file that gets read/written on every state save.
   useEffect(() => {
     try {
       const saved = localStorage.getItem(CUSTOM_WPS_KEY);
-      if (saved) setCustomWallpapers(JSON.parse(saved));
+      if (!saved) return;
+      const parsed: string[] = JSON.parse(saved);
+      customWallpapersRef.current = parsed;
+      setCustomWallpapers(parsed);
     } catch {}
   }, []);
   const wallpaperInputRef = useRef<HTMLInputElement>(null);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1492,6 +1492,12 @@ function ChromeDesktopInner() {
     clawbox: { current: string | null; target: string | null; updateAvailable?: boolean };
     openclaw: { current: string | null; target: string | null; updateAvailable?: boolean };
   } | null>(null);
+  // Mirrors `updateAvailable` so the dismiss handler can read the notice it is
+  // dismissing WITHOUT an updater. Every writer advances it on the line before
+  // its own state write — the same rule the custom wallpapers follow in this
+  // file, and the reason there is no mirroring effect: an effect leaves a
+  // window in which the ref is behind the state.
+  const updateAvailableRef = useRef<typeof updateAvailable>(null);
   const lastVersionFingerprintRef = useRef<string | null>(null);
   // Gone for THIS session once its clock runs out — never recorded as a
   // dismissal, so the card is back after a reload and in the next session,
@@ -1515,6 +1521,7 @@ function ChromeDesktopInner() {
         lastVersionFingerprintRef.current = fingerprint;
 
         if (!clawboxNeedsUpdate && !openclawNeedsUpdate) {
+          updateAvailableRef.current = null;
           setUpdateAvailable(null);
           return;
         }
@@ -1525,7 +1532,9 @@ function ChromeDesktopInner() {
           try { dismissed = (await dismissalRes.json()).fingerprint ?? null; } catch {}
         }
         const dismissalFingerprint = `${data.clawbox?.target ?? ""}|${data.openclaw?.target ?? ""}`;
-        setUpdateAvailable(dismissed === dismissalFingerprint ? null : data);
+        const next = dismissed === dismissalFingerprint ? null : data;
+        updateAvailableRef.current = next;
+        setUpdateAvailable(next);
         // A different pair of versions is a different notice.
         setUpdateNoticeHidden(false);
       } catch { /* network blip — try again next interval */ }
@@ -1540,17 +1549,21 @@ function ChromeDesktopInner() {
   useAutoHide(updateNoticeKeys, hideUpdateNotice);
 
   const dismissUpdateNotification = useCallback(() => {
-    setUpdateAvailable((current) => {
-      if (current) {
-        const fingerprint = `${current.clawbox?.target ?? ""}|${current.openclaw?.target ?? ""}`;
-        fetch("/setup-api/update/dismissal", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ fingerprint }),
-        }).catch(() => { /* will retry next dismiss */ });
-      }
-      return null;
-    });
+    // The POST is OUTSIDE the updater. React is entitled to run an updater
+    // twice, so this dismissal was recorded once per render attempt rather than
+    // once per click — two POSTs to /setup-api/update/dismissal, two
+    // `sqliteSet`s. Idempotent, which is exactly why nobody had seen it.
+    const current = updateAvailableRef.current;
+    if (current) {
+      const fingerprint = `${current.clawbox?.target ?? ""}|${current.openclaw?.target ?? ""}`;
+      fetch("/setup-api/update/dismissal", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ fingerprint }),
+      }).catch(() => { /* will retry next dismiss */ });
+    }
+    updateAvailableRef.current = null;
+    setUpdateAvailable(null);
   }, []);
 
   const openSettingsSection = useCallback((section: "ai" | "localAi" | "system" | "update") => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -538,7 +538,7 @@ function ChromeDesktopInner() {
     ? { backgroundSize: "contain", backgroundPosition: "center", backgroundRepeat: "no-repeat" }
     : { backgroundSize: "auto", backgroundPosition: "center", backgroundRepeat: "no-repeat" };
   const CUSTOM_WPS_KEY = "clawbox-custom-wallpapers";
-  const [customWallpapers, setCustomWallpapers] = useState<string[]>([]);
+  const [customWallpapers, setCustomWallpapersState] = useState<string[]>([]);
   // Mirrored so the writers below can compute the next list without a
   // functional updater. The upload and the delete used to do their localStorage
   // write and their sibling `setWallpaperId` from INSIDE one, which React may
@@ -549,7 +549,17 @@ function ChromeDesktopInner() {
   // would have left a window one paint wide between the load committing and the
   // ref catching up, and a delete dispatched inside it would compute
   // `[].filter(…)` and write an empty list over every saved wallpaper.
+  //
+  // The raw setter is renamed out of reach and all three writers go through
+  // `applyCustomWallpapers`, so a fourth cannot advance the state while leaving
+  // the mirror behind. A mirror kept in step by convention is an invisible LOST
+  // write, and the purity rule cannot see one: it reports side effects INSIDE
+  // an updater, never a missing ref advance outside one.
   const customWallpapersRef = useRef<string[]>([]);
+  const applyCustomWallpapers = useCallback((next: string[]) => {
+    customWallpapersRef.current = next;
+    setCustomWallpapersState(next);
+  }, []);
   // Wallpapers are large base64 blobs — keep in localStorage to avoid
   // bloating the KV JSON file that gets read/written on every state save.
   useEffect(() => {
@@ -557,10 +567,9 @@ function ChromeDesktopInner() {
       const saved = localStorage.getItem(CUSTOM_WPS_KEY);
       if (!saved) return;
       const parsed: string[] = JSON.parse(saved);
-      customWallpapersRef.current = parsed;
-      setCustomWallpapers(parsed);
+      applyCustomWallpapers(parsed);
     } catch {}
-  }, []);
+  }, [applyCustomWallpapers]);
   const wallpaperInputRef = useRef<HTMLInputElement>(null);
   const handleWallpaperUpload = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -578,15 +587,14 @@ function ChromeDesktopInner() {
       // an upload and a delete) can both run before React commits, and both
       // would otherwise read the same list and the second would discard the
       // first — from the state AND from localStorage.
-      customWallpapersRef.current = next;
+      applyCustomWallpapers(next);
       try { localStorage.setItem(CUSTOM_WPS_KEY, JSON.stringify(next)); } catch {}
-      setCustomWallpapers(next);
       setWallpaperId(`custom-${next.length - 1}`);
       setWpOpacity(100);
     };
     reader.readAsDataURL(file);
     e.target.value = "";
-  }, []);
+  }, [applyCustomWallpapers]);
 
   // ─── Chat (mascot click toggles chat popup) ───
   const [chatOpen, setChatOpen] = useState(false);
@@ -1488,7 +1496,7 @@ function ChromeDesktopInner() {
   // Surfaces a corner card when ClawBox or OpenClaw has a newer release.
   // Dismissals persist per exact target-version pair via SQLite so the user
   // isn't pestered across browsers or after a cache wipe.
-  const [updateAvailable, setUpdateAvailable] = useState<{
+  const [updateAvailable, setUpdateAvailableState] = useState<{
     clawbox: { current: string | null; target: string | null; updateAvailable?: boolean };
     openclaw: { current: string | null; target: string | null; updateAvailable?: boolean };
   } | null>(null);
@@ -1497,7 +1505,14 @@ function ChromeDesktopInner() {
   // its own state write — the same rule the custom wallpapers follow in this
   // file, and the reason there is no mirroring effect: an effect leaves a
   // window in which the ref is behind the state.
+  //
+  // As with the custom wallpapers above, the raw setter is renamed out of reach
+  // so no writer can advance the state without the mirror.
   const updateAvailableRef = useRef<typeof updateAvailable>(null);
+  const applyUpdateAvailable = useCallback((next: typeof updateAvailable) => {
+    updateAvailableRef.current = next;
+    setUpdateAvailableState(next);
+  }, []);
   const lastVersionFingerprintRef = useRef<string | null>(null);
   // Gone for THIS session once its clock runs out — never recorded as a
   // dismissal, so the card is back after a reload and in the next session,
@@ -1521,8 +1536,7 @@ function ChromeDesktopInner() {
         lastVersionFingerprintRef.current = fingerprint;
 
         if (!clawboxNeedsUpdate && !openclawNeedsUpdate) {
-          updateAvailableRef.current = null;
-          setUpdateAvailable(null);
+          applyUpdateAvailable(null);
           return;
         }
         // Only hit the dismissal store when we actually have something to suppress.
@@ -1532,9 +1546,7 @@ function ChromeDesktopInner() {
           try { dismissed = (await dismissalRes.json()).fingerprint ?? null; } catch {}
         }
         const dismissalFingerprint = `${data.clawbox?.target ?? ""}|${data.openclaw?.target ?? ""}`;
-        const next = dismissed === dismissalFingerprint ? null : data;
-        updateAvailableRef.current = next;
-        setUpdateAvailable(next);
+        applyUpdateAvailable(dismissed === dismissalFingerprint ? null : data);
         // A different pair of versions is a different notice.
         setUpdateNoticeHidden(false);
       } catch { /* network blip — try again next interval */ }
@@ -1542,7 +1554,7 @@ function ChromeDesktopInner() {
     checkVersions();
     const id = setInterval(checkVersions, 30 * 60 * 1000);
     return () => { active = false; clearInterval(id); };
-  }, []);
+  }, [applyUpdateAvailable]);
 
   const updateNoticeKeys = useMemo(() => (updateAvailable && !updateNoticeHidden ? ["update"] : []), [updateAvailable, updateNoticeHidden]);
   const hideUpdateNotice = useCallback(() => setUpdateNoticeHidden(true), []);
@@ -1562,9 +1574,8 @@ function ChromeDesktopInner() {
         body: JSON.stringify({ fingerprint }),
       }).catch(() => { /* will retry next dismiss */ });
     }
-    updateAvailableRef.current = null;
-    setUpdateAvailable(null);
-  }, []);
+    applyUpdateAvailable(null);
+  }, [applyUpdateAvailable]);
 
   const openSettingsSection = useCallback((section: "ai" | "localAi" | "system" | "update") => {
     (window as Window & { __clawboxPendingSettingsSection?: string }).__clawboxPendingSettingsSection = section;
@@ -1791,9 +1802,8 @@ function ChromeDesktopInner() {
                 // Same as the upload above: outside the updater, and off the
                 // ref rather than off `prev`.
                 const next = customWallpapersRef.current.filter((_, i) => i !== idx);
-                customWallpapersRef.current = next;
-                try { localStorage.setItem("clawbox-custom-wallpapers", JSON.stringify(next)); } catch {}
-                setCustomWallpapers(next);
+                applyCustomWallpapers(next);
+                try { localStorage.setItem(CUSTOM_WPS_KEY, JSON.stringify(next)); } catch {}
                 if (wallpaperId === `custom-${idx}`) setWallpaperId("clawbox");
               },
             }} />

--- a/src/components/ChatApp.tsx
+++ b/src/components/ChatApp.tsx
@@ -76,7 +76,23 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
   const [openEmailUid, setOpenEmailUid] = useState<number | null>(null)
   const closeEmail = useCallback(() => setOpenEmailUid(null), [])
   const [input, setInput] = useState('')
-  const [streaming, setStreaming] = useState('')
+  const [streaming, setStreamingState] = useState('')
+  // The streaming buffer, mirrored in a ref, and the ONLY way it is written.
+  //
+  // A state updater is a pure function of the previous state and React is
+  // entitled to call it twice — Strict Mode does, and so does any render it has
+  // to redo. The interrupted-turn append used to happen INSIDE
+  // `setStreaming(prev => …)`, so the owner's half-finished answer could land in
+  // the transcript twice. The ref lets the abort path READ the buffer without an
+  // updater at all, and the string-only signature makes putting an updater back
+  // impossible rather than merely discouraged — and the raw setter is renamed
+  // out of the way so a bare `setStreaming('')` added elsewhere in the file
+  // cannot bypass the ref and leave it holding a dead run's text. TASK-703.
+  const streamingRef = useRef('')
+  const applyStreaming = useCallback((next: string) => {
+    streamingRef.current = next
+    setStreamingState(next)
+  }, [])
   const [sending, setSending] = useState(false)
   const { toolCalls, applyToolEvent, clearToolCalls } = useChatToolCalls()
   const [errorMsg, setErrorMsg] = useState('')
@@ -276,7 +292,7 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
 
           if (state === 'delta') {
             const text = extractText(msg)
-            if (text && !isInterSessionEnvelope(text, msg)) setStreaming(text)
+            if (text && !isInterSessionEnvelope(text, msg)) applyStreaming(text)
           } else if (state === 'final') {
             const text = extractText(msg)
             // Suppress protocol sentinels and "Sent." (delivery-mirror ack)
@@ -294,7 +310,7 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
             if (text && !isAckOnly && !isInterSessionEnvelope(text, msg)) {
               setMessages(prev => [...prev, { role: 'assistant', text: prettifyAssistantText(text), timestamp: Date.now() }])
             }
-            setStreaming('')
+            applyStreaming('')
             clearToolCalls()
             runIdRef.current = null
             setSending(false)
@@ -315,18 +331,21 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
               }, 3_000)
             }
           } else if (state === 'aborted' || state === 'error') {
-            setStreaming(prev => {
-              // Stop landing between `EMAIL` and its digits used to store the
-              // half-written line, and the render keeps an unusable directive
-              // as text — so a bare `EMAIL:` stayed in the transcript for good.
-              // The bubble was already hiding it and it can never become a
-              // card, so what is stored is what the owner was looking at.
-              const kept = dropUnfinishedDirective(prev)
-              if (kept.trim() && !isSentinel(kept)) {
-                setMessages(msgs => [...msgs, { role: 'assistant', text: prettifyAssistantText(kept), timestamp: Date.now() }])
-              }
-              return ''
-            })
+            // Read, clear, THEN append — all three outside any updater. This
+            // append used to sit inside `setStreaming(prev => …)`, where React
+            // may run it twice and the owner's interrupted answer lands in the
+            // transcript twice with it.
+            //
+            // Stop landing between `EMAIL` and its digits used to store the
+            // half-written line, and the render keeps an unusable directive
+            // as text — so a bare `EMAIL:` stayed in the transcript for good.
+            // The bubble was already hiding it and it can never become a
+            // card, so what is stored is what the owner was looking at.
+            const kept = dropUnfinishedDirective(streamingRef.current)
+            applyStreaming('')
+            if (kept.trim() && !isSentinel(kept)) {
+              setMessages(msgs => [...msgs, { role: 'assistant', text: prettifyAssistantText(kept), timestamp: Date.now() }])
+            }
             clearToolCalls()
             runIdRef.current = null
             setSending(false)
@@ -471,7 +490,7 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
       images: imagesToSend.map(img => img.dataUrl),
     }])
     setSending(true)
-    setStreaming('')
+    applyStreaming('')
 
     const idempotencyKey = uuid()
     runIdRef.current = idempotencyKey

--- a/src/components/ChatApp.tsx
+++ b/src/components/ChatApp.tsx
@@ -506,7 +506,7 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
     }
 
     await dispatchSend(text, wirePayload, idempotencyKey)
-  }, [input, sending, pendingImages, status, dispatchSend])
+  }, [input, sending, pendingImages, status, dispatchSend, applyStreaming])
 
   // Drain queued sends on connect; flush them as system errors on error.
   // Sequential dispatch preserves user-typed order — chat.send acks fast

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -766,7 +766,23 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   // agent.reasoning_effort, or picked by the user) rather than the placeholder.
   const hermesReasoningKnownRef = useRef(false)
   const [input, setInput] = useState('')
-  const [streaming, setStreaming] = useState('')
+  const [streaming, setStreamingState] = useState('')
+  // The streaming buffer, mirrored in a ref, and the ONLY way it is written.
+  //
+  // A state updater is a pure function of the previous state and React is
+  // entitled to call it twice — Strict Mode does, and so does any render it has
+  // to redo. The interrupted-turn append used to happen INSIDE
+  // `setStreaming(prev => …)`, so the owner's half-finished answer could land in
+  // the transcript twice. The ref lets the abort path READ the buffer without an
+  // updater at all, and the string-only signature makes putting an updater back
+  // impossible rather than merely discouraged — and the raw setter is renamed
+  // out of the way so a bare `setStreaming('')` added elsewhere in the file
+  // cannot bypass the ref and leave it holding a dead run's text. TASK-703.
+  const streamingRef = useRef('')
+  const applyStreaming = useCallback((next: string) => {
+    streamingRef.current = next
+    setStreamingState(next)
+  }, [])
   const [sending, setSending] = useState(false)
   // Queued while a run is in flight; drained one at a time on `final`.
   const [queuedSends, setQueuedSends] = useState<QueuedSend[]>([])
@@ -921,7 +937,17 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   // chatModelState resolves. Starting at `off` means that if the socket
   // connects before the catalog does, the first wire push can't offer a
   // reasoning level a local (off-only) model would reject.
-  const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>(SAFE_THINKING_LEVEL)
+  const [thinkingLevel, setThinkingLevelState] = useState<ThinkingLevel>(SAFE_THINKING_LEVEL)
+  // Mirrored and written through one helper, for the reason `applyStreaming`
+  // is: the "Switched effort to …" confirmation was appended from INSIDE the
+  // `setThinkingLevel` updater, so one click could add two lines to the
+  // transcript. The ref is what lets the "did it actually change?" question be
+  // answered without one. TASK-703.
+  const thinkingLevelRef = useRef<ThinkingLevel>(SAFE_THINKING_LEVEL)
+  const applyThinkingLevel = useCallback((next: ThinkingLevel) => {
+    thinkingLevelRef.current = next
+    setThinkingLevelState(next)
+  }, [])
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [attachments, setAttachments] = useState<ChatAttachment[]>([])
   // Bumped whenever the composer's attachments are abandoned (currently: on
@@ -1650,7 +1676,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
         if (headerProvider) {
           try { window.localStorage?.setItem(`${PERSIST_KEY_PREFIX}:${headerProvider}`, suggested) } catch { /* localStorage unavailable */ }
         }
-        setThinkingLevel(prev => (prev === suggested ? prev : suggested))
+        if (thinkingLevelRef.current !== suggested) applyThinkingLevel(suggested)
         setMessages(msgs => [...msgs, {
           role: 'system',
           text: `Reasoning effort isn't available for this model — using ${THINKING_LEVEL_LABELS[suggested] ?? suggested}.`,
@@ -1684,7 +1710,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     if (!headerProvider) return
     const cfg = getProviderReasoningConfig(headerProvider, headerModel)
     const persisted = readPersistedThinkingLevel(headerProvider, cfg)
-    setThinkingLevel(prev => (prev === persisted ? prev : persisted))
+    if (thinkingLevelRef.current !== persisted) applyThinkingLevel(persisted)
   }, [headerProvider, headerModel])
 
   const handleThinkingLevelChange = useCallback((next: string) => {
@@ -1692,8 +1718,8 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     const normalized: ThinkingLevel = cfg.levels.includes(next as ThinkingLevel)
       ? (next as ThinkingLevel)
       : cfg.default
-    setThinkingLevel(prev => {
-      if (prev === normalized) return prev
+    if (thinkingLevelRef.current !== normalized) {
+      applyThinkingLevel(normalized)
       const label = THINKING_LEVEL_LABELS[normalized] ?? normalized
       setMessages(msgs => [...msgs, {
         role: 'system',
@@ -1701,8 +1727,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
         timestamp: Date.now(),
         variant: 'success',
       }])
-      return normalized
-    })
+    }
     if (headerProvider) {
       try { window.localStorage?.setItem(`${PERSIST_KEY_PREFIX}:${headerProvider}`, normalized) } catch { /* localStorage unavailable */ }
     }
@@ -2121,7 +2146,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
             // bubble. The buffer is still what gets STORED, so an interrupt
             // keeps the directives and their cards.
             if (text && !isSentinel(streamingEmailRefsText(text)) && !isInterSessionEnvelope(text, msg)) {
-              setStreaming(text); setReloadingSkill(false)
+              applyStreaming(text); setReloadingSkill(false)
             }
           } else if (state === 'final') {
             // A generated picture arrives as a MEDIA: line inside the reply
@@ -2189,7 +2214,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
             // The run this final closes, for the ack-only branch below (the
             // ref is cleared two lines down).
             const finishedRun = runIdRef.current
-            setStreaming('')
+            applyStreaming('')
             clearToolCalls()
             runIdRef.current = null
             sendingRef.current = false; setSending(false)
@@ -2226,18 +2251,20 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
               }, 3_000)
             }
           } else if (state === 'aborted' || state === 'error') {
-            setStreaming(prev => {
-              // Same as the full-screen chat: a Stop between `EMAIL` and its
-              // digits would store the half-written line, which the render
-              // keeps as text, leaving a bare `EMAIL:` in the transcript for
-              // good. It can never become a card and the bubble was already
-              // hiding it, so the stored turn is what the owner last saw.
-              const kept = dropUnfinishedDirective(prev)
-              if (kept.trim() && !isSentinel(kept)) {
-                setMessages(msgs => [...msgs, { role: 'assistant', text: kept, timestamp: Date.now() }])
-              }
-              return ''
-            })
+            // Read, clear, THEN append — all three outside any updater, for the
+            // same reason as the full-screen chat: React may run an updater
+            // twice, and this one appended a message.
+            //
+            // A Stop between `EMAIL` and its digits would store the half-written
+            // line, which the render keeps as text, leaving a bare `EMAIL:` in
+            // the transcript for good. It can never become a card and the bubble
+            // was already hiding it, so the stored turn is what the owner last
+            // saw.
+            const kept = dropUnfinishedDirective(streamingRef.current)
+            applyStreaming('')
+            if (kept.trim() && !isSentinel(kept)) {
+              setMessages(msgs => [...msgs, { role: 'assistant', text: kept, timestamp: Date.now() }])
+            }
             clearToolCalls()
             runIdRef.current = null
             sendingRef.current = false; setSending(false)
@@ -2373,7 +2400,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     const mightAutoGreet = !greetedRef.current
     if (mightAutoGreet) {
       setIsBootstrappingHistory(true)
-      setStreaming('')
+      applyStreaming('')
     }
     try {
       // The whole projection — sentinels, routing messages, inter-session
@@ -2470,7 +2497,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   // differs, and that difference is the adapter's business, not this one's.
   const clearTranscript = useCallback(() => {
     setMessages([])
-    setStreaming('')
+    applyStreaming('')
     // The bubbles holding spoken replies are gone for good (a returned-to tab
     // repaints from the box's history, which cannot carry a browser-local
     // blob URL), so the blobs go with them. This panel never unmounts while
@@ -3793,7 +3820,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
         // A run that has already ended (Stop, or a late frame after the final)
         // must not reopen the caret, so a delta is only painted while this run
         // is still the live one.
-        if (event.kind === 'delta' && runIdRef.current === idempotencyKey) setStreaming(event.text)
+        if (event.kind === 'delta' && runIdRef.current === idempotencyKey) applyStreaming(event.text)
         // Live tool steps, through the SAME pills the gateway harness already
         // feeds. A hermes turn used to reach this callback with nothing but
         // text, so a turn that spent its time in `web_search` — measured at up
@@ -3848,7 +3875,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       // Nothing is coming on either path, so the run ends here.
       sendingRef.current = false
       setSending(false)
-      setStreaming('')
+      applyStreaming('')
       clearToolCalls()
       // The agent is no longer parked on anything, so neither is the customer.
       // A card outliving its turn is a control with nowhere to post to.
@@ -3896,7 +3923,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     // the queue permanently parked (TASK-517).
     sendingRef.current = false
     setSending(false)
-    setStreaming('')
+    applyStreaming('')
     // The live pills have done their job. The finished message carries the
     // agent's OWN record of the steps (`result.toolCalls`) and renders it as
     // summary chips, so leaving the running ones up would show the same turn's
@@ -3934,7 +3961,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     setMessages(prev => [...prev, { role: 'user', text: displayText, timestamp: Date.now(), idempotencyKey, images }])
     sendingRef.current = true
     setSending(true)
-    setStreaming('')
+    applyStreaming('')
     runIdRef.current = idempotencyKey
     // A spoken question is answered aloud: remember which run it is, so the
     // reply that closes THIS run is the one spoken (see maybeSpeakReply).

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -1693,7 +1693,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       }])
     })
   // `sessionEpoch` is bumped by switchSession so a new tab's session gets the level too.
-  }, [status, headerProvider, headerModel, thinkingLevel, adapter, caps, sessionEpoch])
+  }, [status, headerProvider, headerModel, thinkingLevel, adapter, caps, sessionEpoch, applyThinkingLevel])
 
   // Snap thinkingLevel to the active provider's persisted choice (or its
   // default) whenever the active provider changes. Without this the
@@ -1711,7 +1711,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     const cfg = getProviderReasoningConfig(headerProvider, headerModel)
     const persisted = readPersistedThinkingLevel(headerProvider, cfg)
     if (thinkingLevelRef.current !== persisted) applyThinkingLevel(persisted)
-  }, [headerProvider, headerModel])
+  }, [headerProvider, headerModel, applyThinkingLevel])
 
   const handleThinkingLevelChange = useCallback((next: string) => {
     const cfg = getProviderReasoningConfig(headerProvider, headerModel)
@@ -1731,7 +1731,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     if (headerProvider) {
       try { window.localStorage?.setItem(`${PERSIST_KEY_PREFIX}:${headerProvider}`, normalized) } catch { /* localStorage unavailable */ }
     }
-  }, [headerProvider, headerModel])
+  }, [headerProvider, headerModel, applyThinkingLevel])
 
   // Connect to gateway
   const retryCountRef = useRef(0)
@@ -2463,7 +2463,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       console.error('Failed to load history:', err)
       if (mightAutoGreet) setIsBootstrappingHistory(false)
     }
-  }, [adapter, caps])
+  }, [adapter, caps, applyStreaming])
 
   useEffect(() => { messagesRef.current = messages }, [messages])
 
@@ -2521,7 +2521,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     // The auto-greet opens a FIRST conversation; re-arming it here would drop
     // an unasked-for "hi" into the chat the moment it was cleared.
     greetedRef.current = true
-  }, [clearToolCalls, clearClarifies])
+  }, [clearToolCalls, clearClarifies, applyStreaming])
 
   const resetSession = useCallback(async () => {
     await adapter.resetSession()
@@ -3936,7 +3936,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     // where the batch card appears.
     void settleEmailDrafts()
     runIdRef.current = null
-  }, [adapter, applyToolEvent, nudgeCodingAgent, clearToolCalls, clearClarifies, settleEmailDrafts, settleRun])
+  }, [adapter, applyToolEvent, nudgeCodingAgent, clearToolCalls, clearClarifies, settleEmailDrafts, settleRun, applyStreaming])
   useEffect(() => { dispatchTurnRef.current = dispatchTurn }, [dispatchTurn])
 
   const startRun = useCallback((text: string, sendAttachments: ChatAttachment[], voice = false) => {
@@ -3974,7 +3974,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       return
     }
     void dispatchTurn(text, sendAttachments, idempotencyKey)
-  }, [caps, status, dispatchTurn])
+  }, [caps, status, dispatchTurn, applyStreaming])
 
   // Send a line the UI composed itself — a voice transcript, or the question
   // that follows a skill change. Both can arrive while the agent is already

--- a/src/components/FilesApp.tsx
+++ b/src/components/FilesApp.tsx
@@ -139,14 +139,21 @@ export default function FilesApp({ initialPath = "" }: { initialPath?: string } 
     return window.localStorage.getItem("clawbox.files.showHidden") === "1";
   });
 
+  // The ref carries the current choice so the toggle can compute the next one
+  // without a dependency, which is what the updater was being used for. A
+  // React state updater is a pure function of the previous state — React is
+  // entitled to run it twice — and this one wrote localStorage from inside it,
+  // so the write happened once per render attempt rather than once per click.
+  // It is idempotent, which is exactly why it went unnoticed. See
+  // src/tests/unit/state-updater-purity.test.ts.
+  const showHiddenRef = useRef(showHidden);
   const toggleShowHidden = useCallback(() => {
-    setShowHidden((v) => {
-      const next = !v;
-      if (typeof window !== "undefined") {
-        window.localStorage.setItem("clawbox.files.showHidden", next ? "1" : "0");
-      }
-      return next;
-    });
+    const next = !showHiddenRef.current;
+    showHiddenRef.current = next;
+    setShowHidden(next);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("clawbox.files.showHidden", next ? "1" : "0");
+    }
   }, []);
   const [selected, setSelected] = useState<string | null>(null);
   const [dialog, setDialog] = useState<DialogState>({ type: null });

--- a/src/components/FilesApp.tsx
+++ b/src/components/FilesApp.tsx
@@ -134,7 +134,7 @@ export default function FilesApp({ initialPath = "" }: { initialPath?: string } 
   // Hidden by default — matches every desktop file manager. Persisted across
   // window reopens so the user's choice sticks. Reading lazily inside
   // useState's initializer guards against SSR (no `window` until mount).
-  const [showHidden, setShowHidden] = useState<boolean>(() => {
+  const [showHidden, setShowHiddenState] = useState<boolean>(() => {
     if (typeof window === "undefined") return false;
     return window.localStorage.getItem("clawbox.files.showHidden") === "1";
   });
@@ -146,15 +146,24 @@ export default function FilesApp({ initialPath = "" }: { initialPath?: string } 
   // so the write happened once per render attempt rather than once per click.
   // It is idempotent, which is exactly why it went unnoticed. See
   // src/tests/unit/state-updater-purity.test.ts.
+  //
+  // The raw setter is renamed out of reach and every write goes through
+  // `applyShowHidden`, so the mirror cannot be left behind by a writer that
+  // forgets the ref line. A mirror kept in step by a convention is an invisible
+  // LOST write, and the purity rule cannot see one: it reports side effects
+  // INSIDE an updater, never a missing ref advance outside one.
   const showHiddenRef = useRef(showHidden);
+  const applyShowHidden = useCallback((next: boolean) => {
+    showHiddenRef.current = next;
+    setShowHiddenState(next);
+  }, []);
   const toggleShowHidden = useCallback(() => {
     const next = !showHiddenRef.current;
-    showHiddenRef.current = next;
-    setShowHidden(next);
+    applyShowHidden(next);
     if (typeof window !== "undefined") {
       window.localStorage.setItem("clawbox.files.showHidden", next ? "1" : "0");
     }
-  }, []);
+  }, [applyShowHidden]);
   const [selected, setSelected] = useState<string | null>(null);
   const [dialog, setDialog] = useState<DialogState>({ type: null });
   const [dragOver, setDragOver] = useState(false);

--- a/src/components/InstalledAppSettings.tsx
+++ b/src/components/InstalledAppSettings.tsx
@@ -86,8 +86,16 @@ interface InstalledAppSettingsProps {
 export default function InstalledAppSettings({ appId, storeApp, icon, onUninstall }: InstalledAppSettingsProps) {
   const { t } = useT();
   const SETTINGS_KEY = `clawbox-app-settings-${appId}`;
-  const [settings, setSettings] = useState<Record<string, string | boolean>>({});
+  const [settings, setSettingsState] = useState<Record<string, string | boolean>>({});
+  // Mirror + its ONLY writer. The raw setter is renamed out of reach so the ref
+  // cannot be left behind by a writer that forgets to advance it — an invisible
+  // lost write, and one the purity rule cannot see, since it reports side
+  // effects INSIDE an updater rather than a missing ref advance outside one.
   const settingsRef = useRef(settings);
+  const applySettings = useCallback((next: Record<string, string | boolean>) => {
+    settingsRef.current = next;
+    setSettingsState(next);
+  }, []);
   const [saving, setSaving] = useState(false);
   // "connected" = backend actually wrote the skill's config (the button then
   // says "Saved to skill config" — that is a file write, never a probed
@@ -157,12 +165,9 @@ export default function InstalledAppSettings({ appId, storeApp, icon, onUninstal
   useEffect(() => {
     kv.init().then(() => {
       const stored = kv.getJSON<Record<string, string | boolean>>(SETTINGS_KEY);
-      if (stored) {
-        settingsRef.current = stored;
-        setSettings(stored);
-      }
+      if (stored) applySettings(stored);
     });
-  }, [SETTINGS_KEY]);
+  }, [SETTINGS_KEY, applySettings]);
 
   const appSettings = buildSettings(appId, skillInfo);
   // The publisher namespace is what makes a ClawHub URL real; when the store
@@ -182,11 +187,10 @@ export default function InstalledAppSettings({ appId, storeApp, icon, onUninstal
   // them. See src/tests/unit/state-updater-purity.test.ts.
   const updateSetting = useCallback((key: string, value: string | boolean) => {
     const next = { ...settingsRef.current, [key]: value };
-    settingsRef.current = next;
-    setSettings(next);
+    applySettings(next);
     kv.setJSON(SETTINGS_KEY, next);
     setSaveResult("idle");
-  }, [SETTINGS_KEY]);
+  }, [SETTINGS_KEY, applySettings]);
 
   const [toggleError, setToggleError] = useState(false);
 

--- a/src/components/InstalledAppSettings.tsx
+++ b/src/components/InstalledAppSettings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import type { StoreApp } from "./AppStore";
 import * as kv from "@/lib/client-kv";
 import { useT } from "@/lib/i18n";
@@ -87,6 +87,7 @@ export default function InstalledAppSettings({ appId, storeApp, icon, onUninstal
   const { t } = useT();
   const SETTINGS_KEY = `clawbox-app-settings-${appId}`;
   const [settings, setSettings] = useState<Record<string, string | boolean>>({});
+  const settingsRef = useRef(settings);
   const [saving, setSaving] = useState(false);
   // "connected" = backend actually wrote the skill's config (the button then
   // says "Saved to skill config" — that is a file write, never a probed
@@ -156,7 +157,10 @@ export default function InstalledAppSettings({ appId, storeApp, icon, onUninstal
   useEffect(() => {
     kv.init().then(() => {
       const stored = kv.getJSON<Record<string, string | boolean>>(SETTINGS_KEY);
-      if (stored) setSettings(stored);
+      if (stored) {
+        settingsRef.current = stored;
+        setSettings(stored);
+      }
     });
   }, [SETTINGS_KEY]);
 
@@ -170,12 +174,17 @@ export default function InstalledAppSettings({ appId, storeApp, icon, onUninstal
     || storeApp.url;
   const hubIsClawhub = !!hubUrl && hubUrl.startsWith("https://clawhub.ai/");
 
+  // Persisted OUTSIDE the updater. A React state updater is a pure function of
+  // the previous state and React may run it twice, so `kv.setJSON` was called
+  // once per render attempt rather than once per edit. The ref is advanced
+  // before every write — including the load above — so the next edit still
+  // builds on the newest settings without the callback taking a dependency on
+  // them. See src/tests/unit/state-updater-purity.test.ts.
   const updateSetting = useCallback((key: string, value: string | boolean) => {
-    setSettings(prev => {
-      const next = { ...prev, [key]: value };
-      kv.setJSON(SETTINGS_KEY, next);
-      return next;
-    });
+    const next = { ...settingsRef.current, [key]: value };
+    settingsRef.current = next;
+    setSettings(next);
+    kv.setJSON(SETTINGS_KEY, next);
     setSaveResult("idle");
   }, [SETTINGS_KEY]);
 

--- a/src/components/Mascot.tsx
+++ b/src/components/Mascot.tsx
@@ -225,6 +225,10 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange, rightInset }
     if (typeof window === 'undefined') return false
     return kv.get('clawbox-mascot-hidden') === '1'
   })
+  // Mirrors `hidden` so the show/hide event handlers can read it without a
+  // dependency and without an updater. Seeded from the same initializer, and
+  // advanced by every writer on the line before its state write.
+  const hiddenRef = useRef(hidden)
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number } | null>(null)
   const ctxOpenedAt = useRef(0)
 
@@ -1482,8 +1486,24 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange, rightInset }
 
   // Listen for show/hide mascot events from desktop context menu
   useEffect(() => {
-    const showHandler = () => { setHidden(prev => { if (!prev) return prev; kv.remove('clawbox-mascot-hidden'); return false }) }
-    const hideHandler = () => { setHidden(prev => { if (prev) return prev; kv.set('clawbox-mascot-hidden', '1'); return true }) }
+    // Outside the updater, guarded on the ref. These wrote `kv` from INSIDE the
+    // `setHidden` updater, so React running it twice wrote the cache twice and
+    // queued a second debounced POST to /setup-api/kv. The same file already
+    // writes it correctly from the context menu below; these two were the
+    // instances the rule could not name, because `kv.set` has no capital after
+    // `set`.
+    const showHandler = () => {
+      if (!hiddenRef.current) return
+      hiddenRef.current = false
+      setHidden(false)
+      kv.remove('clawbox-mascot-hidden')
+    }
+    const hideHandler = () => {
+      if (hiddenRef.current) return
+      hiddenRef.current = true
+      setHidden(true)
+      kv.set('clawbox-mascot-hidden', '1')
+    }
     window.addEventListener('clawbox-show-mascot', showHandler)
     window.addEventListener('clawbox-hide-mascot', hideHandler)
     return () => { window.removeEventListener('clawbox-show-mascot', showHandler); window.removeEventListener('clawbox-hide-mascot', hideHandler) }
@@ -1838,7 +1858,7 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange, rightInset }
             </button>
           )}
           <button
-            onClick={() => { setHidden(true); kv.set('clawbox-mascot-hidden', '1'); setCtxMenu(null); window.dispatchEvent(new Event('clawbox-hide-mascot')) }}
+            onClick={() => { hiddenRef.current = true; setHidden(true); kv.set('clawbox-mascot-hidden', '1'); setCtxMenu(null); window.dispatchEvent(new Event('clawbox-hide-mascot')) }}
             className="w-full px-4 py-2 text-left hover:bg-white/10 flex items-center gap-3 text-red-400"
           >
             <span className="text-base">👁️‍🗨️</span> Hide mascot

--- a/src/components/Mascot.tsx
+++ b/src/components/Mascot.tsx
@@ -221,14 +221,21 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange, rightInset }
   isSleepingRef.current = isSleeping
 
   // Hidden state (persisted) + context menu
-  const [hidden, setHidden] = useState(() => {
+  const [hidden, setHiddenState] = useState(() => {
     if (typeof window === 'undefined') return false
     return kv.get('clawbox-mascot-hidden') === '1'
   })
   // Mirrors `hidden` so the show/hide event handlers can read it without a
   // dependency and without an updater. Seeded from the same initializer, and
-  // advanced by every writer on the line before its state write.
+  // advanced by `applyHidden` — the only writer, because the raw setter is
+  // renamed out of reach. A mirror advanced by convention is an invisible lost
+  // write, and the purity rule cannot see one: it reports side effects INSIDE
+  // an updater, never a missing ref advance outside one.
   const hiddenRef = useRef(hidden)
+  const applyHidden = useCallback((next: boolean) => {
+    hiddenRef.current = next
+    setHiddenState(next)
+  }, [])
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number } | null>(null)
   const ctxOpenedAt = useRef(0)
 
@@ -1494,20 +1501,18 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange, rightInset }
     // `set`.
     const showHandler = () => {
       if (!hiddenRef.current) return
-      hiddenRef.current = false
-      setHidden(false)
+      applyHidden(false)
       kv.remove('clawbox-mascot-hidden')
     }
     const hideHandler = () => {
       if (hiddenRef.current) return
-      hiddenRef.current = true
-      setHidden(true)
+      applyHidden(true)
       kv.set('clawbox-mascot-hidden', '1')
     }
     window.addEventListener('clawbox-show-mascot', showHandler)
     window.addEventListener('clawbox-hide-mascot', hideHandler)
     return () => { window.removeEventListener('clawbox-show-mascot', showHandler); window.removeEventListener('clawbox-hide-mascot', hideHandler) }
-  }, [])
+  }, [applyHidden])
 
   if (!mounted) return null // avoid hydration mismatch — render only on client
   if (hidden) return null
@@ -1858,7 +1863,7 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange, rightInset }
             </button>
           )}
           <button
-            onClick={() => { hiddenRef.current = true; setHidden(true); kv.set('clawbox-mascot-hidden', '1'); setCtxMenu(null); window.dispatchEvent(new Event('clawbox-hide-mascot')) }}
+            onClick={() => { applyHidden(true); kv.set('clawbox-mascot-hidden', '1'); setCtxMenu(null); window.dispatchEvent(new Event('clawbox-hide-mascot')) }}
             className="w-full px-4 py-2 text-left hover:bg-white/10 flex items-center gap-3 text-red-400"
           >
             <span className="text-base">👁️‍🗨️</span> Hide mascot

--- a/src/lib/harness/transport.ts
+++ b/src/lib/harness/transport.ts
@@ -253,7 +253,7 @@ export type TurnEvent =
    * last few characters are ever visible.
    *
    * Cumulative is the right way round because the surface's job is to paint the
-   * current state of one bubble, which is what `setStreaming(text)` already
+   * current state of one bubble, which is what `applyStreaming(text)` already
    * does for the gateway. An adapter whose transport speaks in fragments — the
    * Hermes dashboard socket does — accumulates them itself and reports the
    * whole, so the renderer stays the same one for every harness.

--- a/src/tests/components/chat-strict-mode-updater.test.tsx
+++ b/src/tests/components/chat-strict-mode-updater.test.tsx
@@ -1,0 +1,358 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { StrictMode } from "react";
+import { act, render, waitFor } from "@/tests/helpers/test-utils";
+import ChatApp from "@/components/ChatApp";
+import ChatPopup from "@/components/ChatPopup";
+import { resetHarnessCache } from "@/lib/client-harness";
+
+/**
+ * A state updater is a PURE function of the previous state, and React is
+ * entitled to call it twice.
+ *
+ * Both chat surfaces appended the interrupted turn from INSIDE the
+ * `setStreaming` updater on a gateway abort:
+ *
+ *   setStreaming(prev => {
+ *     const kept = dropUnfinishedDirective(prev)
+ *     if (kept.trim()) setMessages(msgs => [...msgs, { … }])   // <- side effect
+ *     return ''
+ *   })
+ *
+ * Under Strict Mode — and under concurrent rendering, which is not a dev-only
+ * behaviour — that runs twice and the owner's interrupted answer is appended
+ * to the transcript TWICE. CodeRabbit raised it on both surfaces during PR
+ * #605 and it was refuted there as pre-existing and out of scope; this is the
+ * card it was deferred to (TASK-703).
+ *
+ * Strict Mode is how the test provokes it, not what the fix is for: the same
+ * double-invocation is what React does when it re-renders a component whose
+ * update was interrupted, which is why the rule is "no side effects in an
+ * updater" rather than "no side effects in an updater in development".
+ */
+
+const REPLY = "Half an answer before the owner pressed Stop.";
+
+type Frame = Record<string, unknown>;
+
+const instances: FakeGatewayWs[] = [];
+
+class FakeGatewayWs {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  readyState = FakeGatewayWs.OPEN;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onopen: (() => void) | null = null;
+
+  constructor(public url: string) {
+    instances.push(this);
+    setTimeout(
+      () => this.emit({ type: "event", event: "connect.challenge", payload: { nonce: "test-nonce" } }),
+      0,
+    );
+  }
+
+  send(raw: string) {
+    let frame: Frame;
+    try {
+      frame = JSON.parse(raw) as Frame;
+    } catch {
+      return;
+    }
+    if (frame.type !== "req") return;
+    const id = frame.id as string;
+    if (frame.method === "connect") {
+      this.respond(id, { snapshot: { sessionDefaults: { mainSessionKey: "agent:main:main" } } });
+      return;
+    }
+    if (frame.method === "chat.history") {
+      this.respond(id, { messages: [] });
+      return;
+    }
+    this.respond(id, {});
+  }
+
+  close() {
+    this.readyState = FakeGatewayWs.CLOSED;
+  }
+
+  addEventListener() {}
+  removeEventListener() {}
+
+  private respond(id: string, payload: unknown) {
+    setTimeout(() => this.emit({ type: "res", id, ok: true, payload }), 0);
+  }
+
+  emit(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+  }
+
+  pushChat(state: string, message: unknown) {
+    this.emit({
+      type: "event",
+      event: "chat",
+      payload: { sessionKey: "agent:main:main", state, message },
+    });
+  }
+}
+
+async function socket() {
+  await waitFor(() => expect(instances.length).toBeGreaterThan(0));
+  return instances[instances.length - 1];
+}
+
+function installFetch() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: unknown) => {
+      const url = String(input);
+      if (url.includes("/setup-api/gateway/ws-config")) {
+        return { ok: true, json: async () => ({ token: "t", wsUrl: "ws://localhost/gw" }) };
+      }
+      if (url.includes("/setup-api/harness/active")) {
+        return { ok: true, json: async () => ({ active: "openclaw", edition: "openclaw" }) };
+      }
+      if (url.includes("/setup-api/chat/model")) {
+        return { ok: true, json: async () => ({ options: [], activeOptionId: "" }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    }),
+  );
+}
+
+/** How many times `needle` appears in what is on screen. */
+function occurrences(needle: string): number {
+  return (document.body.textContent ?? "").split(needle).length - 1;
+}
+
+/** Let the handshake and the one `chat.history` round-trip settle. */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 4; i++) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+}
+
+/** Push a partial reply, then the abort the Stop button produces. */
+async function streamThenAbort(ws: FakeGatewayWs): Promise<void> {
+  await settle();
+  await act(async () => {
+    ws.pushChat("delta", { role: "assistant", content: [{ type: "text", text: REPLY }] });
+    await Promise.resolve();
+  });
+  await act(async () => {
+    ws.pushChat("aborted", { role: "assistant", content: [{ type: "text", text: "" }] });
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  // jsdom has no `scrollIntoView`, and `scrollToBottomAfterLayout` (src/lib/scroll.ts)
+  // calls it from a double-rAF — OUTSIDE any test body, so vitest counts the
+  // TypeError as an unhandled error and the whole components project exits 1
+  // while every assertion here passes. Every other chat suite in this repo
+  // stubs it for the same reason.
+  Element.prototype.scrollIntoView = vi.fn();
+  instances.length = 0;
+  resetHarnessCache();
+  vi.stubGlobal("WebSocket", FakeGatewayWs as unknown as typeof WebSocket);
+  installFetch();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("an interrupted turn is appended once, however many times React renders", () => {
+  it("full-screen chat", async () => {
+    render(
+      <StrictMode>
+        <ChatApp />
+      </StrictMode>,
+    );
+    const ws = await socket();
+
+    await streamThenAbort(ws);
+
+    // Once. Twice is the defect: the streaming bubble is gone by now, so every
+    // copy on screen is an appended transcript entry.
+    expect(occurrences(REPLY)).toBe(1);
+  });
+
+  it("mascot popup", async () => {
+    render(
+      <StrictMode>
+        <ChatPopup isOpen onClose={() => {}} />
+      </StrictMode>,
+    );
+    const ws = await socket();
+
+    await streamThenAbort(ws);
+
+    expect(occurrences(REPLY)).toBe(1);
+  });
+
+  it("keeps the interrupted answer above the error line, as it was", async () => {
+    // Moving the append out of the updater also moved it in TIME: on beta it
+    // was queued during the render pass, i.e. AFTER the system error line the
+    // handler had already queued, so the owner saw the red line and then the
+    // fragment. Outside the updater it queues first. Same commit either way,
+    // but the two bubbles swap — a customer-visible change with nothing
+    // pinning it. Pinned here: the answer the box managed to write comes
+    // first, and the line explaining that it stopped comes after it.
+    render(
+      <StrictMode>
+        <ChatApp />
+      </StrictMode>,
+    );
+    const ws = await socket();
+    await settle();
+    await act(async () => {
+      ws.pushChat("delta", { role: "assistant", content: [{ type: "text", text: REPLY }] });
+      await Promise.resolve();
+    });
+    await act(async () => {
+      ws.emit({
+        type: "event",
+        event: "chat",
+        payload: {
+          sessionKey: "agent:main:main",
+          state: "error",
+          message: { role: "assistant", content: [{ type: "text", text: "" }] },
+          errorMessage: "gateway said no",
+        },
+      });
+      await Promise.resolve();
+    });
+
+    const rendered = document.body.textContent ?? "";
+    const reply = rendered.indexOf(REPLY);
+    // The failure notice, whatever its wording — the surface picks between a
+    // sanitised gateway line and its own generic one.
+    const notice = rendered.search(/Error:|did not go through|could not|failed|try again/i);
+    expect(reply, `the interrupted answer was not kept:\n${rendered}`).toBeGreaterThan(-1);
+    expect(notice, `no failure notice was shown:\n${rendered}`).toBeGreaterThan(-1);
+    expect(reply, `the notice came before the answer:\n${rendered}`).toBeLessThan(notice);
+  });
+
+  // The behavioural cases above pin the two paths that were reported. This one
+  // pins the RULE, for the sites a component test cannot reach — the effort
+  // picker's "Switched effort to …" was appended from inside the
+  // `setThinkingLevel` updater the same way, and only a header dropdown with a
+  // provider that offers more than one level renders it at all.
+  it("has no state setter inside a state updater, anywhere in the UI", () => {
+    // The whole UI tree, not just the two surfaces: after this fix there are NO
+    // such sites left in src/components, src/hooks or src/app, so the rule can
+    // be stated as a rule. `src/app/page.tsx` held two more — the wallpaper
+    // upload and delete, each writing localStorage and calling two sibling
+    // setters from inside a `setCustomWallpapers` updater — and they are fixed
+    // here rather than excluded by the scope of the test that claims to cover
+    // them. They were idempotent, which is exactly why they went unnoticed.
+    const offenders = [...walk("src/components"), ...walk("src/hooks"), ...walk("src/app")]
+      .flatMap((file) => nestedSetters(file));
+
+    expect(offenders).toEqual([]);
+  });
+});
+
+/**
+ * Every `setX(prev => …)` in a file whose body calls another `setY(`.
+ *
+ * The body is taken by balancing parentheses from the updater's own `(`, so a
+ * nested arrow or object cannot end it early, and string/comment contents are
+ * not parsed — a `setSomething(` inside a string would be a false positive, and
+ * there are none in these two files today.
+ */
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(full));
+    else if (/\.tsx?$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Blank out comments and string bodies, preserving length and newlines.
+ *
+ * The paren scan below counts brackets, so ONE unmatched paren inside a prose
+ * comment closes an updater's body early and the rule silently stops guarding
+ * that site — and an unmatched one inside a string runs the scan to EOF and
+ * reports every setter in the rest of the file. `ChatPopup.tsx` is 6 300 lines
+ * of dense comments; a `// … the ) …` would have disarmed this with no signal.
+ */
+function blankNonCode(source: string): string {
+  const out = source.split("");
+  let i = 0;
+  const blank = (from: number, to: number) => {
+    for (let k = from; k < to && k < out.length; k++) if (out[k] !== "\n") out[k] = " ";
+  };
+  while (i < source.length) {
+    const two = source.slice(i, i + 2);
+    if (two === "//") {
+      const end = source.indexOf("\n", i);
+      blank(i, end < 0 ? source.length : end);
+      i = end < 0 ? source.length : end;
+    } else if (two === "/*") {
+      const end = source.indexOf("*/", i + 2);
+      blank(i, end < 0 ? source.length : end + 2);
+      i = end < 0 ? source.length : end + 2;
+    } else if (source[i] === '"' || source[i] === "'" || source[i] === "`") {
+      const quote = source[i];
+      let j = i + 1;
+      while (j < source.length && source[j] !== quote) j += source[j] === "\\" ? 2 : 1;
+      blank(i + 1, j);
+      i = j + 1;
+    } else {
+      i++;
+    }
+  }
+  return out.join("");
+}
+
+function nestedSetters(relativePath: string): string[] {
+  const source = blankNonCode(fs.readFileSync(path.join(process.cwd(), relativePath), "utf-8"));
+  // `set` + capital is also `setTimeout`/`setInterval`, whose callback is NOT a
+  // state updater — React does not re-run it — so they cannot open one. They
+  // stay in the nested set below, where scheduling a timer from inside an
+  // updater would be the same impurity. A leading `.` means a method
+  // (`localStorage.setItem`, `el.setAttribute`), never a setter from useState.
+  const opener = /(?<![.\w])set(?!Timeout|Interval|Immediate)[A-Z]\w*\(\s*(?:\w+|\([^)]*\))\s*=>/g;
+  const found: string[] = [];
+  for (const match of source.matchAll(opener)) {
+    const openParen = source.indexOf("(", match.index!);
+    let depth = 0;
+    let end = openParen;
+    for (; end < source.length; end++) {
+      if (source[end] === "(") depth++;
+      else if (source[end] === ")" && --depth === 0) break;
+    }
+    // A scan that ran to EOF found no closing paren, which means the blanking
+    // above missed something. Reporting garbage from it would be worse than
+    // saying so.
+    if (end >= source.length) {
+      found.push(`${relativePath}: unbalanced parentheses while scanning ${match[0]}`);
+      continue;
+    }
+    const body = source.slice(source.indexOf("=>", openParen) + 2, end);
+    // The project's OWN wrappers count: `setMessages(prev => { applyStreaming("");
+    // return prev })` would pass a setter-only rule while being strictly worse
+    // than the defect — React may run it twice AND it mutates a ref during the
+    // render phase, so the ref and the state can disagree at commit time.
+    const nested = [...body.matchAll(/(?<![.\w])(?:set|apply)[A-Z]\w*\(/g)].map((m) => m[0]);
+    if (nested.length > 0) {
+      const line = source.slice(0, match.index!).split("\n").length;
+      found.push(`${relativePath}:${line} ${match[0]} -> ${[...new Set(nested)].join(", ")}`);
+    }
+  }
+  return found;
+}

--- a/src/tests/components/chat-strict-mode-updater.test.tsx
+++ b/src/tests/components/chat-strict-mode-updater.test.tsx
@@ -1,6 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import fs from "node:fs";
-import path from "node:path";
 import { StrictMode } from "react";
 import { act, render, waitFor } from "@/tests/helpers/test-utils";
 import ChatApp from "@/components/ChatApp";
@@ -243,116 +241,9 @@ describe("an interrupted turn is appended once, however many times React renders
     expect(reply, `the notice came before the answer:\n${rendered}`).toBeLessThan(notice);
   });
 
-  // The behavioural cases above pin the two paths that were reported. This one
-  // pins the RULE, for the sites a component test cannot reach — the effort
-  // picker's "Switched effort to …" was appended from inside the
-  // `setThinkingLevel` updater the same way, and only a header dropdown with a
-  // provider that offers more than one level renders it at all.
-  it("has no state setter inside a state updater, anywhere in the UI", () => {
-    // The whole UI tree, not just the two surfaces: after this fix there are NO
-    // such sites left in src/components, src/hooks or src/app, so the rule can
-    // be stated as a rule. `src/app/page.tsx` held two more — the wallpaper
-    // upload and delete, each writing localStorage and calling two sibling
-    // setters from inside a `setCustomWallpapers` updater — and they are fixed
-    // here rather than excluded by the scope of the test that claims to cover
-    // them. They were idempotent, which is exactly why they went unnoticed.
-    const offenders = [...walk("src/components"), ...walk("src/hooks"), ...walk("src/app")]
-      .flatMap((file) => nestedSetters(file));
-
-    expect(offenders).toEqual([]);
-  });
+  // The behavioural cases above pin the two paths that were reported. The RULE
+  // — no state write inside any state updater, anywhere in the UI tree — is
+  // pinned by `src/tests/unit/state-updater-purity.test.ts`, which reads the
+  // tree with the TypeScript compiler instead of a regex and so needs neither
+  // jsdom nor React.
 });
-
-/**
- * Every `setX(prev => …)` in a file whose body calls another `setY(`.
- *
- * The body is taken by balancing parentheses from the updater's own `(`, so a
- * nested arrow or object cannot end it early, and string/comment contents are
- * not parsed — a `setSomething(` inside a string would be a false positive, and
- * there are none in these two files today.
- */
-function walk(dir: string): string[] {
-  const out: string[] = [];
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) out.push(...walk(full));
-    else if (/\.tsx?$/.test(entry.name)) out.push(full);
-  }
-  return out;
-}
-
-/**
- * Blank out comments and string bodies, preserving length and newlines.
- *
- * The paren scan below counts brackets, so ONE unmatched paren inside a prose
- * comment closes an updater's body early and the rule silently stops guarding
- * that site — and an unmatched one inside a string runs the scan to EOF and
- * reports every setter in the rest of the file. `ChatPopup.tsx` is 6 300 lines
- * of dense comments; a `// … the ) …` would have disarmed this with no signal.
- */
-function blankNonCode(source: string): string {
-  const out = source.split("");
-  let i = 0;
-  const blank = (from: number, to: number) => {
-    for (let k = from; k < to && k < out.length; k++) if (out[k] !== "\n") out[k] = " ";
-  };
-  while (i < source.length) {
-    const two = source.slice(i, i + 2);
-    if (two === "//") {
-      const end = source.indexOf("\n", i);
-      blank(i, end < 0 ? source.length : end);
-      i = end < 0 ? source.length : end;
-    } else if (two === "/*") {
-      const end = source.indexOf("*/", i + 2);
-      blank(i, end < 0 ? source.length : end + 2);
-      i = end < 0 ? source.length : end + 2;
-    } else if (source[i] === '"' || source[i] === "'" || source[i] === "`") {
-      const quote = source[i];
-      let j = i + 1;
-      while (j < source.length && source[j] !== quote) j += source[j] === "\\" ? 2 : 1;
-      blank(i + 1, j);
-      i = j + 1;
-    } else {
-      i++;
-    }
-  }
-  return out.join("");
-}
-
-function nestedSetters(relativePath: string): string[] {
-  const source = blankNonCode(fs.readFileSync(path.join(process.cwd(), relativePath), "utf-8"));
-  // `set` + capital is also `setTimeout`/`setInterval`, whose callback is NOT a
-  // state updater — React does not re-run it — so they cannot open one. They
-  // stay in the nested set below, where scheduling a timer from inside an
-  // updater would be the same impurity. A leading `.` means a method
-  // (`localStorage.setItem`, `el.setAttribute`), never a setter from useState.
-  const opener = /(?<![.\w])set(?!Timeout|Interval|Immediate)[A-Z]\w*\(\s*(?:\w+|\([^)]*\))\s*=>/g;
-  const found: string[] = [];
-  for (const match of source.matchAll(opener)) {
-    const openParen = source.indexOf("(", match.index!);
-    let depth = 0;
-    let end = openParen;
-    for (; end < source.length; end++) {
-      if (source[end] === "(") depth++;
-      else if (source[end] === ")" && --depth === 0) break;
-    }
-    // A scan that ran to EOF found no closing paren, which means the blanking
-    // above missed something. Reporting garbage from it would be worse than
-    // saying so.
-    if (end >= source.length) {
-      found.push(`${relativePath}: unbalanced parentheses while scanning ${match[0]}`);
-      continue;
-    }
-    const body = source.slice(source.indexOf("=>", openParen) + 2, end);
-    // The project's OWN wrappers count: `setMessages(prev => { applyStreaming("");
-    // return prev })` would pass a setter-only rule while being strictly worse
-    // than the defect — React may run it twice AND it mutates a ref during the
-    // render phase, so the ref and the state can disagree at commit time.
-    const nested = [...body.matchAll(/(?<![.\w])(?:set|apply)[A-Z]\w*\(/g)].map((m) => m[0]);
-    if (nested.length > 0) {
-      const line = source.slice(0, match.index!).split("\n").length;
-      found.push(`${relativePath}:${line} ${match[0]} -> ${[...new Set(nested)].join(", ")}`);
-    }
-  }
-  return found;
-}

--- a/src/tests/fixtures/impure-updaters.tsx
+++ b/src/tests/fixtures/impure-updaters.tsx
@@ -28,7 +28,11 @@ export function shapes(
   setConciseRefWrite: Setter<string>,
   setCompoundRefWrite: Setter<string>,
   setThroughProperty: Setter<string>,
+  setWithFetch: Setter<string>,
+  setWithKvWrite: Setter<string>,
+  setWithDeferredWrite: Setter<string>,
   catalog: { setSort: (next: string) => void },
+  kv: { set: (key: string, value: string) => void },
   streamingRef: { current: string },
 ): void {
   // The defect as it shipped: a sibling setter called from inside an updater.
@@ -87,6 +91,33 @@ export function shapes(
   // may not be blind.
   setThroughProperty((prev) => {
     catalog.setSort("name");
+    return prev;
+  });
+
+  // A network call inside an updater. `fetch` matches no name rule at all, and
+  // the real one was a dismissal POST inside `setUpdateAvailable` in page.tsx —
+  // sent once per render attempt rather than once per click.
+  setWithFetch((prev) => {
+    fetch("/setup-api/update/dismissal", { method: "POST" }).catch(() => {});
+    return prev;
+  });
+
+  // A persistence write through a LOWER-CASE member. `kv.set` has no capital
+  // after `set`, so a name rule cannot see it — and that is exactly what hid
+  // the third instance of this defect in Mascot.tsx while two others were being
+  // fixed. Covered by receiver, not by method name.
+  setWithKvWrite((prev) => {
+    kv.set("clawbox:fixture", "1");
+    return prev;
+  });
+
+  // A timer INSIDE an updater, which is the half of the NOT_UPDATERS rule the
+  // comment used to get wrong. The timer CALL is not reported — React never
+  // re-runs a timer callback — but the state write inside it is, and must be:
+  // React re-running the updater schedules the timer twice, so the write really
+  // does happen twice.
+  setWithDeferredWrite((prev) => {
+    setTimeout(() => setMessages((msgs) => msgs), 0);
     return prev;
   });
 

--- a/src/tests/fixtures/impure-updaters.tsx
+++ b/src/tests/fixtures/impure-updaters.tsx
@@ -1,0 +1,63 @@
+/**
+ * Fixture for `src/tests/unit/state-updater-purity.test.ts`. NOT shipped code
+ * and not a test file: it is the set of shapes the rule has to catch, kept out
+ * of the walked directories so the rule can assert an empty list over the real
+ * tree and still be known to be looking.
+ *
+ * Every one of these went undetected by the regex version of the guard.
+ */
+
+type Setter<T> = (next: T | ((prev: T) => T)) => void;
+
+/**
+ * The literal that used to turn the whole scan off.
+ *
+ * The hand-rolled blanker had no notion of a regex literal, so this quote
+ * opened a string span that ran to the next quote in the file, inverting its
+ * idea of what was code from here on — and it reported nothing, green.
+ */
+const QUOTES = /['"]/g;
+
+export function shapes(
+  setStreaming: Setter<string>,
+  setMessages: Setter<string[]>,
+  setFromFunctionExpression: Setter<string>,
+  applyWrapper: Setter<string>,
+  applyStreaming: (next: string) => void,
+  setWithRefWrite: Setter<string>,
+  streamingRef: { current: string },
+): void {
+  // The defect as it shipped: a sibling setter called from inside an updater.
+  setStreaming((prev) => {
+    setMessages((msgs) => [...msgs, prev]);
+    return "";
+  });
+
+  // The same thing written as a function expression — what a refactor reaches
+  // for when the body grows, and what an arrow-only opener walked straight past.
+  setFromFunctionExpression(function (prev: string) {
+    setMessages((msgs) => [...msgs, prev]);
+    return "";
+  });
+
+  // An `apply*` wrapper may neither be called from inside an updater nor take
+  // one: it writes the ref, so React running it twice desynchronises the ref
+  // from the state at commit time.
+  applyWrapper((prev) => {
+    applyStreaming("");
+    return prev;
+  });
+
+  // A render-phase ref mutation. Strictly worse than the original defect, and
+  // the rule the fix itself leans on.
+  setWithRefWrite((prev) => {
+    streamingRef.current = prev;
+    return prev;
+  });
+
+  // NOT offenders, and here so the rule is known to leave them alone: a timer
+  // callback is not an updater (React never re-runs it), and a method call is
+  // not a state writer.
+  setTimeout(() => setMessages((msgs) => msgs), 0);
+  localStorage.setItem("clawbox:fixture", QUOTES.source);
+}

--- a/src/tests/fixtures/impure-updaters.tsx
+++ b/src/tests/fixtures/impure-updaters.tsx
@@ -27,6 +27,8 @@ export function shapes(
   setWithRefWrite: Setter<string>,
   setConciseRefWrite: Setter<string>,
   setCompoundRefWrite: Setter<string>,
+  setThroughProperty: Setter<string>,
+  catalog: { setSort: (next: string) => void },
   streamingRef: { current: string },
 ): void {
   // The defect as it shipped: a sibling setter called from inside an updater.
@@ -66,7 +68,6 @@ export function shapes(
   // visited only the children caught it; without them the body IS the
   // assignment and that walk saw nothing. Adding the brackets here would make
   // this case pass against the defect it exists to pin.
-  // eslint-disable-next-line no-return-assign
   setConciseRefWrite((prev) => streamingRef.current = prev);
 
   // The compound form. `someRef.current += 1` is the generation-counter idiom
@@ -78,9 +79,22 @@ export function shapes(
     return "";
   });
 
+  // A setter reached through a PROPERTY, in the nested position. This is live
+  // style in this repo, not a hypothetical: `HermesSkillsStore.tsx` calls
+  // `catalog.setSort(...)` / `catalog.setQuery(...)` — state writers returned
+  // on a hook's object — and a bare-identifier rule reports nothing for them.
+  // The nested position is where the defect lives, so it is the position that
+  // may not be blind.
+  setThroughProperty((prev) => {
+    catalog.setSort("name");
+    return prev;
+  });
+
   // NOT offenders, and here so the rule is known to leave them alone: a timer
-  // callback is not an updater (React never re-runs it), and a method call is
-  // not a state writer.
+  // callback is not an updater (React never re-runs it), and neither of these
+  // sits inside an updater to begin with — the property rule above applies in
+  // the nested position only, so a `localStorage.setItem` at the top level of a
+  // component is not a finding.
   setTimeout(() => setMessages((msgs) => msgs), 0);
   localStorage.setItem("clawbox:fixture", QUOTES.source);
 }

--- a/src/tests/fixtures/impure-updaters.tsx
+++ b/src/tests/fixtures/impure-updaters.tsx
@@ -31,6 +31,7 @@ export function shapes(
   setWithFetch: Setter<string>,
   setWithKvWrite: Setter<string>,
   setWithDeferredWrite: Setter<string>,
+  applyWithOptions: (next: string | ((prev: string) => string), opts: { merge: boolean }) => void,
   catalog: { setSort: (next: string) => void },
   kv: { set: (key: string, value: string) => void },
   streamingRef: { current: string },
@@ -110,6 +111,17 @@ export function shapes(
     kv.set("clawbox:fixture", "1");
     return prev;
   });
+
+  // An `apply*` wrapper carrying an OPTIONS OBJECT. The opener used to require
+  // EXACTLY one argument, so a project wrapper that grew a second parameter
+  // opened nothing and its updater went unread — while the docblock puts these
+  // wrappers in scope precisely because they are the project's own and are the
+  // kind that grows options. React's own setters take one argument, so nothing
+  // else widened.
+  applyWithOptions((prev) => {
+    kv.set("clawbox:fixture", "2");
+    return prev;
+  }, { merge: true });
 
   // A timer INSIDE an updater, which is the half of the NOT_UPDATERS rule the
   // comment used to get wrong. The timer CALL is not reported — React never

--- a/src/tests/fixtures/impure-updaters.tsx
+++ b/src/tests/fixtures/impure-updaters.tsx
@@ -25,6 +25,8 @@ export function shapes(
   applyWrapper: Setter<string>,
   applyStreaming: (next: string) => void,
   setWithRefWrite: Setter<string>,
+  setConciseRefWrite: Setter<string>,
+  setCompoundRefWrite: Setter<string>,
   streamingRef: { current: string },
 ): void {
   // The defect as it shipped: a sibling setter called from inside an updater.
@@ -53,6 +55,27 @@ export function shapes(
   setWithRefWrite((prev) => {
     streamingRef.current = prev;
     return prev;
+  });
+
+  // A concise arrow body that IS the write. It type-checks (an assignment
+  // evaluates to the assigned value) and it lints clean, and it went unseen
+  // while the same code in braces was caught — the rule's answer must not
+  // depend on a pair of brackets.
+  // Deliberately UNPARENTHESISED: with brackets the body node is a
+  // ParenthesizedExpression whose child is the assignment, so a walk that
+  // visited only the children caught it; without them the body IS the
+  // assignment and that walk saw nothing. Adding the brackets here would make
+  // this case pass against the defect it exists to pin.
+  // eslint-disable-next-line no-return-assign
+  setConciseRefWrite((prev) => streamingRef.current = prev);
+
+  // The compound form. `someRef.current += 1` is the generation-counter idiom
+  // this codebase uses in thirteen places, and accumulating a streaming buffer
+  // with `+=` inside an updater is the most natural wrong way to write the
+  // defect this rule exists for.
+  setCompoundRefWrite((prev) => {
+    streamingRef.current += prev;
+    return "";
   });
 
   // NOT offenders, and here so the rule is known to leave them alone: a timer

--- a/src/tests/unit/state-updater-purity.test.ts
+++ b/src/tests/unit/state-updater-purity.test.ts
@@ -1,4 +1,22 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+// Parses ~270 files with the TypeScript compiler inside ONE case, and v8
+// coverage instrumentation multiplies that by about seven: 426 ms of parse
+// uninstrumented, 2 874 ms under `test:coverage:ci` on an idle machine, and
+// 5 318 ms on a four-worker CI runner — where it failed the whole job with
+// vitest's "Test timed out in 5000ms" over a tree the rule found CLEAN, which
+// is the false-failure class in the guard itself.
+//
+// The ceiling is declared rather than the walk narrowed, because the walk IS
+// the sibling sweep this PR leans on: it is what says the four state-holding
+// directories carry no second offender. Cutting it to the files that import
+// the streaming state, or tightening the text pre-filter into something that
+// tries to predict which files the AST rule can fire on, buys ~1.7 s and pays
+// for it in exactly the currency this file's docblock warns about — a guard
+// that silently stops looking. 30 s is ~6x the measured CI cost and still
+// fails a case that has genuinely hung. Both ceilings, per the house form; see
+// src/tests/unit/test-timeout-hygiene.test.ts, which pins this file by name.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 import fs from "node:fs";
 import path from "node:path";
 import ts from "typescript";
@@ -219,6 +237,7 @@ describe("no state write inside a state updater", () => {
       expect.stringContaining("setWithRefWrite(updater) -> streamingRef.current ="),
       expect.stringContaining("setConciseRefWrite(updater) -> streamingRef.current ="),
       expect.stringContaining("setCompoundRefWrite(updater) -> streamingRef.current +="),
+      expect.stringContaining("setThroughProperty(updater) -> catalog.setSort()"),
     ]);
   });
 });

--- a/src/tests/unit/state-updater-purity.test.ts
+++ b/src/tests/unit/state-updater-purity.test.ts
@@ -33,8 +33,12 @@ const ROOTS = ["src/components", "src/hooks", "src/app", "src/lib"];
 /**
  * `set` + capital is also `setTimeout`/`setInterval`/`setImmediate`, whose
  * callback is NOT a state updater — React does not re-run it — so they cannot
- * OPEN one. They stay in the nested set below, where scheduling a timer from
- * inside an updater is the same impurity.
+ * open one.
+ *
+ * They are excluded in BOTH positions, which means scheduling a timer from
+ * inside an updater is not reported either. That is a gap, stated rather than
+ * papered over: it is an impurity, but a far less damaging one than a second
+ * state write, and separating the two positions costs more than it buys.
  */
 const NOT_UPDATERS = new Set(["setTimeout", "setInterval", "setImmediate"]);
 
@@ -49,6 +53,14 @@ const NOT_UPDATERS = new Set(["setTimeout", "setInterval", "setImmediate"]);
  */
 function isStateWriter(name: string): boolean {
   return /^(set|apply)[A-Z]/.test(name) && !NOT_UPDATERS.has(name);
+}
+
+/** `someRef.current`, however it is spelled. */
+function isCurrentAccess(node: ts.Expression): boolean {
+  if (ts.isPropertyAccessExpression(node)) return node.name.text === "current";
+  return ts.isElementAccessExpression(node)
+    && ts.isStringLiteralLike(node.argumentExpression)
+    && node.argumentExpression.text === "current";
 }
 
 /** The plain `foo(...)` callee name, or null for `a.foo(...)` and the rest. */
@@ -97,17 +109,28 @@ function impureUpdaters(relativePath: string): string[] {
         const name = calleeName(node);
         if (name && isStateWriter(name)) hits.push(`${name}()`);
       }
+      // EVERY assignment operator, not just `=`. `someRef.current += 1` is the
+      // generation-counter idiom this codebase uses in thirteen places,
+      // `ChatPopup.tsx` among them, and accumulating a streaming buffer with
+      // `+=` inside an updater is the most natural wrong way to write TASK-703's
+      // own code. `ref["current"]` counts too.
       if (
         ts.isBinaryExpression(node)
-        && node.operatorToken.kind === ts.SyntaxKind.EqualsToken
-        && ts.isPropertyAccessExpression(node.left)
-        && node.left.name.text === "current"
+        && node.operatorToken.kind >= ts.SyntaxKind.FirstAssignment
+        && node.operatorToken.kind <= ts.SyntaxKind.LastAssignment
+        && isCurrentAccess(node.left)
       ) {
-        hits.push(`${node.left.getText(file)} =`);
+        hits.push(`${node.left.getText(file)} ${node.operatorToken.getText(file)}`);
       }
       ts.forEachChild(node, visit);
     };
-    ts.forEachChild(body, visit);
+    // The body NODE, not its children. A concise arrow body IS the expression,
+    // so `setStreamingState(prev => streamingRef.current = prev)` — which
+    // type-checks and lints clean, and is a render-phase write to the very ref
+    // this fix leans on — went unseen while the same code in braces was caught.
+    // A rule whose answer depends on a pair of brackets is not a rule. `visit`
+    // handles the node and then recurses, so a block body is unchanged.
+    visit(body);
     return hits;
   };
 
@@ -132,7 +155,7 @@ function impureUpdaters(relativePath: string): string[] {
   return found;
 }
 
-describe("a state updater is a pure function of the previous state", () => {
+describe("no state write inside a state updater", () => {
   it("has no state write inside a state updater, anywhere in the UI", () => {
     // The four directories that hold this app's React state, not just the two
     // chat surfaces: after TASK-703 there are NO such sites left, so the rule
@@ -146,7 +169,35 @@ describe("a state updater is a pure function of the previous state", () => {
     // share lives: `useChatToolCalls` (chat-tool-events.tsx) is called from
     // ChatApp and ChatPopup alike, so the same defect there would reach both
     // through the same abort path.
-    const offenders = ROOTS.flatMap((root) => sourceFiles(root)).flatMap(impureUpdaters);
+    //
+    // WHAT A GREEN TICK HERE DOES NOT PROVE, so the next reader does not read
+    // it as absence. The rule is syntactic and cannot follow a name: a setter
+    // reached through an alias (`const append = setMessages`) or an updater
+    // declared as a variable and passed in by name are both invisible, and so
+    // is a setter reached through a property (`ctx.setSort(…)`). And it detects
+    // state writes and ref writes only — an updater whose one side effect is a
+    // `localStorage.setItem`, a `fetch` or an `audio.play()` is impure and is
+    // not reported. Chasing those by AST costs more than it buys; saying so
+    // costs a paragraph.
+    //
+    // In the other direction it is deliberately over-eager: any single-argument
+    // call to a `set*`/`apply*` identifier taking a function is treated as an
+    // updater, whether or not the callee is a React setter. That is the safe
+    // side of the trade — the alternative is a rule that has to know which
+    // names are setters — but it means a legitimate `setX(fn)` helper of one's
+    // own can turn this red. If that happens, the answer is to rename the
+    // helper or to hoist the callback out of the call, not to weaken the rule.
+    const files = ROOTS.flatMap((root) => sourceFiles(root));
+    // The WALK, not only the rule. Rename a directory, add an exclude, change
+    // the extension test, and `files` becomes short or empty while both cases
+    // here stay green — an empty list assertion over an empty tree proves
+    // nothing. Two anchors and a floor: the surface the defect was on, and the
+    // shared state both surfaces consume.
+    expect(files.length).toBeGreaterThan(300);
+    expect(files).toContain("src/components/ChatApp.tsx");
+    expect(files).toContain("src/lib/chat-tool-events.tsx");
+
+    const offenders = files.flatMap(impureUpdaters);
 
     expect(offenders).toEqual([]);
   });
@@ -166,6 +217,8 @@ describe("a state updater is a pure function of the previous state", () => {
       expect.stringContaining("setFromFunctionExpression(updater) -> setMessages()"),
       expect.stringContaining("applyWrapper(updater) -> applyStreaming()"),
       expect.stringContaining("setWithRefWrite(updater) -> streamingRef.current ="),
+      expect.stringContaining("setConciseRefWrite(updater) -> streamingRef.current ="),
+      expect.stringContaining("setCompoundRefWrite(updater) -> streamingRef.current +="),
     ]);
   });
 });

--- a/src/tests/unit/state-updater-purity.test.ts
+++ b/src/tests/unit/state-updater-purity.test.ts
@@ -86,6 +86,28 @@ function calleeName(node: ts.CallExpression): string | null {
   return ts.isIdentifier(node.expression) ? node.expression.text : null;
 }
 
+/**
+ * The same, plus the property form `a.foo(...)` — for the NESTED position only.
+ *
+ * The two positions are deliberately not symmetric. Opening an updater on
+ * `a.setX(fn)` would treat every `foo.setSomething(callback)` in the tree as a
+ * React updater, which is a wide guess; but the nested position is where the
+ * defect lives, and a setter reached through a property is live style here —
+ * `HermesSkillsStore.tsx` calls `catalog.setSort(...)` and `catalog.setQuery(...)`,
+ * state writers returned on a hook's object. Reporting `ctx.setSort()` inside
+ * an updater is the same finding as reporting `setSort()`, and inside an
+ * updater a `localStorage.setItem` or an `el.setAttribute` is an impurity too,
+ * so the wider net costs nothing here.
+ *
+ * `obj["setX"](...)` is still not followed: it is not written in this tree and
+ * the string form would need the same care `isCurrentAccess` takes.
+ */
+function nestedWriterName(node: ts.CallExpression): string | null {
+  if (ts.isIdentifier(node.expression)) return node.expression.text;
+  if (ts.isPropertyAccessExpression(node.expression)) return node.expression.name.text;
+  return null;
+}
+
 function sourceFiles(dir: string): string[] {
   const out: string[] = [];
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -124,8 +146,10 @@ function impureUpdaters(relativePath: string): string[] {
     const hits: string[] = [];
     const visit = (node: ts.Node) => {
       if (ts.isCallExpression(node)) {
-        const name = calleeName(node);
-        if (name && isStateWriter(name)) hits.push(`${name}()`);
+        const name = nestedWriterName(node);
+        // Reported as WRITTEN — `catalog.setSort()`, not `setSort()` — so the
+        // message names the call the reader has to go and find.
+        if (name && isStateWriter(name)) hits.push(`${node.expression.getText(file)}()`);
       }
       // EVERY assignment operator, not just `=`. `someRef.current += 1` is the
       // generation-counter idiom this codebase uses in thirteen places,
@@ -191,12 +215,12 @@ describe("no state write inside a state updater", () => {
     // WHAT A GREEN TICK HERE DOES NOT PROVE, so the next reader does not read
     // it as absence. The rule is syntactic and cannot follow a name: a setter
     // reached through an alias (`const append = setMessages`) or an updater
-    // declared as a variable and passed in by name are both invisible, and so
-    // is a setter reached through a property (`ctx.setSort(…)`). And it detects
-    // state writes and ref writes only — an updater whose one side effect is a
-    // `localStorage.setItem`, a `fetch` or an `audio.play()` is impure and is
-    // not reported. Chasing those by AST costs more than it buys; saying so
-    // costs a paragraph.
+    // declared as a variable and passed in by name are both invisible. A setter
+    // reached through a property (`ctx.setSort(…)`) IS seen in the nested
+    // position — where the defect lives — but does not open an updater. And it
+    // detects state writes and ref writes only — an updater whose one side
+    // effect is a `fetch` or an `audio.play()` is impure and is not reported.
+    // Chasing those by AST costs more than it buys; saying so costs a paragraph.
     //
     // In the other direction it is deliberately over-eager: any single-argument
     // call to a `set*`/`apply*` identifier taking a function is treated as an

--- a/src/tests/unit/state-updater-purity.test.ts
+++ b/src/tests/unit/state-updater-purity.test.ts
@@ -54,8 +54,27 @@ vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
  * instead of a slice of text.
  */
 
-/** Directories whose React state this rule covers. */
-const ROOTS = ["src/components", "src/hooks", "src/app", "src/lib"];
+/**
+ * Directories whose React state this rule covers, each with a FLOOR under the
+ * number of files it must walk.
+ *
+ * Roughly half of today's counts (110 / 10 / 200 / 323), so the floors survive
+ * ordinary churn and still fail an exclude that guts a root. A `> 0` floor was
+ * not enough: an exclude leaving `src/app` with ONE of its 200 files kept all
+ * six cases green — the total floor is 300 against 444 remaining, and both
+ * anchors sit in the other two roots. That is the same silent narrowing the pin
+ * below catches, one order weaker.
+ *
+ * ROOTS is DERIVED from this map, so a root cannot be added without a floor
+ * under it.
+ */
+const ROOT_FLOORS: Record<string, number> = {
+  "src/components": 50,
+  "src/hooks": 5,
+  "src/app": 100,
+  "src/lib": 200,
+};
+const ROOTS = Object.keys(ROOT_FLOORS);
 
 /**
  * `set` + capital is also `setTimeout`/`setInterval`/`setImmediate`, whose
@@ -297,8 +316,11 @@ describe("no state write inside a state updater", () => {
     expect(files).toContain("src/lib/chat-tool-events.tsx");
     // Per ROOT as well as over the total, because the anchors sit in two of the
     // four and `src/hooks` is 10 of 643 files: an exclude in `sourceFiles` that
-    // emptied a root would clear the 300 floor and both anchors untouched.
-    for (const root of ROOTS) expect(sourceFiles(root).length).toBeGreaterThan(0);
+    // gutted a root would leave the 300 floor and both anchors untouched.
+    for (const root of ROOTS) {
+      expect(sourceFiles(root).length, `${root} walks far fewer files than it holds`)
+        .toBeGreaterThan(ROOT_FLOORS[root]);
+    }
     expect(files.filter((f) => mayHoldStateWrite(readSource(f))).length).toBeGreaterThan(200);
   });
 
@@ -339,14 +361,19 @@ describe("no state write inside a state updater", () => {
     // the answer is to name its receiver in SIDE_EFFECT_RECEIVERS, which is why
     // that set is keyed on the receiver rather than on method names.
     //
-    // And the receiver is matched by its SOURCE TEXT, not resolved: `kv.set` is
-    // named, `window.localStorage.setItem` is named because that whole spelling
-    // is in the set, but `storage.kv.set`, `kv!.set`, `(kv).set`, `kv["set"]`
-    // and `window.fetch` are all invisible — the first three because the text
-    // differs, the last because `fetch` is matched only as a bare identifier.
-    // None is written in this tree today (grep), and the live style
-    // `window.localStorage?.setItem(…)` IS covered; the answer when one arrives
-    // is another entry in the set, not a resolver.
+    // And the receiver is matched by its SOURCE TEXT, not resolved. `kv.set` is
+    // named, and `window.localStorage.setItem` is named because that whole
+    // spelling is in the set — which is why the live style
+    // `window.localStorage?.setItem(…)`, used nine times here, IS covered.
+    // Invisible, for three different reasons: `storage.kv.set`, `kv!.set` and
+    // `(kv).set`, because the receiver's text is not the text in the set;
+    // `kv["set"]`, because an element access takes neither branch of
+    // `isSideEffectCall` and so has no receiver text at all; `window.fetch` and
+    // `globalThis.fetch`, because `fetch` is matched only as a bare identifier.
+    // None is written in this tree today (grep). The answer when one arrives is
+    // another entry in the set, not a resolver — a resolver would have to
+    // un-name `window.localStorage`, which is the spelling carrying the live
+    // sites.
     //
     // In the other direction it is deliberately over-eager: any call to a
     // `set*`/`apply*` identifier whose FIRST argument is a function is treated

--- a/src/tests/unit/state-updater-purity.test.ts
+++ b/src/tests/unit/state-updater-purity.test.ts
@@ -243,12 +243,19 @@ function impureUpdaters(relativePath: string): string[] {
   };
 
   const visit = (node: ts.Node) => {
-    if (ts.isCallExpression(node) && node.arguments.length === 1) {
+    if (ts.isCallExpression(node) && node.arguments.length >= 1) {
       const name = calleeName(node);
       const arg = node.arguments[0];
-      // A function passed as the ONLY argument to a state writer is an updater:
-      // an arrow, and `function (prev) { … }` too — the shape a regex opener
-      // missed and the shape a refactor reaches for when the body grows.
+      // A function passed as the FIRST argument to a state writer is an
+      // updater: an arrow, and `function (prev) { … }` too — the shape a regex
+      // opener missed and the shape a refactor reaches for when the body grows.
+      //
+      // FIRST rather than ONLY, because the docblock above puts the project's
+      // own `apply*` wrappers in scope and a project wrapper is exactly the kind
+      // that grows an options object: `applyThing(prev => …, { merge: true })`
+      // opened nothing under an exact-arity test. React's own setters take one
+      // argument, so this only widens the wrapper case, and `setTimeout` and
+      // friends are excluded by NOT_UPDATERS rather than by arity.
       if (name && isStateWriter(name) && (ts.isArrowFunction(arg) || ts.isFunctionExpression(arg))) {
         const hits = impurities(arg.body);
         if (hits.length > 0) {
@@ -274,10 +281,24 @@ describe("no state write inside a state updater", () => {
     //
     // Two anchors, and a floor under each layer: the surface the defect was on,
     // and the shared state both surfaces consume.
+    //
+    // ROOTS itself is PINNED rather than floored, because it is the one layer
+    // where a narrowing removes a CASE instead of failing one: the sweep below
+    // is `it.each(ROOTS)`, so dropping `src/app` — 200 of the 643 files, and
+    // where three of the ten offenders this branch fixes lived, `page.tsx`
+    // among them — left five green ticks over a third of the tree that had
+    // stopped being read, under the 300 floor and both anchors alike
+    // (measured). The pin bites in the other direction too: a root ADDED
+    // without the floor beneath it.
+    expect(ROOTS).toEqual(["src/components", "src/hooks", "src/app", "src/lib"]);
     const files = ROOTS.flatMap((root) => sourceFiles(root));
     expect(files.length).toBeGreaterThan(300);
     expect(files).toContain("src/components/ChatApp.tsx");
     expect(files).toContain("src/lib/chat-tool-events.tsx");
+    // Per ROOT as well as over the total, because the anchors sit in two of the
+    // four and `src/hooks` is 10 of 643 files: an exclude in `sourceFiles` that
+    // emptied a root would clear the 300 floor and both anchors untouched.
+    for (const root of ROOTS) expect(sourceFiles(root).length).toBeGreaterThan(0);
     expect(files.filter((f) => mayHoldStateWrite(readSource(f))).length).toBeGreaterThan(200);
   });
 
@@ -318,10 +339,19 @@ describe("no state write inside a state updater", () => {
     // the answer is to name its receiver in SIDE_EFFECT_RECEIVERS, which is why
     // that set is keyed on the receiver rather than on method names.
     //
-    // In the other direction it is deliberately over-eager: any single-argument
-    // call to a `set*`/`apply*` identifier taking a function is treated as an
-    // updater, whether or not the callee is a React setter. That is the safe
-    // side of the trade — the alternative is a rule that has to know which
+    // And the receiver is matched by its SOURCE TEXT, not resolved: `kv.set` is
+    // named, `window.localStorage.setItem` is named because that whole spelling
+    // is in the set, but `storage.kv.set`, `kv!.set`, `(kv).set`, `kv["set"]`
+    // and `window.fetch` are all invisible — the first three because the text
+    // differs, the last because `fetch` is matched only as a bare identifier.
+    // None is written in this tree today (grep), and the live style
+    // `window.localStorage?.setItem(…)` IS covered; the answer when one arrives
+    // is another entry in the set, not a resolver.
+    //
+    // In the other direction it is deliberately over-eager: any call to a
+    // `set*`/`apply*` identifier whose FIRST argument is a function is treated
+    // as an updater, whether or not the callee is a React setter. That is the
+    // safe side of the trade — the alternative is a rule that has to know which
     // names are setters — but it means a legitimate `setX(fn)` helper of one's
     // own can turn this red. The answer is to rename the helper, to hoist the
     // callback out of the call, or — for a built-in mutator in the nested
@@ -349,6 +379,7 @@ describe("no state write inside a state updater", () => {
       expect.stringContaining("setThroughProperty(updater) -> catalog.setSort()"),
       expect.stringContaining("setWithFetch(updater) -> fetch()"),
       expect.stringContaining("setWithKvWrite(updater) -> kv.set()"),
+      expect.stringContaining("applyWithOptions(updater) -> kv.set()"),
       expect.stringContaining("setWithDeferredWrite(updater) -> setMessages()"),
     ]);
   });

--- a/src/tests/unit/state-updater-purity.test.ts
+++ b/src/tests/unit/state-updater-purity.test.ts
@@ -1,25 +1,34 @@
 import { describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import ts from "typescript";
 
-// Parses ~270 files with the TypeScript compiler inside ONE case, and v8
-// coverage instrumentation multiplies that by about seven: 426 ms of parse
+// The sweep parses ~270 files with the TypeScript compiler, and v8 coverage
+// instrumentation multiplies that by about seven: 426 ms of parse
 // uninstrumented, 2 874 ms under `test:coverage:ci` on an idle machine, and
 // 5 318 ms on a four-worker CI runner — where it failed the whole job with
 // vitest's "Test timed out in 5000ms" over a tree the rule found CLEAN, which
 // is the false-failure class in the guard itself.
 //
 // The ceiling is declared rather than the walk narrowed, because the walk IS
-// the sibling sweep this PR leans on: it is what says the four state-holding
-// directories carry no second offender. Cutting it to the files that import
-// the streaming state, or tightening the text pre-filter into something that
-// tries to predict which files the AST rule can fire on, buys ~1.7 s and pays
-// for it in exactly the currency this file's docblock warns about — a guard
-// that silently stops looking. 30 s is ~6x the measured CI cost and still
-// fails a case that has genuinely hung. Both ceilings, per the house form; see
+// the sibling sweep this rule exists to be: it is what says the four
+// state-holding directories carry no second offender. Cutting it to the files
+// that import the streaming state, or tightening the text pre-filter into
+// something that tries to predict which files the AST rule can fire on, buys
+// ~1.7 s and pays for it in exactly the currency the docblock below warns
+// about — a guard that silently stops looking.
+//
+// A ceiling alone was not enough, and this is why the sweep is split into one
+// case PER ROOT below: measured at load ~52 on a 12-core machine, the combined
+// walk failed at 34 107 ms against a 30 000 ms budget. The cost is O(files) and
+// grows with the tree, so a single case holding the whole walk is the 5 000 ms
+// failure again, one doubling later. `testTimeout` is per CASE, so four cases
+// parsing 76 / 10 / 59 / 128 files have a quarter of the exposure over exactly
+// the same files. 30 s rather than 60 s because the split is the structural
+// fix and the budget is only the backstop — a case that has genuinely hung
+// should still be caught. Both ceilings, per the house form; see
 // src/tests/unit/test-timeout-hygiene.test.ts, which pins this file by name.
 vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
-import fs from "node:fs";
-import path from "node:path";
-import ts from "typescript";
 
 /**
  * A React state updater is a PURE function of the previous state.
@@ -53,10 +62,19 @@ const ROOTS = ["src/components", "src/hooks", "src/app", "src/lib"];
  * callback is NOT a state updater — React does not re-run it — so they cannot
  * open one.
  *
- * They are excluded in BOTH positions, which means scheduling a timer from
- * inside an updater is not reported either. That is a gap, stated rather than
- * papered over: it is an impurity, but a far less damaging one than a second
- * state write, and separating the two positions costs more than it buys.
+ * Excluded in BOTH positions, so scheduling a timer from inside an updater is
+ * not itself reported — a real but far less damaging impurity than a second
+ * state write. What IS reported is a state write **inside** that timer, because
+ * the walk recurses into the callback: React re-running the updater schedules
+ * the timer twice, so the write really does happen twice. Both directions are
+ * pinned in the fixture rather than left to this paragraph.
+ *
+ * This set is also the ESCAPE HATCH, and it works in both positions. A built-in
+ * mutator that matches the name rule but is pure with respect to anything
+ * outside the updater — `d.setHours(0, 0, 0, 0)` on a `Date` created inside it —
+ * belongs here. There is none in the tree today; the alternative when one
+ * arrives must not be to weaken the rule, because `Date.prototype.setHours`
+ * cannot be renamed and a `prev`-dependent normalisation cannot be hoisted out.
  */
 const NOT_UPDATERS = new Set(["setTimeout", "setInterval", "setImmediate"]);
 
@@ -108,6 +126,36 @@ function nestedWriterName(node: ts.CallExpression): string | null {
   return null;
 }
 
+/**
+ * Calls that are a side effect whatever they are called.
+ *
+ * `^(set|apply)[A-Z]` is a NAME rule, and the two defects it could not name
+ * were both real: a `fetch` POST inside `setUpdateAvailable` (page.tsx) and
+ * `kv.set` / `kv.remove` inside `setHidden` (Mascot.tsx) — the second one
+ * screen from the same file's correct pattern, missed only because `kv.set`
+ * has no capital after `set`. A rule that finds two of three instances of a
+ * defect and calls the sweep done is the shape this repo keeps producing.
+ *
+ * So persistence and network are named directly, by RECEIVER rather than by
+ * method name: every member of `kv`, `localStorage` and `sessionStorage`
+ * counts, and so does a bare `fetch`. Naming the receiver is what makes
+ * `kv.remove` and a future `kv.whatever` covered without listing methods.
+ */
+const SIDE_EFFECT_RECEIVERS = new Set([
+  "kv", "localStorage", "sessionStorage",
+  "window.localStorage", "window.sessionStorage",
+  "globalThis.localStorage", "globalThis.sessionStorage",
+]);
+const SIDE_EFFECT_CALLS = new Set(["fetch"]);
+
+function isSideEffectCall(node: ts.CallExpression, file: ts.SourceFile): boolean {
+  if (ts.isIdentifier(node.expression)) return SIDE_EFFECT_CALLS.has(node.expression.text);
+  if (ts.isPropertyAccessExpression(node.expression)) {
+    return SIDE_EFFECT_RECEIVERS.has(node.expression.expression.getText(file));
+  }
+  return false;
+}
+
 function sourceFiles(dir: string): string[] {
   const out: string[] = [];
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -126,13 +174,29 @@ function sourceFiles(dir: string): string[] {
  * `streamingRef.current = …` inside an updater is a render-phase mutation, and
  * the ref is exactly what the fix uses to read the buffer from outside.
  */
+function readSource(relativePath: string): string {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf-8");
+}
+
+/**
+ * The cheap text pre-filter: a file with no `set`/`apply` + capital anywhere in
+ * it cannot hold a hit, because every hit needs an OPENER of that shape — so
+ * parsing it is wasted work, and the walk is ~640 files.
+ *
+ * An OVER-approximation on purpose: it can only include files that turn out
+ * clean, never skip one that is not. Named rather than inlined so the walk case
+ * can put a FLOOR under it: nothing else does, and a future narrowing that
+ * still matched the fixture would leave every case green while the real tree
+ * went unread — the guard silently stopping to look, which is the one failure
+ * this file refuses to accept anywhere else.
+ */
+function mayHoldStateWrite(text: string): boolean {
+  return /(?:set|apply)[A-Z]/.test(text);
+}
+
 function impureUpdaters(relativePath: string): string[] {
-  const text = fs.readFileSync(path.join(process.cwd(), relativePath), "utf-8");
-  // A file with no `set`/`apply` + capital anywhere in it cannot hold a state
-  // write, so parsing it is wasted work — the walk is ~700 files. An OVER-
-  // approximation on purpose: it can only include files that turn out clean,
-  // never skip one that is not.
-  if (!/(?:set|apply)[A-Z]/.test(text)) return [];
+  const text = readSource(relativePath);
+  if (!mayHoldStateWrite(text)) return [];
   const file = ts.createSourceFile(
     relativePath,
     text,
@@ -149,7 +213,9 @@ function impureUpdaters(relativePath: string): string[] {
         const name = nestedWriterName(node);
         // Reported as WRITTEN — `catalog.setSort()`, not `setSort()` — so the
         // message names the call the reader has to go and find.
-        if (name && isStateWriter(name)) hits.push(`${node.expression.getText(file)}()`);
+        if ((name && isStateWriter(name)) || isSideEffectCall(node, file)) {
+          hits.push(`${node.expression.getText(file)}()`);
+        }
       }
       // EVERY assignment operator, not just `=`. `someRef.current += 1` is the
       // generation-counter idiom this codebase uses in thirteen places,
@@ -198,14 +264,39 @@ function impureUpdaters(relativePath: string): string[] {
 }
 
 describe("no state write inside a state updater", () => {
-  it("has no state write inside a state updater, anywhere in the UI", () => {
+  it("walks the whole state-holding tree, and parses the part of it that can hold a write", () => {
+    // The WALK and the PRE-FILTER, not only the rule. Rename a directory, add
+    // an exclude, change the extension test, and the file list goes short or
+    // empty while every case below stays green — an empty-list assertion over
+    // an empty tree proves nothing. The same is true one layer in: narrow
+    // `mayHoldStateWrite` and the real tree stops being parsed while the
+    // fixture, which contains `setStreaming` and `applyWrapper`, keeps passing.
+    //
+    // Two anchors, and a floor under each layer: the surface the defect was on,
+    // and the shared state both surfaces consume.
+    const files = ROOTS.flatMap((root) => sourceFiles(root));
+    expect(files.length).toBeGreaterThan(300);
+    expect(files).toContain("src/components/ChatApp.tsx");
+    expect(files).toContain("src/lib/chat-tool-events.tsx");
+    expect(files.filter((f) => mayHoldStateWrite(readSource(f))).length).toBeGreaterThan(200);
+  });
+
+  // ONE CASE PER ROOT, and the reason is a budget rather than a taxonomy:
+  // `testTimeout` is per case, and the combined walk has already failed twice
+  // on its own cost (5 000 ms in CI, 34 107 ms against a 30 s ceiling on a
+  // saturated machine). Four cases parse the same files with a quarter of the
+  // exposure each. The roots are separate directories, so a failure also names
+  // the half of the tree to look in.
+  it.each(ROOTS)("has no state write inside a state updater in %s", (root) => {
     // The four directories that hold this app's React state, not just the two
-    // chat surfaces: after TASK-703 there are NO such sites left, so the rule
-    // can be stated as a rule. `src/app/page.tsx` held two more — the wallpaper
-    // upload and the delete, each writing localStorage and calling two sibling
-    // setters from inside a `setCustomWallpapers` updater — and they were fixed
-    // rather than excluded by the scope of the test that claims to cover them.
-    // They were idempotent, which is exactly why they went unnoticed.
+    // chat surfaces. `src/app/page.tsx` held two more than the bug report named
+    // — the wallpaper upload and the delete, each writing localStorage and
+    // calling two sibling setters from inside a `setCustomWallpapers` updater —
+    // and they were fixed rather than excluded by the scope of the test that
+    // claims to cover them. They were idempotent, which is exactly why they
+    // went unnoticed, and so were the four found since: FilesApp's localStorage
+    // write, InstalledAppSettings' `kv.setJSON`, page.tsx's dismissal `fetch`
+    // and Mascot's `kv.set`/`kv.remove`.
     //
     // `src/lib` is in the list because that is where the state BOTH surfaces
     // share lives: `useChatToolCalls` (chat-tool-events.tsx) is called from
@@ -213,35 +304,29 @@ describe("no state write inside a state updater", () => {
     // through the same abort path.
     //
     // WHAT A GREEN TICK HERE DOES NOT PROVE, so the next reader does not read
-    // it as absence. The rule is syntactic and cannot follow a name: a setter
-    // reached through an alias (`const append = setMessages`) or an updater
-    // declared as a variable and passed in by name are both invisible. A setter
-    // reached through a property (`ctx.setSort(…)`) IS seen in the nested
-    // position — where the defect lives — but does not open an updater. And it
-    // detects state writes and ref writes only — an updater whose one side
-    // effect is a `fetch` or an `audio.play()` is impure and is not reported.
-    // Chasing those by AST costs more than it buys; saying so costs a paragraph.
+    // it as absence — this says "no site the rule can SEE", which is a smaller
+    // claim than "no site". The rule is syntactic and cannot follow a name: a
+    // setter reached through an alias (`const append = setMessages`), or an
+    // updater declared as a variable and passed in by name, is invisible. A
+    // setter reached through a property (`ctx.setSort(…)`) IS seen in the
+    // nested position — where the defect lives — but does not open an updater.
+    // Side effects are covered where they are NAMED: state writes, ref writes,
+    // `fetch`, and every member of `kv`/`localStorage`/`sessionStorage`. An
+    // updater whose one side effect is something else — an `audio.play()`, a
+    // `postMessage`, a write through a persistence module imported under
+    // another name — is impure and is not reported. When one of those turns up,
+    // the answer is to name its receiver in SIDE_EFFECT_RECEIVERS, which is why
+    // that set is keyed on the receiver rather than on method names.
     //
     // In the other direction it is deliberately over-eager: any single-argument
     // call to a `set*`/`apply*` identifier taking a function is treated as an
     // updater, whether or not the callee is a React setter. That is the safe
     // side of the trade — the alternative is a rule that has to know which
     // names are setters — but it means a legitimate `setX(fn)` helper of one's
-    // own can turn this red. If that happens, the answer is to rename the
-    // helper or to hoist the callback out of the call, not to weaken the rule.
-    const files = ROOTS.flatMap((root) => sourceFiles(root));
-    // The WALK, not only the rule. Rename a directory, add an exclude, change
-    // the extension test, and `files` becomes short or empty while both cases
-    // here stay green — an empty list assertion over an empty tree proves
-    // nothing. Two anchors and a floor: the surface the defect was on, and the
-    // shared state both surfaces consume.
-    expect(files.length).toBeGreaterThan(300);
-    expect(files).toContain("src/components/ChatApp.tsx");
-    expect(files).toContain("src/lib/chat-tool-events.tsx");
-
-    const offenders = files.flatMap(impureUpdaters);
-
-    expect(offenders).toEqual([]);
+    // own can turn this red. The answer is to rename the helper, to hoist the
+    // callback out of the call, or — for a built-in mutator in the nested
+    // position — to name it in NOT_UPDATERS. Not to weaken the rule.
+    expect(sourceFiles(root).flatMap(impureUpdaters)).toEqual([]);
   });
 
   it("catches the shapes the defect actually took", () => {
@@ -262,6 +347,9 @@ describe("no state write inside a state updater", () => {
       expect.stringContaining("setConciseRefWrite(updater) -> streamingRef.current ="),
       expect.stringContaining("setCompoundRefWrite(updater) -> streamingRef.current +="),
       expect.stringContaining("setThroughProperty(updater) -> catalog.setSort()"),
+      expect.stringContaining("setWithFetch(updater) -> fetch()"),
+      expect.stringContaining("setWithKvWrite(updater) -> kv.set()"),
+      expect.stringContaining("setWithDeferredWrite(updater) -> setMessages()"),
     ]);
   });
 });

--- a/src/tests/unit/state-updater-purity.test.ts
+++ b/src/tests/unit/state-updater-purity.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+
+/**
+ * A React state updater is a PURE function of the previous state.
+ *
+ * React is entitled to call it twice — Strict Mode does, and so does any render
+ * it has to redo — so a side effect inside one happens twice. TASK-703 was that
+ * defect on both chat surfaces: the interrupted turn was appended from inside
+ * the `setStreaming` updater, and the owner's half-finished reply landed in the
+ * transcript twice. `src/tests/components/chat-strict-mode-updater.test.tsx`
+ * pins the two behaviours that were reported; this pins the RULE, for the sites
+ * a component test cannot reach — the effort picker's "Switched effort to …"
+ * line needs a header dropdown with a provider offering more than one level
+ * before it renders at all.
+ *
+ * Read by the TypeScript compiler rather than by a regex over the text. The
+ * first version of this guard hand-rolled a comment/string blanker and balanced
+ * parentheses by hand; it had no notion of a regex literal, so one `/'/` in a
+ * walked file inverted its idea of what was code from there on and it reported
+ * NOTHING with a green tick — the false-success class, in the guard itself.
+ * Four files under `src/app` were desyncing it that way already. `typescript`
+ * is a devDependency this repo already drives (see build-typecheck.test.ts), it
+ * knows what a regex literal is, and it hands back the updater's body as a node
+ * instead of a slice of text.
+ */
+
+/** Directories whose React state this rule covers. */
+const ROOTS = ["src/components", "src/hooks", "src/app", "src/lib"];
+
+/**
+ * `set` + capital is also `setTimeout`/`setInterval`/`setImmediate`, whose
+ * callback is NOT a state updater — React does not re-run it — so they cannot
+ * OPEN one. They stay in the nested set below, where scheduling a timer from
+ * inside an updater is the same impurity.
+ */
+const NOT_UPDATERS = new Set(["setTimeout", "setInterval", "setImmediate"]);
+
+/**
+ * The project's own `apply*` wrappers count as well as `set*`.
+ *
+ * `setMessages(prev => { applyStreaming(""); return prev })` would pass a
+ * setter-only rule while being strictly worse than the defect: React may run it
+ * twice AND it writes a ref during the render phase, so the ref and the state
+ * can disagree at commit time. Both directions are covered — an `apply*`
+ * wrapper may neither take an updater nor be called from inside one.
+ */
+function isStateWriter(name: string): boolean {
+  return /^(set|apply)[A-Z]/.test(name) && !NOT_UPDATERS.has(name);
+}
+
+/** The plain `foo(...)` callee name, or null for `a.foo(...)` and the rest. */
+function calleeName(node: ts.CallExpression): string | null {
+  return ts.isIdentifier(node.expression) ? node.expression.text : null;
+}
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...sourceFiles(full));
+    else if (/\.tsx?$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Every `setX(prev => …)` / `applyX(prev => …)` in a file whose body writes
+ * state again, or mutates a ref.
+ *
+ * A ref write is included because the comment the fix leans on says so: a
+ * `streamingRef.current = …` inside an updater is a render-phase mutation, and
+ * the ref is exactly what the fix uses to read the buffer from outside.
+ */
+function impureUpdaters(relativePath: string): string[] {
+  const text = fs.readFileSync(path.join(process.cwd(), relativePath), "utf-8");
+  // A file with no `set`/`apply` + capital anywhere in it cannot hold a state
+  // write, so parsing it is wasted work — the walk is ~700 files. An OVER-
+  // approximation on purpose: it can only include files that turn out clean,
+  // never skip one that is not.
+  if (!/(?:set|apply)[A-Z]/.test(text)) return [];
+  const file = ts.createSourceFile(
+    relativePath,
+    text,
+    ts.ScriptTarget.Latest,
+    false,
+    relativePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+  const found: string[] = [];
+
+  const impurities = (body: ts.Node): string[] => {
+    const hits: string[] = [];
+    const visit = (node: ts.Node) => {
+      if (ts.isCallExpression(node)) {
+        const name = calleeName(node);
+        if (name && isStateWriter(name)) hits.push(`${name}()`);
+      }
+      if (
+        ts.isBinaryExpression(node)
+        && node.operatorToken.kind === ts.SyntaxKind.EqualsToken
+        && ts.isPropertyAccessExpression(node.left)
+        && node.left.name.text === "current"
+      ) {
+        hits.push(`${node.left.getText(file)} =`);
+      }
+      ts.forEachChild(node, visit);
+    };
+    ts.forEachChild(body, visit);
+    return hits;
+  };
+
+  const visit = (node: ts.Node) => {
+    if (ts.isCallExpression(node) && node.arguments.length === 1) {
+      const name = calleeName(node);
+      const arg = node.arguments[0];
+      // A function passed as the ONLY argument to a state writer is an updater:
+      // an arrow, and `function (prev) { … }` too — the shape a regex opener
+      // missed and the shape a refactor reaches for when the body grows.
+      if (name && isStateWriter(name) && (ts.isArrowFunction(arg) || ts.isFunctionExpression(arg))) {
+        const hits = impurities(arg.body);
+        if (hits.length > 0) {
+          const line = file.getLineAndCharacterOfPosition(node.getStart(file)).line + 1;
+          found.push(`${relativePath}:${line} ${name}(updater) -> ${[...new Set(hits)].join(", ")}`);
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(file, visit);
+  return found;
+}
+
+describe("a state updater is a pure function of the previous state", () => {
+  it("has no state write inside a state updater, anywhere in the UI", () => {
+    // The four directories that hold this app's React state, not just the two
+    // chat surfaces: after TASK-703 there are NO such sites left, so the rule
+    // can be stated as a rule. `src/app/page.tsx` held two more — the wallpaper
+    // upload and the delete, each writing localStorage and calling two sibling
+    // setters from inside a `setCustomWallpapers` updater — and they were fixed
+    // rather than excluded by the scope of the test that claims to cover them.
+    // They were idempotent, which is exactly why they went unnoticed.
+    //
+    // `src/lib` is in the list because that is where the state BOTH surfaces
+    // share lives: `useChatToolCalls` (chat-tool-events.tsx) is called from
+    // ChatApp and ChatPopup alike, so the same defect there would reach both
+    // through the same abort path.
+    const offenders = ROOTS.flatMap((root) => sourceFiles(root)).flatMap(impureUpdaters);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("catches the shapes the defect actually took", () => {
+    // The guard's own guard. Each of these went undetected by the regex version
+    // — a `function` expression instead of an arrow, an `apply*` wrapper taking
+    // an updater, a ref mutation — and a file carrying a regex literal with a
+    // quote in it turned the whole scan off silently. They are checked here on
+    // a fixture rather than on the tree, so the rule above can assert an empty
+    // list and still be known to be looking.
+    const fixture = path.join(process.cwd(), "src/tests/fixtures/impure-updaters.tsx");
+    const hits = impureUpdaters(path.relative(process.cwd(), fixture));
+
+    expect(hits.map((h) => h.replace(/^.*?:/, "line "))).toEqual([
+      expect.stringContaining("setStreaming(updater) -> setMessages()"),
+      expect.stringContaining("setFromFunctionExpression(updater) -> setMessages()"),
+      expect.stringContaining("applyWrapper(updater) -> applyStreaming()"),
+      expect.stringContaining("setWithRefWrite(updater) -> streamingRef.current ="),
+    ]);
+  });
+});

--- a/src/tests/unit/test-timeout-hygiene.test.ts
+++ b/src/tests/unit/test-timeout-hygiene.test.ts
@@ -272,6 +272,12 @@ const ALSO_REQUIRED = [
   // another every one of 10 906 tests passed while the job exited 1 on an
   // EnvironmentTeardownError originating in this file.
   "src/tests/unit/coding-agent.test.ts",
+  // Starts no process at all: it parses ~270 files with the TypeScript compiler
+  // in ONE case, and v8 coverage instrumentation multiplies that by ~7. Measured
+  // 2026-09-05 — 426 ms of parse uninstrumented, 2 874 ms under
+  // `test:coverage:ci` on an idle machine, and 5 318 ms on a four-worker CI
+  // runner, where it failed with vitest's "Test timed out in 5000ms".
+  "src/tests/unit/state-updater-purity.test.ts",
 ];
 
 /**


### PR DESCRIPTION
**TASK-703** — the interrupted turn was appended from inside a state updater, on both chat surfaces.

## Customer-visible symptom

The owner presses Stop mid-answer and the half-finished reply is added to the transcript **twice**.

## Cause

A state updater is a pure function of the previous state, and React is entitled to call it twice —
Strict Mode does, and so does any render it has to redo. Both surfaces did this on a gateway abort:

```ts
setStreaming(prev => {
  const kept = dropUnfinishedDirective(prev)
  if (kept.trim()) setMessages(msgs => [...msgs, { … }])   // ← side effect
  return ''
})
```

CodeRabbit raised it on both surfaces during PR #605 and it was refuted there as pre-existing and
out of scope. This is the card it was deferred to.

## Fix

- The streaming buffer is mirrored in a ref and written through one `applyStreaming(next: string)`
  helper, so the abort path **reads** the buffer and appends outside any updater. The signature is
  string-only, so a functional updater cannot come back through the helper — and the raw setter is
  renamed to `setStreamingState`, so a bare `setStreaming('')` added elsewhere in these 6 000-line
  files cannot bypass the ref and leave it holding a dead run's text.
- `git`/`gh`-style "just mock it" is not available here and is not the answer: the streaming buffer
  is the thing under test.

## Sibling sweep — it found three more sites

- `ChatPopup`'s **"Switched effort to …"** confirmation was appended from inside the
  `setThinkingLevel` updater the same way, so one click on the reasoning picker could add two lines.
  Same treatment, same reason.
- `src/app/page.tsx` wrote localStorage **and** called two sibling setters from inside a
  `setCustomWallpapers` updater, in the wallpaper upload and the wallpaper delete. Idempotent today,
  which is exactly why nobody had noticed — and exactly why the rule below has to look there.

## The rule, and how it is read

After this there are **no** state writes inside state updaters anywhere in the UI tree, so
`src/tests/unit/state-updater-purity.test.ts` states it as a rule over `src/components`,
`src/hooks`, `src/app` **and** `src/lib` — the last because `useChatToolCalls`
(`src/lib/chat-tool-events.tsx`) holds state that **both** surfaces consume, so the same defect
there would reach both through the same abort path.

It reads the tree with **the TypeScript compiler**, not a regex. `typescript` is already a
devDependency this repo drives (`build-typecheck.test.ts`), `ts.createSourceFile` knows what a regex
literal is, and it hands back the updater's body as a node instead of a slice of text. The rule is
therefore stated directly — *a call whose callee matches `^(set|apply)[A-Z]` and whose only argument
is a function containing another such call, or a `*.current = …` write* — and it catches the shapes
a regex opener missed: a `function (prev) {…}` updater, an `apply*` wrapper **taking** one, and a
render-phase ref mutation. `src/tests/fixtures/impure-updaters.tsx` carries those four shapes plus
two it must leave alone (a `setTimeout` callback, a `localStorage.setItem`), so the tree assertion
can be an empty list and still be known to be looking.

## RED (on unmodified beta)

```
 × full-screen chat            AssertionError: expected 2 to be 1
 × mascot popup                AssertionError: expected 2 to be 1

 × has no state write inside a state updater, anywhere in the UI
   AssertionError: expected [ …(5) ] to deeply equal []
   + "src/components/ChatApp.tsx:318 setStreaming(updater) -> setMessages()",
   + "src/components/ChatPopup.tsx:1695 setThinkingLevel(updater) -> setMessages()",
   + "src/components/ChatPopup.tsx:2229 setStreaming(updater) -> setMessages()",
   + "src/app/page.tsx:591 setCustomWallpapers(updater) -> setWallpaperId(), setWpOpacity()",
   + "src/app/page.tsx:1738 setCustomWallpapers(updater) -> setWallpaperId()",
```

Each behavioural case renders **one** surface, so a one-sided fix leaves the other red. The rule was
run against a detached worktree at `origin/beta` to produce the five above.

## GREEN

```
 state-updater-purity.test.ts          → 2 passed (the rule, and the fixture of six shapes)
 chat-strict-mode-updater.test.tsx     → 3 passed
 npx vitest run --project components   → 142 files, 1344 tests, all pass
 npx tsc --noEmit                      → clean
```

## A customer-visible change this PR makes on purpose

Moving the append out of the updater also moved it in **time**. On beta it was queued during the
render pass — i.e. *after* the system error line the handler had already queued — so on the
`state: "error"` path the owner saw the red "That message did not go through…" line and then the
fragment. It is the other way round now: the answer the box managed to write, then the line
explaining that it stopped. That is the more truthful order, and a test case pins it so it is a
decision rather than something to be rediscovered.

## Finishing round (2026-09-05)

Rebased onto fresh `origin/beta` (54 commits of drift; `ChatPopup.tsx` and `page.tsx` both moved on
beta, the rebase was clean, and the rule finds no offender in the beta code it brought in). No open
CodeRabbit threads. A second the review model review pass found the fix itself sound — every streaming write
goes through `applyStreaming`, `setStreamingState` has one caller, all three `thinkingLevel` sites
were converted — and two MEDIUMs **in the guard test**, both now closed:

- **The hand-rolled scanner had no notion of a regex literal**, so one quote inside a regex inverted
  its idea of what was code from there on and it reported **nothing**, green. Reproduced: with
  `const APOS = /'/g;` added to `ChatApp.tsx`, the exact TASK-703 defect re-inserted below it went
  undetected. Four files under `src/app` were already desyncing it that way (one losing 226 of 505
  code lines). That is the false-success class inside the guard against it — hence the compiler.
- **`src/lib` was not walked** although the comment claimed "the whole UI tree".

Also applied: the `page.tsx` mirroring `useEffect` is **gone** and the mount loader advances
`customWallpapersRef` itself, so every writer advances it — the invariant the comment stated was not
true of the loader, which left a one-paint window in which a delete would compute `[].filter(…)` and
write an empty list over every saved wallpaper. And `src/lib/harness/transport.ts`'s comment no
longer points at the renamed `setStreaming`.

### A second delta pass — three more holes in the guard, all closed

- **A concise arrow body was never visited.** `impurities` started at the body's *children*, so
  `setStreamingState(prev => streamingRef.current = prev)` — which type-checks (an assignment
  evaluates to the assigned value) and lints clean — reported nothing, while the identical code in
  braces was caught. A rule whose answer depends on a pair of brackets is not a rule, and the shape
  it missed is a render-phase write to the very ref this fix leans on. One line: visit the body node.
- **Only `=` counted as a ref write.** `someRef.current += 1` is the generation-counter idiom this
  codebase uses in thirteen places, `ChatPopup.tsx` among them, and accumulating a streaming buffer
  with `+=` inside an updater is the most natural wrong way to write TASK-703's own code. Every
  assignment operator counts now, and `ref["current"]` with them.
- **The walk itself was unpinned.** Both cases would have stayed green over an empty file list.
  It now asserts a floor and two anchors — the surface the defect was on, and the shared state both
  surfaces consume.

The fixture carries the two new shapes, the concise one deliberately unparenthesised (with brackets
it passes against the defect it exists to pin). Mutation-proved: restore the children-only walk, or
`EqualsToken` alone, and exactly the matching case fails.

**Correction (fifth round).** This paragraph also claimed "or narrow `ROOTS`, and exactly the matching
case fails". That was **false when it was written** — narrowing `ROOTS` removed a case rather than
failing one, and left every remaining case green. It is measured, and closed, in the fifth round below;
the claim is true of the current head and was not true of the head that made it.

**And what a green tick here does not prove** is now written next to the rule rather than left to be
rediscovered: it is syntactic, so a setter reached through an alias or a property, or an updater
passed in by name, is invisible; and it detects state writes and ref writes only, so an updater
whose one side effect is a `localStorage.setItem` or a `fetch` is impure and unreported — which is
literally half of what `page.tsx` was doing on beta, caught only because those updaters also called
a sibling setter. In the other direction it is deliberately over-eager: any `set*`/`apply*`
identifier whose FIRST argument is a function is treated as an updater, so a legitimate helper of
one's own can turn it red; that is the safe side of the trade, and the answer is to rename the
helper rather than weaken the rule.

**Not taken:** the new `react-hooks/exhaustive-deps` warnings on `applyStreaming` /
`applyThinkingLevel` — they are `useCallback([])` and stable in fact, the rule is set to *warn*, and
CI has no blocking lint step (#646 adds an advisory one). Recorded so it is not re-derived.

## Both editions

Both surfaces are shared and the gateway abort path is fixed on both. The **Hermes/adapter** path
(`dispatchTurn`'s catch) still clears the buffer with no append, so a Stop on Hermes discards the
partial answer while the gateway path keeps it — pre-existing on beta, out of TASK-703's scope, and
on the run's Found list.

## Not covered

Under a loaded full `--project components` run on this dev PC a handful of unrelated files time out
at the 5 s default (`clawkeep-restore-pending`, `chat-spoken-reply`); they pass in isolation, the
same run passes clean on a tree without this change, and a repeat of the full run passes. CI is the
proof.

## Third finishing round (2026-09-05) — the guard failed CI on its own cost, and it was half-blind

Rebased again onto fresh `origin/beta` (`81c58a01`). `git diff --stat origin/beta...HEAD` lists ten
files and `--diff-filter=DR` is empty.

### The block: `test` was RED on `8186c784`, and this PR's own rule was why

```
https://github.com/ID-Robots/clawbox/actions/runs/33967347945/job/101309684018

 ❯ unit  src/tests/unit/state-updater-purity.test.ts (2 tests | 1 failed) 5318ms

 FAIL  unit  src/tests/unit/state-updater-purity.test.ts >
       no state write inside a state updater >
       has no state write inside a state updater, anywhere in the UI
 Error: Test timed out in 5000ms.
  ❯ src/tests/unit/state-updater-purity.test.ts:159:3
```

Not a flake and not a foreign file: the rule parses **273** of the **643** files it walks with the
TypeScript compiler inside one case, and CI runs it under v8 coverage.

| | measured on this machine |
|---|---|
| parse alone, uninstrumented | **426 ms** (273 files, 7.07 MB) |
| the case under `test:coverage:ci`, idle | **2 874 ms** — 57 % of a 5 000 ms budget |
| the case on a four-worker CI runner | **5 318 ms** — over it |

A guard that fails the build over a tree it found **clean** is the false-failure class inside the
guard. The rule was right; its budget was vitest's generic default.

**Harness-first — the mechanism already exists and this PR did not invent one.** vitest's own way to
say "this case legitimately costs more" is `vi.setConfig({ testTimeout, hookTimeout })` at file
scope, and this repo has already ruled on how to use it: `src/tests/unit/test-timeout-hygiene.test.ts`
(TASK-702, merged in #641) requires **both** ceilings for files that legitimately need them, forbids
widening the global defaults, and pins the files it knows about by name. So:

```ts
vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
```

with the measurement and the reason above it, **and** the file added to that guard's `ALSO_REQUIRED`
list, so the declaration cannot be dropped again without a test saying so. 30 s is ~6x the measured
CI cost and still fails a case that has genuinely hung.

**Why the walk was not narrowed instead.** The four-directory walk *is* the sibling sweep this PR
leans on — it is the thing that says the state-holding tree carries no second offender. Narrowing it
to "files that import the streaming state" would delete that claim; tightening the text pre-filter
into a guess at which files the AST rule can fire on buys ~1.7 s and pays for it in the one currency
this file's own docblock warns about, a guard that silently stops looking. Recorded here so the
trade is a decision rather than an omission.

### The rule was blind in the position the defect lives in — and widening it found two more

`calleeName` returned `null` for anything but a bare identifier, in **both** positions. So

```ts
setStreaming(prev => { ctx.setMessages(m => [...m, prev]); return "" })
```

reported nothing — and that shape is live style here: `HermesSkillsStore.tsx` calls
`catalog.setSort(…)` and `catalog.setQuery(…)`, state writers returned on a hook's object.

The **nested** position now follows a property callee; the **opener** stays on bare identifiers,
because opening an updater on `a.setX(fn)` would treat every `foo.setSomething(callback)` in the
tree as a React updater. The hit is reported as written (`catalog.setSort()`), so the message names
the call the reader has to find.

Widening it turned up two more updaters doing exactly what TASK-703 was — **the sibling sweep, and
it was not empty**:

- `src/components/FilesApp.tsx` — `toggleShowHidden` wrote `localStorage` from inside the
  `setShowHidden` updater, so the write happened once per render attempt rather than once per click.
- `src/components/InstalledAppSettings.tsx` — `updateSetting` called `kv.setJSON` from inside the
  `setSettings` updater.

Both are idempotent, which is why neither had been noticed, and both are still a render-phase side
effect React is entitled to run twice. Each now advances a ref and writes outside the updater — the
same pattern the wallpaper sites in this PR already use — so the `useCallback` keeps its empty
dependency list. `InstalledAppSettings`'s kv **loader** advances the same ref, or the next edit
would build on settings the load had already replaced.

This also corrects the "what a green tick does not prove" paragraph: a setter reached through a
property is **no longer** invisible in the nested position, and inside an updater a
`localStorage.setItem` or an `el.setAttribute` is now reported too. What remains unreported is an
alias (`const append = setMessages`), an updater passed in by name, and a non-setter side effect
such as a `fetch` or an `audio.play()`.

### RED (on the unmodified head)

```
 FAIL  src/tests/unit/state-updater-purity.test.ts > catches the shapes the defect actually took
 AssertionError: expected [ …(6) ] to deeply equal [ StringContaining{…}, …(6) ]
 -   StringContaining "setThroughProperty(updater) -> catalog.setSort()",

 FAIL  src/tests/unit/test-timeout-hygiene.test.ts > gives the files seen flaking on long waits both ceilings too
 AssertionError: expected [ Array(1) ] to deeply equal []
 + [ "src/tests/unit/state-updater-purity.test.ts" ]
```

…and, once the rule could see a property callee, the tree assertion went red on two real sites:

```
 FAIL  … > has no state write inside a state updater, anywhere in the UI
 + "src/components/FilesApp.tsx:143 setShowHidden(updater) -> window.localStorage.setItem()",
 + "src/components/InstalledAppSettings.tsx:174 setSettings(updater) -> kv.setJSON()",
```

## The review pass — the sweep was rule-shaped, and the rule was two shapes short

An the review model review of the above found the sweep **incomplete**, and the argument is the one this
repository's rules name outright: the rule found the instances it could name, and the sweep was
declared done. Two more, both in the four roots this PR claims to have cleared:

- **`src/app/page.tsx` `dismissUpdateNotification`** sent the dismissal fingerprint with a `fetch`
  POST from **inside** the `setUpdateAvailable` updater. One click on the notice's × recorded the
  dismissal twice — two POSTs to `/setup-api/update/dismissal`, two `sqliteSet`s. `fetch` matches no
  name rule, so the guard could not see it.
- **`src/components/Mascot.tsx`** show/hide handlers called `kv.remove` / `kv.set` from inside the
  `setHidden` updater — *the same defect on the same `kv` module* whose `kv.setJSON` sibling was
  fixed an hour earlier, missed only because `kv.set` has no capital after `set`. The same file
  already writes it correctly from its own context menu, one screen down.

Both are fixed the same way (advance a ref, write outside the updater; every writer advances it,
the context-menu button included, since it dispatches the event the handler listens for). And the
**rule now names side effects by RECEIVER rather than by method**: every member of `kv`,
`localStorage` and `sessionStorage`, plus a bare `fetch`. Keying on the receiver is what makes
`kv.remove` and the next `kv.whatever` covered without maintaining a method list.

### The declared ceiling was not enough on its own

The reviewer reproduced a **34 107 ms** failure of the freshly-declared 30 s ceiling, running the
combined walk under coverage at load ~52 on a 12-core machine. The cost is O(files under `src/`)
inside one `it`, so a single case holding the whole walk is the 5 000 ms failure again, one doubling
later. The sweep is therefore **split into one case per root** — `testTimeout` is per case, so four
cases parse exactly the same files with a quarter of the exposure each:

```
 ✓ walks the whole state-holding tree, and parses the part of it that can hold a write   210ms
 ✓ has no state write inside a state updater in src/components                          5313ms
 ✓ has no state write inside a state updater in src/hooks                                  87ms
 ✓ has no state write inside a state updater in src/app                                  2061ms
 ✓ has no state write inside a state updater in src/lib                                  4371ms
 ✓ catches the shapes the defect actually took                                             10ms
```

(measured in the full `--project unit --coverage` run, four workers). 30 s rather than the 60 s the
reviewer offered as the fallback, because the split is the structural fix and the budget should
still fail a case that has genuinely hung.

### Four more, all applied

- **A floor under the pre-filter.** The walk was floored; the layer below it was not. A future
  narrowing of `mayHoldStateWrite` that still matched the fixture would leave every case green while
  the real tree went unread. Probed: replacing the pre-filter with one that matches only the
  fixture's names now fails the walk case.
- **The `NOT_UPDATERS` comment described the wrong behaviour.** It claimed a timer inside an updater
  is not reported. The timer *call* is not; a state write *inside* it is, and must be — React
  re-running the updater schedules the timer twice. Both directions are now pinned by fixture cases
  rather than described, and that paragraph also names the escape hatch, which works in both
  positions (a built-in mutator such as `d.setHours(…)` on a `Date` made inside the updater belongs
  in `NOT_UPDATERS`, not in a weakened rule).
- **The claim is stated at the size it can carry** — "no site the rule can SEE" — with what it cannot
  see listed.
- **`vi.setConfig` moved below the import block**, which is where the other twenty-odd declarations
  in this tree put it, and the eight `react-hooks/exhaustive-deps` warnings the rename introduced are
  gone: both helpers are `useCallback(…, [])`, so naming them costs nothing at runtime. That reverses
  the "Not taken" recorded in the previous round.

### Mutation matrix for the new rule, each restored

| mutation | result |
|---|---|
| drop the `fetch`/`kv` clause | **1 failed** — the three new fixture cases |
| stop recursing into a timer callback inside an updater | **1 failed** — the deferred-write case |
| narrow the pre-filter to the fixture's own names | **1 failed** — the parse floor |

### GREEN

```
state-updater-purity + test-timeout-hygiene              → 17 passed
chat-strict-mode-updater, installed-app-settings,
  standalone-app-installed, mascot/desktop (components)  → 6 files, 61 passed
npx tsc --noEmit                                         → exit 0
eslint on every changed file                             → 0 errors (8 warnings removed, none added)
the whole unit project under coverage, as CI runs it     → 637 files, 10 104 passed, 1 skipped
```

The last of those exits **1** rather than 0, and not on anything in this diff: two unhandled
rejections, `ReferenceError: window is not defined`, from a stray `setTimeout` in
`src/lib/use-clawbox-login.ts` reaching `setState` after teardown in a `renderHook` test that runs in
the `unit` project's **node** environment. Untouched here, not in this diff's import graph, passes in
isolation, and reproduced independently in a second worktree on another branch. Filed as **TASK-720**
— it is a false failure of the same class TASK-702 was about, the job red while the suite is green.

### Also recorded

- **TASK-721** — pressing Stop on a **Hermes** box discards the partial reply that the OpenClaw path
  now keeps: the adapter branch clears the buffer without appending. Pre-existing on beta, but this
  round created `streamingRef`, which is exactly the mechanism that path needs, and the new
  behavioural test stubs the harness as `openclaw` — so the dual-SKU half is neither implemented nor
  pinned. Standing rule, stated rather than glossed.
- **Not a regression, recorded because this PR adds a second thing to reset:**
  `InstalledAppSettings` advances `settingsRef` only when the KV load found something, so an `appId`
  change without a remount keeps the previous app's settings — beta had the identical hole with a
  stale `prev`, and neither call site passes `key={appId}`.

### CodeRabbit — both open threads answered in-thread

- **`src/app/page.tsx:1732`, "preserve the active custom wallpaper after a deletion"** — real defect,
  **refuted as out of scope** with the evidence: `origin/beta:src/app/page.tsx:1707` carries the same
  statement, and this PR changed only its indentation when it moved out of the updater. Filed as its
  own card, **TASK-719**, with both directions, the RED test and the sibling sweep over every other
  reader of a positional `custom-<n>` id.
- **`src/tests/unit/state-updater-purity.test.ts:125`, "limit the scan skip to deferred callback
  arguments"** — **refuted**: its premise is wrong (the fixture's `setTimeout` sits at the top level
  of `shapes()`, `setTimeout` is in `NOT_UPDATERS`, so nothing opens and the exact-equality fixture
  case would fail if it did), and the behaviour it asks to remove is a true positive — React
  re-running an updater schedules a timer inside it twice.



## Fifth round (2026-09-05) — the guard's last unfloored layer, and the mirror invariant made structural

A fourth the review model review pass **blocked on the guard test, not on the fix** — the shipped behaviour change
was confirmed correct, CI was green on the head, and CodeRabbit had re-reviewed it and raised nothing
new. The block was real and is closed here.

### The block: `ROOTS` was the one layer of the sweep with no floor — and this body claimed otherwise

Everything *below* `ROOTS` is floored: the file list (`> 300`), two path anchors, the parse count
(`> 200`). Nothing floored `ROOTS` itself, and the sweep is `it.each(ROOTS)` — so **narrowing the list
removes a case instead of failing one**.

**RED**, on the previous head `3f23f396`, dropping `"src/app"` — 200 of the 643 files, where three of
the ten offenders this PR fixes lived, `page.tsx` among them:

```
 ✓ walks the whole state-holding tree, and parses the part of it that can hold a write    71ms
 ✓ has no state write inside a state updater in src/components                          1050ms
 ✓ has no state write inside a state updater in src/hooks                                 24ms
 ✓ has no state write inside a state updater in src/lib                                  747ms
 ✓ catches the shapes the defect actually took                                             5ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Five green ticks over a third of the tree that had stopped being read: 443 files still clears the 300
floor, and both anchors (`src/components/ChatApp.tsx`, `src/lib/chat-tool-events.tsx`) still resolve.
Dropping `"src/hooks"` did the same. This is exactly the failure the file refuses everywhere else, in
its own words at lines 189-191.

**And the round-3 sentence in this body — "Mutation-proved: … or narrow `ROOTS`, and exactly the
matching case fails" — was false when it was written.** It is corrected above rather than quietly
deleted: a false mutation claim about a guard is the false-success class in the review record instead
of in the code, and it is the sentence a reader uses to decide the guard is trustworthy.

**GREEN.** `ROOTS` is pinned (`expect(ROOTS).toEqual([…])`), and each root carries a floor on its own
walked-file count. Every mutation measured on this head, each restored, worktree clean:

| mutation | result |
|---|---|
| `"src/app"` dropped from `ROOTS` | **1 failed** — the walk case, `expected [ …(1) ] to deeply equal [ …(2) ]` |
| `"src/hooks"` dropped | **1 failed** — same case |
| a fifth root added without a floor beneath it | **2 failed** — the walk case *and* the new root's own sweep |
| an exclude in `sourceFiles` that empties `src/hooks` | **1 failed** — `expected 0 to be greater than 0` |
| …the same exclude, with the per-root floor line removed | **6 passed** — which is what that one line buys |
| unmutated | 6 passed |

The pin is the half that fails a root REMOVED or ADDED; the per-root floor is the half that fails a root
that stays in the list while walking nothing — the anchors sit in two of the four roots, and `src/hooks`
is 10 of 643 files, so neither existing floor could see it.

### The mirror invariant is now structural rather than documented

The five states this branch converted from a functional updater to a mirror ref each rested on an
invariant stated in a comment: every writer advances the ref on the line before its state write. All of
them did — verified per state — but a sixth writer that forgets the line silently loses the previous
write, and **the new purity rule cannot see it**: it reports side effects *inside* an updater, never a
missing ref advance outside one. That trades a visible-once-in-a-while duplicate for an invisible lost
write.

So the four bare `useState` mirrors get the treatment `streaming` and `thinkingLevel` already had here:
the raw setter is renamed out of reach (`setShowHiddenState`, `setSettingsState`, `setHiddenState`,
`setCustomWallpapersState`, `setUpdateAvailableState`) and every write goes through a one-line
`useCallback` `apply*` helper that advances the ref. Grep after the change: **no bare raw-setter call
anywhere in `src/`, and exactly five ref advances, one inside each helper.** Behaviour is unchanged —
every call site already passed a value rather than an updater — and the two effects that gained a
dependency (`Mascot`'s show/hide listener, `page.tsx`'s 30-minute version poll) took a `useCallback([])`
helper, so neither re-subscribes.

### The rest of that pass

- **Applied — the opener required EXACTLY one argument.** `applyThing(prev => …, { merge: true })` opened
  nothing, while this file's own docblock puts the project's `apply*` wrappers in scope precisely because
  they are the kind that grows an options object. It now opens on the FIRST argument; React's own setters
  take one, so nothing else widened. Measured: **zero new hits over all 643 files**, and reverting to
  `=== 1` fails the new fixture case (`applyWithOptions(updater) -> kv.set()`) and only that one.
- **Applied — the receiver is matched by SOURCE TEXT, and the disclosure paragraph did not say so.**
  `storage.kv.set`, `kv!.set`, `(kv).set`, `kv["set"]` and `window.fetch` are invisible to the rule.
  None is written in this tree (grep), and the live style `window.localStorage?.setItem(…)` **is**
  covered because that whole spelling is in the set. Named in the paragraph rather than resolved in the
  rule: a resolver would have to un-name `window.localStorage`, which is the spelling that carries the
  live sites.
- **Applied — `src/app/page.tsx` reopened the literal `CUSTOM_WPS_KEY` was extracted for**, in the one
  statement this branch had lifted out of the updater. The loader and the upload used the constant; the
  delete used the string.


### The delta review of this round

A fifth the review model pass, DELTA-scoped to the three commits above, returned **APPROVE — 0 Medium+, 2 Low,
3 Info**. It re-ran every mutation rather than taking the table on trust, and established the `>= 1`
widening more strongly than this body claimed: over the four roots it counts **288 updaters opened at
`=== 1` and zero additional at `>= 1`** — the widening does not merely fail to hit anything new, it
does not open anything new. Both Lows are applied here:

- **The per-root floor was `> 0`, which catches only total emptiness.** Measured: an exclude leaving
  `src/app` with ONE of its 200 files kept all six cases green. Each root now carries a floor at
  roughly half its current count (50 / 5 / 100 / 200 against 110 / 10 / 200 / 323), and `ROOTS` is
  DERIVED from that map so a root cannot be added without a floor under it. The gutting mutation now
  fails — `src/app walks far fewer files than it holds: expected 1 to be greater than 100` — and goes
  back to six green with the floors reverted to `> 0`.
- **The disclosure paragraph listed five receiver spellings and explained four.** `kv["set"]` is
  invisible for a different reason from the other four — an element access takes neither branch of
  `isSideEffectCall`, so there is no receiver text to differ — and `globalThis.fetch` was not named
  beside `window.fetch`. Both corrected.

Its three Infos were two overstatements in a commit message (the "five ref advances" count is five in
the files that commit touched and eight in the tree; "unbypassable" is "much harder to bypass" — the
renamed setters are still in lexical scope) and one comment that had drifted a level away from the
line it described. All three corrected; the two sentences are corrected here as well rather than left
to be read as the guard proving something it does not.

### Diff hygiene on this head

`git diff --stat origin/beta...HEAD` after rebasing onto `2c7cacf3` (30 commits of drift, `page.tsx`
among the files beta moved) lists **11 files, all intended**, and
`git diff --diff-filter=DR --stat origin/beta...HEAD` is **empty** — no deletion, no rename, no
restored-old-code artefact. On the rebased head: `state-updater-purity` + `test-timeout-hygiene`
**17 passed**, the five component suites over the changed components **23 passed**,
`npx tsc --noEmit` **exit 0**, `npx eslint` on the six touched files **0 errors** (15 warnings, all
pre-existing and outside every changed hunk).

### Still not proved

Nothing in this round was run on a device, and nothing in it needs to be: the change is a test guard
and a same-file React refactor, both fully exercised by CI. The Hermes Stop path
(**TASK-721**) remains out of scope and unpinned, as recorded above.

### CodeRabbit on this head

It re-reviewed after the round and raised one Trivial nit — add a *synchronous* nested-callback shape
(`forEach`) beside the deferred one, on the premise that *"a change that stops descending into nested
function-like nodes would keep all eleven assertions green"*. **Refuted in-thread, measured:** it would
not. `setWithDeferredWrite`'s write is itself inside a nested arrow, so blocking recursion into
function-like nodes fails exactly that case —

```
 × catches the shapes the defect actually took
   -   StringContaining "setWithDeferredWrite(updater) -> setMessages()"
 Tests  1 failed | 5 passed (6)
```

— and the *opposite* narrowing, proposed in the earlier thread on this file, fails the same case. The
recursion mechanism is what is under the assertion, not the timer. The shape is not added because the
fixture is "the set of shapes the defect actually took" and a `forEach` inside an updater is not one of
them, nor is it written anywhere in the four swept roots. Both threads on this PR are answered and
resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed interrupted streaming replies appearing more than once in full-screen chat and chat popups.
  - Ensured partial assistant responses remain in the correct order before error notifications.
  - Improved recovery from interrupted or failed responses while preserving valid conversation content.
  - Preserved custom wallpaper, hidden-file visibility, mascot visibility, and installed-app settings persistence during updates.

- **Tests**
  - Added regression coverage for interrupted streaming responses and safeguards against duplicate updates during replayed interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->