### PR TITLE
fix: llama.cpp provider repair writes a config OpenClaw accepts

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -643,23 +643,6 @@ elif _wants_llamacpp and _llamacpp_gaps:
     except OSError:
         _local_ai_token = ""
 
-    # And the bearer we would write is PROVIDER-WIDE. OpenClaw resolves a row's
-    # endpoint as `model.baseUrl ?? provider.baseUrl` and has no per-model
-    # credential slot, so pointing the entry at our proxy and putting this box's
-    # local-AI token beside a row that keeps its OWN baseUrl sends that token to
-    # that host on every turn of the row. Any row-level baseUrl disqualifies the
-    # entry, not only a foreign one: ClawBox writes the endpoint on the PROVIDER
-    # and its rows carry none, so a row that names one is per-row routing we did
-    # not build. Same rule `ensureLocalAiProxyUrls` applies on the TypeScript
-    # side and `foreignOpenAiRoute` applies to the image migration: a provider
-    # block we did not build is one to leave alone, not to half-configure.
-    _llamacpp_rows_route_themselves = any(
-        isinstance(_r, dict)
-        and isinstance(_r.get("baseUrl"), str)
-        and _r["baseUrl"].strip()
-        for _r in (_entry_models if isinstance(_entry_models, list) else [])
-    )
-
     if _llamacpp_takes_proxy and len(_local_ai_token) < 16:
         print(
             "  Skipped llamacpp provider repair: "
@@ -667,12 +650,9 @@ elif _wants_llamacpp and _llamacpp_gaps:
             + " is configured but "
             + _token_path
             + " is missing or too short, so the proxy would reject every call."
-        )
-    elif _llamacpp_takes_proxy and _llamacpp_rows_route_themselves:
-        print(
-            "  Skipped llamacpp provider repair: a model row under"
-            " models.providers.llamacpp names its own baseUrl, and this box's"
-            " local-AI token would be the bearer for it."
+            + " The entry still has no models.providers.llamacpp.baseUrl, which"
+            + " OpenClaw's schema requires for this provider, so the gateway"
+            + " will refuse this config until that file is restored."
         )
     else:
         # Touch models/providers only on the repair path. A malformed scalar must
@@ -781,7 +761,66 @@ elif _wants_llamacpp and _llamacpp_gaps:
                 "contextWindow": _ctx,
                 "maxTokens": _max_tokens,
             } for _mid in _llamacpp_missing_ids]
+        # The bearer we are about to write is PROVIDER-WIDE. OpenClaw resolves a
+        # row's endpoint as `model.baseUrl ?? provider.baseUrl` and has no
+        # per-model credential slot, so completing this entry while a row keeps
+        # its own baseUrl ON ANOTHER HOST sends this box's local-AI token to
+        # that host on every turn of the row. Such an entry is one we did not
+        # build: leave it, and say what leaving it costs.
+        #
+        # ANOTHER HOST, not merely a row-level baseUrl. There is no ownership
+        # marker on a llamacpp row the way `isOurImageRow` has one for an image
+        # row, so ownership is decided by host: loopback and the proxy's own
+        # authority are this box, and everything else — including a URL that
+        # will not parse, because guessing permissively is the wrong way to be
+        # wrong about a credential — is not. Refusing over a row that points AT
+        # US would cost a gateway for nothing: the entry we decline to complete
+        # still has no provider baseUrl, which OpenClaw's schema requires for
+        # llamacpp (it is not a bundled overlay), so ExecStart refuses the whole
+        # config. Rows are the ones that SURVIVE the repair — a row without an
+        # id is dropped above and `ModelDefinitionSchema` rejects it anyway, so
+        # it can never route a turn.
+        _llamacpp_foreign_row = False
         if _llamacpp_takes_proxy:
+            import urllib.parse as _lc_url
+
+            def _lc_host(_raw):
+                try:
+                    return (_lc_url.urlsplit(_raw).hostname or "").lower() or None
+                except ValueError:
+                    return None
+
+            _lc_ours = {"127.0.0.1", "localhost", "::1"}
+            _lc_proxy_host = _lc_host(_proxy_root)
+            if _lc_proxy_host:
+                _lc_ours.add(_lc_proxy_host)
+            for _r in (_repaired_entry.get("models") or []):
+                if not isinstance(_r, dict):
+                    continue
+                _rid = _r.get("id")
+                if not (isinstance(_rid, str) and _rid.strip()):
+                    continue
+                _rb = _r.get("baseUrl")
+                if not (isinstance(_rb, str) and _rb.strip()):
+                    continue
+                if _lc_host(_rb.strip()) not in _lc_ours:
+                    _llamacpp_foreign_row = True
+                    break
+
+        if _llamacpp_foreign_row:
+            # The URL itself is never printed: an owner-configured endpoint can
+            # carry user-info or query credentials, and the journal keeps what
+            # it is given.
+            print(
+                "  Skipped llamacpp provider repair: a model row under"
+                " models.providers.llamacpp names its own baseUrl on another"
+                " host, and this box's local-AI token would be the bearer for"
+                " it. The entry still has no models.providers.llamacpp.baseUrl,"
+                " which OpenClaw's schema requires for this provider, so the"
+                " gateway will refuse this config until you set one or remove"
+                " that row's baseUrl."
+            )
+        if _llamacpp_takes_proxy and not _llamacpp_foreign_row:
             _repaired_entry["baseUrl"] = _proxy_root + "/setup-api/local-ai/llamacpp/v1"
             # The key travels WITH the baseUrl or not at all: our proxy accepts
             # only our bearer, so leaving a foreign apiKey beside it would be
@@ -790,30 +829,31 @@ elif _wants_llamacpp and _llamacpp_gaps:
                 if isinstance(_repaired_entry.get("apiKey"), str) and _repaired_entry["apiKey"].strip():
                     print("  Replaced models.providers.llamacpp.apiKey: the entry now points at this box's local-AI proxy, which accepts only its own bearer")
                 _repaired_entry["apiKey"] = _local_ai_token
-        if not isinstance(_llamacpp_entry, dict):
+        if not isinstance(_llamacpp_entry, dict) and not _llamacpp_foreign_row:
             # Only on a FRESH entry. `api` is optional in the schema, and an
             # entry an operator deliberately left api-less routes as
             # openai-compatible anyway, so injecting it would change nothing but
             # their file.
             _repaired_entry["api"] = "openai-completions"
-        _providers_now["llamacpp"] = _repaired_entry
-        changed = True
-        if isinstance(_llamacpp_entry, dict):
-            print(
-                "  Completed models.providers.llamacpp ("
-                + ", ".join(_llamacpp_gaps)
-                + "): OpenClaw's schema requires them"
-                + (
-                    " — dropped " + str(_llamacpp_dropped_rows) + " model row(s) naming no id"
-                    if _llamacpp_dropped_rows
-                    else ""
+        if not _llamacpp_foreign_row:
+            _providers_now["llamacpp"] = _repaired_entry
+            changed = True
+            if isinstance(_llamacpp_entry, dict):
+                print(
+                    "  Completed models.providers.llamacpp ("
+                    + ", ".join(_llamacpp_gaps)
+                    + "): OpenClaw's schema requires them"
+                    + (
+                        " — dropped " + str(_llamacpp_dropped_rows) + " model row(s) naming no id"
+                        if _llamacpp_dropped_rows
+                        else ""
+                    )
                 )
-            )
-        else:
-            print(
-                "  Repaired models.providers.llamacpp for "
-                + ", ".join(_llamacpp_model_ids)
-            )
+            else:
+                print(
+                    "  Repaired models.providers.llamacpp for "
+                    + ", ".join(_llamacpp_model_ids)
+                )
 
 # Model migration: legacy ChatGPT-subscription devices can have their active
 # model — or a fallback — stored as `openai/<gpt>` from before the setup UI

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -517,37 +517,72 @@ if isinstance(_fallbacks_now, list):
 # the local runtime but would skip this repair and still fail model resolution.
 _wants_llamacpp = [r.strip() for r in _llamacpp_refs if r.strip().startswith("llamacpp/")]
 
-# Key presence, not truthiness: an existing but empty {} entry is a deliberate
-# operator choice and must be preserved, which .get() would silently overwrite.
+# One row per DISTINCT id, in the order they are configured. Registering only
+# the first left a second llamacpp id among the fallbacks resolving to "Unknown
+# model" — the very failure this migration exists to remove. An EMPTY id (a bare
+# "llamacpp/") is dropped rather than written: ModelDefinitionSchema requires
+# id.min(1), so a row of {"id": "", "name": ""} makes the WHOLE openclaw.json
+# fail validation, and a box that merely could not answer ends up with a gateway
+# that cannot load its config at all.
+_llamacpp_model_ids = []
+for _ref in _wants_llamacpp:
+    _model_id = _ref[len("llamacpp/"):].strip()
+    if _model_id and _model_id not in _llamacpp_model_ids:
+        _llamacpp_model_ids.append(_model_id)
+
 _models_now = cfg.get("models")
 _providers_now = _models_now.get("providers") if isinstance(_models_now, dict) else None
-if _wants_llamacpp and not (
-    isinstance(_providers_now, dict) and "llamacpp" in _providers_now
-):
-    # Touch models/providers only on the repair path. A malformed scalar must
-    # not crash ExecStartPre, and an unrelated config must not gain an empty
-    # models key merely because some other migration changed the file.
-    if not isinstance(_models_now, dict):
-        _models_now = {}
-        cfg["models"] = _models_now
-    if not isinstance(_providers_now, dict):
-        _providers_now = {}
-        _models_now["providers"] = _providers_now
-    _mp = _providers_now
+_llamacpp_entry = _providers_now.get("llamacpp") if isinstance(_providers_now, dict) else None
+
+# PRESENT is not the same as USABLE. Key presence alone treated an existing `{}`
+# as a deliberate operator choice, but OpenClaw 2026.8.1 REJECTS a custom
+# provider with no baseUrl and no models: preserving that entry leaves a config
+# that fails validation outright, which is strictly worse than the "Unknown
+# model" this migration exists to fix. So ask what the schema actually requires
+# and fill only what is missing — an operator's own baseUrl or key survives
+# untouched, and a complete entry is still left entirely alone.
+_llamacpp_gaps = []
+if _wants_llamacpp:
+    _entry_now = _llamacpp_entry if isinstance(_llamacpp_entry, dict) else {}
+    for _field in ("baseUrl", "api", "apiKey"):
+        _value_now = _entry_now.get(_field)
+        if not (isinstance(_value_now, str) and _value_now.strip()):
+            _llamacpp_gaps.append(_field)
+    _entry_models = _entry_now.get("models")
+    if not (
+        isinstance(_entry_models, list)
+        and any(
+            isinstance(_m, dict) and isinstance(_m.get("id"), str) and _m["id"].strip()
+            for _m in _entry_models
+        )
+    ):
+        _llamacpp_gaps.append("models")
+
+_clawbox_root = os.environ.get("CLAWBOX_ROOT", "/home/clawbox/clawbox")
+
+if _wants_llamacpp and _llamacpp_gaps and not _llamacpp_model_ids:
+    print(
+        "  Skipped llamacpp provider repair: "
+        + _wants_llamacpp[0]
+        + " names no model id, and a provider row with an empty id fails"
+        + " OpenClaw's schema for the whole config."
+    )
+elif _wants_llamacpp and _llamacpp_gaps:
     # The proxy authenticates openclaw -> Next.js with a per-install bearer
     # (src/lib/local-ai-token.ts). Writing the entry WITHOUT it would trade
     # "Unknown model" for a 401 on every turn, which is not an improvement, so
-    # a box with no token file is left alone and told why.
-    _token_path = os.path.join(
-        os.environ.get("CLAWBOX_ROOT", "/home/clawbox/clawbox"), "data", ".local-ai-token"
-    )
+    # a box with no token file is left alone and told why. Only when WE have to
+    # supply the key: an operator entry that already carries one needs nothing
+    # from us, and refusing there would leave their config invalid for a
+    # credential it never wanted.
+    _token_path = os.path.join(_clawbox_root, "data", ".local-ai-token")
     try:
         with open(_token_path) as _tf:
             _local_ai_token = _tf.read().strip()
     except OSError:
         _local_ai_token = ""
 
-    if len(_local_ai_token) < 16:
+    if "apiKey" in _llamacpp_gaps and len(_local_ai_token) < 16:
         print(
             "  Skipped llamacpp provider repair: "
             + _wants_llamacpp[0]
@@ -556,41 +591,115 @@ if _wants_llamacpp and not (
             + " is missing or too short, so the proxy would reject every call."
         )
     else:
-        _model_id = _wants_llamacpp[0][len("llamacpp/"):]
-        # A non-numeric override must not abort gateway pre-start: this migration
-        # runs on the path that repairs a mute box, so raising here would turn a
-        # bad env var into a box that never starts at all.
+        # Touch models/providers only on the repair path. A malformed scalar must
+        # not crash ExecStartPre, and an unrelated config must not gain an empty
+        # models key merely because some other migration changed the file.
+        if not isinstance(_models_now, dict):
+            _models_now = {}
+            cfg["models"] = _models_now
+        if not isinstance(_providers_now, dict):
+            _providers_now = {}
+            _models_now["providers"] = _providers_now
+
+        # The tuning below lives in $CLAWBOX_ROOT/.env (install.sh and
+        # install-x64.sh both write it with ensure_env_setting) and NEITHER
+        # gateway unit loads that file: clawbox-gateway.service takes
+        # network.env and discord.env, the x64 unit only Environment= lines.
+        # .env reaches clawbox-setup.service alone. Read from os.environ alone,
+        # this repair therefore ALWAYS wrote the 131072 default while
+        # llama-server — started under clawbox-setup, which does see .env — ran
+        # at the configured size: OpenClaw believed 131k, compaction never
+        # fired, and a long session died with context-exceeded. Reading the few
+        # keys we need is deliberately narrower than adding
+        # `EnvironmentFile=-.../.env` to the unit, which would hand every key in
+        # a clawbox-writable file to the long-running gateway process,
+        # CLAWBOX_TEST_MODE included.
+        _llamacpp_dotenv = {}
         try:
-            _ctx = int(os.environ.get("LLAMACPP_CONTEXT_WINDOW") or 0)
-        except ValueError:
-            _ctx = 0
-        if _ctx < 16384:
-            _ctx = 131072
-        _proxy_port = (os.environ.get("CLAWBOX_PORT") or os.environ.get("PORT") or "80").strip()
+            with open(os.path.join(_clawbox_root, ".env")) as _ef:
+                for _line in _ef:
+                    _line = _line.strip()
+                    if not _line or _line.startswith("#") or "=" not in _line:
+                        continue
+                    _key, _, _value = _line.partition("=")
+                    _key = _key.strip()
+                    if _key.startswith("export "):
+                        _key = _key[len("export "):].strip()
+                    _value = _value.strip()
+                    if len(_value) >= 2 and _value[0] == _value[-1] and _value[0] in ("'", '"'):
+                        _value = _value[1:-1]
+                    _llamacpp_dotenv[_key] = _value
+        except OSError:
+            pass
+
+        def _llamacpp_setting(_name):
+            """The process environment first, then the shipped .env."""
+            _from_env = (os.environ.get(_name) or "").strip()
+            return _from_env if _from_env else _llamacpp_dotenv.get(_name, "").strip()
+
+        def _llamacpp_int(_raw, _minimum, _default):
+            """Number() semantics, not int(): see src/lib/llamacpp.ts.
+
+            int() raises on "32768.0" and "1e5" — both of which the TypeScript
+            side accepts and llama-server is genuinely started with — and the
+            except swallowed it, so the provider silently got the default while
+            the server ran at the configured size. A non-numeric override must
+            still not abort gateway pre-start: this migration runs on the path
+            that repairs a mute box, so raising here would turn a bad env var
+            into a box that never starts at all.
+            """
+            try:
+                _value = int(float(_raw))
+            except (TypeError, ValueError, OverflowError):
+                return _default
+            return _value if _value >= _minimum else _default
+
+        _ctx = _llamacpp_int(_llamacpp_setting("LLAMACPP_CONTEXT_WINDOW"), 16384, 131072)
+        # getLlamaCppMaxTokens(): an absent or unusable value means the context
+        # window, not the 131072 default.
+        _max_tokens_raw = _llamacpp_setting("LLAMACPP_MAX_TOKENS")
+        _max_tokens = _llamacpp_int(_max_tokens_raw, 1, _ctx) if _max_tokens_raw else _ctx
+        _proxy_port = (
+            _llamacpp_setting("CLAWBOX_PORT") or _llamacpp_setting("PORT") or "80"
+        )
         if not _proxy_port.isdigit() or not 1 <= int(_proxy_port) <= 65535:
             _proxy_port = "80"
         _proxy_default = "http://127.0.0.1" + (
             "" if _proxy_port == "80" else ":" + _proxy_port
         )
         _proxy_root = (
-            os.environ.get("CLAWBOX_LOCAL_AI_PROXY_BASE_URL") or _proxy_default
-        ).strip().rstrip("/")
-        _mp["llamacpp"] = {
+            _llamacpp_setting("CLAWBOX_LOCAL_AI_PROXY_BASE_URL") or _proxy_default
+        ).rstrip("/")
+        _llamacpp_repair = {
             "baseUrl": _proxy_root + "/setup-api/local-ai/llamacpp/v1",
             "api": "openai-completions",
             "apiKey": _local_ai_token,
             "models": [{
-                "id": _model_id,
-                "name": _model_id,
+                "id": _mid,
+                "name": _mid,
                 "reasoning": False,
                 "input": ["text"],
                 "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
                 "contextWindow": _ctx,
-                "maxTokens": _ctx,
-            }],
+                "maxTokens": _max_tokens,
+            } for _mid in _llamacpp_model_ids],
         }
