### PR TITLE
team tree: one node per agent the card counts, captions with counts, the sentence beneath

### DIFF
--- a/src/components/CodingTeamCard.tsx
+++ b/src/components/CodingTeamCard.tsx
@@ -198,17 +198,20 @@ export default function CodingTeamCard({ directory, projectId, onOpenRun, onPlan
           </button>
         )}
       </div>
-      {/* The team as a tree — who hands to whom — sized by the board: as
-          many workers as have worked here, the ones at work pulsing. With no
-          team yet it shows the shape a team takes. */}
-      <div className="mt-2 flex flex-col @md:flex-row @md:items-center gap-3">
+      {/* The team as a tree — who hands to whom — sized by the board: the
+          planner, as many workers and reviewers as have worked here, the
+          ones at work pulsing; the sentence beneath it. With no team yet
+          it shows the shape a team takes. */}
+      <div className="mt-2 flex flex-col items-center gap-2">
         <CodingTeamTree
           workers={team?.agents && team.agents.workers > 0 ? team.agents.workers : 3}
-          reviewer
           activeWorkers={team ? team.tasks.filter((x) => x.status === "in_progress").length : 0}
-          className="shrink-0 @md:w-[22rem]"
+          reviewers={team?.agents ? team.agents.reviewers : 1}
+          activeReviewers={team && active ? team.tasks.filter((x) => x.status === "complete" && !x.review).length : 0}
+          plannerActive={team?.status === "planning"}
+          className="shrink-0"
         />
-        <p className="text-[11px] text-[var(--text-muted)] leading-relaxed">{t("codingAgent.team.help")}</p>
+        <p className="text-[11px] text-[var(--text-muted)] leading-relaxed text-center max-w-[40rem]">{t("codingAgent.team.help")}</p>
       </div>
       {/* Who worked, and where: the owner asked to see how many agents a
           run had. Planner, workers (an attempt is a new worker), reviewers. */}

--- a/src/components/CodingTeamTree.tsx
+++ b/src/components/CodingTeamTree.tsx
@@ -1,62 +1,84 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { useT } from "@/lib/i18n";
 
 /**
  * The coding team as a tree, drawn once: the assistant hands a goal to the
- * Coding Agent, which fans it out to workers side by side, and every
- * worker's result converges on the reviewer. Read-only — a picture of who
- * is who, sized by the board (how many workers, how many are at work), not
- * a control.
+ * Coding Agent, which asks a planner for the tasks, fans them out to workers
+ * side by side, and every worker's result passes a reviewer. Read-only — a
+ * picture of who is who, sized by the board (how many workers, how many
+ * reviewers, which of them are at work right now), so the nodes it draws are
+ * the agents the card counts: planner + workers + reviewers.
  *
  * A deliberate sibling of CodingAgentDelegationArt and MemoryShardArt: the
  * same stroke weights, the same muted palette over the product's coral, the
- * same restraint. Where the delegation art fans OUT and the shard art
- * CONVERGES, this one does both in turn, which is what a team is. Every
- * animation lives under `@media (prefers-reduced-motion: no-preference)` in
- * globals.css (`ct-art-*`), so an owner who turned motion off gets the same
- * diagram. `aria-hidden` because the card's sentence says this in words.
+ * same restraint. Every animation lives under `@media
+ * (prefers-reduced-motion: no-preference)` in globals.css (`ct-art-*`), so an
+ * owner who turned motion off gets the same diagram. `aria-hidden` because
+ * the card's sentence says this in words.
  */
 export interface CodingTeamTreeProps {
   /** Worker nodes drawn, 1–5; a board with more is drawn with five. */
   workers?: number;
-  /** Whether a reviewer node is drawn: every team has the role, so the card always draws it. */
-  reviewer?: boolean;
-  /** How many of the workers are at work right now — those pulse faster. */
+  /** How many of the workers are at work right now — those pulse in coral. */
   activeWorkers?: number;
+  /** Reviewer nodes drawn, 0–5. */
+  reviewers?: number;
+  /** How many reviewers are deciding right now. */
+  activeReviewers?: number;
+  /** The planner is reading the folder right now. */
+  plannerActive?: boolean;
   className?: string;
 }
 
 export const MAX_TREE_WORKERS = 5;
+export const MAX_TREE_REVIEWERS = 5;
 
