### PR TITLE
fix: keep the chat picture wait in its own tab, and give the tab strip a panel

### DIFF
--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -529,10 +529,15 @@ const TRANSCRIPT_PANEL_ID = 'chat-transcript-panel'
 /**
  * A tab's DOM id, derived from its session key so the panel can name the
  * selected tab as its label without either side holding an index. `null` is the
- * main conversation, which has no tab key of its own. The key is REBUILT from
- * the id alphabet rather than interpolated: a session key carries colons
- * (`agent:main:clawbox-…`), which are legal in an HTML id but not in the CSS
- * selectors an id is looked up with.
+ * main conversation, which has no tab key of its own.
+ *
+ * The key's punctuation is folded to `_` — an OpenClaw session key is
+ * `agent:main:clawbox-…`, and while a colon is legal in an HTML id it has to be
+ * escaped in every CSS selector that looks one up. `aria-controls` and
+ * `aria-labelledby` are IDREFs and would not care; a later `querySelector`
+ * would, and this is the cheaper end to fix it at. The fold is lossy, which is
+ * harmless here: one id per open tab, and two live keys that differ only in
+ * punctuation do not exist.
  */
 const tabDomId = (key: string | null) =>
   `chat-tab-${key === null ? 'main' : key.replace(/[^A-Za-z0-9_-]/g, '_')}`
@@ -1010,7 +1015,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   // image…" over another tab's transcript and greyed ITS picture button until
   // the request settled — while the picture itself already followed the rule
   // `dispatchTurn` and `loadHistory` follow and landed in the tab that asked.
-  const [drawingTabs, setDrawingTabs] = useState<ReadonlySet<string | null>>(new Set())
+  const [drawingTabs, setDrawingTabs] = useState<ReadonlySet<string | null>>(() => new Set())
   // The controllers behind them. Re-entry is decided from the ref, which does
   // not lag a rapid second click on one tab — two generations would be two
   // charges against the customer's daily allowance for one intent — and it
@@ -2615,6 +2620,10 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       window.clearTimeout(ackOnlyHistoryTimerRef.current)
       ackOnlyHistoryTimerRef.current = null
     }
+    // The AGENT's picture wait, which belongs to the turn being left behind.
+    // The COMPOSER's (`drawingTabs`) deliberately survives: it is keyed by tab
+    // now, so it stays with the conversation that asked and is on screen again
+    // when the owner comes back to it.
     endImageWait()
     imageWaitFromRef.current = 0
     imageBaselineRef.current = 0
@@ -2730,6 +2739,14 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       next.delete(key)
       return next
     })
