### PR TITLE
fix: name a gateway unit systemd cannot load instead of guessing at it

### DIFF
--- a/src/app/setup-api/gateway/route.ts
+++ b/src/app/setup-api/gateway/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getGatewayToken } from "@/lib/gateway-proxy";
 import { getGatewayServiceHealth, type GatewayServiceHealth } from "@/lib/gateway-health";
 import { envPort } from "@/lib/port-probe";
-import { readEdition } from "@/lib/edition-source";
+import { readEditionSource } from "@/lib/edition-source";
 
 export const dynamic = "force-dynamic";
 
@@ -98,37 +98,58 @@ function gatewayOfflineResponse(health: GatewayServiceHealth) {
   // port 18789", with a Retry that can never succeed and a restart command
   // systemctl refuses outright on a masked unit.
   //
-  // The Hermes SKU is the permanent case — install.sh's
-  // step_edition_gateway_state removes the unit file and masks the name to
-  // /dev/null, so the port will never open — and an update or factory reset
-  // holding the same mask is the temporary one, on any SKU.
+  // The BRANCH is systemd's own LoadState, so it is right on a device whose
+  // edition lock cannot be read; only the WORDING consults the edition, and
+  // only where it can say something true.
   //
-  // The BRANCH is taken from the device (systemd's own LoadState), not from the
-  // edition, so a Hermes box whose /etc/clawbox/edition.env cannot be read still
-  // gets a page that is true. The edition only picks the WORDING below, where
-  // being wrong costs a vague sentence rather than a false one.
-  const unitAbsent = health.unitLoaded === false;
-  const breaker = health.breakerActive && !unitAbsent
+  // `unloadableState` rather than a boolean so the state itself is in scope
+  // below: `masked` is the one value that licenses a claim about WHY (the
+  // Hermes SKU's step_edition_gateway_state, or an update/factory reset holding
+  // the lock), and `not-found` / `error` / `bad-setting` are units that will not
+  // start for reasons this page has not measured.
+  const unloadableState = health.unitLoaded === false ? health.loadState : null;
+  const breaker = health.breakerActive && unloadableState === null
     ? `<p class="breaker" role="alert"><strong>Automatic restart breaker activated.</strong> Repair the configuration, then run <code>sudo systemctl reset-failed clawbox-gateway &amp;&amp; sudo systemctl restart clawbox-gateway</code>.</p>`
     : "";
   const finalError = health.finalStartupError
     ? `<pre>${escapeHtml(health.finalStartupError)}</pre>`
     : "";
-  const hermesEdition = readEdition() === "hermes";
-  const heading = unitAbsent
-    ? (hermesEdition ? "OpenClaw Is Not Installed" : "Gateway Unavailable")
-    : "OpenClaw Gateway Offline";
-  const detail = unitAbsent
-    ? (hermesEdition
-      ? "This device runs the Hermes agent. The OpenClaw gateway is not installed here, so its Control UI has nothing to show."
-      : `The gateway service cannot be started: systemd reports it as <code>${escapeHtml(health.loadState ?? "unavailable")}</code>. An update or factory reset holds that lock while it runs.`)
-    : `The gateway service is not running on port ${GATEWAY_PORT}.`;
+
+  // `readEditionSource`, not `readEdition`/`openclawIsAbsent`: those collapse
+  // "the device said openclaw" and "nothing on this device said anything, so I
+  // guessed openclaw" into one value. A Hermes box whose root-owned lock cannot
+  // be read would then be handed the OpenClaw sentence — the exact false claim
+  // the device-derived branch above exists to avoid — so a guessed edition
+  // names no cause at all.
+  const { edition, defaulted } = readEditionSource();
+  const hermesEdition = !defaulted && edition === "hermes";
+
+  let status = 503;
+  let heading = "OpenClaw Gateway Offline";
+  let detail = `The gateway service is not running on port ${GATEWAY_PORT}.`;
   // Retrying a device that has no gateway unit at all only repaints the same
-  // page; while the mask is an update's lock it clears on its own, so the
-  // button stays for that case and goes for the SKU that will never have one.
-  const retry = unitAbsent && hermesEdition
-    ? ""
-    : `<button onclick="location.reload()">Retry</button>`;
+  // page; while the mask is an update's lock it clears on its own, so the button
+  // stays for that case and goes for the SKU that will never have one.
+  let retry = true;
+
+  if (unloadableState !== null) {
+    if (hermesEdition) {
+      // 404, like every other OpenClaw-only path on this SKU (`/api/*`,
+      // `/assets/*`, `/chat`): 503 would tell a monitor or a service worker to
+      // re-poll a condition that cannot change.
+      status = 404;
+      heading = "OpenClaw Is Not Installed";
+      detail = "This device runs the Hermes agent. The OpenClaw gateway is not installed here — open the Hermes app from the desktop instead.";
+      retry = false;
+    } else {
+      heading = "Gateway Unavailable";
+      detail = unloadableState === "masked" && !defaulted
+        ? "The gateway service is masked, so it cannot start. An update or factory reset holds that lock while it runs."
+        : `systemd cannot load <code>clawbox-gateway.service</code> (<code>${escapeHtml(unloadableState)}</code>), so it cannot be started from here.`;
+    }
+  }
+
+  const retryButton = retry ? `<button onclick="location.reload()">Retry</button>` : "";
   const html = `<!DOCTYPE html>
 <html><head><style>
   body { margin:0; height:100vh; display:flex; align-items:center; justify-content:center;
@@ -151,11 +172,11 @@ function gatewayOfflineResponse(health: GatewayServiceHealth) {
   <p>${detail}</p>
   ${breaker}
   ${finalError}
-  ${retry}
+  ${retryButton}
 </div>
 </body></html>`;
   return new NextResponse(html, {
-    status: 503,
+    status,
     headers: {
       "Content-Type": "text/html; charset=utf-8",
       "Cache-Control": "no-store, no-cache",

--- a/src/app/setup-api/gateway/route.ts
+++ b/src/app/setup-api/gateway/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getGatewayToken } from "@/lib/gateway-proxy";
 import { getGatewayServiceHealth, type GatewayServiceHealth } from "@/lib/gateway-health";
 import { envPort } from "@/lib/port-probe";
+import { readEdition } from "@/lib/edition-source";
 
 export const dynamic = "force-dynamic";
 
@@ -92,12 +93,42 @@ function escapeHtml(value: string): string {
 }
 
 function gatewayOfflineResponse(health: GatewayServiceHealth) {
-  const breaker = health.breakerActive
+  // A unit systemd cannot LOAD is not a unit that is down, and this page used to
+  // tell both stories the same way: "OpenClaw Gateway Offline … not running on
+  // port 18789", with a Retry that can never succeed and a restart command
+  // systemctl refuses outright on a masked unit.
+  //
+  // The Hermes SKU is the permanent case — install.sh's
+  // step_edition_gateway_state removes the unit file and masks the name to
+  // /dev/null, so the port will never open — and an update or factory reset
+  // holding the same mask is the temporary one, on any SKU.
+  //
+  // The BRANCH is taken from the device (systemd's own LoadState), not from the
+  // edition, so a Hermes box whose /etc/clawbox/edition.env cannot be read still
+  // gets a page that is true. The edition only picks the WORDING below, where
+  // being wrong costs a vague sentence rather than a false one.
+  const unitAbsent = health.unitLoaded === false;
+  const breaker = health.breakerActive && !unitAbsent
     ? `<p class="breaker" role="alert"><strong>Automatic restart breaker activated.</strong> Repair the configuration, then run <code>sudo systemctl reset-failed clawbox-gateway &amp;&amp; sudo systemctl restart clawbox-gateway</code>.</p>`
     : "";
   const finalError = health.finalStartupError
     ? `<pre>${escapeHtml(health.finalStartupError)}</pre>`
     : "";
+  const hermesEdition = readEdition() === "hermes";
+  const heading = unitAbsent
+    ? (hermesEdition ? "OpenClaw Is Not Installed" : "Gateway Unavailable")
+    : "OpenClaw Gateway Offline";
+  const detail = unitAbsent
+    ? (hermesEdition
+      ? "This device runs the Hermes agent. The OpenClaw gateway is not installed here, so its Control UI has nothing to show."
+      : `The gateway service cannot be started: systemd reports it as <code>${escapeHtml(health.loadState ?? "unavailable")}</code>. An update or factory reset holds that lock while it runs.`)
+    : `The gateway service is not running on port ${GATEWAY_PORT}.`;
+  // Retrying a device that has no gateway unit at all only repaints the same
+  // page; while the mask is an update's lock it clears on its own, so the
+  // button stays for that case and goes for the SKU that will never have one.
+  const retry = unitAbsent && hermesEdition
+    ? ""
+    : `<button onclick="location.reload()">Retry</button>`;
   const html = `<!DOCTYPE html>
 <html><head><style>
   body { margin:0; height:100vh; display:flex; align-items:center; justify-content:center;
@@ -116,11 +147,11 @@ function gatewayOfflineResponse(health: GatewayServiceHealth) {
   button:hover { background:#334155; }
 </style></head><body>
 <div class="box">
-  <h2>OpenClaw Gateway Offline</h2>
-  <p>The gateway service is not running on port ${GATEWAY_PORT}.</p>
+  <h2>${heading}</h2>
+  <p>${detail}</p>
   ${breaker}
   ${finalError}
-  <button onclick="location.reload()">Retry</button>
+  ${retry}
 </div>
 </body></html>`;
   return new NextResponse(html, {

--- a/src/lib/gateway-health.ts
+++ b/src/lib/gateway-health.ts
@@ -12,7 +12,41 @@ export interface GatewayServiceHealth {
   result: string | null;
   restartCount: number | null;
   finalStartupError: string | null;
+  /**
+   * systemd's own `LoadState` for the unit — "loaded" when there is a unit file
+   * to start, "masked"/"not-found" when there is not.
+   *
+   * `null` means systemctl did not answer, which is not evidence either way.
+   */
+  loadState: string | null;
+  /**
+   * Whether systemd has a unit to start at all: `false` for masked and
+   * not-found, `null` when the question could not be asked.
+   *
+   * Read off the DEVICE rather than inferred from the edition. The Hermes SKU
+   * masks the unit to /dev/null (install.sh step_edition_gateway_state) and an
+   * update or factory reset masks it on any SKU while it holds the lock — and
+   * `systemctl restart` refuses a masked unit in both cases, so advice built on
+   * a guessed edition would be wrong on the box whose lock file cannot be read.
+   */
+  unitLoaded: boolean | null;
 }
+
+/**
+ * The properties `systemctl show` is asked for.
+ *
+ * Exported so the query and the parser cannot drift: a parser that reads a
+ * property this list omits answers `undefined` forever, silently, and the
+ * branch that depends on it never runs.
+ */
+export const GATEWAY_SHOW_PROPERTIES = [
+  "LoadState",
+  "ActiveState",
+  "SubState",
+  "Result",
+  "NRestarts",
+  "InvocationID",
+] as const;
 
 export function parseGatewaySystemctlProperties(output: string): Omit<GatewayServiceHealth, "finalStartupError"> {
   const properties: Record<string, string> = Object.fromEntries(
@@ -26,6 +60,7 @@ export function parseGatewaySystemctlProperties(output: string): Omit<GatewaySer
       }),
   );
   const restartCount = Number.parseInt(properties.NRestarts ?? "", 10);
+  const loadState = properties.LoadState || null;
   return {
     active: properties.ActiveState === "active",
     // systemd 249 (Ubuntu 22.04) exposes rate limiting through the documented
@@ -35,6 +70,12 @@ export function parseGatewaySystemctlProperties(output: string): Omit<GatewaySer
     subState: properties.SubState || null,
     result: properties.Result || null,
     restartCount: Number.isFinite(restartCount) ? restartCount : null,
+    loadState,
+    // Only "loaded" is a unit systemd can act on. "masked" and "not-found" are
+    // the two this device produces; every other LoadState ("error",
+    // "bad-setting", "stub") is also a unit that will not start, so the test is
+    // written as "loaded or nothing" rather than as a list of bad values.
+    unitLoaded: loadState === null ? null : loadState === "loaded",
   };
 }
 
@@ -86,7 +127,7 @@ export async function getGatewayServiceHealth(): Promise<GatewayServiceHealth> {
       [
         "show",
         GATEWAY_UNIT,
-        "--property=ActiveState,SubState,Result,NRestarts,InvocationID",
+        `--property=${GATEWAY_SHOW_PROPERTIES.join(",")}`,
         "--no-pager",
       ],
       { timeout: 2_000 },
@@ -124,6 +165,11 @@ export async function getGatewayServiceHealth(): Promise<GatewayServiceHealth> {
       result: null,
       restartCount: null,
       finalStartupError: null,
+      loadState: null,
+      // systemctl itself did not answer. Not knowing whether the unit exists is
+      // not the same as knowing it does not, so the caller keeps its ordinary
+      // "offline" page rather than claiming the gateway is not installed.
+      unitLoaded: null,
     };
   }
 }

--- a/src/tests/routes/gateway/gateway.test.ts
+++ b/src/tests/routes/gateway/gateway.test.ts
@@ -1,3 +1,7 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+
 import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
@@ -25,9 +29,12 @@ vi.mock("@/lib/gateway-health", () => ({
 import { getGatewayToken } from "@/lib/gateway-proxy";
 import { getGatewayServiceHealth } from "@/lib/gateway-health";
 
-// The real edition reader, driven the way a device drives it: no
-// /etc/clawbox/edition.env in CI, so the env fallback answers.
-const NO_EDITION_FILE = "/nonexistent/clawbox/edition.env";
+// The hermetic floor vitest.config.ts installs, captured so `afterEach` can put
+// it BACK. Deleting it instead leaves the next `vi.resetModules()` re-import
+// reading the real /etc/clawbox/edition.env — invisible in CI, and red on the
+// Hermes box this fix was validated on, which is where the repo says to run.
+const CONFIG_EDITION_FILE = process.env.CLAWBOX_EDITION_FILE;
+const CONFIG_EDITION = process.env.CLAWBOX_EDITION;
 
 /** systemd's answer for a unit masked to /dev/null. */
 const maskedUnit = {
@@ -44,8 +51,21 @@ const maskedUnit = {
 
 describe("/setup-api/gateway", () => {
   let GET: (req: NextRequest) => Promise<Response>;
+  let editionDir: string;
+  let editionLock: string;
+
+  /** Bake the root-owned lock, the authority the route actually reads. */
+  const lockEdition = (value: string) =>
+    fs.writeFileSync(editionLock, `CLAWBOX_EDITION=${value}\n`);
 
   beforeEach(async () => {
+    // `edition-source` binds the lock PATH at module scope, so it has to be set
+    // before the route below is imported; the CONTENT is read per call, so each
+    // test bakes the SKU it means. Driving the file rather than the env
+    // fallback is the point — the file is what a device has.
+    editionDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-gateway-edition-"));
+    editionLock = path.join(editionDir, "edition.env");
+    process.env.CLAWBOX_EDITION_FILE = editionLock;
     vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(getGatewayToken).mockResolvedValue("test-token");
@@ -62,6 +82,12 @@ describe("/setup-api/gateway", () => {
     });
     const mod = await import("@/app/setup-api/gateway/route");
     GET = mod.GET;
+  });
+
+  afterEach(() => {
+    fs.rmSync(editionDir, { recursive: true, force: true });
+    process.env.CLAWBOX_EDITION_FILE = CONFIG_EDITION_FILE;
+    process.env.CLAWBOX_EDITION = CONFIG_EDITION;
   });
 
   it("proxies gateway HTML with injected script", async () => {
@@ -98,15 +124,14 @@ describe("/setup-api/gateway", () => {
 
   describe("a unit systemd cannot load", () => {
     beforeEach(() => {
-      process.env.CLAWBOX_EDITION_FILE = NO_EDITION_FILE;
       mockFetch.mockRejectedValue(new Error("Connection refused"));
       vi.mocked(getGatewayServiceHealth).mockResolvedValue(maskedUnit);
     });
 
-    afterEach(() => {
-      delete process.env.CLAWBOX_EDITION_FILE;
-      delete process.env.CLAWBOX_EDITION;
-    });
+    const render = async () => {
+      const res = await GET(new NextRequest(new URL("http://clawbox.local/setup-api/gateway")));
+      return { status: res.status, html: await res.text() };
+    };
 
     it("does not report an OpenClaw gateway on a Hermes device", async () => {
       // install.sh step_edition_gateway_state removes the unit file and masks
@@ -114,12 +139,13 @@ describe("/setup-api/gateway", () => {
       // `systemctl restart clawbox-gateway` is refused outright. The page used
       // to say "OpenClaw Gateway Offline … not running on port 18789" with a
       // Retry that can only repaint itself.
-      process.env.CLAWBOX_EDITION = "hermes";
+      lockEdition("hermes");
 
-      const res = await GET(new NextRequest(new URL("http://clawbox.local/setup-api/gateway")));
-      const html = await res.text();
+      const { status, html } = await render();
 
-      expect(res.status).toBe(503);
+      // 404, like every other OpenClaw-only path on this SKU — a 503 invites a
+      // monitor to re-poll a condition that cannot change.
+      expect(status).toBe(404);
       expect(html).not.toContain("Gateway Offline");
       expect(html).not.toContain("not running on port");
       expect(html).not.toContain("systemctl restart clawbox-gateway");
@@ -131,26 +157,74 @@ describe("/setup-api/gateway", () => {
     it("calls a masked unit on an OpenClaw device what it is, and keeps Retry", async () => {
       // The same mask is temporary here: an update or factory reset holds it.
       // The owner still must not be told to restart a unit systemd refuses.
-      process.env.CLAWBOX_EDITION = "openclaw";
+      lockEdition("openclaw");
 
-      const res = await GET(new NextRequest(new URL("http://clawbox.local/setup-api/gateway")));
-      const html = await res.text();
+      const { status, html } = await render();
 
+      expect(status).toBe(503);
       expect(html).not.toContain("Gateway Offline");
       expect(html).not.toContain("not running on port");
       expect(html).toContain("Gateway Unavailable");
       expect(html).toContain("masked");
+      expect(html).toContain("update or factory reset");
       expect(html).toContain("Retry");
+    });
+
+    it("gives a dual box the OpenClaw wording, not the Hermes one", async () => {
+      // `dual` has BOTH harnesses, so the OpenClaw gateway does exist there and
+      // a mask on it is the temporary kind.
+      lockEdition("dual");
+
+      const { status, html } = await render();
+
+      expect(status).toBe(503);
+      expect(html).toContain("Gateway Unavailable");
+      expect(html).not.toContain("OpenClaw Is Not Installed");
+    });
+
+    it("names a missing unit file without inventing a cause for it", async () => {
+      // An install run that unmasks but dies before step_systemd_services
+      // re-copies the unit leaves LoadState=not-found. Telling that owner an
+      // update is in progress sends them to wait for something that is not
+      // running.
+      lockEdition("openclaw");
+      vi.mocked(getGatewayServiceHealth).mockResolvedValue({
+        ...maskedUnit,
+        loadState: "not-found",
+      });
+
+      const { html } = await render();
+
+      expect(html).toContain("not-found");
+      expect(html).not.toContain("update or factory reset");
+      expect(html).not.toContain("not running on port");
+    });
+
+    it("attributes no cause when nothing on the device named an edition", async () => {
+      // No lock file and no CLAWBOX_EDITION: `readEditionSource` answers
+      // "openclaw, defaulted". A Hermes box in that state (a pre-3.x install, a
+      // partial image) must not be handed the OpenClaw sentence — the branch is
+      // device-derived, so the page still refuses the restart advice, and the
+      // wording simply names the state.
+      delete process.env.CLAWBOX_EDITION;
+
+      const { status, html } = await render();
+
+      expect(status).toBe(503);
+      expect(html).toContain("masked");
+      expect(html).not.toContain("update or factory reset");
+      expect(html).not.toContain("OpenClaw Is Not Installed");
+      expect(html).not.toContain("not running on port");
     });
 
     it("does not print restart advice systemd would refuse", async () => {
       // Belt and braces: a masked unit cannot reach start-limit-hit, but the
       // breaker paragraph is the one place that names the two commands, so it
       // is pinned off rather than left to that argument.
-      process.env.CLAWBOX_EDITION = "hermes";
+      lockEdition("hermes");
       vi.mocked(getGatewayServiceHealth).mockResolvedValue({ ...maskedUnit, breakerActive: true });
 
-      const html = await (await GET(new NextRequest(new URL("http://clawbox.local/setup-api/gateway")))).text();
+      const { html } = await render();
 
       expect(html).not.toContain("systemctl reset-failed clawbox-gateway");
       expect(html).not.toContain("Automatic restart breaker activated");
@@ -159,15 +233,16 @@ describe("/setup-api/gateway", () => {
     it("keeps the ordinary offline page when systemctl did not answer", async () => {
       // `unitLoaded: null` is "the question could not be asked", which is not
       // evidence that the gateway is missing.
-      process.env.CLAWBOX_EDITION = "openclaw";
+      lockEdition("openclaw");
       vi.mocked(getGatewayServiceHealth).mockResolvedValue({
         ...maskedUnit,
         loadState: null,
         unitLoaded: null,
       });
 
-      const html = await (await GET(new NextRequest(new URL("http://clawbox.local/setup-api/gateway")))).text();
+      const { status, html } = await render();
 
+      expect(status).toBe(503);
       expect(html).toContain("OpenClaw Gateway Offline");
       expect(html).toContain("not running on port 18789");
     });

--- a/src/tests/routes/gateway/gateway.test.ts
+++ b/src/tests/routes/gateway/gateway.test.ts
@@ -36,6 +36,12 @@ import { getGatewayServiceHealth } from "@/lib/gateway-health";
 const CONFIG_EDITION_FILE = process.env.CLAWBOX_EDITION_FILE;
 const CONFIG_EDITION = process.env.CLAWBOX_EDITION;
 
+/** `process.env.X = undefined` stores the STRING "undefined"; absence is a delete. */
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
 /** systemd's answer for a unit masked to /dev/null. */
 const maskedUnit = {
   active: false,
@@ -86,8 +92,8 @@ describe("/setup-api/gateway", () => {
 
   afterEach(() => {
     fs.rmSync(editionDir, { recursive: true, force: true });
-    process.env.CLAWBOX_EDITION_FILE = CONFIG_EDITION_FILE;
-    process.env.CLAWBOX_EDITION = CONFIG_EDITION;
+    restoreEnv("CLAWBOX_EDITION_FILE", CONFIG_EDITION_FILE);
+    restoreEnv("CLAWBOX_EDITION", CONFIG_EDITION);
   });
 
   it("proxies gateway HTML with injected script", async () => {

--- a/src/tests/routes/gateway/gateway.test.ts
+++ b/src/tests/routes/gateway/gateway.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
 const mockFetch = vi.fn();
@@ -17,11 +17,30 @@ vi.mock("@/lib/gateway-health", () => ({
     result: "exit-code",
     restartCount: 2,
     finalStartupError: "Config validation failed",
+    loadState: "loaded",
+    unitLoaded: true,
   }),
 }));
 
 import { getGatewayToken } from "@/lib/gateway-proxy";
 import { getGatewayServiceHealth } from "@/lib/gateway-health";
+
+// The real edition reader, driven the way a device drives it: no
+// /etc/clawbox/edition.env in CI, so the env fallback answers.
+const NO_EDITION_FILE = "/nonexistent/clawbox/edition.env";
+
+/** systemd's answer for a unit masked to /dev/null. */
+const maskedUnit = {
+  active: false,
+  breakerActive: false,
+  activeState: "inactive",
+  subState: "dead",
+  result: "success",
+  restartCount: 0,
+  finalStartupError: null,
+  loadState: "masked",
+  unitLoaded: false,
+};
 
 describe("/setup-api/gateway", () => {
   let GET: (req: NextRequest) => Promise<Response>;
@@ -38,6 +57,8 @@ describe("/setup-api/gateway", () => {
       result: "exit-code",
       restartCount: 2,
       finalStartupError: "Config validation failed",
+      loadState: "loaded",
+      unitLoaded: true,
     });
     const mod = await import("@/app/setup-api/gateway/route");
     GET = mod.GET;
@@ -75,6 +96,83 @@ describe("/setup-api/gateway", () => {
     expect(html).toContain("Gateway Offline");
   });
 
+  describe("a unit systemd cannot load", () => {
+    beforeEach(() => {
+      process.env.CLAWBOX_EDITION_FILE = NO_EDITION_FILE;
+      mockFetch.mockRejectedValue(new Error("Connection refused"));
+      vi.mocked(getGatewayServiceHealth).mockResolvedValue(maskedUnit);
+    });
+
+    afterEach(() => {
+      delete process.env.CLAWBOX_EDITION_FILE;
+      delete process.env.CLAWBOX_EDITION;
+    });
+
+    it("does not report an OpenClaw gateway on a Hermes device", async () => {
+      // install.sh step_edition_gateway_state removes the unit file and masks
+      // the name to /dev/null on this SKU, so port 18789 will never open and
+      // `systemctl restart clawbox-gateway` is refused outright. The page used
+      // to say "OpenClaw Gateway Offline … not running on port 18789" with a
+      // Retry that can only repaint itself.
+      process.env.CLAWBOX_EDITION = "hermes";
+
+      const res = await GET(new NextRequest(new URL("http://clawbox.local/setup-api/gateway")));
+      const html = await res.text();
+
+      expect(res.status).toBe(503);
+      expect(html).not.toContain("Gateway Offline");
+      expect(html).not.toContain("not running on port");
+      expect(html).not.toContain("systemctl restart clawbox-gateway");
+      expect(html).not.toContain("Retry");
+      expect(html).toContain("OpenClaw Is Not Installed");
+      expect(html).toContain("Hermes");
+    });
+
+    it("calls a masked unit on an OpenClaw device what it is, and keeps Retry", async () => {
+      // The same mask is temporary here: an update or factory reset holds it.
+      // The owner still must not be told to restart a unit systemd refuses.
+      process.env.CLAWBOX_EDITION = "openclaw";
+
+      const res = await GET(new NextRequest(new URL("http://clawbox.local/setup-api/gateway")));
+      const html = await res.text();
+
+      expect(html).not.toContain("Gateway Offline");
+      expect(html).not.toContain("not running on port");
+      expect(html).toContain("Gateway Unavailable");
+      expect(html).toContain("masked");
+      expect(html).toContain("Retry");
+    });
+
+    it("does not print restart advice systemd would refuse", async () => {
+      // Belt and braces: a masked unit cannot reach start-limit-hit, but the
+      // breaker paragraph is the one place that names the two commands, so it
+      // is pinned off rather than left to that argument.
+      process.env.CLAWBOX_EDITION = "hermes";
+      vi.mocked(getGatewayServiceHealth).mockResolvedValue({ ...maskedUnit, breakerActive: true });
+
+      const html = await (await GET(new NextRequest(new URL("http://clawbox.local/setup-api/gateway")))).text();
+
+      expect(html).not.toContain("systemctl reset-failed clawbox-gateway");
+      expect(html).not.toContain("Automatic restart breaker activated");
+    });
+
+    it("keeps the ordinary offline page when systemctl did not answer", async () => {
+      // `unitLoaded: null` is "the question could not be asked", which is not
+      // evidence that the gateway is missing.
+      process.env.CLAWBOX_EDITION = "openclaw";
+      vi.mocked(getGatewayServiceHealth).mockResolvedValue({
+        ...maskedUnit,
+        loadState: null,
+        unitLoaded: null,
+      });
+
+      const html = await (await GET(new NextRequest(new URL("http://clawbox.local/setup-api/gateway")))).text();
+
+      expect(html).toContain("OpenClaw Gateway Offline");
+      expect(html).toContain("not running on port 18789");
+    });
+  });
+
   it("reports an activated breaker with safe actionable recovery", async () => {
     mockFetch.mockRejectedValue(new Error("Connection refused"));
     vi.mocked(getGatewayServiceHealth).mockResolvedValue({
@@ -85,6 +183,8 @@ describe("/setup-api/gateway", () => {
       result: "start-limit-hit",
       restartCount: 3,
       finalStartupError: "bad config <script>alert(1)</script>",
+      loadState: "loaded",
+      unitLoaded: true,
     });
 
     const req = new NextRequest(new URL("http://clawbox.local/setup-api/gateway"));

--- a/src/tests/unit/gateway-health.test.ts
+++ b/src/tests/unit/gateway-health.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import path from "node:path";
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as childProcess from "child_process";
 
@@ -104,6 +107,22 @@ describe("gateway service health", () => {
       expect(value, `${field} is not settled by --property=${GATEWAY_SHOW_PROPERTIES.join(",")}`)
         .not.toBeUndefined();
     }
+    // Fields the parser DERIVES are booleans and never go null — `active` is
+    // false for an absent ActiveState just as it is for an inactive unit — so
+    // the shape check above cannot see one of those added from an unqueried
+    // property. Read the property names out of the source as well.
+    const source = fs.readFileSync(
+      path.resolve(__dirname, "..", "..", "lib", "gateway-health.ts"),
+      "utf8",
+    );
+    const readProperties = [
+      ...new Set(Array.from(source.matchAll(/properties\.([A-Za-z]+)/g), (m) => m[1])),
+    ];
+    expect(readProperties.length).toBeGreaterThan(3);
+    for (const property of readProperties) {
+      expect(GATEWAY_SHOW_PROPERTIES, `${property} is read but never queried`).toContain(property);
+    }
+
     // The journal scope reads InvocationID off the SAME stdout, so it is part of
     // the same contract.
     expect(gatewayJournalArgs(`InvocationID=${"a".repeat(32)}\n`)).not.toBeNull();

--- a/src/tests/unit/gateway-health.test.ts
+++ b/src/tests/unit/gateway-health.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as childProcess from "child_process";
+
+vi.mock("child_process", () => ({ execFile: vi.fn() }));
+
 import {
+  GATEWAY_SHOW_PROPERTIES,
   gatewayJournalArgs,
+  getGatewayServiceHealth,
   lastUsefulJournalLine,
   parseGatewaySystemctlProperties,
 } from "@/lib/gateway-health";
@@ -49,6 +55,90 @@ describe("gateway service health", () => {
       subState: "failed",
       result: "start-limit-hit",
       restartCount: 5,
+      loadState: null,
+      unitLoaded: null,
+    });
+  });
+
+  it("separates a unit systemd cannot load from one that is merely down", () => {
+    // The Hermes SKU masks clawbox-gateway.service to /dev/null (install.sh
+    // step_edition_gateway_state) and an update holds the same mask on any SKU.
+    // systemctl refuses both `reset-failed` and `restart` on such a unit, so
+    // "offline, retry" is the wrong story to tell about it.
+    const masked = parseGatewaySystemctlProperties([
+      "LoadState=masked",
+      "ActiveState=inactive",
+      "SubState=dead",
+      "Result=success",
+      "NRestarts=0",
+    ].join("\n"));
+    expect(masked.loadState).toBe("masked");
+    expect(masked.unitLoaded).toBe(false);
+
+    const missing = parseGatewaySystemctlProperties("LoadState=not-found\nActiveState=inactive\n");
+    expect(missing.unitLoaded).toBe(false);
+
+    const loaded = parseGatewaySystemctlProperties("LoadState=loaded\nActiveState=failed\n");
+    expect(loaded.unitLoaded).toBe(true);
+
+    // Not asked is not answered: a systemctl that printed nothing about the
+    // load state must not be read as "the unit is fine".
+    expect(parseGatewaySystemctlProperties("ActiveState=failed\n").unitLoaded).toBeNull();
+  });
+
+  it("asks systemd for every property it parses", () => {
+    // A parser reading a property the query omits answers undefined forever,
+    // and the branch that depends on it silently never runs.
+    expect(GATEWAY_SHOW_PROPERTIES).toContain("LoadState");
+    expect(GATEWAY_SHOW_PROPERTIES).toContain("Result");
+    expect(GATEWAY_SHOW_PROPERTIES).toContain("InvocationID");
+  });
+
+  describe("getGatewayServiceHealth", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    function answerSystemctl(stdout: string) {
+      vi.mocked(childProcess.execFile).mockImplementation(((
+        _cmd: string,
+        _args: string[],
+        optsOrCallback?: object | ((error: Error | null, result: { stdout: string; stderr: string }) => void),
+        maybeCallback?: (error: Error | null, result: { stdout: string; stderr: string }) => void,
+      ) => {
+        const callback = typeof optsOrCallback === "function" ? optsOrCallback : maybeCallback;
+        callback?.(null, { stdout, stderr: "" });
+        return {} as unknown as ReturnType<typeof childProcess.execFile>;
+      }) as unknown as typeof childProcess.execFile);
+    }
+
+    it("requests LoadState and reports a masked unit as unloadable", async () => {
+      answerSystemctl("LoadState=masked\nActiveState=inactive\nSubState=dead\nResult=success\nNRestarts=0\n");
+
+      const health = await getGatewayServiceHealth();
+
+      const args = vi.mocked(childProcess.execFile).mock.calls[0][1] as string[];
+      expect(args.some((arg) => arg.includes("LoadState"))).toBe(true);
+      expect(health.loadState).toBe("masked");
+      expect(health.unitLoaded).toBe(false);
+    });
+
+    it("answers 'unknown' rather than 'missing' when systemctl fails", async () => {
+      vi.mocked(childProcess.execFile).mockImplementation(((
+        _cmd: string,
+        _args: string[],
+        optsOrCallback?: object | ((error: Error | null, result: { stdout: string; stderr: string }) => void),
+        maybeCallback?: (error: Error | null, result: { stdout: string; stderr: string }) => void,
+      ) => {
+        const callback = typeof optsOrCallback === "function" ? optsOrCallback : maybeCallback;
+        callback?.(new Error("systemctl: command not found"), { stdout: "", stderr: "" });
+        return {} as unknown as ReturnType<typeof childProcess.execFile>;
+      }) as unknown as typeof childProcess.execFile);
+
+      const health = await getGatewayServiceHealth();
+
+      expect(health.unitLoaded).toBeNull();
+      expect(health.loadState).toBeNull();
     });
   });
 

--- a/src/tests/unit/gateway-health.test.ts
+++ b/src/tests/unit/gateway-health.test.ts
@@ -88,9 +88,25 @@ describe("gateway service health", () => {
 
   it("asks systemd for every property it parses", () => {
     // A parser reading a property the query omits answers undefined forever,
-    // and the branch that depends on it silently never runs.
-    expect(GATEWAY_SHOW_PROPERTIES).toContain("LoadState");
-    expect(GATEWAY_SHOW_PROPERTIES).toContain("Result");
+    // the branch that depends on it silently never runs, and no test that feeds
+    // the parser its own hand-written stdout can see it. So the stdout here is
+    // built FROM the query list: every field the parser returns must be settled
+    // by it, and a field added to the parser without being added to the query
+    // comes back null.
+    const stdout = GATEWAY_SHOW_PROPERTIES
+      .map((property) => `${property}=${property === "NRestarts" ? "0" : "loaded"}`)
+      .join("\n");
+    const parsed = parseGatewaySystemctlProperties(stdout) as Record<string, unknown>;
+
+    for (const [field, value] of Object.entries(parsed)) {
+      expect(value, `${field} is not settled by --property=${GATEWAY_SHOW_PROPERTIES.join(",")}`)
+        .not.toBeNull();
+      expect(value, `${field} is not settled by --property=${GATEWAY_SHOW_PROPERTIES.join(",")}`)
+        .not.toBeUndefined();
+    }
+    // The journal scope reads InvocationID off the SAME stdout, so it is part of
+    // the same contract.
+    expect(gatewayJournalArgs(`InvocationID=${"a".repeat(32)}\n`)).not.toBeNull();
     expect(GATEWAY_SHOW_PROPERTIES).toContain("InvocationID");
   });
 


### PR DESCRIPTION
TASK-546 — the gateway offline page described a unit systemd cannot even load, and told the owner to restart it.

## Customer-visible symptom

`GET /setup-api/gateway` on a Hermes box answers 503 with "**OpenClaw Gateway Offline** / The gateway service is not running on port 18789" and a Retry button that can only repaint itself. `install.sh`'s `step_edition_gateway_state` removes the unit file and masks the name to `/dev/null` on that SKU, so the port will never open. The breaker paragraph on the same page names `sudo systemctl reset-failed clawbox-gateway && sudo systemctl restart clawbox-gateway` — two commands systemctl refuses outright on a masked unit.

The same page is wrong for a second, non-Hermes reason the card did not cover: an update or factory reset masks that unit on any SKU while it holds the lock, and an install run that unmasks but dies before `step_systemd_services` re-copies the unit leaves `LoadState=not-found`. In all of those the page says "offline, retry" about a unit that cannot be started at all.

**Scope, stated plainly:** `/setup-api/gateway` is an orphan HTTP surface. Nothing in the shipped UI navigates to it — the desktop's `<iframe src="/setup-api/gateway">` was replaced by the app-registry entry `{ id: "openclaw", type: "external", url: "/chat" }`, and `openclaw` is in `OPENCLAW_ONLY_APP_IDS` so it is hidden on Hermes anyway. It is reachable only by URL (a bookmark, an operator, a monitor, the agent fetching its own box), which is how the device evidence below was taken. This is a defensive fix to a live endpoint, exactly as the card anticipated ("the fix may be purely defensive") — the on-device validation step is `curl` the path, not "open the app".

## Cause

`gatewayOfflineResponse()` had one story for two different device states, because `getGatewayServiceHealth()` never asked systemd the question that separates them. It queried `ActiveState,SubState,Result,NRestarts,InvocationID` — everything about whether the unit *ran*, nothing about whether there is a unit to run.

## Fix

- `src/lib/gateway-health.ts` — the `systemctl show` query gains `LoadState`, and `GatewayServiceHealth` gains `loadState` plus `unitLoaded` (`false` for `masked` / `not-found` / anything that is not `loaded`, `null` when systemctl did not answer). The property list is exported as `GATEWAY_SHOW_PROPERTIES` and the query is built from it, so the query and the parser cannot drift apart.
- `src/app/setup-api/gateway/route.ts` — when the unit is not loadable the page no longer claims a port, no longer offers the restart advice, and says what it actually knows:
  - Hermes SKU → **404** "OpenClaw Is Not Installed", pointing at the Hermes app, no Retry. 404 matches what every other OpenClaw-only path answers on that SKU (`/api/*`, `/assets/*`, `/chat`); a 503 invites a monitor or a service worker to re-poll a condition that cannot change.
  - Otherwise, `masked` → "Gateway Unavailable … an update or factory reset holds that lock while it runs", Retry kept, still 503.
  - Otherwise, any other non-loaded state → "systemd cannot load `clawbox-gateway.service` (`not-found`)" — it names the state and attributes no cause it has not measured.
  - `unitLoaded === null` (systemctl did not answer) → today's page, unchanged. "Not asked" is not "not installed".

## Harness-first

The question "is there a gateway unit on this box" is systemd's, and `systemctl show` already answers it — one more property on a call the route was already making. Nothing is re-implemented: readiness stays the port probe behind `/setup-api/gateway/health` and `awaitGatewayReady`, which is a different question.

The **branch** is taken from the device rather than from the edition, so a Hermes box whose root-owned lock cannot be read still gets a page that is true. Only the **wording** consults the edition, through `readEditionSource()` rather than `readEdition()`/`openclawIsAbsent()`: those collapse "the device said openclaw" and "nothing said anything, so I guessed openclaw" into one value, and on a lockless Hermes device the guess would print the OpenClaw sentence. A guessed edition now names no cause at all.

## RED → GREEN

RED, both source files reverted to beta (`git checkout origin/beta -- src/lib/gateway-health.ts src/app/setup-api/gateway/route.ts`), tests unchanged:

```
 × does not report an OpenClaw gateway on a Hermes device
   AssertionError: expected 503 to be 404
 × calls a masked unit on an OpenClaw device what it is, and keeps Retry
   AssertionError: expected '<!DOCTYPE html>…' not to contain 'Gateway Offline'
 × gives a dual box the OpenClaw wording, not the Hermes one
   AssertionError: expected '<!DOCTYPE html>…' to contain 'Gateway Unavailable'
 × names a missing unit file without inventing a cause for it
   AssertionError: expected '<!DOCTYPE html>…' to contain 'not-found'
 × attributes no cause when nothing on the device named an edition
   AssertionError: expected '<!DOCTYPE html>…' to contain 'masked'
 × does not print restart advice systemd would refuse
   AssertionError: expected '<!DOCTYPE html>…' not to contain 'systemctl reset-failed clawbox-gateway'
 × separates a unit systemd cannot load from one that is merely down
   AssertionError: expected undefined to be 'masked'
 × requests LoadState and reports a masked unit as unloadable
   AssertionError: expected false to be true
 × answers 'unknown' rather than 'missing' when systemctl fails
   AssertionError: expected undefined to be null
 Tests  11 failed | 8 passed (19)
```

GREEN, the two suites plus the neighbours (the whole `routes/gateway` directory, `middleware`, `edition-source`, `mcp-edition`, `gateway-restart-readiness` and the two hygiene gates):

```
 Test Files  12 passed (12)
      Tests  237 passed (237)
```

`tsc --noEmit` clean; eslint clean on every touched file.

## Device evidence (read-only, Hermes box on beta head 6719c8f0 — the branch's own base)

```
/etc/clawbox/edition.env            CLAWBOX_EDITION=hermes
/etc/systemd/system/clawbox-gateway.service -> /dev/null
systemctl is-enabled                masked
systemctl is-active                 inactive
systemctl show clawbox-gateway.service
  LoadState=masked  ActiveState=inactive  SubState=dead  Result=success  NRestarts=0

GET /setup-api/gateway (authenticated owner session)
  HTTP 503
  … "OpenClaw Gateway Offline" … "not running on port 18789"
```

That output also settles the card's open question: **`breakerActive` can never be true on a Hermes box.** It is `Result === "start-limit-hit"`, and a masked unit never starts, so `Result` stays `success`. The `reset-failed`/`restart` sentence was therefore latent rather than rendered — the page's *heading and port claim* were what the owner actually saw. The breaker text is still pinned off for a non-loadable unit rather than left to that argument.

No mutation and no device lock: every call above is a read.

## Sibling call sites

- `GatewayServiceHealth` is constructed in exactly two places, both in `gateway-health.ts`, and consumed only by this route. No unupdated construction site.
- `getGatewayServiceHealth` — one caller, this route (twice, both offline paths).
- `src/middleware.ts`'s `isGatewayOnlyPath` covers `/api/*`, `/assets/*` and the two gateway favicons, **not** `/setup-api/gateway`, which is why the route is reachable on Hermes at all. Left as is: the middleware gate exists because `next.config.ts` rewrites are compiled at build time and cannot see the edition, a reason that does not apply to a route handler, and the route now answers correctly on its own.
- **Recorded, not fixed here:** `src/components/OpenClawApp.tsx` carries the same "OpenClaw Gateway Offline / not running / Retry" copy (plus `openclaw.offline` and `openclaw.notRunning` in ten locales), and `CLAUDE.md` still lists it as the live Control UI wrapper — but nothing imports the component since the desktop switched to the external `/chat` entry. Deleting a dead component and ten locale keys is a wider change than this card, so it goes on the residual list rather than into this diff.
- **Recorded, not fixed here:** `restartGateway()` still decides "the unit is masked" by regex-matching systemctl's stderr text, which is locale- and wording-dependent. `loadState` is now the same fact taken from systemd's own property; swapping it in belongs with that function's own change.

## Review

One the review model review pass on the diff: 1 high, 3 medium, 5 low. Applied: the over-claimed cause for every non-`loaded` state (M2), `readEditionSource().defaulted` so the wording cannot contradict the comment that justifies it (M3), the test hygiene — the suite now bakes a real tmp edition lock and **restores** `vitest.config.ts`'s hermetic floor in `afterEach` instead of deleting it, which would have made this file pass in CI and fail on the device it was validated on (M4), a drift test that actually detects drift by building its stdout from the query list (L6), the unreachable `??` fallback (L7), 404 for the Hermes case (L8), and route cases for the `dual` SKU and `not-found` (L9). The high finding is the orphan-surface point, which is stated in full at the top of this description rather than hidden.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved gateway status reporting when the service is missing, masked, or otherwise unavailable.
  - Hermes devices now receive a clear 404 message when OpenClaw is not installed.
  - Other unavailable gateway states display more specific availability details when verified.
  - Retry guidance is omitted when the gateway cannot exist, and irrelevant restart instructions are hidden.
  - Gateway health checks now better distinguish unavailable services from states that cannot be determined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->