### PR TITLE
fix: refuse an API key that would delete a subscription sign-in

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -76,6 +76,7 @@ import {
   chatgptModelRef,
   chatgptRuntimeArmOp,
   chatgptRuntimeEntryPath,
+  isOauthProfile,
   openaiAuthOrder,
 } from "@/lib/chatgpt-subscription";
 import { fetchPortalTier } from "@/lib/clawbox-ai-portal-tier";
@@ -388,10 +389,107 @@ async function writeAuthProfiles(authProfiles: AuthProfilesFile) {
  * never argv.
  */
 async function pasteAuthApiKey(provider: string, profileId: string, key: string): Promise<void> {
+  // The sign-in guard is NOT here, deliberately: see `assertNoSignInAt`. By
+  // the time this runs the request has already written its own
+  // `auth.profiles.<key>` metadata, and on the ClawBox AI lane that metadata
+  // says `oauth` — a guard reading the box at this point would refuse the very
+  // save that wrote it. It is asked once, of the store as it was BEFORE this
+  // request touched anything.
   await spawnOpenclawCli(
     ["models", "auth", "paste-api-key", "--provider", provider, "--profile-id", profileId],
     { stdinData: key + "\n", timeoutMs: 60_000 },
   );
+}
+
+/** A pasted API key would have replaced a subscription sign-in. */
+class SignInWouldBeLostError extends Error {
+  constructor(readonly profileId: string) {
+    super(`auth profile ${profileId} holds a sign-in`);
+    this.name = "SignInWouldBeLostError";
+  }
+}
+
+/**
+ * Refuse a save whose API key would delete a subscription sign-in.
+ *
+ * `models auth paste-api-key` REPLACES whatever sits at `--profile-id`; there
+ * is no merge and no refusal of its own. The CLI's default id is
+ * `<provider>:manual`, chosen so a pasted key never lands on another
+ * credential — ClawBox overrides it to `<provider>:default`, and that override
+ * is what makes a collision possible at all. Measured with `openclaw models
+ * auth list --json` on an OpenClaw box: `anthropic:default` is `oauth` there
+ * TODAY, because this route's own subscription lane writes the OAuth bundle to
+ * it (PROVIDERS has no `subscriptionOverride` for anthropic) and its API-key
+ * lane pastes to the same id. The OpenAI shape needs a migration —
+ * `doctor --fix` renames an OpenClaw 1 `openai-codex:*` profile to
+ * `openai:<suffix>`, landing the ChatGPT sign-in where the key lane targets
+ * (TASK-662, the #584 follow-up).
+ *
+ * ASKED OF THE STORE, not of openclaw.json's `auth.profiles` metadata. The
+ * metadata is a false negative for the one credential most worth protecting:
+ * `models auth login` — the Terminal sign-in — persists to the agent
+ * credential store and never calls `applyAuthProfileConfig`, so a profile
+ * created that way is invisible in the config. `models auth list --json` is
+ * the store's own reader and is what `models auth logout` — the verb this
+ * refusal names — acts on, so the guard and its remedy cannot disagree. It
+ * costs one CLI cold start, which is why it is skipped for the providers that
+ * have no sign-in lane at all.
+ *
+ * ASKED ONCE, BEFORE ANY WRITE. Later in the same request the save writes
+ * `auth.profiles.<key>` itself — `{mode: "oauth"}` on the ClawBox AI lane —
+ * so a guard consulted at paste time would refuse the save that wrote it.
+ *
+ * REFUSED rather than written under a second id. `applyAuthProfileConfig` does
+ * record an order preferring a newly pasted peer, so a second profile is not
+ * the false success it first looked like; the reason to refuse anyway is
+ * narrower and worth stating plainly. A second id silently changes which
+ * credential answers, on a box where ClawBox writes a STORE-level order for
+ * openai (`applyOpenAiAuthOrder`) that outranks the config one and names only
+ * the ids it knows about — so "both survive" would be true for anthropic and
+ * argued for openai. One sentence the owner can act on beats a credential
+ * shuffle he was not shown.
+ *
+ * Fails OPEN: a store that cannot be read does not refuse a save the owner
+ * asked for. The failure is logged, and the paste that follows is the same one
+ * beta performed unconditionally.
+ */
+async function assertNoSignInAt(profileId: string): Promise<void> {
+  // Nothing to lose where there is no OpenClaw auth store: the Hermes SKU
+  // keeps its credentials in the harness's own config and never reaches
+  // `paste-api-key` at all.
+  if (openclawIsAbsent()) return;
+  let raw: string;
+  try {
+    raw = await spawnOpenclawCli(["models", "auth", "list", "--json"], {
+      captureStdout: true,
+      timeoutMs: 60_000,
+    });
+  } catch (err) {
+    console.warn(
+      "[configure] could not read the auth profiles before pasting a key:",
+      err instanceof Error ? logSafe(err.message) : err,
+    );
+    return;
+  }
+  let profiles: unknown;
+  try {
+    profiles = (JSON.parse(raw) as { profiles?: unknown }).profiles;
+  } catch {
+    console.warn("[configure] `models auth list --json` was not JSON; the key paste is unguarded");
+    return;
+  }
+  if (!Array.isArray(profiles)) return;
+  // The store's own shape, measured on 2026.8.1:
+  // `{profiles: [{id, provider, type, label, expiresAt}]}`, `type` being
+  // `oauth` or `api_key`. Any OAuth row AT THIS ID counts, whatever provider it
+  // names: the paste replaces the row, so what it would destroy is the
+  // question, not who owns it.
+  const holdsSignIn = profiles.some((row) => {
+    if (!row || typeof row !== "object") return false;
+    const entry = row as { id?: unknown; type?: unknown };
+    return entry.id === profileId && isOauthProfile({ mode: String(entry.type ?? "") });
+  });
+  if (holdsSignIn) throw new SignInWouldBeLostError(profileId);
 }
 
 /**
@@ -1795,6 +1893,20 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     // key; the auth mode is what tells the two apart from here on.
     const isChatgptSubscription = authMode === "subscription" && ocProvider === CHATGPT_PROVIDER;
 
+    // BEFORE anything is written, and before this request has put anything of
+    // its own in the store — a refusal is not a failure and must not leave a
+    // trail, and by the time the save reaches the paste it has unpaired
+    // ClawKeep on an account switch, enabled provider plugins and written the
+    // profile metadata. The throw is mapped to a 409 by this handler's own
+    // catch.
+    //
+    // Skipped where no sign-in lane exists: the two local providers have no
+    // OAuth flow, and the ClawBox AI profile is written by this route alone.
+    // It is one CLI cold start, and this is the wizard's critical path.
+    if (authMode !== "subscription" && !isOllama && !isLlamaCpp && !isClawAI) {
+      await assertNoSignInAt(config.profileKey);
+    }
+
     // Codex (OpenAI subscription) authenticates with a JWT id_token, and the
     // gateway synthesizes ~/.codex/auth.json from `id` (falling back to
     // `access`). If neither is JWT-shaped, that synthesis produces an invalid
@@ -2988,6 +3100,28 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
       .join(" ");
     return NextResponse.json({ success: true, ...(warning ? { warning } : {}) });
   } catch (err) {
+    // The one refusal that is not a failure: the save was REFUSED before
+    // anything was written, and the owner can act on it. Its own status and
+    // code, and the sentence names the credential slot so the Terminal
+    // instruction can be followed literally. Answered before the sanitising
+    // branch below, which would otherwise turn it into "check your
+    // credentials" over a key that is perfectly good (TASK-662).
+    if (err instanceof SignInWouldBeLostError) {
+      console.warn(
+        `[configure] refused an API key that would replace the sign-in at ${err.profileId}`,
+      );
+      return NextResponse.json(
+        {
+          error: "This box is signed in to that provider, and the sign-in is stored in the same "
+            + `credential slot (${err.profileId}). Saving an API key here would delete it. `
+            + "Remove the sign-in first — in the Terminal: "
+            + `openclaw models auth logout ${err.profileId} — then paste the key.`,
+          code: "sign_in_would_be_lost",
+          profileId: err.profileId,
+        },
+        { status: 409 },
+      );
+    }
     // Never surface the raw error: it can carry CLI internals and filesystem
     // paths. Log it server-side for diagnosis and return a generic, actionable
     // message (mirrors the sanitized gateway-restart branch above).

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -396,7 +396,17 @@ async function pasteAuthApiKey(provider: string, profileId: string, key: string)
   // save that wrote it. It is asked once, of the store as it was BEFORE this
   // request touched anything.
   await spawnOpenclawCli(
-    ["models", "auth", "paste-api-key", "--provider", provider, "--profile-id", profileId],
+    [
+      "models", "auth", "paste-api-key",
+      // `--agent` omitted means "the configured default agent", which is not
+      // necessarily the one ClawBox operates on. `applyOpenAiAuthOrder` already
+      // pins CLAWBOX_AGENT_ID for the order over these same profiles, and
+      // `assertNoSignInAt` reads with the same pin — a guard that read one
+      // store while the paste wrote another would be no guard at all.
+      "--agent", CLAWBOX_AGENT_ID,
+      "--provider", provider,
+      "--profile-id", profileId,
+    ],
     { stdinData: key + "\n", timeoutMs: 60_000 },
   );
 }
@@ -460,10 +470,12 @@ async function assertNoSignInAt(profileId: string): Promise<void> {
   if (openclawIsAbsent()) return;
   let raw: string;
   try {
-    raw = await spawnOpenclawCli(["models", "auth", "list", "--json"], {
-      captureStdout: true,
-      timeoutMs: 60_000,
-    });
+    // Same agent as the paste this guards and as the auth order beside it: the
+    // store `--agent` selects is the whole subject of the question.
+    raw = await spawnOpenclawCli(
+      ["models", "auth", "list", "--agent", CLAWBOX_AGENT_ID, "--json"],
+      { captureStdout: true, timeoutMs: 60_000 },
+    );
   } catch (err) {
     console.warn(
       "[configure] could not read the auth profiles before pasting a key:",

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -3137,7 +3137,14 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
           error: "This box is signed in to that provider, and the sign-in is stored in the same "
             + `credential slot (${err.profileId}). Saving an API key here would delete it. `
             + "Remove the sign-in first — in the Terminal: "
-            + `openclaw models auth logout ${err.profileId} — then paste the key.`,
+            // The same `--agent` the guard read with and the paste writes to.
+            // Without it the CLI takes the configured default agent, so on a
+            // multi-agent box the owner's command clears a different store and
+            // the refusal never goes away. Argument order is the command's own
+            // (`models auth logout [options] <profileId>`, read from its
+            // --help on 2026.8.1).
+            + `openclaw models auth logout --agent ${CLAWBOX_AGENT_ID} ${err.profileId}`
+            + " — then paste the key.",
           code: "sign_in_would_be_lost",
           profileId: err.profileId,
         },

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -471,13 +471,18 @@ async function assertNoSignInAt(profileId: string): Promise<void> {
     );
     return;
   }
-  let profiles: unknown;
+  let parsed: unknown;
   try {
-    profiles = (JSON.parse(raw) as { profiles?: unknown }).profiles;
+    parsed = JSON.parse(raw);
   } catch {
     console.warn("[configure] `models auth list --json` was not JSON; the key paste is unguarded");
     return;
   }
+  // `JSON.parse("null")` succeeds and `null.profiles` throws, which the
+  // handler's own catch would turn into a 500 — the opposite of the fail-open
+  // this guard promises, over a save that is perfectly good.
+  if (!parsed || typeof parsed !== "object") return;
+  const profiles = (parsed as { profiles?: unknown }).profiles;
   if (!Array.isArray(profiles)) return;
   // The store's own shape, measured on 2026.8.1:
   // `{profiles: [{id, provider, type, label, expiresAt}]}`, `type` being
@@ -1900,10 +1905,15 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     // profile metadata. The throw is mapped to a 409 by this handler's own
     // catch.
     //
-    // Skipped where no sign-in lane exists: the two local providers have no
-    // OAuth flow, and the ClawBox AI profile is written by this route alone.
-    // It is one CLI cold start, and this is the wizard's critical path.
-    if (authMode !== "subscription" && !isOllama && !isLlamaCpp && !isClawAI) {
+    // Skipped where no sign-in lane exists: the two local providers have none,
+    // OpenRouter is deliberately absent from OAUTH_PROVIDERS (see the
+    // openrouter branch below — every save that reaches it is key-based), and
+    // the ClawBox AI profile is written by this route alone. It is one CLI cold
+    // start, and this is the wizard's critical path.
+    if (
+      authMode !== "subscription"
+      && !isOllama && !isLlamaCpp && !isClawAI && !isOpenRouter
+    ) {
       await assertNoSignInAt(config.profileKey);
     }
 

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -842,6 +842,26 @@ describe("POST /setup-api/ai-models/configure over an existing sign-in", () => {
     expect(pasteWasSpawned()).toBe(true);
   });
 
+  it("reads and writes the SAME agent's credential store", async () => {
+    // `--agent` omitted means "the configured default agent", which is not
+    // necessarily the one ClawBox operates on — and a guard that read one
+    // store while the paste wrote another would be no guard at all. The auth
+    // order over these same profiles already pins it.
+    profilesInStore([{ id: "anthropic:default", provider: "anthropic", type: "api_key" }]);
+
+    const res = await configurePost(jsonRequest({ provider: "anthropic", apiKey: "sk-a-real-key" }));
+    expect(res.status).toBe(200);
+
+    const args = vi.mocked(spawnOpenclawCli).mock.calls.map(([a]) => a as string[]);
+    const read = args.find((a) => a.includes("auth") && a.includes("list"));
+    const paste = args.find((a) => a.includes("paste-api-key"));
+    for (const call of [read, paste]) {
+      expect(call).toBeDefined();
+      expect(call).toContain("--agent");
+      expect(call?.[(call?.indexOf("--agent") ?? -1) + 1]).toBe("main");
+    }
+  });
+
   it("fails open on a store that answers something other than a profile list", async () => {
     // `JSON.parse("null")` succeeds and `null.profiles` throws, which the
     // handler's catch would turn into a 500 over a save that is perfectly

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -825,7 +825,11 @@ describe("POST /setup-api/ai-models/configure over an existing sign-in", () => {
     // The sentence has to be followable literally: it names the slot and the
     // native verb that clears it.
     expect(body.error).toContain(profileId);
-    expect(body.error).toContain("openclaw models auth logout");
+    // Followable literally, against the SAME store the guard read: without the
+    // selector the CLI takes the configured default agent, so on a
+    // multi-agent box the owner clears a different store and the refusal
+    // never goes away.
+    expect(body.error).toContain(`openclaw models auth logout --agent main ${profileId}`);
     // A refusal is not a failure: nothing may have been written on the way to it.
     expect(pasteWasSpawned()).toBe(false);
     expectNoSideEffects();

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -144,6 +144,7 @@ import {
   runOpenclawConfigSet,
   runOpenclawConfigSetBatch,
   runOpenclawDoctorFix,
+  spawnOpenclawCli,
   applyModelOverrideToAllAgentSessions,
   inferConfiguredLocalModel,
   setProviderPlugins,
@@ -755,5 +756,114 @@ describe("POST /setup-api/ai-models/configure and the gateway doctor --fix stopp
     expect(res.status).toBe(500);
     expect(runOpenclawDoctorFix).not.toHaveBeenCalled();
     expect(restartGateway).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * TASK-662 (the #584 follow-up). `models auth paste-api-key` REPLACES whatever
+ * sits at `--profile-id`, and ClawBox overrides the CLI's own default
+ * (`<provider>:manual`, chosen so a paste never lands on another credential)
+ * with `<provider>:default`. For Anthropic that is the id this route's OWN
+ * subscription lane writes the Claude OAuth bundle to, so connecting Claude by
+ * subscription and pasting an Anthropic key afterwards destroyed the sign-in
+ * with a clean "saved" — a false success over a credential the owner may have
+ * no way to re-create. On OpenAI the same collision needs a migrated box:
+ * `doctor --fix` renames an OpenClaw 1 `openai-codex:*` profile to
+ * `openai:<suffix>`, landing the sign-in at exactly the id the key lane targets.
+ */
+describe("POST /setup-api/ai-models/configure over an existing sign-in", () => {
+  let configurePost: (request: Request) => Promise<Response>;
+
+  beforeEach(async () => {
+    configurePost = await primeConfigureRoute();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  /**
+   * `openclaw models auth list --json` as the store answers it — the shape
+   * measured on 2026.8.1: `{profiles: [{id, provider, type, label,
+   * expiresAt}]}`.
+   *
+   * openclaw.json's `auth.profiles` metadata is deliberately left EMPTY in
+   * these cases. It is what the first draft of this guard read, and it is a
+   * false negative for the credential most worth protecting: `models auth
+   * login` — the Terminal sign-in — writes the store and never
+   * `applyAuthProfileConfig`, so a profile created that way is invisible
+   * there. If the guard ever goes back to the config, these tests go red.
+   */
+  function profilesInStore(profiles: { id: string; provider: string; type: string }[]) {
+    vi.mocked(spawnOpenclawCli).mockImplementation(async (args) =>
+      Array.isArray(args) && args.includes("list") && args.includes("auth")
+        ? JSON.stringify({ profiles })
+        : "",
+    );
+  }
+
+  /** Did the save reach the CLI verb that would have replaced the credential? */
+  function pasteWasSpawned(): boolean {
+    return vi.mocked(spawnOpenclawCli).mock.calls.some(
+      ([args]) => Array.isArray(args) && args.includes("paste-api-key"),
+    );
+  }
+
+  it.each([
+    ["anthropic", "anthropic:default"],
+    ["openai", "openai:default"],
+  ])("refuses an %s API key that would replace the sign-in at %s", async (provider, profileId) => {
+    profilesInStore([{ id: profileId, provider, type: "oauth" }]);
+
+    const res = await configurePost(jsonRequest({ provider, apiKey: "sk-a-real-key" }));
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe("sign_in_would_be_lost");
+    expect(body.profileId).toBe(profileId);
+    // The sentence has to be followable literally: it names the slot and the
+    // native verb that clears it.
+    expect(body.error).toContain(profileId);
+    expect(body.error).toContain("openclaw models auth logout");
+    // A refusal is not a failure: nothing may have been written on the way to it.
+    expect(pasteWasSpawned()).toBe(false);
+    expectNoSideEffects();
+  });
+
+  it("saves normally over an API-KEY profile at the same id", async () => {
+    // Replacing one API key with another is exactly what the owner asked for.
+    // The guard is about credentials that cannot be pasted back.
+    profilesInStore([{ id: "anthropic:default", provider: "anthropic", type: "api_key" }]);
+
+    const res = await configurePost(jsonRequest({ provider: "anthropic", apiKey: "sk-a-real-key" }));
+
+    expect(res.status).toBe(200);
+    expect(pasteWasSpawned()).toBe(true);
+  });
+
+  it("never asks the store on a lane that has no sign-in to lose", async () => {
+    // The read is one CLI cold start on the wizard's critical path, and the
+    // two local providers and the ClawBox AI profile have no OAuth flow at
+    // all. Spending it there would be a slower wizard for nothing.
+    profilesInStore([{ id: "anthropic:default", provider: "anthropic", type: "oauth" }]);
+
+    const res = await configurePost(jsonRequest({ provider: "llamacpp" }));
+
+    expect(res.status).toBe(200);
+    expect(
+      vi.mocked(spawnOpenclawCli).mock.calls.some(
+        ([args]) => Array.isArray(args) && args.includes("auth") && args.includes("list"),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not refuse the sign-in lane itself", async () => {
+    // Signing in again over an existing sign-in is a refresh, not a loss.
+    profilesInStore([{ id: "anthropic:default", provider: "anthropic", type: "oauth" }]);
+
+    const res = await configurePost(subscribe());
+
+    expect(res.status).toBe(200);
   });
 });

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -842,20 +842,36 @@ describe("POST /setup-api/ai-models/configure over an existing sign-in", () => {
     expect(pasteWasSpawned()).toBe(true);
   });
 
+  it("fails open on a store that answers something other than a profile list", async () => {
+    // `JSON.parse("null")` succeeds and `null.profiles` throws, which the
+    // handler's catch would turn into a 500 over a save that is perfectly
+    // good. A guard that cannot read the box does not refuse.
+    vi.mocked(spawnOpenclawCli).mockImplementation(async (args) =>
+      Array.isArray(args) && args.includes("list") && args.includes("auth") ? "null" : "",
+    );
+
+    const res = await configurePost(jsonRequest({ provider: "anthropic", apiKey: "sk-a-real-key" }));
+
+    expect(res.status).toBe(200);
+    expect(pasteWasSpawned()).toBe(true);
+  });
+
   it("never asks the store on a lane that has no sign-in to lose", async () => {
     // The read is one CLI cold start on the wizard's critical path, and the
     // two local providers and the ClawBox AI profile have no OAuth flow at
     // all. Spending it there would be a slower wizard for nothing.
     profilesInStore([{ id: "anthropic:default", provider: "anthropic", type: "oauth" }]);
 
-    const res = await configurePost(jsonRequest({ provider: "llamacpp" }));
-
-    expect(res.status).toBe(200);
-    expect(
-      vi.mocked(spawnOpenclawCli).mock.calls.some(
-        ([args]) => Array.isArray(args) && args.includes("auth") && args.includes("list"),
-      ),
-    ).toBe(false);
+    for (const provider of ["llamacpp", "openrouter"]) {
+      vi.mocked(spawnOpenclawCli).mockClear();
+      const res = await configurePost(jsonRequest({ provider, apiKey: "sk-or-a-real-key" }));
+      expect(res.status).toBe(200);
+      expect(
+        vi.mocked(spawnOpenclawCli).mock.calls.some(
+          ([args]) => Array.isArray(args) && args.includes("auth") && args.includes("list"),
+        ),
+      ).toBe(false);
+    }
   });
 
   it("does not refuse the sign-in lane itself", async () => {


### PR DESCRIPTION
Closes TASK-662 (the #584 follow-up).

## Symptom

Pasting a provider API key deletes a subscription sign-in stored under the same auth-profile id, and answers **200 success**. The owner has no way to know, and on a subscription that was signed in through a browser flow, no easy way back.

## Harness first, and what it settles

`openclaw models auth paste-api-key --help` on the pinned core (2026.8.1), read on a box:

```
  --profile-id <id>  Auth profile id (default: <provider>:manual)
```

The CLI's **own default keeps a pasted key off another credential's id** — `<provider>:manual`, not `<provider>:default`. ClawBox overrides it to `<provider>:default`, and that override is the whole precondition for a collision. `models auth list --json` is the store's own reader; `models auth logout <id>` is the verb that removes a profile, and it drops the `openclaw.json` entry with it.

## Cause, measured

`openclaw models auth list --json` on an OpenClaw box, ids and modes only:

```
  anthropic:default       provider=anthropic   type=oauth
  anthropic:models-json   provider=anthropic   type=api_key
  openai:chatgpt          provider=openai      type=oauth
  openai:default          provider=openai      type=api_key
  deepseek:default        provider=deepseek    type=api_key
  …
```

`anthropic:default` holds an **oauth** credential on that box **today**. This route's subscription lane writes the OAuth bundle there (`PROVIDERS.anthropic` has no `subscriptionOverride`) and its API-key lane pastes to the same id, so it needs no migration and no unusual history: connect the subscription, paste an Anthropic key later, and the sign-in is gone.

The OpenAI shape is the one the card describes and does need a migrated box: `doctor --fix` renames an OpenClaw 1 `openai-codex:*` profile to `openai:<suffix>`, landing the ChatGPT sign-in at exactly the id the key lane targets. Normally the sign-in lives at `openai:chatgpt` and there is no collision.

That is the repo's **false success** class, over a credential.

## Fix

The save is refused — 409, `code: "sign_in_would_be_lost"`, `profileId` — with a sentence the owner can follow literally: it names the credential slot and the Terminal command that clears it.

Three properties, each load-bearing:

* **Asked of the STORE, not of `openclaw.json`'s `auth.profiles`.** The metadata is a false negative for the credential most worth protecting: `models auth login` — the Terminal sign-in this refusal points the owner at — persists to the agent credential store and never calls `applyAuthProfileConfig`, so a profile created that way is invisible in the config. The guard and its remedy now read and write the same place. Cost is one CLI cold start.
* **Asked once, before this request writes anything.** Later in the same save the route writes `auth.profiles.<key>` itself — `{mode: "oauth"}` on the ClawBox AI lane — so a guard consulted at paste time would have refused the save that wrote it, 409-ing every ClawBox AI connect. A refusal must also leave no trail: by the paste, the save has already unpaired ClawKeep on an account switch and enabled provider plugins.
* **Skipped where there is no sign-in to lose** — the two local providers and ClawBox AI have no OAuth lane, and an edition without an OpenClaw auth store has no store to read. Fails open: a store that cannot be read does not refuse a save the owner asked for; the paste that follows is the one beta performed unconditionally.

## Why refuse rather than write under a second id

The card offers both. A second id is more workable than it first looks — `applyAuthProfileConfig` does record an order preferring a newly pasted peer, so the key would serve rather than sit behind the sign-in. The narrower reason to refuse anyway: a second id silently changes which credential answers, on a box where ClawBox also writes a STORE-level order for openai (`applyOpenAiAuthOrder`) that outranks the config one and names only the ids it knows about — so "both survive, the key serves" is true for anthropic and argued for openai. One sentence the owner can act on beats a credential shuffle he was not shown.

## Both editions

Hermes keeps its credentials in the harness's own config and never reaches `paste-api-key`; `openclawIsAbsent()` skips the guard there. Named as a residual below: the Hermes writers have the same hazard in their own store, and this PR does not close it.

## RED

On unmodified `origin/beta`, with only the test file copied in:

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  configure-subscription-surface.test.ts > over an existing sign-in
       > refuses an anthropic API key that would replace the sign-in at anthropic:default
 FAIL  configure-subscription-surface.test.ts > over an existing sign-in
       > refuses an openai API key that would replace the sign-in at openai:default
AssertionError: expected 200 to be 409 // Object.is equality
 Test Files  1 failed (1)
      Tests  2 failed | 31 passed (33)
```

200 is the false success itself. The other three cases in the block are guards that pass on beta as well: an API-key profile at the same id is still replaced, the sign-in lane is not refused, and the store is not read on a lane that has no sign-in to lose.

## GREEN

`configure-subscription-surface.test.ts` 33 passed; all 17 `routes/ai-models` suites 331 passed; full `--project unit` 650 files / 10489 passed. `tsc --noEmit` clean; `eslint` on the changed files reports only the two `no-unused-vars` warnings the route already had on beta.

## Sibling call sites

Every writer of an auth profile in the repo: `pasteAuthApiKey` (both call sites — the provider lane and `configureClawboxAi`), the subscription lane's `writeAuthProfiles`, and the two `config set auth.profiles.<key>` metadata writes that follow each. All of them are downstream of the one guard, which runs before the first of them. `hermes-cloud-provider.ts` and the other Hermes writers use the harness's own store and never this verb.

## Residuals, recorded not hidden

* **The mirror case is not guarded**: the SUBSCRIPTION lane writing OAuth over an existing API-key profile at the same id. It is the same overwrite in the other direction, and it is not the same loss — an API key can be pasted again, and the owner explicitly signed in.
* **Hermes has the same hazard** in its own credential store, unguarded, through `hermes-cloud-provider.ts` and its siblings.

## Review

`clawbox-review`, findings at `code-review-662.md` (3 HIGH, 4 MEDIUM, 3 LOW). All three HIGHs were real and are fixed here: the ClawBox AI connect lane 409-ing on every box (the guard now runs once, before the request's own metadata write), the config-metadata read being a false negative for `models auth login` (it reads the store), and the refuse-vs-second-id rationale being wrong as originally written (restated above). MEDIUM-1/2/3 fall out with them; MEDIUM-4 is the Hermes residual above. The review also confirmed, against the whole path, that nothing is written before the guard, and that `models auth logout <profileId>` is the correct positional form and does drop the config entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - API-key saves are now protected from accidentally replacing existing OAuth sign-in credentials.
  - Conflicting saves are rejected with a clear error and instructions to sign out first.
  - Existing profile details are preserved when a conflict is detected.
  - Subscription, local, OpenRouter, and ClawBox AI configurations continue to work without this check.
  - API-key replacements remain available after the existing sign-in is removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->