### PR TITLE
fix: report the failed Hermes local-AI unregister instead of answering success

### DIFF
--- a/src/app/setup-api/local-ai/route.ts
+++ b/src/app/setup-api/local-ai/route.ts
@@ -138,9 +138,12 @@ export async function POST(request: Request) {
       // The panel paints `error` red on a non-2xx and never looks at `warning`
       // there, so a box that hit both failures gets both sentences or it gets
       // one of them told wrongly.
-      // Covers both refusals `removeLocalAiFromHermes` can raise — a key that
-      // demonstrably survived, and one the config could not be read back for —
-      // because the route sees only that it threw.
+      // Covers all three refusals `removeLocalAiFromHermes` can raise — a key
+      // that demonstrably survived, one the config could not be read back for,
+      // and one where the selection could not be read at all so nothing was
+      // attempted — because the route sees only that it threw. "May still be
+      // offered" understates the third (there it definitely still is), and the
+      // action it asks for is the same in all three.
       const failed = "Local AI was stopped, but removing it from Hermes could not be confirmed — it may still be offered as a provider. Try turning Local AI off again.";
       return NextResponse.json(
         { error: warning ? `${failed} ${warning}` : failed },

--- a/src/app/setup-api/local-ai/route.ts
+++ b/src/app/setup-api/local-ai/route.ts
@@ -61,14 +61,31 @@ export async function POST(request: Request) {
     // Clearing the OpenClaw fallback only applies where OpenClaw exists. On the
     // Hermes SKU there is no binary to spawn (it would ENOENT); the Hermes
     // unregister below is what actually takes effect there.
+    //
+    // A failure here is REPORTED, not swallowed: the model is stopped, so a
+    // fallback list that still names it sends the next turn that falls back to
+    // an endpoint with nothing behind it. It is a qualification rather than a
+    // refusal, though — the stop and the flag clear above are the steps this
+    // click is for, and they landed — so it rides the `warning` channel the
+    // panel already paints amber, and a retry re-runs only what is left.
+    let warning: string | null = null;
     if (!openclawIsAbsent()) {
-      await runCommand(OPENCLAW_BIN, [
+      const cleared = await runCommand(OPENCLAW_BIN, [
         "config",
         "set",
         "agents.defaults.model.fallbacks",
         JSON.stringify([]),
         "--json",
-      ]).catch(() => {});
+      ]).then(
+        () => true,
+        (err) => {
+          console.error("[local-ai] Failed to clear the OpenClaw fallback list:", err);
+          return false;
+        },
+      );
+      if (!cleared) {
+        warning = "Local AI is stopped, but OpenClaw still lists it as a fallback model. Turn it off again to finish clearing it.";
+      }
     }
 
     // Hermes keeps its own providers block, so disabling here has to unregister
@@ -81,11 +98,29 @@ export async function POST(request: Request) {
       // "Unknown provider 'clawlocal'"), and we remember that it WAS the
       // selection so re-enabling puts the device back where it was rather than
       // on nothing.
+      //
+      // The failure is ANSWERED rather than logged. On this SKU the unregister
+      // is the only step that reaches the customer: the OpenClaw clear above is
+      // skipped (no binary) and the restart below returns immediately (no
+      // gateway unit), so a swallowed failure left `providers.clawlocal` in
+      // config.yaml and the route still said `{success:true}` — Settings showed
+      // Local AI off while Hermes' own pickers went on offering the stopped
+      // model, and the owner learned otherwise from a chat turn. The steps that
+      // did run stand: a retry has only this one left to do.
       const removal = await removeLocalAiFromHermes().catch((err) => {
         console.error("[local-ai] Hermes local provider removal failed:", err);
         return null;
       });
-      if (removal?.wasDefault) {
+      if (!removal) {
+        return NextResponse.json(
+          {
+            error: "Local AI was stopped, but Hermes still lists it as a provider. Try turning Local AI off again.",
+            code: "hermes_unregister_failed",
+          },
+          { status: 502 },
+        );
+      }
+      if (removal.wasDefault) {
         await setMany({ local_ai_was_default: true });
       }
     }
@@ -95,7 +130,7 @@ export async function POST(request: Request) {
     // add up to the whole budget to an owner's "Turn off Local AI" click.
     await restartGateway({ awaitReady: false }).catch(() => {});
 
-    return NextResponse.json({ success: true });
+    return NextResponse.json(warning ? { success: true, warning } : { success: true });
   } catch (err) {
     return NextResponse.json(
       { error: err instanceof Error ? err.message : "Failed to disable Local AI" },

--- a/src/app/setup-api/local-ai/route.ts
+++ b/src/app/setup-api/local-ai/route.ts
@@ -5,7 +5,7 @@ import { get, setMany } from "@/lib/config-store";
 import { stopLocalAiProvider } from "@/lib/local-ai-runtime";
 import { readConfig as readOpenClawConfig, inferConfiguredLocalModel, restartGateway, runOpenclawConfigSet, openclawIsAbsent } from "@/lib/openclaw-config";
 import { getActiveHarness } from "@/lib/harness";
-import { removeLocalAiFromHermes } from "@/lib/hermes-local-ai";
+import { HermesLocalRemovalError, removeLocalAiFromHermes } from "@/lib/hermes-local-ai";
 
 const CLAWBOX_HOME_DIR = process.env.CLAWBOX_HOME_DIR || process.env.HOME || "/home/clawbox";
 
@@ -112,12 +112,19 @@ export async function POST(request: Request) {
       // Local AI off while Hermes' own pickers went on offering the stopped
       // model, and the owner learned otherwise from a chat turn. The steps that
       // did run stand: a retry has only this one left to do.
+      // Recorded even when the removal FAILS. A partial unset can clear
+      // `model.provider` and leave a providers key, and the refusal is the last
+      // moment that fact exists: the retry reads a selection that is already
+      // gone, so the flag would be lost for good and re-enabling Local AI would
+      // leave the device on nothing.
+      let wasDefault = false;
       const removal = await removeLocalAiFromHermes().catch((err) => {
         console.error("[local-ai] Hermes local provider removal failed:", err);
+        if (err instanceof HermesLocalRemovalError) wasDefault = err.wasDefault;
         return null;
       });
       hermesUnregisterFailed = !removal;
-      if (removal?.wasDefault) {
+      if (removal?.wasDefault || wasDefault) {
         await setMany({ local_ai_was_default: true });
       }
     }
@@ -136,10 +143,7 @@ export async function POST(request: Request) {
       // because the route sees only that it threw.
       const failed = "Local AI was stopped, but removing it from Hermes could not be confirmed — it may still be offered as a provider. Try turning Local AI off again.";
       return NextResponse.json(
-        {
-          error: warning ? `${failed} ${warning}` : failed,
-          code: "hermes_unregister_failed",
-        },
+        { error: warning ? `${failed} ${warning}` : failed },
         { status: 502 },
       );
     }

--- a/src/app/setup-api/local-ai/route.ts
+++ b/src/app/setup-api/local-ai/route.ts
@@ -131,7 +131,10 @@ export async function POST(request: Request) {
       // The panel paints `error` red on a non-2xx and never looks at `warning`
       // there, so a box that hit both failures gets both sentences or it gets
       // one of them told wrongly.
-      const failed = "Local AI was stopped, but Hermes still lists it as a provider. Try turning Local AI off again.";
+      // Covers both refusals `removeLocalAiFromHermes` can raise — a key that
+      // demonstrably survived, and one the config could not be read back for —
+      // because the route sees only that it threw.
+      const failed = "Local AI was stopped, but removing it from Hermes could not be confirmed — it may still be offered as a provider. Try turning Local AI off again.";
       return NextResponse.json(
         {
           error: warning ? `${failed} ${warning}` : failed,

--- a/src/app/setup-api/local-ai/route.ts
+++ b/src/app/setup-api/local-ai/route.ts
@@ -1,25 +1,13 @@
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import { promisify } from "util";
-import { execFile as execFileCb } from "child_process";
 import { get, setMany } from "@/lib/config-store";
 import { stopLocalAiProvider } from "@/lib/local-ai-runtime";
-import { readConfig as readOpenClawConfig, inferConfiguredLocalModel, findOpenclawBin, restartGateway, openclawIsAbsent } from "@/lib/openclaw-config";
+import { readConfig as readOpenClawConfig, inferConfiguredLocalModel, restartGateway, runOpenclawConfigSet, openclawIsAbsent } from "@/lib/openclaw-config";
 import { getActiveHarness } from "@/lib/harness";
 import { removeLocalAiFromHermes } from "@/lib/hermes-local-ai";
 
-const execFile = promisify(execFileCb);
-const OPENCLAW_BIN = findOpenclawBin();
 const CLAWBOX_HOME_DIR = process.env.CLAWBOX_HOME_DIR || process.env.HOME || "/home/clawbox";
-
-async function runCommand(cmd: string, args: string[]) {
-  return await execFile(cmd, args, {
-    cwd: CLAWBOX_HOME_DIR,
-    env: { ...process.env, HOME: CLAWBOX_HOME_DIR },
-    timeout: 30_000,
-  });
-}
 
 export async function POST(request: Request) {
   let body: { action?: string };
@@ -68,15 +56,28 @@ export async function POST(request: Request) {
     // refusal, though — the stop and the flag clear above are the steps this
     // click is for, and they landed — so it rides the `warning` channel the
     // panel already paints amber, and a retry re-runs only what is left.
+    //
+    // Through `runOpenclawConfigSet`, not a raw spawn, precisely BECAUSE the
+    // outcome is now shown to the owner: that wrapper retries the
+    // `ConfigMutationConflictError` this route races (it writes while the
+    // gateway is reloading on the stop above), and settles a spawn killed at
+    // its deadline by reading the assignment back off disk — `openclaw config
+    // set` writes early and then spends seconds validating catalogs, so on a
+    // Jetson the value routinely lands inside the window a 30 s timeout kills
+    // in. A hand-rolled `execFile` would have turned both into an amber banner
+    // over a write that succeeded. It also resolves the binary per call, so a
+    // web server that started mid-reinstall does not freeze a stale path.
     let warning: string | null = null;
+    // Set below, answered after the restart: the branch also fires on a
+    // licensed `dual` box running Hermes, where OpenClaw exists and its gateway
+    // does too — so returning from inside it would drop the fallback warning
+    // and skip the restart that makes the clear above take effect.
+    let hermesUnregisterFailed = false;
     if (!openclawIsAbsent()) {
-      const cleared = await runCommand(OPENCLAW_BIN, [
-        "config",
-        "set",
-        "agents.defaults.model.fallbacks",
-        JSON.stringify([]),
-        "--json",
-      ]).then(
+      const cleared = await runOpenclawConfigSet(
+        ["agents.defaults.model.fallbacks", JSON.stringify([]), "--json"],
+        { cwd: CLAWBOX_HOME_DIR, env: { ...process.env, HOME: CLAWBOX_HOME_DIR } },
+      ).then(
         () => true,
         (err) => {
           console.error("[local-ai] Failed to clear the OpenClaw fallback list:", err);
@@ -84,7 +85,11 @@ export async function POST(request: Request) {
         },
       );
       if (!cleared) {
-        warning = "Local AI is stopped, but OpenClaw still lists it as a fallback model. Turn it off again to finish clearing it.";
+        // Says what did not happen, not what the list contains: the route never
+        // checked whether the local model was IN `fallbacks`, and a box running
+        // it as primary with an already-empty list would be told about an entry
+        // that was never there.
+        warning = "Local AI is stopped, but clearing OpenClaw's fallback model list failed. Turn it off again to finish.";
       }
     }
 
@@ -111,16 +116,8 @@ export async function POST(request: Request) {
         console.error("[local-ai] Hermes local provider removal failed:", err);
         return null;
       });
-      if (!removal) {
-        return NextResponse.json(
-          {
-            error: "Local AI was stopped, but Hermes still lists it as a provider. Try turning Local AI off again.",
-            code: "hermes_unregister_failed",
-          },
-          { status: 502 },
-        );
-      }
-      if (removal.wasDefault) {
+      hermesUnregisterFailed = !removal;
+      if (removal?.wasDefault) {
         await setMany({ local_ai_was_default: true });
       }
     }
@@ -130,7 +127,21 @@ export async function POST(request: Request) {
     // add up to the whole budget to an owner's "Turn off Local AI" click.
     await restartGateway({ awaitReady: false }).catch(() => {});
 
-    return NextResponse.json(warning ? { success: true, warning } : { success: true });
+    if (hermesUnregisterFailed) {
+      // The panel paints `error` red on a non-2xx and never looks at `warning`
+      // there, so a box that hit both failures gets both sentences or it gets
+      // one of them told wrongly.
+      const failed = "Local AI was stopped, but Hermes still lists it as a provider. Try turning Local AI off again.";
+      return NextResponse.json(
+        {
+          error: warning ? `${failed} ${warning}` : failed,
+          code: "hermes_unregister_failed",
+        },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json({ success: true, ...(warning ? { warning } : {}) });
   } catch (err) {
     return NextResponse.json(
       { error: err instanceof Error ? err.message : "Failed to disable Local AI" },

--- a/src/lib/hermes-config-yaml.ts
+++ b/src/lib/hermes-config-yaml.ts
@@ -307,19 +307,57 @@ export async function readHermesConfigTopLevelScalar(
 }
 
 /** Read one dotted key straight from the file. Returns null when unset. */
-export async function readHermesConfigValue(key: string): Promise<string | null> {
+/**
+ * What the file says about one key, with "not set" kept apart from "could not
+ * be read".
+ *
+ *   "value"      — the key resolves to a scalar, and here it is.
+ *   "absent"     — the file parsed and the key is not there. A nested BLOCK
+ *                  reads as absent too: `getYamlPath` answers only for scalars,
+ *                  which is the same limit the writer works to.
+ *   "unreadable" — the file could not be read (EACCES), or the path could not
+ *                  be resolved in it (a flow mapping, a duplicate key). Not an
+ *                  answer, and never to be treated as one.
+ *
+ * {@link readHermesConfigValue} collapses the last two into `null`, which is
+ * right for "what is configured" and wrong for "did my write take": a caller
+ * PROVING a removal must not read a failed question as a removed key. The CLI
+ * fallback in {@link patchHermesConfig} is entered precisely BECAUSE the line
+ * editor could not work with the file, so an unreadable read-back is the likely
+ * case there rather than the exotic one.
+ */
+export type HermesConfigRead =
+  | { state: "value"; value: string }
+  | { state: "absent" }
+  | { state: "unreadable" };
+
+export async function resolveHermesConfigValue(key: string): Promise<HermesConfigRead> {
+  let text: string;
   try {
-    const { text } = await readConfigText(hermesConfigPath());
-    return getYamlPath(text, splitKey(key));
+    ({ text } = await readConfigText(hermesConfigPath()));
   } catch (err) {
-    // `null` means "unset" to every caller (hermes-local-ai reads it as "this
-    // leaf is not a scalar" and as "not applied yet"), and this signature has
-    // no third state to give them. A value we could not RESOLVE is a different
-    // fact, so it is at least said out loud rather than passing silently for a
-    // key nobody set.
-    if (err instanceof YamlEditUnsupported) {
-      console.error(`[hermes-config-yaml] ${key} could not be resolved, reading as unset:`, err.message);
-    }
-    return null;
+    // ENOENT/ENOTDIR never reach here — readConfigText answers them with an
+    // empty file, which is genuinely "nothing configured".
+    console.error(`[hermes-config-yaml] ${key} could not be read:`, err instanceof Error ? err.message : err);
+    return { state: "unreadable" };
   }
+  try {
+    const value = getYamlPath(text, splitKey(key));
+    return value === null ? { state: "absent" } : { state: "value", value };
+  } catch (err) {
+    console.error(
+      `[hermes-config-yaml] ${key} could not be resolved:`,
+      err instanceof Error ? err.message : err,
+    );
+    return { state: "unreadable" };
+  }
+}
+
+export async function readHermesConfigValue(key: string): Promise<string | null> {
+  // `null` means "unset" to every caller (hermes-local-ai reads it as "this
+  // leaf is not a scalar" and as "not applied yet"), and this signature has no
+  // third state to give them. A caller that needs the third state asks
+  // `resolveHermesConfigValue` instead; the failure is logged there either way.
+  const read = await resolveHermesConfigValue(key);
+  return read.state === "value" ? read.value : null;
 }

--- a/src/lib/hermes-config-yaml.ts
+++ b/src/lib/hermes-config-yaml.ts
@@ -317,8 +317,8 @@ export async function readHermesConfigTopLevelScalar(
  *                  discovery writes into `providers.<slug>.models`), or a key
  *                  with no value at all. Still a key in the file.
  *   "absent"     — the file parsed and the key is not there — including under a
- *                  parent PyYAML has emptied to the inline `{}`, which is what
- *                  a successful `hermes config unset` leaves behind.
+ *                  parent written as the inline `{}`, since a mapping with no
+ *                  members cannot hold a member by that name.
  *   "unreadable" — the file could not be read (EACCES), or the path could not
  *                  be resolved in it (a non-empty flow mapping, a duplicate
  *                  key). Not an answer, and never to be treated as one.

--- a/src/lib/hermes-config-yaml.ts
+++ b/src/lib/hermes-config-yaml.ts
@@ -47,7 +47,7 @@ import { safeHermesFailureMessage } from "@/lib/hermes-cli-message";
 import { invalidateHermesConfigCache } from "@/lib/hermes-config-cache";
 import { sanitizeErrorMessage } from "@/lib/safe-error-text";
 import { hermesHome } from "@/lib/hermes-env";
-import { getTopLevelScalar, getYamlPath, setYamlPath, unsetYamlPath, YamlEditUnsupported } from "@/lib/yaml-block-edit";
+import { getTopLevelScalar, getYamlPath, readYamlPath, setYamlPath, unsetYamlPath, YamlEditUnsupported } from "@/lib/yaml-block-edit";
 
 export class HermesConfigWriteError extends Error {}
 
@@ -312,22 +312,27 @@ export async function readHermesConfigTopLevelScalar(
  * be read".
  *
  *   "value"      — the key resolves to a scalar, and here it is.
- *   "absent"     — the file parsed and the key is not there. A nested BLOCK
- *                  reads as absent too: `getYamlPath` answers only for scalars,
- *                  which is the same limit the writer works to.
+ *   "present"    — the key is written here in a shape that is not a scalar: a
+ *                  nested block or a list (which is what Hermes' own model
+ *                  discovery writes into `providers.<slug>.models`), or a key
+ *                  with no value at all. Still a key in the file.
+ *   "absent"     — the file parsed and the key is not there — including under a
+ *                  parent PyYAML has emptied to the inline `{}`, which is what
+ *                  a successful `hermes config unset` leaves behind.
  *   "unreadable" — the file could not be read (EACCES), or the path could not
- *                  be resolved in it (a flow mapping, a duplicate key). Not an
- *                  answer, and never to be treated as one.
+ *                  be resolved in it (a non-empty flow mapping, a duplicate
+ *                  key). Not an answer, and never to be treated as one.
  *
- * {@link readHermesConfigValue} collapses the last two into `null`, which is
- * right for "what is configured" and wrong for "did my write take": a caller
- * PROVING a removal must not read a failed question as a removed key. The CLI
- * fallback in {@link patchHermesConfig} is entered precisely BECAUSE the line
- * editor could not work with the file, so an unreadable read-back is the likely
- * case there rather than the exotic one.
+ * {@link readHermesConfigValue} collapses everything but `value` into `null`,
+ * which is right for "what is configured" and wrong for "did my write take": a
+ * caller PROVING a removal must read neither a failed question nor a shape it
+ * cannot name as a removed key. The CLI fallback in {@link patchHermesConfig}
+ * is entered precisely BECAUSE the line editor could not work with the file, so
+ * both are ordinary outcomes there rather than exotic ones.
  */
 export type HermesConfigRead =
   | { state: "value"; value: string }
+  | { state: "present" }
   | { state: "absent" }
   | { state: "unreadable" };
 
@@ -342,8 +347,7 @@ export async function resolveHermesConfigValue(key: string): Promise<HermesConfi
     return { state: "unreadable" };
   }
   try {
-    const value = getYamlPath(text, splitKey(key));
-    return value === null ? { state: "absent" } : { state: "value", value };
+    return readYamlPath(text, splitKey(key));
   } catch (err) {
     console.error(
       `[hermes-config-yaml] ${key} could not be resolved:`,
@@ -356,7 +360,7 @@ export async function resolveHermesConfigValue(key: string): Promise<HermesConfi
 export async function readHermesConfigValue(key: string): Promise<string | null> {
   // `null` means "unset" to every caller (hermes-local-ai reads it as "this
   // leaf is not a scalar" and as "not applied yet"), and this signature has no
-  // third state to give them. A caller that needs the third state asks
+  // other state to give them. A caller that needs the rest asks
   // `resolveHermesConfigValue` instead; the failure is logged there either way.
   const read = await resolveHermesConfigValue(key);
   return read.state === "value" ? read.value : null;

--- a/src/lib/hermes-config-yaml.ts
+++ b/src/lib/hermes-config-yaml.ts
@@ -316,9 +316,11 @@ export async function readHermesConfigTopLevelScalar(
  *                  nested block or a list (which is what Hermes' own model
  *                  discovery writes into `providers.<slug>.models`), or a key
  *                  with no value at all. Still a key in the file.
- *   "absent"     — the file parsed and the key is not there — including under a
- *                  parent written as the inline `{}`, since a mapping with no
- *                  members cannot hold a member by that name.
+ *   "absent"     — the key is not there — including under a parent written as
+ *                  the inline `{}`, since a mapping with no members cannot hold
+ *                  a member by that name. Line-scanned, never parsed: a level
+ *                  the reader could not index answers `unreadable` instead, so
+ *                  this stays a positive fact rather than "we found nothing".
  *   "unreadable" — the file could not be read (EACCES), or the path could not
  *                  be resolved in it (a non-empty flow mapping, a duplicate
  *                  key). Not an answer, and never to be treated as one.

--- a/src/lib/hermes-local-ai.ts
+++ b/src/lib/hermes-local-ai.ts
@@ -229,9 +229,6 @@ type LocalCatalogueState = "absent" | "scalar" | "foreign" | "unknown";
  * there", and anything else — including the 126/127 a `step_hermes_install`
  * rebuild produces without ever reaching argparse — is the CLI failing to
  * answer rather than answering "no".
- *
- * Never logs or returns the value: this file holds `TELEGRAM_BOT_TOKEN` and the
- * provider `api_key`s, and the question here is only whether the key is there.
  */
 type HermesKeyPresence = "present" | "absent" | "unknown";
 
@@ -242,11 +239,13 @@ type HermesCliRead =
 /**
  * The one spawn behind both readers below.
  *
- * NOT to be pointed at a credential key. It carries the value out, and this
- * file also names `providers.<slug>.api_key`; the two callers that read a value
- * ask only for `model.provider` and `model.default`, which name a provider slug
- * and a model id. `cliKeyPresence` is what every other key goes through, and it
- * drops the value on the floor.
+ * It carries the value out, and the read-back loop points it at
+ * `providers.<slug>.api_key` on every removal that reaches the CLI — so the
+ * rule is not "never ask it about a credential", it is that the value never
+ * leaves this function except through `selectionValue`, whose only two call
+ * sites pass the literals `model.provider` and `model.default` (a provider slug
+ * and a model id). `cliKeyPresence` is what every other key goes through and it
+ * drops the value on the floor; nothing here logs one.
  */
 async function cliKeyRead(key: string): Promise<HermesCliRead> {
   // `runHermesCli` REJECTS for a missing binary, a timeout and its own SIGKILL.
@@ -427,10 +426,20 @@ async function removeLocalAi(): Promise<{ wasDefault: boolean; model: string | n
   // BEFORE the write, and three-state. There is no safe unset list to send
   // while this is unknown: putting `model.provider` on it blind would drop the
   // owner's cloud selection on a Local AI toggle-off, and leaving it off is the
-  // 502-per-turn state above. Refusing here costs nothing that a retry cannot
-  // redo — nothing has been written yet, so Local AI stays registered and the
-  // box goes on working — whereas the same doubt one step later would leave the
-  // providers block half removed around a selection nobody could read.
+  // 502-per-turn state above. Nothing has been written when we refuse, so Local
+  // AI stays registered and the box goes on working, whereas the same doubt one
+  // step later would leave the providers block half removed around a selection
+  // nobody could read.
+  //
+  // It is NOT free, and one shape pays for it: a `model:` written as a flow
+  // mapping over an ordinary two-space `providers:` block is the only config
+  // where our line reader can resolve the providers keys while it cannot
+  // resolve the selection. With the CLI also dead (a `step_hermes_install`
+  // rebuild, ~90 s), that removal used to complete through the merge path with
+  // no CLI spawn at all and now answers 502 with the block still in place. That
+  // success was luck rather than knowledge — "not the default" was a guess, and
+  // the guess being wrong is precisely the defect this read exists to end — so
+  // the conservative branch is kept and the cost is stated instead of hidden.
   const selection = await selectionValue("model.provider");
   if (!selection.known) {
     console.error("[hermes-local-ai] the active provider could not be read; nothing was removed");
@@ -440,6 +449,13 @@ async function removeLocalAi(): Promise<{ wasDefault: boolean; model: string | n
     );
   }
   const wasDefault = selection.value === HERMES_LOCAL_PROVIDER;
+  // `known` is deliberately not checked for this one. It is reached only once
+  // `wasDefault` is PROVED true, so whatever is there is a local model id and
+  // goes on the unset list either way; the value is a courtesy for a later
+  // enable, and nothing reads it today (`local-ai/route.ts` takes only
+  // `wasDefault`). Refusing the whole removal because the id could not be
+  // re-read would trade a completed removal for a 502 over a field with no
+  // consumer.
   const model = wasDefault ? (await selectionValue("model.default")).value : null;
 
   // `models` rides with the endpoint it describes. Left behind, it is a

--- a/src/lib/hermes-local-ai.ts
+++ b/src/lib/hermes-local-ai.ts
@@ -1,7 +1,7 @@
 import { runHermesCli } from "@/lib/hermes-cli";
 import { hermesCliAnswered } from "@/lib/hermes-cli-answered";
 import { get } from "@/lib/config-store";
-import { patchHermesConfig, readHermesConfigValue } from "@/lib/hermes-config-yaml";
+import { HermesConfigWriteError, patchHermesConfig, readHermesConfigValue } from "@/lib/hermes-config-yaml";
 import { invalidateModelOptions } from "@/lib/hermes-model-options";
 import { withProviderMcpRefresh } from "@/lib/provider-mcp-refresh";
 import { getLocalAiToken } from "@/lib/local-ai-token";
@@ -343,6 +343,24 @@ async function removeLocalAi(): Promise<{ wasDefault: boolean; model: string | n
     unset.push("model.provider", "model.default");
   }
   await patchHermesConfig({ unset });
+
+  // PROVED, not inferred. `patchHermesConfig`'s merge path reads every key back
+  // (patchText), but its CLI fallback does not: `applyViaCli`'s unset loop
+  // discards the exit code, because `hermes config unset` on a key that was
+  // never there is the no-op the loop relies on. So a config.yaml the line
+  // editor refuses (a flow mapping, a duplicate key) sends the patch to a CLI
+  // that a `step_hermes_install` rebuild has left exiting 127 before argparse,
+  // and this function returned as if the provider were gone.
+  //
+  // That return is the ONE fact the disable route answers on for this SKU, so
+  // it has to be a fact. A non-null read is positive evidence the key survived;
+  // `readHermesConfigValue` also answers null for a file it could not read, so
+  // an unreadable config cannot manufacture a failure here.
+  const stillRegistered = await readHermesConfigValue(`providers.${HERMES_LOCAL_PROVIDER}.base_url`);
+  const stillSelected = wasDefault ? await readHermesConfigValue("model.provider") : null;
+  if (typeof stillRegistered === "string" || stillSelected === HERMES_LOCAL_PROVIDER) {
+    throw new HermesConfigWriteError("The local model is still registered with Hermes.");
+  }
 
   invalidateModelOptions();
   return { wasDefault, model };

--- a/src/lib/hermes-local-ai.ts
+++ b/src/lib/hermes-local-ai.ts
@@ -1,7 +1,7 @@
 import { runHermesCli } from "@/lib/hermes-cli";
 import { hermesCliAnswered } from "@/lib/hermes-cli-answered";
 import { get } from "@/lib/config-store";
-import { HermesConfigWriteError, patchHermesConfig, readHermesConfigValue } from "@/lib/hermes-config-yaml";
+import { HermesConfigWriteError, patchHermesConfig, readHermesConfigValue, resolveHermesConfigValue } from "@/lib/hermes-config-yaml";
 import { invalidateModelOptions } from "@/lib/hermes-model-options";
 import { withProviderMcpRefresh } from "@/lib/provider-mcp-refresh";
 import { getLocalAiToken } from "@/lib/local-ai-token";
@@ -359,17 +359,30 @@ async function removeLocalAi(): Promise<{ wasDefault: boolean; model: string | n
   // call at a time, so it can land some and drop others — and `models` left
   // behind on its own is a `providers.clawlocal` entry that Hermes still
   // renders as a picker row, which is the exact state this function exists to
-  // end. A key that still resolves to a scalar is positive evidence it
-  // survived; `readHermesConfigValue` answers null for a file it could not read
-  // as well as for an absent key, so an unreadable config cannot manufacture a
-  // failure here.
+  // end.
+  //
+  // Through `resolveHermesConfigValue`, because `readHermesConfigValue` answers
+  // `null` for a file it could not read as well as for a key that is gone, and
+  // the two are not interchangeable HERE: the CLI fallback runs precisely
+  // because the line editor could not work with this file, so a read-back that
+  // cannot resolve the path is the likely companion of the write that failed.
+  // Reading that as "removed" would rebuild the false success one layer down.
+  // A key that still resolves to a scalar is a leftover; a key the file cannot
+  // answer for is unproven; only "absent" is removal.
   const leftovers: string[] = [];
+  const unproven: string[] = [];
   for (const key of unset) {
-    if (typeof (await readHermesConfigValue(key)) === "string") leftovers.push(key);
+    const read = await resolveHermesConfigValue(key);
+    if (read.state === "value") leftovers.push(key);
+    else if (read.state === "unreadable") unproven.push(key);
   }
   if (leftovers.length > 0) {
     console.error("[hermes-local-ai] keys survived the removal:", leftovers.join(", "));
     throw new HermesConfigWriteError("The local model is still registered with Hermes.");
+  }
+  if (unproven.length > 0) {
+    console.error("[hermes-local-ai] removal could not be verified for:", unproven.join(", "));
+    throw new HermesConfigWriteError("The Hermes config could not be read back, so the removal is unproven.");
   }
 
   invalidateModelOptions();

--- a/src/lib/hermes-local-ai.ts
+++ b/src/lib/hermes-local-ai.ts
@@ -431,15 +431,18 @@ async function removeLocalAi(): Promise<{ wasDefault: boolean; model: string | n
   // step later would leave the providers block half removed around a selection
   // nobody could read.
   //
-  // It is NOT free, and one shape pays for it: a `model:` written as a flow
-  // mapping over an ordinary two-space `providers:` block is the only config
-  // where our line reader can resolve the providers keys while it cannot
-  // resolve the selection. With the CLI also dead (a `step_hermes_install`
-  // rebuild, ~90 s), that removal used to complete through the merge path with
-  // no CLI spawn at all and now answers 502 with the block still in place. That
-  // success was luck rather than knowledge — "not the default" was a guess, and
-  // the guess being wrong is precisely the defect this read exists to end — so
-  // the conservative branch is kept and the cost is stated instead of hidden.
+  // It is NOT free, and a family of shapes pays for it: any anomaly confined to
+  // the `model:` block while `providers:` stays ordinary — a flow mapping, a
+  // block at any indent but two, a duplicate key inside it, an alias, a
+  // sequence, or an inline comment on the `model:` line (which the merge path
+  // deliberately preserves, so it persists) — leaves our line reader able to
+  // resolve the providers keys and unable to resolve the selection. With the
+  // CLI also dead (a `step_hermes_install` rebuild, ~90 s), those removals used
+  // to complete through the merge path with no CLI spawn at all and now answer
+  // 502 with the block still in place. That success was luck rather than
+  // knowledge — "not the default" was a guess, and the guess being wrong is
+  // precisely the defect this read exists to end — so the conservative branch
+  // is kept and the cost is stated instead of hidden.
   const selection = await selectionValue("model.provider");
   if (!selection.known) {
     console.error("[hermes-local-ai] the active provider could not be read; nothing was removed");

--- a/src/lib/hermes-local-ai.ts
+++ b/src/lib/hermes-local-ai.ts
@@ -1,7 +1,7 @@
 import { runHermesCli } from "@/lib/hermes-cli";
 import { hermesCliAnswered } from "@/lib/hermes-cli-answered";
 import { get } from "@/lib/config-store";
-import { HermesConfigWriteError, patchHermesConfig, readHermesConfigValue, resolveHermesConfigValue } from "@/lib/hermes-config-yaml";
+import { patchHermesConfig, readHermesConfigValue, resolveHermesConfigValue } from "@/lib/hermes-config-yaml";
 import { invalidateModelOptions } from "@/lib/hermes-model-options";
 import { withProviderMcpRefresh } from "@/lib/provider-mcp-refresh";
 import { getLocalAiToken } from "@/lib/local-ai-token";
@@ -33,6 +33,29 @@ export const HERMES_LOCAL_PROVIDER = "clawlocal";
 export type LocalAiProviderId = "llamacpp" | "ollama";
 
 export class HermesLocalApplyError extends Error {}
+
+/**
+ * A removal that did not land, carrying the selection state read BEFORE it ran.
+ *
+ * `wasDefault` — "the local model was this device's active provider" — is read
+ * at the top of `removeLocalAi`, and a partial unset can clear `model.provider`
+ * and still leave a `providers.clawlocal` key behind. This refusal is the last
+ * moment the fact exists: the retry reads a `model.provider` that is already
+ * gone, answers `false`, and re-enabling Local AI would then put the device on
+ * nothing instead of back on the model it was on. So it rides out with the
+ * error, and the route stores it either way.
+ *
+ * A plain `Error` and NOT a `HermesConfigWriteError` subclass, deliberately:
+ * nothing narrows on that class (the route catches whatever comes), and
+ * extending it would evaluate an imported class at MODULE LOAD time — which
+ * breaks every suite that mocks `hermes-config-yaml` without listing it, for a
+ * lineage no caller reads.
+ */
+export class HermesLocalRemovalError extends Error {
+  constructor(message: string, readonly wasDefault: boolean) {
+    super(message);
+  }
+}
 
 
 /**
@@ -189,15 +212,40 @@ function handRepairBack(): void {
  */
 type LocalCatalogueState = "absent" | "scalar" | "foreign" | "unknown";
 
+/**
+ * Is the key still in config.yaml, according to HERMES' OWN READER?
+ *
+ * `hermes config get <key>` loads the file with PyYAML, which is the same
+ * loader the gateway uses, so it answers for every shape — an emptied `{}`, a
+ * discovered `models` block, a duplicate key — that our line reader has to
+ * decline. Exit 0 is "there in some shape", "config key not set" is "not
+ * there", and anything else — including the 126/127 a `step_hermes_install`
+ * rebuild produces without ever reaching argparse — is the CLI failing to
+ * answer rather than answering "no".
+ *
+ * Never logs or returns the value: this file holds `TELEGRAM_BOT_TOKEN` and the
+ * provider `api_key`s, and the question here is only whether the key is there.
+ */
+type HermesKeyPresence = "present" | "absent" | "unknown";
+
+async function cliKeyPresence(key: string): Promise<HermesKeyPresence> {
+  // `runHermesCli` REJECTS for a missing binary, a timeout and its own SIGKILL.
+  // None of those is an answer either, and the callers here all treat "could
+  // not ask" the same way, so it is folded in rather than thrown.
+  const answer = await runHermesCli(["config", "get", key], { timeoutMs: 15_000 }).catch(() => null);
+  if (!answer || !hermesCliAnswered(answer)) return "unknown";
+  if (answer.code === 0) return "present";
+  return /config key not set/i.test(`${answer.stdout ?? ""}\n${answer.stderr ?? ""}`)
+    ? "absent"
+    : "unknown";
+}
+
 async function localCatalogueState(): Promise<LocalCatalogueState> {
   const key = `providers.${HERMES_LOCAL_PROVIDER}.models`;
   if ((await readHermesConfigValue(key)) !== null) return "scalar";
-  const declared = await runHermesCli(["config", "get", key], { timeoutMs: 15_000 });
-  if (!hermesCliAnswered(declared)) return "unknown";
-  if (declared.code === 0) return "foreign";
-  return /config key not set/i.test(`${declared.stdout ?? ""}\n${declared.stderr ?? ""}`)
-    ? "absent"
-    : "unknown";
+  const declared = await cliKeyPresence(key);
+  if (declared === "unknown") return "unknown";
+  return declared === "present" ? "foreign" : "absent";
 }
 
 /**
@@ -367,22 +415,48 @@ async function removeLocalAi(): Promise<{ wasDefault: boolean; model: string | n
   // because the line editor could not work with this file, so a read-back that
   // cannot resolve the path is the likely companion of the write that failed.
   // Reading that as "removed" would rebuild the false success one layer down.
-  // A key that still resolves to a scalar is a leftover; a key the file cannot
-  // answer for is unproven; only "absent" is removal.
+  //
+  // "present" is a leftover as much as "value" is: `providers.clawlocal.models`
+  // is a scalar only while WE own it, and Hermes' own discovery writes a nested
+  // block there — which the scalar reader answered `null` for, exactly as it
+  // does for a key that is gone.
   const leftovers: string[] = [];
   const unproven: string[] = [];
+  const unresolved: string[] = [];
   for (const key of unset) {
     const read = await resolveHermesConfigValue(key);
-    if (read.state === "value") leftovers.push(key);
-    else if (read.state === "unreadable") unproven.push(key);
+    if (read.state === "value" || read.state === "present") leftovers.push(key);
+    else if (read.state === "unreadable") unresolved.push(key);
+  }
+  if (unresolved.length > 0) {
+    // HARNESS FIRST, and it is what keeps this proof from inventing a failure.
+    // Our line reader is not the only reader of config.yaml: `hermes config
+    // get` is Hermes' own, loading the file with PyYAML exactly as the gateway
+    // does, and `localCatalogueState` above already trusts it for the shape
+    // question. Asking it is the difference between "the file is not
+    // line-editable" and "nobody can say whether the removal landed" — and
+    // answering the first as the second is a 502 the owner can never clear,
+    // because the retry the banner asks for reads the same file.
+    //
+    // In parallel, and only for the keys the file could not answer: this is the
+    // exotic branch, and six 15-second timeouts in series would sit in front of
+    // a click the owner is holding open.
+    const answers = await Promise.all(unresolved.map(cliKeyPresence));
+    unresolved.forEach((key, i) => {
+      if (answers[i] === "present") leftovers.push(key);
+      else if (answers[i] === "unknown") unproven.push(key);
+    });
   }
   if (leftovers.length > 0) {
     console.error("[hermes-local-ai] keys survived the removal:", leftovers.join(", "));
-    throw new HermesConfigWriteError("The local model is still registered with Hermes.");
+    throw new HermesLocalRemovalError("The local model is still registered with Hermes.", wasDefault);
   }
   if (unproven.length > 0) {
     console.error("[hermes-local-ai] removal could not be verified for:", unproven.join(", "));
-    throw new HermesConfigWriteError("The Hermes config could not be read back, so the removal is unproven.");
+    throw new HermesLocalRemovalError(
+      "The Hermes config could not be read back, so the removal is unproven.",
+      wasDefault,
+    );
   }
 
   invalidateModelOptions();

--- a/src/lib/hermes-local-ai.ts
+++ b/src/lib/hermes-local-ai.ts
@@ -353,12 +353,22 @@ async function removeLocalAi(): Promise<{ wasDefault: boolean; model: string | n
   // and this function returned as if the provider were gone.
   //
   // That return is the ONE fact the disable route answers on for this SKU, so
-  // it has to be a fact. A non-null read is positive evidence the key survived;
-  // `readHermesConfigValue` also answers null for a file it could not read, so
-  // an unreadable config cannot manufacture a failure here.
-  const stillRegistered = await readHermesConfigValue(`providers.${HERMES_LOCAL_PROVIDER}.base_url`);
-  const stillSelected = wasDefault ? await readHermesConfigValue("model.provider") : null;
-  if (typeof stillRegistered === "string" || stillSelected === HERMES_LOCAL_PROVIDER) {
+  // it has to be a fact.
+  //
+  // EVERY key, not just the endpoint: `applyViaCli` walks the unsets one CLI
+  // call at a time, so it can land some and drop others — and `models` left
+  // behind on its own is a `providers.clawlocal` entry that Hermes still
+  // renders as a picker row, which is the exact state this function exists to
+  // end. A key that still resolves to a scalar is positive evidence it
+  // survived; `readHermesConfigValue` answers null for a file it could not read
+  // as well as for an absent key, so an unreadable config cannot manufacture a
+  // failure here.
+  const leftovers: string[] = [];
+  for (const key of unset) {
+    if (typeof (await readHermesConfigValue(key)) === "string") leftovers.push(key);
+  }
+  if (leftovers.length > 0) {
+    console.error("[hermes-local-ai] keys survived the removal:", leftovers.join(", "));
     throw new HermesConfigWriteError("The local model is still registered with Hermes.");
   }
 

--- a/src/lib/hermes-local-ai.ts
+++ b/src/lib/hermes-local-ai.ts
@@ -392,16 +392,24 @@ async function removeLocalAi(): Promise<{ wasDefault: boolean; model: string | n
   if (wasDefault) {
     unset.push("model.provider", "model.default");
   }
-  await patchHermesConfig({ unset });
-  // BEFORE the proof, not after it. `withProviderMcpRefresh` samples the
+  // `finally`, and BEFORE the proof. `withProviderMcpRefresh` samples the
   // provider set either side of this call and re-reads it in a `finally`
   // precisely because "the write threw" is not "nothing was written" — and that
   // re-read only sees the new catalogue if the memo has been dropped. Left at
   // the end, a partial removal that then refuses would leave `getModelOptions`
   // serving the pre-removal set, so no `reload.mcp` is asked for and
   // `ai_set_provider`'s enum goes on offering a provider whose endpoint is
-  // already gone. The file may have changed whatever the proof below concludes.
-  invalidateModelOptions();
+  // already out of the file.
+  //
+  // The `finally` is for the same reason one call earlier: `applyViaCli` walks
+  // the unsets one spawn at a time and does not catch, and `runHermesCli`
+  // REJECTS on a timeout — so three keys can land and the fourth take the whole
+  // call down. The file may have changed whatever happens after this line.
+  try {
+    await patchHermesConfig({ unset });
+  } finally {
+    invalidateModelOptions();
+  }
 
   // PROVED, not inferred. `patchHermesConfig`'s merge path reads every key back
   // (patchText), but its CLI fallback does not: `applyViaCli`'s unset loop
@@ -456,7 +464,11 @@ async function removeLocalAi(): Promise<{ wasDefault: boolean; model: string | n
   // Jetson is precisely the case where they all time out and a removal that
   // landed answers 502. A CLI that failed to ANSWER once will not answer for
   // the next key either: that is a fact about the shim, not about the key.
-  let cliAnswering = true;
+  //
+  // Not asked at all once a leftover is on the record: "still registered" is
+  // already certain, and every question here is a serial 15-second budget in
+  // front of a click the owner is holding open.
+  let cliAnswering = leftovers.length === 0;
   for (const key of unresolved) {
     const presence = cliAnswering ? await cliKeyPresence(key) : "unknown";
     if (presence === "present") leftovers.push(key);

--- a/src/lib/hermes-local-ai.ts
+++ b/src/lib/hermes-local-ai.ts
@@ -431,12 +431,12 @@ async function removeLocalAi(): Promise<{ wasDefault: boolean; model: string | n
   // step later would leave the providers block half removed around a selection
   // nobody could read.
   //
-  // It is NOT free, and a family of shapes pays for it: any anomaly confined to
-  // the `model:` block while `providers:` stays ordinary — a flow mapping, a
-  // block at any indent but two, a duplicate key inside it, an alias, a
-  // sequence, or an inline comment on the `model:` line (which the merge path
-  // deliberately preserves, so it persists) — leaves our line reader able to
-  // resolve the providers keys and unable to resolve the selection. With the
+  // It is NOT free, and a family of shapes pays for it: several anomalies
+  // confined to the `model:` block while `providers:` stays ordinary — a flow
+  // mapping, a block at any indent but two, a duplicate key inside it, an
+  // alias, a sequence, or an inline comment on the `model:` line (which the
+  // merge path deliberately preserves, so it persists) — leave our line reader
+  // able to resolve the providers keys and unable to resolve the selection. With the
   // CLI also dead (a `step_hermes_install` rebuild, ~90 s), those removals used
   // to complete through the merge path with no CLI spawn at all and now answer
   // 502 with the block still in place. That success was luck rather than

--- a/src/lib/hermes-local-ai.ts
+++ b/src/lib/hermes-local-ai.ts
@@ -1,7 +1,12 @@
 import { runHermesCli } from "@/lib/hermes-cli";
 import { hermesCliAnswered } from "@/lib/hermes-cli-answered";
 import { get } from "@/lib/config-store";
-import { patchHermesConfig, readHermesConfigValue, resolveHermesConfigValue } from "@/lib/hermes-config-yaml";
+import {
+  patchHermesConfig,
+  readHermesConfigValue,
+  resolveHermesConfigValue,
+  type HermesConfigRead,
+} from "@/lib/hermes-config-yaml";
 import { invalidateModelOptions } from "@/lib/hermes-model-options";
 import { withProviderMcpRefresh } from "@/lib/provider-mcp-refresh";
 import { getLocalAiToken } from "@/lib/local-ai-token";
@@ -230,16 +235,58 @@ type LocalCatalogueState = "absent" | "scalar" | "foreign" | "unknown";
  */
 type HermesKeyPresence = "present" | "absent" | "unknown";
 
-async function cliKeyPresence(key: string): Promise<HermesKeyPresence> {
+type HermesCliRead =
+  | { presence: "present"; value: string }
+  | { presence: "absent" | "unknown" };
+
+/**
+ * The one spawn behind both readers below.
+ *
+ * NOT to be pointed at a credential key. It carries the value out, and this
+ * file also names `providers.<slug>.api_key`; the two callers that read a value
+ * ask only for `model.provider` and `model.default`, which name a provider slug
+ * and a model id. `cliKeyPresence` is what every other key goes through, and it
+ * drops the value on the floor.
+ */
+async function cliKeyRead(key: string): Promise<HermesCliRead> {
   // `runHermesCli` REJECTS for a missing binary, a timeout and its own SIGKILL.
   // None of those is an answer either, and the callers here all treat "could
   // not ask" the same way, so it is folded in rather than thrown.
   const answer = await runHermesCli(["config", "get", key], { timeoutMs: 15_000 }).catch(() => null);
-  if (!answer || !hermesCliAnswered(answer)) return "unknown";
-  if (answer.code === 0) return "present";
+  if (!answer || !hermesCliAnswered(answer)) return { presence: "unknown" };
+  if (answer.code === 0) return { presence: "present", value: (answer.stdout ?? "").trim() };
   return /config key not set/i.test(`${answer.stdout ?? ""}\n${answer.stderr ?? ""}`)
-    ? "absent"
-    : "unknown";
+    ? { presence: "absent" }
+    : { presence: "unknown" };
+}
+
+async function cliKeyPresence(key: string): Promise<HermesKeyPresence> {
+  return (await cliKeyRead(key)).presence;
+}
+
+/**
+ * What one key is SET TO, asking Hermes' own reader for the shapes ours has to
+ * decline — with "nobody could say" kept apart from "nothing is set there".
+ *
+ * `readHermesConfigValue` collapses both into `null`, and the difference is the
+ * whole of TASK-545's remaining half: on a config.yaml our line editor cannot
+ * index, reading "could not be read" as "the local model is not the selection"
+ * left `model.provider: clawlocal` in the file with its providers block removed
+ * — the state this module's header describes, where every chat turn 502s with
+ * `Unknown provider 'clawlocal'` — while the route answered `{success:true}`.
+ */
+async function selectionValue(key: string): Promise<{ known: boolean; value: string | null }> {
+  const read = await resolveHermesConfigValue(key).catch(
+    (): HermesConfigRead => ({ state: "unreadable" }),
+  );
+  if (read.state === "value") return { known: true, value: read.value };
+  // `absent` is nothing there; `present` is a non-scalar under a key that is a
+  // scalar wherever Hermes wrote it. Neither can be a provider slug, and both
+  // are answers.
+  if (read.state !== "unreadable") return { known: true, value: null };
+  const cli = await cliKeyRead(key);
+  if (cli.presence === "unknown") return { known: false, value: null };
+  return { known: true, value: cli.presence === "present" ? cli.value : null };
 }
 
 async function localCatalogueState(): Promise<LocalCatalogueState> {
@@ -377,9 +424,23 @@ export async function removeLocalAiFromHermes(): Promise<{ wasDefault: boolean; 
 }
 
 async function removeLocalAi(): Promise<{ wasDefault: boolean; model: string | null }> {
-  const activeProvider = await readHermesConfigValue("model.provider").catch(() => null);
-  const wasDefault = activeProvider === HERMES_LOCAL_PROVIDER;
-  const model = wasDefault ? await readHermesConfigValue("model.default").catch(() => null) : null;
+  // BEFORE the write, and three-state. There is no safe unset list to send
+  // while this is unknown: putting `model.provider` on it blind would drop the
+  // owner's cloud selection on a Local AI toggle-off, and leaving it off is the
+  // 502-per-turn state above. Refusing here costs nothing that a retry cannot
+  // redo — nothing has been written yet, so Local AI stays registered and the
+  // box goes on working — whereas the same doubt one step later would leave the
+  // providers block half removed around a selection nobody could read.
+  const selection = await selectionValue("model.provider");
+  if (!selection.known) {
+    console.error("[hermes-local-ai] the active provider could not be read; nothing was removed");
+    throw new HermesLocalRemovalError(
+      "The Hermes config could not be read, so the removal was not attempted.",
+      false,
+    );
+  }
+  const wasDefault = selection.value === HERMES_LOCAL_PROVIDER;
+  const model = wasDefault ? (await selectionValue("model.default")).value : null;
 
   // `models` rides with the endpoint it describes. Left behind, it is a
   // `providers.clawlocal` block naming a model with nowhere to send it — and

--- a/src/lib/hermes-local-ai.ts
+++ b/src/lib/hermes-local-ai.ts
@@ -216,9 +216,11 @@ type LocalCatalogueState = "absent" | "scalar" | "foreign" | "unknown";
  * Is the key still in config.yaml, according to HERMES' OWN READER?
  *
  * `hermes config get <key>` loads the file with PyYAML, which is the same
- * loader the gateway uses, so it answers for every shape — an emptied `{}`, a
- * discovered `models` block, a duplicate key — that our line reader has to
- * decline. Exit 0 is "there in some shape", "config key not set" is "not
+ * loader the gateway uses, so it answers for the shapes our line reader has to
+ * decline but PyYAML reads happily — a block at an indent we cannot index, a
+ * duplicate key, a flow mapping with members. A document PyYAML itself refuses
+ * is declined by both, and lands in `unknown` where it belongs. Exit 0 is
+ * "there in some shape", "config key not set" is "not
  * there", and anything else — including the 126/127 a `step_hermes_install`
  * rebuild produces without ever reaching argparse — is the CLI failing to
  * answer rather than answering "no".
@@ -391,6 +393,15 @@ async function removeLocalAi(): Promise<{ wasDefault: boolean; model: string | n
     unset.push("model.provider", "model.default");
   }
   await patchHermesConfig({ unset });
+  // BEFORE the proof, not after it. `withProviderMcpRefresh` samples the
+  // provider set either side of this call and re-reads it in a `finally`
+  // precisely because "the write threw" is not "nothing was written" — and that
+  // re-read only sees the new catalogue if the memo has been dropped. Left at
+  // the end, a partial removal that then refuses would leave `getModelOptions`
+  // serving the pre-removal set, so no `reload.mcp` is asked for and
+  // `ai_set_provider`'s enum goes on offering a provider whose endpoint is
+  // already gone. The file may have changed whatever the proof below concludes.
+  invalidateModelOptions();
 
   // PROVED, not inferred. `patchHermesConfig`'s merge path reads every key back
   // (patchText), but its CLI fallback does not: `applyViaCli`'s unset loop
@@ -413,7 +424,8 @@ async function removeLocalAi(): Promise<{ wasDefault: boolean; model: string | n
   // `null` for a file it could not read as well as for a key that is gone, and
   // the two are not interchangeable HERE: the CLI fallback runs precisely
   // because the line editor could not work with this file, so a read-back that
-  // cannot resolve the path is the likely companion of the write that failed.
+  // cannot resolve the path is the ordinary companion of that write, not the
+  // exotic one.
   // Reading that as "removed" would rebuild the false success one layer down.
   //
   // "present" is a leftover as much as "value" is: `providers.clawlocal.models`
@@ -428,24 +440,30 @@ async function removeLocalAi(): Promise<{ wasDefault: boolean; model: string | n
     if (read.state === "value" || read.state === "present") leftovers.push(key);
     else if (read.state === "unreadable") unresolved.push(key);
   }
-  if (unresolved.length > 0) {
-    // HARNESS FIRST, and it is what keeps this proof from inventing a failure.
-    // Our line reader is not the only reader of config.yaml: `hermes config
-    // get` is Hermes' own, loading the file with PyYAML exactly as the gateway
-    // does, and `localCatalogueState` above already trusts it for the shape
-    // question. Asking it is the difference between "the file is not
-    // line-editable" and "nobody can say whether the removal landed" — and
-    // answering the first as the second is a 502 the owner can never clear,
-    // because the retry the banner asks for reads the same file.
-    //
-    // In parallel, and only for the keys the file could not answer: this is the
-    // exotic branch, and six 15-second timeouts in series would sit in front of
-    // a click the owner is holding open.
-    const answers = await Promise.all(unresolved.map(cliKeyPresence));
-    unresolved.forEach((key, i) => {
-      if (answers[i] === "present") leftovers.push(key);
-      else if (answers[i] === "unknown") unproven.push(key);
-    });
+  // HARNESS FIRST, and it is what keeps this proof from inventing a failure.
+  // Our line reader is not the only reader of config.yaml: `hermes config get`
+  // is Hermes' own, loading the file with PyYAML exactly as the gateway does,
+  // and `localCatalogueState` above already trusts it for the shape question.
+  // Asking it is the difference between "this file is not line-editable" and
+  // "nobody can say whether the removal landed" — and answering the first as
+  // the second is a 502 the owner can never clear, because the retry the banner
+  // asks for reads the same file.
+  //
+  // One at a time, and only until the CLI stops answering. This branch is an
+  // ordinary outcome rather than an exotic one — the whole reason the write
+  // took the CLI is that the reader could not work with this file, so it can be
+  // all six keys — and six `hermes` python interpreters started at once on a
+  // Jetson is precisely the case where they all time out and a removal that
+  // landed answers 502. A CLI that failed to ANSWER once will not answer for
+  // the next key either: that is a fact about the shim, not about the key.
+  let cliAnswering = true;
+  for (const key of unresolved) {
+    const presence = cliAnswering ? await cliKeyPresence(key) : "unknown";
+    if (presence === "present") leftovers.push(key);
+    else if (presence === "unknown") {
+      cliAnswering = false;
+      unproven.push(key);
+    }
   }
   if (leftovers.length > 0) {
     console.error("[hermes-local-ai] keys survived the removal:", leftovers.join(", "));
@@ -459,6 +477,5 @@ async function removeLocalAi(): Promise<{ wasDefault: boolean; model: string | n
     );
   }
 
-  invalidateModelOptions();
   return { wasDefault, model };
 }

--- a/src/lib/provider-mcp-refresh.ts
+++ b/src/lib/provider-mcp-refresh.ts
@@ -209,8 +209,10 @@ export async function refreshProviderToolsIfSetChanged(
  *
  * The wrapper exists so the SIX write paths that move this set cannot each get
  * the ordering subtly different. The "after" read is deliberately taken AFTER
- * `run` has finished, because every one of those paths ends by calling
- * `invalidateModelOptions()` — so the read that follows sees the new catalogue
+ * `run` has finished, because every one of those paths calls
+ * `invalidateModelOptions()` BEFORE IT RETURNS — the local-AI removal does it in
+ * a `finally` around its own write, so a proof that then refuses cannot leave
+ * the memo standing — so the read that follows sees the new catalogue
  * rather than a memo of the old one, and the verdict is RE-READ rather than
  * assumed from the fact that the write returned. Assuming it is the exact shape
  * this round of fixes exists to remove.

--- a/src/lib/yaml-block-edit.ts
+++ b/src/lib/yaml-block-edit.ts
@@ -151,9 +151,6 @@ function scanBlock(lines: string[], start: number, end: number, indent: number):
   return entries;
 }
 
-function findEntry(lines: string[], start: number, end: number, indent: number, key: string): Entry | null {
-  return scanBlock(lines, start, end, indent).find((e) => e.key === key) ?? null;
-}
 
 /**
  * Where a quoted scalar ends, scanning from `from`, or -1 when it does not
@@ -494,9 +491,11 @@ export function readYamlPath(text: string, path: string[]): YamlPathRead {
   let indent = 0;
 
   for (let depth = 0; depth < path.length; depth += 1) {
-    // `scanBlock` rather than `findEntry`, because a key that is not among the
-    // entries and a LEVEL WITH NO ENTRIES AT ALL are different facts and only
-    // the first is "absent".
+    // The WHOLE level, rather than a lookup that answers only "is this key
+    // here": a key that is not among the entries and a LEVEL WITH NO ENTRIES AT
+    // ALL are different facts, and only the first is "absent". (The one-key
+    // helper that used to sit over `scanBlock` was removed with its last caller
+    // for exactly that reason — it could not tell them apart.)
     //
     // The walk descends exactly INDENT_STEP per level and `scanBlock` skips
     // every line deeper than the level it is scanning, so a block written at

--- a/src/lib/yaml-block-edit.ts
+++ b/src/lib/yaml-block-edit.ts
@@ -417,10 +417,12 @@ const EMPTY_FLOW_RE = /^(?:\{\s*\}|\[\s*\])$/;
  * `providers.clawlocal.models:` catalogue (the shape Hermes' own model
  * discovery writes) reads as "not there". And it THROWS as soon as any segment
  * on the way down carries an inline value — the empty flow mapping `{}`
- * included, which is what PyYAML emits for a mapping it has just emptied. As
- * `hermes config unset` is what empties one, `{}` is the ordinary shape of a
- * removal that fully SUCCEEDED, and refusing over it turns that success into
- * "we could not look".
+ * included, which is what PyYAML writes for ANY mapping with no members, and
+ * which Hermes' own shipped `cli-config.yaml.example` carries twice
+ * (`agent.reasoning_overrides`, `agent.personalities`). A `providers: {}` on
+ * the way to `providers.clawlocal.base_url` is a POSITIVE answer — the key
+ * cannot be there — and refusing over it reports "we could not look" about a
+ * file that just said so plainly.
  *
  * So an empty flow collection on the way down is an ANSWER here: a mapping
  * with no members cannot hold a member by that name. Anything else inline is

--- a/src/lib/yaml-block-edit.ts
+++ b/src/lib/yaml-block-edit.ts
@@ -348,6 +348,14 @@ function assertPath(path: string[]): void {
   }
 }
 
+/** Is there anything but blank lines and comments in [start, end)? */
+function hasContent(lines: string[], start: number, end: number): boolean {
+  for (let i = start; i < end; i += 1) {
+    if (!isSkippable(lines[i])) return true;
+  }
+  return false;
+}
+
 /** Walk as far down `path` as the file already goes. */
 function descend(
   lines: string[],
@@ -364,8 +372,29 @@ function descend(
   let indent = 0;
 
   for (let depth = 0; depth < path.length; depth += 1) {
-    const entry = findEntry(lines, start, end, indent, path[depth]);
-    if (!entry) break;
+    const entries = scanBlock(lines, start, end, indent);
+    const entry = entries.find((e) => e.key === path[depth]) ?? null;
+    if (!entry) {
+      // "No entries at all, but there are lines here" is not "the key is not
+      // written" — it is a block this editor cannot INDEX. The walk descends
+      // exactly INDENT_STEP per level and `scanBlock` skips everything deeper,
+      // so a block at any other indent (a hand edit, a writer that dumps at
+      // `indent=4`) reads as empty. Breaking here made both writers silently
+      // wrong on such a file: `unsetYamlPath` removed nothing and returned the
+      // text unchanged, and `setYamlPath` APPENDED a second `clawlocal:` at two
+      // spaces — a duplicate key written into the file that holds the provider
+      // api_keys. Both then passed `patchText`'s verification, because it reads
+      // through the same blind spot.
+      //
+      // Refusing is what hands the job to `hermes config set/unset`, which
+      // loads the file with PyYAML and does not care how it is indented.
+      if (entries.length === 0 && hasContent(lines, start, end)) {
+        throw new YamlEditUnsupported(
+          `could not read the block at ${path.slice(0, depth).join(".") || "the document root"}`,
+        );
+      }
+      break;
+    }
     matched.push(entry);
     if (depth < path.length - 1 && entry.inline !== "") {
       // `providers: {}` / `model: null` / a block scalar — descending into it
@@ -402,14 +431,6 @@ export function getYamlPath(text: string, path: string[]): string | null {
 
 /** `{}` / `[ ]` — a collection written inline with no members in it. */
 const EMPTY_FLOW_RE = /^(?:\{\s*\}|\[\s*\])$/;
-
-/** Is there anything but blank lines and comments in [start, end)? */
-function hasContent(lines: string[], start: number, end: number): boolean {
-  for (let i = start; i < end; i += 1) {
-    if (!isSkippable(lines[i])) return true;
-  }
-  return false;
-}
 
 /**
  * Is the path THERE, and — when it is a scalar — what does it say?
@@ -454,6 +475,18 @@ export type YamlPathRead =
 
 export function readYamlPath(text: string, path: string[]): YamlPathRead {
   assertPath(path);
+  // The one WHOLE-FILE fact that is evidence about every key, and the doctrine
+  // this module already states: Hermes' bridge and `hermes config get` both
+  // load config.yaml with PyYAML, so a document PyYAML refuses is a file in
+  // which no line is in effect — a tab in some other provider's value, an
+  // unterminated quote, a second document. Answering a confident `absent` there
+  // is a 200 "the provider is gone" about a file nobody can load, which is the
+  // same false success from the whole-document side. `getTopLevelScalar` has
+  // read it this way all along; this reader now asks the same question.
+  const document = documentLines(text.split(/\r\n|\r|\n/));
+  if (document.unterminated || !document.loadable) {
+    throw new YamlEditUnsupported("document PyYAML will not load");
+  }
   const { lines } = splitLines(text);
   let start = 0;
   let end = lines.length;

--- a/src/lib/yaml-block-edit.ts
+++ b/src/lib/yaml-block-edit.ts
@@ -396,6 +396,80 @@ export function getYamlPath(text: string, path: string[]): string | null {
   return value;
 }
 
+/** `{}` / `[ ]` — a collection written inline with no members in it. */
+const EMPTY_FLOW_RE = /^(?:\{\s*\}|\[\s*\])$/;
+
+/**
+ * Is the path THERE, and — when it is a scalar — what does it say?
+ *
+ *   "value"   — a scalar this reader can name.
+ *   "present" — the key is there in a shape that is not a scalar: a nested
+ *               block, a sequence, an empty flow collection, a bare `key:`, a
+ *               quoted value carrying an escape PyYAML resolves and this
+ *               reader does not.
+ *   "absent"  — the file parsed and the key is not in it.
+ *
+ * Separate from {@link getYamlPath} because that answers a different question
+ * — "give me the scalar to splice" — and gets THIS one wrong in both
+ * directions.
+ *
+ * It returns `null` for a key whose value is a block or a list, so a surviving
+ * `providers.clawlocal.models:` catalogue (the shape Hermes' own model
+ * discovery writes) reads as "not there". And it THROWS as soon as any segment
+ * on the way down carries an inline value — the empty flow mapping `{}`
+ * included, which is what PyYAML emits for a mapping it has just emptied. As
+ * `hermes config unset` is what empties one, `{}` is the ordinary shape of a
+ * removal that fully SUCCEEDED, and refusing over it turns that success into
+ * "we could not look".
+ *
+ * So an empty flow collection on the way down is an ANSWER here: a mapping
+ * with no members cannot hold a member by that name. Anything else inline is
+ * not — `clawlocal: {base_url: …}` may well hold the key, and this reader
+ * cannot say — and still raises, which the caller reads as "we could not
+ * look" rather than as a fact about the key.
+ */
+export type YamlPathRead =
+  | { state: "value"; value: string }
+  | { state: "present" }
+  | { state: "absent" };
+
+export function readYamlPath(text: string, path: string[]): YamlPathRead {
+  assertPath(path);
+  const { lines } = splitLines(text);
+  let start = 0;
+  let end = lines.length;
+  while (end > 0 && isSkippable(lines[end - 1])) end -= 1;
+  let indent = 0;
+
+  for (let depth = 0; depth < path.length; depth += 1) {
+    const entry = findEntry(lines, start, end, indent, path[depth]);
+    if (!entry) return { state: "absent" };
+
+    if (depth === path.length - 1) {
+      // A key with no inline text opens a block, a sequence, or nothing at all;
+      // whichever it is, the key IS written in this file.
+      if (entry.inline === "" || EMPTY_FLOW_RE.test(entry.inline)) return { state: "present" };
+      const split = splitTrailingComment(entry.inline);
+      if (!split.closed) return { state: "present" };
+      const value = parseYamlScalar(split.value);
+      return value === null ? { state: "present" } : { state: "value", value };
+    }
+
+    if (entry.inline !== "") {
+      if (EMPTY_FLOW_RE.test(entry.inline)) return { state: "absent" };
+      throw new YamlEditUnsupported(`cannot descend into inline value at ${path.slice(0, depth + 1).join(".")}`);
+    }
+    start = entry.childStart;
+    end = entry.childEnd;
+    indent += INDENT_STEP.length;
+  }
+
+  // Unreachable — the last iteration always returns — and thrown rather than
+  // answered so a future edit that makes it reachable cannot invent an
+  // "absent" nobody proved.
+  throw new YamlEditUnsupported(`could not resolve ${path.join(".")}`);
+}
+
 /** One top-level entry as {@link getTopLevelScalar} reads it. */
 export interface TopLevelScalar {
   /** The key's top-level scalar, or null when it has none we can read. */

--- a/src/lib/yaml-block-edit.ts
+++ b/src/lib/yaml-block-edit.ts
@@ -31,8 +31,12 @@
  * to fall back to the Hermes CLI on that signal: losing the comments is bad,
  * corrupting the config is worse.
  *
- * That contract belongs to the EDITING half. {@link getTopLevelScalar} is a
- * reader, and a reader may not raise on a construct somewhere else in the file:
+ * That contract belongs to the EDITING half. {@link readYamlPath} is a third
+ * category and does raise, on purpose: it is a reader whose CALLER turns the
+ * refusal into a state ("we could not look") and then asks Hermes' own reader,
+ * so giving up loudly is strictly better there than answering a shape it cannot
+ * index. {@link getTopLevelScalar} is a reader of the second kind, and a reader
+ * of that kind may not raise on a construct somewhere else in the file:
  * a sequence, a duplicate key or a nested block is not evidence about the key it
  * was asked for, and a caller would have to turn the refusal into one. It never
  * throws; it answers a third state (`readable: false`) for a value it cannot
@@ -399,15 +403,28 @@ export function getYamlPath(text: string, path: string[]): string | null {
 /** `{}` / `[ ]` — a collection written inline with no members in it. */
 const EMPTY_FLOW_RE = /^(?:\{\s*\}|\[\s*\])$/;
 
+/** Is there anything but blank lines and comments in [start, end)? */
+function hasContent(lines: string[], start: number, end: number): boolean {
+  for (let i = start; i < end; i += 1) {
+    if (!isSkippable(lines[i])) return true;
+  }
+  return false;
+}
+
 /**
  * Is the path THERE, and — when it is a scalar — what does it say?
  *
  *   "value"   — a scalar this reader can name.
- *   "present" — the key is there in a shape that is not a scalar: a nested
- *               block, a sequence, an empty flow collection, a bare `key:`, a
- *               quoted value carrying an escape PyYAML resolves and this
- *               reader does not.
- *   "absent"  — the file parsed and the key is not in it.
+ *   "present" — the key is there in a shape this reader will not name: a block
+ *               or a sequence written underneath it, an empty flow collection,
+ *               a bare `key:`, a quoted value carrying an escape PyYAML
+ *               resolves and this reader does not. A NON-empty flow collection
+ *               on the leaf answers `value` with its literal text instead —
+ *               `models: [a, b]` is `"[a, b]"` — which is what `getYamlPath`
+ *               has always done and is a leftover either way here.
+ *   "absent"  — the key is not in the file. Line-scanned, never parsed, so
+ *               this is only an answer where the level it looked at could be
+ *               indexed; see the `scanBlock` note in the walk below.
  *
  * Separate from {@link getYamlPath} because that answers a different question
  * — "give me the scalar to splice" — and gets THIS one wrong in both
@@ -444,8 +461,33 @@ export function readYamlPath(text: string, path: string[]): YamlPathRead {
   let indent = 0;
 
   for (let depth = 0; depth < path.length; depth += 1) {
-    const entry = findEntry(lines, start, end, indent, path[depth]);
-    if (!entry) return { state: "absent" };
+    // `scanBlock` rather than `findEntry`, because a key that is not among the
+    // entries and a LEVEL WITH NO ENTRIES AT ALL are different facts and only
+    // the first is "absent".
+    //
+    // The walk descends exactly INDENT_STEP per level and `scanBlock` skips
+    // every line deeper than the level it is scanning, so a block written at
+    // any other indent — a hand-edited file, a `yaml.dump(indent=4)` by some
+    // other writer — yields no entries and no error. Answering `absent` there
+    // would be the worst possible direction, because it is the SAME blind spot
+    // that makes the WRITER a silent no-op on that file: `unsetYamlPath`
+    // changes nothing, `patchText`'s own verification passes on the same
+    // reader, no CLI fallback is entered, and a read-back sharing the blind
+    // spot could only ever confirm the write it cannot see.
+    //
+    // So: entries at this level and none of them ours → the key is absent.
+    // No entries but lines we skipped → we could not look, which the caller
+    // turns into "unreadable" and asks Hermes' own reader instead.
+    const entries = scanBlock(lines, start, end, indent);
+    const entry = entries.find((e) => e.key === path[depth]) ?? null;
+    if (!entry) {
+      if (entries.length === 0 && hasContent(lines, start, end)) {
+        throw new YamlEditUnsupported(
+          `could not read the block at ${path.slice(0, depth).join(".") || "the document root"}`,
+        );
+      }
+      return { state: "absent" };
+    }
 
     if (depth === path.length - 1) {
       // A key with no inline text opens a block, a sequence, or nothing at all;

--- a/src/tests/routes/local-ai.test.ts
+++ b/src/tests/routes/local-ai.test.ts
@@ -183,8 +183,7 @@ describe("POST /setup-api/local-ai", () => {
 
       expect(res.status).toBe(502);
       expect(body.success).toBeUndefined();
-      expect(body.code).toBe("hermes_unregister_failed");
-      expect(typeof body.error).toBe("string");
+      expect(body.error).toMatch(/removing it from Hermes could not be confirmed/);
       // The steps that DID run are not undone, and the answer must not claim
       // they failed: the runtime is stopped and our own flags are cleared, so a
       // retry only has the unregister left to do.
@@ -242,7 +241,6 @@ describe("POST /setup-api/local-ai", () => {
     const body = await res.json();
 
     expect(res.status).toBe(502);
-    expect(body.code).toBe("hermes_unregister_failed");
     // The panel paints `error` red on a non-2xx and never reads `warning`
     // there, so the fallback sentence has to ride in `error` or be lost.
     expect(body.error).toMatch(/removing it from Hermes could not be confirmed/);

--- a/src/tests/routes/local-ai.test.ts
+++ b/src/tests/routes/local-ai.test.ts
@@ -1,9 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import * as childProcess from "child_process";
-
-vi.mock("child_process", () => ({
-  execFile: vi.fn(),
-}));
 
 vi.mock("@/lib/config-store", () => ({
   get: vi.fn(),
@@ -11,12 +6,13 @@ vi.mock("@/lib/config-store", () => ({
 }));
 
 vi.mock("@/lib/openclaw-config", () => ({
-  findOpenclawBin: vi.fn().mockReturnValue("/usr/local/bin/openclaw"),
   inferConfiguredLocalModel: vi.fn(),
   readConfig: vi.fn(),
   restartGateway: vi.fn(),
-  // Default to "openclaw present". The Hermes-edition disable path is asserted
-  // in its own test below by flipping this to true.
+  runOpenclawConfigSet: vi.fn(),
+  // Default to "openclaw present" — the OpenClaw and dual SKUs. The Hermes SKU
+  // flips this to true in its own describe block below, where it is what makes
+  // the fallback clear and the gateway restart no-ops.
   openclawIsAbsent: vi.fn().mockReturnValue(false),
 }));
 
@@ -38,17 +34,18 @@ vi.mock("@/lib/hermes-local-ai", () => ({
 
 import { get, setMany } from "@/lib/config-store";
 import { stopLocalAiProvider } from "@/lib/local-ai-runtime";
-import { inferConfiguredLocalModel, readConfig, restartGateway } from "@/lib/openclaw-config";
+import { inferConfiguredLocalModel, openclawIsAbsent, readConfig, restartGateway, runOpenclawConfigSet } from "@/lib/openclaw-config";
 import { getActiveHarness } from "@/lib/harness";
 import { removeLocalAiFromHermes } from "@/lib/hermes-local-ai";
 
-const mockExecFile = vi.mocked(childProcess.execFile);
 const mockSetMany = vi.mocked(setMany);
 const mockGet = vi.mocked(get);
 const mockStopLocalAiProvider = vi.mocked(stopLocalAiProvider);
 const mockInferConfiguredLocalModel = vi.mocked(inferConfiguredLocalModel);
 const mockReadConfig = vi.mocked(readConfig);
 const mockRestartGateway = vi.mocked(restartGateway);
+const mockOpenclawIsAbsent = vi.mocked(openclawIsAbsent);
+const mockRunOpenclawConfigSet = vi.mocked(runOpenclawConfigSet);
 const mockGetActiveHarness = vi.mocked(getActiveHarness);
 const mockRemoveLocalAiFromHermes = vi.mocked(removeLocalAiFromHermes);
 
@@ -58,27 +55,6 @@ function jsonRequest(body: unknown): Request {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
-}
-
-function setupExecFileMock() {
-  mockExecFile.mockImplementation(((
-    _cmd: string,
-    _args: string[],
-    optsOrCallback?: object | ((error: Error | null, result: { stdout: string; stderr: string }) => void),
-    maybeCallback?: (error: Error | null, result: { stdout: string; stderr: string }) => void,
-  ) => {
-    const callback = typeof optsOrCallback === "function" ? optsOrCallback : maybeCallback;
-    callback?.(null, { stdout: "", stderr: "" });
-    return {
-      then: (resolve: (value: { stdout: string; stderr: string }) => void) => {
-        resolve({ stdout: "", stderr: "" });
-        return {
-          catch: () => ({})
-        };
-      },
-      catch: () => ({}),
-    } as unknown as ReturnType<typeof childProcess.execFile>;
-  }) as unknown as typeof childProcess.execFile);
 }
 
 describe("POST /setup-api/local-ai", () => {
@@ -95,7 +71,8 @@ describe("POST /setup-api/local-ai", () => {
     mockGet.mockResolvedValue(undefined);
     mockGetActiveHarness.mockResolvedValue("openclaw");
     mockRemoveLocalAiFromHermes.mockResolvedValue({ wasDefault: false, model: null });
-    setupExecFileMock();
+    mockOpenclawIsAbsent.mockReturnValue(false);
+    mockRunOpenclawConfigSet.mockResolvedValue();
 
     const mod = await import("@/app/setup-api/local-ai/route");
     localAiPost = mod.POST;
@@ -149,16 +126,12 @@ describe("POST /setup-api/local-ai", () => {
     // so this is a qualification and not a refusal — but it must reach the
     // owner: a fallback entry pointing at a model we just stopped is a dead
     // endpoint the next fallback turn walks into.
-    mockExecFile.mockImplementation(((
-      _cmd: string,
-      _args: string[],
-      optsOrCallback?: object | ((error: Error | null, result: { stdout: string; stderr: string }) => void),
-      maybeCallback?: (error: Error | null, result: { stdout: string; stderr: string }) => void,
-    ) => {
-      const callback = typeof optsOrCallback === "function" ? optsOrCallback : maybeCallback;
-      callback?.(new Error("openclaw config set failed"), { stdout: "", stderr: "" });
-      return {} as unknown as ReturnType<typeof childProcess.execFile>;
-    }) as unknown as typeof childProcess.execFile);
+    //
+    // Rejecting from `runOpenclawConfigSet` and not from a raw spawn is the
+    // point: that wrapper has already retried the mutation conflict and read a
+    // deadline-killed write back off disk, so a rejection from it is a write
+    // that genuinely did not land.
+    mockRunOpenclawConfigSet.mockRejectedValue(new Error("openclaw config set failed"));
 
     const res = await localAiPost(jsonRequest({ action: "disable" }));
     const body = await res.json();
@@ -169,9 +142,23 @@ describe("POST /setup-api/local-ai", () => {
     expect(body.warning).toMatch(/fallback/i);
   });
 
+  it("clears the OpenClaw fallback list through the verified wrapper", async () => {
+    await localAiPost(jsonRequest({ action: "disable" }));
+
+    expect(mockRunOpenclawConfigSet).toHaveBeenCalledWith(
+      ["agents.defaults.model.fallbacks", "[]", "--json"],
+      expect.anything(),
+    );
+  });
+
   describe("the Hermes edition", () => {
     beforeEach(() => {
       mockGetActiveHarness.mockResolvedValue("hermes");
+      // The SKU, not just the active harness: `openclawIsAbsent()` is
+      // `readEdition() === "hermes"`, and leaving it false ran these cases as a
+      // dual box — spawning the OpenClaw CLI on a device that has no binary,
+      // which is the very state the guard exists for.
+      mockOpenclawIsAbsent.mockReturnValue(true);
     });
 
     it("answers 502 when the Hermes unregister failed", async () => {
@@ -200,6 +187,8 @@ describe("POST /setup-api/local-ai", () => {
         local_ai_model: undefined,
         local_ai_configured_at: undefined,
       });
+      // Nothing was spawned at OpenClaw on a box that has no OpenClaw.
+      expect(mockRunOpenclawConfigSet).not.toHaveBeenCalled();
     });
 
     it("answers 200 when the Hermes unregister landed", async () => {
@@ -212,6 +201,29 @@ describe("POST /setup-api/local-ai", () => {
       expect(body.success).toBe(true);
       expect(mockSetMany).toHaveBeenCalledWith({ local_ai_was_default: true });
     });
+  });
+
+  it("answers both failures on a dual box running Hermes", async () => {
+    // The Hermes branch is gated on the ACTIVE harness, which a licensed `dual`
+    // box also satisfies — and there OpenClaw exists and its gateway does too.
+    // Returning from inside that branch dropped the fallback warning and skipped
+    // the restart that makes the clear take effect, so both are answered after
+    // the restart instead.
+    mockGetActiveHarness.mockResolvedValue("hermes");
+    mockOpenclawIsAbsent.mockReturnValue(false);
+    mockRunOpenclawConfigSet.mockRejectedValue(new Error("openclaw config set failed"));
+    mockRemoveLocalAiFromHermes.mockRejectedValue(new Error("hermes config write failed"));
+
+    const res = await localAiPost(jsonRequest({ action: "disable" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.code).toBe("hermes_unregister_failed");
+    // The panel paints `error` red on a non-2xx and never reads `warning`
+    // there, so the fallback sentence has to ride in `error` or be lost.
+    expect(body.error).toMatch(/Hermes still lists it as a provider/);
+    expect(body.error).toMatch(/fallback model list/i);
+    expect(mockRestartGateway).toHaveBeenCalled();
   });
 
   it("does not touch Hermes on an OpenClaw box", async () => {

--- a/src/tests/routes/local-ai.test.ts
+++ b/src/tests/routes/local-ai.test.ts
@@ -30,13 +30,21 @@ vi.mock("@/lib/harness", () => ({
 
 vi.mock("@/lib/hermes-local-ai", () => ({
   removeLocalAiFromHermes: vi.fn(),
+  // Listed because the ROUTE narrows on it: an export the factory omits is
+  // `undefined`, and `err instanceof undefined` is a TypeError inside the very
+  // catch that is meant to keep the failure readable.
+  HermesLocalRemovalError: class HermesLocalRemovalError extends Error {
+    constructor(message: string, readonly wasDefault: boolean) {
+      super(message);
+    }
+  },
 }));
 
 import { get, setMany } from "@/lib/config-store";
 import { stopLocalAiProvider } from "@/lib/local-ai-runtime";
 import { inferConfiguredLocalModel, openclawIsAbsent, readConfig, restartGateway, runOpenclawConfigSet } from "@/lib/openclaw-config";
 import { getActiveHarness } from "@/lib/harness";
-import { removeLocalAiFromHermes } from "@/lib/hermes-local-ai";
+import { HermesLocalRemovalError, removeLocalAiFromHermes } from "@/lib/hermes-local-ai";
 
 const mockSetMany = vi.mocked(setMany);
 const mockGet = vi.mocked(get);
@@ -189,6 +197,22 @@ describe("POST /setup-api/local-ai", () => {
       });
       // Nothing was spawned at OpenClaw on a box that has no OpenClaw.
       expect(mockRunOpenclawConfigSet).not.toHaveBeenCalled();
+    });
+
+    it("still records that the local model WAS the selection when the removal failed", async () => {
+      // A partial unset can clear `model.provider` and leave a providers key,
+      // and this answer is the last time the fact exists: the retry reads a
+      // `model.provider` that is already gone, so `wasDefault` is false for
+      // ever and re-enabling Local AI puts the device on nothing rather than
+      // back on the model it was on.
+      mockRemoveLocalAiFromHermes.mockRejectedValue(
+        new HermesLocalRemovalError("The local model is still registered with Hermes.", true),
+      );
+
+      const res = await localAiPost(jsonRequest({ action: "disable" }));
+
+      expect(res.status).toBe(502);
+      expect(mockSetMany).toHaveBeenCalledWith({ local_ai_was_default: true });
     });
 
     it("answers 200 when the Hermes unregister landed", async () => {

--- a/src/tests/routes/local-ai.test.ts
+++ b/src/tests/routes/local-ai.test.ts
@@ -24,9 +24,23 @@ vi.mock("@/lib/local-ai-runtime", () => ({
   stopLocalAiProvider: vi.fn(),
 }));
 
+// The Hermes edition. Both are mocked so the edition-dependent half of the
+// route can be driven from a test: `getActiveHarness` decides whether the
+// unregister runs at all, and `removeLocalAiFromHermes` is the step that
+// matters on that SKU.
+vi.mock("@/lib/harness", () => ({
+  getActiveHarness: vi.fn(),
+}));
+
+vi.mock("@/lib/hermes-local-ai", () => ({
+  removeLocalAiFromHermes: vi.fn(),
+}));
+
 import { get, setMany } from "@/lib/config-store";
 import { stopLocalAiProvider } from "@/lib/local-ai-runtime";
 import { inferConfiguredLocalModel, readConfig, restartGateway } from "@/lib/openclaw-config";
+import { getActiveHarness } from "@/lib/harness";
+import { removeLocalAiFromHermes } from "@/lib/hermes-local-ai";
 
 const mockExecFile = vi.mocked(childProcess.execFile);
 const mockSetMany = vi.mocked(setMany);
@@ -35,6 +49,8 @@ const mockStopLocalAiProvider = vi.mocked(stopLocalAiProvider);
 const mockInferConfiguredLocalModel = vi.mocked(inferConfiguredLocalModel);
 const mockReadConfig = vi.mocked(readConfig);
 const mockRestartGateway = vi.mocked(restartGateway);
+const mockGetActiveHarness = vi.mocked(getActiveHarness);
+const mockRemoveLocalAiFromHermes = vi.mocked(removeLocalAiFromHermes);
 
 function jsonRequest(body: unknown): Request {
   return new Request("http://localhost/setup-api/local-ai", {
@@ -77,6 +93,8 @@ describe("POST /setup-api/local-ai", () => {
     mockRestartGateway.mockResolvedValue();
     mockStopLocalAiProvider.mockResolvedValue();
     mockGet.mockResolvedValue(undefined);
+    mockGetActiveHarness.mockResolvedValue("openclaw");
+    mockRemoveLocalAiFromHermes.mockResolvedValue({ wasDefault: false, model: null });
     setupExecFileMock();
 
     const mod = await import("@/app/setup-api/local-ai/route");
@@ -124,6 +142,83 @@ describe("POST /setup-api/local-ai", () => {
 
     expect(res.status).toBe(200);
     expect(mockStopLocalAiProvider).not.toHaveBeenCalled();
+  });
+
+  it("warns when the OpenClaw fallback list could not be cleared", async () => {
+    // The OpenClaw twin of the same swallow. The stop and the flag clear landed,
+    // so this is a qualification and not a refusal — but it must reach the
+    // owner: a fallback entry pointing at a model we just stopped is a dead
+    // endpoint the next fallback turn walks into.
+    mockExecFile.mockImplementation(((
+      _cmd: string,
+      _args: string[],
+      optsOrCallback?: object | ((error: Error | null, result: { stdout: string; stderr: string }) => void),
+      maybeCallback?: (error: Error | null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      const callback = typeof optsOrCallback === "function" ? optsOrCallback : maybeCallback;
+      callback?.(new Error("openclaw config set failed"), { stdout: "", stderr: "" });
+      return {} as unknown as ReturnType<typeof childProcess.execFile>;
+    }) as unknown as typeof childProcess.execFile);
+
+    const res = await localAiPost(jsonRequest({ action: "disable" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(typeof body.warning).toBe("string");
+    expect(body.warning).toMatch(/fallback/i);
+  });
+
+  describe("the Hermes edition", () => {
+    beforeEach(() => {
+      mockGetActiveHarness.mockResolvedValue("hermes");
+    });
+
+    it("answers 502 when the Hermes unregister failed", async () => {
+      // On this SKU the unregister is the ONLY step that takes effect: the
+      // OpenClaw fallback clear is skipped (no binary) and the gateway restart
+      // is a no-op. Swallowing the failure and answering {success:true} left
+      // `providers.clawlocal` in config.yaml, so Hermes' own pickers kept
+      // offering a model that is no longer running — and the customer found out
+      // only when a chat turn 502'd with "Unknown provider 'clawlocal'".
+      mockRemoveLocalAiFromHermes.mockRejectedValue(new Error("hermes config write failed"));
+
+      const res = await localAiPost(jsonRequest({ action: "disable" }));
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expect(body.success).toBeUndefined();
+      expect(body.code).toBe("hermes_unregister_failed");
+      expect(typeof body.error).toBe("string");
+      // The steps that DID run are not undone, and the answer must not claim
+      // they failed: the runtime is stopped and our own flags are cleared, so a
+      // retry only has the unregister left to do.
+      expect(mockStopLocalAiProvider).toHaveBeenCalledWith("llamacpp");
+      expect(mockSetMany).toHaveBeenCalledWith({
+        local_ai_configured: false,
+        local_ai_provider: undefined,
+        local_ai_model: undefined,
+        local_ai_configured_at: undefined,
+      });
+    });
+
+    it("answers 200 when the Hermes unregister landed", async () => {
+      mockRemoveLocalAiFromHermes.mockResolvedValue({ wasDefault: true, model: "gemma4-e2b-it-q4_0" });
+
+      const res = await localAiPost(jsonRequest({ action: "disable" }));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(mockSetMany).toHaveBeenCalledWith({ local_ai_was_default: true });
+    });
+  });
+
+  it("does not touch Hermes on an OpenClaw box", async () => {
+    const res = await localAiPost(jsonRequest({ action: "disable" }));
+
+    expect(res.status).toBe(200);
+    expect(mockRemoveLocalAiFromHermes).not.toHaveBeenCalled();
   });
 
   it("ignores a stored provider value that names nothing we run", async () => {

--- a/src/tests/routes/local-ai.test.ts
+++ b/src/tests/routes/local-ai.test.ts
@@ -221,7 +221,7 @@ describe("POST /setup-api/local-ai", () => {
     expect(body.code).toBe("hermes_unregister_failed");
     // The panel paints `error` red on a non-2xx and never reads `warning`
     // there, so the fallback sentence has to ride in `error` or be lost.
-    expect(body.error).toMatch(/Hermes still lists it as a provider/);
+    expect(body.error).toMatch(/removing it from Hermes could not be confirmed/);
     expect(body.error).toMatch(/fallback model list/i);
     expect(mockRestartGateway).toHaveBeenCalled();
   });

--- a/src/tests/unit/hermes-config-yaml.test.ts
+++ b/src/tests/unit/hermes-config-yaml.test.ts
@@ -194,16 +194,19 @@ describe("patchHermesConfig on the real 3175-byte Hermes config", () => {
 });
 
 /**
- * What a removal that SUCCEEDED actually leaves in the file.
+ * The two shapes the read-back proof has to answer for, and got wrong.
  *
- * `patchHermesConfig`'s CLI fallback runs `hermes config unset`, which
- * re-serialises config.yaml through PyYAML — and PyYAML writes a mapping it has
- * just emptied as the inline `{}`. Emptying `providers.clawlocal` is what
- * removing the local model does, and on a box whose only provider it was,
- * emptying `providers` itself is the normal outcome. So `{}` is the shape of
- * success on the one path the read-back proof exists for, and a reader that
- * refuses over it answers "could not be confirmed" to a removal that fully
- * landed — for ever, because the retry reads the same file.
+ * An EMPTY MAPPING is written `{}` by PyYAML — the loader `hermes config`
+ * re-serialises this file with (measured on a Hermes box, PyYAML 5.4.1:
+ * `safe_dump({"providers": {}})` → `providers: {}\n`) — and Hermes' own shipped
+ * `cli-config.yaml.example` carries two of them. Our reader THREW on one
+ * anywhere along the path, so `providers: {}` made `providers.clawlocal.base_url`
+ * "we could not look" instead of the plain "not there" the file was stating,
+ * and a removal that had landed was answered "could not be confirmed" — for
+ * ever, because the retry reads the same file. (The pinned 0.20.5 `unset` does
+ * prune a container it empties, `hermes_cli/config.py:1157-1174`, so this is
+ * not what a COMPLETE unset leaves — it is what any other writer of an empty
+ * mapping leaves.)
  *
  * The same reader was blind in the other direction: a `models:` catalogue
  * written as a block or a list — the shape Hermes' own discovery produces — is
@@ -217,14 +220,14 @@ describe("resolveHermesConfigValue over the shapes a removal leaves behind", () 
     return await resolveHermesConfigValue(key);
   }
 
-  it("reads a provider PyYAML emptied to {} as gone, not as unreadable", async () => {
+  it("reads a key under an empty {} mapping as gone, not as unreadable", async () => {
     expect(
       await readBack("providers:\n  clawlocal: {}\nmodel:\n  provider: openrouter\n",
         "providers.clawlocal.base_url"),
     ).toEqual({ state: "absent" });
   });
 
-  it("reads an emptied providers block as gone", async () => {
+  it("reads a key under an empty providers block as gone", async () => {
     expect(await readBack("providers: {}\n", "providers.clawlocal.models")).toEqual({ state: "absent" });
   });
 

--- a/src/tests/unit/hermes-config-yaml.test.ts
+++ b/src/tests/unit/hermes-config-yaml.test.ts
@@ -262,6 +262,42 @@ describe("resolveHermesConfigValue over the shapes a removal leaves behind", () 
     ).toEqual({ state: "unreadable" });
   });
 
+  /**
+   * A block this reader cannot INDEX must never answer "the key is not there".
+   *
+   * The walk descends two columns per level and skips every line deeper than
+   * the level it is scanning, so a block written at any other indent yields no
+   * entries at all — and "I found no lines I could classify" was being returned
+   * as the positive fact "the key is absent". That is the worst possible
+   * direction here, because it is the SAME blind spot that makes the writer a
+   * silent no-op on that file: `unsetYamlPath` changes nothing, `patchText`'s
+   * own verification passes, no CLI fallback is entered, and the read-back then
+   * confirms the write it cannot see. The removal answers 200 with
+   * `providers.clawlocal` intact.
+   *
+   * config.yaml is hand-edited by design — the comment-preserving writer exists
+   * because owners edit it — so this is a shape the file really takes.
+   */
+  it.each([
+    ["four-space children", "providers:\n    clawlocal:\n        base_url: http://127.0.0.1/v1\n"],
+    ["three-space children", "providers:\n   clawlocal:\n      base_url: http://127.0.0.1/v1\n"],
+    ["a deeper grandchild", "providers:\n  clawlocal:\n      base_url: http://127.0.0.1/v1\n"],
+    ["an indented root", "  providers:\n    clawlocal:\n      base_url: http://127.0.0.1/v1\n"],
+  ])("says unreadable, never absent, for %s", async (_name, text) => {
+    expect(await readBack(text, "providers.clawlocal.base_url")).toEqual({ state: "unreadable" });
+  });
+
+  it("still calls a genuinely empty block absent", async () => {
+    // The other side of the same test: a parent that opens NO block at all, and
+    // one holding only a comment, are both real answers and must stay `absent`
+    // or every removal on a normal box would go to the CLI for nothing.
+    expect(await readBack("providers:\nmodel:\n  provider: openrouter\n", "providers.clawlocal"))
+      .toEqual({ state: "absent" });
+    expect(await readBack("providers:\n  # nothing yet\nmodel:\n  provider: openrouter\n", "providers.clawlocal"))
+      .toEqual({ state: "absent" });
+    expect(await readBack("", "providers.clawlocal.base_url")).toEqual({ state: "absent" });
+  });
+
   it("keeps readHermesConfigValue's two-state contract", async () => {
     await fs.writeFile(configPath, "providers:\n  clawlocal:\n    models:\n      - gemma4\n", { mode: 0o600 });
     const { readHermesConfigValue } = await loadModule();

--- a/src/tests/unit/hermes-config-yaml.test.ts
+++ b/src/tests/unit/hermes-config-yaml.test.ts
@@ -298,11 +298,116 @@ describe("resolveHermesConfigValue over the shapes a removal leaves behind", () 
     expect(await readBack("", "providers.clawlocal.base_url")).toEqual({ state: "absent" });
   });
 
+  it("says unreadable for a document PyYAML itself refuses", async () => {
+    // The whole-file fact that IS evidence about every key: Hermes' bridge and
+    // `hermes config get` both load config.yaml with PyYAML, so when PyYAML
+    // raises, nothing in the file is in effect and no line in it describes what
+    // the gateway is running. The module already implements that doctrine for
+    // the top-level reader; this one answered a confident `absent` — which,
+    // over a removal, is a 200 "it is gone" about a file nobody can load. The
+    // damage is deliberately somewhere ELSE than the path being read.
+    const tab = "providers:\n  openrouter:\n    api_key:\tsk-x\nmodel:\n  provider: openrouter\n";
+    expect(await readBack(tab, "providers.clawlocal.base_url")).toEqual({ state: "unreadable" });
+
+    const unterminated = 'providers:\n  openrouter:\n    api_key: "sk-x\nmodel:\n  provider: openrouter\n';
+    expect(await readBack(unterminated, "providers.clawlocal.base_url")).toEqual({ state: "unreadable" });
+  });
+
   it("keeps readHermesConfigValue's two-state contract", async () => {
     await fs.writeFile(configPath, "providers:\n  clawlocal:\n    models:\n      - gemma4\n", { mode: 0o600 });
     const { readHermesConfigValue } = await loadModule();
     // A block is not a scalar, so the scalar reader still answers null — the
     // signature every other caller reads.
     expect(await readHermesConfigValue("providers.clawlocal.models")).toBeNull();
+  });
+});
+
+/**
+ * The false-failure direction, on the file this module was measured against.
+ *
+ * The reader refuses a block it cannot index, and every refusal costs a
+ * `hermes config get` spawn on the removal path. This pins that an ORDINARY
+ * config — the real 3175-byte fixture with a provider block written into it —
+ * still answers every removal key without a single throw, before and after the
+ * unset, so a later change to the walk cannot quietly add six CLI spawns to
+ * every normal "turn Local AI off".
+ */
+describe("an ordinary config still reads without asking the CLI", () => {
+  const KEYS = [
+    "providers.clawlocal.base_url",
+    "providers.clawlocal.api_key",
+    "providers.clawlocal.api_mode",
+    "providers.clawlocal.models",
+    "model.provider",
+    "model.default",
+  ];
+
+  it("answers every removal key before and after the unset", async () => {
+    const { patchHermesConfig, resolveHermesConfigValue } = await loadModule();
+    await patchHermesConfig({
+      set: {
+        "providers.clawlocal.base_url": "http://127.0.0.1/setup-api/local-ai/llamacpp/v1",
+        "providers.clawlocal.api_key": "local-token-xyz",
+        "providers.clawlocal.api_mode": "openai",
+        "providers.clawlocal.models": "gemma4-e2b-it-q4_0",
+        "model.provider": "clawlocal",
+        "model.default": "gemma4-e2b-it-q4_0",
+      },
+    });
+
+    for (const key of KEYS) {
+      expect((await resolveHermesConfigValue(key)).state, key).toBe("value");
+    }
+
+    const result = await patchHermesConfig({ unset: KEYS });
+    expect(result.mode).toBe("merge");
+
+    for (const key of KEYS) {
+      expect((await resolveHermesConfigValue(key)).state, key).toBe("absent");
+    }
+    // The comment banner the whole module exists to protect is still there.
+    expect(commentLines(await fs.readFile(configPath, "utf-8"))).toBe(36);
+    expect(cliMock).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * A file the line editor cannot INDEX must reach the CLI, which can do the job.
+ *
+ * `unsetYamlPath` changed nothing on such a file and `patchText`'s own
+ * verification passed on the same blind spot, so `patchHermesConfig` reported a
+ * successful merge over a file it never touched — and the read-back, refusing
+ * the same shape, then answered "still registered" for ever. The removal has to
+ * fall through to `hermes config unset`, which loads with PyYAML and does not
+ * care how the file is indented.
+ */
+describe("patchHermesConfig on a config the line editor cannot index", () => {
+  const FOUR_SPACE = "providers:\n    clawlocal:\n        base_url: http://127.0.0.1/v1\n";
+
+  it("sends the unset to the CLI instead of reporting a merge that did nothing", async () => {
+    await fs.writeFile(configPath, FOUR_SPACE, { mode: 0o600 });
+    const { patchHermesConfig } = await loadModule();
+
+    const result = await patchHermesConfig({ unset: ["providers.clawlocal.base_url"] });
+
+    expect(result.mode).toBe("cli");
+    expect(cliMock).toHaveBeenCalledWith(
+      ["config", "unset", "providers.clawlocal.base_url"],
+      expect.anything(),
+    );
+    expect(await fs.readFile(configPath, "utf-8")).toBe(FOUR_SPACE);
+  });
+
+  it("sends the set to the CLI instead of writing a duplicate key", async () => {
+    await fs.writeFile(configPath, FOUR_SPACE, { mode: 0o600 });
+    const { patchHermesConfig } = await loadModule();
+
+    const result = await patchHermesConfig({ set: { "providers.clawlocal.api_key": "sk-new" } });
+
+    expect(result.mode).toBe("cli");
+    const after = await fs.readFile(configPath, "utf-8");
+    expect(after).toBe(FOUR_SPACE);
+    // The shape that used to be written into the credential file.
+    expect(after.match(/clawlocal:/g)?.length).toBe(1);
   });
 });

--- a/src/tests/unit/hermes-config-yaml.test.ts
+++ b/src/tests/unit/hermes-config-yaml.test.ts
@@ -192,3 +192,78 @@ describe("patchHermesConfig on the real 3175-byte Hermes config", () => {
     expect(commentLines(after)).toBe(36);
   });
 });
+
+/**
+ * What a removal that SUCCEEDED actually leaves in the file.
+ *
+ * `patchHermesConfig`'s CLI fallback runs `hermes config unset`, which
+ * re-serialises config.yaml through PyYAML — and PyYAML writes a mapping it has
+ * just emptied as the inline `{}`. Emptying `providers.clawlocal` is what
+ * removing the local model does, and on a box whose only provider it was,
+ * emptying `providers` itself is the normal outcome. So `{}` is the shape of
+ * success on the one path the read-back proof exists for, and a reader that
+ * refuses over it answers "could not be confirmed" to a removal that fully
+ * landed — for ever, because the retry reads the same file.
+ *
+ * The same reader was blind in the other direction: a `models:` catalogue
+ * written as a block or a list — the shape Hermes' own discovery produces — is
+ * a `providers.clawlocal` entry Hermes still renders as a picker row, and it
+ * read as "not there".
+ */
+describe("resolveHermesConfigValue over the shapes a removal leaves behind", () => {
+  async function readBack(text: string, key: string) {
+    await fs.writeFile(configPath, text, { mode: 0o600 });
+    const { resolveHermesConfigValue } = await loadModule();
+    return await resolveHermesConfigValue(key);
+  }
+
+  it("reads a provider PyYAML emptied to {} as gone, not as unreadable", async () => {
+    expect(
+      await readBack("providers:\n  clawlocal: {}\nmodel:\n  provider: openrouter\n",
+        "providers.clawlocal.base_url"),
+    ).toEqual({ state: "absent" });
+  });
+
+  it("reads an emptied providers block as gone", async () => {
+    expect(await readBack("providers: {}\n", "providers.clawlocal.models")).toEqual({ state: "absent" });
+  });
+
+  it("does not read a block-form models catalogue as removed", async () => {
+    expect(
+      await readBack("providers:\n  clawlocal:\n    models:\n      gemma4:\n        ctx: 4096\n",
+        "providers.clawlocal.models"),
+    ).toEqual({ state: "present" });
+  });
+
+  it("does not read a list-form models catalogue as removed", async () => {
+    expect(
+      await readBack("providers:\n  clawlocal:\n    models:\n      - gemma4\n",
+        "providers.clawlocal.models"),
+    ).toEqual({ state: "present" });
+  });
+
+  it("still answers a scalar with its value and a missing key with absent", async () => {
+    const text = "providers:\n  clawlocal:\n    base_url: http://127.0.0.1/v1\n";
+    expect(await readBack(text, "providers.clawlocal.base_url")).toEqual({
+      state: "value",
+      value: "http://127.0.0.1/v1",
+    });
+    expect(await readBack(text, "providers.clawlocal.models")).toEqual({ state: "absent" });
+  });
+
+  it("still says unreadable for an inline value it cannot descend into", async () => {
+    // Not an empty collection: `clawlocal` may well hold the key, and this
+    // reader cannot say. "We could not look" is the honest answer.
+    expect(
+      await readBack("providers:\n  clawlocal: {base_url: http://x/v1}\n", "providers.clawlocal.base_url"),
+    ).toEqual({ state: "unreadable" });
+  });
+
+  it("keeps readHermesConfigValue's two-state contract", async () => {
+    await fs.writeFile(configPath, "providers:\n  clawlocal:\n    models:\n      - gemma4\n", { mode: 0o600 });
+    const { readHermesConfigValue } = await loadModule();
+    // A block is not a scalar, so the scalar reader still answers null — the
+    // signature every other caller reads.
+    expect(await readHermesConfigValue("providers.clawlocal.models")).toBeNull();
+  });
+});

--- a/src/tests/unit/hermes-local-ai-unindexable-config.test.ts
+++ b/src/tests/unit/hermes-local-ai-unindexable-config.test.ts
@@ -179,7 +179,7 @@ describe("removing the local provider from a config.yaml our reader cannot index
     const before = configText();
     cliMock.mockRejectedValue(new Error("hermes: timed out"));
 
-    await expect(removeLocalAiFromHermes()).rejects.toThrow();
+    await expect(removeLocalAiFromHermes()).rejects.toThrow(/was not attempted/);
     expect(configText()).toBe(before);
     expect(cliUnsets()).toEqual([]);
   });

--- a/src/tests/unit/hermes-local-ai-unindexable-config.test.ts
+++ b/src/tests/unit/hermes-local-ai-unindexable-config.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { saveEnv } from "@/tests/helpers/env";
+
+/**
+ * TASK-545 — the removal over a config.yaml OUR line editor cannot index.
+ *
+ * The rest of the suite mocks `@/lib/hermes-config-yaml`, so it can only pin
+ * what the removal does with an answer it is HANDED. This file hands it a real
+ * file instead: a four-space `config.yaml`, which `readYamlPath` refuses to
+ * descend (`YamlEditUnsupported`) and `hermes` itself reads without complaint.
+ * That gap is the whole defect — a reader that reports "could not read the
+ * file" and "the key is not there" as the same `null` decided whether the
+ * device's SELECTION was cleared, so on this shape `model.provider: clawlocal`
+ * survived a removal that answered `200 {success:true}`, and every chat turn
+ * afterwards 502s with `Unknown provider 'clawlocal'`.
+ *
+ * Only `hermes` itself is simulated (faithfully: `config unset` rewrites the
+ * document through PyYAML, which is what makes it two-space and indexable
+ * again; `config get` exits 1 with "Config key not set" for a missing key).
+ * Everything else — the reader, the writer, the CLI fallback, the read-back
+ * proof — is the real module.
+ */
+
+const cliMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
+vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
+vi.mock("@/lib/local-ai-token", () => ({ getLocalAiToken: () => "local-token-xyz" }));
+// Mirrors the real builders byte for byte; the point here is to keep
+// `llamacpp-server` (and the whole runtime tree) out of this suite's graph.
+vi.mock("@/lib/local-ai-runtime", () => ({
+  getLocalAiProxyRootUrl: () => "http://127.0.0.1",
+  getLocalAiOpenAiBaseUrl: (p: string) =>
+    p === "llamacpp"
+      ? "http://127.0.0.1/setup-api/local-ai/llamacpp/v1"
+      : "http://127.0.0.1/setup-api/local-ai/ollama/v1",
+}));
+vi.mock("@/lib/config-store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/config-store")>()),
+  get: vi.fn(async () => undefined),
+}));
+
+import { HERMES_LOCAL_PROVIDER, removeLocalAiFromHermes } from "@/lib/hermes-local-ai";
+
+type Node = { [key: string]: Node | string };
+
+/** What `safe_dump` would write: block style, `indent` spaces per level. */
+function render(node: Node, indent: number, depth = 0): string {
+  const pad = " ".repeat(indent * depth);
+  return Object.entries(node)
+    .map(([key, value]) =>
+      typeof value === "string"
+        ? `${pad}${key}: ${value}\n`
+        : `${pad}${key}:\n${render(value, indent, depth + 1)}`)
+    .join("");
+}
+
+function lookup(node: Node, key: string): Node | string | undefined {
+  return key.split(".").reduce<Node | string | undefined>(
+    (at, part) => (at && typeof at === "object" ? at[part] : undefined),
+    node,
+  );
+}
+
+/** `hermes config unset`: drop the leaf, then the containers it emptied. */
+function drop(node: Node, key: string): void {
+  const parts = key.split(".");
+  const chain: Node[] = [node];
+  for (const part of parts.slice(0, -1)) {
+    const next = chain[chain.length - 1][part];
+    if (!next || typeof next === "string") return;
+    chain.push(next);
+  }
+  delete chain[chain.length - 1][parts[parts.length - 1]];
+  for (let i = chain.length - 1; i > 0; i--) {
+    if (Object.keys(chain[i]).length > 0) break;
+    delete chain[i - 1][parts[i - 1]];
+  }
+}
+
+let home: string;
+let restoreEnv: () => void;
+let config: Node;
+
+/** The document on disk, as `safe_dump` at `indent` would have written it. */
+function writeConfig(indent: number): void {
+  fs.writeFileSync(path.join(home, "config.yaml"), render(config, indent), { mode: 0o600 });
+}
+
+function configText(): string {
+  return fs.readFileSync(path.join(home, "config.yaml"), "utf8");
+}
+
+/** Every key `hermes config unset` was asked for. */
+function cliUnsets(): string[] {
+  return cliMock.mock.calls.filter((c) => c[0]?.[1] === "unset").map((c) => c[0]?.[2] as string);
+}
+
+beforeEach(() => {
+  restoreEnv = saveEnv("HERMES_HOME");
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-unindexable-hermes-"));
+  process.env.HERMES_HOME = home;
+  config = {
+    model: { provider: HERMES_LOCAL_PROVIDER, default: "gemma-4-e2b" },
+    providers: {
+      [HERMES_LOCAL_PROVIDER]: {
+        base_url: "http://127.0.0.1/setup-api/local-ai/llamacpp/v1",
+        api_key: "local-token-xyz",
+        api_mode: "openai",
+        models: "gemma-4-e2b",
+      },
+    },
+  };
+  // FOUR spaces: a document `hermes` loads happily and `readYamlPath` refuses
+  // to descend, which is the shape this file exists for.
+  writeConfig(4);
+  cliMock.mockReset();
+  cliMock.mockImplementation(async (args: string[]) => {
+    if (args?.[0] !== "config") return { code: 0, stdout: "", stderr: "" };
+    if (args[1] === "unset") {
+      drop(config, args[2]);
+      // PyYAML round-trips the whole document, so the file comes back at the
+      // dumper's own two-space indent — indexable again from here on.
+      writeConfig(2);
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    if (args[1] === "get") {
+      const value = lookup(config, args[2]);
+      return typeof value === "string"
+        ? { code: 0, stdout: `${value}\n`, stderr: "" }
+        : { code: 1, stdout: "", stderr: `Config key not set: ${args[2]}` };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+});
+
+afterEach(() => {
+  restoreEnv();
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+describe("removing the local provider from a config.yaml our reader cannot index", () => {
+  it("clears a selection that still points at the local model", async () => {
+    // The state the module header names: providers block gone, selection left
+    // behind, every chat turn 502s with "Unknown provider 'clawlocal'". It is
+    // reached through a reader that answers "I could not read this file" and
+    // "that key is not here" with the same `null`.
+    const result = await removeLocalAiFromHermes();
+
+    expect(result).toEqual({ wasDefault: true, model: "gemma-4-e2b" });
+    expect(cliUnsets()).toContain("model.provider");
+    expect(cliUnsets()).toContain("model.default");
+    // ...and in the file itself, which is what the next chat turn reads.
+    expect(configText()).not.toContain(HERMES_LOCAL_PROVIDER);
+  });
+
+  it("leaves another provider's selection alone", async () => {
+    // The mirror mistake, and the destructive one: unsetting `model.provider`
+    // because we could not read it would drop the owner's cloud provider on a
+    // Local AI toggle-off.
+    config.model = { provider: "openrouter", default: "anthropic/claude-sonnet-4" };
+    writeConfig(4);
+
+    const result = await removeLocalAiFromHermes();
+
+    expect(result.wasDefault).toBe(false);
+    expect(cliUnsets()).not.toContain("model.provider");
+    expect(cliUnsets()).not.toContain("model.default");
+    expect(configText()).toContain("provider: openrouter");
+  });
+
+  it("writes nothing and refuses when Hermes' own reader cannot answer either", async () => {
+    // Neither reader can say what the selection is, so there is no safe unset
+    // list to send: unsetting `model.provider` blind would evict a cloud
+    // provider, and leaving it is the 502-per-turn state. Refuse BEFORE the
+    // write, so the box keeps working and the retry has everything still to do.
+    const before = configText();
+    cliMock.mockRejectedValue(new Error("hermes: timed out"));
+
+    await expect(removeLocalAiFromHermes()).rejects.toThrow();
+    expect(configText()).toBe(before);
+    expect(cliUnsets()).toEqual([]);
+  });
+});

--- a/src/tests/unit/hermes-local-ai.test.ts
+++ b/src/tests/unit/hermes-local-ai.test.ts
@@ -210,17 +210,27 @@ describe("registering the local model with Hermes", () => {
   });
 
   /**
+   * A key that is THERE in a shape that is not a scalar — a `models:` block or
+   * list, which is what Hermes' own discovery writes. The file reader answers
+   * `{ state: "present" }` for it, and the removal has to read that as a
+   * leftover: an entry Hermes still renders as a picker row.
+   */
+  const NON_SCALAR = Symbol("non-scalar");
+
+  /**
    * A config.yaml the reads and the writes SHARE, because the removal is now
    * proved by reading the file back rather than by the patch call returning.
    * `patchHermesConfig` is stubbed to apply the unsets, which is what a device
    * does; the failing case below stubs one that does not.
    */
-  function deviceConfig(initial: Record<string, string>) {
-    const file: Record<string, string | null> = { ...initial };
-    readMock.mockImplementation(async (key: string) => file[key] ?? null);
-    resolveMock.mockImplementation(async (key: string) =>
-      typeof file[key] === "string" ? { state: "value", value: file[key] as string } : { state: "absent" },
-    );
+  function deviceConfig(initial: Record<string, string | typeof NON_SCALAR>) {
+    const file: Record<string, string | typeof NON_SCALAR | undefined> = { ...initial };
+    readMock.mockImplementation(async (key: string) => (typeof file[key] === "string" ? file[key] : null));
+    resolveMock.mockImplementation(async (key: string) => {
+      const value = file[key];
+      if (typeof value === "string") return { state: "value", value };
+      return value === NON_SCALAR ? { state: "present" } : { state: "absent" };
+    });
     patchMock.mockImplementation(async (patch: { unset?: string[] }) => {
       for (const key of patch.unset ?? []) delete file[key];
       return { mode: "merge", backupPath: null };
@@ -287,18 +297,86 @@ describe("registering the local model with Hermes", () => {
     await expect(removeLocalAiFromHermes()).rejects.toThrow(/still registered/i);
   });
 
-  it("refuses when the config could not be read back at all", async () => {
-    // The CLI fallback is entered BECAUSE the line editor could not work with
-    // this file, so a read-back that cannot resolve the path is the likely
-    // companion of the write that failed. Reading that as "removed" would put
-    // the false success back one layer down.
+  it("refuses when the catalogue survived as a block Hermes wrote itself", async () => {
+    // `providers.clawlocal.models` is a scalar only while WE own it. Hermes'
+    // own discovery writes a nested block, and a hand-edited file may hold a
+    // list — both are still a `providers.clawlocal` entry Hermes renders as a
+    // picker row. The scalar-only reader answered `null` for them, exactly as
+    // it does for a key that is gone, so a partial removal read as complete.
+    const file = deviceConfig({
+      [`providers.${HERMES_LOCAL_PROVIDER}.base_url`]: "http://127.0.0.1/setup-api/local-ai/llamacpp/v1",
+      [`providers.${HERMES_LOCAL_PROVIDER}.models`]: NON_SCALAR,
+    });
+    patchMock.mockImplementation(async (patch: { unset?: string[] }) => {
+      for (const key of patch.unset ?? []) {
+        if (!key.endsWith(".models")) delete file[key];
+      }
+      return { mode: "cli", backupPath: null };
+    });
+
+    await expect(removeLocalAiFromHermes()).rejects.toThrow(/still registered/i);
+  });
+
+  it("carries wasDefault out with the refusal so the selection can be restored", async () => {
+    // The partial `applyViaCli`'s one-call-per-key loop produces: the selection
+    // goes, a providers key stays. `wasDefault` was read BEFORE the patch, and
+    // this refusal is the last moment it exists — the retry reads a
+    // `model.provider` that is already gone, answers false, and re-enabling
+    // Local AI would put the device on nothing instead of back where it was.
+    const file = deviceConfig({
+      [`providers.${HERMES_LOCAL_PROVIDER}.base_url`]: "http://127.0.0.1/setup-api/local-ai/llamacpp/v1",
+      "model.provider": HERMES_LOCAL_PROVIDER,
+      "model.default": "gemma4-e2b-it-q4_0",
+    });
+    patchMock.mockImplementation(async (patch: { unset?: string[] }) => {
+      for (const key of patch.unset ?? []) {
+        if (!key.startsWith("providers.")) delete file[key];
+      }
+      return { mode: "cli", backupPath: null };
+    });
+
+    await expect(removeLocalAiFromHermes()).rejects.toMatchObject({ wasDefault: true });
+  });
+
+  it("asks Hermes' own reader when our reader cannot resolve the file", async () => {
+    // HARNESS FIRST. The CLI fallback is entered BECAUSE the line editor could
+    // not work with this file, so a read-back that cannot resolve the path is
+    // the companion of the write, not the exotic case — and answering
+    // "unproven" there is a 502 the owner can never clear, because the retry
+    // reads the same file. `hermes config get` is Hermes' own reader of it.
     deviceConfig({
       [`providers.${HERMES_LOCAL_PROVIDER}.base_url`]: "http://127.0.0.1/setup-api/local-ai/llamacpp/v1",
     });
     patchMock.mockResolvedValue({ mode: "cli", backupPath: null });
     resolveMock.mockResolvedValue({ state: "unreadable" });
+    cliMock.mockResolvedValue({ code: 1, stdout: "", stderr: "config key not set" });
+
+    await expect(removeLocalAiFromHermes()).resolves.toMatchObject({ wasDefault: false });
+  });
+
+  it("refuses when Hermes' own reader cannot answer either", async () => {
+    // Both readers silent is the only genuinely unknowable state, and it is the
+    // one this sentence is for: a `hermes` shim mid-`step_hermes_install`
+    // rebuild exits 127 without reaching argparse.
+    deviceConfig({
+      [`providers.${HERMES_LOCAL_PROVIDER}.base_url`]: "http://127.0.0.1/setup-api/local-ai/llamacpp/v1",
+    });
+    patchMock.mockResolvedValue({ mode: "cli", backupPath: null });
+    resolveMock.mockResolvedValue({ state: "unreadable" });
+    cliMock.mockResolvedValue({ code: 127, stdout: "", stderr: "" });
 
     await expect(removeLocalAiFromHermes()).rejects.toThrow(/could not be read back/i);
+  });
+
+  it("reports a key Hermes' own reader says is still there", async () => {
+    deviceConfig({
+      [`providers.${HERMES_LOCAL_PROVIDER}.base_url`]: "http://127.0.0.1/setup-api/local-ai/llamacpp/v1",
+    });
+    patchMock.mockResolvedValue({ mode: "cli", backupPath: null });
+    resolveMock.mockResolvedValue({ state: "unreadable" });
+    cliMock.mockResolvedValue({ code: 0, stdout: "http://127.0.0.1/v1", stderr: "" });
+
+    await expect(removeLocalAiFromHermes()).rejects.toThrow(/still registered/i);
   });
 
   it("refuses when the selection still points at a provider that is gone", async () => {

--- a/src/tests/unit/hermes-local-ai.test.ts
+++ b/src/tests/unit/hermes-local-ai.test.ts
@@ -10,10 +10,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const cliMock = vi.hoisted(() => vi.fn());
 const patchMock = vi.hoisted(() => vi.fn());
 const readMock = vi.hoisted(() => vi.fn());
+// Defaults survive `mockReset` because they are the implementation `vi.fn()` was
+// created with — the resolved form answers "absent" unless a test says otherwise.
+const resolveMock = vi.hoisted(() =>
+  vi.fn<(key: string) => Promise<{ state: string; value?: string }>>(async () => ({ state: "absent" })),
+);
 vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
 vi.mock("@/lib/hermes-config-yaml", () => ({
   patchHermesConfig: patchMock,
   readHermesConfigValue: readMock,
+  resolveHermesConfigValue: resolveMock,
   // Listed because the module UNDER TEST throws it: a factory that omits an
   // export makes it `undefined`, and `new undefined()` is a TypeError, not the
   // failure the caller is meant to see.
@@ -212,6 +218,9 @@ describe("registering the local model with Hermes", () => {
   function deviceConfig(initial: Record<string, string>) {
     const file: Record<string, string | null> = { ...initial };
     readMock.mockImplementation(async (key: string) => file[key] ?? null);
+    resolveMock.mockImplementation(async (key: string) =>
+      typeof file[key] === "string" ? { state: "value", value: file[key] as string } : { state: "absent" },
+    );
     patchMock.mockImplementation(async (patch: { unset?: string[] }) => {
       for (const key of patch.unset ?? []) delete file[key];
       return { mode: "merge", backupPath: null };
@@ -276,6 +285,20 @@ describe("registering the local model with Hermes", () => {
     });
 
     await expect(removeLocalAiFromHermes()).rejects.toThrow(/still registered/i);
+  });
+
+  it("refuses when the config could not be read back at all", async () => {
+    // The CLI fallback is entered BECAUSE the line editor could not work with
+    // this file, so a read-back that cannot resolve the path is the likely
+    // companion of the write that failed. Reading that as "removed" would put
+    // the false success back one layer down.
+    deviceConfig({
+      [`providers.${HERMES_LOCAL_PROVIDER}.base_url`]: "http://127.0.0.1/setup-api/local-ai/llamacpp/v1",
+    });
+    patchMock.mockResolvedValue({ mode: "cli", backupPath: null });
+    resolveMock.mockResolvedValue({ state: "unreadable" });
+
+    await expect(removeLocalAiFromHermes()).rejects.toThrow(/could not be read back/i);
   });
 
   it("refuses when the selection still points at a provider that is gone", async () => {

--- a/src/tests/unit/hermes-local-ai.test.ts
+++ b/src/tests/unit/hermes-local-ai.test.ts
@@ -259,6 +259,25 @@ describe("registering the local model with Hermes", () => {
     await expect(removeLocalAiFromHermes()).rejects.toThrow(/still registered/i);
   });
 
+  it("refuses when only the model list survived the removal", async () => {
+    // `providers.clawlocal.models` on its own is still an entry Hermes renders
+    // as a picker row, so a removal that dropped the endpoint and kept the
+    // catalogue has not ended the state it was called to end. The CLI fallback
+    // walks the unsets one call at a time, so partial is a real outcome.
+    const file = deviceConfig({
+      [`providers.${HERMES_LOCAL_PROVIDER}.base_url`]: "http://127.0.0.1/setup-api/local-ai/llamacpp/v1",
+      [`providers.${HERMES_LOCAL_PROVIDER}.models`]: "gemma4-e2b-it-q4_0",
+    });
+    patchMock.mockImplementation(async (patch: { unset?: string[] }) => {
+      for (const key of patch.unset ?? []) {
+        if (!key.endsWith(".models")) delete file[key];
+      }
+      return { mode: "cli", backupPath: null };
+    });
+
+    await expect(removeLocalAiFromHermes()).rejects.toThrow(/still registered/i);
+  });
+
   it("refuses when the selection still points at a provider that is gone", async () => {
     // The other half of the same state, and the worse one: every chat turn 502s
     // with "Unknown provider 'clawlocal'".

--- a/src/tests/unit/hermes-local-ai.test.ts
+++ b/src/tests/unit/hermes-local-ai.test.ts
@@ -401,7 +401,9 @@ describe("registering the local model with Hermes", () => {
   it("does not spend CLI spawns on an outcome a leftover already decided", async () => {
     // One key that demonstrably survived makes "still registered" certain, so
     // asking Hermes about the others buys nothing and costs a serial 15-second
-    // budget each in front of a click the owner is holding open.
+    // budget each in front of a click the owner is holding open. The SELECTION
+    // is readable here, so its own three-state read spends no spawn either and
+    // this stays an assertion about the read-back loop.
     const file = deviceConfig({
       [`providers.${HERMES_LOCAL_PROVIDER}.models`]: NON_SCALAR,
     });
@@ -411,9 +413,10 @@ describe("registering the local model with Hermes", () => {
       }
       return { mode: "cli", backupPath: null };
     });
-    resolveMock.mockImplementation(async (key: string) =>
-      key.endsWith(".models") ? { state: "present" } : { state: "unreadable" },
-    );
+    resolveMock.mockImplementation(async (key: string) => {
+      if (key.endsWith(".models")) return { state: "present" };
+      return key.startsWith("model.") ? { state: "absent" } : { state: "unreadable" };
+    });
     cliMock.mockReset();
 
     await expect(removeLocalAiFromHermes()).rejects.toThrow(/still registered/i);
@@ -423,12 +426,17 @@ describe("registering the local model with Hermes", () => {
   it("refuses when Hermes' own reader cannot answer either", async () => {
     // Both readers silent is the only genuinely unknowable state, and it is the
     // one this sentence is for: a `hermes` shim mid-`step_hermes_install`
-    // rebuild exits 127 without reaching argparse.
+    // rebuild exits 127 without reaching argparse. Scoped to the READ-BACK: the
+    // selection is answered here, so what cannot be settled is only whether the
+    // write landed. (The other half — a selection neither reader can resolve —
+    // is refused before the write, in hermes-local-ai-unindexable-config.)
     deviceConfig({
       [`providers.${HERMES_LOCAL_PROVIDER}.base_url`]: "http://127.0.0.1/setup-api/local-ai/llamacpp/v1",
     });
     patchMock.mockResolvedValue({ mode: "cli", backupPath: null });
-    resolveMock.mockResolvedValue({ state: "unreadable" });
+    resolveMock.mockImplementation(async (key: string) =>
+      key.startsWith("model.") ? { state: "absent" } : { state: "unreadable" },
+    );
     cliMock.mockResolvedValue({ code: 127, stdout: "", stderr: "" });
 
     await expect(removeLocalAiFromHermes()).rejects.toThrow(/could not be read back/i);

--- a/src/tests/unit/hermes-local-ai.test.ts
+++ b/src/tests/unit/hermes-local-ai.test.ts
@@ -14,6 +14,10 @@ vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
 vi.mock("@/lib/hermes-config-yaml", () => ({
   patchHermesConfig: patchMock,
   readHermesConfigValue: readMock,
+  // Listed because the module UNDER TEST throws it: a factory that omits an
+  // export makes it `undefined`, and `new undefined()` is a TypeError, not the
+  // failure the caller is meant to see.
+  HermesConfigWriteError: class HermesConfigWriteError extends Error {},
 }));
 vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
 vi.mock("@/lib/local-ai-token", () => ({ getLocalAiToken: () => "local-token-xyz" }));
@@ -199,12 +203,30 @@ describe("registering the local model with Hermes", () => {
     ]);
   });
 
+  /**
+   * A config.yaml the reads and the writes SHARE, because the removal is now
+   * proved by reading the file back rather than by the patch call returning.
+   * `patchHermesConfig` is stubbed to apply the unsets, which is what a device
+   * does; the failing case below stubs one that does not.
+   */
+  function deviceConfig(initial: Record<string, string>) {
+    const file: Record<string, string | null> = { ...initial };
+    readMock.mockImplementation(async (key: string) => file[key] ?? null);
+    patchMock.mockImplementation(async (patch: { unset?: string[] }) => {
+      for (const key of patch.unset ?? []) delete file[key];
+      return { mode: "merge", backupPath: null };
+    });
+    return file;
+  }
+
   it("clears a model.provider that still points at the local model", async () => {
     // Leaving it set with the providers block gone is what made every chat turn
     // 502 with "Unknown provider 'clawlocal'" after a Local AI toggle-off.
-    readMock.mockImplementation(async (key: string) =>
-      key === "model.provider" ? HERMES_LOCAL_PROVIDER : "qwen2.5:3b",
-    );
+    deviceConfig({
+      [`providers.${HERMES_LOCAL_PROVIDER}.base_url`]: "http://127.0.0.1/setup-api/local-ai/llamacpp/v1",
+      "model.provider": HERMES_LOCAL_PROVIDER,
+      "model.default": "qwen2.5:3b",
+    });
     const result = await removeLocalAiFromHermes();
     expect(result).toEqual({ wasDefault: true, model: "qwen2.5:3b" });
     expect(unsets()).toContain("model.provider");
@@ -212,13 +234,48 @@ describe("registering the local model with Hermes", () => {
   });
 
   it("leaves someone else's provider selection alone", async () => {
-    readMock.mockImplementation(async (key: string) =>
-      key === "model.provider" ? "openrouter" : "anthropic/claude-sonnet-4",
-    );
+    deviceConfig({
+      [`providers.${HERMES_LOCAL_PROVIDER}.base_url`]: "http://127.0.0.1/setup-api/local-ai/llamacpp/v1",
+      "model.provider": "openrouter",
+      "model.default": "anthropic/claude-sonnet-4",
+    });
     const result = await removeLocalAiFromHermes();
     expect(result.wasDefault).toBe(false);
     expect(unsets()).not.toContain("model.provider");
     expect(unsets()).not.toContain("model.default");
+  });
+
+  it("refuses to report a removal the config did not take", async () => {
+    // `patchHermesConfig`'s merge path reads every key back, but its CLI
+    // fallback does not: `applyViaCli`'s unset loop discards the exit code, so
+    // a `hermes` binary mid-rebuild (127 before argparse) let a whole removal
+    // return normally with `providers.clawlocal` still in the file. The disable
+    // route answers on this return for the Hermes SKU, so it has to be a fact.
+    deviceConfig({
+      [`providers.${HERMES_LOCAL_PROVIDER}.base_url`]: "http://127.0.0.1/setup-api/local-ai/llamacpp/v1",
+    });
+    patchMock.mockResolvedValue({ mode: "cli", backupPath: null });
+
+    await expect(removeLocalAiFromHermes()).rejects.toThrow(/still registered/i);
+  });
+
+  it("refuses when the selection still points at a provider that is gone", async () => {
+    // The other half of the same state, and the worse one: every chat turn 502s
+    // with "Unknown provider 'clawlocal'".
+    const file = deviceConfig({
+      [`providers.${HERMES_LOCAL_PROVIDER}.base_url`]: "http://127.0.0.1/setup-api/local-ai/llamacpp/v1",
+      "model.provider": HERMES_LOCAL_PROVIDER,
+      "model.default": "gemma4-e2b-it-q4_0",
+    });
+    patchMock.mockImplementation(async (patch: { unset?: string[] }) => {
+      // The providers block goes; the selection does not.
+      for (const key of patch.unset ?? []) {
+        if (key !== "model.provider") delete file[key];
+      }
+      return { mode: "cli", backupPath: null };
+    });
+
+    await expect(removeLocalAiFromHermes()).rejects.toThrow(/still registered/i);
   });
 });
 

--- a/src/tests/unit/hermes-local-ai.test.ts
+++ b/src/tests/unit/hermes-local-ai.test.ts
@@ -141,6 +141,18 @@ describe("registering the local model with Hermes", () => {
     expect(sets()).toContain(`providers.${HERMES_LOCAL_PROVIDER}.models=qwen3:8b`);
   });
 
+  it("still registers when the CLI could not be RUN at all", async () => {
+    // `runHermesCli` rejects (a missing binary, a timeout, its own SIGKILL)
+    // rather than returning a code. That is a question that failed, exactly as
+    // 127 is, and it is now read the same way: no catalogue is written, the
+    // repair is handed back, and the endpoint keys still land. It used to
+    // propagate and fail the whole enable with a raw error.
+    cliMock.mockRejectedValue(new Error("hermes timed out"));
+    await applyLocalAiToHermes({ provider: "ollama", model: "qwen3:8b" });
+    expect(sets().some((kv) => kv.startsWith(`providers.${HERMES_LOCAL_PROVIDER}.models=`))).toBe(false);
+    expect(sets()).toContain(`providers.${HERMES_LOCAL_PROVIDER}.api_mode=openai`);
+  });
+
   it("writes no catalogue when the CLI never answered", async () => {
     // 127 is the shim over a rebuilding venv, not "the key is unset".
     cliMock.mockImplementation(async (args: string[]) =>

--- a/src/tests/unit/hermes-local-ai.test.ts
+++ b/src/tests/unit/hermes-local-ai.test.ts
@@ -350,6 +350,24 @@ describe("registering the local model with Hermes", () => {
     await expect(removeLocalAiFromHermes()).resolves.toMatchObject({ wasDefault: false });
   });
 
+  it("refuses a write that changed nothing rather than confirming it", async () => {
+    // The shape that makes the proof worth having: a config.yaml the line
+    // editor cannot INDEX makes `unsetYamlPath` a no-op, `patchText`'s own
+    // verification pass, and no CLI fallback run — so `patchHermesConfig`
+    // returns `{mode:"merge"}` over a file it never touched. If the read-back
+    // uses the same reader and reads its blind spot as "absent", it can only
+    // ever confirm that no-op. Here the file cannot answer and Hermes says the
+    // keys are still there.
+    deviceConfig({
+      [`providers.${HERMES_LOCAL_PROVIDER}.base_url`]: "http://127.0.0.1/setup-api/local-ai/llamacpp/v1",
+    });
+    patchMock.mockResolvedValue({ mode: "merge", backupPath: null });
+    resolveMock.mockResolvedValue({ state: "unreadable" });
+    cliMock.mockResolvedValue({ code: 0, stdout: "http://127.0.0.1/v1", stderr: "" });
+
+    await expect(removeLocalAiFromHermes()).rejects.toThrow(/still registered/i);
+  });
+
   it("refuses when Hermes' own reader cannot answer either", async () => {
     // Both readers silent is the only genuinely unknowable state, and it is the
     // one this sentence is for: a `hermes` shim mid-`step_hermes_install`

--- a/src/tests/unit/hermes-local-ai.test.ts
+++ b/src/tests/unit/hermes-local-ai.test.ts
@@ -20,10 +20,6 @@ vi.mock("@/lib/hermes-config-yaml", () => ({
   patchHermesConfig: patchMock,
   readHermesConfigValue: readMock,
   resolveHermesConfigValue: resolveMock,
-  // Listed because the module UNDER TEST throws it: a factory that omits an
-  // export makes it `undefined`, and `new undefined()` is a TypeError, not the
-  // failure the caller is meant to see.
-  HermesConfigWriteError: class HermesConfigWriteError extends Error {},
 }));
 vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
 vi.mock("@/lib/local-ai-token", () => ({ getLocalAiToken: () => "local-token-xyz" }));

--- a/src/tests/unit/hermes-local-ai.test.ts
+++ b/src/tests/unit/hermes-local-ai.test.ts
@@ -21,7 +21,8 @@ vi.mock("@/lib/hermes-config-yaml", () => ({
   readHermesConfigValue: readMock,
   resolveHermesConfigValue: resolveMock,
 }));
-vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
+const invalidateMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: invalidateMock }));
 vi.mock("@/lib/local-ai-token", () => ({ getLocalAiToken: () => "local-token-xyz" }));
 // Mirrors the REAL url builders byte-for-byte — the previous mock answered a
 // /v1 Ollama URL the real builder never produced, so this suite asserted a
@@ -378,6 +379,45 @@ describe("registering the local model with Hermes", () => {
     cliMock.mockResolvedValue({ code: 0, stdout: "http://127.0.0.1/v1", stderr: "" });
 
     await expect(removeLocalAiFromHermes()).rejects.toThrow(/still registered/i);
+  });
+
+  it("drops the model-options memo even when the patch itself threw", async () => {
+    // `applyViaCli` walks the unsets one spawn at a time and does not catch, and
+    // `runHermesCli` REJECTS on a timeout — so keys 1-3 can land and key 4 take
+    // the whole call down. `withProviderMcpRefresh` re-reads the provider set in
+    // a `finally` precisely because "the write threw" is not "nothing was
+    // written", and that re-read only sees the new catalogue once the memo has
+    // been dropped. Left to the success path, the enum would go on offering a
+    // provider whose endpoint is already out of the file.
+    deviceConfig({
+      [`providers.${HERMES_LOCAL_PROVIDER}.base_url`]: "http://127.0.0.1/setup-api/local-ai/llamacpp/v1",
+    });
+    patchMock.mockRejectedValue(new Error("hermes timed out"));
+
+    await expect(removeLocalAiFromHermes()).rejects.toThrow(/timed out/);
+    expect(invalidateMock).toHaveBeenCalled();
+  });
+
+  it("does not spend CLI spawns on an outcome a leftover already decided", async () => {
+    // One key that demonstrably survived makes "still registered" certain, so
+    // asking Hermes about the others buys nothing and costs a serial 15-second
+    // budget each in front of a click the owner is holding open.
+    const file = deviceConfig({
+      [`providers.${HERMES_LOCAL_PROVIDER}.models`]: NON_SCALAR,
+    });
+    patchMock.mockImplementation(async (patch: { unset?: string[] }) => {
+      for (const key of patch.unset ?? []) {
+        if (!key.endsWith(".models")) delete file[key];
+      }
+      return { mode: "cli", backupPath: null };
+    });
+    resolveMock.mockImplementation(async (key: string) =>
+      key.endsWith(".models") ? { state: "present" } : { state: "unreadable" },
+    );
+    cliMock.mockReset();
+
+    await expect(removeLocalAiFromHermes()).rejects.toThrow(/still registered/i);
+    expect(cliMock).not.toHaveBeenCalled();
   });
 
   it("refuses when Hermes' own reader cannot answer either", async () => {

--- a/src/tests/unit/provider-write-paths.test.ts
+++ b/src/tests/unit/provider-write-paths.test.ts
@@ -33,6 +33,10 @@ vi.mock("@/lib/config-store", () => ({ get: storeGetMock, setMany: vi.fn() }));
 vi.mock("@/lib/hermes-config-yaml", () => ({
   patchHermesConfig: patchMock,
   readHermesConfigValue: readConfigMock,
+  // Listed because the module UNDER TEST throws it: a factory that omits an
+  // export makes it `undefined`, and `new undefined()` is a TypeError, not the
+  // failure the caller is meant to see.
+  HermesConfigWriteError: class HermesConfigWriteError extends Error {},
 }));
 vi.mock("@/lib/local-ai-token", () => ({ getLocalAiToken: () => "local-token-xyz" }));
 vi.mock("@/lib/local-ai-runtime", () => ({

--- a/src/tests/unit/provider-write-paths.test.ts
+++ b/src/tests/unit/provider-write-paths.test.ts
@@ -24,6 +24,11 @@ const cliMock = vi.hoisted(() => vi.fn());
 const optionsMock = vi.hoisted(() => vi.fn());
 const patchMock = vi.hoisted(() => vi.fn());
 const readConfigMock = vi.hoisted(() => vi.fn());
+// The removal proves itself by reading every unset key back; "absent" is the
+// answer a device gives after a write that landed.
+const resolveConfigMock = vi.hoisted(() =>
+  vi.fn<(key: string) => Promise<{ state: string; value?: string }>>(async () => ({ state: "absent" })),
+);
 
 vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: rpcMock }));
 vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn(async () => "hermes") }));
@@ -33,6 +38,7 @@ vi.mock("@/lib/config-store", () => ({ get: storeGetMock, setMany: vi.fn() }));
 vi.mock("@/lib/hermes-config-yaml", () => ({
   patchHermesConfig: patchMock,
   readHermesConfigValue: readConfigMock,
+  resolveHermesConfigValue: resolveConfigMock,
   // Listed because the module UNDER TEST throws it: a factory that omits an
   // export makes it `undefined`, and `new undefined()` is a TypeError, not the
   // failure the caller is meant to see.

--- a/src/tests/unit/provider-write-paths.test.ts
+++ b/src/tests/unit/provider-write-paths.test.ts
@@ -39,10 +39,6 @@ vi.mock("@/lib/hermes-config-yaml", () => ({
   patchHermesConfig: patchMock,
   readHermesConfigValue: readConfigMock,
   resolveHermesConfigValue: resolveConfigMock,
-  // Listed because the module UNDER TEST throws it: a factory that omits an
-  // export makes it `undefined`, and `new undefined()` is a TypeError, not the
-  // failure the caller is meant to see.
-  HermesConfigWriteError: class HermesConfigWriteError extends Error {},
 }));
 vi.mock("@/lib/local-ai-token", () => ({ getLocalAiToken: () => "local-token-xyz" }));
 vi.mock("@/lib/local-ai-runtime", () => ({

--- a/src/tests/unit/yaml-block-edit.test.ts
+++ b/src/tests/unit/yaml-block-edit.test.ts
@@ -583,3 +583,53 @@ describe("getTopLevelScalar and a document PyYAML will not load", () => {
     expect(getTopLevelScalar(text, "TELEGRAM_BOT_TOKEN")).toEqual({ value, readable: true });
   });
 });
+
+/**
+ * A block the line editor cannot INDEX must stop the write, not be written over.
+ *
+ * The walk descends exactly two columns per level and skips every line deeper
+ * than the level it is scanning, so a block written at any other indent — a
+ * hand edit, or any writer that dumps at `indent=4` — yields no entries at all.
+ * Silently, in both directions:
+ *
+ *  - `unsetYamlPath` removes nothing and returns the text unchanged, and
+ *    `patchText`'s own verification passes on the same blind spot, so the CLI
+ *    fallback that COULD do the removal is never entered;
+ *  - `setYamlPath` appends a SECOND `clawlocal:` at two spaces, and the
+ *    verification passes on that too — writing a config.yaml with a duplicate
+ *    key into the file that holds the provider api_keys.
+ *
+ * Refusing is what hands the job to `hermes config set/unset`, which loads the
+ * file with PyYAML and does not care how it is indented.
+ */
+describe("a block this editor cannot index", () => {
+  const FOUR_SPACE = "providers:\n    clawlocal:\n        base_url: http://127.0.0.1/v1\n";
+
+  it("refuses the unset instead of silently changing nothing", () => {
+    expect(() => unsetYamlPath(FOUR_SPACE, ["providers", "clawlocal", "base_url"]))
+      .toThrow(YamlEditUnsupported);
+  });
+
+  it("refuses the set instead of appending a duplicate key", () => {
+    expect(() => setYamlPath(FOUR_SPACE, ["providers", "clawlocal", "api_key"], "sk-new"))
+      .toThrow(YamlEditUnsupported);
+  });
+
+  it("refuses a root mapping that is not at column zero", () => {
+    const indented = "  providers:\n    clawlocal:\n      base_url: http://127.0.0.1/v1\n";
+    expect(() => setYamlPath(indented, ["model", "provider"], "openrouter")).toThrow(YamlEditUnsupported);
+  });
+
+  it("still writes, and still creates, on an ordinary two-space file", () => {
+    const ok = "providers:\n  clawlocal:\n    base_url: http://127.0.0.1/v1\nmodel:\n  provider: openrouter\n";
+    expect(getYamlPath(setYamlPath(ok, ["providers", "clawlocal", "api_key"], "sk-new"),
+      ["providers", "clawlocal", "api_key"])).toBe("sk-new");
+    // A key whose parent does not exist yet is created, not refused.
+    expect(getYamlPath(setYamlPath(ok, ["security", "tirith_enabled"], "true"),
+      ["security", "tirith_enabled"])).toBe("true");
+    // An empty parent block is an answer, not an unreadable one.
+    expect(getYamlPath(setYamlPath("providers:\nmodel:\n  provider: x\n", ["providers", "clawlocal", "api_key"], "k"),
+      ["providers", "clawlocal", "api_key"])).toBe("k");
+    expect(unsetYamlPath(ok, ["providers", "clawlocal", "base_url"])).not.toContain("base_url");
+  });
+});


### PR DESCRIPTION
TASK-545 — Hermes: "Turn off Local AI" reported success when the one step that matters had failed.

## Customer-visible symptom

On a Hermes box, `POST /setup-api/local-ai {action:"disable"}` answered `{success:true}` whatever happened to `removeLocalAiFromHermes()`. Settings then showed Local AI off while `providers.clawlocal` was still in `~/.hermes/config.yaml`, so Hermes' own pickers (the Telegram/Discord `/model` keyboard, the Hermes dashboard Models page, our chat header) went on offering a model that is no longer running — and the owner found out at the next chat turn, which 502s with `Unknown provider 'clawlocal'`.

The route's own comment (lines 73-75 on beta) spelled out that exact consequence, and the one failure mode it documented was the one it reported as success. False success, the second of the three recurring classes.

## Cause

Two swallows in the same block, and one contract that was never kept:

1. `removeLocalAiFromHermes().catch(() => null)` — the failure was logged and the route fell through to `{success:true}`. On this SKU that unregister is the only step that reaches the customer: the OpenClaw fallback clear is skipped (`openclawIsAbsent()`), and `restartGateway()` returns immediately because `gatewayIsAbsent()` is `readEdition() === "hermes"`.
2. `removeLocalAiFromHermes()` returning was not evidence that the removal landed. `patchHermesConfig` proves a **merge** write (`patchText` reads every key back), but its CLI fallback does not: `applyViaCli`'s `unset` loop discards the exit code — deliberately, because `hermes config unset` on an absent key is the no-op it relies on. So a `config.yaml` the line editor refuses (a flow mapping, a duplicate key) plus a `hermes` binary mid-`step_hermes_install` rebuild (127 before argparse) returned normally with the provider still registered. Fixing only (1) would have left the original bug reachable.
3. The OpenClaw twin in the same block — `openclaw config set agents.defaults.model.fallbacks []` — was swallowed with `.catch(() => {})`, leaving a fallback entry pointing at a model this request had just stopped.

## Fix

- `src/lib/hermes-local-ai.ts` — `removeLocalAi()` now **proves** the removal: after the patch it re-reads `providers.clawlocal.base_url` (and `model.provider` when the local model was the selection) and throws `HermesConfigWriteError` if either survives. It reads through `resolveHermesConfigValue`, not `readHermesConfigValue`, because that one collapses "could not be read" into the same `null` it uses for "not set" — and the CLI fallback runs precisely BECAUSE the line editor could not work with this file, so reading a failed question as a removed key would rebuild the false success one layer down. Round 2 below completes this: the read-back walks EVERY key the removal unsets, and answers for the two shapes `getYamlPath` could not.
- `src/app/setup-api/local-ai/route.ts` — a failed unregister is answered `502 {error}` instead of `{success:true}` (this bullet originally described a `code` field beside it; it had no consumer and was dropped in a later round, below). The steps that did run stand (the runtime is stopped, our flags are cleared), so a retry has only the unregister left to do.
- Same route — the OpenClaw fallback clear now rides the existing 200 `warning` channel (`LocalAiPanel.runAction` already paints it amber) rather than being dropped. It goes through `runOpenclawConfigSet` instead of a hand-rolled `execFile`, because the outcome is now shown to the owner: that wrapper retries `ConfigMutationConflictError` (a race this route is exposed to — it writes while the gateway reloads on the stop above) and settles a deadline-killed spawn by reading the assignment back off disk, since `openclaw config set` writes early and then spends seconds validating catalogs. A raw spawn would have turned both into an amber banner over a write that succeeded. It also drops the module-scope `findOpenclawBin()` constant, which froze whichever answer the first import got for the life of the process.
- One exit instead of an early return: the Hermes branch fires on a licensed `dual` box too, where OpenClaw and its gateway both exist, so returning from inside it dropped the fallback warning and skipped the restart. Both failures now come back together, and the fallback sentence rides in `error` because the panel does not read `warning` on a non-2xx.

## Harness-first

No mechanism is re-implemented. De-registering the provider is Hermes' own config write — `patchHermesConfig` → the comment-preserving YAML merge, falling back to `hermes config unset` — which ClawBox already used; what was missing was believing its result. The OpenClaw half now uses the repo's verified wrapper around `openclaw config set` rather than spawning the binary by hand. The read-back proof was written against `readHermesConfigValue`, the reader the module already consults. The rounds below replace that with a three-state reader in the same module and, where it cannot answer, with **`hermes config get` — Hermes' own reader of the file**, which is the strongest harness-first move in this PR and is described there.

## RED → GREEN

RED, route reverted to beta (`git checkout origin/beta -- src/app/setup-api/local-ai/route.ts`; `findOpenclawBin` re-added to the test's module mock, which beta's route imports):

```
 × warns when the OpenClaw fallback list could not be cleared
   AssertionError: expected 'undefined' to be 'string'
 × clears the OpenClaw fallback list through the verified wrapper
   AssertionError: expected "vi.fn()" to be called with arguments: [ [ …(3) ], Anything ]
 × the Hermes edition > answers 502 when the Hermes unregister failed
   AssertionError: expected 200 to be 502
 × answers both failures on a dual box running Hermes
   AssertionError: expected 200 to be 502
 Tests  4 failed | 6 passed (10)
```

RED, `src/lib/hermes-local-ai.ts` reverted to beta, tests unchanged:

```
 × refuses to report a removal the config did not take
   AssertionError: promise resolved "{ wasDefault: false, model: null }" instead of rejecting
 × refuses when the selection still points at a provider that is gone
   AssertionError: promise resolved "{ wasDefault: true, …(1) }" instead of rejecting
 Tests  2 failed | 27 passed (29)
```

GREEN, the two suites plus the neighbours (`local-ai*` routes, `hermes-local-ai`, `provider-write-paths`, `local-ai-panel`, `hermes-config-yaml`, and the two hygiene gates):

```
 Test Files  10 passed (10)
      Tests  125 passed (125)
```

`tsc --noEmit` clean; eslint clean on every touched file.

## Device evidence (read-only, Hermes box on beta head 6719c8f0)

- `/etc/clawbox/edition.env` → `CLAWBOX_EDITION=hermes`.
- `/etc/systemd/system/clawbox-gateway.service -> /dev/null`, `systemctl is-active` → `inactive` — so the gateway restart at the end of this route is genuinely a no-op there, which is why the unregister is the only step that reaches the customer.
- `hermes config get providers.clawlocal.base_url` → `http://127.0.0.1/setup-api/local-ai/llamacpp/v1` — the key this route has to remove is registered on that device right now.

No mutation, no device lock taken: proving the failure branch means breaking a config file on a box the owner is using, so the failure path is covered by the unit tests and the read-back is exercised against a real `config.yaml` shape in `hermes-local-ai.test.ts`.

## Sibling call sites

- `removeLocalAiFromHermes` — one production caller, this route. Both other references are tests.
- `patchHermesConfig`'s unset path — the read-back proof is added at the local-AI removal, the only unset caller whose result a route answers on.
- `src/app/setup-api/local-ai/exclusive/route.ts` writes the same OpenClaw key through `runOpenclawConfigSetBatch` already; this route was the odd caller out and now matches it.
- **Not fixed here, and stated rather than left silent:** the register half has the same swallow on the `dual` SKU — `src/app/setup-api/ai-models/configure/route.ts` catches an `applyLocalAiToHermes` failure as "Non-fatal: the local model is configured and running either way" and answers `{success:true}`, which is the configured-but-invisible state `hermes-local-ai.ts`'s own header describes. The Hermes-SKU branch of the same route already answers 502 for it. It is a different route and a different surface, so it is recorded as a residual rather than folded in here.

## Review

One review pass on the diff: 2 high, 4 medium, 2 low. All applied — the read-back proof (H1), the verified wrapper and the dropped module-scope binary path (H2/M1), the Hermes tests that were silently running as a dual box because `openclawIsAbsent()` stayed false (M3), the single exit that keeps the warning and the restart on `dual` (M4), and a warning sentence that no longer claims the fallback list contained an entry the route never checked for (L1). The `dual`-SKU register twin (M2) is the residual above.

Three further review passes followed, and each found a real defect in the round before it — they are what the rounds below are: the read-back's two blind shapes, then the reader's own unindexable-block false success, then the writer behind it plus the unloadable-document case. Counts: 1 high / 3 medium / 2 low, then 1 high / 3 medium / 4 low, then 2 high / 1 medium / 5 low. Every finding is applied except the ones named as residuals here.

---

## Rounds 2 to 4 — the read-back the proof rests on, and the writer behind it

The first round made the disable route answer on `removeLocalAiFromHermes()` instead of assuming it. Review found the proof itself could not answer for two shapes a real `~/.hermes/config.yaml` carries, one in each direction, and both were reached through `getYamlPath` — a reader written for the SPLICER, not for this question.

**The false failure.** `getYamlPath` throws as soon as any segment on the path holds an inline value, and the empty flow mapping `{}` is one. PyYAML writes every member-less mapping that way, and Hermes' own shipped `cli-config.yaml.example` carries two (`agent.reasoning_overrides`, `agent.personalities`). So a config with `providers: {}` made `providers.clawlocal.base_url` read `unreadable` — "we could not look" over a file that had just said, plainly, that the key is not there. That is a 502 `removing it from Hermes could not be confirmed` over a removal that landed, and the retry the banner asks for reads the same file and says the same thing, for ever.

**The false success**, and CodeRabbit's open Major on `hermes-config-yaml.ts:346`. The same reader answers `null` — read as "absent" — for a key whose value is a **block or a list**. `providers.clawlocal.models` is a scalar only while ClawBox owns it; Hermes' own model discovery writes a nested block there, which this module already models as `LocalCatalogueState "foreign"`. `applyViaCli` walks the unsets one CLI call at a time, so "the endpoint went, the catalogue stayed" is a real partial — and it was proved removed. The round-1 test for this case used a **scalar** `models` fixture, so it passed without touching the gap.

**And the one the first attempt at this fix introduced.** The new reader walks two columns per
level and its block scanner skips every line deeper than the level it is scanning, so a block
written at ANY other indent — a hand-edited file, a `yaml.dump(indent=4)` by some other writer —
yielded no entries, no error, and a positive `absent`. Worse than it sounds, because it is the
same blind spot that makes the WRITER a silent no-op on that file: `unsetYamlPath` changes
nothing, `patchText`'s own verification passes on the same reader, no CLI fallback is entered,
and a read-back sharing the blind spot can only ever confirm the write it cannot see. Driving
the branch's own modules over a 4-space config: all six unsets change nothing, `patchHermesConfig`
returns `{mode:"merge"}`, all six read-backs answer `absent`, and the route answers
**200 `{success:true}`** with `providers.clawlocal` intact and `model.provider: clawlocal` still
pointing at a model the request just stopped — the whole TASK-545 symptom, end to end.

**And then the writer, which had the identical blind spot.** Teaching the READER to refuse a block it cannot index turned the false success into a *permanent* false failure, because the WRITE on such a file is a silent no-op that verifies as success: `unsetYamlPath` changes nothing, `patchText` checks its work through the same blind spot and passes, so `patchHermesConfig` reports `{mode:"merge"}` over a file it never touched and **the CLI that could actually do the removal is never entered**. The owner would have got an unclearable 502 where they used to get a false 200 — neither of which removes the provider. The rule therefore belongs in the shared walk, not only in the reader.

Measured on the same shape, the SET direction is worse and is a defect that has been shipping: `setYamlPath` appends a **second `clawlocal:`** at two spaces and `getYamlPath` verifies it happily, so saving a local model wrote a duplicate key into the file that holds `TELEGRAM_BOT_TOKEN` and the provider `api_key`s. One rule fixes both directions.

### Fix

- `src/lib/yaml-block-edit.ts` — a new `readYamlPath()` beside `getYamlPath()`, answering `value` / `present` / `absent`. An empty flow collection on the way down is an ANSWER (a mapping with no members has no member by that name) → `absent`; a leaf that is a block, a list, a bare `key:` or a value this reader cannot name is `present`, because the key IS written in the file. `getYamlPath` is unchanged — for the editing pass its refusals are right, and `patchText` and `hermes-shell-scan` still use it.
  It also distinguishes **"there are entries at this level and none is ours"** (a real `absent`) from **"this level has lines but yielded no entries"** (we could not look → `unreadable` → ask Hermes). That is what stops the reader confirming its own writer's blind spot, and it is the finding above.
- `src/lib/yaml-block-edit.ts` `descend()` — the same indexability rule for the WRITERS: a level that yields no entries while holding lines is refused, which is exactly the signal `patchHermesConfig` already falls back to `hermes config set`/`unset` on. So on such a file the removal now *happens*, through the harness's own reader-writer, instead of being reported as done (before) or as unprovable for ever (round 3).
- `readYamlPath` also refuses a **document PyYAML will not load** — a tab in some other provider's value, an unterminated quote, a second document. The module already implements that doctrine for `getTopLevelScalar` (`documentLines`'s `loadable`), and it is the one whole-file fact that IS evidence about every key: when PyYAML raises, the gateway exports nothing and no line in the file describes what the box is running, so a confident `absent` there is a 200 "the provider is gone" about a file nobody can load.
- `src/lib/hermes-local-ai.ts` — `invalidateModelOptions()` in a `finally` around the patch, ahead of the proof. `withProviderMcpRefresh` re-reads the provider set in a `finally` precisely because "the write threw" is not "nothing was written", and that re-read only sees the new catalogue once the memo is dropped: left after the throws, a partial removal that then refused would keep `ai_set_provider`'s enum offering a provider whose endpoint is already gone — and the `finally` covers the same shape one call earlier, since `applyViaCli` walks the unsets one spawn at a time and `runHermesCli` rejects on a timeout, so three keys can land and the fourth take the call down.
- The CLI read-backs are sequential and are not asked at all once a leftover is on the record: "still registered" is already certain there, and each question is a serial 15-second budget in front of a click the owner is holding open. Sequential rather than parallel is a deliberate trade — six `hermes` interpreters at once on a Jetson is the case where they all time out — and after the writer fix above this branch is genuinely rare again, because a file the editor cannot index now reaches the CLI, whose output is ordinary two-space PyYAML.
- `src/lib/hermes-config-yaml.ts` — `HermesConfigRead` gains a fourth state, `present`. `readHermesConfigValue` is unchanged in behaviour (everything but `value` is still `null`, which is what a block already read as), so no existing caller moves.
- `src/lib/hermes-local-ai.ts` — `present` is a leftover, exactly as `value` is. And for a key the file genuinely cannot answer for, the proof now asks **Hermes' own reader** rather than giving up (see Harness-first below).
- `HermesLocalRemovalError` carries `wasDefault` out with the refusal — CodeRabbit's second open Major on `hermes-local-ai.ts:381`. It is read before the patch, and a partial unset can clear `model.provider` and leave a providers key: the refusal is the last moment the fact exists, since the retry reads a selection that is already gone. The route stores `local_ai_was_default` on the failure path too, so an off→on round-trip still puts the device back on the model it was on. Deliberately a plain `Error` subclass and not a `HermesConfigWriteError` one — nothing narrows on that class, and extending an imported class evaluates it at module load, which breaks every suite that mocks `hermes-config-yaml` without listing it.
- The unconsumed `code: "hermes_unregister_failed"` is dropped (review L2/F5: `LocalAiPanel.runAction` reads `data.error` on a non-2xx and `data.warning` on a 2xx; nothing read `code`). Named residual: every server sentence on this route is English, `warning` included — translating them is a separate change, not half of one.

### Harness-first

Whether a key is still in config.yaml is a question **Hermes already answers**: `hermes config get <key>` loads the file with PyYAML — the same loader the gateway uses — and this module's own `localCatalogueState()` has always trusted it for the shape question. The read-back now uses it as the authority for exactly the keys our line reader declines, through one shared `cliKeyPresence()` helper that `localCatalogueState` also moved onto (device-verified below: an absent key exits 1 with "config key not set", a present one exits 0). So `unproven` — the 502 — now means *neither reader could answer*, instead of *our reader is not a YAML parser*. The calls are made only for those keys and in parallel, so the exotic branch costs one timeout rather than six on a click the owner is holding open; nothing logs or returns the value, because this file holds `TELEGRAM_BOT_TOKEN` and the provider `api_key`s.

### RED → GREEN

RED, on this branch's own head `41859e1f` (this round's defects are ones the branch introduced, so beta has nothing to revert to):

```
 FAIL  src/tests/unit/hermes-config-yaml.test.ts > reads a key under an empty {} mapping as gone, not as unreadable
   AssertionError: expected { state: 'unreadable' } to deeply equal { state: 'absent' }
 FAIL  src/tests/unit/hermes-config-yaml.test.ts > reads a key under an empty providers block as gone
 FAIL  src/tests/unit/hermes-config-yaml.test.ts > does not read a block-form models catalogue as removed
 FAIL  src/tests/unit/hermes-config-yaml.test.ts > does not read a list-form models catalogue as removed
 FAIL  src/tests/unit/hermes-local-ai.test.ts > refuses when the catalogue survived as a block Hermes wrote itself
   AssertionError: promise resolved "{ wasDefault: false, model: null }" instead of rejecting
 FAIL  src/tests/unit/hermes-local-ai.test.ts > carries wasDefault out with the refusal so the selection can be restored
   AssertionError: expected Error: The local model is still registere… to match object { wasDefault: true }
 FAIL  src/tests/unit/hermes-local-ai.test.ts > asks Hermes' own reader when our reader cannot resolve the file
   AssertionError: promise rejected "Error: The Hermes config could not be rea…" instead of resolving
 FAIL  src/tests/unit/hermes-local-ai.test.ts > reports a key Hermes' own reader says is still there
 FAIL  src/tests/routes/local-ai.test.ts > the Hermes edition > still records that the local model WAS the selection when the removal failed
   AssertionError: expected "vi.fn()" to be called with arguments: [ { local_ai_was_default: true } ]
 Tests  9 failed | 54 passed (63)
```

RED for the writer's blind spot and the unloadable document, on the round-3 head:

```
 FAIL  src/tests/unit/yaml-block-edit.test.ts > a block this editor cannot index > refuses the unset instead of silently changing nothing
 FAIL  … > refuses the set instead of appending a duplicate key
 FAIL  … > refuses a root mapping that is not at column zero
 FAIL  src/tests/unit/hermes-config-yaml.test.ts > says unreadable for a document PyYAML itself refuses
 FAIL  … > sends the unset to the CLI instead of reporting a merge that did nothing
 FAIL  … > sends the set to the CLI instead of writing a duplicate key
 FAIL  src/tests/unit/hermes-local-ai.test.ts > drops the model-options memo even when the patch itself threw
 FAIL  … > does not spend CLI spawns on an outcome a leftover already decided
 Tests  8 failed | 182 passed (190)
```

RED for the reader's own blind spot, on the round-2 head:

```
 FAIL  src/tests/unit/hermes-config-yaml.test.ts > says unreadable, never absent, for four-space children
   AssertionError: expected { state: 'absent' } to deeply equal { state: 'unreadable' }
 FAIL  … > says unreadable, never absent, for three-space children
 FAIL  … > says unreadable, never absent, for a deeper grandchild
 FAIL  … > says unreadable, never absent, for an indented root
 Tests  4 failed | 54 passed (58)
```

GREEN — the touched suites and their neighbours (`yaml-block-edit`, `hermes-config-yaml`, `hermes-local-ai`, `hermes-shell-scan`, `provider-write-paths`, `hermes-config-write-error-text`, the `local-ai` route):

```
 Test Files  7 passed (7)
      Tests  251 passed (251)
```

The whole `unit` project, which is what the `test` job runs:

```
 Test Files  3 failed | 662 passed (665)
      Tests  4 failed | 10740 passed | 1 skipped (10745)
```

The three are reported rather than rounded off, and none is this diff's: `routes/telegram/status`, `routes/telegram/status-hermes` and `unit/run-tunnel`, all failing on 5-second test timeouts under a full-project load on this development machine. Run on their own they pass (`3 passed / 21 tests`), the failing cases differ from run to run, and the two telegram suites **fail on pristine `origin/beta`** in a detached worktree under the same conditions while passing on this branch. Nothing in this diff is on their path — they read `openclaw.json` and `~/.hermes/.env` through `getTopLevelScalar`, which this PR does not touch. CI runs them on a quieter machine.

`tsc --noEmit` clean; eslint clean on every touched file.

### Device evidence (read-only, Hermes box; no mutation, no lock taken)

- PyYAML **5.4.1** on the box: `safe_dump({"providers": {}})` → `providers: {}\n`; `safe_dump({"providers": {"clawlocal": {}}})` → `providers:\n  clawlocal: {}\n` — the two fixtures the new reader tests use, byte for byte.
- `hermes config get <a key that does not exist>` → exit 1, "config key not set"; three keys that do exist → exit 0. That is exactly what `cliKeyPresence()` reads, and nothing but the exit code and that phrase is looked at.
- **A correction to the finding as filed.** The pinned 0.20.5 `unset` *prunes* a dict container it empties (`hermes_cli/config.py`, "Drop empty dict containers left behind by the deletion"), so `{}` is not what a COMPLETE unset leaves — our own `unsetYamlPath` prunes too. `{}` is what any other writer of an empty mapping leaves, and Hermes ships two. The false failure is therefore narrower than reported and still real; the comments and test names in this round say so rather than repeating the stronger claim.

### Sibling call sites

- `getYamlPath` — unchanged and left alone. Its two other callers (`patchText`'s write verification, `hermes-shell-scan.ts:321`) want the splicer's refusals, not this question's answers.
- `resolveHermesConfigValue` — two callers: `readHermesConfigValue` (behaviour unchanged) and the removal proof (updated). No third.
- `readHermesConfigValue` — every caller keeps its two-state contract; `localCatalogueState`'s "a non-null result is the only thing it settles on its own" still holds, and a new test pins it.
- `cliKeyPresence` — factored out of `localCatalogueState`, which now shares it; the absent/foreign/unknown mapping is byte-identical, and a `runHermesCli` rejection reaches the same `retryLater()` it always did.
- `code: "hermes_unregister_failed"` — no consumer anywhere in `src/`, `mcp/`, `scripts/` or `docs/` after removal (grep clean).
- `descend()` is shared by `getYamlPath`, `hasYamlPath`, `setYamlPath` and `unsetYamlPath`. The two writers are the point of the change; `getYamlPath` now refuses the same shape, which `resolveHermesConfigValue` turns into `unreadable` and asks Hermes about — consistent with `readYamlPath` rather than in conflict with it. `hasYamlPath`'s only production caller (`hermes-shell-scan.ts:320`) already wraps both readers in a `try/catch` that answers "could not read", which is the right answer for a block nobody can index.
- A regression guard for the FALSE-FAILURE direction, on the file this module was measured against: the real 3175-byte fixture with a provider block written into it answers all six removal keys before and after the unset, with no throw and **no CLI spawn** — so a later change to the walk cannot quietly put six `hermes config get` calls in front of every ordinary "turn Local AI off".
- `cliKeyPresence` also changes the ENABLE path, stated rather than left silent: it folds `runHermesCli`'s REJECTIONS (a missing binary, a timeout, its own SIGKILL) into `unknown`, where they used to propagate out of `localCatalogueState` and fail the whole enable with a raw error. That matches the module's own rule — "a catalogue question that FAILED is not a reason to stop asking" — and now has a test.
- Unchanged from round 1: `removeLocalAiFromHermes` has one production caller (this route); the `dual`-SKU register twin in `ai-models/configure/route.ts` remains the stated residual.


## Round 5 — the other half of the removal: the SELECTION

The merge-gate review blocked on the half this branch had not finished. Rounds 2 to 4 made the
`providers.clawlocal.*` removal a proved fact; `model.provider` / `model.default` were still decided
by `readHermesConfigValue("model.provider")` — the reader this same diff documents, fifty lines
below the call, as unusable for exactly this purpose, because it collapses "the file could not be
read" and "the key is gone" into the same `null`.

So on a `config.yaml` our line editor cannot index — a four-space document, a duplicate key, a flow
mapping — `wasDefault` came back `false`, `model.provider` and `model.default` never entered the
unset list, `local_ai_was_default` was never stored, and the route answered
`200 {success:true}` over a file still holding `model.provider: clawlocal` with its providers block
removed. That is the state this module's own header names in as many words: every chat turn 502s
with `Unknown provider 'clawlocal'`, and the picker keeps offering the dead model. False success,
one layer up from where round 4 removed it.

### RED

A new suite drives the real `removeLocalAiFromHermes()` over a real four-space `config.yaml` under a
temporary `HERMES_HOME`, with the reader, the writer, the CLI fallback and the read-back proof all
unmocked — only `hermes` itself is simulated, and faithfully (`config unset` rewrites the document
through the loader, which is what makes it two-space and indexable again; `config get` exits 1 with
"Config key not set" for a missing key):

```
 × clears a selection that still points at the local model
   AssertionError: expected { wasDefault: false, model: null }
                   to deeply equal { wasDefault: true, model: 'gemma-4-e2b' }
 × writes nothing and refuses when Hermes' own reader cannot answer either
   AssertionError: expected [ 'providers.clawlocal.base_url' ] to deeply equal []
 Tests  2 failed | 1 passed (3)
```

### Fix

`selectionValue()` reads a key three-state: our line reader first, and only where that answers
`unreadable` does it ask Hermes' own — `hermes config get`, the PyYAML loader the gateway itself
uses, through the `cliKeyRead` spawn the read-back proof already had. `unknown` from both is neither
"clawlocal" nor "something else", so the removal is refused BEFORE anything is written: there is no
safe unset list to send while the selection is unreadable, because putting `model.provider` on it
blind would drop the owner's cloud provider on a Local AI toggle-off, and leaving it off is the
502-per-turn state.

### What that refusal costs, stated rather than hidden

A family of shapes pays for it, and it is named in the code: several anomalies confined to the
`model:` block while `providers:` stays ordinary — a flow mapping, a block at any indent but two, a duplicate
key inside it, an alias, a sequence, or an inline comment on the `model:` line (which the merge path
deliberately preserves, so it persists) — leaves our line reader able to resolve the providers keys
and unable to resolve the selection. Measured against the real reader across 27 shapes: six split
that way. With the `hermes` shim also dead at that
moment (a `step_hermes_install` rebuild, ~90 s), that removal previously completed through the merge
path with no CLI spawn at all and now answers 502 with the block still in place. The old success was
luck rather than knowledge — "not the default" was a guess, and the guess being wrong is the defect
this read exists to end — so the conservative branch is kept and the cost is written down. It is
self-clearing: the dominant cause of `unknown` is the rebuild, after which a retry succeeds.

### Harness-first, and the memo that was deliberately not reused

`hermes config get` is the harness's own reader and is already this file's authority for the shapes
our line editor declines — nothing is re-implemented. `src/lib/hermes-config-cache.ts`'s
`hermesConfigGet` does own "read one key through the CLI", and it is deliberately NOT reused here:
it returns `""` both for an unset key and for a read that failed, and a non-zero exit that is not
"config key not set" still counts as answered, so that `""` is stamped against config.yaml's mtime
and survives until the file is next written — a false "absent" that would have rebuilt this very
bug one layer down. The cost of bypassing it is one un-memoised CLI start per selection read, and
only on the shapes our reader declines.

### GREEN

```
 Test Files  10 passed (10)
      Tests  271 passed (271)
```

(`yaml-block-edit`, `hermes-config-yaml`, `hermes-local-ai`, the new
`hermes-local-ai-unindexable-config`, `provider-write-paths`, `hermes-shell-scan`,
`routes/local-ai`, plus `openclaw-config-mock-completeness`, `test-timeout-hygiene`,
`state-updater-purity`.) `tsc --noEmit` clean, eslint clean. Rebased onto `origin/beta` `5c7170b8`;
`git diff --stat origin/beta...HEAD` lists only the 11 files this PR intends and
`--diff-filter=DR` is empty.

### Sibling call sites of the collapsing reader

`readHermesConfigValue` has two remaining callers, both in this file, both cleared with reasons
rather than by assertion. `localCatalogueState()` treats a non-null answer as the only thing that
reader settles and sends every other state — `unreadable` included — to `cliKeyPresence`, which
keeps `unknown` separate and which its callers already fail closed on. `declareLocalCatalogue()` is
reached only once `localCatalogueState()` has answered `scalar`, i.e. the key resolved to a value; a
second read that came back null makes the equality test false and falls through to a write that is
idempotent, so the worst case is a redundant write, never a wrong one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved removal of local AI providers by verifying registrations and configuration entries are fully cleared.
  - Added clearer warnings when cleanup partially fails or cannot be confirmed.
  - Failed provider removal now reports actionable errors with retry guidance.
  - Combined cleanup failures are surfaced together when multiple configurations require attention.
  - Preserved the default model when removing other provider settings.
  - Prevented unnecessary cleanup attempts on systems that do not use the affected provider.
  - Improved handling of malformed or unsupported configuration files to avoid silent changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



