### PR TITLE
fix: record plugin capability consent for every ClawBox-managed plugin

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2983,8 +2983,16 @@ for p in d.get("plugins", []):
       # rollback override) gives a CLI that rejects the unknown option, and
       # every iteration would then fail behind the WARN below with no plugin
       # refreshed at all.
+      #
+      # Matched on the NORMALISED id: the registry can key a plugin as
+      # `openclaw-discord` or `@openclaw/discord`, and the raw name would then
+      # fall through to the default arm and be refreshed without consent —
+      # silently, behind the WARN below. `$spec` keeps the raw name, which is
+      # what the CLI has to be given.
       local CAP_ARGS=()
-      case "$plugin" in
+      local PLUGIN_KEY="${plugin#@openclaw/}"
+      PLUGIN_KEY="${PLUGIN_KEY#openclaw-}"
+      case "$PLUGIN_KEY" in
         codex|deepseek|discord|whatsapp|clawbox-email-directives)
           openclaw_is_v2 && CAP_ARGS=(--accept-capabilities)
           ;;

--- a/install.sh
+++ b/install.sh
@@ -2963,7 +2963,36 @@ for p in d.get("plugins", []):
         @openclaw/*) spec="$pkg@$TARGET" ;;
       esac
       echo "    - $spec"
-      if ! as_clawbox -H "$OPENCLAW_BIN" plugins install "$spec" --force >/dev/null 2>&1; then
+      # --accept-capabilities, for the plugins CLAWBOX installs and only those.
+      #
+      # OpenClaw 2 refuses to install a managed plugin whose declared capability
+      # surface has not been consented to, and a refresh to a new core target is
+      # exactly when that surface changes. Without the flag this loop's only
+      # outcome on a widened plugin is the WARN below, and the gateway then
+      # refuses readiness with 'Plugin "<id>" requires capability consent' until
+      # somebody runs the CLI by hand (TASK-603).
+      #
+      # But the flag consents to the NEW surface, not to the one already on the
+      # box, so passing it for a plugin the owner installed himself would answer
+      # a widened-capabilities question in his name. Same whitelist and same
+      # reason as CLAWBOX_MANAGED_PLUGIN_IDS in src/lib/updater.ts; anything
+      # else is refreshed without it and says so, so he can rerun the CLI.
+      #
+      # Gated on the INSTALLED generation the way the codex install in
+      # gateway-pre-start.sh is: a v1 pin (OPENCLAW_PIN_VERSION, a documented
+      # rollback override) gives a CLI that rejects the unknown option, and
+      # every iteration would then fail behind the WARN below with no plugin
+      # refreshed at all.
+      local CAP_ARGS=()
+      case "$plugin" in
+        codex|deepseek|discord|whatsapp|clawbox-email-directives)
+          openclaw_is_v2 && CAP_ARGS=(--accept-capabilities)
+          ;;
+        *)
+          echo "      (not a ClawBox-managed plugin: refreshed without accepting new capabilities)"
+          ;;
+      esac
+      if ! as_clawbox -H "$OPENCLAW_BIN" plugins install "$spec" --force "${CAP_ARGS[@]}" >/dev/null 2>&1; then
         echo "      WARN: refresh failed (non-fatal; gateway-pre-start will retry on next boot)"
       fi
     done <<< "$INSTALLED_PLUGINS"

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -2275,6 +2275,55 @@ elif [ "$CLAWBOX_OPENCLAW_V2" = "1" ] && [ "$CODEX_SHOULD_LOAD" = "1" ]; then
   fi
 fi
 
+# ── Capability consent for the OTHER ClawBox-managed plugins ────────────────
+#
+# The block above is the codex half of this, and has been here since OpenClaw 2
+# added declared-capability consent. The gateway refuses readiness for ANY
+# enabled plugin whose declared surface has not been consented to, and ClawBox
+# installs four more: deepseek (the provider ClawBox AI rides on), discord and
+# whatsapp (installed by the Settings panel when the owner asks for that
+# channel) and clawbox-email-directives (ours, copied out of the checkout
+# below).
+#
+# WHY IT MATTERS THAT THIS IS THE BOOT PATH. src/lib/updater.ts repairs the same
+# state from the gateway's journal, but only during an update. A box that is
+# already down — the 2026-09-01 outage was exactly this, on discord — gets a
+# reboot from its owner long before it gets an update, and every boot runs this
+# script. Without this block the reboot changed nothing and the gateway came
+# back to the same refusal (TASK-603).
+#
+# `enable` is the idempotent consent verb, as for codex: it records the current
+# reviewed surface when needed and leaves an already-consented plugin alone.
+# Only for entries openclaw.json ALREADY says to load, so this can never switch
+# a channel on — a plugin the owner disabled stays disabled, and one he never
+# asked for is never enabled by a boot script. Time-boxed and non-fatal,
+# because this is a blocking ExecStartPre.
+if [ "$CLAWBOX_OPENCLAW_V2" = "1" ]; then
+  MANAGED_ENABLED_PLUGINS="$(python3 - "$OPENCLAW_CONFIG" <<'MANAGEDPY' || true
+import json, sys
+MANAGED = ("deepseek", "discord", "whatsapp", "clawbox-email-directives")
+try:
+    with open(sys.argv[1], encoding="utf-8") as fh:
+        entries = (json.load(fh).get("plugins") or {}).get("entries") or {}
+except (OSError, json.JSONDecodeError):
+    raise SystemExit(0)
+if not isinstance(entries, dict):
+    raise SystemExit(0)
+for name in MANAGED:
+    entry = entries.get(name)
+    if isinstance(entry, dict) and entry.get("enabled") is True:
+        print(name)
+MANAGEDPY
+)"
+  for MANAGED_PLUGIN in $MANAGED_ENABLED_PLUGINS; do
+    if timeout 60 "$OPENCLAW_BIN" plugins enable "$MANAGED_PLUGIN" --accept-capabilities </dev/null >/dev/null 2>&1; then
+      echo "  $MANAGED_PLUGIN plugin capabilities accepted/current"
+    else
+      echo "  WARN: could not confirm $MANAGED_PLUGIN plugin capabilities; gateway readiness may remain blocked"
+    fi
+  done
+fi
+
 # Codex reads its ChatGPT session from a Codex CLI-style auth.json. Without
 # one the app-server falls back to api.openai.com with no bearer -> 401
 # "Missing bearer or basic authentication in header", which is what users hit

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -2302,6 +2302,21 @@ if [ "$CLAWBOX_OPENCLAW_V2" = "1" ]; then
   MANAGED_ENABLED_PLUGINS="$(python3 - "$OPENCLAW_CONFIG" <<'MANAGEDPY' || true
 import json, sys
 MANAGED = ("deepseek", "discord", "whatsapp", "clawbox-email-directives")
+
+
+def canonical(name):
+    """`@openclaw/discord` and `openclaw-discord` are the same plugin as `discord`.
+
+    The registry keys a plugin under any of the three and `ensureChannelPlugin`
+    enables it under whichever one it found, so matching the literal key would
+    skip an enabled alias and leave the gateway blocked on its consent refusal.
+    """
+    for prefix in ("@openclaw/", "openclaw-"):
+        if name.startswith(prefix):
+            return name[len(prefix):]
+    return name
+
+
 try:
     with open(sys.argv[1], encoding="utf-8") as fh:
         entries = (json.load(fh).get("plugins") or {}).get("entries") or {}
@@ -2309,10 +2324,13 @@ except (OSError, json.JSONDecodeError):
     raise SystemExit(0)
 if not isinstance(entries, dict):
     raise SystemExit(0)
-for name in MANAGED:
-    entry = entries.get(name)
+# The CONFIGURED key is what `plugins enable` is given — the alias is the name
+# the registry answers to — while MANAGED is matched on the canonical one.
+for key, entry in entries.items():
+    if not isinstance(key, str) or canonical(key) not in MANAGED:
+        continue
     if isinstance(entry, dict) and entry.get("enabled") is True:
-        print(name)
+        print(key)
 MANAGEDPY
 )"
   for MANAGED_PLUGIN in $MANAGED_ENABLED_PLUGINS; do

--- a/src/lib/openclaw-channels.ts
+++ b/src/lib/openclaw-channels.ts
@@ -66,6 +66,42 @@ export const OFFICIAL_CHANNEL_PLUGINS: Readonly<Record<string, string>> = Object
  */
 export const PLUGIN_INSTALL_TIMEOUT_MS = 180_000;
 
+/**
+ * Record consent for the plugin's declared capability surface.
+ *
+ * OpenClaw 2 refuses both verbs without it. `resolvePluginCapabilityConsent`
+ * (the core's `dist/capability-consent-*.js`) throws `Plugin "<id>" requires
+ * capability consent. Use openclaw plugins install or openclaw plugins enable
+ * with --accept-capabilities, then retry.` unless the install record already
+ * carries an accepted surface hash for the manifest on disk — and the only
+ * other way to satisfy it is an interactive consent callback, which a spawned
+ * CLI does not have. So without the flag a first install cannot succeed at
+ * all: the owner's Discord save answered `install_failed`, and where the
+ * package landed anyway the gateway refused readiness with that same sentence
+ * for as long as the entry said to load the plugin (TASK-603).
+ *
+ * ClawBox already passes it everywhere else it drives this CLI — codex and the
+ * DeepSeek provider in `scripts/gateway-pre-start.sh`, codex again in
+ * `updater.ts`, the DeepSeek provider in `openclaw-deepseek-plugin.ts`. The
+ * channel plugins were the ones left out.
+ *
+ * WHAT THIS PATH DOES NOT COVER, deliberately. A plugin ALREADY installed and
+ * already switched on in the config skips both verbs below, so a save cannot
+ * re-consent a surface that widened under it — and it should not have to: a
+ * surface widens when the package version changes, which happens in
+ * `install.sh`'s plugin refresh (which now carries the flag) and is repaired
+ * from the gateway's own refusal by `gateway-pre-start.sh` on every boot and by
+ * `updater.ts` during an update. Running the CLI unconditionally here would buy
+ * a ~10-12 s cold start on every channel save to cover a case those three
+ * already own.
+ *
+ * It is not a widening of what ClawBox trusts: the specs in
+ * `OFFICIAL_CHANNEL_PLUGINS` are OpenClaw's own published packages, chosen by
+ * this module rather than by the caller, and installing one at all is already
+ * the owner's decision — the Settings panel that asked for the channel.
+ */
+const ACCEPT_CAPABILITIES = "--accept-capabilities";
+
 /** Ceiling for `plugins list` / `plugins enable` — CLI cold start is ~10-12 s. */
 const PLUGIN_QUERY_TIMEOUT_MS = 45_000;
 
