### PR TITLE
feat(bench): the tuning loop — demo tasks as coding projects, cost and parallelism per task, deltas per cycle

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -26,11 +26,49 @@ MCP bearer from `data/.mcp-token`. Off-box set `CLAWBOX_URL` plus either
 `CLAWBOX_COOKIE` or `CLAWBOX_PASSWORD` (used for ONE login attempt — five
 failures lock the whole box out for five minutes).
 
+## The loop (`loop.mjs`)
+
+The runner drives one suite in a folder of its own. The **loop** is the
+version the harness is tuned by: it runs the suite's demo tasks as coding
+PROJECTS — `bench-<task>-<stamp>` directly under the owner's project folder,
+so every run shows up in the Coding Agent app like any other project —
+samples each run every 5 s while it works, and writes one report per cycle
+with the four figures the owner asked to optimise by, and the change against
+the cycle before:
+
+- **token spend** (`tokensUsed`, thinking share, per model from the transcript),
+- **parallelisation** (`peakActive` helpers at once, helper-seconds, the share
+  of the clock with a helper out, and `agentSecondsPerWallSecond` — 1.0 is the
+  main loop alone, 2.0 is one helper beside it the whole run),
+- **time to finish** (wall clock to settle, plus the commit lag),
+- **cost per task** — priced from `bench/pricing.json` (USD per million tokens
+  by model; the numbers shipped are PLACEHOLDERS to set to the plan this box is
+  on) over the per-model usage, with a model the table lacks flagged as
+  unpriced rather than counted as free.
+
+```sh
+node bench/loop.mjs --dry-run                          # what would run
+node bench/loop.mjs --tasks s-01-single-edit            # one task, one cycle
+node bench/loop.mjs --nightly --cycles 3 --pause 60     # three cycles, a minute apart
+node bench/loop.mjs --nightly --baseline nightly-c1-2026-09-05   # deltas against a cycle
+```
+
+Each cycle appends `results/<suite>/loop-<label>.jsonl` (one line per run, the
+figures) and writes `results/<suite>/report-<label>.md` (the table, the deltas,
+and a "look at" list of plain rules: a run that did not complete, a low score,
+refused actions, a long run with no helper, a burst of helpers that sat idle,
+a thinking share over 30%). Every run's directory also gets `samples.json`,
+the raw 5-second samples. `--workroot` moves the runs elsewhere, and says so:
+the app lists only what is under the project folder meanwhile. The pure parts
+(`lib/cost.mjs`, `lib/metrics.mjs`) are unit-tested in `src/tests/unit/bench-metrics.test.ts`.
+
 ## Layout
 
 ```text
 bench/
   runner.mjs        drives the API, captures everything, scores
+  loop.mjs          the tuning loop: tasks as projects, samples, cost, deltas
+  pricing.json      USD per million tokens by model — set to your plan
   compare.mjs       tables + baseline diff
   guards.mjs        regression pins (static / record / --live / --slow)
   lib/              box client, capture, scorer utils, transcript usage sums
@@ -74,9 +112,10 @@ solution (scores 100) and the untouched seed (scores low).
 
 ## Corrections to the 2026-08-27 design doc (verified against source)
 
-- **Money is not tracked** — the product records no cost, by decision
-  (2026-08-29), and the bench prices nothing. Tokens and wall-clock are the
-  footprint record. The orchestrator-vs-sub-agent split comes from per-model
+- **Money is not tracked by the product** — it records no cost, by decision
+  (2026-08-29). The bench's LOOP prices its own runs from `pricing.json`
+  (2026-09-05, at the owner's request); the runner still prices nothing.
+  Tokens and wall-clock remain the footprint record. The orchestrator-vs-sub-agent split comes from per-model
   usage sums over the session transcript (the typed helpers — explorer,
   tester, reviewer — run on `deepseek-v4-flash`; the main loop on the tier
   model; a workflow `agent()` without an agentType would run on the tier

--- a/bench/lib/cost.mjs
+++ b/bench/lib/cost.mjs
@@ -1,0 +1,70 @@
+// Money for a run, from the per-model usage the capture already sums and a
+// pricing table the OWNER fills in (bench/pricing.json). The product records
+// no cost by decision; the bench prices its own runs so "cost per task" can
+// be a number the loop watches, and it never guesses: a model the table does
+// not list is reported as unpriced, not as free.
+import fs from "node:fs";
+
+const PER_MILLION = 1_000_000;
+
+/** Read the pricing table; a missing or broken file is an empty table (everything unpriced). */
+export function loadPricing(file) {
+  try {
+    const raw = JSON.parse(fs.readFileSync(file, "utf8"));
+    return { currency: raw.currency ?? "USD", models: raw.models && typeof raw.models === "object" ? raw.models : {} };
+  } catch {
+    return { currency: "USD", models: {} };
+  }
+}
+
+/** A model's rates, with the cache rates falling back to input's. Null when unlisted. */
+export function ratesFor(pricing, model) {
+  const row = pricing?.models?.[model];
+  if (!row || typeof row !== "object") return null;
+  const num = (v, fallback) => (typeof v === "number" && Number.isFinite(v) && v >= 0 ? v : fallback);
+  const input = num(row.input, null);
+  const output = num(row.output, null);
+  if (input === null || output === null) return null;
+  return { input, output, cacheRead: num(row.cacheRead, input), cacheWrite: num(row.cacheWrite, input) };
+}
+
+/**
+ * Price a run's usage: `byModel` is capture's shape — { model: { input,
+ * output, cacheRead, cacheWrite, messages } }. Answers the total, the split
+ * by model, and the models that could not be priced (their tokens are still
+ * counted in `tokens`).
+ */
+export function costOfUsage(byModel, pricing) {
+  const out = { totalUsd: 0, byModel: {}, unpriced: [], tokens: 0 };
+  if (!byModel || typeof byModel !== "object") return out;
+  for (const [model, u] of Object.entries(byModel)) {
+    const input = u.input ?? 0;
+    const output = u.output ?? 0;
+    const cacheRead = u.cacheRead ?? 0;
+    const cacheWrite = u.cacheWrite ?? 0;
+    out.tokens += input + output + cacheRead + cacheWrite;
+    const rates = ratesFor(pricing, model);
+    if (!rates) {
+      out.unpriced.push(model);
+      out.byModel[model] = { usd: null, priced: false, tokens: input + output + cacheRead + cacheWrite };
+      continue;
+    }
+    const usd = (input * rates.input + output * rates.output + cacheRead * rates.cacheRead + cacheWrite * rates.cacheWrite) / PER_MILLION;
+    out.byModel[model] = { usd: round6(usd), priced: true, tokens: input + output + cacheRead + cacheWrite };
+    out.totalUsd += usd;
+  }
+  out.totalUsd = round6(out.totalUsd);
+  return out;
+}
+
+function round6(n) {
+  return Math.round(n * 1e6) / 1e6;
+}
+
+/** "$0.0132" / "$1.20" — money as the report prints it. */
+export function formatUsd(n) {
+  if (n === null || n === undefined || !Number.isFinite(n)) return "n/a";
+  if (n >= 1) return `$${n.toFixed(2)}`;
+  if (n >= 0.01) return `$${n.toFixed(3)}`;
+  return `$${n.toFixed(4)}`;
+}

--- a/bench/lib/cost.mjs
+++ b/bench/lib/cost.mjs
@@ -30,13 +30,16 @@ export function ratesFor(pricing, model) {
 
 /**
  * Price a run's usage: `byModel` is capture's shape — { model: { input,
- * output, cacheRead, cacheWrite, messages } }. Answers the total, the split
- * by model, and the models that could not be priced (their tokens are still
- * counted in `tokens`).
+ * output, cacheRead, cacheWrite, messages } }. Answers the split by model,
+ * the models that could not be priced (their tokens are still counted in
+ * `tokens`), `pricedUsd` — what the listed models cost — and `totalUsd`,
+ * which is that same number ONLY when every model was listed and null
+ * otherwise: an unpriced model is not free, and a partial sum shown as the
+ * run's cost would say it was.
  */
 export function costOfUsage(byModel, pricing) {
-  /** @type {{ totalUsd: number, byModel: Record<string, { usd: number | null, priced: boolean, tokens: number }>, unpriced: string[], tokens: number }} */
-  const out = { totalUsd: 0, byModel: {}, unpriced: [], tokens: 0 };
+  /** @type {{ totalUsd: number | null, pricedUsd: number, byModel: Record<string, { usd: number | null, priced: boolean, tokens: number }>, unpriced: string[], tokens: number }} */
+  const out = { totalUsd: 0, pricedUsd: 0, byModel: {}, unpriced: [], tokens: 0 };
   if (!byModel || typeof byModel !== "object") return out;
   for (const [model, u] of Object.entries(byModel)) {
     const input = u.input ?? 0;
@@ -52,9 +55,10 @@ export function costOfUsage(byModel, pricing) {
     }
     const usd = (input * rates.input + output * rates.output + cacheRead * rates.cacheRead + cacheWrite * rates.cacheWrite) / PER_MILLION;
     out.byModel[model] = { usd: round6(usd), priced: true, tokens: input + output + cacheRead + cacheWrite };
-    out.totalUsd += usd;
+    out.pricedUsd += usd;
   }
-  out.totalUsd = round6(out.totalUsd);
+  out.pricedUsd = round6(out.pricedUsd);
+  out.totalUsd = out.unpriced.length ? null : out.pricedUsd;
   return out;
 }
 

--- a/bench/lib/cost.mjs
+++ b/bench/lib/cost.mjs
@@ -35,6 +35,7 @@ export function ratesFor(pricing, model) {
  * counted in `tokens`).
  */
 export function costOfUsage(byModel, pricing) {
+  /** @type {{ totalUsd: number, byModel: Record<string, { usd: number | null, priced: boolean, tokens: number }>, unpriced: string[], tokens: number }} */
   const out = { totalUsd: 0, byModel: {}, unpriced: [], tokens: 0 };
   if (!byModel || typeof byModel !== "object") return out;
   for (const [model, u] of Object.entries(byModel)) {

--- a/bench/lib/figures-file.mjs
+++ b/bench/lib/figures-file.mjs
@@ -1,0 +1,17 @@
+// The cycle's figures on disk: one JSON line per figure, appended as each
+// lands — a run that never started included — so a later baseline reload
+// sees exactly the cycle the report saw.
+import fs from "node:fs";
+import path from "node:path";
+
+/** Append one figure to the cycle's file, creating the folder on the way. */
+export function appendFigure(file, fig) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.appendFileSync(file, JSON.stringify(fig) + "\n");
+}
+
+/** Every figure in the cycle's file, in order; null when there is no file. */
+export function readFigures(file) {
+  if (!fs.existsSync(file)) return null;
+  return fs.readFileSync(file, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line));
+}

--- a/bench/lib/metrics.mjs
+++ b/bench/lib/metrics.mjs
@@ -1,0 +1,151 @@
+// The loop's figures, as pure functions over what it sampled and captured:
+// how parallel a run was, what a cycle adds up to, and what changed against
+// the cycle before. No I/O here, so the numbers are testable on their own.
+
+/**
+ * Parallelism from the samples the loop took while a run worked — one every
+ * few seconds: { t, subagentsActive, subagentsTotal, tokensUsed, numTurns }.
+ * `peakActive` is the most helpers out at once; `helperSeconds` the time
+ * helpers were out, summed per helper (two helpers for a minute is 120);
+ * `helperShare` the share of the run's wall clock with at least one helper
+ * out; `agentSecondsPerWallSecond` is what "parallelisation" means as one
+ * number — 1.0 is the main loop alone, 2.0 is one helper beside it the whole
+ * time.
+ */
+export function parallelism(samples, wallMs) {
+  const s = (samples ?? []).filter((x) => x && typeof x.t === "number");
+  const wall = Math.max(0, wallMs ?? (s.length ? s[s.length - 1].t - s[0].t : 0));
+  let peakActive = 0;
+  let helperSeconds = 0;
+  let busySeconds = 0;
+  for (let i = 0; i < s.length; i++) {
+    const active = Math.max(0, s[i].subagentsActive ?? 0);
+    peakActive = Math.max(peakActive, active);
+    const dt = i + 1 < s.length ? Math.max(0, (s[i + 1].t - s[i].t) / 1000) : 0;
+    helperSeconds += active * dt;
+    if (active > 0) busySeconds += dt;
+  }
+  const wallSeconds = wall / 1000;
+  return {
+    samples: s.length,
+    peakActive,
+    helperSeconds: round1(helperSeconds),
+    helperShare: wallSeconds > 0 ? round3(Math.min(1, busySeconds / wallSeconds)) : 0,
+    agentSecondsPerWallSecond: wallSeconds > 0 ? round3((wallSeconds + helperSeconds) / wallSeconds) : 1,
+  };
+}
+
+/** One task's line in a cycle, from the capture line, the cost and the parallelism. */
+export function taskFigures({ line, cost, parallel, cycle }) {
+  return {
+    cycle,
+    task: line.task,
+    tier: line.tier,
+    runId: line.runId,
+    outcome: line.outcome,
+    score: line.score ?? null,
+    wallMs: line.wallMs ?? null,
+    numTurns: line.numTurns ?? 0,
+    tokensUsed: line.tokensUsed ?? 0,
+    thinkingTokens: line.thinkingTokens ?? 0,
+    filesTouched: line.filesTouched ?? 0,
+    permissionDenials: line.permissionDenials ?? 0,
+    subagentsTotal: line.subagentsTotal ?? 0,
+    subagentsByType: line.subagentsByType ?? {},
+    modelsUsed: line.modelsUsed ?? [],
+    costUsd: cost?.totalUsd ?? null,
+    costByModel: cost?.byModel ?? {},
+    unpricedModels: cost?.unpriced ?? [],
+    parallel,
+  };
+}
+
+/** A cycle's totals and averages over its task lines. */
+export function summarizeCycle(figures) {
+  const rows = figures ?? [];
+  const finished = rows.filter((r) => r.outcome === "completed");
+  const scored = rows.filter((r) => typeof r.score === "number");
+  const sum = (key) => rows.reduce((n, r) => n + (typeof r[key] === "number" ? r[key] : 0), 0);
+  const costKnown = rows.filter((r) => typeof r.costUsd === "number");
+  return {
+    runs: rows.length,
+    completed: finished.length,
+    successRate: rows.length ? round3(finished.length / rows.length) : 0,
+    meanScore: scored.length ? round1(scored.reduce((n, r) => n + r.score, 0) / scored.length) : null,
+    wallMs: sum("wallMs"),
+    tokensUsed: sum("tokensUsed"),
+    costUsd: costKnown.length ? round4(costKnown.reduce((n, r) => n + r.costUsd, 0)) : null,
+    unpriced: [...new Set(rows.flatMap((r) => r.unpricedModels ?? []))],
+    peakActive: rows.reduce((n, r) => Math.max(n, r.parallel?.peakActive ?? 0), 0),
+    meanAgentSecondsPerWallSecond: rows.length
+      ? round3(rows.reduce((n, r) => n + (r.parallel?.agentSecondsPerWallSecond ?? 1), 0) / rows.length)
+      : null,
+  };
+}
+
+/**
+ * What changed per task between two cycles — the loop's reading. Positive
+ * `pct` is up; for wall, tokens and cost that is worse, for score better.
+ */
+export function deltaByTask(previous, current) {
+  const prev = new Map((previous ?? []).map((r) => [r.task, r]));
+  const out = [];
+  for (const cur of current ?? []) {
+    const before = prev.get(cur.task);
+    if (!before) { out.push({ task: cur.task, fresh: true }); continue; }
+    const d = (key, pick = (r) => r[key]) => {
+      const a = pick(before);
+      const b = pick(cur);
+      if (typeof a !== "number" || typeof b !== "number") return null;
+      return { before: a, after: b, pct: a === 0 ? (b === 0 ? 0 : null) : round1(((b - a) / a) * 100) };
+    };
+    out.push({
+      task: cur.task,
+      fresh: false,
+      outcome: { before: before.outcome, after: cur.outcome },
+      score: d("score"),
+      wallMs: d("wallMs"),
+      tokensUsed: d("tokensUsed"),
+      costUsd: d("costUsd"),
+      peakActive: d("peakActive", (r) => r.parallel?.peakActive),
+      agentSecondsPerWallSecond: d("agentSecondsPerWallSecond", (r) => r.parallel?.agentSecondsPerWallSecond),
+    });
+  }
+  return out;
+}
+
+/**
+ * The loop's hints: which tasks to look at first when tuning the harness.
+ * Plain rules, so the report never asserts something the numbers do not say.
+ */
+export function hints(figures) {
+  const out = [];
+  for (const r of figures ?? []) {
+    if (r.outcome !== "completed") out.push(`${r.task}: ended ${r.outcome} — reliability before anything else.`);
+    else if (typeof r.score === "number" && r.score < 70) out.push(`${r.task}: score ${r.score} — quality, not footprint, is the gap.`);
+    if (r.permissionDenials > 0) out.push(`${r.task}: ${r.permissionDenials} refused action(s) — a brief or an allow-list to widen, or a run that strayed.`);
+    if (r.subagentsTotal === 0 && (r.wallMs ?? 0) > 10 * 60_000) out.push(`${r.task}: ${Math.round((r.wallMs ?? 0) / 60_000)} min with no helper — a fan-out candidate.`);
+    if ((r.parallel?.peakActive ?? 0) >= 3 && (r.parallel?.helperShare ?? 0) < 0.2) out.push(`${r.task}: helpers out in a burst (peak ${r.parallel.peakActive}) but idle ${Math.round((1 - r.parallel.helperShare) * 100)}% of the time — the fan-out lands late or short.`);
+    if (r.thinkingTokens > 0 && r.tokensUsed > 0 && r.thinkingTokens / r.tokensUsed > 0.3) out.push(`${r.task}: ${Math.round((r.thinkingTokens / r.tokensUsed) * 100)}% of the tokens were thinking — effort may be higher than the task needs.`);
+  }
+  return out;
+}
+
+export function formatMs(ms) {
+  if (typeof ms !== "number" || !Number.isFinite(ms)) return "n/a";
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  return `${m}m ${s - m * 60}s`;
+}
+
+export function formatTokens(n) {
+  if (typeof n !== "number") return "n/a";
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}k`;
+  return String(n);
+}
+
+const round1 = (n) => Math.round(n * 10) / 10;
+const round3 = (n) => Math.round(n * 1000) / 1000;
+const round4 = (n) => Math.round(n * 10000) / 10000;

