### PR TITLE
fix: say what was actually removed, and confirm a Hermes skill removal at all

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1060,8 +1060,9 @@ function ChromeDesktopInner() {
 
   // Same reason, for the same callback: it needs the removed app's meta to say
   // WHAT it removed, and taking `installedMeta` as a dependency would rebuild
-  // the callback on every install. The meta is read after the route confirms
-  // the removal, before the state that holds it is pruned below.
+  // the callback on every install. Captured before the request is issued, so
+  // neither the prune below nor a preferences reload in flight can take it
+  // away.
   const installedMetaRef = useRef<Record<string, InstalledMeta>>({});
   useEffect(() => {
     installedMetaRef.current = installedMeta;
@@ -1085,6 +1086,10 @@ function ChromeDesktopInner() {
     // is safe: a second uninstall of an app already gone answers `ok:true`.
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), 10_000);
+    // Read inside the try, said outside it: the route reports whether a store
+    // skill of the same id went with the tile, and the sentence that mentions
+    // it is dispatched after the state cleanup below.
+    let skillRemoved: boolean | null | undefined;
     try {
       const res = await fetch("/setup-api/apps/uninstall", {
         method: "POST",
@@ -1107,6 +1112,7 @@ function ChromeDesktopInner() {
       // desktop, so the cleanup below is right — but saying nothing would put
       // this route's own defect back in the one surface the owner watches.
       const removed = await res.json().catch(() => null);
+      skillRemoved = removed?.skillRemoved;
       if (removed?.skillHalfChecked === false) {
         window.dispatchEvent(new CustomEvent("clawbox:toast", {
           detail: {
@@ -1164,7 +1170,10 @@ function ChromeDesktopInner() {
     // live separate concept with its own store, so the old wording sent the
     // agent to check a list the app was never in. `installedAppRemovedDetail`
     // reads the meta captured above, which is still the pre-prune copy.
-    announceSkillChange(installedAppRemovedDetail(appId, removedMeta));
+    // `removed?.skillRemoved` is the route's own answer to "did a store skill
+    // of this id go too" — one id can be both, and a line that mentions only
+    // the tile hides a capability the owner has just lost.
+    announceSkillChange(installedAppRemovedDetail(appId, removedMeta, skillRemoved));
   }, []);
 
   // Get all apps including installed ones

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -41,6 +41,7 @@ import { cleanVersion } from "@/lib/version-utils";
 import { fetchHarness } from "@/lib/client-harness";
 import { samePairingToken } from "@/lib/telegram-pairing-token";
 import type { InstalledMeta } from "@/lib/store-categories";
+import { SKILL_CHANGE_EVENT, announceSkillChange, installedAppRemovedDetail } from "@/lib/skill-change-message";
 import { apps, type AppDef } from "@/lib/desktop-apps";
 import { hiddenAppIdsForHarness, isInstalledAppVisible } from "@/lib/desktop-app-editions";
 import {
@@ -615,14 +616,14 @@ function ChromeDesktopInner() {
   // the user can watch the agent's response.
   useEffect(() => {
     const handler = () => setChatOpen(true);
-    window.addEventListener('clawbox-skill-installed', handler);
+    window.addEventListener(SKILL_CHANGE_EVENT, handler);
     window.addEventListener(FIX_ERROR_EVENT, handler);
     window.addEventListener(CHAT_MESSAGE_EVENT, handler);
     // The Coding Agent's "Create app" button: the chat has to be open before
     // the card inside it can be seen.
     window.addEventListener(NEW_APP_EVENT, handler);
     return () => {
-      window.removeEventListener('clawbox-skill-installed', handler);
+      window.removeEventListener(SKILL_CHANGE_EVENT, handler);
       window.removeEventListener(FIX_ERROR_EVENT, handler);
       window.removeEventListener(CHAT_MESSAGE_EVENT, handler);
       window.removeEventListener(NEW_APP_EVENT, handler);
@@ -1057,9 +1058,19 @@ function ChromeDesktopInner() {
     uninstallConfirmRef.current = uninstallConfirm;
   }, [uninstallConfirm]);
 
+  // Same reason, for the same callback: it needs the removed app's meta to say
+  // WHAT it removed, and taking `installedMeta` as a dependency would rebuild
+  // the callback on every install. The meta is read after the route confirms
+  // the removal, before the state that holds it is pruned below.
+  const installedMetaRef = useRef<Record<string, InstalledMeta>>({});
+  useEffect(() => {
+    installedMetaRef.current = installedMeta;
+  }, [installedMeta]);
+
   const confirmUninstallApp = useCallback(async () => {
     const appId = uninstallConfirmRef.current;
     if (!appId) return;
+    const removedMeta = installedMetaRef.current[appId];
     // Remove skill files and reload gateway.
     //
     // The desktop only takes the app off itself once the route has said it
@@ -1147,8 +1158,13 @@ function ChromeDesktopInner() {
       return next;
     });
     setUninstallConfirm(null);
-    // Refresh agent session with updated skills
-    window.dispatchEvent(new CustomEvent('clawbox-skill-installed', { detail: { action: 'uninstall', id: appId } }));
+    // Tell the chat what was actually removed. A webapp is not a skill — on
+    // Hermes it is the ONLY installed app an owner can remove
+    // (`isInstalledAppVisible` hides every other kind there) and "skill" is a
+    // live separate concept with its own store, so the old wording sent the
+    // agent to check a list the app was never in. `installedAppRemovedDetail`
+    // reads the meta captured above, which is still the pre-prune copy.
+    announceSkillChange(installedAppRemovedDetail(appId, removedMeta));
   }, []);
 
   // Get all apps including installed ones

--- a/src/components/AppStore.tsx
+++ b/src/components/AppStore.tsx
@@ -6,6 +6,7 @@ import { useT } from "@/lib/i18n";
 import { CATEGORY_COLORS, DEFAULT_CATEGORY_COLOR } from "@/lib/store-categories";
 import { clawhubSkillUrl } from "@/lib/clawhub-url";
 import { categoryLabelFromKey } from "@/lib/hermes-skill-facets";
+import { announceSkillChange } from "@/lib/skill-change-message";
 
 const STORE_API = "/setup-api/apps/store";
 const STORE_ICONS_BASE = "https://clawbox.com/store/icons";
@@ -475,7 +476,9 @@ export default function AppStore({ installedAppIds, onInstall, onUninstall }: Ap
       setInstallProgress(prev => ({ ...prev, [app.id]: { appId: app.id, status: "success" } }));
       onInstall(app);
       // Notify chat to refresh agent skills
-      window.dispatchEvent(new CustomEvent('clawbox-skill-installed', { detail: { action: 'install', name: app.name, id: app.id } }));
+      // The store installs OpenClaw skills; it is registered on no other
+      // harness (`store` is OpenClaw-only), so the kind is not in doubt.
+      announceSkillChange({ action: 'install', name: app.name, id: app.id, kind: 'skill' });
       setTimeout(() => clearProgress(app.id), 2000);
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Network error";

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -36,7 +36,7 @@ import { installPendingRefresh } from '@/lib/email-pending-refresh'
 import { describeChatFailure, describeImageFailure } from '@/lib/chat-error-text'
 import { NEW_APP_EVENT, CHAT_MESSAGE_EVENT, FIX_ERROR_EVENT, VOICE_SETTINGS_CHANGED_EVENT, buildFixErrorPrompt, dispatchOpenApp, onProvidersChanged, type ChatMessageDetail, type FixErrorContext, dispatchOpenCodingRun } from '@/lib/ui-events'
 import { speechTextFor } from '@/lib/speech-text'
-import { SKILL_CHANGE_EVENT, buildSkillChangeMessage } from '@/lib/skill-change-message'
+import { SKILL_CHANGE_EVENT, buildSkillChangeMessage, type SkillChangeEvent } from '@/lib/skill-change-message'
 import { isSentinel, isInterSessionEnvelope } from '@/lib/chat-sentinels'
 import { useModalDialog } from '@/hooks/useModalDialog'
 // ── The harness transport ──
@@ -4723,7 +4723,11 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     // answer is the confirmation the overlay was standing in for, and it is a
     // truthful one — it comes from the session that now has the skill.
     const skillHandler = (e: Event) => {
-      const detail = ((e as CustomEvent).detail || {}) as { action?: string; name?: string; id?: string }
+      // The shared type, not a restatement of three of its fields: the local
+      // cast used to omit `kind`, which survived only because the object was
+      // handed on by reference — one destructure away from every webapp
+      // removal saying "skill" again with the whole suite green.
+      const detail = ((e as CustomEvent).detail || {}) as SkillChangeEvent
       // Goes out the same door a typed message does — queued behind a turn
       // that is still answering, sent through startRun otherwise, which owns
       // the disconnected queue, the Hermes branch and the run bookkeeping.

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -36,7 +36,7 @@ import { installPendingRefresh } from '@/lib/email-pending-refresh'
 import { describeChatFailure, describeImageFailure } from '@/lib/chat-error-text'
 import { NEW_APP_EVENT, CHAT_MESSAGE_EVENT, FIX_ERROR_EVENT, VOICE_SETTINGS_CHANGED_EVENT, buildFixErrorPrompt, dispatchOpenApp, onProvidersChanged, type ChatMessageDetail, type FixErrorContext, dispatchOpenCodingRun } from '@/lib/ui-events'
 import { speechTextFor } from '@/lib/speech-text'
-import { buildSkillChangeMessage } from '@/lib/skill-change-message'
+import { SKILL_CHANGE_EVENT, buildSkillChangeMessage } from '@/lib/skill-change-message'
 import { isSentinel, isInterSessionEnvelope } from '@/lib/chat-sentinels'
 import { useModalDialog } from '@/hooks/useModalDialog'
 // ── The harness transport ──
@@ -4753,10 +4753,10 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       retryCountRef.current = 0
       connect()
     }
-    window.addEventListener('clawbox-skill-installed', skillHandler)
+    window.addEventListener(SKILL_CHANGE_EVENT, skillHandler)
     window.addEventListener('clawbox:primary-ai-configured', providerHandler)
     return () => {
-      window.removeEventListener('clawbox-skill-installed', skillHandler)
+      window.removeEventListener(SKILL_CHANGE_EVENT, skillHandler)
       window.removeEventListener('clawbox:primary-ai-configured', providerHandler)
       if (reloadTimerRef.current) clearInterval(reloadTimerRef.current)
     }

--- a/src/components/HermesSkillsStore.tsx
+++ b/src/components/HermesSkillsStore.tsx
@@ -33,6 +33,7 @@ import {
   rankFacets,
 } from '@/lib/hermes-skill-facets';
 import { type SkillsCopy, useCopy } from './hermes-skills/copy';
+import { announceSkillChange } from '@/lib/skill-change-message';
 import {
   Alert,
   EmptyState,
@@ -409,6 +410,7 @@ export default function HermesSkillsStore({ testId }: { testId?: string }) {
         // it has to be told to run again.
         detail.refresh(key);
         setLive(COPY.liveInstalled(skill.name));
+        announceSkillChange({ action: 'install', name: skill.name, id: key, kind: 'skill' });
         await installed.refresh();
       } catch (err) {
         const outcome = outcomeOf(err);
@@ -467,6 +469,7 @@ export default function HermesSkillsStore({ testId }: { testId?: string }) {
         // whatever the button tracked progress under.
         detail.refresh(key, name, identifier);
         setLive(COPY.liveRemoved(name));
+        announceSkillChange({ action: 'uninstall', name, id: identifier ?? key, kind: 'skill' });
         await installed.refresh();
       } catch (err) {
         const outcome = outcomeOf(err);

--- a/src/components/HermesSkillsStore.tsx
+++ b/src/components/HermesSkillsStore.tsx
@@ -105,7 +105,19 @@ function outcomeOf(err: unknown): 'failed' | 'unknown' {
  * detail cache is keyed by registry identifier, so invalidating only the lock
  * name left a removed skill still reading as installed on its Browse card.
  */
-type UninstallTarget = { name: string; key: string; identifier?: string };
+type UninstallTarget = {
+  /** The lock key — `hermes skills uninstall`'s positional argument. */
+  name: string;
+  key: string;
+  identifier?: string;
+  /**
+   * What the owner READ on the card. A ClawHub row's display name ("QR Code
+   * Decode") is not its lock key ("qr-code-decode"), and the install path
+   * announces the display name — so without this the same skill appeared in
+   * the owner's own transcript under two different names.
+   */
+  label?: string;
+};
 
 /** The fields of an install/uninstall refusal the card reads. */
 type RefusalBody = {
@@ -313,7 +325,7 @@ export default function HermesSkillsStore({ testId }: { testId?: string }) {
       // rule is shared with the agent's skill_list/skill_uninstall so the page
       // and the assistant cannot answer one device state two ways.
       if (!match || !isRemovableOrigin(match.origin)) return null;
-      return { name: match.id, key: skill.id, identifier: match.identifier || skill.id };
+      return { name: match.id, key: skill.id, identifier: match.identifier || skill.id, label: match.name || match.id };
     },
     [installed.skills],
   );
@@ -431,7 +443,7 @@ export default function HermesSkillsStore({ testId }: { testId?: string }) {
   );
 
   const doUninstall = useCallback(
-    async ({ name, key, identifier }: UninstallTarget) => {
+    async ({ name, key, identifier, label }: UninstallTarget) => {
       setConfirmUninstall(null);
       setProgress((p) => ({ ...p, [key]: { status: 'working' } }));
       setLive(COPY.liveRemoving(name));
@@ -469,7 +481,10 @@ export default function HermesSkillsStore({ testId }: { testId?: string }) {
         // whatever the button tracked progress under.
         detail.refresh(key, name, identifier);
         setLive(COPY.liveRemoved(name));
-        announceSkillChange({ action: 'uninstall', name, id: identifier ?? key, kind: 'skill' });
+        // The display name in the sentence, the lock key beside it: the lock
+        // key is the string `skill_list` and `skill_uninstall` resolve, so it
+        // is what the agent can actually verify against.
+        announceSkillChange({ action: 'uninstall', name: label ?? name, id: name, kind: 'skill' });
         await installed.refresh();
       } catch (err) {
         const outcome = outcomeOf(err);
@@ -596,7 +611,7 @@ export default function HermesSkillsStore({ testId }: { testId?: string }) {
         <GhostButton
           tone="danger"
           onClick={() =>
-            setConfirmUninstall({ name: skill.id, key: skill.id, identifier: skill.identifier })
+            setConfirmUninstall({ name: skill.id, key: skill.id, identifier: skill.identifier, label: skill.name || skill.id })
           }
         >
           {COPY.remove}

--- a/src/components/InstalledAppSettings.tsx
+++ b/src/components/InstalledAppSettings.tsx
@@ -5,6 +5,7 @@ import type { StoreApp } from "./AppStore";
 import * as kv from "@/lib/client-kv";
 import { useT } from "@/lib/i18n";
 import { clawhubSkillUrl } from "@/lib/clawhub-url";
+import { announceSkillChange } from "@/lib/skill-change-message";
 
 interface AppSetting {
   key: string;
@@ -208,7 +209,9 @@ export default function InstalledAppSettings({ appId, storeApp, icon, onUninstal
       // No local record: skill-info reads the value back from openclaw.json,
       // which the write above just changed — a KV mirror only ever disagreed.
       setEnabled(newEnabled);
-      window.dispatchEvent(new CustomEvent('clawbox-skill-installed', { detail: { action: newEnabled ? 'enable' : 'disable', id: appId } }));
+      // `kind` left at its default: this toggle writes openclaw.json's skill
+      // enable flag, so it is only ever reached for a skill.
+      announceSkillChange({ action: newEnabled ? 'enable' : 'disable', id: appId });
     } catch (err) {
       console.warn("[settings] Failed to toggle skill:", err);
       setToggleError(true);

--- a/src/lib/skill-change-message.ts
+++ b/src/lib/skill-change-message.ts
@@ -29,10 +29,9 @@ export type SkillChangeKind = "skill" | "app";
 
 /**
  * The one name for the event. It says "skill-installed" and it is dispatched
- * for installs, removals, enables and disables of both skills and apps — kept
- * as it is because an older tab left open across an update still listens for
- * this string, and renaming it would drop the confirmation the desktop owes
- * the owner. The constant exists so the next sender cannot invent a variant.
+ * for installs, removals, enables and disables of both skills and apps. Kept as
+ * it is because renaming a string four senders and two listeners agree on buys
+ * nothing; the constant exists so the next sender cannot invent a variant.
  */
 export const SKILL_CHANGE_EVENT = "clawbox-skill-installed";
 
@@ -43,10 +42,19 @@ export type SkillChangeEvent = {
   /** Skill or app id — what the uninstall/enable/disable paths carry. */
   id?: string;
   /**
-   * Absent means "skill": that is what every sender meant before this field
-   * existed, and an older tab left open across an update still emits it.
+   * Absent means "skill". Not a compatibility story — every sender ships in the
+   * same bundle as the listener — but a sender that forgets it should get the
+   * historical wording rather than `undefined` in the owner's own bubble.
    */
   kind?: SkillChangeKind;
+  /**
+   * One id can be BOTH: `webapp_create` replaces `installed_meta[<id>]` for any
+   * id with no collision check, and the uninstall route then removes the webapp
+   * and the store skill of that name and reports which in `skillRemoved`. Only
+   * set where the route confirmed the skill half went too — the owner has just
+   * lost a capability, and a line that mentions only the tile does not say so.
+   */
+  alsoSkill?: boolean;
 };
 
 /**
@@ -61,17 +69,28 @@ export function installedAppKind(meta: { webappUrl?: unknown } | undefined | nul
   return meta?.webappUrl ? "app" : "skill";
 }
 
-/** The event detail the desktop emits when it removes an installed app. */
+/**
+ * The event detail the desktop emits when it removes an installed app.
+ *
+ * @param skillRemoved the route's own `skillRemoved` field: true where it
+ *        confirmed a store skill of the same id went as well, null where it
+ *        could not look.
+ */
 export function installedAppRemovedDetail(
   appId: string,
   meta: { name?: string; webappUrl?: unknown } | undefined | null,
+  skillRemoved?: boolean | null,
 ): SkillChangeEvent {
+  const kind = installedAppKind(meta);
   return {
     action: "uninstall",
     id: appId,
-    // The id is a slug; the owner clicked a tile with a name on it.
+    // The id is a slug; the owner clicked a tile with a name on it. Both
+    // travel: the name is what the owner recognises, the id is what
+    // `ui_list_apps` and `skill_uninstall` actually report.
     ...(meta?.name ? { name: meta.name } : {}),
-    kind: installedAppKind(meta),
+    kind,
+    ...(kind === "app" && skillRemoved === true ? { alsoSkill: true } : {}),
   };
 }
 
@@ -80,28 +99,38 @@ export function announceSkillChange(detail: SkillChangeEvent): void {
   window.dispatchEvent(new CustomEvent(SKILL_CHANGE_EVENT, { detail }));
 }
 
-const NOUN: Record<SkillChangeKind, string> = { skill: "skill", app: "app" };
-
 export function buildSkillChangeMessage(evt: SkillChangeEvent | null | undefined): string {
   const label = evt?.name || evt?.id;
-  const noun = NOUN[evt?.kind ?? "skill"];
+  // Not an index into a record: `kind` arrives from an untyped
+  // `CustomEvent.detail`, and every other unknown input to this function is
+  // already defended. A stray value must not put `undefined` in the bubble.
+  const noun = evt?.kind === "app" ? "app" : "skill";
+  // The name is what the OWNER recognises; the id is what the agent's lists
+  // report. `ui_list_apps` emits an installed app as `{ id: "installed-<id>",
+  // name: <id> }` — the display name is never in it — and `skill_list` leads
+  // with the lock id, so a sentence carrying only the name asks the agent to
+  // verify against a string neither list contains.
+  const qualifier = evt?.name && evt?.id && evt.name !== evt.id ? ` (id: ${evt.id})` : "";
   // No label means we cannot name the thing without inventing one, so ask the
   // open question instead of asserting something we do not know.
   if (!label) return "My skills were just updated. What skills do you have available now?";
   switch (evt?.action) {
     case "install":
-      return `I just installed the "${label}" ${noun}. Can you confirm you have it and briefly tell me what it does?`;
+      return noun === "app"
+        ? `I just installed the "${label}" app${qualifier} on the desktop. Can you confirm you can see it?`
+        : `I just installed the "${label}" skill${qualifier}. Can you confirm you have it and briefly tell me what it does?`;
     case "uninstall":
       // An app is gone from the DESKTOP, which is where the agent can check
       // for it (`ui_list_apps`) — asking it to confirm a skill is gone sends
       // it to a list the app was never in.
-      return evt.kind === "app"
-        ? `I just removed the "${label}" app from the desktop. Can you confirm it is gone?`
-        : `I just removed the "${label}" skill. Can you confirm it is gone?`;
+      if (noun !== "app") return `I just removed the "${label}" skill${qualifier}. Can you confirm it is gone?`;
+      return evt?.alsoSkill
+        ? `I just removed the "${label}" app${qualifier} from the desktop, and the skill of the same id went with it. Can you confirm both are gone?`
+        : `I just removed the "${label}" app${qualifier} from the desktop. Can you confirm it is gone?`;
     case "enable":
-      return `I just enabled the "${label}" ${noun}. Can you confirm you have it?`;
+      return `I just enabled the "${label}" ${noun}${qualifier}. Can you confirm you have it?`;
     case "disable":
-      return `I just disabled the "${label}" ${noun}. Can you confirm it is no longer active?`;
+      return `I just disabled the "${label}" ${noun}${qualifier}. Can you confirm it is no longer active?`;
     default:
       return "My skills were just updated. What skills do you have available now?";
   }

--- a/src/lib/skill-change-message.ts
+++ b/src/lib/skill-change-message.ts
@@ -1,5 +1,5 @@
 /**
- * The line the chat asks the agent after the owner changes a skill.
+ * The line the chat asks the agent after the owner changes a skill or an app.
  *
  * Installing, removing, enabling or disabling a skill does not restart
  * anything (see the note in `openclaw-config.ts`): OpenClaw watches its skill
@@ -11,28 +11,97 @@
  * flow worth pinning down in a test: the wording is what the owner reads, and
  * it must never again claim a session was refreshed when nothing was.
  */
+
+/**
+ * What was actually changed.
+ *
+ * TASK-544: every branch below said "skill", and the desktop's uninstall path
+ * sends this event for anything with a tile on it — including a **webapp**,
+ * which is not a skill on either harness. On Hermes that made it wrong every
+ * time: `isInstalledAppVisible` hides every non-webapp there, so a webapp is
+ * the only installed app an owner can remove, while "skill" is a live separate
+ * concept with its own store and its own `skill_uninstall`. The agent was
+ * asked to confirm a skill was gone, looked in the skill list, and answered
+ * about the wrong thing — or worse, about a real skill that happened to share
+ * the id.
+ */
+export type SkillChangeKind = "skill" | "app";
+
+/**
+ * The one name for the event. It says "skill-installed" and it is dispatched
+ * for installs, removals, enables and disables of both skills and apps — kept
+ * as it is because an older tab left open across an update still listens for
+ * this string, and renaming it would drop the confirmation the desktop owes
+ * the owner. The constant exists so the next sender cannot invent a variant.
+ */
+export const SKILL_CHANGE_EVENT = "clawbox-skill-installed";
+
 export type SkillChangeEvent = {
   action?: string;
-  /** Display name — present on install, which is the only case that has one. */
+  /** Display name — preferred over the id wherever the sender has one. */
   name?: string;
-  /** Skill id — what the uninstall/enable/disable paths carry. */
+  /** Skill or app id — what the uninstall/enable/disable paths carry. */
   id?: string;
+  /**
+   * Absent means "skill": that is what every sender meant before this field
+   * existed, and an older tab left open across an update still emits it.
+   */
+  kind?: SkillChangeKind;
 };
+
+/**
+ * Which of the two an installed desktop app is.
+ *
+ * The webapp URL is the whole rule, and it is the same on both harnesses: a
+ * webapp is a page the desktop frames, a skill is something the agent gained.
+ * Deriving it here rather than from the edition also fixes the OpenClaw box,
+ * where removing a `webapp_create` tile claimed a skill had been removed too.
+ */
+export function installedAppKind(meta: { webappUrl?: unknown } | undefined | null): SkillChangeKind {
+  return meta?.webappUrl ? "app" : "skill";
+}
+
+/** The event detail the desktop emits when it removes an installed app. */
+export function installedAppRemovedDetail(
+  appId: string,
+  meta: { name?: string; webappUrl?: unknown } | undefined | null,
+): SkillChangeEvent {
+  return {
+    action: "uninstall",
+    id: appId,
+    // The id is a slug; the owner clicked a tile with a name on it.
+    ...(meta?.name ? { name: meta.name } : {}),
+    kind: installedAppKind(meta),
+  };
+}
+
+/** Tell the chat what just changed. Browser only — it is a window event. */
+export function announceSkillChange(detail: SkillChangeEvent): void {
+  window.dispatchEvent(new CustomEvent(SKILL_CHANGE_EVENT, { detail }));
+}
+
+const NOUN: Record<SkillChangeKind, string> = { skill: "skill", app: "app" };
 
 export function buildSkillChangeMessage(evt: SkillChangeEvent | null | undefined): string {
   const label = evt?.name || evt?.id;
-  // No label means we cannot name the skill without inventing one, so ask the
+  const noun = NOUN[evt?.kind ?? "skill"];
+  // No label means we cannot name the thing without inventing one, so ask the
   // open question instead of asserting something we do not know.
   if (!label) return "My skills were just updated. What skills do you have available now?";
   switch (evt?.action) {
     case "install":
-      return `I just installed the "${label}" skill. Can you confirm you have it and briefly tell me what it does?`;
+      return `I just installed the "${label}" ${noun}. Can you confirm you have it and briefly tell me what it does?`;
     case "uninstall":
-      return `I just removed the "${label}" skill. Can you confirm it is gone?`;
+      // An app is gone from the DESKTOP, which is where the agent can check
+      // for it (`ui_list_apps`) — asking it to confirm a skill is gone sends
+      // it to a list the app was never in.
+      return evt.kind === "app"
+        ? `I just removed the "${label}" app from the desktop. Can you confirm it is gone?`
+        : `I just removed the "${label}" skill. Can you confirm it is gone?`;
     case "enable":
-      return `I just enabled the "${label}" skill. Can you confirm you have it?`;
+      return `I just enabled the "${label}" ${noun}. Can you confirm you have it?`;
     case "disable":
-      return `I just disabled the "${label}" skill. Can you confirm it is no longer active?`;
+      return `I just disabled the "${label}" ${noun}. Can you confirm it is no longer active?`;
     default:
       return "My skills were just updated. What skills do you have available now?";
   }

--- a/src/tests/components/chat-skill-install-no-freeze.test.tsx
+++ b/src/tests/components/chat-skill-install-no-freeze.test.tsx
@@ -221,3 +221,56 @@ describe("a skill change does not freeze the chat", () => {
     expect(screen.queryByText(SEED_TEXT)).not.toBeNull();
   });
 });
+
+/**
+ * TASK-544. What the chat SENDS is the only thing the owner and the agent see,
+ * and it is the one hop `kind` has to survive: the unit suite calls
+ * `buildSkillChangeMessage` directly and the Hermes store suite inspects the
+ * dispatched event, so a `kind` dropped in this handler's cast would revert the
+ * whole card with both of them green.
+ */
+describe("what the chat sends carries the kind the sender set", () => {
+  beforeEach(() => {
+    history = [assistantMessage(SEED_TEXT, 500)];
+    sent.length = 0;
+    sockets.length = 0;
+    resetHarnessCache();
+    window.localStorage.clear();
+    Element.prototype.scrollIntoView = vi.fn();
+    vi.stubGlobal("WebSocket", FakeGatewayWs as unknown as typeof WebSocket);
+    installFetch();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    resetHarnessCache();
+  });
+
+  it("calls a removed webapp an app, all the way to the wire", async () => {
+    await mountReady();
+    const before = sendFrames().length;
+
+    await fireSkillEvent({ action: "uninstall", name: "Pomodoro", id: "pomodoro-timer", kind: "app" });
+
+    await waitFor(() => expect(sendFrames().length).toBe(before + 1));
+    const message = String((sendFrames()[before].params as Record<string, unknown>).message);
+    expect(message).toMatch(/"Pomodoro" app .* from the desktop/);
+    // And the id the agent can actually look up: `ui_list_apps` reports
+    // installed apps by id, never by display name.
+    expect(message).toContain("pomodoro-timer");
+    expect(message).not.toMatch(/skill/);
+  });
+
+  it("still calls a removed skill a skill", async () => {
+    await mountReady();
+    const before = sendFrames().length;
+
+    await fireSkillEvent({ action: "uninstall", name: "PDF Tools", id: "pdf-tools", kind: "skill" });
+
+    await waitFor(() => expect(sendFrames().length).toBe(before + 1));
+    const message = String((sendFrames()[before].params as Record<string, unknown>).message);
+    expect(message).toMatch(/"PDF Tools" skill/);
+    expect(message).not.toMatch(/\bapp\b/);
+  });
+});

--- a/src/tests/components/hermes-skills-chat-confirmation.test.tsx
+++ b/src/tests/components/hermes-skills-chat-confirmation.test.tsx
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor, within } from "@/tests/helpers/test-utils";
+import HermesSkillsStore from "@/components/HermesSkillsStore";
+import { SKILL_CHANGE_EVENT, buildSkillChangeMessage, type SkillChangeEvent } from "@/lib/skill-change-message";
+
+/**
+ * TASK-544, the inverted half.
+ *
+ * The desktop's confirmation flow — dispatch `clawbox-skill-installed`, the
+ * chat opens and asks the agent to confirm the change — was wired to the
+ * OpenClaw App Store and to the desktop's uninstall. The Hermes skills store,
+ * the ONE surface on that edition where a real skill is installed or removed,
+ * dispatched nothing: the owner removed a skill and the agent was never told,
+ * while removing a WEBAPP announced that a skill had gone.
+ */
+
+vi.mock("@/lib/i18n", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/i18n")>();
+  const { skillsEn } = await import("@/lib/hermes-translations/en-skills");
+  return {
+    ...actual,
+    useT: () => ({
+      locale: "en" as const,
+      localeResolved: true,
+      setLocale: () => {},
+      t: (key: string, params?: Record<string, string | number>) =>
+        Object.entries(params ?? {}).reduce(
+          (out, [name, value]) => out.replaceAll(`{${name}}`, String(value)),
+          skillsEn[key] ?? key,
+        ),
+    }),
+  };
+});
+
+const SKILL = { id: "official/pdf-tools", name: "PDF Tools", source: "official", trust: "official" };
+
+const BROWSE = {
+  skills: [SKILL],
+  page: 1,
+  pageSize: 24,
+  total: 1,
+  totalPages: 1,
+  hasMore: false,
+  facets: { sources: [{ id: "official", label: "Official", count: 1 }], providers: [] },
+  catalog: { origin: "index", skillCount: 90_600, fetchedAt: new Date().toISOString(), stale: false },
+  degraded: false,
+};
+
+const HUB_ROW = {
+  id: "pdf-tools",
+  name: "PDF Tools",
+  category: "other",
+  origin: "hub",
+  source: "official",
+  identifier: "official/pdf-tools",
+  enabled: true,
+};
+
+const INSTALLED = { skills: [HUB_ROW], counts: { total: 1 }, categories: [] };
+const EMPTY = { skills: [], counts: { total: 0 }, categories: [] };
+
+/** Every skill-change event the store fires, in order. */
+function captureChanges(): SkillChangeEvent[] {
+  const seen: SkillChangeEvent[] = [];
+  window.addEventListener(SKILL_CHANGE_EVENT, ((e: Event) => {
+    seen.push((e as CustomEvent<SkillChangeEvent>).detail);
+  }) as EventListener);
+  return seen;
+}
+
+function mockStore(installedPages: unknown[]) {
+  let calls = 0;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: unknown) => {
+      const url = String(input);
+      if (url.includes("/skills/browse")) return { ok: true, status: 200, json: async () => BROWSE };
+      // `/skills/installed` is a prefix match for `/skills/install`.
+      if (url.includes("/skills/installed")) {
+        const body = installedPages[Math.min(calls, installedPages.length - 1)];
+        calls += 1;
+        return { ok: true, status: 200, json: async () => body };
+      }
+      if (url.includes("/skills/install") || url.includes("/skills/uninstall")) {
+        return { ok: true, status: 200, json: async () => ({ ok: true }) };
+      }
+      return { ok: true, status: 200, json: async () => ({}) };
+    }),
+  );
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("removing a real Hermes skill tells the agent about it", () => {
+  it("announces the removal, as a skill, with the name the owner saw", async () => {
+    mockStore([INSTALLED, EMPTY]);
+    const changes = captureChanges();
+
+    render(<HermesSkillsStore />);
+    const remove = await screen.findByRole("button", { name: /remove/i });
+    await act(async () => {
+      fireEvent.click(remove);
+    });
+    const dialog = await screen.findByRole("dialog");
+    await act(async () => {
+      fireEvent.click(within(dialog).getByRole("button", { name: /remove/i }));
+    });
+
+    await waitFor(() => expect(changes).toHaveLength(1));
+    expect(changes[0]).toMatchObject({ action: "uninstall", kind: "skill", name: "pdf-tools" });
+    // And the line the owner's bubble carries says skill, not app.
+    expect(buildSkillChangeMessage(changes[0])).toMatch(/skill/);
+  });
+});
+
+describe("installing a Hermes skill tells the agent about it", () => {
+  it("announces the install, as a skill", async () => {
+    mockStore([EMPTY, INSTALLED]);
+    const changes = captureChanges();
+
+    render(<HermesSkillsStore />);
+    await act(async () => {
+      fireEvent.click(await screen.findByTestId("skill-tab-browse"));
+    });
+    await screen.findByText("PDF Tools");
+    const card = await screen.findByTestId("skill-install-btn");
+    await act(async () => {
+      fireEvent.click(within(card).getByRole("button"));
+    });
+    const dialog = await screen.findByRole("dialog");
+    await act(async () => {
+      fireEvent.click(within(dialog).getByRole("button", { name: "Install" }));
+    });
+
+    await waitFor(() => expect(changes).toHaveLength(1));
+    expect(changes[0]).toMatchObject({ action: "install", kind: "skill", name: "PDF Tools" });
+  });
+});

--- a/src/tests/components/hermes-skills-chat-confirmation.test.tsx
+++ b/src/tests/components/hermes-skills-chat-confirmation.test.tsx
@@ -59,16 +59,20 @@ const HUB_ROW = {
 const INSTALLED = { skills: [HUB_ROW], counts: { total: 1 }, categories: [] };
 const EMPTY = { skills: [], counts: { total: 0 }, categories: [] };
 
-/** Every skill-change event the store fires, in order. */
+/** Every skill-change event the store fires, in order. Removed after each test. */
+const listeners: EventListener[] = [];
 function captureChanges(): SkillChangeEvent[] {
   const seen: SkillChangeEvent[] = [];
-  window.addEventListener(SKILL_CHANGE_EVENT, ((e: Event) => {
+  const listener = ((e: Event) => {
     seen.push((e as CustomEvent<SkillChangeEvent>).detail);
-  }) as EventListener);
+  }) as EventListener;
+  window.addEventListener(SKILL_CHANGE_EVENT, listener);
+  listeners.push(listener);
   return seen;
 }
 
-function mockStore(installedPages: unknown[]) {
+/** @param action what the install/uninstall route answers. */
+function mockStore(installedPages: unknown[], action: () => unknown = () => ({ ok: true, status: 200, json: async () => ({ ok: true }) })) {
   let calls = 0;
   vi.stubGlobal(
     "fetch",
@@ -81,12 +85,22 @@ function mockStore(installedPages: unknown[]) {
         calls += 1;
         return { ok: true, status: 200, json: async () => body };
       }
-      if (url.includes("/skills/install") || url.includes("/skills/uninstall")) {
-        return { ok: true, status: 200, json: async () => ({ ok: true }) };
-      }
+      if (url.includes("/skills/install") || url.includes("/skills/uninstall")) return action();
       return { ok: true, status: 200, json: async () => ({}) };
     }),
   );
+}
+
+async function removeFromInstalledTab() {
+  render(<HermesSkillsStore />);
+  const remove = await screen.findByRole("button", { name: /remove/i });
+  await act(async () => {
+    fireEvent.click(remove);
+  });
+  const dialog = await screen.findByRole("dialog");
+  await act(async () => {
+    fireEvent.click(within(dialog).getByRole("button", { name: /remove/i }));
+  });
 }
 
 beforeEach(() => {
@@ -96,6 +110,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
+  for (const listener of listeners.splice(0)) window.removeEventListener(SKILL_CHANGE_EVENT, listener);
 });
 
 describe("removing a real Hermes skill tells the agent about it", () => {
@@ -103,20 +118,56 @@ describe("removing a real Hermes skill tells the agent about it", () => {
     mockStore([INSTALLED, EMPTY]);
     const changes = captureChanges();
 
-    render(<HermesSkillsStore />);
-    const remove = await screen.findByRole("button", { name: /remove/i });
-    await act(async () => {
-      fireEvent.click(remove);
-    });
-    const dialog = await screen.findByRole("dialog");
-    await act(async () => {
-      fireEvent.click(within(dialog).getByRole("button", { name: /remove/i }));
-    });
+    await removeFromInstalledTab();
 
     await waitFor(() => expect(changes).toHaveLength(1));
-    expect(changes[0]).toMatchObject({ action: "uninstall", kind: "skill", name: "pdf-tools" });
-    // And the line the owner's bubble carries says skill, not app.
-    expect(buildSkillChangeMessage(changes[0])).toMatch(/skill/);
+    // The DISPLAY name the card showed, with the lock key beside it — the
+    // install path announces the display name, and the same skill under two
+    // names in one transcript is the defect this card is about, one surface up.
+    expect(changes[0]).toMatchObject({ action: "uninstall", kind: "skill", name: "PDF Tools", id: "pdf-tools" });
+    const line = buildSkillChangeMessage(changes[0]);
+    expect(line).toMatch(/skill/);
+    expect(line).toContain('"PDF Tools"');
+    // `skill_list` and `skill_uninstall` resolve the lock key, so that is what
+    // the agent needs to check against.
+    expect(line).toContain("pdf-tools");
+  });
+});
+
+describe("an outcome the store does not call a success announces nothing", () => {
+  const REFUSALS: [string, () => unknown][] = [
+    [
+      "a leftover the device could not undo (409)",
+      () => ({
+        ok: false,
+        status: 409,
+        json: async () => ({ error: "x", code: "removal_incomplete", name: "pdf-tools", leftover: { lockEntry: false, directory: "present" } }),
+      }),
+    ],
+    [
+      "an unproven removal (502)",
+      () => ({ ok: false, status: 502, json: async () => ({ error: "x", code: "uninstall_unproven", name: "pdf-tools" }) }),
+    ],
+    [
+      "a device that timed out (502)",
+      () => ({ ok: false, status: 502, json: async () => ({ error: "x", code: "cli_timeout" }) }),
+    ],
+  ];
+
+  it.each(REFUSALS)("stays silent on %s", async (_label, action) => {
+    // This store's whole design is that an unknown outcome is not a success.
+    // The guard that matters is against a later edit moving the announcement
+    // into the catch, or above the `!res.ok` throw.
+    mockStore([INSTALLED, INSTALLED], action);
+    const changes = captureChanges();
+
+    await removeFromInstalledTab();
+    // Let the failure path finish before asserting nothing happened.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(changes).toEqual([]);
   });
 });
 

--- a/src/tests/unit/skill-change-message.test.ts
+++ b/src/tests/unit/skill-change-message.test.ts
@@ -85,6 +85,50 @@ describe("buildSkillChangeMessage — what was removed decides what it is called
     expect(msg).toMatch(/desktop/i);
   });
 
+  it("carries the id the agent's own lists report, beside the name the owner read", () => {
+    // `ui_list_apps` emits an installed app as `{ id: "installed-<id>", name:
+    // <id> }` and `skill_list` leads with the lock id — the display name is in
+    // neither, so a sentence carrying only the name asks the agent to verify
+    // against a string it can never find, and "confirmed, it's gone" is a guess.
+    const app = buildSkillChangeMessage({ action: "uninstall", name: "Pomodoro", id: "pomodoro-timer", kind: "app" });
+    expect(app).toContain('"Pomodoro"');
+    expect(app).toContain("pomodoro-timer");
+
+    const skill = buildSkillChangeMessage({ action: "uninstall", name: "QR Code Decode", id: "qr-code-decode", kind: "skill" });
+    expect(skill).toContain('"QR Code Decode"');
+    expect(skill).toContain("qr-code-decode");
+  });
+
+  it("does not repeat the id when it is the name", () => {
+    const msg = buildSkillChangeMessage({ action: "uninstall", name: "pdf-tools", id: "pdf-tools", kind: "skill" });
+
+    expect(msg).toBe('I just removed the "pdf-tools" skill. Can you confirm it is gone?');
+  });
+
+  it("says the skill went too when one id was both", () => {
+    // `webapp_create` replaces `installed_meta[<id>]` for any id with no
+    // collision check, and the uninstall route removes BOTH halves. A line
+    // that mentions only the tile hides a capability the owner just lost.
+    const msg = buildSkillChangeMessage({
+      action: "uninstall",
+      name: "Notes",
+      id: "notes",
+      kind: "app",
+      alsoSkill: true,
+    });
+
+    expect(msg).toMatch(/skill/);
+    expect(msg).toMatch(/both are gone/i);
+  });
+
+  it("puts no undefined in the owner's bubble for a kind it does not know", () => {
+    // `kind` arrives from an untyped CustomEvent.detail.
+    const msg = buildSkillChangeMessage({ action: "install", name: "X", kind: "webapp" as never });
+
+    expect(msg).not.toMatch(/undefined/);
+    expect(msg).toContain("skill");
+  });
+
   it("still calls a removed skill a skill", () => {
     const msg = buildSkillChangeMessage({ action: "uninstall", name: "PDF Tools", kind: "skill" });
 
@@ -98,6 +142,10 @@ describe("buildSkillChangeMessage — what was removed decides what it is called
   });
 
   it.each(["install", "enable", "disable"])("names an app an app on %s too", (action) => {
+    // Defensive: no sender emits `kind: "app"` with these actions today —
+    // `register_webapp` announces nothing (the agent made the webapp itself)
+    // and the enable/disable toggle is unreachable for a webapp. Kept so a
+    // future sender gets the right noun rather than the historical one.
     const msg = buildSkillChangeMessage({ action, name: "Pomodoro", kind: "app" });
 
     expect(msg).toMatch(/\bapp\b/);
@@ -121,7 +169,7 @@ describe("what the desktop sends when it removes an installed app", () => {
     expect(installedAppKind(undefined)).toBe("skill");
   });
 
-  it("sends the name off the tile the owner clicked, not the slug", () => {
+  it("sends the name off the tile the owner clicked, and the slug beside it", () => {
     const detail = installedAppRemovedDetail("pomodoro-timer", {
       name: "Pomodoro",
       webappUrl: "/webapps/pomodoro/index.html",
@@ -129,6 +177,19 @@ describe("what the desktop sends when it removes an installed app", () => {
 
     expect(detail).toEqual({ action: "uninstall", id: "pomodoro-timer", name: "Pomodoro", kind: "app" });
     expect(buildSkillChangeMessage(detail)).toContain('"Pomodoro"');
+    expect(buildSkillChangeMessage(detail)).toContain("pomodoro-timer");
+  });
+
+  it("carries the route's skillRemoved only when it really said yes", () => {
+    const meta = { name: "Notes", webappUrl: "/webapps/notes/index.html" };
+
+    expect(installedAppRemovedDetail("notes", meta, true).alsoSkill).toBe(true);
+    // `null` is the route saying it could not look — not a removal to announce.
+    expect(installedAppRemovedDetail("notes", meta, null).alsoSkill).toBeUndefined();
+    expect(installedAppRemovedDetail("notes", meta, false).alsoSkill).toBeUndefined();
+    expect(installedAppRemovedDetail("notes", meta).alsoSkill).toBeUndefined();
+    // And never on a skill: there is no second half to have gone.
+    expect(installedAppRemovedDetail("pdf-tools", { name: "PDF" }, true).alsoSkill).toBeUndefined();
   });
 
   it("falls back to the id when there is no meta to read a name from", () => {

--- a/src/tests/unit/skill-change-message.test.ts
+++ b/src/tests/unit/skill-change-message.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildSkillChangeMessage } from "@/lib/skill-change-message";
+import {
+  buildSkillChangeMessage,
+  installedAppKind,
+  installedAppRemovedDetail,
+} from "@/lib/skill-change-message";
 
 /**
  * The wording is the whole product here: after a skill change the owner sees
@@ -56,5 +60,81 @@ describe("buildSkillChangeMessage", () => {
     // stripped it before display, so the bubble and the wire disagreed. What
     // the owner reads is now exactly what the agent is asked.
     expect(buildSkillChangeMessage({ action: "install", name: "X" })).not.toContain("[System:");
+  });
+});
+
+/**
+ * TASK-544 — every branch said "skill", and the desktop's uninstall path sends
+ * this event for anything with a tile on it, including a WEBAPP.
+ *
+ * On Hermes that made it wrong every time: `isInstalledAppVisible` hides every
+ * non-webapp there, so a webapp is the only installed app an owner can remove,
+ * while "skill" is a live separate concept with its own store and its own
+ * `skill_uninstall`. The agent was asked to confirm a skill was gone, looked in
+ * the skill list, and answered about the wrong thing — or, on an id collision,
+ * confirmed the removal of a skill that is still installed.
+ */
+describe("buildSkillChangeMessage — what was removed decides what it is called", () => {
+  it("calls a removed webapp an app, and points at the desktop", () => {
+    const msg = buildSkillChangeMessage({ action: "uninstall", name: "Pomodoro", kind: "app" });
+
+    expect(msg).toContain('"Pomodoro"');
+    expect(msg).toMatch(/app/);
+    expect(msg).not.toMatch(/skill/);
+    // `ui_list_apps` is where the agent can actually check.
+    expect(msg).toMatch(/desktop/i);
+  });
+
+  it("still calls a removed skill a skill", () => {
+    const msg = buildSkillChangeMessage({ action: "uninstall", name: "PDF Tools", kind: "skill" });
+
+    expect(msg).toContain("skill");
+    expect(msg).not.toMatch(/\bapp\b/);
+  });
+
+  it("reads an event with no kind as a skill, the way every sender meant it before", () => {
+    // An older tab left open across an update still emits the two-field shape.
+    expect(buildSkillChangeMessage({ action: "uninstall", id: "pdf-tools" })).toContain("skill");
+  });
+
+  it.each(["install", "enable", "disable"])("names an app an app on %s too", (action) => {
+    const msg = buildSkillChangeMessage({ action, name: "Pomodoro", kind: "app" });
+
+    expect(msg).toMatch(/\bapp\b/);
+    expect(msg).not.toMatch(/skill/);
+  });
+
+  it("never claims the session was refreshed on the app branches either", () => {
+    for (const action of ["install", "uninstall", "enable", "disable"]) {
+      expect(buildSkillChangeMessage({ action, name: "X", kind: "app" })).not.toMatch(/refresh|restart/i);
+    }
+  });
+});
+
+describe("what the desktop sends when it removes an installed app", () => {
+  it("calls a webapp an app", () => {
+    expect(installedAppKind({ webappUrl: "/webapps/pomodoro/index.html" })).toBe("app");
+  });
+
+  it("calls everything else a skill — including an app whose meta the desktop lost", () => {
+    expect(installedAppKind({})).toBe("skill");
+    expect(installedAppKind(undefined)).toBe("skill");
+  });
+
+  it("sends the name off the tile the owner clicked, not the slug", () => {
+    const detail = installedAppRemovedDetail("pomodoro-timer", {
+      name: "Pomodoro",
+      webappUrl: "/webapps/pomodoro/index.html",
+    });
+
+    expect(detail).toEqual({ action: "uninstall", id: "pomodoro-timer", name: "Pomodoro", kind: "app" });
+    expect(buildSkillChangeMessage(detail)).toContain('"Pomodoro"');
+  });
+
+  it("falls back to the id when there is no meta to read a name from", () => {
+    const detail = installedAppRemovedDetail("pdf-tools", undefined);
+
+    expect(detail).toEqual({ action: "uninstall", id: "pdf-tools", kind: "skill" });
+    expect(buildSkillChangeMessage(detail)).toContain('"pdf-tools"');
   });
 });


### PR DESCRIPTION
**TASK-544** — Hermes: uninstalling a desktop app claims a SKILL was removed.

## Customer-visible symptom
Removing a tile from the desktop posted, **as the owner's own chat bubble**,
`I just removed the "<id>" skill. Can you confirm it is gone?` — and the agent confirmed it.

On Hermes that was wrong 100% of the time. `isInstalledAppVisible` hides every non-webapp there,
so a **webapp** is the only installed app an owner can remove, a webapp is not a skill, and "skill"
is a live separate concept on that edition with its own store and its own `skill_uninstall`. An id
collision had the agent confirm the removal of a skill that was still installed. The same message is
wrong on OpenClaw for a `webapp_create` tile, for the same reason.

Inverted the other way: `HermesSkillsStore` — the one surface on that edition where a **real** skill
is installed or removed — dispatched nothing, so removing a real skill produced no confirmation at
all.

## Cause
`src/lib/skill-change-message.ts` had one noun for every branch, and `src/app/page.tsx`'s uninstall
sent `{action, id}` with nothing to say what had been removed. The confirmation flow was wired to
the OpenClaw App Store and never extended to the Hermes one.

## Harness-first
Nothing native is re-implemented. The confirmation is deliberately the agent's own answer rather
than a claim by the UI (the module's docblock: nothing restarts, so the cheapest honest confirmation
is the agent saying so itself), and it is checked against the harness's own listings — `ui_list_apps`
for a desktop app, `skill_list` / `skill_uninstall` for a Hermes skill. What decides the wording is
ClawBox's own record of what the thing is (`installed_meta[<id>].webappUrl`) and the uninstall
route's own `skillRemoved` field, both of which already existed and were being thrown away.

## What changed
- `SkillChangeEvent` gains `kind: "skill" | "app"`. `installedAppKind(meta)` derives it from the
  webapp URL — edition-independent, so it fixes the OpenClaw `webapp_create` case too — and
  `installedAppRemovedDetail(appId, meta, skillRemoved)` builds the whole detail.
- **Both strings travel.** The message carries the display name the owner read *and* the id the
  agent's lists actually report: `ui_list_apps` emits an installed app as
  `{ id: "installed-<id>", name: <id> }` and `skill_list` leads with the lock id, so a sentence with
  only the display name asks the agent to verify against a string neither list contains — and
  "confirmed, it's gone" would be a guess dressed as verification.
- **One id can be both.** `webapp_create` replaces `installed_meta[<id>]` for any id with no
  collision check, and the uninstall route removes the webapp *and* a store skill of that name,
  reporting which in `skillRemoved`. The desktop already parsed that body for `skillHalfChecked` and
  dropped this field; it is now carried, and the line says the skill went too rather than hiding a
  capability the owner just lost.
- `HermesSkillsStore` announces install and uninstall — on the success paths only. Both calls sit
  after the `!res.ok` throw and after the `rollback_incomplete` / `removal_incomplete` /
  `incomplete_install` / `dangerous_skill` branches; the uninstall route answers 200 only when both
  the lock entry and the directory are verified gone, and `too_large` / `uninstall_unproven` are
  502s. The removal announcement carries the card's **display name** with the lock key beside it —
  the install path already sent the display name, and the same skill under two names in one
  transcript is the defect this card is about, one surface up.
- The event name is now one exported constant (`SKILL_CHANGE_EVENT`) with one dispatcher
  (`announceSkillChange`), used by all four senders and both listeners. A magic string four senders
  agreed on is how "skill-installed" came to be dispatched for an app uninstall.
- `ChatPopup`'s handler casts the detail to the shared `SkillChangeEvent` instead of restating three
  of its fields — the local cast omitted `kind`, which survived only because the object was passed
  on by reference, one destructure away from reverting the whole card with every suite green.

## Both editions
- Hermes: a webapp removal says "app"; a real skill removal now confirms at all, as a skill.
- OpenClaw: a `webapp_create` tile removal says "app" (it never should have said skill); a store
  skill still says skill; `AppStore` passes `kind: 'skill'` explicitly (`store` is OpenClaw-only and
  `handleInstallApp` never records a `webappUrl`).
- `InstalledAppSettings`'s enable/disable leaves `kind` at its default: it writes openclaw.json's
  skill enable flag, and a webapp renders as `type: "webapp"` and never reaches that panel.

## RED → GREEN
Two suites. Against the unmodified beta sources
(`git checkout origin/beta -- src/lib/skill-change-message.ts src/components/HermesSkillsStore.tsx
src/app/page.tsx src/components/AppStore.tsx src/components/InstalledAppSettings.tsx
src/components/ChatPopup.tsx`):

```
 ❯ |unit| src/tests/unit/skill-change-message.test.ts (23 tests | 11 failed)
     × calls a removed webapp an app, and points at the desktop
     × carries the id the agent's own lists report, beside the name the owner read
     × says the skill went too when one id was both
     × names an app an app on install too
     × names an app an app on enable too
     × names an app an app on disable too
     × calls a webapp an app
     × calls everything else a skill — including an app whose meta the desktop lost
     × sends the name off the tile the owner clicked, and the slug beside it
     × carries the route's skillRemoved only when it really said yes
     × falls back to the id when there is no meta to read a name from

 FAIL … > calls a removed webapp an app, and points at the desktop
 AssertionError: expected 'I just removed the "Pomodoro" skill. …' to match /app/
 + Received: "I just removed the \"Pomodoro\" skill. Can you confirm it is gone?"
```

```
 ❯ |components| src/tests/components/hermes-skills-chat-confirmation.test.tsx (5 tests | 2 failed)
     × announces the removal, as a skill, with the name the owner saw
     × announces the install, as a skill

 ❯ |components| src/tests/components/chat-skill-install-no-freeze.test.tsx (8 tests | 1 failed)
     × calls a removed webapp an app, all the way to the wire
```

With the fix: `skill-change-message` 23/23, `hermes-skills-chat-confirmation` 5/5,
`chat-skill-install-no-freeze` 8/8 (two new cases drive the whole path
dispatch → ChatPopup → the sent frame, which is the one hop `kind` has to survive).

Neighbouring component suites — the two above plus `app-store-errors`,
`app-store-install-modal`, `installed-app-settings`, `hermes-skills-store-errors`,
`hermes-skills-leftover-refresh`, `hermes-skills-warming`,
`hermes-skills-preexisting-incomplete`, `hermes-skill-docs-loading`: 83 passed.

Whole unit project: 650 files, 10500 passed. (Two unhandled rejections from
`use-clawbox-login.test.ts`, a teardown timer in a file this diff does not touch.)

Whole `--project components`: 1361 passed, 3 failed in `chat-spoken-reply.test.tsx` and
`chat-email-refs-surfaces.test.tsx` — both known flakes under a full parallel run, neither naming
any module in this diff, and 26/26 green when the two are run together on their own.

`tsc --noEmit` clean; `eslint` on the seven changed files, 0 errors. The
`state-updater-purity` guard passes: every `announceSkillChange` call is a plain statement, none
inside a state updater.

## Sibling call sites — handled or cleared
- `src/components/AppStore.tsx` and `src/components/InstalledAppSettings.tsx` — converted to the
  shared dispatcher; their `kind` decided above.
- `src/app/page.tsx`'s `register_webapp` path announces nothing, correctly: the agent created the
  webapp itself and does not need to be told.
- `src/tests/components/chat-skill-install-no-freeze.test.tsx` still dispatches the literal event
  name; `SKILL_CHANGE_EVENT` is that exact string, so it is equivalent, and the file now also
  covers `kind` end to end.

## Recorded, not claimed
- **`/app/hermes-skills` (the "Open in new tab" window) mounts no chat surface**, so the new
  announcement goes nowhere there — only `case "clawbox"` renders a chat, and that component does
  not listen for this event. Pre-existing for the App Store and the settings toggle too; the
  confirmation is closed for the desktop window, not for the standalone one.
- **The chat opens on every announcement** (`page.tsx`'s other listener is
  `() => setChatOpen(true)`), so installing or removing a Hermes skill now pops the chat over the
  Skills window and queues one agent turn. That is exactly what the OpenClaw App Store already does
  and there is no batch path to storm it (one confirm dialog per action), but it is new behaviour on
  that edition and worth a look on the box.
- **The four sentences are English-only.** Pre-existing in this module, but `HermesSkillsStore` is
  localized end to end, so this PR makes a localized surface emit an untranslated line as the
  owner's own bubble — which also steers the agent's reply into English for a non-English owner.
  Routing them through `t()` is a separate change.
- **`confirmUninstallApp` still has no re-entry guard** — a double-click sends two POSTs. Refuted
  in-thread on #637 and already on the residual list; untouched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer notifications for app and skill installations, enabling, disabling, and removals.
  - Notifications now distinguish between apps and skills and include relevant names or identifiers.
  - App removal messages can indicate when an associated skill was removed as well.

- **Bug Fixes**
  - Improved consistency of skill-change updates across the app, store, and chat interfaces.
  - Prevented incorrect item types from appearing in removal messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->