+    // A composer picture still being fetched for THIS tab. `deleteSession`
+    // cannot reach it — it aborts the adapter's own turn controller, and only
+    // when `running`, which a drawing tab never sets — and the image route
+    // appends the picture to the transcript when it lands, so a generation left
+    // running would re-create the file this close is about to delete, with the
+    // owner's conversation back on disk and the picture billed against a
+    // conversation that no longer exists.
+    drawingRef.current.get(key)?.abort()
     const dispose = async () => {
       // switchSession marks the key busy on the way out when its run is
       // live; the tab is gone now, so the mark must go too.
@@ -4055,6 +4072,12 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     // Re-entry is decided from the ref, not from `drawing`: a second click can
     // land in the window before the state commit, and two generations would be
     // two charges against the customer's daily allowance for one intent.
+    //
+    // PER CONVERSATION, not per popup: two tabs are two intents and may each
+    // buy a picture, which is a real change to what a burst of clicking can
+    // spend — nothing on the box refuses the second request, and the only
+    // back-stop is the plan's daily allowance (a 429 the chat words). It is
+    // the right UI model, and it is the owner's call to make: see the PR body.
     // The tab that asked, so the wait is shown where it belongs and a second
     // click on THIS tab is refused while another conversation may still ask.
     const tabAtSend = activeTabKeyRef.current
@@ -5235,12 +5258,13 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
         tabIndex={0}
         data-testid="chat-transcript"
         style={{
-        flex: 1, overflowY: 'auto', padding: '12px 14px 12px',
-        display: 'flex', flexDirection: 'column', gap: 10,
-        userSelect: 'text',
-        scrollbarWidth: 'thin',
-        scrollbarColor: 'rgba(255,255,255,0.1) transparent',
-      }}>
+          flex: 1, overflowY: 'auto', padding: '12px 14px 12px',
+          display: 'flex', flexDirection: 'column', gap: 10,
+          userSelect: 'text',
+          scrollbarWidth: 'thin',
+          scrollbarColor: 'rgba(255,255,255,0.1) transparent',
+        }}
+      >
         {(status === 'connecting' || reloadingSkill) && (reloadingSkill || messages.length === 0) && (
           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', flex: 1, gap: 14, color: 'rgba(255,255,255,0.5)', fontSize: 13 }}>
             <style>{`@keyframes spin { to { transform: rotate(360deg) } } @keyframes dots { 0%,20% { content: '' } 40% { content: '.' } 60% { content: '..' } 80%,100% { content: '...' } } @keyframes clawReloadFill { from { transform: scaleX(0.04) } to { transform: scaleX(0.9) } }`}</style>

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -524,6 +524,19 @@ interface ChatTab {
 const TABS_STORAGE_KEY = 'clawbox-chat-tabs'
 const TAB_LABEL_MAX = 24
 
+/** The transcript, as the tab strip's one panel. */
+const TRANSCRIPT_PANEL_ID = 'chat-transcript-panel'
+/**
+ * A tab's DOM id, derived from its session key so the panel can name the
+ * selected tab as its label without either side holding an index. `null` is the
+ * main conversation, which has no tab key of its own. The key is REBUILT from
+ * the id alphabet rather than interpolated: a session key carries colons
+ * (`agent:main:clawbox-…`), which are legal in an HTML id but not in the CSS
+ * selectors an id is looked up with.
+ */
+const tabDomId = (key: string | null) =>
+  `chat-tab-${key === null ? 'main' : key.replace(/[^A-Za-z0-9_-]/g, '_')}`
+
 /**
  * The ✕ on a tab plate — it closes a side tab, and restarts main. One control
  * in two places, so its box, its hover ladder and its glyph are written once.
@@ -991,12 +1004,22 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   // BOX is fetching, where the call itself resolves with the media — so it ends
   // when the promise does, and sharing the other flag would start that poll and
   // let a history read paint the same picture the promise is about to.
-  const [drawing, setDrawing] = useState(false)
-  // Guards re-entry from the render-time state, which lags a rapid second
-  // click, and carries the abort so closing the popup can end a wait nobody is
+  //
+  // Tracked PER CONVERSATION, keyed by tab (null is the main one). It was one
+  // component-wide flag, so a picture asked for in one tab put "Generating
+  // image…" over another tab's transcript and greyed ITS picture button until
+  // the request settled — while the picture itself already followed the rule
+  // `dispatchTurn` and `loadHistory` follow and landed in the tab that asked.
+  const [drawingTabs, setDrawingTabs] = useState<ReadonlySet<string | null>>(new Set())
+  // The controllers behind them. Re-entry is decided from the ref, which does
+  // not lag a rapid second click on one tab — two generations would be two
+  // charges against the customer's daily allowance for one intent — and it
+  // carries the aborts, so closing the popup can end every wait nobody is
   // watching any more.
-  const drawingRef = useRef(false)
-  const drawingAbortRef = useRef<AbortController | null>(null)
+  const drawingRef = useRef(new Map<string | null, AbortController>())
+  const syncDrawingTabs = useCallback(() => {
+    setDrawingTabs(new Set(drawingRef.current.keys()))
+  }, [])
 
   // ── The Create button's wizard ──
   // The same card the Coding Agent app opens: name, what it should do, which
@@ -1423,6 +1446,8 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   const [tabs, setTabs] = useState<ChatTab[]>(storedTabs.tabs)
   const [activeTabKey, setActiveTabKey] = useState<string | null>(storedTabs.active)
   const activeTabKeyRef = useRef<string | null>(storedTabs.active)
+  /** Is THIS conversation waiting on a composer picture? See `drawingTabs`. */
+  const drawing = drawingTabs.has(activeTabKey)
   const [mainSessionKey, setMainSessionKey] = useState('')
   const mainSessionKeyRef = useRef('')
   // Sessions whose turn is still running while another tab is shown. The
@@ -4030,7 +4055,10 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     // Re-entry is decided from the ref, not from `drawing`: a second click can
     // land in the window before the state commit, and two generations would be
     // two charges against the customer's daily allowance for one intent.
-    if (!prompt || drawingRef.current) return
+    // The tab that asked, so the wait is shown where it belongs and a second
+    // click on THIS tab is refused while another conversation may still ask.
+    const tabAtSend = activeTabKeyRef.current
+    if (!prompt || drawingRef.current.has(tabAtSend)) return
     // The conversation that asked. A generation takes 15-40 seconds and the
     // route records it under this key, so a tab switch mid-wait must not paint
     // the picture into whichever conversation is on screen when it lands —
@@ -4038,9 +4066,8 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     const keyAtSend = sessionKeyRef.current
     setInput('')
     const controller = new AbortController()
-    drawingAbortRef.current = controller
-    drawingRef.current = true
-    setDrawing(true)
+    drawingRef.current.set(tabAtSend, controller)
+    syncDrawingTabs()
     setMessages(prev => [...prev, { role: 'user', text: prompt, timestamp: Date.now() }])
     try {
       const { media } = await adapter.generateImage(prompt, controller.signal)
@@ -4069,17 +4096,20 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
         timestamp: Date.now(),
       }])
     } finally {
-      drawingRef.current = false
-      setDrawing(false)
-      drawingAbortRef.current = null
+      // Only ever clear our OWN entry: a generation that settles must not take
+      // down one this tab started after it.
+      if (drawingRef.current.get(tabAtSend) === controller) {
+        drawingRef.current.delete(tabAtSend)
+        syncDrawingTabs()
+      }
     }
