### PR TITLE
perf: stop respawning df, ps and uname on every system-stats tick

### DIFF
--- a/src/app/setup-api/system/stats/route.ts
+++ b/src/app/setup-api/system/stats/route.ts
@@ -11,39 +11,55 @@ const execFileAsync = promisify(execFile);
 export const dynamic = "force-dynamic";
 
 /**
- * Remember one async answer for `ttlMs`, and let concurrent callers share the
- * read that is already in flight.
+ * Remember one async answer for a few seconds, and let concurrent callers share
+ * the read that is already in flight.
  *
  * Two surfaces poll this route every 3 s while their panel is open — Settings >
  * System (`SettingsApp.tsx`) and the System app (`SystemApp.tsx`) — and each
- * request spawned `df`, `ps aux --sort=-%cpu` and `uname -r`. That is six
- * processes every three seconds on a Jetson for two answers that barely move
- * and one that cannot change without a reboot.
+ * request spawned its own `df` and `ps aux --sort=-%cpu`. Measured on an Orin
+ * Nano: 2.8 ms and 28.5 ms per run, four processes every three seconds for two
+ * answers that barely move.
  *
- * A REJECTION is never remembered: the caller sees it, and the next call tries
- * again. Caching the failure would turn one lost `uname` into a box that
- * reports the fallback for the rest of the process's life — the probe-once
- * shape this repository keeps producing. The in-flight promise is dropped on
- * rejection for the same reason.
+ * ONE window for both, and a short one. A longer window for the disk buys
+ * almost nothing — `ps` is 91% of the cost — and it would make the payload's
+ * own `timestamp` a lie: the System app draws it as "last updated", and a disk
+ * figure half a minute old under a stamp that says "now" is how a `disk_cleanup`
+ * that worked reads as one that did nothing. Five seconds is inside the jitter
+ * of the 3 s poll that reads it.
+ *
+ * A FAILURE is remembered too, but for less. Caching only successes means the
+ * harder the box is struggling — a `fork` refused with EAGAIN under memory
+ * pressure is exactly when this matters — the more often it is asked to spawn,
+ * which is the wrong way round. Same success/failure split, and the same
+ * reasoning, as the memos in `hermes-telegram.ts` and `openclaw-channels.ts`.
+ *
+ * Callers share the value rather than a copy; nothing here mutates it, the
+ * route only serialises it.
  */
