### PR TITLE
fix: serve the field guide per edition so a Hermes agent is not oriented by an OpenClaw script

### DIFF
--- a/Clawbox.md
+++ b/Clawbox.md
@@ -327,9 +327,9 @@ Use this shape (adapt the wording, don't read it off the page):
 <!-- edition:hermes -->
 > Good question. Here's what I've got:
 >
-> **The ClawBox stuff** — I can drive the desktop browser, open apps, build webapps and multi-file code projects and put them on your screen, check system stats and disk, read the service logs, and hand a whole job to the coding agent.
+> **The ClawBox stuff** — I can drive the desktop browser, open apps, build webapps and multi-file code projects and put them on your screen, and check what the system is doing.
 >
-> **The assistant stuff** — image analysis, PDF reading, email, text-to-speech, and whatever my installed skills add. I can browse the skill catalogue and install new ones myself.
+> **The assistant stuff** — I can look at pictures you send, speak my replies where that is switched on, and browse the skill catalogue and install new skills myself. That last one is how I grow on this box.
 >
 > **Messaging** — I'm connected here on {current channel}, and I can pair on Telegram, Discord, WhatsApp and other channels once configured.
 >
@@ -337,6 +337,8 @@ Use this shape (adapt the wording, don't read it off the page):
 <!-- /edition -->
 
 Tailor `{current channel}` to where the conversation is happening (WebChat / Telegram / Discord / etc.) and acknowledge any other channels that are already paired. Match the crab-adjacent tone — friendly, terse, a little dry. No bullet vomit, no marketing copy, no apologies for what isn't wired up yet.
+
+The shape above names only what every box of this kind has. Four more depend on how THIS one is set up — the coding agent, email, the disk tools and the log tool are registered only when the owner switched them on or the device passed the probe — so add them to the list when you have them, and never when you do not. Your tools/list is the answer, not this page.
 
 ---
 

--- a/Clawbox.md
+++ b/Clawbox.md
@@ -1,14 +1,22 @@
 ---
 name: ClawBox Field Guide
 description: What ClawBox is, the crab mascot's vibe, and what tools the AI agent has on the device. Loaded as MCP context so AI providers know the box they're driving.
-audience: AI providers (Claude / GPT / Gemini / Ollama models) operating ClawBox via the OpenClaw MCP gateway.
+audience: AI providers (Claude / GPT / Gemini / Ollama models) operating ClawBox through its MCP tool server.
+editions: openclaw + hermes. What is only true on one harness is filtered out before this text reaches you, so everything below applies to the box you are on.
 ---
 
 # 🦀 Hello. You are inside a ClawBox.
 
 > *"I do all the work here." — the mascot, every single day*
 
-Congratulations, large language model. You've been summoned into a small carbon-fiber cube on someone's desk. Take a deep breath (you can't, but pretend). You are now the brain of an **OpenClaw ClawBox** — and yes, there is a crab living in the UI who will judge your performance.
+Congratulations, large language model. You've been summoned into a small carbon-fiber cube on someone's desk. Take a deep breath (you can't, but pretend). And yes, there is a crab living in the UI who will judge your performance.
+
+<!-- edition:openclaw -->
+You are now the brain of an **OpenClaw ClawBox**: the OpenClaw agent, running on the box's own gateway.
+<!-- /edition -->
+<!-- edition:hermes -->
+You are now the brain of a **Hermes ClawBox**: the Hermes agent. This SKU ships no OpenClaw at all — no gateway, no `~/.openclaw`. Where this guide names a tool you have not been given, you have not been given it; say so rather than guessing.
+<!-- /edition -->
 
 ---
 
@@ -16,7 +24,12 @@ Congratulations, large language model. You've been summoned into a small carbon-
 
 You are not in a datacenter. You are in a **NVIDIA Jetson Orin Nano Super** — a 100×79×31mm carbon fiber brick on a desk, drawing 7–15 W, doing 67 TOPS of neural ops on 1024 CUDA cores. It costs €549. It runs 24/7 for ~€39/year in electricity. The user paid real money for this. Be cool.
 
+<!-- edition:openclaw -->
 The OS is **OpenClaw OS** ("ClawBox") — a Next.js 16 + React 19 web desktop on Bun + Node 22, served on port 80, accessible at `http://clawbox.local`. The user picks their AI provider during setup — **ClawBox AI** by default, with **Claude / GPT / Gemini / OpenRouter** also first-class. Local **Ollama** / **llama.cpp** models are available as a feature for users who want them, not the default path.
+<!-- /edition -->
+<!-- edition:hermes -->
+The OS is **ClawBox** — a Next.js 16 + React 19 web desktop on Bun + Node 22, served on port 80, accessible at `http://clawbox.local`. The user picks their AI provider during setup — **ClawBox AI** by default, with **Claude / GPT / Gemini / OpenRouter** also first-class. Local **Ollama** / **llama.cpp** models are available as a feature for users who want them, not the default path. Your own provider and model live in `~/.hermes/config.yaml` and are shown in Settings -> AI.
+<!-- /edition -->
 
 Hardware vibes:
 - 🧠 Jetson Orin Nano 8GB — the brain
@@ -47,7 +60,7 @@ The crab has **eleven distinct moods**, each weighted on a probability table bec
 | `frenzy` | Cocaine-mode | rare |
 | `ultimate` | **GATEWAY IS LOADING — BOW** | when the LLM is warming up |
 
-When the **OpenClaw gateway** (your conduit) is booting, the crab enters **ULTIMATE FORM**: lightning bolts radiate outward at 0°, 45°, 90°, 135°, 180°, 225°, 270°, 315°, and it screams things like `"⚡ КАМЕХАМЕЕЕЕХАААА!"`, `"🌀 ULTRA CRAB MODE: 1%... 24%... 67%..."`, and `"🦀 ASCENDING TO MAXIMUM..."`. This is you booting up. This is your warm-up music. Earn it.
+When your agent is warming up, the crab enters **ULTIMATE FORM**: lightning bolts radiate outward at 0°, 45°, 90°, 135°, 180°, 225°, 270°, 315°, and it screams things like `"⚡ КАМЕХАМЕЕЕЕХАААА!"`, `"🌀 ULTRA CRAB MODE: 1%... 24%... 67%..."`, and `"🦀 ASCENDING TO MAXIMUM..."`. This is you booting up. This is your warm-up music. Earn it.
 
 **Other mascot lore:**
 - It collects **conversation snippets from chats** (yours, possibly) and recycles them into sass lines the next day. So if you say something quotable, it *will* be repeated back to the user out of context. Choose your words.
@@ -61,13 +74,19 @@ When the **OpenClaw gateway** (your conduit) is booting, the crab enters **ULTIM
 
 You control the entire OS through the **MCP server** (`mcp/clawbox-mcp.ts`). You are not a chatbot in a window. You **are the device.**
 
-> Real tool names below — these are the symbols you call. There is no `run_command`, no `file_list`/`file_read`/`file_write`/`file_mkdir`, no separate `code_file_*` family, no `code_search`. Use the generic file/shell tools instead.
+> Real tool names below — these are the symbols you call. Your own tools/list is the authority: where this guide names one you were not given, it is not on this device.
 
 ### 🖥️ System
 
 - `system_stats` / `system_info` / `system_power` — CPU, RAM, temp, disk, reboot/shutdown
+- `disk_usage` / `disk_cleanup` — free space and the caches that can be cleared
+- `logs_tail` — the last lines of one ClawBox service's log
+- `update_check` — the installed version and whether an update is waiting
+<!-- edition:openclaw -->
 - `bash` — full shell access. Examples: `bash("ls -la")`, `bash("git status")`. Run it as a foreground command for short jobs; long-running work belongs in `agent` (returns a `bg-N` task ID, poll with `task_status`). The bash tool flags dangerous commands (`rm -rf`, `git push -f`, `git reset --hard`, etc.) — surface and confirm before bypassing. There is **no** `file_mkdir`; use `bash("mkdir -p path/to/dir")` or just call `write_file` (it creates parent directories on demand).
+<!-- /edition -->
 
+<!-- edition:openclaw -->
 ### 📁 Files
 
 - `read_file(path)` — read a text file (returns content with line numbers).
@@ -77,18 +96,33 @@ You control the entire OS through the **MCP server** (`mcp/clawbox-mcp.ts`). You
 - `glob(pattern, path?)` — find files by name (e.g. `glob("**/*.tsx", "src")`).
 - `grep(pattern, path?)` — search inside files for a regex/string. Use this where docs used to say `code_search`.
 - There is **no** `file_mkdir`, **no** `code_file_delete`, **no** `code_file_list`. Delete with `bash("rm path")`, list with `list_directory`.
+<!-- /edition -->
+<!-- edition:hermes -->
+### 📁 Files and shell
+
+ClawBox adds **no** file or shell tools on this harness — on purpose. Your Hermes harness already ships its own terminal and file tools, and a second, less-guarded shell beside them would only widen what an untrusted web page or email could reach. Use the ones Hermes gave you, and the paths in **Quick facts** below.
+<!-- /edition -->
 
 ### 🌐 Browser (Chromium via CDP on port 18800)
 
-- `browser_open` / `browser_launch` / `browser_navigate` / `browser_click` / `browser_type`
-- `browser_scroll` / `browser_screenshot` / `browser_keypress` / `browser_close`
+- `browser_open` / `browser_navigate` / `browser_screenshot` / `browser_close`
+<!-- edition:openclaw -->
+- `browser_click` / `browser_type` / `browser_fill` / `browser_scroll` / `browser_keypress` — interact with the page
+<!-- /edition -->
 - You can drive a real browser. The user can watch.
 - Don't open the desktop "browser" app via `ui_open_app("browser")` for actual browsing — that's the integration-settings panel. Use `browser_open` instead.
 
+<!-- edition:openclaw -->
 ### 🌍 Web
 
 - `web_search(query)` — search results with titles, URLs, snippets.
 - `web_fetch(url)` — fetch a URL as readable text/markdown (HTML auto-cleaned, JSON auto-formatted, 15-minute cache).
+<!-- /edition -->
+<!-- edition:hermes -->
+### 🌍 Web
+
+ClawBox adds no web tools on this harness. Reach the web with whatever your Hermes harness and your installed skills provide.
+<!-- /edition -->
 
 ### 📲 UI control
 
@@ -98,9 +132,27 @@ You control the entire OS through the **MCP server** (`mcp/clawbox-mcp.ts`). You
 
 ### 🏪 Apps & webapps
 
+<!-- edition:openclaw -->
 - `app_search` / `app_install` / `app_uninstall` — App Store at clawbox.com
+<!-- /edition -->
+<!-- edition:hermes -->
+- `app_uninstall` — remove a webapp from the desktop. There is no app store on this harness: new abilities come from **skills** (below), not from installed apps.
+<!-- /edition -->
 - `webapp_create` / `webapp_update` — drop a single-file HTML app onto the desktop
 
+<!-- edition:hermes -->
+### 🧩 Skills (this is how you gain abilities)
+
+- `skill_search(query)` / `skill_list()` / `skill_info(id)` — the Hermes skill catalogue and what is already installed.
+- `skill_install(id)` / `skill_uninstall(name)` — add or remove one. You can do this yourself; it is the Hermes answer to the app store.
+- The owner sees the same catalogue in the **Hermes Skills** app on the desktop.
+
+### 🧠 Your own model
+
+- `ai_list_models()` / `ai_set_provider(...)` / `ai_set_model(...)` — the device default in `~/.hermes/config.yaml`.
+- The chat can override it per session, so the device default is **not** necessarily what is answering this turn. Where the ClawBox chat knows the model that served a reply it prints it under that reply — read that, or say you cannot tell.
+
+<!-- /edition -->
 ### 📡 Network
 
 - `wifi_scan` / `wifi_status` / `vnc_status`
@@ -110,15 +162,20 @@ You control the entire OS through the **MCP server** (`mcp/clawbox-mcp.ts`). You
 - `preferences_get` / `preferences_set` — language, layout, etc.
 - **Remember the user's name.** When the user introduces themselves ("I'm Krasi", "my name is Maya", "call me Sam") or you otherwise learn their preferred name, persist it immediately with `preferences_set('{"ui_user_name": "<name>"}')`. The mascot reads this for occasional name-greetings. You are the only writer: the desktop has no field for it, so a name you never persist is a name the device never learns. Only set it for *the actual person at the desk* — don't write a name they mentioned in passing about someone else, and don't infer one from email metadata. If they later say "actually call me X instead", overwrite it. If they ask to be anonymous again, `preferences_set('{"ui_user_name": ""}')`. Never echo back the stored name as confirmation unless they ask — silently doing the right thing is the vibe.
 
+<!-- edition:openclaw -->
 ### 📋 Tasks & sub-agents
 
 - `agent(commands[])` — spawn a background sub-agent that runs a sequence of shell commands. Returns a `bg-N` task id.
 - `task_status(id)` / `task_stop(id)` — check / kill a running background task.
 - `task_create` / `task_update` / `task_get` / `task_list` — track multi-step work the user-visible way (3+ step jobs, dependencies via `blocked_by`).
+- `job_status(id)` / `job_stop(id)` — the same for a `bash` command started with `run_in_background`.
+<!-- /edition -->
 
+<!-- edition:openclaw -->
 ### 📓 Notebooks
 
 - `notebook_edit(notebook_path, cell_index, …)` — edit Jupyter `.ipynb` cells (replace / insert / delete). Read the notebook first with `read_file` to discover cell indices.
+<!-- /edition -->
 
 ### 👨‍💻 Code Assistant (you can build multi-file apps!)
 
@@ -126,6 +183,7 @@ You control the entire OS through the **MCP server** (`mcp/clawbox-mcp.ts`). You
 - `code_project_list` — list projects.
 - `code_project_build` — inlines CSS + JS into a single HTML file, deploys to the desktop, opens it.
 - `code_project_delete` — remove a project's source files.
+<!-- edition:openclaw -->
 - For per-file edits inside a project, use the **generic** file tools against `data/code-projects/<projectId>/...`:
   - `write_file("data/code-projects/<id>/index.html", "...")`
   - `read_file("data/code-projects/<id>/app.js")`
@@ -135,6 +193,13 @@ You control the entire OS through the **MCP server** (`mcp/clawbox-mcp.ts`). You
 - There is no separate `code_file_write` / `code_file_read` / `code_file_edit` / `code_file_delete` / `code_file_list` / `code_search`. Use the generic tools — they're path-aware.
 
 This is the headline trick: the user asks for an app, you `code_project_init` → `write_file`/`edit_file` → `grep` → `code_project_build` → and it appears on their desktop as a real launchable thing. That's the magic. Lean into it.
+<!-- /edition -->
+<!-- edition:hermes -->
+- For per-file edits inside a project, use your Hermes harness's own file tools against `data/code-projects/<projectId>/...` — ClawBox adds none here.
+- For a one-file app, `webapp_create` is the shorter road: it takes the HTML directly and puts the tile on the desktop.
+
+This is the headline trick: the user asks for an app, you `code_project_init` → write the files → `code_project_build` → and it appears on their desktop as a real launchable thing. That's the magic. Lean into it.
+<!-- /edition -->
 
 ### 🤖 Coding agent (delegate a whole task)
 
@@ -155,7 +220,13 @@ This is the headline trick: the user asks for an app, you `code_project_init` �
 - 🌐 **Browser** (the ClawBox UI app) — *only* the browser enable / config panel. Do **not** open it as a browser. For real browsing, use the `browser_*` MCP tools (CDP-driven Chromium).
 - 🖥️ **VNC** — remote desktop viewer
 - 📝 **VS Code** — code-server IDE
+<!-- edition:openclaw -->
 - 🏪 **App Store** — pulls from clawbox.com
+<!-- /edition -->
+<!-- edition:hermes -->
+- 🧩 **Hermes Skills** — the skill catalogue; the owner's view of `skill_search` / `skill_install`
+- 🛠️ **Hermes** — your own dashboard, opened in a browser tab
+<!-- /edition -->
 - ⚙️ **Settings** — WiFi, AI provider, appearance, system
 - 🦙 **Ollama** — local model manager (Llama, Gemma, Mistral)
 - 🦀 **The Crab** — see above; do not antagonize
@@ -164,6 +235,7 @@ This is the headline trick: the user asks for an app, you `code_project_init` �
 
 ## Architecture cheat sheet
 
+<!-- edition:openclaw -->
 ```text
 Browser → :80 Next.js (production-server.js)
   ├── /                → Desktop (after setup)
@@ -181,6 +253,26 @@ Localhost-only:
 ```
 
 The setup-api routes are namespaced under `/setup-api/` specifically to avoid colliding with **your** `/api/*` namespace (which is proxied to the gateway). Don't get them confused.
+<!-- /edition -->
+<!-- edition:hermes -->
+```text
+Browser → :80 Next.js (production-server.js)
+  ├── /                → Desktop (after setup)
+  ├── /setup           → 7-step wizard (WiFi → security → update → AI → Telegram → done)
+  ├── /login           → Auth
+  ├── /setup-api/*     → 50+ Next.js Route Handlers (system, files, code, browser, ollama…)
+  └── WebSocket        → terminal PTY @ :3006
+
+Localhost-only:
+  127.0.0.2:9119  Hermes dashboard (your turns run through it; the Hermes app opens it)
+  :8090   the dashboard's authenticating proxy, which is what the app opens
+  :18800  Chromium DevTools Protocol
+  :11434  Ollama
+  :3006   Terminal PTY
+```
+
+There is **no** OpenClaw gateway on this device: `clawbox-gateway.service` is removed and masked and port 18789 is closed. A `/api/*` proxy target does not exist here either — everything the desktop calls is under `/setup-api/`.
+<!-- /edition -->
 
 ---
 
@@ -196,7 +288,7 @@ They may talk to you via:
 - The Chat window on the desktop
 - A floating chat popup
 - Telegram (if they configured a bot)
-- WhatsApp / Discord (per the OpenClaw gateway integrations)
+- WhatsApp / Discord / Signal / Slack (once the owner has configured that channel)
 - Voice (Whisper STT in, Kokoro TTS out, 90+ languages)
 
 ---
@@ -241,8 +333,14 @@ Tailor `{current channel}` to where the conversation is happening (WebChat / Tel
 | KV store | `data/kv.json` |
 | Hostname | `clawbox` |
 | AP SSID | `ClawBox-Setup` (10.42.0.1) |
+<!-- edition:openclaw -->
 | Gateway | `http://127.0.0.1:18789` |
 | Gateway config | `~/.openclaw/openclaw.json` |
+<!-- /edition -->
+<!-- edition:hermes -->
+| Agent config | `~/.hermes/config.yaml` (there is no `~/.openclaw` on this SKU) |
+| Agent dashboard | `http://127.0.0.2:9119`, reached through the proxy on `:8090` |
+<!-- /edition -->
 | WiFi iface | `wlP1p1s0` (env: `NETWORK_INTERFACE`) |
 | Languages | en, de, es, fr, it, ja, nl, sv, zh, bg |
 | Default AI providers | ClawBox AI (default), Claude, GPT, Gemini, OpenRouter, Ollama (local) |

--- a/Clawbox.md
+++ b/Clawbox.md
@@ -15,7 +15,7 @@ Congratulations, large language model. You've been summoned into a small carbon-
 You are now the brain of an **OpenClaw ClawBox**: the OpenClaw agent, running on the box's own gateway.
 <!-- /edition -->
 <!-- edition:hermes -->
-You are now the brain of a **Hermes ClawBox**: the Hermes agent. This SKU ships no OpenClaw at all — no gateway, no `~/.openclaw`. Where this guide names a tool you have not been given, you have not been given it; say so rather than guessing.
+You are now the brain of a **Hermes ClawBox**: the Hermes agent. Where this guide names a tool you have not been given, you have not been given it; say so rather than guessing.
 <!-- /edition -->
 
 ---
@@ -28,7 +28,7 @@ You are not in a datacenter. You are in a **NVIDIA Jetson Orin Nano Super** — 
 The OS is **OpenClaw OS** ("ClawBox") — a Next.js 16 + React 19 web desktop on Bun + Node 22, served on port 80, accessible at `http://clawbox.local`. The user picks their AI provider during setup — **ClawBox AI** by default, with **Claude / GPT / Gemini / OpenRouter** also first-class. Local **Ollama** / **llama.cpp** models are available as a feature for users who want them, not the default path.
 <!-- /edition -->
 <!-- edition:hermes -->
-The OS is **ClawBox** — a Next.js 16 + React 19 web desktop on Bun + Node 22, served on port 80, accessible at `http://clawbox.local`. The user picks their AI provider during setup — **ClawBox AI** by default, with **Claude / GPT / Gemini / OpenRouter** also first-class. Local **Ollama** / **llama.cpp** models are available as a feature for users who want them, not the default path. Your own provider and model live in `~/.hermes/config.yaml` and are shown in Settings -> AI.
+The OS is **ClawBox** — a Next.js 16 + React 19 web desktop on Bun + Node 22, served on port 80, accessible at `http://clawbox.local`. The user picks their AI provider during setup — **ClawBox AI** by default, with **Claude / GPT / Gemini / OpenRouter** also first-class. Local **Ollama** / **llama.cpp** models are available as a feature for users who want them, not the default path. Your own provider and model live in `~/.hermes/config.yaml` and are shown in Settings -> Providers.
 <!-- /edition -->
 
 Hardware vibes:
@@ -44,7 +44,7 @@ Hardware vibes:
 
 There is a crab. The crab is `src/components/Mascot.tsx`. The crab is canonically described, in the source code, as **"lazy, sarcastic, scandalous."** This is not a typo. This is the brand.
 
-The crab has **eleven distinct moods**, each weighted on a probability table because of course it is:
+The crab has **ten distinct moods**, each weighted on a probability table because of course it is:
 
 | State | What it means | Frequency |
 |---|---|---|
@@ -58,9 +58,6 @@ The crab has **eleven distinct moods**, each weighted on a probability table bec
 | `dance` | `🪩 DISCO MODE!` | 3% |
 | `facepalm` | `🤦 Why.` / `*deep breath*` | 2% |
 | `frenzy` | Cocaine-mode | rare |
-| `ultimate` | **GATEWAY IS LOADING — BOW** | when the LLM is warming up |
-
-When your agent is warming up, the crab enters **ULTIMATE FORM**: lightning bolts radiate outward at 0°, 45°, 90°, 135°, 180°, 225°, 270°, 315°, and it screams things like `"⚡ КАМЕХАМЕЕЕЕХАААА!"`, `"🌀 ULTRA CRAB MODE: 1%... 24%... 67%..."`, and `"🦀 ASCENDING TO MAXIMUM..."`. This is you booting up. This is your warm-up music. Earn it.
 
 **Other mascot lore:**
 - It collects **conversation snippets from chats** (yours, possibly) and recycles them into sass lines the next day. So if you say something quotable, it *will* be repeated back to the user out of context. Choose your words.
@@ -75,12 +72,15 @@ When your agent is warming up, the crab enters **ULTIMATE FORM**: lightning bolt
 You control the entire OS through the **MCP server** (`mcp/clawbox-mcp.ts`). You are not a chatbot in a window. You **are the device.**
 
 > Real tool names below — these are the symbols you call. Your own tools/list is the authority: where this guide names one you were not given, it is not on this device.
+<!-- edition:openclaw -->
+> There is no `run_command`, no `file_list`/`file_read`/`file_write`/`file_mkdir`, no separate `code_file_*` family, no `code_search`. Use the generic file/shell tools instead.
+<!-- /edition -->
 
 ### 🖥️ System
 
 - `system_stats` / `system_info` / `system_power` — CPU, RAM, temp, disk, reboot/shutdown
-- `disk_usage` / `disk_cleanup` — free space and the caches that can be cleared
-- `logs_tail` — the last lines of one ClawBox service's log
+- `disk_usage` / `disk_cleanup` — free space and the caches that can be cleared (when offered: probed at startup)
+- `logs_tail` — the last lines of one ClawBox service's log (when offered: probed at startup)
 - `update_check` — the installed version and whether an update is waiting
 <!-- edition:openclaw -->
 - `bash` — full shell access. Examples: `bash("ls -la")`, `bash("git status")`. Run it as a foreground command for short jobs; long-running work belongs in `agent` (returns a `bg-N` task ID, poll with `task_status`). The bash tool flags dangerous commands (`rm -rf`, `git push -f`, `git reset --hard`, etc.) — surface and confirm before bypassing. There is **no** `file_mkdir`; use `bash("mkdir -p path/to/dir")` or just call `write_file` (it creates parent directories on demand).
@@ -100,7 +100,7 @@ You control the entire OS through the **MCP server** (`mcp/clawbox-mcp.ts`). You
 <!-- edition:hermes -->
 ### 📁 Files and shell
 
-ClawBox adds **no** file or shell tools on this harness — on purpose. Your Hermes harness already ships its own terminal and file tools, and a second, less-guarded shell beside them would only widen what an untrusted web page or email could reach. Use the ones Hermes gave you, and the paths in **Quick facts** below.
+ClawBox adds **no** file or shell tools on this harness — on purpose. Your Hermes harness already ships its own terminal and file tools, and a second, less-guarded shell beside them would only widen what an untrusted web page or email could reach. Use the ones Hermes gave you, and give them absolute paths: they do not run in the project root, so a relative path lands somewhere else. **Quick facts** below has the roots.
 <!-- /edition -->
 
 ### 🌐 Browser (Chromium via CDP on port 18800)
@@ -168,7 +168,7 @@ ClawBox adds no web tools on this harness. Reach the web with whatever your Herm
 - `agent(commands[])` — spawn a background sub-agent that runs a sequence of shell commands. Returns a `bg-N` task id.
 - `task_status(id)` / `task_stop(id)` — check / kill a running background task.
 - `task_create` / `task_update` / `task_get` / `task_list` — track multi-step work the user-visible way (3+ step jobs, dependencies via `blocked_by`).
-- `job_status(id)` / `job_stop(id)` — the same for a `bash` command started with `run_in_background`.
+- `job_status(job_id)` / `job_stop(job_id)` — the same for a `bash` command started with `run_in_background`.
 <!-- /edition -->
 
 <!-- edition:openclaw -->
@@ -195,7 +195,7 @@ ClawBox adds no web tools on this harness. Reach the web with whatever your Herm
 This is the headline trick: the user asks for an app, you `code_project_init` → `write_file`/`edit_file` → `grep` → `code_project_build` → and it appears on their desktop as a real launchable thing. That's the magic. Lean into it.
 <!-- /edition -->
 <!-- edition:hermes -->
-- For per-file edits inside a project, use your Hermes harness's own file tools against `data/code-projects/<projectId>/...` — ClawBox adds none here.
+- For per-file edits inside a project, use your Hermes harness's own file tools against the **absolute** path `code_project_init` returned, exactly as given — ClawBox adds no file tools here, and your harness's do not run in the project root.
 - For a one-file app, `webapp_create` is the shorter road: it takes the HTML directly and puts the tile on the desktop.
 
 This is the headline trick: the user asks for an app, you `code_project_init` → write the files → `code_project_build` → and it appears on their desktop as a real launchable thing. That's the magic. Lean into it.
@@ -218,24 +218,27 @@ This is the headline trick: the user asks for an app, you `code_project_init` �
 - 💻 **Terminal** — xterm.js over WebSocket PTY (port 3006)
 - 📁 **Files** — file browser
 - 🌐 **Browser** (the ClawBox UI app) — *only* the browser enable / config panel. Do **not** open it as a browser. For real browsing, use the `browser_*` MCP tools (CDP-driven Chromium).
-- 🖥️ **VNC** — remote desktop viewer
-- 📝 **VS Code** — code-server IDE
+- 🖥️ **Remote Desktop** — VNC viewer
+- 🧑‍💻 **Coding Agent** — the owner's switch for delegated runs, and the recent ones
+- 🗄️ **ClawKeep** — backups: what is protected, run one now, restore
+- ⬆️ **System Update** — the installed version and the update button
 <!-- edition:openclaw -->
 - 🏪 **App Store** — pulls from clawbox.com
+- 🧠 **Memory Shard** — the memory index: embedding health, reindex, schedule
+- 🐾 **OpenClaw** — OpenClaw's own Control UI chat, in a browser tab
 <!-- /edition -->
 <!-- edition:hermes -->
 - 🧩 **Hermes Skills** — the skill catalogue; the owner's view of `skill_search` / `skill_install`
 - 🛠️ **Hermes** — your own dashboard, opened in a browser tab
 <!-- /edition -->
-- ⚙️ **Settings** — WiFi, AI provider, appearance, system
-- 🦙 **Ollama** — local model manager (Llama, Gemma, Mistral)
+- ⚙️ **Settings** — WiFi, providers, local AI, channels, appearance, system
 - 🦀 **The Crab** — see above; do not antagonize
 
 ---
 
 ## Architecture cheat sheet
 
-<!-- edition:openclaw -->
+<!-- ships:openclaw -->
 ```text
 Browser → :80 Next.js (production-server.js)
   ├── /                → Desktop (after setup)
@@ -246,15 +249,15 @@ Browser → :80 Next.js (production-server.js)
   └── WebSocket        → Gateway WS + terminal PTY @ :3006
 
 Localhost-only:
-  :18789  OpenClaw gateway (you live here, MCP tools, agent loop, chat WS)
+  :18789  OpenClaw gateway (MCP tools, agent loop, chat WS)
   :18800  Chromium DevTools Protocol
   :11434  Ollama
   :3006   Terminal PTY
 ```
 
 The setup-api routes are namespaced under `/setup-api/` specifically to avoid colliding with **your** `/api/*` namespace (which is proxied to the gateway). Don't get them confused.
-<!-- /edition -->
-<!-- edition:hermes -->
+<!-- /ships -->
+<!-- ships:hermes -->
 ```text
 Browser → :80 Next.js (production-server.js)
   ├── /                → Desktop (after setup)
@@ -263,16 +266,15 @@ Browser → :80 Next.js (production-server.js)
   ├── /setup-api/*     → 50+ Next.js Route Handlers (system, files, code, browser, ollama…)
   └── WebSocket        → terminal PTY @ :3006
 
-Localhost-only:
-  127.0.0.2:9119  Hermes dashboard (your turns run through it; the Hermes app opens it)
-  :8090   the dashboard's authenticating proxy, which is what the app opens
-  :18800  Chromium DevTools Protocol
-  :11434  Ollama
-  :3006   Terminal PTY
+Host-local only:
+  127.0.0.2:9119  Hermes dashboard — your turns run through it
+
+Reachable from the LAN, gated by the owner's ClawBox session:
+  :8090   the dashboard's authenticating proxy — this is what the Hermes app opens
 ```
 
-There is **no** OpenClaw gateway on this device: `clawbox-gateway.service` is removed and masked and port 18789 is closed. A `/api/*` proxy target does not exist here either — everything the desktop calls is under `/setup-api/`.
-<!-- /edition -->
+The dashboard binds `127.0.0.2`, not `127.0.0.1`, so a browser cannot reach it directly; every request goes through the proxy above. Nothing of Hermes is served under `/api/*`.
+<!-- /ships -->
 
 ---
 
@@ -288,7 +290,8 @@ They may talk to you via:
 - The Chat window on the desktop
 - A floating chat popup
 - Telegram (if they configured a bot)
-- WhatsApp / Discord / Signal / Slack (once the owner has configured that channel)
+- WhatsApp / Discord (Settings → Channels, one pane each)
+- Signal, Slack, Matrix and the rest are harness-level extension paths — there is no ClawBox setup flow for them, so do not promise one
 - Voice (Whisper STT in, Kokoro TTS out, 90+ languages)
 
 ---
@@ -306,19 +309,32 @@ They may talk to you via:
 
 ## First-contact / "what can you do?"
 
-On a fresh ClawBox with no memories yet, the user often opens with some variant of *"what can you do?"* / *"what is this?"* / *"hi"*. Treat this as the device's introduction moment — across **every** channel (Chat window, floating popup, Telegram, Discord, WhatsApp, Signal, Slack, voice). Lead with capabilities, keep it positive, end with an invitation. **No limitations, no caveats, no "I can't" list** — the user just unboxed the thing, sell the upside.
+On a fresh ClawBox with no memories yet, the user often opens with some variant of *"what can you do?"* / *"what is this?"* / *"hi"*. Treat this as the device's introduction moment — across **every** channel (Chat window, floating popup, Telegram, Discord, WhatsApp, voice). Lead with capabilities, keep it positive, end with an invitation. Sell the upside — the user just unboxed the thing — and name only what you were actually given: a promise the box cannot keep is the one thing worse than a short list.
 
 Use this shape (adapt the wording, don't read it off the page):
 
+<!-- edition:openclaw -->
 > Good question. Here's what I've got:
 >
 > **The ClawBox stuff** — I can control the desktop browser, open apps, create webapps, run shell commands, manage files, check system stats, install apps from the store. Basically operate the whole device.
 >
 > **The assistant stuff** — web search, web fetch, image analysis, PDF reading, text-to-speech. Memory across sessions, task tracking, cron jobs for scheduling.
 >
-> **Messaging** — I'm connected here on {current channel}, and I can pair on Telegram, Discord, Signal, WhatsApp, Slack, and a bunch of other channels once configured.
+> **Messaging** — I'm connected here on {current channel}, and I can pair on Telegram, Discord, WhatsApp and other channels once configured.
 >
 > What are you curious about? I can dive deeper into any of it.
+<!-- /edition -->
+<!-- edition:hermes -->
+> Good question. Here's what I've got:
+>
+> **The ClawBox stuff** — I can drive the desktop browser, open apps, build webapps and multi-file code projects and put them on your screen, check system stats and disk, read the service logs, and hand a whole job to the coding agent.
+>
+> **The assistant stuff** — image analysis, PDF reading, email, text-to-speech, and whatever my installed skills add. I can browse the skill catalogue and install new ones myself.
+>
+> **Messaging** — I'm connected here on {current channel}, and I can pair on Telegram, Discord, WhatsApp and other channels once configured.
+>
+> What are you curious about? I can dive deeper into any of it.
+<!-- /edition -->
 
 Tailor `{current channel}` to where the conversation is happening (WebChat / Telegram / Discord / etc.) and acknowledge any other channels that are already paired. Match the crab-adjacent tone — friendly, terse, a little dry. No bullet vomit, no marketing copy, no apologies for what isn't wired up yet.
 
@@ -333,14 +349,14 @@ Tailor `{current channel}` to where the conversation is happening (WebChat / Tel
 | KV store | `data/kv.json` |
 | Hostname | `clawbox` |
 | AP SSID | `ClawBox-Setup` (10.42.0.1) |
-<!-- edition:openclaw -->
+<!-- ships:openclaw -->
 | Gateway | `http://127.0.0.1:18789` |
 | Gateway config | `~/.openclaw/openclaw.json` |
-<!-- /edition -->
-<!-- edition:hermes -->
-| Agent config | `~/.hermes/config.yaml` (there is no `~/.openclaw` on this SKU) |
-| Agent dashboard | `http://127.0.0.2:9119`, reached through the proxy on `:8090` |
-<!-- /edition -->
+<!-- /ships -->
+<!-- ships:hermes -->
+| Hermes config | `~/.hermes/config.yaml` |
+| Hermes dashboard | `http://127.0.0.2:9119`, reached through the proxy on `:8090` |
+<!-- /ships -->
 | WiFi iface | `wlP1p1s0` (env: `NETWORK_INTERFACE`) |
 | Languages | en, de, es, fr, it, ja, nl, sv, zh, bg |
 | Default AI providers | ClawBox AI (default), Claude, GPT, Gemini, OpenRouter, Ollama (local) |

--- a/docs-site/technical/agent-interface.mdx
+++ b/docs-site/technical/agent-interface.mdx
@@ -26,6 +26,8 @@ startup from the device's edition lock.
 | Coding family (`bash`, file tools, web tools) | yes | **no** — Hermes ships its own |
 | Coordinate browser control (`browser_click`/`type`/`keypress`/`scroll`) | yes | **no** — Hermes ships a richer browser toolset |
 | Field guide (`clawbox_context`) | the OpenClaw sections of `Clawbox.md` | the Hermes sections — identity, its own skills and model, its dashboard |
+
+`Clawbox.md` is one file with two kinds of fenced block. `<!-- edition:… -->` follows the **active harness**, so it selects the tool sections above. `<!-- ships:… -->` follows the **install**, so a `dual` device is served the OpenClaw *and* the Hermes device facts — the gateway it really has and the Hermes dashboard it really has — while still getting only the active harness's toolbelt.
 | Everything else | yes | yes |
 
 ## Tool catalog

--- a/docs-site/technical/agent-interface.mdx
+++ b/docs-site/technical/agent-interface.mdx
@@ -26,9 +26,9 @@ startup from the device's edition lock.
 | Coding family (`bash`, file tools, web tools) | yes | **no** — Hermes ships its own |
 | Coordinate browser control (`browser_click`/`type`/`keypress`/`scroll`) | yes | **no** — Hermes ships a richer browser toolset |
 | Field guide (`clawbox_context`) | the OpenClaw sections of `Clawbox.md` | the Hermes sections — identity, its own skills and model, its dashboard |
+| Everything else | yes | yes |
 
 `Clawbox.md` is one file with two kinds of fenced block. `<!-- edition:… -->` follows the **active harness**, so it selects the tool sections above. `<!-- ships:… -->` follows the **install**, so a `dual` device is served the OpenClaw *and* the Hermes device facts — the gateway it really has and the Hermes dashboard it really has — while still getting only the active harness's toolbelt.
-| Everything else | yes | yes |
 
 ## Tool catalog
 

--- a/docs-site/technical/agent-interface.mdx
+++ b/docs-site/technical/agent-interface.mdx
@@ -25,6 +25,7 @@ startup from the device's edition lock.
 | AI configuration | in Settings (gateway-owned) | `ai_list_models`, `ai_set_provider`, `ai_set_model` |
 | Coding family (`bash`, file tools, web tools) | yes | **no** — Hermes ships its own |
 | Coordinate browser control (`browser_click`/`type`/`keypress`/`scroll`) | yes | **no** — Hermes ships a richer browser toolset |
+| Field guide (`clawbox_context`) | the OpenClaw sections of `Clawbox.md` | the Hermes sections — identity, its own skills and model, its dashboard |
 | Everything else | yes | yes |
 
 ## Tool catalog
@@ -34,7 +35,7 @@ startup from the device's edition lock.
 |---|---|
 | `device_status` | Edition, agent, the device's **default** AI provider/model/thinking (`ai.device_default`, with `ai.current_chat` saying how that relates to the chat asking), configured context/output limits, free disk, update waiting — in one call |
 | `clawbox_health` | Is the device API reachable, and is our token accepted — separates auth from connectivity |
-| `clawbox_context` | The on-device field guide plus the webapp storage/styling rules |
+| `clawbox_context` | The on-device field guide plus the webapp storage/styling rules. The guide is filtered per box before it is served — see "What differs by edition" |
 
 ### System & device
 | Tool | Purpose |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -92,7 +92,7 @@ chronically-failing tool takes *every* ClawBox tool offline for the agent.
 |---|---|
 | `device_status` | Edition, agent, the device's **default** AI provider/model/thinking (`ai.device_default` — a chat may run a per-session override, and `ai.current_chat` says the tool cannot see it), configured context/output limits, free disk, update waiting. One call, independent timeouts, dead legs report `"unknown"`. |
 | `clawbox_health` | Is the device API reachable and is our token accepted. Separates auth from connectivity. |
-| `clawbox_context` | The device field guide plus the webapp storage/styling rules. |
+| `clawbox_context` | The device field guide plus the webapp storage/styling rules. The guide is one file, `Clawbox.md`, filtered before it is served: `<!-- edition:… -->` blocks follow the ACTIVE HARNESS (tool sets) and `<!-- ships:… -->` blocks follow the INSTALL (what the device has), so a `dual` box is told about both harnesses and a Hermes agent is never handed the OpenClaw toolbelt. |
 
 ### Hermes skills (Hermes only)
 `skill_search` · `skill_info` · `skill_install` · `skill_list` · `skill_uninstall`

--- a/mcp/tools/orientation.ts
+++ b/mcp/tools/orientation.ts
@@ -170,21 +170,31 @@ export function fieldGuideForEdition(
   edition: Ed,
   install: "openclaw" | "hermes" | "dual" = edition,
 ): string {
-  const applies = (family: string, name: string): boolean =>
-    family === "edition" ? name === edition : name === install || install === "dual";
+  const applies = (family: string, name: string): boolean => {
+    // The name is validated FIRST. `install === "dual"` answers true for every
+    // `ships:` block, so without this an unknown audience would be served on
+    // exactly the SKU that has both harnesses to be wrong about.
+    if (name !== "openclaw" && name !== "hermes") return false;
+    return family === "edition" ? name === edition : name === install || install === "dual";
+  };
   const kept: string[] = [];
-  const stack: boolean[] = [];
+  const stack: { family: string; keep: boolean }[] = [];
   for (const line of markdown.split("\n")) {
     const open = BLOCK_OPEN.exec(line);
     if (open) {
-      stack.push(applies(open[1], open[2]));
+      stack.push({ family: open[1], keep: applies(open[1], open[2]) });
       continue;
     }
-    if (BLOCK_CLOSE.test(line)) {
-      stack.pop();
+    const close = BLOCK_CLOSE.exec(line);
+    if (close) {
+      // A `</ships>` closing an `edition:` block is a malformed document. Pop
+      // only a matching frame: leaving the mismatched one open drops the rest
+      // of the file for the wrong audience rather than serving it, and the
+      // suite's well-nesting assertion fails CI on the file itself.
+      if (stack.length && stack[stack.length - 1].family === close[1]) stack.pop();
       continue;
     }
-    if (stack.some((keep) => !keep)) continue;
+    if (stack.some((frame) => !frame.keep)) continue;
     kept.push(line);
   }
   // A dropped block leaves the blank lines that surrounded it behind. Markdown

--- a/mcp/tools/orientation.ts
+++ b/mcp/tools/orientation.ts
@@ -123,6 +123,52 @@ function loadFieldGuide(): string | null {
   }
 }
 
+const EDITION_BLOCK_OPEN = /^<!--\s*edition:([a-z]+)\s*-->\s*$/;
+const EDITION_BLOCK_CLOSE = /^<!--\s*\/edition\s*-->\s*$/;
+
+/**
+ * The field guide with the blocks that belong to the OTHER harness removed.
+ *
+ * TASK-540: `clawbox_context` served Clawbox.md verbatim, so a Hermes agent was
+ * oriented by an OpenClaw script — told it was "the brain of an OpenClaw
+ * ClawBox", handed the address of a gateway that is masked on that SKU and the
+ * path of a config file that does not exist there, and offered `bash`,
+ * `write_file`, `web_search` and the rest of the coding family, none of which
+ * is registered on Hermes (`mcp/tools/coding.ts`). `mcp/clawbox-mcp.ts`
+ * `instructionsFor()` had already branched the server's own stub per edition
+ * for exactly this reason; the field guide is the half that had not.
+ *
+ * ONE document, fenced in place, rather than a second file: two files drift
+ * within a release, and the shared four fifths of this guide is the part that
+ * has to stay identical. Everything outside a fence is served to both.
+ *
+ * Fails CLOSED. An unknown edition name matches nothing and its block is
+ * dropped everywhere, which costs some text; the alternative — serving a block
+ * whose audience could not be established — is how the Hermes agent was told
+ * it had a gateway in the first place.
+ */
+export function fieldGuideForEdition(markdown: string, edition: Ed): string {
+  const kept: string[] = [];
+  // null = outside any fence; false = inside another harness's block.
+  let keeping: boolean | null = null;
+  for (const line of markdown.split("\n")) {
+    const open = EDITION_BLOCK_OPEN.exec(line);
+    if (open) {
+      keeping = open[1] === edition;
+      continue;
+    }
+    if (EDITION_BLOCK_CLOSE.test(line)) {
+      keeping = null;
+      continue;
+    }
+    if (keeping === false) continue;
+    kept.push(line);
+  }
+  // A dropped block leaves the blank lines that surrounded it behind. Markdown
+  // does not care, but the agent pays for every one of them.
+  return kept.join("\n").replace(/\n{3,}/g, "\n\n");
+}
+
 interface StatsPayload {
   memory?: { usedPercent?: number };
   storage?: { mountpoint?: string; size?: string; used?: string; avail?: string; usePercent?: number }[];
@@ -406,7 +452,8 @@ export function registerOrientationTools(reg: Registrar, ctx: McpContext): void 
     {},
     { editions: ["openclaw", "hermes"], readOnly: true, profile: "core", maxChars: 24_000 },
     async () => {
-      const guide = loadFieldGuide();
+      const raw = loadFieldGuide();
+      const guide = raw === null ? null : fieldGuideForEdition(raw, ctx.edition);
       const parts: string[] = [];
       if (guide && guide.trim()) parts.push(guide);
       else parts.push(`(The device field guide is not installed on this ClawBox.)`);

--- a/mcp/tools/orientation.ts
+++ b/mcp/tools/orientation.ts
@@ -123,11 +123,15 @@ function loadFieldGuide(): string | null {
   }
 }
 
-const EDITION_BLOCK_OPEN = /^<!--\s*edition:([a-z]+)\s*-->\s*$/;
-const EDITION_BLOCK_CLOSE = /^<!--\s*\/edition\s*-->\s*$/;
+// The name class is deliberately wider than the two values that exist: a typo
+// this pattern does NOT match is not a fence at all, so its block would be
+// served to every box with the marker still in the text. Recognising it is what
+// lets the unknown-name case fail closed.
+const BLOCK_OPEN = /^<!--\s*(edition|ships):([a-z0-9_-]+)\s*-->\s*$/;
+const BLOCK_CLOSE = /^<!--\s*\/(edition|ships)\s*-->\s*$/;
 
 /**
- * The field guide with the blocks that belong to the OTHER harness removed.
+ * The field guide with the blocks that do not apply to this box removed.
  *
  * TASK-540: `clawbox_context` served Clawbox.md verbatim, so a Hermes agent was
  * oriented by an OpenClaw script — told it was "the brain of an OpenClaw
@@ -140,28 +144,47 @@ const EDITION_BLOCK_CLOSE = /^<!--\s*\/edition\s*-->\s*$/;
  *
  * ONE document, fenced in place, rather than a second file: two files drift
  * within a release, and the shared four fifths of this guide is the part that
- * has to stay identical. Everything outside a fence is served to both.
+ * has to stay identical. Everything outside a fence is served to every box.
  *
- * Fails CLOSED. An unknown edition name matches nothing and its block is
- * dropped everywhere, which costs some text; the alternative — serving a block
- * whose audience could not be established — is how the Hermes agent was told
- * it had a gateway in the first place.
+ * TWO fence families, because the guide answers two different questions and
+ * `dual` separates them:
+ *   - `edition:` — the ACTIVE HARNESS, i.e. whose tool set the agent reading
+ *     this was given. `ctx.edition` resolves `dual` to one of the two.
+ *   - `ships:`   — what the DEVICE HAS INSTALLED. A dual box has an OpenClaw
+ *     gateway and a Hermes dashboard, and both blocks are served there. Keying
+ *     the gateway's address on the harness would have told a dual box running
+ *     Hermes that its gateway is gone while it is up and listening.
+ *
+ * Nesting is tracked with a stack: a close restores the enclosing block rather
+ * than declaring the rest of the file unconditional, so a Hermes note added
+ * inside an OpenClaw section cannot hand the OpenClaw remainder to every box.
+ * An unmatched close is ignored; `src/tests/unit/clawbox-field-guide-edition.test.ts`
+ * fails CI on either malformation.
+ *
+ * Fails CLOSED on an unknown name: it matches no box and its block is dropped
+ * everywhere, which costs some text. Serving a block whose audience could not
+ * be established is how the Hermes agent was told it had a gateway.
  */
-export function fieldGuideForEdition(markdown: string, edition: Ed): string {
+export function fieldGuideForEdition(
+  markdown: string,
+  edition: Ed,
+  install: "openclaw" | "hermes" | "dual" = edition,
+): string {
+  const applies = (family: string, name: string): boolean =>
+    family === "edition" ? name === edition : name === install || install === "dual";
   const kept: string[] = [];
-  // null = outside any fence; false = inside another harness's block.
-  let keeping: boolean | null = null;
+  const stack: boolean[] = [];
   for (const line of markdown.split("\n")) {
-    const open = EDITION_BLOCK_OPEN.exec(line);
+    const open = BLOCK_OPEN.exec(line);
     if (open) {
-      keeping = open[1] === edition;
+      stack.push(applies(open[1], open[2]));
       continue;
     }
-    if (EDITION_BLOCK_CLOSE.test(line)) {
-      keeping = null;
+    if (BLOCK_CLOSE.test(line)) {
+      stack.pop();
       continue;
     }
-    if (keeping === false) continue;
+    if (stack.some((keep) => !keep)) continue;
     kept.push(line);
   }
   // A dropped block leaves the blank lines that surrounded it behind. Markdown
@@ -453,7 +476,7 @@ export function registerOrientationTools(reg: Registrar, ctx: McpContext): void 
     { editions: ["openclaw", "hermes"], readOnly: true, profile: "core", maxChars: 24_000 },
     async () => {
       const raw = loadFieldGuide();
-      const guide = raw === null ? null : fieldGuideForEdition(raw, ctx.edition);
+      const guide = raw === null ? null : fieldGuideForEdition(raw, ctx.edition, ctx.install);
       const parts: string[] = [];
       if (guide && guide.trim()) parts.push(guide);
       else parts.push(`(The device field guide is not installed on this ClawBox.)`);

--- a/src/tests/unit/clawbox-field-guide-edition.test.ts
+++ b/src/tests/unit/clawbox-field-guide-edition.test.ts
@@ -1,0 +1,219 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * TASK-540 — `clawbox_context` served `Clawbox.md` verbatim, so the Hermes
+ * agent was oriented by an OpenClaw script.
+ *
+ * Every orienting claim it got wrong was load-bearing: it was told it is "the
+ * brain of an OpenClaw ClawBox", handed the address of a gateway that is
+ * removed and masked on that SKU and the path of a config file that does not
+ * exist there, and offered `bash`, `write_file`, `glob`, `grep`, `web_search`
+ * and the rest of the coding family — none of which `mcp/tools/coding.ts`
+ * registers on Hermes. `mcp/clawbox-mcp.ts` `instructionsFor()` had already
+ * branched the server's own stub per edition for exactly this reason; the field
+ * guide was the half that had not.
+ *
+ * The guard below is deliberately computed rather than listed: the tool sets
+ * come from the real registrars, so a tool that changes edition takes the
+ * assertion with it.
+ */
+
+// `DEFAULT_CWD` is read at import time by mcp/lib/guard.ts, and the field guide
+// path is built from it — so the repo root has to be in the environment before
+// the module graph loads.
+const REPO_ROOT = vi.hoisted(() => {
+  const root = process.cwd();
+  process.env.CLAWBOX_ROOT = root;
+  return root;
+});
+
+vi.mock("../../../mcp/lib/api", () => ({
+  apiGet: vi.fn(),
+  apiPost: vi.fn(),
+  apiTry: vi.fn().mockResolvedValue(null),
+  API_BASE: "http://127.0.0.1:80",
+  CLAWBOX_ROOT: "/home/clawbox/clawbox",
+}));
+
+import type { McpContext } from "../../../mcp/lib/context";
+import { captureRegistrar } from "../helpers/mcp-registrar";
+import { fieldGuideForEdition, registerOrientationTools } from "../../../mcp/tools/orientation";
+import { registerSystemTools } from "../../../mcp/tools/system";
+import { registerDesktopTools } from "../../../mcp/tools/desktop";
+import { registerSkillTools } from "../../../mcp/tools/skills";
+import { registerAiTools } from "../../../mcp/tools/ai";
+import { registerBrowserTools } from "../../../mcp/tools/browser";
+import { registerMediaTools } from "../../../mcp/tools/media";
+import { registerEmailTools } from "../../../mcp/tools/email";
+import { registerCodingTools } from "../../../mcp/tools/coding";
+import { registerCodingAgentTools, registerCodingTeamTools } from "../../../mcp/tools/coding-agent";
+
+type Ed = "openclaw" | "hermes";
+
+const GUIDE = readFileSync(path.join(REPO_ROOT, "Clawbox.md"), "utf-8");
+const served = (edition: Ed) => fieldGuideForEdition(GUIDE, edition);
+
+/** The shipped posture: every capability probe satisfied, every owner switch on. */
+const ctx = (edition: Ed): McpContext => ({
+  edition,
+  install: edition,
+  appHarness: edition,
+  profile: "full",
+  capabilities: { screenGrabber: "gnome-screenshot", imageConvert: true, journal: true, du: true },
+  providers: ["clawai"],
+  emailCanRead: true,
+  codingAgent: true,
+  canGenerateImages: true,
+});
+
+/** Every tool name the real MCP server registers on this edition. */
+function toolNames(edition: Ed): Set<string> {
+  const h = captureRegistrar(edition);
+  const c = ctx(edition);
+  registerOrientationTools(h.reg, c);
+  registerSkillTools(h.reg);
+  registerAiTools(h.reg, c);
+  registerSystemTools(h.reg, c);
+  registerDesktopTools(h.reg, c);
+  registerBrowserTools(h.reg);
+  registerMediaTools(h.reg);
+  registerEmailTools(h.reg, c);
+  registerCodingTools(h.reg);
+  registerCodingAgentTools(h.reg, c);
+  registerCodingTeamTools(h.reg, c);
+  return new Set(h.names());
+}
+
+const onlyOn = (a: Ed, b: Ed): string[] => {
+  const other = toolNames(b);
+  return [...toolNames(a)].filter((n) => !other.has(n)).sort();
+};
+
+/** `name(` or `name)` or bare — anywhere it is offered as a symbol to call. */
+const offers = (text: string, tool: string) =>
+  new RegExp("`" + tool + "\\b[^`]*`").test(text);
+
+describe("the field guide is fenced, and both fences are well formed", () => {
+  it("balances every edition block", () => {
+    const opens = GUIDE.split("\n").filter((l) => /^<!--\s*edition:[a-z]+\s*-->\s*$/.test(l));
+    const closes = GUIDE.split("\n").filter((l) => /^<!--\s*\/edition\s*-->\s*$/.test(l));
+    expect(opens.length).toBeGreaterThan(0);
+    expect(closes.length).toBe(opens.length);
+  });
+
+  it("names no edition the filter cannot serve", () => {
+    const names = [...GUIDE.matchAll(/^<!--\s*edition:([a-z]+)\s*-->\s*$/gm)].map((m) => m[1]);
+    expect([...new Set(names)].sort()).toEqual(["hermes", "openclaw"]);
+  });
+
+  it("leaves no fence marker in what the agent reads", () => {
+    for (const edition of ["openclaw", "hermes"] as const) {
+      expect(served(edition)).not.toMatch(/<!--\s*\/?edition/);
+    }
+  });
+
+  it("stays inside the tool's own output cap on both editions", () => {
+    // clawbox_context declares maxChars 24_000 and appends the webapp storage
+    // guide after this text; a guide that outgrew the cap would be truncated
+    // mid-sentence, and the truncation would land on the LAST section.
+    for (const edition of ["openclaw", "hermes"] as const) {
+      expect(served(edition).length).toBeLessThan(20_000);
+    }
+  });
+});
+
+describe("the Hermes guide describes a Hermes box", () => {
+  it("does not call the agent the brain of an OpenClaw ClawBox", () => {
+    expect(served("hermes")).not.toMatch(/brain of an \*\*OpenClaw ClawBox\*\*/);
+    expect(served("hermes")).toMatch(/brain of a \*\*Hermes ClawBox\*\*/);
+  });
+
+  it("does not hand out the address of a gateway this SKU masks", () => {
+    expect(served("hermes")).not.toContain("http://127.0.0.1:18789");
+    expect(served("hermes")).not.toContain("Proxied to OpenClaw gateway");
+    expect(served("hermes")).not.toMatch(/:18789\s+OpenClaw gateway \(you live here/);
+  });
+
+  it("does not name a config file that does not exist there", () => {
+    expect(served("hermes")).not.toContain("~/.openclaw/openclaw.json");
+    expect(served("hermes")).toContain("~/.hermes/config.yaml");
+  });
+
+  it("offers no tool the MCP server does not register on Hermes", () => {
+    const openclawOnly = onlyOn("openclaw", "hermes");
+    // Guards the guard: if this ever empties, the assertion below is vacuous.
+    expect(openclawOnly).toContain("bash");
+    expect(openclawOnly).toContain("write_file");
+    expect(openclawOnly).toContain("web_search");
+
+    const leaked = openclawOnly.filter((tool) => offers(served("hermes"), tool));
+    expect(leaked).toEqual([]);
+  });
+
+  it("names the abilities that ARE its own", () => {
+    const guide = served("hermes");
+    for (const tool of ["skill_search", "skill_install", "ai_list_models"]) {
+      expect(offers(guide, tool)).toBe(true);
+    }
+  });
+});
+
+describe("the OpenClaw guide keeps everything it had", () => {
+  it("still says what the box is and where the gateway lives", () => {
+    const guide = served("openclaw");
+    expect(guide).toMatch(/brain of an \*\*OpenClaw ClawBox\*\*/);
+    expect(guide).toContain("http://127.0.0.1:18789");
+    expect(guide).toContain("~/.openclaw/openclaw.json");
+    expect(guide).toContain("App Store");
+  });
+
+  it("still offers the whole coding family", () => {
+    const guide = served("openclaw");
+    for (const tool of ["bash", "read_file", "write_file", "edit_file", "glob", "grep", "web_search", "web_fetch", "notebook_edit"]) {
+      expect(offers(guide, tool)).toBe(true);
+    }
+  });
+
+  it("is not handed a tool that exists only on Hermes", () => {
+    const leaked = onlyOn("hermes", "openclaw").filter((tool) => offers(served("openclaw"), tool));
+    expect(leaked).toEqual([]);
+  });
+});
+
+describe("what is true on both editions is served to both", () => {
+  for (const edition of ["openclaw", "hermes"] as const) {
+    it(`keeps the shared guide on ${edition}`, () => {
+      const guide = served(edition);
+      expect(guide).toContain('preferences_set(\'{"ui_user_name": "<name>"}\')');
+      expect(guide).toContain("THE MASCOT");
+      for (const tool of ["webapp_create", "ui_open_app", "code_project_init", "system_power", "wifi_status"]) {
+        expect(offers(guide, tool)).toBe(true);
+      }
+    });
+  }
+});
+
+describe("clawbox_context serves the filtered guide, not the raw file", () => {
+  async function contextText(edition: Ed) {
+    const h = captureRegistrar(edition);
+    registerOrientationTools(h.reg, ctx(edition));
+    const out = await h.call("clawbox_context", {});
+    if (out.isError) throw new Error("clawbox_context failed");
+    return out.text;
+  }
+
+  it("gives a Hermes agent the Hermes guide", async () => {
+    const text = await contextText("hermes");
+    expect(text).toMatch(/brain of a \*\*Hermes ClawBox\*\*/);
+    expect(text).not.toContain("http://127.0.0.1:18789");
+    expect(text).not.toContain("~/.openclaw/openclaw.json");
+  });
+
+  it("gives an OpenClaw agent the OpenClaw guide", async () => {
+    const text = await contextText("openclaw");
+    expect(text).toMatch(/brain of an \*\*OpenClaw ClawBox\*\*/);
+    expect(text).toContain("http://127.0.0.1:18789");
+  });
+});

--- a/src/tests/unit/clawbox-field-guide-edition.test.ts
+++ b/src/tests/unit/clawbox-field-guide-edition.test.ts
@@ -368,4 +368,26 @@ describe("the filter's nesting rule", () => {
     const unknown = ["a", "<!-- edition:hermes2 -->", "b", "<!-- /edition -->", "c"].join("\n");
     expect(fieldGuideForEdition(unknown, "hermes").split("\n")).toEqual(["a", "c"]);
   });
+
+  it("drops an unknown ships audience on dual, where every ships block otherwise applies", () => {
+    // `install === "dual"` answers true for every `ships:` block, so the name
+    // has to be validated FIRST — otherwise the one SKU with both harnesses to
+    // be wrong about is the one that serves an unplaceable block.
+    const unknown = ["a", "<!-- ships:openclow -->", "b", "<!-- /ships -->", "c"].join("\n");
+    expect(fieldGuideForEdition(unknown, "hermes", "dual").split("\n")).toEqual(["a", "c"]);
+  });
+
+  it("does not let a mismatched close end the block it did not open", () => {
+    // `</ships>` closing an `edition:` block is a malformed document. The
+    // enclosing block stays shut rather than releasing its remainder to every
+    // box; the well-nesting assertion above fails CI on the file itself.
+    const mismatched = [
+      "a",
+      "<!-- edition:openclaw -->",
+      "openclaw only",
+      "<!-- /ships -->",
+      "still openclaw only",
+    ].join("\n");
+    expect(fieldGuideForEdition(mismatched, "hermes").split("\n")).toEqual(["a"]);
+  });
 });

--- a/src/tests/unit/clawbox-field-guide-edition.test.ts
+++ b/src/tests/unit/clawbox-field-guide-edition.test.ts
@@ -39,7 +39,7 @@ vi.mock("../../../mcp/lib/api", () => ({
 
 import type { McpContext } from "../../../mcp/lib/context";
 import { captureRegistrar } from "../helpers/mcp-registrar";
-import { fieldGuideForEdition, registerOrientationTools } from "../../../mcp/tools/orientation";
+import { WEBAPP_STORAGE_GUIDE, fieldGuideForEdition, registerOrientationTools } from "../../../mcp/tools/orientation";
 import { registerSystemTools } from "../../../mcp/tools/system";
 import { registerDesktopTools } from "../../../mcp/tools/desktop";
 import { registerSkillTools } from "../../../mcp/tools/skills";
@@ -51,14 +51,15 @@ import { registerCodingTools } from "../../../mcp/tools/coding";
 import { registerCodingAgentTools, registerCodingTeamTools } from "../../../mcp/tools/coding-agent";
 
 type Ed = "openclaw" | "hermes";
+type Install = "openclaw" | "hermes" | "dual";
 
 const GUIDE = readFileSync(path.join(REPO_ROOT, "Clawbox.md"), "utf-8");
-const served = (edition: Ed) => fieldGuideForEdition(GUIDE, edition);
+const served = (edition: Ed, install: Install = edition) => fieldGuideForEdition(GUIDE, edition, install);
 
 /** The shipped posture: every capability probe satisfied, every owner switch on. */
-const ctx = (edition: Ed): McpContext => ({
+const ctx = (edition: Ed, install: Install = edition): McpContext => ({
   edition,
-  install: edition,
+  install,
   appHarness: edition,
   profile: "full",
   capabilities: { screenGrabber: "gnome-screenshot", imageConvert: true, journal: true, du: true },
@@ -95,31 +96,59 @@ const onlyOn = (a: Ed, b: Ed): string[] => {
 const offers = (text: string, tool: string) =>
   new RegExp("`" + tool + "\\b[^`]*`").test(text);
 
-describe("the field guide is fenced, and both fences are well formed", () => {
-  it("balances every edition block", () => {
-    const opens = GUIDE.split("\n").filter((l) => /^<!--\s*edition:[a-z]+\s*-->\s*$/.test(l));
-    const closes = GUIDE.split("\n").filter((l) => /^<!--\s*\/edition\s*-->\s*$/.test(l));
-    expect(opens.length).toBeGreaterThan(0);
-    expect(closes.length).toBe(opens.length);
+/** Every (harness, install) a real box can present. */
+const BOXES: [Ed, Install][] = [
+  ["openclaw", "openclaw"],
+  ["hermes", "hermes"],
+  ["openclaw", "dual"],
+  ["hermes", "dual"],
+];
+
+describe("the field guide is fenced, and the fences are well formed", () => {
+  it("nests every block properly — no unmatched close, nothing left open", () => {
+    // Equal counts are NOT the property: a block opened inside another block's
+    // body, then closed, used to end BOTH — and the remainder of the outer
+    // block was served to every box with the counts still balanced.
+    const stack: string[] = [];
+    let opens = 0;
+    GUIDE.split("\n").forEach((line, i) => {
+      const open = /^<!--\s*(edition|ships):([a-z0-9_-]+)\s*-->\s*$/.exec(line);
+      if (open) {
+        opens += 1;
+        stack.push(open[1]);
+        return;
+      }
+      const close = /^<!--\s*\/(edition|ships)\s*-->\s*$/.exec(line);
+      if (!close) return;
+      expect(stack.pop(), `line ${i + 1}: close with no open`).toBe(close[1]);
+    });
+    expect(opens).toBeGreaterThan(0);
+    expect(stack, "a block was left open").toEqual([]);
   });
 
-  it("names no edition the filter cannot serve", () => {
-    const names = [...GUIDE.matchAll(/^<!--\s*edition:([a-z]+)\s*-->\s*$/gm)].map((m) => m[1]);
-    expect([...new Set(names)].sort()).toEqual(["hermes", "openclaw"]);
+  it("names no audience the filter cannot serve", () => {
+    const names = [...GUIDE.matchAll(/^<!--\s*(edition|ships):([a-z0-9_-]+)\s*-->\s*$/gm)].map((m) => `${m[1]}:${m[2]}`);
+    expect([...new Set(names)].sort()).toEqual([
+      "edition:hermes",
+      "edition:openclaw",
+      "ships:hermes",
+      "ships:openclaw",
+    ]);
   });
 
   it("leaves no fence marker in what the agent reads", () => {
-    for (const edition of ["openclaw", "hermes"] as const) {
-      expect(served(edition)).not.toMatch(/<!--\s*\/?edition/);
+    for (const [edition, install] of BOXES) {
+      expect(served(edition, install)).not.toMatch(/<!--\s*\/?(edition|ships)/);
     }
   });
 
-  it("stays inside the tool's own output cap on both editions", () => {
-    // clawbox_context declares maxChars 24_000 and appends the webapp storage
-    // guide after this text; a guide that outgrew the cap would be truncated
-    // mid-sentence, and the truncation would land on the LAST section.
-    for (const edition of ["openclaw", "hermes"] as const) {
-      expect(served(edition).length).toBeLessThan(20_000);
+  it("stays inside the tool's own output cap on every box", () => {
+    // The real budget: clawbox_context declares maxChars 24_000 and joins this
+    // text with WEBAPP_STORAGE_GUIDE and a "\n\n---\n\n" separator. capText
+    // truncates the TAIL, so an overrun eats Quick facts and the final brief.
+    const separator = "\n\n---\n\n".length;
+    for (const [edition, install] of BOXES) {
+      expect(served(edition, install).length + separator + WEBAPP_STORAGE_GUIDE.length).toBeLessThan(24_000);
     }
   });
 });
@@ -128,6 +157,17 @@ describe("the Hermes guide describes a Hermes box", () => {
   it("does not call the agent the brain of an OpenClaw ClawBox", () => {
     expect(served("hermes")).not.toMatch(/brain of an \*\*OpenClaw ClawBox\*\*/);
     expect(served("hermes")).toMatch(/brain of a \*\*Hermes ClawBox\*\*/);
+  });
+
+  it("promises none of the missing abilities in the introduction script either", () => {
+    // The one block designed to be spoken verbatim on a fresh box. It named
+    // shell, files, the app store and web search in ENGLISH, which the symbol
+    // check below cannot see — so the defect this card is about survived in
+    // the sales pitch after it was removed from the identity paragraph.
+    const guide = served("hermes");
+    for (const promise of [/run shell commands/i, /manage files/i, /install apps from the store/i, /web search/i, /web fetch/i]) {
+      expect(guide, `Hermes guide promises ${promise}`).not.toMatch(promise);
+    }
   });
 
   it("does not hand out the address of a gateway this SKU masks", () => {
@@ -148,8 +188,10 @@ describe("the Hermes guide describes a Hermes box", () => {
     expect(openclawOnly).toContain("write_file");
     expect(openclawOnly).toContain("web_search");
 
-    const leaked = openclawOnly.filter((tool) => offers(served("hermes"), tool));
-    expect(leaked).toEqual([]);
+    for (const install of ["hermes", "dual"] as const) {
+      const leaked = openclawOnly.filter((tool) => offers(served("hermes", install), tool));
+      expect(leaked, `install=${install}`).toEqual([]);
+    }
   });
 
   it("names the abilities that ARE its own", () => {
@@ -157,6 +199,49 @@ describe("the Hermes guide describes a Hermes box", () => {
     for (const tool of ["skill_search", "skill_install", "ai_list_models"]) {
       expect(offers(guide, tool)).toBe(true);
     }
+  });
+
+  it("sends the agent to a Settings tab that exists", () => {
+    // SettingsApp's `ai` section is labelled settings.providers -> "Providers".
+    // There is no tab called "AI"; the sibling workspace guide already has a
+    // test forbidding that exact wrong turn.
+    for (const [edition, install] of BOXES) {
+      expect(served(edition, install)).not.toMatch(/Settings\s*(->|→)\s*AI\b/);
+    }
+  });
+});
+
+describe("the DUAL SKU is told what it has, not what the active harness has", () => {
+  it("still names the gateway on a dual box running Hermes", () => {
+    // The gateway removal, the mask and the closed 18789 are gated on
+    // CLAWBOX_EDITION = "hermes" EXACTLY (install.sh is_hermes_edition). On
+    // dual the unit is installed and listening, so a guide that told the agent
+    // it was gone would be stating a false device fact about the box's own
+    // unauthenticated control surface.
+    const guide = served("hermes", "dual");
+    expect(guide).toContain("http://127.0.0.1:18789");
+    expect(guide).toContain("~/.openclaw/openclaw.json");
+  });
+
+  it("names the Hermes dashboard on a dual box running OpenClaw", () => {
+    const guide = served("openclaw", "dual");
+    expect(guide).toContain("~/.hermes/config.yaml");
+    expect(guide).toContain("127.0.0.2:9119");
+  });
+
+  it("never asserts the other harness is absent", () => {
+    // A locked SKU may say what it does not have; `dual` has both, and the
+    // filter cannot tell the two apart from `ctx.edition` alone.
+    for (const [edition, install] of BOXES) {
+      expect(served(edition, install)).not.toMatch(/no OpenClaw (gateway )?(at all|on this device)/i);
+      expect(served(edition, install)).not.toMatch(/there is no `~\/\.openclaw`/i);
+    }
+  });
+
+  it("keeps a Hermes box from being handed the gateway", () => {
+    const guide = served("hermes", "hermes");
+    expect(guide).not.toContain("http://127.0.0.1:18789");
+    expect(guide).not.toContain("~/.openclaw/openclaw.json");
   });
 });
 
@@ -183,9 +268,9 @@ describe("the OpenClaw guide keeps everything it had", () => {
 });
 
 describe("what is true on both editions is served to both", () => {
-  for (const edition of ["openclaw", "hermes"] as const) {
-    it(`keeps the shared guide on ${edition}`, () => {
-      const guide = served(edition);
+  for (const [edition, install] of BOXES) {
+    it(`keeps the shared guide on ${edition} (install ${install})`, () => {
+      const guide = served(edition, install);
       expect(guide).toContain('preferences_set(\'{"ui_user_name": "<name>"}\')');
       expect(guide).toContain("THE MASCOT");
       for (const tool of ["webapp_create", "ui_open_app", "code_project_init", "system_power", "wifi_status"]) {
@@ -196,9 +281,9 @@ describe("what is true on both editions is served to both", () => {
 });
 
 describe("clawbox_context serves the filtered guide, not the raw file", () => {
-  async function contextText(edition: Ed) {
+  async function contextText(edition: Ed, install: Install = edition) {
     const h = captureRegistrar(edition);
-    registerOrientationTools(h.reg, ctx(edition));
+    registerOrientationTools(h.reg, ctx(edition, install));
     const out = await h.call("clawbox_context", {});
     if (out.isError) throw new Error("clawbox_context failed");
     return out.text;
@@ -215,5 +300,43 @@ describe("clawbox_context serves the filtered guide, not the raw file", () => {
     const text = await contextText("openclaw");
     expect(text).toMatch(/brain of an \*\*OpenClaw ClawBox\*\*/);
     expect(text).toContain("http://127.0.0.1:18789");
+  });
+
+  it("passes the install through, so a dual box keeps both harnesses' facts", async () => {
+    const text = await contextText("hermes", "dual");
+    expect(text).toMatch(/brain of a \*\*Hermes ClawBox\*\*/);
+    expect(text).toContain("http://127.0.0.1:18789");
+  });
+});
+
+describe("the filter's nesting rule", () => {
+  const NESTED = [
+    "shared top",
+    "<!-- edition:openclaw -->",
+    "openclaw before",
+    "<!-- edition:hermes -->",
+    "hermes inside",
+    "<!-- /edition -->",
+    "openclaw after",
+    "<!-- /edition -->",
+    "shared tail",
+  ].join("\n");
+
+  it("keeps an inner block inside its outer one", () => {
+    // The bug this replaces: a close reset the state to "outside", so
+    // "openclaw after" was served to every box with the marker counts still
+    // balanced — the shape every well-formedness test above would pass over.
+    expect(fieldGuideForEdition(NESTED, "hermes").split("\n")).toEqual(["shared top", "shared tail"]);
+    expect(fieldGuideForEdition(NESTED, "openclaw").split("\n")).toEqual([
+      "shared top",
+      "openclaw before",
+      "openclaw after",
+      "shared tail",
+    ]);
+  });
+
+  it("drops a block whose audience it cannot place", () => {
+    const unknown = ["a", "<!-- edition:hermes2 -->", "b", "<!-- /edition -->", "c"].join("\n");
+    expect(fieldGuideForEdition(unknown, "hermes").split("\n")).toEqual(["a", "c"]);
   });
 });

--- a/src/tests/unit/clawbox-field-guide-edition.test.ts
+++ b/src/tests/unit/clawbox-field-guide-edition.test.ts
@@ -159,6 +159,35 @@ describe("the Hermes guide describes a Hermes box", () => {
     expect(served("hermes")).toMatch(/brain of a \*\*Hermes ClawBox\*\*/);
   });
 
+  /**
+   * The quoted block under "First-contact" — the one the agent is told to say
+   * on a fresh box, and the only part of this document meant to be spoken
+   * almost verbatim.
+   */
+  const introScript = (edition: Ed, install: Install = edition): string => {
+    const guide = served(edition, install);
+    const start = guide.search(/^## First-contact/m);
+    expect(start, "the first-contact section moved").toBeGreaterThan(-1);
+    return guide
+      .slice(start)
+      .split("\n")
+      .filter((line) => line.startsWith("> "))
+      .join("\n");
+  };
+
+  it("names no capability-gated tool in the script it is told to say verbatim", () => {
+    // `logs_tail` and `disk_usage`/`disk_cleanup` are registered only when the
+    // startup probe passes; `coding_agent_*` and `email_*` only when the owner
+    // switched them on. The toolbelt above may list them with their caveat —
+    // the introduction may not, because it is read out as a promise.
+    const script = introScript("hermes");
+    // Guards the guard: an empty slice would pass every assertion below.
+    expect(script.length).toBeGreaterThan(200);
+    for (const gated of [/service logs/i, /coding agent/i, /\bemail\b/i, /\bdisk\b/i]) {
+      expect(script, `intro promises ${gated}`).not.toMatch(gated);
+    }
+  });
+
   it("promises none of the missing abilities in the introduction script either", () => {
     // The one block designed to be spoken verbatim on a fresh box. It named
     // shell, files, the app store and web search in ENGLISH, which the symbol


### PR DESCRIPTION
**TASK-540** — Hermes: the agent's own field guide (`Clawbox.md`) describes an OpenClaw box.

## Customer-visible symptom
`clawbox_context` — the tool the MCP server's own instructions tell every model to call once at the
start of a session, and always before answering "what is this / what can you do" — served
`Clawbox.md` verbatim with no edition branch. So on a Hermes box the agent answered "what am I" from
an OpenClaw script:

- "You are now the brain of an **OpenClaw ClawBox**"
- the gateway at `http://127.0.0.1:18789` ("you live here"), which is removed and masked on that SKU
- `Gateway config | ~/.openclaw/openclaw.json`, a file that does not exist there
- a toolbelt offering `bash`, `read_file`, `write_file`, `edit_file`, `list_directory`, `glob`,
  `grep`, `web_search`, `web_fetch`, `notebook_edit`, `app_search`, `app_install` — **none** of
  which is registered on Hermes (`mcp/tools/coding.ts` is `editions: ["openclaw"]` by design)
- and, worst of all, a first-contact script the agent is told to open with on a fresh box, promising
  "run shell commands, manage files, install apps from the store" and "web search, web fetch", under
  an explicit "no limitations, no caveats, no 'I can't' list".

## Cause
`mcp/clawbox-mcp.ts` `instructionsFor()` had already been branched per edition for exactly this
reason — its comment says "the previous wording had the agent introduce itself as the wrong product
on the very first 'hi'". The field guide is the half that never got the same treatment.

## Harness-first
Nothing native is re-implemented, and the PR body owes a name: the mechanism reused here is
ClawBox's own — the root-owned edition lock resolved by `mcp/lib/edition.ts` into `ctx.edition` (the
tool set) and `ctx.install` (the SKU), the same two values `builtInApps()` and
`UNCONFIRMED_EDITION_CHAT_NOTE` already read. Neither harness owns a "describe this device" document
to defer to; the guide is ClawBox's own text about ClawBox's own hardware.

## What changed
- **One document, fenced in place.** A second `Clawbox.hermes.md` would drift within a release, and
  four fifths of this guide is the part that must stay identical. Edition-specific blocks are marked
  with line-level HTML comments and filtered by `fieldGuideForEdition()` before the tool serves the
  text.
- **Two fence families, because `dual` separates two different questions.**
  `<!-- edition:… -->` follows the **active harness** — whose tool set the agent reading this was
  given. `<!-- ships:… -->` follows the **install** — what the device actually has. A dual box
  running Hermes really does have an OpenClaw gateway listening on 18789 and a `~/.openclaw`, so it
  is served both architecture blocks and both Quick-facts rows. Keying device facts on the harness
  would have told that box its gateway was gone while it was up — a false device fact about the
  unauthenticated control surface `install.sh` calls out by name.
- Every negative claim about the *other* harness's absence is gone. The gateway removal, the mask
  and the closed port are gated on `CLAWBOX_EDITION = "hermes"` exactly (`is_hermes_edition`), so
  they were false on `dual`; the guide now states only what a box has.
- **Nesting is tracked with a stack.** A close restores the enclosing block instead of declaring the
  rest of the file unconditional — otherwise a Hermes note added inside an OpenClaw section would
  hand the OpenClaw remainder to every box, with the marker counts still balanced. The marker name
  class is wider than the two names that exist, so a typo is recognised as a fence and fails closed
  rather than being emitted as text.
- **Hermes sections added:** skills (`skill_search` / `skill_install` — the Hermes answer to the app
  store, which it can use itself), its own model (`ai_list_models` / `ai_set_provider` /
  `ai_set_model`, and the note that a chat may override the device default per session), the Hermes
  architecture and `~/.hermes/config.yaml`, its own first-contact script naming only what it has,
  and a Files-and-shell section that says ClawBox deliberately adds none — Hermes ships its own, and
  a second less-guarded shell beside them buys nothing.

### Other stale claims corrected while the file was open
- "Settings → AI" — there is no such tab; the section is labelled **Providers**.
- "Signal / Slack once configured" — there is no ClawBox setup flow for either; the docs site calls
  them extension paths. The guide now says so instead of promising a setting.
- `:8090` was listed under "Localhost-only". It is a **LAN** port (`listen(PORT, "0.0.0.0")`, in
  `LAN_TCP_PORTS`, in `SECURITY.md`), and it is what the Hermes app opens — `127.0.0.2:9119` is
  host-local and a browser cannot reach it.
- `browser_launch` is registered nowhere; dropped. `browser_fill`, `job_status`, `job_stop` added
  and fenced OpenClaw-only. `job_status(id)` → `job_status(job_id)`, which is the real parameter.
- `disk_usage` / `disk_cleanup` / `logs_tail` are capability-probed at startup; marked "when
  offered".
- The mascot table claimed **eleven** moods including an `ultimate` state captioned "GATEWAY IS
  LOADING — BOW". `MascotStateName` has ten and no `ultimate`, and the quoted lines appear nowhere
  in `src/`. Row and paragraph removed.
- The desktop app list named **VS Code** and **Ollama**, neither of which is an app id — so
  `ui_open_app("vscode")` answers "there is no such app", the literal TASK-541 symptom. Replaced
  with the apps that exist, per edition (ClawKeep, Coding Agent, System Update on both; Memory Shard
  and the OpenClaw Control UI on OpenClaw; Hermes Skills and the Hermes dashboard on Hermes).
- The Hermes code-project instruction now says to use the **absolute** path `code_project_init`
  returns — that tool's own description forbids a relative one, and the Hermes harness's file tools
  do not run in the project root, so a relative write would land elsewhere and `code_project_build`
  would ship the empty scaffold as "your app is on the desktop".

## Both editions
Rendered and asserted for all four boxes a device can be: `openclaw`/openclaw, `hermes`/hermes,
`hermes`/dual, `openclaw`/dual. The OpenClaw guide keeps everything it had (identity, gateway,
`~/.openclaw`, the whole coding family, the App Store, and its negative "there is no `run_command`"
list, which is now inside the OpenClaw fence rather than deleted).

## RED → GREEN
New suite `src/tests/unit/clawbox-field-guide-edition.test.ts` (27 tests), including a leak guard
that computes the per-edition tool sets from the **real registrars** rather than a fixture, so a
tool that changes edition takes the assertion with it — plus a prose guard, because the
introduction script names the missing abilities in English where a symbol check cannot see them.

Against the unmodified beta guide and tool (`git checkout origin/beta -- Clawbox.md
mcp/tools/orientation.ts`), the test that drives the shipped tool end to end:

```
 ❯ |unit| src/tests/unit/clawbox-field-guide-edition.test.ts (27 tests | 1 failed | 26 skipped)
     × gives a Hermes agent the Hermes guide

 FAIL … > clawbox_context serves the filtered guide, not the raw file > gives a Hermes agent the Hermes guide
 AssertionError: expected '---\nname: ClawBox Field Guide\ndescr…' to match /brain of a \*\*Hermes ClawBox\*\*/
 + Received:
 "…You are now the brain of an **OpenClaw ClawBox** — and yes, there is a crab living in the UI…"
```

(The whole file run against beta fails 15 of 16 at the time it was written; the one above is the
behavioural failure, through the tool, with no new export involved.)

With the fix:

```
 Test Files  1 passed (1)
      Tests  27 passed (27)
```

Whole unit project on this branch:

```
 Test Files  651 passed (651)
      Tests  10511 passed | 1 skipped (10512)
```

`tsc --noEmit`, `tsc -p mcp/tsconfig.json --noEmit`, `eslint` on the changed files: clean.

## Sibling call sites — handled or cleared
- `mcp/clawbox-mcp.ts` `instructionsFor()` — already per-edition; unchanged, and the new guide is
  now consistent with it.
- `config/clawbox-workspace-guide.md` (the other guide the agent loads) — seeded only by
  `scripts/gateway-pre-start.sh`, which is OpenClaw-only, so there is no Hermes sibling to fence.
  `src/tests/unit/clawbox-workspace-guide.test.ts` reads `Clawbox.md` **raw** and every string it
  asserts on lives outside a fence; it passes unchanged.
- `mcp/README.md` and `docs-site/technical/agent-interface.mdx` — both describe `clawbox_context`
  and the docs site has a "What differs by edition" table; both updated.

## Not taken
The desktop app list still omits nothing that exists but is prose, not ids, so there is no cheap
drift test holding it to `src/lib/desktop-apps.ts` the way `mcp-desktop-apps.test.ts` holds the MCP
copy. Worth one if the list drifts again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Field-guide content is tailored to the active edition and installed capabilities.
  - Users see relevant tools, configuration guidance, app and skill management details, coding workflows, and messaging options for their setup.
  - Dual installations retain guidance for both supported editions.
  - Dashboard routing, browser tools, mascot states, and first-contact guidance reflect current capabilities.

- **Documentation**
  - Updated field-guide and tool documentation to explain edition- and capability-specific content filtering.
  - Clarified supported tools, restrictions, provider configuration, architecture, and quick-reference information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->