### PR TITLE
fix: keep a rebuild from coming back on the build it was replacing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,11 @@
 # would just double the disk footprint and cache mismatches.
 node_modules
 .next
+# The previous build install.sh parks during a rebuild (set_previous_build_aside).
+# `.next` above does not cover it — it is a sibling, not a child — so a dev
+# machine that has ever had a rebuild killed would ship a whole extra build tree
+# into the e2e-install context, stamp and all.
+.next-old
 .git/lfs
 .git/logs
 test-results

--- a/e2e-install/entrypoint.sh
+++ b/e2e-install/entrypoint.sh
@@ -21,7 +21,12 @@ if [ ! -f "$PROJECT_DIR/install.sh" ]; then
   (
     cd "$SRC_DIR"
     # Using tar avoids rsync as a dependency and handles dotfiles cleanly.
-    tar --exclude=node_modules --exclude=.next --exclude=.git/logs -cf - . \
+    # `--exclude=.next` is an exact-name match and does NOT cover `.next-old`,
+    # the build install.sh parks during a rebuild — seeding one into the
+    # container would hand production-server.js a parked build to reclaim on
+    # first boot. `.dockerignore` keeps it out of the image too; the pair has to
+    # stay in step.
+    tar --exclude=node_modules --exclude=.next --exclude=.next-old --exclude=.git/logs -cf - . \
       | (cd "$PROJECT_DIR" && tar -xf -)
   )
   chown -R clawbox:clawbox "$PROJECT_DIR"