-  }, [input, adapter])
+  }, [input, adapter, syncDrawingTabs])
 
   // A wait nobody is watching is a paid generation still running. Closing the
   // popup ends it, the same way it drops the agent's image wait just above.
   useEffect(() => {
     if (isOpen) return
-    drawingAbortRef.current?.abort()
+    for (const controller of drawingRef.current.values()) controller.abort()
   }, [isOpen])
 
   const sendMessage = useCallback(() => {
@@ -5007,6 +5037,14 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
                     // mean eight presses to reach the composer.
                     tabIndex={active ? 0 : -1}
                     aria-selected={active}
+                    // The other half of the ARIA tabs pattern: a `tab` that
+                    // controls nothing leaves assistive tech with a strip of
+                    // buttons and no way to say what selecting one changed.
+                    // One panel for every tab, because the transcript IS the
+                    // panel — it is re-read for the conversation that was
+                    // selected rather than swapped for a second element.
+                    id={tabDomId(tab.main ? null : tab.key)}
+                    aria-controls={TRANSCRIPT_PANEL_ID}
                     data-testid="chat-tab"
                     data-session-key={tab.key}
                     // Both dots are aria-hidden decoration, so without this a
@@ -5182,8 +5220,21 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       </div>
 
       {/* Messages area — sits under the header bar in the flow, so it needs
-          no clearance beyond its own breathing room. */}
-      <div style={{
+          no clearance beyond its own breathing room.
+
+          It is the tab strip's PANEL: `aria-labelledby` names whichever tab is
+          selected, so the conversation on screen is announced as that tab's
+          content. `tabIndex={0}` because a scrollable region has to be
+          reachable by keyboard — several of its bubbles carry nothing
+          focusable, and the transcript is the one thing here worth paging
+          through. */}
+      <div
+        id={TRANSCRIPT_PANEL_ID}
+        role="tabpanel"
+        aria-labelledby={tabDomId(activeTabKey)}
+        tabIndex={0}
+        data-testid="chat-transcript"
+        style={{
         flex: 1, overflowY: 'auto', padding: '12px 14px 12px',
         display: 'flex', flexDirection: 'column', gap: 10,
         userSelect: 'text',

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -4129,10 +4129,18 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   }, [input, adapter, syncDrawingTabs])
 
   // A wait nobody is watching is a paid generation still running. Closing the
-  // popup ends it, the same way it drops the agent's image wait just above.
+  // popup ends it, the same way it drops the agent's image wait just above —
+  // and so does UNMOUNTING while open, which the `isOpen` branch alone never
+  // saw: an effect keyed on it only fires when the flag changes, so a popup
+  // taken off the page mid-generation left the request running and billed.
+  // The controllers take themselves out of the map in `generatePicture`'s
+  // `finally`, which runs whether the request was aborted or not.
   useEffect(() => {
-    if (isOpen) return
-    for (const controller of drawingRef.current.values()) controller.abort()
+    const abortAll = () => {
+      for (const controller of drawingRef.current.values()) controller.abort()
+    }
+    if (isOpen) return abortAll
+    abortAll()
   }, [isOpen])
 
   const sendMessage = useCallback(() => {

--- a/src/tests/components/chat-hermes-tabs.test.tsx
+++ b/src/tests/components/chat-hermes-tabs.test.tsx
@@ -442,6 +442,10 @@ describe("what a screen reader is told about a tab", () => {
     expect(screen.queryByText(translations.en["chat.generatingImage"])).toBeNull();
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "a blue whale" } });
     await waitFor(() => expect(screen.getByTestId("generate-image")).not.toBeDisabled());
+    // And the button works, rather than merely looking enabled: the guard is
+    // one generation PER CONVERSATION now, so this tab may ask for its own.
+    fireEvent.click(screen.getByTestId("generate-image"));
+    await waitFor(() => expect(box.imagePrompts).toEqual(["a red maple leaf", "a blue whale"]));
 
     // Back where it was asked for, the wait is still on screen and the button
     // is still held — one generation per conversation, as before.

--- a/src/tests/components/chat-hermes-tabs.test.tsx
+++ b/src/tests/components/chat-hermes-tabs.test.tsx
@@ -416,4 +416,65 @@ describe("what a screen reader is told about a tab", () => {
     await waitFor(() => expect(activeTabKey()).toBe(DESKTOP));
     await screen.findByText(/nothing was written/i);
   });
+  it("keeps the composer's picture wait in the tab that asked for it", async () => {
+    // The picture already lands in the right conversation; the WAIT did not.
+    // `drawing` was one component-wide flag, so a generation started in main
+    // put "Generating image…" over a second tab's transcript and greyed its
+    // picture button — a control the owner can see is not disabled by anything
+    // in the conversation they are looking at.
+    box.facts.hasClawaiToken = true;
+    box.facts.hasClawaiImageRoute = true;
+    let release!: (answer: unknown) => void;
+    const held = new Promise<unknown>((resolve) => { release = resolve; });
+    box.imageReply = () => ({ ok: true, status: 200, payload: held });
+    await mountHermesChat(box);
+
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "a red maple leaf" } });
+    const draw = await screen.findByTestId("generate-image");
+    await waitFor(() => expect(draw).not.toBeDisabled());
+    fireEvent.click(draw);
+    await waitFor(() => expect(box.imagePrompts).toEqual(["a red maple leaf"]));
+    await screen.findByText(translations.en["chat.generatingImage"]);
+
+    await openNewTab();
+    // This conversation asked for nothing and is not waiting for anything.
+    expect(screen.queryByText(translations.en["chat.generatingImage"])).toBeNull();
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "a blue whale" } });
+    await waitFor(() => expect(screen.getByTestId("generate-image")).not.toBeDisabled());
+
+    // Back where it was asked for, the wait is still on screen and the button
+    // is still held — one generation per conversation, as before.
+    fireEvent.click(tabs()[0]);
+    await waitFor(() => expect(activeTabKey()).toBe(DESKTOP));
+    await screen.findByText(translations.en["chat.generatingImage"]);
+    expect(screen.getByTestId("generate-image")).toBeDisabled();
+
+    release({ ok: true, media: [] });
+    await waitFor(() =>
+      expect(screen.queryByText(translations.en["chat.generatingImage"])).toBeNull());
+  });
+
+  it("names the transcript as the tab strip's panel", async () => {
+    // The strip implements the ARIA tabs pattern — tablist, roving tabindex,
+    // manual activation — with no `tabpanel` anywhere, so a screen reader was
+    // told these were tabs and never what selecting one changed.
+    await mountHermesChat(box);
+    await openNewTab();
+
+    const panel = screen.getByTestId("chat-transcript");
+    expect(panel).toHaveAttribute("role", "tabpanel");
+    for (const tab of tabs()) {
+      expect(tab.getAttribute("aria-controls"), tab.getAttribute("data-session-key") ?? "")
+        .toBe(panel.id);
+      expect(tab.id).toBeTruthy();
+    }
+    // Labelled by whichever tab is selected, and it follows the selection.
+    const selected = () => tabs().find((el) => el.getAttribute("aria-selected") === "true")!;
+    expect(panel.getAttribute("aria-labelledby")).toBe(selected().id);
+
+    fireEvent.click(tabs()[0]);
+    await waitFor(() => expect(activeTabKey()).toBe(DESKTOP));
+    expect(panel.getAttribute("aria-labelledby")).toBe(selected().id);
+  });
 });

