### PR TITLE
fix: 404 percent-encoded spellings of ClawBox namespaces, and guard the namespace list

### DIFF
--- a/src/app/[...gateway]/route.ts
+++ b/src/app/[...gateway]/route.ts
@@ -30,12 +30,20 @@ export async function GET(request: NextRequest) {
     // OpenClaw and a text one on Hermes — a shared surface answering two
     // shapes by edition.
     //
+    // A path in NOBODY's namespace is refused here too, and that is the one
+    // case this paragraph does not describe on its own: `"unreadable"` means
+    // the percent-decode ran out of passes before it settled, so the box
+    // cannot say whose the path is and does not hand it to the gateway on a
+    // guess. Deny-only, so the cost is a 404 on a spelling no client produces.
+    //
     // The list and the segment-boundary matching live in
     // src/lib/clawbox-namespaces.ts, beside the evidence.
     const owned = clawboxNamespaceKind(request.nextUrl.pathname);
     if (owned) {
       // Code asked, so code is answered: the endpoint namespaces get the same
-      // `{ error: "Not found" }` shape the real routes under them use.
+      // `{ error: "Not found" }` shape the real routes under them use. An
+      // `"unreadable"` path answers as text, because nothing here knows it was
+      // code that asked — that is precisely what could not be decoded.
       return owned === "api"
         ? NextResponse.json({ error: "Not found" }, { status: 404 })
         : new NextResponse("Not found", {

--- a/src/lib/clawbox-namespaces.ts
+++ b/src/lib/clawbox-namespaces.ts
@@ -39,20 +39,74 @@
  * its caller is code: it gets JSON, like every real route under them and like
  * the middleware's own 401 for the same prefix.
  */
-const CLAWBOX_API_ROOTS = ["/setup-api", "/login-api"] as const;
+export const CLAWBOX_API_ROOTS = ["/setup-api", "/login-api"] as const;
 
 /**
  * ClawBox's page namespaces. `/app` is one of them: `src/app/app/[id]/page.tsx`
  * matches ONE segment and there is no page at the root, so both `/app` and
  * `/app/x/y` reached the catch-all (measured: 200 Control UI, token injected).
  *
- * `/api`, `/assets` and the gateway's static trees are absent for the opposite
- * reason — they are the GATEWAY's, and serving them is what the catch-all is
- * for. Checked against the pinned Control UI's own bundle rather than assumed:
- * `dist/control-ui/assets/*.js` carries route literals for `/chat`,
- * `/sessions` and `/logs`, and none for any root below.
+ * `/apps` is deliberately NOT here — see `UNCLAIMED_ROOTS`, which is where the
+ * evidence for that lives. `clawbox-namespace-coverage.test.ts` reads `src/app/`
+ * and fails when a top-level route directory is in neither list, so a namespace
+ * added later cannot be missed the way `/app` was.
  */
-const CLAWBOX_PAGE_ROOTS = ["/setup", "/login", "/portal", "/updating", "/app"] as const;
+export const CLAWBOX_PAGE_ROOTS = [
+  "/setup",
+  "/login",
+  "/portal",
+  "/updating",
+  "/app",
+] as const;
+
+/**
+ * Top-level route directories this module deliberately does NOT claim, so the
+ * coverage guard can tell "decided against" from "never noticed". An unmatched
+ * path under one of these keeps reaching the catch-all, which is the point.
+ *
+ * `/api` is the GATEWAY's own API surface — ClawBox's routes live under
+ * `/setup-api` precisely so this prefix stays the gateway's
+ * (src/app/api/[...path]/route.ts says so in as many words). `/assets` is the
+ * Control UI's static tree (src/lib/gateway-static.ts). The two favicons are
+ * the gateway's too: `public/` has no copy, their handlers proxy, and
+ * `src/middleware.ts` lists them in `GATEWAY_ONLY_EXACT`.
+ *
+ * `/apps` IS ClawBox's below the root and the GATEWAY'S at it, which is why
+ * claiming it would be wrong in both directions:
+ *
+ *   - Below it, `src/app/apps/[id]/[[...path]]/route.ts` is an OPTIONAL
+ *     catch-all, so `/apps/<id>` AND `/apps/<id>/…` are matched by a real
+ *     route. Nothing under `/apps/` ever reaches the catch-all, so an entry
+ *     here could never fire on a real path.
+ *   - At the root, `/apps` is a Control UI PAGE. Claiming it would 404 a
+ *     gateway page that works today.
+ *
+ * That second half is measured, not assumed, and the check is written down
+ * because the previous one was not reproducible: the bundle spells its route
+ * paths as backtick template literals, so a grep for double-quoted `"/apps"`
+ * finds nothing — and finds nothing for `/chat` either, which is how a grep
+ * that could not see its own positives got read as proof of a negative. Run in
+ * `/usr/lib/node_modules/openclaw/dist/control-ui/assets` at the pinned
+ * OPENCLAW_VERSION (2026.8.1, install.sh):
+ *
+ *     grep -ohE '\bpath:`/[^`]{0,50}`' *.js | sed 's/path://; s/`//g' | sort -u
+ *
+ * That is 55 routes. `/apps` is among them (and `apps-page-*.js/.css` ship with
+ * it); `/setup`, `/login`, `/portal`, `/updating`, `/app`, `/setup-api` and
+ * `/login-api` are all absent, so every root claimed above is genuinely free.
+ *
+ * SIBLINGS: adding a gateway-owned root here is not the whole job —
+ * `GATEWAY_ONLY_EXACT` / `GATEWAY_ONLY_PREFIXES` in src/middleware.ts decide
+ * the Hermes 404 gate for the same paths, and src/lib/gateway-static.ts decides
+ * which are served as bytes. Nothing cross-checks the three lists yet.
+ */
+export const UNCLAIMED_ROOTS = [
+  "/api",
+  "/assets",
+  "/favicon.svg",
+  "/favicon-32.png",
+  "/apps",
+] as const;
 
 /**
  * `/a` matches `/a` and `/a/b`, never `/ab`.
@@ -72,6 +126,49 @@ export function isSetupApiPath(pathname: string): boolean {
 }
 
 /**
+ * Percent-decoding, repeated until it stops changing, for the OWNERSHIP question
+ * only.
+ *
+ * Deny-only, which is what makes it safe. This module's decoded answer is read
+ * by exactly one caller — `src/app/[...gateway]/route.ts` — and the only thing
+ * it can produce is a 404. Claiming one path too many costs a 404 on a path
+ * that would otherwise have been answered with the Control UI shell and an
+ * injected gateway credential; that is the strictly safer error. `isUnderRoot`
+ * and `isSetupApiPath` stay literal on purpose: those feed the middleware's
+ * ALLOW gates, and decoding there would widen an auth decision.
+ *
+ * To a fixpoint because one pass is not enough: `/setup%252Fnope` decodes to
+ * `/setup%2Fnope`, which is still an encoded separator. Each pass strictly
+ * shortens the string or returns at the `next === current` fixpoint, so the
+ * loop terminates with or without the cap.
+ *
+ * The cap is NOT free, and the deny-only argument above is what pays for it:
+ * past four nestings the loop gives up with `%` still in the string and the
+ * path stays the gateway's — as it does for any path carrying one malformed
+ * escape, since `decodeURIComponent` is all-or-nothing. The decoded match is
+ * therefore BEST-EFFORT hardening and must never be leaned on as a boundary;
+ * missing one costs exactly the answer beta gives today.
+ *
+ * A malformed escape (`/%zz`) makes `decodeURIComponent` throw. That returns
+ * whatever was decoded so far, so the caller falls back to the literal spelling
+ * and today's answer, rather than the request failing.
+ */
+function decodePercentEncoding(pathname: string): string {
+  let current = pathname;
+  for (let pass = 0; pass < 4 && current.includes("%"); pass++) {
+    let next: string;
+    try {
+      next = decodeURIComponent(current);
+    } catch {
+      return current;
+    }
+    if (next === current) return current;
+    current = next;
+  }
+  return current;
+}
+
+/**
  * Which ClawBox namespace owns this path, or null when it is the gateway's.
  *
  * `"api"` and `"page"` differ only in what an unmatched path should answer
@@ -85,8 +182,20 @@ export function clawboxNamespaceKind(pathname: string): "api" | "page" | null {
   // `serveGatewayHTML` still carries a comment about. Ownership is not a
   // question of spelling; the middleware's own gates, which get a pathname that
   // is already lower-cased, keep the exact comparison.
-  const lower = pathname.toLowerCase();
-  if (CLAWBOX_API_ROOTS.some((root) => isUnderRoot(lower, root))) return "api";
-  if (CLAWBOX_PAGE_ROOTS.some((root) => isUnderRoot(lower, root))) return "page";
+  //
+  // The DECODED spelling too. Measured anonymously on an OpenClaw box at beta
+  // `dd058938`: `GET /setup-api/nope` answers 401 application/json from the
+  // middleware's own `/setup-api` gate, and `GET /setup-api%2Fnope` answers 307
+  // to /login — the gate missed it, so the platform does not decode `%2F` and
+  // the encoded spelling stays one segment, matches no route and lands here.
+  // For an owner session that was the shell with the gateway token in it.
+  const spellings = new Set([
+    pathname.toLowerCase(),
+    decodePercentEncoding(pathname).toLowerCase(),
+  ]);
+  for (const candidate of spellings) {
+    if (CLAWBOX_API_ROOTS.some((root) => isUnderRoot(candidate, root))) return "api";
+    if (CLAWBOX_PAGE_ROOTS.some((root) => isUnderRoot(candidate, root))) return "page";
+  }
   return null;
 }

--- a/src/lib/clawbox-namespaces.ts
+++ b/src/lib/clawbox-namespaces.ts
@@ -86,8 +86,11 @@ export const CLAWBOX_PAGE_ROOTS = [
  * paths as backtick template literals, so a grep for double-quoted `"/apps"`
  * finds nothing — and finds nothing for `/chat` either, which is how a grep
  * that could not see its own positives got read as proof of a negative. Run in
- * `/usr/lib/node_modules/openclaw/dist/control-ui/assets` at the pinned
- * OPENCLAW_VERSION (2026.8.1, install.sh):
+ * the pinned OPENCLAW_VERSION's bundle (2026.8.1, install.sh) — on a box that
+ * is `/home/clawbox/.npm-global/lib/node_modules/openclaw/dist/control-ui/assets`,
+ * NOT the `npm root -g` of `/usr/lib/node_modules`, which is where this said to
+ * look and where openclaw is not installed (and `openclaw` is not on the
+ * `clawbox` user's PATH either, so `dirname $(which openclaw)` does not find it):
  *
  *     grep -ohE '\bpath:`/[^`]{0,50}`' *.js | sed 's/path://; s/`//g' | sort -u
  *

--- a/src/lib/clawbox-namespaces.ts
+++ b/src/lib/clawbox-namespaces.ts
@@ -139,33 +139,50 @@ export function isSetupApiPath(pathname: string): boolean {
  *
  * To a fixpoint because one pass is not enough: `/setup%252Fnope` decodes to
  * `/setup%2Fnope`, which is still an encoded separator. Each pass strictly
- * shortens the string or returns at the `next === current` fixpoint, so the
- * loop terminates with or without the cap.
+ * shortens the string (a `%XX` triple becomes one code unit) or returns at the
+ * `next === current` fixpoint, so the loop terminates with or without the cap.
  *
- * The cap is NOT free, and the deny-only argument above is what pays for it:
- * past four nestings the loop gives up with `%` still in the string and the
- * path stays the gateway's — as it does for any path carrying one malformed
- * escape, since `decodeURIComponent` is all-or-nothing. The decoded match is
- * therefore BEST-EFFORT hardening and must never be leaned on as a boundary;
- * missing one costs exactly the answer beta gives today.
+ * The cap is a RUNAWAY GUARD, not a policy, and it fails CLOSED: a path still
+ * carrying `%` when the passes run out is one this box cannot read, so it is
+ * claimed rather than handed to the gateway. A cap that gave up and allowed
+ * made the function non-idempotent under its own decode — it denied
+ * `/portal%2Fnope` and permitted `/portal%252525252Fnope`, which is four
+ * passes away from it, so "append two more `25`s" walked around the check this
+ * module exists to make. Failing closed is what makes the depth uninteresting:
+ * the cost of guessing wrong is a 404 on a path nobody can spell on purpose.
  *
- * A malformed escape (`/%zz`) makes `decodeURIComponent` throw. That returns
- * whatever was decoded so far, so the caller falls back to the literal spelling
- * and today's answer, rather than the request failing.
+ * A malformed escape (`/%zz`) is the OTHER outcome and keeps today's answer.
+ * `decodeURIComponent` is all-or-nothing, so it throws, and that is a settled
+ * fact about the path rather than a budget running out: the caller falls back
+ * to the literal spelling and `/assets/a%zz.js` stays the gateway's, rather
+ * than a real asset 404ing over one stray `%`.
  */
-function decodePercentEncoding(pathname: string): string {
+const MAX_DECODE_PASSES = 32;
+
+type DecodedPath = {
+  /** The path as far as it could be decoded. */
+  spelling: string;
+  /**
+   * The passes ran out with `%` still in the string — this box does not know
+   * what the path says. Never set for a malformed escape, which has an answer.
+   */
+  undecodable: boolean;
+};
+
+function decodePercentEncoding(pathname: string): DecodedPath {
   let current = pathname;
-  for (let pass = 0; pass < 4 && current.includes("%"); pass++) {
+  for (let pass = 0; pass < MAX_DECODE_PASSES; pass++) {
+    if (!current.includes("%")) return { spelling: current, undecodable: false };
     let next: string;
     try {
       next = decodeURIComponent(current);
     } catch {
-      return current;
+      return { spelling: current, undecodable: false };
     }
-    if (next === current) return current;
+    if (next === current) return { spelling: current, undecodable: false };
     current = next;
   }
-  return current;
+  return { spelling: current, undecodable: current.includes("%") };
 }
 
 /**
@@ -189,13 +206,19 @@ export function clawboxNamespaceKind(pathname: string): "api" | "page" | null {
   // to /login — the gate missed it, so the platform does not decode `%2F` and
   // the encoded spelling stays one segment, matches no route and lands here.
   // For an owner session that was the shell with the gateway token in it.
+  const decoded = decodePercentEncoding(pathname);
   const spellings = new Set([
     pathname.toLowerCase(),
-    decodePercentEncoding(pathname).toLowerCase(),
+    decoded.spelling.toLowerCase(),
   ]);
   for (const candidate of spellings) {
     if (CLAWBOX_API_ROOTS.some((root) => isUnderRoot(candidate, root))) return "api";
     if (CLAWBOX_PAGE_ROOTS.some((root) => isUnderRoot(candidate, root))) return "page";
   }
+  // Neither spelling is the path's LAST word — the decode gave up with `%`
+  // still in it — so "this is the gateway's" is not something this box knows.
+  // Claimed, as a plain 404: the deny-only argument above is what makes that
+  // the safe guess, and no client can spell a path this deep by accident.
+  if (decoded.undecodable) return "page";
   return null;
 }

--- a/src/lib/clawbox-namespaces.ts
+++ b/src/lib/clawbox-namespaces.ts
@@ -141,24 +141,37 @@ export function isSetupApiPath(pathname: string): boolean {
  * ALLOW gates, and decoding there would widen an auth decision.
  *
  * To a fixpoint because one pass is not enough: `/setup%252Fnope` decodes to
- * `/setup%2Fnope`, which is still an encoded separator. Each pass strictly
- * shortens the string (a `%XX` triple becomes one code unit) or returns at the
- * `next === current` fixpoint, so the loop terminates with or without the cap.
+ * `/setup%2Fnope`, which is still an encoded separator. Each pass that changes
+ * anything strictly SHORTENS the string — an escape sequence is at least three
+ * characters in and at most two UTF-16 code units out (`%F0%9F%98%80` is 12
+ * characters and one emoji) — so the loop reaches a fixpoint on its own.
  *
- * The cap is a RUNAWAY GUARD, not a policy, and it fails CLOSED: a path still
- * carrying `%` when the passes run out is one this box cannot read, so it is
- * claimed rather than handed to the gateway. A cap that gave up and allowed
- * made the function non-idempotent under its own decode — it denied
- * `/portal%2Fnope` and permitted `/portal%252525252Fnope`, which is four
- * passes away from it, so "append two more `25`s" walked around the check this
- * module exists to make. Failing closed is what makes the depth uninteresting:
- * the cost of guessing wrong is a 404 on a path nobody can spell on purpose.
+ * PER ESCAPE RUN, not all-or-nothing, and that is the difference between
+ * denying a spelling and denying a family. `decodeURIComponent` over the whole
+ * path throws on the first malformed escape and yields nothing, so
+ * `/portal%2Fnope` was denied while `/portal%2Fnope%zz` — the same path with a
+ * junk suffix — decoded to nothing, matched nothing and was handed to the
+ * gateway. Appending `%zz` was a cheaper walk-around than the nested-encoding
+ * one this module was written to close. Decoding each maximal run of
+ * well-formed escapes and leaving the rest alone closes both.
  *
- * A malformed escape (`/%zz`) is the OTHER outcome and keeps today's answer.
- * `decodeURIComponent` is all-or-nothing, so it throws, and that is a settled
- * fact about the path rather than a budget running out: the caller falls back
- * to the literal spelling and `/assets/a%zz.js` stays the gateway's, rather
- * than a real asset 404ing over one stray `%`.
+ * Nothing is lost by it: over the 55 Control UI routes and the gateway's
+ * static paths, in every encoding either decoder was measured on, both claim
+ * NOTHING — `/assets/a%zz.js` and `/assets/100%25.png` stay the gateway's
+ * under this one exactly as they did under the old one.
+ *
+ * The cap bounds the work AND, when it fires, chooses the answer — so it is
+ * not only a runaway guard, and the two must not be read apart. It fails
+ * CLOSED: a path the passes ran out on is one this box cannot read to the end,
+ * so it is claimed rather than handed to the gateway. A cap that gave up and
+ * ALLOWED made the function non-idempotent under its own decode — it denied
+ * `/portal%2Fnope` and permitted `/portal%252525252Fnope`, four passes away
+ * from it. Note what the number therefore decides: at more than
+ * MAX_DECODE_PASSES nestings EVERY path is 404'd, the gateway's included, so
+ * lowering it is a behaviour change and `gateway.test.ts` pins both sides.
+ * 33 nestings is a 73-character URL — short, but unreachable by accident,
+ * because only a NESTED escape consumes a pass: `"%25".repeat(50)` is 50
+ * sequential escapes and costs two.
  */
 const MAX_DECODE_PASSES = 32;
 
@@ -166,26 +179,44 @@ type DecodedPath = {
   /** The path as far as it could be decoded. */
   spelling: string;
   /**
-   * The passes ran out with `%` still in the string — this box does not know
-   * what the path says. Never set for a malformed escape, which has an answer.
+   * The passes ran out before the fixpoint — this box does not know what the
+   * path says. Never set for a path that simply CONTAINS a `%` it cannot
+   * decode: that is a settled answer, not a budget running out.
    */
   undecodable: boolean;
 };
 
+/**
+ * One pass: every maximal run of well-formed `%XX` escapes decoded, everything
+ * else left exactly as it was.
+ *
+ * A RUN rather than one escape at a time, because a non-ASCII character is
+ * several escapes together (`%E2%82%AC` is one euro sign) and decoding them
+ * singly would produce mojibake instead of the character the client sent. A run
+ * that is well-formed percent-encoding but not valid UTF-8 makes
+ * `decodeURIComponent` throw, and that run is then left alone too.
+ */
+function decodeEscapeRuns(pathname: string): string {
+  return pathname.replace(/(?:%[0-9A-Fa-f]{2})+/g, (run) => {
+    try {
+      return decodeURIComponent(run);
+    } catch {
+      return run;
+    }
+  });
+}
+
 function decodePercentEncoding(pathname: string): DecodedPath {
   let current = pathname;
   for (let pass = 0; pass < MAX_DECODE_PASSES; pass++) {
-    if (!current.includes("%")) return { spelling: current, undecodable: false };
-    let next: string;
-    try {
-      next = decodeURIComponent(current);
-    } catch {
-      return { spelling: current, undecodable: false };
-    }
+    const next = decodeEscapeRuns(current);
     if (next === current) return { spelling: current, undecodable: false };
     current = next;
   }
-  return { spelling: current, undecodable: current.includes("%") };
+  // "Would one more pass still change it?" — the honest test for a budget that
+  // ran out, and not "does it still contain `%`", which is also true of the
+  // settled `/assets/a%zz.js`.
+  return { spelling: current, undecodable: decodeEscapeRuns(current) !== current };
 }
 
 /**
@@ -193,8 +224,16 @@ function decodePercentEncoding(pathname: string): DecodedPath {
  *
  * `"api"` and `"page"` differ only in what an unmatched path should answer
  * WITH — the ownership question has one answer for both.
+ *
+ * `"unreadable"` is not a namespace and deliberately not spelled as one: it is
+ * "this box could not decode the path to the end, so it is refused rather than
+ * handed on". The caller answers it like a page, but that is the CALLER's
+ * decision to make with the fact in front of it — folding it into `"page"`
+ * would tell a second reader that a path nobody could read is a ClawBox page.
  */
-export function clawboxNamespaceKind(pathname: string): "api" | "page" | null {
+export function clawboxNamespaceKind(
+  pathname: string,
+): "api" | "page" | "unreadable" | null {
   // Lower-cased HERE and not in `isUnderRoot`: Next's router is case-sensitive,
   // so `/Setup-Api/nope` and `/Portal/nope` matched no ClawBox route and were
   // answered with the shell and the token (measured on a box). This is the same
@@ -218,10 +257,10 @@ export function clawboxNamespaceKind(pathname: string): "api" | "page" | null {
     if (CLAWBOX_API_ROOTS.some((root) => isUnderRoot(candidate, root))) return "api";
     if (CLAWBOX_PAGE_ROOTS.some((root) => isUnderRoot(candidate, root))) return "page";
   }
-  // Neither spelling is the path's LAST word — the decode gave up with `%`
-  // still in it — so "this is the gateway's" is not something this box knows.
-  // Claimed, as a plain 404: the deny-only argument above is what makes that
-  // the safe guess, and no client can spell a path this deep by accident.
-  if (decoded.undecodable) return "page";
+  // Neither spelling is the path's LAST word — the passes ran out before the
+  // fixpoint — so "this is the gateway's" is not something this box knows.
+  // Refused rather than guessed: the deny-only argument above is what makes
+  // that the safe answer, and no client can spell a path this deep by accident.
+  if (decoded.undecodable) return "unreadable";
   return null;
 }

--- a/src/tests/routes/gateway.test.ts
+++ b/src/tests/routes/gateway.test.ts
@@ -228,6 +228,13 @@ describe("GET /[...gateway] (catch-all route)", () => {
     // decode and two more `25`s walked around it.
     ["http://localhost/portal%252525252Fnope", "page"],
     ["http://localhost/setup-api%252525252Fnope", "api"],
+    // A junk escape appended to a spelling that IS denied. All-or-nothing
+    // decoding threw on the `%zz`, yielded nothing, matched nothing and handed
+    // these to the gateway — a cheaper walk-around than the nesting above it.
+    // Decoding per escape RUN leaves the `%zz` alone and still reads the `%2F`.
+    ["http://localhost/portal%2Fnope%zz", "page"],
+    ["http://localhost/setup-api%2Fnope%zz", "api"],
+    ["http://localhost/setup%252Fnope%25zz", "page"],
   ];
 
   it.each(CLAWBOX_OWNED_UNMATCHED)(
@@ -256,18 +263,20 @@ describe("GET /[...gateway] (catch-all route)", () => {
     },
   );
 
-  it.each([
-    ["a claimed root", "/portal"],
-    ["a root the gateway would otherwise own", "/nope"],
-  ])(
-    "answers 404 for a path nested past the decode cap (%s)",
-    async (_what, root) => {
-      // Past the cap the box cannot read the path AT ALL, and an unreadable
-      // path is not handed to the gateway either — the give-up fails CLOSED,
-      // which is what stops "append two more `25`s" from being a bypass
-      // whatever the cap is set to. Deep enough that no value of
-      // MAX_DECODE_PASSES worth having could reach the end of it.
-      const separator = `%${"25".repeat(199)}2F`;
+  it("answers 404 for a path nested past the decode cap, whoever's root it is", async () => {
+    // Past the cap the box cannot read the path AT ALL, and an unreadable path
+    // is not handed to the gateway either — the give-up fails CLOSED, which is
+    // what stops "append two more `25`s" from being a bypass whatever the cap
+    // is set to. Deep enough that no value of MAX_DECODE_PASSES worth having
+    // could reach the end of it.
+    //
+    // `/nope` is here to say what the branch really does: at this depth the
+    // LITERAL spelling is under nobody's root, so this case does not reach the
+    // claimed-root path at all and the 404 comes from the give-up alone. It is
+    // one branch, deliberately shown from the side where nothing else could
+    // produce the answer.
+    const separator = `%${"25".repeat(199)}2F`;
+    for (const root of ["/portal", "/nope"]) {
       mockGetAll.mockResolvedValue({ setup_complete: true });
 
       const res = await gatewayGet(
@@ -277,11 +286,11 @@ describe("GET /[...gateway] (catch-all route)", () => {
         }),
       );
 
-      expect(res.status).toBe(404);
-      expect(mockServeGatewayHTML).not.toHaveBeenCalled();
-      expect(mockProxyGatewayRequest).not.toHaveBeenCalled();
-    },
-  );
+      expect(res.status, root).toBe(404);
+      expect(mockServeGatewayHTML, root).not.toHaveBeenCalled();
+      expect(mockProxyGatewayRequest, root).not.toHaveBeenCalled();
+    }
+  });
 
   it("still serves the shell for the gateway's OWN namespaces", async () => {
     // The other half of the boundary: a prefix test that swallowed /api or
@@ -322,6 +331,11 @@ describe("GET /[...gateway] (catch-all route)", () => {
     // that DOES fail closed keys on the pass count and never on "contains
     // `%`": a gateway path carrying one stray `%` must go on being answered.
     "http://localhost/setup-api%zz",
+    // The OTHER side of MAX_DECODE_PASSES. Without this the cap could be
+    // lowered to 4 "for performance" and every gateway path with five
+    // nestings would start 404ing with the whole suite still green — failing
+    // closed harder never trips a claimed-side assertion.
+    "http://localhost/chat%252525252Fnope",
   ])("leaves %s with the gateway, decoded or not", async (url) => {
     mockGetAll.mockResolvedValue({ setup_complete: true });
 

--- a/src/tests/routes/gateway.test.ts
+++ b/src/tests/routes/gateway.test.ts
@@ -206,6 +206,21 @@ describe("GET /[...gateway] (catch-all route)", () => {
     ["http://localhost/updating/nope", "page"],
     ["http://localhost/app", "page"],
     ["http://localhost/app/x/y", "page"],
+    // Percent-encoded separators. Measured anonymously on BOTH boxes:
+    // `GET /setup-api/nope` answers 401 application/json from the middleware's
+    // own /setup-api gate and `GET /setup-api%2Fnope` answers 307 to /login,
+    // so that gate did not recognise it — the platform does not decode `%2F`.
+    // These stay one segment, match no route, and reached the catch-all, which
+    // answered a navigation with the shell and the injected gateway token.
+    ["http://localhost/setup-api%2Fnope", "api"],
+    ["http://localhost/setup-api%2fnope", "api"],
+    ["http://localhost/Setup-Api%2Fnope", "api"],
+    ["http://localhost/login-api%2Fnope", "api"],
+    ["http://localhost/portal%2Fnope", "page"],
+    ["http://localhost/app%2fx", "page"],
+    // Double-encoded: one decode leaves `%2F` behind, so the match has to go
+    // to a fixpoint.
+    ["http://localhost/setup%252Fnope", "page"],
   ];
 
   it.each(CLAWBOX_OWNED_UNMATCHED)(
@@ -242,6 +257,34 @@ describe("GET /[...gateway] (catch-all route)", () => {
     await gatewayGet(
       createRequest("http://localhost/chat/main", { "sec-fetch-mode": "navigate" }),
     );
+
+    expect(mockServeGatewayHTML).toHaveBeenCalled();
+  });
+
+  /**
+   * The other side of the probe, recorded because each of these is a RESULT
+   * and not an oversight: nothing here belongs to ClawBox, decoded or not, so
+   * the catch-all must go on serving it.
+   */
+  it.each([
+    // `/apps` is the Control UI's OWN page — the pinned 2026.8.1 bundle
+    // registers `apps:{path:`/apps`}` and ships apps-page-*.js/.css — so the
+    // shell is the RIGHT answer here and a 404 would break a working page.
+    // Everything BELOW it is ClawBox's and is matched by a real route
+    // (`[[...path]]` is an optional catch-all), so it never arrives here.
+    "http://localhost/apps",
+    "http://localhost/apps/",
+    "http://localhost/apps%2Fzzz",
+    // `%2e%2e` decodes to `..` inside the SAME segment: `/apps%2e%2e` is
+    // `/apps..`, no more ClawBox's than `/appsomething`. A real `/apps/..` is
+    // normalised to `/` by the platform before anything here sees it.
+    "http://localhost/setup%2e%2e",
+    "http://localhost/setup%2E%2E",
+    "http://localhost/setupsomething%2Fx",
+  ])("leaves %s with the gateway, decoded or not", async (url) => {
+    mockGetAll.mockResolvedValue({ setup_complete: true });
+
+    await gatewayGet(createRequest(url, { "sec-fetch-mode": "navigate" }));
 
     expect(mockServeGatewayHTML).toHaveBeenCalled();
   });

--- a/src/tests/routes/gateway.test.ts
+++ b/src/tests/routes/gateway.test.ts
@@ -221,6 +221,13 @@ describe("GET /[...gateway] (catch-all route)", () => {
     // Double-encoded: one decode leaves `%2F` behind, so the match has to go
     // to a fixpoint.
     ["http://localhost/setup%252Fnope", "page"],
+    // FIVE nestings, the exact spellings the review raised. A four-pass cap
+    // that gave up with `%` still in the string handed these to the gateway:
+    // `/portal%252525252Fnope` is four passes from `/portal%2Fnope`, which is
+    // denied one nesting down — so the check was not idempotent under its own
+    // decode and two more `25`s walked around it.
+    ["http://localhost/portal%252525252Fnope", "page"],
+    ["http://localhost/setup-api%252525252Fnope", "api"],
   ];
 
   it.each(CLAWBOX_OWNED_UNMATCHED)(
@@ -246,6 +253,33 @@ describe("GET /[...gateway] (catch-all route)", () => {
         expect(res.headers.get("content-type")).toContain("text/plain");
         await expect(res.text()).resolves.toBe("Not found");
       }
+    },
+  );
+
+  it.each([
+    ["a claimed root", "/portal"],
+    ["a root the gateway would otherwise own", "/nope"],
+  ])(
+    "answers 404 for a path nested past the decode cap (%s)",
+    async (_what, root) => {
+      // Past the cap the box cannot read the path AT ALL, and an unreadable
+      // path is not handed to the gateway either — the give-up fails CLOSED,
+      // which is what stops "append two more `25`s" from being a bypass
+      // whatever the cap is set to. Deep enough that no value of
+      // MAX_DECODE_PASSES worth having could reach the end of it.
+      const separator = `%${"25".repeat(199)}2F`;
+      mockGetAll.mockResolvedValue({ setup_complete: true });
+
+      const res = await gatewayGet(
+        createRequest(`http://localhost${root}${separator}nope`, {
+          "sec-fetch-mode": "navigate",
+          accept: "text/html",
+        }),
+      );
+
+      expect(res.status).toBe(404);
+      expect(mockServeGatewayHTML).not.toHaveBeenCalled();
+      expect(mockProxyGatewayRequest).not.toHaveBeenCalled();
     },
   );
 
@@ -281,6 +315,13 @@ describe("GET /[...gateway] (catch-all route)", () => {
     "http://localhost/setup%2e%2e",
     "http://localhost/setup%2E%2E",
     "http://localhost/setupsomething%2Fx",
+    // A MALFORMED escape is a settled fact about the path, not a decode budget
+    // running out: `decodeURIComponent` is all-or-nothing, so the literal
+    // spelling stands and `/setup-api%zz` is one segment of that name — as
+    // little ClawBox's as `/setupsomething`. This is why the give-up branch
+    // that DOES fail closed keys on the pass count and never on "contains
+    // `%`": a gateway path carrying one stray `%` must go on being answered.
+    "http://localhost/setup-api%zz",
   ])("leaves %s with the gateway, decoded or not", async (url) => {
     mockGetAll.mockResolvedValue({ setup_complete: true });
 

--- a/src/tests/unit/clawbox-namespace-coverage.test.ts
+++ b/src/tests/unit/clawbox-namespace-coverage.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  CLAWBOX_API_ROOTS,
+  CLAWBOX_PAGE_ROOTS,
+  UNCLAIMED_ROOTS,
+} from "@/lib/clawbox-namespaces";
+
+/**
+ * The guard that keeps src/lib/clawbox-namespaces.ts honest as the route tree
+ * grows.
+ *
+ * WHY IT EXISTS. That module answers "is this top-level path ClawBox's or the
+ * gateway's", and the catch-all serves a NAVIGATION it does not claim with the
+ * Control UI shell — into which `serveGatewayHTML` injects the gateway auth
+ * token for an owner session. A namespace missing from the list is therefore
+ * not a cosmetic gap: an unmatched path under it is answered with somebody
+ * else's application and a credential in it.
+ *
+ * `/app` was missed exactly this way (#675 review H-1,
+ * `src/app/app/[id]/page.tsx`): a dynamic `[id]` segment is REQUIRED, so the
+ * namespace root itself matches no route and falls through to the catch-all,
+ * and the list had been written by reading `src/app/` once while `src/app/`
+ * kept growing.
+ *
+ * So the list stops being derived by hand. `src/app/` IS the route table —
+ * that is Next's file-system routing convention, and it is the only
+ * enumeration of top-level segments that cannot drift from the router. This
+ * test reads it and fails when a directory is in neither the ClawBox lists nor
+ * `UNCLAIMED_ROOTS`, which turns "nobody noticed" into a failing build and
+ * forces a decision. Being forced to make that decision is what established
+ * that `/apps` must NOT be claimed and that the two favicon directories are
+ * the gateway's — neither was in any list before.
+ *
+ * It is a TEST rather than a runtime lookup for two reasons, and NOT because
+ * middleware cannot read a file (it declares `runtime: "nodejs"` and reads
+ * `data/config.json` on every request): `output: "standalone"` does not ship
+ * `src/` to the box, and Next's own route manifest
+ * (`.next/app-path-routes-manifest.json`) exists only after a production
+ * build, which a unit run has not done.
+ */
+
+const REPO = path.resolve(__dirname, "../../..");
+const APP_DIR = path.join(REPO, "src", "app");
+
+/**
+ * Directories in `src/app/` that never become a URL segment of their own:
+ *
+ *   `[...]` / `[[...]]`  dynamic and catch-all segments — `[...gateway]` IS the
+ *                        fall-through this whole module exists to fence off
+ *   `_...`               Next's private folders, never routed
+ */
+function isRouted(name: string): boolean {
+  return !/^[[_]/.test(name);
+}
+
+/**
+ * Next STRIPS a route group `(x)` and a parallel slot `@y` from the URL, so
+ * `src/app/(desktop)/studio/page.tsx` serves `/studio` — the child is the
+ * top-level segment, not the wrapper. Skipping these directories rather than
+ * descending through them would leave the guard blind to exactly the namespace
+ * it exists to catch: `src/app/page.tsx` is large enough that splitting the
+ * desktop into `src/app/(desktop)/…` is the obvious next move, and a namespace
+ * added under it would reach the catch-all with the guard still green.
+ */
+function isTransparentWrapper(name: string): boolean {
+  return /^[(@]/.test(name);
+}
+
+/** Every literal top-level URL segment, seen through Next's routing rules. */
+function topLevelRouteSegments(dir: string = APP_DIR): string[] {
+  const segments = fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && isRouted(entry.name))
+    .flatMap((entry) =>
+      isTransparentWrapper(entry.name)
+        ? topLevelRouteSegments(path.join(dir, entry.name))
+        : [entry.name],
+    );
+
+  return [...new Set(segments)].sort();
+}
+
+const CLAWBOX_ROOTS: readonly string[] = [...CLAWBOX_API_ROOTS, ...CLAWBOX_PAGE_ROOTS];
+const ALL_ROOTS: readonly string[] = [...CLAWBOX_ROOTS, ...UNCLAIMED_ROOTS];
+
+describe("clawbox-namespaces covers the app router's top-level route tree", () => {
+  it("classifies every top-level route directory as ClawBox's or the gateway's", () => {
+    const unclassified = topLevelRouteSegments().filter(
+      (segment) => !ALL_ROOTS.includes(`/${segment}`),
+    );
+
+    // The message carries the fix, because whoever trips this is adding a
+    // feature and not reading this file: an unmatched path under a new
+    // ClawBox namespace is answered with the gateway shell and the injected
+    // token until its root is listed.
+    expect(
+      unclassified,
+      `src/app/${unclassified.join(", src/app/")} is a top-level route directory that `
+        + "src/lib/clawbox-namespaces.ts does not classify. Add its root to "
+        + "CLAWBOX_API_ROOTS or CLAWBOX_PAGE_ROOTS if it is ClawBox's, or to "
+        + "UNCLAIMED_ROOTS if the catch-all should keep serving it.",
+    ).toEqual([]);
+  });
+
+  it("sees a namespace nested under a route group", () => {
+    // The guard's own blind spot, pinned: a wrapper Next strips from the URL
+    // must not hide its children. Asserted on the shape of the walk rather
+    // than on a fixture directory, so it stays true with no `(group)` in the
+    // tree today.
+    expect(isTransparentWrapper("(desktop)")).toBe(true);
+    expect(isTransparentWrapper("@modal")).toBe(true);
+    expect(isTransparentWrapper("apps")).toBe(false);
+    expect(isRouted("[...gateway]")).toBe(false);
+    expect(isRouted("_private")).toBe(false);
+  });
+
+  it("claims no namespace that has no route directory", () => {
+    // The other direction: a root left behind after its directory was renamed
+    // or deleted 404s a path the gateway may legitimately own.
+    const segments = topLevelRouteSegments();
+    const stale = CLAWBOX_ROOTS.filter(
+      (root) => !segments.includes(root.replace(/^\//, "")),
+    );
+
+    expect(
+      stale,
+      `${stale.join(", ")} is claimed by src/lib/clawbox-namespaces.ts but has no `
+        + "matching src/app/ directory, so the catch-all now 404s it for nothing.",
+    ).toEqual([]);
+  });
+
+  it("gives each root exactly one owner", () => {
+    const duplicated = ALL_ROOTS.filter(
+      (root, i) => ALL_ROOTS.indexOf(root) !== i,
+    );
+
+    expect(duplicated, `${duplicated.join(", ")} is listed twice`).toEqual([]);
+  });
+});

--- a/src/tests/unit/clawbox-namespace-coverage.test.ts
+++ b/src/tests/unit/clawbox-namespace-coverage.test.ts
@@ -68,7 +68,15 @@ function isTransparentWrapper(name: string): boolean {
   return /^[(@]/.test(name);
 }
 
-/** Every literal top-level URL segment, seen through Next's routing rules. */
+/**
+ * Every literal top-level URL segment, seen through Next's routing rules.
+ *
+ * DIRECTORIES only, which is the edge of what this guard can see: Next's
+ * metadata-file conventions make a top-level URL out of a FILE — `robots.ts` is
+ * `/robots.txt`, `sitemap.ts` is `/sitemap.xml` — and one of those would be
+ * invisible here. None exists today; adding one means widening this walk, not
+ * just adding a root.
+ */
 function topLevelRouteSegments(dir: string = APP_DIR): string[] {
   const segments = fs
     .readdirSync(dir, { withFileTypes: true })


### PR DESCRIPTION
Follow-up to #675 (TASK-631), for the two findings its final review left open. One of them is real and fixed here. **The other is refuted, with evidence — and had it been implemented as written it would have broken a working gateway page.**

## Finding MEDIUM-2 — confirmed, fixed

**Symptom.** On a box the owner is signed in to, a ClawBox address spelled with a percent-encoded separator — `/setup-api%2Fnope`, `/portal%2Fnope`, `/app%2Fx`, `/login-api%2Fnope` — was answered **200 `text/html`: the OpenClaw Control UI shell, with the gateway auth token injected into it**. Somebody else's application, carrying a credential, over a ClawBox address.

**Cause.** `%2F` is not a path separator, so the whole request is a single segment. It matches no ClawBox route, falls through `src/middleware.ts` to the catch-all `src/app/[...gateway]/route.ts`, and a navigation there gets `serveGatewayHTML`. The #675 review asked for this to be probed and it never was.

**The probe, run read-only and anonymously from the dev PC against BOTH boxes** at beta `dd058938`, `curl --path-as-is -o /dev/null -w '%{http_code}|%{content_type}|%{redirect_url}'`. Both editions answered identically on every line.

| request | code | content-type / redirect | reading |
|---|---|---|---|
| `/setup-api/nope` | `401` | `application/json` | the middleware's own `/setup-api` gate fired |
| `/setup-api%2Fnope` | `307` | → `/login?redirect=%2Fsetup-api%252Fnope` | **the same gate missed it** |
| `/setup-api%2fnope` | `307` | → `/login` | lower-case `%2f`, same |
| `/apps/zzz-no-such-app/x` (fetch) | `404` | `text/plain` | app-proxy answered — it *is* an app-proxy path |
| `/apps%2Fzzz-no-such-app%2Fx` (fetch) | `307` | → `/login` | **not** an app-proxy path — so `%2F` is not a separator |
| `/apps` | `307` | → `/login?redirect=%2Fapps` | matched no route |
| `/apps/` | `308` | → `/apps/` | see "Found while probing" below |
| `/apps%2F..` | `307` | → `/login` | one segment |
| `/apps%2e%2e`, `/apps%2E%2E` | `307` | → `/login` | one segment |
| `/app%2Fx`, `/app%2fx` | `307` | → `/login` | one segment |
| `/apps%252F..` | `307` | → `/login` | double-encoded |
| `/Apps%2Fx`, `/APPS%2FX` | `307` | → `/login` | mixed case |
| `/apps/..` | `307` | → `/login?redirect=%2F` | a *real* `..` **is** normalised, to `/` |
| `/app`, `/chat/main`, `/setupsomething` | `307` | → `/login` | controls |

The 401-vs-307 pair on the first two rows is decisive: `isSetupApiPath` sees `/setup-api%2Fnope` and does not recognise it, which is only possible if `nextUrl.pathname` still carries the literal `%2F`. The platform does not normalise the encoded family, so these requests reach the catch-all — and for an owner session that was the shell plus the token.

Two members are **not** defects and are pinned as results rather than fixed: `%2e%2e` decodes *inside* one segment, so `/setup%2e%2e` is `/setup..`, no more ClawBox's than `/setupsomething`; and a genuine `/apps/..` is normalised to `/` before anything here sees it.

**Fix.** `clawboxNamespaceKind` now matches the percent-**decoded** spelling as well as the literal one. This is **deny-only**, which is what makes it safe: the module's answer has exactly one caller and its only output is a 404, so over-claiming costs a 404 where the answer used to be the shell with a credential in it. `isUnderRoot` and `isSetupApiPath` stay literal on purpose — those feed three middleware **allow** gates, and decoding there would widen an auth decision. The decode goes to a fixpoint because one pass leaves `%2F` behind on a double-encoded path.

**The give-up fails CLOSED, and the decode is per escape run.** Two rounds of review found the same shape twice, and both are closed here rather than documented as residuals:

* **The cap failed open** (CodeRabbit, Critical; answered and resolved in-thread). Four passes left `%2F` in the string and the path went to the gateway, so the function denied `/portal%2Fnope` and permitted `/portal%252525252Fnope`, which is four passes away from it — "append two more `25`s" walked around the whole check. `decodePercentEncoding` now returns `{ spelling, undecodable }`; `MAX_DECODE_PASSES` (32) is a runaway guard, and a path the passes ran out on — tested as "would one more pass still change it?", never as "does it still contain `%`" — is CLAIMED. `clawboxNamespaceKind` answers `"unreadable"` for it, a third value rather than an overloaded `"page"`, so the caller decides the shape of the 404 with the fact in front of it.
* **`decodeURIComponent` was all-or-nothing**, so appending one junk escape defeated the deny more cheaply than nesting ever did: `/portal%2Fnope` was denied while `/portal%2Fnope%zz` decoded to nothing, matched nothing and got the shell. Decoding is now per maximal RUN of well-formed escapes (`/(?:%[0-9A-Fa-f]{2})+/g`) — runs, so a multi-byte character still decodes as one character — leaving malformed ones exactly as they were. A malformed escape stays a settled answer, which is why `/setup-api%zz` and a gateway path carrying a stray `%` are still the gateway's.

Measured after both changes, against the pinned 2026.8.1 Control UI bundle: its 55 routes plus 14 gateway static/API paths in 16 encodings each — **1104 tested, 0 claimed**. `/assets/a%zz.js`, `/assets/100%25.png` and `/chat/main` unchanged; a 400 KB path costs 14 ms; `"%25".repeat(50)` is 50 sequential escapes and costs two passes, not fifty. The claimed-side and gateway-side cases are both pinned at depth, so lowering the cap can no longer pass unnoticed in either direction.

## Finding MEDIUM-1 (`/apps`) — REFUTED

The #675 review asked for `/apps` to be added to `CLAWBOX_PAGE_ROOTS`. **Doing that would 404 a gateway page that works today.** It is not in this PR, and the reason is recorded in the module so nobody adds it next quarter.

- **`/apps` is the Control UI's own page.** The pinned Control UI — `OPENCLAW_VERSION="2026.8.1"`, `install.sh:603` — registers it: `apps:{path:`/apps`}`, and ships `apps-page-Dze4Pwkv.js` / `apps-page-YnV-N0U5.css` alongside. Serving the shell there is the *correct* answer.
- **Nothing under `/apps/` reaches the catch-all anyway.** `src/app/apps/[id]/[[...path]]/route.ts` is an *optional* catch-all, so `/apps/<id>` **and** `/apps/<id>/…` are matched by a real route. An entry could never have fired on a real path.

So `/apps` is the gateway's at the root and ClawBox's below it, and the honest place for it is the "deliberately not claimed" list.

**Why the original check missed this** is worth recording, because it is the *false success* class in the evidence rather than in the code: the old comment claimed the bundle had been checked and carried no ClawBox root, but the bundle spells its route paths as **backtick template literals**, so the grep behind that claim finds nothing for `/apps` — and finds nothing for `/chat` or `/sessions` either. A grep that could not see its own positives was read as proof of a negative. The reproducible command and its result are now in the module:

```sh
# in /usr/lib/node_modules/openclaw/dist/control-ui/assets, at the pinned version
grep -ohE '\bpath:`/[^`]{0,50}`' *.js | sed 's/path://; s/`//g' | sort -u   # 55 routes
```

Cross-checked every ClawBox root against those 55: `/setup`, `/login`, `/portal`, `/updating`, `/app`, `/setup-api`, `/login-api` are all absent. `/apps` was the only collision.

## The guard — so the question is answerable next time

`src/tests/unit/clawbox-namespace-coverage.test.ts` derives the expected roots from `src/app/`'s top-level directories and fails when one is in neither list.

**Harness mechanism.** No OpenClaw/Hermes mechanism applies — this is ClawBox's own route table, not anything the harness owns. The native mechanism used is **Next's file-system routing**: under the App Router `src/app/`'s directories *are* the route table, so the guard reads that rather than maintaining a second enumeration beside it. It descends through route groups `(x)` and parallel slots `@y`, because Next strips those from the URL — `src/app/(desktop)/studio/page.tsx` serves `/studio` — and skipping them would leave the guard blind to exactly the namespace it exists to catch. It stays a test rather than a runtime lookup for the real reasons: `output: "standalone"` does not ship `src/`, and Next's own `app-path-routes-manifest.json` exists only after a production build. (Not because middleware cannot read files — it declares `runtime: "nodejs"` and reads `data/config.json` per request.)

Being forced to classify every directory is what produced two of this PR's conclusions: that `/apps` belongs to the gateway, and that `src/app/favicon.svg/` and `src/app/favicon-32.png/` — real route directories that were in **no** list — are gateway-owned (their handlers proxy; `src/middleware.ts` has them in `GATEWAY_ONLY_EXACT`).

Proven live, both directions:

```
# a new top-level namespace
AssertionError: src/app/zz-fake-namespace is a top-level route directory that
src/lib/clawbox-namespaces.ts does not classify. …

# and one hidden under a route group
AssertionError: src/app/studio is a top-level route directory that
src/lib/clawbox-namespaces.ts does not classify. …
```

## RED

Against **unmodified** `origin/beta`, `npx vitest run src/tests/routes/gateway.test.ts`:

```
⎯⎯⎯ Failed Tests 7 ⎯⎯⎯
 FAIL … answers 404 for http://localhost/setup-api%2Fnope rather than the gateway shell
 FAIL … answers 404 for http://localhost/setup-api%2fnope rather than the gateway shell
 FAIL … answers 404 for http://localhost/Setup-Api%2Fnope rather than the gateway shell
 FAIL … answers 404 for http://localhost/login-api%2Fnope rather than the gateway shell
 FAIL … answers 404 for http://localhost/portal%2Fnope rather than the gateway shell
 FAIL … answers 404 for http://localhost/app%2fx rather than the gateway shell
 FAIL … answers 404 for http://localhost/setup%252Fnope rather than the gateway shell
AssertionError: expected 200 to be 404
- Expected   404
+ Received   200
      Tests  7 failed | 29 passed (36)
```

`200` there is the shell with the token.

## GREEN

On the rebased head:

```
npx vitest run src/tests/routes/gateway.test.ts src/tests/unit/clawbox-namespace-coverage.test.ts \
  src/tests/middleware/ src/tests/unit/openclaw-config-mock-completeness.test.ts \
  src/tests/unit/test-timeout-hygiene.test.ts src/tests/unit/state-updater-purity.test.ts \
  src/tests/unit/app-proxy.test.ts src/tests/routes/apps
  Test Files  20 passed (20)
      Tests  335 passed (335)

npx tsc --noEmit    — clean
npx eslint <the three changed files>    — clean
git diff --diff-filter=DR --stat origin/beta...HEAD    — empty
```

## Sibling call sites

- `src/app/[...gateway]/route.ts` — the one caller of `clawboxNamespaceKind`; covered by the tests above.
- `src/middleware.ts:490, 507, 520` — three `isSetupApiPath` **allow** gates (bootstrap window, `CLAWBOX_TEST_MODE`, MCP bearer). Deliberately unchanged: decoding in any of them would newly admit `/setup-api%2F…` to the bootstrap allow-list and the MCP carve-out. Literal is right.
- `src/middleware.ts:581` — the fourth site, and **not** an allow gate: it picks a JSON 401 over an HTML login redirect. It stays literal too, so with this PR the catch-all calls `/setup-api%2Fnope` an API path while the middleware still calls it a page — the same URL answers `307 → /login` with no session and `404 application/json` with an owner session. Not a regression and nothing gains access, but it is named here rather than left implicit, since "one surface, one shape" is the argument the catch-all's own comment uses.
- `src/middleware.ts:293` `isAppProxyPath` — cleared; its length test excludes the bare `/apps` root on purpose, a proxy needs an id.
- `src/middleware.ts:240` `isDesktopPagePath` — cleared, not extended. A proxied app runs from its own server outside the checkout an update rewrites, and its document is framed by `/`, which *is* redirected to the updating page.
- `src/lib/app-proxy.ts` `APP_PROXY_PREFIX` — cleared; the proxy's own prefix, feeding a route that already matches every `/apps/<id>[/…]`.
- `src/lib/ui-events.ts:172` — cleared; a client-side `/app/` check, a different question.

## Deliberately not in this PR

**Every trailing-slash page path on beta 308-redirects to itself** — `/setup/`, `/portal/`, `/app/`, `/apps/`, `/chat/` — an infinite loop, on both boxes, since f14a52b8. `src/middleware.ts:~390` builds the target with `nextUrl.clone()` and then sets `.pathname`, but `NextURL`'s setter updates `.pathname` without updating `.href`/`toString()`, and `NextResponse.redirect` serialises via `toString()`. Measured in-process on beta:

```
before:    pathname=/apps/  href=http://localhost/apps/
after set: pathname=/apps   href=http://localhost/apps/   toString=http://localhost/apps/
redirect Location=http://localhost/apps/
plain URL (control): http://localhost/apps
```

It is a #670 regression touching a redirect every root shares, so it gets its own RED/GREEN and review rather than riding along here. It is also why the `/apps/` row in the table above shows `308`.

**`UNCLAIMED_ROOTS` is a third list of gateway-owned roots**, beside `GATEWAY_ONLY_EXACT`/`GATEWAY_ONLY_PREFIXES` in `src/middleware.ts` and `src/lib/gateway-static.ts`, and nothing cross-checks them. The new list is test-enforced; the middleware one decides the Hermes 404 gate. Unifying them touches an auth-adjacent middleware path and belongs in its own PR; the module records the dependency in the meantime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected handling of percent-encoded, double-encoded, deeply nested, malformed, and case-variant paths so ClawBox-owned routes return a proper 404 instead of displaying the gateway shell.
  - Added fail-closed handling for paths that cannot be safely decoded.
  - Preserved gateway shell behavior for gateway-owned and unrelated encoded paths.
  - Improved route classification consistency across encoded path variations.

- **Tests**
  - Expanded coverage for encoded route handling, malformed paths, decode limits, and namespace-to-route consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
