### PR TITLE
fix: let the provider name and model wrap in a narrow pane

### DIFF
--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -1776,7 +1776,10 @@ export default function AIModelsStep({
             <span className="text-[length:var(--t-2)] font-semibold text-[var(--text-secondary)]">
               {t("ai.model")}
             </span>
-            <span className="truncate text-[length:var(--t-4)] text-[var(--text-primary)]">
+            {/* Wrapped, not clipped: this line is the model id, which is the
+                one thing a customer opens this button to read, and "Change"
+                beside it never shrinks. Same call as the provider hero. */}
+            <span className="break-words text-[length:var(--t-4)] text-[var(--text-primary)]">
               {currentModelLabel}
             </span>
           </span>

--- a/src/components/AiProviderList.tsx
+++ b/src/components/AiProviderList.tsx
@@ -146,7 +146,16 @@ export default function AiProviderList() {
           ))}
         </div>
       ) : (
-        <ul className="rounded-xl border border-white/[0.08] overflow-hidden divide-y divide-white/[0.06]">
+        /* A CONTAINER, not the viewport. The defect is about how wide this
+           PANE is: Settings caps it at `max-w-xl` (576 px) and draws it inside
+           a ChromeWindow the owner can drag down to 300 px, so a `sm:`
+           breakpoint — which asks the viewport — is answered "wide" on a
+           desktop whose provider rows are 300 px across. `@container` is what
+           the rest of this codebase already uses for exactly this (the Coding
+           Agent panel, the skills store). `@md` is 28 rem: below it the icon,
+           the name, the Default pill, the Make-default button and the 44 px
+           switch cannot share a line without the name giving way. */
+        <ul className="@container rounded-xl border border-white/[0.08] overflow-hidden divide-y divide-white/[0.06]">
           {rows.map((row) => {
             const busy = toggling === row.id || settingDefault === row.id;
             const canMakeDefault = row.enabled && row.state === "connected" && !row.isDefault;
@@ -157,16 +166,21 @@ export default function AiProviderList() {
                  could give — the name — gave: "OpenAI G…", "Anthropic Cla…".
                  The controls go under the name at phone widths instead, and
                  the name is allowed to wrap there rather than be clipped. */
-              <li key={row.id} className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3 px-3 py-2.5" data-testid={`ai-provider-${row.id}`}>
-                <span className="flex items-center gap-3 min-w-0 sm:flex-1">
+              <li key={row.id} className="flex flex-col @md:flex-row @md:items-center gap-2 @md:gap-3 px-3 py-2.5" data-testid={`ai-provider-${row.id}`}>
+                <span className="flex items-center gap-3 min-w-0 @md:flex-1">
                   <span className={`flex items-center justify-center w-9 h-9 rounded-lg shrink-0 bg-white/[0.06] ${row.enabled ? "" : "opacity-40"}`}>
                     <AIProviderIcon provider={row.id} size={20} />
                   </span>
                   <span className="min-w-0 flex-1">
-                    <span className="flex flex-wrap items-center gap-2">
+                    <span className="flex flex-wrap @md:flex-nowrap items-center gap-2">
                       <span
                         data-testid={`ai-provider-name-${row.id}`}
-                        className={`text-sm font-medium sm:truncate ${row.enabled ? "text-[var(--text-primary)]" : "text-[var(--text-muted)]"}`}
+                        /* `break-words` beside the wrap: on Hermes the label
+                           is whatever the dashboard reports, and an unbroken
+                           one would be hard-clipped by the row's `min-w-0`
+                           with no ellipsis to say so — worse than the
+                           truncation being removed. */
+                        className={`text-sm font-medium break-words @md:truncate ${row.enabled ? "text-[var(--text-primary)]" : "text-[var(--text-muted)]"}`}
                       >
                         {row.label}
                       </span>
@@ -194,7 +208,7 @@ export default function AiProviderList() {
                   </span>
                 </span>
 
-                <span className="flex items-center gap-3 shrink-0 self-end sm:self-auto" data-testid={`ai-provider-controls-${row.id}`}>
+                <span className="flex items-center gap-3 shrink-0 self-start @md:self-auto" data-testid={`ai-provider-controls-${row.id}`}>
                   {canMakeDefault && (
                     <button
                       type="button"

--- a/src/components/AiProviderList.tsx
+++ b/src/components/AiProviderList.tsx
@@ -151,68 +151,81 @@ export default function AiProviderList() {
             const busy = toggling === row.id || settingDefault === row.id;
             const canMakeDefault = row.enabled && row.state === "connected" && !row.isDefault;
             return (
-              <li key={row.id} className="flex items-center gap-3 px-3 py-2.5" data-testid={`ai-provider-${row.id}`}>
-                <span className={`flex items-center justify-center w-9 h-9 rounded-lg shrink-0 bg-white/[0.06] ${row.enabled ? "" : "opacity-40"}`}>
-                  <AIProviderIcon provider={row.id} size={20} />
-                </span>
-                <span className="min-w-0 flex-1">
-                  <span className="flex items-center gap-2">
-                    <span className={`text-sm font-medium truncate ${row.enabled ? "text-[var(--text-primary)]" : "text-[var(--text-muted)]"}`}>
-                      {row.label}
+              /* Stacked below `sm:`, one line above it. At 390 px the row had
+                 an icon, a name, a Default pill, a Make-default button and a
+                 44 px switch competing for ~290 px, so the only thing that
+                 could give — the name — gave: "OpenAI G…", "Anthropic Cla…".
+                 The controls go under the name at phone widths instead, and
+                 the name is allowed to wrap there rather than be clipped. */
+              <li key={row.id} className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3 px-3 py-2.5" data-testid={`ai-provider-${row.id}`}>
+                <span className="flex items-center gap-3 min-w-0 sm:flex-1">
+                  <span className={`flex items-center justify-center w-9 h-9 rounded-lg shrink-0 bg-white/[0.06] ${row.enabled ? "" : "opacity-40"}`}>
+                    <AIProviderIcon provider={row.id} size={20} />
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="flex flex-wrap items-center gap-2">
+                      <span
+                        data-testid={`ai-provider-name-${row.id}`}
+                        className={`text-sm font-medium sm:truncate ${row.enabled ? "text-[var(--text-primary)]" : "text-[var(--text-muted)]"}`}
+                      >
+                        {row.label}
+                      </span>
+                      {row.isDefault && (
+                        <span className="text-[10px] font-semibold uppercase tracking-wider border rounded-full px-2 py-0.5 text-[var(--coral-bright)] border-[var(--coral-bright)]/40" data-testid={`ai-provider-default-${row.id}`}>
+                          {t("settings.providers.default")}
+                        </span>
+                      )}
                     </span>
+                    {row.enabled
+                      ? <ProviderConnectionLabel state={row.state} className="text-[11px]" />
+                      : <span className="block text-[11px] text-[var(--text-muted)]">{t("settings.providers.switchedOff")}</span>}
+                    {/* Visible, not only a hover title: on a phone there is no
+                        hover, and a dimmed switch with no reason looks broken.
+                        The switch names this line as its description. */}
                     {row.isDefault && (
-                      <span className="text-[10px] font-semibold uppercase tracking-wider border rounded-full px-2 py-0.5 text-[var(--coral-bright)] border-[var(--coral-bright)]/40" data-testid={`ai-provider-default-${row.id}`}>
-                        {t("settings.providers.default")}
+                      <span
+                        id={`ai-provider-locked-${row.id}`}
+                        className="block text-[11px] text-[var(--text-secondary)]"
+                        data-testid={`ai-provider-locked-hint-${row.id}`}
+                      >
+                        {t("settings.providers.lockedHint")}
                       </span>
                     )}
                   </span>
-                  {row.enabled
-                    ? <ProviderConnectionLabel state={row.state} className="text-[11px]" />
-                    : <span className="block text-[11px] text-[var(--text-muted)]">{t("settings.providers.switchedOff")}</span>}
-                  {/* Visible, not only a hover title: on a phone there is no
-                      hover, and a dimmed switch with no reason looks broken.
-                      The switch names this line as its description. */}
-                  {row.isDefault && (
-                    <span
-                      id={`ai-provider-locked-${row.id}`}
-                      className="block text-[11px] text-[var(--text-secondary)]"
-                      data-testid={`ai-provider-locked-hint-${row.id}`}
-                    >
-                      {t("settings.providers.lockedHint")}
-                    </span>
-                  )}
                 </span>
 
-                {canMakeDefault && (
+                <span className="flex items-center gap-3 shrink-0 self-end sm:self-auto" data-testid={`ai-provider-controls-${row.id}`}>
+                  {canMakeDefault && (
+                    <button
+                      type="button"
+                      onClick={() => void setDefault(row.id)}
+                      disabled={busy}
+                      data-testid={`ai-provider-make-default-${row.id}`}
+                      className="text-[11px] px-2.5 py-1 rounded-lg border border-white/10 text-[var(--text-secondary)] hover:bg-white/5 disabled:opacity-50 shrink-0"
+                    >
+                      {t("settings.providers.makeDefault")}
+                    </button>
+                  )}
+
+                  {/* The default cannot be switched off — the hint says what to do instead. */}
                   <button
                     type="button"
-                    onClick={() => void setDefault(row.id)}
-                    disabled={busy}
-                    data-testid={`ai-provider-make-default-${row.id}`}
-                    className="text-[11px] px-2.5 py-1 rounded-lg border border-white/10 text-[var(--text-secondary)] hover:bg-white/5 disabled:opacity-50 shrink-0"
+                    role="switch"
+                    aria-checked={row.enabled}
+                    aria-label={t("settings.providers.enable", { name: row.label })}
+                    aria-busy={busy}
+                    aria-describedby={row.isDefault ? `ai-provider-locked-${row.id}` : undefined}
+                    disabled={busy || row.isDefault}
+                    title={row.isDefault ? t("settings.providers.lockedHint") : undefined}
+                    onClick={() => void setEnabled(row, !row.enabled)}
+                    data-testid={`ai-provider-switch-${row.id}`}
+                    className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed shrink-0 ${
+                      row.enabled ? "bg-[var(--coral-bright)]" : "bg-gray-600"
+                    }`}
                   >
-                    {t("settings.providers.makeDefault")}
+                    <span className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${row.enabled ? "translate-x-6" : "translate-x-1"}`} />
                   </button>
-                )}
-
-                {/* The default cannot be switched off — the hint says what to do instead. */}
-                <button
-                  type="button"
-                  role="switch"
-                  aria-checked={row.enabled}
-                  aria-label={t("settings.providers.enable", { name: row.label })}
-                  aria-busy={busy}
-                  aria-describedby={row.isDefault ? `ai-provider-locked-${row.id}` : undefined}
-                  disabled={busy || row.isDefault}
-                  title={row.isDefault ? t("settings.providers.lockedHint") : undefined}
-                  onClick={() => void setEnabled(row, !row.enabled)}
-                  data-testid={`ai-provider-switch-${row.id}`}
-                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed shrink-0 ${
-                    row.enabled ? "bg-[var(--coral-bright)]" : "bg-gray-600"
-                  }`}
-                >
-                  <span className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${row.enabled ? "translate-x-6" : "translate-x-1"}`} />
-                </button>
+                </span>
               </li>
             );
           })}

--- a/src/components/AiProviderList.tsx
+++ b/src/components/AiProviderList.tsx
@@ -175,12 +175,15 @@ export default function AiProviderList() {
                     <span className="flex flex-wrap @md:flex-nowrap items-center gap-2">
                       <span
                         data-testid={`ai-provider-name-${row.id}`}
-                        /* `break-words` beside the wrap: on Hermes the label
-                           is whatever the dashboard reports, and an unbroken
-                           one would be hard-clipped by the row's `min-w-0`
-                           with no ellipsis to say so — worse than the
-                           truncation being removed. */
-                        className={`text-sm font-medium break-words @md:truncate ${row.enabled ? "text-[var(--text-primary)]" : "text-[var(--text-muted)]"}`}
+                        /* `break-words` beside the wrap: on Hermes the label is
+                           whatever the dashboard reports, so an unbroken one
+                           has to be allowed to break rather than be hard-clipped
+                           with no ellipsis to say so. `min-w-0` is what lets it:
+                           `overflow-wrap: break-word` does NOT reduce a flex
+                           item's min-content width, so without it the item
+                           refuses to shrink and the long word overflows the
+                           pane instead of wrapping inside it. */
+                        className={`min-w-0 text-sm font-medium break-words @md:truncate ${row.enabled ? "text-[var(--text-primary)]" : "text-[var(--text-muted)]"}`}
                       >
                         {row.label}
                       </span>

--- a/src/components/ProviderDefaultHero.tsx
+++ b/src/components/ProviderDefaultHero.tsx
@@ -73,7 +73,10 @@ export default function ProviderDefaultHero({
 
           <div className="flex flex-col gap-[3px] flex-1 min-w-0">
             <span className="flex flex-wrap @md:flex-nowrap items-center gap-2 text-base font-bold text-[var(--text-primary)]">
-              <span className="break-words @md:truncate" data-testid="provider-default-hero-name">{row.label}</span>
+              {/* `min-w-0` beside `break-words`: `overflow-wrap: break-word`
+                does not reduce a flex item's min-content width, so without it
+                an unbroken vendor name refuses to shrink and overflows. */}
+            <span className="min-w-0 break-words @md:truncate" data-testid="provider-default-hero-name">{row.label}</span>
               <span className="shrink-0 inline-flex items-center gap-1 px-1.5 py-px rounded-[var(--r-1)] bg-[var(--fill-2)] text-[9px] font-bold uppercase tracking-[0.08em] leading-[1.6] text-[var(--text-primary)]">
                 <span
                   className="material-symbols-rounded"
@@ -90,7 +93,7 @@ export default function ProviderDefaultHero({
               /* `break-words` because a model id is one long hyphenated token:
                  with the ellipsis gone below `sm:` it would otherwise push the
                  card wider than the phone. */
-              <span className="text-xs text-[var(--text-secondary)] break-words @md:truncate" data-testid="provider-default-hero-model">
+              <span className="min-w-0 text-xs text-[var(--text-secondary)] break-words @md:truncate" data-testid="provider-default-hero-model">
                 {model ? <span className="font-mono">{model}</span> : null}
                 {model && note ? " · " : null}
                 {note}

--- a/src/components/ProviderDefaultHero.tsx
+++ b/src/components/ProviderDefaultHero.tsx
@@ -50,48 +50,57 @@ export default function ProviderDefaultHero({
   const { t } = useT();
 
   return (
+    /* Stacked below `sm:`, one line above it. At 390 px the vendor name and
+       the model id both truncated behind a "Change model" button that never
+       shrinks, so the card that exists to say WHICH BRAIN IS ANSWERING said
+       "Anthropic Cla…" and half a model id. */
     <div
       data-testid="provider-default-hero"
-      className="flex items-center gap-4 mb-4 p-[18px] rounded-[var(--r-2)] border border-[var(--cyan-rim)] bg-[linear-gradient(135deg,var(--cyan-mist),var(--bg-deep-veil))]"
+      className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4 mb-4 p-[18px] rounded-[var(--r-2)] border border-[var(--cyan-rim)] bg-[linear-gradient(135deg,var(--cyan-mist),var(--bg-deep-veil))]"
     >
-      <span
-        aria-hidden="true"
-        className="flex items-center justify-center w-11 h-11 rounded-[var(--r-1)] bg-[var(--fill-2)] shrink-0"
-      >
-        <AIProviderIcon provider={row.id} size={26} />
-      </span>
-
-      <div className="flex flex-col gap-[3px] flex-1 min-w-0">
-        <span className="flex items-center gap-2 text-base font-bold text-[var(--text-primary)]">
-          <span className="truncate">{row.label}</span>
-          <span className="shrink-0 inline-flex items-center gap-1 px-1.5 py-px rounded-[var(--r-1)] bg-[var(--fill-2)] text-[9px] font-bold uppercase tracking-[0.08em] leading-[1.6] text-[var(--text-primary)]">
-            <span
-              className="material-symbols-rounded"
-              style={{ fontSize: 11, fontVariationSettings: "'FILL' 1" }}
-              aria-hidden="true"
-            >
-              star
-            </span>
-            {t("settings.providers.default")}
-          </span>
+      <div className="flex items-center gap-4 min-w-0 sm:flex-1">
+        <span
+          aria-hidden="true"
+          className="flex items-center justify-center w-11 h-11 rounded-[var(--r-1)] bg-[var(--fill-2)] shrink-0"
+        >
+          <AIProviderIcon provider={row.id} size={26} />
         </span>
 
-        {(model || note) && (
-          <span className="text-xs text-[var(--text-secondary)] truncate">
-            {model ? <span className="font-mono">{model}</span> : null}
-            {model && note ? " · " : null}
-            {note}
+        <div className="flex flex-col gap-[3px] flex-1 min-w-0">
+          <span className="flex flex-wrap items-center gap-2 text-base font-bold text-[var(--text-primary)]">
+            <span className="sm:truncate" data-testid="provider-default-hero-name">{row.label}</span>
+            <span className="shrink-0 inline-flex items-center gap-1 px-1.5 py-px rounded-[var(--r-1)] bg-[var(--fill-2)] text-[9px] font-bold uppercase tracking-[0.08em] leading-[1.6] text-[var(--text-primary)]">
+              <span
+                className="material-symbols-rounded"
+                style={{ fontSize: 11, fontVariationSettings: "'FILL' 1" }}
+                aria-hidden="true"
+              >
+                star
+              </span>
+              {t("settings.providers.default")}
+            </span>
           </span>
-        )}
 
-        <ProviderConnectionLabel state={row.state} className="mt-[2px]" />
+          {(model || note) && (
+            /* `break-words` because a model id is one long hyphenated token:
+               with the ellipsis gone below `sm:` it would otherwise push the
+               card wider than the phone. */
+            <span className="text-xs text-[var(--text-secondary)] break-words sm:truncate" data-testid="provider-default-hero-model">
+              {model ? <span className="font-mono">{model}</span> : null}
+              {model && note ? " · " : null}
+              {note}
+            </span>
+          )}
+
+          <ProviderConnectionLabel state={row.state} className="mt-[2px]" />
+        </div>
       </div>
 
       {onChangeModel && (
         <button
           type="button"
           onClick={onChangeModel}
-          className="shrink-0 whitespace-nowrap bg-transparent border-none p-0 text-xs font-semibold text-[var(--coral-bright)] cursor-pointer hover:opacity-80 transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--coral-bright)] rounded-[var(--r-1)]"
+          className="shrink-0 self-start sm:self-auto whitespace-nowrap bg-transparent border-none p-0 text-xs font-semibold text-[var(--coral-bright)] cursor-pointer hover:opacity-80 transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--coral-bright)] rounded-[var(--r-1)]"
         >
           {t("settings.providers.changeModel")}
         </button>

--- a/src/components/ProviderDefaultHero.tsx
+++ b/src/components/ProviderDefaultHero.tsx
@@ -50,61 +50,67 @@ export default function ProviderDefaultHero({
   const { t } = useT();
 
   return (
-    /* Stacked below `sm:`, one line above it. At 390 px the vendor name and
+    /* Stacked in a narrow pane, one line in a wide one. The vendor name and
        the model id both truncated behind a "Change model" button that never
        shrinks, so the card that exists to say WHICH BRAIN IS ANSWERING said
-       "Anthropic Cla…" and half a model id. */
-    <div
-      data-testid="provider-default-hero"
-      className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4 mb-4 p-[18px] rounded-[var(--r-2)] border border-[var(--cyan-rim)] bg-[linear-gradient(135deg,var(--cyan-mist),var(--bg-deep-veil))]"
-    >
-      <div className="flex items-center gap-4 min-w-0 sm:flex-1">
-        <span
-          aria-hidden="true"
-          className="flex items-center justify-center w-11 h-11 rounded-[var(--r-1)] bg-[var(--fill-2)] shrink-0"
-        >
-          <AIProviderIcon provider={row.id} size={26} />
-        </span>
-
-        <div className="flex flex-col gap-[3px] flex-1 min-w-0">
-          <span className="flex flex-wrap items-center gap-2 text-base font-bold text-[var(--text-primary)]">
-            <span className="sm:truncate" data-testid="provider-default-hero-name">{row.label}</span>
-            <span className="shrink-0 inline-flex items-center gap-1 px-1.5 py-px rounded-[var(--r-1)] bg-[var(--fill-2)] text-[9px] font-bold uppercase tracking-[0.08em] leading-[1.6] text-[var(--text-primary)]">
-              <span
-                className="material-symbols-rounded"
-                style={{ fontSize: 11, fontVariationSettings: "'FILL' 1" }}
-                aria-hidden="true"
-              >
-                star
-              </span>
-              {t("settings.providers.default")}
-            </span>
+       "Anthropic Cla…" and half a model id.
+       The query is the CONTAINER's, not the viewport's: this card is drawn in
+       a `max-w-xl` pane inside a window the owner can drag to 300 px, so a
+       viewport breakpoint answers "wide" for a card that is not. The wrapper
+       exists because an element cannot query the container it declares. */
+    <div className="@container mb-4">
+      <div
+        data-testid="provider-default-hero"
+        className="flex flex-col @md:flex-row @md:items-center gap-3 @md:gap-4 p-[18px] rounded-[var(--r-2)] border border-[var(--cyan-rim)] bg-[linear-gradient(135deg,var(--cyan-mist),var(--bg-deep-veil))]"
+      >
+        <div className="flex items-center gap-4 min-w-0 @md:flex-1">
+          <span
+            aria-hidden="true"
+            className="flex items-center justify-center w-11 h-11 rounded-[var(--r-1)] bg-[var(--fill-2)] shrink-0"
+          >
+            <AIProviderIcon provider={row.id} size={26} />
           </span>
 
-          {(model || note) && (
-            /* `break-words` because a model id is one long hyphenated token:
-               with the ellipsis gone below `sm:` it would otherwise push the
-               card wider than the phone. */
-            <span className="text-xs text-[var(--text-secondary)] break-words sm:truncate" data-testid="provider-default-hero-model">
-              {model ? <span className="font-mono">{model}</span> : null}
-              {model && note ? " · " : null}
-              {note}
+          <div className="flex flex-col gap-[3px] flex-1 min-w-0">
+            <span className="flex flex-wrap @md:flex-nowrap items-center gap-2 text-base font-bold text-[var(--text-primary)]">
+              <span className="break-words @md:truncate" data-testid="provider-default-hero-name">{row.label}</span>
+              <span className="shrink-0 inline-flex items-center gap-1 px-1.5 py-px rounded-[var(--r-1)] bg-[var(--fill-2)] text-[9px] font-bold uppercase tracking-[0.08em] leading-[1.6] text-[var(--text-primary)]">
+                <span
+                  className="material-symbols-rounded"
+                  style={{ fontSize: 11, fontVariationSettings: "'FILL' 1" }}
+                  aria-hidden="true"
+                >
+                  star
+                </span>
+                {t("settings.providers.default")}
+              </span>
             </span>
-          )}
 
-          <ProviderConnectionLabel state={row.state} className="mt-[2px]" />
+            {(model || note) && (
+              /* `break-words` because a model id is one long hyphenated token:
+                 with the ellipsis gone below `sm:` it would otherwise push the
+                 card wider than the phone. */
+              <span className="text-xs text-[var(--text-secondary)] break-words @md:truncate" data-testid="provider-default-hero-model">
+                {model ? <span className="font-mono">{model}</span> : null}
+                {model && note ? " · " : null}
+                {note}
+              </span>
+            )}
+
+            <ProviderConnectionLabel state={row.state} className="mt-[2px]" />
+          </div>
         </div>
-      </div>
 
-      {onChangeModel && (
-        <button
-          type="button"
-          onClick={onChangeModel}
-          className="shrink-0 self-start sm:self-auto whitespace-nowrap bg-transparent border-none p-0 text-xs font-semibold text-[var(--coral-bright)] cursor-pointer hover:opacity-80 transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--coral-bright)] rounded-[var(--r-1)]"
-        >
-          {t("settings.providers.changeModel")}
-        </button>
-      )}
+        {onChangeModel && (
+          <button
+            type="button"
+            onClick={onChangeModel}
+            className="shrink-0 self-start @md:self-auto whitespace-nowrap bg-transparent border-none p-0 text-xs font-semibold text-[var(--coral-bright)] cursor-pointer hover:opacity-80 transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--coral-bright)] rounded-[var(--r-1)]"
+          >
+            {t("settings.providers.changeModel")}
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/tests/components/provider-rows-narrow.test.tsx
+++ b/src/tests/components/provider-rows-narrow.test.tsx
@@ -33,7 +33,9 @@ vi.mock("@/components/AIProviderIcon", () => ({ default: () => <span data-testid
 const ROWS = [
   { id: "openai", label: "OpenAI GPT", state: "connected", isDefault: true, section: "ai", enabled: true },
   { id: "anthropic", label: "Anthropic Claude", state: "connected", isDefault: false, section: "ai", enabled: true },
-  { id: "openrouter", label: "OpenRouter", state: "connected", isDefault: false, section: "ai", enabled: true },
+  // One UNBROKEN label, which is the shape `break-words` alone cannot save: on
+  // Hermes the label is whatever the dashboard reports.
+  { id: "openrouter", label: "OpenRouterUnbrokenVendorName", state: "connected", isDefault: false, section: "ai", enabled: true },
 ];
 
 function stubFetch() {
@@ -104,6 +106,9 @@ describe("provider rows at phone widths", () => {
       // An unbroken label must still be legible rather than hard-clipped by
       // the row's `min-w-0`: on Hermes the label is dashboard data.
       expect(hasClass(name!, "break-words"), `${row.label} must be allowed to break`).toBe(true);
+      // `overflow-wrap: break-word` does not reduce a flex item's min-content
+      // width, so `break-words` without `min-w-0` still overflows the pane.
+      expect(hasClass(name!, "min-w-0"), `${row.label} must be able to shrink`).toBe(true);
       // Still one line where the PANE has room for one.
       expect(hasClass(name!, "@md:truncate"), `${row.label} should truncate in a wide pane`).toBe(true);
       expect(viewportQueries(name!), `${row.label} must not ask the viewport`).toEqual([]);
@@ -127,7 +132,9 @@ describe("provider rows at phone widths", () => {
   });
 
   it("does not clip the vendor or the model on the hero card", () => {
-    const row = { id: "anthropic", label: "Anthropic Claude", state: "connected", isDefault: true, section: "ai", enabled: true } as unknown as ProviderStatusRow;
+    // An unbroken label and an unbroken model id: the pair `break-words` alone
+    // cannot keep inside a narrow pane.
+    const row = { id: "anthropic", label: "AnthropicUnbrokenVendorName", state: "connected", isDefault: true, section: "ai", enabled: true } as unknown as ProviderStatusRow;
     render(
       <I18nProvider>
         <ProviderDefaultHero row={row} model="claude-opus-5-20260401" onChangeModel={() => {}} />
@@ -141,9 +148,10 @@ describe("provider rows at phone widths", () => {
     expect(containerAncestor(hero), "the hero declares no query container").not.toBeNull();
 
     const name = screen.getByTestId("provider-default-hero-name");
-    expect(name).toHaveTextContent("Anthropic Claude");
+    expect(name).toHaveTextContent("AnthropicUnbrokenVendorName");
     expect(clipsAtEveryWidth(name), "the vendor name is clipped at every width").toBe(false);
     expect(hasClass(name, "break-words"), "the vendor name must be allowed to break").toBe(true);
+    expect(hasClass(name, "min-w-0"), "the vendor name must be able to shrink").toBe(true);
 
     const model = screen.getByTestId("provider-default-hero-model");
     expect(model).toHaveTextContent("claude-opus-5-20260401");
@@ -151,5 +159,6 @@ describe("provider rows at phone widths", () => {
     // A model id is one long hyphenated token: without the ellipsis it has to
     // be allowed to break, or it pushes the card wider than the phone.
     expect(hasClass(model, "break-words"), "the model id must be allowed to wrap").toBe(true);
+    expect(hasClass(model, "min-w-0"), "the model id must be able to shrink").toBe(true);
   });
 });

--- a/src/tests/components/provider-rows-narrow.test.tsx
+++ b/src/tests/components/provider-rows-narrow.test.tsx
@@ -10,10 +10,15 @@
  * keep their width.
  *
  * jsdom does no layout, so these are assertions about the CLASS CONTRACT that
- * produces the clipping rather than about measured pixels: below `sm:` the name
- * must not be `truncate`d, and the controls must not share the line with it.
- * That is the half a unit test can hold; the pixels are the screenshot on the
- * card.
+ * produces the clipping rather than about measured pixels: in a narrow pane the
+ * name must not be `truncate`d, and the controls must not share its line. That
+ * is the half a unit test can hold; the pixels are the screenshot on the card.
+ *
+ * The queries must be the CONTAINER's, not the viewport's, and that is pinned
+ * here rather than left to a comment: Settings caps this pane at `max-w-xl`
+ * (576 px) and draws it inside a window the owner can drag to 300 px, so a
+ * `sm:` breakpoint is answered "wide" on a desktop whose provider rows are
+ * 300 px across — the reported clipping, at a width no phone is involved in.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, screen, within } from "@/tests/helpers/test-utils";
@@ -40,15 +45,19 @@ function stubFetch() {
     if (url.startsWith("/setup-api/providers/status")) {
       return json({ harness: "openclaw", providers: ROWS, defaultProvider: "openai", degraded: false });
     }
-    return json({});
+    // Loud, like the sibling suite: a call this fixture does not know about is
+    // a change in what the component reads, not something to answer `{}` to.
+    return new Response(JSON.stringify({ error: "unexpected" }), {
+      status: 404, headers: { "content-type": "application/json" },
+    });
   }));
 }
 
 /**
  * True when this element clips its text at EVERY width. Tailwind's `truncate`
- * is `overflow-hidden text-ellipsis whitespace-nowrap`; prefixed with a
- * breakpoint (`sm:truncate`) it only applies from that width up, which is what
- * lets the name wrap on a phone and stay on one line on a desktop.
+ * is `overflow-hidden text-ellipsis whitespace-nowrap`; behind a container
+ * query (`@md:truncate`) it applies only where the pane is wide enough, which
+ * is what lets the name wrap in a narrow one and stay on a line in a wide one.
  */
 function clipsAtEveryWidth(el: HTMLElement): boolean {
   return el.className.split(/\s+/).includes("truncate");
@@ -56,6 +65,23 @@ function clipsAtEveryWidth(el: HTMLElement): boolean {
 
 function hasClass(el: HTMLElement, cls: string): boolean {
   return el.className.split(/\s+/).includes(cls);
+}
+
+/**
+ * Every responsive class on this element, and whether it asks the CONTAINER
+ * (`@md:`) or the VIEWPORT (`sm:`). A viewport query here is the bug: the pane
+ * is narrower than `sm` on every desktop.
+ */
+function viewportQueries(el: HTMLElement): string[] {
+  return el.className.split(/\s+/).filter((c) => /^(sm|md|lg|xl|2xl):/.test(c));
+}
+
+/** The nearest ancestor that declares itself a query container. */
+function containerAncestor(el: HTMLElement): HTMLElement | null {
+  for (let node = el.parentElement; node; node = node.parentElement) {
+    if (hasClass(node, "@container")) return node;
+  }
+  return null;
 }
 
 afterEach(() => {
@@ -75,18 +101,25 @@ describe("provider rows at phone widths", () => {
       expect(name, `${row.label} has no name element of its own`).not.toBeNull();
       expect(name!).toHaveTextContent(row.label);
       expect(clipsAtEveryWidth(name!), `${row.label} is clipped at every width`).toBe(false);
-      // Still one line where there is room for one.
-      expect(hasClass(name!, "sm:truncate"), `${row.label} should still truncate from sm: up`).toBe(true);
+      // An unbroken label must still be legible rather than hard-clipped by
+      // the row's `min-w-0`: on Hermes the label is dashboard data.
+      expect(hasClass(name!, "break-words"), `${row.label} must be allowed to break`).toBe(true);
+      // Still one line where the PANE has room for one.
+      expect(hasClass(name!, "@md:truncate"), `${row.label} should truncate in a wide pane`).toBe(true);
+      expect(viewportQueries(name!), `${row.label} must not ask the viewport`).toEqual([]);
+      expect(containerAncestor(name!), `${row.label} has no query container`).not.toBeNull();
     }
   });
 
-  it("stacks the row's controls under the name below sm:", async () => {
+  it("stacks the row's controls under the name in a narrow pane", async () => {
     stubFetch();
     render(<I18nProvider><AiProviderList /></I18nProvider>);
 
     const li = await screen.findByTestId("ai-provider-anthropic");
-    expect(hasClass(li, "flex-col"), "the row stacks on a phone").toBe(true);
-    expect(hasClass(li, "sm:flex-row"), "and is one line from sm: up").toBe(true);
+    expect(hasClass(li, "flex-col"), "the row stacks in a narrow pane").toBe(true);
+    expect(hasClass(li, "@md:flex-row"), "and is one line in a wide one").toBe(true);
+    expect(viewportQueries(li), "the row must not ask the viewport").toEqual([]);
+    expect(containerAncestor(li), "the row has no query container").not.toBeNull();
     // The switch and Make-default travel together, off the name's line.
     const controls = await screen.findByTestId("ai-provider-controls-anthropic");
     expect(controls).toContainElement(screen.getByTestId("ai-provider-switch-anthropic"));
@@ -102,12 +135,15 @@ describe("provider rows at phone widths", () => {
     );
 
     const hero = screen.getByTestId("provider-default-hero");
-    expect(hasClass(hero, "flex-col"), "the hero stacks on a phone").toBe(true);
-    expect(hasClass(hero, "sm:flex-row"), "and is one line from sm: up").toBe(true);
+    expect(hasClass(hero, "flex-col"), "the hero stacks in a narrow pane").toBe(true);
+    expect(hasClass(hero, "@md:flex-row"), "and is one line in a wide one").toBe(true);
+    expect(viewportQueries(hero), "the hero must not ask the viewport").toEqual([]);
+    expect(containerAncestor(hero), "the hero declares no query container").not.toBeNull();
 
     const name = screen.getByTestId("provider-default-hero-name");
     expect(name).toHaveTextContent("Anthropic Claude");
     expect(clipsAtEveryWidth(name), "the vendor name is clipped at every width").toBe(false);
+    expect(hasClass(name, "break-words"), "the vendor name must be allowed to break").toBe(true);
 
     const model = screen.getByTestId("provider-default-hero-model");
     expect(model).toHaveTextContent("claude-opus-5-20260401");

--- a/src/tests/components/provider-rows-narrow.test.tsx
+++ b/src/tests/components/provider-rows-narrow.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * The Providers panel at a phone width.
+ *
+ * Measured with a Playwright screenshot at 390x844 (TASK-632/F-30): the rows
+ * read "OpenAI G…", "Anthropic Cla…", "OpenRou…", and the hero card that exists
+ * to answer "which brain is my box using?" showed a clipped vendor name over
+ * half a model id. There is no horizontal overflow and no console error — the
+ * name is simply the only thing in the row that can give, so it gives, while
+ * the icon, the Default pill, the Make-default button and the 44 px switch all
+ * keep their width.
+ *
+ * jsdom does no layout, so these are assertions about the CLASS CONTRACT that
+ * produces the clipping rather than about measured pixels: below `sm:` the name
+ * must not be `truncate`d, and the controls must not share the line with it.
+ * That is the half a unit test can hold; the pixels are the screenshot on the
+ * card.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@/tests/helpers/test-utils";
+import { I18nProvider } from "@/lib/i18n";
+import AiProviderList from "@/components/AiProviderList";
+import ProviderDefaultHero from "@/components/ProviderDefaultHero";
+import type { ProviderStatusRow } from "@/lib/provider-status";
+
+vi.mock("@/components/AIProviderIcon", () => ({ default: () => <span data-testid="icon" /> }));
+
+/** The three labels the screenshot caught mid-word. */
+const ROWS = [
+  { id: "openai", label: "OpenAI GPT", state: "connected", isDefault: true, section: "ai", enabled: true },
+  { id: "anthropic", label: "Anthropic Claude", state: "connected", isDefault: false, section: "ai", enabled: true },
+  { id: "openrouter", label: "OpenRouter", state: "connected", isDefault: false, section: "ai", enabled: true },
+];
+
+function stubFetch() {
+  vi.stubGlobal("fetch", vi.fn(async (input: string | URL) => {
+    const url = input.toString();
+    const json = (body: unknown) =>
+      new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
+    if (url.startsWith("/setup-api/preferences")) return json({});
+    if (url.startsWith("/setup-api/providers/status")) {
+      return json({ harness: "openclaw", providers: ROWS, defaultProvider: "openai", degraded: false });
+    }
+    return json({});
+  }));
+}
+
+/**
+ * True when this element clips its text at EVERY width. Tailwind's `truncate`
+ * is `overflow-hidden text-ellipsis whitespace-nowrap`; prefixed with a
+ * breakpoint (`sm:truncate`) it only applies from that width up, which is what
+ * lets the name wrap on a phone and stay on one line on a desktop.
+ */
+function clipsAtEveryWidth(el: HTMLElement): boolean {
+  return el.className.split(/\s+/).includes("truncate");
+}
+
+function hasClass(el: HTMLElement, cls: string): boolean {
+  return el.className.split(/\s+/).includes(cls);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("provider rows at phone widths", () => {
+  it("does not clip the provider name in the list", async () => {
+    stubFetch();
+    render(<I18nProvider><AiProviderList /></I18nProvider>);
+
+    for (const row of ROWS) {
+      // Found through the row rather than waited for on its own, so a build
+      // without the hook fails on the assertion instead of on a timeout.
+      const li = await screen.findByTestId(`ai-provider-${row.id}`);
+      const name = within(li).queryByTestId(`ai-provider-name-${row.id}`);
+      expect(name, `${row.label} has no name element of its own`).not.toBeNull();
+      expect(name!).toHaveTextContent(row.label);
+      expect(clipsAtEveryWidth(name!), `${row.label} is clipped at every width`).toBe(false);
+      // Still one line where there is room for one.
+      expect(hasClass(name!, "sm:truncate"), `${row.label} should still truncate from sm: up`).toBe(true);
+    }
+  });
+
+  it("stacks the row's controls under the name below sm:", async () => {
+    stubFetch();
+    render(<I18nProvider><AiProviderList /></I18nProvider>);
+
+    const li = await screen.findByTestId("ai-provider-anthropic");
+    expect(hasClass(li, "flex-col"), "the row stacks on a phone").toBe(true);
+    expect(hasClass(li, "sm:flex-row"), "and is one line from sm: up").toBe(true);
+    // The switch and Make-default travel together, off the name's line.
+    const controls = await screen.findByTestId("ai-provider-controls-anthropic");
+    expect(controls).toContainElement(screen.getByTestId("ai-provider-switch-anthropic"));
+    expect(controls).toContainElement(screen.getByTestId("ai-provider-make-default-anthropic"));
+  });
+
+  it("does not clip the vendor or the model on the hero card", () => {
+    const row = { id: "anthropic", label: "Anthropic Claude", state: "connected", isDefault: true, section: "ai", enabled: true } as unknown as ProviderStatusRow;
+    render(
+      <I18nProvider>
+        <ProviderDefaultHero row={row} model="claude-opus-5-20260401" onChangeModel={() => {}} />
+      </I18nProvider>,
+    );
+
+    const hero = screen.getByTestId("provider-default-hero");
+    expect(hasClass(hero, "flex-col"), "the hero stacks on a phone").toBe(true);
+    expect(hasClass(hero, "sm:flex-row"), "and is one line from sm: up").toBe(true);
+
+    const name = screen.getByTestId("provider-default-hero-name");
+    expect(name).toHaveTextContent("Anthropic Claude");
+    expect(clipsAtEveryWidth(name), "the vendor name is clipped at every width").toBe(false);
+
+    const model = screen.getByTestId("provider-default-hero-model");
+    expect(model).toHaveTextContent("claude-opus-5-20260401");
+    expect(clipsAtEveryWidth(model), "the model id is clipped at every width").toBe(false);
+    // A model id is one long hyphenated token: without the ellipsis it has to
+    // be allowed to break, or it pushes the card wider than the phone.
+    expect(hasClass(model, "break-words"), "the model id must be allowed to wrap").toBe(true);
+  });
+});


### PR DESCRIPTION
**TASK-632 (F-30)** — the Providers rows truncate to "OpenAI G…", "Anthropic Cla…", "OpenRou…" and the active card is unreadable.

### Customer-visible symptom
Measured with a Playwright screenshot at 390×844: the provider rows read "OpenAI G…", "Anthropic Cla…", "OpenRou…", and the hero card — the one thing on the page that answers "which brain is my box using?" — shows a clipped vendor name over half a model id. No horizontal overflow, no console error: the name is simply the only thing in the row that can give, while the icon, the Default pill, the Make-default button and the 44 px switch all keep their width.

### Cause
`src/components/AiProviderList.tsx` and `src/components/ProviderDefaultHero.tsx` both laid the row out as one flex line with `truncate` on the name (and on the hero's model id), and every control `shrink-0`.

### Harness first
Nothing here belongs to OpenClaw or Hermes — the harness is Tailwind, and the native mechanism the fix uses is **container queries** (`@container` + `@md:`), which this repo already uses for exactly this question: `CodingAgentApp.tsx:1195` carries the comment "`@container` so the panel sizes to its WINDOW, not the viewport", and `HermesSkillsStore` / `SkillDetail` do the same.

That is also the correction the review forced. The first cut used `sm:`, a **viewport** query — and the width that matters here is the pane's: Settings caps it at `max-w-xl` (576 px, always under the 640 px `sm` breakpoint) and draws it inside a `ChromeWindow` the owner can drag down to `MIN_WIDTH = 300`. So a `sm:` fix engaged only on a phone and left the reported clipping alive on a desktop at the default window size. The test now pins that no responsive class on these rows asks the viewport.

### The change
- `@container` on the provider list's `<ul>` and around the hero card (a wrapper, because an element cannot query the container it declares). `@md` is 28 rem: below it the icon, the name, the Default pill, the Make-default button and the switch cannot share a line without the name giving way.
- Below that width the row and the card **stack** — controls under the name — and the name **wraps** instead of being clipped. From `@md` up both keep exactly the single line and the ellipsis they had (`@md:truncate`, `@md:flex-nowrap`, `@md:self-auto`).
- `break-words` on both names and on the model id. Removing an ellipsis without it would be a downgrade on Hermes, where the label is whatever the dashboard reports: an unbroken string is hard-clipped by the row's `min-w-0` with nothing to say so.
- One more site in the same shape, found by the review: the setup wizard's collapsed model-picker button (`AIModelsStep.tsx`) clipped the model id beside a "Change" link that never shrinks. The model id is the one thing a customer opens that button to read, so it wraps now. The progress row's provider name at `AIModelsStep.tsx:266` is deliberately left alone — that row is a fixed 280 px by design.

### RED → GREEN

RED on unmodified `origin/beta` (a0a6b408):

```
 × does not clip the provider name in the list
 × stacks the row's controls under the name in a narrow pane
 × does not clip the vendor or the model on the hero card
AssertionError: OpenAI GPT has no name element of its own: expected null not to be null
AssertionError: the row stacks in a narrow pane: expected false to be true
AssertionError: the hero stacks in a narrow pane: expected false to be true
```

GREEN, with the neighbours:

```
$ npx vitest run --project components ai-provider-list ai-providers-section \
    hermes-provider-config openclaw-provider-panel provider-events \
    hermes-provider-invalidation ai-models-step header-dropdown-listbox \
    settings-app provider-rows-narrow
 Test Files  10 passed (10)
      Tests  122 passed (122)
```

`build-typecheck` green; eslint clean on all four changed files.

### What is proven and what is not
jsdom does no layout, so the new test asserts the **class contract** that produces the clipping — the name is not `truncate`d in a narrow pane, the controls do not share its line, and every responsive class here is a container query. Twenty-one existing component tests in this repo assert classes the same way.

The **pixels** are the card's own 390×844 screenshot. The 300–576 px desktop pane widths — the case the review found and this PR now covers — have not been measured on hardware: the e2e harness needs a full production build plus a Chromium download, and the working rules keep builds off the dev PC. That gap is the honest one to state; the phone case the card measured is unchanged by it.

### Siblings handled
`truncate` in the provider surfaces existed at exactly three places and all three are fixed: `AiProviderList` (the name), `ProviderDefaultHero` (name + model), and `AIModelsStep`'s model-picker button. `ProviderRadioRow` already wraps (`flex flex-wrap`, no truncate) and `ClawboxAiProviderRow` / `ProviderConnectionLabel` carry none. `AIModelsStep.tsx:266` is cleared with a reason above. The e2e specs assert hero TEXT (`toContainText`), not layout, so none needed changing.

### Both editions
`AiProviderList` and `ProviderDefaultHero` are the shared components: the fix reaches Settings → Providers on OpenClaw, `HermesProviderConfig` on Hermes, and the setup wizard's `AIModelsStep` on both, from one change each.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Provider names and model labels now wrap cleanly in narrow panels instead of being truncated.
  - Provider controls remain visible and grouped, stacking beneath provider details when space is limited.
  - The default provider section adapts between stacked and horizontal layouts based on available space.
  - The “Change” action remains visible and accessible across screen sizes.
  - Wider layouts retain a compact horizontal presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->