-export default function CodingTeamTree({ workers = 3, reviewer = true, activeWorkers = 0, className = "" }: CodingTeamTreeProps) {
+/** `n` points spread evenly between `top` and `bottom`; one point on the middle line. */
+function spread(n: number, top: number, bottom: number, mid: number): number[] {
+  if (n <= 1) return n === 1 ? [mid] : [];
+  return Array.from({ length: n }, (_, i) => top + ((bottom - top) * i) / (n - 1));
+}
+
+export default function CodingTeamTree({ workers = 3, activeWorkers = 0, reviewers = 1, activeReviewers = 0, plannerActive = false, className = "" }: CodingTeamTreeProps) {
   const { t } = useT();
-  const n = Math.min(MAX_TREE_WORKERS, Math.max(1, Math.round(workers)));
-  const live = Math.min(n, Math.max(0, Math.round(activeWorkers)));
-  // The workers' column: evenly spread between the top and bottom margins,
-  // a lone worker on the centre line.
-  const top = 34;
-  const bottom = 134;
-  const ys = n === 1 ? [84] : Array.from({ length: n }, (_, i) => top + ((bottom - top) * i) / (n - 1));
-  const mid = 84;
+  const w = Math.min(MAX_TREE_WORKERS, Math.max(1, Math.round(workers)));
+  const r = Math.min(MAX_TREE_REVIEWERS, Math.max(0, Math.round(reviewers)));
+  const liveW = Math.min(w, Math.max(0, Math.round(activeWorkers)));
+  const liveR = Math.min(r, Math.max(0, Math.round(activeReviewers)));
+  const mid = 100;
+  const wys = spread(w, 40, 160, mid);
+  const rys = spread(r, 40, 160, mid);
+  // Five columns: assistant, Coding Agent, planner, workers, reviewers.
+  const X = { assistant: 40, agent: 130, planner: 220, workers: 310, reviewers: 400 };
+  const node = (cx: number, cy: number, live: boolean, extra?: ReactNode) => (
+    <g className={live ? "ct-art-live" : "ct-art-node"} data-live={live || undefined}>
+      <rect x={cx - 12} y={cy - 12} width="24" height="24" rx="7" fill="var(--fill-2)" stroke={live ? "var(--coral-bright)" : "var(--border-subtle)"} strokeOpacity={live ? 0.7 : 1} strokeWidth="1.4" />
+      {extra ?? <circle cx={cx} cy={cy} r="3" fill={live ? "var(--coral-bright)" : "var(--text-muted)"} fillOpacity="0.9" />}
+    </g>
+  );
 
   return (
     <svg
-      viewBox="0 0 360 150"
-      className={`w-full max-w-[24rem] h-auto ${className}`}
+      viewBox="0 0 440 180"
+      className={`w-full max-w-[30rem] h-auto ${className}`}
       aria-hidden="true"
       focusable="false"
       data-testid="coding-team-tree"
-      data-workers={n}
-      data-reviewer={reviewer ? "true" : "false"}
-      data-active={live}
+      data-workers={w}
+      data-reviewers={r}
+      data-active={liveW}
+      data-active-reviewers={liveR}
+      data-planner-active={plannerActive || undefined}
     >
-      {/* Column captions. */}
+      {/* Column captions, with the count the card states. */}
       {[
-        { x: 40, label: t("codingAgent.team.artMain") },
-        { x: 146, label: t("codingAgent.title") },
-        { x: 250, label: t("codingAgent.team.artWorkers") },
-        ...(reviewer ? [{ x: 330, label: t("codingAgent.artReviewer") }] : []),
+        { x: X.assistant, label: t("codingAgent.team.artMain") },
+        { x: X.agent, label: t("codingAgent.title") },
+        { x: X.planner, label: `${t("codingAgent.team.artPlanner")} · 1` },
+        { x: X.workers, label: `${t("codingAgent.team.artWorkers")} · ${w}` },
+        { x: X.reviewers, label: `${t("codingAgent.team.artReviewers")} · ${r}` },
       ].map((c) => (
         <text key={c.x} x={c.x} y="14" textAnchor="middle" className="fill-[var(--text-muted)]" style={{ fontSize: 10, fontWeight: 500, letterSpacing: 0.4 }}>
           {c.label}
@@ -65,55 +87,71 @@ export default function CodingTeamTree({ workers = 3, reviewer = true, activeWor
 
       {/* The assistant: the one the owner talks to. */}
       <g className="ct-art-hub">
-        <rect x="10" y={mid - 18} width="60" height="36" rx="10" fill="var(--fill-2)" stroke="var(--border-subtle)" strokeWidth="1.4" />
-        <circle cx="30" cy={mid} r="3.5" fill="var(--coral-bright)" />
-        <path d={`M40 ${mid - 6} h16 M40 ${mid} h12 M40 ${mid + 6} h8`} stroke="var(--text-muted)" strokeOpacity="0.8" strokeWidth="1.6" strokeLinecap="round" />
+        <rect x={X.assistant - 30} y={mid - 18} width="60" height="36" rx="10" fill="var(--fill-2)" stroke="var(--border-subtle)" strokeWidth="1.4" />
+        <circle cx={X.assistant - 10} cy={mid} r="3.5" fill="var(--coral-bright)" />
+        <path d={`M${X.assistant} ${mid - 6} h16 M${X.assistant} ${mid} h12 M${X.assistant} ${mid + 6} h8`} stroke="var(--text-muted)" strokeOpacity="0.8" strokeWidth="1.6" strokeLinecap="round" />
       </g>
+      <path d={`M${X.assistant + 34} ${mid} H${X.agent - 34}`} fill="none" stroke="var(--text-muted)" strokeOpacity="0.45" strokeWidth="1.4" strokeDasharray="5 6" strokeLinecap="round" className="ct-art-flow" />
 
-      {/* The goal, handed to the Coding Agent. */}
-      <path d={`M74 ${mid} H112`} fill="none" stroke="var(--text-muted)" strokeOpacity="0.45" strokeWidth="1.4" strokeDasharray="5 6" strokeLinecap="round" className="ct-art-flow" />
-
-      {/* The Coding Agent: the planner, in the product's coral. */}
+      {/* The Coding Agent: the orchestrator, in the product's coral. */}
       <g className="ct-art-hub" style={{ animationDelay: "0.4s" }}>
-        <rect x="116" y={mid - 18} width="60" height="36" rx="10" fill="var(--coral-bright)" fillOpacity="0.10" stroke="var(--coral-bright)" strokeOpacity="0.55" strokeWidth="1.5" />
-        <path d={`M134 ${mid - 6} L144 ${mid} L134 ${mid + 6}`} fill="none" stroke="var(--coral-bright)" strokeOpacity="0.85" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
-        <path d={`M150 ${mid + 6} L156 ${mid - 6}`} fill="none" stroke="var(--coral-bright)" strokeOpacity="0.85" strokeWidth="1.8" strokeLinecap="round" />
+        <rect x={X.agent - 30} y={mid - 18} width="60" height="36" rx="10" fill="var(--coral-bright)" fillOpacity="0.10" stroke="var(--coral-bright)" strokeOpacity="0.55" strokeWidth="1.5" />
+        <path d={`M${X.agent - 12} ${mid - 6} L${X.agent - 2} ${mid} L${X.agent - 12} ${mid + 6}`} fill="none" stroke="var(--coral-bright)" strokeOpacity="0.85" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+        <path d={`M${X.agent + 4} ${mid + 6} L${X.agent + 10} ${mid - 6}`} fill="none" stroke="var(--coral-bright)" strokeOpacity="0.85" strokeWidth="1.8" strokeLinecap="round" />
+      </g>
+      <path d={`M${X.agent + 34} ${mid} H${X.planner - 16}`} fill="none" stroke="var(--text-muted)" strokeOpacity="0.45" strokeWidth="1.4" strokeDasharray="5 6" strokeLinecap="round" className="ct-art-flow" style={{ animationDelay: "0.2s" }} />
+
+      {/* The planner: reads the folder, answers the tasks. */}
+      <g data-testid="coding-team-tree-planner">
+        {node(X.planner, mid, plannerActive, (
+          <path d={`M${X.planner - 5} ${mid - 4} h10 M${X.planner - 5} ${mid} h10 M${X.planner - 5} ${mid + 4} h6`} stroke={plannerActive ? "var(--coral-bright)" : "var(--text-muted)"} strokeOpacity="0.9" strokeWidth="1.5" strokeLinecap="round" />
+        ))}
       </g>
 
-      {/* The workers: tasks out, results back. */}
-      {ys.map((y, i) => {
-        const at = i < live;
+      {/* The workers: tasks out from the planner, results on to the reviewers. */}
+      {wys.map((y, i) => {
+        const at = i < liveW;
         return (
-          <g key={i} data-testid="coding-team-tree-worker" data-live={at || undefined}>
+          <g key={`w${i}`} data-testid="coding-team-tree-worker" data-live={at || undefined}>
             <path
-              d={`M180 ${mid} C 208 ${mid}, 212 ${y}, 236 ${y}`}
+              d={`M${X.planner + 14} ${mid} C ${X.planner + 50} ${mid}, ${X.workers - 50} ${y}, ${X.workers - 14} ${y}`}
               fill="none" stroke="var(--text-muted)" strokeOpacity="0.45" strokeWidth="1.4"
               strokeDasharray="5 6" strokeLinecap="round"
               className="ct-art-flow" style={{ animationDelay: `${i * 0.3}s` }}
             />
-            <g className={at ? "ct-art-live" : "ct-art-node"} style={{ animationDelay: `${i * 0.3 + 0.5}s` }}>
-              <rect x="238" y={y - 12} width="24" height="24" rx="7" fill="var(--fill-2)" stroke={at ? "var(--coral-bright)" : "var(--border-subtle)"} strokeOpacity={at ? 0.7 : 1} strokeWidth="1.4" />
-              <circle cx="250" cy={y} r="3" fill={at ? "var(--coral-bright)" : "var(--text-muted)"} fillOpacity="0.9" />
-            </g>
-            {reviewer && (
-              <path
-                d={`M266 ${y} C 290 ${y}, 296 ${mid}, 318 ${mid}`}
-                fill="none" stroke="var(--text-muted)" strokeOpacity="0.35" strokeWidth="1.3"
-                strokeDasharray="4 7" strokeLinecap="round"
-                className="ct-art-flow" style={{ animationDelay: `${i * 0.3 + 0.9}s` }}
-              />
-            )}
+            {node(X.workers, y, at)}
           </g>
         );
       })}
 
-      {/* The reviewer: every result passes through it. */}
-      {reviewer && (
-        <g className="ct-art-node" style={{ animationDelay: "1.2s" }} data-testid="coding-team-tree-reviewer">
-          <rect x="318" y={mid - 13} width="26" height="26" rx="8" fill="var(--fill-2)" stroke="var(--border-subtle)" strokeWidth="1.4" />
-          <path d={`M325 ${mid} l4 4 l8 -8`} fill="none" stroke="var(--coral-bright)" strokeOpacity="0.9" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
-        </g>
-      )}
+      {/* Every worker's result passes a reviewer: the results converge on the
+          column and fan to each reviewer, since which one took which task
+          is the board's to say. */}
+      {r > 0 && wys.map((y, i) => (
+        <path
+          key={`wr${i}`}
+          d={`M${X.workers + 14} ${y} C ${X.workers + 40} ${y}, ${X.reviewers - 60} ${mid}, ${X.reviewers - 36} ${mid}`}
+          fill="none" stroke="var(--text-muted)" strokeOpacity="0.35" strokeWidth="1.3"
+          strokeDasharray="4 7" strokeLinecap="round"
+          className="ct-art-flow" style={{ animationDelay: `${i * 0.3 + 0.9}s` }}
+        />
+      ))}
+      {rys.map((y, i) => {
+        const at = i < liveR;
+        return (
+          <g key={`r${i}`} data-testid="coding-team-tree-reviewer" data-live={at || undefined}>
+            <path
+              d={`M${X.reviewers - 36} ${mid} C ${X.reviewers - 28} ${mid}, ${X.reviewers - 26} ${y}, ${X.reviewers - 14} ${y}`}
+              fill="none" stroke="var(--text-muted)" strokeOpacity="0.35" strokeWidth="1.3"
+              strokeDasharray="4 7" strokeLinecap="round"
+              className="ct-art-flow" style={{ animationDelay: `${i * 0.3 + 1.2}s` }}
+            />
+            {node(X.reviewers, y, at, (
+              <path d={`M${X.reviewers - 5} ${y} l4 4 l8 -8`} fill="none" stroke="var(--coral-bright)" strokeOpacity="0.9" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+            ))}
+          </g>
+        );
+      })}
     </svg>
   );
 }

--- a/src/lib/hermes-translations/bg.ts
+++ b/src/lib/hermes-translations/bg.ts
@@ -841,7 +841,7 @@ export const bg: Record<string, string> = {
   "codingAgent.artBrowser": "Браузър",
   "codingAgent.team.artMain": "Асистент",
   "codingAgent.team.artWorkers": "Работници",
-  "codingAgent.team.artPlanner": "Планиращ",
+  "codingAgent.team.artPlanner": "Планировчик",
   "codingAgent.team.artReviewers": "Рецензенти",
   "codingAgent.resetConfirm": "Нулиране на всичко — докоснете отново",
   "codingAgent.resetFailed": "Кодиращият агент не можа да бъде нулиран.",

--- a/src/lib/hermes-translations/bg.ts
+++ b/src/lib/hermes-translations/bg.ts
@@ -841,6 +841,8 @@ export const bg: Record<string, string> = {
   "codingAgent.artBrowser": "Браузър",
   "codingAgent.team.artMain": "Асистент",
   "codingAgent.team.artWorkers": "Работници",
+  "codingAgent.team.artPlanner": "Планиращ",
+  "codingAgent.team.artReviewers": "Рецензенти",
   "codingAgent.resetConfirm": "Нулиране на всичко — докоснете отново",
   "codingAgent.resetFailed": "Кодиращият агент не можа да бъде нулиран.",
 

--- a/src/lib/hermes-translations/de.ts
+++ b/src/lib/hermes-translations/de.ts
@@ -853,6 +853,8 @@ export const de: Record<string, string> = {
   "codingAgent.artBrowser": "Webbrowser",
   "codingAgent.team.artMain": "Assistent",
   "codingAgent.team.artWorkers": "Worker",
+  "codingAgent.team.artPlanner": "Planer",
+  "codingAgent.team.artReviewers": "Reviewer",
   "codingAgent.resetConfirm": "Alles zurücksetzen — erneut tippen",
   "codingAgent.resetFailed": "Der Coding-Agent konnte nicht zurückgesetzt werden.",
 

--- a/src/lib/hermes-translations/en-coding-agent.ts
+++ b/src/lib/hermes-translations/en-coding-agent.ts
@@ -420,6 +420,8 @@ export const codingAgentEn: Record<string, string> = {
   "codingAgent.artBrowser": "Browser",
   "codingAgent.team.artMain": "Assistant",
   "codingAgent.team.artWorkers": "Workers",
+  "codingAgent.team.artPlanner": "Planner",
+  "codingAgent.team.artReviewers": "Reviewers",
   "codingAgent.resetConfirm": "Reset everything — tap again",
   "codingAgent.resetFailed": "Could not reset the coding agent.",
 };

--- a/src/lib/hermes-translations/es.ts
+++ b/src/lib/hermes-translations/es.ts
@@ -849,6 +849,8 @@ export const es: Record<string, string> = {
   "codingAgent.artBrowser": "Navegador",
   "codingAgent.team.artMain": "Asistente",
   "codingAgent.team.artWorkers": "Trabajadores",
+  "codingAgent.team.artPlanner": "Planificador",
+  "codingAgent.team.artReviewers": "Revisores",
   "codingAgent.resetConfirm": "Restablecer todo — toca otra vez",
   "codingAgent.resetFailed": "No se pudo restablecer el agente de código.",
 

--- a/src/lib/hermes-translations/fr.ts
+++ b/src/lib/hermes-translations/fr.ts
@@ -854,6 +854,8 @@ export const fr: Record<string, string> = {
   "codingAgent.artBrowser": "Navigateur",
   "codingAgent.team.artMain": "L'assistant",
   "codingAgent.team.artWorkers": "Ouvriers",
+  "codingAgent.team.artPlanner": "Planificateur",
+  "codingAgent.team.artReviewers": "Relecteurs",
   "codingAgent.resetConfirm": "Tout réinitialiser — appuyez à nouveau",
   "codingAgent.resetFailed": "L'agent de code n'a pas pu être réinitialisé.",
 

--- a/src/lib/hermes-translations/it.ts
+++ b/src/lib/hermes-translations/it.ts
@@ -865,6 +865,8 @@ export const it: Record<string, string> = {
   "codingAgent.artBrowser": "Browser web",
   "codingAgent.team.artMain": "Assistente",
   "codingAgent.team.artWorkers": "Lavoratori",
+  "codingAgent.team.artPlanner": "Pianificatore",
+  "codingAgent.team.artReviewers": "Revisori",
   "codingAgent.resetConfirm": "Reimposta tutto — tocca di nuovo",
   "codingAgent.resetFailed": "Non è stato possibile reimpostare l'agente di codice.",
 

--- a/src/lib/hermes-translations/ja.ts
+++ b/src/lib/hermes-translations/ja.ts
@@ -856,6 +856,8 @@ export const ja: Record<string, string> = {
   "codingAgent.artBrowser": "ブラウザー",
   "codingAgent.team.artMain": "アシスタント",
   "codingAgent.team.artWorkers": "ワーカー",
+  "codingAgent.team.artPlanner": "プランナー",
+  "codingAgent.team.artReviewers": "レビュアー",
   "codingAgent.resetConfirm": "すべてリセット — もう一度タップ",
   "codingAgent.resetFailed": "コーディングエージェントをリセットできませんでした。",
 

--- a/src/lib/hermes-translations/nl.ts
+++ b/src/lib/hermes-translations/nl.ts
@@ -854,7 +854,7 @@ export const nl: Record<string, string> = {
   "codingAgent.artBrowser": "Webbrowser",
   "codingAgent.team.artMain": "Assistent",
   "codingAgent.team.artWorkers": "Werkers",
-  "codingAgent.team.artPlanner": "Plannenmaker",
+  "codingAgent.team.artPlanner": "Teamplanner",
   "codingAgent.team.artReviewers": "Beoordelaars",
   "codingAgent.resetConfirm": "Alles resetten — tik nogmaals",
   "codingAgent.resetFailed": "De codeagent kon niet worden gereset.",

--- a/src/lib/hermes-translations/nl.ts
+++ b/src/lib/hermes-translations/nl.ts
@@ -854,6 +854,8 @@ export const nl: Record<string, string> = {
   "codingAgent.artBrowser": "Webbrowser",
   "codingAgent.team.artMain": "Assistent",
   "codingAgent.team.artWorkers": "Werkers",
+  "codingAgent.team.artPlanner": "Plannenmaker",
+  "codingAgent.team.artReviewers": "Beoordelaars",
   "codingAgent.resetConfirm": "Alles resetten — tik nogmaals",
   "codingAgent.resetFailed": "De codeagent kon niet worden gereset.",
 

--- a/src/lib/hermes-translations/sv.ts
+++ b/src/lib/hermes-translations/sv.ts
@@ -850,6 +850,8 @@ export const sv: Record<string, string> = {
   "codingAgent.artBrowser": "Webbläsare",
   "codingAgent.team.artMain": "Assistent",
   "codingAgent.team.artWorkers": "Arbetare",
+  "codingAgent.team.artPlanner": "Planerare",
+  "codingAgent.team.artReviewers": "Granskare",
   "codingAgent.resetConfirm": "Återställ allt — tryck igen",
   "codingAgent.resetFailed": "Kodagenten kunde inte återställas.",
 

--- a/src/lib/hermes-translations/zh.ts
+++ b/src/lib/hermes-translations/zh.ts
@@ -865,6 +865,8 @@ export const zh: Record<string, string> = {
   "codingAgent.artBrowser": "浏览器",
   "codingAgent.team.artMain": "助手",
   "codingAgent.team.artWorkers": "工作者",
+  "codingAgent.team.artPlanner": "规划者",
+  "codingAgent.team.artReviewers": "审核者",
   "codingAgent.resetConfirm": "重置全部 — 再次点击",
   "codingAgent.resetFailed": "无法重置编程助手。",
 

--- a/src/tests/components/coding-team-card.test.tsx
+++ b/src/tests/components/coding-team-card.test.tsx
@@ -77,8 +77,12 @@ describe("with no team yet", () => {
     const card = await screen.findByTestId("coding-team-card");
     const tree = within(card).getByTestId("coding-team-tree");
     expect(tree).toHaveAttribute("data-workers", "3");
-    expect(tree).toHaveAttribute("data-reviewer", "true");
+    expect(tree).toHaveAttribute("data-reviewers", "1");
     expect(tree).toHaveAttribute("data-active", "0");
+    // The sentence stands beneath the tree, not beside it.
+    const wrap = tree.parentElement!;
+    expect(wrap.className).toContain("flex-col");
+    expect(wrap.lastElementChild?.textContent).toBe(t("codingAgent.team.help"));
   });
 
   it("offers to plan the team in the chat, and hands over on a click", async () => {
@@ -108,13 +112,17 @@ describe("with no team yet", () => {
 describe("with a team working here", () => {
   it("sizes the tree by the board: the workers who worked, the ones at work pulsing", async () => {
     stub();
-    teams = [{ ...WORKING, agents: { planner: 1, workers: 2, reviewers: 1, total: 4 } }];
+    teams = [{ ...WORKING, agents: { planner: 1, workers: 5, reviewers: 3, total: 9 } }];
     render(<CodingTeamCard directory={DIR} projectId={null} onOpenRun={() => {}} />);
     const tree = await screen.findByTestId("coding-team-tree");
-    expect(tree).toHaveAttribute("data-workers", "2");
-    expect(tree).toHaveAttribute("data-reviewer", "true");
-    // t2 is in progress: one worker at work.
+    // Nine agents stated, nine drawn: the planner, five workers, three reviewers.
+    expect(tree).toHaveAttribute("data-workers", "5");
+    expect(tree).toHaveAttribute("data-reviewers", "3");
+    expect(within(tree).getAllByTestId("coding-team-tree-worker")).toHaveLength(5);
+    expect(within(tree).getAllByTestId("coding-team-tree-reviewer")).toHaveLength(3);
+    // t2 is in progress: one worker at work; t1 is complete and reviewed: no reviewer deciding.
     expect(tree).toHaveAttribute("data-active", "1");
+    expect(tree).toHaveAttribute("data-active-reviewers", "0");
   });
 
   it("says who worked and on which branch, and links each task's reviewer beside its worker", async () => {

--- a/src/tests/components/coding-team-tree.test.tsx
+++ b/src/tests/components/coding-team-tree.test.tsx
@@ -1,46 +1,62 @@
 /**
  * The team as a tree (src/components/CodingTeamTree.tsx): the assistant,
- * the Coding Agent, as many workers as the board says, the reviewer — a
- * picture sized by data and hidden from the screen reader, whose caption is
- * the card's own sentence.
+ * the Coding Agent, the planner, as many workers and reviewers as the board
+ * counts — the nodes are the agents the card states — each column captioned
+ * with its count, the ones at work marked live, hidden from assistive tech.
  */
 import { describe, expect, it, vi } from "vitest";
 import { render, screen, within } from "@/tests/helpers/test-utils";
 import { translations } from "@/lib/translations";
-import CodingTeamTree, { MAX_TREE_WORKERS } from "@/components/CodingTeamTree";
+import CodingTeamTree, { MAX_TREE_REVIEWERS, MAX_TREE_WORKERS } from "@/components/CodingTeamTree";
 
 const t = (key: string) => translations.en[key] ?? key;
 vi.mock("@/lib/i18n", () => ({ useT: () => ({ locale: "en", t }) }));
 
 describe("CodingTeamTree", () => {
-  it("draws three workers and a reviewer by default, captioned by column, hidden from assistive tech", () => {
+  it("draws the planner, three workers and one reviewer by default, captioned with counts, hidden from assistive tech", () => {
     render(<CodingTeamTree />);
     const svg = screen.getByTestId("coding-team-tree");
     expect(svg).toHaveAttribute("aria-hidden", "true");
     expect(svg).toHaveAttribute("data-workers", "3");
-    expect(svg).toHaveAttribute("data-reviewer", "true");
+    expect(svg).toHaveAttribute("data-reviewers", "1");
+    expect(within(svg).getByTestId("coding-team-tree-planner")).toBeInTheDocument();
     expect(within(svg).getAllByTestId("coding-team-tree-worker")).toHaveLength(3);
-    expect(within(svg).getByTestId("coding-team-tree-reviewer")).toBeInTheDocument();
-    for (const key of ["codingAgent.team.artMain", "codingAgent.title", "codingAgent.team.artWorkers", "codingAgent.artReviewer"]) {
+    expect(within(svg).getAllByTestId("coding-team-tree-reviewer")).toHaveLength(1);
+    for (const key of ["codingAgent.team.artMain", "codingAgent.title", "codingAgent.team.artPlanner", "codingAgent.team.artWorkers", "codingAgent.team.artReviewers"]) {
       expect(svg.textContent).toContain(t(key));
     }
-    expect(svg.querySelectorAll(".ct-art-flow").length).toBeGreaterThan(3);
+    expect(svg.textContent).toContain(`${t("codingAgent.team.artWorkers")} · 3`);
+    expect(svg.textContent).toContain(`${t("codingAgent.team.artReviewers")} · 1`);
+    expect(svg.querySelectorAll(".ct-art-flow").length).toBeGreaterThan(5);
   });
 
-  it("draws as many workers as the board has, capped, the ones at work marked live, and no reviewer when told", () => {
-    render(<CodingTeamTree workers={MAX_TREE_WORKERS + 4} activeWorkers={2} reviewer={false} />);
+  it("draws one node per agent the board counts — workers and reviewers alike, capped — the ones at work live", () => {
+    render(<CodingTeamTree workers={5} activeWorkers={2} reviewers={3} activeReviewers={1} plannerActive />);
     const svg = screen.getByTestId("coding-team-tree");
-    expect(svg).toHaveAttribute("data-workers", String(MAX_TREE_WORKERS));
+    expect(within(svg).getAllByTestId("coding-team-tree-worker")).toHaveLength(5);
+    expect(within(svg).getAllByTestId("coding-team-tree-reviewer")).toHaveLength(3);
+    // Planner + 5 workers + 3 reviewers = the 9 agents the card would state.
+    expect(1 + within(svg).getAllByTestId("coding-team-tree-worker").length + within(svg).getAllByTestId("coding-team-tree-reviewer").length).toBe(9);
     const workers = within(svg).getAllByTestId("coding-team-tree-worker");
     expect(workers.filter((w) => w.getAttribute("data-live") === "true")).toHaveLength(2);
-    expect(workers[0].querySelector(".ct-art-live")).not.toBeNull();
-    expect(workers[2].querySelector(".ct-art-node")).not.toBeNull();
-    expect(within(svg).queryByTestId("coding-team-tree-reviewer")).toBeNull();
-    expect(svg.textContent).not.toContain(t("codingAgent.artReviewer"));
+    const reviewers = within(svg).getAllByTestId("coding-team-tree-reviewer");
+    expect(reviewers.filter((w) => w.getAttribute("data-live") === "true")).toHaveLength(1);
+    expect(svg).toHaveAttribute("data-planner-active", "true");
+    expect(within(svg).getByTestId("coding-team-tree-planner").querySelector(".ct-art-live")).not.toBeNull();
+    expect(svg.textContent).toContain(`${t("codingAgent.team.artReviewers")} · 3`);
+    // Past the caps, the caps.
+    const { unmount } = render(<CodingTeamTree workers={MAX_TREE_WORKERS + 4} reviewers={MAX_TREE_REVIEWERS + 2} />);
+    const capped = screen.getAllByTestId("coding-team-tree")[1];
+    expect(capped).toHaveAttribute("data-workers", String(MAX_TREE_WORKERS));
+    expect(capped).toHaveAttribute("data-reviewers", String(MAX_TREE_REVIEWERS));
+    unmount();
   });
 
-  it("never draws fewer than one worker", () => {
-    render(<CodingTeamTree workers={0} />);
-    expect(screen.getByTestId("coding-team-tree")).toHaveAttribute("data-workers", "1");
+  it("never draws fewer than one worker, and no reviewer when the board has none", () => {
+    render(<CodingTeamTree workers={0} reviewers={0} />);
+    const svg = screen.getByTestId("coding-team-tree");
+    expect(svg).toHaveAttribute("data-workers", "1");
+    expect(within(svg).queryByTestId("coding-team-tree-reviewer")).toBeNull();
+    expect(svg.textContent).toContain(`${t("codingAgent.team.artReviewers")} · 0`);
   });
 });


### PR DESCRIPTION
## What

The Team card said "9 agents worked here — planner 1 · workers 5 · reviewers 3" while the tree drew eight nodes, no planner and one reviewer. Now:

- Five columns: assistant → Coding Agent → **Planner** → **Workers** → **Reviewers**; one node per worker and per reviewer the board counts (capped at five each), so the nodes are the agents the card states.
- Each agent column captioned with its count (`Planner · 1`, `Workers · 5`, `Reviewers · 3`).
- The ones at work pulse: a worker in progress, a reviewer deciding (a task complete with no verdict yet), the planner while the team is planning.
- The card's sentence sits beneath the tree, centred, instead of beside it.
- Ten locales gain `codingAgent.team.artPlanner` / `artReviewers`.

## Tests

`coding-team-tree` (defaults, nine nodes for nine agents, caps, live marks, no reviewer when none), `coding-team-card` (sized by the board; the sentence beneath).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Fz3uZVzYQzcNAkw1cQ8ff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Coding team visualization now includes a planner between the coding agent and workers.
  - Displays configurable worker and reviewer counts, activity states, and support for up to five reviewers.
  - Shows clearer connections between workers and reviewers, with updated role labels.
  - Team artwork is centered with vertically stacked helper text.

- **Localization**
  - Added planner and reviewer labels in Bulgarian, German, English, Spanish, French, Italian, Japanese, Dutch, Swedish, and Simplified Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->