### PR TITLE
fix: let a waiting client force one catalogue retry per backoff window

### DIFF
--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -220,6 +220,47 @@ const FAILED_REFRESH_BACKOFF_MS = 2 * 60_000;
 const changeSeq = new Map<string, number>();
 const publishedSeq = new Map<string, number>();
 
+/**
+ * When each provider last spent a client-facing retry.
+ *
+ * TASK-669. The failed-refresh backoff starts at two minutes and doubles to
+ * the full six-hour interval, which is the right schedule for the BOX's own
+ * retries and was also the only schedule there was. A blip during boot warmup
+ * — the network not up yet, the CLI mid-upgrade — records a wait while nobody
+ * is looking, and the first person to open the picker afterwards is shown the
+ * curated fallback with nothing on the box willing to try again. Before the
+ * change generations landed, any picker open re-forked; now nothing does.
+ *
+ * `?refresh=1` is not the answer, and that is worth writing down because the
+ * card proposed it: the client sends it ONLY as its echo of a provider-set
+ * change (`useProviderCatalog`'s `forceNextLoad`), and by then
+ * `notifyProviderSetChanged` has already cleared the wait server-side. The
+ * plain picker open — the one that finds the box in this state — sends no
+ * parameter at all.
+ *
+ * So the attempt is spent by the REQUEST that finds itself without the box's
+ * own current answer, and it is a MINIMUM GAP rather than a once-ever count.
+ * This process runs for weeks: a single allowance would be burnt by the first
+ * picker open after the boot blip — very likely the one where the uplink is
+ * still coming up — and the provider would then be unreachable for the life of
+ * the server. `src/lib/hermes-model-options.ts` had the same problem on the
+ * other edition and solved it with `EXPLICIT_REFRESH_MIN_GAP_MS`; this is that
+ * primitive.
+ *
+ * The gap is longer than an enumeration (~3 minutes on a Jetson) so a mounted
+ * picker's warming poll cannot chain one fork into the next, and it is cleared
+ * by the two events that make an old failure meaningless — a successful
+ * refresh, and a provider-set change.
+ */
+const CLIENT_RETRY_MIN_GAP_MS = 5 * 60_000;
+const clientRetryAt = new Map<string, number>();
+
+/** May a client-facing retry be spent for this provider now? */
+function clientRetryIsDue(provider: string): boolean {
+  const last = clientRetryAt.get(provider);
+  return last === undefined || Date.now() - last >= CLIENT_RETRY_MIN_GAP_MS;
+}
+
 function currentSeq(provider: string): number {
   return changeSeq.get(provider) ?? 0;
 }
