### PR TITLE
fix: strip the OpenClaw version block from update_check on a Hermes device

### DIFF
--- a/mcp/lib/versions.ts
+++ b/mcp/lib/versions.ts
@@ -7,7 +7,10 @@
  * answering differently: `getVersionInfo()` fills `openclaw.target` from the
  * ClawBox pin even where `openclaw.current` is null, so the raw payload offers
  * a Hermes box an OpenClaw version to converge on for a harness it does not
- * ship. One predicate here, imported by both, so they cannot diverge again.
+ * ship. One predicate here, imported by both, so those two cannot diverge
+ * again. The same rule is written out once more for the browser in
+ * `SettingsApp.tsx`'s About panel (a client component, which cannot import the
+ * fs-backed edition modules) — that is the prior art this matches.
  */
 
 import type { McpContext } from "./context";
@@ -21,22 +24,37 @@ interface ComponentVersion {
 export interface VersionsPayload {
   clawbox?: ComponentVersion;
   openclaw?: ComponentVersion;
-  /** Present only on the SKUs that ship Hermes — its presence is the signal. */
+  /** Present only on the SKUs that ship Hermes; carried through untouched. */
   hermes?: ComponentVersion;
-  /** The install edition, read from the root-owned edition lock per call. */
+  /**
+   * The install edition, from the root-owned edition lock. Absent on a device
+   * whose software predates the field.
+   */
   edition?: string;
 }
 
 /**
  * Whether an OpenClaw version block means anything on this device.
  *
- * The payload's own `edition` decides, ahead of the context: `ctx.install` is a
- * snapshot taken once when the MCP child spawned, while the route answers from
- * `readEdition()` on every call. Only the `hermes` SKU ships no OpenClaw —
- * `dual` has one to update even while Hermes is the harness answering.
+ * `dual` settles it outright: that SKU has an OpenClaw to update even while
+ * Hermes is the harness answering, which is why `ctx.edition` — the resolved
+ * TOOL SET — cannot be the gate on its own.
+ *
+ * Otherwise every source has to agree the device is not Hermes, and that is
+ * deliberate rather than belt-and-braces. `readEdition()` — behind both
+ * `payload.edition` and `ctx.install` — collapses an unreadable lock into its
+ * "openclaw" default, while `ctx.edition` is the one input that fails CLOSED
+ * there (`mcp/lib/edition.ts` resolves an unreadable lock to "hermes" and says
+ * why). Requiring both keeps a truncated `/etc/clawbox/edition.env` on a Hermes
+ * box from putting the block back.
+ *
+ * The payload is preferred over `ctx.install` for the positive answer because
+ * the context is a snapshot taken once when the MCP child spawned, while the
+ * payload is read per request (cached for 60 s in `getVersionInfo()`).
  */
 export function shipsOpenclaw(payload: VersionsPayload | null | undefined, ctx: McpContext): boolean {
-  return (payload?.edition ?? ctx.install) !== "hermes";
+  if (payload?.edition === "dual" || ctx.install === "dual") return true;
+  return (payload?.edition ?? ctx.install) !== "hermes" && ctx.edition !== "hermes";
 }
 
 /** The versions payload as the agent on this device should see it. */

--- a/mcp/lib/versions.ts
+++ b/mcp/lib/versions.ts
@@ -1,0 +1,48 @@
+/**
+ * The `/setup-api/update/versions` payload, and the one predicate that decides
+ * whether its OpenClaw component is about something this device has.
+ *
+ * Two tools read that route — `update_check` (mcp/tools/system.ts) and
+ * `device_status` (mcp/tools/orientation.ts). TASK-543 was the two of them
+ * answering differently: `getVersionInfo()` fills `openclaw.target` from the
+ * ClawBox pin even where `openclaw.current` is null, so the raw payload offers
+ * a Hermes box an OpenClaw version to converge on for a harness it does not
+ * ship. One predicate here, imported by both, so they cannot diverge again.
+ */
+
+import type { McpContext } from "./context";
+
+interface ComponentVersion {
+  current?: string | null;
+  target?: string | null;
+  updateAvailable?: boolean;
+}
+
+export interface VersionsPayload {
+  clawbox?: ComponentVersion;
+  openclaw?: ComponentVersion;
+  /** Present only on the SKUs that ship Hermes — its presence is the signal. */
+  hermes?: ComponentVersion;
+  /** The install edition, read from the root-owned edition lock per call. */
+  edition?: string;
+}
+
+/**
+ * Whether an OpenClaw version block means anything on this device.
+ *
+ * The payload's own `edition` decides, ahead of the context: `ctx.install` is a
+ * snapshot taken once when the MCP child spawned, while the route answers from
+ * `readEdition()` on every call. Only the `hermes` SKU ships no OpenClaw —
+ * `dual` has one to update even while Hermes is the harness answering.
+ */
+export function shipsOpenclaw(payload: VersionsPayload | null | undefined, ctx: McpContext): boolean {
+  return (payload?.edition ?? ctx.install) !== "hermes";
+}
+
+/** The versions payload as the agent on this device should see it. */
+export function versionsForDevice(payload: VersionsPayload, ctx: McpContext): VersionsPayload {
+  if (shipsOpenclaw(payload, ctx)) return payload;
+  const shaped = { ...payload };
+  delete shaped.openclaw;
+  return shaped;
+}

--- a/mcp/lib/versions.ts
+++ b/mcp/lib/versions.ts
@@ -53,8 +53,13 @@ export interface VersionsPayload {
  * payload is read per request (cached for 60 s in `getVersionInfo()`).
  */
 export function shipsOpenclaw(payload: VersionsPayload | null | undefined, ctx: McpContext): boolean {
-  if (payload?.edition === "dual" || ctx.install === "dual") return true;
-  return (payload?.edition ?? ctx.install) !== "hermes" && ctx.edition !== "hermes";
+  // Resolve the install FIRST, then ask whether it is dual — asking `ctx.install
+  // === "dual"` on its own would let the stale snapshot outvote a payload that
+  // now says `hermes`, which is the one direction this whole predicate exists
+  // to get right.
+  const install = payload?.edition ?? ctx.install;
+  if (install === "dual") return true;
+  return install !== "hermes" && ctx.edition !== "hermes";
 }
 
 /** The versions payload as the agent on this device should see it. */

--- a/mcp/tools/orientation.ts
+++ b/mcp/tools/orientation.ts
@@ -403,6 +403,13 @@ export function registerOrientationTools(reg: Registrar, ctx: McpContext): void 
           ? {
               clawbox: versions.clawbox ?? "unknown",
               ...(shipsOpenclaw(versions, ctx) ? { openclaw: versions.openclaw ?? "unknown" } : {}),
+              // Emitted on its PRESENCE, which is the payload's own "this box
+              // ships Hermes" signal. Without it the tool the server's
+              // instructions tell every model to call FIRST had no answer to
+              // "what version of Hermes am I running" on the two SKUs that have
+              // one — and a model with no answer states one from training
+              // memory. It never carries a target: see updater.ts.
+              ...(versions.hermes ? { hermes: versions.hermes } : {}),
               waiting:
                 versions.clawbox?.updateAvailable === true
                 || (shipsOpenclaw(versions, ctx) && versions.openclaw?.updateAvailable === true),

--- a/mcp/tools/orientation.ts
+++ b/mcp/tools/orientation.ts
@@ -8,6 +8,7 @@ import { DEFAULT_CWD } from "../lib/guard";
 import { json, text, type Ed, type Registrar } from "../lib/register";
 import { CURRENT_CHAT_MODEL_NOTE, hermesDeviceDefault, reported, type HermesDefaultSource } from "../lib/report";
 import type { McpContext } from "../lib/context";
+import { shipsOpenclaw, type VersionsPayload } from "../lib/versions";
 import { WEBAPP_KV_CLIENT_SNIPPET } from "../../src/lib/webapp-sandbox";
 
 const FIELD_GUIDE_PATH = join(DEFAULT_CWD, "Clawbox.md");
@@ -208,11 +209,6 @@ interface StatsPayload {
   temperature?: unknown;
 }
 
-interface VersionsPayload {
-  clawbox?: { current?: string | null; target?: string | null; updateAvailable?: boolean };
-  openclaw?: { current?: string | null; target?: string | null; updateAvailable?: boolean };
-}
-
 interface ClawaiPayload {
   hasToken?: boolean;
   tier?: string;
@@ -399,13 +395,17 @@ export function registerOrientationTools(reg: Registrar, ctx: McpContext): void 
         ai,
         disk: rootDisk(stats),
         memory_used_percent: stats?.memory?.usedPercent ?? "unknown",
+        // `shipsOpenclaw`, not `ctx.edition`: the question is whether the DEVICE
+        // has an OpenClaw to update, which the payload answers itself. Reading
+        // the active harness here hid a waiting OpenClaw update from a dual box
+        // whenever Hermes happened to be the one answering.
         update: versions
           ? {
               clawbox: versions.clawbox ?? "unknown",
-              ...(ctx.edition === "openclaw" ? { openclaw: versions.openclaw ?? "unknown" } : {}),
+              ...(shipsOpenclaw(versions, ctx) ? { openclaw: versions.openclaw ?? "unknown" } : {}),
               waiting:
                 versions.clawbox?.updateAvailable === true
-                || (ctx.edition === "openclaw" && versions.openclaw?.updateAvailable === true),
+                || (shipsOpenclaw(versions, ctx) && versions.openclaw?.updateAvailable === true),
             }
           : "unknown",
       });

--- a/mcp/tools/system.ts
+++ b/mcp/tools/system.ts
@@ -18,6 +18,7 @@ import { HOME, spawnArgv } from "../lib/guard";
 import { json, text, type Registrar, type ToolResult } from "../lib/register";
 import { zBool, zConfirm, zEnumOf, zInt, zText } from "../lib/schema";
 import type { McpContext } from "../lib/context";
+import { versionsForDevice, type VersionsPayload } from "../lib/versions";
 import { PREFERENCE_LANGUAGES, WALLPAPER_FITS } from "../../src/lib/preference-schema";
 import { deriveProtection, type Protection, type ProtectionInput } from "../../src/lib/clawkeep-protection";
 
@@ -371,7 +372,17 @@ export function registerSystemTools(reg: Registrar, ctx: McpContext): void {
     "Check whether a newer ClawBox software version is available, and report the installed version. This only reports — it never installs anything. If an update is waiting, tell the user to install it from Settings -> System Update.",
     {},
     { editions: ["openclaw", "hermes"], readOnly: true, openWorld: true, profile: "core" },
-    async () => json(await apiGet("/setup-api/update/versions", { timeoutMs: 20_000 })),
+    // Shaped, not raw: the route always carries an `openclaw` component and
+    // fills its target from the ClawBox pin, so the raw payload names an
+    // OpenClaw version for a device that ships no OpenClaw. Same strip
+    // device_status applies to the same payload — see mcp/lib/versions.ts.
+    async () =>
+      json(
+        versionsForDevice(
+          await apiGet<VersionsPayload>("/setup-api/update/versions", { timeoutMs: 20_000 }),
+          ctx,
+        ),
+      ),
   );
 
   if (ctx.capabilities.journal) {

--- a/src/tests/unit/mcp-update-versions-edition.test.ts
+++ b/src/tests/unit/mcp-update-versions-edition.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+/**
+ * TASK-543 — `update_check` handed the agent an OpenClaw version block on a
+ * device that ships no OpenClaw.
+ *
+ * `/setup-api/update/versions` always carries an `openclaw` component, and
+ * `getVersionInfo()` fills its `target` from the ClawBox pin even when
+ * `current` is null — so on the Hermes SKU the raw payload reads
+ * `openclaw: { current: null, target: "<pin>" }`: a version to converge on for
+ * a harness the box does not have. `device_status`, reading the SAME payload in
+ * the same MCP server, drops that key on purpose. Two tools, one payload,
+ * opposite honesty.
+ *
+ * The property pinned here is the agreement, not one tool's shape: whichever
+ * tool the agent calls, the OpenClaw block is present exactly when the device
+ * really ships OpenClaw.
+ */
+
+const { apiGet, apiTry } = vi.hoisted(() => ({ apiGet: vi.fn(), apiTry: vi.fn() }));
+
+vi.mock("../../../mcp/lib/api", () => ({
+  apiGet: (...a: unknown[]) => apiGet(...a),
+  apiPost: vi.fn(),
+  apiTry: (...a: unknown[]) => apiTry(...a),
+  API_BASE: "http://127.0.0.1:80",
+  CLAWBOX_ROOT: "/home/clawbox/clawbox",
+}));
+
+import type { McpContext } from "../../../mcp/lib/context";
+import { captureRegistrar } from "../helpers/mcp-registrar";
+import { registerOrientationTools } from "../../../mcp/tools/orientation";
+import { registerSystemTools } from "../../../mcp/tools/system";
+
+type Install = "openclaw" | "hermes" | "dual";
+
+const ctx = (edition: "openclaw" | "hermes", install: Install = edition): McpContext => ({
+  edition,
+  install,
+  appHarness: edition,
+  profile: "full",
+  capabilities: { screenGrabber: null, imageConvert: false, journal: false, du: false },
+  providers: [],
+  emailCanRead: false,
+  codingAgent: false,
+  canGenerateImages: true,
+});
+
+/** The shape `getVersionInfo()` really returns, per SKU. */
+const payload = (edition: Install) => ({
+  clawbox: { current: "v4.0.0", target: null, updateAvailable: false },
+  openclaw: { current: edition === "hermes" ? null : "2026.8.1", target: "2026.8.1", updateAvailable: false },
+  ...(edition === "openclaw" ? {} : { hermes: { current: "0.20.5", target: null, updateAvailable: false } }),
+  edition,
+});
+
+async function updateCheck(edition: "openclaw" | "hermes", install: Install = edition) {
+  const h = captureRegistrar(edition);
+  registerSystemTools(h.reg, ctx(edition, install));
+  const out = await h.call("update_check", {});
+  if (out.isError) throw new Error(`update_check failed: ${JSON.stringify(out.error)}`);
+  return JSON.parse(out.text) as Record<string, unknown>;
+}
+
+async function deviceStatus(edition: "openclaw" | "hermes", install: Install = edition) {
+  const h = captureRegistrar(edition);
+  registerOrientationTools(h.reg, ctx(edition, install));
+  const out = await h.call("device_status", {});
+  if (out.isError) throw new Error("device_status failed");
+  return JSON.parse(out.text) as { update: Record<string, unknown> | string };
+}
+
+beforeEach(() => {
+  apiGet.mockReset();
+  apiTry.mockReset().mockResolvedValue(null);
+});
+
+describe("update_check — no OpenClaw block on a device that ships no OpenClaw", () => {
+  it("drops the openclaw component on the Hermes SKU", async () => {
+    apiGet.mockResolvedValue(payload("hermes"));
+
+    const body = await updateCheck("hermes");
+
+    expect(body).not.toHaveProperty("openclaw");
+  });
+
+  it("still reports the ClawBox and Hermes components there", async () => {
+    apiGet.mockResolvedValue(payload("hermes"));
+
+    const body = await updateCheck("hermes");
+
+    expect(body.clawbox).toEqual({ current: "v4.0.0", target: null, updateAvailable: false });
+    expect(body.hermes).toEqual({ current: "0.20.5", target: null, updateAvailable: false });
+  });
+
+  it("keeps the openclaw component on the OpenClaw SKU", async () => {
+    apiGet.mockResolvedValue(payload("openclaw"));
+
+    const body = await updateCheck("openclaw");
+
+    expect(body.openclaw).toEqual({ current: "2026.8.1", target: "2026.8.1", updateAvailable: false });
+  });
+
+  it("keeps it on the dual SKU, where OpenClaw is installed even while Hermes answers", async () => {
+    apiGet.mockResolvedValue(payload("dual"));
+
+    const body = await updateCheck("hermes", "dual");
+
+    expect(body).toHaveProperty("openclaw");
+  });
+
+  it("believes the payload's own edition over a stale startup snapshot", async () => {
+    // ctx.install is resolved once when the MCP child spawns. The payload's
+    // `edition` is read per call from the root-owned edition lock, so it is the
+    // one that decides.
+    apiGet.mockResolvedValue(payload("hermes"));
+
+    const body = await updateCheck("openclaw", "openclaw");
+
+    expect(body).not.toHaveProperty("openclaw");
+  });
+});
+
+describe("update_check and device_status agree about the OpenClaw block", () => {
+  const versionsOnly = (edition: Install) =>
+    apiTry.mockImplementation(async (route: unknown) =>
+      route === "/setup-api/update/versions" ? payload(edition) : null,
+    );
+
+  it("both omit it on Hermes", async () => {
+    apiGet.mockResolvedValue(payload("hermes"));
+    versionsOnly("hermes");
+
+    expect(await updateCheck("hermes")).not.toHaveProperty("openclaw");
+    expect((await deviceStatus("hermes")).update).not.toHaveProperty("openclaw");
+  });
+
+  it("both carry it on dual, where the device really has an OpenClaw to update", async () => {
+    apiGet.mockResolvedValue(payload("dual"));
+    versionsOnly("dual");
+
+    expect(await updateCheck("hermes", "dual")).toHaveProperty("openclaw");
+    expect((await deviceStatus("hermes", "dual")).update).toHaveProperty("openclaw");
+  });
+});

--- a/src/tests/unit/mcp-update-versions-edition.test.ts
+++ b/src/tests/unit/mcp-update-versions-edition.test.ts
@@ -170,6 +170,39 @@ describe("update_check and device_status agree about the OpenClaw block", () => 
   });
 });
 