-function memoAsync<T>(read: () => Promise<T>, ttlMs: number): () => Promise<T> {
-  let cached: { value: T; at: number } | null = null;
+const STATS_TTL_MS = 5_000;
+const STATS_FAILURE_TTL_MS = 3_000;
+
+function memoAsync<T>(read: () => Promise<T>): () => Promise<T> {
+  let cached: { at: number; ok: true; value: T } | { at: number; ok: false; err: unknown } | null = null;
   let inFlight: Promise<T> | null = null;
 
   return () => {
     // `age >= 0` because Date.now() is wall-clock: an RTC corrected BACKWARDS
     // by NTP would otherwise pin the entry until the clock caught up.
     const age = cached ? Date.now() - cached.at : Infinity;
-    if (cached && age >= 0 && age < ttlMs) return Promise.resolve(cached.value);
+    if (cached && age >= 0 && age < (cached.ok ? STATS_TTL_MS : STATS_FAILURE_TTL_MS)) {
+      return cached.ok ? Promise.resolve(cached.value) : Promise.reject(cached.err);
+    }
     if (inFlight) return inFlight;
 
     const promise = read().then(
       (value) => {
-        cached = { value, at: Date.now() };
+        cached = { at: Date.now(), ok: true, value };
         inFlight = null;
         return value;
       },
       (err) => {
+        cached = { at: Date.now(), ok: false, err };
         inFlight = null;
         throw err;
       },
@@ -52,10 +68,6 @@ function memoAsync<T>(read: () => Promise<T>, ttlMs: number): () => Promise<T> {
     return promise;
   };
 }
-
-/** How long each answer stays good. The kernel release is a constant. */
-const DISK_TTL_MS = 30_000;
-const PROCESSES_TTL_MS = 5_000;
 
 interface DiskMount {
   filesystem: string;
@@ -101,7 +113,7 @@ async function readDiskUsage(): Promise<DiskMount[]> {
   return result.slice(0, 8); // max 8 mounts
 }
 
-const diskUsage = memoAsync(readDiskUsage, DISK_TTL_MS);
+const diskUsage = memoAsync(readDiskUsage);
 
 async function getDiskUsage(): Promise<DiskMount[]> {
   try {
@@ -173,7 +185,7 @@ async function readTopProcesses(): Promise<ProcessEntry[]> {
   }).filter((p) => p.pid);
 }
 
-const topProcesses = memoAsync(readTopProcesses, PROCESSES_TTL_MS);
+const topProcesses = memoAsync(readTopProcesses);
 
 async function getTopProcesses(): Promise<ProcessEntry[]> {
   try {
@@ -205,27 +217,6 @@ function getUptime(): string {
     if (h > 0) parts.push(`${h}h`);
     parts.push(`${m}m`);
     return parts.join(" ");
-  }
-}
-
-async function readKernelRelease(): Promise<string> {
-  const { stdout } = await execFileAsync("uname", ["-r"], { encoding: "utf-8", timeout: 3000 });
-  return stdout.trim();
-}
-
-/**
- * The running kernel cannot change without a reboot, and a reboot restarts this
- * process — so the answer is good for the life of the process. The FALLBACK is
- * deliberately outside the memo: a `uname` that lost one race must not pin
- * `os.release()` until the next restart.
- */
-const kernelRelease = memoAsync(readKernelRelease, Infinity);
-
-async function getKernelRelease(): Promise<string> {
-  try {
-    return await kernelRelease();
-  } catch {
-    return os.release();
   }
 }
 
@@ -274,10 +265,9 @@ export async function GET() {
     // await. Everything below it still touches the event loop (temp/gpu reads,
     // promisified execFile shells) so it stays in one Promise.all.
     const cpuUsage = getCpuUsage();
-    const [temp, gpuUsage, kernel, storage, processes] = await Promise.all([
+    const [temp, gpuUsage, storage, processes] = await Promise.all([
       getTemperature(),
       getGpuUsage(),
-      getKernelRelease(),
       getDiskUsage(),
       getTopProcesses(),
     ]);
@@ -286,7 +276,11 @@ export async function GET() {
       overview: {
         hostname: os.hostname(),
         os: `${os.type()} ${os.release()}`,
-        kernel,
+        // `uname -r` and os.release() are the same string — both are the
+        // `release` field of the utsname the kernel answers with (verified on
+        // an Orin Nano: 5.15.185-tegra from each). Spawning a process for it,
+        // two lines under a call that already has the answer, was pure cost.
+        kernel: os.release(),
         uptime: getUptime(),
         arch: os.arch(),
         platform: os.platform(),

--- a/src/app/setup-api/system/stats/route.ts
+++ b/src/app/setup-api/system/stats/route.ts
@@ -10,6 +10,53 @@ const execFileAsync = promisify(execFile);
 
 export const dynamic = "force-dynamic";
 
+/**
+ * Remember one async answer for `ttlMs`, and let concurrent callers share the
+ * read that is already in flight.
+ *
+ * Two surfaces poll this route every 3 s while their panel is open — Settings >
+ * System (`SettingsApp.tsx`) and the System app (`SystemApp.tsx`) — and each
+ * request spawned `df`, `ps aux --sort=-%cpu` and `uname -r`. That is six
+ * processes every three seconds on a Jetson for two answers that barely move
+ * and one that cannot change without a reboot.
+ *
+ * A REJECTION is never remembered: the caller sees it, and the next call tries
+ * again. Caching the failure would turn one lost `uname` into a box that
+ * reports the fallback for the rest of the process's life — the probe-once
+ * shape this repository keeps producing. The in-flight promise is dropped on
+ * rejection for the same reason.
+ */
+function memoAsync<T>(read: () => Promise<T>, ttlMs: number): () => Promise<T> {
+  let cached: { value: T; at: number } | null = null;
+  let inFlight: Promise<T> | null = null;
+
+  return () => {
+    // `age >= 0` because Date.now() is wall-clock: an RTC corrected BACKWARDS
+    // by NTP would otherwise pin the entry until the clock caught up.
+    const age = cached ? Date.now() - cached.at : Infinity;
+    if (cached && age >= 0 && age < ttlMs) return Promise.resolve(cached.value);
+    if (inFlight) return inFlight;
+
+    const promise = read().then(
+      (value) => {
+        cached = { value, at: Date.now() };
+        inFlight = null;
+        return value;
+      },
+      (err) => {
+        inFlight = null;
+        throw err;
+      },
+    );
+    inFlight = promise;
+    return promise;
+  };
+}
+
+/** How long each answer stays good. The kernel release is a constant. */
+const DISK_TTL_MS = 30_000;
+const PROCESSES_TTL_MS = 5_000;
+
 interface DiskMount {
   filesystem: string;
   size: string;
@@ -34,25 +81,31 @@ interface ProcessEntry {
   command: string;
 }
 
+async function readDiskUsage(): Promise<DiskMount[]> {
+  const { stdout: output } = await execFileAsync(
+    "df",
+    ["-h", "-x", "tmpfs", "-x", "devtmpfs", "-x", "squashfs"],
+    { encoding: "utf-8", timeout: 5000 },
+  );
+  const lines = output.trim().split("\n").slice(1); // skip header
+  const result: DiskMount[] = [];
+  for (const line of lines) {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length < 6) continue;
+    const [filesystem, size, used, avail, usePercentStr, mountpoint] = parts;
+    const usePercent = parseInt(usePercentStr.replace("%", ""), 10) || 0;
+    // Filter out uninteresting mounts
+    if (mountpoint.startsWith("/sys") || mountpoint.startsWith("/proc") || mountpoint.startsWith("/dev/")) continue;
+    result.push({ filesystem, size, used, avail, usePercent, mountpoint });
+  }
+  return result.slice(0, 8); // max 8 mounts
+}
+
+const diskUsage = memoAsync(readDiskUsage, DISK_TTL_MS);
+
 async function getDiskUsage(): Promise<DiskMount[]> {
   try {
-    const { stdout: output } = await execFileAsync(
-      "df",
-      ["-h", "-x", "tmpfs", "-x", "devtmpfs", "-x", "squashfs"],
-      { encoding: "utf-8", timeout: 5000 },
-    );
-    const lines = output.trim().split("\n").slice(1); // skip header
-    const result: DiskMount[] = [];
-    for (const line of lines) {
-      const parts = line.trim().split(/\s+/);
-      if (parts.length < 6) continue;
-      const [filesystem, size, used, avail, usePercentStr, mountpoint] = parts;
-      const usePercent = parseInt(usePercentStr.replace("%", ""), 10) || 0;
-      // Filter out uninteresting mounts
-      if (mountpoint.startsWith("/sys") || mountpoint.startsWith("/proc") || mountpoint.startsWith("/dev/")) continue;
-      result.push({ filesystem, size, used, avail, usePercent, mountpoint });
-    }
-    return result.slice(0, 8); // max 8 mounts
+    return await diskUsage();
   } catch {
     return [];
   }
@@ -100,25 +153,31 @@ function getNetworkInterfaces(): NetworkInterface[] {
   return result;
 }
 
+async function readTopProcesses(): Promise<ProcessEntry[]> {
+  const { stdout: output } = await execFileAsync("ps", ["aux", "--sort=-%cpu"], {
+    encoding: "utf-8",
+    timeout: 5000,
+  });
+  // Skip the header, keep the top 10 by CPU (the old `| head -11` limit).
+  const lines = output.trim().split("\n").slice(1, 11);
+  return lines.map((line) => {
+    const parts = line.trim().split(/\s+/);
+    const [user, pid, cpu, mem, , , , , , , ...cmdParts] = parts;
+    return {
+      pid: pid || "",
+      user: user || "",
+      cpu: parseFloat(cpu) || 0,
+      mem: parseFloat(mem) || 0,
+      command: cmdParts.join(" ").slice(0, 60) || parts[10] || "?",
+    };
+  }).filter((p) => p.pid);
+}
+
+const topProcesses = memoAsync(readTopProcesses, PROCESSES_TTL_MS);
+
 async function getTopProcesses(): Promise<ProcessEntry[]> {
   try {
-    const { stdout: output } = await execFileAsync("ps", ["aux", "--sort=-%cpu"], {
-      encoding: "utf-8",
-      timeout: 5000,
-    });
-    // Skip the header, keep the top 10 by CPU (the old `| head -11` limit).
-    const lines = output.trim().split("\n").slice(1, 11);
-    return lines.map((line) => {
-      const parts = line.trim().split(/\s+/);
-      const [user, pid, cpu, mem, , , , , , , ...cmdParts] = parts;
-      return {
-        pid: pid || "",
-        user: user || "",
-        cpu: parseFloat(cpu) || 0,
-        mem: parseFloat(mem) || 0,
-        command: cmdParts.join(" ").slice(0, 60) || parts[10] || "?",
-      };
-    }).filter((p) => p.pid);
+    return await topProcesses();
   } catch {
     return [];
   }
@@ -149,10 +208,22 @@ function getUptime(): string {
   }
 }
 
+async function readKernelRelease(): Promise<string> {
+  const { stdout } = await execFileAsync("uname", ["-r"], { encoding: "utf-8", timeout: 3000 });
+  return stdout.trim();
+}
+
+/**
+ * The running kernel cannot change without a reboot, and a reboot restarts this
+ * process — so the answer is good for the life of the process. The FALLBACK is
+ * deliberately outside the memo: a `uname` that lost one race must not pin
+ * `os.release()` until the next restart.
+ */
+const kernelRelease = memoAsync(readKernelRelease, Infinity);
+
 async function getKernelRelease(): Promise<string> {
   try {
-    const { stdout } = await execFileAsync("uname", ["-r"], { encoding: "utf-8", timeout: 3000 });
-    return stdout.trim();
+    return await kernelRelease();
   } catch {
     return os.release();
   }

--- a/src/tests/routes/system/stats-memo.test.ts
+++ b/src/tests/routes/system/stats-memo.test.ts
@@ -3,16 +3,17 @@
  *
  * `/setup-api/system/stats` spawned `df`, `ps aux --sort=-%cpu` and `uname -r`
  * on EVERY request, and two pollers ask for it every 3 s while the panel is
- * open (Settings > System at SettingsApp.tsx and the System app at
- * SystemApp.tsx). On a Jetson that is three process spawns per poller per tick
- * for two answers that barely move and one — the kernel release — that cannot
- * change without a reboot.
+ * open (Settings > System in `SettingsApp.tsx` and the System app in
+ * `SystemApp.tsx`). On an Orin Nano that measured 2.8 / 28.5 / 2.0 ms per run:
+ * six spawns every three seconds, one of them (`uname -r`) for a string
+ * `os.release()` already holds.
  *
  * These are spawn-budget assertions, not timing ones: they count calls into
  * child_process, so they mean the same thing on a laptop and on a loaded CI
  * runner.
  */
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import os from "os";
 import { promisify } from "util";
 
 const h = vi.hoisted(() => {
@@ -27,7 +28,6 @@ const h = vi.hoisted(() => {
       "USER  PID %CPU %MEM    VSZ   RSS TTY STAT START TIME COMMAND",
       "root    1  0.1  0.2  10000  5000 ?   Ss   09:00 0:01 /sbin/init",
     ].join("\n"),
-    uname: "5.15.148-tegra",
   };
   const run = vi.fn(async (file: string) => {
     calls.push(file);
@@ -41,7 +41,17 @@ vi.mock("child_process", () => {
   // `promisify(execFile)` follows util.promisify.custom, which is how the real
   // execFile resolves to `{ stdout, stderr }` rather than a bare stdout.
   const execFile = Object.assign(vi.fn(), { [promisify.custom]: h.run });
-  return { execFile, execFileSync: vi.fn(), execSync: vi.fn(), spawn: vi.fn() };
+  // Every spawn entry point, so a process started anywhere in this route's
+  // module graph shows up as an unmocked-call failure rather than as silence.
+  return {
+    execFile,
+    exec: vi.fn(),
+    execSync: vi.fn(),
+    execFileSync: vi.fn(),
+    spawn: vi.fn(),
+    spawnSync: vi.fn(),
+    fork: vi.fn(),
+  };
 });
 
 function countOf(file: string): number {
@@ -50,13 +60,15 @@ function countOf(file: string): number {
 
 describe("GET /setup-api/system/stats spawn budget", () => {
   let GET: () => Promise<Response>;
+  let startedAt: number;
 
   beforeEach(async () => {
     vi.resetModules();
     vi.useFakeTimers();
+    startedAt = new Date("2026-09-05T10:00:00Z").getTime();
+    vi.setSystemTime(startedAt);
     h.calls.length = 0;
     h.failing.clear();
-    h.outputs.uname = "5.15.148-tegra";
     h.run.mockClear();
     GET = (await import("@/app/setup-api/system/stats/route")).GET;
   });
@@ -65,64 +77,75 @@ describe("GET /setup-api/system/stats spawn budget", () => {
     vi.useRealTimers();
   });
 
-  it("does not respawn df, ps and uname for every 3 s tick", async () => {
-    // Both pollers, three ticks: six requests, which used to be eighteen
-    // spawns.
-    let res: Response | undefined;
-    for (const offset of [0, 3_000, 6_000]) {
-      vi.setSystemTime(Date.now() + offset);
-      [, res] = await Promise.all([GET(), GET()]);
+  /** Absolute, never `Date.now() + n` — offsets from "now" compound. */
+  function at(msFromStart: number) {
+    vi.setSystemTime(startedAt + msFromStart);
+  }
+
+  it("spawns nothing for the kernel release", async () => {
+    const body = await (await GET()).json();
+    // `uname -r` and os.release() are the same utsname field; the route reads
+    // os.release() two lines above for `overview.os` anyway.
+    expect(h.calls).not.toContain("uname");
+    expect(body.overview.kernel).toBe(os.release());
+    expect(body.overview.os).toContain(os.release());
+  });
+
+  it("does not respawn df and ps for every 3 s tick", async () => {
+    // Both pollers, four ticks: eight requests, which used to be 24 spawns.
+    for (const ms of [0, 3_000, 6_000, 9_000]) {
+      at(ms);
+      await Promise.all([GET(), GET()]);
     }
 
-    expect(res?.status).toBe(200);
-    expect(countOf("uname"), "uname -r is a constant for the life of the process").toBe(1);
-    expect(countOf("df"), "disk usage over three ticks").toBe(1);
-    // The 5 s window means a 3 s poll pays for `ps` every OTHER tick.
-    expect(countOf("ps"), "top processes over three ticks").toBe(2);
-    expect(h.calls.length, "six requests, three ticks").toBe(4);
+    // The 5 s window means a 3 s poll pays for each command every other tick,
+    // and the two pollers share the one spawn rather than racing for two.
+    expect(countOf("df"), "df over four ticks").toBe(2);
+    expect(countOf("ps"), "ps over four ticks").toBe(2);
+    expect(h.calls.length, "eight requests").toBe(4);
   });
 
   it("serves the two concurrent pollers from one spawn each", async () => {
-    // Settings > System and the System app poll the same route independently.
     const [a, b] = await Promise.all([GET(), GET()]);
 
     expect(a.status).toBe(200);
     expect(b.status).toBe(200);
     expect(countOf("df")).toBe(1);
     expect(countOf("ps")).toBe(1);
-    expect(countOf("uname")).toBe(1);
   });
 
-  it("still refreshes what can actually change, once its window is up", async () => {
+  it("re-reads once the window is up", async () => {
     await GET();
-    // Past the processes window but inside the disk one.
-    vi.setSystemTime(Date.now() + 6_000);
+    at(4_000);
     await GET();
-    expect(countOf("ps")).toBe(2);
     expect(countOf("df")).toBe(1);
+    expect(countOf("ps")).toBe(1);
 
-    vi.setSystemTime(Date.now() + 31_000);
+    at(5_001);
     await GET();
     expect(countOf("df")).toBe(2);
-    expect(countOf("uname"), "the kernel cannot change without a reboot").toBe(1);
+    expect(countOf("ps")).toBe(2);
   });
 
-  it("does not pin a failed uname for the life of the process", async () => {
-    // Probe-once: caching the FALLBACK forever would leave a box reporting
-    // os.release() until the next restart because one spawn lost a race.
-    h.failing.add("uname");
-    const first = await (await GET()).json();
-    expect(first.overview.kernel).toBeTruthy();
+  it("does not spawn once per request while a command keeps failing", async () => {
+    // A `fork` refused under memory pressure is exactly when the box can least
+    // afford to be asked again on every tick, so a failure is remembered too —
+    // just for less time than a success.
+    h.failing.add("df");
+    expect((await (await GET()).json()).storage).toEqual([]);
+    at(1_500);
+    expect((await (await GET()).json()).storage).toEqual([]);
+    expect(countOf("df"), "inside the failure window").toBe(1);
 
-    h.failing.delete("uname");
-    vi.setSystemTime(Date.now() + 3_000);
-    const second = await (await GET()).json();
-    expect(second.overview.kernel).toBe("5.15.148-tegra");
+    h.failing.delete("df");
+    at(3_500);
+    const body = await (await GET()).json();
+    expect(countOf("df"), "past it").toBe(2);
+    expect(body.storage).toHaveLength(1);
   });
 
   it("still answers with real values, not an empty shell", async () => {
     const body = await (await GET()).json();
-    expect(body.overview.kernel).toBe("5.15.148-tegra");
     expect(body.storage).toHaveLength(1);
     expect(body.storage[0].mountpoint).toBe("/");
     expect(body.processes).toHaveLength(1);

--- a/src/tests/routes/system/stats-memo.test.ts
+++ b/src/tests/routes/system/stats-memo.test.ts
@@ -1,0 +1,131 @@
+/**
+ * What one 3 s tick of the System panel is allowed to cost.
+ *
+ * `/setup-api/system/stats` spawned `df`, `ps aux --sort=-%cpu` and `uname -r`
+ * on EVERY request, and two pollers ask for it every 3 s while the panel is
+ * open (Settings > System at SettingsApp.tsx and the System app at
+ * SystemApp.tsx). On a Jetson that is three process spawns per poller per tick
+ * for two answers that barely move and one — the kernel release — that cannot
+ * change without a reboot.
+ *
+ * These are spawn-budget assertions, not timing ones: they count calls into
+ * child_process, so they mean the same thing on a laptop and on a loaded CI
+ * runner.
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { promisify } from "util";
+
+const h = vi.hoisted(() => {
+  const calls: string[] = [];
+  const failing = new Set<string>();
+  const outputs: Record<string, string> = {
+    df: [
+      "Filesystem      Size  Used Avail Use% Mounted on",
+      "/dev/sda1       128G   64G   64G  50% /",
+    ].join("\n"),
+    ps: [
+      "USER  PID %CPU %MEM    VSZ   RSS TTY STAT START TIME COMMAND",
+      "root    1  0.1  0.2  10000  5000 ?   Ss   09:00 0:01 /sbin/init",
+    ].join("\n"),
+    uname: "5.15.148-tegra",
+  };
+  const run = vi.fn(async (file: string) => {
+    calls.push(file);
+    if (failing.has(file)) throw new Error(`${file}: boom`);
+    return { stdout: outputs[file] ?? "", stderr: "" };
+  });
+  return { calls, failing, outputs, run };
+});
+
+vi.mock("child_process", () => {
+  // `promisify(execFile)` follows util.promisify.custom, which is how the real
+  // execFile resolves to `{ stdout, stderr }` rather than a bare stdout.
+  const execFile = Object.assign(vi.fn(), { [promisify.custom]: h.run });
+  return { execFile, execFileSync: vi.fn(), execSync: vi.fn(), spawn: vi.fn() };
+});
+
+function countOf(file: string): number {
+  return h.calls.filter((c) => c === file).length;
+}
+
+describe("GET /setup-api/system/stats spawn budget", () => {
+  let GET: () => Promise<Response>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    h.calls.length = 0;
+    h.failing.clear();
+    h.outputs.uname = "5.15.148-tegra";
+    h.run.mockClear();
+    GET = (await import("@/app/setup-api/system/stats/route")).GET;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not respawn df, ps and uname for every 3 s tick", async () => {
+    // Both pollers, three ticks: six requests, which used to be eighteen
+    // spawns.
+    let res: Response | undefined;
+    for (const offset of [0, 3_000, 6_000]) {
+      vi.setSystemTime(Date.now() + offset);
+      [, res] = await Promise.all([GET(), GET()]);
+    }
+
+    expect(res?.status).toBe(200);
+    expect(countOf("uname"), "uname -r is a constant for the life of the process").toBe(1);
+    expect(countOf("df"), "disk usage over three ticks").toBe(1);
+    // The 5 s window means a 3 s poll pays for `ps` every OTHER tick.
+    expect(countOf("ps"), "top processes over three ticks").toBe(2);
+    expect(h.calls.length, "six requests, three ticks").toBe(4);
+  });
+
+  it("serves the two concurrent pollers from one spawn each", async () => {
+    // Settings > System and the System app poll the same route independently.
+    const [a, b] = await Promise.all([GET(), GET()]);
+
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+    expect(countOf("df")).toBe(1);
+    expect(countOf("ps")).toBe(1);
+    expect(countOf("uname")).toBe(1);
+  });
+
+  it("still refreshes what can actually change, once its window is up", async () => {
+    await GET();
+    // Past the processes window but inside the disk one.
+    vi.setSystemTime(Date.now() + 6_000);
+    await GET();
+    expect(countOf("ps")).toBe(2);
+    expect(countOf("df")).toBe(1);
+
+    vi.setSystemTime(Date.now() + 31_000);
+    await GET();
+    expect(countOf("df")).toBe(2);
+    expect(countOf("uname"), "the kernel cannot change without a reboot").toBe(1);
+  });
+
+  it("does not pin a failed uname for the life of the process", async () => {
+    // Probe-once: caching the FALLBACK forever would leave a box reporting
+    // os.release() until the next restart because one spawn lost a race.
+    h.failing.add("uname");
+    const first = await (await GET()).json();
+    expect(first.overview.kernel).toBeTruthy();
+
+    h.failing.delete("uname");
+    vi.setSystemTime(Date.now() + 3_000);
+    const second = await (await GET()).json();
+    expect(second.overview.kernel).toBe("5.15.148-tegra");
+  });
+
+  it("still answers with real values, not an empty shell", async () => {
+    const body = await (await GET()).json();
+    expect(body.overview.kernel).toBe("5.15.148-tegra");
+    expect(body.storage).toHaveLength(1);
+    expect(body.storage[0].mountpoint).toBe("/");
+    expect(body.processes).toHaveLength(1);
+    expect(body.processes[0].pid).toBe("1");
+  });
+});


### PR DESCRIPTION
**TASK-642 (PERF-12)** — `system/stats` spawns `df`, `ps aux --sort=-%cpu` and `uname -r` on every 3 s tick while the System section is open.

### Customer-visible symptom
Opening Settings → System, or the System app, puts the box under a steady trickle of process spawns for as long as the panel is on screen: three per request, and two surfaces poll the same route every 3 s independently (`SettingsApp.tsx:574`, `SystemApp.tsx:423`), so six every three seconds on a Jetson. Nothing breaks — it is a tax the owner pays for looking at a panel.

### Cause
`src/app/setup-api/system/stats/route.ts` ran `getDiskUsage()`, `getTopProcesses()` and `getKernelRelease()` in one `Promise.all` per request, with no cache and no dedup between the two pollers. One of the three was never needed at all: `uname -r` is the `release` field of the utsname, which is exactly what `os.release()` returns — and the route already calls `os.release()` two lines above, to build the `overview.os` string beside it.

### Harness first
Nothing here belongs to OpenClaw or Hermes; the source of truth is the kernel, reached through Node's own `os` module and coreutils. The native mechanism that was being re-implemented is `os.release()` itself — the PR deletes the spawn rather than caching it. `src/lib/cpu-usage.ts` had already made this route's CPU figure a cached delta for the same reason (TASK-456).

### Measurements (read-only, on the OpenClaw box, NVIDIA Jetson Orin Nano)

```
df -h -x tmpfs -x devtmpfs -x squashfs        2.8 ms/run
ps aux --sort=-%cpu                          28.5 ms/run
uname -r                                      2.0 ms/run
df+ps+uname in parallel                      29.8 ms/request

/setup-api/system/stats, 8 authenticated GETs on loopback:
200 0.072s  200 0.058s  200 0.051s  200 0.051s
200 0.050s  200 0.050s  200 0.051s  200 0.053s
```

So roughly 30 ms of subprocess work inside a 50–72 ms response, and `ps` is 91% of it. Over 30 s with both panels open (20 requests) that is ~666 ms of spawn work; with this change it is ~188 ms, and the `uname` third of the spawn count is gone permanently rather than cached.

The post-fix number on hardware is **unrun**: measuring it needs beta deployed to a box, and this batch does not mutate boxes. The RED figures above and the spawn counts below are what is proven.

### The shape of the fix
- `uname -r` deleted; `overview.kernel` is `os.release()`. Verified on the box that they are byte-identical (`5.15.185-tegra` from each).
- `df` and `ps` go through a small local `memoAsync()` with in-flight dedup, on **one** 5 s window rather than the 30 s / 5 s the card proposed. A longer disk window buys ~0.3 ms/s on the numbers above and would make the payload's own `timestamp` — which the System app renders as "last updated" — claim a freshness it does not have; a disk figure half a minute old under a stamp that says "now" is how a `disk_cleanup` that worked reads as one that did nothing. Five seconds is inside the jitter of the 3 s poll that reads it.
- A failure is remembered for 3 s, a success for 5 s. Caching only successes means the harder the box is struggling — a `fork` refused with EAGAIN under memory pressure is exactly when this matters — the more often it is asked to spawn. Same success/failure split, and the same written reasoning, as the memos in `src/lib/hermes-telegram.ts` and `src/lib/openclaw-channels.ts`.
- The `try/catch` that turns a failure into `[]` stays OUTSIDE the memo, so the memo sees the real outcome and the route's contract is unchanged.

### RED → GREEN

RED, on unmodified `origin/beta` (b632bdc7):

```
 × spawns nothing for the kernel release
 × does not respawn df and ps for every 3 s tick
 × serves the two concurrent pollers from one spawn each
 × re-reads once the window is up
 × does not spawn once per request while a command keeps failing
AssertionError: expected [ 'uname', 'df', 'ps' ] to not include 'uname'
AssertionError: df over four ticks: expected 8 to be 2
AssertionError: expected 2 to be 1
AssertionError: inside the failure window: expected 2 to be 1
 Tests  5 failed | 1 passed (6)
```

GREEN, with the fix:

```
$ npx vitest run --project unit src/tests/routes/system/
 Test Files  9 passed (9)
      Tests  102 passed (102)
```

`build-typecheck` and `test-timeout-hygiene` green. The assertions count calls into `child_process`, not milliseconds, so they mean the same thing on a laptop and on a loaded CI runner.

### Siblings handled
- `src/lib/system-info.ts:178` also spawns `df` (and `uptime`), but nothing polls it: `/setup-api/system/info` has no UI caller — only the MCP `system_info` tool and `clawbox system info`. **Cleared, deliberately unmemoised** — an agent asking a question wants the answer now.
- `mcp/tools/system.ts:314` spawns its own `df` for `disk_usage`. **Cleared and must stay unmemoised** for the same reason; it is also what keeps the agent's own disk tool exact after a `disk_cleanup`.
- `src/lib/cdp-probe.ts:107,109` spawns `ps -o ppid=/comm=` per browser probe, not per tick. **Cleared.**
- The two existing hand-rolled memos (`hermes-telegram.ts`, `openclaw-channels.ts`) were deliberately **not** refactored onto this helper: they carry per-key epochs, invalidation hooks and abort-signal semantics this one does not need, and they sit in the channel-status paths another PR in this batch touches.

### Both editions
The route is edition-blind — `/proc`, `os` and coreutils — and is reached the same way on OpenClaw and Hermes.

### Follow-ups named, not taken
- The repo already owns a spawn-free disk read: `fs.statfsSync` in `src/app/setup-api/files/route.ts:19`. Parsing `/proc/mounts` and calling `statfs` per mount would remove the `df` spawn (and its cache) entirely, the way `os.release()` removed `uname`. Out of scope here because it changes the shape of every `DiskMount` field (`df -h` formats the sizes) and needs its own test pass.
- `device_status` (MCP) reads free space from this route, so an agent can now see a figure up to 5 s old right after a cleanup. Bounded by the short window, and `disk_usage` — the tool an agent uses to check a cleanup — spawns its own `df`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved system statistics polling by reusing recent disk and process results.
  * Reduced duplicate requests when multiple polls occur simultaneously.
  * Added short-term handling for failed statistics lookups to avoid repeated retries.

* **Bug Fixes**
  * Improved kernel release reporting.
  * Preserved fallback behavior when storage or process information is unavailable.

* **Tests**
  * Added coverage for caching, concurrent polling, expiration, failures, and successful system statistics responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->