### PR TITLE
team: a reviewer run keeps its team on reload, a branchless worker's failed commit is rejected, the bench's idle poll is bounded

### DIFF
--- a/bench/lib/box.mjs
+++ b/bench/lib/box.mjs
@@ -46,8 +46,23 @@ function mintCookie() {
   }
 }
 
+/**
+ * A credential that will not become right by asking again: none at all, a
+ * refused password, a login with no cookie in it. Callers that retry
+ * transport failures must let this one through — the login limiter's shared
+ * bucket locks everyone out after five failures.
+ */
+export class CredentialError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "CredentialError";
+    this.permanent = true;
+  }
+}
+
 let cachedCookie = null;
-export async function ownerCookie() {
+/** `signal` bounds the one login request a password credential makes. */
+export async function ownerCookie(signal) {
   if (cachedCookie) return cachedCookie;
   if (process.env.CLAWBOX_COOKIE) return (cachedCookie = process.env.CLAWBOX_COOKIE.trim());
   const minted = mintCookie();
@@ -59,34 +74,37 @@ export async function ownerCookie() {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ password: process.env.CLAWBOX_PASSWORD, duration: 21600 }),
+      ...(signal ? { signal } : {}),
     });
-    if (!res.ok) throw new Error(`login failed: ${res.status} ${await res.text()}`);
+    if (!res.ok) throw new CredentialError(`login failed: ${res.status} ${await res.text()}`);
     const setCookie = res.headers.get("set-cookie") ?? "";
     const m = setCookie.match(/clawbox_session=([^;]+)/);
-    if (!m) throw new Error("login succeeded but no clawbox_session cookie came back");
+    if (!m) throw new CredentialError("login succeeded but no clawbox_session cookie came back");
     return (cachedCookie = m[1]);
   }