--- a/src/tests/components/chat-tabs.test.tsx
+++ b/src/tests/components/chat-tabs.test.tsx
@@ -408,4 +408,31 @@ describe("chat tabs", () => {
     expect(frames("chat.send")).toHaveLength(0);
     expect(tabKeys()).toEqual([MAIN]);
   });
+  it("names the transcript as the tab strip's panel, with ids a session key can carry", async () => {
+    // The strip and the transcript are the SAME JSX on both editions; the
+    // Hermes suite proves the behaviour, and this proves the half that only
+    // exists here — an OpenClaw session key is `agent:main:clawbox-…`, and a
+    // colon has to be escaped in every CSS selector an id is looked up with.
+    await mountReady();
+    await openNewTab();
+
+    const panel = screen.getByTestId("chat-transcript");
+    expect(panel).toHaveAttribute("role", "tabpanel");
+    expect(panel.id).toBeTruthy();
+    for (const tab of tabs()) {
+      const key = tab.getAttribute("data-session-key") ?? "";
+      expect(tab.getAttribute("aria-controls"), key).toBe(panel.id);
+      expect(tab.id, key).toMatch(/^chat-tab-[A-Za-z0-9_-]+$/);
+      expect(tab.id, key).not.toContain(":");
+    }
+    expect(tabs()[0].id).toBe("chat-tab-main");
+    expect(tabs()[1].id).toMatch(/^chat-tab-agent_main_clawbox-[a-z0-9]{12}$/);
+
+    const selected = () => tabs().find((el) => el.getAttribute("aria-selected") === "true")!;
+    expect(panel.getAttribute("aria-labelledby")).toBe(selected().id);
+
+    fireEvent.click(tabs()[0]);
+    await waitFor(() => expect(activeTabKey()).toBe(MAIN));
+    expect(panel.getAttribute("aria-labelledby")).toBe(selected().id);
+  });
 });