@@ -222,7 +258,7 @@ export async function ensureChannelPlugin(
   let installed = false;
   if (!owner) {
     try {
-      await spawnOpenclawCli(["plugins", "install", spec], {
+      await spawnOpenclawCli(["plugins", "install", spec, ACCEPT_CAPABILITIES], {
         timeoutMs: options.timeoutMs ?? PLUGIN_INSTALL_TIMEOUT_MS,
       });
       installed = true;
@@ -248,7 +284,7 @@ export async function ensureChannelPlugin(
   const pluginId = typeof owner?.id === "string" ? owner.id : channelId;
   if (!(await pluginEnabledInConfig(pluginId))) {
     try {
-      await spawnOpenclawCli(["plugins", "enable", pluginId], {
+      await spawnOpenclawCli(["plugins", "enable", pluginId, ACCEPT_CAPABILITIES], {
         timeoutMs: PLUGIN_QUERY_TIMEOUT_MS,
       });
     } catch (err) {

--- a/src/lib/openclaw-channels.ts
+++ b/src/lib/openclaw-channels.ts
@@ -37,6 +37,7 @@ import {
   readConfig,
   spawnOpenclawCli,
 } from "@/lib/openclaw-config";
+import { installedOpenclawRelease } from "@/lib/openclaw-deepseek-plugin";
 
 /**
  * The official channel plugins ClawBox knows how to install.
@@ -101,6 +102,47 @@ export const PLUGIN_INSTALL_TIMEOUT_MS = 180_000;
  * the owner's decision — the Settings panel that asked for the channel.
  */
 const ACCEPT_CAPABILITIES = "--accept-capabilities";
+
+/**
+ * `<generation>` is what decides whether the flag may be passed at all.
+ *
+ * Declared-capability consent arrived with OpenClaw 2; a v1 CLI rejects
+ * `--accept-capabilities` as an unknown option and fails the whole command
+ * before any plugin state changes. `OPENCLAW_PIN_VERSION` is a documented
+ * rollback override, so that is a reachable state and not a hypothetical, and
+ * a Discord save that dies on an unknown flag is the false failure this module
+ * exists to remove. `scripts/gateway-pre-start.sh` builds its own
+ * `CODEX_CAPABILITY_ARGS` the same way; this is that rule in TypeScript.
+ *
+ * Asked of the INSTALLED binary, because it is the process that will parse the
+ * argv. Unknown answers v2 — the shipped pin, and the generation every box in
+ * the field runs — so a probe that times out cannot turn the ordinary path
+ * into the consent refusal.
+ *
+ * Asked ONCE PER SAVE and passed to both verbs, rather than memoised for the
+ * life of the process: the generation changes when the package is reinstalled,
+ * and a value cached past that is the probe-once class this codebase keeps
+ * producing. One `--version` on a path that may spend three minutes on an npm
+ * install is not the cost to optimise.
+ */
+async function capabilityArgs(): Promise<string[]> {
+  const release = await installedOpenclawRelease();
+  if (!release) return [ACCEPT_CAPABILITIES];
+  const [major, minor] = release.split(".").map((part) => Number.parseInt(part, 10));
+  const isV2 = major > 2026 || (major === 2026 && minor >= 8);
+  return isV2 ? [ACCEPT_CAPABILITIES] : [];
+}
+
+/**
+ * `@openclaw/discord` and `openclaw-discord` are the same plugin as `discord`.
+ *
+ * The registry can key a plugin under any of the three — `findChannelOwner`
+ * exists precisely because it does — so anything that decides "is this one of
+ * ours" has to ask about the same name every time.
+ */
+export function normalizeChannelPluginId(id: string): string {
+  return id.replace(/^@openclaw\//, "").replace(/^openclaw-/, "");
+}
 
 /** Ceiling for `plugins list` / `plugins enable` — CLI cold start is ~10-12 s. */
 const PLUGIN_QUERY_TIMEOUT_MS = 45_000;
@@ -240,6 +282,8 @@ export async function ensureChannelPlugin(
   const spec = OFFICIAL_CHANNEL_PLUGINS[channelId];
   if (!spec) return { ok: false, reason: "unsupported_channel" };
 
+  const capArgs = await capabilityArgs();
+
   let owner: PluginRow | null = null;
   try {
     const out = await spawnOpenclawCli(["plugins", "list", "--json"], {
@@ -258,7 +302,7 @@ export async function ensureChannelPlugin(
   let installed = false;
   if (!owner) {
     try {
-      await spawnOpenclawCli(["plugins", "install", spec, ACCEPT_CAPABILITIES], {
+      await spawnOpenclawCli(["plugins", "install", spec, ...capArgs], {
         timeoutMs: options.timeoutMs ?? PLUGIN_INSTALL_TIMEOUT_MS,
       });
       installed = true;
@@ -284,7 +328,7 @@ export async function ensureChannelPlugin(
   const pluginId = typeof owner?.id === "string" ? owner.id : channelId;
   if (!(await pluginEnabledInConfig(pluginId))) {
     try {
-      await spawnOpenclawCli(["plugins", "enable", pluginId, ACCEPT_CAPABILITIES], {
+      await spawnOpenclawCli(["plugins", "enable", pluginId, ...capArgs], {
         timeoutMs: PLUGIN_QUERY_TIMEOUT_MS,
       });
     } catch (err) {

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1094,10 +1094,18 @@ async function pluginConsentRepairIsAllowed(pluginId: string): Promise<boolean> 
   const entries = plugins.entries && typeof plugins.entries === "object"
     ? plugins.entries as Record<string, unknown>
     : {};
-  const entry = entries[pluginId] && typeof entries[pluginId] === "object"
-    ? entries[pluginId] as Record<string, unknown>
-    : null;
-  return entry?.enabled !== false;
+  // Matched on the NORMALISED id, not the literal one. The journal names the
+  // core's own plugin id while `plugins.entries` can be keyed under the alias
+  // `ensureChannelPlugin` writes (`openclaw-discord`), and a lookup that missed
+  // the alias would read an owner's explicit `enabled: false` as "no opinion"
+  // and switch his channel back on.
+  const wanted = normalizeManagedPluginId(pluginId);
+  return !Object.entries(entries).some(([key, entry]) =>
+    normalizeManagedPluginId(key) === wanted
+    && !!entry
+    && typeof entry === "object"
+    && (entry as Record<string, unknown>).enabled === false,
+  );
 }
 
 /**

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -809,8 +809,12 @@ const GATEWAY_PRE_START_TIMEOUT_MS = 600_000;
 const ROOT_STEP_SETTLE_TIMEOUT_MS = Number(process.env.ROOT_STEP_SETTLE_TIMEOUT_MS || "7200000");
 const LEGACY_GATEWAY_BLOCKER_RE =
   /installs\.json|conflicting plugin install metadata|carl_pir|belongs to agent piper/i;
-const CODEX_CAPABILITY_CONSENT_RE =
-  /Plugin\s+["']?codex["']?\s+requires capability consent/i;
+// The core names the plugin in its refusal — `Plugin "discord" requires
+// capability consent…` — so the id is captured rather than hard-coded, and
+// `managedPluginNeedingConsent` decides whether it is one ClawBox may answer
+// for. Not global: `.match()` and `.test()` share this object.
+const PLUGIN_CAPABILITY_CONSENT_RE =
+  /Plugin\s+["']?([A-Za-z0-9@._/-]+?)["']?\s+requires capability consent/i;
 const CURRENT_GATEWAY_PRE_START = path.join(PROJECT_DIR, "scripts", "gateway-pre-start.sh");
 const GATEWAY_QUIESCED_ROOT_STEPS = new Set(["openclaw_install", "post_update"]);
 
@@ -1013,10 +1017,124 @@ async function runCurrentGatewayPreStart(): Promise<void> {
   });
 }
 
-/** Accept only the ClawBox-managed plugin named by a concrete gateway error. */
-async function repairCodexCapabilityConsent(journal: string): Promise<void> {
-  if (!CODEX_CAPABILITY_CONSENT_RE.test(journal)) return;
-  if (!(await codexCapabilityRepairIsAllowed())) return;
+/**
+ * The plugins ClawBox installs, and may therefore consent for.
+ *
+ * The whitelist is the point. Consenting on the owner's behalf is only
+ * defensible for a package ClawBox chose, pinned and installed — codex and the
+ * DeepSeek provider from `scripts/gateway-pre-start.sh`, discord and whatsapp
+ * from `openclaw-channels.ts` when the owner asked for that channel in
+ * Settings, and `clawbox-email-directives`, which is ClawBox's own plugin
+ * copied out of the checkout. A plugin the owner installed from the Terminal
+ * has an owner who can answer for it, and the updater must not answer in his
+ * place — which is also why this is not `openclaw update repair
+ * --accept-capabilities`, the harness's own command for this recovery: that one
+ * consents for everything blocked, including his.
+ */
+const CLAWBOX_MANAGED_PLUGIN_IDS: ReadonlySet<string> = new Set([
+  "codex",
+  "deepseek",
+  "discord",
+  "whatsapp",
+  "clawbox-email-directives",
+]);
+
+/**
+ * `@openclaw/discord` and `openclaw-discord` are the same plugin as `discord`.
+ *
+ * The core names its own normalised plugin id in the refusal, which on a
+ * measured box is the bare one — but `ensureChannelPlugin` already handles a
+ * registry that calls the Discord plugin `openclaw-discord`
+ * (`openclaw-channels.ts`, and a test pins it), so the membership test must not
+ * be the thing that decides a box gets no repair.
+ */
+function normalizeManagedPluginId(id: string): string {
+  return id.replace(/^@openclaw\//, "").replace(/^openclaw-/, "");
+}
+
+/** Every plugin a consent refusal in this journal names, split by who owns it. */
+function pluginsNeedingConsent(journal: string): { managed: string[]; unmanaged: string[] } {
+  // A GLOBAL copy of the shared pattern, built here so the shared one keeps a
+  // stable `lastIndex` for its `.test()` callers. Reading only the FIRST match
+  // was a live dead end: the journal tail spans the whole boot (`-b`) and the
+  // gateway restarts several times during an update, so a stale `codex` line
+  // ahead of a live `discord` one had the repair fix codex while
+  // `getGatewayFailureDetail` — which scans in REVERSE — handed the owner the
+  // discord sentence.
+  const namesRe = new RegExp(PLUGIN_CAPABILITY_CONSENT_RE.source, "gi");
+  const managed = new Set<string>();
+  const unmanaged = new Set<string>();
+  for (const match of journal.matchAll(namesRe)) {
+    const id = match[1];
+    // Bucketed by the NORMALISED id, repaired under the id the journal used:
+    // that is the name the registry answers to.
+    (CLAWBOX_MANAGED_PLUGIN_IDS.has(normalizeManagedPluginId(id)) ? managed : unmanaged).add(id);
+  }
+  return { managed: [...managed], unmanaged: [...unmanaged] };
+}
+
+/**
+ * Respect an owner-disabled plugin even if the journal still mentions it.
+ *
+ * The sibling of `codexCapabilityRepairIsAllowed`, and needed for the same
+ * reason. `plugins enable` is not a consent-only verb — it writes
+ * `plugins.entries.<id>.enabled = true` — and the journal tail is the whole
+ * boot, captured BEFORE the pre-start runs. So an owner who opened the Terminal
+ * and ran `openclaw plugins disable discord` to get his box back would have had
+ * the channel switched on again, with consent granted in his name, by the very
+ * next update. Explicitly `false` is the only answer that stops the repair;
+ * absent or unreadable is not an opt-out.
+ */
+async function pluginConsentRepairIsAllowed(pluginId: string): Promise<boolean> {
+  const cfg = await readOpenclawConfigForRepair();
+  if (!cfg) return true;
+  const plugins = cfg.plugins && typeof cfg.plugins === "object"
+    ? cfg.plugins as Record<string, unknown>
+    : {};
+  const entries = plugins.entries && typeof plugins.entries === "object"
+    ? plugins.entries as Record<string, unknown>
+    : {};
+  const entry = entries[pluginId] && typeof entries[pluginId] === "object"
+    ? entries[pluginId] as Record<string, unknown>
+    : null;
+  return entry?.enabled !== false;
+}
+
+/**
+ * Accept every ClawBox-managed plugin a concrete gateway error names.
+ *
+ * WHY THIS IS NOT CODEX-ONLY ANY MORE (TASK-603). The gateway refuses readiness
+ * for ANY enabled plugin whose declared capability surface has not been
+ * consented to, and it names the plugin in the refusal. Until now this repair
+ * matched the literal word `codex`, so a box blocked on `discord` or `whatsapp`
+ * — the channel plugins the Settings panel installs — went through the whole
+ * recovery untouched and ended at `getGatewayFailureDetail`, which handed the
+ * owner the core's own sentence: "rerun with --accept-capabilities". That is
+ * advice about a CLI he never ran, over a box that will not come back until
+ * somebody runs it for him. This is the tool doing the thing itself.
+ */
+async function repairPluginCapabilityConsent(journal: string): Promise<void> {
+  const { managed, unmanaged } = pluginsNeedingConsent(journal);
+  for (const pluginId of unmanaged) {
+    // Said out loud rather than skipped in silence: this is the one case where
+    // the owner still has to run the CLI himself, and the update log is where
+    // he or a support session will look for why nothing happened.
+    console.info(
+      `[Updater] "${pluginId}" needs capability consent and is not a ClawBox-managed plugin — leaving it to its owner`,
+    );
+  }
+  for (const pluginId of managed) {
+    if (normalizeManagedPluginId(pluginId) === "codex") {
+      if (await codexCapabilityRepairIsAllowed()) await repairCodexCapabilityConsent();
+      continue;
+    }
+    if (!(await pluginConsentRepairIsAllowed(pluginId))) continue;
+    await recordPluginCapabilityConsent(pluginId);
+  }
+}
+
+/** The pinned force-install that repairs a partial Codex project AND consents it. */
+async function repairCodexCapabilityConsent(): Promise<void> {
   let target = OPENCLAW_VERSION_FALLBACK;
   try {
     target = (await readFile(OPENCLAW_TARGET_FILE, "utf-8")).trim().split(/\s+/)[0] || target;
@@ -1050,15 +1168,66 @@ async function repairCodexCapabilityConsent(journal: string): Promise<void> {
   }
 }
 
-/** Respect an owner-disabled unused Codex plugin even if old logs mention it. */
-async function codexCapabilityRepairIsAllowed(): Promise<boolean> {
+/**
+ * Record consent for an already-installed managed plugin.
+ *
+ * `plugins enable` rather than a reinstall, for the reason
+ * `scripts/gateway-pre-start.sh` gives at its own codex consent branch: it is
+ * the idempotent local operation that records the current reviewed surface and
+ * leaves an already-consented plugin alone, and it touches no registry — which
+ * matters here, because this runs mid-update on a box whose network may be
+ * exactly why the update is being repaired. The Codex arm above reinstalls
+ * instead only because a v1 migration can leave that ONE plugin as a project
+ * declaration with no `node_modules`, a state its own pin repairs.
+ *
+ * LIMIT, deliberately not papered over: if a managed plugin is in that partial
+ * state, `enable` answers "Plugin not found" and this warns rather than
+ * fetching an unpinned package from npm mid-update. The gateway's own refusal
+ * then still reaches the owner through `getGatewayFailureDetail`; what he does
+ * not get is a silent claim that ClawBox repaired it.
+ */
+async function recordPluginCapabilityConsent(pluginId: string): Promise<void> {
+  try {
+    await execFile(
+      OPENCLAW_BIN,
+      ["plugins", "enable", pluginId, "--accept-capabilities"],
+      { timeout: 60_000, maxBuffer: 4 * 1024 * 1024 },
+    );
+  } catch (err) {
+    // Best effort, like the Codex branch above: the clean restart and the
+    // positive port probe decide the result, and this must not replace a
+    // preceding pre-start failure.
+    console.warn(
+      `[Updater] capability consent for "${pluginId}" did not complete:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+}
+
+/**
+ * openclaw.json as the consent repairs read it, or null when it cannot be read.
+ *
+ * Null is "no explicit opt-out on record", never "switched off": a missing or
+ * malformed config must not be what stops a box from coming back.
+ */
+async function readOpenclawConfigForRepair(): Promise<Record<string, unknown> | null> {
   const home = process.env.CLAWBOX_HOME_DIR || process.env.HOME || "/home/clawbox";
   const openclawHome = process.env.CLAWBOX_OPENCLAW_HOME
     || process.env.OPENCLAW_HOME
     || path.join(home, ".openclaw");
   const configPath = process.env.OPENCLAW_CONFIG || path.join(openclawHome, "openclaw.json");
   try {
-    const cfg = JSON.parse(await readFile(configPath, "utf-8")) as Record<string, unknown>;
+    return JSON.parse(await readFile(configPath, "utf-8")) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/** Respect an owner-disabled unused Codex plugin even if old logs mention it. */
+async function codexCapabilityRepairIsAllowed(): Promise<boolean> {
+  try {
+    const cfg = await readOpenclawConfigForRepair();
+    if (!cfg) return true;
     const plugins = cfg.plugins && typeof cfg.plugins === "object"
       ? cfg.plugins as Record<string, unknown>
       : {};
@@ -1138,7 +1307,7 @@ function getGatewayFailureDetail(logText: string): string | null {
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean);
-  for (const pattern of [CODEX_CAPABILITY_CONSENT_RE, /SQLite transaction lock wait failed/i]) {
+  for (const pattern of [PLUGIN_CAPABILITY_CONSENT_RE, /SQLite transaction lock wait failed/i]) {
     const match = [...lines].reverse().find((line) => pattern.test(line));
     if (match) return match;
   }
@@ -1180,10 +1349,10 @@ async function ensureGatewayHealthy(options: { restartFirst?: boolean } = {}): P
       // If an earlier pre-start migration fails, still record the narrowly
       // scoped consent named by the existing journal. Do not restart after a
       // partial pre-start; propagate its failure once the repair is recorded.
-      await repairCodexCapabilityConsent(journal);
+      await repairPluginCapabilityConsent(journal);
       throw err;
     }
-    await repairCodexCapabilityConsent(journal);
+    await repairPluginCapabilityConsent(journal);
     await runOpenclawDoctorFix();
   });
   // `awaitReady: false` on both restarts in this function, and only here: the

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1062,15 +1062,21 @@ function pluginsNeedingConsent(journal: string): { managed: string[]; unmanaged:
   // `getGatewayFailureDetail` — which scans in REVERSE — handed the owner the
   // discord sentence.
   const namesRe = new RegExp(PLUGIN_CAPABILITY_CONSENT_RE.source, "gi");
-  const managed = new Set<string>();
-  const unmanaged = new Set<string>();
+  // KEYED by the normalised id, VALUED by the first raw id seen for it. One
+  // boot's journal can name the same plugin twice under different spellings —
+  // `codex` from one start, `@openclaw/codex` from another — and a set of raw
+  // ids would then repair it twice, giving the pinned force-install two
+  // separate six-minute budgets back to back on a Jetson. The repair runs
+  // under the raw name because that is what the registry answers to.
+  const managed = new Map<string, string>();
+  const unmanaged = new Map<string, string>();
   for (const match of journal.matchAll(namesRe)) {
     const id = match[1];
-    // Bucketed by the NORMALISED id, repaired under the id the journal used:
-    // that is the name the registry answers to.
-    (CLAWBOX_MANAGED_PLUGIN_IDS.has(normalizeManagedPluginId(id)) ? managed : unmanaged).add(id);
+    const key = normalizeManagedPluginId(id);
+    const bucket = CLAWBOX_MANAGED_PLUGIN_IDS.has(key) ? managed : unmanaged;
+    if (!bucket.has(key)) bucket.set(key, id);
   }
-  return { managed: [...managed], unmanaged: [...unmanaged] };
+  return { managed: [...managed.values()], unmanaged: [...unmanaged.values()] };
 }
 
 /**

--- a/src/tests/unit/gateway-pre-start-codex-runtime.test.ts
+++ b/src/tests/unit/gateway-pre-start-codex-runtime.test.ts
@@ -93,14 +93,28 @@ function extractPluginResolver(): string {
 const PLUGIN_RESOLVER = extractPluginResolver();
 
 /** Pull the package-health/repair/consent command flow out verbatim. */
+const MANAGED_CONSENT_MARKER = "# \u2500\u2500 Capability consent for the OTHER ClawBox-managed plugins";
+
 function extractPluginFlow(): string {
   const start = SCRIPT_SOURCE.indexOf('CODEX_SHOULD_LOAD="$NEEDS_CODEX_PLUGIN"');
-  const end = SCRIPT_SOURCE.indexOf("# Codex reads its ChatGPT session", start);
+  // Ends where the block for the OTHER managed plugins begins: that one has its
+  // own extraction and its own harness below, and it reads openclaw.json, which
+  // this fragment's environment does not set.
+  const end = SCRIPT_SOURCE.indexOf(MANAGED_CONSENT_MARKER, start);
   if (start < 0 || end < 0) throw new Error("Codex plugin command flow not found");
   return SCRIPT_SOURCE.slice(start, end);
 }
 
+/** The boot-path consent pass for deepseek / discord / whatsapp / our own plugin. */
+function extractManagedConsentFlow(): string {
+  const start = SCRIPT_SOURCE.indexOf(MANAGED_CONSENT_MARKER);
+  const end = SCRIPT_SOURCE.indexOf("# Codex reads its ChatGPT session", start);
+  if (start < 0 || end < 0) throw new Error("Managed-plugin consent flow not found");
+  return SCRIPT_SOURCE.slice(start, end);
+}
+
 const PLUGIN_FLOW = extractPluginFlow();
+const MANAGED_CONSENT_FLOW = extractManagedConsentFlow();
 
 let dir: string;
 
@@ -206,6 +220,89 @@ function runPluginFlow(options: PluginFlowOptions): string[] {
     ? readFileSync(log, "utf-8").trim().split("\n").filter(Boolean)
     : [];
 }
+
+/**
+ * Run the boot-path consent pass for the managed plugins that are NOT codex.
+ *
+ * TASK-603. The codex arm above has consented its one plugin on every boot
+ * since OpenClaw 2 introduced declared-capability consent; the gateway refuses
+ * readiness for any enabled plugin in that state, and ClawBox installs four
+ * more. The 2026-09-01 outage was `discord`, and a reboot — the owner's first
+ * move on a box that will not come up — changed nothing.
+ */
+function runManagedConsentFlow(options: {
+  v2?: boolean;
+  entries?: Record<string, unknown>;
+  writeConfig?: boolean;
+}): string[] {
+  const config = path.join(dir, "managed-consent.json");
+  if (options.writeConfig !== false) {
+    writeFileSync(config, JSON.stringify({ plugins: { entries: options.entries ?? {} } }));
+  }
+
+  const log = path.join(dir, "managed-consent.log");
+  const fakeOpenClaw = path.join(dir, "openclaw-managed");
+  writeFileSync(fakeOpenClaw, '#!/usr/bin/env bash\nprintf \'%s\\n\' "$*" >> "$CODEX_TEST_LOG"\n');
+  chmodSync(fakeOpenClaw, 0o755);
+
+  execFileSync("bash", ["-c", `set -euo pipefail\n${MANAGED_CONSENT_FLOW}`], {
+    env: {
+      ...process.env,
+      CLAWBOX_OPENCLAW_V2: options.v2 === false ? "0" : "1",
+      OPENCLAW_CONFIG: config,
+      OPENCLAW_BIN: fakeOpenClaw,
+      CODEX_TEST_LOG: log,
+    },
+    stdio: "pipe",
+  });
+
+  return existsSync(log)
+    ? readFileSync(log, "utf-8").trim().split("\n").filter(Boolean)
+    : [];
+}
+
+describe("gateway-pre-start.sh managed-plugin capability consent", () => {
+  it("consents every managed plugin openclaw.json says to load", () => {
+    expect(runManagedConsentFlow({
+      entries: {
+        deepseek: { enabled: true },
+        discord: { enabled: true },
+        whatsapp: { enabled: true },
+        "clawbox-email-directives": { enabled: true },
+      },
+    })).toEqual([
+      "plugins enable deepseek --accept-capabilities",
+      "plugins enable discord --accept-capabilities",
+      "plugins enable whatsapp --accept-capabilities",
+      "plugins enable clawbox-email-directives --accept-capabilities",
+    ]);
+  });
+
+  it("never switches a plugin ON — only entries already enabled are consented", () => {
+    // `plugins enable` writes `plugins.entries.<id>.enabled = true`, so a boot
+    // script that ran it over an absent or disabled entry would be turning a
+    // channel on behind the owner. Consent is for what the box already loads.
+    expect(runManagedConsentFlow({
+      entries: { discord: { enabled: false }, whatsapp: {} },
+    })).toEqual([]);
+  });
+
+  it("leaves a plugin ClawBox does not manage alone", () => {
+    expect(runManagedConsentFlow({ entries: { weatherbot: { enabled: true } } })).toEqual([]);
+  });
+
+  it("does nothing on OpenClaw 1, which has no capability consent", () => {
+    expect(runManagedConsentFlow({ v2: false, entries: { discord: { enabled: true } } }))
+      .toEqual([]);
+  });
+
+  it("survives a missing or unparseable config rather than failing the pre-start", () => {
+    // This is a blocking ExecStartPre under `set -euo pipefail`: a throw here
+    // is a box with no gateway, which is strictly worse than an unconsented
+    // plugin the journal will name.
+    expect(runManagedConsentFlow({ writeConfig: false })).toEqual([]);
+  });
+});
 
 /** Resolve a plugin exposed only through OpenClaw's own global registry. */
 function resolveRegistryOnlyPlugin(): string {

--- a/src/tests/unit/gateway-pre-start-codex-runtime.test.ts
+++ b/src/tests/unit/gateway-pre-start-codex-runtime.test.ts
@@ -291,6 +291,29 @@ describe("gateway-pre-start.sh managed-plugin capability consent", () => {
     expect(runManagedConsentFlow({ entries: { weatherbot: { enabled: true } } })).toEqual([]);
   });
 
+  it("recognises the plugin under the alias the registry may have keyed it as", () => {
+    // `ensureChannelPlugin` enables the plugin under the id `plugins list`
+    // reports, which can be `openclaw-discord` or `@openclaw/discord`. Matching
+    // the literal key would skip an enabled alias and leave the gateway
+    // blocked on the very consent refusal this block exists to clear — and the
+    // CLI has to be given the configured key back, because that is the name
+    // the registry answers to.
+    expect(runManagedConsentFlow({
+      entries: {
+        "openclaw-discord": { enabled: true },
+        "@openclaw/whatsapp": { enabled: true },
+      },
+    })).toEqual([
+      "plugins enable openclaw-discord --accept-capabilities",
+      "plugins enable @openclaw/whatsapp --accept-capabilities",
+    ]);
+  });
+
+  it("respects a disabled ALIAS as it respects a disabled canonical entry", () => {
+    expect(runManagedConsentFlow({ entries: { "openclaw-discord": { enabled: false } } }))
+      .toEqual([]);
+  });
+
   it("does nothing on OpenClaw 1, which has no capability consent", () => {
     expect(runManagedConsentFlow({ v2: false, entries: { discord: { enabled: true } } }))
       .toEqual([]);

--- a/src/tests/unit/install-plugin-capability-consent.test.ts
+++ b/src/tests/unit/install-plugin-capability-consent.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * TASK-603 — the plugin refresh inside `step_openclaw_install` records consent.
+ *
+ * OpenClaw 2 refuses to install a managed plugin whose declared capability
+ * surface has not been consented to (`resolvePluginArtifactCapabilityConsent`
+ * in the pinned core's `dist/capability-consent-*.js`), and a spawned,
+ * non-interactive CLI has no consent callback to answer with — so without
+ * `--accept-capabilities` the install cannot succeed at all. The gateway then
+ * refuses readiness with `Plugin "<id>" requires capability consent` for as
+ * long as the config says to load it.
+ *
+ * That loop (`install.sh`, inside `step_openclaw_install`) reinstalls every
+ * external plugin the box already has against the new core target, which is
+ * exactly the moment a declared surface changes. Its failure branch is a WARN,
+ * so the refusal was invisible and the box came up without a gateway.
+ *
+ * Two things have to stay true of it, and they pull in opposite directions:
+ * the flag must be passed for the plugins ClawBox installs, and must NOT be
+ * passed for a plugin the owner installed himself — consenting to a widened
+ * surface in his name is the thing the whitelist in `src/lib/updater.ts`
+ * exists to prevent. It is also gated on the installed generation, because a
+ * v1 pin rejects the option and would fail every refresh behind that WARN.
+ *
+ * Source assertions rather than a run: this loop reaches the network and the
+ * plugin registry, and what has to be true of it is its argv.
+ */
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
+const LINES = INSTALL_SH.split("\n");
+
+/** Lines that actually run a CLI verb, comments excluded. */
+function callsTo(verb: string): string[] {
+  return LINES.filter(
+    (line) => !line.trimStart().startsWith("#") && new RegExp(`\\bplugins ${verb}\\b`).test(line),
+  );
+}
+
+describe("install.sh plugin refresh", () => {
+  it("passes the consent argv it built, rather than a hard-coded flag", () => {
+    const installs = callsTo("install");
+    expect(installs).toHaveLength(1);
+    expect(installs[0]).toContain('"${CAP_ARGS[@]}"');
+  });
+
+  it("builds that argv only on OpenClaw 2", () => {
+    // A v1 pin (OPENCLAW_PIN_VERSION is a documented rollback override) gives a
+    // CLI that rejects the unknown option — every iteration would then fail
+    // behind the swallowed WARN with no plugin refreshed at all.
+    const built = LINES.findIndex((l) => l.includes("CAP_ARGS=(--accept-capabilities)"));
+    expect(built).toBeGreaterThan(-1);
+    expect(LINES[built]).toContain("openclaw_is_v2");
+  });
+
+  it("builds it only for the plugins ClawBox installs", () => {
+    // The same whitelist as CLAWBOX_MANAGED_PLUGIN_IDS in src/lib/updater.ts.
+    // The flag consents to the NEW surface, so passing it for a plugin the
+    // owner installed himself answers a widened-capabilities question in his
+    // name — which is exactly what that whitelist exists to prevent.
+    const built = LINES.findIndex((l) => l.includes("CAP_ARGS=(--accept-capabilities)"));
+    const guard = LINES[built - 1];
+    expect(guard).toContain("codex|deepseek|discord|whatsapp|clawbox-email-directives)");
+  });
+
+  it("has no `plugins install` or `plugins enable` that skips consent entirely", () => {
+    // The invariant this PR is about: every ClawBox-driven use of either verb
+    // either carries the flag or carries the argv that may hold it. install.sh
+    // has no `plugins enable` today, which is when a guard is cheapest to add.
+    const offenders = [...callsTo("install"), ...callsTo("enable")].filter(
+      (line) => !line.includes("--accept-capabilities") && !line.includes("CAP_ARGS"),
+    );
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/tests/unit/install-plugin-capability-consent.test.ts
+++ b/src/tests/unit/install-plugin-capability-consent.test.ts
@@ -66,6 +66,18 @@ describe("install.sh plugin refresh", () => {
     expect(guard).toContain("codex|deepseek|discord|whatsapp|clawbox-email-directives)");
   });
 
+  it("matches the whitelist on the NORMALISED plugin id", () => {
+    // `plugins list --json` can key the Discord plugin as `openclaw-discord` or
+    // `@openclaw/discord`. The raw name would fall through the case to the
+    // default arm and be refreshed without consent — silently, behind the WARN
+    // — while `$spec` still has to carry the raw name for the CLI.
+    const built = LINES.findIndex((l) => l.includes("CAP_ARGS=(--accept-capabilities)"));
+    const region = LINES.slice(Math.max(0, built - 8), built).join("\n");
+    expect(region).toContain("${plugin#@openclaw/}");
+    expect(region).toContain("${PLUGIN_KEY#openclaw-}");
+    expect(region).toContain('case "$PLUGIN_KEY" in');
+  });
+
   it("has no `plugins install` or `plugins enable` that skips consent entirely", () => {
     // The invariant this PR is about: every ClawBox-driven use of either verb
     // either carries the flag or carries the argv that may hold it. install.sh

--- a/src/tests/unit/openclaw-channel-plugins.test.ts
+++ b/src/tests/unit/openclaw-channel-plugins.test.ts
@@ -31,9 +31,18 @@ vi.mock("@/lib/openclaw-config", async () => {
   };
 });
 
+// The installed OpenClaw generation, pinned rather than probed: it decides
+// whether `--accept-capabilities` may be passed at all, and the real reader
+// spawns `openclaw --version`, which would shift every argv index below.
+vi.mock("@/lib/openclaw-deepseek-plugin", () => ({
+  installedOpenclawRelease: vi.fn(async () => "2026.8.1"),
+}));
+
 import { OpenclawSpawnTimeoutError, readConfig, spawnOpenclawCli } from "@/lib/openclaw-config";
+import { installedOpenclawRelease } from "@/lib/openclaw-deepseek-plugin";
 
 const mockSpawn = vi.mocked(spawnOpenclawCli);
+const mockRelease = vi.mocked(installedOpenclawRelease);
 const mockReadConfig = vi.mocked(readConfig);
 
 /** openclaw.json with the given plugin ids switched on in `plugins.entries`. */
@@ -67,6 +76,7 @@ describe("ensureChannelPlugin", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    mockRelease.mockResolvedValue("2026.8.1");
     // Default: the gateway config already carries the entry, so the common path
     // does not shell out to `plugins enable`.
     mockReadConfig.mockResolvedValue(configWithEnabled("discord", "whatsapp"));
@@ -287,6 +297,7 @@ describe("readChannelStatus", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    mockRelease.mockResolvedValue("2026.8.1");
     // Default: the gateway config already carries the entry, so the common path
     // does not shell out to `plugins enable`.
     mockReadConfig.mockResolvedValue(configWithEnabled("discord", "whatsapp"));
@@ -374,6 +385,7 @@ describe("waitForChannelConnected", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    mockRelease.mockResolvedValue("2026.8.1");
     // Default: the gateway config already carries the entry, so the common path
     // does not shell out to `plugins enable`.
     mockReadConfig.mockResolvedValue(configWithEnabled("discord", "whatsapp"));
@@ -441,6 +453,7 @@ describe("ensureChannelPlugin capability consent", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    mockRelease.mockResolvedValue("2026.8.1");
     mockReadConfig.mockResolvedValue(configWithEnabled("discord", "whatsapp"));
     lib = await import("@/lib/openclaw-channels");
   });
@@ -461,6 +474,48 @@ describe("ensureChannelPlugin capability consent", () => {
 
     expect(await lib.ensureChannelPlugin("whatsapp")).toEqual({ ok: true, installed: true });
     expect(mockSpawn.mock.calls[1][0]).toContain("--accept-capabilities");
+  });
+
+  it("does NOT pass the flag on an OpenClaw 1 rollback, which rejects it", async () => {
+    // Declared-capability consent arrived with OpenClaw 2. A v1 CLI treats
+    // `--accept-capabilities` as an unknown option and fails the whole command
+    // before any plugin state changes, so passing it unconditionally would
+    // turn every Discord save on a rolled-back box (`OPENCLAW_PIN_VERSION` is
+    // a documented override) into `install_failed` over a plugin that would
+    // have installed. `gateway-pre-start.sh` builds its own capability argv
+    // the same way.
+    mockRelease.mockResolvedValue("2026.7.4");
+    mockSpawn
+      .mockResolvedValueOnce(pluginsListJson([{ id: "telegram" }]))
+      .mockResolvedValueOnce("Installed plugin: discord.");
+
+    expect(await lib.ensureChannelPlugin("discord")).toEqual({ ok: true, installed: true });
+    expect(mockSpawn.mock.calls[1][0]).toEqual(["plugins", "install", "@openclaw/discord"]);
+  });
+
+  it("passes it when the generation cannot be read — v2 is what every box runs", async () => {
+    mockRelease.mockResolvedValue(null);
+    mockSpawn
+      .mockResolvedValueOnce(pluginsListJson([{ id: "telegram" }]))
+      .mockResolvedValueOnce("Installed plugin: discord.");
+
+    expect(await lib.ensureChannelPlugin("discord")).toEqual({ ok: true, installed: true });
+    expect(mockSpawn.mock.calls[1][0]).toContain("--accept-capabilities");
+  });
+
+  it("asks the generation ONCE per save, not once per verb", async () => {
+    // A probe memoised for the life of the process would be the probe-once
+    // class; a probe per verb is two `openclaw --version` cold starts on a
+    // Jetson for one save.
+    mockReadConfig.mockResolvedValue(configWithEnabled());
+    mockSpawn
+      .mockResolvedValueOnce(pluginsListJson([{ id: "telegram" }]))
+      .mockResolvedValueOnce("Installed plugin: discord.")
+      .mockResolvedValueOnce("ok");
+
+    await lib.ensureChannelPlugin("discord");
+
+    expect(mockRelease).toHaveBeenCalledTimes(1);
   });
 
   it("accepts them on the ENABLE too — the verb that runs on an already-installed plugin", async () => {

--- a/src/tests/unit/openclaw-channel-plugins.test.ts
+++ b/src/tests/unit/openclaw-channel-plugins.test.ts
@@ -96,7 +96,8 @@ describe("ensureChannelPlugin", () => {
       .mockResolvedValueOnce('Enabled plugin "discord". Restart the gateway to apply.');
 
     expect(await lib.ensureChannelPlugin("discord")).toEqual({ ok: true, installed: false });
-    expect(mockSpawn.mock.calls[1][0]).toEqual(["plugins", "enable", "discord"]);
+    expect(mockSpawn.mock.calls[1][0])
+      .toEqual(["plugins", "enable", "discord", "--accept-capabilities"]);
   });
 
   it("enables under the OWNING plugin's id, not the channel's", async () => {
@@ -107,7 +108,8 @@ describe("ensureChannelPlugin", () => {
 
     await lib.ensureChannelPlugin("discord");
 
-    expect(mockSpawn.mock.calls[1][0]).toEqual(["plugins", "enable", "openclaw-discord"]);
+    expect(mockSpawn.mock.calls[1][0])
+      .toEqual(["plugins", "enable", "openclaw-discord", "--accept-capabilities"]);
   });
 
   it("reports install_failed when the enable fails", async () => {
@@ -130,7 +132,8 @@ describe("ensureChannelPlugin", () => {
     const result = await lib.ensureChannelPlugin("discord");
 
     expect(result).toEqual({ ok: true, installed: true });
-    expect(mockSpawn.mock.calls[1][0]).toEqual(["plugins", "install", "@openclaw/discord"]);
+    expect(mockSpawn.mock.calls[1][0])
+      .toEqual(["plugins", "install", "@openclaw/discord", "--accept-capabilities"]);
     // `plugins install` writes plugins.entries.<id> itself, so no second write.
     expect(mockSpawn).toHaveBeenCalledTimes(2);
   });
@@ -143,7 +146,8 @@ describe("ensureChannelPlugin", () => {
       .mockResolvedValueOnce("ok");
 
     expect(await lib.ensureChannelPlugin("discord")).toEqual({ ok: true, installed: true });
-    expect(mockSpawn.mock.calls[2][0]).toEqual(["plugins", "enable", "discord"]);
+    expect(mockSpawn.mock.calls[2][0])
+      .toEqual(["plugins", "enable", "discord", "--accept-capabilities"]);
   });
 
   it("treats OpenClaw's 'plugin already exists' refusal as installed, not as a failure", async () => {
@@ -179,7 +183,8 @@ describe("ensureChannelPlugin", () => {
     const result = await lib.ensureChannelPlugin("whatsapp");
 
     expect(result).toEqual({ ok: true, installed: true });
-    expect(mockSpawn.mock.calls[1][0]).toEqual(["plugins", "install", "@openclaw/whatsapp"]);
+    expect(mockSpawn.mock.calls[1][0])
+      .toEqual(["plugins", "install", "@openclaw/whatsapp", "--accept-capabilities"]);
   });
 
   it("matches a plugin that OWNS the channel under a different plugin id", async () => {
@@ -408,5 +413,66 @@ describe("waitForChannelConnected", () => {
 
     expect(status?.tokenStatus).toBe("configured_unavailable");
     expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * OpenClaw 2 refuses to install OR enable a managed plugin whose declared
+ * capability surface has not been consented to. Verified read-only against the
+ * pinned core (2026.8.1) on an OpenClaw box:
+ *
+ *   dist/capability-consent-*.js — `resolvePluginCapabilityConsent` throws
+ *     ManagedPluginLifecycleError('Plugin "<id>" requires capability consent.
+ *     Use openclaw plugins install or openclaw plugins enable with
+ *     --accept-capabilities, then retry.') unless the install record already
+ *     carries an accepted surface hash for the current manifest.
+ *
+ * `spawnOpenclawCli` runs non-interactively, so there is no consent callback to
+ * answer that prompt: without the flag the refusal is the only outcome. ClawBox
+ * already passes it for the other three plugins it manages (codex and deepseek
+ * in gateway-pre-start.sh, codex again in updater.ts) — the channel plugins are
+ * the ones it was never passed for, which is how a Discord save turned into
+ * "the plugin could not be installed" and, on the update path, into a gateway
+ * that refused readiness (TASK-603).
+ */
+describe("ensureChannelPlugin capability consent", () => {
+  let lib: typeof import("@/lib/openclaw-channels");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockReadConfig.mockResolvedValue(configWithEnabled("discord", "whatsapp"));
+    lib = await import("@/lib/openclaw-channels");
+  });
+
+  it("accepts the declared capabilities when it installs a channel plugin", async () => {
+    mockSpawn
+      .mockResolvedValueOnce(pluginsListJson([{ id: "telegram" }]))
+      .mockResolvedValueOnce("Installed plugin: discord.");
+
+    expect(await lib.ensureChannelPlugin("discord")).toEqual({ ok: true, installed: true });
+    expect(mockSpawn.mock.calls[1][0]).toContain("--accept-capabilities");
+  });
+
+  it("accepts them for WhatsApp too — nothing is special-cased to Discord", async () => {
+    mockSpawn
+      .mockResolvedValueOnce(pluginsListJson([{ id: "telegram" }]))
+      .mockResolvedValueOnce("Installed plugin: whatsapp.");
+
+    expect(await lib.ensureChannelPlugin("whatsapp")).toEqual({ ok: true, installed: true });
+    expect(mockSpawn.mock.calls[1][0]).toContain("--accept-capabilities");
+  });
+
+  it("accepts them on the ENABLE too — the verb that runs on an already-installed plugin", async () => {
+    // The live shape of TASK-603: the package is on disk from an earlier core,
+    // so nothing reinstalls it, and the enable is the only call left to record
+    // the consent the gateway demands before it opens its port.
+    mockReadConfig.mockResolvedValue(configWithEnabled());
+    mockSpawn
+      .mockResolvedValueOnce(pluginsListJson([{ id: "discord" }]))
+      .mockResolvedValueOnce('Enabled plugin "discord".');
+
+    expect(await lib.ensureChannelPlugin("discord")).toEqual({ ok: true, installed: false });
+    expect(mockSpawn.mock.calls[1][0]).toContain("--accept-capabilities");
   });
 });

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -864,6 +864,52 @@ describe("updater", () => {
       expect(calls.some((call) => call.includes("plugins enable discord"))).toBe(false);
     });
 
+    it("repairs a plugin named twice under different spellings only ONCE", async () => {
+      // One boot's journal can carry both spellings — a restart before the
+      // registry key changed, an alias from `plugins list`. Repairing per raw
+      // name would give the pinned force-install two six-minute budgets back
+      // to back on a Jetson for one plugin.
+      setupExecFileMock({
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
+        "/usr/bin/journalctl -u clawbox-gateway.service": {
+          stdout: [
+            'Plugin "discord" requires capability consent; rerun with --accept-capabilities.',
+            'Plugin "openclaw-discord" requires capability consent; rerun with --accept-capabilities.',
+            "",
+          ].join("\n"),
+          stderr: "",
+        },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+        "/bin/bash": { stdout: "", stderr: "" },
+      });
+
+      vi.resetModules();
+      mockGet.mockResolvedValue(true);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockRebuiltBox();
+      mockGatewayUp.mockImplementation(async () =>
+        mockExecFile.mock.calls.some(([cmd, args]) =>
+          `${cmd} ${(args as string[]).join(" ")}`.includes("plugins enable"),
+        ),
+      );
+      updater = await import("@/lib/updater");
+
+      updater.resetUpdateState();
+      expect(await updater.checkContinuation()).toBe(true);
+      await vi.waitFor(() => expect(updater.getUpdateState().phase).toBe("completed"));
+
+      const enables = mockExecFile.mock.calls
+        .map(([cmd, args]) => `${cmd} ${(args as string[]).join(" ")}`)
+        .filter((call) => call.includes("plugins enable"));
+      expect(enables).toHaveLength(1);
+      // The FIRST spelling the journal used — the name the registry answered to
+      // when it refused.
+      expect(enables[0]).toContain("plugins enable discord --accept-capabilities");
+    });
+
     it("respects an owner-disabled plugin recorded under its ALIAS", async () => {
       // The journal names the core's own plugin id (`discord`), while
       // `plugins.entries` can be keyed under the alias `ensureChannelPlugin`

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -864,6 +864,52 @@ describe("updater", () => {
       expect(calls.some((call) => call.includes("plugins enable discord"))).toBe(false);
     });
 
+    it("respects an owner-disabled plugin recorded under its ALIAS", async () => {
+      // The journal names the core's own plugin id (`discord`), while
+      // `plugins.entries` can be keyed under the alias `ensureChannelPlugin`
+      // enabled it as (`openclaw-discord`). A literal lookup misses the
+      // owner's explicit `enabled: false` and reads it as "no opinion", so the
+      // repair switches his channel back on with consent granted in his name.
+      setupExecFileMock({
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
+        "/usr/bin/journalctl -u clawbox-gateway.service": {
+          stdout: 'Plugin "discord" requires capability consent; rerun with --accept-capabilities.\n',
+          stderr: "",
+        },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+        "/bin/bash": { stdout: "", stderr: "" },
+      });
+
+      vi.resetModules();
+      mockGet.mockResolvedValue(true);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockRebuiltBox();
+      mockReadFile.mockImplementation(async (file) => {
+        const name = String(file);
+        if (name.endsWith("BUILD_ID")) return "rebuilt-build-id\n";
+        if (name.endsWith("openclaw.json")) {
+          return JSON.stringify({
+            plugins: { entries: { "openclaw-discord": { enabled: false } } },
+          });
+        }
+        throw new Error("ENOENT");
+      });
+      mockGatewayUp.mockResolvedValue(false);
+      updater = await import("@/lib/updater");
+
+      updater.resetUpdateState();
+      expect(await updater.checkContinuation()).toBe(true);
+      await vi.waitFor(() => expect(updater.getUpdateState().phase).toBe("failed"));
+
+      const calls = mockExecFile.mock.calls.map(([cmd, args]) =>
+        `${cmd} ${(args as string[]).join(" ")}`,
+      );
+      expect(calls.some((call) => call.includes("plugins enable discord"))).toBe(false);
+    });
+
     it("leaves a plugin ClawBox does not manage to its owner", async () => {
       // Consenting on the owner's behalf is only defensible for a package
       // ClawBox chose and installed. Something he added from the Terminal has

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -711,6 +711,197 @@ describe("updater", () => {
         .toBe("/tmp/clawbox-updater-openclaw-home/openclaw.json");
     });
 
+    it("records consent for a NON-Codex managed plugin the gateway named", async () => {
+      // TASK-603. The 2026-09-01 outage was `discord`, not `codex`: the core
+      // refuses readiness for any enabled plugin whose declared capability
+      // surface is unconsented, names it, and tells the operator to rerun with
+      // --accept-capabilities. This recovery matched the literal word `codex`,
+      // so the box went through the whole quiesce/pre-start/doctor/restart pass
+      // untouched and the owner was handed that sentence about a CLI he never
+      // ran. `plugins enable <id> --accept-capabilities` is the harness's own
+      // idempotent consent verb — the same one gateway-pre-start.sh uses for
+      // Codex — and it touches no registry, which matters on a box whose
+      // network may be why the update is being repaired.
+      setupExecFileMock({
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
+        "/usr/bin/journalctl -u clawbox-gateway.service": {
+          stdout: "Plugin \"discord\" requires capability consent; rerun with --accept-capabilities.\n",
+          stderr: "",
+        },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+        "/bin/bash": { stdout: "", stderr: "" },
+      });
+
+      vi.resetModules();
+      mockGet.mockResolvedValue(true);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockRebuiltBox();
+      // Health is impossible until the consent AND the later restart happened,
+      // so merely running the pre-start can never make this green.
+      mockGatewayUp.mockImplementation(async () => {
+        const calls = mockExecFile.mock.calls.map(([cmd, args]) =>
+          `${cmd} ${(args as string[]).join(" ")}`,
+        );
+        const consentIndex = calls.findIndex((call) =>
+          call.includes("plugins enable discord --accept-capabilities"),
+        );
+        const restartIndex = calls.findIndex((call) =>
+          call.includes("systemctl restart clawbox-gateway.service"),
+        );
+        return consentIndex >= 0 && restartIndex > consentIndex;
+      });
+      updater = await import("@/lib/updater");
+
+      updater.resetUpdateState();
+      expect(await updater.checkContinuation()).toBe(true);
+      await vi.waitFor(() => expect(updater.getUpdateState().phase).toBe("completed"));
+
+      const calls = mockExecFile.mock.calls.map(([cmd, args]) =>
+        `${cmd} ${(args as string[]).join(" ")}`,
+      );
+      expect(calls.some((call) => call.includes("plugins enable discord --accept-capabilities")))
+        .toBe(true);
+      // Never a reinstall for this arm: the package is on disk (the gateway
+      // would not be naming it otherwise) and an unpinned npm fetch mid-update
+      // is the failure this repair exists to get out of.
+      expect(calls.some((call) => call.includes("plugins install @openclaw/discord"))).toBe(false);
+    });
+
+    it("repairs EVERY managed plugin the boot journal names, not just the first", async () => {
+      // The journal tail is the whole boot (`journalctl -b`) and the gateway
+      // restarts several times during an update, so a stale line can sit ahead
+      // of the live one. Reading only the first match repaired codex — already
+      // consented by the pre-start — while `getGatewayFailureDetail`, which
+      // scans in reverse, handed the owner the DISCORD sentence. Same call,
+      // two halves disagreeing about which plugin is blocking.
+      setupExecFileMock({
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
+        "/usr/bin/journalctl -u clawbox-gateway.service": {
+          stdout: [
+            'Plugin "codex" requires capability consent; rerun with --accept-capabilities.',
+            "Codex runtime plugin capabilities accepted/current",
+            'Plugin "discord" requires capability consent; rerun with --accept-capabilities.',
+            "",
+          ].join("\n"),
+          stderr: "",
+        },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+        "/bin/bash": { stdout: "", stderr: "" },
+      });
+
+      vi.resetModules();
+      mockGet.mockResolvedValue(true);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockRebuiltBox();
+      mockGatewayUp.mockImplementation(async () =>
+        mockExecFile.mock.calls.some(([cmd, args]) =>
+          `${cmd} ${(args as string[]).join(" ")}`
+            .includes("plugins enable discord --accept-capabilities"),
+        ),
+      );
+      updater = await import("@/lib/updater");
+
+      updater.resetUpdateState();
+      expect(await updater.checkContinuation()).toBe(true);
+      await vi.waitFor(() => expect(updater.getUpdateState().phase).toBe("completed"));
+
+      const calls = mockExecFile.mock.calls.map(([cmd, args]) =>
+        `${cmd} ${(args as string[]).join(" ")}`,
+      );
+      expect(calls.some((call) => call.includes("plugins install @openclaw/codex@2026.8.1 --force --accept-capabilities")))
+        .toBe(true);
+      expect(calls.some((call) => call.includes("plugins enable discord --accept-capabilities")))
+        .toBe(true);
+    });
+
+    it("leaves a managed plugin the OWNER switched off switched off", async () => {
+      // `plugins enable` writes `plugins.entries.<id>.enabled = true`, and the
+      // journal tail predates the pre-start. So an owner who reached for the
+      // Terminal and ran `openclaw plugins disable discord` to get his box back
+      // would have had the channel — and consent in his name — restored by the
+      // next update. The Codex arm has always respected this; the new one must.
+      setupExecFileMock({
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
+        "/usr/bin/journalctl -u clawbox-gateway.service": {
+          stdout: 'Plugin "discord" requires capability consent; rerun with --accept-capabilities.\n',
+          stderr: "",
+        },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+        "/bin/bash": { stdout: "", stderr: "" },
+      });
+
+      vi.resetModules();
+      mockGet.mockResolvedValue(true);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockRebuiltBox();
+      mockReadFile.mockImplementation(async (file) => {
+        const name = String(file);
+        if (name.endsWith("BUILD_ID")) return "rebuilt-build-id\n";
+        if (name.endsWith("openclaw.json")) {
+          return JSON.stringify({ plugins: { entries: { discord: { enabled: false } } } });
+        }
+        throw new Error("ENOENT");
+      });
+      mockGatewayUp.mockResolvedValue(false);
+      updater = await import("@/lib/updater");
+
+      updater.resetUpdateState();
+      expect(await updater.checkContinuation()).toBe(true);
+      await vi.waitFor(() => expect(updater.getUpdateState().phase).toBe("failed"));
+
+      const calls = mockExecFile.mock.calls.map(([cmd, args]) =>
+        `${cmd} ${(args as string[]).join(" ")}`,
+      );
+      expect(calls.some((call) => call.includes("plugins enable discord"))).toBe(false);
+    });
+
+    it("leaves a plugin ClawBox does not manage to its owner", async () => {
+      // Consenting on the owner's behalf is only defensible for a package
+      // ClawBox chose and installed. Something he added from the Terminal has
+      // an owner who can answer for it, and the failure detail still names it.
+      setupExecFileMock({
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
+        "/usr/bin/journalctl -u clawbox-gateway.service": {
+          stdout: "Plugin \"weatherbot\" requires capability consent; rerun with --accept-capabilities.\n",
+          stderr: "",
+        },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+        "/bin/bash": { stdout: "", stderr: "" },
+      });
+
+      vi.resetModules();
+      mockGet.mockResolvedValue(true);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockRebuiltBox();
+      mockGatewayUp.mockResolvedValue(false);
+      updater = await import("@/lib/updater");
+
+      updater.resetUpdateState();
+      expect(await updater.checkContinuation()).toBe(true);
+      await vi.waitFor(() => {
+        const state = updater.getUpdateState();
+        expect(state.phase).toBe("failed");
+        expect(state.error).toContain('Plugin "weatherbot" requires capability consent');
+      });
+
+      const calls = mockExecFile.mock.calls.map(([cmd, args]) =>
+        `${cmd} ${(args as string[]).join(" ")}`,
+      );
+      expect(calls.some((call) => call.includes("plugins enable weatherbot"))).toBe(false);
+    });
+
     it("continues to doctor and restart when the targeted Codex repair fails", async () => {
       setupExecFileMock({
         "plugins install @openclaw/codex@2026.8.1 --force --accept-capabilities": new Error(


### PR DESCRIPTION
Closes TASK-603.

## Symptom

A gateway that will not come back, and printed advice that cannot fix it.

`openclaw update repair` ends with `Plugin "discord" requires capability consent; rerun with --accept-capabilities.` An operator who follows it literally loops: the flag belongs to a command he was not told to run. That is what turned the 2026-09-01 plugin problem into a dead end, and rebooting the box changed nothing.

## Harness first

The card is written as an upstream complaint. Half of it is refuted on the pinned core, and the other half is ours.

Verified read-only on an OpenClaw box (core **2026.8.1**):

* **`openclaw update repair --accept-capabilities` EXISTS** — it is in the command's own `--help` and in its examples. The card's claim 1 ("`update repair` has no such flag") does not hold on the core we ship. Not used here all the same, and the reason is in the code: `update repair --accept-capabilities` consents for **every** blocked plugin, including ones the owner installed himself from the Terminal. This PR consents only for the five ClawBox installs.
* The consent gate itself: `resolvePluginCapabilityConsent` / `resolvePluginArtifactCapabilityConsent` (`dist/capability-consent-2iHYP71I.js`) throw `Plugin "<id>" requires capability consent. Use openclaw plugins install or openclaw plugins enable with --accept-capabilities, then retry.` unless the install record already carries an accepted surface hash for the manifest on disk — or an **interactive** consent callback answers. A spawned CLI has neither.
* The native mechanisms used are the CLI's own: `plugins install … --accept-capabilities` and `plugins enable <id> --accept-capabilities`. Nothing is re-implemented.
* Claim 2 (legacy `exec-approvals.json`) is also weaker than the card says on 2026.8.1: `doctor` registers `ownerStep(detected.execApprovals, migrateLegacyExecApprovals)` in its own migration list, and the refusal text is built by `doctorFixInstruction`, which names `OPENCLAW_STATE_DIR` when it is set — the trap the card describes. Confirming the residue needs a destructive experiment on a box (planting a legacy file), so it was **not** attempted; recorded rather than guessed.

## Cause

ClawBox drove that CLI without the flag in four places, while passing it correctly for codex and the DeepSeek provider everywhere else:

| where | verb | effect |
|---|---|---|
| `src/lib/openclaw-channels.ts` `ensureChannelPlugin` | `plugins install @openclaw/discord\|whatsapp` | the Settings save answers `install_failed`; the npm error goes to `console.error` |
| same function | `plugins enable <id>` | same, one verb over |
| `install.sh`, in `step_openclaw_install` | `plugins install "$spec" --force` | refreshes every external plugin to the new core target — exactly when a declared surface changes — and swallows the refusal into `WARN: refresh failed` |
| `scripts/gateway-pre-start.sh` | `plugins enable codex --accept-capabilities` | the boot-time consent pass existed, for **codex only** |

And the recovery could not clear the state either. `src/lib/updater.ts`'s `repairCodexCapabilityConsent` matched the literal word `codex`, so a box blocked on `discord` went through the whole quiesce → pre-start → doctor → restart pass untouched and ended at `getGatewayFailureDetail`, which handed the owner the core's own sentence about a command he never ran.

Three of the repo's recurring classes are in that table: the **false success** of `|| echo WARN` over a refusal, the **false failure** of `install_failed` over a plugin that could have been installed, and a **dead end** the tool had the means to clear.

## Fix

Every ClawBox-driven `plugins install` / `plugins enable` records consent, and the repair covers every plugin ClawBox installs.

* `ensureChannelPlugin` passes `--accept-capabilities` on both verbs.
* `install.sh`'s refresh passes it for `codex|deepseek|discord|whatsapp|clawbox-email-directives` only — a plugin the owner installed himself is refreshed **without** it and the loop says so, because the flag consents to the *new* surface, not the one already on the box. Gated on `openclaw_is_v2`, like the codex install in the pre-start: a v1 pin (`OPENCLAW_PIN_VERSION`, a documented rollback override) rejects the option and would have failed every refresh behind that WARN.
* `gateway-pre-start.sh` gains the same consent pass for the other four managed plugins, **only for entries `openclaw.json` already says to load** — so it can never switch a channel on — time-boxed and non-fatal, as the codex arm is. This is the half that matters for a box that is already down: the owner reboots long before he updates.
* `updater.ts` reads **every** consent refusal in the journal, not the first. That was a live defect in the first draft of this PR: the tail spans the whole boot (`journalctl -b`) and the gateway restarts several times during an update, so a stale `codex` line ahead of a live `discord` one had the repair fix codex while `getGatewayFailureDetail` — which scans in reverse — reported discord. Ids are matched after stripping an `@openclaw/` or `openclaw-` prefix, since `ensureChannelPlugin` already handles a registry that calls the plugin `openclaw-discord`.
* Both new arms respect an owner-disabled entry, as `codexCapabilityRepairIsAllowed` always has. `plugins enable` is not a consent-only verb — it writes `plugins.entries.<id>.enabled = true` — so without that check an owner who ran `openclaw plugins disable discord` to get his box back would have had the channel switched on again, with consent granted in his name, by the next update.
* A refusal naming a plugin ClawBox does **not** manage is logged at `console.info` rather than skipped in silence, so the update log says why nothing happened.

## Both editions

Hermes has no OpenClaw plugins. `spawnOpenclaw` refuses on that edition (`OpenclawUnavailableError`), `step_openclaw_install` returns early for it, and `gateway-pre-start.sh` is the OpenClaw gateway's own ExecStartPre. Every path here is inert on the Hermes SKU; nothing is hidden or explained away in the UI because there is no control.

## RED

On unmodified `origin/beta` (`c2b1a44b`), with only the test files copied in:

```
 FAIL  src/tests/unit/gateway-pre-start-codex-runtime.test.ts [ … ]
Error: Codex plugin command flow not found
⎯⎯⎯⎯⎯⎯ Failed Tests 14 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  install-plugin-capability-consent.test.ts > passes the consent argv it built, rather than a hard-coded flag
AssertionError: expected '      if ! as_clawbox -H "$OPENCLAW_B…' to contain '"${CAP_ARGS[@]}"'
 FAIL  install-plugin-capability-consent.test.ts > builds that argv only on OpenClaw 2
AssertionError: expected -1 to be greater than -1
 FAIL  install-plugin-capability-consent.test.ts > builds it only for the plugins ClawBox installs
 FAIL  install-plugin-capability-consent.test.ts > has no `plugins install` or `plugins enable` that skips consent entirely
AssertionError: expected [ Array(1) ] to deeply equal []
 FAIL  openclaw-channel-plugins.test.ts > installs the official npm plugin when the channel has none
AssertionError: expected [ 'plugins', 'install', …(1) ] to deeply equal [ 'plugins', 'install', …(2) ]
 FAIL  openclaw-channel-plugins.test.ts > enables a plugin the GATEWAY CONFIG does not carry …
AssertionError: expected [ 'plugins', 'enable', 'discord' ] to deeply equal [ Array(4) ]
 FAIL  openclaw-channel-plugins.test.ts > capability consent > accepts the declared capabilities when it installs a channel plugin
AssertionError: expected [ 'plugins', 'install', …(1) ] to include '--accept-capabilities'
 FAIL  openclaw-channel-plugins.test.ts > capability consent > accepts them on the ENABLE too …
AssertionError: expected [ 'plugins', 'enable', 'discord' ] to include '--accept-capabilities'
 FAIL  updater.test.ts > records consent for a NON-Codex managed plugin the gateway named
AssertionError: expected 'failed' to be 'completed'
 FAIL  updater.test.ts > repairs EVERY managed plugin the boot journal names, not just the first
 Test Files  4 failed (4)
      Tests  14 failed | … passed
```

(Five lines elided for length, all of the same two shapes. The pre-start file fails to LOAD on beta rather than failing test-by-test: the block its new harness extracts does not exist there, so the extraction throws at module scope. Honest, if blunt.)

## GREEN

Same four suites on this branch: **128 passed**. Full `--project unit` on the rebased head: **651 files, 10500 passed, 1 skipped**. `tsc --noEmit` clean; `eslint` on the changed files reports only the two `no-unused-vars` warnings `updater.ts` already had on beta; `bash -n` clean on both shell files.

## Sibling call sites swept

Every `plugins install` / `plugins enable` / `plugins disable` in the repo: `openclaw-deepseek-plugin.ts:60` and `gateway-pre-start.sh:3122,3124` already passed the flag; `gateway-pre-start.sh:2254,2271` (codex) already passed it; the four in the table above are fixed. `hermes-clawai.ts:1395` and `register-mcp.sh` are the Hermes CLI, which has no such flag.

## Named limits, not papered over

* `ensureChannelPlugin` still skips both verbs when the plugin is installed **and** already enabled in the config, so a save cannot re-consent a surface that widened underneath it. It does not have to: a surface widens when the package version changes, which is `install.sh`'s refresh, and the boot pass and the updater repair the state from the gateway's own refusal. Doing it unconditionally would buy a 10-12 s CLI cold start on every channel save.
* `trustChannelPlugin` (`openclaw-config.ts`) writes `plugins.entries.<id>.enabled` straight into openclaw.json, so it cannot pass the flag — but it runs on the same configure request, immediately after `ensureChannelPlugin` has consented that plugin. `gateway-pre-start.sh`'s `clawbox-email-directives` enable is the same shape, and the new boot pass now consents that id too.
* The updater's non-codex arm uses `plugins enable`, which cannot repair a plugin left as a project declaration with no `node_modules` (the state the codex arm's pinned force-install exists for). It warns instead of fetching an unpinned package from npm mid-update, and the gateway's own refusal still reaches the owner — what he does not get is a false claim that ClawBox repaired it.
* No device proof of the repair itself: it needs a box deliberately put into a consent-blocked state, which is a mutation of a box the owner is using. The gate and its message were read out of the installed core read-only, and the box's four managed plugins (`codex`, `deepseek`, `discord`, `whatsapp`) were enumerated the same way.

## Overlap

None with the concurrent `scripts/` / `production-server.js` build-race work: this touches `scripts/gateway-pre-start.sh` only, and only in the plugin-consent region.

## Review

`clawbox-review`, findings at `code-review-603.md` (2 HIGH, 7 MEDIUM, 5 LOW, 2 INFO). Applied: H1 (first-match-only), H2 (boot path unswept), M1 (unconditional flag on a v1 pin), M2 (blanket consent contradicting the whitelist), M3 (no owner opt-out on the new arm), M4/M5 (docstrings that overclaimed), M6 (missing `clawbox-email-directives`, id normalisation, the silent no-op), L1/L3/L5 (test docstring, path resolution and the `plugins enable` arm of the source sweep, commit body).
Refuted with reasons: L4 (a bespoke env for two `execFile` calls, where every other CLI call in this process uses the unit's env, would be inconsistent rather than safer; `--accept-capabilities` is itself the answer to the only prompt, and the 60 s timeout bounds it), and the M4 install-fallback (an unpinned npm fetch mid-update is the failure this repair exists to get out of). I1/I2 recorded as residuals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plugin installation, refresh, and startup handling for OpenClaw 2.
  - Automatically handles required capability consent for supported ClawBox-managed plugins, including Discord, WhatsApp, DeepSeek, Codex, and email directives.
  - Maintains compatibility with OpenClaw 1 and unknown releases.
  - Recovers from capability-consent failures across multiple plugins without unnecessary reinstallation.
  - Preserves explicitly disabled plugins and leaves owner-installed or unmanaged plugins unchanged.
  - Supports canonical and aliased plugin names.
  - Added clearer reporting and more resilient recovery when plugin configuration is missing or incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->