+describe("device_status names the harness this box actually runs", () => {
+  const versions = (edition: Install) =>
+    apiTry.mockImplementation(async (route: unknown) =>
+      route === "/setup-api/update/versions" ? payload(edition) : null,
+    );
+
+  async function update(edition: "openclaw" | "hermes", install: Install) {
+    versions(install);
+    const { update: block } = await deviceStatus(edition, install);
+    if (typeof block === "string") throw new Error("versions leg returned nothing");
+    return block;
+  }
+
+  it("reports the Hermes version on the Hermes SKU", async () => {
+    // The tool the server's instructions tell every model to call FIRST. With
+    // no answer here, "what version of Hermes am I running" is answered from
+    // training memory.
+    expect(await update("hermes", "hermes")).toMatchObject({
+      hermes: { current: "0.20.5", target: null, updateAvailable: false },
+    });
+  });
+
+  it("reports it on dual too, beside the OpenClaw block", async () => {
+    const block = await update("hermes", "dual");
+    expect(block).toHaveProperty("hermes");
+    expect(block).toHaveProperty("openclaw");
+  });
+
+  it("says nothing about Hermes on a SKU that does not ship it", async () => {
+    expect(await update("openclaw", "openclaw")).not.toHaveProperty("hermes");
+  });
+});
+
 describe("device_status — an OpenClaw pin delta is an update waiting on the SKUs that have one", () => {
   const versions = (edition: Install) =>
     apiTry.mockImplementation(async (route: unknown) =>

--- a/src/tests/unit/mcp-update-versions-edition.test.ts
+++ b/src/tests/unit/mcp-update-versions-edition.test.ts
@@ -230,6 +230,19 @@ describe("device_status — an OpenClaw pin delta is an update waiting on the SK
 });
 
 describe("shipsOpenclaw fails closed when the edition lock cannot be read", () => {
+  it("lets a payload that now says hermes outvote a stale dual snapshot", () => {
+    // `ctx.install` is read once when the MCP child spawns. A box relocked to
+    // hermes after that answers `edition: "hermes"` from the route while the
+    // context still says `dual` — and `dual` is the value that returns true
+    // outright, so checking it before resolving the install would keep the
+    // block on the one box that just stopped having an OpenClaw.
+    apiGet.mockResolvedValue(payload("hermes"));
+
+    return updateCheck("hermes", "dual").then((body) => {
+      expect(body).not.toHaveProperty("openclaw");
+    });
+  });
+
   it("keeps the block off on a Hermes box whose lock resolved to the openclaw default", async () => {
     // `mcp/lib/edition.ts` resolves an unreadable /etc/clawbox/edition.env to
     // the SMALLER hermes tool set while `readEdition()` — behind both

--- a/src/tests/unit/mcp-update-versions-edition.test.ts
+++ b/src/tests/unit/mcp-update-versions-edition.test.ts
@@ -46,10 +46,31 @@ const ctx = (edition: "openclaw" | "hermes", install: Install = edition): McpCon
   canGenerateImages: true,
 });
 
-/** The shape `getVersionInfo()` really returns, per SKU. */
-const payload = (edition: Install) => ({
+/**
+ * The shape `getVersionInfo()` really returns, per SKU — including the detail
+ * this card is about: `openclaw.target` is the ClawBox pin even where
+ * `openclaw.current` is null, because the producer only nulls the target when a
+ * current version exists and already contains it.
+ */
+const payload = (edition: Install) =>
+  edition === "hermes"
+    ? {
+        clawbox: { current: "v4.0.0", target: null, updateAvailable: false },
+        openclaw: { current: null, target: "2026.8.1", updateAvailable: false },
+        hermes: { current: "0.20.5", target: null, updateAvailable: false },
+        edition,
+      }
+    : {
+        clawbox: { current: "v4.0.0", target: null, updateAvailable: false },
+        openclaw: { current: "2026.8.1", target: null, updateAvailable: false },
+        ...(edition === "dual" ? { hermes: { current: "0.20.5", target: null, updateAvailable: false } } : {}),
+        edition,
+      };
+
+/** A box where only the OpenClaw pin moved — ClawBox itself is current. */
+const openclawDeltaOnly = (edition: Install) => ({
   clawbox: { current: "v4.0.0", target: null, updateAvailable: false },
-  openclaw: { current: edition === "hermes" ? null : "2026.8.1", target: "2026.8.1", updateAvailable: false },
+  openclaw: { current: "2026.7.1", target: "2026.8.1", updateAvailable: true },
   ...(edition === "openclaw" ? {} : { hermes: { current: "0.20.5", target: null, updateAvailable: false } }),
   edition,
 });
@@ -98,7 +119,7 @@ describe("update_check — no OpenClaw block on a device that ships no OpenClaw"
 
     const body = await updateCheck("openclaw");
 
-    expect(body.openclaw).toEqual({ current: "2026.8.1", target: "2026.8.1", updateAvailable: false });
+    expect(body.openclaw).toEqual({ current: "2026.8.1", target: null, updateAvailable: false });
   });
 
   it("keeps it on the dual SKU, where OpenClaw is installed even while Hermes answers", async () => {
@@ -132,7 +153,12 @@ describe("update_check and device_status agree about the OpenClaw block", () => 
     versionsOnly("hermes");
 
     expect(await updateCheck("hermes")).not.toHaveProperty("openclaw");
-    expect((await deviceStatus("hermes")).update).not.toHaveProperty("openclaw");
+    const { update } = await deviceStatus("hermes");
+    // Positively, first: when the versions leg returns null `update` degrades to
+    // the string "unknown", and every `not.toHaveProperty` below would pass over
+    // a mock that answered nothing at all.
+    expect(update).toHaveProperty("clawbox");
+    expect(update).not.toHaveProperty("openclaw");
   });
 
   it("both carry it on dual, where the device really has an OpenClaw to update", async () => {
@@ -141,5 +167,46 @@ describe("update_check and device_status agree about the OpenClaw block", () => 
 
     expect(await updateCheck("hermes", "dual")).toHaveProperty("openclaw");
     expect((await deviceStatus("hermes", "dual")).update).toHaveProperty("openclaw");
+  });
+});
+
+describe("device_status — an OpenClaw pin delta is an update waiting on the SKUs that have one", () => {
+  const versions = (edition: Install) =>
+    apiTry.mockImplementation(async (route: unknown) =>
+      route === "/setup-api/update/versions" ? openclawDeltaOnly(edition) : null,
+    );
+
+  async function waiting(edition: "openclaw" | "hermes", install: Install) {
+    versions(install);
+    const { update } = await deviceStatus(edition, install);
+    if (typeof update === "string") throw new Error("versions leg returned nothing");
+    return update.waiting;
+  }
+
+  it("reports it on dual, where Hermes may be the harness answering but OpenClaw is installed", async () => {
+    expect(await waiting("hermes", "dual")).toBe(true);
+  });
+
+  it("still reports it on the OpenClaw SKU", async () => {
+    expect(await waiting("openclaw", "openclaw")).toBe(true);
+  });
+
+  it("does not report it on Hermes, where there is no OpenClaw to install", async () => {
+    expect(await waiting("hermes", "hermes")).toBe(false);
+  });
+});
+
+describe("shipsOpenclaw fails closed when the edition lock cannot be read", () => {
+  it("keeps the block off on a Hermes box whose lock resolved to the openclaw default", async () => {
+    // `mcp/lib/edition.ts` resolves an unreadable /etc/clawbox/edition.env to
+    // the SMALLER hermes tool set while `readEdition()` — behind both
+    // `payload.edition` and `ctx.install` — defaults to "openclaw". Trusting
+    // either of those alone would hand the block back on exactly the box this
+    // card is about.
+    apiGet.mockResolvedValue(payload("openclaw"));
+
+    const body = await updateCheck("hermes", "openclaw");
+
+    expect(body).not.toHaveProperty("openclaw");
   });
 });


### PR DESCRIPTION
**TASK-543** — Hermes: `update_check` MCP tool reports an OpenClaw version block.

## Customer-visible symptom
On a Hermes box, asking the assistant "what version am I on / is there an update" returned an
OpenClaw version block for a harness the SKU does not ship:
`openclaw: { current: null, target: "2026.8.1", updateAvailable: false }` — a version to converge on
for software that is not installed. `device_status`, reading the *same* payload in the *same* MCP
server, dropped that key on purpose. Two tools, one payload, opposite honesty.

## Cause
`mcp/tools/system.ts` `update_check` returned `/setup-api/update/versions` raw. The producer
(`src/lib/updater.ts` `getVersionInfo()`) only nulls `openclaw.target` when a *current* version
exists and already contains the target, so with `openclawCurrent === null` the ternary
short-circuits and the pin is emitted as a target on every SKU.

## Harness-first
Nothing here belongs to OpenClaw or Hermes: "which SKU is this box" is ClawBox's own concept, the
root-owned `/etc/clawbox/edition.env` lock read through `src/lib/edition-source.ts`. No harness CLI,
RPC or catalog answers it, and the fix reads the lock's answer (through the payload and the MCP
context) rather than probing a binary or asking a harness. The *native ClawBox* mechanism reused
here is `device_status`'s existing edition strip — the fix does not write a second one, it factors
the one that already existed into `mcp/lib/versions.ts` and points both tools at it.

## What changed
- New `mcp/lib/versions.ts`: the payload type plus one predicate, `shipsOpenclaw()`, and
  `versionsForDevice()`.
- `update_check` now shapes the payload through it; `device_status` uses the same predicate instead
  of its hand-written `ctx.edition === "openclaw"`.
- The predicate **fails closed**. `readEdition()` — behind both `payload.edition` and `ctx.install` —
  collapses an unreadable lock into its `"openclaw"` default, while `ctx.edition` is the one input
  that fails closed to `"hermes"` there (`mcp/lib/edition.ts` spends 40 lines on why). Requiring both
  keeps a truncated `edition.env` on a Hermes box from putting the block back — which a
  payload-only or `install`-only predicate would have done, regressing `device_status` against beta.
- `dual` settles it outright: that SKU has an OpenClaw to update even while Hermes is the harness
  answering, so `ctx.edition` alone cannot be the gate. This is a deliberate widening of
  `device_status`'s `waiting` term on `dual`, where beta hid a waiting OpenClaw update whenever
  Hermes happened to be the harness that spawned the MCP child — a non-determinism, not a rule.

## Both editions
- `hermes`: block dropped from both tools; `clawbox` and `hermes` components still reported.
- `openclaw`: unchanged.
- `dual`: block kept by both tools (it was already kept by `update_check`, and is now kept by
  `device_status` too).

## RED → GREEN
New suite `src/tests/unit/mcp-update-versions-edition.test.ts` (11 tests). Against the unmodified
beta sources (`git checkout origin/beta -- mcp/`):

```
 ❯ |unit| src/tests/unit/mcp-update-versions-edition.test.ts (11 tests | 6 failed) 20ms
     × drops the openclaw component on the Hermes SKU 8ms
     × believes the payload's own edition over a stale startup snapshot 1ms
     × both omit it on Hermes 1ms
     × both carry it on dual, where the device really has an OpenClaw to update 2ms
     × reports it on dual, where Hermes may be the harness answering but OpenClaw is installed 2ms
     × keeps the block off on a Hermes box whose lock resolved to the openclaw default 1ms

 FAIL … > drops the openclaw component on the Hermes SKU
 AssertionError: expected { clawbox: { …(3) }, …(3) } to not have property "openclaw"
 - Expected: undefined
 + Received: { "current": null, "target": "2026.8.1", "updateAvailable": false }
```

With the fix:

```
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

Neighbouring suites and the whole unit project on this branch:

```
 Test Files  649 passed (649)
      Tests  10480 passed | 1 skipped (10481)
```

`tsc --noEmit`, `tsc -p mcp/tsconfig.json --noEmit` and `eslint` on the changed files: clean.

## Sibling call sites of the payload — each handled or cleared
- `mcp/tools/orientation.ts` `device_status` — **fixed**, shares the predicate.
- `src/components/SettingsApp.tsx:5754` (About) — already applies the identical rule
  (`versionInfo?.edition !== "hermes"`). Left alone: it is a client component and cannot import the
  fs-backed edition modules, so the rule stays written out there; it is the prior art this matches.
- `src/app/setup-api/update/status/route.ts:58` and `src/components/SystemUpdateApp.tsx` — read
  `openclaw.updateAvailable`, which the producer sets to `false` on Hermes. Cleared, not changed:
  they type `openclaw` as required, so shaping the *route* would throw there. That is also why the
  shaping is consumer-side rather than in `updater.ts`.
- `mcp/README.md`, `mcp/test-tools.sh`, `docs-site/technical/agent-interface.mdx` — describe
  `update_check`'s behaviour, never its payload shape. Nothing stale.

## Residuals recorded, deliberately not taken here
- `src/app/page.tsx:1531` falls back to `!!data.openclaw?.target && target !== current` when
  `updateAvailable` is absent — TRUE on a Hermes payload. Only the producer's explicit
  `updateAvailable: false` prevents a desktop "update available" card there today, and no test pins
  it. Not touched to keep this diff off a file two other open PRs are editing.
- An OpenClaw-only pin delta makes `device_status` answer `waiting: true` while `SystemUpdateApp`
  shows "You're up to date" with no button (`SystemUpdateApp.tsx:284-288`, "Only ClawBox drives
  availability"). Pre-existing on the `openclaw` SKU and on the desktop's own update notice; this PR
  extends it to `dual`, so `device_status` now agrees with the desktop and `SystemUpdateApp` is the
  surface out of step. Reachable because `openclaw_install` is not `failFast`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Update checks now show OpenClaw versions only on devices that support OpenClaw.
  - Dual installations correctly report OpenClaw updates, including when Hermes is active.
  - Device status now accurately reports OpenClaw updates and available Hermes versions.
  - Version reporting is consistent across update checks and device status.
  - Devices with unavailable edition information safely avoid exposing unsupported OpenClaw updates.

- **Tests**
  - Added coverage for device-specific filtering, dual installations, update detection, Hermes reporting, and unavailable edition data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->