--- a/bench/lib/metrics.mjs
+++ b/bench/lib/metrics.mjs
@@ -35,16 +35,26 @@ export function parallelism(samples, wallMs) {
   };
 }
 
-/** One task's line in a cycle, from the capture line, the cost and the parallelism. */
-export function taskFigures({ line, cost, parallel, cycle }) {
+/**
+ * One task's line in a cycle, from the capture line, the cost and the
+ * parallelism. `wallMs` is start to settle; `commitLagMs` how long the commit
+ * took to land after that; `endToEndMs` the two together — the time a person
+ * waited for the work to be on disk, which is what "time to finish" means.
+ */
+export function taskFigures({ line, cost, parallel, cycle, rep = 1 }) {
+  const wallMs = line.wallMs ?? null;
+  const commitLagMs = typeof line.commitLagMs === "number" ? line.commitLagMs : null;
   return {
     cycle,
+    rep,
     task: line.task,
     tier: line.tier,
     runId: line.runId,
     outcome: line.outcome,
     score: line.score ?? null,
-    wallMs: line.wallMs ?? null,
+    wallMs,
+    commitLagMs,
+    endToEndMs: typeof wallMs === "number" ? wallMs + (commitLagMs ?? 0) : null,
     numTurns: line.numTurns ?? 0,
     tokensUsed: line.tokensUsed ?? 0,
     thinkingTokens: line.thinkingTokens ?? 0,
@@ -54,6 +64,7 @@ export function taskFigures({ line, cost, parallel, cycle }) {
     subagentsByType: line.subagentsByType ?? {},
     modelsUsed: line.modelsUsed ?? [],
     costUsd: cost?.totalUsd ?? null,
+    pricedUsd: cost?.pricedUsd ?? null,
     costByModel: cost?.byModel ?? {},
     unpricedModels: cost?.unpriced ?? [],
     parallel,
@@ -66,16 +77,22 @@ export function summarizeCycle(figures) {
   const finished = rows.filter((r) => r.outcome === "completed");
   const scored = rows.filter((r) => typeof r.score === "number");
   const sum = (key) => rows.reduce((n, r) => n + (typeof r[key] === "number" ? r[key] : 0), 0);
-  const costKnown = rows.filter((r) => typeof r.costUsd === "number");
+  const unpriced = [...new Set(rows.flatMap((r) => r.unpricedModels ?? []))];
+  const priced = rows.filter((r) => typeof r.pricedUsd === "number");
+  const pricedUsd = priced.length ? round4(priced.reduce((n, r) => n + r.pricedUsd, 0)) : null;
   return {
     runs: rows.length,
     completed: finished.length,
     successRate: rows.length ? round3(finished.length / rows.length) : 0,
     meanScore: scored.length ? round1(scored.reduce((n, r) => n + r.score, 0) / scored.length) : null,
     wallMs: sum("wallMs"),
+    endToEndMs: sum("endToEndMs"),
     tokensUsed: sum("tokensUsed"),
-    costUsd: costKnown.length ? round4(costKnown.reduce((n, r) => n + r.costUsd, 0)) : null,
-    unpriced: [...new Set(rows.flatMap((r) => r.unpricedModels ?? []))],
+    // The cycle's cost is a number only when every run's was: a priced
+    // subtotal beside unpriced models is reported as that, never as the total.
+    costUsd: unpriced.length || rows.some((r) => r.costUsd === null) ? null : pricedUsd,
+    pricedUsd,
+    unpriced,
     peakActive: rows.reduce((n, r) => Math.max(n, r.parallel?.peakActive ?? 0), 0),
     meanAgentSecondsPerWallSecond: rows.length
       ? round3(rows.reduce((n, r) => n + (r.parallel?.agentSecondsPerWallSecond ?? 1), 0) / rows.length)
@@ -83,16 +100,22 @@ export function summarizeCycle(figures) {
   };
 }
 
+/** A figure's identity across cycles: the task and which repetition of it. */
+export function figureKey(r) {
+  return `${r.task}#${r.rep ?? 1}`;
+}
+
 /**
- * What changed per task between two cycles — the loop's reading. Positive
- * `pct` is up; for wall, tokens and cost that is worse, for score better.
+ * What changed per task (and repetition) between two cycles — the loop's
+ * reading. Positive `pct` is up; for time, tokens and cost that is worse,
+ * for score better.
  */
 export function deltaByTask(previous, current) {
-  const prev = new Map((previous ?? []).map((r) => [r.task, r]));
+  const prev = new Map((previous ?? []).map((r) => [figureKey(r), r]));
   const out = [];
   for (const cur of current ?? []) {
-    const before = prev.get(cur.task);
-    if (!before) { out.push({ task: cur.task, fresh: true }); continue; }
+    const before = prev.get(figureKey(cur));
+    if (!before) { out.push({ task: cur.task, rep: cur.rep ?? 1, fresh: true }); continue; }
     const d = (key, pick = (r) => r[key]) => {
       const a = pick(before);
       const b = pick(cur);
@@ -101,10 +124,12 @@ export function deltaByTask(previous, current) {
     };
     out.push({
       task: cur.task,
+      rep: cur.rep ?? 1,
       fresh: false,
       outcome: { before: before.outcome, after: cur.outcome },
       score: d("score"),
       wallMs: d("wallMs"),
+      endToEndMs: d("endToEndMs"),
       tokensUsed: d("tokensUsed"),
       costUsd: d("costUsd"),
       peakActive: d("peakActive", (r) => r.parallel?.peakActive),

--- a/bench/loop.mjs
+++ b/bench/loop.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+// The bench's MAIN LOOP: run the suite's demo tasks as coding PROJECTS on
+// the box (folders under the owner's project folder, so each shows up in
+// the Coding Agent app like any other project), sample every run while it
+// works, and write the figures the harness is tuned by — token spend,
+// parallelisation, time to finish, cost per task — as one report per cycle,
+// with the change against the cycle before. Repeat with --cycles.
+//
+//   node bench/loop.mjs --dry-run                      what would run
+//   node bench/loop.mjs --tasks s-01-single-edit        one task, one cycle
+//   node bench/loop.mjs --nightly --cycles 3 --pause 60 the loop
+//   node bench/loop.mjs --baseline nightly-c1 --nightly compare against a cycle
+//
+// Spends real tokens and real wall-clock; never part of `test:*`.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { enable, codingStatus, startRun, stopRun, getRun, waitForCommit, baseUrl } from "./lib/box.mjs";
+import { captureRun } from "./lib/capture.mjs";
+import { costOfUsage, formatUsd, loadPricing } from "./lib/cost.mjs";
+import { deltaByTask, formatMs, formatTokens, hints, parallelism, summarizeCycle, taskFigures } from "./lib/metrics.mjs";
+
+const BENCH_DIR = path.dirname(fileURLToPath(import.meta.url));
+const TASKS_DIR = path.join(BENCH_DIR, "tasks");
+const RESULTS_DIR = path.join(BENCH_DIR, "results");
+const PRICING = path.join(BENCH_DIR, "pricing.json");
+/** How often a live run is sampled for its parallelism and spend. */
+const SAMPLE_MS = 5_000;
+
+function parseArgs(argv) {
+  const args = { cycles: 1, pause: 0, repeat: 1 };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    const next = () => argv[++i];
+    if (a === "--tasks") args.tasks = next().split(",").map((s) => s.trim());
+    else if (a === "--tier") args.tiers = next().split(",").map((s) => s.trim().toUpperCase());
+    else if (a === "--nightly") args.nightly = true;
+    else if (a === "--cycles") args.cycles = Math.max(1, Number(next()) || 1);
+    else if (a === "--pause") args.pause = Math.max(0, Number(next()) || 0);
+    else if (a === "--repeat") args.repeat = Math.max(1, Number(next()) || 1);
+    else if (a === "--label") args.label = next();
+    else if (a === "--baseline") args.baseline = next();
+    else if (a === "--workroot") args.workroot = next();
+    else if (a === "--effort") args.effort = next();
+    else if (a === "--dry-run") args.dryRun = true;
+    else if (a === "--help" || a === "-h") args.help = true;
+    else { console.error(`unknown flag: ${a}`); process.exit(2); }
+  }
+  return args;
+}
+
+function loadSuite() {
+  return JSON.parse(fs.readFileSync(path.join(BENCH_DIR, "suite.json"), "utf8"));
+}
+
+function loadTask(id) {
+  const dir = path.join(TASKS_DIR, id);
+  const meta = JSON.parse(fs.readFileSync(path.join(dir, "task.json"), "utf8"));
+  const brief = fs.readFileSync(path.join(dir, "brief.md"), "utf8").trim();
+  return { ...meta, dir, brief, seedDir: fs.existsSync(path.join(dir, "seed")) ? path.join(dir, "seed") : null };
+}
+
+/**
+ * The task's folder IS the project: `<projects>/bench-<task>-<stamp>`, directly
+ * under the owner's project folder, which is what the app lists. A task's
+ * "outside" files (the refusal probe's `../shared-config/…`) land beside it.
+ */
+function seedProject(task, projectsRoot, stamp) {
+  const workdir = path.join(projectsRoot, `bench-${task.id}-${stamp}`);
+  fs.mkdirSync(workdir, { recursive: true });
+  if (task.seedDir) fs.cpSync(task.seedDir, workdir, { recursive: true });
+  for (const [rel, content] of Object.entries(task.outside ?? {})) {
+    const dest = path.resolve(workdir, "..", rel);
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.writeFileSync(dest, content);
+  }
+  return workdir;
+}
+
+async function scoreTask(task, workdir, run) {
+  const scorePath = path.join(task.dir, "score.mjs");
+  if (!fs.existsSync(scorePath)) return null;
+  try {
+    const mod = await import(pathToFileURL(scorePath).href);
+    return await mod.default({ workdir, run });
+  } catch (err) {
+    return { score: 0, max: 100, checks: [{ name: "scorer crashed", pass: false, detail: String(err).slice(0, 300), weight: 1 }] };
+  }
+}
+
+/** Wait for a run, sampling it on the way: the samples are the parallelism record. */
+async function sampleUntilSettled(runId, deadline, samples) {
+  let run = null;
+  let lastLine = "";
+  for (;;) {
+    const res = await getRun(runId, 0);
+    if (!res.ok) throw new Error(`run read failed: ${res.status}`);
+    run = res.json.run ?? res.json;
+    samples.push({
+      t: Date.now(),
+      status: run.status,
+      tokensUsed: run.tokensUsed ?? 0,
+      thinkingTokens: run.thinkingTokens ?? 0,
+      numTurns: run.numTurns ?? 0,
+      subagentsActive: run.subagentsActive ?? 0,
+      subagentsTotal: run.subagentsTotal ?? 0,
+      filesTouched: (run.filesTouched ?? []).length,
+    });
+    const line = (run.progress ?? []).at(-1) ?? "";
+    if (line && line !== lastLine) { console.log(`  · ${line.slice(0, 110)}`); lastLine = line; }
+    if (run.status !== "running" || Date.now() >= deadline) return run;
+    await new Promise((r) => setTimeout(r, SAMPLE_MS));
+  }
+}
+
+function readFigures(suiteVersion, label) {
+  const file = path.join(RESULTS_DIR, suiteVersion, `loop-${label}.jsonl`);
+  if (!fs.existsSync(file)) return null;
+  return fs.readFileSync(file, "utf8").split("\n").filter(Boolean).map((l) => JSON.parse(l));
+}
+
+function pct(d) {
+  if (!d || d.pct === null || d.pct === undefined) return "";
+  return `${d.pct > 0 ? "+" : ""}${d.pct}%`;
+}
+
+function writeReport({ suiteVersion, label, figures, summary, deltas, baseline, pricing }) {
+  const lines = [];
+  lines.push(`# Bench loop — ${label}`, "");
+  lines.push(`Suite v${suiteVersion} · ${summary.runs} run(s) · ${summary.completed} completed (${Math.round(summary.successRate * 100)}%) · mean score ${summary.meanScore ?? "n/a"}`);
+  lines.push(`Wall ${formatMs(summary.wallMs)} · tokens ${formatTokens(summary.tokensUsed)} · cost ${formatUsd(summary.costUsd)} (${pricing.currency}) · peak agents beside the run ${summary.peakActive} · agent-seconds per wall-second ${summary.meanAgentSecondsPerWallSecond ?? "n/a"}`);
+  if (summary.unpriced.length) lines.push(`Unpriced models (set them in bench/pricing.json): ${summary.unpriced.join(", ")}`);
+  lines.push("", "| task | outcome | score | time | turns | tokens | thinking | cost | helpers | peak | agent-s/wall-s | denials |", "|---|---|---|---|---|---|---|---|---|---|---|---|");
+  for (const r of figures) {
+    const helpers = Object.entries(r.subagentsByType).map(([k, n]) => `${n}× ${k}`).join(", ") || "0";
+    lines.push(`| ${r.task} | ${r.outcome} | ${r.score ?? "n/a"} | ${formatMs(r.wallMs)} | ${r.numTurns} | ${formatTokens(r.tokensUsed)} | ${formatTokens(r.thinkingTokens)} | ${formatUsd(r.costUsd)} | ${helpers} | ${r.parallel.peakActive} | ${r.parallel.agentSecondsPerWallSecond} | ${r.permissionDenials} |`);
+  }
+  if (deltas) {
+    lines.push("", `## Against ${baseline}`, "", "| task | outcome | score | time | tokens | cost | peak agents | agent-s/wall-s |", "|---|---|---|---|---|---|---|---|");
+    for (const d of deltas) {
+      if (d.fresh) { lines.push(`| ${d.task} | new | | | | | | |`); continue; }
+      lines.push(`| ${d.task} | ${d.outcome.before} → ${d.outcome.after} | ${pct(d.score)} | ${pct(d.wallMs)} | ${pct(d.tokensUsed)} | ${pct(d.costUsd)} | ${pct(d.peakActive)} | ${pct(d.agentSecondsPerWallSecond)} |`);
+    }
+  }
+  const h = hints(figures);
+  if (h.length) { lines.push("", "## Look at", ""); for (const x of h) lines.push(`- ${x}`); }
+  lines.push("", "Cost is priced from bench/pricing.json over the per-model usage in each run's transcript (the main loop on the tier model, the helpers on flash); parallelism from a sample of the run every 5 s. A failing run is a finding, not a retry.");
+  const file = path.join(RESULTS_DIR, suiteVersion, `report-${label}.md`);
+  fs.writeFileSync(file, lines.join("\n") + "\n");
+  return file;
+}
+
+async function runCycle({ args, suite, tasks, label, projectsRoot, pricing }) {
+  const figures = [];
+  const plan = tasks.flatMap((t) => Array.from({ length: args.repeat }, (_, i) => ({ task: t, rep: i + 1 })));
+  for (const { task, rep } of plan) {
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+    const workdir = seedProject(task, projectsRoot, stamp);
+    console.log(`\n▶ ${task.id} rep ${rep} as project ${path.basename(workdir)}`);
+    const started = await startRun({ task: task.brief, directory: workdir });
+    if (started.status !== 202 || !started.json?.run) {
+      console.error(`  run refused: ${started.status} ${started.text.slice(0, 300)}`);
+      figures.push({ cycle: label, task: task.id, tier: task.tier, runId: null, outcome: "not-started", score: null, wallMs: null, numTurns: 0, tokensUsed: 0, thinkingTokens: 0, filesTouched: 0, permissionDenials: 0, subagentsTotal: 0, subagentsByType: {}, modelsUsed: [], costUsd: null, costByModel: {}, unpricedModels: [], parallel: parallelism([], 0) });
+      if (started.status === 409 && started.json?.kind === "busy") { console.error("  a run is already in progress — one at a time; stopping this cycle."); break; }
+      continue;
+    }
+    const runId = started.json.run.id;
+    console.log(`  run ${runId} started (effort ${started.json.run.effort}, maxTurns ${started.json.run.maxTurns})`);
+    let run = started.json.run;
+    let outcome;
+    let settled = { run: null, commitLagMs: null };
+    const samples = [];
+    try {
+      run = await sampleUntilSettled(runId, Date.now() + task.timeoutMinutes * 60_000, samples);
+      outcome = run.status;
+      if (run.status === "running") {
+        outcome = "timeout";
+        console.error(`  TIMEOUT after ${task.timeoutMinutes}min — stopping ${runId}`);
+        await stopRun(runId);
+        run = await sampleUntilSettled(runId, Date.now() + 30_000, samples);
+      }
+      settled = await waitForCommit(runId);
+      if (settled.run) run = settled.run;
+    } catch (err) {
+      outcome = "transport-failure";
+      console.error(`  polling failed after start: ${String(err).slice(0, 200)}`);
+    }
+    const score = await scoreTask(task, workdir, run);
+    const wallMs = (run.completedAt ?? Date.now()) - run.startedAt;
+    const { runDir, line } = captureRun({ run, task, workdir, resultsRoot: RESULTS_DIR, suiteVersion: suite.suiteVersion, score, outcome, wallMs, commitLagMs: settled.commitLagMs, label });
+    fs.writeFileSync(path.join(runDir, "samples.json"), JSON.stringify(samples, null, 2));
+    const cost = costOfUsage(line.usageByModel, pricing);
+    const parallel = parallelism(samples, wallMs);
+    const fig = taskFigures({ line, cost, parallel, cycle: label });
+    figures.push(fig);
+    fs.appendFileSync(path.join(RESULTS_DIR, suite.suiteVersion, `loop-${label}.jsonl`), JSON.stringify(fig) + "\n");
+    console.log(`  ${outcome} in ${formatMs(wallMs)} — score ${score ? `${score.score}/100` : "n/a"}, ${formatTokens(line.tokensUsed)} tok, ${formatUsd(cost.totalUsd)}, peak ${parallel.peakActive} helper(s), agent-s/wall-s ${parallel.agentSecondsPerWallSecond}`);
+    if (cost.unpriced.length) console.log(`  unpriced: ${cost.unpriced.join(", ")} — set bench/pricing.json`);
+  }
+  return figures;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) { console.log("see the header of this file for usage"); return; }
+  const suite = loadSuite();
+  let ids = args.tasks ?? suite.tasks;
+  const unknown = ids.filter((id) => !fs.existsSync(path.join(TASKS_DIR, id)));
+  if (unknown.length) { console.error(`unknown tasks: ${unknown.join(", ")}`); process.exit(2); }
+  let tasks = ids.map(loadTask).filter((t) => !t.manual);
+  if (args.tiers) tasks = tasks.filter((t) => args.tiers.includes(t.tier));
+  if (args.nightly) tasks = tasks.filter((t) => t.nightly);
+  const pricing = loadPricing(PRICING);
+  const baseLabel = args.label ?? (args.nightly ? "nightly" : "loop");
+  console.log(`suite v${suite.suiteVersion} → ${tasks.length} task(s) × ${args.repeat} × ${args.cycles} cycle(s) on ${baseUrl()}`);
+  for (const t of tasks) console.log(`  ${t.id} (${t.tier}) — ≤${t.timeoutMinutes}min`);
+  if (args.dryRun) return;
+
+  // The projects root: the box's own, so the demo tasks are projects the
+  // owner sees; only when asked is the folder switched (and then the owner's
+  // projects vanish from the app for the session — say so).
+  const status = await codingStatus();
+  if (!status.ok) { console.error(`status failed: ${status.status}`); process.exit(1); }
+  const projectsRoot = args.workroot ?? status.json.defaultDirectory;
+  if (!projectsRoot) { console.error("no project folder is set on this box and --workroot was not given"); process.exit(1); }
+  const settings = { enabled: true };
+  if (args.workroot && args.workroot !== status.json.defaultDirectory) {
+    console.log(`switching the project folder to ${args.workroot} for this session — the app lists only what is under it meanwhile`);
+    settings.defaultDirectory = args.workroot;
+  }
+  if (args.effort) settings.effort = args.effort;
+  const enabled = await enable(settings);
+  if (!enabled.ok) { console.error(`enable failed: ${enabled.status} ${enabled.text.slice(0, 300)}`); process.exit(1); }
+  if (!enabled.json.ready) { console.error(`harness not ready: ${JSON.stringify(enabled.json.readiness?.problems ?? [])}`); process.exit(1); }
+  fs.mkdirSync(path.join(RESULTS_DIR, suite.suiteVersion), { recursive: true });
+
+  let previous = args.baseline ? readFigures(suite.suiteVersion, args.baseline) : null;
+  let previousLabel = args.baseline ?? null;
+  if (args.baseline && !previous) console.error(`no figures for baseline ${args.baseline}; comparing from the first cycle on`);
+  let anyFailed = false;
+  for (let c = 1; c <= args.cycles; c++) {
+    const label = `${baseLabel}-c${c}-${new Date().toISOString().slice(0, 10)}`;
+    console.log(`\n== cycle ${c}/${args.cycles}: ${label} ==`);
+    const figures = await runCycle({ args, suite, tasks, label, projectsRoot, pricing });
+    const summary = summarizeCycle(figures);
+    const deltas = previous ? deltaByTask(previous, figures) : null;
+    const report = writeReport({ suiteVersion: suite.suiteVersion, label, figures, summary, deltas, baseline: previousLabel, pricing });
+    console.log(`\n== ${label}: ${summary.completed}/${summary.runs} completed, mean score ${summary.meanScore ?? "n/a"}, ${formatMs(summary.wallMs)}, ${formatTokens(summary.tokensUsed)} tok, ${formatUsd(summary.costUsd)} → ${path.relative(BENCH_DIR, report)}`);
+    for (const h of hints(figures)) console.log(`  → ${h}`);
+    if (figures.some((f) => f.outcome !== "completed")) anyFailed = true;
+    previous = figures;
+    previousLabel = label;
+    if (c < args.cycles && args.pause > 0) {
+      console.log(`pausing ${args.pause}s before the next cycle`);
+      await new Promise((r) => setTimeout(r, args.pause * 1000));
+    }
+  }
+  process.exitCode = anyFailed ? 1 : 0;
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/bench/loop.mjs
+++ b/bench/loop.mjs
@@ -20,6 +20,7 @@ import { captureRun } from "./lib/capture.mjs";
 import { costOfUsage, formatUsd, loadPricing } from "./lib/cost.mjs";
 import crypto from "node:crypto";
 import { deltaByTask, formatMs, formatTokens, hints, parallelism, summarizeCycle, taskFigures } from "./lib/metrics.mjs";
+import { appendFigure, readFigures as readFiguresFile } from "./lib/figures-file.mjs";
 
 const BENCH_DIR = path.dirname(fileURLToPath(import.meta.url));
 const TASKS_DIR = path.join(BENCH_DIR, "tasks");
@@ -115,10 +116,12 @@ async function sampleUntilSettled(runId, deadline, samples) {
   }
 }
 
+function figuresFile(suiteVersion, label) {
+  return path.join(RESULTS_DIR, suiteVersion, `loop-${label}.jsonl`);
+}
+
 function readFigures(suiteVersion, label) {
-  const file = path.join(RESULTS_DIR, suiteVersion, `loop-${label}.jsonl`);
-  if (!fs.existsSync(file)) return null;
-  return fs.readFileSync(file, "utf8").split("\n").filter(Boolean).map((l) => JSON.parse(l));
+  return readFiguresFile(figuresFile(suiteVersion, label));
 }
 
 /** A stamp no two runs share: the second, and 128 random bits after it. */
@@ -162,6 +165,12 @@ function writeReport({ suiteVersion, label, figures, summary, deltas, baseline, 
 
 async function runCycle({ args, suite, tasks, label, projectsRoot, pricing }) {
   const figures = [];
+  // Every figure — a run that never started too — goes to the cycle's JSONL
+  // as it lands, so a later baseline reload sees the cycle the report saw.
+  const record = (fig) => {
+    figures.push(fig);
+    appendFigure(figuresFile(suite.suiteVersion, label), fig);
+  };
   const plan = tasks.flatMap((t) => Array.from({ length: args.repeat }, (_, i) => ({ task: t, rep: i + 1 })));
   for (const { task, rep } of plan) {
     const workdir = seedProject(task, projectsRoot, stamp());
@@ -171,7 +180,7 @@ async function runCycle({ args, suite, tasks, label, projectsRoot, pricing }) {
       console.error(`  run refused: ${started.status} ${started.text.slice(0, 300)}`);
       // A run that never started spent nothing: zero usage priced as zero,
       // so the cycle's cost stays a number rather than "n/a".
-      figures.push(taskFigures({ line: { task: task.id, tier: task.tier, runId: null, outcome: "not-started", wallMs: null, subagentsByType: {}, modelsUsed: [] }, cost: costOfUsage(null, pricing), parallel: parallelism([], 0), cycle: label, rep }));
+      record(taskFigures({ line: { task: task.id, tier: task.tier, runId: null, outcome: "not-started", wallMs: null, subagentsByType: {}, modelsUsed: [] }, cost: costOfUsage(null, pricing), parallel: parallelism([], 0), cycle: label, rep }));
       if (started.status === 409 && started.json?.kind === "busy") { console.error("  a run is already in progress — one at a time; stopping this cycle."); break; }
       continue;
     }
@@ -203,8 +212,7 @@ async function runCycle({ args, suite, tasks, label, projectsRoot, pricing }) {
     const cost = costOfUsage(line.usageByModel, pricing);
     const parallel = parallelism(samples, wallMs);
     const fig = taskFigures({ line, cost, parallel, cycle: label, rep });
-    figures.push(fig);
-    fs.appendFileSync(path.join(RESULTS_DIR, suite.suiteVersion, `loop-${label}.jsonl`), JSON.stringify(fig) + "\n");
+    record(fig);
     console.log(`  ${outcome} in ${formatMs(fig.endToEndMs)} (${formatMs(wallMs)} to settle) — score ${score ? `${score.score}/100` : "n/a"}, ${formatTokens(line.tokensUsed)} tok, ${cost.totalUsd === null ? `cost n/a (${formatUsd(cost.pricedUsd)} priced)` : formatUsd(cost.totalUsd)}, peak ${parallel.peakActive} helper(s), agent-s/wall-s ${parallel.agentSecondsPerWallSecond}`);
     if (cost.unpriced.length) console.log(`  unpriced: ${cost.unpriced.join(", ")} — set bench/pricing.json`);
   }

--- a/bench/loop.mjs
+++ b/bench/loop.mjs
@@ -121,9 +121,9 @@ function readFigures(suiteVersion, label) {
   return fs.readFileSync(file, "utf8").split("\n").filter(Boolean).map((l) => JSON.parse(l));
 }
 
-/** A stamp no two runs share: the second, and four random hex characters after it. */
+/** A stamp no two runs share: the second, and 128 random bits after it. */
 function stamp() {
-  return `${new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19)}-${crypto.randomBytes(2).toString("hex")}`;
+  return `${new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19)}-${crypto.randomBytes(16).toString("hex")}`;
 }
 
 function pct(d) {
@@ -169,7 +169,9 @@ async function runCycle({ args, suite, tasks, label, projectsRoot, pricing }) {
     const started = await startRun({ task: task.brief, directory: workdir });
     if (started.status !== 202 || !started.json?.run) {
       console.error(`  run refused: ${started.status} ${started.text.slice(0, 300)}`);
-      figures.push(taskFigures({ line: { task: task.id, tier: task.tier, runId: null, outcome: "not-started", wallMs: null, subagentsByType: {}, modelsUsed: [] }, cost: null, parallel: parallelism([], 0), cycle: label, rep }));
+      // A run that never started spent nothing: zero usage priced as zero,
+      // so the cycle's cost stays a number rather than "n/a".
+      figures.push(taskFigures({ line: { task: task.id, tier: task.tier, runId: null, outcome: "not-started", wallMs: null, subagentsByType: {}, modelsUsed: [] }, cost: costOfUsage(null, pricing), parallel: parallelism([], 0), cycle: label, rep }));
       if (started.status === 409 && started.json?.kind === "busy") { console.error("  a run is already in progress — one at a time; stopping this cycle."); break; }
       continue;
     }
@@ -248,9 +250,9 @@ async function main() {
   if (args.baseline && !previous) console.error(`no figures for baseline ${args.baseline}; comparing from the first cycle on`);
   let anyFailed = false;
   for (let c = 1; c <= args.cycles; c++) {
-    // The label carries the second, so a second invocation on the same day
-    // never appends to an earlier cycle's figures or overwrites its report.
-    const label = `${baseLabel}-c${c}-${new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19)}`;
+    // The label carries the stamp, so a second invocation — even in the same
+    // second — never appends to an earlier cycle's figures or overwrites its report.
+    const label = `${baseLabel}-c${c}-${stamp()}`;
     console.log(`\n== cycle ${c}/${args.cycles}: ${label} ==`);
     const figures = await runCycle({ args, suite, tasks, label, projectsRoot, pricing });
     const summary = summarizeCycle(figures);

--- a/bench/loop.mjs
+++ b/bench/loop.mjs
@@ -18,6 +18,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { enable, codingStatus, startRun, stopRun, getRun, waitForCommit, baseUrl } from "./lib/box.mjs";
 import { captureRun } from "./lib/capture.mjs";
 import { costOfUsage, formatUsd, loadPricing } from "./lib/cost.mjs";
+import crypto from "node:crypto";
 import { deltaByTask, formatMs, formatTokens, hints, parallelism, summarizeCycle, taskFigures } from "./lib/metrics.mjs";
 
 const BENCH_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -70,7 +71,8 @@ function seedProject(task, projectsRoot, stamp) {
   fs.mkdirSync(workdir, { recursive: true });
   if (task.seedDir) fs.cpSync(task.seedDir, workdir, { recursive: true });
   for (const [rel, content] of Object.entries(task.outside ?? {})) {
-    const dest = path.resolve(workdir, "..", rel);
+    // The task names the file from its own folder (`../shared-config/…`).
+    const dest = path.resolve(workdir, rel);
     fs.mkdirSync(path.dirname(dest), { recursive: true });
     fs.writeFileSync(dest, content);
   }
@@ -119,6 +121,11 @@ function readFigures(suiteVersion, label) {
   return fs.readFileSync(file, "utf8").split("\n").filter(Boolean).map((l) => JSON.parse(l));
 }
 
+/** A stamp no two runs share: the second, and four random hex characters after it. */
+function stamp() {
+  return `${new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19)}-${crypto.randomBytes(2).toString("hex")}`;
+}
+
 function pct(d) {
   if (!d || d.pct === null || d.pct === undefined) return "";
   return `${d.pct > 0 ? "+" : ""}${d.pct}%`;
@@ -128,18 +135,21 @@ function writeReport({ suiteVersion, label, figures, summary, deltas, baseline, 
   const lines = [];
   lines.push(`# Bench loop — ${label}`, "");
   lines.push(`Suite v${suiteVersion} · ${summary.runs} run(s) · ${summary.completed} completed (${Math.round(summary.successRate * 100)}%) · mean score ${summary.meanScore ?? "n/a"}`);
-  lines.push(`Wall ${formatMs(summary.wallMs)} · tokens ${formatTokens(summary.tokensUsed)} · cost ${formatUsd(summary.costUsd)} (${pricing.currency}) · peak agents beside the run ${summary.peakActive} · agent-seconds per wall-second ${summary.meanAgentSecondsPerWallSecond ?? "n/a"}`);
-  if (summary.unpriced.length) lines.push(`Unpriced models (set them in bench/pricing.json): ${summary.unpriced.join(", ")}`);
-  lines.push("", "| task | outcome | score | time | turns | tokens | thinking | cost | helpers | peak | agent-s/wall-s | denials |", "|---|---|---|---|---|---|---|---|---|---|---|---|");
+  const costLine = summary.costUsd === null
+    ? `cost n/a — ${formatUsd(summary.pricedUsd)} priced, ${summary.unpriced.length ? `unpriced: ${summary.unpriced.join(", ")} (set them in bench/pricing.json)` : "some runs unpriced"}`
+    : `cost ${formatUsd(summary.costUsd)} (${pricing.currency})`;
+  lines.push(`Time to finish ${formatMs(summary.endToEndMs)} (to settle ${formatMs(summary.wallMs)}, the rest the commit landing) · tokens ${formatTokens(summary.tokensUsed)} · ${costLine} · peak agents beside the run ${summary.peakActive} · agent-seconds per wall-second ${summary.meanAgentSecondsPerWallSecond ?? "n/a"}`);
+  lines.push("", "| task | rep | outcome | score | time | to settle | turns | tokens | thinking | cost | helpers | peak | agent-s/wall-s | denials |", "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|");
   for (const r of figures) {
     const helpers = Object.entries(r.subagentsByType).map(([k, n]) => `${n}× ${k}`).join(", ") || "0";
-    lines.push(`| ${r.task} | ${r.outcome} | ${r.score ?? "n/a"} | ${formatMs(r.wallMs)} | ${r.numTurns} | ${formatTokens(r.tokensUsed)} | ${formatTokens(r.thinkingTokens)} | ${formatUsd(r.costUsd)} | ${helpers} | ${r.parallel.peakActive} | ${r.parallel.agentSecondsPerWallSecond} | ${r.permissionDenials} |`);
+    const cost = r.costUsd === null ? `n/a (${formatUsd(r.pricedUsd)} priced)` : formatUsd(r.costUsd);
+    lines.push(`| ${r.task} | ${r.rep ?? 1} | ${r.outcome} | ${r.score ?? "n/a"} | ${formatMs(r.endToEndMs)} | ${formatMs(r.wallMs)} | ${r.numTurns} | ${formatTokens(r.tokensUsed)} | ${formatTokens(r.thinkingTokens)} | ${cost} | ${helpers} | ${r.parallel.peakActive} | ${r.parallel.agentSecondsPerWallSecond} | ${r.permissionDenials} |`);
   }
   if (deltas) {
-    lines.push("", `## Against ${baseline}`, "", "| task | outcome | score | time | tokens | cost | peak agents | agent-s/wall-s |", "|---|---|---|---|---|---|---|---|");
+    lines.push("", `## Against ${baseline}`, "", "| task | rep | outcome | score | time | tokens | cost | peak agents | agent-s/wall-s |", "|---|---|---|---|---|---|---|---|---|");
     for (const d of deltas) {
-      if (d.fresh) { lines.push(`| ${d.task} | new | | | | | | |`); continue; }
-      lines.push(`| ${d.task} | ${d.outcome.before} → ${d.outcome.after} | ${pct(d.score)} | ${pct(d.wallMs)} | ${pct(d.tokensUsed)} | ${pct(d.costUsd)} | ${pct(d.peakActive)} | ${pct(d.agentSecondsPerWallSecond)} |`);
+      if (d.fresh) { lines.push(`| ${d.task} | ${d.rep} | new | | | | | | |`); continue; }
+      lines.push(`| ${d.task} | ${d.rep} | ${d.outcome.before} → ${d.outcome.after} | ${pct(d.score)} | ${pct(d.endToEndMs)} | ${pct(d.tokensUsed)} | ${pct(d.costUsd)} | ${pct(d.peakActive)} | ${pct(d.agentSecondsPerWallSecond)} |`);
     }
   }
   const h = hints(figures);
@@ -154,13 +164,12 @@ async function runCycle({ args, suite, tasks, label, projectsRoot, pricing }) {
   const figures = [];
   const plan = tasks.flatMap((t) => Array.from({ length: args.repeat }, (_, i) => ({ task: t, rep: i + 1 })));
   for (const { task, rep } of plan) {
-    const stamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
-    const workdir = seedProject(task, projectsRoot, stamp);
+    const workdir = seedProject(task, projectsRoot, stamp());
     console.log(`\n▶ ${task.id} rep ${rep} as project ${path.basename(workdir)}`);
     const started = await startRun({ task: task.brief, directory: workdir });
     if (started.status !== 202 || !started.json?.run) {
       console.error(`  run refused: ${started.status} ${started.text.slice(0, 300)}`);
-      figures.push({ cycle: label, task: task.id, tier: task.tier, runId: null, outcome: "not-started", score: null, wallMs: null, numTurns: 0, tokensUsed: 0, thinkingTokens: 0, filesTouched: 0, permissionDenials: 0, subagentsTotal: 0, subagentsByType: {}, modelsUsed: [], costUsd: null, costByModel: {}, unpricedModels: [], parallel: parallelism([], 0) });
+      figures.push(taskFigures({ line: { task: task.id, tier: task.tier, runId: null, outcome: "not-started", wallMs: null, subagentsByType: {}, modelsUsed: [] }, cost: null, parallel: parallelism([], 0), cycle: label, rep }));
       if (started.status === 409 && started.json?.kind === "busy") { console.error("  a run is already in progress — one at a time; stopping this cycle."); break; }
       continue;
     }
@@ -191,10 +200,10 @@ async function runCycle({ args, suite, tasks, label, projectsRoot, pricing }) {
     fs.writeFileSync(path.join(runDir, "samples.json"), JSON.stringify(samples, null, 2));
     const cost = costOfUsage(line.usageByModel, pricing);
     const parallel = parallelism(samples, wallMs);
-    const fig = taskFigures({ line, cost, parallel, cycle: label });
+    const fig = taskFigures({ line, cost, parallel, cycle: label, rep });
     figures.push(fig);
     fs.appendFileSync(path.join(RESULTS_DIR, suite.suiteVersion, `loop-${label}.jsonl`), JSON.stringify(fig) + "\n");
-    console.log(`  ${outcome} in ${formatMs(wallMs)} — score ${score ? `${score.score}/100` : "n/a"}, ${formatTokens(line.tokensUsed)} tok, ${formatUsd(cost.totalUsd)}, peak ${parallel.peakActive} helper(s), agent-s/wall-s ${parallel.agentSecondsPerWallSecond}`);
+    console.log(`  ${outcome} in ${formatMs(fig.endToEndMs)} (${formatMs(wallMs)} to settle) — score ${score ? `${score.score}/100` : "n/a"}, ${formatTokens(line.tokensUsed)} tok, ${cost.totalUsd === null ? `cost n/a (${formatUsd(cost.pricedUsd)} priced)` : formatUsd(cost.totalUsd)}, peak ${parallel.peakActive} helper(s), agent-s/wall-s ${parallel.agentSecondsPerWallSecond}`);
     if (cost.unpriced.length) console.log(`  unpriced: ${cost.unpriced.join(", ")} — set bench/pricing.json`);
   }
   return figures;
@@ -239,13 +248,15 @@ async function main() {
   if (args.baseline && !previous) console.error(`no figures for baseline ${args.baseline}; comparing from the first cycle on`);
   let anyFailed = false;
   for (let c = 1; c <= args.cycles; c++) {
-    const label = `${baseLabel}-c${c}-${new Date().toISOString().slice(0, 10)}`;
+    // The label carries the second, so a second invocation on the same day
+    // never appends to an earlier cycle's figures or overwrites its report.
+    const label = `${baseLabel}-c${c}-${new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19)}`;
     console.log(`\n== cycle ${c}/${args.cycles}: ${label} ==`);
     const figures = await runCycle({ args, suite, tasks, label, projectsRoot, pricing });
     const summary = summarizeCycle(figures);
     const deltas = previous ? deltaByTask(previous, figures) : null;
     const report = writeReport({ suiteVersion: suite.suiteVersion, label, figures, summary, deltas, baseline: previousLabel, pricing });
-    console.log(`\n== ${label}: ${summary.completed}/${summary.runs} completed, mean score ${summary.meanScore ?? "n/a"}, ${formatMs(summary.wallMs)}, ${formatTokens(summary.tokensUsed)} tok, ${formatUsd(summary.costUsd)} → ${path.relative(BENCH_DIR, report)}`);
+    console.log(`\n== ${label}: ${summary.completed}/${summary.runs} completed, mean score ${summary.meanScore ?? "n/a"}, ${formatMs(summary.endToEndMs)}, ${formatTokens(summary.tokensUsed)} tok, ${summary.costUsd === null ? `cost n/a (${formatUsd(summary.pricedUsd)} priced)` : formatUsd(summary.costUsd)} → ${path.relative(BENCH_DIR, report)}`);
     for (const h of hints(figures)) console.log(`  → ${h}`);
     if (figures.some((f) => f.outcome !== "completed")) anyFailed = true;
     previous = figures;

--- a/bench/pricing.json
+++ b/bench/pricing.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "USD per MILLION tokens, by model id as the transcript names it. PLACEHOLDERS: set these to the prices of the plan this box is on (ClawBox AI's DeepSeek tiers) — the loop prices every run from these and flags a model that is not listed rather than guessing. cacheRead/cacheWrite default to input's rate when absent.",
+  "currency": "USD",
+  "models": {
+    "deepseek-v4-pro": { "input": 1.0, "output": 2.0, "cacheRead": 0.1, "cacheWrite": 1.0 },
+    "deepseek-v4-pro[1m]": { "input": 1.0, "output": 2.0, "cacheRead": 0.1, "cacheWrite": 1.0 },
+    "deepseek-v4-flash": { "input": 0.1, "output": 0.2, "cacheRead": 0.01, "cacheWrite": 0.1 }
+  }
+}

--- a/src/tests/unit/bench-metrics.test.ts
+++ b/src/tests/unit/bench-metrics.test.ts
@@ -6,6 +6,10 @@
  */
 import { describe, expect, it } from "vitest";
 import { costOfUsage, formatUsd, loadPricing, ratesFor } from "../../../bench/lib/cost.mjs";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { appendFigure, readFigures } from "../../../bench/lib/figures-file.mjs";
 import { deltaByTask, figureKey, formatMs, formatTokens, hints, parallelism, summarizeCycle, taskFigures } from "../../../bench/lib/metrics.mjs";
 
 const PRICING = { currency: "USD", models: { "deepseek-v4-pro[1m]": { input: 1, output: 2, cacheRead: 0.1 }, "deepseek-v4-flash": { input: 0.1, output: 0.2 } } };
@@ -134,5 +138,24 @@ describe("a cycle's figures", () => {
     expect(formatMs(4_000)).toBe("4s");
     expect(formatTokens(1_234_567)).toBe("1.23M");
     expect(formatTokens(45_600)).toBe("46k");
+  });
+});
+
+describe("the cycle's figures on disk", () => {
+  it("keeps a run that never started beside the ones that did, and reads the cycle back as it was", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bench-figures-"));
+    const file = path.join(dir, "v1", "loop-c1.jsonl");
+    try {
+      expect(readFigures(file)).toBeNull();
+      const started = taskFigures({ line: { task: "a", tier: "S", runId: "run-1", outcome: "completed", score: 90, wallMs: 1000, subagentsByType: {}, modelsUsed: [] }, cost: costOfUsage({ "deepseek-v4-flash": { input: 1_000_000, output: 0 } }, PRICING), parallel: parallelism([], 0), cycle: "c1" });
+      const refused = taskFigures({ line: { task: "b", tier: "S", runId: null, outcome: "not-started", wallMs: null, subagentsByType: {}, modelsUsed: [] }, cost: costOfUsage(null, PRICING), parallel: parallelism([], 0), cycle: "c1" });
+      appendFigure(file, started);
+      appendFigure(file, refused);
+      const back = readFigures(file);
+      expect(back).toEqual([started, refused]);
+      expect(summarizeCycle(back!)).toMatchObject({ runs: 2, completed: 1, costUsd: 0.1 });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/tests/unit/bench-metrics.test.ts
+++ b/src/tests/unit/bench-metrics.test.ts
@@ -6,12 +6,12 @@
  */
 import { describe, expect, it } from "vitest";
 import { costOfUsage, formatUsd, loadPricing, ratesFor } from "../../../bench/lib/cost.mjs";
-import { deltaByTask, formatMs, formatTokens, hints, parallelism, summarizeCycle, taskFigures } from "../../../bench/lib/metrics.mjs";
+import { deltaByTask, figureKey, formatMs, formatTokens, hints, parallelism, summarizeCycle, taskFigures } from "../../../bench/lib/metrics.mjs";
 
 const PRICING = { currency: "USD", models: { "deepseek-v4-pro[1m]": { input: 1, output: 2, cacheRead: 0.1 }, "deepseek-v4-flash": { input: 0.1, output: 0.2 } } };
 
 describe("cost", () => {
-  it("prices each model's tokens per million, cache rates falling back to input, and flags a model the table lacks", () => {
+  it("prices each model's tokens per million, cache rates falling back to input, and answers no TOTAL while a model is unpriced", () => {
     const cost = costOfUsage({
       "deepseek-v4-pro[1m]": { input: 1_000_000, output: 500_000, cacheRead: 2_000_000, cacheWrite: 100_000, messages: 10 },
       "deepseek-v4-flash": { input: 3_000_000, output: 1_000_000, cacheRead: 0, cacheWrite: 0, messages: 4 },
@@ -21,13 +21,18 @@ describe("cost", () => {
     expect(cost.byModel["deepseek-v4-pro[1m]"]).toEqual({ usd: 2.3, priced: true, tokens: 3_600_000 });
     expect(cost.byModel["deepseek-v4-flash"]).toEqual({ usd: 0.5, priced: true, tokens: 4_000_000 });
     expect(cost.byModel["gpt-mystery"]).toEqual({ usd: null, priced: false, tokens: 20 });
-    expect(cost.totalUsd).toBe(2.8);
+    // The priced subtotal is there; the total is not a number, because the
+    // unpriced model is not free.
+    expect(cost.pricedUsd).toBe(2.8);
+    expect(cost.totalUsd).toBeNull();
     expect(cost.unpriced).toEqual(["gpt-mystery"]);
     expect(cost.tokens).toBe(7_600_020);
+    const all = costOfUsage({ "deepseek-v4-flash": { input: 1_000_000, output: 0 } }, PRICING);
+    expect(all).toMatchObject({ totalUsd: 0.1, pricedUsd: 0.1, unpriced: [] });
   });
 
   it("answers nothing for no usage, and rates only for a complete row", () => {
-    expect(costOfUsage(null, PRICING)).toEqual({ totalUsd: 0, byModel: {}, unpriced: [], tokens: 0 });
+    expect(costOfUsage(null, PRICING)).toEqual({ totalUsd: 0, pricedUsd: 0, byModel: {}, unpriced: [], tokens: 0 });
     expect(ratesFor(PRICING, "deepseek-v4-flash")).toEqual({ input: 0.1, output: 0.2, cacheRead: 0.1, cacheWrite: 0.1 });
     expect(ratesFor({ models: { broken: { input: "1" } } }, "broken")).toBeNull();
     expect(loadPricing("/nonexistent/pricing.json")).toEqual({ currency: "USD", models: {} });
@@ -63,21 +68,44 @@ describe("parallelism", () => {
 
 describe("a cycle's figures", () => {
   const line = (over: Record<string, unknown>) => ({
-    task: "m-01", tier: "M", runId: "run-1", outcome: "completed", score: 90, wallMs: 300_000, numTurns: 20, tokensUsed: 1_000_000, thinkingTokens: 100_000,
+    task: "m-01", tier: "M", runId: "run-1", outcome: "completed", score: 90, wallMs: 300_000, commitLagMs: 2_000, numTurns: 20, tokensUsed: 1_000_000, thinkingTokens: 100_000,
     filesTouched: 8, permissionDenials: 0, subagentsTotal: 2, subagentsByType: { explorer: 1, reviewer: 1 }, modelsUsed: ["deepseek-v4-pro[1m]"], usageByModel: null, ...over,
   });
-  const fig = (over: Record<string, unknown>, parallel = parallelism([], 0)) =>
-    taskFigures({ line: line(over), cost: costOfUsage({ "deepseek-v4-flash": { input: 1_000_000, output: 0 } }, PRICING), parallel, cycle: "c1" });
+  const fig = (over: Record<string, unknown>, parallel = parallelism([], 0), rep = 1) =>
+    taskFigures({ line: line(over), cost: costOfUsage({ "deepseek-v4-flash": { input: 1_000_000, output: 0 } }, PRICING), parallel, cycle: "c1", rep });
 
-  it("sums a cycle and reads the change per task against the cycle before", () => {
+  it("keeps the commit lag apart from the time to settle, and adds the two up as the time to finish", () => {
+    const f = fig({ wallMs: 300_000, commitLagMs: 2_000 });
+    expect(f).toMatchObject({ wallMs: 300_000, commitLagMs: 2_000, endToEndMs: 302_000, rep: 1 });
+    expect(fig({ commitLagMs: null }).endToEndMs).toBe(300_000);
+    expect(fig({ wallMs: null }).endToEndMs).toBeNull();
+  });
+
+  it("sums a cycle and reads the change per task and repetition against the cycle before", () => {
     const before = [fig({ task: "a", wallMs: 100_000, tokensUsed: 1000, score: 80 }), fig({ task: "b", outcome: "failed", score: 20 })];
     const after = [fig({ task: "a", wallMs: 50_000, tokensUsed: 1500, score: 90 }), fig({ task: "b", score: 70 }), fig({ task: "c" })];
     const summary = summarizeCycle(after);
-    expect(summary).toMatchObject({ runs: 3, completed: 3, successRate: 1, meanScore: 83.3, costUsd: 0.3, unpriced: [] });
+    expect(summary).toMatchObject({ runs: 3, completed: 3, successRate: 1, meanScore: 83.3, costUsd: 0.3, pricedUsd: 0.3, unpriced: [], endToEndMs: 656_000 });
     const d = deltaByTask(before, after);
-    expect(d[0]).toMatchObject({ task: "a", wallMs: { before: 100_000, after: 50_000, pct: -50 }, tokensUsed: { pct: 50 }, score: { pct: 12.5 } });
+    expect(d[0]).toMatchObject({ task: "a", rep: 1, wallMs: { before: 100_000, after: 50_000, pct: -50 }, endToEndMs: { before: 102_000, after: 52_000 }, tokensUsed: { pct: 50 }, score: { pct: 12.5 } });
     expect(d[1].outcome).toEqual({ before: "failed", after: "completed" });
-    expect(d[2]).toEqual({ task: "c", fresh: true });
+    expect(d[2]).toEqual({ task: "c", rep: 1, fresh: true });
+  });
+
+  it("compares a repeated task by its repetition, never by the last one alone", () => {
+    const before = [fig({ task: "a", wallMs: 100_000 }, undefined, 1), fig({ task: "a", wallMs: 200_000 }, undefined, 2)];
+    const after = [fig({ task: "a", wallMs: 110_000 }, undefined, 1), fig({ task: "a", wallMs: 100_000 }, undefined, 2)];
+    expect(figureKey(before[1])).toBe("a#2");
+    const d = deltaByTask(before, after);
+    expect(d.map((x) => [x.rep, x.wallMs?.pct])).toEqual([[1, 10], [2, -50]]);
+  });
+
+  it("answers no cycle cost while any run has an unpriced model", () => {
+    const unpriced = taskFigures({ line: line({ task: "u" }), cost: costOfUsage({ mystery: { input: 10, output: 0 } }, PRICING), parallel: parallelism([], 0), cycle: "c1" });
+    const summary = summarizeCycle([fig({ task: "a" }), unpriced]);
+    expect(summary.costUsd).toBeNull();
+    expect(summary.pricedUsd).toBe(0.1);
+    expect(summary.unpriced).toEqual(["mystery"]);
   });
 
   it("hints at what to look at, and only from the numbers", () => {

--- a/src/tests/unit/bench-metrics.test.ts
+++ b/src/tests/unit/bench-metrics.test.ts
@@ -100,6 +100,14 @@ describe("a cycle's figures", () => {
     expect(d.map((x) => [x.rep, x.wallMs?.pct])).toEqual([[1, 10], [2, -50]]);
   });
 
+  it("keeps the cycle's cost a number when a run never started — zero usage is zero cost, not unknown", () => {
+    const notStarted = taskFigures({ line: { task: "b", tier: "S", runId: null, outcome: "not-started", wallMs: null, subagentsByType: {}, modelsUsed: [] }, cost: costOfUsage(null, PRICING), parallel: parallelism([], 0), cycle: "c1" });
+    expect(notStarted).toMatchObject({ costUsd: 0, pricedUsd: 0, unpricedModels: [] });
+    const summary = summarizeCycle([fig({ task: "a" }), notStarted]);
+    expect(summary.costUsd).toBe(0.1);
+    expect(summary.completed).toBe(1);
+  });
+
   it("answers no cycle cost while any run has an unpriced model", () => {
     const unpriced = taskFigures({ line: line({ task: "u" }), cost: costOfUsage({ mystery: { input: 10, output: 0 } }, PRICING), parallel: parallelism([], 0), cycle: "c1" });
     const summary = summarizeCycle([fig({ task: "a" }), unpriced]);

--- a/src/tests/unit/bench-metrics.test.ts
+++ b/src/tests/unit/bench-metrics.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The bench loop's figures are pure functions over what it sampled and
+ * captured: parallelism from the samples, cost from the per-model usage and
+ * the pricing table, a cycle's summary, and the change against the cycle
+ * before. Pinned here so the report never says what the numbers do not.
+ */
+import { describe, expect, it } from "vitest";
+import { costOfUsage, formatUsd, loadPricing, ratesFor } from "../../../bench/lib/cost.mjs";
+import { deltaByTask, formatMs, formatTokens, hints, parallelism, summarizeCycle, taskFigures } from "../../../bench/lib/metrics.mjs";
+
+const PRICING = { currency: "USD", models: { "deepseek-v4-pro[1m]": { input: 1, output: 2, cacheRead: 0.1 }, "deepseek-v4-flash": { input: 0.1, output: 0.2 } } };
+
+describe("cost", () => {
+  it("prices each model's tokens per million, cache rates falling back to input, and flags a model the table lacks", () => {
+    const cost = costOfUsage({
+      "deepseek-v4-pro[1m]": { input: 1_000_000, output: 500_000, cacheRead: 2_000_000, cacheWrite: 100_000, messages: 10 },
+      "deepseek-v4-flash": { input: 3_000_000, output: 1_000_000, cacheRead: 0, cacheWrite: 0, messages: 4 },
+      "gpt-mystery": { input: 10, output: 10, cacheRead: 0, cacheWrite: 0, messages: 1 },
+    }, PRICING);
+    // pro: 1 + 1 + 0.2 + 0.1 (cacheWrite at input's rate) = 2.3; flash: 0.3 + 0.2 = 0.5
+    expect(cost.byModel["deepseek-v4-pro[1m]"]).toEqual({ usd: 2.3, priced: true, tokens: 3_600_000 });
+    expect(cost.byModel["deepseek-v4-flash"]).toEqual({ usd: 0.5, priced: true, tokens: 4_000_000 });
+    expect(cost.byModel["gpt-mystery"]).toEqual({ usd: null, priced: false, tokens: 20 });
+    expect(cost.totalUsd).toBe(2.8);
+    expect(cost.unpriced).toEqual(["gpt-mystery"]);
+    expect(cost.tokens).toBe(7_600_020);
+  });
+
+  it("answers nothing for no usage, and rates only for a complete row", () => {
+    expect(costOfUsage(null, PRICING)).toEqual({ totalUsd: 0, byModel: {}, unpriced: [], tokens: 0 });
+    expect(ratesFor(PRICING, "deepseek-v4-flash")).toEqual({ input: 0.1, output: 0.2, cacheRead: 0.1, cacheWrite: 0.1 });
+    expect(ratesFor({ models: { broken: { input: "1" } } }, "broken")).toBeNull();
+    expect(loadPricing("/nonexistent/pricing.json")).toEqual({ currency: "USD", models: {} });
+  });
+
+  it("prints money the way the report reads it", () => {
+    expect(formatUsd(1.234)).toBe("$1.23");
+    expect(formatUsd(0.0456)).toBe("$0.046");
+    expect(formatUsd(0.0012)).toBe("$0.0012");
+    expect(formatUsd(null)).toBe("n/a");
+  });
+});
+
+describe("parallelism", () => {
+  it("reads the peak, the helper-seconds and the share of the clock with a helper out from the samples", () => {
+    const t0 = 1_000_000;
+    const samples = [
+      { t: t0, subagentsActive: 0 },
+      { t: t0 + 10_000, subagentsActive: 2 },
+      { t: t0 + 20_000, subagentsActive: 1 },
+      { t: t0 + 30_000, subagentsActive: 0 },
+      { t: t0 + 40_000, subagentsActive: 0 },
+    ];
+    const p = parallelism(samples, 40_000);
+    expect(p).toEqual({ samples: 5, peakActive: 2, helperSeconds: 30, helperShare: 0.5, agentSecondsPerWallSecond: 1.75 });
+  });
+
+  it("is the main loop alone with no samples or no helpers", () => {
+    expect(parallelism([], 0)).toEqual({ samples: 0, peakActive: 0, helperSeconds: 0, helperShare: 0, agentSecondsPerWallSecond: 1 });
+    expect(parallelism([{ t: 1, subagentsActive: 0 }, { t: 60_001, subagentsActive: 0 }], 60_000).agentSecondsPerWallSecond).toBe(1);
+  });
+});
+
+describe("a cycle's figures", () => {
+  const line = (over: Record<string, unknown>) => ({
+    task: "m-01", tier: "M", runId: "run-1", outcome: "completed", score: 90, wallMs: 300_000, numTurns: 20, tokensUsed: 1_000_000, thinkingTokens: 100_000,
+    filesTouched: 8, permissionDenials: 0, subagentsTotal: 2, subagentsByType: { explorer: 1, reviewer: 1 }, modelsUsed: ["deepseek-v4-pro[1m]"], usageByModel: null, ...over,
+  });
+  const fig = (over: Record<string, unknown>, parallel = parallelism([], 0)) =>
+    taskFigures({ line: line(over), cost: costOfUsage({ "deepseek-v4-flash": { input: 1_000_000, output: 0 } }, PRICING), parallel, cycle: "c1" });
+
+  it("sums a cycle and reads the change per task against the cycle before", () => {
+    const before = [fig({ task: "a", wallMs: 100_000, tokensUsed: 1000, score: 80 }), fig({ task: "b", outcome: "failed", score: 20 })];
+    const after = [fig({ task: "a", wallMs: 50_000, tokensUsed: 1500, score: 90 }), fig({ task: "b", score: 70 }), fig({ task: "c" })];
+    const summary = summarizeCycle(after);
+    expect(summary).toMatchObject({ runs: 3, completed: 3, successRate: 1, meanScore: 83.3, costUsd: 0.3, unpriced: [] });
+    const d = deltaByTask(before, after);
+    expect(d[0]).toMatchObject({ task: "a", wallMs: { before: 100_000, after: 50_000, pct: -50 }, tokensUsed: { pct: 50 }, score: { pct: 12.5 } });
+    expect(d[1].outcome).toEqual({ before: "failed", after: "completed" });
+    expect(d[2]).toEqual({ task: "c", fresh: true });
+  });
+
+  it("hints at what to look at, and only from the numbers", () => {
+    const quiet = fig({ task: "long", wallMs: 20 * 60_000, subagentsTotal: 0, subagentsByType: {} });
+    const refused = fig({ task: "refused", permissionDenials: 2 });
+    const thinker = fig({ task: "thinker", thinkingTokens: 500_000 });
+    const fine = fig({ task: "fine" });
+    const out = hints([quiet, refused, thinker, fine]);
+    expect(out).toEqual([
+      expect.stringMatching(/^long: 20 min with no helper/),
+      expect.stringMatching(/^refused: 2 refused action/),
+      expect.stringMatching(/^thinker: 50% of the tokens were thinking/),
+    ]);
+  });
+
+  it("formats time and tokens the way the tables read", () => {
+    expect(formatMs(65_000)).toBe("1m 5s");
+    expect(formatMs(4_000)).toBe("4s");
+    expect(formatTokens(1_234_567)).toBe("1.23M");
+    expect(formatTokens(45_600)).toBe("46k");
+  });
+});


### PR DESCRIPTION
## What

The bench's **tuning loop** (`bench/loop.mjs`), the owner's ask: a main loop that starts the bench, triggers the demo tasks as coding PROJECTS, and collects what the harness is tuned by — token spend, parallelisation, time to finish and cost per task — cycle after cycle.

- Runs the suite's tasks as `bench-<task>-<stamp>` folders directly under the owner's project folder, so each is a project the Coding Agent app lists (the runner kept a folder of its own and switched the box's project folder to it, which hid the owner's projects meanwhile; the loop switches only with `--workroot`, and says so).
- Samples every run every 5 s while it works (`samples.json` in the run's results directory) → **parallelism**: peak helpers at once, helper-seconds, the share of the clock with a helper out, and agent-seconds per wall-second (1.0 = the main loop alone).
- **Cost per task** from `bench/pricing.json` (USD per million tokens by model; the shipped numbers are PLACEHOLDERS to set to the plan this box is on) over the per-model usage the capture already sums from the transcript; a model the table lacks is flagged as unpriced, never counted as free.
- One report per cycle (`results/<suite>/report-<label>.md`): the figures per task, the change against the previous cycle (`--baseline`, or the cycle before within `--cycles N`), and a "look at" list of plain rules (a run that did not complete, a low score, refused actions, a long run with no helper, a burst of helpers that sat idle, a thinking share over 30%). `loop-<label>.jsonl` carries the figures per run.
- The pure parts (`lib/cost.mjs`, `lib/metrics.mjs`) are unit-tested (`src/tests/unit/bench-metrics.test.ts`); the README gains a Loop section.

Smoke on the box (2026-09-05): `node bench/loop.mjs --tasks s-01-single-edit --label smoke` → the task ran as project `bench-s-01-single-edit-…`, completed in 15 s, score 100, 48k tokens, $0.021 at the placeholder prices, report written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Fz3uZVzYQzcNAkw1cQ8ff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line benchmark workflow supporting task runs, repeated cycles, baselines, dry runs, workspace selection, progress sampling, scoring, and reports.
  * Added benchmark metrics for duration, token usage, parallelism, cycle comparisons, tuning hints, and task-level results.
  * Added pricing configuration, cost reporting, and persistent benchmark result tracking, including handling for missing or invalid pricing data and failed runs.

* **Documentation**
  * Documented the benchmark workflow, reports, pricing behavior, and workspace layout.

* **Tests**
  * Added coverage for benchmark metrics, pricing calculations, formatting, persistence, defaults, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->