### PR TITLE
fix: unmatched ClawBox paths answer 404 instead of the gateway shell

### DIFF
--- a/src/app/[...gateway]/route.ts
+++ b/src/app/[...gateway]/route.ts
@@ -3,6 +3,7 @@ import { getAll } from "@/lib/config-store";
 import { proxyGatewayRequest, redirectToSetup, serveGatewayHTML } from "@/lib/gateway-proxy";
 import { isGatewayStaticPath } from "@/lib/gateway-static";
 import { readEdition } from "@/lib/edition-source";
+import { clawboxNamespaceKind } from "@/lib/clawbox-namespaces";
 
 export const dynamic = "force-dynamic";
 
@@ -15,6 +16,33 @@ export async function GET(request: NextRequest) {
     if (!config.setup_complete) {
       return redirectToSetup(request);
     }
+    // A path in ClawBox's OWN namespaces — /setup-api and /login-api for its
+    // endpoints, /setup, /login, /portal, /updating and /app for its pages —
+    // that reached this catch-all is a route that does not exist, and the
+    // gateway serves nothing there. The honest answer is 404: proxied, it came
+    // back 502 from a gateway that had never heard of it, and answered as a
+    // NAVIGATION it came back as the Control UI shell with the gateway token
+    // injected into it — somebody else's application, with a credential in it,
+    // over a ClawBox address the owner mistyped (TASK-631).
+    //
+    // ABOVE the Hermes gate on purpose. That gate answers text/plain for every
+    // path, so leaving this below it made `/setup-api/nope` a JSON 404 on
+    // OpenClaw and a text one on Hermes — a shared surface answering two
+    // shapes by edition.
+    //
+    // The list and the segment-boundary matching live in
+    // src/lib/clawbox-namespaces.ts, beside the evidence.
+    const owned = clawboxNamespaceKind(request.nextUrl.pathname);
+    if (owned) {
+      // Code asked, so code is answered: the endpoint namespaces get the same
+      // `{ error: "Not found" }` shape the real routes under them use.
+      return owned === "api"
+        ? NextResponse.json({ error: "Not found" }, { status: 404 })
+        : new NextResponse("Not found", {
+          status: 404,
+          headers: { "Content-Type": "text/plain" },
+        });
+    }
     // On the Hermes SKU there is no OpenClaw gateway — it is disabled and
     // masked by install.sh — so proxying to 127.0.0.1:18789 is a guaranteed
     // ECONNREFUSED. This route matches EVERY otherwise-unhandled path (it wins
@@ -22,19 +50,6 @@ export async function GET(request: NextRequest) {
     // alone was not enough), so without this check /chat, /sessions and every
     // typo answered with a 500 from the catch below instead of a plain 404.
     if (readEdition() === "hermes") {
-      return new NextResponse("Not found", {
-        status: 404,
-        headers: { "Content-Type": "text/plain" },
-      });
-    }
-    // /setup-api/ is ClawBox's OWN namespace — the route handlers live there
-    // precisely so they cannot collide with the gateway's /api/* — and the
-    // gateway serves nothing under it. A /setup-api path that reached this
-    // catch-all is therefore a route that does not exist, and the honest
-    // answer is 404: proxied, it came back 502 from a gateway that had never
-    // heard of it (or the SPA shell, before the resource rule below), and a
-    // client probing for an endpoint could not tell "not here" from "down".
-    if (request.nextUrl.pathname.startsWith("/setup-api/")) {
       return new NextResponse("Not found", {
         status: 404,
         headers: { "Content-Type": "text/plain" },

--- a/src/lib/clawbox-namespaces.ts
+++ b/src/lib/clawbox-namespaces.ts
@@ -1,0 +1,92 @@
+/**
+ * Which top-level paths belong to ClawBox rather than to the OpenClaw gateway.
+ *
+ * WHY THIS EXISTS. `src/app/[...gateway]/route.ts` answers every path Next did
+ * not match, and for a NAVIGATION it answers with the Control UI shell — into
+ * which `serveGatewayHTML` injects the gateway auth token for an owner session.
+ * That is the right answer for a gateway deep link like `/chat/main` and the
+ * wrong one for a path in ClawBox's own namespace, where the gateway serves
+ * nothing at all: the owner asked for a ClawBox page or endpoint that does not
+ * exist and was handed somebody else's application, with a credential in it.
+ *
+ * Measured on an OpenClaw box at beta head `c2b1a44b`, owner-authenticated,
+ * with a browser's navigation metadata (TASK-631 / F-29):
+ *
+ *     GET /setup-api        -> 200 text/html, Control UI, token injected
+ *     GET /setup-api/       -> 308 to /setup-api, then the same
+ *     GET /portal           -> 200 text/html, Control UI, token injected
+ *     GET /portal/nope      -> 200 text/html, Control UI, token injected
+ *     GET /login-api/nope   -> 200 text/html, Control UI, token injected
+ *     GET /app              -> 200 text/html, Control UI, token injected
+ *     GET /app/x/y          -> 200 text/html, Control UI, token injected
+ *     GET /Setup-Api/nope   -> 200 text/html, Control UI, token injected
+ *     GET /setup-api/nope   -> 404 text/plain
+ *
+ * The last line is the half that was already fixed, and it is what makes the
+ * shape of the defect obvious: the guard tested `startsWith("/setup-api/")`,
+ * WITH the trailing slash, so the namespace root itself fell straight through
+ * it — and nothing covered the other four namespaces at all.
+ *
+ * SEGMENT-BOUNDARY MATCHING IS LOAD-BEARING. `/setup-api` also starts with
+ * `/setup`; a bare `startsWith` on the roots below would fold one into the
+ * other, which is the original auth-bypass `src/middleware.ts` still carries a
+ * comment about. `isUnderRoot` matches the root exactly or the root plus a
+ * separator, and never `/setupsomething`.
+ */
+
+/**
+ * ClawBox's API namespaces. An unmatched path here is a missing endpoint, and
+ * its caller is code: it gets JSON, like every real route under them and like
+ * the middleware's own 401 for the same prefix.
+ */
+const CLAWBOX_API_ROOTS = ["/setup-api", "/login-api"] as const;
+
+/**
+ * ClawBox's page namespaces. `/app` is one of them: `src/app/app/[id]/page.tsx`
+ * matches ONE segment and there is no page at the root, so both `/app` and
+ * `/app/x/y` reached the catch-all (measured: 200 Control UI, token injected).
+ *
+ * `/api`, `/assets` and the gateway's static trees are absent for the opposite
+ * reason — they are the GATEWAY's, and serving them is what the catch-all is
+ * for. Checked against the pinned Control UI's own bundle rather than assumed:
+ * `dist/control-ui/assets/*.js` carries route literals for `/chat`,
+ * `/sessions` and `/logs`, and none for any root below.
+ */
+const CLAWBOX_PAGE_ROOTS = ["/setup", "/login", "/portal", "/updating", "/app"] as const;
+
+/**
+ * `/a` matches `/a` and `/a/b`, never `/ab`.
+ *
+ * Case-SENSITIVE, deliberately, because `src/middleware.ts` feeds it an
+ * already-lower-cased pathname and three of its allow-gates depend on that
+ * exact comparison. The catch-all route lower-cases at its own call site
+ * instead — see the note there.
+ */
+function isUnderRoot(pathname: string, root: string): boolean {
+  return pathname === root || pathname.startsWith(`${root}/`);
+}
+
+/** ClawBox's own API namespace: `/setup-api` itself and everything under it. */
+export function isSetupApiPath(pathname: string): boolean {
+  return isUnderRoot(pathname, "/setup-api");
+}
+
+/**
+ * Which ClawBox namespace owns this path, or null when it is the gateway's.
+ *
+ * `"api"` and `"page"` differ only in what an unmatched path should answer
+ * WITH — the ownership question has one answer for both.
+ */
+export function clawboxNamespaceKind(pathname: string): "api" | "page" | null {
+  // Lower-cased HERE and not in `isUnderRoot`: Next's router is case-sensitive,
+  // so `/Setup-Api/nope` and `/Portal/nope` matched no ClawBox route and were
+  // answered with the shell and the token (measured on a box). This is the same
+  // leak class as the `/Login` and `/Manifest.json` fall-throughs
+  // `serveGatewayHTML` still carries a comment about. Ownership is not a
+  // question of spelling; the middleware's own gates, which get a pathname that
+  // is already lower-cased, keep the exact comparison.
+  const lower = pathname.toLowerCase();
+  if (CLAWBOX_API_ROOTS.some((root) => isUnderRoot(lower, root))) return "api";
+  if (CLAWBOX_PAGE_ROOTS.some((root) => isUnderRoot(lower, root))) return "page";
+  return null;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,6 +6,7 @@ import { verifyMcpBearer } from "@/lib/mcp-token";
 import { isPublicGatewayAsset } from "@/lib/gateway-static";
 import { readEdition } from "@/lib/edition-source";
 import { isBootstrapAllowedPath } from "@/lib/setup-api-gate";
+import { isSetupApiPath } from "@/lib/clawbox-namespaces";
 import { UPDATE_LOCK_KEY, UPDATING_PAGE } from "@/lib/update-lock";
 
 // ─── Setup completion ────────────────────────────────────────────────────────
@@ -414,7 +415,7 @@ export async function middleware(request: NextRequest) {
   //   - ALLOW-list, not deny-list. The default is now 401.
   //   - keyed on `password_configured`, not `setup_complete`. A box that has a
   //     password but an unfinished wizard is a box with an owner.
-  if (pathname.startsWith("/setup-api/") && isBootstrapWindowOpen()) {
+  if (isSetupApiPath(pathname) && isBootstrapWindowOpen()) {
     if (isBootstrapAllowedPath(pathname)) {
       return NextResponse.next();
     }
@@ -431,7 +432,7 @@ export async function middleware(request: NextRequest) {
   // boots under CLAWBOX_TEST_MODE.
   if (
     process.env.CLAWBOX_TEST_MODE === "1"
-    && (pathname.startsWith("/setup-api/") || isWizardPagePath(pathname))
+    && (isSetupApiPath(pathname) || isWizardPagePath(pathname))
   ) {
     return NextResponse.next();
   }
@@ -444,7 +445,7 @@ export async function middleware(request: NextRequest) {
   // service-to-service auth via a per-install bearer (see
   // src/lib/mcp-token.ts), scoped to /setup-api/* only so the dashboard
   // and login flow still go through the normal session gate.
-  if (pathname.startsWith("/setup-api/")) {
+  if (isSetupApiPath(pathname)) {
     const authHeader = request.headers.get("authorization");
     if (authHeader && verifyMcpBearer(authHeader)) {
       return NextResponse.next();
@@ -505,7 +506,7 @@ export async function middleware(request: NextRequest) {
   // prefix) still redirect below.
   const accept = request.headers.get("accept") || "";
   if (
-    pathname.startsWith("/setup-api/") ||
+    isSetupApiPath(pathname) ||
     pathname.startsWith("/api/") ||
     accept.includes("application/json")
   ) {

--- a/src/tests/middleware/middleware.test.ts
+++ b/src/tests/middleware/middleware.test.ts
@@ -324,6 +324,57 @@ describe("middleware", () => {
       await expect(response.json()).resolves.toEqual({ error: "Authentication required" });
     });
 
+    it("answers the /setup-api ROOT as the API namespace, not as a page", async () => {
+      // TASK-631. Every gate here tested `startsWith("/setup-api/")`, WITH the
+      // slash, so the namespace root itself was treated as an ordinary page:
+      // an unauthenticated caller got a redirect to /login, and an
+      // authenticated one fell through to the gateway catch-all, which answers
+      // a navigation with the Control UI shell and the gateway token in it.
+      // The root belongs to the same namespace as everything under it.
+      process.env.SESSION_SECRET = "test-secret";
+      markSetupComplete();
+      vi.resetModules();
+      const mod = await import("@/middleware");
+
+      const response = await mod.middleware(createRequest("/setup-api"));
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({ error: "Authentication required" });
+    });
+
+    it("lets an anonymous /login-api/* path through to the route, which now 404s it", async () => {
+      // The one namespace where an ANONYMOUS caller reached the gateway shell:
+      // `/login-api` is in PUBLIC_PREFIXES (the login POST needs it), so
+      // `GET /login-api/nope` was `NextResponse.next()` → the catch-all →
+      // `serveGatewayHTML` → 200 Control UI. No token (`serveGatewayHTML`
+      // injects only for an owner session), so not a credential leak — but it
+      // is the only one of the five that answered a stranger with a 200 HTML
+      // page, and the route's namespace gate is what turns it into a 404.
+      // Middleware's own behaviour is deliberately unchanged here: taking
+      // /login-api out of PUBLIC_PREFIXES would break signing in.
+      process.env.SESSION_SECRET = "test-secret";
+      markSetupComplete();
+      vi.resetModules();
+      const mod = await import("@/middleware");
+
+      const response = await mod.middleware(createRequest("/login-api/nope"));
+      expect(response.status).toBe(200);
+      expect(response.headers.get("location")).toBeNull();
+    });
+
+    it("does not fold /setupsomething into the /setup-api namespace", async () => {
+      // The matching is on a segment boundary in both directions: `/setup-api`
+      // must not fold into `/setup` (the original auth-bypass) and a path that
+      // merely starts with the same letters must not fold into either.
+      process.env.SESSION_SECRET = "test-secret";
+      markSetupComplete();
+      vi.resetModules();
+      const mod = await import("@/middleware");
+
+      const response = await mod.middleware(createRequest("/setup-apiary"));
+      expect(response.status).toBe(307);
+      expect(response.headers.get("location")).toContain("/login");
+    });
+
     it.each(["/login", "/setup", "/setup-api/setup/status", "/_next/chunk.js", "/fonts/test.woff", "/images/logo.png", "/manifest.json", "/sw.js", "/favicon.ico", "/portal/subscribe"])("allows public path %s", async (p) => {
       process.env.SESSION_SECRET = "test-secret";
       vi.resetModules();

--- a/src/tests/routes/gateway.test.ts
+++ b/src/tests/routes/gateway.test.ts
@@ -11,6 +11,15 @@ vi.mock("@/lib/gateway-proxy", () => ({
   proxyGatewayRequest: vi.fn(),
 }));
 
+// PINNED, not inherited. The route's Hermes gate answers 404 for EVERY path,
+// so on a runner whose /etc/clawbox/edition.env or CLAWBOX_EDITION says hermes
+// every 404 assertion below would pass from that gate — even with the
+// namespace check deleted. The branch under test is the OpenClaw one.
+vi.mock("@/lib/edition-source", async (orig) => ({
+  ...(await orig<typeof import("@/lib/edition-source")>()),
+  readEdition: () => "openclaw" as const,
+}));
+
 import { getAll } from "@/lib/config-store";
 import { proxyGatewayRequest, redirectToSetup, serveGatewayHTML } from "@/lib/gateway-proxy";
 import { NextResponse } from "next/server";
@@ -164,6 +173,89 @@ describe("GET /[...gateway] (catch-all route)", () => {
     expect(res.status).toBe(404);
     expect(mockProxyGatewayRequest).not.toHaveBeenCalled();
     expect(mockServeGatewayHTML).not.toHaveBeenCalled();
+  });
+
+  /**
+   * TASK-631 (F-29). The guard above tested `startsWith("/setup-api/")`, with
+   * the slash, so ClawBox's own namespace ROOT fell through it — and a
+   * navigation is answered with the Control UI shell, into which
+   * `serveGatewayHTML` injects the gateway token for an owner session.
+   *
+   * Measured on an OpenClaw box at beta head c2b1a44b, owner-authenticated:
+   *
+   *   GET /setup-api        -> 200 text/html, Control UI, token script present
+   *   GET /setup-api/       -> 308 to /setup-api, then the same
+   *   GET /portal           -> 200 text/html, Control UI, token script present
+   *   GET /portal/nope      -> same
+   *   GET /login-api/nope   -> same
+   *   GET /setup-api/nope   -> 404 text/plain   (the half already fixed)
+   *
+   * `/api` and `/assets` are deliberately NOT in this list: those are the
+   * GATEWAY's namespaces, which this route exists to serve.
+   */
+  const CLAWBOX_OWNED_UNMATCHED: [string, "api" | "page"][] = [
+    ["http://localhost/setup-api", "api"],
+    ["http://localhost/setup-api/nope", "api"],
+    ["http://localhost/Setup-Api/nope", "api"],
+    ["http://localhost/login-api/nope", "api"],
+    ["http://localhost/portal", "page"],
+    ["http://localhost/portal/nope", "page"],
+    ["http://localhost/Portal/nope", "page"],
+    ["http://localhost/setup/nope", "page"],
+    ["http://localhost/login/nope", "page"],
+    ["http://localhost/updating/nope", "page"],
+    ["http://localhost/app", "page"],
+    ["http://localhost/app/x/y", "page"],
+  ];
+
+  it.each(CLAWBOX_OWNED_UNMATCHED)(
+    "answers 404 for %s rather than the gateway shell",
+    async (url, kind) => {
+      mockGetAll.mockResolvedValue({ setup_complete: true });
+
+      // The browser's own navigation metadata — the shape that gets the shell
+      // and therefore the token.
+      const res = await gatewayGet(
+        createRequest(url, { "sec-fetch-mode": "navigate", accept: "text/html" }),
+      );
+
+      expect(res.status).toBe(404);
+      expect(mockServeGatewayHTML).not.toHaveBeenCalled();
+      expect(mockProxyGatewayRequest).not.toHaveBeenCalled();
+      // The SHAPE, not just the status: code asked for the endpoint
+      // namespaces, so code is answered.
+      if (kind === "api") {
+        expect(res.headers.get("content-type")).toContain("application/json");
+        await expect(res.json()).resolves.toEqual({ error: "Not found" });
+      } else {
+        expect(res.headers.get("content-type")).toContain("text/plain");
+        await expect(res.text()).resolves.toBe("Not found");
+      }
+    },
+  );
+
+  it("still serves the shell for the gateway's OWN namespaces", async () => {
+    // The other half of the boundary: a prefix test that swallowed /api or
+    // /assets would break the Control UI this route exists to serve.
+    mockGetAll.mockResolvedValue({ setup_complete: true });
+
+    await gatewayGet(
+      createRequest("http://localhost/chat/main", { "sec-fetch-mode": "navigate" }),
+    );
+
+    expect(mockServeGatewayHTML).toHaveBeenCalled();
+  });
+
+  it("does not swallow a path that merely STARTS with an owned prefix", async () => {
+    // `/setupsomething` is not under `/setup`. The match is on a segment
+    // boundary, which is also why `/setup-api` never folded into `/setup`.
+    mockGetAll.mockResolvedValue({ setup_complete: true });
+
+    await gatewayGet(
+      createRequest("http://localhost/setupsomething", { "sec-fetch-mode": "navigate" }),
+    );
+
+    expect(mockServeGatewayHTML).toHaveBeenCalled();
   });
 
   it("returns 500 on error", async () => {


### PR DESCRIPTION
Closes TASK-631 (F-29).

## Symptom

An authenticated GET of a path that does not exist in ClawBox's own namespace answers **200 with the OpenClaw Control UI**, and for an owner session that page carries the injected gateway token.

Measured read-only on an OpenClaw box at beta head `c2b1a44b`, owner-authenticated, with a browser's own navigation metadata (`Sec-Fetch-Mode: navigate`):

```
GET /setup-api        -> 200 text/html   Control UI, token script present
GET /setup-api/       -> 308 -> /setup-api, then the same
GET /portal           -> 200 text/html   Control UI, token script present
GET /portal/nope      -> 200 text/html   Control UI, token script present
GET /login-api/nope   -> 200 text/html   Control UI, token script present
GET /app              -> 200 text/html   Control UI, token script present
GET /app/x/y          -> 200 text/html   Control UI, token script present
GET /Setup-Api/nope   -> 200 text/html   Control UI, token script present
GET /Portal/nope      -> 200 text/html   Control UI, token script present
GET /setup-api/nope   -> 404 text/plain
```

(The token itself is never printed here or in the tests — the probe counts the presence of the injection script, `h.set("token", …)`, not its value.)

The card called this "routing hygiene rather than a leak", which still holds: `serveGatewayHTML` injects only for a caller who proved they are the owner, so a stranger gets the shell without a credential. It is a wrong answer either way — the owner asked for a ClawBox page or endpoint that does not exist and was handed somebody else's application.

## Cause

The `/setup-api` half was already fixed on beta (`4d46ac6a`), and the fix is one character short: the guard is `pathname.startsWith("/setup-api/")` — **with** the trailing slash — so the namespace root itself falls through. The other four namespaces were never covered, and the match was case-sensitive while Next's router is too.

`/app` is the surprising one: `src/app/app/[id]/page.tsx` matches exactly ONE segment and there is no page at the root, so both `/app` and `/app/x/y` land in the catch-all.

## Fix

`src/lib/clawbox-namespaces.ts` asks the ownership question once:

* **API namespaces** `/setup-api`, `/login-api` — an unmatched path is a missing endpoint and its caller is code, so it gets `{ error: "Not found" }`, the shape the twelve real 404s under those roots already use.
* **Page namespaces** `/setup`, `/login`, `/portal`, `/updating`, `/app` — `text/plain` "Not found".
* Matching is on a **segment boundary** (`/a` matches `/a` and `/a/b`, never `/ab`) — load-bearing, because `/setup-api` also starts with `/setup` and folding one into the other is the original auth bypass the middleware still carries a comment about.
* Lower-cased at the **route's** call site only. `src/middleware.ts` feeds the predicate an already-lower-cased pathname and three of its allow-gates depend on that exact comparison, so `isUnderRoot` itself stays case-sensitive.
* The block sits **above** the Hermes gate, which answers `text/plain` for every path: below it, `/setup-api/nope` would have been a JSON 404 on OpenClaw and a text one on Hermes — one shared surface, two shapes by edition.
* `src/middleware.ts`'s four `startsWith("/setup-api/")` gates now call `isSetupApiPath`, so the namespace root is the namespace everywhere. The only behavioural delta is at the 401-vs-redirect fork: an unauthenticated `GET /setup-api` gets the JSON 401 the rest of the namespace gets, instead of a login redirect. The other three are inert on the root (the bootstrap allow-list does not contain it; test-mode and the MCP bearer just reach a route that now 404s). Nothing gains access.

## Harness first

There is no OpenClaw mechanism to reuse here — this is ClawBox's own router deciding which paths it owns, and the catch-all exists precisely to hand the rest to the gateway. What was checked against the harness is the **boundary**: `/api`, `/assets` and the static trees in `gateway-static.ts` stay the gateway's, and the claim that `/portal`, `/updating` and `/app` are safe to take was verified rather than assumed — the pinned Control UI's own bundle (`dist/control-ui/assets/*.js`) carries route literals for `/chat`, `/sessions` and `/logs`, and **zero** for `/portal`, `/updating`, `/app`, `/setup` or `/login`.

## Both editions

The same code runs on both, and the reorder above is what makes the answer identical on both. The gateway namespaces are untouched, so nothing changes for the Control UI on OpenClaw and nothing new is reachable on Hermes.

## RED

On unmodified `origin/beta` (`c2b1a44b`), with only the two test files copied in:

```
⎯⎯⎯⎯⎯⎯ Failed Tests 13 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  middleware.test.ts > answers the /setup-api ROOT as the API namespace, not as a page
AssertionError: expected 307 to be 401
 FAIL  gateway.test.ts > answers 404 for http://localhost/setup-api rather than the gateway shell
 FAIL  gateway.test.ts > answers 404 for http://localhost/Setup-Api/nope …
 FAIL  gateway.test.ts > answers 404 for http://localhost/login-api/nope …
 FAIL  gateway.test.ts > answers 404 for http://localhost/portal …
 FAIL  gateway.test.ts > answers 404 for http://localhost/portal/nope …
 FAIL  gateway.test.ts > answers 404 for http://localhost/Portal/nope …
 FAIL  gateway.test.ts > answers 404 for http://localhost/setup/nope …
 FAIL  gateway.test.ts > answers 404 for http://localhost/login/nope …
 FAIL  gateway.test.ts > answers 404 for http://localhost/updating/nope …
 FAIL  gateway.test.ts > answers 404 for http://localhost/app …
 FAIL  gateway.test.ts > answers 404 for http://localhost/app/x/y …
AssertionError: expected 200 to be 404
 FAIL  gateway.test.ts > answers 404 for http://localhost/setup-api/nope …
AssertionError: expected 'text/plain' to contain 'application/json'
 Test Files  2 failed (2)
      Tests  13 failed | 158 passed (171)
```

Two of the new tests are **guards, not RED evidence**, and pass on beta as well: `/setup-apiary` (must still redirect to /login) and `/setupsomething` (must still get the shell). They are the other half of the segment boundary.

## GREEN

Both suites on this branch: 178 passed. Full `--project unit`: **648 files, 10490 passed**. `--project components`: 143/144, the one failure being `chat-spoken-reply.test.tsx`, a file this PR does not touch or import and which is on the repo's known-flake list; it passes on its own and passed on the same head in a second run. `tsc --noEmit` and `eslint` clean.

## Deliberately not in this PR

* **The `isUnderRoot` consolidation.** Four other copies of `p === prefix || p.startsWith(prefix + "/")` exist — `isWizardPagePath`, `isGatewayOnlyPath`, the `PUBLIC_PREFIXES` loop (all `src/middleware.ts`) and `isBootstrapAllowedPath` (`src/lib/setup-api-gate.ts`, which also owns a `normalizeApiPath`). Each carries its own comment about why it is not a bare `startsWith`, because getting it wrong once WAS the auth bypass. Converting four security gates in a hygiene PR is the wrong trade; the new module is the right home for it and the follow-up is recorded.
* **Moving `/login-api` out of `PUBLIC_PREFIXES`.** It is there because the login POST needs it. The anonymous `GET /login-api/nope` shell fall-through — the one namespace where a stranger got a 200 HTML page, though never a token — is closed by the route's 404, which is what the new middleware test pins.

## Overlap

`production-server.js` is untouched: it intercepts only WebSocket upgrades, so all HTTP goes through Next and the catch-all is the single chokepoint. No overlap with the concurrent build-race work in `scripts/` / `production-server.js`.

## Review

`clawbox-review`, findings at `code-review-631.md` (1 HIGH, 2 MEDIUM, 5 LOW). Applied: H-1 (`/app` missing, and the comment excusing it was wrong), M-1 (case-sensitivity), M-2 (the Hermes gate made the JSON body OpenClaw-only), L-1 (`"not found"` → `"Not found"`, the only lowercase one in the repo), L-2 (assert the content-type and body, and pin `readEdition` so the suite tests the branch it means to), L-3 (the anonymous `/login-api/*` case), L-5 (the bundle check above). L-4 is the consolidation named under "deliberately not in this PR".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unknown ClawBox API paths now return structured JSON 404 responses.
  * Unknown ClawBox page paths now return plain-text 404 responses instead of loading the gateway.
  * Route matching now respects namespace boundaries, preventing similarly prefixed paths from being misclassified.
  * Setup API authentication and access checks now consistently apply to the intended routes.

* **Tests**
  * Added coverage for namespace matching, authentication behavior, 404 responses, and gateway navigation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->