### PR TITLE
fix: two update-breaking bugs found on hardware (data/ in tsconfig, STT probe library path)

### DIFF
--- a/src/lib/stt-local.ts
+++ b/src/lib/stt-local.ts
@@ -56,16 +56,49 @@ const IMPORT_MISSING_TTL_MS = 60_000;
 const IMPORT_OK_TTL_MS = 6 * 60 * 60 * 1000;
 
 /**
+ * Where the CUDA CTranslate2 build puts its shared library, and the CUDA
+ * runtime beside it.
+ *
+ * `install-voice.sh` builds CTranslate2 with `-DCMAKE_INSTALL_PREFIX=~/.local`,
+ * so `libctranslate2.so.4` lands somewhere the dynamic linker does not search:
+ * `ldconfig -p` has no entry for it. `import faster_whisper` therefore fails
+ * with "libctranslate2.so.4: cannot open shared object file" in any process
+ * that does not name the directory itself.
+ *
+ * The whisper-server unit sets exactly this, which is why TRANSCRIPTION works.
+ * The probe below did not, so Settings reported "faster-whisper is not
+ * installed for python3" on a box where it was installed, working and serving
+ * — measured on hardware 2026-09-04, minutes after the install succeeded.
+ *
+ * Kept identical to the unit's own Environment= line and to stt-client.py's
+ * fallback, because three readers disagreeing about where the library lives is
+ * how this went unnoticed in the first place.
+ */
+function ldLibraryPath(): string {
+  const h = home();
+  return [
+    `${h}/.local/lib`,
+    `${h}/.local/lib/python3.10/site-packages/nvidia/cusparselt/lib`,
+    "/usr/local/cuda/lib64",
+  ].join(":");
+}
+
+/**
  * The whole environment the script gets. `systemctl --user` needs
  * XDG_RUNTIME_DIR to find the user bus — from a system service there is none
  * inherited, and without it every start attempt answers "Failed to connect"
  * and the client falls through to the slow in-process decode.
+ *
+ * LD_LIBRARY_PATH is here for the reason above: without it the import probe
+ * cannot load the library the install just built, and answers "not installed"
+ * about an engine that is running.
  */
 function childEnv(): Record<string, string> {
   return {
     HOME: home(),
     PATH: process.env.PATH || "/usr/local/bin:/usr/bin:/bin",
     XDG_RUNTIME_DIR: process.env.XDG_RUNTIME_DIR || `/run/user/${process.getuid?.() ?? 1000}`,
+    LD_LIBRARY_PATH: ldLibraryPath(),
   };
 }
 

