### PR TITLE
fix: serve the PWA and document-head icons without a session

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -256,23 +256,31 @@ const PUBLIC_EXACT = new Set([
   "/favicon.svg",
   "/favicon-32.png",
   // The icons the browser is TOLD about while it has no session: the two
-  // `public/manifest.json` declares (the manifest itself is public two lines
-  // up) and the ones the root layout puts in the document head. Gating them
+  // `public/manifest.json` declares (the manifest is listed at the top of this
+  // set) and the ones the root layout puts in the document head. Gating them
   // did not protect anything — an app icon is the same class of asset as the
   // favicons and the clawbox-* logos below — it only broke the feature the
   // manifest exists for: a browser fetching /icon-192.png to offer "Install
   // page as app" followed the redirect to /login and got a 31-byte HTML body,
   // so the prompt showed no icon, or was refused outright by browsers that
   // require a resolvable 192 px icon first. `curl -f` cannot even see it,
-  // because a redirect is not a 4xx. `/apple-touch-icon.png` is already
-  // admitted (read-only) by the gateway-static list; the drift guard in
-  // src/tests/middleware/pwa-icons-public.test.ts derives the whole set from
-  // manifest.json and layout.tsx so a new icon cannot be declared without
-  // opening the gate for it.
+  // because a redirect is not a 4xx.
+  //
+  // `/apple-touch-icon.png` is listed here too, though the gateway-static list
+  // already admits it: that list is the OpenClaw Control UI's own files, and it
+  // is also what the catch-all asks before PROXYING a path to the gateway — so
+  // leaving our head icon governed by it means renaming the file quietly turns
+  // it into an unauthenticated proxy to 127.0.0.1:18789 rather than a 404. The
+  // file that declares an icon should own its public status.
+  //
+  // The drift guard in src/tests/middleware/pwa-icons-public.test.ts derives
+  // the whole set from manifest.json and layout.tsx's metadata object, so a new
+  // icon cannot be declared without the gate being opened for it.
   "/icon-192.png",
   "/icon-512.png",
   "/favicon-32x32.png",
   "/favicon-16x16.png",
+  "/apple-touch-icon.png",
   "/clawbox-crab.png",
   "/clawbox-icon.png",
   "/clawbox-logo.png",
@@ -291,8 +299,14 @@ function isDocumentRequest(headers: Headers): boolean {
   return (headers.get("accept") ?? "").includes("text/html");
 }
 
-function isPublicPath(pathname: string): boolean {
-  if (PUBLIC_EXACT.has(pathname)) return true;
+function isPublicPath(pathname: string, method: string): boolean {
+  // Every entry in PUBLIC_EXACT is something a browser READS — a manifest, a
+  // service worker, an icon, one public page — so the opening is GET/HEAD, the
+  // way `isPublicGatewayAsset` and the public-webapp carve-out below already
+  // are. A write to one of these paths happens to 405 today (Next's public/
+  // handler and the gateway catch-all both answer GET only), which makes the
+  // list safe by accident of what sits behind it rather than by construction.
+  if (PUBLIC_EXACT.has(pathname)) return method === "GET" || method === "HEAD";
   if (PRE_AUTH_API_PATHS.has(pathname)) return true;
   // `/setup-api/...` also starts with `/setup`, so this must not be a bare
   // prefix test — isWizardPagePath matches on a segment boundary.
@@ -422,7 +436,7 @@ export async function middleware(request: NextRequest) {
   // gateway catch-all and was answered, unauthenticated, with the token-
   // bearing SPA shell. Same for `/Manifest.json` and `/SW.JS`. Any gate must
   // decide on the string the router will actually use.
-  if (isPublicPath(request.nextUrl.pathname)) {
+  if (isPublicPath(request.nextUrl.pathname, request.method)) {
     return NextResponse.next();
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -255,6 +255,24 @@ const PUBLIC_EXACT = new Set([
   "/favicon.ico",
   "/favicon.svg",
   "/favicon-32.png",
+  // The icons the browser is TOLD about while it has no session: the two
+  // `public/manifest.json` declares (the manifest itself is public two lines
+  // up) and the ones the root layout puts in the document head. Gating them
+  // did not protect anything — an app icon is the same class of asset as the
+  // favicons and the clawbox-* logos below — it only broke the feature the
+  // manifest exists for: a browser fetching /icon-192.png to offer "Install
+  // page as app" followed the redirect to /login and got a 31-byte HTML body,
+  // so the prompt showed no icon, or was refused outright by browsers that
+  // require a resolvable 192 px icon first. `curl -f` cannot even see it,
+  // because a redirect is not a 4xx. `/apple-touch-icon.png` is already
+  // admitted (read-only) by the gateway-static list; the drift guard in
+  // src/tests/middleware/pwa-icons-public.test.ts derives the whole set from
+  // manifest.json and layout.tsx so a new icon cannot be declared without
+  // opening the gate for it.
+  "/icon-192.png",
+  "/icon-512.png",
+  "/favicon-32x32.png",
+  "/favicon-16x16.png",
   "/clawbox-crab.png",
   "/clawbox-icon.png",
   "/clawbox-logo.png",

--- a/src/tests/middleware/pwa-icons-public.test.ts
+++ b/src/tests/middleware/pwa-icons-public.test.ts
@@ -10,58 +10,99 @@
  * resolvable 192 px icon refused the prompt outright. `curl -f` does not even
  * error on it — the box answers a redirect, not a 4xx.
  *
- * The assertions are DERIVED from the declaration sites (the manifest's own
- * `icons[]` and the root layout's `metadata.icons`) rather than hard-coded, so
- * adding an icon to either place without opening the gate fails here.
+ * The assertions are DERIVED from the declaration sites — the manifest's own
+ * `icons[]` and the root layout's `metadata.icons` object, read as VALUES and
+ * not as text, so every legal shape counts (a bare string in `icons.icon`, a
+ * manifest `src` relative to the manifest URL) rather than only the two spelt
+ * today. A guard that filtered for one shape would go quietly green over an
+ * icon declared in another and 307ing on every box, which is this defect again.
  */
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { NextRequest } from "next/server";
+import type { Metadata } from "next";
 import fs from "fs";
 import os from "os";
 import path from "path";
 
 const repoRoot = path.resolve(__dirname, "../../..");
 
+/**
+ * Every icon path `public/manifest.json` declares.
+ *
+ * A manifest `src` is resolved against the manifest's own URL, so a relative
+ * one is just as real as an absolute one — resolve rather than filter.
+ */
 function manifestIconPaths(): string[] {
   const manifest = JSON.parse(
     fs.readFileSync(path.join(repoRoot, "public/manifest.json"), "utf8"),
   ) as { icons?: Array<{ src?: string }> };
-  const srcs = (manifest.icons ?? [])
-    .map((i) => i.src)
-    .filter((s): s is string => typeof s === "string" && s.startsWith("/"));
-  expect(srcs.length, "manifest.json declares no icons").toBeGreaterThan(0);
-  return srcs;
+  const paths = (manifest.icons ?? [])
+    .map((icon) => icon.src)
+    .filter((src): src is string => typeof src === "string")
+    .map((src) => new URL(src, "http://box/manifest.json").pathname);
+  expect(paths.length, "manifest.json declares no icons").toBeGreaterThan(0);
+  return paths;
 }
 
 /**
- * The icon URLs `src/app/layout.tsx` puts in the document head. Read as text
- * rather than imported: layout.tsx pulls in globals.css and the whole app
- * shell, and this only needs the declared URLs.
+ * Every icon URL `src/app/layout.tsx` puts in the document head.
+ *
+ * `Metadata["icons"]` is a union: a bare string or URL, an array of those or of
+ * `{ url }` descriptors, or an object keyed by rel (`icon`, `shortcut`,
+ * `apple`, `other`). All of them end up as a `<link>` the browser fetches, so
+ * all of them are walked. Anything absolute is somebody else's origin and not
+ * this gate's business.
  */
-function layoutIconPaths(): string[] {
-  const source = fs.readFileSync(path.join(repoRoot, "src/app/layout.tsx"), "utf8");
-  const block = source.slice(source.indexOf("icons: {"), source.indexOf("appleWebApp:"));
-  const urls = [...block.matchAll(/url:\s*"(\/[^"]+)"/g)].map((m) => m[1]);
-  expect(urls.length, "layout.tsx declares no icon urls").toBeGreaterThan(0);
+function collectIconUrls(node: unknown, into: string[]): void {
+  if (node === null || node === undefined) return;
+  if (typeof node === "string" || node instanceof URL) {
+    const value = String(node);
+    if (value.startsWith("/")) into.push(value);
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const item of node) collectIconUrls(item, into);
+    return;
+  }
+  if (typeof node === "object") {
+    for (const value of Object.values(node as Record<string, unknown>)) {
+      collectIconUrls(value, into);
+    }
+  }
+}
+
+async function layoutIconPaths(): Promise<string[]> {
+  const { metadata } = (await import("@/app/layout")) as { metadata: Metadata };
+  const urls: string[] = [];
+  collectIconUrls(metadata.icons, urls);
+  // The manifest is declared here too and is fetched by the same logged-out
+  // browser, so it belongs in the same check.
+  collectIconUrls(metadata.manifest, urls);
+  expect(urls.length, "layout.tsx declares no head icons").toBeGreaterThan(0);
   return urls;
 }
 
-describe("icons declared to the browser are reachable without a session", () => {
+describe("assets declared to the browser are reachable without a session", () => {
   let tmpRoot: string;
+
+  function armAuth(bootstrapOpen: boolean) {
+    fs.mkdirSync(path.join(tmpRoot, "data"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpRoot, "data/config.json"),
+      // An owner and a finished wizard = the gate fully armed. The empty
+      // object is a box still inside the first-boot bootstrap window, whose
+      // wizard pages carry the same head icons.
+      JSON.stringify(bootstrapOpen ? {} : { setup_complete: true, password_configured: true }),
+    );
+  }
 
   beforeEach(() => {
     vi.resetModules();
     tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-pwa-icons-"));
     process.env.CLAWBOX_ROOT = tmpRoot;
-    // A box with an owner and a finished wizard — the state in which the auth
-    // gate is fully armed.
-    fs.mkdirSync(path.join(tmpRoot, "data"), { recursive: true });
-    fs.writeFileSync(
-      path.join(tmpRoot, "data/config.json"),
-      JSON.stringify({ setup_complete: true, password_configured: true }),
-    );
     process.env.SESSION_SECRET = "test-secret";
     delete process.env.CLAWBOX_TEST_MODE;
+    armAuth(false);
   });
 
   afterEach(() => {
@@ -71,30 +112,60 @@ describe("icons declared to the browser are reachable without a session", () => 
     fs.rmSync(tmpRoot, { recursive: true, force: true });
   });
 
-  async function get(pathname: string) {
+  async function get(pathname: string, method = "GET") {
     const mod = await import("@/middleware");
-    return mod.middleware(new NextRequest(new URL(`http://localhost${pathname}`)));
+    return mod.middleware(
+      new NextRequest(new URL(`http://localhost${pathname}`), { method }),
+    );
+  }
+
+  async function expectServed(pathname: string) {
+    const response = await get(pathname);
+    expect(response.status, `${pathname} must not need a session`).toBe(200);
+    expect(response.headers.get("Location"), pathname).toBeNull();
   }
 
   it("serves every icon public/manifest.json declares", async () => {
-    for (const iconPath of manifestIconPaths()) {
-      const response = await get(iconPath);
-      expect(response.status, `${iconPath} must not need a session`).toBe(200);
-      expect(response.headers.get("Location"), iconPath).toBeNull();
-    }
+    for (const iconPath of manifestIconPaths()) await expectServed(iconPath);
   });
 
-  it("serves every icon the root layout puts in the document head", async () => {
-    for (const iconPath of layoutIconPaths()) {
-      const response = await get(iconPath);
-      expect(response.status, `${iconPath} must not need a session`).toBe(200);
-      expect(response.headers.get("Location"), iconPath).toBeNull();
+  it("serves everything the root layout puts in the document head", async () => {
+    for (const iconPath of await layoutIconPaths()) await expectServed(iconPath);
+  });
+
+  it("serves them during the first-boot bootstrap window too", async () => {
+    // The wizard's own pages carry the same head, and this is the state a box
+    // is in when its owner first opens it.
+    armAuth(true);
+    vi.resetModules();
+    for (const iconPath of [...manifestIconPaths(), ...(await layoutIconPaths())]) {
+      await expectServed(iconPath);
     }
   });
 
   it("still shields a non-icon page and the API surface", async () => {
-    // The opening is icons only; it must not have widened the gate.
+    // The opening is these assets only; it must not have widened the gate.
     expect((await get("/dashboard")).status).toBe(307);
     expect((await get("/setup-api/system/info")).status).toBe(401);
+  });
+
+  it("admits the exact path only — never a case-folded or trailing-slash lookalike", async () => {
+    // middleware.ts decides on the RAW pathname because the ROUTER routes the
+    // raw string: a lower-cased match would admit /ICON-192.PNG, which matches
+    // no file in public/ and falls through to the gateway catch-all — served,
+    // unauthenticated, with the SPA shell. That bypass has been shipped twice
+    // (/Login, /ASSETS/x.css); this pins it for the entries added here.
+    for (const lookalike of ["/ICON-192.PNG", "/Icon-512.png", "/icon-192.png/", "/favicon-32X32.png"]) {
+      expect((await get(lookalike)).status, lookalike).toBe(307);
+    }
+  });
+
+  it("is read-only — a write to an icon path still needs a session", async () => {
+    // Safe today only because Next's public/ handler and the gateway catch-all
+    // both answer GET, so a POST 405s before anything else looks at it. The
+    // gate says so itself rather than relying on what happens to sit behind it.
+    for (const method of ["POST", "PUT", "PATCH", "DELETE"]) {
+      expect((await get("/icon-192.png", method)).status, method).toBe(307);
+    }
   });
 });

--- a/src/tests/middleware/pwa-icons-public.test.ts
+++ b/src/tests/middleware/pwa-icons-public.test.ts
@@ -1,0 +1,100 @@
+/**
+ * The icons a logged-out browser must be able to fetch.
+ *
+ * `public/manifest.json` is public, `display: standalone`, `sw.js` and
+ * `appleWebApp.capable` are all in place — installing the box UI as an app is a
+ * shipped feature. But the two icons the manifest DECLARES were not on the
+ * middleware allow-list, so a browser fetching them while offering "Install
+ * page as app" followed the 307 to /login and got a 31-byte redirect body
+ * instead of a PNG: no icon in the install prompt, and browsers that require a
+ * resolvable 192 px icon refused the prompt outright. `curl -f` does not even
+ * error on it — the box answers a redirect, not a 4xx.
+ *
+ * The assertions are DERIVED from the declaration sites (the manifest's own
+ * `icons[]` and the root layout's `metadata.icons`) rather than hard-coded, so
+ * adding an icon to either place without opening the gate fails here.
+ */
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const repoRoot = path.resolve(__dirname, "../../..");
+
+function manifestIconPaths(): string[] {
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, "public/manifest.json"), "utf8"),
+  ) as { icons?: Array<{ src?: string }> };
+  const srcs = (manifest.icons ?? [])
+    .map((i) => i.src)
+    .filter((s): s is string => typeof s === "string" && s.startsWith("/"));
+  expect(srcs.length, "manifest.json declares no icons").toBeGreaterThan(0);
+  return srcs;
+}
+
+/**
+ * The icon URLs `src/app/layout.tsx` puts in the document head. Read as text
+ * rather than imported: layout.tsx pulls in globals.css and the whole app
+ * shell, and this only needs the declared URLs.
+ */
+function layoutIconPaths(): string[] {
+  const source = fs.readFileSync(path.join(repoRoot, "src/app/layout.tsx"), "utf8");
+  const block = source.slice(source.indexOf("icons: {"), source.indexOf("appleWebApp:"));
+  const urls = [...block.matchAll(/url:\s*"(\/[^"]+)"/g)].map((m) => m[1]);
+  expect(urls.length, "layout.tsx declares no icon urls").toBeGreaterThan(0);
+  return urls;
+}
+
+describe("icons declared to the browser are reachable without a session", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    vi.resetModules();
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-pwa-icons-"));
+    process.env.CLAWBOX_ROOT = tmpRoot;
+    // A box with an owner and a finished wizard — the state in which the auth
+    // gate is fully armed.
+    fs.mkdirSync(path.join(tmpRoot, "data"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpRoot, "data/config.json"),
+      JSON.stringify({ setup_complete: true, password_configured: true }),
+    );
+    process.env.SESSION_SECRET = "test-secret";
+    delete process.env.CLAWBOX_TEST_MODE;
+  });
+
+  afterEach(() => {
+    delete process.env.SESSION_SECRET;
+    delete process.env.CLAWBOX_TEST_MODE;
+    delete process.env.CLAWBOX_ROOT;
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  async function get(pathname: string) {
+    const mod = await import("@/middleware");
+    return mod.middleware(new NextRequest(new URL(`http://localhost${pathname}`)));
+  }
+
+  it("serves every icon public/manifest.json declares", async () => {
+    for (const iconPath of manifestIconPaths()) {
+      const response = await get(iconPath);
+      expect(response.status, `${iconPath} must not need a session`).toBe(200);
+      expect(response.headers.get("Location"), iconPath).toBeNull();
+    }
+  });
+
+  it("serves every icon the root layout puts in the document head", async () => {
+    for (const iconPath of layoutIconPaths()) {
+      const response = await get(iconPath);
+      expect(response.status, `${iconPath} must not need a session`).toBe(200);
+      expect(response.headers.get("Location"), iconPath).toBeNull();
+    }
+  });
+
+  it("still shields a non-icon page and the API surface", async () => {
+    // The opening is icons only; it must not have widened the gate.
+    expect((await get("/dashboard")).status).toBe(307);
+    expect((await get("/setup-api/system/info")).status).toBe(401);
+  });
+});

--- a/src/tests/middleware/pwa-icons-public.test.ts
+++ b/src/tests/middleware/pwa-icons-public.test.ts
@@ -166,9 +166,15 @@ describe("assets declared to the browser are reachable without a session", () =>
     // no file in public/ and falls through to the gateway catch-all — served,
     // unauthenticated, with the SPA shell. That bypass has been shipped twice
     // (/Login, /ASSETS/x.css); this pins it for the entries added here.
-    for (const lookalike of ["/ICON-192.PNG", "/Icon-512.png", "/icon-192.png/", "/favicon-32X32.png"]) {
+    for (const lookalike of ["/ICON-192.PNG", "/Icon-512.png", "/favicon-32X32.png"]) {
       expect((await get(lookalike)).status, lookalike).toBe(307);
     }
+    // A trailing slash never reaches the gate at all — middleware's own
+    // trailing-slash redirect (308) runs first for page paths — so what
+    // matters is only that it is not SERVED as the icon.
+    const trailing = await get("/icon-192.png/");
+    expect(trailing.status).toBe(308);
+    expect(trailing.headers.get("Location"), "redirected to the exact path, still gated").toContain("/icon-192.png");
   });
 
   it("admits a HEAD as well as a GET — a browser asks before it fetches", async () => {

--- a/src/tests/middleware/pwa-icons-public.test.ts
+++ b/src/tests/middleware/pwa-icons-public.test.ts
@@ -56,8 +56,12 @@ function manifestIconPaths(): string[] {
 function collectIconUrls(node: unknown, into: string[]): void {
   if (node === null || node === undefined) return;
   if (typeof node === "string" || node instanceof URL) {
-    const value = String(node);
-    if (value.startsWith("/")) into.push(value);
+    // Resolved, not filtered on a leading slash: a `new URL("/icon.png", …)`
+    // stringifies absolute, and dropping it would be this guard
+    // under-deriving again. Anything on another ORIGIN is somebody else's
+    // asset and not this gate's business.
+    const resolved = new URL(String(node), "http://box/");
+    if (resolved.origin === "http://box") into.push(resolved.pathname + resolved.search);
     return;
   }
   if (Array.isArray(node)) {
@@ -65,9 +69,16 @@ function collectIconUrls(node: unknown, into: string[]): void {
     return;
   }
   if (typeof node === "object") {
-    for (const value of Object.values(node as Record<string, unknown>)) {
-      collectIconUrls(value, into);
+    const record = node as Record<string, unknown>;
+    // An `IconDescriptor` is `{ url, sizes?, type?, … }` — only `url` is a URL.
+    // Walking every value turned `sizes: "48x48"` into a path and asked the
+    // gate for `/48x48`. Anything else here is the rel-keyed `Icons` object
+    // (`icon`, `shortcut`, `apple`, `other`), whose values are all icons.
+    if ("url" in record) {
+      collectIconUrls(record.url, into);
+      return;
     }
+    for (const value of Object.values(record)) collectIconUrls(value, into);
   }
 }
 
@@ -157,6 +168,14 @@ describe("assets declared to the browser are reachable without a session", () =>
     // (/Login, /ASSETS/x.css); this pins it for the entries added here.
     for (const lookalike of ["/ICON-192.PNG", "/Icon-512.png", "/icon-192.png/", "/favicon-32X32.png"]) {
       expect((await get(lookalike)).status, lookalike).toBe(307);
+    }
+  });
+
+  it("admits a HEAD as well as a GET — a browser asks before it fetches", async () => {
+    for (const iconPath of manifestIconPaths()) {
+      const response = await get(iconPath, "HEAD");
+      expect(response.status, `HEAD ${iconPath}`).toBe(200);
+      expect(response.headers.get("Location"), iconPath).toBeNull();
     }
   });
 


### PR DESCRIPTION
**TASK-591** — PWA install has no icon: `manifest.json` is public but the icons it declares are behind the login wall.

### Customer-visible symptom
`curl -fsS -o icon.png http://<box>/icon-512.png` writes a **31-byte** file and does not error, because the box answers a redirect to `/login` rather than a 4xx. A browser fetching the manifest to offer "Install page as app" fetches the icons the same way, so the install prompt shows no icon — or is refused outright by browsers that require a resolvable 192 px icon first. `display: standalone`, `sw.js` and `appleWebApp.capable` are all in place, so the icon gate is the only thing degrading a shipped feature.

### Cause
`src/middleware.ts` `PUBLIC_EXACT` lists `/manifest.json`, `/sw.js`, the favicons and the `clawbox-*` logos, but **not** `/icon-192.png` or `/icon-512.png` — exactly the two icons `public/manifest.json` declares. The manifest is publicly readable while everything it points at needs a session.

The same gate caught two siblings the card did not name: `/favicon-32x32.png` and `/favicon-16x16.png`, the icons `src/app/layout.tsx` puts in the document head, so a logged-out `/login` page had no tab icon either. (`/favicon-32.png` in the list is a different path — a gateway route handler.)

### Harness first
There is no OpenClaw/Hermes mechanism here; the harness in question is Next.js, and it has **no** native mechanism that removes the allow-list — its file-based metadata conventions (`app/icon.png`, `app/apple-icon.png`, `app/manifest.ts`) still produce middleware-matched routes. Considered and rejected:
- the middleware `matcher`'s negative lookahead (it already excludes `_next/static`, `_next/image`, `fonts/`, `images/`) — rejected because moving the icons under `/images/` changes URLs an already-installed PWA holds;
- `app/manifest.ts` / `app/icon.png` metadata routes — a larger change; see "Left for the owner" below.

### RED → GREEN

RED, on the device (read-only, logged-out, over loopback on the OpenClaw box, box head `c2b1a44b`):

```
/icon-512.png            307 31 -> http://127.0.0.1/login?redirect=%2Ficon-512.png
/icon-192.png            307 31 -> http://127.0.0.1/login?redirect=%2Ficon-192.png
/favicon-32x32.png       307 36 -> http://127.0.0.1/login?redirect=%2Ffavicon-32x32.png
/favicon-16x16.png       307 36 -> http://127.0.0.1/login?redirect=%2Ffavicon-16x16.png
/apple-touch-icon.png    200 30294
/clawbox-icon.png        200 46841
/manifest.json           200 620
```

RED, in the suite, on unmodified `origin/beta` (b632bdc7):

```
 × serves every icon public/manifest.json declares
 × serves everything the root layout puts in the document head
 × serves them during the first-boot bootstrap window too
AssertionError: /icon-192.png must not need a session: expected 307 to be 200
AssertionError: /favicon-32x32.png must not need a session: expected 307 to be 200
 Tests  3 failed | 3 passed (6)
```

GREEN, with the fix:

```
$ npx vitest run --project unit src/tests/middleware/
 Test Files  3 passed (3)
      Tests  158 passed (158)
```

Plus `build-typecheck`, `test-timeout-hygiene`, `state-updater-purity` and the other middleware consumer (`src/tests/routes/hermes/oauth-wizard-handoff.test.ts`) — all green.

The post-fix device leg is **unrun**: proving the 200 on hardware needs beta deployed to a box, and this batch does not mutate boxes.

### The guard
The new test derives its assertions from the declaration sites as **values**, not text: `layout.tsx`'s `metadata.icons` walked through every shape `Metadata["icons"]` accepts (bare string, `URL`, descriptor, the rel-keyed object), and each manifest `src` resolved against the manifest URL rather than filtered on a leading slash. A text-matching guard would have gone green over an icon declared in any other legal shape while it 307'd on every box — this defect again, under a passing test. It also pins the negatives: `/ICON-192.PNG` and `/icon-192.png/` must still need a session (a case-folded match falls through to the gateway catch-all, which has been a real bypass twice), and a write to an icon path is not admitted.

### Siblings handled
- `/apple-touch-icon.png` was already reachable — but only through `src/lib/gateway-static.ts`, which is *also* what `src/app/[...gateway]/route.ts` asks before proxying a path to `127.0.0.1:18789`. Renaming the file would have turned our own head icon into an unauthenticated proxy to the gateway rather than a 404, so it is listed in `PUBLIC_EXACT` too: the file that declares an icon owns its public status.
- `PUBLIC_EXACT` is now GET/HEAD. Every entry is something a browser reads; a write to one 405s today only because Next's `public/` handler and the catch-all both answer GET, i.e. the list was safe by accident of what sits behind it. `PUBLIC_PREFIXES` (`/login`, `/login-api`, …) and the loopback proxy prefixes are untouched, so every POST that matters still passes.
- Cleared with reasons: `src/lib/setup-api-gate.ts` (only `/setup-api/*`), `public/sw.js` (installs no `fetch` handler — it is a kill switch), `next.config.ts` (`beforeFiles`/`afterFiles` empty; the fallback rewrite is unreachable behind `[...gateway]`), the Hermes 404 gate (`GATEWAY_ONLY_EXACT` is `/favicon.svg` + `/favicon-32.png`, neither of them an added path), `middleware.test.ts` (nothing enumerates `PUBLIC_EXACT`), and every other logged-out surface (`/login`, `/setup`, `/portal/subscribe`, `/updating`, `globals.css`) — their only root-relative assets are `/clawbox-crab.png`, `/clawbox-icon.png` and `/fonts/*`, all already public.

### Both editions
The four paths are served from `public/` on OpenClaw and Hermes alike; the Hermes gateway-404 gate does not fire for any of them.

### Left for the owner (not in this PR)
`public/manifest.json` is edition-blind: it hard-codes `name`/`short_name` "ClawBox" and the crab icons. Before this change a Hermes box was effectively **not** installable in Chrome, because Chrome refuses the prompt when no declared icon ≥192 px is fetchable — the auth gate was an accidental brake. Making the icons public removes it, so a Hermes appliance will now offer "Install ClawBox". iOS already did this through `/apple-touch-icon.png` + `appleWebApp.title`. Making it edition-aware means replacing the static manifest with a `src/app/manifest.ts` metadata route reading `readEdition()` — a branding decision, not a rider on an auth fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted unauthenticated access on public paths to read-only requests.
  * Added public access for configured PWA and Apple touch icons.
  * Ensured write requests to icon paths still require authentication.
* **Tests**
  * Added coverage for icon accessibility during normal and first-boot states.
  * Verified exact icon paths, including case sensitivity and trailing-slash behavior.
  * Confirmed that protected pages and APIs remain restricted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->