+        _repaired_entry = dict(_llamacpp_entry) if isinstance(_llamacpp_entry, dict) else {}
+        for _field in _llamacpp_gaps:
+            _repaired_entry[_field] = _llamacpp_repair[_field]
+        _providers_now["llamacpp"] = _repaired_entry
         changed = True
-        print("  Repaired models.providers.llamacpp for " + _wants_llamacpp[0])
+        if isinstance(_llamacpp_entry, dict):
+            print(
+                "  Completed models.providers.llamacpp ("
+                + ", ".join(_llamacpp_gaps)
+                + "): OpenClaw rejects an entry without them"
+            )
+        else:
+            print(
+                "  Repaired models.providers.llamacpp for "
+                + ", ".join(_llamacpp_model_ids)
+            )
 
 # Model migration: legacy ChatGPT-subscription devices can have their active
 # model — or a fallback — stored as `openai/<gpt>` from before the setup UI
@@ -863,10 +972,35 @@ if isinstance(plugin_entries, dict) and isinstance(channels, dict):
 # through the same baseUrl, so listing just the current default is enough.
 auth_profiles = cfg.get("auth", {}).get("profiles", {}) if isinstance(cfg.get("auth"), dict) else {}
 has_openrouter_auth = isinstance(auth_profiles, dict) and "openrouter:default" in auth_profiles
-models_providers = cfg.setdefault("models", {}).setdefault("providers", {})
+# `models` and `models.providers` are not guaranteed to be objects. A hand-edited
+# or half-written config can leave a scalar in either, and `.setdefault` on a str
+# — or `.get` on the None a `"providers": null` yields — raises AttributeError.
+# This line runs on EVERY config, not only on OpenRouter boxes, and under
+# `set -euo pipefail` an exception here aborts ExecStartPre: the gateway never
+# reaches ExecStart at all. Repair the containers instead, the way the llamacpp
+# repair above already does, and say so rather than silently discarding a value.
+_models_block = cfg.get("models")
+if not isinstance(_models_block, dict):
+    if _models_block is not None:
+        print("  WARN: models was not an object; replacing it — OpenClaw's schema requires one")
+    _models_block = {}
+    cfg["models"] = _models_block
+models_providers = _models_block.get("providers")
+if not isinstance(models_providers, dict):
+    models_providers = {}
+    _models_block["providers"] = models_providers
 if has_openrouter_auth and not models_providers.get("openrouter"):
     primary = (cfg.get("agents", {}).get("defaults", {}).get("model", {}) or {}).get("primary", "")
-    default_model = primary[len("openrouter/"):] if isinstance(primary, str) and primary.startswith("openrouter/") else "moonshotai/kimi-k2-0905"
+    # The runtime trims the ref before it checks the prefix, and a bare
+    # "openrouter/" leaves an EMPTY id — which ModelDefinitionSchema rejects
+    # (id.min(1)), failing validation for the whole openclaw.json. OpenRouter
+    # routes any `openrouter/<slug>` through the same baseUrl and this list is
+    # UI-only, so falling back to the bundled default is both safe and honest.
+    default_model = ""
+    if isinstance(primary, str) and primary.strip().startswith("openrouter/"):
+        default_model = primary.strip()[len("openrouter/"):].strip()
+    if not default_model:
+        default_model = "moonshotai/kimi-k2-0905"
     models_providers["openrouter"] = {
         "baseUrl": "https://openrouter.ai/api/v1",
         "api": "openai-completions",

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -582,6 +582,7 @@ _llamacpp_gaps = []
 _llamacpp_rows = []
 _llamacpp_dropped_rows = 0
 _llamacpp_named_rows = 0
+_llamacpp_trimmed_rows = 0
 if _wants_llamacpp:
     _entry_now = _llamacpp_entry if isinstance(_llamacpp_entry, dict) else {}
     _base_url_now = _entry_now.get("baseUrl")
@@ -593,12 +594,27 @@ if _wants_llamacpp:
         # and no `name` fails the schema exactly as an empty id does, and is
         # trivially completable; a row naming no model at all cannot be
         # repaired into one, so it is dropped and counted.
+        #
+        # The id is TRIMMED into the kept row, not only into the comparison
+        # below. `_llamacpp_have_ids` strips before matching, so a padded id
+        # satisfies the "this row already exists" test and nothing is appended —
+        # while the row that stays in the file keeps its padding, and the
+        # harness matches a row id with a strict `==` against a ref it has
+        # already normalised. The migration would print "Completed", the gateway
+        # would start, and every turn would still end "Unknown model", which is
+        # the exact failure this block exists to remove. Counted for the same
+        # reason `_llamacpp_named_rows` is: on an entry whose baseUrl is already
+        # usable nothing else makes `models` a gap, so an uncounted correction
+        # is computed and never written.
         for _row in _entry_models:
             _row_id = _row.get("id") if isinstance(_row, dict) else None
             if not (isinstance(_row_id, str) and _row_id.strip()):
                 _llamacpp_dropped_rows += 1
                 continue
             _row = dict(_row)
+            if _row["id"] != _row_id.strip():
+                _row["id"] = _row_id.strip()
+                _llamacpp_trimmed_rows += 1
             _row_name = _row.get("name")
             if not (isinstance(_row_name, str) and _row_name.strip()):
                 _row["name"] = _row_id.strip()
@@ -607,13 +623,14 @@ if _wants_llamacpp:
     # Missing rows are APPENDED, never a replacement: an entry that lists one
     # model while `primary`/`fallbacks` name another left the box mute with
     # "Unknown model" and said nothing, because the entry looked complete.
-    _llamacpp_have_ids = {_r["id"].strip() for _r in _llamacpp_rows}
+    _llamacpp_have_ids = {_r["id"] for _r in _llamacpp_rows}
     _llamacpp_missing_ids = [i for i in _llamacpp_model_ids if i not in _llamacpp_have_ids]
     if (
         not isinstance(_entry_models, list)
         or _llamacpp_missing_ids
         or _llamacpp_dropped_rows
         or _llamacpp_named_rows
+        or _llamacpp_trimmed_rows
     ):
         _llamacpp_gaps.append("models")
 
@@ -846,6 +863,14 @@ elif _wants_llamacpp and _llamacpp_gaps:
                     + (
                         " — dropped " + str(_llamacpp_dropped_rows) + " model row(s) naming no id"
                         if _llamacpp_dropped_rows
+                        else ""
+                    )
+                    # A value CHANGED is named for the same reason a value
+                    # discarded is: an id corrected in place is otherwise an
+                    # invisible edit to the operator's own file.
+                    + (
+                        " — trimmed whitespace from " + str(_llamacpp_trimmed_rows) + " model row id(s)"
+                        if _llamacpp_trimmed_rows
                         else ""
                     )
                 )

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -643,6 +643,23 @@ elif _wants_llamacpp and _llamacpp_gaps:
     except OSError:
         _local_ai_token = ""
 
+    # And the bearer we would write is PROVIDER-WIDE. OpenClaw resolves a row's
+    # endpoint as `model.baseUrl ?? provider.baseUrl` and has no per-model
+    # credential slot, so pointing the entry at our proxy and putting this box's
+    # local-AI token beside a row that keeps its OWN baseUrl sends that token to
+    # that host on every turn of the row. Any row-level baseUrl disqualifies the
+    # entry, not only a foreign one: ClawBox writes the endpoint on the PROVIDER
+    # and its rows carry none, so a row that names one is per-row routing we did
+    # not build. Same rule `ensureLocalAiProxyUrls` applies on the TypeScript
+    # side and `foreignOpenAiRoute` applies to the image migration: a provider
+    # block we did not build is one to leave alone, not to half-configure.
+    _llamacpp_rows_route_themselves = any(
+        isinstance(_r, dict)
+        and isinstance(_r.get("baseUrl"), str)
+        and _r["baseUrl"].strip()
+        for _r in (_entry_models if isinstance(_entry_models, list) else [])
+    )
+
     if _llamacpp_takes_proxy and len(_local_ai_token) < 16:
         print(
             "  Skipped llamacpp provider repair: "
@@ -650,6 +667,12 @@ elif _wants_llamacpp and _llamacpp_gaps:
             + " is configured but "
             + _token_path
             + " is missing or too short, so the proxy would reject every call."
+        )
+    elif _llamacpp_takes_proxy and _llamacpp_rows_route_themselves:
+        print(
+            "  Skipped llamacpp provider repair: a model row under"
+            " models.providers.llamacpp names its own baseUrl, and this box's"
+            " local-AI token would be the bearer for it."
         )
     else:
         # Touch models/providers only on the repair path. A malformed scalar must

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -235,6 +235,10 @@ fi
 # restart + MCP server) are guarded by their own idempotency checks.
 export CLAWBOX_HOSTNAME="$CONFIGURED_HOSTNAME"
 export CLAWBOX_PORT