--- a/src/tests/unit/stt-local-library-path.test.ts
+++ b/src/tests/unit/stt-local-library-path.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * The STT probe has to be able to LOAD what the installer built.
+ *
+ * install-voice.sh builds CTranslate2 with CUDA and
+ * `-DCMAKE_INSTALL_PREFIX=$CLAWBOX_HOME/.local`, so `libctranslate2.so.4`
+ * lands in a directory the dynamic linker does not search — `ldconfig -p` has
+ * no entry for it. Any process that does not name that directory itself fails:
+ *
+ *   ImportError: libctranslate2.so.4: cannot open shared object file
+ *
+ * `whisper-server.service` sets LD_LIBRARY_PATH, which is why TRANSCRIPTION
+ * works. `childEnv()` builds a deliberately clean environment for the probe and
+ * did not, so Settings → Local AI showed
+ *
+ *   "faster-whisper is not installed for python3."
+ *
+ * on a box where it was installed, imported and serving — measured on hardware
+ * 2026-09-04, minutes after the install reported success. The engine was fine;
+ * the reader was blind.
+ */
+const SRC = readFileSync(path.join(process.cwd(), "src/lib/stt-local.ts"), "utf-8");
+
+describe("the STT probe can load the CUDA CTranslate2 build", () => {
+  it("passes LD_LIBRARY_PATH to the children it spawns", () => {
+    const at = SRC.indexOf("function childEnv()");
+    expect(at).toBeGreaterThan(-1);
+    const body = SRC.slice(at, SRC.indexOf("\n}", at));
+    expect(body, "childEnv must carry the library path").toContain("LD_LIBRARY_PATH");
+  });
+
+  it("names the directory the installer actually writes to", () => {
+    // -DCMAKE_INSTALL_PREFIX=$CLAWBOX_HOME/.local puts the .so in .local/lib.
+    expect(SRC).toContain(".local/lib");
+  });
+
+  it("carries the CUDA runtime beside it", () => {
+    // ctranslate2's CUDA build links libcublas/libcudnn; without this the
+    // import fails one library later than it used to.
+    expect(SRC).toContain("/usr/local/cuda/lib64");
+  });
+
+  it("agrees with the unit the installer writes", () => {
+    // Three readers disagreeing about where the library lives is exactly how
+    // this went unnoticed: the unit worked, the probe did not, and the box
+    // reported the engine missing while it was answering.
+    const installVoice = readFileSync(path.join(process.cwd(), "scripts/install-voice.sh"), "utf-8");
+    expect(installVoice, "the unit must still set the path this mirrors").toContain("LD_LIBRARY_PATH");
+  });
+});

