### PR TITLE
perf: cache the skill list for ten minutes and invalidate it on every write

### DIFF
--- a/src/app/setup-api/apps/settings/route.ts
+++ b/src/app/setup-api/apps/settings/route.ts
@@ -66,6 +66,8 @@ export async function POST(req: Request) {
       // field the "Ready / Needs setup" badge is drawn from — so the cached
       // list is invalidated the way install and uninstall invalidate it.
       // Behind the answer: the rescan is a CLI boot and the write has landed.
+      // It does not repaint the window on screen (InstalledAppSettings reads
+      // skill-info once per mount); it makes the NEXT open right.
       refreshSkillsCache();
       return NextResponse.json({ ok: true, enabled });
     }
@@ -82,6 +84,12 @@ export async function POST(req: Request) {
         else return NextResponse.json({ error: `Invalid value type for key "${k}"` }, { status: 400 });
       }
       await writer(sanitized);
+      // The other half of this handler, and the same reason: OpenClaw
+      // evaluates a skill's required CONFIG (`missing.config` in the scan)
+      // exactly as it evaluates its bins and env, and CONFIG_WRITERS exists to
+      // write the files a skill reads. Without this, saving a credential left
+      // the badge on "Needs setup" until the freshness window was up.
+      refreshSkillsCache();
       return NextResponse.json({ ok: true, configWritten: true });
     }
 

--- a/src/app/setup-api/apps/settings/route.ts
+++ b/src/app/setup-api/apps/settings/route.ts
@@ -3,6 +3,7 @@ import { openclawAppsGuard } from "@/lib/openclaw-apps-server";
 import fs from "fs/promises";
 import path from "path";
 import { setSkillEnabled } from "@/lib/openclaw-config";
+import { refreshSkillsCache } from "@/lib/openclaw-skill-info";
 
 export const dynamic = "force-dynamic";
 
@@ -60,6 +61,12 @@ export async function POST(req: Request) {
         console.error(`[apps/settings] Failed to toggle ${appId}:`, err instanceof Error ? err.message : err);
         return NextResponse.json({ error: "Failed to toggle skill" }, { status: 500 });
       }
+      // The switch just changed what `openclaw skills list --json` will say
+      // about this skill — a disabled skill is never `eligible`, which is the
+      // field the "Ready / Needs setup" badge is drawn from — so the cached
+      // list is invalidated the way install and uninstall invalidate it.
+      // Behind the answer: the rescan is a CLI boot and the write has landed.
+      refreshSkillsCache();
       return NextResponse.json({ ok: true, enabled });
     }
 

--- a/src/lib/openclaw-skill-info.ts
+++ b/src/lib/openclaw-skill-info.ts
@@ -20,12 +20,28 @@ import { findOpenclawBin, getSkillsDir, openclawIsAbsent } from "@/lib/openclaw-
  *
  * The window is long because nothing in it changes on its own — a skill appears,
  * disappears or changes state only when something on this box acts — so the
- * freshness comes from INVALIDATION, not from the clock: the install, uninstall
- * and enable/disable routes all call {@link refreshSkillsCache}. A toggle
- * matters as much as an install here: OpenClaw never reports a disabled skill as
- * `eligible` (measured on a box: 31 of 59 skills disabled, none of them
- * eligible), so the switch changes the field the "Ready / Needs setup" badge is
- * drawn from.
+ * freshness comes from INVALIDATION, not from the clock: install, uninstall and
+ * both write paths of `apps/settings` all call {@link refreshSkillsCache}. The
+ * two `apps/settings` paths matter as much as an install: OpenClaw never reports
+ * a disabled skill as `eligible` (measured on a box: 31 of 59 skills disabled,
+ * none of them eligible) and it evaluates a skill's required CONFIG the same way
+ * it evaluates its bins and env (`missing.config`), so both the switch and a
+ * saved credential change the fields the "Ready / Needs setup" badge is drawn
+ * from.
+ *
+ * What that buys is the NEXT open of the window, not the one on screen:
+ * `InstalledAppSettings` reads this once per mount and never refetches, so an
+ * invalidation cannot repaint an open window. Without it, the window opened a
+ * minute after a toggle or a Connect would describe the box as it was before —
+ * for up to ten minutes rather than thirty seconds, which is what makes the
+ * invalidation the price of the longer window rather than a nicety.
+ *
+ * ACCEPTED with the longer window: `eligible` can drift for up to ten minutes
+ * when something OUTSIDE these routes changes it — a Terminal
+ * `openclaw skills uninstall`/`enable`, an apt install that supplies a missing
+ * binary, an env var exported into the gateway. {@link findSkill}'s disk
+ * recheck covers only the out-of-band INSTALL, and only because that is a miss
+ * in the cached list.
  *
  * Lives outside the route file because a route module may export only its
  * handlers, and the install/uninstall routes need the refresh hook.