-  throw new Error(
+  throw new CredentialError(
     "No owner credential: run on the box (data/.session-secret readable), or set CLAWBOX_COOKIE or CLAWBOX_PASSWORD.",
   );
 }
 
 async function request(method, apiPath, { body, auth, timeoutMs } = {}) {
+  // Node's fetch has no timeout of its own: a request that hangs would hold
+  // the loop past any deadline it was given. The signal is made BEFORE the
+  // credential is resolved, so a login the credential needs is bounded too.
+  const signal = timeoutMs ? AbortSignal.timeout(timeoutMs) : undefined;
   const headers = { accept: "application/json" };
   if (body !== undefined) headers["content-type"] = "application/json";
-  if (auth === "owner") headers.cookie = `clawbox_session=${await ownerCookie()}`;
+  if (auth === "owner") headers.cookie = `clawbox_session=${await ownerCookie(signal)}`;
   else {
     const bearer = readBearer();
     if (bearer) headers.authorization = `Bearer ${bearer}`;
-    else headers.cookie = `clawbox_session=${await ownerCookie()}`;
+    else headers.cookie = `clawbox_session=${await ownerCookie(signal)}`;
   }
   const res = await fetch(`${baseUrl()}${apiPath}`, {
     method,
     headers,
     body: body === undefined ? undefined : JSON.stringify(body),
-    // Node's fetch has no timeout of its own: a request that hangs would
-    // hold the loop past any deadline it was given.
-    ...(timeoutMs ? { signal: AbortSignal.timeout(timeoutMs) } : {}),
+    ...(signal ? { signal } : {}),
   });
   const text = await res.text();
   let json = null;
@@ -128,14 +146,22 @@ export async function liveRuns(timeoutMs = 30_000) {
 export async function waitForIdle(deadlineMs = 10 * 60_000, everyMs = 5_000) {
   const until = Date.now() + deadlineMs;
   for (;;) {
-    // A poll that failed is not an answer: asked again, never read as idle.
+    const remaining = until - Date.now();
+    if (remaining <= 0) return false;
+    // A poll that failed is not an answer: asked again, never read as idle —
+    // unless the credential itself is wrong, which asking again cannot fix
+    // and the login limiter would punish. Each poll, and the pause after
+    // it, stays inside what is left of the deadline.
     let live = null;
-    // Each poll is bounded by what is left of the deadline, so a stalled
-    // request cannot hold the loop past it.
-    try { live = await liveRuns(Math.max(1_000, Math.min(30_000, until - Date.now()))); } catch { /* asked again below */ }
+    try {
+      live = await liveRuns(Math.min(30_000, remaining));
+    } catch (err) {
+      if (err?.permanent) throw err;
+    }
     if (live !== null && live.length === 0) return true;
-    if (Date.now() >= until) return false;
-    await new Promise((r) => setTimeout(r, everyMs));
+    const left = until - Date.now();
+    if (left <= 0) return false;
+    await new Promise((r) => setTimeout(r, Math.min(everyMs, left)));
   }
 }
 

--- a/bench/lib/box.mjs
+++ b/bench/lib/box.mjs
@@ -71,7 +71,7 @@ export async function ownerCookie() {
   );
 }
 
-async function request(method, apiPath, { body, auth } = {}) {
+async function request(method, apiPath, { body, auth, timeoutMs } = {}) {
   const headers = { accept: "application/json" };
   if (body !== undefined) headers["content-type"] = "application/json";
   if (auth === "owner") headers.cookie = `clawbox_session=${await ownerCookie()}`;
@@ -84,6 +84,9 @@ async function request(method, apiPath, { body, auth } = {}) {
     method,
     headers,
     body: body === undefined ? undefined : JSON.stringify(body),
+    // Node's fetch has no timeout of its own: a request that hangs would
+    // hold the loop past any deadline it was given.
+    ...(timeoutMs ? { signal: AbortSignal.timeout(timeoutMs) } : {}),
   });
   const text = await res.text();
   let json = null;
@@ -115,8 +118,8 @@ export async function startRun({ task, directory, projectId, resumeRunId }) {
 export const stopRun = (id) => post("/setup-api/coding-agent/stop", { runId: id, id });
 
 /** The runs going right now — a task's own, and the review pass that follows it. */
-export async function liveRuns() {
-  const res = await request("GET", "/setup-api/coding-agent/runs");
+export async function liveRuns(timeoutMs = 30_000) {
+  const res = await request("GET", "/setup-api/coding-agent/runs", { timeoutMs });
   const runs = Array.isArray(res.json?.runs) ? res.json.runs : [];
   return runs.filter((r) => r.status === "running");
 }
@@ -127,7 +130,9 @@ export async function waitForIdle(deadlineMs = 10 * 60_000, everyMs = 5_000) {
   for (;;) {
     // A poll that failed is not an answer: asked again, never read as idle.
     let live = null;
-    try { live = await liveRuns(); } catch { /* asked again below */ }
+    // Each poll is bounded by what is left of the deadline, so a stalled
+    // request cannot hold the loop past it.
+    try { live = await liveRuns(Math.max(1_000, Math.min(30_000, until - Date.now()))); } catch { /* asked again below */ }
     if (live !== null && live.length === 0) return true;
     if (Date.now() >= until) return false;
     await new Promise((r) => setTimeout(r, everyMs));

--- a/src/lib/coding-agent.ts
+++ b/src/lib/coding-agent.ts
@@ -1687,7 +1687,10 @@ function normalizeTeam(raw: unknown): RunTeam | null {
   if (!raw || typeof raw !== "object") return null;
   const t = raw as Record<string, unknown>;
   if (typeof t.id !== "string" || !t.id) return null;
-  if (t.role !== "planner" && t.role !== "worker") return null;
+  // Every role the team has: a reviewer run reloaded without its team would
+  // be resumed and settled as a project run — icon, review pass, pull
+  // request — in a folder that is the team's.
+  if (t.role !== "planner" && t.role !== "worker" && t.role !== "reviewer") return null;
   return { id: t.id, role: t.role, taskId: typeof t.taskId === "string" ? t.taskId : null };
 }
 

--- a/src/lib/coding-team.ts
+++ b/src/lib/coding-team.ts
@@ -397,14 +397,19 @@ async function workTask(team: LiveTeam, task: TeamTask, source: CodingRunSource,
   // once more, and the next attempt starts from the merged state.
   let files: string[] = settled?.filesTouched ?? [];
   let mergeRefusal: string | null = null;
+  if (ok && settled?.commitError) {
+    // The runner could not commit the worker's work — in a worktree there
+    // is then nothing on the branch to merge, and in the project itself
+    // (a code project, no team branch) the next worker would build on
+    // uncommitted files. Rejected with the reason, offered once more,
+    // whichever way the worker ran.
+    mergeRefusal = `NOT COMMITTED: ${firstLine(settled.commitError, 300)}`;
+    result = `${result}\n\n${mergeRefusal}`;
+    bus.send(SYSTEM, { type: "alert", task_id: task.task_id, reason: `Commit failed for ${task.task_id} (${run.id}): ${firstLine(settled.commitError, 200)}` });
+  }
   if (worktree) {
-    if (ok && settled?.commitError) {
-      // The runner could not commit the worker's work: there is nothing on
-      // the branch to merge, and merging the scaffold would count the task
-      // done with none of it. Rejected with the reason, offered once more.
-      mergeRefusal = `NOT COMMITTED: ${firstLine(settled.commitError, 300)}`;
-      result = `${result}\n\n${mergeRefusal}`;
-      bus.send(SYSTEM, { type: "alert", task_id: task.task_id, reason: `Commit failed for ${task.task_id} (${run.id}): ${firstLine(settled.commitError, 200)}` });
+    if (mergeRefusal) {
+      // Nothing to merge; the worktree goes back below.
     } else if (ok) {
       // What the branch changed; a worker that committed nothing has no
       // branch diff, and what it touched uncommitted is still what it touched.

--- a/src/tests/unit/coding-agent.test.ts
+++ b/src/tests/unit/coding-agent.test.ts
@@ -2094,6 +2094,25 @@ describe("the run's plan", () => {
   });
 });
 
+describe("a team run reloaded from disk", () => {
+  it("keeps its team, whichever role it had — a reviewer included", async () => {
+    const base = { task: "t", directory: home, projectId: null, source: "agent", status: "completed", startedAt: 1, completedAt: 2, sessionId: null, model: null, summary: null, error: null, progress: [], filesTouched: [], commands: [], permissionDenials: [], numTurns: 0, tokensUsed: 0 };
+    fs.writeFileSync(runsFile(), JSON.stringify([
+      { ...base, id: "run-teamplan1", team: { id: "team-1", role: "planner", taskId: null } },
+      { ...base, id: "run-teamwork1", team: { id: "team-1", role: "worker", taskId: "t1" } },
+      { ...base, id: "run-teamrevw1", team: { id: "team-1", role: "reviewer", taskId: "t1" } },
+      { ...base, id: "run-teamnone1", team: { id: "team-1", role: "auditor", taskId: "t1" } },
+    ]));
+    vi.resetModules();
+    lib = await import("@/lib/coding-agent");
+    expect(lib.getRun("run-teamplan1")?.team).toEqual({ id: "team-1", role: "planner", taskId: null });
+    expect(lib.getRun("run-teamwork1")?.team).toEqual({ id: "team-1", role: "worker", taskId: "t1" });
+    expect(lib.getRun("run-teamrevw1")?.team).toEqual({ id: "team-1", role: "reviewer", taskId: "t1" });
+    // A role the team does not have is not a team.
+    expect(lib.getRun("run-teamnone1")?.team).toBeNull();
+  });
+});
+
 describe("a run's commit", () => {
   it("records why the work could not be committed, on the record, and clears it when it is", async () => {
     writeConfig({ clawai_token: "claw_test_token", clawai_tier: "flash", coding_agent_enabled: true });

--- a/src/tests/unit/coding-team.test.ts
+++ b/src/tests/unit/coding-team.test.ts
@@ -214,6 +214,26 @@ describe("a worker whose commit failed", () => {
   });
 });
 
+describe("a worker in the project itself whose commit failed", () => {
+  it("is rejected with the reason too — no worktree, no merge, still not counted done", async () => {
+    // No team branch: the code-project shape, workers one at a time in the folder.
+    runner.resolveWorkingDirectory.mockResolvedValue({ directory: "/home/clawbox/clawbox/data/code-projects/site", projectId: "site" });
+    outcomes = [
+      { summary: PARALLEL_PLAN },
+      { summary: "index done", filesTouched: ["index.html"], commitError: "fatal: index.lock exists" },
+      { summary: "index done for real", filesTouched: ["index.html"] },
+      { summary: "styles done", filesTouched: ["styles.css"] },
+      { summary: "app wired", filesTouched: ["app.js"] },
+    ];
+    const board = await team.startTeam({ goal: "Build it", projectId: "site", source: "owner" });
+    const done = await finished(board.id);
+    expect(done.status).toBe("done");
+    expect(done.tasks.find((t) => t.task_id === "t1")!.attempts).toBe(2);
+    expect(done.log.some((e) => e.type === "review" && /NOT COMMITTED: fatal: index.lock exists/.test(e.message))).toBe(true);
+    expect(plumbing.mergeWorkerBranch).not.toHaveBeenCalled();
+  });
+});
+
 describe("a stop that lands while a worker is being made", () => {
   it("starts no worker and gives the worktree back", async () => {
     outcomes = [{ summary: PARALLEL_PLAN }];

--- a/src/tests/unit/coding-team.test.ts
+++ b/src/tests/unit/coding-team.test.ts
@@ -230,6 +230,9 @@ describe("a worker in the project itself whose commit failed", () => {
     expect(done.status).toBe("done");
     expect(done.tasks.find((t) => t.task_id === "t1")!.attempts).toBe(2);
     expect(done.log.some((e) => e.type === "review" && /NOT COMMITTED: fatal: index.lock exists/.test(e.message))).toBe(true);
+    // The alert is what the card counts and what MAX_ALERTS adds up.
+    expect(done.alerts).toBe(1);
+    expect(done.log.some((e) => e.type === "alert" && /Commit failed for t1 \(run-\w+\): fatal: index.lock exists/.test(e.message))).toBe(true);
     expect(plumbing.mergeWorkerBranch).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What

CodeRabbit's three findings that landed after #665 merged.

- `normalizeTeam` accepts the `reviewer` role: a reviewer run reloaded from disk kept no team and would have been resumed and settled as a project run (icon, review pass, pull request). Tested with every role and a role the team does not have.
- `workTask` checks `commitError` before the worktree-specific path: a worker in a code project (no team branch, one at a time) whose commit failed is now rejected with the reason and offered once more, instead of counted done on uncommitted files. Tested.
- The bench's status poll passes an `AbortSignal.timeout` bounded by what is left of the idle deadline, so a stalled request cannot hold the loop past it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Fz3uZVzYQzcNAkw1cQ8ff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Worker commit failures are now reported clearly and handled safely, including work performed directly in the project directory.
  - Failed worker attempts are retried correctly and are not marked complete until successful.
  - Team run records now preserve reviewer assignments when reloaded.
  - Long-running status checks now honor deadlines and retry transient failures without incorrectly reporting an idle state.
  - Credential-related failures are reported more consistently.

- **Reliability**
  - Operations waiting for active runs now have a default 30-second timeout.
  - Authentication and network requests can now stop promptly when their deadline expires.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->