--- a/src/tests/unit/tsconfig-excludes-data.test.ts
+++ b/src/tests/unit/tsconfig-excludes-data.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * `data/` must never be type-checked.
+ *
+ * It is the device's runtime directory, and a coding-agent run writes into it:
+ * `data/coding-agent-artifacts/<runId>/` is that run's evidence folder, and a
+ * run is free to save whatever it produced there — including TypeScript.
+ *
+ * tsconfig.json includes `**\/*.ts`, so before this exclusion those files were
+ * part of the project. `next build` type-checks the project, so one scratch file
+ * a run left behind failed the build:
+ *
+ *   data/coding-agent-artifacts/run-cds5h5f6/_verify-logic.ts(1,25):
+ *     error TS2307: Cannot find module './src/data/forests'
+ *
+ * That is not a cosmetic failure. `do_rebuild` runs `bun run build`, so the box
+ * could no longer build — and therefore could no longer UPDATE ITSELF. Observed
+ * on hardware 2026-09-04: an in-app update reached the rebuild step and exited
+ * 1, leaving the device with no web server until it was repaired by hand.
+ *
+ * CI cannot catch it: a fresh checkout has no artifacts, so the same commit
+ * builds green in the pipeline and fails on any box where a run has saved a
+ * `.ts` file. The exclusion is the only thing standing between the two.
+ */
+const REPO = process.cwd();
+
+/** tsconfig.json permits comments; strip them before parsing. */
+function tsconfig(): { include?: string[]; exclude?: string[] } {
+  const raw = readFileSync(path.join(REPO, "tsconfig.json"), "utf-8");
+  return JSON.parse(raw.replace(/^\s*\/\/.*$/gm, ""));
+}
+
+describe("tsconfig keeps the runtime data directory out of the project", () => {
+  it("excludes data/", () => {
+    expect(tsconfig().exclude ?? []).toContain("data");
+  });
+
+  it("still includes the source it is meant to check", () => {
+    // The exclusion must not have been achieved by narrowing `include` — the
+    // whole point is that src/ is still type-checked.
+    expect(tsconfig().include ?? []).toContain("**/*.ts");
+  });
+
+  it("keeps the exclusions that were already there", () => {
+    // A regression here would quietly re-admit node_modules or the MCP tree,
+    // which is a slow build at best and a wall of errors at worst.
+    const exclude = tsconfig().exclude ?? [];
+    for (const dir of ["node_modules", "mcp", "code-source-code", "bench"]) {
+      expect(exclude, `${dir} must stay excluded`).toContain(dir);
+    }
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "paths": { "@/*": ["./src/*"] }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts", "**/*.mts", "scripts/terminal-server.mjs"],
-  "exclude": ["node_modules", "mcp", "code-source-code", "bench"]
+  "exclude": ["node_modules", "mcp", "code-source-code", "bench", "data"]
 }


### PR DESCRIPTION
Two bugs found by running a real update on hardware. Neither is visible in CI, and both were breaking things silently.

---

## 1. A coding-agent run had stopped the device updating itself (`5c9f4bf3`)

`data/coding-agent-artifacts/<runId>/` is a run's evidence folder, and a run may save whatever it produced there — including TypeScript. `tsconfig.json` includes `**/*.ts` and excluded only `node_modules`, `mcp`, `code-source-code` and `bench`, so those files were part of the project, and `next build` type-checks the project:

```
data/coding-agent-artifacts/run-cds5h5f6/_verify-logic.ts(1,25):
  error TS2307: Cannot find module './src/data/forests'
  ...5 more
error: script "build" exited with code 1
```

**`do_rebuild` runs `bun run build`, so the box could no longer build — and therefore could no longer update itself.** Observed today: an in-app update reached the rebuild step, exited 1, and left the device **with no web server** until it was repaired by hand. The scratch file had been there since an earlier run, so every update after it would have failed identically.

CI cannot catch this: a fresh checkout has no artifacts, so the same commit is green in the pipeline and broken on the device.

Two things contained the damage, both worth recording:

- **The memory free ran first** — 3151 MB → 5719 MB — so this was a clean `exit 1`, not an OOM, which made the diagnosis unambiguous.
- **The update lock released correctly** when the run failed, so the owner was not trapped on an updating screen for an update that was never coming back.

## 2. Settings reported an installed engine as missing (`fae4332e`)

Local AI showed **"faster-whisper is not installed for python3."** on a box where it was installed, imported and serving.

`install-voice.sh` builds CTranslate2 with CUDA and `-DCMAKE_INSTALL_PREFIX=$CLAWBOX_HOME/.local`, so `libctranslate2.so.4` lands where the dynamic linker does not search — `ldconfig -p` has **no** entry for it. Any process that does not name that directory gets:

```
ImportError: libctranslate2.so.4: cannot open shared object file
```

`whisper-server.service` sets `LD_LIBRARY_PATH`, which is why **transcription works**. `childEnv()` builds a deliberately clean environment for the probe and did not — so the probe alone could not import what the unit runs happily. Measured on the box:

```
with LD_LIBRARY_PATH   ->  import OK — 1.2.1
clean env              ->  ImportError: libctranslate2.so.4
ldconfig -p            ->  0 entries
```

The engine was fine; the reader was blind. The path is now identical to the unit's own `Environment=` line and to `stt-client.py`'s fallback — three readers disagreeing about where the library lives is exactly how this went unnoticed, because two of them worked.

**This is not the deeper fix.** The library is still outside the linker's search path, so every future reader has to know about it too. Installing it somewhere `ldconfig` already looks would end the class of bug, and deserves its own change.

## Tests

`tsconfig-excludes-data` (3) pins the exclusion, that `include` still carries `**/*.ts` so `src/` is still checked, and that the pre-existing exclusions survive. `stt-local-library-path` (4) pins that the probe carries the path, names the directory the installer writes to, carries the CUDA runtime, and that the unit still sets what it mirrors.

`tsc --noEmit` clean, eslint clean, and the box rebuilt successfully with both changes applied — which is how it is serving again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5wDEic7kbWnVvMXjvnPbY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local speech-to-text reliability by ensuring required native libraries can be located during transcription.
* **Chores**
  * Updated TypeScript project configuration to exclude the `data` directory from processing while preserving existing exclusions.
* **Tests**
  * Added coverage for TypeScript configuration exclusions and local speech-to-text library path handling, including CUDA runtime support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->