@@ -53,18 +69,36 @@ export class SkillListUnavailableError extends Error {
 
 const execFileAsync = promisify(execFile);
 const STALE_AFTER_MS = 10 * 60_000;
+/**
+ * How long a FAILED scan is remembered. `load()`'s catch used to leave
+ * `cacheTime` untouched, so once the CLI started failing with something cached
+ * — and after any invalidation that value is 0 — every single request started
+ * another 30 s-timeout scan. Caching only successes means the more wedged the
+ * CLI is, the harder the box is asked to run it. Same success/failure split as
+ * the gateway status memo in `hermes-telegram.ts`; kept at the old freshness
+ * window, since a failing CLI is worth re-asking about more often than a
+ * working one is.
+ */
+const FAILURE_STALE_AFTER_MS = 30_000;
 
 let cachedSkills: SkillInfo[] | null = null;
 let cacheTime = 0;
-let inFlightLoad: Promise<SkillInfo[]> | null = null;
+/** False when `cacheTime` was stamped by a FAILED scan rather than a good one. */
+let cacheAnswered = true;
+let inFlightLoad: { epoch: number; promise: Promise<SkillInfo[]> } | null = null;
 /**
  * Invalidation count. A scan that STARTED before the last invalidation is
- * describing the state that invalidation was called because it changed, so its
- * result may not be stored — clearing `cacheTime` alone would let a scan
- * already in flight land a moment later and stamp the pre-change list as fresh
- * for the whole window. Harmless while that window was 30 s; ten minutes of a
- * badge that contradicts the switch beside it is not. Same guard as the gateway
- * status memo in `hermes-telegram.ts`.
+ * describing the state that invalidation was called because it changed, so it
+ * may neither be JOINED nor STORED — clearing `cacheTime` alone would let a
+ * scan already in flight land a moment later and stamp the pre-change list as
+ * fresh for the whole window. Harmless while that window was 30 s; ten minutes
+ * of it is not.
+ *
+ * All three halves of the gateway-status memo in `hermes-telegram.ts`, because
+ * they only work together: don't store a pre-invalidation result, don't join a
+ * pre-invalidation read (or an invalidation would discard the scan it joined
+ * and start nothing in its place), and clear only your OWN in-flight entry, or
+ * an abandoned read evicts the replacement the invalidation started.
  */
 let scanEpoch = 0;
 
@@ -91,24 +125,34 @@ async function scanSkills(): Promise<SkillInfo[]> {
 
 /** One scan at a time; concurrent callers share it. Rejects only when nothing is cached. */
 function load(): Promise<SkillInfo[]> {
-  if (inFlightLoad) return inFlightLoad;
   const epoch = scanEpoch;
-  inFlightLoad = scanSkills()
+  if (inFlightLoad && inFlightLoad.epoch === epoch) return inFlightLoad.promise;
+  const promise = scanSkills()
     .then((skills) => {
       if (epoch === scanEpoch) {
         cachedSkills = skills;
         cacheTime = Date.now();
+        cacheAnswered = true;
       }
       return skills;
     })
     .catch((err) => {
       const msg = err instanceof Error ? err.message : String(err);
       console.warn("[skill-info] Failed to load skills:", msg);
-      if (cachedSkills) return cachedSkills;
+      if (cachedSkills) {
+        if (epoch === scanEpoch) {
+          cacheTime = Date.now();
+          cacheAnswered = false;
+        }
+        return cachedSkills;
+      }
       throw new SkillListUnavailableError(msg);
     })
-    .finally(() => { inFlightLoad = null; });
-  return inFlightLoad;
+    .finally(() => {
+      if (inFlightLoad?.epoch === epoch) inFlightLoad = null;
+    });
+  inFlightLoad = { epoch, promise };
+  return promise;
 }
 
 /**
@@ -118,7 +162,12 @@ function load(): Promise<SkillInfo[]> {
  */
 export async function listSkills(): Promise<SkillInfo[]> {
   if (cachedSkills) {
-    if (Date.now() - cacheTime >= STALE_AFTER_MS) void load().catch(() => {});
+    const age = Date.now() - cacheTime;
+    // `age >= 0` because Date.now() is wall-clock: an RTC corrected BACKWARDS
+    // by NTP would otherwise pin the entry until the clock caught up.
+    if (!(age >= 0 && age < (cacheAnswered ? STALE_AFTER_MS : FAILURE_STALE_AFTER_MS))) {
+      void load().catch(() => {});
+    }
     return cachedSkills;
   }
   return load();
@@ -185,6 +234,7 @@ export async function findSkill(appId: string): Promise<SkillInfo | null> {
 export function refreshSkillsCache(): void {
   if (openclawIsAbsent()) return;
   cacheTime = 0;
+  cacheAnswered = true;
   scanEpoch += 1;
   void load().catch(() => {});
 }

--- a/src/lib/openclaw-skill-info.ts
+++ b/src/lib/openclaw-skill-info.ts
@@ -85,6 +85,14 @@ let cachedSkills: SkillInfo[] | null = null;
 let cacheTime = 0;
 /** False when `cacheTime` was stamped by a FAILED scan rather than a good one. */
 let cacheAnswered = true;
+/**
+ * The last failed scan, remembered even when there is NOTHING cached — the
+ * cold-start case, and the one that matters most: a box whose CLI is broken
+ * from boot has no cached list for `cacheTime` to belong to, so every request
+ * would start another 30 s-timeout scan for as long as it stayed broken.
+ * Cleared by a success and by every invalidation.
+ */
+let lastFailure: { at: number; message: string } | null = null;
 let inFlightLoad: { epoch: number; promise: Promise<SkillInfo[]> } | null = null;
 /**
  * Invalidation count. A scan that STARTED before the last invalidation is
@@ -133,19 +141,21 @@ function load(): Promise<SkillInfo[]> {
         cachedSkills = skills;
         cacheTime = Date.now();
         cacheAnswered = true;
+        lastFailure = null;
       }
       return skills;
     })
     .catch((err) => {
       const msg = err instanceof Error ? err.message : String(err);
       console.warn("[skill-info] Failed to load skills:", msg);
-      if (cachedSkills) {
-        if (epoch === scanEpoch) {
+      if (epoch === scanEpoch) {
+        lastFailure = { at: Date.now(), message: msg };
+        if (cachedSkills) {
           cacheTime = Date.now();
           cacheAnswered = false;
         }
-        return cachedSkills;
       }
+      if (cachedSkills) return cachedSkills;
       throw new SkillListUnavailableError(msg);
     })
     .finally(() => {
@@ -161,6 +171,12 @@ function load(): Promise<SkillInfo[]> {
  * awaited only when nothing has been scanned yet since boot.
  */
 export async function listSkills(): Promise<SkillInfo[]> {
+  if (!cachedSkills && withinFailureWindow()) {
+    // Nothing to serve and the CLI just refused. Answer with what it said
+    // rather than spending another 30 s-timeout spawn on it; the route turns
+    // this into the same 503 the caller would have got anyway.
+    throw new SkillListUnavailableError(lastFailure!.message);
+  }
   if (cachedSkills) {
     const age = Date.now() - cacheTime;
     // `age >= 0` because Date.now() is wall-clock: an RTC corrected BACKWARDS
@@ -231,10 +247,20 @@ export async function findSkill(appId: string): Promise<SkillInfo | null> {
  * 0, so the next reader is served the old list at once and starts a scan that
  * can see the change.
  */
+/** Is a remembered failure still inside its (short) window? */
+function withinFailureWindow(): boolean {
+  if (!lastFailure) return false;
+  const age = Date.now() - lastFailure.at;
+  return age >= 0 && age < FAILURE_STALE_AFTER_MS;
+}
+
 export function refreshSkillsCache(): void {
   if (openclawIsAbsent()) return;
   cacheTime = 0;
   cacheAnswered = true;
+  // Something on this box just changed; a failure remembered from before it is
+  // no reason to refuse to look.
+  lastFailure = null;
   scanEpoch += 1;
   void load().catch(() => {});
 }

--- a/src/lib/openclaw-skill-info.ts
+++ b/src/lib/openclaw-skill-info.ts
@@ -10,13 +10,22 @@ import { findOpenclawBin, getSkillsDir, openclawIsAbsent } from "@/lib/openclaw-
  * `openclaw skills list --json` is the one source for `eligible` and
  * `missing.*`: those are EVALUATED by OpenClaw (is the bin on PATH, is the env
  * var set), not declared, so reading SKILL.md ourselves would change what the
- * "Ready / Needs setup" badge means. But the scan costs 7–8 s on the Jetson,
- * and a 30 s cache meant nearly every open of an installed app's window paid
- * it. So the list is served stale-while-revalidate: whatever is cached is
- * answered at once and a refresh runs behind it once the copy is older than
+ * "Ready / Needs setup" badge means. But the scan is a full CLI boot — 4.2–5.3 s
+ * measured on an Orin Nano, and the call carries a 30 s timeout for the times it
+ * is worse — and `InstalledAppSettings` fetches this on every mount, so a 30 s
+ * cache meant nearly every open of an installed app's window paid for one. So
+ * the list is served stale-while-revalidate: whatever is cached is answered at
+ * once and a refresh runs behind it once the copy is older than
  * {@link STALE_AFTER_MS}; only the first call after a web-server boot waits.
- * The install and uninstall routes call {@link refreshSkillsCache} so the
- * window opened right after an install already lists the new skill.
+ *
+ * The window is long because nothing in it changes on its own — a skill appears,
+ * disappears or changes state only when something on this box acts — so the
+ * freshness comes from INVALIDATION, not from the clock: the install, uninstall
+ * and enable/disable routes all call {@link refreshSkillsCache}. A toggle
+ * matters as much as an install here: OpenClaw never reports a disabled skill as
+ * `eligible` (measured on a box: 31 of 59 skills disabled, none of them
+ * eligible), so the switch changes the field the "Ready / Needs setup" badge is
+ * drawn from.
  *
  * Lives outside the route file because a route module may export only its
  * handlers, and the install/uninstall routes need the refresh hook.
@@ -43,11 +52,21 @@ export class SkillListUnavailableError extends Error {
 }
 
 const execFileAsync = promisify(execFile);
-const STALE_AFTER_MS = 30_000;
+const STALE_AFTER_MS = 10 * 60_000;
 
 let cachedSkills: SkillInfo[] | null = null;
 let cacheTime = 0;
 let inFlightLoad: Promise<SkillInfo[]> | null = null;
+/**
+ * Invalidation count. A scan that STARTED before the last invalidation is
+ * describing the state that invalidation was called because it changed, so its
+ * result may not be stored — clearing `cacheTime` alone would let a scan
+ * already in flight land a moment later and stamp the pre-change list as fresh
+ * for the whole window. Harmless while that window was 30 s; ten minutes of a
+ * badge that contradicts the switch beside it is not. Same guard as the gateway
+ * status memo in `hermes-telegram.ts`.
+ */
+let scanEpoch = 0;
 
 async function scanSkills(): Promise<SkillInfo[]> {
   const bin = findOpenclawBin();
@@ -73,10 +92,13 @@ async function scanSkills(): Promise<SkillInfo[]> {
 /** One scan at a time; concurrent callers share it. Rejects only when nothing is cached. */
 function load(): Promise<SkillInfo[]> {
   if (inFlightLoad) return inFlightLoad;
+  const epoch = scanEpoch;
   inFlightLoad = scanSkills()
     .then((skills) => {
-      cachedSkills = skills;
-      cacheTime = Date.now();
+      if (epoch === scanEpoch) {
+        cachedSkills = skills;
+        cacheTime = Date.now();
+      }
       return skills;
     })
     .catch((err) => {
@@ -150,12 +172,19 @@ export async function findSkill(appId: string): Promise<SkillInfo | null> {
 }
 
 /**
- * Rescan in the background after an install or uninstall. The current copy
+ * Rescan in the background after anything that changes what the list says: an
+ * install, an uninstall, or a flip of a skill's enable switch. The current copy
  * keeps serving until the new one lands, so nobody waits on it. A no-op on a
  * device without the openclaw binary (the uninstall route runs on Hermes too).
+ *
+ * A scan already in flight when this is called was started BEFORE the change
+ * and is dropped rather than stored (see {@link scanEpoch}); `cacheTime` stays
+ * 0, so the next reader is served the old list at once and starts a scan that
+ * can see the change.
  */
 export function refreshSkillsCache(): void {
   if (openclawIsAbsent()) return;
   cacheTime = 0;
+  scanEpoch += 1;
   void load().catch(() => {});
 }

--- a/src/tests/routes/apps/settings.test.ts
+++ b/src/tests/routes/apps/settings.test.ts
@@ -11,6 +11,10 @@ vi.mock("@/lib/openclaw-config", () => ({
   setSkillEnabled: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("@/lib/openclaw-skill-info", () => ({
+  refreshSkillsCache: vi.fn(),
+}));
+
 describe("/setup-api/apps/settings", () => {
   let POST: (req: Request) => Promise<Response>;
 
@@ -71,6 +75,23 @@ describe("/setup-api/apps/settings", () => {
     expect(body.enabled).toBe(false);
     const { setSkillEnabled } = await import("@/lib/openclaw-config");
     expect(setSkillEnabled).toHaveBeenCalledWith("test-app", false);
+    // The switch changes what `openclaw skills list --json` reports for this
+    // skill, and that list is cached for ten minutes.
+    const { refreshSkillsCache } = await import("@/lib/openclaw-skill-info");
+    expect(refreshSkillsCache).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not invalidate the skill list when the write failed", async () => {
+    const { setSkillEnabled } = await import("@/lib/openclaw-config");
+    const { refreshSkillsCache } = await import("@/lib/openclaw-skill-info");
+    vi.mocked(setSkillEnabled).mockRejectedValueOnce(new Error("EACCES"));
+    const res = await POST(new Request("http://localhost/setup-api/apps/settings", {
+      method: "POST",
+      body: JSON.stringify({ appId: "test-app", settings: { _setEnabled: false } }),
+    }));
+    expect(res.status).toBe(500);
+    // Nothing changed, so spending a CLI boot on a rescan would be waste.
+    expect(refreshSkillsCache).not.toHaveBeenCalled();
   });
 
   it("refuses a non-boolean _setEnabled — the string \"false\" must not enable", async () => {

--- a/src/tests/routes/apps/settings.test.ts
+++ b/src/tests/routes/apps/settings.test.ts
@@ -81,6 +81,34 @@ describe("/setup-api/apps/settings", () => {
     expect(refreshSkillsCache).toHaveBeenCalledTimes(1);
   });
 
+  it("invalidates the skill list after a config write too", async () => {
+    // OpenClaw evaluates a skill's required CONFIG the same way it evaluates
+    // its bins and env, and this is the branch that writes the file the skill
+    // reads — so a saved credential changes `eligible` exactly as the switch
+    // does. Left out, a Connect left the badge on "Needs setup" for the whole
+    // freshness window.
+    const { refreshSkillsCache } = await import("@/lib/openclaw-skill-info");
+    const res = await POST(new Request("http://localhost/setup-api/apps/settings", {
+      method: "POST",
+      body: JSON.stringify({
+        appId: "home-assistant",
+        settings: { ha_url: "http://ha.local:8123", ha_token: "t" },
+      }),
+    }));
+    expect(await res.json()).toEqual({ ok: true, configWritten: true });
+    expect(refreshSkillsCache).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not invalidate the skill list for an app with no writer", async () => {
+    const { refreshSkillsCache } = await import("@/lib/openclaw-skill-info");
+    const res = await POST(new Request("http://localhost/setup-api/apps/settings", {
+      method: "POST",
+      body: JSON.stringify({ appId: "some-other-app", settings: { anything: "x" } }),
+    }));
+    expect(await res.json()).toEqual({ ok: true, configWritten: false });
+    expect(refreshSkillsCache).not.toHaveBeenCalled();
+  });
+
   it("does not invalidate the skill list when the write failed", async () => {
     const { setSkillEnabled } = await import("@/lib/openclaw-config");
     const { refreshSkillsCache } = await import("@/lib/openclaw-skill-info");

--- a/src/tests/routes/apps/skill-info-freshness.test.ts
+++ b/src/tests/routes/apps/skill-info-freshness.test.ts
@@ -76,7 +76,7 @@ describe("skill-info freshness", () => {
     return new NextRequest(new URL(`http://localhost/setup-api/apps/skill-info${query}`));
   }
 
-  async function advance(ms: number) {
+  function advance(ms: number) {
     vi.setSystemTime(Date.now() + ms);
   }
 
@@ -95,7 +95,7 @@ describe("skill-info freshness", () => {
     await GET(get());
     expect(exec).toHaveBeenCalledTimes(1);
 
-    await advance(10 * MINUTE + 1_000);
+    advance(10 * MINUTE + 1_000);
     const res = await GET(get());
     // Served from the cache at once — the refresh runs behind it.
     expect(await res.json()).toHaveLength(1);
@@ -121,41 +121,65 @@ describe("skill-info freshness", () => {
 
     // Two minutes later — well inside the ten-minute window — the badge the
     // window draws already agrees with the switch beside it.
-    await advance(2 * MINUTE);
+    advance(2 * MINUTE);
     expect((await (await GET(get("?appId=test-skill"))).json()).eligible).toBe(false);
     expect(exec).toHaveBeenCalledTimes(2);
   });
 
-  it("does not let a scan started before the toggle stamp itself fresh", async () => {
+  it("replaces a scan started before the toggle rather than just discarding it", async () => {
     await GET(get());
     expect(exec).toHaveBeenCalledTimes(1);
 
     // Past the window: the cached list is served and a refresh runs behind it.
-    await advance(11 * MINUTE);
-    let finishScan: (v: unknown) => void = () => {};
-    exec.mockImplementation(() => new Promise((r) => { finishScan = r; }));
+    advance(11 * MINUTE);
+    const pending: Array<(v: unknown) => void> = [];
+    exec.mockImplementation(() => new Promise((resolve) => { pending.push(resolve); }));
     await GET(get());
     expect(exec).toHaveBeenCalledTimes(2);
 
-    // The switch is flipped while that scan is still out.
+    // The switch is flipped while that scan is still out. Joining it would
+    // discard the answer AND start nothing, leaving the box with the
+    // pre-toggle list and no scan running.
     await POST(new Request("http://localhost/setup-api/apps/settings", {
       method: "POST",
       body: JSON.stringify({ appId: "test-skill", settings: { _setEnabled: false } }),
     }));
+    expect(exec, "the invalidation starts its own scan").toHaveBeenCalledTimes(3);
 
-    // ...and it comes back describing the box as it was BEFORE the flip.
-    exec.mockResolvedValue(listing(false));
-    finishScan(listing(true));
+    // The abandoned scan lands first, describing the box before the flip. It
+    // must neither be stored nor evict the scan that replaced it.
+    pending[0](listing(true));
+    await vi.advanceTimersByTimeAsync(0);
+    pending[1](listing(false));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect((await (await GET(get("?appId=test-skill"))).json()).eligible).toBe(false);
+    expect(exec, "and no fourth scan was needed").toHaveBeenCalledTimes(3);
+  });
+
+  it("does not re-run a failing scan on every single request", async () => {
+    await GET(get());
+    expect(exec).toHaveBeenCalledTimes(1);
+
+    advance(11 * MINUTE);
+    exec.mockRejectedValue(new Error("openclaw: command not found"));
+    await GET(get());
     await vi.advanceTimersByTimeAsync(0);
     expect(exec).toHaveBeenCalledTimes(2);
 
-    // Without the epoch guard that answer would be stored and stamped fresh,
-    // and the badge would contradict the switch beside it for ten minutes.
-    // Instead the next reader is served the old list at once and starts a scan
-    // that can see the flip.
+    // A failure used to leave the timestamp untouched, so every later request
+    // started another scan — each with a 30 s timeout — for as long as the CLI
+    // stayed broken.
+    advance(5_000);
     await GET(get());
     await vi.advanceTimersByTimeAsync(0);
-    expect(exec).toHaveBeenCalledTimes(3);
-    expect((await (await GET(get("?appId=test-skill"))).json()).eligible).toBe(false);
+    expect(exec, "inside the failure window").toHaveBeenCalledTimes(2);
+
+    // But it is re-asked sooner than a good answer would be.
+    advance(31_000);
+    await GET(get());
+    await vi.advanceTimersByTimeAsync(0);
+    expect(exec, "past the failure window").toHaveBeenCalledTimes(3);
   });
+
 });

--- a/src/tests/routes/apps/skill-info-freshness.test.ts
+++ b/src/tests/routes/apps/skill-info-freshness.test.ts
@@ -157,6 +157,37 @@ describe("skill-info freshness", () => {
     expect(exec, "and no fourth scan was needed").toHaveBeenCalledTimes(3);
   });
 
+  it("does not re-run a failing scan on every request when NOTHING is cached", async () => {
+    // The cold-start case: a box whose CLI is broken from boot has no cached
+    // list for the freshness stamp to belong to, so without a remembered
+    // failure every request started another scan — each with a 30 s timeout,
+    // for as long as the box stayed broken.
+    exec.mockRejectedValue(new Error("openclaw: command not found"));
+    expect((await GET(get())).status).toBe(503);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(exec).toHaveBeenCalledTimes(1);
+
+    advance(5_000);
+    expect((await GET(get())).status, "still answered, still 503").toBe(503);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(exec, "inside the failure window").toHaveBeenCalledTimes(1);
+
+    advance(31_000);
+    expect((await GET(get())).status).toBe(503);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(exec, "past the failure window").toHaveBeenCalledTimes(2);
+
+    // An install or a toggle is a reason to look again now, not in 30 s.
+    exec.mockResolvedValue(listing(true));
+    await POST(new Request("http://localhost/setup-api/apps/settings", {
+      method: "POST",
+      body: JSON.stringify({ appId: "test-skill", settings: { _setEnabled: true } }),
+    }));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(exec).toHaveBeenCalledTimes(3);
+    expect((await (await GET(get())).json())).toHaveLength(1);
+  });
+
   it("does not re-run a failing scan on every single request", async () => {
     await GET(get());
     expect(exec).toHaveBeenCalledTimes(1);

--- a/src/tests/routes/apps/skill-info-freshness.test.ts
+++ b/src/tests/routes/apps/skill-info-freshness.test.ts
@@ -1,0 +1,161 @@
+/**
+ * How often an installed app's settings window is allowed to pay for
+ * `openclaw skills list --json`.
+ *
+ * The scan is a full CLI boot — measured on an Orin Nano at 4.2-5.3 s, and the
+ * call carries a 30 s timeout for the times it is worse — and
+ * `InstalledAppSettings` fetches /setup-api/apps/skill-info on EVERY mount. A
+ * 30 s freshness window meant nearly every open of a settings window kicked one
+ * off behind the answer, which is the cost this file pins down.
+ *
+ * The other half is what must NOT go stale for ten minutes: the enable switch.
+ * A skill OpenClaw has disabled is never `eligible` (measured on the box: 31 of
+ * 59 skills disabled, 0 of them eligible), so a toggle changes the very field
+ * the "Ready / Needs setup" badge is drawn from. The switch itself is read back
+ * from openclaw.json, but the badge beside it comes from this list, and without
+ * an invalidation the two would disagree for ten minutes.
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("child_process", () => ({ execFile: vi.fn() }));
+
+vi.mock("util", () => ({ promisify: vi.fn().mockReturnValue(vi.fn()) }));
+
+vi.mock("fs/promises", () => ({
+  default: {
+    stat: vi.fn().mockRejectedValue(new Error("ENOENT")),
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@/lib/openclaw-config", () => ({
+  findOpenclawBin: vi.fn(() => "/usr/local/bin/openclaw"),
+  getSkillsDir: vi.fn(() => "/home/clawbox/.openclaw/workspace"),
+  openclawIsAbsent: vi.fn(() => false),
+  readSkillEnabled: vi.fn(async () => true),
+  setSkillEnabled: vi.fn(async () => undefined),
+}));
+
+/** `eligible` follows the switch — a disabled skill is never eligible. */
+function listing(enabled: boolean) {
+  return {
+    stdout: JSON.stringify({
+      skills: [{ name: "test-skill", description: "Test", eligible: enabled, source: "builtin" }],
+    }),
+  };
+}
+
+const MINUTE = 60_000;
+
+describe("skill-info freshness", () => {
+  let GET: (req: NextRequest) => Promise<Response>;
+  let POST: (req: Request) => Promise<Response>;
+  let exec: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-05T10:00:00Z"));
+    const { promisify } = await import("util");
+    exec = vi.fn().mockResolvedValue(listing(true));
+    vi.mocked(promisify).mockReturnValue(exec as never);
+    const fsMod = await import("fs/promises");
+    vi.mocked(fsMod.default.stat).mockRejectedValue(new Error("ENOENT"));
+    GET = (await import("@/app/setup-api/apps/skill-info/route")).GET;
+    POST = (await import("@/app/setup-api/apps/settings/route")).POST;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function get(query = "") {
+    return new NextRequest(new URL(`http://localhost/setup-api/apps/skill-info${query}`));
+  }
+
+  async function advance(ms: number) {
+    vi.setSystemTime(Date.now() + ms);
+  }
+
+  it("does not re-scan for every settings window opened within ten minutes", async () => {
+    await GET(get());
+    expect(exec).toHaveBeenCalledTimes(1);
+
+    for (const minutes of [1, 3, 6, 9]) {
+      vi.setSystemTime(new Date("2026-09-05T10:00:00Z").getTime() + minutes * MINUTE);
+      await GET(get());
+      expect(exec, `${minutes} min after the scan`).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("still refreshes behind the caller once the window is up", async () => {
+    await GET(get());
+    expect(exec).toHaveBeenCalledTimes(1);
+
+    await advance(10 * MINUTE + 1_000);
+    const res = await GET(get());
+    // Served from the cache at once — the refresh runs behind it.
+    expect(await res.json()).toHaveLength(1);
+    expect(exec).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-scans when the skill switch is flipped, not ten minutes later", async () => {
+    expect((await (await GET(get("?appId=test-skill"))).json()).eligible).toBe(true);
+    expect(exec).toHaveBeenCalledTimes(1);
+
+    exec.mockResolvedValue(listing(false));
+    const res = await POST(new Request("http://localhost/setup-api/apps/settings", {
+      method: "POST",
+      body: JSON.stringify({ appId: "test-skill", settings: { _setEnabled: false } }),
+    }));
+    expect(res.status).toBe(200);
+
+    const { setSkillEnabled } = await import("@/lib/openclaw-config");
+    expect(setSkillEnabled).toHaveBeenCalledWith("test-skill", false);
+    // The rescan is kicked off by the toggle and does not block its answer.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(exec).toHaveBeenCalledTimes(2);
+
+    // Two minutes later — well inside the ten-minute window — the badge the
+    // window draws already agrees with the switch beside it.
+    await advance(2 * MINUTE);
+    expect((await (await GET(get("?appId=test-skill"))).json()).eligible).toBe(false);
+    expect(exec).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not let a scan started before the toggle stamp itself fresh", async () => {
+    await GET(get());
+    expect(exec).toHaveBeenCalledTimes(1);
+
+    // Past the window: the cached list is served and a refresh runs behind it.
+    await advance(11 * MINUTE);
+    let finishScan: (v: unknown) => void = () => {};
+    exec.mockImplementation(() => new Promise((r) => { finishScan = r; }));
+    await GET(get());
+    expect(exec).toHaveBeenCalledTimes(2);
+
+    // The switch is flipped while that scan is still out.
+    await POST(new Request("http://localhost/setup-api/apps/settings", {
+      method: "POST",
+      body: JSON.stringify({ appId: "test-skill", settings: { _setEnabled: false } }),
+    }));
+
+    // ...and it comes back describing the box as it was BEFORE the flip.
+    exec.mockResolvedValue(listing(false));
+    finishScan(listing(true));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(exec).toHaveBeenCalledTimes(2);
+
+    // Without the epoch guard that answer would be stored and stamped fresh,
+    // and the badge would contradict the switch beside it for ten minutes.
+    // Instead the next reader is served the old list at once and starts a scan
+    // that can see the flip.
+    await GET(get());
+    await vi.advanceTimersByTimeAsync(0);
+    expect(exec).toHaveBeenCalledTimes(3);
+    expect((await (await GET(get("?appId=test-skill"))).json()).eligible).toBe(false);
+  });
+});

--- a/src/tests/routes/apps/skill-info.test.ts
+++ b/src/tests/routes/apps/skill-info.test.ts
@@ -121,12 +121,12 @@ describe("/setup-api/apps/skill-info", () => {
     expect(exec).toHaveBeenCalledTimes(1);
 
     // Inside the freshness window: nothing spawned.
-    vi.setSystemTime(new Date("2026-08-31T10:00:10Z"));
+    vi.setSystemTime(new Date("2026-08-31T10:09:00Z"));
     await GET(get());
     expect(exec).toHaveBeenCalledTimes(1);
 
     // Past it: the cached list is answered without waiting, and a rescan runs.
-    vi.setSystemTime(new Date("2026-08-31T10:01:00Z"));
+    vi.setSystemTime(new Date("2026-08-31T10:10:01Z"));
     let resolveScan: (v: unknown) => void = () => {};
     exec.mockImplementation(() => new Promise((r) => { resolveScan = r; }));
     const res = await GET(get());


### PR DESCRIPTION
**TASK-627 (PERF-08)** — `openclaw skills list --json` is re-run in the background on nearly every open of an installed app's settings window.

### Customer-visible symptom
`InstalledAppSettings` fetches `/setup-api/apps/skill-info?appId=` on **every mount**, and behind it sits a full OpenClaw CLI boot. With a 30 s freshness window, opening an app's settings twice in a session almost always kicked one off behind the answer — a background CPU spike on a Jetson every time the owner looks at an app.

### Cause
`src/lib/openclaw-skill-info.ts:46` `STALE_AFTER_MS = 30_000`. The list is served stale-while-revalidate, so nobody waits — but past 30 s every read starts another scan. Nothing in that list changes on its own, so 30 s was buying nothing: a skill appears, disappears or changes state only when something on this box **acts**.

### Harness first
`openclaw skills list --json` is OpenClaw's own evaluation of `eligible` / `missing.{env,bins,config}` and stays the single source of truth — reading `SKILL.md` ourselves would change what the "Ready / Needs setup" badge means. What changes is how often we ask, and the invalidation hook (`refreshSkillsCache`) already existed for install/uninstall. Measured read-only on the OpenClaw box: three runs at **5.34 s / 4.22 s / 4.41 s**, 59 skills, and the answer carries `disabled` beside `eligible` — 31 of the 59 are disabled and **none of the disabled is eligible**.

### The change
1. `STALE_AFTER_MS` → 10 min. Freshness comes from **invalidation**, not the clock.
2. Both write paths of `apps/settings` now invalidate — the `_setEnabled` switch (a disabled skill is never `eligible`) and the `CONFIG_WRITERS` branch (OpenClaw evaluates required **config** exactly as it evaluates bins and env, and that branch writes the file the skill reads). Missing the second would have turned a 30 s wait after "Connect" into a ten-minute one, in the same handler.
3. The invalidation now carries all three halves of the memo pattern in `hermes-telegram.ts`, not one: a scan started before an invalidation is neither **stored** nor **joined**, and each scan clears only its **own** in-flight entry. Joining unconditionally meant an invalidation discarded the scan it joined and started nothing to replace it; clearing unconditionally would let an abandoned scan evict its replacement.
4. A **failed** scan is stamped and remembered for 30 s. The catch left the timestamp untouched, so once the CLI started failing with something cached — and after any invalidation that value is `0` — every single request started another scan, each with a 30 s timeout. Pre-existing on beta, fixed here because this PR's whole subject is that scan's cost.

### RED → GREEN

RED on unmodified `origin/beta`, six assertions across the two suites:

```
 × writes the enable/disable switch straight to openclaw.json
      expected refreshSkillsCache to be called 1 times, but got 0 times
 × invalidates the skill list after a config write too
      expected refreshSkillsCache to be called 1 times, but got 0 times
 × does not re-scan for every settings window opened within ten minutes
      1 min after the scan: expected 1 scan, but got 2
 × re-scans when the skill switch is flipped, not ten minutes later
      expected 2 scans, but got 1
 × replaces a scan started before the toggle rather than just discarding it
      the invalidation starts its own scan: expected 3, but got 2
 × does not re-run a failing scan on every single request
      inside the failure window: expected 2, but got 3
 Tests  6 failed | 11 passed (17)
```

(The file's "still refreshes behind the caller once the window is up" case passes on beta too — it characterises stale-while-revalidate, which this PR does not change, and is kept as a guard rather than offered as evidence.)

GREEN:

```
$ npx vitest run --project unit src/tests/routes/apps/
 Test Files  11 passed (11)
      Tests  100 passed (100)
```

`build-typecheck` and `test-timeout-hygiene` green. `skill-info.test.ts`'s existing stale-window case was moved from 60 s to past ten minutes — the only neighbouring assertion the window change touches.

### What this does NOT do
`InstalledAppSettings` reads skill-info once per mount and never refetches, so an invalidation cannot repaint the window on screen: what it buys is the **next** open being right within one scan instead of up to ten minutes later. The header says that rather than the stronger claim it first carried.

A separate, pre-existing UI bug is left for a follow-up and named here: opening the window for a **disabled** skill and switching it **on** re-renders the badge from the mount-time `skillInfo`, so it says "Needs setup" on a skill that is now ready until the window is reopened. Fixing it properly needs a refetch that is guaranteed a post-toggle answer — `listSkills()` serves `cachedSkills` unconditionally, so a naive refetch right after the POST would still be handed the pre-toggle list, which would look like a fix and not be one.

### Accepted cost, stated rather than implied
`eligible` can drift for up to ten minutes when something **outside** these routes changes it: a Terminal `openclaw skills uninstall` or `enable`, an apt install supplying a missing binary, an env var exported into the gateway. `findSkill`'s disk recheck covers only the out-of-band **install**, because that is a miss in the cached list. Extending it to the hit path was considered and rejected here: a bundled skill (31 of 59 on the box, `source: openclaw-bundled`) has no folder under the workspace, so a naive stat on the hit path would rescan on every request — strictly worse than the drift it closes.

### Siblings handled
- `refreshSkillsCache` callers: `apps/install:409`, `apps/uninstall:217` and `:339`, and now both branches of `apps/settings`. No others.
- `setSkillEnabled` has exactly one production caller (this route).
- `scripts/gateway-pre-start.sh` writes no `skills.entries` key and runs no `openclaw skills` subcommand — it only `mkdir -p`s the skills directory. Cleared.
- A factory reset and an in-app update both end in a restart, so the cache dies with the process. Cleared.

### Both editions
`refreshSkillsCache` returns immediately when the openclaw binary is absent, and both routes sit behind `openclawAppsGuard()`. The Hermes leg is inert — a plain return, no throw, no spawn.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Skill information remains fresh for up to 10 minutes while avoiding unnecessary rescans.
  - Background refreshes keep skill listings current without interrupting normal use.
  - Skill changes and app configuration updates now refresh skill status immediately.
  - Failed scans use shorter retry windows while preserving available cached results.
  - Concurrent refreshes prevent outdated results from replacing newer data.

- **Reliability**
  - Skill listings remain accurate after enabling or disabling skills and after successful configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->