### PR TITLE
fix: keep the checkout .env and .git out of the standalone build

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -73,6 +73,18 @@ const nextConfig: NextConfig = {
   // for this build's entry. Narrowing the sweep is a separate change: parts of
   // it are load-bearing today (`.next/standalone/scripts` comes from it, and
   // system-profile.ts resolves scripts/ from the process cwd).
+  //
+  // The `.git` in that list is the second thing scripts/postbuild.sh sweeps
+  // (TASK-692): 88 MB of it on the OpenClaw box, measured 2026-09-05. Its
+  // companion, the checkout's own `.env`, does not come from the trace at all
+  // and so cannot be excluded here either — Next copies `.env` and
+  // `.env.production` ITSELF, after the trace, in writeStandaloneDirectory()
+  // (next/dist/build/index.js), with no config switch anywhere in that path.
+  // On a box that file is 0600 and holds GOOGLE_OAUTH_CLIENT_SECRET and, where
+  // install.sh was given one, CLAWBOX_AI_API_KEY, so the copy is removed from
+  // the build artifact and its survival fails the build. Nothing loses by it:
+  // systemd hands the real file to clawbox-setup as an EnvironmentFile and
+  // @next/env never overwrites a variable that is already in the environment.
   outputFileTracingExcludes: {
     // No "./" prefix: Next matches these globs relative to the tracing root,
     // and "./data/**" silently matched nothing — the build kept dying on

--- a/next.config.ts
+++ b/next.config.ts
@@ -74,23 +74,45 @@ const nextConfig: NextConfig = {
   // it are load-bearing today (`.next/standalone/scripts` comes from it, and
   // system-profile.ts resolves scripts/ from the process cwd).
   //
-  // The `.git` in that list is the second thing scripts/postbuild.sh sweeps
-  // (TASK-692): 88 MB of it on the OpenClaw box, measured 2026-09-05. Its
-  // companion, the checkout's own `.env`, does not come from the trace at all
-  // and so cannot be excluded here either — Next copies `.env` and
-  // `.env.production` ITSELF, after the trace, in writeStandaloneDirectory()
-  // (next/dist/build/index.js), with no config switch anywhere in that path.
-  // On a box that file is 0600 and holds GOOGLE_OAUTH_CLIENT_SECRET and, where
-  // install.sh was given one, CLAWBOX_AI_API_KEY, so the copy is removed from
-  // the build artifact and its survival fails the build. Nothing loses by it:
-  // systemd hands the real file to clawbox-setup as an EnvironmentFile and
-  // @next/env never overwrites a variable that is already in the environment.
+  // `.git` is in that 6186-file list too — 88 MB of it on the OpenClaw box,
+  // measured 2026-09-05 — and unlike the middleware half it CAN be excluded
+  // here. Read out of the installed next@16.3.3 in this checkout (TASK-692),
+  // because the paragraph above led a review to the opposite conclusion:
+  //
+  //   * next-trace-entrypoints-plugin.js keys `entryNameFilesMap` by
+  //     `entrypoint.name` for EVERY server-compiler entrypoint, not only route
+  //     entries, so `instrumentation` has an entry in it.
+  //   * collect-build-traces.js iterates that map and applies these globs to
+  //     each `.nft.json`, skipping only static pages and `edgeRuntimeRoutes` —
+  //     which is exactly why MIDDLEWARE keeps its `data/` entry and the
+  //     server-compiler traces do not.
+  //   * `picomatch("*", { dot: true, contains: true })("instrumentation")` is
+  //     `true`, and `.git/**` matches `.git/objects/...` under the same
+  //     options. Both checked with the vendored matcher.
+  //   * build/utils.js copies the standalone tree FROM those lists, so an
+  //     entry dropped here is a file never copied.
+  //
+  // So `.git` is excluded at the source rather than deleted afterwards. What
+  // is NOT measured: a real `next build` on a box with this line in place —
+  // that is device work. scripts/postbuild.sh therefore still sweeps `.git`
+  // and still FAILS the build if a copy survives, which is the post-condition
+  // the suites pin; this line is meant to make that sweep find nothing.
+  //
+  // Its companion, the checkout's own `.env`, genuinely has no switch: Next
+  // copies `.env` and `.env.production` ITSELF, AFTER the trace, in
+  // writeStandaloneDirectory() (next/dist/build/index.js) — nothing on that
+  // path reads this config. On a box that file is 0600 and holds
+  // GOOGLE_OAUTH_CLIENT_SECRET and, where install.sh was given one,
+  // CLAWBOX_AI_API_KEY, so the copy is removed from the build artifact and its
+  // survival fails the build. Nothing loses by it: systemd hands the real file
+  // to clawbox-setup as an EnvironmentFile and @next/env never overwrites a
+  // variable that is already in the environment.
   outputFileTracingExcludes: {
     // No "./" prefix: Next matches these globs relative to the tracing root,
     // and "./data/**" silently matched nothing — the build kept dying on
     // data/webapps/<app>/index.html whenever a webapp was created or removed
     // while it ran.
-    "*": ["data/**", "**/data/webapps/**", "**/data/code-projects/**"],
+    "*": ["data/**", "**/data/webapps/**", "**/data/code-projects/**", ".git/**"],
   },
   outputFileTracingIncludes: {
     "/setup-api/pets/thumb": [

--- a/scripts/postbuild.sh
+++ b/scripts/postbuild.sh
@@ -142,6 +142,49 @@ if [ -e "$SDIR/data" ]; then
   fail "$SDIR/data survived removal - the standalone tree would ship a duplicate of the runtime data directory, including 0600 secrets (see next.config.ts)"
 fi
 
+# The checkout's own `.env` and `.git`, for the same reason and by the same
+# rule — but swept from the WHOLE tree, not just beside the entry.
+#
+# Two different routes put them there and neither can be closed in
+# next.config.ts (the measurement is recorded there):
+#
+#   * `.env` and `.env.production` are copied by Next ITSELF, outside the
+#     trace: writeStandaloneDirectory() walks `loadedEnvFiles` and copyFile()s
+#     exactly those two names (next/dist/build/index.js), with no config switch.
+#   * `.git` rides in on the instrumentation trace — the same whole-project
+#     asset directory that brings `.next-old` in above. Read off the OpenClaw
+#     box on 2026-09-05: `.next/standalone/.git` was 88 MB.
+#
+# On a box the checkout `.env` is 0600 and holds GOOGLE_OAUTH_CLIENT_SECRET
+# and, where install.sh was given one, CLAWBOX_AI_API_KEY. Nothing reads the
+# copy: systemd hands the real file to clawbox-setup as an EnvironmentFile, and
+# @next/env never overwrites a variable that is already in the environment.
+#
+# Depth-unbounded because the trace copies whole project subdirectories:
+# `e2e-install/.env.test` (gitignored, and its tracked .example documents seven
+# provider keys) lands at `.next/standalone/e2e-install/.env.test`, two levels
+# down. `node_modules` is pruned — packages ship `.env` fixtures of their own,
+# and failing a build over one would be a false failure.
+env_and_git_copies() {
+  find "$STANDALONE" \
+    -name node_modules -prune \
+    -o \( -name .env -o -name '.env.*' -o -name .git \) -prune "$@"
+}
+
+# `|| true` so the check below is what reports a failed removal, rather than
+# errexit killing the script on `rm` with nothing said — the same shape the
+# data/ removal above uses.
+env_and_git_copies -exec rm -rf {} + || true
+
+# `-quit` rather than a pipe to `head`: under `pipefail` a `find` that is still
+# writing when `head` exits dies of SIGPIPE, and errexit would then end the
+# build with no output at all.
+LEFT="$(env_and_git_copies -print -quit)" \
+  || fail "could not scan $STANDALONE for copied .env/.git files"
+if [ -n "$LEFT" ]; then
+  fail "$LEFT survived removal - the standalone tree would ship a copy of the checkout's environment files or of its .git (see next.config.ts)"
+fi
+
 rm -rf "$SDIR/.next/static" "$SDIR/public"
 cp -r .next/static "$SDIR/.next/static"
 cp -r public "$SDIR/public"

--- a/scripts/postbuild.sh
+++ b/scripts/postbuild.sh
@@ -145,15 +145,21 @@ fi
 # The checkout's own `.env` and `.git`, for the same reason and by the same
 # rule — but swept from the WHOLE tree, not just beside the entry.
 #
-# Two different routes put them there and neither can be closed in
-# next.config.ts (the measurement is recorded there):
+# Two different routes put them there, and only one of them has a native
+# switch (the measurement for both is recorded in next.config.ts):
 #
 #   * `.env` and `.env.production` are copied by Next ITSELF, outside the
 #     trace: writeStandaloneDirectory() walks `loadedEnvFiles` and copyFile()s
 #     exactly those two names (next/dist/build/index.js), with no config switch.
+#     This sweep is the only thing that removes them.
 #   * `.git` rides in on the instrumentation trace — the same whole-project
 #     asset directory that brings `.next-old` in above. Read off the OpenClaw
-#     box on 2026-09-05: `.next/standalone/.git` was 88 MB.
+#     box on 2026-09-05: `.next/standalone/.git` was 88 MB. That trace IS
+#     reachable by `outputFileTracingExcludes` (only middleware's is not), so
+#     `.git/**` is excluded there now and this sweep should find nothing —
+#     kept because no real build has been measured with that line in place,
+#     and because a post-condition that fails the build is worth more than an
+#     exclude nobody would notice regressing.
 #
 # On a box the checkout `.env` is 0600 and holds GOOGLE_OAUTH_CLIENT_SECRET
 # and, where install.sh was given one, CLAWBOX_AI_API_KEY. Nothing reads the
@@ -165,10 +171,14 @@ fi
 # provider keys) lands at `.next/standalone/e2e-install/.env.test`, two levels
 # down. `node_modules` is pruned — packages ship `.env` fixtures of their own,
 # and failing a build over one would be a false failure.
+# Every pattern quoted, including the three that need no quoting today: this
+# script runs with the project root as cwd, where `.env` and `.git` both exist,
+# so one added `*` in an unquoted word would be expanded by the shell against
+# the checkout before `find` ever saw it.
 env_and_git_copies() {
   find "$STANDALONE" \
-    -name node_modules -prune \
-    -o \( -name .env -o -name '.env.*' -o -name .git \) -prune "$@"
+    -name 'node_modules' -prune \
+    -o \( -name '.env' -o -name '.env.*' -o -name '.git' \) -prune "$@"
 }
 
 # `|| true` so the check below is what reports a failed removal, rather than

--- a/src/tests/unit/postbuild-standalone-data.test.ts
+++ b/src/tests/unit/postbuild-standalone-data.test.ts
@@ -27,6 +27,17 @@ import path from "path";
  * So the postbuild step removes it, and asserts that it is gone — the removal
  * failing silently would put the duplicate straight back.
  *
+ * TASK-692 gave the checkout's own `.env` (0600 on a box — the file systemd
+ * hands to clawbox-setup, holding GOOGLE_OAUTH_CLIENT_SECRET and, where
+ * install.sh was given one, CLAWBOX_AI_API_KEY), every `.env.*` beside it and
+ * `.git` the same treatment. Neither can be excluded through Next's own
+ * mechanism: `writeStandaloneDirectory()` copies `.env`/`.env.production`
+ * outside the trace with no switch, and `.git` arrives on the instrumentation
+ * trace, which `outputFileTracingExcludes` does not reach. Removing them costs
+ * the box nothing — @next/env never overwrites a variable systemd has already
+ * set — and the sweep is depth-unbounded because that trace copies whole
+ * project subdirectories, `.env` files and all.
+ *
  * These tests run the REAL postbuild script out of package.json against a
  * temp tree, so they cannot drift from what ships.
  */
@@ -97,6 +108,32 @@ function buildFixture() {
   for (const secret of [".session-secret", ".mcp-token", ".local-ai-token", "internal-token.env"]) {
     fs.writeFileSync(path.join(data, secret), "redacted\n", { mode: 0o600 });
   }
+
+  // The two routes TASK-692 closes. `.env`/`.env.production` are copied by
+  // Next itself beside the entry; `.git` and the rest of the project root
+  // arrive on the instrumentation trace, which is why one of these sits two
+  // levels down: `e2e-install/.env.test` is gitignored and its tracked
+  // `.example` documents seven provider keys.
+  fs.writeFileSync(path.join(standalone, ".env"), "GOOGLE_OAUTH_CLIENT_SECRET=redacted\n", {
+    mode: 0o600,
+  });
+  fs.writeFileSync(path.join(standalone, ".env.production"), "LLAMACPP_REASONING=off\n", {
+    mode: 0o600,
+  });
+  fs.writeFileSync(path.join(standalone, ".env.example"), "ALLOW_INSECURE_CONTROL_UI=\n");
+  fs.mkdirSync(path.join(standalone, "e2e-install"), { recursive: true });
+  fs.writeFileSync(path.join(standalone, "e2e-install", ".env.test"), "OPENAI_API_KEY=redacted\n", {
+    mode: 0o600,
+  });
+  fs.mkdirSync(path.join(standalone, ".git", "objects"), { recursive: true });
+  fs.writeFileSync(path.join(standalone, ".git", "config"), "[core]\n");
+  fs.writeFileSync(path.join(standalone, ".git", "objects", "blob"), "object\n");
+
+  // …and one that must SURVIVE. Packages ship their own `.env` fixtures, and
+  // a sweep that failed the build over somebody else's test data would be a
+  // false failure on a healthy build.
+  fs.mkdirSync(path.join(standalone, "node_modules", "dotenv", "tests"), { recursive: true });
+  fs.writeFileSync(path.join(standalone, "node_modules", "dotenv", "tests", ".env"), "FIXTURE=1\n");
 }
 
 function runPostbuild() {
@@ -129,6 +166,31 @@ d("postbuild step", () => {
     const res = runPostbuild();
     expect(res.status, res.stderr).toBe(0);
     expect(fs.existsSync(path.join(standalone, "data"))).toBe(false);
+  });
+
+  it("removes every copy of the checkout's .env, wherever the trace put it", () => {
+    const res = runPostbuild();
+    expect(res.status, res.stderr).toBe(0);
+    expect(fs.existsSync(path.join(standalone, ".env"))).toBe(false);
+    expect(fs.existsSync(path.join(standalone, ".env.production"))).toBe(false);
+    expect(fs.existsSync(path.join(standalone, ".env.example"))).toBe(false);
+    // Depth 2: the trace copies whole project subdirectories, so a top-level
+    // sweep would have shipped this one and reported the build clean.
+    expect(fs.existsSync(path.join(standalone, "e2e-install", ".env.test"))).toBe(false);
+  });
+
+  it("removes the copied .git", () => {
+    const res = runPostbuild();
+    expect(res.status, res.stderr).toBe(0);
+    expect(fs.existsSync(path.join(standalone, ".git"))).toBe(false);
+  });
+
+  it("leaves a package's own .env fixture under node_modules alone", () => {
+    const res = runPostbuild();
+    expect(res.status, res.stderr).toBe(0);
+    expect(
+      fs.existsSync(path.join(standalone, "node_modules", "dotenv", "tests", ".env")),
+    ).toBe(true);
   });
 
   it("still assembles the standalone tree it is there to assemble", () => {
@@ -165,6 +227,29 @@ d("postbuild step", () => {
     },
   );
 
+  // The same post-condition for the secrets half. data/ is checked first and
+  // would be the path named, so this fixture removes data/ — and every other
+  // top-level match — before making the tree read-only, leaving .env as the
+  // one thing that can survive. The assertion is on the GUARD's own line, not
+  // merely on the path: `rm` writes its own "Permission denied" naming the
+  // same path onto the same stream, so a message-free guard would pass.
+  it.skipIf(isRoot)(
+    "fails the build, naming the path, when the .env copy survives the removal (non-root uid only)",
+    () => {
+      for (const gone of ["data", ".git", ".env.production", ".env.example"]) {
+        fs.rmSync(path.join(standalone, gone), { recursive: true, force: true });
+      }
+      // Deeper matches stay removable — only the top level is frozen.
+      fs.chmodSync(standalone, 0o555);
+      const res = runPostbuild();
+      expect(fs.existsSync(path.join(standalone, ".env"))).toBe(true);
+      expect(res.status).not.toBe(0);
+      expect(res.stderr).toContain(
+        `postbuild: ${path.join(".next", "standalone", ".env")} survived removal`,
+      );
+    },
+  );
+
   // The nested layout is the one where $SDIR is not .next/standalone: Next
   // writes server.js AND the traced data/ under
   // <standalone>/<path from the tracing root to the app>, and the postbuild
@@ -179,10 +264,17 @@ d("postbuild step", () => {
     fs.writeFileSync(path.join(nested, "server.js"), "// standalone server\n");
     fs.mkdirSync(path.join(nested, "data", "llamacpp"), { recursive: true });
     fs.writeFileSync(path.join(nested, "data", "config.json"), "{}\n");
+    // Next writes .env beside the entry it writes, so in this layout that is
+    // the nested directory rather than the top of the standalone tree.
+    fs.writeFileSync(path.join(nested, ".env"), "GOOGLE_OAUTH_CLIENT_SECRET=redacted\n", {
+      mode: 0o600,
+    });
 
     const res = runPostbuild();
     expect(res.status, res.stderr).toBe(0);
     expect(fs.existsSync(path.join(nested, "data"))).toBe(false);
+    expect(fs.existsSync(path.join(nested, ".env"))).toBe(false);
+    expect(fs.existsSync(path.join(standalone, ".git"))).toBe(false);
     expect(fs.lstatSync(path.join(standalone, "server.js")).isSymbolicLink()).toBe(true);
     expect(fs.realpathSync(path.join(standalone, "server.js")))
       .toBe(fs.realpathSync(path.join(nested, "server.js")));

--- a/src/tests/unit/postbuild-standalone-data.test.ts
+++ b/src/tests/unit/postbuild-standalone-data.test.ts
@@ -83,8 +83,10 @@ function buildFixture() {
   fs.mkdirSync(path.join(standalone, ".next"), { recursive: true });
   fs.writeFileSync(path.join(standalone, "server.js"), "// standalone server\n");
 
-  // scripts/ IS resolved from the process cwd by system-profile.ts and
-  // hermes-image-plugin.ts, so it must survive whatever the data/ removal does.
+  // scripts/ IS resolved from the process cwd — system-profile.ts's
+  // `resolveScript(..., { allowRepoFallback: true })` falls back to
+  // `CLAWBOX_ROOT || process.cwd()` — so it must survive whatever the data/
+  // removal does.
   fs.mkdirSync(path.join(standalone, "scripts"), { recursive: true });
   fs.writeFileSync(path.join(standalone, "scripts", "start-llamacpp.sh"), "#!/bin/sh\n");
 

--- a/src/tests/unit/postbuild-standalone-data.test.ts
+++ b/src/tests/unit/postbuild-standalone-data.test.ts
@@ -30,10 +30,14 @@ import path from "path";
  * TASK-692 gave the checkout's own `.env` (0600 on a box — the file systemd
  * hands to clawbox-setup, holding GOOGLE_OAUTH_CLIENT_SECRET and, where
  * install.sh was given one, CLAWBOX_AI_API_KEY), every `.env.*` beside it and
- * `.git` the same treatment. Neither can be excluded through Next's own
- * mechanism: `writeStandaloneDirectory()` copies `.env`/`.env.production`
- * outside the trace with no switch, and `.git` arrives on the instrumentation
- * trace, which `outputFileTracingExcludes` does not reach. Removing them costs
+ * `.git` the same treatment. Only ONE of the two has a native switch:
+ * `writeStandaloneDirectory()` copies `.env`/`.env.production` outside the
+ * trace with no config key on that path, so the sweep is the only thing that
+ * removes those; `.git` arrives on the instrumentation trace, which
+ * `outputFileTracingExcludes` DOES reach (see next.config.ts), so it is
+ * excluded there and swept here as the enforced post-condition — these cases
+ * plant the copies by hand, so they pin the sweep whatever the trace does.
+ * Removing them costs
  * the box nothing — @next/env never overwrites a variable systemd has already
  * set — and the sweep is depth-unbounded because that trace copies whole
  * project subdirectories, `.env` files and all.
@@ -83,10 +87,14 @@ function buildFixture() {
   fs.mkdirSync(path.join(standalone, ".next"), { recursive: true });
   fs.writeFileSync(path.join(standalone, "server.js"), "// standalone server\n");
 
-  // scripts/ IS resolved from the process cwd — system-profile.ts's
-  // `resolveScript(..., { allowRepoFallback: true })` falls back to
-  // `CLAWBOX_ROOT || process.cwd()` — so it must survive whatever the data/
-  // removal does.
+  // scripts/ IS resolved from the process cwd, so it must survive whatever the
+  // data/ removal does. Two readers today: system-profile.ts:81
+  // (`resolveScript(..., { allowRepoFallback: true })` → `CLAWBOX_ROOT ||
+  // process.cwd()`), which stays a cwd reader; and hermes-image-plugin.ts:99,
+  // which is one until PR #697 moves it to `resolveConfigRoot()`. Both are
+  // named because the invariant is "something still resolves scripts/ from the
+  // cwd", and dropping the second early would lose the record if #697 changes
+  // shape.
   fs.mkdirSync(path.join(standalone, "scripts"), { recursive: true });
   fs.writeFileSync(path.join(standalone, "scripts", "start-llamacpp.sh"), "#!/bin/sh\n");
 

--- a/src/tests/unit/postbuild-standalone-entry.test.ts
+++ b/src/tests/unit/postbuild-standalone-entry.test.ts
@@ -51,9 +51,16 @@ const POSTBUILD: string = JSON.parse(
   fs.readFileSync(path.join(REPO, "package.json"), "utf-8"),
 ).scripts.postbuild;
 
+// The real `find`, resolved before the stub below can shadow it: the stub
+// answers the entry lookup only and hands every other call to this one.
+const REAL_FIND = (
+  spawnSync("sh", ["-c", "command -v find"], { encoding: "utf-8" }).stdout ?? ""
+).trim();
+
 const CAN_RUN =
   process.platform !== "win32"
-  && spawnSync("sh", ["-c", "true"], { stdio: "ignore" }).status === 0;
+  && spawnSync("sh", ["-c", "true"], { stdio: "ignore" }).status === 0
+  && REAL_FIND !== "";
 const d = CAN_RUN ? describe : describe.skip;
 
 let tmp: string;
@@ -119,11 +126,28 @@ function sweepParkedBuildIn() {
  * got — and the step is asked what it does with it. A lookup that consults
  * `find` at all is handed the parked entry; a lookup that takes the entry
  * `next build` wrote never runs it.
+ *
+ * It answers the ENTRY lookup only — the one call that names `server.js`. The
+ * step's other `find` sweeps the whole tree for copied `.env`/`.git` files
+ * (TASK-692) and gets the real one: entry SELECTION does not need `find`, that
+ * sweep does, and a stub that answered both would fail the build over a
+ * leftover this fixture never planted.
  */
 function stubFindReturning(rel: string) {
   fs.mkdirSync(stubBin, { recursive: true });
   const stub = path.join(stubBin, "find");
-  fs.writeFileSync(stub, `#!/usr/bin/env bash\nprintf '%s\\n' ${JSON.stringify(rel)}\n`);
+  fs.writeFileSync(
+    stub,
+    `#!/usr/bin/env bash
+for arg in "$@"; do
+  if [ "$arg" = server.js ]; then
+    printf '%s\\n' ${JSON.stringify(rel)}
+    exit 0
+  fi
+done
+exec ${JSON.stringify(REAL_FIND)} "$@"
+`,
+  );
   fs.chmodSync(stub, 0o755);
 }
 

--- a/src/tests/unit/postbuild-standalone-entry.test.ts
+++ b/src/tests/unit/postbuild-standalone-entry.test.ts
@@ -53,6 +53,14 @@ const POSTBUILD: string = JSON.parse(
 
 // The real `find`, resolved before the stub below can shadow it: the stub
 // answers the entry lookup only and hands every other call to this one.
+//
+// It has to be an ABSOLUTE path, and that is a hard condition rather than a
+// tidiness rule: `command -v` prints a BARE NAME for a shell function or alias,
+// and the stub is first on PATH, so `exec find "$@"` on a bare name re-enters
+// the stub forever. That loop sits inside `spawnSync`, which blocks the worker
+// synchronously — `testTimeout` cannot interrupt it, so the symptom would be a
+// hung CI job rather than a failing test. A `sh` that reads `$ENV`/`BASH_ENV`
+// is the way in; skipping the suite is the safe answer.
 const REAL_FIND = (
   spawnSync("sh", ["-c", "command -v find"], { encoding: "utf-8" }).stdout ?? ""
 ).trim();
@@ -60,7 +68,7 @@ const REAL_FIND = (
 const CAN_RUN =
   process.platform !== "win32"
   && spawnSync("sh", ["-c", "true"], { stdio: "ignore" }).status === 0
-  && REAL_FIND !== "";
+  && REAL_FIND.startsWith("/");
 const d = CAN_RUN ? describe : describe.skip;
 
 let tmp: string;
@@ -132,6 +140,14 @@ function sweepParkedBuildIn() {
  * (TASK-692) and gets the real one: entry SELECTION does not need `find`, that
  * sweep does, and a stub that answered both would fail the build over a
  * leftover this fixture never planted.
+ *
+ * That narrows the negative control, deliberately and with a limit worth
+ * knowing: a lookup reintroduced in a DIFFERENT shape — matching `server*.js`,
+ * or a `-path`/`-regex` form that never passes the bare word — would fall
+ * through to the real `find`, which prunes `.next-old*` here and hands back the
+ * right entry, so both cases would pass while the regression was live. The
+ * shape this pins is the one the defect had (TASK-725: `find … -name
+ * node_modules -prune -o -name server.js -print -quit`), which carries it.
  */
 function stubFindReturning(rel: string) {
   fs.mkdirSync(stubBin, { recursive: true });


### PR DESCRIPTION
**TASK-692** — the standalone build ships the checkout's `.env` and `.git`.

## Symptom

Every build writes a byte copy of `$PROJECT_DIR/.env` — the 0600 file systemd hands
`clawbox-setup` as an `EnvironmentFile`, holding `GOOGLE_OAUTH_CLIENT_SECRET` and, where
`install.sh` was given one, `CLAWBOX_AI_API_KEY` — into `.next/standalone/`, together with
`.env.example` and a full copy of `.git`. A secrets-shaped file gets a second home inside a
build artifact that is re-made by every update, copied by `set_previous_build_aside`, and
included in anything that archives the build. `.git` also costs 88-103 MB of eMMC per build.

Measured read-only on both editions, 2026-09-05:

| | OpenClaw box | Hermes box |
|---|---|---|
| `.next/standalone/.env` | present, 0600, 2105 bytes | present, 0600, 2105 bytes |
| byte-identical to `$PROJECT_DIR/.env` | `cmp` says yes | `cmp` says yes |
| `.next/standalone/.git` | 88 MB | 103 MB |
| `EnvironmentFile=` on clawbox-setup | `/home/clawbox/clawbox/.env` | `/home/clawbox/clawbox/.env` |

(The Hermes box has since gone into a rebuild that has been running 2.5 h and currently has no
`.next/standalone` at all — noted for the driver, unrelated to this PR.)

## Harness first — the native mechanism, corrected

**An earlier version of this PR said `outputFileTracingExcludes` reaches neither file. That is
right for `.env` and wrong for `.git`, and the review caught it.** Read out of the installed
`next@16.3.3` in this checkout:

* `.env` and `.env.production` are **not traced at all**, so no config key can reach them.
  `writeStandaloneDirectory()` walks `loadedEnvFiles`, filters to exactly those two names and
  `copyFile()`s them *after* `copyTracedFiles` (`next/dist/build/index.js`). The sweep is the
  only thing that removes those — the native mechanism genuinely does not exist here.
* `.git` arrives on the **instrumentation** trace, and that trace **is** reachable.
  `next-trace-entrypoints-plugin.js` keys `entryNameFilesMap` by `entrypoint.name` for *every*
  server-compiler entrypoint, not only route entries, so `instrumentation` has an entry;
  `collect-build-traces.js` iterates that map and applies these globs to each `.nft.json`,
  skipping only static pages and `edgeRuntimeRoutes` — which is exactly why MIDDLEWARE keeps its
  `data/` entry (the observation already recorded in `next.config.ts`) while the server-compiler
  traces are cleaned. Checked with the vendored matcher:
  `picomatch("*", { dot: true, contains: true })("instrumentation")` is `true`, and `.git/**`
  matches `.git/objects/…`. `build/utils.js` copies the standalone tree *from* those lists.

So `".git/**"` is added to `outputFileTracingExcludes["*"]` — the harness's own switch, used.
**Not measured:** a real `next build` on a box with that line in place; that is device work.
The postbuild sweep therefore stays and still FAILS the build if a copy survives, which is the
post-condition the suites pin — the exclude is meant to make that sweep find nothing.

So the mechanism this repo already owns is the right one: the `postbuild` guard that F-27
(#592) built for `data/` and TASK-725 (#672) moved into `scripts/postbuild.sh`. This extends
it rather than adding a second thing.

## The fix

`scripts/postbuild.sh`, right after the `data/` block: sweep `.env`, `.env.*` and `.git` out
of the standalone tree and `fail` when one survives.

* **Depth-unbounded**, because that trace copies whole project subdirectories.
  `e2e-install/.env.test` is gitignored and its tracked `.example` documents seven provider
  keys; it lands at `.next/standalone/e2e-install/.env.test`, two levels down, where a
  top-level sweep would have shipped it and reported the build clean.
* **`node_modules` pruned** — packages ship their own `.env` fixtures, and failing a build
  over somebody else's test data would be a false failure.
* **`|| true` on the removal** so the named check reports it, rather than `errexit` killing
  the script on `rm` with nothing said — the shape the `data/` removal above already uses.
* **`-print -quit`, not `| head -n 1`** — under `pipefail` a `find` still writing when `head`
  exits dies of SIGPIPE and would end the build silently.

## Why removing them is safe

The standalone copy is byte-identical to the checkout file (`cmp`, both boxes); systemd loads
the checkout file into the service environment; and `@next/env`'s `processEnv` only fills keys
**absent** from its initial `process.env` snapshot, so the copy could never have overridden
systemd. Nothing in the repo reads `.next/standalone/.env` or `.next/standalone/.git`
(`build-identity.ts` pins `PROJECT_ROOT` to `CLAWBOX_ROOT` or the absolute default, never the
cwd).

One behaviour does go, deliberately: `playwright.config.ts`'s `webServer` runs
`node .next/standalone/server.js` with no systemd, and Next's runtime `loadEnvConfig(this.dir)`
used to pick a developer's checkout `.env` up through the copy. CI never had one (gitignored,
never created by `e2e-tests.yml`), so local runs now match CI. If a spec ever needs a variable,
pass it on the `webServer` command rather than restoring the copy.

## The blocker from the first merge gate, fixed

The `.env`/`.git` sweep added two unconditional `find` calls, and
`src/tests/unit/postbuild-standalone-entry.test.ts` — the OTHER test file for this same script,
already on beta — puts a stub `find` on `PATH` that ignores its arguments and answers every call
with a parked build's entry. Both new calls got that answer, `$LEFT` was non-empty, and the guard
failed the build: two deterministic failures, and the `test` check red.

RED on the previous head:

```
 FAIL  src/tests/unit/postbuild-standalone-entry.test.ts > stamps the entry next build wrote…
 FAIL  src/tests/unit/postbuild-standalone-entry.test.ts > takes the entry from the path Next recorded for it
AssertionError: postbuild: .next/standalone/.next-old/standalone/server.js survived removal …
 Test Files  1 failed (1)   Tests  2 failed | 5 passed (7)
```

The stub is now argument-aware: it answers only the call naming `server.js` — the ENTRY lookup it
exists to pin — and `exec`s the real `find` for everything else, because entry *selection* does
not need `find` and the sweep does. The negative proof it carries still bites: forcing the entry
lookup down the `find` branch (`if false` on both preceding conditions) makes both cases fail
again with `…/.next-old/standalone/server.js is not a standalone entry`.

```
 Test Files  5 passed (5)
      Tests  36 passed (36)     (both postbuild suites + the three shared guard suites)
tsc --noEmit  exit 0
```

## RED → GREEN

RED, on unmodified `origin/beta` (d428b044):

```
 ❯ src/tests/unit/postbuild-standalone-data.test.ts (9 tests | 4 failed)
   × removes every copy of the checkout's .env, wherever the trace put it
   × removes the copied .git
   × fails the build, naming the path, when the .env copy survives the removal (non-root uid only)
   × removes data/ and still links server.js in the nested standalone layout

AssertionError: expected true to be false
 ❯ src/tests/unit/postbuild-standalone-data.test.ts:174
    expect(fs.existsSync(path.join(standalone, ".env"))).toBe(false);
```

GREEN, with the fix, plus the neighbouring suites and the three beta guards
(`openclaw-config-mock-completeness`, `test-timeout-hygiene`, `state-updater-purity`):

```
 Test Files  6 passed (6)
      Tests  79 passed (79)
```

The cases run the real `scripts/postbuild.sh` against a temp tree, so they cannot drift from
what ships. One of them pins that a `node_modules` `.env` fixture SURVIVES, and the
failure-mode case asserts on the guard's own line — `rm` writes its own "Permission denied"
naming the same path onto the same stream, so an assertion on the path alone would pass with
the guard silent.

## Sibling call sites

Every build entry point goes through `bun run build`, which runs `postbuild`: `install.sh`
`step_build` and `do_rebuild`, `install-x64.sh`, `scripts/force-update.sh`,
`.github/workflows/build-identity.yml`, `playwright.config.ts`. There is no direct
`next build` caller in the repo. No reader of the standalone `.env`/`.git` exists.
`.dockerignore` already keeps `.env*` out of the e2e-install build context.

## Both editions

The guard is edition-blind — it runs in the one build step both SKUs use — and the defect was
measured on both boxes (table above).

## Review

**Second pass, on the head that fixed the first pass's blocker.** It found three things, all
applied here:

* The `.git` half of the harness-first claim was wrong (above) — the exclude is now used and the
  four comments that stated the opposite are corrected.
* The `find` stub added in the previous commit `exec`s whatever `command -v find` prints, and
  `command -v` prints a BARE NAME when `find` is a shell function — which makes the stub `exec`
  itself forever inside `spawnSync`, where the vitest timeout cannot interrupt it. Reproduced at
  108,894 invocations. `CAN_RUN` now requires an absolute path, so such a host skips the suite.
* The corrected `scripts/` comment had dropped `hermes-image-plugin.ts`, which is still a cwd
  reader on beta until #697 lands. Both readers are named again, with #697 noted.

Also from that pass: every `-name` pattern in the sweep is quoted (this script runs with the
project root as cwd, where `.env` and `.git` both exist), and the entry stub's docblock records
what its narrowing does not cover.

**First pass**, findings applied: the depth-unbounded sweep with the `node_modules`
prune, `|| true` on the removal, `-quit` instead of `| head -n 1`, the generic failure
message, the mis-aimed assertion in the failure-mode case, and folding the `next.config.ts`
note into the existing TASK-725 block instead of adding a second one. Its blocker — that
`origin/beta` had replaced the inline `postbuild` one-liner with `scripts/postbuild.sh` under
`set -euo pipefail` — is why this was re-authored from `origin/beta` rather than rebased
through a conflict.

Not done here: nothing narrows the instrumentation trace itself, which is what puts the whole
project root in there. `next.config.ts` records why (parts of the sweep are load-bearing) and
that is TASK-670's neighbourhood.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Reliability**
  * Standalone build artifacts now remove copied checkout environment files and `.git` directories, including deeply nested instances.
  * The postbuild process reports an error when sensitive files or directories cannot be removed.
  * Package dependencies remain intact during cleanup.

* **Documentation**
  * Documented environment-file handling and secret removal for standalone deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