@@ -258,6 +299,10 @@ function recordFailedRefresh(provider: string): void {
 
 function recordSuccessfulRefresh(provider: string): void {
   failedRefreshes.delete(provider);
+  // The gap only exists to ration retries against a FAILING provider. One that
+  // has just answered owes nothing, and the next time it fails the client's
+  // first look should get an attempt.
+  clientRetryAt.delete(provider);
 }
 
 /**
@@ -1046,6 +1091,22 @@ export function refreshInBackground(
      * clear, no running fork's work to discard.
      */
     serveCurrent?: boolean;
+    /**
+     * A CLIENT is looking at this provider and does NOT have the box's own
+     * current answer — the curated fallback, a live list every current
+     * sanitiser rule filters away, or one older than the refresh interval.
+     *
+     * Set by the GET handler, which has already computed exactly that three
+     * lines above the call, and by nothing else. It counts no change and bumps
+     * nothing; all it buys is one attempt against a recorded failure, no more
+     * often than `CLIENT_RETRY_MIN_GAP_MS`.
+     *
+     * Deliberately NOT `isStale`: that includes `refreshFailedLast`, which is
+     * true by construction whenever the wait is running, so gating on it would
+     * fire for every blocked provider including one whose catalogue is
+     * perfectly good.
+     */
+    clientHasNoCurrentAnswer?: boolean;
   } = {},
 ): void {
   // Providers that never touch the CLI (see NO_CLI_ENUMERATION_PROVIDERS);
@@ -1081,14 +1142,52 @@ export function refreshInBackground(
     // changed, so the next attempt must not be made to wait it out. Cleared
     // here rather than after the single-flight check, because the fork in
     // flight is about to be discarded and it is the re-entry that needs the
-    // wait gone.
+    // wait gone. The client-retry gap goes with it, for the same reason: it
+    // describes a box that no longer exists.
     clearFailedRefresh(provider);
+    clientRetryAt.delete(provider);
   }
 
   // Nothing to do: the answer on file is already for the box as it is.
   if (opts.serveCurrent === true && publishedIsCurrent(provider)) return;
 
   if (refreshing.has(provider)) return;
+  // Somebody is looking at a catalogue that is not the box's own current
+  // answer, and the box has decided to wait. Spend one attempt.
+  //
+  // NOT for the two providers that can never enumerate here: `cliMissing` and
+  // the no-enumeration-on-this-core case both `recordFailedRefresh` precisely
+  // so their one log line appears once per backoff window instead of once per
+  // picker open, and `changeCouldMakeItEnumerable` is the question they
+  // already answer.
+  //
+  // NOT while anything else is enumerating. `refreshing` is per-provider, so
+  // it is the only concurrency discipline this file has apart from
+  // `bootWarmup`'s 5 s stagger — and the wizard's provider list re-runs
+  // `useProviderCatalog` on every click, so a walk down anthropic → openai →
+  // google could otherwise start three ~2-core, ~3-minute forks at once on an
+  // Orin. Leaving it unspent is also the honest answer: something IS on its
+  // way, and the response says `warming`.
+  //
+  // The wait is LIFTED, not cleared: `clearFailedRefresh` deletes the entry
+  // and `recordFailedRefresh` then restarts the doubling from its two-minute
+  // floor, so a provider that had climbed to the six-hour cap would re-climb
+  // it through eight more picker-driven forks — and `refreshFailedLast` would
+  // go false for the length of the retry, dropping the `stale` flag off a
+  // payload no device produced. Expiring the deadline while keeping the window
+  // it had reached does neither.
+  if (
+    opts.clientHasNoCurrentAnswer === true
+    && changeCouldMakeItEnumerable
+    && refreshing.size === 0
+    && refreshIsBlocked(provider)
+    && clientRetryIsDue(provider)
+  ) {
+    clientRetryAt.set(provider, Date.now());
+    const failure = failedRefreshes.get(provider);
+    if (failure) failedRefreshes.set(provider, { until: 0, waitMs: failure.waitMs });
+    console.log(`[catalog] ${provider}: a client is waiting on a fallback list, retrying once`);
+  }
   if (refreshIsBlocked(provider)) return;
 
   // Skip a missing binary cleanly rather than fork it for each provider on
@@ -1353,7 +1452,19 @@ export async function GET(req: NextRequest) {
   // on an upgraded box those files hold the curated list a failed enumeration
   // left behind, and nothing else would ever dislodge them.
   if (isStale || !isLivePayload(cached)) {
-    refreshInBackground(provider);
+    // On THIS branch and not only on the nudge below: a cold process whose
+    // boot warmup failed lands here, never on `serveCurrent`, and the plain
+    // picker open carries no `?refresh=1` at all (TASK-669).
+    //
+    // The flag is the question this handler has already answered — is what we
+    // are about to serve the box's own current answer? — rather than a second
+    // derivation of half of it. `servedEmpty` is a live payload the current
+    // sanitiser rules empty out, which is exactly the state that arrives the
+    // first time a filter is tightened; the age term is the box that was off
+    // for three weeks. In both the client is looking at the curated list.
+    refreshInBackground(provider, {
+      clientHasNoCurrentAnswer: !isLivePayload(cached) || servedEmpty || ageMs > REFRESH_INTERVAL_MS,
+    });
   } else if (force) {
     // `?refresh=1` is a NUDGE, not news. The client cannot know the provider
     // set changed — only the write that changed it can, and every such write

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -1463,7 +1463,15 @@ export async function GET(req: NextRequest) {
     // first time a filter is tightened; the age term is the box that was off
     // for three weeks. In both the client is looking at the curated list.
     refreshInBackground(provider, {
-      clientHasNoCurrentAnswer: !isLivePayload(cached) || servedEmpty || ageMs > REFRESH_INTERVAL_MS,
+      clientHasNoCurrentAnswer: !isLivePayload(cached)
+        || servedEmpty
+        || ageMs > REFRESH_INTERVAL_MS
+        // The box changed after this payload was enumerated, and the fork that
+        // change started has already failed. `notifyProviderSetChanged` cleared
+        // the wait and forked; when that fork fails, the wait is back and every
+        // later request is blocked — so without this term a picker sits on the
+        // PRE-change list, seconds old and live, for the whole window.
+        || !publishedIsCurrent(provider),
     });
   } else if (force) {
     // `?refresh=1` is a NUDGE, not news. The client cannot know the provider

--- a/src/tests/routes/ai-models/catalog-forced-retry.test.ts
+++ b/src/tests/routes/ai-models/catalog-forced-retry.test.ts
@@ -100,12 +100,16 @@ function settle(): Promise<void> {
 describe("catalog: forcing a retry after a failed enumeration", () => {
   let GET: (req: NextRequest) => Promise<Response>;
 
+  let notifyProviderSetChanged: (p: string | null | undefined) => void;
+
   beforeEach(async () => {
     fs.rmSync(DATA_DIR, { recursive: true, force: true });
     fs.mkdirSync(path.join(DATA_DIR, "catalog-cache"), { recursive: true });
     vi.resetModules();
     vi.clearAllMocks();
-    GET = (await import("@/app/setup-api/ai-models/catalog/route")).GET;
+    const mod = await import("@/app/setup-api/ai-models/catalog/route");
+    GET = mod.GET;
+    notifyProviderSetChanged = mod.notifyProviderSetChanged;
   });
 
   async function get(params = ""): Promise<Record<string, unknown>> {
@@ -168,6 +172,37 @@ describe("catalog: forcing a retry after a failed enumeration", () => {
     await get();
     await settle();
     expect(spawnsFor("anthropic")).toBe(afterRetry);
+  });
+
+  it("counts a LIVE list from before a provider-set change as not current", async () => {
+    // The change's own fork is the one that failed. `notifyProviderSetChanged`
+    // cleared the wait and started it; when it fails the wait is back, and the
+    // payload on file is seconds old and stamped live — so age and
+    // `isLivePayload` both say "current" while the generation says otherwise.
+    // Without the generation term the picker sits on the PRE-change list for
+    // the whole window, which is the shape this card is about.
+    mockSpawn.mockImplementation(
+      () => okChild(ANTHROPIC_LIVE) as unknown as ReturnType<typeof childProcess.spawn>,
+    );
+    await get();
+    await settle();
+    const afterWarmup = spawnsFor("anthropic");
+
+    mockSpawn.mockImplementation(
+      () => failingChild() as unknown as ReturnType<typeof childProcess.spawn>,
+    );
+    notifyProviderSetChanged("anthropic");
+    await settle();
+    const afterChange = spawnsFor("anthropic");
+    expect(afterChange).toBe(afterWarmup + 1);
+
+    mockSpawn.mockImplementation(
+      () => okChild(ANTHROPIC_LIVE) as unknown as ReturnType<typeof childProcess.spawn>,
+    );
+    await get();
+    await settle();
+
+    expect(spawnsFor("anthropic")).toBe(afterChange + 1);
   });
 
   it("leaves a provider with a LIVE, CURRENT catalogue alone", async () => {

--- a/src/tests/routes/ai-models/catalog-forced-retry.test.ts
+++ b/src/tests/routes/ai-models/catalog-forced-retry.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+import * as childProcess from "child_process";
+import fs from "fs";
+import path from "path";
+import { NextRequest } from "next/server";
+
+/**
+ * TASK-669 (#587 follow-up M2) — the owner can force a retry after a transient
+ * enumeration failure.
+ *
+ * A failed enumeration records a backoff that starts at two minutes and
+ * doubles up to the full six-hour refresh interval. That is the right schedule
+ * for the BOX's own retries; it was also the only schedule there was. A blip
+ * during boot warmup — a network hiccup while the picker was never open —
+ * left the owner looking at the curated fallback with `?refresh=1` doing
+ * nothing at all, because the GET's stale branch calls `refreshInBackground`
+ * with no options and the wait stops it before anything forks.
+ *
+ * Two things in the card turned out not to be the mechanism, and the fix is
+ * shaped by both:
+ *
+ *   * `serveCurrent` being a no-op on a cold process (both generation counters
+ *     default to 0) is true and is not what bites — with a failed warmup the
+ *     GET takes the `isStale` branch and never reaches `serveCurrent`;
+ *   * `?refresh=1` is not the owner's force button. `useProviderCatalog` sends
+ *     it ONLY as its echo of a provider-set change, by which point
+ *     `notifyProviderSetChanged` has already cleared the wait. The plain
+ *     picker open — the request that finds the box in this state — sends no
+ *     parameter at all.
+ *
+ * So the attempt belongs to the first REQUEST that finds no live payload
+ * behind a recorded failure, and there is exactly one per provider per
+ * process: the warming poll returns every two seconds and must not become a
+ * fork loop.
+ */
+
+vi.mock("child_process", () => ({ spawn: vi.fn() }));
+
+vi.mock("@/lib/openclaw-config", () => ({
+  findOpenclawBin: () => "openclaw",
+  openclawIsAbsent: () => false,
+}));
+
+const DATA_DIR = "/tmp/clawbox-catalog-forced-retry-test";
+vi.mock("@/lib/config-store", () => ({ DATA_DIR: "/tmp/clawbox-catalog-forced-retry-test" }));
+
+const mockSpawn = vi.mocked(childProcess.spawn);
+
+/** A child that answers `json` on stdout and exits 0. */
+function okChild(json: unknown) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter; stderr: EventEmitter; kill: () => void;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = () => {};
+  queueMicrotask(() => {
+    child.stdout.emit("data", Buffer.from(JSON.stringify(json), "utf8"));
+    child.emit("close", 0);
+  });
+  return child;
+}
+
+/** A child that fails the way a network blip does: something on stderr, exit 1. */
+function failingChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter; stderr: EventEmitter; kill: () => void;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = () => {};
+  queueMicrotask(() => {
+    child.stderr.emit("data", Buffer.from("getaddrinfo EAI_AGAIN api.anthropic.com", "utf8"));
+    child.emit("close", 1);
+  });
+  return child;
+}
+
+const ANTHROPIC_LIVE = {
+  count: 2,
+  models: [
+    { key: "anthropic/claude-opus-5", name: "Opus 5", contextWindow: 1_000_000, available: true, tags: [] },
+    { key: "anthropic/claude-sonnet-5", name: "Sonnet 5", contextWindow: 1_000_000, available: true, tags: ["default"] },
+  ],
+};
+
+function spawnsFor(provider: string): number {
+  return mockSpawn.mock.calls.filter((call) => {
+    const args = call[1] as string[];
+    return args[args.indexOf("--provider") + 1] === provider;
+  }).length;
+}
+
+/** Let a detached refresh get as far as it is going to get. */
+function settle(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 250));
+}
+
+describe("catalog: forcing a retry after a failed enumeration", () => {
+  let GET: (req: NextRequest) => Promise<Response>;
+
+  beforeEach(async () => {
+    fs.rmSync(DATA_DIR, { recursive: true, force: true });
+    fs.mkdirSync(path.join(DATA_DIR, "catalog-cache"), { recursive: true });
+    vi.resetModules();
+    vi.clearAllMocks();
+    GET = (await import("@/app/setup-api/ai-models/catalog/route")).GET;
+  });
+
+  async function get(params = ""): Promise<Record<string, unknown>> {
+    const res = await GET(new NextRequest(
+      `http://clawbox.local/setup-api/ai-models/catalog?provider=anthropic${params}`,
+    ));
+    return (await res.json()) as Record<string, unknown>;
+  }
+
+  it("re-enumerates ONCE when a picker opens over a failed warmup", async () => {
+    // The blip. Every enumeration in this window fails, which is what records
+    // the wait.
+    mockSpawn.mockImplementation(
+      () => failingChild() as unknown as ReturnType<typeof childProcess.spawn>,
+    );
+    await get();
+    await settle();
+    const afterFailure = spawnsFor("anthropic");
+    expect(afterFailure).toBeGreaterThan(0);
+
+    // The network is back, and the owner opens the picker. No `?refresh=1`:
+    // that is the client's echo of a change, and no change happened here.
+    mockSpawn.mockImplementation(
+      () => okChild(ANTHROPIC_LIVE) as unknown as ReturnType<typeof childProcess.spawn>,
+    );
+    await get();
+    await settle();
+
+    expect(spawnsFor("anthropic")).toBe(afterFailure + 1);
+    // And the attempt actually landed: the picker's next read is a live list,
+    // not the curated fallback it was sitting on.
+    const cache = JSON.parse(
+      fs.readFileSync(path.join(DATA_DIR, "catalog-cache", "anthropic.json"), "utf8"),
+    ) as { source?: string; models: { id: string }[] };
+    expect(cache.source).toBe("live");
+    expect(cache.models.map((m) => m.id)).toContain("claude-opus-5");
+  });
+
+  it("rations the attempt, so a polling picker cannot chain forks", async () => {
+    // `useProviderCatalog` comes back every two seconds while the box is
+    // warming, and a mounted picker must not turn a failing provider into a
+    // fork loop. The gap is longer than an enumeration for exactly that
+    // reason. It is a gap and not a once-ever count because this process runs
+    // for weeks: a single allowance would be burnt by the first picker open
+    // after the boot blip and the provider would be unreachable for good.
+    mockSpawn.mockImplementation(
+      () => failingChild() as unknown as ReturnType<typeof childProcess.spawn>,
+    );
+    await get();
+    await settle();
+    const afterWarmup = spawnsFor("anthropic");
+
+    await get();
+    await settle();
+    const afterRetry = spawnsFor("anthropic");
+    expect(afterRetry).toBe(afterWarmup + 1);
+
+    await get();
+    await get();
+    await get();
+    await settle();
+    expect(spawnsFor("anthropic")).toBe(afterRetry);
+  });
+
+  it("leaves a provider with a LIVE, CURRENT catalogue alone", async () => {
+    // The attempt is for somebody who does not have the box's own current
+    // answer. A box that enumerated fine is not owed a fork because a picker
+    // mounted.
+    mockSpawn.mockImplementation(
+      () => okChild(ANTHROPIC_LIVE) as unknown as ReturnType<typeof childProcess.spawn>,
+    );
+    await get();
+    await settle();
+    const afterWarmup = spawnsFor("anthropic");
+
+    await get();
+    await get();
+    await settle();
+
+    expect(spawnsFor("anthropic")).toBe(afterWarmup);
+  });
+
+  it("counts a LIVE list older than the refresh interval as not current", async () => {
+    // The discriminating case, and the one a `!isLivePayload(...)` test alone
+    // gets wrong: the box was off for three weeks, so the disk cache is a real
+    // enumeration and `isLivePayload` is true. The owner is still looking at a
+    // three-week-old list with the wait running, which is the same complaint
+    // the card makes with an old real list instead of a curated one.
+    fs.writeFileSync(
+      path.join(DATA_DIR, "catalog-cache", "anthropic.json"),
+      JSON.stringify({
+        provider: "anthropic",
+        models: [{ id: "claude-sonnet-4-6", label: "Sonnet 4.6", contextWindow: 200_000 }],
+        defaultModelId: "claude-sonnet-4-6",
+        allowCustom: false,
+        source: "live",
+        fetchedAt: Date.now() - 21 * 24 * 60 * 60_000,
+      }),
+      "utf8",
+    );
+    mockSpawn.mockImplementation(
+      () => failingChild() as unknown as ReturnType<typeof childProcess.spawn>,
+    );
+    await get();
+    await settle();
+    const afterWarmup = spawnsFor("anthropic");
+
+    mockSpawn.mockImplementation(
+      () => okChild(ANTHROPIC_LIVE) as unknown as ReturnType<typeof childProcess.spawn>,
+    );
+    await get();
+    await settle();
+
+    expect(spawnsFor("anthropic")).toBe(afterWarmup + 1);
+  });
+});


### PR DESCRIPTION
Closes TASK-669 (the #587 follow-up M2).

## Symptom

The box's boot warmup fails a model enumeration — the network is not up yet, the CLI is mid-upgrade — while nobody is looking. The failure records a backoff that starts at two minutes and doubles up to the full six-hour refresh interval. The first person to open the model picker afterwards is shown the curated fallback list, and **nothing on the box is willing to try again**. Before the change generations landed, any picker open re-forked.

## Two things the card names, neither of which is the mechanism

Both were reproduced before anything was written, and both are recorded in the code rather than left for the next reader:

* **The generation counters defaulting to 0 does make `serveCurrent` a structural no-op on a cold process — and it is not what bites.** With a failed warmup the GET's own freshness test is true (`refreshFailedLast`, and `ageMs = Infinity` with no cache), so it takes the `isStale || !isLivePayload` branch and never reaches `serveCurrent` at all. `refreshIsBlocked` is the blocker.
* **`?refresh=1` is not the owner's force button.** `src/hooks/useProviderCatalog.ts` sends it only from `forceNextLoad`, i.e. as the client's echo of a `PROVIDERS_CHANGED` event — by which point `notifyProviderSetChanged` has already cleared the wait server-side. The plain picker open, the request that actually finds the box in this state, sends no parameter at all.

So the attempt belongs to the request, not to a query parameter.

## Fix

The request that finds itself **without the box's own current answer** spends one attempt against a recorded failure.

* **"Without the box's own current answer" is the question the GET has already answered**, three lines above the call, and is passed in rather than re-derived: `!isLivePayload(cached) || servedEmpty || ageMs > REFRESH_INTERVAL_MS`. That covers two states a `!isLivePayload` test alone gets wrong — a payload stamped `live` whose every row the current sanitiser rules filter away (the state that arrives the first time a filter is tightened, which `catalog-sanitised-empty-cache.test.ts` exists to pin), and a real enumeration from three weeks ago on a box that was switched off. In both the owner is looking at the curated rows. Deliberately **not** `isStale`, which includes `refreshFailedLast` and is therefore true by construction whenever the wait is running.
* **Rationed by a minimum gap, not a once-ever count.** This process runs for weeks. A single allowance would be burnt by the first picker open after the blip — very likely the one where the uplink is still coming up — and the provider would then be unreachable for the life of the server, which is the probe-once class this repo keeps producing. `src/lib/hermes-model-options.ts` solved the same problem on the other edition with `EXPLICIT_REFRESH_MIN_GAP_MS`; this is that primitive. The gap is longer than an enumeration (~3 minutes on a Jetson) so a mounted picker's two-second warming poll cannot chain one fork into the next.
* **Nothing is spent while another enumeration is running.** `refreshing` is per-provider, so apart from `bootWarmup`'s 5 s stagger it is the only fork-concurrency discipline in the file — and the wizard's provider list re-runs `useProviderCatalog` on every click, so a walk down anthropic → openai → google could otherwise start three ~2-core, ~3-minute forks at once on an Orin. Leaving it unspent is also the honest answer: something IS on its way, and the response says `warming`.
* **The wait is LIFTED, not cleared.** `clearFailedRefresh` deletes the record, so `recordFailedRefresh` restarts the doubling from its two-minute floor: a provider that had climbed to the six-hour cap would re-climb it through eight more picker-driven forks, and `refreshFailedLast` would go false for the length of the retry, dropping the `stale` flag off a payload no device produced. Expiring the deadline while keeping the window it had reached does neither.
* **Both the gap and the wait are dropped** by a successful refresh and by a provider-set change — the two events after which an old failure describes a box that no longer exists, which is the doctrine `clearFailedRefresh` already followed.
* **Not for a provider that can never enumerate here.** `cliMissing` (the Hermes SKU) and the no-enumeration-on-this-core case both `recordFailedRefresh` precisely so their one log line appears once per backoff window instead of once per picker open; `changeCouldMakeItEnumerable` is the question they already answer, and the new branch is behind it.

## Harness first

Nothing here re-implements a harness mechanism: the enumeration IS `openclaw models list --provider <id> --all --json`, and this change only decides when ClawBox is allowed to ask again. The scheduling primitive is borrowed from this repo's own Hermes-side answer to the same question rather than invented.

## Both editions

On Hermes `openclawIsAbsent()` makes `cliMissing` true for every CLI-enumerated provider, so `changeCouldMakeItEnumerable` is false and the retry never fires — which is required, because that branch's `recordFailedRefresh` is what keeps its "no CLI on this edition" log line to once per window.

## RED

On unmodified `origin/beta`, with only the test file copied in:

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  catalog-forced-retry.test.ts > re-enumerates ONCE when a picker opens over a failed warmup
 FAIL  catalog-forced-retry.test.ts > rations the attempt, so a polling picker cannot chain forks
 FAIL  catalog-forced-retry.test.ts > counts a LIVE list older than the refresh interval as not current
AssertionError: expected 1 to be 2 // Object.is equality
 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
```

`1` is the boot warmup's own attempt and nothing after it. The fourth case — a provider with a live, current catalogue is not owed a fork because a picker mounted — passes on beta too; it is the boundary guard, not evidence.

## GREEN

`catalog-forced-retry.test.ts` 4 passed; all 18 `routes/ai-models` suites 330 passed on the rebased head; full `--project unit` 658 files / 10546 passed. `tsc --noEmit` and `eslint` clean.

## Overlap

`src/app/setup-api/ai-models/catalog/route.ts` is also touched by the TASK-668 branch, which adds an exported `notifyModelsModeChanged` in a different region of the same file (the notify block, not the refresh gate). Both are based on the same `origin/beta`; whichever merges second may want a trivial rebase.

## Review

`clawbox-review`, findings at `code-review-669.md` (1 HIGH, 6 MEDIUM, 4 LOW). The departure from the card's stated fix direction was independently reproduced and upheld. Applied: HIGH-1 (the one-shot `Set` was a probe-once decision held for a process that runs for weeks — now a minimum gap), MEDIUM-1 (the retry was asking a narrower "is there a live payload" question than the GET had already answered), MEDIUM-2 (the allowance is renewed by a provider-set change and by a successful refresh), MEDIUM-3 (lift the deadline instead of clearing the record, and fix the two comments that claimed it), MEDIUM-4 (nothing spent while another fork runs), MEDIUM-5 (a discriminating test — the live-but-three-weeks-old cache — so the condition cannot be deleted with the suite still green).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI model catalog recovery when provider responses are missing, empty, or outdated.
  * Limited client-triggered retries to one attempt every five minutes, while preserving exponential backoff.
  * Retry state now resets after successful updates or provider changes, preventing unnecessary repeated refreshes.

* **Tests**
  * Added coverage for transient provider failures, stale catalogs, repeated polling, provider changes, and avoiding unnecessary retries for current catalogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->