+# The migrations below resolve $CLAWBOX_ROOT/.env and the local-AI token from
+# this value; without the export python falls back to the compiled-in default
+# and the two disagree on any box whose root is not /home/clawbox/clawbox.
+export CLAWBOX_ROOT
 # Serialize the LAN_IPS bash array into an env var Python can parse —
 # newline-separated is bash-safe (IPv4s contain no newlines).
 if [ ${#LAN_IPS[@]} -gt 0 ]; then
@@ -457,7 +461,26 @@ if CLAWBOX_OPENCLAW_V2:
         changed = True
 
 # Strip invalid agent keys that prevent gateway from starting.
-agents_defaults = cfg.setdefault("agents", {}).setdefault("defaults", {})
+# `agents` and `agents.defaults` are not guaranteed to be objects either: a
+# hand-edited or half-written config leaves a scalar or a null there, and
+# `setdefault` returns it rather than a dict — every `.get` below then raises
+# AttributeError, which under `set -euo pipefail` aborts ExecStartPre and the
+# gateway never reaches ExecStart at all. Same coercion, same reasoning, as the
+# `models` containers further down.
+_agents_block = cfg.get("agents")
+if not isinstance(_agents_block, dict):
+    if _agents_block is not None:
+        print("  WARN: agents was not an object; replacing it — OpenClaw's schema requires one")
+        changed = True
+    _agents_block = {}
+    cfg["agents"] = _agents_block
+agents_defaults = _agents_block.get("defaults")
+if not isinstance(agents_defaults, dict):
+    if agents_defaults is not None:
+        print("  WARN: agents.defaults was not an object; replacing it")
+        changed = True
+    agents_defaults = {}
+    _agents_block["defaults"] = agents_defaults
 for k in ("tools", "systemPromptSuffix"):
     if k in agents_defaults:
         del agents_defaults[k]
@@ -473,7 +496,13 @@ if CLAWBOX_OPENCLAW_V2:
 # longer recognize it, so every chat turn fails before the agent can reply.
 # Move only those known-dead defaults back to the bundled local model; a user
 # can still re-authorize ClawBox AI / ChatGPT afterward.
-model_defaults = agents_defaults.setdefault("model", {})
+model_defaults = agents_defaults.get("model")
+if not isinstance(model_defaults, dict):
+    if model_defaults is not None:
+        print("  WARN: agents.defaults.model was not an object; replacing it")
+        changed = True
+    model_defaults = {}
+    agents_defaults["model"] = model_defaults
 primary_model = model_defaults.get("primary")
 if isinstance(primary_model, str) and primary_model.lower() in (
     "anthropic/claude-sonnet-4-20250514",
@@ -534,27 +563,57 @@ _models_now = cfg.get("models")
 _providers_now = _models_now.get("providers") if isinstance(_models_now, dict) else None
 _llamacpp_entry = _providers_now.get("llamacpp") if isinstance(_providers_now, dict) else None
 
-# PRESENT is not the same as USABLE. Key presence alone treated an existing `{}`
-# as a deliberate operator choice, but OpenClaw 2026.8.1 REJECTS a custom
-# provider with no baseUrl and no models: preserving that entry leaves a config
-# that fails validation outright, which is strictly worse than the "Unknown
-# model" this migration exists to fix. So ask what the schema actually requires
-# and fill only what is missing — an operator's own baseUrl or key survives
-# untouched, and a complete entry is still left entirely alone.
+# PRESENT is not the same as USABLE, and "usable" means exactly what OpenClaw's
+# own schema means by it — read off the installed package rather than guessed:
+#
+#   ModelProvidersSchema.superRefine  a non-built-in provider id (llamacpp is
+#                                     not in BUILT_IN_MODEL_PROVIDER_OVERLAY_IDS)
+#                                     needs a truthy `baseUrl` and an array
+#                                     `models`. `api` and `apiKey` are optional.
+#   ModelDefinitionSchema             every row needs `id` AND `name`, both
+#                                     .min(1).
+#
+# Key presence alone treated an existing `{}` as a deliberate operator choice,
+# but such an entry fails validation outright — strictly worse than the "Unknown
+# model" this migration exists to fix. So fill exactly what the schema is
+# missing and nothing else: an entry OpenClaw already accepts is never touched,
+# and `api`/`apiKey` are not invented on one that chose to omit them.
 _llamacpp_gaps = []
+_llamacpp_rows = []
+_llamacpp_dropped_rows = 0
+_llamacpp_named_rows = 0
 if _wants_llamacpp:
     _entry_now = _llamacpp_entry if isinstance(_llamacpp_entry, dict) else {}
-    for _field in ("baseUrl", "api", "apiKey"):
-        _value_now = _entry_now.get(_field)
-        if not (isinstance(_value_now, str) and _value_now.strip()):
-            _llamacpp_gaps.append(_field)
+    _base_url_now = _entry_now.get("baseUrl")
+    if not (isinstance(_base_url_now, str) and _base_url_now.strip()):
+        _llamacpp_gaps.append("baseUrl")
     _entry_models = _entry_now.get("models")
-    if not (
-        isinstance(_entry_models, list)
-        and any(
-            isinstance(_m, dict) and isinstance(_m.get("id"), str) and _m["id"].strip()
-            for _m in _entry_models
-        )
+    if isinstance(_entry_models, list):
+        # Keep the operator's rows and repair them in place. A row with an id
+        # and no `name` fails the schema exactly as an empty id does, and is
+        # trivially completable; a row naming no model at all cannot be
+        # repaired into one, so it is dropped and counted.
+        for _row in _entry_models:
+            _row_id = _row.get("id") if isinstance(_row, dict) else None
+            if not (isinstance(_row_id, str) and _row_id.strip()):
+                _llamacpp_dropped_rows += 1
+                continue
+            _row = dict(_row)
+            _row_name = _row.get("name")
+            if not (isinstance(_row_name, str) and _row_name.strip()):
+                _row["name"] = _row_id.strip()
+                _llamacpp_named_rows += 1
+            _llamacpp_rows.append(_row)
+    # Missing rows are APPENDED, never a replacement: an entry that lists one
+    # model while `primary`/`fallbacks` name another left the box mute with
+    # "Unknown model" and said nothing, because the entry looked complete.
+    _llamacpp_have_ids = {_r["id"].strip() for _r in _llamacpp_rows}
+    _llamacpp_missing_ids = [i for i in _llamacpp_model_ids if i not in _llamacpp_have_ids]
+    if (
+        not isinstance(_entry_models, list)
+        or _llamacpp_missing_ids
+        or _llamacpp_dropped_rows
+        or _llamacpp_named_rows
     ):
         _llamacpp_gaps.append("models")
 
@@ -569,12 +628,14 @@ if _wants_llamacpp and _llamacpp_gaps and not _llamacpp_model_ids:
     )
 elif _wants_llamacpp and _llamacpp_gaps:
     # The proxy authenticates openclaw -> Next.js with a per-install bearer
-    # (src/lib/local-ai-token.ts). Writing the entry WITHOUT it would trade
-    # "Unknown model" for a 401 on every turn, which is not an improvement, so
-    # a box with no token file is left alone and told why. Only when WE have to
-    # supply the key: an operator entry that already carries one needs nothing
-    # from us, and refusing there would leave their config invalid for a
-    # credential it never wanted.
+    # (src/lib/local-ai-token.ts). Writing OUR baseUrl WITHOUT it would trade
+    # "Unknown model" for a 401 on every turn, which is not an improvement, so a
+    # box with no token file is left alone and told why. The guard keys on
+    # whether we are about to point the entry at our proxy, NOT on whether
+    # `apiKey` happens to be absent: an entry naming the operator's own
+    # llama-server needs no token from us, and refusing there would leave their
+    # config invalid over a credential it never wanted.
+    _llamacpp_takes_proxy = "baseUrl" in _llamacpp_gaps
     _token_path = os.path.join(_clawbox_root, "data", ".local-ai-token")
     try:
         with open(_token_path) as _tf:
@@ -582,7 +643,7 @@ elif _wants_llamacpp and _llamacpp_gaps:
     except OSError:
         _local_ai_token = ""
 
-    if "apiKey" in _llamacpp_gaps and len(_local_ai_token) < 16:
+    if _llamacpp_takes_proxy and len(_local_ai_token) < 16:
         print(
             "  Skipped llamacpp provider repair: "
             + _wants_llamacpp[0]
@@ -593,11 +654,20 @@ elif _wants_llamacpp and _llamacpp_gaps:
     else:
         # Touch models/providers only on the repair path. A malformed scalar must
         # not crash ExecStartPre, and an unrelated config must not gain an empty
-        # models key merely because some other migration changed the file.
+        # models key merely because some other migration changed the file. A
+        # value that IS discarded is named, never dropped in silence — the
+        # OpenRouter repair further down says the same thing about the same two
+        # containers, and the two are deliberately not factored into one helper
+        # because each region is extracted and executed on its own by its
+        # regression suite.
         if not isinstance(_models_now, dict):
+            if _models_now is not None:
+                print("  WARN: models was not an object; replacing it — OpenClaw's schema requires one")
             _models_now = {}
             cfg["models"] = _models_now
         if not isinstance(_providers_now, dict):
+            if _providers_now is not None:
+                print("  WARN: models.providers was not an object; replacing it")
             _providers_now = {}
             _models_now["providers"] = _providers_now
 
@@ -605,18 +675,23 @@ elif _wants_llamacpp and _llamacpp_gaps:
         # install-x64.sh both write it with ensure_env_setting) and NEITHER
         # gateway unit loads that file: clawbox-gateway.service takes
         # network.env and discord.env, the x64 unit only Environment= lines.
-        # .env reaches clawbox-setup.service alone. Read from os.environ alone,
-        # this repair therefore ALWAYS wrote the 131072 default while
-        # llama-server — started under clawbox-setup, which does see .env — ran
-        # at the configured size: OpenClaw believed 131k, compaction never
-        # fired, and a long session died with context-exceeded. Reading the few
-        # keys we need is deliberately narrower than adding
-        # `EnvironmentFile=-.../.env` to the unit, which would hand every key in
-        # a clawbox-writable file to the long-running gateway process,
-        # CLAWBOX_TEST_MODE included.
+        # (Other units do read .env — clawbox-setup, clawbox-embed,
+        # clawbox-browser — which is exactly why llama-server, started under
+        # clawbox-setup, ran at the configured size while this repair, reading
+        # os.environ alone, ALWAYS wrote the 131072 default: OpenClaw believed
+        # 131k, compaction never fired, and a long session died with
+        # context-exceeded.) Reading the few keys we need is deliberately
+        # narrower than adding `EnvironmentFile=-.../.env` to the gateway unit,
+        # which would hand every key in a clawbox-writable file to the
+        # long-running gateway process, CLAWBOX_TEST_MODE included.
+        #
+        # errors="replace" and a bare except: .env is clawbox-writable and one
+        # latin-1 byte in an operator's key would otherwise raise
+        # UnicodeDecodeError out of this heredoc, fail ExecStartPre under
+        # `set -euo pipefail`, and leave the box with no gateway at all.
         _llamacpp_dotenv = {}
         try:
-            with open(os.path.join(_clawbox_root, ".env")) as _ef:
+            with open(os.path.join(_clawbox_root, ".env"), encoding="utf-8", errors="replace") as _ef:
                 for _line in _ef:
                     _line = _line.strip()
                     if not _line or _line.startswith("#") or "=" not in _line:
@@ -629,8 +704,8 @@ elif _wants_llamacpp and _llamacpp_gaps:
                     if len(_value) >= 2 and _value[0] == _value[-1] and _value[0] in ("'", '"'):
                         _value = _value[1:-1]
                     _llamacpp_dotenv[_key] = _value
-        except OSError:
-            pass
+        except Exception:
+            _llamacpp_dotenv = {}
 
         def _llamacpp_setting(_name):
             """The process environment first, then the shipped .env."""
@@ -659,9 +734,11 @@ elif _wants_llamacpp and _llamacpp_gaps:
         # window, not the 131072 default.
         _max_tokens_raw = _llamacpp_setting("LLAMACPP_MAX_TOKENS")
         _max_tokens = _llamacpp_int(_max_tokens_raw, 1, _ctx) if _max_tokens_raw else _ctx
-        _proxy_port = (
-            _llamacpp_setting("CLAWBOX_PORT") or _llamacpp_setting("PORT") or "80"
-        )
+        # The port is in the unit environment on both installers (this script
+        # defaults and exports it; the x64 unit sets Environment=CLAWBOX_PORT),
+        # and no installer writes it to .env — so it is read from the process
+        # environment alone, unlike the tuning above.
+        _proxy_port = (os.environ.get("CLAWBOX_PORT") or os.environ.get("PORT") or "80").strip()
         if not _proxy_port.isdigit() or not 1 <= int(_proxy_port) <= 65535:
             _proxy_port = "80"
         _proxy_default = "http://127.0.0.1" + (
@@ -670,11 +747,9 @@ elif _wants_llamacpp and _llamacpp_gaps:
         _proxy_root = (
             _llamacpp_setting("CLAWBOX_LOCAL_AI_PROXY_BASE_URL") or _proxy_default
         ).rstrip("/")
-        _llamacpp_repair = {
-            "baseUrl": _proxy_root + "/setup-api/local-ai/llamacpp/v1",
-            "api": "openai-completions",
-            "apiKey": _local_ai_token,
-            "models": [{
+        _repaired_entry = dict(_llamacpp_entry) if isinstance(_llamacpp_entry, dict) else {}
+        if "models" in _llamacpp_gaps:
+            _repaired_entry["models"] = _llamacpp_rows + [{
                 "id": _mid,
                 "name": _mid,
                 "reasoning": False,
@@ -682,18 +757,34 @@ elif _wants_llamacpp and _llamacpp_gaps:
                 "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
                 "contextWindow": _ctx,
                 "maxTokens": _max_tokens,
-            } for _mid in _llamacpp_model_ids],
-        }
-        _repaired_entry = dict(_llamacpp_entry) if isinstance(_llamacpp_entry, dict) else {}
-        for _field in _llamacpp_gaps:
-            _repaired_entry[_field] = _llamacpp_repair[_field]
+            } for _mid in _llamacpp_missing_ids]
+        if _llamacpp_takes_proxy:
+            _repaired_entry["baseUrl"] = _proxy_root + "/setup-api/local-ai/llamacpp/v1"
+            # The key travels WITH the baseUrl or not at all: our proxy accepts
+            # only our bearer, so leaving a foreign apiKey beside it would be
+            # the 401-per-turn the guard above exists to prevent.
+            if _repaired_entry.get("apiKey") != _local_ai_token:
+                if isinstance(_repaired_entry.get("apiKey"), str) and _repaired_entry["apiKey"].strip():
+                    print("  Replaced models.providers.llamacpp.apiKey: the entry now points at this box's local-AI proxy, which accepts only its own bearer")
+                _repaired_entry["apiKey"] = _local_ai_token
+        if not isinstance(_llamacpp_entry, dict):
+            # Only on a FRESH entry. `api` is optional in the schema, and an
+            # entry an operator deliberately left api-less routes as
+            # openai-compatible anyway, so injecting it would change nothing but
+            # their file.
+            _repaired_entry["api"] = "openai-completions"
         _providers_now["llamacpp"] = _repaired_entry
         changed = True
         if isinstance(_llamacpp_entry, dict):
             print(
                 "  Completed models.providers.llamacpp ("
                 + ", ".join(_llamacpp_gaps)
-                + "): OpenClaw rejects an entry without them"
+                + "): OpenClaw's schema requires them"
+                + (
+                    " — dropped " + str(_llamacpp_dropped_rows) + " model row(s) naming no id"
+                    if _llamacpp_dropped_rows
+                    else ""
+                )
             )
         else:
             print(
@@ -983,10 +1074,17 @@ _models_block = cfg.get("models")
 if not isinstance(_models_block, dict):
     if _models_block is not None:
         print("  WARN: models was not an object; replacing it — OpenClaw's schema requires one")
+        # Persisted deliberately: the value on disk fails validation as it
+        # stands, so writing the object form IS the repair. Left unpersisted it
+        # would warn on every boot and be undone by the next writer.
+        changed = True
     _models_block = {}
     cfg["models"] = _models_block
 models_providers = _models_block.get("providers")
 if not isinstance(models_providers, dict):
+    if models_providers is not None:
+        print("  WARN: models.providers was not an object; replacing it")
+        changed = True
     models_providers = {}
     _models_block["providers"] = models_providers
 if has_openrouter_auth and not models_providers.get("openrouter"):

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -16,6 +16,7 @@ import { DISABLED_PROVIDERS_KEY, parseDisabledProviders } from "@/lib/provider-s
 import { ANTHROPIC_PLUGIN_ENABLED_KEY } from "@/lib/provider-plugin-ops";
 import { isSafeDiscordToken } from "@/lib/discord-api";
 import { envPort, waitForPortOpen } from "@/lib/port-probe";
+import { getLocalAiToken } from "@/lib/local-ai-token";
 
 const exec = promisify(execFile);
 
@@ -1887,17 +1888,25 @@ export async function ensureLocalAiProxyUrls(): Promise<boolean> {
 
   let changed = false;
 
-  const llamaProvider = providers.llamacpp;
-  if (llamaProvider && llamaProvider.baseUrl !== getLlamaCppProxyBaseUrl()) {
-    llamaProvider.baseUrl = getLlamaCppProxyBaseUrl();
-    changed = true;
-  }
+  // The bearer travels WITH the URL. This repair points the entry at ClawBox's
+  // own local-AI proxy, and that proxy validates `Authorization` against
+  // data/.local-ai-token and answers 401 to anything else — so moving the
+  // baseUrl while leaving somebody else's apiKey beside it turns "the wrong
+  // endpoint" into "a refused request on every single turn", which is not an
+  // improvement. Only ever alongside a baseUrl WE just wrote: an entry already
+  // on the proxy is left exactly as the owner has it.
+  const adoptProxy = (
+    provider: { baseUrl?: string; apiKey?: string } | undefined,
+    proxyUrl: string,
+  ): boolean => {
+    if (!provider || provider.baseUrl === proxyUrl) return false;
+    provider.baseUrl = proxyUrl;
+    provider.apiKey = getLocalAiToken();
+    return true;
+  };
 
-  const ollamaProvider = providers.ollama;
-  if (ollamaProvider && ollamaProvider.baseUrl !== getOllamaProxyBaseUrl()) {
-    ollamaProvider.baseUrl = getOllamaProxyBaseUrl();
-    changed = true;
-  }
+  if (adoptProxy(providers.llamacpp, getLlamaCppProxyBaseUrl())) changed = true;
+  if (adoptProxy(providers.ollama, getOllamaProxyBaseUrl())) changed = true;
 
   if (changed) {
     await writeConfig(config);

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -1899,29 +1899,63 @@ export async function ensureLocalAiProxyUrls(): Promise<boolean> {
   // And the bearer is PROVIDER-WIDE. OpenClaw resolves a row's endpoint as
   // `model.baseUrl ?? provider.baseUrl` (see the `models.providers` type above)
   // and has no per-model credential slot, so `providers.<p>.apiKey` is the
-  // bearer for every row under the entry. An entry carrying a row on some other
-  // host is therefore one we cannot re-point without mailing this box's
-  // local-AI token to that host on every turn of that row — so it is left
-  // exactly as its owner wrote it. Any row-level `baseUrl` at all disqualifies
-  // it, not only a foreign one: ClawBox writes the endpoint on the PROVIDER and
-  // its rows carry none (the configure route's ollama block and this script's
-  // llamacpp sibling both do), so a row that names its own is per-row routing we
-  // did not build. Same rule `foreignOpenAiRoute` applies to the image
-  // migration: a provider block we did not build is one to leave alone, not to
-  // half-configure.
-  const routesItsOwnRows = (provider: Record<string, unknown>): boolean =>
-    (Array.isArray(provider.models) ? provider.models : []).some((row) =>
-      isPlainObject(row) && typeof row.baseUrl === "string" && row.baseUrl.trim() !== "");
+  // bearer for every row under the entry. An entry carrying a row on ANOTHER
+  // HOST is therefore one we cannot re-point without mailing this box's local-AI
+  // token to that host on every turn of that row — so it is left exactly as its
+  // owner wrote it.
+  //
+  // Foreign, not merely present. The same principle as `foreignOpenAiRoute` in
+  // the configure route — a provider block we did not build is one to leave
+  // alone rather than half-configure — but the test there can be sharper,
+  // because ClawBox marks its own image rows and can recognise them. There is no
+  // such marker on a llamacpp row, so ownership is decided by HOST: loopback and
+  // the proxy's own authority are this box, and everything else (including a URL
+  // that will not parse — guessing permissively is the wrong way to be wrong
+  // about a credential) is not. Refusing over a row that points AT US would be a
+  // false failure, and its sibling in `scripts/gateway-pre-start.sh` pays for
+  // that one in a dead gateway: the entry it declines to complete has no
+  // provider `baseUrl`, which OpenClaw's schema requires for this provider.
+  //
+  // A row without an id is skipped: `ModelDefinitionSchema` requires a non-empty
+  // one, so such a row can never route a turn and its `baseUrl` can never
+  // receive anything.
+  const hostOf = (url: string): string | null => {
+    try {
+      return new URL(url).hostname.toLowerCase();
+    } catch {
+      return null;
+    }
+  };
+
+  const routesToAnotherHost = (provider: Record<string, unknown>, proxyUrl: string): boolean => {
+    const ours = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
+    const proxyHost = hostOf(proxyUrl);
+    if (proxyHost) ours.add(proxyHost);
+    return (Array.isArray(provider.models) ? provider.models : []).some((row) => {
+      if (!isPlainObject(row)) return false;
+      if (typeof row.id !== "string" || row.id.trim() === "") return false;
+      const baseUrl = typeof row.baseUrl === "string" ? row.baseUrl.trim() : "";
+      if (!baseUrl) return false;
+      const host = hostOf(baseUrl);
+      return host === null || !ours.has(host);
+    });
+  };
 
   const adoptProxy = (provider: unknown, proxyUrl: string, id: string): boolean => {
     // `readConfig()` validates the ROOT object only, so anything at all can be
     // sitting at `models.providers.<id>` in a hand-edited file. Module code is
     // strict mode: the assignments below THROW on a primitive, and on an array
     // they land on named properties that `JSON.stringify` then drops — a repair
-    // reported to the caller and never written. Neither is an entry.
+    // reported to the caller and never written. Neither is an entry. (The boot
+    // migration in `scripts/gateway-pre-start.sh` REPLACES such an entry with a
+    // fresh valid one; here we only decline to write into it, because this
+    // function repairs a URL and is not the place that rebuilds a provider.)
     if (!isPlainObject(provider) || provider.baseUrl === proxyUrl) return false;
-    if (routesItsOwnRows(provider)) {
-      console.warn(`[openclaw-config] ${id} routes a model row through its own baseUrl; leaving the entry as configured`);
+    if (routesToAnotherHost(provider, proxyUrl)) {
+      // The URL is deliberately not logged: an owner-configured endpoint can
+      // carry user-info or query credentials, and the journal keeps what it is
+      // given.
+      console.warn(`[openclaw-config] ${id} has a model row on another host; leaving the entry as configured`);
       return false;
     }
     provider.baseUrl = proxyUrl;

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -1895,18 +1895,42 @@ export async function ensureLocalAiProxyUrls(): Promise<boolean> {
   // endpoint" into "a refused request on every single turn", which is not an
   // improvement. Only ever alongside a baseUrl WE just wrote: an entry already
   // on the proxy is left exactly as the owner has it.
-  const adoptProxy = (
-    provider: { baseUrl?: string; apiKey?: string } | undefined,
-    proxyUrl: string,
-  ): boolean => {
-    if (!provider || provider.baseUrl === proxyUrl) return false;
+  //
+  // And the bearer is PROVIDER-WIDE. OpenClaw resolves a row's endpoint as
+  // `model.baseUrl ?? provider.baseUrl` (see the `models.providers` type above)
+  // and has no per-model credential slot, so `providers.<p>.apiKey` is the
+  // bearer for every row under the entry. An entry carrying a row on some other
+  // host is therefore one we cannot re-point without mailing this box's
+  // local-AI token to that host on every turn of that row — so it is left
+  // exactly as its owner wrote it. Any row-level `baseUrl` at all disqualifies
+  // it, not only a foreign one: ClawBox writes the endpoint on the PROVIDER and
+  // its rows carry none (the configure route's ollama block and this script's
+  // llamacpp sibling both do), so a row that names its own is per-row routing we
+  // did not build. Same rule `foreignOpenAiRoute` applies to the image
+  // migration: a provider block we did not build is one to leave alone, not to
+  // half-configure.
+  const routesItsOwnRows = (provider: Record<string, unknown>): boolean =>
+    (Array.isArray(provider.models) ? provider.models : []).some((row) =>
+      isPlainObject(row) && typeof row.baseUrl === "string" && row.baseUrl.trim() !== "");
+
+  const adoptProxy = (provider: unknown, proxyUrl: string, id: string): boolean => {
+    // `readConfig()` validates the ROOT object only, so anything at all can be
+    // sitting at `models.providers.<id>` in a hand-edited file. Module code is
+    // strict mode: the assignments below THROW on a primitive, and on an array
+    // they land on named properties that `JSON.stringify` then drops — a repair
+    // reported to the caller and never written. Neither is an entry.
+    if (!isPlainObject(provider) || provider.baseUrl === proxyUrl) return false;
+    if (routesItsOwnRows(provider)) {
+      console.warn(`[openclaw-config] ${id} routes a model row through its own baseUrl; leaving the entry as configured`);
+      return false;
+    }
     provider.baseUrl = proxyUrl;
     provider.apiKey = getLocalAiToken();
     return true;
   };
 
-  if (adoptProxy(providers.llamacpp, getLlamaCppProxyBaseUrl())) changed = true;
-  if (adoptProxy(providers.ollama, getOllamaProxyBaseUrl())) changed = true;
+  if (adoptProxy(providers.llamacpp, getLlamaCppProxyBaseUrl(), "llamacpp")) changed = true;
+  if (adoptProxy(providers.ollama, getOllamaProxyBaseUrl(), "ollama")) changed = true;
 
   if (changed) {
     await writeConfig(config);

--- a/src/tests/unit/gateway-pre-start-llamacpp-provider.test.ts
+++ b/src/tests/unit/gateway-pre-start-llamacpp-provider.test.ts
@@ -59,7 +59,7 @@ type ProviderDef = {
   baseUrl?: string;
   api?: string;
   apiKey?: string;
-  models?: Array<{ id?: string; name?: string; contextWindow?: number; maxTokens?: number }>;
+  models?: Array<{ id?: string; name?: string; baseUrl?: string; contextWindow?: number; maxTokens?: number }>;
 };
 
 const TOKEN = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
@@ -271,6 +271,35 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh — llamacpp primary without 
 
     expect(changed).toBe(false);
     expect(llamacppProvider(cfg)).toEqual(existing);
+  });
+
+  it("does not write this box's local-AI token beside a model row that routes itself", () => {
+    // The bearer is PROVIDER-WIDE: OpenClaw resolves a row's endpoint as
+    // `model.baseUrl ?? provider.baseUrl` and has no per-model credential slot,
+    // so pointing the entry at our proxy and writing our token beside a row
+    // that keeps its own baseUrl mails that token to that host on every turn of
+    // the row. ClawBox writes the endpoint on the PROVIDER and never on a row,
+    // so a row that names one is per-row routing we did not build — leave the
+    // entry alone and say why. The same rule the TypeScript half of this repair
+    // applies in `ensureLocalAiProxyUrls`.
+    writeToken(TOKEN);
+    const existing = {
+      api: "openai-completions",
+      models: [{
+        id: "gemma4-e2b-it-q4_0",
+        name: "gemma4-e2b-it-q4_0",
+        baseUrl: "https://models.example.net/v1",
+      }],
+    };
+
+    const { cfg, changed, log } = migrate({
+      models: { providers: { llamacpp: existing } },
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+
+    expect(llamacppProvider(cfg)).toEqual(existing);
+    expect(changed).toBe(false);
+    expect(log).toContain("Skipped llamacpp provider repair");
   });
 
   it("does nothing on a box that does not use llamacpp at all", () => {

--- a/src/tests/unit/gateway-pre-start-llamacpp-provider.test.ts
+++ b/src/tests/unit/gateway-pre-start-llamacpp-provider.test.ts
@@ -518,4 +518,159 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh — llamacpp primary without 
     expect(llamacppProvider(partial.cfg).apiKey).toBe("operators-own");
     expect(llamacppProvider(partial.cfg).models?.[0]?.id).toBe("gemma4-e2b-it-q4_0");
   });
+
+  // --- TASK-643 review round -------------------------------------------
+
+  it("survives a .env byte that is not UTF-8 instead of killing the gateway", () => {
+    // .env is clawbox-writable and one latin-1 byte in an operator's value
+    // raised UnicodeDecodeError out of the heredoc — which under
+    // `set -euo pipefail` fails ExecStartPre, and Restart=always then spends
+    // StartLimitBurst. No gateway, no chat, over one byte.
+    writeToken(TOKEN);
+    writeFileSync(
+      path.join(root, ".env"),
+      Buffer.concat([
+        Buffer.from("LLAMACPP_CONTEXT_WINDOW=32768\nSOME_VALUE="),
+        Buffer.from([0xe9]),
+        Buffer.from("\n"),
+      ]),
+    );
+
+    const { cfg, changed } = migrate({
+      models: { providers: {} },
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+
+    expect(changed).toBe(true);
+    expect(llamacppProvider(cfg).models?.[0]?.contextWindow).toBe(32768);
+  });
+
+  it("fills a model row's missing name, which the schema requires as much as the id", () => {
+    // ModelDefinitionSchema is id.min(1) AND name.min(1). A row with an id and
+    // no name looked usable, was left alone, and the whole config still failed
+    // validation — the outcome this migration exists to prevent.
+    writeToken(TOKEN);
+    const { cfg, changed } = migrate({
+      models: {
+        providers: {
+          llamacpp: {
+            baseUrl: "http://127.0.0.1:8080/v1",
+            models: [{ id: "gemma4-e2b-it-q4_0" }],
+          },
+        },
+      },
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+
+    expect(changed).toBe(true);
+    expect(llamacppProvider(cfg).models?.[0]?.name).toBe("gemma4-e2b-it-q4_0");
+  });
+
+  it("registers a referenced id the existing entry does not list, keeping the rows it has", () => {
+    // The entry looked complete, so nothing ran and nothing was said, while the
+    // box answered every turn with "Unknown model".
+    writeToken(TOKEN);
+    const { cfg, changed } = migrate({
+      models: {
+        providers: {
+          llamacpp: {
+            baseUrl: "http://127.0.0.1:8080/v1",
+            models: [{ id: "qwen3-1.7b-q4", name: "qwen3-1.7b-q4" }],
+          },
+        },
+      },
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+
+    expect(changed).toBe(true);
+    expect(llamacppProvider(cfg).models?.map((m) => m.id))
+      .toEqual(["qwen3-1.7b-q4", "gemma4-e2b-it-q4_0"]);
+  });
+
+  it("leaves an entry OpenClaw already accepts alone, api or no api", () => {
+    // `api` and `apiKey` are .optional() in ModelProviderSchema. Treating them
+    // as required rewrote configs that were already valid — and injecting `api`
+    // into one an operator left api-less changes how it routes.
+    writeToken(TOKEN);
+    const existing = {
+      baseUrl: "http://127.0.0.1:8080/v1",
+      models: [{ id: "gemma4-e2b-it-q4_0", name: "gemma4-e2b-it-q4_0" }],
+    };
+    const { cfg, changed } = migrate({
+      models: { providers: { llamacpp: existing } },
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+
+    expect(changed).toBe(false);
+    expect(llamacppProvider(cfg)).toEqual(existing);
+  });
+
+  it("does not demand the proxy bearer for an entry that names its own server", () => {
+    // The refusal spoke about a baseUrl that is not the proxy, and left the
+    // config invalid over a credential the entry never wanted.
+    writeToken(null);
+    const { cfg, changed } = migrate({
+      models: {
+        providers: { llamacpp: { baseUrl: "http://127.0.0.1:8080/v1", models: "broken" } },
+      },
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+
+    expect(changed).toBe(true);
+    expect(llamacppProvider(cfg).baseUrl).toBe("http://127.0.0.1:8080/v1");
+    expect(llamacppProvider(cfg).models?.[0]?.id).toBe("gemma4-e2b-it-q4_0");
+    // ...and no key of ours was put beside a server of theirs.
+    expect(llamacppProvider(cfg)).not.toHaveProperty("apiKey");
+  });
+
+  it("never leaves a foreign key beside this box's own proxy", () => {
+    // The proxy validates the bearer against data/.local-ai-token and answers
+    // 401 to anything else: our baseUrl with somebody else's key is the
+    // 401-per-turn the token guard exists to prevent.
+    writeToken(TOKEN);
+    const { cfg, log } = migrate({
+      models: { providers: { llamacpp: { apiKey: "an-operators-own-key" } } },
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+
+    expect(llamacppProvider(cfg).baseUrl)
+      .toBe("http://127.0.0.1/setup-api/local-ai/llamacpp/v1");
+    expect(llamacppProvider(cfg).apiKey).toBe(TOKEN);
+    expect(log).toContain("Replaced models.providers.llamacpp.apiKey");
+  });
+
+  it("says so when it replaces a malformed models value", () => {
+    writeToken(TOKEN);
+    const { log } = migrate({
+      models: "operator-owned-scalar",
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+
+    expect(log).toContain("models was not an object");
+  });
+
+  it("survives agents.defaults.model = null instead of aborting ExecStartPre", () => {
+    // `setdefault` returned the null and every `.get` on it raised
+    // AttributeError, which under `set -euo pipefail` means the gateway never
+    // reaches ExecStart. A null is an absence rather than a discarded value, so
+    // it is repaired without a WARN — the point is only that the run survives.
+    writeToken(TOKEN);
+    const { cfg, changed } = migrate({
+      models: { providers: {} },
+      agents: { defaults: { model: null } },
+    });
+
+    expect(changed).toBe(false);
+    expect(llamacppProvider(cfg)).toEqual({});
+  });
+
+  it("says so when it replaces a NON-null malformed model block", () => {
+    writeToken(TOKEN);
+    const { log } = migrate({
+      models: { providers: {} },
+      agents: { defaults: { model: "operator-owned-scalar" } },
+    });
+
+    expect(log).toContain("agents.defaults.model was not an object");
+  });
 });

--- a/src/tests/unit/gateway-pre-start-llamacpp-provider.test.ts
+++ b/src/tests/unit/gateway-pre-start-llamacpp-provider.test.ts
@@ -253,7 +253,63 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh — llamacpp primary without 
     });
 
     expect(changed).toBe(false);
-    expect(log).toContain("Skipped llamacpp provider repair");
+    expect(log).toContain("is missing or too short");
+    // ...and the journal says what the skip costs: the entry is left with no
+    // provider baseUrl, which OpenClaw's schema requires for llamacpp, so
+    // ExecStart refuses the whole config rather than merely losing a model.
+    expect(log).toContain("gateway will refuse this config");
+  });
+
+  it("completes the entry when a row names THIS box rather than another host", () => {
+    // Loopback and our own proxy are where the bearer already goes. Refusing
+    // there buys no security and costs a gateway: the entry is left with no
+    // provider baseUrl, which OpenClaw's schema requires for llamacpp, so
+    // ExecStart refuses the config outright.
+    writeToken(TOKEN);
+    const { cfg, changed, log } = migrate({
+      models: {
+        providers: {
+          llamacpp: {
+            api: "openai-completions",
+            models: [
+              { id: "own-server", name: "own-server", baseUrl: "http://127.0.0.1:8080/v1" },
+              {
+                id: "gemma4-e2b-it-q4_0",
+                name: "gemma4-e2b-it-q4_0",
+                baseUrl: "http://127.0.0.1/setup-api/local-ai/llamacpp/v1",
+              },
+            ],
+          },
+        },
+      },
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+
+    expect(changed).toBe(true);
+    expect(llamacppProvider(cfg).baseUrl).toBe("http://127.0.0.1/setup-api/local-ai/llamacpp/v1");
+    expect(llamacppProvider(cfg).apiKey).toBe(TOKEN);
+    expect(log).not.toContain("another host");
+  });
+
+  it("ignores a row OpenClaw's own schema rejects when deciding that", () => {
+    // A row with no id is dropped by this very repair and rejected by
+    // `ModelDefinitionSchema`, so it can never route a turn — letting it veto
+    // the repair would be the same false failure one shape over.
+    writeToken(TOKEN);
+    const { cfg, changed } = migrate({
+      models: {
+        providers: {
+          llamacpp: {
+            api: "openai-completions",
+            models: [{ name: "no id here", baseUrl: "https://models.example.net/v1" }],
+          },
+        },
+      },
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+
+    expect(changed).toBe(true);
+    expect(llamacppProvider(cfg).baseUrl).toBe("http://127.0.0.1/setup-api/local-ai/llamacpp/v1");
   });
 
   it("leaves an existing llamacpp provider untouched", () => {
@@ -299,7 +355,14 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh — llamacpp primary without 
 
     expect(llamacppProvider(cfg)).toEqual(existing);
     expect(changed).toBe(false);
-    expect(log).toContain("Skipped llamacpp provider repair");
+    // Named by its own sentence, not by the shared prefix: the empty-id skip
+    // and the missing-token skip open with the same words, so a prefix match
+    // would pass if a regression fired the wrong branch.
+    expect(log).toContain("names its own baseUrl on another host");
+    // ...and the journal says what the skip costs, because the entry it
+    // declines to complete has no provider baseUrl and OpenClaw's schema
+    // requires one for llamacpp — the gateway refuses the whole config.
+    expect(log).toContain("gateway will refuse this config");
   });
 
   it("does nothing on a box that does not use llamacpp at all", () => {

--- a/src/tests/unit/gateway-pre-start-llamacpp-provider.test.ts
+++ b/src/tests/unit/gateway-pre-start-llamacpp-provider.test.ts
@@ -64,9 +64,23 @@ type ProviderDef = {
 
 const TOKEN = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
+/** Tuning the block reads from the environment; never inherited (see migrate). */
+const AMBIENT_KEYS = [
+  "LLAMACPP_CONTEXT_WINDOW",
+  "LLAMACPP_MAX_TOKENS",
+  "CLAWBOX_LOCAL_AI_PROXY_BASE_URL",
+  "CLAWBOX_PORT",
+  "PORT",
+] as const;
+
 function writeToken(value: string | null): void {
   if (value === null) return;
   writeFileSync(path.join(root, "data", ".local-ai-token"), value);
+}
+
+/** The shipped `$CLAWBOX_ROOT/.env` that install.sh's ensure_env_setting writes. */
+function writeEnvFile(body: string): void {
+  writeFileSync(path.join(root, ".env"), body);
 }
 
 /**
@@ -88,9 +102,16 @@ function migrate(cfg: Config, env: Record<string, string> = {}): { cfg: Config; 
     POLICY,
     "print(json.dumps({'cfg': cfg, 'changed': changed}))",
   ].join("\n");
+  // The block reads its tuning from the environment, so a developer or CI job
+  // that happens to export LLAMACPP_CONTEXT_WINDOW would fail every
+  // default-asserting case here while the script is perfectly correct. Drop
+  // the ambient values and let each case state its own — the same reason
+  // gateway-pre-start-clawai-images.test.ts clears its override.
+  const inherited = { ...process.env };
+  for (const key of AMBIENT_KEYS) delete inherited[key];
   const lines = execFileSync("python3", ["-c", program, file], {
     encoding: "utf-8",
-    env: { ...process.env, CLAWBOX_ROOT: root, ...env },
+    env: { ...inherited, CLAWBOX_ROOT: root, ...env },
   }).trim().split("\n");
   return { ...JSON.parse(lines[lines.length - 1]), log: lines.slice(0, -1).join("\n") };
 }
@@ -307,17 +328,23 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh — llamacpp primary without 
     expect(llamacppProvider(cfg).models?.[0]?.id).toBe("gemma4-e2b-it-q4_0");
   });
 
-  it("preserves an existing but EMPTY llamacpp provider entry", () => {
-    // {} is falsy, so a .get() check would silently overwrite an operator's
-    // deliberate empty entry, contrary to the migration's preservation contract.
+  it("completes an existing but EMPTY llamacpp entry instead of leaving a config the gateway rejects", () => {
+    // Key presence alone treated `{}` as a deliberate operator choice, but
+    // OpenClaw's ModelDefinitionSchema requires a baseUrl and at least one
+    // model on a custom provider: an empty entry fails validation outright, so
+    // preserving it leaves a box whose gateway cannot load its config at all —
+    // strictly worse than the "Unknown model" this migration exists to fix.
     writeToken(TOKEN);
     const { cfg, changed } = migrate({
       models: { providers: { llamacpp: {} } },
       agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
     });
 
-    expect(changed).toBe(false);
-    expect(llamacppProvider(cfg)).toEqual({});
+    expect(changed).toBe(true);
+    const p = llamacppProvider(cfg);
+    expect(p.baseUrl).toBe("http://127.0.0.1/setup-api/local-ai/llamacpp/v1");
+    expect(p.apiKey).toBe(TOKEN);
+    expect(p.models?.[0]?.id).toBe("gemma4-e2b-it-q4_0");
   });
 
   it("survives a non-numeric LLAMACPP_CONTEXT_WINDOW instead of aborting pre-start", () => {
@@ -336,5 +363,159 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh — llamacpp primary without 
     const ctx = llamacppProvider(cfg).models?.[0]?.contextWindow;
     expect(typeof ctx).toBe("number");
     expect(ctx).toBeGreaterThan(0);
+  });
+
+  // --- TASK-643: the review findings on #562 -----------------------------
+
+  it("refuses a bare `llamacpp/` ref rather than writing a model row with an empty id", () => {
+    // ModelDefinitionSchema requires id.min(1). Writing {id:"",name:""} makes
+    // the WHOLE openclaw.json fail validation, so a box that merely could not
+    // answer ends up with a gateway that cannot load at all.
+    writeToken(TOKEN);
+    const { cfg, changed, log } = migrate({
+      models: { providers: {} },
+      agents: { defaults: { model: { primary: "llamacpp/" } } },
+    });
+
+    expect(changed).toBe(false);
+    expect(llamacppProvider(cfg)).toEqual({});
+    expect(log).toContain("Skipped llamacpp provider repair");
+  });
+
+  it("skips an empty id but still repairs a usable one beside it", () => {
+    writeToken(TOKEN);
+    const { cfg, changed } = migrate({
+      models: { providers: {} },
+      agents: { defaults: { model: { primary: "llamacpp/", fallbacks: ["llamacpp/gemma4-e2b-it-q4_0"] } } },
+    });
+
+    expect(changed).toBe(true);
+    expect(llamacppProvider(cfg).models?.map((m) => m.id)).toEqual(["gemma4-e2b-it-q4_0"]);
+  });
+
+  it("registers a row for every distinct llamacpp id, not only the first", () => {
+    // A second llamacpp id in the fallbacks stays "Unknown model" — the exact
+    // failure this migration exists to remove.
+    writeToken(TOKEN);
+    const { cfg } = migrate({
+      models: { providers: {} },
+      agents: {
+        defaults: {
+          model: {
+            primary: "llamacpp/gemma4-e2b-it-q4_0",
+            fallbacks: ["llamacpp/qwen3-1.7b-q4", "clawai/x", " llamacpp/gemma4-e2b-it-q4_0 "],
+          },
+        },
+      },
+    });
+
+    expect(llamacppProvider(cfg).models?.map((m) => m.id))
+      .toEqual(["gemma4-e2b-it-q4_0", "qwen3-1.7b-q4"]);
+  });
+
+  it("reads the tuning from the shipped .env, which the gateway unit does not load", () => {
+    // clawbox-gateway.service loads network.env and discord.env only, while
+    // install.sh's ensure_env_setting writes LLAMACPP_* into
+    // $CLAWBOX_ROOT/.env. Read from os.environ alone, the repair ALWAYS wrote
+    // 131072 while llama-server (started under clawbox-setup, which does load
+    // .env) ran at the configured size: compaction never fires and long
+    // sessions die with context-exceeded.
+    writeToken(TOKEN);
+    writeEnvFile("LLAMACPP_CONTEXT_WINDOW=32768\nLLAMACPP_MAX_TOKENS=4096\n");
+    const { cfg } = migrate({
+      models: { providers: {} },
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+
+    expect(llamacppProvider(cfg).models?.[0]?.contextWindow).toBe(32768);
+    expect(llamacppProvider(cfg).models?.[0]?.maxTokens).toBe(4096);
+  });
+
+  it("lets the process environment win over the .env file", () => {
+    writeToken(TOKEN);
+    writeEnvFile("LLAMACPP_CONTEXT_WINDOW=32768\n");
+    const { cfg } = migrate(
+      {
+        models: { providers: {} },
+        agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+      },
+      { LLAMACPP_CONTEXT_WINDOW: "65536" },
+    );
+
+    expect(llamacppProvider(cfg).models?.[0]?.contextWindow).toBe(65536);
+  });
+
+  it("takes the local-AI proxy authority from the .env too", () => {
+    writeToken(TOKEN);
+    writeEnvFile('CLAWBOX_LOCAL_AI_PROXY_BASE_URL="http://10.42.0.1:8080/"\n');
+    const { cfg } = migrate({
+      models: { providers: {} },
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+
+    expect(llamacppProvider(cfg).baseUrl)
+      .toBe("http://10.42.0.1:8080/setup-api/local-ai/llamacpp/v1");
+  });
+
+  it("honours LLAMACPP_MAX_TOKENS the way src/lib/llamacpp.ts does", () => {
+    writeToken(TOKEN);
+    const explicit = migrate(
+      { models: { providers: {} }, agents: { defaults: { model: { primary: "llamacpp/m" } } } },
+      { LLAMACPP_CONTEXT_WINDOW: "32768", LLAMACPP_MAX_TOKENS: "2048" },
+    );
+    expect(llamacppProvider(explicit.cfg).models?.[0]?.maxTokens).toBe(2048);
+
+    // Unusable value falls back to the context window, as getLlamaCppMaxTokens does.
+    const junk = migrate(
+      { models: { providers: {} }, agents: { defaults: { model: { primary: "llamacpp/m" } } } },
+      { LLAMACPP_CONTEXT_WINDOW: "32768", LLAMACPP_MAX_TOKENS: "nope" },
+    );
+    expect(llamacppProvider(junk.cfg).models?.[0]?.maxTokens).toBe(32768);
+  });
+
+  it("accepts the numeric spellings the TypeScript side accepts", () => {
+    // Number("32768.0") and Number("1e5") both start llama-server at that size
+    // on the TS path; python int() raises on both, the except swallowed it and
+    // the provider silently got 131072 instead.
+    writeToken(TOKEN);
+    const dotted = migrate(
+      { models: { providers: {} }, agents: { defaults: { model: { primary: "llamacpp/m" } } } },
+      { LLAMACPP_CONTEXT_WINDOW: "32768.0" },
+    );
+    expect(llamacppProvider(dotted.cfg).models?.[0]?.contextWindow).toBe(32768);
+
+    const exponent = migrate(
+      { models: { providers: {} }, agents: { defaults: { model: { primary: "llamacpp/m" } } } },
+      { LLAMACPP_CONTEXT_WINDOW: "1e5" },
+    );
+    expect(llamacppProvider(exponent.cfg).models?.[0]?.contextWindow).toBe(100000);
+  });
+
+  it("survives models.providers = null instead of aborting ExecStartPre", () => {
+    // set -euo pipefail: a TypeError here means the gateway never reaches
+    // ExecStart at all.
+    writeToken(TOKEN);
+    const { cfg, changed } = migrate({
+      models: { providers: null },
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+
+    expect(changed).toBe(true);
+    expect(llamacppProvider(cfg).models?.[0]?.id).toBe("gemma4-e2b-it-q4_0");
+  });
+
+  it("leaves a usable operator entry alone but completes a half-written one", () => {
+    writeToken(TOKEN);
+    const partial = migrate({
+      models: { providers: { llamacpp: { baseUrl: "http://127.0.0.1:8080/v1", apiKey: "operators-own" } } },
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+
+    // The operator's own baseUrl and key survive; only the schema-required
+    // models list is filled in, so the config validates.
+    expect(partial.changed).toBe(true);
+    expect(llamacppProvider(partial.cfg).baseUrl).toBe("http://127.0.0.1:8080/v1");
+    expect(llamacppProvider(partial.cfg).apiKey).toBe("operators-own");
+    expect(llamacppProvider(partial.cfg).models?.[0]?.id).toBe("gemma4-e2b-it-q4_0");
   });
 });

--- a/src/tests/unit/gateway-pre-start-llamacpp-provider.test.ts
+++ b/src/tests/unit/gateway-pre-start-llamacpp-provider.test.ts
@@ -365,6 +365,57 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh — llamacpp primary without 
     expect(log).toContain("gateway will refuse this config");
   });
 
+  it("trims a row id the operator padded, instead of reporting a repair that changes nothing", () => {
+    // The comparison that decides whether a row already exists strips the id
+    // (`_llamacpp_have_ids`), but the row KEPT carries the padded value. So a
+    // padded row satisfies the check, no row is appended, the migration prints
+    // "Completed", and the gateway starts on a config whose row id the core
+    // matches with a strict `===` against an already-normalised ref — every
+    // turn still ends "Unknown model: llamacpp/<id>", which is the exact
+    // failure this migration exists to remove.
+    writeToken(TOKEN);
+    const { cfg, changed } = migrate({
+      models: {
+        providers: {
+          llamacpp: {
+            api: "openai-completions",
+            models: [{ id: " gemma4-e2b-it-q4_0 ", name: "gemma4-e2b-it-q4_0" }],
+          },
+        },
+      },
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+
+    expect(changed).toBe(true);
+    expect((llamacppProvider(cfg).models ?? []).map((m) => m.id)).toEqual(["gemma4-e2b-it-q4_0"]);
+  });
+
+  it("trims it on an entry that is otherwise complete, where nothing else would fire", () => {
+    // The counter half of the same fix. With a usable provider baseUrl already
+    // there, `baseUrl` is not a gap; unless the padded id is itself counted as
+    // one, the repair never runs and the corrected row is never written — the
+    // box stays mute with an entry that looks complete, which is the state the
+    // "APPENDED, never a replacement" note above was written for.
+    writeToken(TOKEN);
+    const { cfg, changed } = migrate({
+      models: {
+        providers: {
+          llamacpp: {
+            baseUrl: "http://127.0.0.1/setup-api/local-ai/llamacpp/v1",
+            api: "openai-completions",
+            models: [{ id: "gemma4-e2b-it-q4_0\n", name: "gemma4-e2b-it-q4_0" }],
+          },
+        },
+      },
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+
+    expect(changed).toBe(true);
+    expect((llamacppProvider(cfg).models ?? []).map((m) => m.id)).toEqual(["gemma4-e2b-it-q4_0"]);
+    // ...and the entry it did not need to re-point is left alone.
+    expect(llamacppProvider(cfg).baseUrl).toBe("http://127.0.0.1/setup-api/local-ai/llamacpp/v1");
+  });
+
   it("does nothing on a box that does not use llamacpp at all", () => {
     writeToken(TOKEN);
     const { cfg, changed } = migrate({

--- a/src/tests/unit/gateway-pre-start-openrouter-provider.test.ts
+++ b/src/tests/unit/gateway-pre-start-openrouter-provider.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// Starts a real process (python3): vitest's 5 s test and 10 s hook defaults are
+// not enough on a loaded CI runner. See src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+// The OpenRouter provider-def repair is the llamacpp repair's twin, and the
+// TASK-643 review of #562 found the same two failures living on in it:
+//
+//  - `cfg.setdefault("models", {}).setdefault("providers", {})` raises
+//    AttributeError when `models` is a scalar. It runs on EVERY config, not
+//    only on OpenRouter boxes, and under `set -euo pipefail` an exception here
+//    aborts ExecStartPre — the gateway never reaches ExecStart at all.
+//  - a primary of exactly `openrouter/` yields an empty model id, and
+//    ModelDefinitionSchema requires id.min(1), so the whole openclaw.json
+//    fails validation.
+//
+// Runs the migration out of the shipped .sh, not a copy, so the test fails if
+// the real script drifts.
+
+const SCRIPT = path.resolve(process.cwd(), "scripts/gateway-pre-start.sh");
+const hasPython3 = spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
+
+function extractPolicy(): string {
+  const src = readFileSync(SCRIPT, "utf-8");
+  const start = src.indexOf("# Migration: devices that configured OpenRouter before the provider-def");
+  const end = src.indexOf('gateway = cfg.setdefault("gateway", {})', start);
+  if (start < 0 || end < 0) throw new Error("openrouter provider migration block not found");
+  return src.slice(start, end);
+}
+
+const POLICY = hasPython3 ? extractPolicy() : "";
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(path.join(tmpdir(), "openrouter-provider-")); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+type Config = Record<string, unknown>;
+type ProviderDef = { baseUrl?: string; models?: Array<{ id?: string; name?: string }> };
+
+function migrate(cfg: Config): { cfg: Config; changed: boolean; log: string } {
+  const file = path.join(dir, "config.json");
+  writeFileSync(file, JSON.stringify(cfg));
+  const program = [
+    "import json, os, sys",
+    "cfg = json.load(open(sys.argv[1]))",
+    "changed = False",
+    POLICY,
+    "print(json.dumps({'cfg': cfg, 'changed': changed}))",
+  ].join("\n");
+  const lines = execFileSync("python3", ["-c", program, file], { encoding: "utf-8" })
+    .trim().split("\n");
+  return { ...JSON.parse(lines[lines.length - 1]), log: lines.slice(0, -1).join("\n") };
+}
+
+function openrouterProvider(cfg: Config): ProviderDef {
+  const models = (cfg.models ?? {}) as { providers?: Record<string, ProviderDef> };
+  return models.providers?.openrouter ?? {};
+}
+
+const WITH_AUTH = { auth: { profiles: { "openrouter:default": { key: "sk-or-x" } } } };
+
+describe.skipIf(!hasPython3)("gateway-pre-start.sh — OpenRouter provider def", () => {
+  it("registers the provider for a legacy OpenRouter box", () => {
+    const { cfg, changed } = migrate({
+      ...WITH_AUTH,
+      agents: { defaults: { model: { primary: "openrouter/moonshotai/kimi-k2-0905" } } },
+    });
+
+    expect(changed).toBe(true);
+    expect(openrouterProvider(cfg).baseUrl).toBe("https://openrouter.ai/api/v1");
+    expect(openrouterProvider(cfg).models?.[0]?.id).toBe("moonshotai/kimi-k2-0905");
+  });
+
+  it("survives a scalar models value instead of aborting ExecStartPre", () => {
+    // AttributeError on `"broken".setdefault` took the whole gateway down, and
+    // this line runs on every config — an OpenRouter profile is not needed to
+    // reach it.
+    const { cfg, log } = migrate({ models: "operator-owned-scalar", agents: {} });
+
+    expect(typeof (cfg.models as { providers?: unknown })?.providers).toBe("object");
+    expect(log).toContain("models");
+  });
+
+  it("survives models.providers = null", () => {
+    const { cfg } = migrate({
+      ...WITH_AUTH,
+      models: { providers: null },
+      agents: { defaults: { model: { primary: "openrouter/moonshotai/kimi-k2-0905" } } },
+    });
+
+    expect(openrouterProvider(cfg).models?.[0]?.id).toBe("moonshotai/kimi-k2-0905");
+  });
+
+  it("never writes a model row with an empty id", () => {
+    // `openrouter/` alone yields "" and ModelDefinitionSchema requires
+    // id.min(1): the whole config then fails validation. OpenRouter routes any
+    // slug through the same baseUrl and this list is UI-only, so the bundled
+    // default is the right thing to fall back to.
+    const { cfg } = migrate({
+      ...WITH_AUTH,
+      agents: { defaults: { model: { primary: "openrouter/" } } },
+    });
+
+    expect(openrouterProvider(cfg).models?.[0]?.id).toBe("moonshotai/kimi-k2-0905");
+    expect(openrouterProvider(cfg).models?.[0]?.name).toBeTruthy();
+  });
+
+  it("trims a primary carrying stray whitespace, as the runtime does", () => {
+    const { cfg } = migrate({
+      ...WITH_AUTH,
+      agents: { defaults: { model: { primary: "  openrouter/z-ai/glm-4.6  " } } },
+    });
+
+    expect(openrouterProvider(cfg).models?.[0]?.id).toBe("z-ai/glm-4.6");
+  });
+
+  it("leaves an existing OpenRouter provider entry alone", () => {
+    const existing = { baseUrl: "https://openrouter.ai/api/v1", models: [{ id: "own/model" }] };
+    const { cfg, changed } = migrate({
+      ...WITH_AUTH,
+      models: { providers: { openrouter: existing } },
+      agents: { defaults: { model: { primary: "openrouter/own/model" } } },
+    });
+
+    expect(changed).toBe(false);
+    expect(openrouterProvider(cfg)).toEqual(existing);
+  });
+
+  it("does nothing on a box with no OpenRouter auth profile", () => {
+    const { cfg, changed } = migrate({
+      agents: { defaults: { model: { primary: "anthropic/claude-opus-5" } } },
+    });
+
+    expect(changed).toBe(false);
+    expect(openrouterProvider(cfg)).toEqual({});
+  });
+});

--- a/src/tests/unit/gateway-pre-start-openrouter-provider.test.ts
+++ b/src/tests/unit/gateway-pre-start-openrouter-provider.test.ts
@@ -83,7 +83,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh — OpenRouter provider def",
     const { cfg, log } = migrate({ models: "operator-owned-scalar", agents: {} });
 
     expect(typeof (cfg.models as { providers?: unknown })?.providers).toBe("object");
-    expect(log).toContain("models");
+    expect(log).toContain("models was not an object");
   });
 
   it("survives models.providers = null", () => {

--- a/src/tests/unit/openclaw-config.test.ts
+++ b/src/tests/unit/openclaw-config.test.ts
@@ -823,6 +823,75 @@ describe("openclaw-config", () => {
       expect(written).not.toContain("an-operators-own-key");
     });
 
+    it("pins the proxy bearer itself, not merely the absence of the old one", async () => {
+      // The assertion above only proves the operator's key is gone. Deleting
+      // `apiKey`, or writing an unrelated value there, would satisfy it too —
+      // and either leaves the proxy answering 401 to every turn.
+      mockFs.readFile.mockResolvedValueOnce(JSON.stringify({
+        models: { providers: { llamacpp: { baseUrl: "http://127.0.0.1:8080/v1", apiKey: "an-operators-own-key" } } },
+      }) as never);
+
+      expect(await openclawConfig.ensureLocalAiProxyUrls()).toBe(true);
+
+      // From the SAME module instance the code under test got: `beforeEach`
+      // resets the registry, and this module caches the token it creates, so a
+      // top-level import would hold a different one and the assertion would be
+      // about module identity rather than about the value written.
+      const { getLocalAiToken } = await import("@/lib/local-ai-token");
+      const written = JSON.parse(mockFs.writeFile.mock.calls.at(-1)?.[1] as string);
+      expect(written.models.providers.llamacpp.apiKey).toBe(getLocalAiToken());
+    });
+
+    it("leaves a provider entry that is not an object alone, rather than throwing over it", async () => {
+      // `readConfig()` validates the ROOT object only, so anything at all can
+      // be sitting at `models.providers.llamacpp`. Module code is strict mode:
+      // assigning `baseUrl` on a string primitive throws a TypeError, and the
+      // repair's caller would see a crash where a hand-edited config needed a
+      // no-op.
+      mockFs.readFile.mockResolvedValueOnce(JSON.stringify({
+        models: { providers: { llamacpp: "http://127.0.0.1:8080/v1" } },
+      }) as never);
+
+      await expect(openclawConfig.ensureLocalAiProxyUrls()).resolves.toBe(false);
+      expect(mockFs.writeFile).not.toHaveBeenCalled();
+    });
+
+    it("does not report a repair it could not persist, for an entry written as a list", async () => {
+      // An array takes the assignments and `JSON.stringify` drops every named
+      // property off it, so the write lands without `baseUrl` or `apiKey` while
+      // the function answers `true` — a repair reported and never made.
+      mockFs.readFile.mockResolvedValueOnce(JSON.stringify({
+        models: { providers: { llamacpp: [] } },
+      }) as never);
+
+      await expect(openclawConfig.ensureLocalAiProxyUrls()).resolves.toBe(false);
+      expect(mockFs.writeFile).not.toHaveBeenCalled();
+    });
+
+    it("does not put the proxy bearer beside a model row that points somewhere else", async () => {
+      // OpenClaw resolves a row's endpoint as `model.baseUrl ?? provider.baseUrl`
+      // and there is no per-model credential slot — `providers.<p>.apiKey` is
+      // the bearer for every row under it. So adopting the proxy's token beside
+      // a row that keeps its own foreign baseUrl mails that token to a third
+      // party on every turn of that row. The same rule the openai image
+      // migration already applies through `foreignOpenAiRoute`: a provider
+      // block we did not build is one to leave alone, not to half-configure.
+      mockFs.readFile.mockResolvedValueOnce(JSON.stringify({
+        models: {
+          providers: {
+            llamacpp: {
+              baseUrl: "http://127.0.0.1:8080/v1",
+              apiKey: "an-operators-own-key",
+              models: [{ id: "gemma-4-e2b", baseUrl: "https://models.example.net/v1" }],
+            },
+          },
+        },
+      }) as never);
+
+      await expect(openclawConfig.ensureLocalAiProxyUrls()).resolves.toBe(false);
+      expect(mockFs.writeFile).not.toHaveBeenCalled();
+    });
+
     it("skips writes when local AI providers already point at the proxy", async () => {
       mockFs.readFile.mockResolvedValueOnce(JSON.stringify({
         models: {

--- a/src/tests/unit/openclaw-config.test.ts
+++ b/src/tests/unit/openclaw-config.test.ts
@@ -892,6 +892,50 @@ describe("openclaw-config", () => {
       expect(mockFs.writeFile).not.toHaveBeenCalled();
     });
 
+    it("still adopts the proxy when a row names THIS box", async () => {
+      // A row on loopback or on our own proxy is not somewhere the bearer could
+      // leak to — it is where the bearer already goes. Refusing there would be a
+      // false failure, and on the boot-migration side it leaves the entry with
+      // no provider baseUrl at all, which OpenClaw's schema rejects for this
+      // provider: a dead gateway bought for no security at all.
+      mockFs.readFile.mockResolvedValueOnce(JSON.stringify({
+        models: {
+          providers: {
+            llamacpp: {
+              baseUrl: "http://127.0.0.1:8080/v1",
+              models: [
+                { id: "own-server", baseUrl: "http://127.0.0.1:8080/v1" },
+                { id: "on-the-proxy", baseUrl: "http://127.0.0.1/setup-api/local-ai/llamacpp/v1" },
+              ],
+            },
+          },
+        },
+      }) as never);
+
+      await expect(openclawConfig.ensureLocalAiProxyUrls()).resolves.toBe(true);
+      const written = JSON.parse(mockFs.writeFile.mock.calls.at(-1)?.[1] as string);
+      expect(written.models.providers.llamacpp.baseUrl)
+        .toBe("http://127.0.0.1/setup-api/local-ai/llamacpp/v1");
+    });
+
+    it("ignores a row OpenClaw's own schema would reject when deciding that", async () => {
+      // `ModelDefinitionSchema` requires a non-empty `id`, so a row without one
+      // can never route a turn and its baseUrl cannot receive anything. Letting
+      // it veto the repair would be the same false failure one shape over.
+      mockFs.readFile.mockResolvedValueOnce(JSON.stringify({
+        models: {
+          providers: {
+            llamacpp: {
+              baseUrl: "http://127.0.0.1:8080/v1",
+              models: [{ name: "no id here", baseUrl: "https://models.example.net/v1" }],
+            },
+          },
+        },
+      }) as never);
+
+      await expect(openclawConfig.ensureLocalAiProxyUrls()).resolves.toBe(true);
+    });
+
     it("skips writes when local AI providers already point at the proxy", async () => {
       mockFs.readFile.mockResolvedValueOnce(JSON.stringify({
         models: {

--- a/src/tests/unit/openclaw-config.test.ts
+++ b/src/tests/unit/openclaw-config.test.ts
@@ -803,6 +803,26 @@ describe("openclaw-config", () => {
       );
     });
 
+    it("moves the proxy bearer with the URL, never leaving a foreign key beside it", async () => {
+      // The proxy validates Authorization against data/.local-ai-token and
+      // answers 401 to anything else, so adopting the proxy URL while keeping
+      // somebody else's key turns "the wrong endpoint" into a refused request
+      // on every turn.
+      mockFs.readFile.mockResolvedValueOnce(JSON.stringify({
+        models: {
+          providers: {
+            llamacpp: { baseUrl: "http://127.0.0.1:8080/v1", apiKey: "an-operators-own-key" },
+          },
+        },
+      }) as never);
+
+      expect(await openclawConfig.ensureLocalAiProxyUrls()).toBe(true);
+
+      const written = mockFs.writeFile.mock.calls.at(-1)?.[1] as string;
+      expect(written).toContain('"baseUrl": "http://127.0.0.1/setup-api/local-ai/llamacpp/v1"');
+      expect(written).not.toContain("an-operators-own-key");
+    });
+
     it("skips writes when local AI providers already point at the proxy", async () => {
       mockFs.readFile.mockResolvedValueOnce(JSON.stringify({
         models: {


### PR DESCRIPTION
Closes the eight review findings on PR #562's llama.cpp provider repair (TASK-643), plus the two the same review class turned up in the OpenRouter repair beside it.

## Customer-visible symptom

A box whose primary or fallback names `llamacpp/<model>` could come out of the repair **worse than it went in**: a bare `llamacpp/` ref wrote `models: [{"id": "", "name": ""}]`, and `ModelDefinitionSchema` requires `id.min(1)`, so the whole `openclaw.json` failed validation — a box that merely could not answer ended up with a gateway that could not load its config at all. A second `llamacpp` id among the fallbacks was never registered and kept resolving to `Unknown model`. And the repair never saw the context window the box was actually running at.

## Cause

`scripts/gateway-pre-start.sh`, the llama.cpp provider-def migration:

1. **Empty model id** — `_wants_llamacpp[0][len("llamacpp/"):]` on a bare `llamacpp/` yields `""`, written straight into a model row.
2. **One row only** — only the first ref was registered.
3. **`.env` never reaches this process** — `LLAMACPP_CONTEXT_WINDOW`, `LLAMACPP_MAX_TOKENS` and `CLAWBOX_LOCAL_AI_PROXY_BASE_URL` are written into `$CLAWBOX_ROOT/.env` by `ensure_env_setting` in both installers, and **neither gateway unit loads that file**. So the repair always wrote 131072 while `llama-server` — started under `clawbox-setup.service`, which does load `.env` — ran at the configured size: OpenClaw believed 131k, compaction never fired, and a long session died with context-exceeded.
4. **`int()` vs `Number()`** — `"32768.0"` and `"1e5"` are accepted by `src/lib/llamacpp.ts` and genuinely start `llama-server` at that size; `int()` raised on both, the `except` swallowed it and the provider silently got the default.
5. **Presence read as usability** — an existing but empty `{}` entry was preserved as a deliberate operator choice, but 2026.8.1 rejects a custom provider with no `baseUrl`/`models`.

## Fix

The usability rule is now **OpenClaw's own schema**, read off the installed package (`dist/zod-schema.core-*.js`, 2026.8.1) rather than guessed: a non-built-in provider needs a truthy `baseUrl` and an array `models`, and every row needs `id` **and** `name`, both `.min(1)`. `api` and `apiKey` are `.optional()` there, so an entry OpenClaw already accepts is never touched and `api` is written only on a fresh entry. Only the schema-missing fields are filled: a row lacking `name` is completed from its id, a referenced id the entry does not list is **appended** rather than the list replaced, and a row naming no model at all is dropped and counted in the journal line.

The local-AI bearer is required only when we are the ones writing the proxy `baseUrl` — an entry naming the operator's own `llama-server` needs no token from us, and refusing there left their config invalid over a credential it never wanted. When we do write our proxy URL, the key travels with it, because the proxy validates `Authorization` against `data/.local-ai-token` and answers 401 to anything else.

The tuning is read from `$CLAWBOX_ROOT/.env`, process environment first, decoded with `errors="replace"` and guarded broadly — one latin-1 byte in that clawbox-writable file raised `UnicodeDecodeError` out of the heredoc, failing `ExecStartPre` under `set -euo pipefail`, and `Restart=always` then spends `StartLimitBurst`: no gateway and no chat.

## Harness-first

The native mechanism for the config write is `openclaw config set --batch-json`, and this file states at its head why the boot repair edits `openclaw.json` directly instead (~10 s CLI cold start per key on a Jetson, before the gateway is up). Nothing here re-implements a model list or a credential store: the provider-def shape mirrors `src/app/setup-api/ai-models/configure/route.ts` and the numeric semantics mirror `src/lib/llamacpp.ts`, and the schema it validates against is the harness's own.

For the environment, the native mechanism is systemd's `EnvironmentFile=`. It is **deliberately not used**: adding `EnvironmentFile=-/home/clawbox/clawbox/.env` to the gateway unit would hand every key in a clawbox-writable file to the long-running gateway process — `CLAWBOX_TEST_MODE` included — so the migration reads the handful of keys it needs itself.

## Sibling call sites

- **OpenRouter provider repair, same file.** `cfg.setdefault("models", {}).setdefault("providers", {})` raised `AttributeError` on a scalar `models` or a null `models.providers` — on **every** config, not only on OpenRouter boxes — which aborts `ExecStartPre`. And a bare `openrouter/` primary wrote the same empty-id row. Both guarded, with the migration extracted into its own regression suite.
- **`agents`, `agents.defaults`, `agents.defaults.model`** — the identical crash one screen above the guards this PR adds. Coerced, with a WARN when a non-null value is discarded.
- **`ensureLocalAiProxyUrls` (`src/lib/openclaw-config.ts`, run at every web-server boot from `src/instrumentation.ts`)** forces the `llamacpp` and `ollama` `baseUrl`s onto the ClawBox proxy and left the entry's `apiKey` alone — the same 401-per-turn from the other direction. The bearer now travels with the URL.
- **Cleared, no change needed:** `scripts/ensure-local-embeddings.sh` reads `CLAWBOX_LOCAL_AI_PROXY_BASE_URL` and the `EMBED_*` keys from the process environment only, and is launched from this same script, so it shares the blindness — but no installer writes those keys to `.env` and its compiled-in defaults are byte-identical to what `ensure_env_setting` writes, so nothing diverges today. Recorded rather than changed.
- **`install.sh` / `install-x64.sh`** both write the `.env` keys and neither gateway unit loads them, so the fix covers both installers.

## RED

On unmodified `origin/beta` (`dd058938`), 9 of the new llama.cpp cases and 4 of the new OpenRouter cases fail:

```
 × completes an existing but EMPTY llamacpp entry instead of leaving a config the gateway rejects
 × refuses a bare `llamacpp/` ref rather than writing a model row with an empty id
 × skips an empty id but still repairs a usable one beside it
 × registers a row for every distinct llamacpp id, not only the first
 × reads the tuning from the shipped .env, which the gateway unit does not load
 × takes the local-AI proxy authority from the .env too
 × honours LLAMACPP_MAX_TOKENS the way src/lib/llamacpp.ts does
 × accepts the numeric spellings the TypeScript side accepts
 × leaves a usable operator entry alone but completes a half-written one
      Tests  9 failed | 17 passed (26)

 × survives a scalar models value instead of aborting ExecStartPre
   AttributeError: 'str' object has no attribute 'setdefault'
 × survives models.providers = null
   AttributeError: 'NoneType' object has no attribute 'get'
 × never writes a model row with an empty id
 × trims a primary carrying stray whitespace, as the runtime does
      Tests  4 failed | 3 passed (7)
```

## GREEN

```
 Test Files  3 passed (3)
      Tests  94 passed (94)      (the two migration suites + openclaw-config)

 Test Files  47 passed (47)
      Tests  728 passed (728)    (every gateway-pre-start, openclaw-config,
                                  instrumentation, llamacpp, openrouter and
                                  local-ai suite, plus the beta guard suites)
```

`tsc --noEmit` clean; `bash -n scripts/gateway-pre-start.sh` clean; eslint reports only the six pre-existing unused-var warnings already in `openclaw-config.ts`.

## Device proof (read-only, both editions)

**OpenClaw box** — the `.env` gap reproduced on hardware:

```
=== gateway unit EnvironmentFile ===
EnvironmentFile=-/home/clawbox/clawbox/data/network.env
EnvironmentFile=-/home/clawbox/clawbox/data/discord.env
=== .env llamacpp keys ===
LLAMACPP_CONTEXT_WINDOW=131072
LLAMACPP_MAX_TOKENS=131072
=== gateway process env ===
LLAMACPP_ vars in gateway env: 0
=== configured llamacpp provider ===
llamacpp entry present: True
  models: [('gemma4-e2b-it-q4_0', 131072, 131072)]
primary: deepseek/deepseek-v4-pro fallbacks: ['llamacpp/gemma4-e2b-it-q4_0']
```

The unit loads `network.env` and `discord.env` only, `.env` carries the two `LLAMACPP_*` keys, and the running gateway's environment contains **zero** of them — so the repair could never have read the configured size. This box happens to be at the default, which is exactly why the divergence was invisible.

**Hermes box** — inert, as it must be: `CLAWBOX_EDITION=hermes`, no `clawbox-gateway.service` on the box at all and no `models.providers.llamacpp` to touch. `setup-hermes-edition.sh` stops, disables and masks that unit, so this `ExecStartPre` never runs on that edition; the Hermes edition reaches llama.cpp through `applyLocalAiToHermes` instead. Nothing in this diff can execute there.

No box was mutated: every command above is a read.

## Review

Reviewed at high effort against the installed OpenClaw package rather than from memory; 2 high, 7 medium and 5 low findings, all applied or explicitly answered. The two high ones — the non-UTF-8 `.env` crash and the foreign-key-beside-our-proxy 401 — were both introduced by the first pass of this fix and are closed above. Findings deliberately not taken: the `models`/`models.providers` coercion is duplicated in the two migrations rather than factored into one helper, because each region is extracted and executed standalone by its own regression suite and a shared helper would be unbound there; that is stated in a comment beside both.

One residual is recorded and not fixed here: `ensureLocalAiProxyUrls` makes the `llamacpp` `baseUrl` ClawBox-owned at every web-server boot, so an operator's own `baseUrl` does not survive on this device however carefully the boot script preserves it. This PR keeps the boot script conservative (it only fills a missing `baseUrl`) and makes the bearer follow the URL so the combination can no longer 401; whether the field should be operator-owned is a product question, not a bug fix.


## Merge-gate round — the bearer this PR started writing, and where it could go

The review round raised three points on the `apiKey` this branch added beside the proxy URL. Two
were real and are fixed with a RED test first; the third is a test-strength point and is applied.

### The credential, and the row that routes itself

`ensureLocalAiProxyUrls` began writing `provider.apiKey = getLocalAiToken()` alongside the proxy
`baseUrl` — correct on its own, because the proxy answers 401 to anything but its own bearer. But
that key is PROVIDER-WIDE: OpenClaw resolves a row's endpoint as `model.baseUrl ?? provider.baseUrl`
and has no per-model credential slot, so a model row that keeps its own `baseUrl` on another host
would receive this box's local-AI token on every turn of that row. Confirmed against the installed
core, read as files with the config paths pointed at a scratch directory: the
`model.baseUrl ?? entry.baseUrl` expression appears in the inline-provider builder and in six other
runtime modules, and there is no per-model key.

Both writers of this entry now decline it: `ensureLocalAiProxyUrls`, and the boot migration in
`scripts/gateway-pre-start.sh`, which does the same repair in Python at `ExecStartPre` and which
this PR also owns. The second one is the call site that would otherwise have shipped unguarded.

**Foreign, not merely present.** The first version of the guard refused on ANY row-level `baseUrl`,
and that was too blunt in a way that costs more than it buys: a row on loopback or on this box's own
proxy is where the bearer already goes, and a row with no `id` is dropped by the repair and rejected
by the core's own model schema, so none of the three can leak anything. On the boot-migration side
refusing there is not free — the entry it declines to complete has no provider `baseUrl`, and
`llamacpp` is not a bundled overlay, so the core's schema rejects the whole config and the gateway
does not start at all. Ownership is now decided by HOST: loopback and the proxy's own authority are
this box; everything else, including a URL that will not parse, is not. The journal line names the
consequence and the remedy, and never the URL itself (an owner-configured endpoint can carry
user-info or query credentials).

### The entry that is not an object

`readConfig()` validates the root object only, so anything can be sitting at
`models.providers.llamacpp` in a hand-edited file. A primitive made the assignment throw
(`TypeError: Cannot create property 'baseUrl' on string` — reproduced); an array took the
assignments onto named properties that `JSON.stringify` then drops, so the function answered `true`
for a repair that never reached the file. Guarded with the module's own `isPlainObject`. The boot
migration replaces such an entry with a fresh valid one instead — a deliberate difference, now
stated in the comment, because that script rebuilds a provider and this function only repairs a URL.

### The token assertion

The existing case asserted only that the operator's old key was gone, which deleting `apiKey`
entirely would also satisfy. It now parses the written config and asserts the value equals
`getLocalAiToken()` from the same module instance the code under test used (the suite resets the
module registry per test and the token module caches).

### RED

```
 × leaves a provider entry that is not an object alone, rather than throwing over it
   Caused by: TypeError: Cannot create property 'baseUrl' on string
 × does not report a repair it could not persist, for an entry written as a list
   AssertionError: expected true to be false
 × does not put the proxy bearer beside a model row that points somewhere else
   AssertionError: expected true to be false
 Tests  3 failed | 4 passed
```

and on the boot-migration side, the same hazard in the sibling writer:

```
 × does not write this box's local-AI token beside a model row that routes itself
   - "api": "openai-completions"
   + "apiKey": "<the suite's fixed dummy token>"
   + "baseUrl": "http://127.0.0.1/setup-api/local-ai/llamacpp/v1"
```

The narrowing has its own RED against the first version of the guard: `completes the entry when a
row names THIS box rather than another host` and `ignores a row OpenClaw's own schema rejects when
deciding that` both fail on it, in both writers.

### GREEN

```
 Test Files  25 passed (25)
      Tests  511 passed (511)
```

(`openclaw-config`, the two `gateway-pre-start` provider suites, `gateway-pre-start-clawai-images`,
`routes/ai-models`, plus `openclaw-config-mock-completeness`, `test-timeout-hygiene`,
`state-updater-purity`.) `tsc --noEmit` clean, `bash -n scripts/gateway-pre-start.sh` clean, eslint
carries only the six pre-existing warnings elsewhere in that file. Rebased onto `origin/beta`
`3ee50cea`; `git diff --stat origin/beta...HEAD` lists only the 5 files this PR intends and
`--diff-filter=DR` is empty.

### Every other writer of this token, checked

`configure/route.ts` writes the whole `ollama` and `llamacpp` entries as one object, with rows this
repo authors and no row-level `baseUrl`, so no owner row survives to receive the bearer; its third
site writes an auth profile rather than a provider entry. `memory-shard.ts` writes a different key,
`hermes-local-ai.ts` writes a different store (Hermes YAML), and the OpenRouter block in
`gateway-pre-start.sh` only ever creates a fresh entry and writes a reference rather than a
credential. None needs the guard.

### A padded row id, found on the same head

One more false success in the same block, and it is the failure this migration exists to remove
reported as a completed repair. The check that decides whether a row already exists strips the id
(`_llamacpp_have_ids`), but the row the migration KEEPS carries the operator's padding. So an entry
holding `{"id": " gemma4-e2b-it-q4_0 "}` satisfies the check, nothing is appended, the journal says
`Completed`, the config passes the schema — `id.min(1)` accepts a padded id — the gateway starts, and
every turn still ends `Unknown model: llamacpp/gemma4-e2b-it-q4_0`, because the core matches a row id
with a strict comparison against a ref it has already normalised.

The id is now trimmed into the kept row, and the correction is counted alongside the `name` repair.
The counter is not bookkeeping: on an entry whose `baseUrl` is already usable, nothing else puts
`models` in the gap list, so an uncounted correction is computed and never written — the box stays
mute behind an entry that looks complete. `_llamacpp_have_ids` no longer strips either, so one place
decides what an id is rather than two that can drift, and the journal names the change the way it
already names a dropped row.

Two cases pin the two halves; both are RED on the previous head, the second as `expected false to be
true` — the repair did not fire at all. No TypeScript change is needed: `ensureLocalAiProxyUrls`
never reads or writes a row id, so the two writers stay in agreement. Provenance is hand-edit only —
the configure route trims the model before it writes either local-AI entry — which puts it in the
same family as the row-level `baseUrl` above.

### Recorded, not fixed here

The guard covers the moment of adoption, not the standing state: an entry ALREADY on the proxy with
the token beside it, to which an owner later appends a row on another host, is not re-examined by
either writer. Closing that means warning on a path that writes nothing, and it is queued rather
than folded in. Likewise a row whose `baseUrl` is present but not a string is treated as absent by
both writers and still fails the core's row schema — the same pre-existing limitation as the row
repair only completing `id` and `name`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup handling for malformed, incomplete, or unreadable AI configuration without overwriting existing settings or blocking startup.
  - Improved Llama.cpp and OpenRouter setup, including support for multiple models, safer validation, provider repair, and preservation of existing configuration.
  - Local AI providers now receive the current authentication token when switching to local proxy endpoints.
  - Improved handling of tuning settings, credentials, URLs, and partially configured providers with warnings and non-blocking fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