### PR DESCRIPTION
**TASK-656** — the two follow-ups CodeRabbit raised on the restored chat tab strip during the #588 revert review.

### Customer-visible symptoms
1. **The picture wait belonged to the popup, not to the conversation.** Ask for a picture in one chat tab, switch to another, and that second conversation shows "Generating image…" over its transcript with its picture button greyed out — for a picture it never asked for, until the 15–40 s request settles. Meanwhile the picture itself already lands in the tab that asked, so the wait and the result disagreed about whose conversation it was.
2. **The tab strip was a set of tabs that controlled nothing.** It implements the ARIA tabs pattern — `role="tablist"`, roving `tabindex`, manual activation — with no `role="tabpanel"` anywhere, so a screen reader was told these were tabs and never what selecting one changed.

### Cause
1. `ChatPopup.tsx` kept the composer's wait as ONE component-wide `drawing` flag (and one `drawingRef` / `drawingAbortRef`), while `generatePicture`, `dispatchTurn` and `loadHistory` all already key their results on the conversation that asked.
2. Each `role="tab"` carried no `id` and no `aria-controls`, and the transcript container was a plain `<div>`.

### Harness first
Neither half belongs to OpenClaw or Hermes. The relevant "native mechanism" is the ARIA Authoring Practices tabs pattern, and the repo's own precedent: `CodingProjectWorkspace.tsx` and `CodingAgentApp.tsx` already carry `id` + `aria-controls` on the tab and `id` + `aria-labelledby` on the panel. This follows them rather than inventing a third shape.

