### PR TITLE
fix: resolve repo paths from the checkout, not the process cwd

### DIFF
--- a/src/app/setup-api/browser/manage/route.ts
+++ b/src/app/setup-api/browser/manage/route.ts
@@ -8,6 +8,7 @@ import fs from "fs/promises";
 import path from "path";
 import type { OpenClawConfig } from "@/lib/openclaw-config";
 import { openclawIsAbsent, readConfig, restartGateway, runOpenclawConfigSet } from "@/lib/openclaw-config";
+import { CONFIG_ROOT } from "@/lib/config-store";
 import { sqliteGet, sqliteSet } from "@/lib/sqlite-store";
 import { findClawboxBrowserPids, terminateClawboxBrowser, terminateForeignCdpBrowser } from "@/lib/process-match";
 import { findPlaywrightChromium } from "@/lib/cdp-probe";
@@ -60,7 +61,17 @@ function integrationIsAlwaysOn(): boolean {
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 async function installPlaywrightChromium(): Promise<void> {
-  const playwrightBin = path.join(process.cwd(), "node_modules", ".bin", "playwright");
+  // The checkout, not the cwd. In production the cwd is `.next/standalone`
+  // (Next's standalone server.js chdirs there) and scripts/postbuild.sh copies
+  // only the `playwright` and `playwright-core` PACKAGES into that tree — it
+  // creates no `node_modules/.bin` — so this path was a guaranteed ENOENT on
+  // every box. The caller swallows that into a console.warn and still answers
+  // `{ ok: true }` off whatever apt/snap Chromium is around, which on Ubuntu
+  // 24.04 is the snap wrapper `isServiceSafeChromium()` refuses: the one
+  // browser that would have worked could never be installed. Measured
+  // read-only on the OpenClaw box 2026-09-05 — present and executable in the
+  // checkout, absent under `.next/standalone`.
+  const playwrightBin = path.join(CONFIG_ROOT, "node_modules", ".bin", "playwright");
   await fs.access(playwrightBin, fsConstants.X_OK);
   await exec(playwrightBin, ["install", "chromium"], {
     timeout: 300000,

--- a/src/app/setup-api/llamacpp/install/route.ts
+++ b/src/app/setup-api/llamacpp/install/route.ts
@@ -250,7 +250,20 @@ export async function POST(request: Request) {
         emit(controller, { status: "Checking local Gemma 4 runtime..." });
 
         const existingModels = await queryLlamaCppModels(spec.baseUrl);
-        if (existingModels.includes(alias)) {
+        // Any model, not only this alias. `getLlamaCppLaunchSpec()` resolves
+        // `modelPath` from getDefaultLlamaCppFile() whatever the alias is, and
+        // start-llamacpp.sh passes that as `--model` while the alias is only
+        // `--alias` — so every alias on a box is the SAME GGUF and a non-empty
+        // /v1/models means THE runtime is up, whatever it calls itself.
+        //
+        // waitForLlamaCppReady() and isLlamaCppUp() (src/lib/local-ai-runtime.ts)
+        // already read it that way on every proxied inference request. This
+        // route was the one that did not, and it is the one with a 20-minute
+        // budget: a warm runtime under a label from an earlier install left the
+        // live pid blocking a restart, the alias never appeared, and the wizard
+        // polled for the full startupTimeoutMs before reporting a timeout for a
+        // runtime that was answering the whole time.
+        if (existingModels.length > 0) {
           emit(controller, { status: "llama.cpp is already running. Applying configuration..." });
           const configured = await configureLlamaCpp(alias, scope, activate);
           if (!configured.ok) {
@@ -328,7 +341,9 @@ export async function POST(request: Request) {
           }
 
           const models = await queryLlamaCppModels(spec.baseUrl);
-          if (models.includes(alias)) {
+          // Same rule as the pre-check above: the runtime answering at all is
+          // the readiness signal, because one GGUF backs every alias.
+          if (models.length > 0) {
             emit(controller, { status: "llama.cpp is ready. Applying ClawBox configuration..." });
             const configured = await configureLlamaCpp(alias, scope, activate);
             if (!configured.ok) {

--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -1,7 +1,24 @@
 import path from "path";
 import fs from "fs";
 
-export const CONFIG_ROOT = process.env.CLAWBOX_ROOT || (process.env.NODE_ENV === "development" ? process.cwd() : "/home/clawbox/clawbox");
+/**
+ * Where this ClawBox is installed, resolved AT CALL TIME.
+ *
+ * `CONFIG_ROOT` below is the same answer captured at import time, and it is
+ * what almost everything should use. Call this instead only where the root can
+ * still change after the module is loaded — the tests set `CLAWBOX_ROOT` in a
+ * `beforeEach`, which a module-level constant never sees.
+ *
+ * NOT `process.cwd()` outside development: the production server chdirs into
+ * `.next/standalone` (Next's standalone `server.js` does `process.chdir`), so
+ * the cwd there is the build output, not the install.
+ */
+export function resolveConfigRoot(): string {
+  return process.env.CLAWBOX_ROOT
+    || (process.env.NODE_ENV === "development" ? process.cwd() : "/home/clawbox/clawbox");
+}
+
+export const CONFIG_ROOT = resolveConfigRoot();
 export const DATA_DIR = path.join(CONFIG_ROOT, "data");
 const CONFIG_PATH = path.join(DATA_DIR, "config.json");
 

--- a/src/lib/hermes-image-plugin.ts
+++ b/src/lib/hermes-image-plugin.ts
@@ -1,5 +1,6 @@
 import fsp from "fs/promises";
 import path from "path";
+import { resolveConfigRoot } from "@/lib/config-store";
 import { hermesHome } from "@/lib/hermes-env";
 
 /**
@@ -91,13 +92,19 @@ export const HERMES_IMAGE_TOKEN_ENV = "CLAWBOX_AI_TOKEN";
 /**
  * Where the plugin's source lives in THIS checkout.
  *
- * `CLAWBOX_ROOT` first for the same reason `config-store` and `system-profile`
- * read it: the production server runs from the repo root, but a test (and a dev
- * server) may not.
+ * The install, NOT the cwd. The production server does not run from the repo
+ * root: Next's standalone `server.js` does `process.chdir(__dirname)`, so in
+ * production the cwd is `.next/standalone`, and this read the plugin out of the
+ * build output. That worked only because @vercel/nft happened to trace
+ * `scripts/` into that tree — a copy that refreshes on a full rebuild and not
+ * before, so an update shipping a fixed plugin could install the stale one.
+ *
+ * `resolveConfigRoot()` rather than the `CONFIG_ROOT` constant: it is read per
+ * call, and the tests point `CLAWBOX_ROOT` at a temp tree after this module is
+ * imported.
  */
-function pluginSourceDir(): string {
-  const root = process.env.CLAWBOX_ROOT || process.cwd();
-  return path.join(root, "scripts", "hermes-plugins", "image_gen", HERMES_IMAGE_PLUGIN_NAME);
+export function hermesImagePluginSourceDir(): string {
+  return path.join(resolveConfigRoot(), "scripts", "hermes-plugins", "image_gen", HERMES_IMAGE_PLUGIN_NAME);
 }
 
 /** Where Hermes looks for a user-installed image backend. */
@@ -117,7 +124,7 @@ export function hermesImagePluginDir(): string {
  * Python will happily import a stale `.pyc` whose source no longer exists.
  */
 export async function installHermesImagePlugin(): Promise<void> {
-  const source = pluginSourceDir();
+  const source = hermesImagePluginSourceDir();
   const target = hermesImagePluginDir();
   await fsp.mkdir(target, { recursive: true, mode: 0o755 });
   for (const name of PLUGIN_FILES) {

--- a/src/lib/llamacpp-server.ts
+++ b/src/lib/llamacpp-server.ts
@@ -1,7 +1,7 @@
 import fs from "fs/promises";
 import type { FileHandle } from "fs/promises";
 import path from "path";
-import { DATA_DIR, getAll } from "./config-store";
+import { CONFIG_ROOT, DATA_DIR, getAll } from "./config-store";
 import {
   getDefaultLlamaCppFile,
   getDefaultLlamaCppModel,
@@ -113,7 +113,16 @@ export function getLlamaCppLaunchSpec(alias = getDefaultLlamaCppModel()): LlamaC
     hfFile,
     binPath: process.env.LLAMACPP_BIN?.trim() || DEFAULT_LLAMACPP_BIN,
     hfBinPath: process.env.HF_BIN?.trim() || DEFAULT_HF_BIN,
-    scriptPath: path.join(process.cwd(), "scripts", "start-llamacpp.sh"),
+    // The checkout, not the cwd. In production the cwd is `.next/standalone`
+    // (Next's standalone server.js chdirs there), so this resolved to a path
+    // whose only occupant is whatever @vercel/nft happened to trace in — a
+    // build artefact that refreshes on a full rebuild and not before. Every
+    // other path in this spec already comes from CONFIG_ROOT via DATA_DIR;
+    // the launcher script was the one that did not, so the script and the
+    // runtime files it writes could come from two different trees.
+    // src/instrumentation-node.ts resolves scripts/terminal-server.mjs the
+    // same way, for the same reason.
+    scriptPath: path.join(CONFIG_ROOT, "scripts", "start-llamacpp.sh"),
     pidPath: LLAMACPP_PID_PATH,
     logPath: LLAMACPP_LOG_PATH,
     modelDir: path.join(LLAMACPP_RUNTIME_DIR, "models"),

--- a/src/tests/routes/browser/manage.test.ts
+++ b/src/tests/routes/browser/manage.test.ts
@@ -56,7 +56,9 @@ import { openclawIsAbsent, readConfig, restartGateway, runOpenclawConfigSet } fr
 import { sqliteGet, sqliteSet } from "@/lib/sqlite-store";
 import { findPlaywrightChromium } from "@/lib/cdp-probe";
 import fs from "fs/promises";
+import path from "path";
 import { promisify } from "util";
+import { CONFIG_ROOT } from "@/lib/config-store";
 
 describe("/setup-api/browser/manage", () => {
   let GET: () => Promise<Response>;
@@ -264,6 +266,34 @@ describe("/setup-api/browser/manage", () => {
       const res = await POST(req);
       // Will fail since all install methods fail
       expect(res.status).toBe(500);
+    });
+
+    /**
+     * TASK-682 — the Playwright CLI is looked for in the CHECKOUT, not the cwd.
+     *
+     * In production the cwd is `.next/standalone` (Next's standalone server.js
+     * chdirs there) and scripts/postbuild.sh copies only the `playwright` and
+     * `playwright-core` PACKAGES into that tree — no `node_modules/.bin`. So
+     * `path.join(process.cwd(), "node_modules", ".bin", "playwright")` was a
+     * guaranteed ENOENT on every box, the failure was swallowed into a
+     * console.warn, and the route still answered `{ ok: true }` off whatever
+     * apt/snap Chromium was around. Measured read-only on the OpenClaw box
+     * 2026-09-05: `node_modules/.bin/playwright` is present and executable in
+     * the checkout, and absent under `.next/standalone`.
+     */
+    it("looks for the Playwright CLI in the checkout, not in the build output", async () => {
+      const mockExec = vi.fn().mockRejectedValue(new Error("install failed"));
+      vi.mocked(promisify).mockReturnValue(mockExec as never);
+      const req = new Request("http://localhost/setup-api/browser/manage", {
+        method: "POST",
+        body: JSON.stringify({ action: "install-chromium" }),
+      });
+      await POST(req);
+
+      const looked = vi.mocked(fs.access).mock.calls.map(([p]) => String(p));
+      expect(looked).toContain(
+        path.join(CONFIG_ROOT, "node_modules", ".bin", "playwright"),
+      );
     });
 
     it("handles enable action without chromium", async () => {

--- a/src/tests/routes/llamacpp/install.test.ts
+++ b/src/tests/routes/llamacpp/install.test.ts
@@ -176,6 +176,51 @@ describe("POST /setup-api/llamacpp/install", () => {
     expect(text).toContain("\"success\":true");
   });
 
+  /**
+   * TASK-682 — the alias is a WIRE LABEL, not a choice of weights.
+   *
+   * `getLlamaCppLaunchSpec(alias)` resolves `modelPath` from
+   * `getDefaultLlamaCppFile()` whatever the alias is, and start-llamacpp.sh
+   * passes it as `--model` while the alias goes to `--alias`. So every alias on
+   * a box is the SAME GGUF, and `models.includes(alias)` asks a question about
+   * a label rather than about the runtime.
+   *
+   * Two other readers already know this — `waitForLlamaCppReady` and
+   * `isLlamaCppUp` (src/lib/local-ai-runtime.ts) both accept a non-empty
+   * `/v1/models` — and this route was the one that did not. With a warm runtime
+   * under a different label (the install route itself accepts any MODEL_ID_RE
+   * string, and a Settings model change never stops the old server), the pid
+   * file is live so nothing restarts, the alias never appears, and the wizard
+   * sat in a streamed HTTP handler for the FULL startupTimeoutMs — 20 minutes —
+   * before reporting a timeout for a runtime that was up and answering.
+   */
+  it("configures against a runtime that is already up under another alias, instead of polling to the timeout", async () => {
+    // A live pid: this is what stops the loop from restarting anything.
+    mockFs.readFile.mockImplementation((async (target: unknown) =>
+      String(target).endsWith("server.pid")
+        ? `${process.pid}\n`
+        : Promise.reject(new Error("ENOENT"))) as typeof fsp.readFile);
+    // The runtime answers — under the label the install route was given last time.
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [{ id: "gemma-4-e2b" }] }),
+    }));
+    // Without this the RED case would take the real 20 minutes to fail.
+    vi.stubEnv("LLAMACPP_STARTUP_TIMEOUT_MS", "1");
+
+    const res = await installPost(jsonRequest({ model: "gemma4-e2b-it-q4_0" }));
+    const text = await readStream(res);
+
+    vi.unstubAllEnvs();
+
+    expect(text).not.toContain("Timed out");
+    expect(text).toContain("already running");
+    expect(text).toContain("\"success\":true");
+    expect(mockConfigureAiModel).toHaveBeenCalled();
+    // And it must not race the live server for the one port.
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
   it("starts llama-server and configures after the model becomes ready", async () => {
     const mockFetch = vi.fn()
       .mockResolvedValueOnce({

--- a/src/tests/unit/hermes-image-plugin.test.ts
+++ b/src/tests/unit/hermes-image-plugin.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { saveEnv } from "@/tests/helpers/env";
 import fs from "fs";
 import os from "os";
@@ -8,6 +8,7 @@ import {
   HERMES_IMAGE_PLUGIN_NAME,
   hermesImagePluginDir,
   hermesImagePluginInstalled,
+  hermesImagePluginSourceDir,
   installHermesImagePlugin,
   mergePluginsEnabled,
   decodePluginsEnabledJson,
@@ -39,6 +40,37 @@ describe("installing the ClawBox AI image backend", () => {
   afterEach(() => {
     restoreEnv();
     fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  /**
+   * On a box the source of this plugin is the CHECKOUT, and the production
+   * server's cwd is not the checkout: Next's standalone `server.js` chdirs into
+   * `.next/standalone`. Reading it from the cwd installed whatever @vercel/nft
+   * had traced into the build output — a copy that only refreshes on a full
+   * rebuild, so an update that shipped a fixed plugin could install the old one.
+   *
+   * The RESOLVED PATH is what is pinned, not a filesystem outcome: on a box
+   * `/home/clawbox/clawbox/scripts/hermes-plugins/...` exists, so a case that
+   * asserted the install fails would pass on this PC and fail on the hardware
+   * ClawBox is tested on.
+   */
+  it("resolves the plugin source from the install root, never from the cwd", () => {
+    process.env.CLAWBOX_ROOT = "/srv/clawbox-elsewhere";
+    expect(hermesImagePluginSourceDir()).toBe(
+      path.join("/srv/clawbox-elsewhere", "scripts", "hermes-plugins", "image_gen", HERMES_IMAGE_PLUGIN_NAME),
+    );
+
+    // With no CLAWBOX_ROOT, production resolves the install path — not the cwd,
+    // which under the standalone server is `.next/standalone`.
+    delete process.env.CLAWBOX_ROOT;
+    vi.stubEnv("NODE_ENV", "production");
+    try {
+      expect(hermesImagePluginSourceDir()).toBe(
+        path.join("/home/clawbox/clawbox", "scripts", "hermes-plugins", "image_gen", HERMES_IMAGE_PLUGIN_NAME),
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 
   it("puts the manifest and the entry point where Hermes discovers plugins", async () => {

--- a/src/tests/unit/llamacpp-launch-spec.test.ts
+++ b/src/tests/unit/llamacpp-launch-spec.test.ts
@@ -34,17 +34,24 @@ describe("getLlamaCppLaunchSpec", () => {
   }
 
   it("resolves the launcher script from the checkout, not from the cwd", async () => {
-    const root = "/home/clawbox/clawbox";
-    const { getLlamaCppLaunchSpec } = await loadWithRoot(root);
+    // TWO checkouts, one process. A cwd-based spec answers the same path for
+    // both, whatever the cwd happens to be, so one of these two lines fails for
+    // it wherever the suite runs.
+    //
+    // Pinned that way rather than against `process.cwd()` itself: on a box the
+    // checkout IS the cwd (`/home/clawbox/clawbox`, CONFIG_ROOT's production
+    // default) and vitest runs from the project root, so a
+    // `not.toBe(join(process.cwd(), …))` line compares a string with itself and
+    // goes RED over correct code — on the one platform the working rules say to
+    // run the suites on, and on no other. The guard against a cwd reader must
+    // not itself depend on the cwd.
+    const box = await loadWithRoot("/home/clawbox/clawbox");
+    const boxSpec = box.getLlamaCppLaunchSpec("gemma4-e2b-it-q4_0");
+    const elsewhere = await loadWithRoot("/srv/clawbox-elsewhere");
+    const elsewhereSpec = elsewhere.getLlamaCppLaunchSpec("gemma4-e2b-it-q4_0");
 
-    const spec = getLlamaCppLaunchSpec("gemma4-e2b-it-q4_0");
-
-    expect(spec.scriptPath).toBe(path.join(root, "scripts", "start-llamacpp.sh"));
-    // Belt and braces, and it is the assertion that bites ON A BOX: there the
-    // checkout IS /home/clawbox/clawbox, so the line above would pass for a
-    // cwd-based spec whose cwd happened to be the checkout. Naming the cwd
-    // separately is what keeps the case honest wherever it runs.
-    expect(spec.scriptPath).not.toBe(path.join(process.cwd(), "scripts", "start-llamacpp.sh"));
+    expect(boxSpec.scriptPath).toBe(path.join("/home/clawbox/clawbox", "scripts", "start-llamacpp.sh"));
+    expect(elsewhereSpec.scriptPath).toBe(path.join("/srv/clawbox-elsewhere", "scripts", "start-llamacpp.sh"));
   });
 
   it("keeps the script and the runtime files it writes in one tree", async () => {

--- a/src/tests/unit/llamacpp-launch-spec.test.ts
+++ b/src/tests/unit/llamacpp-launch-spec.test.ts
@@ -33,29 +33,33 @@ describe("getLlamaCppLaunchSpec", () => {
     return await import("@/lib/llamacpp-server");
   }
 
+  /** The device's own project directory — CONFIG_ROOT's production default. */
+  const BOX_ROOT = "/home/clawbox/clawbox";
+  /** A root no cwd can be, so the pair discriminates wherever it runs. */
+  const OTHER_ROOT = "/srv/clawbox-elsewhere";
+
   it("resolves the launcher script from the checkout, not from the cwd", async () => {
     // TWO checkouts, one process. A cwd-based spec answers the same path for
     // both, whatever the cwd happens to be, so one of these two lines fails for
     // it wherever the suite runs.
     //
-    // Pinned that way rather than against `process.cwd()` itself: on a box the
-    // checkout IS the cwd (`/home/clawbox/clawbox`, CONFIG_ROOT's production
-    // default) and vitest runs from the project root, so a
-    // `not.toBe(join(process.cwd(), …))` line compares a string with itself and
-    // goes RED over correct code — on the one platform the working rules say to
-    // run the suites on, and on no other. The guard against a cwd reader must
-    // not itself depend on the cwd.
-    const box = await loadWithRoot("/home/clawbox/clawbox");
+    // Pinned that way rather than against `process.cwd()` itself: on a device
+    // the checkout IS the cwd (`/home/clawbox/clawbox`) and vitest runs from the
+    // project root, so a `not.toBe(join(process.cwd(), …))` line compares a
+    // string with itself and goes RED over correct code — on the hardware these
+    // suites are run on, and on no other machine. A guard against a cwd reader
+    // must not itself depend on the cwd.
+    const box = await loadWithRoot(BOX_ROOT);
     const boxSpec = box.getLlamaCppLaunchSpec("gemma4-e2b-it-q4_0");
-    const elsewhere = await loadWithRoot("/srv/clawbox-elsewhere");
+    const elsewhere = await loadWithRoot(OTHER_ROOT);
     const elsewhereSpec = elsewhere.getLlamaCppLaunchSpec("gemma4-e2b-it-q4_0");
 
-    expect(boxSpec.scriptPath).toBe(path.join("/home/clawbox/clawbox", "scripts", "start-llamacpp.sh"));
-    expect(elsewhereSpec.scriptPath).toBe(path.join("/srv/clawbox-elsewhere", "scripts", "start-llamacpp.sh"));
+    expect(boxSpec.scriptPath).toBe(path.join(BOX_ROOT, "scripts", "start-llamacpp.sh"));
+    expect(elsewhereSpec.scriptPath).toBe(path.join(OTHER_ROOT, "scripts", "start-llamacpp.sh"));
   });
 
   it("keeps the script and the runtime files it writes in one tree", async () => {
-    const root = "/srv/clawbox-elsewhere";
+    const root = OTHER_ROOT;
     const { getLlamaCppLaunchSpec } = await loadWithRoot(root);
 
     const spec = getLlamaCppLaunchSpec("gemma4-e2b-it-q4_0");

--- a/src/tests/unit/llamacpp-launch-spec.test.ts
+++ b/src/tests/unit/llamacpp-launch-spec.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import path from "path";
+
+/**
+ * Where the llama.cpp launcher script comes from.
+ *
+ * `getLlamaCppLaunchSpec()` resolved `scripts/start-llamacpp.sh` from
+ * `process.cwd()`. In production the cwd is `.next/standalone` — Next's
+ * standalone `server.js` does `process.chdir(__dirname)` and
+ * `config/clawbox-setup.service` starts `production-server.js`, which requires
+ * that file — so the launcher was read out of the build output rather than out
+ * of the checkout. It worked only because @vercel/nft happened to trace the
+ * script into that tree; nothing copies `scripts/` there on purpose, and the
+ * copy that is there only refreshes on a full rebuild.
+ *
+ * Everything else in the spec (pidPath, logPath, modelDir, modelPath) is
+ * derived from `DATA_DIR`, i.e. from `CONFIG_ROOT`. The script was the one
+ * field that was not, so the launcher and the runtime state it writes could be
+ * read from two different trees. src/instrumentation-node.ts already resolves
+ * `scripts/terminal-server.mjs` from CONFIG_ROOT for exactly this reason, and
+ * src/tests/unit/instrumentation-terminal-server.test.ts pins it there.
+ */
+describe("getLlamaCppLaunchSpec", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  /** Load the module with `root` as the box's project directory. */
+  async function loadWithRoot(root: string) {
+    vi.resetModules();
+    vi.stubEnv("CLAWBOX_ROOT", root);
+    return await import("@/lib/llamacpp-server");
+  }
+
+  it("resolves the launcher script from the checkout, not from the cwd", async () => {
+    const root = "/home/clawbox/clawbox";
+    const { getLlamaCppLaunchSpec } = await loadWithRoot(root);
+
+    const spec = getLlamaCppLaunchSpec("gemma4-e2b-it-q4_0");
+
+    expect(spec.scriptPath).toBe(path.join(root, "scripts", "start-llamacpp.sh"));
+    // Belt and braces, and it is the assertion that bites ON A BOX: there the
+    // checkout IS /home/clawbox/clawbox, so the line above would pass for a
+    // cwd-based spec whose cwd happened to be the checkout. Naming the cwd
+    // separately is what keeps the case honest wherever it runs.
+    expect(spec.scriptPath).not.toBe(path.join(process.cwd(), "scripts", "start-llamacpp.sh"));
+  });
+
+  it("keeps the script and the runtime files it writes in one tree", async () => {
+    const root = "/srv/clawbox-elsewhere";
+    const { getLlamaCppLaunchSpec } = await loadWithRoot(root);
+
+    const spec = getLlamaCppLaunchSpec("gemma4-e2b-it-q4_0");
+
+    // The invariant the cwd broke: the launcher and the pid/log/model paths it
+    // is handed have to come from the same install, or the script started is
+    // one tree's and the state it writes is another's.
+    for (const p of [spec.scriptPath, spec.pidPath, spec.logPath, spec.modelDir]) {
+      expect(p.startsWith(`${root}/`), `${p} is not under ${root}`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
**TASK-682** — the llama.cpp launcher is resolved from `process.cwd()`, plus the two supervision gaps found reviewing PERF-06.

## Symptom

In production the cwd is `.next/standalone`: Next's standalone `server.js` does
`process.chdir(__dirname)` and `production-server.js:719` requires it. Three places read a file out
of the build output instead of out of the install, and one of them is dead on every box today.

| | resolved to | on a box |
|---|---|---|
| `getLlamaCppLaunchSpec().scriptPath` | `.next/standalone/scripts/start-llamacpp.sh` | present — but only because @vercel/nft happens to trace `scripts/` in |
| `pluginSourceDir()` (Hermes image backend) | `.next/standalone/scripts/hermes-plugins/…` | same trace; an update shipping a fixed plugin can install the stale copy |
| `installPlaywrightChromium()` | `.next/standalone/node_modules/.bin/playwright` | **absent** — `postbuild.sh` copies the `playwright` and `playwright-core` packages, never a `.bin` |

Measured read-only on the OpenClaw box, 2026-09-05:

```
node_modules/.bin/playwright -> ../@playwright/test/cli.js   (executable: yes)
ls: cannot access '.next/standalone/node_modules/.bin/playwright': No such file or directory
```

So "Install Chromium" has never been able to install the Playwright build. `manage/route.ts`
swallows the ENOENT into a `console.warn` and still answers `{ ok: true }` off whatever apt/snap
Chromium is around — which on Ubuntu 24.04 is the snap wrapper `isServiceSafeChromium()` refuses.
A false success over the one browser that would have worked.

Also measured: nothing sets `CLAWBOX_ROOT` for `clawbox-setup.service` on either box
(`Environment=NODE_ENV=production BUN_ENV=production PORT=80 HOSTNAME=0.0.0.0 CLAWBOX_EDITION=…`),
so the cwd really is what these three resolved through.

## Harness first

There is no harness mechanism here to leverage — the question is only which of ClawBox's own two
answers to use, and the repo already decided: `src/lib/config-store.ts` `CONFIG_ROOT`, which
`src/instrumentation-node.ts:154` uses for `scripts/terminal-server.mjs` for exactly this reason and
`src/tests/unit/instrumentation-terminal-server.test.ts` pins there. This makes the three
stragglers agree with it. `config-store` gains `resolveConfigRoot()`, the call-time form, so the one
caller that must read the env per call (the tests set `CLAWBOX_ROOT` after the module is imported)
does not spell the expression out a twelfth time.

## The install route's twenty-minute poll

The card's item 3 — the shared pid file making one alias answer for another — is real, and the
review located it precisely. It is **not** in `bootLlamaCppServer`: `waitForLlamaCppReady`
(`local-ai-runtime.ts:165`) returns on `models.length > 0`, so a live server under another label
already satisfies the wake path on its first poll.

It is in `POST /setup-api/llamacpp/install`, which asks `models.includes(alias)` — a question about
a **label**. `getLlamaCppLaunchSpec(alias)` resolves `modelPath` from `getDefaultLlamaCppFile()`
whatever the alias is, and `start-llamacpp.sh` passes that as `--model` while the alias goes to
`--alias`: every alias on a box is the same GGUF. With a runtime warm under a label from an earlier
install (the route accepts any `MODEL_ID_RE` string, and a Settings model change never stops the old
server) the live pid stops any restart, the alias never appears, and the wizard sits in a streamed
handler for the full `startupTimeoutMs` — 20 minutes — before reporting a timeout for a runtime that
was answering the whole time. RED shows exactly that:

```
{"status":"Checking local Gemma 4 runtime..."}
{"status":"llama.cpp is already starting. Waiting for it to become ready..."}
{"error":"Timed out waiting for llama.cpp to become ready."}
```

The fix makes this route read readiness the way `waitForLlamaCppReady` and `isLlamaCppUp` already
do — the runtime answering at all — so four readers now agree instead of three.

## RED → GREEN

RED on unmodified `origin/beta` (d428b044):

```
 × getLlamaCppLaunchSpec > resolves the launcher script from the checkout, not from the cwd
   AssertionError: expected '/home/krasi/clawbox-wt-682/scripts/st…' to be '/home/clawbox/clawbox/scripts/start-l…'
 × getLlamaCppLaunchSpec > keeps the script and the runtime files it writes in one tree
 × installing the ClawBox AI image backend > resolves the plugin source from the install root, never from the cwd
 × /setup-api/browser/manage > looks for the Playwright CLI in the checkout, not in the build output
   AssertionError: expected [ Array(1) ] to include '<CONFIG_ROOT>/node_modules/.bin/playwright'
 × POST /setup-api/llamacpp/install > configures against a runtime that is already up under another alias
   AssertionError: expected … not to contain "Timed out"
```

GREEN, with the fix, plus the neighbouring suites and the three beta guards:

```
 Test Files  12 passed (12)
      Tests  119 passed (119)
```

`tsc --noEmit` and `eslint` clean.

## Sibling call sites

Swept every `process.cwd()` in shipped code. Fixed: `llamacpp-server.ts`, `hermes-image-plugin.ts`,
`browser/manage/route.ts`. Left, with reasons:

* `src/lib/system-profile.ts:81` `resolveScript` — the cwd branch is a DEV/TEST fallback behind
  `allowRepoFallback`, reached only when the root-owned `LIBEXEC_DIR` copy is missing, and only for
  the read-only `--check` mode. Switching it to `CONFIG_ROOT` would break the component tests it
  exists for. It is now the only remaining cwd reader of `scripts/`.
* `middleware.ts`, `openclaw-config.ts`, `build-identity.ts`, `local-ai-token.ts`, `mcp-token.ts`,
  `internal-token.ts`, `route-auth.ts`, `voice-local-wiring.ts`, `hermes-skill-audit.ts` — all use
  the full `dev ? cwd : /home/clawbox/clawbox` expression, so none of them resolves through the cwd
  in production.

Consumers of `LlamaCppStartStatus` are unchanged: the union is untouched.

## Both editions

`CONFIG_ROOT` is edition-independent, and `installHermesImagePlugin` is only ever called in-process
so it always carries the unit's environment. The Hermes image backend is the Hermes SKU's half and
the llama.cpp launcher runs on both. Read-only device checks were run on both boxes; the Hermes box
is currently mid-rebuild (`install.sh --step rebuild_reboot`, 2.5 h and counting, no
`.next/standalone` on disk and `clawbox-setup` inactive), so its standalone tree could not be
inspected — flagged for the driver, unrelated to this PR.

## Review

One review pass. It rejected the original third part of this branch — a `skipped-other-model` status
in `bootLlamaCppServer` — and it was right: that branch fired only where `waitForLlamaCppReady`
already succeeded, so it would have turned answered requests into 502s. It was removed entirely and
the real defect fixed where the review located it. Its other findings applied here: the
`browser/manage` sibling (which the first pass had wrongly cleared), the `resolveConfigRoot()`
extraction instead of a twelfth inline copy, and a rewrite of the Hermes plugin test — it asserted
an install FAILURE whose path does exist on a box, so it would have passed on a dev PC and failed on
the hardware.

## Merge-gate round — the new guard was itself a false failure on hardware

The merge-gate review blocked on one defect in the guard this PR adds, not in the production change.
`src/tests/unit/llamacpp-launch-spec.test.ts`'s first case stubbed `CLAWBOX_ROOT` to
`/home/clawbox/clawbox` and then asserted
`expect(spec.scriptPath).not.toBe(path.join(process.cwd(), "scripts", "start-llamacpp.sh"))`. On a
device the checkout IS `/home/clawbox/clawbox` — `CONFIG_ROOT`'s own production default — and vitest
runs from the project root, so the two strings are equal: the first assertion passes and the second
fails, over a `scriptPath` the fix produced correctly. A false failure, on the hardware these suites
are run on, invisible on a dev PC and in CI where the cwd differs.

RED, reproduced with `process.cwd()` stubbed to the value a device presents, against correct code:

```
 × resolves the launcher script from the checkout, not from the cwd
AssertionError: expected '/home/clawbox/clawbox/scripts/start-l…'
             not to be '/home/clawbox/clawbox/scripts/start-l…'
 Tests  1 failed (1)
```

Fixed by making the guard cwd-independent by construction rather than by choosing a luckier root:
the module is loaded twice, with two different `CLAWBOX_ROOT` values, and each `scriptPath` has to
follow its own root. A cwd-based spec answers the same path for both, whatever the cwd is, so one of
the two assertions fails for it wherever the suite runs. Verified both ways: against the cwd-based
implementation both assertions fail (so the guard is at least as strong as the one it replaces, and
on hardware it is stronger — the old form could only decide the question off-hardware), and with
`process.cwd()` forced to `/home/clawbox/clawbox` the new case passes while the old case body fails.

Sibling sweep for the same class: no other assertion in `src/tests/` or `e2e-install/` compares a
produced path against `process.cwd()` or against a root that could equal it. Every other
`process.cwd()` use in the tree locates a repo file or passes the cwd as data. `vitest.config.ts` floors
`CLAWBOX_ROOT` to a per-pid tmpdir for every suite, so `CONFIG_ROOT` can never equal the cwd under
vitest — which also corrects a residual the review recorded against the new
`browser/manage.test.ts` assertion: that guard is NOT weaker on a device.

GREEN on the pushed head:

```
 Test Files  8 passed (8)
      Tests  109 passed (109)
```

(`browser/manage`, `llamacpp/install`, `hermes-image-plugin`, `llamacpp-launch-spec`, `config-store`,
plus `openclaw-config-mock-completeness`, `test-timeout-hygiene`, `state-updater-purity`.)
`tsc --noEmit` clean, eslint clean. Rebased onto `origin/beta` `5c7170b8`; `git diff --stat
origin/beta...HEAD` lists only the 9 files this PR intends and `--diff-filter=DR` is empty.

### The previous run's `e2e-install` failure

`e2e-install` was red on the previous head, and it was environmental rather than this branch's:
`90-upgrade-main-to-beta.spec.ts` timed out at 45.0 m with the updater never scheduled
(`currentStepIndex: -1`, `checkout-dirty`). The identical failure — same spec, same duration, a
`last state` payload matching byte for byte — hit two unrelated branches whose runs started in the
same window, one of which touches neither `config-store` nor the llama.cpp path, while every run
started a few minutes later went green. Nothing in this diff is on the updater's path. This push
starts a fresh run on the new head; the previous run's result is not carried forward as a judgement
on it.

Deferred, deliberately: the `bootLlamaCppServer` empty-`/v1/models` branch still trusts a live pid
that `isLlamaCppPidRunning` only `kill(pid, 0)`-tests, so a recycled pid can still produce a start
that never happened; and `scripts/postbuild.sh` / `next.config.ts` / the postbuild test still name
`hermes-image-plugin.ts` and `start-llamacpp.sh` as cwd readers, which this PR makes false — those
three files are edited by PR #694, so correcting them here would conflict with it. Both are recorded
in the fixer queue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved standalone production setup so browser automation, llama.cpp, and plugin components locate required files from the configured installation directory.
  - Fixed llama.cpp startup detection to recognize an already-running runtime under a different model alias, preventing unnecessary restarts and timeout failures.
  - Improved path resolution across development and production environments.

- **Tests**
  - Added coverage for standalone installation paths, configured roots, and alternate llama.cpp model aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