--- a/install.sh
+++ b/install.sh
@@ -5130,7 +5130,13 @@ step_gateway_legacy_state_recovery() {
 
   as_clawbox "$OPENCLAW_BIN" doctor --fix --yes --non-interactive || true
   systemctl reset-failed clawbox-gateway.service 2>/dev/null || true
-  systemctl start clawbox-gateway.service || true
+  # `restart`, as the first attempt above already does. This branch is reached
+  # when the gateway is not LISTENING, which is not the same as not running: a
+  # unit that is active and refusing to bind — the symptom this whole function
+  # exists for — makes `start` a no-op, so the files just quarantined would
+  # never be re-read and the port check below would fail over a recovery that
+  # was never attempted.
+  systemctl restart clawbox-gateway.service || true
   sleep 12
 
   if gateway_port_listening; then

--- a/install.sh
+++ b/install.sh
@@ -1344,6 +1344,10 @@ promote_parked_build() {
   echo "  Found a build parked by an interrupted rebuild — putting it back" >&2
   rm -rf "$build_dir"
   mv "$kept_dir" "$build_dir"
+  # The stamp names the run that died (see set_previous_build_aside); it must
+  # not ride into the tree the box is about to serve. `|| true` because a
+  # cosmetic cleanup must never be what aborts a recovery under `set -e`.
+  rm -f "$build_dir/.rebuild-pid" || true
 }
 
 # Keep the build that is serving the box until a new one exists.
@@ -1360,6 +1364,25 @@ promote_parked_build() {
 # runs out of disk is a worse outcome than one with no fallback. Said out loud
 # either way, because which of the two happened decides what an operator does
 # next.
+#
+# The park also stamps the tree it sets aside — `.rebuild-pid`, holding this
+# script's PID and the boot id. Both reclaims (promote_parked_build here and the
+# boot-time one in production-server.js) fire on a single fact: no
+# `.next/standalone/server.js`, but a `.next-old/standalone/server.js`. That is
+# ALSO the ordinary state of a rebuild in flight, for the whole length of the
+# build, because the rename below happens first and `next build` writes the
+# standalone entry last. The stamp is what separates "the rebuild died and left
+# its build here" — reclaim it — from "a rebuild is running and this is its
+# fallback" — leave it alone.
+#
+# The boot id is not decoration. A power cut mid-build, one of the very cases
+# these helpers exist for, leaves the stamp on disk, and after the reboot that
+# PID can belong to any unrelated process — which would make the reclaim refuse
+# forever and re-create the crash loop it was added to end. No rebuild survives
+# a reboot.
+#
+# The stamp lives INSIDE the parked tree, so it cannot outlive it and needs no
+# entry of its own in .gitignore (`.next-old/` is already there).
 set_previous_build_aside() {
   local build_dir="$1" kept_dir="$2" need avail
   rm -rf "$kept_dir"
@@ -1377,6 +1400,16 @@ set_previous_build_aside() {
     return 0
   fi
   echo "Setting the current build aside..."
+  # Before the rename, not after: the stamp and the park then arrive together,
+  # so there is no instant in which a restarting dashboard sees a parked build
+  # with no owner. `$$` is this script's PID — the process whose death is what
+  # "the rebuild died" means. An unreadable boot id writes an empty second
+  # field, which no reader can match: the reclaim then behaves exactly as it did
+  # before the stamp existed, which is the safe direction to fail in.
+  if ! printf '%s %s\n' "$$" "$(cat /proc/sys/kernel/random/boot_id 2>/dev/null)" \
+      > "$build_dir/.rebuild-pid"; then
+    echo "  Warning: could not record this rebuild as the owner of the build it is parking — a dashboard restarting mid-build may reclaim it" >&2
+  fi
   mv "$build_dir" "$kept_dir"
 }
 
@@ -1399,6 +1432,10 @@ restore_previous_build() {
   if [ -d "$kept_dir" ]; then
     rm -rf "$build_dir"
     mv "$kept_dir" "$build_dir"
+    # This shell is about to stop being a rebuild; the stamp it wrote must not
+    # stay behind inside the build the box serves. `|| true` for the same reason
+    # as in promote_parked_build, and more so: this IS the recovery path.
+    rm -f "$build_dir/.rebuild-pid" || true
     restored=1
   fi
   if ! build_entry_present "$build_dir"; then

--- a/install.sh
+++ b/install.sh
@@ -1187,10 +1187,15 @@ llamacpp_pid_if_running() {
 # with the box on a half-written .next and a step painted red.
 #
 # Called from do_rebuild AFTER clawbox-setup.service is stopped, and that order
-# is what makes the free hold: the gateway reaches ollama and llama.cpp through
+# is what lets the free hold: the gateway reaches ollama and llama.cpp through
 # the web server's own proxy (src/lib/local-ai-runtime.ts), so with the web
-# server down nothing can pull a model back in behind us for the length of the
-# build.
+# server down nothing can pull a model back in behind us.
+#
+# "With the web server down" is best-effort, not a guarantee, and it is worth
+# knowing which: clawbox-gateway.service carries `Wants=clawbox-setup.service`,
+# so a gateway (re)start during the build starts the unit do_rebuild had just
+# stopped and the proxy is reachable again. The stop still removes the common
+# case; it does not fence the window.
 #
 # Stop, never disable — the same rule the idle standby follows, and the reason
 # it is safe: every engine here is meant to come back on demand. An update that
@@ -1366,14 +1371,20 @@ promote_parked_build() {
 # next.
 #
 # The park also stamps the tree it sets aside — `.rebuild-pid`, holding this
-# script's PID and the boot id. Both reclaims (promote_parked_build here and the
-# boot-time one in production-server.js) fire on a single fact: no
-# `.next/standalone/server.js`, but a `.next-old/standalone/server.js`. That is
-# ALSO the ordinary state of a rebuild in flight, for the whole length of the
-# build, because the rename below happens first and `next build` writes the
-# standalone entry last. The stamp is what separates "the rebuild died and left
-# its build here" — reclaim it — from "a rebuild is running and this is its
-# fallback" — leave it alone.
+# script's PID and the boot id — for production-server.js's boot-time reclaim to
+# read. That reclaim fires on a single fact: no `.next/standalone/server.js`,
+# but a `.next-old/standalone/server.js`. That is ALSO the ordinary state of a
+# rebuild in flight, for the whole length of the build, because the rename below
+# happens first and `next build` writes the standalone entry last. The stamp is
+# what separates "the rebuild died and left its build here" — reclaim it — from
+# "a rebuild is running and this is its fallback" — leave it alone.
+#
+# promote_parked_build, the reclaim in THIS file, deliberately does not read it.
+# It runs once at the top of do_rebuild, before any park of its own, so a live
+# stamp there could only mean a second rebuild running concurrently — and the
+# very next thing do_rebuild does is `rm -rf "$kept_dir"`, so a guard there
+# would imply a safety this function cannot provide. Two rebuilds at once are
+# unsupported end to end. It only strips the stamp off the tree it promotes.
 #
 # The boot id is not decoration. A power cut mid-build, one of the very cases
 # these helpers exist for, leaves the stamp on disk, and after the reboot that
@@ -1403,11 +1414,16 @@ set_previous_build_aside() {
   # Before the rename, not after: the stamp and the park then arrive together,
   # so there is no instant in which a restarting dashboard sees a parked build
   # with no owner. `$$` is this script's PID — the process whose death is what
-  # "the rebuild died" means. An unreadable boot id writes an empty second
-  # field, which no reader can match: the reclaim then behaves exactly as it did
-  # before the stamp existed, which is the safe direction to fail in.
-  if ! printf '%s %s\n' "$$" "$(cat /proc/sys/kernel/random/boot_id 2>/dev/null)" \
-      > "$build_dir/.rebuild-pid"; then
+  # "the rebuild died" means.
+  #
+  # An empty boot id is a stamp no reader can ever match, so it is the same
+  # outcome as no stamp at all — the reclaim behaves exactly as it did before
+  # the stamp existed. That is the safe direction to fail in, but it is not
+  # silent: a guard that is quietly inoperative is worse than one that is
+  # absent, so both halves take the same warning.
+  local boot_id=""
+  boot_id="$(cat /proc/sys/kernel/random/boot_id 2>/dev/null)" || boot_id=""
+  if [ -z "$boot_id" ] || ! printf '%s %s\n' "$$" "$boot_id" > "$build_dir/.rebuild-pid"; then
     echo "  Warning: could not record this rebuild as the owner of the build it is parking — a dashboard restarting mid-build may reclaim it" >&2
   fi
   mv "$build_dir" "$kept_dir"
@@ -1452,7 +1468,15 @@ restore_previous_build() {
     fi
   fi
 
-  systemctl start clawbox-setup.service 2>/dev/null || true
+  # `restart`, not `start`: `start` on a unit that is already active is a no-op,
+  # and the unit CAN be active here. do_rebuild stopped it, but
+  # clawbox-gateway.service carries `Wants=clawbox-setup.service`, so any
+  # gateway (re)start pulls it back up mid-rebuild — and once `next build` has
+  # written the standalone entry, the restart loop latches onto whatever tree is
+  # in place. A `start` would then be a no-op over a process serving the build
+  # that just FAILED verification, curl would answer 200 from it, and the line
+  # below would report a rollback that never happened.
+  systemctl restart clawbox-setup.service 2>/dev/null || true
 
   # `systemctl is-active` is not the question. clawbox-setup is `Type=simple`
   # with `Restart=always` (config/clawbox-setup.service), so systemd calls the
@@ -1496,6 +1520,12 @@ do_rebuild() {
   # shell, a power cut, an operator's Ctrl-C — is the box's only build. Claim it
   # back before the rename below would delete it. After the stop, never before
   # it: the rename moves the tree the running server is loading from.
+  #
+  # The stop is what makes that ordering worth having, but it does not keep the
+  # dashboard down for the length of the rebuild — clawbox-gateway.service's
+  # `Wants=clawbox-setup.service` starts it again on any gateway (re)start. That
+  # is why the park stamps the tree it sets aside, and why the two `systemctl`
+  # calls that end a rebuild use `restart` rather than `start`.
   promote_parked_build "$build_dir" "$kept_dir"
 
   # After the stop, never before it — see free_memory_for_build.
@@ -5865,8 +5895,15 @@ step_chpasswd() {
 
 step_rebuild() {
   do_rebuild
-  echo "Starting clawbox-setup.service..."
-  systemctl start clawbox-setup.service
+  # `restart`, not `start`, for the reason spelled out in
+  # restore_previous_build: the unit can already be active, latched by its own
+  # `Restart=always` onto the tree that existed the moment `next build` wrote
+  # the standalone entry — which is BEFORE postbuild copied .next/static,
+  # public/ and build-info.json beside it. `start` is a no-op over that process
+  # and would leave the box serving a half-copied build. step_rebuild_reboot is
+  # saved by the reboot that follows it; this step is not.
+  echo "Restarting clawbox-setup.service..."
+  systemctl restart clawbox-setup.service
 }
 
 step_restart() {

--- a/install.sh
+++ b/install.sh
@@ -1373,6 +1373,17 @@ promote_parked_build() {
 # either way, because which of the two happened decides what an operator does
 # next.
 #
+# The real peak is closer to THREE builds, not two, and an operator triaging an
+# ENOSPC here needs to know it: Next's instrumentation trace sweeps the project
+# root, so while `next build` runs it also copies the parked tree into the new
+# standalone output (TASK-725; scripts/postbuild.sh deletes that copy, but only
+# once the build has finished). The threshold is deliberately still `need * 2`.
+# Raising it to 3 would delete the old build on any box between 2x and 3x free
+# — trading a failed update that ROLLS BACK (the ENOSPC build fails, the parked
+# tree goes back, the box serves) for a build with no fallback at all, which is
+# the brick #632 exists to prevent. The fix for the peak is to narrow the sweep,
+# not to park less often.
+#
 # The park also stamps the tree it sets aside — `.rebuild-pid`, holding this
 # script's PID and the boot id — for production-server.js's boot-time reclaim to
 # read. That reclaim fires on a single fact: no `.next/standalone/server.js`,
@@ -1490,6 +1501,13 @@ restore_previous_build() {
   # in place. A `start` would then be a no-op over a process serving the build
   # that just FAILED verification, curl would answer 200 from it, and the line
   # below would report a rollback that never happened.
+  # `reset-failed` first, as both gateway recovery paths do. The reclaim in
+  # production-server.js is now correctly refused for the length of the build,
+  # so clawbox-setup crash-loops on `require`ing a build that is not there yet;
+  # a unit that has hit its start limit answers `restart` with "Start request
+  # repeated too quickly", and `|| true` would carry that into the poll below
+  # and report the dashboard DOWN over a rollback that had worked.
+  systemctl reset-failed clawbox-setup.service 2>/dev/null || true
   systemctl restart clawbox-setup.service 2>/dev/null || true
 
   # `systemctl is-active` is not the question. clawbox-setup is `Type=simple`
@@ -5130,12 +5148,13 @@ step_gateway_legacy_state_recovery() {
 
   as_clawbox "$OPENCLAW_BIN" doctor --fix --yes --non-interactive || true
   systemctl reset-failed clawbox-gateway.service 2>/dev/null || true
-  # `restart`, as the first attempt above already does. This branch is reached
-  # when the gateway is not LISTENING, which is not the same as not running: a
-  # unit that is active and refusing to bind — the symptom this whole function
-  # exists for — makes `start` a no-op, so the files just quarantined would
-  # never be re-read and the port check below would fail over a recovery that
-  # was never attempted.
+  # `restart`, as the first attempt above already does. The stop before the
+  # quarantine loop does NOT make `start` safe here: `doctor --fix` on the line
+  # above writes config and brings the gateway back itself, so by this point the
+  # unit can be up again — and up without binding is the very symptom this
+  # function exists for. `start` over that is a no-op, the files just
+  # quarantined are never re-read, and the port check below reports a failure
+  # over a recovery that was never attempted.
   systemctl restart clawbox-gateway.service || true
   sleep 12
 
@@ -5923,6 +5942,10 @@ step_rebuild() {
   # and would leave the box serving a half-copied build. step_rebuild_reboot is
   # saved by the reboot that follows it; this step is not.
   echo "Restarting clawbox-setup.service..."
+  # `reset-failed` for the same reason as in restore_previous_build: the unit
+  # crash-loops for the length of every rebuild now, and a latched start limit
+  # would turn this restart into a failure over a build that is fine.
+  systemctl reset-failed clawbox-setup.service 2>/dev/null || true
   systemctl restart clawbox-setup.service
 }
 

--- a/install.sh
+++ b/install.sh
@@ -1386,11 +1386,13 @@ promote_parked_build() {
 # would imply a safety this function cannot provide. Two rebuilds at once are
 # unsupported end to end. It only strips the stamp off the tree it promotes.
 #
-# The boot id is not decoration. A power cut mid-build, one of the very cases
-# these helpers exist for, leaves the stamp on disk, and after the reboot that
-# PID can belong to any unrelated process — which would make the reclaim refuse
-# forever and re-create the crash loop it was added to end. No rebuild survives
-# a reboot.
+# It takes three fields, because a PID alone identifies nothing. A power cut
+# mid-build — one of the very cases these helpers exist for — leaves the stamp
+# on disk, and the number in it can later belong to some unrelated process:
+# across a reboot, which the boot id settles because no rebuild survives one,
+# and within a boot, because PIDs are reused. Either would make the reclaim
+# refuse forever and re-create the crash loop it was added to end, so the stamp
+# also carries this process's start time and the reader requires all three.
 #
 # The stamp lives INSIDE the parked tree, so it cannot outlive it and needs no
 # entry of its own in .gitignore (`.next-old/` is already there).
@@ -1416,14 +1418,23 @@ set_previous_build_aside() {
   # with no owner. `$$` is this script's PID — the process whose death is what
   # "the rebuild died" means.
   #
-  # An empty boot id is a stamp no reader can ever match, so it is the same
-  # outcome as no stamp at all — the reclaim behaves exactly as it did before
-  # the stamp existed. That is the safe direction to fail in, but it is not
-  # silent: a guard that is quietly inoperative is worse than one that is
-  # absent, so both halves take the same warning.
-  local boot_id=""
+  # A field this shell cannot fill is a stamp no reader can ever match, so it is
+  # the same outcome as no stamp at all — the reclaim behaves exactly as it did
+  # before the stamp existed. That is the safe direction to fail in, but it is
+  # not silent: a guard that is quietly inoperative is worse than one that is
+  # absent, so every half takes the same warning.
+  #
+  # start_time is field 22 of /proc/<pid>/stat, the process's start in clock
+  # ticks since boot — what makes the PID name one process rather than a number
+  # that will be handed out again. Field 2 is the command, parenthesised and
+  # free to contain spaces and parens of its own, so everything up to the LAST
+  # ") " is dropped first; field 3 is then $1 and field 22 is $20.
+  local boot_id="" start_time=""
   boot_id="$(cat /proc/sys/kernel/random/boot_id 2>/dev/null)" || boot_id=""
-  if [ -z "$boot_id" ] || ! printf '%s %s\n' "$$" "$boot_id" > "$build_dir/.rebuild-pid"; then
+  start_time="$(sed -e 's/^.*) //' "/proc/$$/stat" 2>/dev/null | awk '{print $20}')" || start_time=""
+  case "$start_time" in ''|*[!0-9]*) start_time="" ;; esac
+  if [ -z "$boot_id" ] || [ -z "$start_time" ] \
+     || ! printf '%s %s %s\n' "$$" "$boot_id" "$start_time" > "$build_dir/.rebuild-pid"; then
     echo "  Warning: could not record this rebuild as the owner of the build it is parking — a dashboard restarting mid-build may reclaim it" >&2
   fi
   mv "$build_dir" "$kept_dir"

--- a/install.sh
+++ b/install.sh
@@ -1296,13 +1296,16 @@ build_entry_present() {
 #
 # `bun run build` exiting 0 is not the same thing, and neither is a fresh
 # .next/BUILD_ID: `bun run build` is `next build` PLUS the `postbuild` lifecycle
-# script (package.json), and postbuild is what makes the build servable — it
-# writes build-info.json and copies .next/static, public/ and the server entry
-# into the standalone tree. Next writes BUILD_ID before any of that, and
-# postbuild's own `if [ -n "$SRVJS" ]` guard exits 0 having copied NOTHING when
-# the standalone entry is missing. So a build can be "complete" by BUILD_ID and
-# still leave production-server.js crash-looping on
-# `require("./.next/standalone/server.js")`.
+# script (scripts/postbuild.sh), and postbuild is what makes the build servable
+# — it writes build-info.json and copies .next/static, public/ and the server
+# entry into the standalone tree. Next writes BUILD_ID before any of that. So a
+# build can be "complete" by BUILD_ID and still leave production-server.js
+# crash-looping on `require("./.next/standalone/server.js")`.
+#
+# postbuild now fails rather than exiting 0 over a copy that did not happen
+# (TASK-725), which closes the case where it copied nothing at all. The check
+# below stays regardless: it is the only one that also answers whether the
+# build on disk came from the checked-out commit.
 #
 # Two questions, and the box already owns the answer to the second:
 #   1. the file the service loads exists  — what step_build has always checked;

--- a/next.config.ts
+++ b/next.config.ts
@@ -60,6 +60,19 @@ const nextConfig: NextConfig = {
   // are still open — Next copies those two traces with no error handling,
   // where the page traces are wrapped — and closing them means keeping the
   // paths out of the trace at the source, not another glob.
+  //
+  // How wide the instrumentation half is, measured on Next 16.3.3 (TASK-725):
+  // src/instrumentation-node.ts resolves path.join(CONFIG_ROOT, 'scripts',
+  // 'terminal-server.mjs') and CONFIG_ROOT is read from the environment
+  // (src/lib/config-store.ts), so @vercel/nft cannot resolve it and emits the
+  // WHOLE project directory as an asset directory. instrumentation.js.nft.json
+  // listed 6186 files — src/, scripts/, bench/, docs-site/, e2e/, .git … and,
+  // during an update, all 4202 files of the previous build parked at
+  // `.next-old`. That is where `.next/standalone/.next-old/standalone/server.js`
+  // comes from, which scripts/postbuild.sh now removes and refuses to mistake
+  // for this build's entry. Narrowing the sweep is a separate change: parts of
+  // it are load-bearing today (`.next/standalone/scripts` comes from it, and
+  // system-profile.ts resolves scripts/ from the process cwd).
   outputFileTracingExcludes: {
     // No "./" prefix: Next matches these globs relative to the tracing root,
     // and "./data/**" silently matched nothing — the build kept dying on

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:privileged": "next dev --port 80 --hostname 0.0.0.0",
     "prebuild": "rm -rf .next/standalone/.next/cache/images 2>/dev/null || true",
     "build": "next build",
-    "postbuild": "node scripts/write-build-info.mjs; SRVJS=$(find .next/standalone -maxdepth 3 -name node_modules -prune -o -name server.js -print -quit); if [ -n \"$SRVJS\" ]; then SDIR=$(dirname \"$SRVJS\"); rm -rf \"$SDIR/.next/static\" \"$SDIR/public\"; cp -r .next/static \"$SDIR/.next/static\"; cp -r public \"$SDIR/public\"; cp .next/build-info.json \"$SDIR/.next/build-info.json\"; for pwp in playwright playwright-core; do if [ -d \"node_modules/$pwp\" ]; then rm -rf \"$SDIR/node_modules/$pwp\"; cp -r \"node_modules/$pwp\" \"$SDIR/node_modules/$pwp\"; fi; done; rm -rf \"$SDIR/data\"; if [ -e \"$SDIR/data\" ]; then chmod -R u+w \"$SDIR/data\" 2>/dev/null; rm -rf \"$SDIR/data\"; fi; if [ \"$SRVJS\" != \".next/standalone/server.js\" ]; then ln -sf \"$(pwd)/$SRVJS\" .next/standalone/server.js; fi; if [ -e \"$SDIR/data\" ]; then echo \"postbuild: $SDIR/data survived removal - the standalone tree would ship a duplicate of the runtime data directory, including 0600 secrets (see next.config.ts)\" >&2; exit 1; fi; fi",
+    "postbuild": "bash scripts/postbuild.sh",
     "start": "PORT=80 HOSTNAME=0.0.0.0 node production-server.js",
     "lint": "eslint",
     "test": "vitest run --config vitest.config.ts",

--- a/production-server.js
+++ b/production-server.js
@@ -619,16 +619,66 @@ http.Server.prototype.listen = function (...args) {
 // `Restart=always` means a lost race just tries again in three seconds.
 try {
   const buildEntry = path.join(__dirname, ".next", "standalone", "server.js");
-  const parkedEntry = path.join(__dirname, ".next-old", "standalone", "server.js");
+  const parkedDir = path.join(__dirname, ".next-old");
+  const parkedEntry = path.join(parkedDir, "standalone", "server.js");
   // `lstatSync`, not `existsSync`: for the nested standalone layout `postbuild`
   // supports, this path is a symlink into `.next` that DANGLES while the tree is
   // parked, and `existsSync` would call the box's only build absent.
   const present = (p) => { try { fs.lstatSync(p); return true; } catch { return false; } };
+
+  // …and "no entry, a parked one exists" is not on its own the killed rebuild
+  // this block repairs. It is ALSO the normal state of a rebuild in flight, for
+  // the whole length of the build: install.sh's do_rebuild renames `.next` to
+  // `.next-old` and `next build` writes the standalone entry last. This process
+  // is started inside that window as a matter of routine — clawbox-gateway.service
+  // carries `Wants=clawbox-setup.service`, so every gateway (re)start starts the
+  // service do_rebuild had just stopped (e2e-install run 33971129750: four
+  // seconds after the stop). Reclaiming there `rm -rf`s the half-written build
+  // out from under `next build` and renames the previous one on top of it, and
+  // the box comes back on the build the update was replacing.
+  //
+  // So the rebuild says so: set_previous_build_aside stamps the tree it parks
+  // with its own PID and boot id. Only a stamp that can be PROVEN live refuses
+  // the reclaim — anything else, absent (every build parked before this
+  // existed) or unparseable or from another boot or naming a process that is
+  // gone, leaves this block behaving exactly as it did before the stamp
+  // existed. That is the safe direction to fail in: a mid-build reclaim costs
+  // one failed update, while a stamp wrongly believed live costs a
+  // crash-looping box with its only build on disk — the state this whole block
+  // was added to end.
+  const OWNER_STAMP = ".rebuild-pid";
+  const readTrimmed = (p) => { try { return fs.readFileSync(p, "utf-8").trim(); } catch { return ""; } };
+  const rebuildOwnerPid = () => {
+    const [rawPid, stampBootId] = readTrimmed(path.join(parkedDir, OWNER_STAMP)).split(/\s+/);
+    const pid = Number.parseInt(rawPid, 10);
+    if (!Number.isInteger(pid) || pid <= 0) return 0;
+    // A PID is only meaningful within the boot that issued it: a power cut
+    // mid-build leaves the stamp behind, and after the reboot that number can
+    // belong to anything. No rebuild survives a reboot.
+    const bootId = readTrimmed("/proc/sys/kernel/random/boot_id");
+    if (!bootId || bootId !== stampBootId) return 0;
+    try {
+      process.kill(pid, 0);
+      return pid;
+    } catch (err) {
+      // EPERM: alive, but not ours to signal. do_rebuild runs as root and this
+      // server as `clawbox`, so EPERM is the ordinary answer about a live rebuild.
+      return err.code === "EPERM" ? pid : 0;
+    }
+  };
+
   if (!present(buildEntry) && present(parkedEntry)) {
-    console.warn("[production-server] No .next build, but .next-old holds one — an update was killed mid-rebuild. Putting it back.");
-    fs.rmSync(path.join(__dirname, ".next"), { recursive: true, force: true });
-    fs.renameSync(path.join(__dirname, ".next-old"), path.join(__dirname, ".next"));
-    console.warn("[production-server] Restored the parked build. Run the update again to get the new one.");
+    const owner = rebuildOwnerPid();
+    if (owner) {
+      console.warn(`[production-server] No .next build yet — a rebuild is in progress (pid ${owner}), leaving .next-old alone.`);
+    } else {
+      console.warn("[production-server] No .next build, but .next-old holds one — an update was killed mid-rebuild. Putting it back.");
+      fs.rmSync(path.join(__dirname, ".next"), { recursive: true, force: true });
+      fs.renameSync(parkedDir, path.join(__dirname, ".next"));
+      // The stamp named the run that died; it must not stay in the tree we serve.
+      fs.rmSync(path.join(__dirname, ".next", OWNER_STAMP), { force: true });
+      console.warn("[production-server] Restored the parked build. Run the update again to get the new one.");
+    }
   }
 } catch (err) {
   console.warn("[production-server] Could not reclaim a parked build:", err.message);

--- a/production-server.js
+++ b/production-server.js
@@ -638,46 +638,49 @@ try {
   // the box comes back on the build the update was replacing.
   //
   // So the rebuild says so: set_previous_build_aside stamps the tree it parks
-  // with its own PID and boot id. Only a stamp that can be PROVEN live refuses
-  // the reclaim — anything else, absent (every build parked before this
-  // existed) or unparseable or from another boot or naming a process that is
-  // gone, leaves this block behaving exactly as it did before the stamp
-  // existed. That is the safe direction to fail in: a mid-build reclaim costs
-  // one failed update, while a stamp wrongly believed live costs a
-  // crash-looping box with its only build on disk — the state this whole block
-  // was added to end.
+  // with its PID, the boot id, and that process's start time. Only a stamp that
+  // can be PROVEN to name a running rebuild refuses the reclaim — anything
+  // else, absent (every build parked before this existed) or of another shape
+  // or from another boot or naming a process that is gone, leaves this block
+  // behaving exactly as it did before the stamp existed. That is the safe
+  // direction to fail in: a mid-build reclaim costs one failed update, while a
+  // stamp wrongly believed live costs a crash-looping box with its only build
+  // on disk — the state this whole block was added to end.
   //
-  // A PID that is alive is only proof that SOME process holds that number, and
-  // within one boot a number can be reused. It cannot be reused in time to
-  // matter here: this block runs on every clawbox-setup start, so a rebuild
-  // that dies is seen ~3 s later by the `Restart=always` restart it caused —
-  // millions of process creations before `kernel.pid_max` could wrap.
+  // All three fields, because none of them identifies a process on its own. A
+  // PID means nothing across boots, and within a boot it is REUSED: a number
+  // that has been handed to something unrelated would hold the reclaim off for
+  // as long as that process lives, which is the brick this exists to prevent.
+  // Start time (field 22 of /proc/<pid>/stat) is what pins the number to one
+  // process. Reading /proc is also how liveness is answered — the entry is
+  // world-readable, so this needs no permission over root's rebuild shell.
   const OWNER_STAMP = ".rebuild-pid";
   const stampPath = path.join(parkedDir, OWNER_STAMP);
   const readTrimmed = (p) => { try { return fs.readFileSync(p, "utf-8").trim(); } catch { return ""; } };
+  /** Field 22 of /proc/<pid>/stat, or "" if that process is not there. */
+  const startTimeOf = (pid) => {
+    const stat = readTrimmed(`/proc/${pid}/stat`);
+    // Field 2 is the command, parenthesised and free to contain spaces and
+    // parens of its own, so read from after the LAST ") ": field 3 is then
+    // index 0 and field 22 is index 19.
+    const cut = stat.lastIndexOf(") ");
+    if (cut < 0) return "";
+    return stat.slice(cut + 2).split(" ")[19] ?? "";
+  };
   const rebuildOwnerPid = () => {
-    // Exactly two fields, and a PID that is nothing but digits.
-    // `Number.parseInt` accepts "123junk" and destructuring ignores a third
-    // field, so either would let a stamp this file cannot vouch for refuse the
+    // Exactly three fields, and a PID that is nothing but digits.
+    // `Number.parseInt` accepts "123junk" and destructuring ignores extra
+    // fields, so either would let a stamp this file cannot vouch for refuse the
     // reclaim — the expensive direction, per the paragraph above.
     const fields = readTrimmed(stampPath).split(/\s+/);
-    if (fields.length !== 2 || !/^[1-9][0-9]*$/.test(fields[0])) return 0;
-    const [rawPid, stampBootId] = fields;
+    if (fields.length !== 3 || !/^[1-9][0-9]*$/.test(fields[0])) return 0;
+    const [rawPid, stampBootId, stampStartTime] = fields;
     const pid = Number(rawPid);
     if (!Number.isSafeInteger(pid)) return 0;
-    // A PID is only meaningful within the boot that issued it: a power cut
-    // mid-build leaves the stamp behind, and after the reboot that number can
-    // belong to anything. No rebuild survives a reboot.
     const bootId = readTrimmed("/proc/sys/kernel/random/boot_id");
     if (!bootId || bootId !== stampBootId) return 0;
-    try {
-      process.kill(pid, 0);
-      return pid;
-    } catch (err) {
-      // EPERM: alive, but not ours to signal. do_rebuild runs as root and this
-      // server as `clawbox`, so EPERM is the ordinary answer about a live rebuild.
-      return err.code === "EPERM" ? pid : 0;
-    }
+    if (!stampStartTime || startTimeOf(pid) !== stampStartTime) return 0;
+    return pid;
   };
 
   if (!present(buildEntry) && present(parkedEntry)) {

--- a/production-server.js
+++ b/production-server.js
@@ -656,9 +656,15 @@ try {
   const stampPath = path.join(parkedDir, OWNER_STAMP);
   const readTrimmed = (p) => { try { return fs.readFileSync(p, "utf-8").trim(); } catch { return ""; } };
   const rebuildOwnerPid = () => {
-    const [rawPid, stampBootId] = readTrimmed(stampPath).split(/\s+/);
-    const pid = Number.parseInt(rawPid, 10);
-    if (!Number.isInteger(pid) || pid <= 0) return 0;
+    // Exactly two fields, and a PID that is nothing but digits.
+    // `Number.parseInt` accepts "123junk" and destructuring ignores a third
+    // field, so either would let a stamp this file cannot vouch for refuse the
+    // reclaim — the expensive direction, per the paragraph above.
+    const fields = readTrimmed(stampPath).split(/\s+/);
+    if (fields.length !== 2 || !/^[1-9][0-9]*$/.test(fields[0])) return 0;
+    const [rawPid, stampBootId] = fields;
+    const pid = Number(rawPid);
+    if (!Number.isSafeInteger(pid)) return 0;
     // A PID is only meaningful within the boot that issued it: a power cut
     // mid-build leaves the stamp behind, and after the reboot that number can
     // belong to anything. No rebuild survives a reboot.

--- a/production-server.js
+++ b/production-server.js
@@ -646,10 +646,17 @@ try {
   // one failed update, while a stamp wrongly believed live costs a
   // crash-looping box with its only build on disk — the state this whole block
   // was added to end.
+  //
+  // A PID that is alive is only proof that SOME process holds that number, and
+  // within one boot a number can be reused. It cannot be reused in time to
+  // matter here: this block runs on every clawbox-setup start, so a rebuild
+  // that dies is seen ~3 s later by the `Restart=always` restart it caused —
+  // millions of process creations before `kernel.pid_max` could wrap.
   const OWNER_STAMP = ".rebuild-pid";
+  const stampPath = path.join(parkedDir, OWNER_STAMP);
   const readTrimmed = (p) => { try { return fs.readFileSync(p, "utf-8").trim(); } catch { return ""; } };
   const rebuildOwnerPid = () => {
-    const [rawPid, stampBootId] = readTrimmed(path.join(parkedDir, OWNER_STAMP)).split(/\s+/);
+    const [rawPid, stampBootId] = readTrimmed(stampPath).split(/\s+/);
     const pid = Number.parseInt(rawPid, 10);
     if (!Number.isInteger(pid) || pid <= 0) return 0;
     // A PID is only meaningful within the boot that issued it: a power cut
@@ -672,12 +679,28 @@ try {
     if (owner) {
       console.warn(`[production-server] No .next build yet — a rebuild is in progress (pid ${owner}), leaving .next-old alone.`);
     } else {
+      // Said out loud when a stamp is there but proves nothing — stale, from
+      // another boot, or unreadable. Reclaiming is right in all three cases,
+      // but a guard that is silently inoperative (a future UMask on the
+      // root-update unit would do it) must not look like one that never fired.
+      if (present(stampPath)) {
+        console.warn("[production-server] .next-old carries a rebuild stamp that names no live rebuild — treating the parked build as abandoned.");
+      }
       console.warn("[production-server] No .next build, but .next-old holds one — an update was killed mid-rebuild. Putting it back.");
       fs.rmSync(path.join(__dirname, ".next"), { recursive: true, force: true });
       fs.renameSync(parkedDir, path.join(__dirname, ".next"));
-      // The stamp named the run that died; it must not stay in the tree we serve.
-      fs.rmSync(path.join(__dirname, ".next", OWNER_STAMP), { force: true });
       console.warn("[production-server] Restored the parked build. Run the update again to get the new one.");
+      // Its own try, deliberately: the reclaim is already done by the line
+      // above, and `force` swallows ENOENT but not EACCES or EIO. Letting one
+      // reach the catch below would report "Could not reclaim a parked build"
+      // over a reclaim that succeeded — a false failure in the line an
+      // operator triages from.
+      try {
+        fs.rmSync(path.join(__dirname, ".next", OWNER_STAMP), { force: true });
+      } catch {
+        // A stale stamp inside the restored tree is inert: the next park
+        // overwrites it, and nothing else reads it there.
+      }
     }
   }
 } catch (err) {

--- a/scripts/postbuild.sh
+++ b/scripts/postbuild.sh
@@ -13,8 +13,9 @@
 #
 #   1. It found the entry with
 #      `find .next/standalone -maxdepth 3 -name node_modules -prune -o -name server.js -print -quit`
-#      and trusted whatever readdir handed back first. During an update the
-#      project root also holds `.next-old` — the previous build, parked by
+#      and trusted whatever readdir handed back first — while Next had already
+#      recorded where it put the entry (see "Where the entry is" below).
+#      During an update the project root also holds `.next-old` — parked by
 #      `set_previous_build_aside` so an OOM-killed rebuild cannot leave the box
 #      with no build at all — and Next's file tracing copies it INTO the new
 #      standalone tree (see "why the parked build is in there" below). So the
@@ -66,17 +67,44 @@ for swept in "$STANDALONE"/.next-old*; do
   rm -rf "$swept"
 done
 
-# The entry `next build` wrote, and only then a search.
+# Where the entry is, asked of Next rather than guessed at.
 #
-# `outputFileTracingRoot` is unset, so the tracing root is the project
-# directory and Next writes the entry at `$STANDALONE/server.js`. Next nests
-# the tree under `<standalone>/<path from the tracing root to the app>` when
-# that root is a parent directory (a monorepo layout), and the search below is
-# what supports that shape — pruning the parked tree and `node_modules` (which
-# has `server.js` files of its own in next/ and react-dom/), and taking regular
-# files only, so the symlink a previous run of this script may have left is
-# never mistaken for the entry.
-if [ -f "$STANDALONE/server.js" ] && [ ! -L "$STANDALONE/server.js" ]; then
+# `relativeAppDir` in `.next/required-server-files.json` is
+# `path.relative(outputFileTracingRoot, dir)`
+# (next/dist/build/index.js:1107) — the exact segment `copyTracedFiles` joins
+# under `.next/standalone` when it writes the entry
+# (next/dist/build/utils.js:990). It is "" for this repo, because
+# `outputFileTracingRoot` is unset and therefore the project directory; it is
+# the app's path below the tracing root for the nested layout Next produces
+# when that root is a parent (a monorepo). Either way Next has already
+# recorded the answer, so nothing here has to depend on readdir order.
+#
+# Read with node, as scripts/verify-build-identity.sh reads build-info.json:
+# a Jetson runs the server, so it has node, and it does not necessarily have
+# jq. A value that could climb out of the standalone tree is not an answer
+# this script will act on.
+rel_app_dir() {
+  node -e '
+    const fs = require("fs");
+    try {
+      const v = JSON.parse(fs.readFileSync(process.argv[1], "utf8")).relativeAppDir;
+      if (typeof v !== "string") process.exit(1);
+      if (v.startsWith("/") || v.split("/").includes("..")) process.exit(1);
+      process.stdout.write(v);
+    } catch { process.exit(1); }
+  ' "$1" 2>/dev/null
+}
+
+# The fallbacks, in order: the manifest, then the layout the manifest describes
+# for this repo, then a search for a tree that carries neither. The search
+# prunes the parked build and `node_modules` (next/ and react-dom/ have
+# `server.js` files of their own) and takes regular files only, so the symlink
+# a previous run of this script may have left is never taken for the entry.
+REL="$(rel_app_dir ".next/required-server-files.json")" || REL=""
+CANDIDATE="$STANDALONE${REL:+/$REL}/server.js"
+if [ -f "$CANDIDATE" ] && [ ! -L "$CANDIDATE" ]; then
+  SRVJS="$CANDIDATE"
+elif [ -f "$STANDALONE/server.js" ] && [ ! -L "$STANDALONE/server.js" ]; then
   SRVJS="$STANDALONE/server.js"
 else
   SRVJS="$(find "$STANDALONE" -maxdepth 3 \

--- a/scripts/postbuild.sh
+++ b/scripts/postbuild.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Finish the standalone build — and fail when finishing it did not work.
+#
+# `next build` writes `.next/standalone`, but not everything the dashboard
+# needs to run from it: `.next/static`, `public/`, the build-identity stamp and
+# the Playwright packages are copied in here. `install.sh`'s
+# `verify_build_present` is written around that fact — a build is servable only
+# once this script has run.
+#
+# It used to be one line inside package.json's `postbuild`, and it was a false
+# success in three separate ways, all of them measured in CI on 2026-09-05
+# (e2e-install runs 33971129750, 33974951149, 33977666658 — TASK-725):
+#
+#   1. It found the entry with
+#      `find .next/standalone -maxdepth 3 -name node_modules -prune -o -name server.js -print -quit`
+#      and trusted whatever readdir handed back first. During an update the
+#      project root also holds `.next-old` — the previous build, parked by
+#      `set_previous_build_aside` so an OOM-killed rebuild cannot leave the box
+#      with no build at all — and Next's file tracing copies it INTO the new
+#      standalone tree (see "why the parked build is in there" below). So the
+#      lookup had two candidates, and on those three runs it picked
+#      `.next/standalone/.next-old/standalone/server.js`: the PARKED build's
+#      entry, three levels down.
+#   2. Every `cp` then wrote at the parked copy instead of the real tree, all
+#      four failed with "No such file or directory" — and the step exited 0.
+#   3. Its last clause replaced the real `.next/standalone/server.js` with a
+#      symlink to that parked entry, so `require("./.next/standalone/server.js")`
+#      would have loaded the build the update was replacing.
+#      `verify-build-identity.sh` caught the missing stamp, the rebuild was
+#      rolled back, and the update failed.
+#
+# So: the entry is the one `next build` wrote, not the first one readdir
+# offers; every copy is checked (`set -e`); and a step that cannot do its job
+# says so with a non-zero status.
+#
+# Why the parked build is in there at all: `src/instrumentation-node.ts:154`
+# resolves `path.join(CONFIG_ROOT, 'scripts', 'terminal-server.mjs')`, and
+# CONFIG_ROOT is read from the environment (`src/lib/config-store.ts:4`), so
+# @vercel/nft cannot resolve it and emits the whole project directory as an
+# asset directory. Reproduced locally on Next 16.3.3: with a build parked
+# beside it, `.next/server/instrumentation.js.nft.json` lists 6186 files of
+# which 4202 are `../../.next-old/**`. `outputFileTracingExcludes` does not
+# reach that trace — Next applies it per route entry, and the middleware and
+# instrumentation traces are built separately (the measurement is recorded in
+# next.config.ts). The sweep is also load-bearing today: `.next/standalone/scripts`
+# comes from it and system-profile.ts resolves scripts/ from the process cwd.
+# Narrowing it is its own change, with its own device proof; until then the
+# parked copy is removed here so the tree that ships is only this build.
+set -euo pipefail
+
+STANDALONE=".next/standalone"
+
+fail() { echo "postbuild: $*" >&2; exit 1; }
+
+node scripts/write-build-info.mjs
+
+[ -d "$STANDALONE" ] || fail "no $STANDALONE — next build wrote no standalone output (next.config.ts sets output: \"standalone\")"
+
+# A parked previous build swept in by the trace above is a second, complete
+# build inside this one — hundreds of MB on an eMMC, and a second `server.js`
+# for anything that goes looking. It is a copy; the real parked tree is
+# `$PROJECT_DIR/.next-old` and is not touched here.
+for swept in "$STANDALONE"/.next-old*; do
+  [ -e "$swept" ] || continue
+  echo "postbuild: removing $swept — a parked previous build was traced into the standalone output" >&2
+  rm -rf "$swept"
+done
+
+# The entry `next build` wrote, and only then a search.
+#
+# `outputFileTracingRoot` is unset, so the tracing root is the project
+# directory and Next writes the entry at `$STANDALONE/server.js`. Next nests
+# the tree under `<standalone>/<path from the tracing root to the app>` when
+# that root is a parent directory (a monorepo layout), and the search below is
+# what supports that shape — pruning the parked tree and `node_modules` (which
+# has `server.js` files of its own in next/ and react-dom/), and taking regular
+# files only, so the symlink a previous run of this script may have left is
+# never mistaken for the entry.
+if [ -f "$STANDALONE/server.js" ] && [ ! -L "$STANDALONE/server.js" ]; then
+  SRVJS="$STANDALONE/server.js"
+else
+  SRVJS="$(find "$STANDALONE" -maxdepth 3 \
+    \( -name node_modules -o -name '.next-old*' \) -prune \
+    -o -type f -name server.js -print -quit)"
+  [ -n "$SRVJS" ] || fail "no server.js under $STANDALONE — this build produced nothing the dashboard can load"
+fi
+SDIR="$(dirname "$SRVJS")"
+# The stamp, the static assets and public/ all go NEXT TO the entry, in that
+# tree's own `.next`. If it is not there, $SDIR is not a standalone root and
+# copying into it would write a build nothing can serve.
+[ -d "$SDIR/.next" ] || fail "$SRVJS is not a standalone entry — $SDIR/.next does not exist"
+
+# data/ first, before the copies, because this is the one removal whose failure
+# has to be reported by name: it holds the owner's live state and 0600 secrets
+# (see next.config.ts), and a standalone tree that ships a stale duplicate of
+# them is a build failure, not a warning. `|| true` on the removals so the
+# check below is what reports it rather than errexit on `rm`.
+rm -rf "$SDIR/data" || true
+if [ -e "$SDIR/data" ]; then
+  chmod -R u+w "$SDIR/data" 2>/dev/null || true
+  rm -rf "$SDIR/data" || true
+fi
+if [ -e "$SDIR/data" ]; then
+  fail "$SDIR/data survived removal - the standalone tree would ship a duplicate of the runtime data directory, including 0600 secrets (see next.config.ts)"
+fi
+
+rm -rf "$SDIR/.next/static" "$SDIR/public"
+cp -r .next/static "$SDIR/.next/static"
+cp -r public "$SDIR/public"
+cp .next/build-info.json "$SDIR/.next/build-info.json"
+
+# Playwright is not traced (the browser tests import it dynamically), so it is
+# copied beside the entry for the on-device browser tools.
+for pwp in playwright playwright-core; do
+  if [ -d "node_modules/$pwp" ]; then
+    rm -rf "$SDIR/node_modules/$pwp"
+    mkdir -p "$SDIR/node_modules"
+    cp -r "node_modules/$pwp" "$SDIR/node_modules/$pwp"
+  fi
+done
+
+# Nested layout only: production-server.js and install.sh both load
+# `.next/standalone/server.js`, so point it at the real entry. The link is
+# absolute, which is why `build_entry_present` in install.sh tests `-L` beside
+# `-e` — it dangles while the tree is parked under `.next-old`.
+if [ "$SRVJS" != "$STANDALONE/server.js" ]; then
+  ln -sf "$(pwd)/$SRVJS" "$STANDALONE/server.js"
+fi

--- a/scripts/postbuild.sh
+++ b/scripts/postbuild.sh
@@ -53,19 +53,14 @@ STANDALONE=".next/standalone"
 
 fail() { echo "postbuild: $*" >&2; exit 1; }
 
-node scripts/write-build-info.mjs
+# CLAWBOX_ROOT pinned to the build's own directory: write-build-info.mjs resolves
+# its project dir from that variable first, and a shell that exports it at some
+# other path (a dev box, a test runner) would write the stamp into a tree this
+# build knows nothing about — which under `set -e` is now a failed build rather
+# than a warning. The stamp belongs to the build in this directory.
+CLAWBOX_ROOT="$PWD" node scripts/write-build-info.mjs
 
 [ -d "$STANDALONE" ] || fail "no $STANDALONE — next build wrote no standalone output (next.config.ts sets output: \"standalone\")"
-
-# A parked previous build swept in by the trace above is a second, complete
-# build inside this one — hundreds of MB on an eMMC, and a second `server.js`
-# for anything that goes looking. It is a copy; the real parked tree is
-# `$PROJECT_DIR/.next-old` and is not touched here.
-for swept in "$STANDALONE"/.next-old*; do
-  [ -e "$swept" ] || continue
-  echo "postbuild: removing $swept — a parked previous build was traced into the standalone output" >&2
-  rm -rf "$swept"
-done
 
 # Where the entry is, asked of Next rather than guessed at.
 #
@@ -73,7 +68,7 @@ done
 # `path.relative(outputFileTracingRoot, dir)`
 # (next/dist/build/index.js:1107) — the exact segment `copyTracedFiles` joins
 # under `.next/standalone` when it writes the entry
-# (next/dist/build/utils.js:990). It is "" for this repo, because
+# (next/dist/build/utils.js:1107). It is "" for this repo, because
 # `outputFileTracingRoot` is unset and therefore the project directory; it is
 # the app's path below the tracing root for the nested layout Next produces
 # when that root is a parent (a monorepo). Either way Next has already
@@ -117,6 +112,21 @@ SDIR="$(dirname "$SRVJS")"
 # tree's own `.next`. If it is not there, $SDIR is not a standalone root and
 # copying into it would write a build nothing can serve.
 [ -d "$SDIR/.next" ] || fail "$SRVJS is not a standalone entry — $SDIR/.next does not exist"
+
+# A parked previous build swept in by the trace is a second, complete build
+# inside this one — hundreds of MB on an eMMC, and a second `server.js` for
+# anything that goes looking. It is a copy; the real parked tree is
+# `$PROJECT_DIR/.next-old` and is not touched here.
+#
+# After the entry is chosen, not before: the search above must be able to
+# refuse a parked entry on its own (that is what its `-prune` is for), and in
+# the nested layout the copy lands beside the entry rather than at the top of
+# the standalone tree, so both places are swept.
+for swept in "$STANDALONE"/.next-old* "$SDIR"/.next-old*; do
+  [ -e "$swept" ] || continue
+  echo "postbuild: removing $swept — a parked previous build was traced into the standalone output" >&2
+  rm -rf "$swept"
+done
 
 # data/ first, before the copies, because this is the one removal whose failure
 # has to be reported by name: it holds the owner's live state and 0600 secrets

--- a/src/tests/unit/install-rebuild-build-verify.test.ts
+++ b/src/tests/unit/install-rebuild-build-verify.test.ts
@@ -22,10 +22,12 @@ import path from "node:path";
  *  2. It read `bun run build`'s exit status as the verdict and nothing else.
  *     `bun run build` is `next build` PLUS the `postbuild` lifecycle script,
  *     and postbuild is what makes a build servable — BUILD_ID is written
- *     before any of it, and postbuild's own `if [ -n "$SRVJS" ]` guard exits 0
- *     having copied nothing. So a "successful" build can still leave
+ *     before any of it. So a "successful" build can still leave
  *     production-server.js crash-looping on
- *     `require("./.next/standalone/server.js")`.
+ *     `require("./.next/standalone/server.js")`. (postbuild itself exited 0
+ *     over copies that had not happened until TASK-725; it fails now, and
+ *     scripts/postbuild.sh has that suite. The check here is the one that also
+ *     answers whether the build came from the checked-out commit.)
  *
  * The memory half of the same incident — the build being OOM-killed with
  * ollama, Kokoro and llama.cpp resident — was fixed on beta by

--- a/src/tests/unit/install-rebuild-build-verify.test.ts
+++ b/src/tests/unit/install-rebuild-build-verify.test.ts
@@ -175,7 +175,14 @@ function run(scenario: Scenario = {}): Run {
 
   mkdirSync(projectDir, { recursive: true });
   if (previousBuild === "servable") writeBuild(path.join(projectDir, ".next"), "old-build-id");
-  if (parkedBuild === "servable") writeBuild(path.join(projectDir, ".next-old"), "parked-build-id");
+  if (parkedBuild === "servable") {
+    writeBuild(path.join(projectDir, ".next-old"), "parked-build-id");
+    // With the stamp the earlier, killed run left on it. Without this the
+    // `rm -f "$build_dir/.rebuild-pid"` promote_parked_build performs has
+    // nothing to strip, and the case asserting it does would pass with that
+    // line deleted.
+    writeFileSync(path.join(projectDir, ".next-old", ".rebuild-pid"), "999999 stale-boot\n", "utf-8");
+  }
   if (parkedBuild === "nested-entry") {
     const kept = path.join(projectDir, ".next-old");
     writeBuild(kept, "parked-build-id", false);
@@ -463,9 +470,23 @@ describe("do_rebuild keeps the box serving when the build fails", () => {
     const r = run({ build: "oom-killed", startWorks: false });
 
     expect(r.status).not.toBe(0);
-    expect(r.systemctl.some((l) => /^systemctl start clawbox-setup/.test(l))).toBe(true);
+    expect(r.systemctl.some((l) => /^systemctl restart clawbox-setup/.test(l))).toBe(true);
     expect(r.stderr).toMatch(/it is DOWN/);
     expect(r.stderr).not.toMatch(/answers on :80/);
+  });
+
+  it("restarts clawbox-setup rather than starting it, so a latched unit is replaced", () => {
+    // `start` on an already-active unit is a no-op, and the unit CAN be active
+    // here: clawbox-gateway.service's `Wants=clawbox-setup.service` pulls it
+    // back up mid-rebuild, and its own `Restart=always` latches it onto
+    // whatever tree exists once `next build` writes the standalone entry. A
+    // `start` would then leave the box serving the build that just failed
+    // verification while this function reported a rollback.
+    const r = run({ build: "succeeds", identity: "drift" });
+
+    expect(r.status).not.toBe(0);
+    expect(r.systemctl.some((l) => l === "systemctl restart clawbox-setup.service")).toBe(true);
+    expect(r.systemctl.some((l) => l === "systemctl start clawbox-setup.service")).toBe(false);
   });
 
   it("says the dashboard answers when the restore really comes up", () => {
@@ -598,9 +619,15 @@ describe("do_rebuild says who owns the build it parks", () => {
   it("leaves no owner behind on the build it promotes", () => {
     // Same rename, the other direction: promote_parked_build claims a tree an
     // earlier killed run left behind, and that tree carries that run's stamp.
-    const r = run({ previousBuild: "none", parkedBuild: "servable", build: "succeeds" });
+    //
+    // `bunInstall: "fails"` so the run ENDS on the promoted tree — it aborts
+    // before the park, so nothing writes a fresh stamp and nothing deletes
+    // `.next-old` afterwards. With a successful build both of those would make
+    // the assertion true no matter what promote did.
+    const r = run({ previousBuild: "none", parkedBuild: "servable", bunInstall: "fails" });
 
-    expect(r.status).toBe(0);
+    expect(r.status).not.toBe(0);
+    expect(r.buildId).toBe("parked-build-id");
     expect(r.ownerLeftBehind).toBe(false);
   });
 

--- a/src/tests/unit/install-rebuild-build-verify.test.ts
+++ b/src/tests/unit/install-rebuild-build-verify.test.ts
@@ -586,7 +586,13 @@ describe("step_build asks the same two questions", () => {
   });
 });
 
-describe("do_rebuild says who owns the build it parks", () => {
+// Linux only, and deliberately not made portable: what these cases pin is that
+// the stamp names a process the reader can still PROVE is alive, and the proof
+// is `/proc/sys/kernel/random/boot_id` plus field 22 of `/proc/<pid>/stat` —
+// the two facts production-server.js reads. On a platform with no procfs the
+// probe can only answer "stale", so the suite would fail over the machine it
+// ran on rather than over install.sh. The device and CI are both Linux.
+describe.skipIf(process.platform !== "linux")("do_rebuild says who owns the build it parks", () => {
   /**
    * The park is not a quiet moment. `set_previous_build_aside` renames `.next`
    * to `.next-old` and only then runs `bun run build`, so for the whole length

--- a/src/tests/unit/install-rebuild-build-verify.test.ts
+++ b/src/tests/unit/install-rebuild-build-verify.test.ts
@@ -220,9 +220,12 @@ function run(scenario: Scenario = {}): Run {
   const probeOwner = [
     'OWNER_FILE="$1/.next-old/.rebuild-pid"',
     'if [ -f "$OWNER_FILE" ]; then',
-    '  read -r OWNER_PID OWNER_BOOT < "$OWNER_FILE"',
+    // The same three questions production-server.js asks, in the same order.
+    '  read -r OWNER_PID OWNER_BOOT OWNER_START REST < "$OWNER_FILE"',
     '  THIS_BOOT=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null)',
-    '  if [ -n "$OWNER_BOOT" ] && [ "$OWNER_BOOT" = "$THIS_BOOT" ] && kill -0 "$OWNER_PID" 2>/dev/null; then',
+    '  LIVE_START=$(sed -e "s/^.*) //" "/proc/$OWNER_PID/stat" 2>/dev/null | awk "{print \\$20}")',
+    '  if [ -z "$REST" ] && [ -n "$OWNER_BOOT" ] && [ "$OWNER_BOOT" = "$THIS_BOOT" ] \\',
+    '     && [ -n "$OWNER_START" ] && [ "$OWNER_START" = "$LIVE_START" ]; then',
     '    printf "live %s\\n" "$OWNER_PID" > ' + JSON.stringify(ownerProbe),
     "  else",
     '    printf "stale %s\\n" "$OWNER_PID" > ' + JSON.stringify(ownerProbe),

--- a/src/tests/unit/install-rebuild-build-verify.test.ts
+++ b/src/tests/unit/install-rebuild-build-verify.test.ts
@@ -135,11 +135,23 @@ interface Run {
   buildId: string | null;
   hasEntry: boolean;
   parked: boolean;
+  /**
+   * What the parked tree said about its owner WHILE `bun run build` ran —
+   * "live <pid>", "stale <pid>" or "none". The reclaim in production-server.js
+   * has nothing else to go on: from the park until the standalone entry is
+   * written there is no `.next/standalone/server.js`, which is the only thing
+   * it looks at, and clawbox-setup is pulled back up inside that window by
+   * `clawbox-gateway.service`'s `Wants=`.
+   */
+  buildSawOwner: string;
+  /** Did a stamp survive into the tree the box is left serving? */
+  ownerLeftBehind: boolean;
 }
 
 let sandbox: string;
 let systemctlLog: string;
 let projectDir: string;
+let ownerProbe: string;
 
 function writeBuild(dir: string, buildId: string, withEntry = true): void {
   mkdirSync(path.join(dir, "standalone"), { recursive: true });
@@ -195,7 +207,24 @@ function run(scenario: Scenario = {}): Run {
     "exits-zero-without-output": "exit 0",
     "no-standalone-entry": 'mkdir -p "$1/.next" && printf "new-build-id\\n" > "$1/.next/BUILD_ID" && exit 0',
   };
-  writeFileSync(fakeBuild, "#!/usr/bin/env bash\n" + bodies[build] + "\n", "utf-8");
+  // Sampled from inside the build, because that is the only moment the
+  // question matters: the reclaim fires on a box whose `bun run build` is
+  // still running.
+  const probeOwner = [
+    'OWNER_FILE="$1/.next-old/.rebuild-pid"',
+    'if [ -f "$OWNER_FILE" ]; then',
+    '  read -r OWNER_PID OWNER_BOOT < "$OWNER_FILE"',
+    '  THIS_BOOT=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null)',
+    '  if [ -n "$OWNER_BOOT" ] && [ "$OWNER_BOOT" = "$THIS_BOOT" ] && kill -0 "$OWNER_PID" 2>/dev/null; then',
+    '    printf "live %s\\n" "$OWNER_PID" > ' + JSON.stringify(ownerProbe),
+    "  else",
+    '    printf "stale %s\\n" "$OWNER_PID" > ' + JSON.stringify(ownerProbe),
+    "  fi",
+    "else",
+    '  printf "none\\n" > ' + JSON.stringify(ownerProbe),
+    "fi",
+  ].join("\n");
+  writeFileSync(fakeBuild, "#!/usr/bin/env bash\n" + probeOwner + "\n" + bodies[build] + "\n", "utf-8");
   spawnSync("chmod", ["+x", fakeBuild]);
 
   const lines = [
@@ -310,6 +339,8 @@ function run(scenario: Scenario = {}): Run {
     buildId: existsSync(buildIdPath) ? readFileSync(buildIdPath, "utf-8").trim() : null,
     hasEntry: existsSync(path.join(projectDir, ".next", "standalone", "server.js")),
     parked: existsSync(path.join(projectDir, ".next-old")),
+    buildSawOwner: existsSync(ownerProbe) ? readFileSync(ownerProbe, "utf-8").trim() : "not-run",
+    ownerLeftBehind: existsSync(path.join(projectDir, ".next", ".rebuild-pid")),
   };
 }
 
@@ -317,6 +348,7 @@ beforeEach(() => {
   sandbox = mkdtempSync(path.join(tmpdir(), "clawbox-rebuild-"));
   systemctlLog = path.join(sandbox, "systemctl.log");
   projectDir = path.join(sandbox, "clawbox");
+  ownerProbe = path.join(sandbox, "parked-owner.txt");
 });
 
 afterEach(() => {
@@ -525,5 +557,69 @@ describe("step_build asks the same two questions", () => {
     const r = run({ entry: "step_build", build: "oom-killed", previousBuild: "none", parkedBuild: "servable" });
     expect(r.status).not.toBe(0);
     expect(r.buildId).toBe("parked-build-id");
+  });
+});
+
+describe("do_rebuild says who owns the build it parks", () => {
+  /**
+   * The park is not a quiet moment. `set_previous_build_aside` renames `.next`
+   * to `.next-old` and only then runs `bun run build`, so for the whole length
+   * of the build there is no `.next/standalone/server.js` and there is a parked
+   * one — the exact condition production-server.js's boot-time reclaim fires
+   * on. And clawbox-setup comes back up inside that window as a matter of
+   * routine: `config/clawbox-gateway.service` carries
+   * `Wants=clawbox-setup.service`, so every gateway (re)start starts the
+   * service `do_rebuild` had just stopped (e2e-install run 33971129750: four
+   * seconds after the stop, while `bun install` was still running).
+   *
+   * Nothing in the tree said "a rebuild is in flight", so the reclaim could not
+   * tell that state from the one it exists for — a rebuild whose shell was
+   * KILLED. The parked tree carries the rebuilding shell's PID instead, and
+   * liveness is what separates the two.
+   */
+  it("stamps the parked build with the rebuilding shell while the build runs", () => {
+    const r = run({ build: "succeeds" });
+
+    expect(r.status).toBe(0);
+    expect(r.buildSawOwner).toMatch(/^live \d+$/);
+  });
+
+  it("leaves no owner behind on the build it restores after a failure", () => {
+    // The restore renames the parked tree back over `.next`. A stamp riding
+    // along would sit inside the build the box serves, naming a process that
+    // is about to exit.
+    const r = run({ build: "oom-killed" });
+
+    expect(r.status).not.toBe(0);
+    expect(r.buildId).toBe("old-build-id");
+    expect(r.ownerLeftBehind).toBe(false);
+  });
+
+  it("leaves no owner behind on the build it promotes", () => {
+    // Same rename, the other direction: promote_parked_build claims a tree an
+    // earlier killed run left behind, and that tree carries that run's stamp.
+    const r = run({ previousBuild: "none", parkedBuild: "servable", build: "succeeds" });
+
+    expect(r.status).toBe(0);
+    expect(r.ownerLeftBehind).toBe(false);
+  });
+
+  it("writes the stamp production-server.js reads", () => {
+    // Two files, one filename, and no compiler between them. A rename on either
+    // side puts the race back silently: the reclaim would find no stamp, call
+    // every running rebuild a dead one, and fire mid-build again.
+    const stamp = /\.rebuild-pid/;
+    expect(shellFunction("set_previous_build_aside")).toMatch(stamp);
+    expect(readFileSync(path.join(REPO, "production-server.js"), "utf-8")).toMatch(stamp);
+  });
+
+  it("stamps nothing when the disk could not hold two builds", () => {
+    // The no-fallback branch deletes the serving build rather than parking it.
+    // There is no parked tree to own, and no reclaim can fire — a stamp here
+    // would be a claim about a directory that does not exist.
+    const r = run({ build: "succeeds", diskHeadroom: "tight" });
+
+    expect(r.status).toBe(0);
+    expect(r.buildSawOwner).toBe("none");
   });
 });

--- a/src/tests/unit/postbuild-standalone-data.test.ts
+++ b/src/tests/unit/postbuild-standalone-data.test.ts
@@ -52,10 +52,14 @@ let standalone: string;
 /** A standalone tree shaped like the one `next build` leaves behind. */
 function buildFixture() {
   fs.mkdirSync(path.join(tmp, "scripts"), { recursive: true });
-  fs.copyFileSync(
-    path.join(REPO, "scripts", "write-build-info.mjs"),
-    path.join(tmp, "scripts", "write-build-info.mjs"),
-  );
+  // Whatever package.json's postbuild actually invokes has to be in the
+  // fixture: write-build-info.mjs, and the step's own script. Copied, not
+  // linked, so the fixture is self-contained.
+  for (const script of ["write-build-info.mjs", "postbuild.sh"]) {
+    const dest = path.join(tmp, "scripts", script);
+    fs.copyFileSync(path.join(REPO, "scripts", script), dest);
+    fs.chmodSync(dest, 0o755);
+  }
   fs.writeFileSync(path.join(tmp, "package.json"), JSON.stringify({ version: "0.0.0-test" }));
 
   fs.mkdirSync(path.join(tmp, "public"), { recursive: true });

--- a/src/tests/unit/postbuild-standalone-entry.test.ts
+++ b/src/tests/unit/postbuild-standalone-entry.test.ts
@@ -127,14 +127,14 @@ function stubFindReturning(rel: string) {
   fs.chmodSync(stub, 0o755);
 }
 
-function runPostbuild() {
+function runPostbuild(env: Record<string, string> = {}) {
   return spawnSync("sh", ["-c", POSTBUILD], {
     cwd: tmp,
     encoding: "utf-8",
     // write-build-info.mjs resolves its project dir from CLAWBOX_ROOT first,
     // and the suite sets that globally to a shared temp path — point it at the
     // fixture so the stamp lands where the postbuild step looks for it.
-    env: { ...process.env, CLAWBOX_ROOT: tmp, PATH: `${stubBin}:${process.env.PATH ?? ""}` },
+    env: { ...process.env, CLAWBOX_ROOT: tmp, PATH: `${stubBin}:${process.env.PATH ?? ""}`, ...env },
   });
 }
 
@@ -192,6 +192,24 @@ d("postbuild entry selection", () => {
     expect(fs.existsSync(path.join(nested, ".next", "build-info.json"))).toBe(true);
     expect(fs.realpathSync(path.join(standalone, "server.js")))
       .toBe(fs.realpathSync(path.join(nested, "server.js")));
+  });
+
+  it("stamps the build it is building, whatever CLAWBOX_ROOT says", () => {
+    // write-build-info.mjs resolves its project dir from CLAWBOX_ROOT and this
+    // step copies `.next/build-info.json` out of the build directory. A shell
+    // that exports CLAWBOX_ROOT at some other path — a dev box, a test runner —
+    // used to send the stamp somewhere else and leave the copy to print a
+    // warning; under `set -e` that would be a build that cannot complete, and
+    // playwright.config.ts's webServer starts with `bun run build`.
+    const elsewhere = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-elsewhere-"));
+    try {
+      const res = runPostbuild({ CLAWBOX_ROOT: elsewhere });
+      expect(res.status, res.stderr).toBe(0);
+      expect(fs.existsSync(path.join(standalone, ".next", "build-info.json"))).toBe(true);
+      expect(fs.existsSync(path.join(elsewhere, ".next"))).toBe(false);
+    } finally {
+      fs.rmSync(elsewhere, { recursive: true, force: true });
+    }
   });
 
   it("removes a parked build that the file trace swept into the standalone output", () => {

--- a/src/tests/unit/postbuild-standalone-entry.test.ts
+++ b/src/tests/unit/postbuild-standalone-entry.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { spawnSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+/**
+ * TASK-725 — the postbuild step must stamp the build `next build` just wrote,
+ * and must fail when it cannot.
+ *
+ * During an in-app update the project root holds two builds: the new one under
+ * `.next`, and the previous one parked at `.next-old` by
+ * `set_previous_build_aside` so an OOM-killed rebuild cannot leave the box with
+ * no build at all. Next's file tracing copies the parked one INTO the new
+ * standalone tree — `src/instrumentation-node.ts` resolves
+ * `path.join(CONFIG_ROOT, 'scripts', 'terminal-server.mjs')` and CONFIG_ROOT
+ * comes from the environment, so @vercel/nft cannot resolve it and emits the
+ * whole project directory as an asset directory. Reproduced on Next 16.3.3:
+ * with a build parked beside it, `.next/server/instrumentation.js.nft.json`
+ * lists 6186 files, 4202 of them `../../.next-old/**`.
+ *
+ * So `.next/standalone` contains a SECOND `server.js`, three levels down at
+ * `.next/standalone/.next-old/standalone/server.js`, and the old lookup —
+ * `find … -maxdepth 3 -name node_modules -prune -o -name server.js -print -quit`
+ * — took whichever readdir handed back first. In e2e-install runs 33971129750,
+ * 33974951149 and 33977666658 (2026-09-05) that was the parked one:
+ *
+ *     cp: cannot create directory '.next/standalone/.next-old/standalone/.next/static': No such file or directory
+ *     cp: cannot create regular file '.next/standalone/.next-old/standalone/.next/build-info.json': No such file or directory
+ *     cp: cannot create directory '.next/standalone/.next-old/standalone/node_modules/playwright': No such file or directory
+ *     cp: cannot create directory '.next/standalone/.next-old/standalone/node_modules/playwright-core': No such file or directory
+ *     BUILD IDENTITY: FAIL — .next/standalone/.next holds a deployed build but no build-info.json — the postbuild step did not copy the stamp
+ *
+ * Four failed copies, exit 0, and the step's last clause then replaced the real
+ * `.next/standalone/server.js` with a symlink to the PARKED entry — the update
+ * would have come back on the build it was replacing. Only
+ * `verify-build-identity.sh` noticed, two lines later, and the rebuild was
+ * rolled back.
+ *
+ * These run the REAL postbuild step out of package.json against a temp tree, so
+ * they cannot drift from what ships.
+ */
+
+// Starts a real process (bash / node): vitest's 5 s test and 10 s hook defaults
+// are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+const REPO = path.resolve(__dirname, "../../..");
+const POSTBUILD: string = JSON.parse(
+  fs.readFileSync(path.join(REPO, "package.json"), "utf-8"),
+).scripts.postbuild;
+
+const CAN_RUN =
+  process.platform !== "win32"
+  && spawnSync("sh", ["-c", "true"], { stdio: "ignore" }).status === 0;
+const d = CAN_RUN ? describe : describe.skip;
+
+let tmp: string;
+let standalone: string;
+let stubBin: string;
+
+const PARKED_ENTRY = path.join(".next", "standalone", ".next-old", "standalone", "server.js");
+
+/** The project tree `next build` leaves behind, before postbuild runs. */
+function buildFixture() {
+  fs.mkdirSync(path.join(tmp, "scripts"), { recursive: true });
+  // Whatever package.json's postbuild actually invokes has to be in the
+  // fixture: write-build-info.mjs on every head, and the step's own script
+  // where it is one. Copied, not linked, so the fixture is self-contained.
+  for (const script of ["write-build-info.mjs", "postbuild.sh"]) {
+    const src = path.join(REPO, "scripts", script);
+    if (!fs.existsSync(src)) continue;
+    const dest = path.join(tmp, "scripts", script);
+    fs.copyFileSync(src, dest);
+    fs.chmodSync(dest, 0o755);
+  }
+  fs.writeFileSync(path.join(tmp, "package.json"), JSON.stringify({ version: "0.0.0-test" }));
+
+  fs.mkdirSync(path.join(tmp, "public"), { recursive: true });
+  fs.writeFileSync(path.join(tmp, "public", "marker.txt"), "public asset\n");
+  fs.mkdirSync(path.join(tmp, ".next", "static"), { recursive: true });
+  fs.writeFileSync(path.join(tmp, ".next", "static", "chunk.js"), "// chunk\n");
+  fs.writeFileSync(path.join(tmp, ".next", "BUILD_ID"), "new-build-id\n");
+
+  standalone = path.join(tmp, ".next", "standalone");
+  fs.mkdirSync(path.join(standalone, ".next"), { recursive: true });
+  fs.writeFileSync(path.join(standalone, ".next", "BUILD_ID"), "new-build-id\n");
+  fs.writeFileSync(path.join(standalone, "server.js"), "// standalone server\n");
+
+  // `find -maxdepth 3 -name server.js` reaches package-root server.js files
+  // under node_modules (next/ and react-dom/ both have one), which is what the
+  // `-name node_modules -prune` in the lookup has always been for.
+  for (const pkg of ["next", "react-dom"]) {
+    fs.mkdirSync(path.join(standalone, "node_modules", pkg), { recursive: true });
+    fs.writeFileSync(path.join(standalone, "node_modules", pkg, "server.js"), "// decoy\n");
+  }
+}
+
+/**
+ * The parked previous build, as the trace copies it in.
+ *
+ * Deliberately without a `.next` beside the nested entry: that is the shape the
+ * three CI runs had, and it is why all four copies failed there with
+ * "No such file or directory" instead of silently landing in the wrong tree.
+ */
+function sweepParkedBuildIn() {
+  const parked = path.join(tmp, PARKED_ENTRY);
+  fs.mkdirSync(path.dirname(parked), { recursive: true });
+  fs.writeFileSync(parked, "// the PREVIOUS build's entry\n");
+}
+
+/**
+ * A `find` that hands back the parked copy first.
+ *
+ * readdir order is a property of the filesystem, not of the fixture, so
+ * staging two candidates and hoping proves nothing on someone else's disk.
+ * This stub pins the one order that matters — the one three CI runs actually
+ * got — and the step is asked what it does with it. A lookup that consults
+ * `find` at all is handed the parked entry; a lookup that takes the entry
+ * `next build` wrote never runs it.
+ */
+function stubFindReturning(rel: string) {
+  fs.mkdirSync(stubBin, { recursive: true });
+  const stub = path.join(stubBin, "find");
+  fs.writeFileSync(stub, `#!/usr/bin/env bash\nprintf '%s\\n' ${JSON.stringify(rel)}\n`);
+  fs.chmodSync(stub, 0o755);
+}
+
+function runPostbuild() {
+  return spawnSync("sh", ["-c", POSTBUILD], {
+    cwd: tmp,
+    encoding: "utf-8",
+    // write-build-info.mjs resolves its project dir from CLAWBOX_ROOT first,
+    // and the suite sets that globally to a shared temp path — point it at the
+    // fixture so the stamp lands where the postbuild step looks for it.
+    env: { ...process.env, CLAWBOX_ROOT: tmp, PATH: `${stubBin}:${process.env.PATH ?? ""}` },
+  });
+}
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-postbuild-entry-"));
+  stubBin = path.join(tmp, "stub-bin");
+  fs.mkdirSync(stubBin, { recursive: true });
+  buildFixture();
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+d("postbuild entry selection", () => {
+  it("stamps the entry next build wrote, not the parked build the lookup offers first", () => {
+    sweepParkedBuildIn();
+    stubFindReturning(PARKED_ENTRY);
+
+    const res = runPostbuild();
+    expect(res.status, res.stderr).toBe(0);
+
+    // The stamp and the assets, in the tree the service actually loads. This is
+    // the exact post-condition scripts/verify-build-identity.sh checks, and the
+    // one the three CI runs failed.
+    expect(fs.existsSync(path.join(standalone, ".next", "build-info.json"))).toBe(true);
+    expect(fs.existsSync(path.join(standalone, ".next", "static", "chunk.js"))).toBe(true);
+    expect(fs.existsSync(path.join(standalone, "public", "marker.txt"))).toBe(true);
+
+    // And the entry is still the file, not a symlink into the parked copy.
+    expect(fs.lstatSync(path.join(standalone, "server.js")).isSymbolicLink()).toBe(false);
+    expect(fs.readFileSync(path.join(standalone, "server.js"), "utf-8"))
+      .toContain("standalone server");
+  });
+
+  it("removes a parked build that the file trace swept into the standalone output", () => {
+    sweepParkedBuildIn();
+
+    const res = runPostbuild();
+    expect(res.status, res.stderr).toBe(0);
+    // A second complete build inside the one that ships: hundreds of MB on an
+    // eMMC, and a second server.js for anything that goes looking.
+    expect(fs.existsSync(path.join(standalone, ".next-old"))).toBe(false);
+    // The real parked tree is `$PROJECT_DIR/.next-old` and is none of this
+    // step's business — only the copy inside the standalone output is.
+    expect(fs.existsSync(path.join(standalone, ".next", "build-info.json"))).toBe(true);
+  });
+
+  it("fails the build when a copy into the standalone tree fails", () => {
+    // The failure the three runs had, reduced to one copy: a source that is not
+    // there. Four of these failed in run 33971129750 and the step still exited
+    // 0, so the only thing that noticed was verify-build-identity.sh.
+    fs.rmSync(path.join(tmp, "public"), { recursive: true });
+
+    const res = runPostbuild();
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("public");
+  });
+
+  it("fails the build when there is no standalone entry to assemble around", () => {
+    // `next build` exiting 0 with no standalone entry is a real outcome (an
+    // OOM-killed write, a half-run trace copy). The step used to exit 0 having
+    // copied nothing, which is what let install.sh's do_rebuild call such a
+    // build successful until verify_build_present was added.
+    fs.rmSync(path.join(standalone, "server.js"));
+
+    const res = runPostbuild();
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("server.js");
+  });
+
+  it("takes the nested entry, never one inside a parked tree, in the nested layout", () => {
+    // Next nests the standalone tree under <standalone>/<path from the tracing
+    // root to the app> when outputFileTracingRoot is a parent directory. The
+    // search is what supports that shape; with a parked build swept in beside
+    // it, the pruned search has exactly one candidate whatever readdir does.
+    fs.rmSync(path.join(standalone, "server.js"));
+    const nested = path.join(standalone, "app");
+    fs.mkdirSync(path.join(nested, ".next"), { recursive: true });
+    fs.writeFileSync(path.join(nested, "server.js"), "// nested standalone server\n");
+    sweepParkedBuildIn();
+
+    const res = runPostbuild();
+    expect(res.status, res.stderr).toBe(0);
+    expect(fs.existsSync(path.join(nested, ".next", "build-info.json"))).toBe(true);
+    expect(fs.lstatSync(path.join(standalone, "server.js")).isSymbolicLink()).toBe(true);
+    expect(fs.realpathSync(path.join(standalone, "server.js")))
+      .toBe(fs.realpathSync(path.join(nested, "server.js")));
+  });
+});

--- a/src/tests/unit/postbuild-standalone-entry.test.ts
+++ b/src/tests/unit/postbuild-standalone-entry.test.ts
@@ -170,6 +170,30 @@ d("postbuild entry selection", () => {
       .toContain("standalone server");
   });
 
+  it("takes the entry from the path Next recorded for it", () => {
+    // `relativeAppDir` in .next/required-server-files.json is
+    // path.relative(outputFileTracingRoot, dir) — the same segment
+    // copyTracedFiles joins under .next/standalone. Nesting the tree and
+    // stating it in the manifest is the whole of Next's contract here, so the
+    // parked decoy and a `find` that offers it first must change nothing.
+    fs.rmSync(path.join(standalone, "server.js"));
+    const nested = path.join(standalone, "app");
+    fs.mkdirSync(path.join(nested, ".next"), { recursive: true });
+    fs.writeFileSync(path.join(nested, "server.js"), "// nested standalone server\n");
+    fs.writeFileSync(
+      path.join(tmp, ".next", "required-server-files.json"),
+      JSON.stringify({ version: 1, relativeAppDir: "app" }),
+    );
+    sweepParkedBuildIn();
+    stubFindReturning(PARKED_ENTRY);
+
+    const res = runPostbuild();
+    expect(res.status, res.stderr).toBe(0);
+    expect(fs.existsSync(path.join(nested, ".next", "build-info.json"))).toBe(true);
+    expect(fs.realpathSync(path.join(standalone, "server.js")))
+      .toBe(fs.realpathSync(path.join(nested, "server.js")));
+  });
+
   it("removes a parked build that the file trace swept into the standalone output", () => {
     sweepParkedBuildIn();
 

--- a/src/tests/unit/production-server-parked-build.test.ts
+++ b/src/tests/unit/production-server-parked-build.test.ts
@@ -264,6 +264,38 @@ describe("production-server.js reclaims a parked build at boot", () => {
     expect(existsSync(path.join(projectDir, ".next-old"))).toBe(false);
   });
 
+  it("refuses for a live owner this process may not signal", () => {
+    // The branch that actually runs on a device: do_rebuild is root and this
+    // server is `clawbox`, so `process.kill(pid, 0)` answers EPERM rather than
+    // succeeding, and EPERM means alive. pid 1 stands in for it — owned by
+    // root, always running. (A suite run AS root takes the success branch
+    // instead and asserts the same outcome, which is why there is no skip.)
+    const kept = path.join(projectDir, ".next-old");
+    writeBuild(kept, "parked-build-id");
+    writeFileSync(path.join(kept, OWNER_STAMP), ownerStamp(1), "utf-8");
+
+    const r = runReclaim(projectDir);
+
+    expect(r.threw).toBeNull();
+    expect(existsSync(path.join(kept, "standalone", "server.js"))).toBe(true);
+    expect(r.warnings.join(" ")).toMatch(/rebuild is in progress/);
+  });
+
+  it("reclaims, and says so, when the stamp cannot be read as an owner", () => {
+    // A stamp that is there but proves nothing — truncated, garbled, written by
+    // a shell that could not read the boot id. Reclaiming is right, but a guard
+    // that is silently inoperative must not look like one that never fired.
+    const kept = path.join(projectDir, ".next-old");
+    writeBuild(kept, "parked-build-id");
+    writeFileSync(path.join(kept, OWNER_STAMP), `not-a-pid ${bootId()}\n`, "utf-8");
+
+    const r = runReclaim(projectDir);
+
+    expect(r.threw).toBeNull();
+    expect(buildId(projectDir)).toBe("parked-build-id");
+    expect(r.warnings.join(" ")).toMatch(/names no live rebuild/);
+  });
+
   it("reclaims a parked build that carries no stamp at all", () => {
     // Every build parked before this stamp existed, and every one parked by a
     // shell that could not write it, has none. Absent must mean "nobody is
@@ -274,5 +306,7 @@ describe("production-server.js reclaims a parked build at boot", () => {
 
     expect(r.threw).toBeNull();
     expect(buildId(projectDir)).toBe("parked-build-id");
+    // …and nothing is said about a stamp that was never there.
+    expect(r.warnings.join(" ")).not.toMatch(/names no live rebuild/);
   });
 });

--- a/src/tests/unit/production-server-parked-build.test.ts
+++ b/src/tests/unit/production-server-parked-build.test.ts
@@ -38,8 +38,26 @@ function bootId(): string {
   return id;
 }
 
+/**
+ * Field 22 of /proc/<pid>/stat — the process's start time. Read the same way
+ * the shipped block reads it: from after the LAST ") ", because field 2 is the
+ * command and may contain spaces and parens of its own.
+ */
+function startTimeOf(pid: number): string {
+  let stat: string;
+  try {
+    stat = readFileSync(`/proc/${pid}/stat`, "utf-8").trim();
+  } catch {
+    return "";
+  }
+  const cut = stat.lastIndexOf(") ");
+  return cut < 0 ? "" : stat.slice(cut + 2).split(" ")[19] ?? "";
+}
+
 /** What install.sh's set_previous_build_aside writes into the tree it parks. */
-const ownerStamp = (pid: number): string => `${pid} ${bootId()}\n`;
+function ownerStamp(pid: number, startTime = startTimeOf(pid) || "1"): string {
+  return `${pid} ${bootId()} ${startTime}\n`;
+}
 const START = "// A build parked by an update that was killed OUTRIGHT";
 const END = 'require("./.next/standalone/server.js");';
 
@@ -253,7 +271,7 @@ describe("production-server.js reclaims a parked build at boot", () => {
     writeBuild(kept, "parked-build-id");
     writeFileSync(
       path.join(kept, OWNER_STAMP),
-      `${process.pid} 00000000-0000-4000-8000-000000000000\n`,
+      `${process.pid} 00000000-0000-4000-8000-000000000000 ${startTimeOf(process.pid)}\n`,
       "utf-8",
     );
 
@@ -264,12 +282,11 @@ describe("production-server.js reclaims a parked build at boot", () => {
     expect(existsSync(path.join(projectDir, ".next-old"))).toBe(false);
   });
 
-  it("refuses for a live owner this process may not signal", () => {
-    // The branch that actually runs on a device: do_rebuild is root and this
-    // server is `clawbox`, so `process.kill(pid, 0)` answers EPERM rather than
-    // succeeding, and EPERM means alive. pid 1 stands in for it — owned by
-    // root, always running. (A suite run AS root takes the success branch
-    // instead and asserts the same outcome, which is why there is no skip.)
+  it("refuses for a live owner this process does not own", () => {
+    // The shape that actually runs on a device: do_rebuild is root and this
+    // server is `clawbox`, so the owner is another user's process. pid 1 stands
+    // in for it — root-owned, always running, and its /proc entry readable by
+    // anyone, which is why the check reads /proc rather than sending a signal.
     const kept = path.join(projectDir, ".next-old");
     writeBuild(kept, "parked-build-id");
     writeFileSync(path.join(kept, OWNER_STAMP), ownerStamp(1), "utf-8");
@@ -281,13 +298,33 @@ describe("production-server.js reclaims a parked build at boot", () => {
     expect(r.warnings.join(" ")).toMatch(/rebuild is in progress/);
   });
 
+  it("reclaims when the stamped PID has been handed to another process", () => {
+    // The reuse case, which a PID and a boot id alone cannot see: the rebuild
+    // died, its number was allocated again, and `kill(pid, 0)` would answer
+    // "alive" about a stranger — holding the reclaim off for as long as that
+    // process lives, on a box whose only build is the parked one. The start
+    // time is what tells the two apart, so here it is a live PID from this boot
+    // whose process started at a different moment.
+    const kept = path.join(projectDir, ".next-old");
+    writeBuild(kept, "parked-build-id");
+    const wrongStart = String(Number(startTimeOf(process.pid) || "1") + 1);
+    writeFileSync(path.join(kept, OWNER_STAMP), ownerStamp(process.pid, wrongStart), "utf-8");
+
+    const r = runReclaim(projectDir);
+
+    expect(r.threw).toBeNull();
+    expect(buildId(projectDir)).toBe("parked-build-id");
+    expect(existsSync(path.join(projectDir, ".next-old"))).toBe(false);
+    expect(r.warnings.join(" ")).toMatch(/names no live rebuild/);
+  });
+
   it("reclaims, and says so, when the stamp cannot be read as an owner", () => {
     // A stamp that is there but proves nothing — truncated, garbled, written by
     // a shell that could not read the boot id. Reclaiming is right, but a guard
     // that is silently inoperative must not look like one that never fired.
     const kept = path.join(projectDir, ".next-old");
     writeBuild(kept, "parked-build-id");
-    writeFileSync(path.join(kept, OWNER_STAMP), `not-a-pid ${bootId()}\n`, "utf-8");
+    writeFileSync(path.join(kept, OWNER_STAMP), `not-a-pid ${bootId()} 1\n`, "utf-8");
 
     const r = runReclaim(projectDir);
 
@@ -297,8 +334,9 @@ describe("production-server.js reclaims a parked build at boot", () => {
   });
 
   it.each([
-    ["a pid with trailing junk", (b: string) => `123junk ${b}`],
-    ["a third field", (b: string) => `1 ${b} trailing`],
+    ["a pid with trailing junk", (b: string) => `123junk ${b} 1`],
+    ["a fourth field", (b: string) => `1 ${b} 1 trailing`],
+    ["no start time", (b: string) => `1 ${b}`],
     ["only a pid", () => "1"],
   ])("reclaims when the stamp has %s", (_name, make) => {
     // Only a stamp this file can vouch for may refuse the reclaim. One writer

--- a/src/tests/unit/production-server-parked-build.test.ts
+++ b/src/tests/unit/production-server-parked-build.test.ts
@@ -24,6 +24,22 @@ import path from "node:path";
 
 const REPO = process.cwd();
 const SRC = readFileSync(path.join(REPO, "production-server.js"), "utf-8");
+/** The stamp set_previous_build_aside leaves in the tree it parks. */
+const OWNER_STAMP = ".rebuild-pid";
+
+/**
+ * The stamp's second field. A PID is only evidence within the boot that issued
+ * it — a power cut mid-build leaves the stamp on disk, and after the reboot the
+ * number can belong to anything — so writer and reader both pin it to the boot.
+ */
+function bootId(): string {
+  const id = readFileSync("/proc/sys/kernel/random/boot_id", "utf-8").trim();
+  if (!id) throw new Error("/proc/sys/kernel/random/boot_id is empty — these cases need a Linux host");
+  return id;
+}
+
+/** What install.sh's set_previous_build_aside writes into the tree it parks. */
+const ownerStamp = (pid: number): string => `${pid} ${bootId()}\n`;
 const START = "// A build parked by an update that was killed OUTRIGHT";
 const END = 'require("./.next/standalone/server.js");';
 
@@ -68,6 +84,32 @@ const buildId = (dir: string): string | null => {
   const p = path.join(dir, ".next", "BUILD_ID");
   return existsSync(p) ? readFileSync(p, "utf-8").trim() : null;
 };
+
+/**
+ * A PID that is certainly not running.
+ *
+ * The stamp `set_previous_build_aside` leaves in the parked tree must not become
+ * a latch: an OOM kill leaves it behind together with the build, and that is
+ * the exact case the reclaim exists for. Testing "the owner is gone" needs a
+ * number that really is gone, and `pid_max` is one by definition — proc(5)
+ * says the value in that file "is one greater than the maximum PID", so the
+ * kernel never allocates it. Reading it beats spawning a child and waiting for
+ * it to die: no real process, no second timeout ceiling
+ * (test-timeout-hygiene.test.ts), and no window in which the kernel could hand
+ * the number to something else.
+ */
+function deadPid(): number {
+  const pid = Number.parseInt(readFileSync("/proc/sys/kernel/pid_max", "utf-8").trim(), 10);
+  if (!Number.isInteger(pid) || pid <= 0) throw new Error("could not read /proc/sys/kernel/pid_max");
+  let alive = true;
+  try {
+    process.kill(pid, 0);
+  } catch {
+    alive = false;
+  }
+  if (alive) throw new Error(`pid ${pid} is running after all — it cannot stand in for a dead one`);
+  return pid;
+}
 
 let projectDir: string;
 
@@ -153,5 +195,84 @@ describe("production-server.js reclaims a parked build at boot", () => {
 
     expect(r.threw).toBeNull();
     expect(r.warnings.join(" ")).toMatch(/Could not reclaim a parked build/);
+  });
+
+  it("refuses to reclaim the parked build while the rebuild that parked it is still running", () => {
+    // The window is not narrow: `do_rebuild` renames `.next` to `.next-old`
+    // and only THEN runs `bun run build`, so for the whole length of the build
+    // — minutes on a Jetson — there is no `.next/standalone/server.js` and
+    // there is a parked one. That is exactly the condition this block reclaims
+    // on, and clawbox-setup is pulled back up inside that window routinely:
+    // `clawbox-gateway.service` carries `Wants=clawbox-setup.service`, so every
+    // gateway (re)start starts the service `do_rebuild` had just stopped (seen
+    // in e2e-install run 33971129750, four seconds after the stop). Reclaiming
+    // there `rm -rf`s the half-written build out from under `next build` and
+    // renames the previous one on top of it.
+    const kept = path.join(projectDir, ".next-old");
+    writeBuild(kept, "parked-build-id");
+    writeFileSync(path.join(kept, OWNER_STAMP), ownerStamp(process.pid), "utf-8");
+    // What `next build` has written so far: a `.next` with no standalone entry.
+    mkdirSync(path.join(projectDir, ".next", "server"), { recursive: true });
+    writeFileSync(path.join(projectDir, ".next", "BUILD_ID"), "half-written\n", "utf-8");
+
+    const r = runReclaim(projectDir);
+
+    expect(r.threw).toBeNull();
+    // The in-progress build is untouched…
+    expect(existsSync(path.join(projectDir, ".next", "server"))).toBe(true);
+    expect(buildId(projectDir)).toBe("half-written");
+    // …and so is the fallback the rebuild is counting on.
+    expect(existsSync(path.join(kept, "standalone", "server.js"))).toBe(true);
+    expect(r.warnings.join(" ")).toMatch(/rebuild is in progress/);
+  });
+
+  it("still reclaims once the rebuild that parked the build is gone", () => {
+    // An OOM kill leaves the stamp behind together with the build. A stamp
+    // that outlived its process must not disable the reclaim — that would turn
+    // the repair #632 added into the crash loop it was written to end.
+    const kept = path.join(projectDir, ".next-old");
+    writeBuild(kept, "parked-build-id");
+    writeFileSync(path.join(kept, OWNER_STAMP), ownerStamp(deadPid()), "utf-8");
+
+    const r = runReclaim(projectDir);
+
+    expect(r.threw).toBeNull();
+    expect(buildId(projectDir)).toBe("parked-build-id");
+    expect(existsSync(path.join(projectDir, ".next-old"))).toBe(false);
+    // …and the stamp does not ride into the tree the box now serves.
+    expect(existsSync(path.join(projectDir, ".next", OWNER_STAMP))).toBe(false);
+    expect(r.warnings.join(" ")).toMatch(/killed mid-rebuild/);
+  });
+
+  it("reclaims when the stamp is from an earlier boot", () => {
+    // The power-cut case, after the reboot. The PID in the stamp may well be
+    // live by then — it belongs to whatever systemd started this time — and
+    // believing it would leave the box crash-looping with its only build on
+    // disk, which is the exact state this block exists to end.
+    const kept = path.join(projectDir, ".next-old");
+    writeBuild(kept, "parked-build-id");
+    writeFileSync(
+      path.join(kept, OWNER_STAMP),
+      `${process.pid} 00000000-0000-4000-8000-000000000000\n`,
+      "utf-8",
+    );
+
+    const r = runReclaim(projectDir);
+
+    expect(r.threw).toBeNull();
+    expect(buildId(projectDir)).toBe("parked-build-id");
+    expect(existsSync(path.join(projectDir, ".next-old"))).toBe(false);
+  });
+
+  it("reclaims a parked build that carries no stamp at all", () => {
+    // Every build parked before this stamp existed, and every one parked by a
+    // shell that could not write it, has none. Absent must mean "nobody is
+    // building", or an upgrade would strand exactly the boxes already stuck.
+    writeBuild(path.join(projectDir, ".next-old"), "parked-build-id");
+
+    const r = runReclaim(projectDir);
+
+    expect(r.threw).toBeNull();
+    expect(buildId(projectDir)).toBe("parked-build-id");
   });
 });

--- a/src/tests/unit/production-server-parked-build.test.ts
+++ b/src/tests/unit/production-server-parked-build.test.ts
@@ -296,6 +296,26 @@ describe("production-server.js reclaims a parked build at boot", () => {
     expect(r.warnings.join(" ")).toMatch(/names no live rebuild/);
   });
 
+  it.each([
+    ["a pid with trailing junk", (b: string) => `123junk ${b}`],
+    ["a third field", (b: string) => `1 ${b} trailing`],
+    ["only a pid", () => "1"],
+  ])("reclaims when the stamp has %s", (_name, make) => {
+    // Only a stamp this file can vouch for may refuse the reclaim. One writer
+    // produces `<pid> <boot id>` and nothing else, so anything of another shape
+    // is corruption — and believing it would strand the box on a crash loop
+    // with its only build on disk, which is the expensive direction.
+    const kept = path.join(projectDir, ".next-old");
+    writeBuild(kept, "parked-build-id");
+    writeFileSync(path.join(kept, OWNER_STAMP), `${make(bootId())}\n`, "utf-8");
+
+    const r = runReclaim(projectDir);
+
+    expect(r.threw).toBeNull();
+    expect(buildId(projectDir)).toBe("parked-build-id");
+    expect(r.warnings.join(" ")).toMatch(/names no live rebuild/);
+  });
+
   it("reclaims a parked build that carries no stamp at all", () => {
     // Every build parked before this stamp existed, and every one parked by a
     // shell that could not write it, has none. Absent must mean "nobody is


### PR DESCRIPTION
**TASK-725.** Found by the #647 fixer while chasing the e2e-install failure in run 33971129750 (`90-upgrade-main-to-beta`).

## Symptom

An update finishes and the dashboard comes back on the build the update was replacing. Intermittent, on any branch, on any box update. In run 33971129750 the resumed updater then executed the old `main` code, whose `execAsRoot` calls `systemctl start` directly, and `post_update` died on the polkit denial `Interactive authentication required`.

## Cause

PR #632 (TASK-709) added a parked previous build so an OOM-killed rebuild cannot leave a box with no build at all: `do_rebuild` renames `.next` to `.next-old` before `bun run build`, `restore_previous_build` renames it back on failure, and `production-server.js` reclaims it at boot.

The reclaim fires on one fact — `.next/standalone/server.js` is missing and `.next-old/standalone/server.js` is not. That is **also the ordinary state of a rebuild in flight, for the whole length of the build**: the rename happens first and `next build` writes the standalone entry last.

And the dashboard is started inside that window as a matter of routine. `config/clawbox-gateway.service` carries `Wants=clawbox-setup.service`, so every gateway (re)start starts the service `do_rebuild` had just stopped. The journal of run 33971129750 shows it, four seconds after the stop and three seconds before the park:

```
14:24:33  Stopping clawbox-setup.service for rebuild...
14:24:36  Running bun install...
14:24:37  clawbox-gateway.service: Scheduled restart job, restart counter is at 1.
14:24:37  Started ClawBox Setup Wizard Web Server.        <- Wants= pulled it back up
14:24:39  Setting the current build aside...
14:24:39  Running bun build...
```

A restart landing a few seconds later hits the window with `.next-old` holding the only servable build and `.next` half-written: the reclaim `rm -rf`s the in-progress build out from under `next build` and renames the previous one on top of it. The box ends the update on the old build, and `next build` finishes into a tree that is no longer the one it started.

The gateway was crash-looping in that run (plugin consent), so it was restarting every five seconds against a multi-minute build — that is what makes the race routine rather than theoretical.

## Fix

`set_previous_build_aside` stamps the tree it parks — `.next-old/.rebuild-pid`, holding the rebuilding shell's PID, the boot id, and that process's start time (field 22 of `/proc/<pid>/stat`) — **before** the rename, so the stamp and the park arrive together. `production-server.js` refuses the reclaim only for a stamp whose three fields all still match a running process. Reading `/proc` answers identity and liveness together, and the entry is world-readable, so the check needs no permission over root's rebuild shell.

Everything else behaves exactly as it did before the stamp existed — absent (every build parked by a box on today's beta), unparseable, from another boot, or naming a process that is gone. That is the safe direction to fail in: a mid-build reclaim costs one failed update, while a stamp wrongly believed live costs a crash-looping box with its only build on disk, which is the state #632 was written to end.

All three fields, because a PID identifies nothing on its own. A power cut mid-build — one of the cases #632 exists for — leaves the stamp on disk, and after the reboot that number can belong to anything; within a boot the same is true more slowly, since PIDs are reused. Either would turn the stamp into a latch and re-create the bug it was added to prevent, which is why the boot id and the start time are both in it.

Both renames that end a park (`promote_parked_build`, `restore_previous_build`) and the boot-time reclaim strip the stamp, so it never rides into the tree the box serves.

## Harness-first

(For the postbuild half's harness-first answer — Next publishes the standalone entry's location itself — see Round 2.) The parked build is not a Next.js concept and Next offers nothing to reuse: it owns `distDir` and the tracing root, writes `BUILD_ID` and the standalone entry at the END of a build, and publishes no "build in progress" fact or lock. So the liveness signal has to come from the thing doing the rebuild.

systemd does own that fact for one of the paths. `/usr/local/libexec/clawbox/clawbox-root-step.sh` **execs** install.sh, so the stamped shell IS the MainPID of `clawbox-root-update@rebuild.service` / `@rebuild_reboot.service`, and `systemctl is-active` (or its `InvocationID`) would answer natively — `src/lib/updater.ts` already interrogates that unit family. It was rejected because it covers only the in-app updater. `box-update.sh` and a plain `sudo bash install.sh` rebuild under no unit at all, and those are the deploy paths used on the boxes. `install.sh`'s own shell is the one process common to every rebuild path, so its PID is the fact; the kernel's process table is the lock, and `/proc/sys/kernel/random/boot_id` is Linux's own answer to "is this PID from this boot" rather than a hand-rolled session id. No new lock protocol, no flock helper, no daemon.

Nothing here touches the agent harness, so there is no OpenClaw / Hermes equivalent to defer to. Both editions run this same `install.sh` rebuild and this same `production-server.js`, so the fix is edition-neutral by construction.

## Withdrawn

A section headed "REFUTED, with evidence" stood here: it argued that the parked tree could not reach `postbuild`'s entry lookup, and shipped no fix for it. It was wrong, and the defect it dismissed is behind three of the five failed e2e-install runs of 2026-09-05. See **Round 2** below, which withdraws it with the journal evidence, names the mechanism, and fixes it.

## Sibling sweep

Every other reader of `.next-old`, of a standalone `server.js` entry, and of `.next/standalone` was checked. (The one this missed — `package.json`'s `postbuild`, which was the broken one — is Round 2's subject; its own sweep is below.)

- `promote_parked_build` (install.sh) is the other reclaim. **Deliberately not guarded**: it runs inside `do_rebuild` after the service stop, so a live stamp there could only mean a second concurrent rebuild — and the very next statement is `set_previous_build_aside`'s `rm -rf "$kept_dir"`, so a guard would imply a safety the function cannot provide. It does strip the stamp off the tree it promotes.
- `step_build` (the fresh-install path) calls `promote_parked_build` but never parks, so no rebuild of that shape can be mistaken for a killed one.
- `install-x64.sh:426` checks the same entry after its build but has no parking at all.
- `scripts/verify-build-identity.sh`, `src/lib/updater.ts` `readBuildId()`, `src/lib/build-identity.ts` `resolveBuildDir()`, `scripts/write-build-info.mjs`, `scripts/check-bundled-builtins.sh` all read `.next` / `.next/standalone` and are untouched by a file inside `.next-old`.
- `.gitignore` / drift: the stamp lives inside `.next-old/`, which `.gitignore:8` already ignores, so it is invisible to `git status --porcelain` and to `git ls-files --others --exclude-standard` — no `checkout-dirty`, no About-screen drift banner, no inflated `untracked` count in `build-info.json`. Verified on the branch:

```
$ printf '12345 abc\n' > .next-old/.rebuild-pid
$ git status --porcelain | grep -i next-old        # no output
$ git ls-files --others --exclude-standard | grep -i next-old   # no output
$ git check-ignore -v .next-old/.rebuild-pid
.gitignore:8:.next-old/  .next-old/.rebuild-pid
```

This is why the stamp went inside the parked tree rather than beside it: a marker in the project root would have needed the whole `.deployed-sha` treatment (gitignore entry, an explicit sweep because `git clean -fd` will not take an ignored file, a `removeOrphanDeployedSha` sibling, and a `build-identity-hygiene` block).

## RED

On this branch's base, with only the tests applied:

```
 ❯ src/tests/unit/production-server-parked-build.test.ts (9 tests | 2 failed)
     × refuses to reclaim the parked build while the rebuild that parked it is still running
     × still reclaims once the rebuild that parked the build is gone
 ❯ src/tests/unit/install-rebuild-build-verify.test.ts (30 tests | 2 failed)
     × stamps the parked build with the rebuilding shell while the build runs
     × writes the stamp production-server.js reads

 FAIL install-rebuild-build-verify.test.ts > stamps the parked build with the rebuilding shell while the build runs
 AssertionError: expected 'none' to match /^live \d+$/
   - Expected: /^live \d+$/
   + Received: "none"

 FAIL production-server-parked-build.test.ts > refuses to reclaim the parked build while the rebuild that parked it is still running
 AssertionError: expected false to be true
   ❯ expect(existsSync(path.join(projectDir, ".next", "server"))).toBe(true)

 Test Files  2 failed (2)
      Tests  4 failed | 35 passed (39)
```

Those four are the RED cases, and they are the only ones of the new set that are. The rest of the new cases are green on the base by design and are regression guards, not evidence: "reclaims when the stamp is from an earlier boot", "reclaims a parked build that carries no stamp at all" and "stamps nothing when the disk could not hold two builds" assert that the paths this PR must NOT change have not changed. Two more cases arrived from the review and are RED on the base for the second commit's finding: "restarts clawbox-setup rather than starting it, so a latched unit is replaced" and "leaves no owner behind on the build it promotes".

The first RED case samples the parked tree from inside the stubbed `bun run build` — the only moment the question matters. The second stages the real window (a `.next` with no standalone entry, a parked build, a live owner) and asserts the in-progress build is still there afterwards; on the base it is gone.

Each new assertion was mutation-checked: reverting the single line it guards makes it fail.

## GREEN

```
$ bunx vitest run --config vitest.config.ts --project unit   # on the round-1 head
 Test Files  648 passed (648)
      Tests  10490 passed | 1 skipped (10491)
```

One unrelated file, `src/tests/unit/use-clawbox-login.test.ts`, flaked once under a full parallel run with `ReferenceError: window is not defined` out of a `use-clawbox-login.ts` timer firing after teardown. It is not in this diff, it passes on its own, and CI's `test` job is green.

`bunx tsc --noEmit` clean, `bunx eslint` clean on the touched files.

## Second commit: the dashboard is up, so stop assuming it is down

The review pass turned the PR's own premise back on the installer. `systemctl start` on an already-active unit is a no-op, and both places a rebuild ends used `start`:

- `restore_previous_build` — once `next build` has written the standalone entry, the crash-looping unit latches onto the new tree. If `verify_build_present` then fails, this function renames the old build back on disk, its `start` does nothing, `curl` answers 200 **from the build that just failed verification**, and it prints "Restored the previous build; the dashboard answers on :80 again". A false success in the one function written to avoid one.
- `step_rebuild` — the same no-op on the green path, where the latched process can be sitting on a tree `next build` had written but `postbuild` had not yet copied `.next/static`, `public/` and `build-info.json` into. `step_rebuild_reboot` is saved by the reboot that follows it; `rebuild` is a first-class root step and is not.

Both now `restart`. Also from that pass: an unreadable boot id took no warning branch (a silently inoperative guard); the stamp cleanup after a reclaim could report "could not reclaim" over a reclaim that had already succeeded; a stamp that is present but proves nothing now says so; the comment claiming both reclaims consult the stamp was wrong about `promote_parked_build`; `free_memory_for_build`'s "with the web server down nothing can pull a model back in" was resting on the same disproved guarantee; and the promote test passed because its fixture never wrote a stamp.

## Named, not fixed here

Three findings from the review are real and are deliberately out of this PR. Cards are filed:

1. **Two unsynchronised reclaimers.** `promote_parked_build` and the boot-time reclaim both do a non-atomic `rm -rf .next` + `mv .next-old .next` on the same two paths with no lock; a sub-millisecond interleave can leave a box with neither tree. Pre-existing since #632 and **unchanged by this PR** — it needs a dead stamp, in which case this branch behaves exactly as beta does. Closing it properly wants a claim-rename (with a sweep for an orphaned claim) or one real lock across the whole `do_rebuild` window.
2. **The `Wants=` trigger.** `clawbox-gateway.service`'s `Wants=clawbox-setup.service` starts the dashboard mid-rebuild, and removing it is worth doing on its own account: it opens this race, it defeats `free_memory_for_build`'s memory hold, and it lets the updater resume on the pre-update build. It is **not** what failed runs 33971129750, 33974951149 and 33977666658, and this PR no longer says it is. Those runs failed because `postbuild` selected the parked build's entry (see Round 2), and with the `Wants=` removed they would have failed identically: the dashboard would simply have been down through the rebuild, `verify_build_present` would still have rejected the build, `restore_previous_build` would still have put `main`'s build back, and `post_update` would still have died on polkit. TASK-728 removes a window rather than guarding it and is the right answer to item 3 below — it is not the fix for those three runs.
3. **Cost of the refusal.** Refusing now lets `require` throw, so clawbox-setup crash-loops every ~3.5 s for the length of the build where beta came up once on the stolen build. That is the pre-#632 behaviour restored, and each start fire-and-forgets `scripts/register-mcp.sh` — which is only expensive on `hermes`/`dual` (it exits at the edition check on OpenClaw), and on `hermes` the gateway unit is masked so this trigger does not exist. `dual` is the one SKU that pays it. Fixing the trigger (2) removes it.

(The PID-reuse residual both reviews raised is now closed rather than argued away — see the fourth commit.)

## Third and fourth commits: CodeRabbit

Two findings, both taken.

`Number.parseInt` accepts `123junk` and destructuring ignores extra fields, so a stamp of a shape nothing writes could still name a live PID and hold off the reclaim. The reader now requires exactly what the one writer produces.

And the PID-reuse point, which the review pass had raised too and this PR had argued was unreachable rather than closed: a live PID proves only that *some* process holds the number. The stamp now carries the process's start time as well, and reading `/proc/<pid>/stat` answers identity and liveness in one go — which let `process.kill(pid, 0)` and its EPERM branch go away, so the check got smaller as well as exact. The regression case is a live PID from this boot with a different start time; it fails if the comparison is removed. For the record, measured read-only on the OpenClaw box: `kernel.pid_max` is 4194304 and `/proc` is mounted without `hidepid`, so the reuse window was indeed unreachable in practice — but the consequence was a box needing hand repair, and the guard now matches what its own comment claims.

## Round 2 — the refutation is withdrawn, and the defect it dismissed is fixed here

The first four commits shipped with a section headed "REFUTED, with evidence": the other half of the brief — that a parked tree could be copied into the standalone output and win `postbuild`'s entry lookup — was declared unreachable on Next 16.3.3 and left unfixed. **That verdict was wrong and is withdrawn.** Its reading of Next's source was accurate as far as it went; it argued from `copyTracedFiles` and `writeStandaloneDirectory` and never looked at the artifact on a machine that had actually built with a parked tree beside it. The disproof was already in the journal of the run this PR came from.

### The evidence

e2e-install run **33971129750** (`fix/699-hermes-tts-default`, 2026-09-05), from the failing job's own journal dump:

```
14:24:39  Setting the current build aside...
14:24:39  Running bun build...
...
14:25:49  cp: cannot create directory '.next/standalone/.next-old/standalone/.next/static': No such file or directory
14:25:49  cp: cannot create regular file '.next/standalone/.next-old/standalone/.next/build-info.json': No such file or directory
14:25:49  cp: cannot create directory '.next/standalone/.next-old/standalone/node_modules/playwright': No such file or directory
14:25:49  cp: cannot create directory '.next/standalone/.next-old/standalone/node_modules/playwright-core': No such file or directory
14:25:49  BUILD IDENTITY: FAIL — .next/standalone/.next holds a deployed build but no build-info.json — the postbuild step did not copy the stamp
14:25:49  Error: the build on disk does not match the checked-out commit
14:25:49  Error: rebuild failed (exit 1)
14:25:50    Restored the previous build; the dashboard answers on :80 again
14:25:50  clawbox-root-update@rebuild_reboot.service: Main process exited, code=exited, status=1/FAILURE
```

Those four `cp` destinations are `$SDIR`, and `SDIR=$(dirname "$SRVJS")`, so the lookup had returned `.next/standalone/.next-old/standalone/server.js` — the PARKED build's entry, three levels down inside the NEW standalone tree. What followed, in order:

1. `.next/static`, `public/` and `build-info.json` were copied at the parked copy, all four copies failed, and **postbuild exited 0**.
2. Its last clause — `if [ "$SRVJS" != ".next/standalone/server.js" ]; then ln -sf "$(pwd)/$SRVJS" .next/standalone/server.js; fi` — then replaced the real entry with a symlink into that parked copy, so `require("./.next/standalone/server.js")` would have loaded the build the update was replacing. That is "the dashboard comes back on the PARKED build" reached by a second route, and this time not as a race.
3. `verify-build-identity.sh` caught the missing stamp two lines later, `verify_build_present` failed the rebuild, `restore_previous_build` put the old build back.
4. The resumed updater then ran `main`'s code, whose `execAsRoot` calls `systemctl start` directly, and `post_update` died on `Interactive authentication required`.

Runs **33974951149** and **33977666658** show the same chain the same day: three of the five failed e2e-install runs on 2026-09-05.

### The mechanism, reproduced

Reproduced in this worktree on Next 16.3.3, by building, `mv .next .next-old`, and building again — the exact sequence `do_rebuild` performs:

```
$ find .next/standalone -maxdepth 3 -name node_modules -prune -o -name server.js -print
.next/standalone/.next-old/standalone/server.js      <- readdir yields this one FIRST
.next/standalone/server.js
$ du -sh .next/standalone
527M    .next/standalone
```

`.next/standalone` held a copy of the whole project root — `src/`, `scripts/`, `bench/`, `docs-site/`, `.git`, `install.sh` — and all 4202 files of the parked build. The trace that does it is the **instrumentation** one:

```
instrumentation.js.nft.json: 6186 files traced
  4202 of them ../../.next-old/**
```

`src/instrumentation-node.ts:154` resolves `path.join(CONFIG_ROOT, 'scripts', 'terminal-server.mjs')`, and `CONFIG_ROOT` is read from the environment (`src/lib/config-store.ts:4`), so @vercel/nft cannot resolve the base and emits the whole project directory as an asset directory. `outputFileTracingExcludes` cannot reach that trace — Next applies it per route entry, which this repo already measured and wrote down in `next.config.ts`. The refutation's own source reading was right about the two writers it examined; the sweep comes from a third place it did not look at.

This is also the same mechanism behind `.next/standalone/data`, which the postbuild step has removed by hand since F-27 — so the phenomenon was documented in this repo all along, one directory at a time.

### The fix

`package.json`'s one-line `postbuild` is now `scripts/postbuild.sh`, under `set -euo pipefail`:

- **The entry comes from Next, not from readdir.** `relativeAppDir` in `.next/required-server-files.json` is `path.relative(outputFileTracingRoot, dir)` (`next/dist/build/index.js:1107`) — the exact segment `copyTracedFiles` joins under `.next/standalone` when it writes `server.js` (`next/dist/build/utils.js:990`). It is `""` for this repo, because `outputFileTracingRoot` is unset; it is the app's path below the tracing root for the nested layout Next produces when that root is a parent. Read with `node -e`, as `verify-build-identity.sh` reads `build-info.json`, and refused if it starts with `/` or contains `..`.
- Fallbacks, in order: `.next/standalone/server.js`, then a search that prunes `node_modules` **and** `.next-old*` and takes regular files only (so the symlink a previous run may have left is never taken for the entry).
- **A step that cannot do its job fails.** No standalone output, no entry anywhere, an `$SDIR` with no `.next` beside it, or any failed copy is now a non-zero exit. Previously all four exited 0.
- **The swept parked copy is removed** from the standalone output before anything else looks at it — it is a second complete build inside the one that ships, hundreds of MB on an eMMC. The real parked tree at `$PROJECT_DIR/.next-old` is not touched.
- The `data/` removal and its 0600-secrets guard are unchanged, and moved ahead of the copies so that a standalone tree this step cannot write into still reports the duplicate by name rather than dying on the first `cp`.

End-to-end, in this worktree, on the same build-park-build sequence that produced the CI failures:

```
$ bun run build && mv .next .next-old && bun run build
postbuild: removing .next/standalone/.next-old — a parked previous build was traced into the standalone output
$ ls -la .next/standalone/server.js
-rw-rw-r-- 1 ... 7790 .next/standalone/server.js        <- a file, not a symlink into the parked copy
$ bash scripts/verify-build-identity.sh --project-dir "$PWD"
  ok: .next/build-info.json — commit a4ca8d9 dirty=false
  ok: .next/standalone/.next/build-info.json — commit a4ca8d9 dirty=false
BUILD IDENTITY: OK — 2 artifact(s) built from a4ca8d9
```

### Harness-first

Next owns this and publishes the answer: `required-server-files.json`'s `relativeAppDir` IS where the standalone entry is, written by the same build that writes the entry. Nothing here re-derives it. The pruned `find` survives only as the fallback for a tree that carries no manifest, and `-type f` plus the prune make even that fallback independent of readdir order.

What Next does **not** offer is a way to keep a sibling directory out of the instrumentation trace: `outputFileTracingExcludes` reaches route traces only (measured, recorded in `next.config.ts`), `outputFileTracingIncludes` is the opposite direction, and `outputFileTracingRoot` can only be widened, never narrowed below the project. That absence is the finding; the parked copy is therefore removed after the fact rather than prevented.

### Where the parked build stays, and why it does not move

`$PROJECT_DIR/.next-old`, unchanged — so **no migration is needed and none is missing**: a box that parked a build on today's beta has exactly the tree every consumer already reads.

Parking outside the Next tracing root was the obvious answer and does not survive the shipped topology. The tracing root is the project directory, so "outside it" means outside `/home/clawbox/clawbox` — and in `e2e-install` that path is a docker **named volume** (`e2e-install/docker-compose.test.yml`: `clawbox-home:/home/clawbox/clawbox`). A rename to a sibling of the project directory crosses filesystems there: `mv` degrades to a copy of a whole build, and `production-server.js`'s `fs.renameSync` throws EXDEV outright, which would disable the boot-time reclaim in the very job that gates this PR. Under the project directory, the sweep reaches everything except `node_modules` (nft ignores it), and parking a build inside `node_modules` is worse than the problem. So the location stays and the copy is cleaned up.

Narrowing the instrumentation sweep itself is the real repair and is a separate change with its own device proof: parts of it are load-bearing today — `.next/standalone/scripts` exists only because of the sweep, and `system-profile.ts` resolves `scripts/` from the process cwd.

### Sibling sweep (round 2)

- **`find … server.js`** — `package.json`'s `postbuild` was the only one in the repo (grep-verified). `install.sh`'s `build_entry_present`/`verify_build_present`, `install-x64.sh:426`, `production-server.js`, `src/lib/updater.ts` `readBuildId()` and `src/lib/build-identity.ts` `resolveBuildDir()` all address `.next/standalone/server.js` literally and are unchanged — and `readBuildId()` is the one that would have reported the PARKED build's id after the old symlink, so the fix reaches it without touching it.
- **`systemctl start` on a possibly-active unit** — round 1 converted every `clawbox-setup` start to `restart`. Of the rest: `install.sh`'s second gateway-recovery attempt is now `restart` (own commit — it is reached when the gateway is not LISTENING, which is not the same as not running, so `start` over a unit that is active and refusing to bind was a no-op and the port check twelve seconds later failed over a recovery never attempted; the first attempt in the same function already used `restart`). Explicitly cleared: `install.sh:~2989` (an explicit `systemctl stop` immediately precedes it, and the gateway's `Restart=` does not undo a manual stop), `install-x64.sh:506` (guarded by `GATEWAY_WAS_ACTIVE` plus its own stop), and both `systemctl start ollama` sites — a no-op start is the intended end state there, and a restart would evict a resident model.
- **Readers/writers of `.next-old`** — unchanged from round 1 (`install.sh`, `production-server.js`, `.gitignore`, `.dockerignore`, two test files), plus `e2e-install/entrypoint.sh`, whose `tar --exclude=.next` is an exact-name match that did not cover `.next-old`; a host tree carrying a parked build would have seeded one into the container for the boot-time reclaim to find. Now excluded, keeping it in step with `.dockerignore`.
- **Comments that said the old thing** — `install.sh`'s `verify_build_present` header and `install-rebuild-build-verify.test.ts`'s preamble both stated that postbuild "exits 0 having copied NOTHING"; both now say it fails, and both keep the reason `verify_build_present` exists regardless.
- **Editions**: `next build` + `postbuild` are what both SKUs run, from the same `do_rebuild`. The defect and the fix are edition-neutral; nothing here touches a harness.

### The review pass

Applied, all of it: the build stamp is written with `CLAWBOX_ROOT` pinned to the build's own directory (`write-build-info.mjs` resolves its project dir from that variable, so a shell exporting it elsewhere sent the stamp out of the tree and the copy that follows failed — a printed warning before, a failed build under `set -e`, and `playwright.config.ts`'s `webServer` starts with `bun run build`; there is a case for it); the swept copy is removed **after** the entry is chosen rather than before, so the fallback search has to refuse a parked entry on its own merits and the nested layout's copy — which lands beside the entry, not at the top of the standalone tree — is reached too; the entry-write citation is `utils.js:1107` (`:990` is the `package.json` write); `set_previous_build_aside` now says out loud that the real peak is **three** builds and why the threshold stays at two (raising it would delete the old build on a box between 2× and 3× free, trading a failed update that rolls back for a build with no fallback at all — the brick #632 exists to prevent); the second gateway recovery attempt is a `restart` because `doctor --fix` can bring the unit back, not because the stop above it did not happen; and both `clawbox-setup` restarts `reset-failed` first, as both gateway paths already do, since the unit crash-loops for the length of every rebuild now and a latched start limit would report the dashboard DOWN over a rollback that had worked.

Confirmed by the same pass, and unchanged: the three `systemctl start` sites left alone are correctly left alone (`restart` on ollama would bounce a healthy engine and drop its loaded model mid-install); `promote_parked_build`'s deliberate lack of a stamp guard holds; the stub `find` is a tripwire rather than a model of `find`, installed only where a correct implementation must never call `find`, and every case using it fails on revert.

### RED (round 2)

`src/tests/unit/postbuild-standalone-entry.test.ts` runs the REAL `postbuild` out of `package.json` against a staged tree. Readdir order is a property of the filesystem, not of a fixture, so the order that matters is pinned with a stub `find` first on `PATH` that returns the parked entry — the order three CI runs actually got. A lookup that consults `find` at all is handed the parked entry; one that takes what Next recorded never runs it.

On unmodified `origin/beta` (26ad5dfa), tests only:

```
 ❯ src/tests/unit/postbuild-standalone-entry.test.ts (7 tests | 6 failed)
   × stamps the entry next build wrote, not the parked build the lookup offers first
   × takes the entry from the path Next recorded for it
   × stamps the build it is building, whatever CLAWBOX_ROOT says
   × removes a parked build that the file trace swept into the standalone output
   × fails the build when a copy into the standalone tree fails
   × fails the build when there is no standalone entry to assemble around

 FAIL > stamps the entry next build wrote, not the parked build the lookup offers first
 AssertionError: expected false to be true
  ❯ expect(fs.existsSync(path.join(standalone, ".next", "build-info.json"))).toBe(true)

 FAIL > fails the build when a copy into the standalone tree fails
 AssertionError: expected +0 not to be +0
  ❯ expect(res.status).not.toBe(0);

 Test Files  1 failed (1)
      Tests  6 failed | 1 passed (7)
```

The seventh case ("takes the nested entry, never one inside a parked tree, in the nested layout") passes on beta *on this machine* — it is a regression guard for the nested layout, whose outcome on beta depends on readdir order, and it is not offered as RED evidence.

### GREEN (round 2)

```
$ bunx vitest run --project unit \
    src/tests/unit/postbuild-standalone-entry.test.ts \
    src/tests/unit/postbuild-standalone-data.test.ts \
    src/tests/unit/install-rebuild-build-verify.test.ts \
    src/tests/unit/production-server-parked-build.test.ts \
    src/tests/unit/updater.test.ts \
    src/tests/unit/build-identity-hygiene.test.ts \
    src/tests/unit/sudoers-coverage.test.ts \
    src/tests/unit/install-free-memory-before-build.test.ts
 Test Files  8 passed (8)
      Tests  184 passed (184)

$ bunx vitest run --project unit          # the whole suite
 Test Files  649 passed (649)
      Tests  10496 passed | 1 skipped (10497)
```

(The full run still ends with the same unrelated unhandled rejection the round-1 GREEN section records — `use-clawbox-login.ts`'s timer firing after teardown, in a file this diff does not touch. Every test file passed.)

`bunx tsc --noEmit` clean, `bunx eslint` clean on the touched files, `bash -n` clean on `scripts/postbuild.sh`, `install.sh` and `e2e-install/entrypoint.sh`. The round-1 suites are untouched and green.

`postbuild-standalone-data.test.ts`'s fixture now copies `scripts/postbuild.sh` beside `write-build-info.mjs` — a fixture has to carry whatever the shipped step invokes; no assertion changed.

### CodeRabbit (round 2)

One thread, taken: the ownership suite's probe reads `/proc/sys/kernel/random/boot_id` and field 22 of `/proc/<pid>/stat`, so on a platform without procfs it can only answer `stale` and the suite would fail over the machine it ran on rather than over `install.sh`. It is `describe.skipIf(process.platform !== "linux")` now, with the reason beside it — skipped rather than made portable, because portability would cost the property those cases exist to pin. 31/31 still run on Linux. Answered in-thread.

### CI

All green on `96694b69`: `test`, `e2e`, **`e2e-install` (11m17s, run 33985373026)**, `build-identity`, `CodeQL` / `Analyze`, `ClawReview`, `CodeRabbit`.

For the record, because it cost 55 minutes: `e2e-install` on the previous head (`7d59ddf3`, run 33982237710) FAILED, and it was not this diff. `90-upgrade-main-to-beta` timed out after 45 minutes with `phase: "idle"`, every step `pending`, `currentStepIndex: -1` and **zero failed units** — and `versions.clawbox.current` was `v4.0.0` (read from `package.json` on disk at runtime; `main` is `3.9.0`) with `checkoutVsPin: "match"`, so `bootstrap_updater` had already synced the checkout to this branch and the update then simply never resumed. The head that passed differs from it by one line in a unit test (the `describe.skipIf` above), which `e2e-install` does not run, so the shipping code in both runs is identical. Nothing in this diff executes before `bootstrap_updater` either: the box is on `main`'s code until that step syncs it. Recorded here rather than waved away — if that signature returns, it is an updater-continuation defect of its own and wants its own card.

## Device

Read-only only — both boxes are in use. The upgrade path this defect lives on is exercised by the `e2e-install` job (`90-upgrade-main-to-beta`), which stops and rebuilds under systemd with the gateway restarting beside it. That job is the gate this PR has to clear, and for Round 2 it is also evidence: the three failures Round 2 is written from are its own runs, and the same build-park-build sequence now completes locally with `BUILD IDENTITY: OK`. For the round-1 stamp it is **not** proof — one green run does not retire an intermittent race — and the evidence for that half is the unit suite in the RED section above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rebuild recovery to distinguish active operations from abandoned or interrupted builds.
  * Restored builds are cleaned up safely before being served.
  * Service recovery now reliably reloads the selected build, including after system or gateway restarts.
  * Improved handling of interrupted rebuilds, invalid recovery states, and low-disk-space conditions.
* **Reliability**
  * Prevented stale build data from being included in end-to-end installation environments.
  * Added safeguards to protect active rebuilds from unintended recovery or replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
