### PR TITLE
fix: show the agent harness version on the System Update screen

### DIFF
--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import SystemUpdateApp, { componentNeedsUpdate } from "@/components/SystemUpdateApp";
+import SystemUpdateApp, { componentNeedsUpdate, shipsOpenclaw, type VersionInfo } from "@/components/SystemUpdateApp";
 import Image from "next/image";
 import { createPortal } from "react-dom";
 import StatusMessage from "./StatusMessage";
@@ -582,14 +582,10 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
      itself — its run, the beta channel, the branch pin, the force — is the
      System Update page (SystemUpdateApp, embedded), not state of this
      component any more. ── */
-  const [versionInfo, setVersionInfo] = useState<{
-    clawbox: { current: string; target: string | null; updateAvailable?: boolean };
-    openclaw: { current: string | null; target: string | null; updateAvailable?: boolean };
-    // Both optional: a device that has not been updated yet still answers
-    // /update/versions with the old two-key shape.
-    hermes?: { current: string | null; target: string | null; updateAvailable?: boolean };
-    edition?: "openclaw" | "hermes" | "dual";
-  } | null>(null);
+  // The shape and the per-edition rule come from SystemUpdateApp, the other
+  // reader of this payload. They were restated here, and the two panels had
+  // already drifted three ways by the time TASK-548 lined them up.
+  const [versionInfo, setVersionInfo] = useState<VersionInfo | null>(null);
 
   // Load version info on mount
   useEffect(() => {
@@ -5751,7 +5747,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                     actually runs instead; `dual` has both, so it shows both.
                     A server that predates the `edition` field falls through to
                     the OpenClaw row exactly as before. */}
-                {versionInfo?.edition !== "hermes" && (
+                {shipsOpenclaw(versionInfo) && (
                   <div className="flex justify-between text-sm">
                     <span className="text-[var(--text-muted)]">OpenClaw</span>
                     <span className="text-[var(--text-primary)]">{cleanVersion(versionInfo?.openclaw.current) ?? t("settings.notInstalled")}</span>

--- a/src/components/SystemUpdateApp.tsx
+++ b/src/components/SystemUpdateApp.tsx
@@ -8,13 +8,13 @@ import type { StepStatus, UpdateState } from "@/lib/updater";
 import { RESTART_STEP_ID } from "@/lib/update-constants";
 import { cleanVersion } from "@/lib/version-utils";
 
-interface ComponentVersion {
+export interface ComponentVersion {
   current: string | null;
   target: string | null;
   updateAvailable?: boolean;
 }
 
-interface VersionInfo {
+export interface VersionInfo {
   clawbox: ComponentVersion & { current: string };
   openclaw: ComponentVersion;
   // Both optional: a device that has not been updated yet still answers
@@ -30,7 +30,7 @@ interface VersionInfo {
  * payload from a server that predates the `edition` field reads as OpenClaw,
  * which is what those builds were.
  */
-function shipsOpenclaw(versions: VersionInfo | null): boolean {
+export function shipsOpenclaw(versions: VersionInfo | null): boolean {
   return versions?.edition !== "hermes";
 }
 
@@ -490,9 +490,13 @@ export default function SystemUpdateApp({ embedded = false }: { embedded?: boole
                 available={clawboxAvail}
                 onUpdate={() => void triggerUpdate()}
               />
-              <AgentVersions versions={versions} />
             </div>
           )}
+
+          {/* Outside the gate above: "Update complete" is exactly when an owner
+              wants to read the version their agent came back on, and the
+              components block is hidden in that state. */}
+          {versions && <AgentVersions versions={versions} />}
 
           {/* PROGRESS */}
           {(status === "updating" || status === "completed" || status === "failed") && (
@@ -721,21 +725,35 @@ function ConfirmModal({
  * version in Settings -> About and nowhere here. The rows follow the same
  * per-edition rule About uses: OpenClaw unless the SKU is `hermes`, Hermes
  * whenever the payload carries it.
+ *
+ * BOTH harnesses are pinned by ClawBox and bumped inside the full update —
+ * OpenClaw by `config/openclaw-target.txt`, Hermes by `HERMES_PIN_COMMIT` in
+ * install.sh, which `step_hermes_install` re-checks on every update — so the
+ * note is the same for both. There is no way for an owner to update either one
+ * on its own, and telling them otherwise sends them looking for a button that
+ * does not exist.
+ *
+ * `format` per row, not one shared call: `hermes.current` has already been
+ * normalised server-side by `parseHermesVersion`, whose whole reason for
+ * existing is that `cleanVersion`'s rules are shaped for OpenClaw/git-describe
+ * output. Running the second parser over the first one's result turned
+ * "Hermes Agent (dev build)" into "Hermes Agent" here while About, reading the
+ * same field raw, kept it — two windows the desktop can show side by side.
  */
 function AgentVersions({ versions }: { versions: VersionInfo }) {
-  const rows: { name: string; current: string | null; note: string }[] = [];
+  const rows: { name: string; version: string | null; note: string }[] = [];
   if (shipsOpenclaw(versions)) {
     rows.push({
       name: "OpenClaw",
-      current: versions.openclaw.current,
+      version: cleanVersion(versions.openclaw.current) || versions.openclaw.current,
       note: "Pinned by ClawBox — updated with it",
     });
   }
   if (versions.hermes) {
     rows.push({
       name: "Hermes",
-      current: versions.hermes.current,
-      note: "Installed from its own upstream",
+      version: versions.hermes.current,
+      note: "Pinned by ClawBox — updated with it",
     });
   }
   if (!rows.length) return null;
@@ -747,13 +765,17 @@ function AgentVersions({ versions }: { versions: VersionInfo }) {
       <div className="space-y-2">
         {rows.map((row) => (
           <div key={row.name} className="flex items-baseline justify-between gap-3 text-xs">
-            <div>
+            <div className="min-w-0">
               <div className="text-sm text-gray-100">{row.name}</div>
               <div className="text-[11px] text-[var(--text-muted)]">{row.note}</div>
             </div>
-            <div className="font-mono text-gray-100 truncate">
-              {cleanVersion(row.current ?? "") || row.current || "Not installed"}
-            </div>
+            {/* "—", not "not installed": a null version here means the probe
+                failed, never that the harness is absent. The payload only
+                carries a `hermes` block on a box that HAS Hermes, and
+                `hermes --version` does not answer while step_hermes_install is
+                moving the checkout aside mid-update. ComponentCard below says
+                the same nothing the same way. */}
+            <div className="min-w-0 font-mono text-gray-100 truncate">{row.version || "—"}</div>
           </div>
         ))}
       </div>

--- a/src/components/SystemUpdateApp.tsx
+++ b/src/components/SystemUpdateApp.tsx
@@ -8,9 +8,30 @@ import type { StepStatus, UpdateState } from "@/lib/updater";
 import { RESTART_STEP_ID } from "@/lib/update-constants";
 import { cleanVersion } from "@/lib/version-utils";
 
+interface ComponentVersion {
+  current: string | null;
+  target: string | null;
+  updateAvailable?: boolean;
+}
+
 interface VersionInfo {
-  clawbox: { current: string; target: string | null; updateAvailable?: boolean };
-  openclaw: { current: string | null; target: string | null; updateAvailable?: boolean };
+  clawbox: ComponentVersion & { current: string };
+  openclaw: ComponentVersion;
+  // Both optional: a device that has not been updated yet still answers
+  // /update/versions with the old two-key shape, and the Hermes block is
+  // present only on the SKUs that ship Hermes.
+  hermes?: ComponentVersion;
+  edition?: "openclaw" | "hermes" | "dual";
+}
+
+/**
+ * Whether an OpenClaw row is about software this device has. The `hermes` SKU
+ * ships none; `dual` has one even while Hermes is the harness answering. A
+ * payload from a server that predates the `edition` field reads as OpenClaw,
+ * which is what those builds were.
+ */
+function shipsOpenclaw(versions: VersionInfo | null): boolean {
+  return versions?.edition !== "hermes";
 }
 
 interface BranchInfo {
@@ -334,7 +355,11 @@ export default function SystemUpdateApp({ embedded = false }: { embedded?: boole
       case "available": {
         const updates: string[] = [];
         if (versions && componentNeedsUpdate(versions.clawbox)) updates.push("ClawBox");
-        if (versions && componentNeedsUpdate(versions.openclaw)) updates.push("OpenClaw");
+        // Guarded by the edition, not only by `updateAvailable`: on the Hermes
+        // SKU that flag is false today only because `openclaw.current` is null,
+        // and a headline offering an OpenClaw update on a box that ships no
+        // OpenClaw is not something to leave resting on that.
+        if (versions && shipsOpenclaw(versions) && componentNeedsUpdate(versions.openclaw)) updates.push("OpenClaw");
         return {
           icon: "system_update", iconClass: "text-emerald-300",
           headline: `${updates.length} update${updates.length === 1 ? "" : "s"} available`,
@@ -447,14 +472,14 @@ export default function SystemUpdateApp({ embedded = false }: { embedded?: boole
           </div>
 
           {/* COMPONENTS
-              Only ClawBox is exposed as a standalone update target. OpenClaw
-              is pinned by ClawBox (config/openclaw-target.txt) and bumped
-              automatically inside the full ClawBox update — see
+              Only ClawBox is exposed as a standalone update target. The agent
+              harness is pinned by ClawBox (config/openclaw-target.txt) and
+              bumped automatically inside the full ClawBox update — see
               install.sh::step_openclaw_install. Surfacing a separate
               OpenClaw card would let customers bypass the pin and pick
               whatever was last published to npm, which is what we just
-              moved away from. The OpenClaw version is still shown in the
-              ClawBox card's release notes / version-info section. */}
+              moved away from. The installed harness version is reported
+              below the card instead: read-only, no second update button. */}
           {versions && status !== "updating" && status !== "completed" && status !== "failed" && (
             <div className="grid grid-cols-1 gap-3">
               <ComponentCard
@@ -465,6 +490,7 @@ export default function SystemUpdateApp({ embedded = false }: { embedded?: boole
                 available={clawboxAvail}
                 onUpdate={() => void triggerUpdate()}
               />
+              <AgentVersions versions={versions} />
             </div>
           )}
 
@@ -682,6 +708,54 @@ function ConfirmModal({
             {confirmLabel}
           </button>
         </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The harness this box actually runs, read-only.
+ *
+ * TASK-548: this screen is where an owner goes to ask "what version am I on",
+ * and it named only ClawBox — so a Hermes owner could read their agent's
+ * version in Settings -> About and nowhere here. The rows follow the same
+ * per-edition rule About uses: OpenClaw unless the SKU is `hermes`, Hermes
+ * whenever the payload carries it.
+ */
+function AgentVersions({ versions }: { versions: VersionInfo }) {
+  const rows: { name: string; current: string | null; note: string }[] = [];
+  if (shipsOpenclaw(versions)) {
+    rows.push({
+      name: "OpenClaw",
+      current: versions.openclaw.current,
+      note: "Pinned by ClawBox — updated with it",
+    });
+  }
+  if (versions.hermes) {
+    rows.push({
+      name: "Hermes",
+      current: versions.hermes.current,
+      note: "Installed from its own upstream",
+    });
+  }
+  if (!rows.length) return null;
+
+  return (
+    <div className={CARD} data-testid="agent-versions">
+      <div className="text-base font-semibold text-gray-100">Agent</div>
+      <p className="text-xs text-[var(--text-muted)] mt-0.5 mb-3">The assistant harness running on this device</p>
+      <div className="space-y-2">
+        {rows.map((row) => (
+          <div key={row.name} className="flex items-baseline justify-between gap-3 text-xs">
+            <div>
+              <div className="text-sm text-gray-100">{row.name}</div>
+              <div className="text-[11px] text-[var(--text-muted)]">{row.note}</div>
+            </div>
+            <div className="font-mono text-gray-100 truncate">
+              {cleanVersion(row.current ?? "") || row.current || "Not installed"}
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1664,9 +1664,13 @@ export async function getVersionInfo(): Promise<VersionInfo> {
       target: openclawTarget && openclawCurrent && openclawCurrent.includes(openclawTarget) ? null : openclawTarget,
       updateAvailable: !!(openclawTarget && openclawCurrent && !openclawCurrent.includes(openclawTarget)),
     },
-    // Hermes ships from its own upstream installer, not from a ClawBox pin, so
-    // there is no target to converge on and nothing to offer an update for —
-    // only the installed version is reportable.
+    // Hermes IS pinned by ClawBox — `HERMES_PIN_COMMIT` in install.sh, which
+    // `step_hermes_install` re-checks and repairs on every update, exactly as
+    // `config/openclaw-target.txt` does for OpenClaw. What it has no target for
+    // is this payload: the pin is a 40-char commit SHA and `hermes --version`
+    // answers a release string, so there is nothing here the two can be
+    // compared on. `target: null` therefore means "not comparable", not
+    // "installed from somewhere ClawBox does not control".
     ...(hasHermes
       ? { hermes: { current: hermesCurrent, target: null, updateAvailable: false } }
       : {}),

--- a/src/tests/components/system-update-agent-version.test.tsx
+++ b/src/tests/components/system-update-agent-version.test.tsx
@@ -18,11 +18,18 @@ function jsonResponse(body: unknown): Response {
 
 const clawbox = { current: "4.0.0", target: null, updateAvailable: false };
 
-/** What `getVersionInfo()` really answers, per SKU. */
+/**
+ * What `getVersionInfo()` really answers, per SKU — the SHAPES, not tidied
+ * ones. `openclaw.current` is `openclaw --version` stdout, banner and all (the
+ * same fixture the About suite uses); `hermes.current` has already been through
+ * `parseHermesVersion` server-side, which is why it must not be parsed again
+ * here.
+ */
+const OPENCLAW_BANNER = "OpenClaw 2026.7.1 (3e72c03)";
 const payloads = {
   openclaw: {
     clawbox,
-    openclaw: { current: "2026.8.1", target: "2026.8.1", updateAvailable: false },
+    openclaw: { current: OPENCLAW_BANNER, target: null, updateAvailable: false },
     edition: "openclaw",
   },
   hermes: {
@@ -33,13 +40,30 @@ const payloads = {
   },
   dual: {
     clawbox,
-    openclaw: { current: "2026.8.1", target: "2026.8.1", updateAvailable: false },
+    openclaw: { current: OPENCLAW_BANNER, target: null, updateAvailable: false },
     hermes: { current: "0.20.5", target: null, updateAvailable: false },
     edition: "dual",
   },
-  // A device that has not been updated yet still answers with the old
-  // two-key shape: no `edition`, no `hermes`.
-  legacy: { clawbox, openclaw: { current: "2026.7.1", target: "2026.7.1", updateAvailable: false } },
+  // A `hermes` block with no version: the probe failed. It is NOT "Hermes is
+  // absent" — the key is only spread in on a box that ships Hermes.
+  unprobed: {
+    clawbox,
+    openclaw: { current: null, target: "2026.8.1", updateAvailable: false },
+    hermes: { current: null, target: null, updateAvailable: false },
+    edition: "hermes",
+  },
+  // An unreleased Hermes build: `parseHermesVersion` found no semver-ish token
+  // and returned the banner line as-is.
+  devBuild: {
+    clawbox,
+    openclaw: { current: null, target: "2026.8.1", updateAvailable: false },
+    hermes: { current: "Hermes Agent (dev build)", target: null, updateAvailable: false },
+    edition: "hermes",
+  },
+  // Defensive only: the route always sets `edition` (updater.ts), and page and
+  // route ship together — but the response is cast, not validated, so the
+  // component still has to render something for a body without it.
+  legacy: { clawbox, openclaw: { current: "2026.7.1", target: null, updateAvailable: false } },
 };
 
 async function openUpdateScreen(versions: unknown) {
@@ -87,8 +111,39 @@ describe("SystemUpdateApp — the agent version the box actually runs", () => {
     const block = await openUpdateScreen(payloads.openclaw);
 
     expect(block.getByText("OpenClaw")).toBeTruthy();
-    expect(block.getByText("2026.8.1")).toBeTruthy();
+    // The banner is cleaned for OpenClaw, whose grammar cleanVersion is for.
+    expect(block.getByText("2026.7.1")).toBeTruthy();
     expect(block.queryByText("Hermes")).toBeNull();
+  });
+
+  it("does not re-parse a Hermes version the server already parsed", async () => {
+    const block = await openUpdateScreen(payloads.devBuild);
+
+    // cleanVersion would strip the trailing "(dev build)" — a grammar meant for
+    // git-describe output, applied to a string parseHermesVersion owns. About
+    // renders this field raw, and the desktop can show both windows at once.
+    expect(block.getByText("Hermes Agent (dev build)")).toBeTruthy();
+  });
+
+  it("says nothing rather than 'not installed' when the version could not be read", async () => {
+    const block = await openUpdateScreen(payloads.unprobed);
+
+    // The payload only carries a `hermes` block on a box that HAS Hermes, so
+    // null is a failed probe — which is what `hermes --version` does while the
+    // update is moving the checkout aside.
+    expect(block.getByText("Hermes")).toBeTruthy();
+    expect(block.queryByText(/not installed/i)).toBeNull();
+    expect(block.getByText("—")).toBeTruthy();
+  });
+
+  it("tells the owner both harnesses ride the ClawBox update", async () => {
+    // HERMES_PIN_COMMIT (install.sh) is re-checked by step_hermes_install on
+    // every update, exactly as config/openclaw-target.txt is for OpenClaw.
+    // There is no way to update either one on its own, and saying otherwise
+    // sends the owner looking for a button that does not exist.
+    const block = await openUpdateScreen(payloads.dual);
+
+    expect(block.getAllByText("Pinned by ClawBox — updated with it")).toHaveLength(2);
   });
 
   it("names both on the dual SKU, which really runs both", async () => {
@@ -98,7 +153,9 @@ describe("SystemUpdateApp — the agent version the box actually runs", () => {
     expect(block.getByText("Hermes")).toBeTruthy();
   });
 
-  it("falls through to the OpenClaw row on a payload that predates the edition field", async () => {
+  it("renders an OpenClaw row for a body with no edition field at all", async () => {
+    // Defensive, not a supported server shape: the response is cast rather than
+    // validated, so the component still has to draw something.
     const block = await openUpdateScreen(payloads.legacy);
 
     expect(block.getByText("OpenClaw")).toBeTruthy();

--- a/src/tests/components/system-update-agent-version.test.tsx
+++ b/src/tests/components/system-update-agent-version.test.tsx
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@/tests/helpers/test-utils";
+import SystemUpdateApp from "@/components/SystemUpdateApp";
+
+/**
+ * TASK-548 — the System Update screen never named the agent the box runs.
+ *
+ * `/setup-api/update/versions` carries a `hermes` component on every SKU that
+ * ships Hermes, and Settings -> About already renders it per edition. The
+ * dedicated update screen — the one place an owner goes to ask "what version am
+ * I on" — showed only ClawBox, so a Hermes owner could not read their agent's
+ * version anywhere on it.
+ */
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+const clawbox = { current: "4.0.0", target: null, updateAvailable: false };
+
+/** What `getVersionInfo()` really answers, per SKU. */
+const payloads = {
+  openclaw: {
+    clawbox,
+    openclaw: { current: "2026.8.1", target: "2026.8.1", updateAvailable: false },
+    edition: "openclaw",
+  },
+  hermes: {
+    clawbox,
+    openclaw: { current: null, target: "2026.8.1", updateAvailable: false },
+    hermes: { current: "0.20.5", target: null, updateAvailable: false },
+    edition: "hermes",
+  },
+  dual: {
+    clawbox,
+    openclaw: { current: "2026.8.1", target: "2026.8.1", updateAvailable: false },
+    hermes: { current: "0.20.5", target: null, updateAvailable: false },
+    edition: "dual",
+  },
+  // A device that has not been updated yet still answers with the old
+  // two-key shape: no `edition`, no `hermes`.
+  legacy: { clawbox, openclaw: { current: "2026.7.1", target: "2026.7.1", updateAvailable: false } },
+};
+
+async function openUpdateScreen(versions: unknown) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/setup-api/update/versions")) return jsonResponse(versions);
+      if (url.includes("/setup-api/update/status")) return jsonResponse({ phase: "idle", steps: [] });
+      if (url.includes("/setup-api/system/update-branch")) return jsonResponse({ branch: null });
+      return jsonResponse({});
+    }),
+  );
+
+  render(<SystemUpdateApp />);
+  await screen.findByText("You're up to date");
+
+  // Scoped to the agent block: "OpenClaw" appears in the Advanced options prose
+  // too, and an unscoped query there would pass on the wrong element.
+  const heading = await screen.findByText("Agent");
+  const block = heading.closest("[data-testid='agent-versions']");
+  if (!block) throw new Error("agent version block not found");
+  return within(block as HTMLElement);
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("SystemUpdateApp — the agent version the box actually runs", () => {
+  it("names Hermes and its version on the Hermes SKU", async () => {
+    const block = await openUpdateScreen(payloads.hermes);
+
+    expect(block.getByText("Hermes")).toBeTruthy();
+    expect(block.getByText("0.20.5")).toBeTruthy();
+  });
+
+  it("does not offer an OpenClaw row on a device that ships no OpenClaw", async () => {
+    const block = await openUpdateScreen(payloads.hermes);
+
+    expect(block.queryByText("OpenClaw")).toBeNull();
+  });
+
+  it("names OpenClaw and its version on the OpenClaw SKU", async () => {
+    const block = await openUpdateScreen(payloads.openclaw);
+
+    expect(block.getByText("OpenClaw")).toBeTruthy();
+    expect(block.getByText("2026.8.1")).toBeTruthy();
+    expect(block.queryByText("Hermes")).toBeNull();
+  });
+
+  it("names both on the dual SKU, which really runs both", async () => {
+    const block = await openUpdateScreen(payloads.dual);
+
+    expect(block.getByText("OpenClaw")).toBeTruthy();
+    expect(block.getByText("Hermes")).toBeTruthy();
+  });
+
+  it("falls through to the OpenClaw row on a payload that predates the edition field", async () => {
+    const block = await openUpdateScreen(payloads.legacy);
+
+    expect(block.getByText("OpenClaw")).toBeTruthy();
+    expect(block.getByText("2026.7.1")).toBeTruthy();
+  });
+});
+
+describe("SystemUpdateApp — the hero never offers an OpenClaw update on Hermes", () => {
+  it("keeps OpenClaw out of the update headline there", async () => {
+    // Guard, not a live defect: `updateAvailable` is false on that SKU today
+    // only because `openclaw.current` is null. The headline must not depend on
+    // that staying true.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/setup-api/update/versions")) {
+          return jsonResponse({
+            clawbox: { current: "4.0.0", target: "4.1.0", updateAvailable: true },
+            openclaw: { current: "2026.7.1", target: "2026.8.1", updateAvailable: true },
+            hermes: { current: "0.20.5", target: null, updateAvailable: false },
+            edition: "hermes",
+          });
+        }
+        if (url.includes("/setup-api/update/status")) return jsonResponse({ phase: "idle", steps: [] });
+        if (url.includes("/setup-api/system/update-branch")) return jsonResponse({ branch: null });
+        return jsonResponse({});
+      }),
+    );
+
+    render(<SystemUpdateApp />);
+
+    const subhead = await screen.findByText(/^New version available for /);
+    expect(subhead.textContent).toBe("New version available for ClawBox.");
+  });
+});


### PR DESCRIPTION
**TASK-548** — Hermes: System Update app never shows the Hermes agent version.

## Customer-visible symptom
The System Update screen is where an owner goes to ask "what version am I on". On a Hermes box it
named only ClawBox: the agent's version was readable in Settings → About and nowhere on the screen
built for the question. `VersionInfo` there carried `clawbox` and `openclaw` only, while
`/setup-api/update/versions` has carried a `hermes` block on every SKU that ships Hermes since
`getVersionInfo()` gained it.

## Cause
The payload grew `hermes` and `edition`; About was taught to read them and the update screen was
not. A stale comment in that file also claimed "The OpenClaw version is still shown in the ClawBox
card's release notes / version-info section" — nothing rendered it; the screen showed no harness
version at all.

## Harness-first
Nothing native is re-implemented. The version itself comes from the harness through ClawBox's
existing native call — `runHermesCli(["--version"])`, parsed by the purpose-built
`parseHermesVersion` — and this PR only reads the route that already does that. The reuse that was
missing was intra-repo: the payload shape and the per-edition rule were written out twice, in About
and here, which is what let the two panels drift.

## What changed
- `SystemUpdateApp` gains `hermes?` / `edition?` on `VersionInfo` and a read-only **Agent** card
  under the ClawBox card: OpenClaw unless the SKU is `hermes`, Hermes whenever the payload carries
  it, both on `dual`. Rendered outside the components gate, so it is still there on "Update
  complete" — which is exactly when an owner wants to read the version their agent came back on.
- The hero's `updates.push("OpenClaw")` is now gated on the edition as well as on `updateAvailable`.
  A guard, not a live defect: that flag is false on Hermes today only because `openclaw.current` is
  null, and a headline offering an OpenClaw update on a box that ships no OpenClaw should not rest
  on that.
- **Both harnesses are pinned by ClawBox**, so both rows say so. `HERMES_PIN_COMMIT`
  (`install.sh:625`) is re-checked and repaired by `step_hermes_install` on every update
  (`install.sh:2277`, called from `step_post_update` at `:4925`) — the direct analogue of
  `config/openclaw-target.txt`. The first draft of this card said "Installed from its own upstream",
  copied from a stale comment in `updater.ts`; that comment is corrected here too. Only the
  *installer script* comes from upstream, and it is fetched **from the pinned tree**.
- The Hermes version is rendered as the server produced it. `cleanVersion`'s grammar is shaped for
  OpenClaw/git-describe output — `parseHermesVersion` exists precisely because it does not fit
  Hermes — and running it a second time turned `Hermes Agent (dev build)` into `Hermes Agent` here
  while About, reading the field raw, kept it. The desktop can show both windows side by side.
- A null version renders `—`, not "not installed". The payload only carries a `hermes` block on a
  box that HAS Hermes, so null means the probe failed — which is what `hermes --version` does while
  `step_hermes_install` is moving the checkout aside mid-update. `ComponentCard` ten lines below
  already says the same nothing the same way. (This also removes the hardcoded-English outlier: the
  rest of the file is hardcoded English by convention, but "not installed" is the one string About
  has translated into all ten locales.)
- `VersionInfo` and the `shipsOpenclaw` predicate are exported and `SettingsApp` now imports them
  instead of restating both. That duplication is what the three divergences above were made of.

## Both editions
- `hermes`: Hermes row, no OpenClaw row, no OpenClaw in the update headline.
- `openclaw`: OpenClaw row, unchanged headline.
- `dual`: both rows — that SKU really runs both.

## RED → GREEN
New suite `src/tests/components/system-update-agent-version.test.tsx` (9 tests). Against the
unmodified beta components (`git checkout origin/beta -- src/components/SystemUpdateApp.tsx
src/components/SettingsApp.tsx src/lib/updater.ts`):

```
 ❯ |components| src/tests/components/system-update-agent-version.test.tsx (9 tests | 9 failed)
     × names Hermes and its version on the Hermes SKU 5007ms
     × does not offer an OpenClaw row on a device that ships no OpenClaw 5002ms
     × names OpenClaw and its version on the OpenClaw SKU 5002ms
     × does not re-parse a Hermes version the server already parsed 5002ms
     × says nothing rather than 'not installed' when the version could not be read 5002ms
     × tells the owner both harnesses ride the ClawBox update 5002ms
     × names both on the dual SKU, which really runs both 5002ms
     × renders an OpenClaw row for a body with no edition field at all 5002ms
     × keeps OpenClaw out of the update headline there 16ms

 FAIL … > keeps OpenClaw out of the update headline there
 AssertionError: expected 'New version available for ClawBox and…' to be 'New version available for ClawBox.'
```

(The eight timeouts are the agent card not existing to be found; the ninth is the headline.)

With the fix:

```
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

Neighbouring suites — `system-update-app`, `system-update-app-drift`, `settings-update-section`,
`settings-about-version`, `settings-app`, plus the new one: 52 passed. `updater`,
`updater-branch-resolution`, `updater-build-identity`, `routes/update/versions`, `version-utils`:
110 passed. `tsc --noEmit`: clean. `eslint` on the changed files: 0 errors (7 pre-existing warnings
in `updater.ts`, none on a changed line).

Full `--project components`: 1364 passed, 2 failed in `chat-spoken-reply.test.tsx` — a known flake
in that file under a full parallel run, unrelated to this diff (it names none of these modules) and
18/18 green in isolation.

## Sibling call sites — handled or cleared
- `src/components/SettingsApp.tsx` About panel — **changed**: now imports the shape and the
  predicate rather than restating them.
- `SettingsApp.tsx` sidebar subtitle (`componentNeedsUpdate`) — reads `versionInfo.clawbox` only,
  so the edition gate does not apply. Cleared, unchanged.
- `mcp/tools/system.ts` `update_check` — returns the payload, so it inherits `hermes` for free.
- `mcp/tools/orientation.ts` `device_status` emits no harness version on `hermes` or `dual` — the
  same gap, agent-facing. Being fixed on the branch for TASK-543 (PR #671), which already owns that
  block and whose `VersionsPayload` already carries `hermes`; kept out of here so two PRs do not
  edit the same eight lines.
- `src/app/page.tsx` desktop update notice — unchanged and cleared: its openclaw term is guarded by
  the producer's explicit `updateAvailable: false`. Recorded as a residual (its `??` fallback would
  be true on a Hermes payload if that flag ever went missing).

## Recorded, deliberately not taken
`hermes.target` is hardcoded `null`, so the screen can never tell an owner their agent is off the
pin even though `HERMES_PIN_COMMIT` is a real target. Surfacing it needs the payload to compare a
40-char commit SHA against a release string, which is a different change; the comment in
`updater.ts` now says that is what `target: null` means, instead of the false "ships from its own
upstream".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - System updates now show read-only agent version details for OpenClaw and Hermes devices.
  - Version information is displayed with edition-aware formatting after updates complete.
  - Update controls now identify ClawBox as the available update target.
  - The About page displays OpenClaw details only when supported by the device configuration.

- **Bug Fixes**
  - Hermes devices no longer incorrectly advertise OpenClaw updates.
  - Improved handling and messaging for unavailable, legacy, development, and failed version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->