### The change
- `drawingTabs: ReadonlySet<string | null>` (keyed by tab; `null` is main) with the controllers in a `Map`, and `drawing` derived as `drawingTabs.has(activeTabKey)`. The wait shows where it belongs, survives leaving and returning to that tab, and closing the popup aborts every one of them.
- Each tab gains `id={tabDomId(...)}` and `aria-controls`; the transcript gains `id`, `role="tabpanel"`, `aria-labelledby` (following the selection) and `tabIndex={0}` so a scrollable region is reachable by keyboard. ONE panel for every tab, because the transcript IS re-read for the conversation that was selected rather than swapped for a second element.
- Closing a tab now aborts that tab's picture. `deleteSession` could not: it aborts the adapter's own turn controller and only when `running`, which a drawing tab never sets — so a close mid-generation let the image route append the picture to the transcript it had just deleted, putting the owner's conversation back on disk and billing the picture to a conversation that no longer exists. Pre-existing; this PR is the one that made the registry to fix it with.

### A change to spend, for the owner to confirm
The re-entry guard was "one generation per popup" and is now "one per conversation". I looked for a second guard and there is none: `/setup-api/chat/images` has a prompt-length cap and nothing else, and `clawai-images.ts` has a timeout and a probe cache — no per-box lock, no rate limit. So four tabs can now start four pictures, where the component used to allow one. **Per-tab is the right UI model** (two tabs are two intents, and the alternative is a button that looks enabled and silently does nothing), but it is the customer's daily allowance, so it is stated here rather than buried: on a plan with a low allowance, a burst of clicking across tabs will spend more of it, and the extra requests come back 429 worded as "You have used up today's ClawBox AI pictures". Say the word and the cap goes back to component-wide for the CHARGE while the display stays per tab.

### RED → GREEN

RED on unmodified `origin/beta`:

```
Hermes suite (2 cases)
 × keeps the composer's picture wait in the tab that asked for it
      AssertionError: expected <span></span> to be null      ← the wait drawn in the wrong tab
 × names the transcript as the tab strip's panel
      TestingLibraryElementError: Unable to find an element by: [data-testid="chat-transcript"]

OpenClaw suite (1 case)
 × names the transcript as the tab strip's panel, with ids a session key can carry
      TestingLibraryElementError: Unable to find an element by: [data-testid="chat-transcript"]
```

GREEN:

```
$ npx vitest run --project components chat-tabs chat-hermes-tabs \
    chat-image-generation-wait chat-hermes-image-generation
 Test Files  4 passed (4)
      Tests  51 passed (51)
```

`build-typecheck` green; eslint unchanged at 8 pre-existing warnings, 0 errors. A full parallel run of `src/tests/components/chat-*.test.tsx` flakes on `chat-spoken-reply.test.tsx` — verified to flake the same way on unmodified beta and to pass alone on this branch, so it is the known parallel-run flake and not this change.

### Both editions
The composer picture button renders only where `caps.imageGenerationTrigger === 'composer'`, i.e. Hermes — on OpenClaw the agent draws and the adapter refuses the method outright, so that half is untouched there. The ARIA half is the same JSX on both, and is proven on both: the OpenClaw case also covers the one thing only that edition exercises — a session key is `agent:main:clawbox-…`, and `tabDomId` folds the colons an id would otherwise carry into every CSS selector that looks it up.

### Siblings handled
- Every reader of the touched refs was checked; `switchSession` no longer needs to clear the composer's wait (the derived value does it), and its docblock says which of the two waits it does cancel.
- **`TerminalTabs.tsx` is the one remaining `role="tab"` strip in the tree with neither `aria-controls` on its tabs nor `id`/`aria-labelledby` on its panels** — exactly the state this PR's own comment condemns. NOT fixed here (different component, different suite, no shared code with this change); recorded so it is not silently left.
- `CodingProjectWorkspace.tsx` and `CodingAgentApp.tsx` already do it correctly; nothing to change there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Improved chat tab accessibility with stable tab and transcript panel identifiers.
  - Added ARIA relationships associating the transcript panel with the selected tab.
  - Made the transcript panel keyboard-focusable and ensured labeling updates when switching tabs.

- **Bug Fixes**
  - Image-generation progress is tracked independently for each conversation tab.
  - Switching tabs no longer interrupts another tab’s image-generation wait state.
  - Closing a tab cancels its active image generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->