### PR TITLE
fix: a provider that has answered a turn is reported as verified

### DIFF
--- a/src/app/setup-api/hermes/chat/route.ts
+++ b/src/app/setup-api/hermes/chat/route.ts
@@ -477,14 +477,6 @@ async function settleTurn(
     ...(served.model ? { model: served.model } : {}),
     ...(served.provider ? { provider: served.provider } : {}),
   }, sessionKey);
-  // A COMPLETED TURN IS THE EXERCISE (TASK-583). `served.provider` is not a
-  // guess and not what the box is configured with — it is who the harness
-  // itself recorded as having billed this answer, which is the one thing that
-  // proves the credential works. Remembering it here is what lets the polled
-  // providers route say "verified" without emitting a single request; see
-  // src/lib/provider-verified.ts. Only when a provider was actually named:
-  // marking off a blank would make "verified" mean "a turn happened".
-  if (served.provider) await recordProviderVerified(served.provider);
   return {
     text: answer,
     harness: "hermes",
@@ -583,6 +575,15 @@ async function servedPair(
   const model = source.model || "";
   const provider = source.provider
     || (model && usageBefore ? await billedProviderFor(sessionId, model, usageBefore) : "");
+  // A COMPLETED TURN IS THE EXERCISE (TASK-583), and this is the one place on
+  // the route where the provider is EVIDENCE rather than a label: it is either
+  // the transport's own frame for this turn or what the harness recorded as
+  // having billed it. Deliberately not in `settleTurn`, which the CLI leg also
+  // reaches — `cliServedPair` can fall back to `hermes config get
+  // model.provider`, which is what the box is CONFIGURED with and would mark a
+  // provider that never served anything. Only when one was actually named:
+  // marking off a blank would make "verified" mean "a turn happened".
+  if (provider) await recordProviderVerified(provider);
   return {
     ...(model ? { model } : {}),
     ...(provider ? { provider } : {}),

--- a/src/app/setup-api/hermes/chat/route.ts
+++ b/src/app/setup-api/hermes/chat/route.ts
@@ -48,6 +48,7 @@ import {
   readHermesTurn,
   readHermesUsageMarks,
 } from "@/lib/harness/hermes-turn-record";
+import { recordProviderVerified } from "@/lib/provider-verified";
 import {
   adoptHermesGeneratedImages,
   reclaimImageMentions,
@@ -476,6 +477,14 @@ async function settleTurn(
     ...(served.model ? { model: served.model } : {}),
     ...(served.provider ? { provider: served.provider } : {}),
   }, sessionKey);
+  // A COMPLETED TURN IS THE EXERCISE (TASK-583). `served.provider` is not a
+  // guess and not what the box is configured with — it is who the harness
+  // itself recorded as having billed this answer, which is the one thing that
+  // proves the credential works. Remembering it here is what lets the polled
+  // providers route say "verified" without emitting a single request; see
+  // src/lib/provider-verified.ts. Only when a provider was actually named:
+  // marking off a blank would make "verified" mean "a turn happened".
+  if (served.provider) await recordProviderVerified(served.provider);
   return {
     text: answer,
     harness: "hermes",

--- a/src/app/setup-api/hermes/models/route.ts
+++ b/src/app/setup-api/hermes/models/route.ts
@@ -19,6 +19,7 @@ import {
   type ModelOptionsPayload,
   type ScopedModelsReply,
 } from "@/lib/hermes-model-options";
+import { readProviderVerified } from "@/lib/provider-verified";
 
 // Hermes' provider/model configuration.
 //
@@ -118,6 +119,10 @@ export async function GET(request: Request) {
     }
 
     const payload = await getModelOptions({ refresh });
+    // What has actually ANSWERED on this box, from ClawBox's own store — one
+    // small read, no provider traffic. See src/lib/provider-verified.ts for why
+    // a completed turn is the evidence and a probe is not.
+    const verifiedAt = await readProviderVerified();
     const models = unionModels(payload);
     const current = payload.current.model;
     // Keep the saved model present in the unscoped list even when its provider
@@ -141,7 +146,13 @@ export async function GET(request: Request) {
         // reads `authenticated` as "this will answer" is the reason a bogus
         // provider looked healthy right up until the first turn 403'd.
         credentialPresent: row.authenticated,
-        verified: row.verified,
+        // Hermes' own verdict still wins where it ever reports one. Otherwise
+        // a turn this provider served is the answer, and having served one can
+        // only mean true — a provider that never answered stays NULL, "not
+        // checked", never `false`: an offline box and a rate-limited
+        // subscription must not be painted as a broken credential.
+        verified: row.verified ?? (verifiedAt[row.id] ? true : null),
+        ...(row.verified === null && verifiedAt[row.id] ? { verifiedAt: verifiedAt[row.id] } : {}),
         isUserDefined: row.isUserDefined,
         source: row.source,
         total: row.total,

--- a/src/app/setup-api/hermes/models/route.ts
+++ b/src/app/setup-api/hermes/models/route.ts
@@ -119,9 +119,11 @@ export async function GET(request: Request) {
     }
 
     const payload = await getModelOptions({ refresh });
-    // What has actually ANSWERED on this box, from ClawBox's own store — one
-    // small read, no provider traffic. See src/lib/provider-verified.ts for why
-    // a completed turn is the evidence and a probe is not.
+    // What has actually ANSWERED on this box, from ClawBox's own store: a read
+    // of data/config.json plus one stat of Hermes' pooled credential store, per
+    // request on a polled route — and no provider traffic at all, which is the
+    // whole point. See src/lib/provider-verified.ts for why a completed turn is
+    // the evidence, a probe is not, and what this does and does not cover.
     const verifiedAt = await readProviderVerified();
     const models = unionModels(payload);
     const current = payload.current.model;
@@ -146,11 +148,18 @@ export async function GET(request: Request) {
         // reads `authenticated` as "this will answer" is the reason a bogus
         // provider looked healthy right up until the first turn 403'd.
         credentialPresent: row.authenticated,
-        // Hermes' own verdict still wins where it ever reports one. Otherwise
-        // a turn this provider served is the answer, and having served one can
-        // only mean true — a provider that never answered stays NULL, "not
-        // checked", never `false`: an offline box and a rate-limited
-        // subscription must not be painted as a broken credential.
+        // Hermes' own verdict still wins where it ever reports one — it comes
+        // from the harness and would be a real probe result, while ours is
+        // inference from a turn. In practice Hermes has never populated this
+        // field on any box measured (it is null on all 48 rows), so the
+        // precedence has never actually been exercised; if it starts reporting
+        // `false` transiently, that ordering is the first thing to revisit,
+        // because a working credential painted broken is the failure this field
+        // exists to prevent. Otherwise a turn this provider served is the
+        // answer, and having served one can only mean true — a provider that
+        // never answered stays NULL, "not checked", never `false`: an offline
+        // box and a rate-limited subscription must not be painted as a broken
+        // credential.
         verified: row.verified ?? (verifiedAt[row.id] ? true : null),
         ...(row.verified === null && verifiedAt[row.id] ? { verifiedAt: verifiedAt[row.id] } : {}),
         isUserDefined: row.isUserDefined,

--- a/src/app/setup-api/hermes/oauth/poll/route.ts
+++ b/src/app/setup-api/hermes/oauth/poll/route.ts
@@ -5,6 +5,7 @@ import { dashboardFetch } from "@/lib/hermes-dashboard-auth";
 import { invalidateModelOptions } from "@/lib/hermes-model-options";
 import { readUsableProviderIds, refreshProviderToolsIfSetChanged } from "@/lib/provider-mcp-refresh";
 import { dashboardUnreachable, hermesGate, isValidProviderId, isValidSessionId, relayJson } from "../shared";
+import { forgetProviderVerified } from "@/lib/provider-verified";
 
 // Poll a device-code session until the user approves it on the provider's
 // verification page. Terminal statuses: "approved" | "error" | "expired";
@@ -84,6 +85,11 @@ export async function GET(request: Request) {
     // prompt cache, so a client that keeps polling a finished session must not be
     // able to charge the owner for one per tick.
     if (approved) {
+      // The device-code flow's terminal tick: a credential has just landed, so
+      // an older turn's mark describes one that no longer exists. Only on
+      // "approved", like everything else in this branch. See
+      // src/lib/provider-verified.ts.
+      await forgetProviderVerified(providerId);
       await refreshProviderToolsIfSetChanged(providersBefore, await readUsableProviderIds());
     }
     return relayed;

--- a/src/app/setup-api/hermes/oauth/submit/route.ts
+++ b/src/app/setup-api/hermes/oauth/submit/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 import { dashboardFetch } from "@/lib/hermes-dashboard-auth";
 import { invalidateModelOptions } from "@/lib/hermes-model-options";
 import { readUsableProviderIds, refreshProviderToolsIfSetChanged } from "@/lib/provider-mcp-refresh";
+import { forgetProviderVerified } from "@/lib/provider-verified";
 import {
   dashboardUnreachable,
   isValidProviderId,
@@ -74,6 +75,12 @@ export async function POST(request: Request) {
     // it booted — see `provider-mcp-refresh.ts`. Only on the terminal success:
     // a failed exchange credentialled nothing, and a reload respawns every MCP
     // child and invalidates the model's prompt cache.
+    // A new OAuth credential — a re-sign-in, or a different account entirely —
+    // makes any earlier "this provider served a turn" mark a statement about a
+    // credential that is gone. Forgotten here rather than before the exchange,
+    // because unlike a key paste this call only credentials anything on the
+    // terminal success. See src/lib/provider-verified.ts.
+    if (connected) await forgetProviderVerified(body.providerId);
     if (connected) {
       await refreshProviderToolsIfSetChanged(providersBefore, await readUsableProviderIds());
     }

--- a/src/app/setup-api/hermes/provider-key/route.ts
+++ b/src/app/setup-api/hermes/provider-key/route.ts
@@ -5,6 +5,7 @@ import { runHermesCli } from "@/lib/hermes-cli";
 import { redactKey, safeHermesFailureMessage } from "@/lib/hermes-cli-message";
 import { invalidateModelOptions } from "@/lib/hermes-model-options";
 import { readUsableProviderIds, refreshProviderToolsIfSetChanged } from "@/lib/provider-mcp-refresh";
+import { forgetProviderVerified } from "@/lib/provider-verified";
 
 // Store an API key for a Hermes inference provider via `hermes auth add`. Hermes
 // keeps the credential in its own pooled-auth store (~/.hermes), NOT ClawBox's
@@ -57,6 +58,15 @@ export async function POST(request: Request) {
   // still say what the agent's `ai_set_provider` enum was built from. See
   // `provider-mcp-refresh.ts` for why the enum is not advisory.
   const providersBefore = await readUsableProviderIds();
+
+  // BEFORE the credential lands, for the same reason `providersBefore` is taken
+  // here: after the write there is no moment at which the old fact is still
+  // true. A turn this provider served proves something about the key that was
+  // on disk THEN, and this route is about to replace it — so the row goes back
+  // to "not checked" until something answers on the new one. Losing a mark to a
+  // save that then fails is always safe; the next turn earns it back.
+  // See src/lib/provider-verified.ts.
+  await forgetProviderVerified(provider);
 
   try {
     const r = await runHermesCli(

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -27,6 +27,7 @@ import {
   type ClawboxAiTier,
 } from "@/lib/clawbox-ai-models";
 import { isClawboxAiVisionId, resolveVisionModelId } from "@/lib/clawbox-ai-vision";
+import { forgetProviderVerified } from "@/lib/provider-verified";
 
 // Applying ClawBox AI to a HERMES device, in one place.
 //
@@ -397,6 +398,10 @@ export async function applyClawaiToHermes(
     );
   }
 
+  // The token just changed — an account switch, a re-pair, a rotated device
+  // token — so an earlier turn on the old one proves nothing about this one.
+  // Same rule as every other credential write; see src/lib/provider-verified.ts.
+  await forgetProviderVerified(CLAWAI_PROVIDER);
   return { provider: CLAWAI_PROVIDER, model, tier };
 }
 

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -124,6 +124,12 @@ export async function applyClawaiToHermes(
     throw new ClawaiApplyError("Sign in to ClawBox AI first to get a device token.");
   }
   const model = clawaiModelForTier(tier);
+  // BEFORE the first write. The token is about to change — an account switch, a
+  // re-pair, a rotated device token — and the step loop below can throw after
+  // `providers.clawai.api_key` has already landed, which would leave the new
+  // token on disk beside a mark asserting the old one worked. A mark lost to a
+  // failed apply is always safe. See src/lib/provider-verified.ts.
+  await forgetProviderVerified(CLAWAI_PROVIDER);
 
   // Read BEFORE anything is written, because the refresh at the bottom needs to
   // know whether this call is what turned drawing on. `hermesConfigGet` is keyed
@@ -398,10 +404,6 @@ export async function applyClawaiToHermes(
     );
   }
 
-  // The token just changed — an account switch, a re-pair, a rotated device
-  // token — so an earlier turn on the old one proves nothing about this one.
-  // Same rule as every other credential write; see src/lib/provider-verified.ts.
-  await forgetProviderVerified(CLAWAI_PROVIDER);
   return { provider: CLAWAI_PROVIDER, model, tier };
 }
 

--- a/src/lib/hermes-cloud-provider.ts
+++ b/src/lib/hermes-cloud-provider.ts
@@ -76,14 +76,15 @@ export async function applyCloudProviderKeyToHermes(opts: {
   // into `ai_set_provider`'s enum. The wrapper samples that set either side of
   // the work below and asks the agent to re-advertise only when it actually
   // moved — see `provider-mcp-refresh.ts`.
-  const result = await withProviderMcpRefresh(() => applyCloudProviderKey(opts));
-  // The credential just CHANGED, so what an older turn proved is no longer
-  // about the key on disk: a rotated or corrected key inherits nothing from the
-  // one it replaced. Forget the mark and let the row go back to "not checked"
-  // until something answers again — see src/lib/provider-verified.ts.
+  // BEFORE the write, not after. The credential is about to change, so what an
+  // older turn proved stops being about the key on disk the moment `auth add`
+  // lands — and `applyCloudProviderKey` can still throw on a later step, which
+  // would leave the new key in place beside a mark asserting the old one
+  // worked. A mark lost to a write that failed is always safe: the next turn
+  // earns it straight back. See src/lib/provider-verified.ts.
   const slug = hermesKeyProviderFor(opts.openclawProvider);
   if (slug) await forgetProviderVerified(slug);
-  return result;
+  return withProviderMcpRefresh(() => applyCloudProviderKey(opts));
 }
 
 async function applyCloudProviderKey(opts: {

--- a/src/lib/hermes-cloud-provider.ts
+++ b/src/lib/hermes-cloud-provider.ts
@@ -8,6 +8,7 @@ import {
   scopeFromPayload,
 } from "@/lib/hermes-model-options";
 import { withProviderMcpRefresh } from "@/lib/provider-mcp-refresh";
+import { forgetProviderVerified } from "@/lib/provider-verified";
 
 // Applying an API-key cloud provider to a HERMES device.
 //
@@ -75,7 +76,14 @@ export async function applyCloudProviderKeyToHermes(opts: {
   // into `ai_set_provider`'s enum. The wrapper samples that set either side of
   // the work below and asks the agent to re-advertise only when it actually
   // moved — see `provider-mcp-refresh.ts`.
-  return withProviderMcpRefresh(() => applyCloudProviderKey(opts));
+  const result = await withProviderMcpRefresh(() => applyCloudProviderKey(opts));
+  // The credential just CHANGED, so what an older turn proved is no longer
+  // about the key on disk: a rotated or corrected key inherits nothing from the
+  // one it replaced. Forget the mark and let the row go back to "not checked"
+  // until something answers again — see src/lib/provider-verified.ts.
+  const slug = hermesKeyProviderFor(opts.openclawProvider);
+  if (slug) await forgetProviderVerified(slug);
+  return result;
 }
 
 async function applyCloudProviderKey(opts: {

--- a/src/lib/hermes-local-ai.ts
+++ b/src/lib/hermes-local-ai.ts
@@ -8,6 +8,7 @@ import { getLocalAiToken } from "@/lib/local-ai-token";
 import { getDefaultLlamaCppModel } from "@/lib/llamacpp";
 import { getLocalAiOpenAiBaseUrl, getLocalAiProxyRootUrl } from "@/lib/local-ai-runtime";
 import { sanitizeErrorMessage } from "@/lib/safe-error-text";
+import { forgetProviderVerified } from "@/lib/provider-verified";
 
 /**
  * Register the on-device model with Hermes.
@@ -336,6 +337,12 @@ async function removeLocalAi(): Promise<{ wasDefault: boolean; model: string | n
   // Hermes renders a row for any entry that has models, so the picker would go
   // on offering the stopped model, which is the exact state this function
   // exists to end.
+  // The api_key goes with the endpoint, so an older turn's "this provider
+  // answered" mark stops describing anything. Switching Local AI off and on
+  // again re-registers the provider with a freshly read token; without this the
+  // row would come back reporting a verification from before the teardown.
+  // See src/lib/provider-verified.ts.
+  await forgetProviderVerified(HERMES_LOCAL_PROVIDER);
   const unset = ["base_url", "api_key", "api_mode", "models"].map(
     (key) => `providers.${HERMES_LOCAL_PROVIDER}.${key}`,
   );

--- a/src/lib/provider-verified.ts
+++ b/src/lib/provider-verified.ts
@@ -25,15 +25,43 @@
  * so a polled route can read it without opening the agent's database on a page
  * load, which `hermes-turn-record.ts` documents as the thing not to do.
  *
+ * WHAT IT COVERS, EXACTLY. A turn through ClawBox's OWN chat route, on the
+ * dashboard transport, where the provider came from the harness's record or the
+ * transport's own frame. NOT a Telegram or Discord turn, not `hermes chat` from
+ * the Terminal, and not the CLI leg — whose provider can fall back to
+ * `hermes config get model.provider`, which is what the box is CONFIGURED with
+ * and no evidence at all. Hermes' `session_model_usage` does hold
+ * `billing_provider` and `last_seen` for every one of those transports, and one
+ * grouped query over it would cover them all; it is not read here because that
+ * database must not be opened on a page load (`hermes-turn-record.ts` says why)
+ * and because `last_seen`'s epoch and units have never been established on a
+ * box. A row that has simply never been exercised through this route stays
+ * null — "not checked" — which is the right answer for it.
+ *
  * WHY A MARK EXPIRES ON A CREDENTIAL CHANGE, and not on a clock. "It answered
  * at 19:53" stays true for ever, and the timestamp travels with the flag so a
  * consumer can age it. What is NOT true for ever is that the CURRENT credential
  * works: rotate the key and the old turn says nothing about the new one. So
- * every path that writes or replaces a provider's credential forgets that
- * provider's mark, and the row goes back to "not checked" — never to
+ * every ClawBox path that writes or replaces a provider's credential forgets
+ * that provider's mark, and the row goes back to "not checked" — never to
  * "not connected", which is the third thing TASK-583's acceptance asks for.
+ *
+ * ClawBox is NOT the only writer, though, and pretending otherwise would be the
+ * probe-once class: a key changed in Hermes' own dashboard, or with
+ * `hermes auth add` from the Terminal, never passes through this process. So
+ * every read also asks the harness's own pooled credential store when it was
+ * last written (`~/.hermes/auth.json`, 0600, what `hermes auth add` rewrites)
+ * and drops any mark older than that. It is deliberately coarse — one file for
+ * every provider, so one key change forgets them all — because "not checked" is
+ * always a safe answer and the next turn earns the mark straight back.
+ *
+ * SERVER ONLY.
  */
+import fs from "fs";
+import path from "path";
 import { get, set } from "@/lib/config-store";
+import { createSerialLock } from "@/lib/serial-lock";
+import { HERMES_AUTO_PROVIDER, isPlausibleHermesProviderId } from "@/lib/hermes-providers";
 
 /** The config-store key. A map of provider id → ISO 8601 instant. */
 export const PROVIDER_VERIFIED_KEY = "provider_verified_at";
@@ -48,9 +76,55 @@ export const MAX_VERIFIED_PROVIDERS = 32;
 
 export type ProviderVerifiedMarks = Readonly<Record<string, string>>;
 
-/** Provider ids are slugs — the same charset the Hermes catalogue uses. */
-function isPlausibleProviderId(id: unknown): id is string {
-  return typeof id === "string" && /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/.test(id);
+/**
+ * Both writers are read-modify-writes of one map, and they run concurrently: a
+ * settling turn records while a credential save forgets. Unserialised, the
+ * record writes back the snapshot it read BEFORE the delete and the forget is
+ * silently undone — the same reason `provider-enablement.ts` serialises its own
+ * list. Every failure is swallowed here too: this runs on the settle path of a
+ * turn a customer is waiting on and on a credential save, and losing a status
+ * mark must never cost either.
+ */
+const withMarks = (() => {
+  const lock = createSerialLock();
+  return (work: () => Promise<void>): Promise<void> =>
+    lock(async () => {
+      try {
+        await work();
+      } catch {
+        /* a status mark is never worth failing a turn or a save over */
+      }
+    });
+})();
+
+/**
+ * Providers a mark may be stored under: a real catalogue slug, never a KIND.
+ *
+ * `auto` and `custom` are both, and a turn can report either — a mark under one
+ * matches no row, says nothing about any credential, and occupies a slot.
+ * `billedProviderFor` refuses `custom` for the same reason.
+ */
+const PSEUDO_PROVIDERS = new Set<string>([HERMES_AUTO_PROVIDER, "custom"]);
+
+function isMarkableProviderId(id: unknown): id is string {
+  return typeof id === "string"
+    && isPlausibleHermesProviderId(id)
+    && !PSEUDO_PROVIDERS.has(id);
+}
+
+/**
+ * When Hermes' pooled credential store was last written, or null when it cannot
+ * be asked. One `stat`, on a file the harness owns — never its contents.
+ */
+function credentialsWrittenAtMs(): number | null {
+  const home = process.env.HERMES_HOME || path.join(process.env.HOME || "/home/clawbox", ".hermes");
+  try {
+    return fs.statSync(path.join(home, "auth.json")).mtimeMs;
+  } catch {
+    // No store yet, or not ours to read. Not knowing must not invalidate
+    // everything: a box with no pooled credentials has nothing to invalidate.
+    return null;
+  }
 }
 
 function normalize(raw: unknown): Record<string, string> {
@@ -59,7 +133,7 @@ function normalize(raw: unknown): Record<string, string> {
   for (const [id, at] of Object.entries(raw as Record<string, unknown>)) {
     // A value that is not a usable instant is not evidence of anything, and
     // shipping it would put "verified at Invalid Date" on the panel.
-    if (!isPlausibleProviderId(id) || typeof at !== "string") continue;
+    if (!isMarkableProviderId(id) || typeof at !== "string") continue;
     const when = new Date(at);
     if (Number.isNaN(when.getTime())) continue;
     out[id] = when.toISOString();
@@ -75,11 +149,19 @@ function normalize(raw: unknown): Record<string, string> {
  * providers panel that 500s because a cache file was half-written.
  */
 export async function readProviderVerified(): Promise<ProviderVerifiedMarks> {
+  let marks: Record<string, string>;
   try {
-    return normalize(await get(PROVIDER_VERIFIED_KEY));
+    marks = normalize(await get(PROVIDER_VERIFIED_KEY));
   } catch {
     return {};
   }
+  const credentialsAt = credentialsWrittenAtMs();
+  if (credentialsAt === null) return marks;
+  const fresh: Record<string, string> = {};
+  for (const [id, at] of Object.entries(marks)) {
+    if (Date.parse(at) >= credentialsAt) fresh[id] = at;
+  }
+  return fresh;
 }
 
 /**
@@ -103,11 +185,13 @@ export async function recordProviderVerified(
   providerId: string,
   at: Date = new Date(),
 ): Promise<void> {
-  if (!isPlausibleProviderId(providerId) || Number.isNaN(at.getTime())) return;
-  try {
+  if (!isMarkableProviderId(providerId) || Number.isNaN(at.getTime())) return;
+  await withMarks(async () => {
     const stored = await readProviderVerified();
     const last = stored[providerId] ? Date.parse(stored[providerId]) : NaN;
-    if (!Number.isNaN(last) && at.getTime() - last < RECORD_DEBOUNCE_MS && at.getTime() >= last) return;
+    // Never backwards: a Jetson whose RTC is behind until NTP settles would
+    // otherwise make the panel's "verified <when>" older than the truth.
+    if (!Number.isNaN(last) && (at.getTime() <= last || at.getTime() - last < RECORD_DEBOUNCE_MS)) return;
     const marks = { ...stored, [providerId]: at.toISOString() };
     const ids = Object.keys(marks);
     if (ids.length > MAX_VERIFIED_PROVIDERS) {
@@ -117,9 +201,7 @@ export async function recordProviderVerified(
         .forEach((id) => delete marks[id]);
     }
     await set(PROVIDER_VERIFIED_KEY, marks);
-  } catch {
-    /* a status mark is never worth failing a turn over */
-  }
+  });
 }
 
 /**
@@ -127,13 +209,11 @@ export async function recordProviderVerified(
  * or removed, so what an older turn proved is no longer about the key on disk.
  */
 export async function forgetProviderVerified(providerId: string): Promise<void> {
-  if (!isPlausibleProviderId(providerId)) return;
-  try {
+  if (!isMarkableProviderId(providerId)) return;
+  await withMarks(async () => {
     const marks = { ...(await readProviderVerified()) };
     if (!(providerId in marks)) return;
     delete marks[providerId];
     await set(PROVIDER_VERIFIED_KEY, marks);
-  } catch {
-    /* same reason as above: never fail a credential save over a status mark */
-  }
+  });
 }

--- a/src/lib/provider-verified.ts
+++ b/src/lib/provider-verified.ts
@@ -1,0 +1,139 @@
+/**
+ * Which AI providers have actually SERVED a turn on this box, and when.
+ *
+ * SERVER ONLY.
+ *
+ * WHAT THIS IS FOR. `credentialPresent` says a key is on disk. It does not say
+ * the key works, and on a real box the two came apart: a provider with a
+ * revoked key, a rate-limited subscription and a typo'd custom endpoint all
+ * render exactly like a working one. The honest second field is `verified`, and
+ * on every box measured it was null on all 48 rows — present in the shape,
+ * never populated (TASK-583).
+ *
+ * WHY NOT A PROBE. Verifying by calling each provider is credential-bearing
+ * traffic from a route the UI polls: latency on every render, a request per
+ * provider per poll, bad behaviour on a box with no internet, and it can burn
+ * the owner's own quota. That is why TASK-583 was split out of TASK-446 rather
+ * than implemented as a probe, and its acceptance says so in as many words: no
+ * verification traffic on any polled route.
+ *
+ * WHERE THE EVIDENCE COMES FROM INSTEAD. A COMPLETED TURN IS THE EXERCISE. The
+ * chat route already learns who served each answer from the harness's own
+ * billing record (`session_model_usage.billing_provider`, read once per turn by
+ * `billedProviderFor`) — evidence that already exists, on the device, at zero
+ * cost. This module is only the memory of that: the conclusion is cached here
+ * so a polled route can read it without opening the agent's database on a page
+ * load, which `hermes-turn-record.ts` documents as the thing not to do.
+ *
+ * WHY A MARK EXPIRES ON A CREDENTIAL CHANGE, and not on a clock. "It answered
+ * at 19:53" stays true for ever, and the timestamp travels with the flag so a
+ * consumer can age it. What is NOT true for ever is that the CURRENT credential
+ * works: rotate the key and the old turn says nothing about the new one. So
+ * every path that writes or replaces a provider's credential forgets that
+ * provider's mark, and the row goes back to "not checked" — never to
+ * "not connected", which is the third thing TASK-583's acceptance asks for.
+ */
+import { get, set } from "@/lib/config-store";
+
+/** The config-store key. A map of provider id → ISO 8601 instant. */
+export const PROVIDER_VERIFIED_KEY = "provider_verified_at";
+
+/**
+ * How many providers are remembered. A box has tens of providers, not
+ * thousands, and this store is read on a polled route: an unbounded map grown
+ * by a loop of odd ids would be paid for on every render. The oldest mark is
+ * dropped first, because the newest is the one a customer is looking at.
+ */
+export const MAX_VERIFIED_PROVIDERS = 32;
+
+export type ProviderVerifiedMarks = Readonly<Record<string, string>>;
+
+/** Provider ids are slugs — the same charset the Hermes catalogue uses. */
+function isPlausibleProviderId(id: unknown): id is string {
+  return typeof id === "string" && /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/.test(id);
+}
+
+function normalize(raw: unknown): Record<string, string> {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const out: Record<string, string> = {};
+  for (const [id, at] of Object.entries(raw as Record<string, unknown>)) {
+    // A value that is not a usable instant is not evidence of anything, and
+    // shipping it would put "verified at Invalid Date" on the panel.
+    if (!isPlausibleProviderId(id) || typeof at !== "string") continue;
+    const when = new Date(at);
+    if (Number.isNaN(when.getTime())) continue;
+    out[id] = when.toISOString();
+  }
+  return out;
+}
+
+/**
+ * Every provider this box has seen answer, newest value per provider.
+ *
+ * Never throws: a store that cannot be read means "nothing has been verified",
+ * which is the same honest answer as an empty map — and far better than a
+ * providers panel that 500s because a cache file was half-written.
+ */
+export async function readProviderVerified(): Promise<ProviderVerifiedMarks> {
+  try {
+    return normalize(await get(PROVIDER_VERIFIED_KEY));
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * How recent a stored mark has to be for a new turn to leave it alone.
+ *
+ * This runs on the settle path of EVERY turn, and "it answered at 19:53" does
+ * not get truer by being rewritten at 19:54 — while the WRITE is a read, a
+ * serialise and a rename of the whole config store. The store itself is the
+ * memo, deliberately: a module-level one would go stale against a file another
+ * process (or another test) had changed underneath it.
+ */
+export const RECORD_DEBOUNCE_MS = 60 * 60 * 1000;
+
+/**
+ * Remember that `providerId` served a turn.
+ *
+ * Best effort by design: this runs on the settle path of a turn the customer is
+ * waiting on, and losing a status mark is never worth losing an answer.
+ */
+export async function recordProviderVerified(
+  providerId: string,
+  at: Date = new Date(),
+): Promise<void> {
+  if (!isPlausibleProviderId(providerId) || Number.isNaN(at.getTime())) return;
+  try {
+    const stored = await readProviderVerified();
+    const last = stored[providerId] ? Date.parse(stored[providerId]) : NaN;
+    if (!Number.isNaN(last) && at.getTime() - last < RECORD_DEBOUNCE_MS && at.getTime() >= last) return;
+    const marks = { ...stored, [providerId]: at.toISOString() };
+    const ids = Object.keys(marks);
+    if (ids.length > MAX_VERIFIED_PROVIDERS) {
+      ids
+        .sort((a, b) => Date.parse(marks[a]) - Date.parse(marks[b]))
+        .slice(0, ids.length - MAX_VERIFIED_PROVIDERS)
+        .forEach((id) => delete marks[id]);
+    }
+    await set(PROVIDER_VERIFIED_KEY, marks);
+  } catch {
+    /* a status mark is never worth failing a turn over */
+  }
+}
+
+/**
+ * Forget `providerId`'s mark — its credential has just been written, replaced
+ * or removed, so what an older turn proved is no longer about the key on disk.
+ */
+export async function forgetProviderVerified(providerId: string): Promise<void> {
+  if (!isPlausibleProviderId(providerId)) return;
+  try {
+    const marks = { ...(await readProviderVerified()) };
+    if (!(providerId in marks)) return;
+    delete marks[providerId];
+    await set(PROVIDER_VERIFIED_KEY, marks);
+  } catch {
+    /* same reason as above: never fail a credential save over a status mark */
+  }
+}

--- a/src/lib/provider-verified.ts
+++ b/src/lib/provider-verified.ts
@@ -159,7 +159,16 @@ export async function readProviderVerified(): Promise<ProviderVerifiedMarks> {
   if (credentialsAt === null) return marks;
   const fresh: Record<string, string> = {};
   for (const [id, at] of Object.entries(marks)) {
-    if (Date.parse(at) >= credentialsAt) fresh[id] = at;
+    // Strictly newer. A mark whose instant is EQUAL to the store's write time
+    // cannot say which came first, and the two are not equally safe to guess:
+    // keeping it reports a rotated credential as verified, dropping it reports
+    // "not checked" — the answer this module is allowed to be wrong with,
+    // because the next turn earns the mark straight back. The tie is rare
+    // rather than impossible (`mtimeMs` carries a sub-millisecond fraction on
+    // ext4, but a store restored from a backup or unpacked from an archive
+    // lands on a whole second), and the strict comparison costs one re-earned
+    // mark.
+    if (Date.parse(at) > credentialsAt) fresh[id] = at;
   }
   return fresh;
 }

--- a/src/tests/routes/hermes/chat-reasoning.test.ts
+++ b/src/tests/routes/hermes/chat-reasoning.test.ts
@@ -30,6 +30,10 @@ vi.mock("@/lib/hermes-model-options", async (importOriginal) => {
 vi.mock("@/lib/config-store", () => ({
   DATA_DIR: "/tmp/clawbox-chat-reasoning-test",
   get: vi.fn(),
+  // The settle path records which provider answered. Without a `set` here that
+  // write throws inside the recorder's own catch and is silently swallowed, so
+  // the suite would exercise it against a store that cannot accept it.
+  set: vi.fn(),
 }));
 
 import { spawn } from "child_process";
@@ -146,9 +150,9 @@ describe("/setup-api/hermes/chat — reasoning levels reaching the CLI", () => {
     expect(argvFlag("--reasoning")).toBe("high");
     // The runtime lookup is skipped: only the two-state provider needs to know
     // it, and every other turn must not pay for it. Named rather than counted,
-    // because the settle path legitimately reads one other key — the
-    // verification marks (src/lib/provider-verified.ts), at most once per
-    // provider per hour.
+    // because the dashboard leg legitimately reads one other key — the
+    // verification marks (src/lib/provider-verified.ts). Only the WRITE there is
+    // debounced; the read happens per turn.
     expect(mockGet).not.toHaveBeenCalledWith("local_ai_provider");
   });
 });

--- a/src/tests/routes/hermes/chat-reasoning.test.ts
+++ b/src/tests/routes/hermes/chat-reasoning.test.ts
@@ -144,9 +144,12 @@ describe("/setup-api/hermes/chat — reasoning levels reaching the CLI", () => {
 
     expect(res.status).toBe(200);
     expect(argvFlag("--reasoning")).toBe("high");
-    // No config-store read: only the two-state provider needs to know the
-    // runtime, and every other turn must skip that lookup.
-    expect(mockGet).not.toHaveBeenCalled();
+    // The runtime lookup is skipped: only the two-state provider needs to know
+    // it, and every other turn must not pay for it. Named rather than counted,
+    // because the settle path legitimately reads one other key — the
+    // verification marks (src/lib/provider-verified.ts), at most once per
+    // provider per hour.
+    expect(mockGet).not.toHaveBeenCalledWith("local_ai_provider");
   });
 });
 

--- a/src/tests/routes/hermes/chat-served-model-dashboard.test.ts
+++ b/src/tests/routes/hermes/chat-served-model-dashboard.test.ts
@@ -41,6 +41,17 @@ vi.mock("@/lib/hermes-dashboard-turn", async (importOriginal) => ({
 vi.mock("child_process", () => ({ spawn: spawnMock, execFile: vi.fn() }));
 vi.mock("@/lib/harness", () => ({ HERMES_BIN: "/home/clawbox/.local/bin/hermes" }));
 vi.mock("@/lib/harness/transcript-store", () => ({ appendTranscript: appendMock }));
+// TASK-583: the settle path also remembers WHICH PROVIDER ANSWERED, so a
+// polled route can say "verified" without emitting a probe. The store is
+// mocked rather than the recorder, so this asserts the wiring end to end and
+// still fails cleanly on a tree where the recorder does not exist yet.
+const configSetMock = vi.hoisted(() => vi.fn(async () => {}));
+const configGetMock = vi.hoisted(() => vi.fn(async () => undefined));
+vi.mock("@/lib/config-store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/config-store")>()),
+  get: configGetMock,
+  set: configSetMock,
+}));
 vi.mock("@/lib/harness/media-root", () => ({
   resolveInMediaRoot: vi.fn(async (p: string) => p),
   chatMediaRoot: vi.fn(async () => "/tmp/clawbox-served-model-dashboard-media"),
@@ -264,6 +275,36 @@ describe.skipIf(!sqliteAvailable)(
       // page replays. A bubble that loses its provider on reload is the same
       // defect one layer down.
       expect(persistedAssistant()).toMatchObject({ model: "gpt-5.6-sol", provider: "openai-codex" });
+    });
+
+    it("remembers the provider that answered, so a polled route need never probe", async () => {
+      // `credentialPresent` says a key is on disk; nothing on the box said the
+      // key WORKS, so `verified` was null on all 48 rows. A completed turn IS
+      // the exercise, and the evidence is already here — this is only the
+      // memory of it. No traffic, no latency, nothing of the owner's quota.
+      openTurnMock.mockResolvedValue(fakeTurn({
+        home,
+        model: "gpt-5.6-sol",
+        bills: [{ model: "gpt-5.6-sol", provider: "openai-codex" }],
+      }));
+
+      await doneEvent(await POST(post({ message: "which model are you" })));
+
+      expect(configSetMock).toHaveBeenCalledWith(
+        "provider_verified_at",
+        expect.objectContaining({ "openai-codex": expect.any(String) }),
+      );
+    });
+
+    it("marks nothing when no provider could be named for the turn", async () => {
+      // Not-known must stay not-known: a mark written off a blank would make
+      // "verified" mean "a turn happened", which is the confusion this exists
+      // to remove.
+      openTurnMock.mockResolvedValue(fakeTurn({ home, model: "gpt-5.6-sol" }));
+
+      await doneEvent(await POST(post({ message: "which model are you" })));
+
+      expect(configSetMock).not.toHaveBeenCalledWith("provider_verified_at", expect.anything());
     });
 
     it("still says nothing when the harness recorded no usage for that turn", async () => {

--- a/src/tests/routes/hermes/chat-served-model-dashboard.test.ts
+++ b/src/tests/routes/hermes/chat-served-model-dashboard.test.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import os from "os";
 import path from "path";
+import { saveEnv } from "@/tests/helpers/env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
@@ -244,9 +245,11 @@ describe.skipIf(!sqliteAvailable)(
   "/setup-api/hermes/chat — what the DASHBOARD transport records as the served provider",
   () => {
     let home: string;
+    let restoreEnv: () => void;
 
     beforeEach(async () => {
       vi.clearAllMocks();
+      restoreEnv = saveEnv("HERMES_HOME");
       home = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-served-provider-"));
       process.env.HERMES_HOME = home;
       appendMock.mockResolvedValue(true);
@@ -257,8 +260,10 @@ describe.skipIf(!sqliteAvailable)(
     });
 
     afterEach(() => {
-      delete process.env.HERMES_HOME;
-      fs.rmSync(home, { recursive: true, force: true });
+      // Restored, not deleted — see src/tests/helpers/env.ts on why a worker
+      // reused across files must not simply lose the variable.
+      restoreEnv();
+      if (home) fs.rmSync(home, { recursive: true, force: true });
     });
 
     it("names the provider Hermes itself billed, when the frame gave a model and the request pinned nothing", async () => {

--- a/src/tests/routes/hermes/models-refresh-auth.test.ts
+++ b/src/tests/routes/hermes/models-refresh-auth.test.ts
@@ -175,6 +175,9 @@ describe("the scoped reply and the device's reasoning level", () => {
 
     expect(row.verified).toBe(true);
     expect(row.verifiedAt).toBe("2026-09-02T19:53:34.000Z");
+    // Pinned by KEY: a reader looking up the wrong one would otherwise pass,
+    // because the mock answers any key.
+    expect(configGetMock).toHaveBeenCalledWith("provider_verified_at");
   });
 
   it("leaves a provider nothing has exercised at NOT CHECKED, never at not connected", async () => {

--- a/src/tests/routes/hermes/models-refresh-auth.test.ts
+++ b/src/tests/routes/hermes/models-refresh-auth.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { installSessionFixture, type SessionFixture } from "@/tests/helpers/session";
+import { saveEnv } from "@/tests/helpers/env";
 
 /**
  * `?refresh=1` is not a read. It busts Hermes' per-provider disk cache and fans
@@ -66,6 +70,8 @@ const PAYLOAD = {
 
 let session: SessionFixture;
 let GET: (req: Request) => Promise<Response>;
+let hermesHome: string;
+let restoreEnv: () => void;
 
 function request(query: string, authed: boolean): Request {
   return new Request(`http://localhost/setup-api/hermes/models${query}`, {
@@ -74,6 +80,17 @@ function request(query: string, authed: boolean): Request {
 }
 
 beforeEach(async () => {
+  // `readProviderVerified` drops any mark older than the mtime of Hermes' own
+  // pooled credential store (`$HERMES_HOME/auth.json`) — the anti-probe-once
+  // rule for keys written outside this process. Without an isolated home the
+  // marks below are read against whatever `~/.hermes/auth.json` the HOST has,
+  // so the fixed instants here expire on every real Hermes box (its store is
+  // dated the owner's last key change) while passing on a dev PC and in CI,
+  // which have no such file. An empty directory makes the store unaskable,
+  // which is the "nothing has been rotated" case these assertions mean.
+  restoreEnv = saveEnv("HERMES_HOME");
+  hermesHome = mkdtempSync(path.join(tmpdir(), "clawbox-models-refresh-hermes-"));
+  process.env.HERMES_HOME = hermesHome;
   session = installSessionFixture();
   getModelOptionsMock.mockReset();
   getModelOptionsMock.mockResolvedValue(PAYLOAD);
@@ -89,6 +106,8 @@ beforeEach(async () => {
 
 afterEach(() => {
   session.cleanup();
+  restoreEnv();
+  rmSync(hermesHome, { recursive: true, force: true });
 });
 
 describe("GET /setup-api/hermes/models", () => {

--- a/src/tests/routes/hermes/models-refresh-auth.test.ts
+++ b/src/tests/routes/hermes/models-refresh-auth.test.ts
@@ -36,6 +36,16 @@ vi.mock("@/lib/hermes-cli", () => ({
   runHermesCli: vi.fn(async () => ({ stdout: "", stderr: "", code: 0 })),
 }));
 
+// TASK-583: `verified` is present on every row and null on all of them, so
+// "connected" still means "a key is on disk". The marks a completed turn leaves
+// behind are the one source that costs nothing to read.
+const configGetMock = vi.hoisted(() => vi.fn(async () => undefined as unknown));
+vi.mock("@/lib/config-store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/config-store")>()),
+  get: configGetMock,
+  set: vi.fn(async () => {}),
+}));
+
 const PAYLOAD = {
   providers: [{
     id: "anthropic",
@@ -71,6 +81,8 @@ beforeEach(async () => {
   reconcileClawaiMock.mockClear();
   activeHarnessMock.mockReset();
   activeHarnessMock.mockResolvedValue("hermes");
+  configGetMock.mockReset();
+  configGetMock.mockResolvedValue(undefined);
   vi.resetModules();
   ({ GET } = await import("@/app/setup-api/hermes/models/route"));
 });
@@ -154,5 +166,27 @@ describe("the scoped reply and the device's reasoning level", () => {
     // list, and `savedElsewhere` is null when it IS this provider — so
     // neither can name the default on the box's own provider.
     expect(body.savedPair).toEqual({ provider: "anthropic", model: "anthropic/claude-opus-5" });
+  });
+
+  it("reports a provider that has actually answered as verified, with when", async () => {
+    configGetMock.mockResolvedValue({ anthropic: "2026-09-02T19:53:34.000Z" });
+
+    const row = (await (await GET(request("", false))).json()).providers[0];
+
+    expect(row.verified).toBe(true);
+    expect(row.verifiedAt).toBe("2026-09-02T19:53:34.000Z");
+  });
+
+  it("leaves a provider nothing has exercised at NOT CHECKED, never at not connected", async () => {
+    // An offline box and a rate-limited subscription both land here. Null is
+    // the honest answer; false would say the credential was tried and failed.
+    configGetMock.mockResolvedValue({ openai: "2026-09-02T19:53:34.000Z" });
+
+    const row = (await (await GET(request("", false))).json()).providers[0];
+
+    expect(row.verified).toBeNull();
+    expect(row).not.toHaveProperty("verifiedAt");
+    // ...and presence is still reported separately, exactly as before.
+    expect(row.credentialPresent).toBe(true);
   });
 });

--- a/src/tests/routes/hermes/models-refresh-auth.test.ts
+++ b/src/tests/routes/hermes/models-refresh-auth.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { installSessionFixture, type SessionFixture } from "@/tests/helpers/session";
@@ -73,6 +73,22 @@ let GET: (req: Request) => Promise<Response>;
 let hermesHome: string;
 let restoreEnv: () => void;
 
+/**
+ * Hermes' own pooled credential store, last written at `at`.
+ *
+ * The shape every Hermes box really has: `readProviderVerified` drops any mark
+ * older than this file's mtime, which is how a key written OUTSIDE this process
+ * (`hermes auth add` from the Terminal, or Hermes' own dashboard) expires a mark
+ * that no longer says anything about the credential on disk. An empty home
+ * would leave that filter unreachable and these assertions would pass down a
+ * branch no device takes.
+ */
+function writeAuthStore(at: Date): void {
+  const file = path.join(hermesHome, "auth.json");
+  writeFileSync(file, "{}");
+  utimesSync(file, at, at);
+}
+
 function request(query: string, authed: boolean): Request {
   return new Request(`http://localhost/setup-api/hermes/models${query}`, {
     headers: authed ? { Cookie: session.cookie } : {},
@@ -86,11 +102,15 @@ beforeEach(async () => {
   // marks below are read against whatever `~/.hermes/auth.json` the HOST has,
   // so the fixed instants here expire on every real Hermes box (its store is
   // dated the owner's last key change) while passing on a dev PC and in CI,
-  // which have no such file. An empty directory makes the store unaskable,
-  // which is the "nothing has been rotated" case these assertions mean.
+  // which have no such file.
+  //
+  // Isolated AND populated: a store dated BEFORE the marks is the state of a
+  // device whose keys have not been touched since the turn that earned them, so
+  // the marks travel through the freshness filter rather than around it.
   restoreEnv = saveEnv("HERMES_HOME");
   hermesHome = mkdtempSync(path.join(tmpdir(), "clawbox-models-refresh-hermes-"));
   process.env.HERMES_HOME = hermesHome;
+  writeAuthStore(new Date("2026-09-01T00:00:00.000Z"));
   session = installSessionFixture();
   getModelOptionsMock.mockReset();
   getModelOptionsMock.mockResolvedValue(PAYLOAD);
@@ -105,9 +125,16 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-  session.cleanup();
-  restoreEnv();
-  rmSync(hermesHome, { recursive: true, force: true });
+  // `finally`, and the env first: a throwing `session.cleanup()` would
+  // otherwise leave `HERMES_HOME` pointing at a directory the next test removes.
+  try {
+    session.cleanup();
+  } finally {
+    restoreEnv();
+    // `mkdtempSync` can fail (an unwritable or full TMPDIR), and `rmSync`
+    // called on `undefined` would replace that error in the report.
+    if (hermesHome) rmSync(hermesHome, { recursive: true, force: true });
+  }
 });
 
 describe("GET /setup-api/hermes/models", () => {
@@ -197,6 +224,22 @@ describe("the scoped reply and the device's reasoning level", () => {
     // Pinned by KEY: a reader looking up the wrong one would otherwise pass,
     // because the mock answers any key.
     expect(configGetMock).toHaveBeenCalledWith("provider_verified_at");
+  });
+
+  it("stops calling a provider verified once its credential was rewritten outside ClawBox", async () => {
+    // ClawBox is not the only writer: `hermes auth add` from the Terminal and a
+    // key pasted into Hermes' own dashboard never pass through this process. So
+    // the mark is aged against the harness's own pooled store rather than
+    // pretended away — deliberately coarse (one file for every provider), and
+    // back to "not checked", never to "not connected".
+    writeAuthStore(new Date("2026-09-03T00:00:00.000Z"));
+    configGetMock.mockResolvedValue({ anthropic: "2026-09-02T19:53:34.000Z" });
+
+    const row = (await (await GET(request("", false))).json()).providers[0];
+
+    expect(row.verified).toBeNull();
+    expect(row).not.toHaveProperty("verifiedAt");
+    expect(row.credentialPresent).toBe(true);
   });
 
   it("leaves a provider nothing has exercised at NOT CHECKED, never at not connected", async () => {

--- a/src/tests/unit/provider-verified.test.ts
+++ b/src/tests/unit/provider-verified.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * TASK-583 — `verified` is present on every provider row and null on all of
+ * them, so "connected" still means "a key is on disk". These pin the rules that
+ * make it mean something without a probe: what counts as evidence, what a
+ * credential change does to it, and what the store may cost on the settle path
+ * of a turn a customer is waiting on.
+ */
+
+const store = new Map<string, unknown>();
+const getMock = vi.hoisted(() => vi.fn());
+const setMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/config-store", () => ({ get: getMock, set: setMock }));
+
+let lib: typeof import("@/lib/provider-verified");
+
+beforeEach(async () => {
+  store.clear();
+  getMock.mockReset();
+  setMock.mockReset();
+  getMock.mockImplementation(async (key: string) => store.get(key));
+  setMock.mockImplementation(async (key: string, value: unknown) => { store.set(key, value); });
+  vi.resetModules();
+  lib = await import("@/lib/provider-verified");
+});
+
+describe("provider-verified", () => {
+  it("remembers a provider that served a turn, with when", async () => {
+    await lib.recordProviderVerified("openai-codex", new Date("2026-09-02T19:53:34.000Z"));
+
+    expect(await lib.readProviderVerified())
+      .toEqual({ "openai-codex": "2026-09-02T19:53:34.000Z" });
+  });
+
+  it("does not rewrite the store for every turn of a busy conversation", async () => {
+    // A write is a read, a serialise and a rename of the WHOLE config store,
+    // and "it answered at 19:53" is not made truer by being restated at 19:54.
+    await lib.recordProviderVerified("anthropic", new Date("2026-09-02T19:00:00.000Z"));
+    setMock.mockClear();
+
+    await lib.recordProviderVerified("anthropic", new Date("2026-09-02T19:30:00.000Z"));
+
+    expect(setMock).not.toHaveBeenCalled();
+    // ...and it does write again once the mark has genuinely aged.
+    await lib.recordProviderVerified("anthropic", new Date("2026-09-02T21:00:00.000Z"));
+    expect(setMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("forgets a provider whose credential has just been written", async () => {
+    // A rotated key inherits nothing from the one it replaced: the row goes
+    // back to "not checked", never to "not connected".
+    await lib.recordProviderVerified("anthropic", new Date("2026-09-02T19:00:00.000Z"));
+
+    await lib.forgetProviderVerified("anthropic");
+
+    expect(await lib.readProviderVerified()).toEqual({});
+    // ...and the very next turn may mark it again at once, rather than being
+    // held off by a debounce that outlived the mark it was debouncing.
+    setMock.mockClear();
+    await lib.recordProviderVerified("anthropic", new Date("2026-09-02T19:05:00.000Z"));
+    expect(setMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the store bounded, dropping the oldest marks first", async () => {
+    for (let i = 0; i < lib.MAX_VERIFIED_PROVIDERS + 3; i += 1) {
+      await lib.recordProviderVerified(`p${i}`, new Date(Date.UTC(2026, 0, 1, 0, i)));
+    }
+
+    const marks = await lib.readProviderVerified();
+    expect(Object.keys(marks)).toHaveLength(lib.MAX_VERIFIED_PROVIDERS);
+    expect(marks).not.toHaveProperty("p0");
+    expect(marks).toHaveProperty(`p${lib.MAX_VERIFIED_PROVIDERS + 2}`);
+  });
+
+  it("ignores a mark that is not a usable instant, and one that is not a provider id", async () => {
+    // Shipping either would put "verified at Invalid Date" on the panel.
+    store.set(lib.PROVIDER_VERIFIED_KEY, {
+      anthropic: "not a date",
+      "../etc": "2026-09-02T19:00:00.000Z",
+      openai: 1756843200000,
+      google: "2026-09-02T19:00:00.000Z",
+    });
+
+    expect(await lib.readProviderVerified())
+      .toEqual({ google: "2026-09-02T19:00:00.000Z" });
+  });
+
+  it("never throws over a store it cannot read or write", async () => {
+    // This runs on the settle path of a turn and on a credential save: losing a
+    // status mark must never cost the answer or the save.
+    getMock.mockRejectedValue(new Error("EACCES"));
+    setMock.mockRejectedValue(new Error("EACCES"));
+
+    await expect(lib.readProviderVerified()).resolves.toEqual({});
+    await expect(lib.recordProviderVerified("anthropic")).resolves.toBeUndefined();
+    await expect(lib.forgetProviderVerified("anthropic")).resolves.toBeUndefined();
+  });
+
+  it("refuses an id that is not a provider slug", async () => {
+    await lib.recordProviderVerified("../../etc/passwd");
+    await lib.recordProviderVerified("");
+
+    expect(setMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/unit/provider-verified.test.ts
+++ b/src/tests/unit/provider-verified.test.ts
@@ -148,6 +148,18 @@ describe("provider-verified", () => {
       .toEqual({ anthropic: "2026-09-03T09:00:00.000Z" });
   });
 
+  it("drops a mark whose instant TIES the credential write, rather than guessing", async () => {
+    // A tie says nothing about which came first, and the two guesses are not
+    // equally safe: "verified" over a rotated key is the claim this field must
+    // never make, while "not checked" is the answer the next turn corrects for
+    // free. Reachable whenever the store's mtime lands on a whole millisecond —
+    // a file restored from a backup or unpacked from an archive does.
+    await lib.recordProviderVerified("anthropic", new Date("2026-09-03T08:00:00.000Z"));
+    writeAuthStore(new Date("2026-09-03T08:00:00.000Z"));
+
+    expect(await lib.readProviderVerified()).toEqual({});
+  });
+
   it("keeps every mark when the credential store cannot be asked", async () => {
     // A box with no pooled credentials yet has nothing to invalidate, and "we
     // could not look" must not read as "everything is stale".

--- a/src/tests/unit/provider-verified.test.ts
+++ b/src/tests/unit/provider-verified.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 /**
  * TASK-583 — `verified` is present on every provider row and null on all of
@@ -15,8 +18,23 @@ const setMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/config-store", () => ({ get: getMock, set: setMock }));
 
 let lib: typeof import("@/lib/provider-verified");
+let hermesHome: string;
+
+/** Hermes' pooled credential store, written at `at`. */
+function writeAuthStore(at: Date): void {
+  const file = path.join(hermesHome, "auth.json");
+  writeFileSync(file, "{}");
+  utimesSync(file, at, at);
+}
+
+afterEach(() => {
+  delete process.env.HERMES_HOME;
+  rmSync(hermesHome, { recursive: true, force: true });
+});
 
 beforeEach(async () => {
+  hermesHome = mkdtempSync(path.join(tmpdir(), "clawbox-verified-hermes-"));
+  process.env.HERMES_HOME = hermesHome;
   store.clear();
   getMock.mockReset();
   setMock.mockReset();
@@ -103,5 +121,73 @@ describe("provider-verified", () => {
     await lib.recordProviderVerified("");
 
     expect(setMock).not.toHaveBeenCalled();
+  });
+
+  it("drops a mark older than the last write to Hermes' own credential store", async () => {
+    // ClawBox is not the only writer: a key pasted into Hermes' own dashboard,
+    // or `hermes auth add` from the Terminal, never passes through this
+    // process. Without this the flag would outlive the credential it describes
+    // — a fact captured once and treated as current for the life of the box.
+    await lib.recordProviderVerified("anthropic", new Date("2026-09-02T19:00:00.000Z"));
+    writeAuthStore(new Date("2026-09-03T08:00:00.000Z"));
+
+    expect(await lib.readProviderVerified()).toEqual({});
+  });
+
+  it("keeps a mark earned after that write", async () => {
+    writeAuthStore(new Date("2026-09-03T08:00:00.000Z"));
+    await lib.recordProviderVerified("anthropic", new Date("2026-09-03T09:00:00.000Z"));
+
+    expect(await lib.readProviderVerified())
+      .toEqual({ anthropic: "2026-09-03T09:00:00.000Z" });
+  });
+
+  it("keeps every mark when the credential store cannot be asked", async () => {
+    // A box with no pooled credentials yet has nothing to invalidate, and "we
+    // could not look" must not read as "everything is stale".
+    await lib.recordProviderVerified("anthropic", new Date("2026-09-02T19:00:00.000Z"));
+
+    expect(await lib.readProviderVerified())
+      .toEqual({ anthropic: "2026-09-02T19:00:00.000Z" });
+  });
+
+  it("refuses a KIND that is not a real provider slug", async () => {
+    // `auto` and `custom` are kinds as well as words: a mark under either
+    // matches no row, describes no credential, and takes one of the slots.
+    await lib.recordProviderVerified("auto");
+    await lib.recordProviderVerified("custom");
+    await lib.recordProviderVerified("Anthropic");
+
+    expect(setMock).not.toHaveBeenCalled();
+  });
+
+  it("never moves a mark backwards when the clock is behind", async () => {
+    // A Jetson's RTC lags until NTP settles, and rewriting the mark with the
+    // earlier reading would make the panel's "verified <when>" older than the
+    // truth.
+    await lib.recordProviderVerified("anthropic", new Date("2026-09-02T19:00:00.000Z"));
+    setMock.mockClear();
+
+    await lib.recordProviderVerified("anthropic", new Date("2026-09-02T17:00:00.000Z"));
+
+    expect(setMock).not.toHaveBeenCalled();
+    expect(await lib.readProviderVerified())
+      .toEqual({ anthropic: "2026-09-02T19:00:00.000Z" });
+  });
+
+  it("does not let a concurrent record write a forget back into the store", async () => {
+    // Both writers are read-modify-writes of one map. Unserialised, the record
+    // writes back the snapshot it read before the delete and the forget is
+    // silently undone — the same reason provider-enablement serialises its own
+    // list.
+    await lib.recordProviderVerified("anthropic", new Date("2026-09-02T19:00:00.000Z"));
+
+    await Promise.all([
+      lib.forgetProviderVerified("anthropic"),
+      lib.recordProviderVerified("openai-codex", new Date("2026-09-02T21:00:00.000Z")),
+    ]);
+
+    expect(await lib.readProviderVerified())
+      .toEqual({ "openai-codex": "2026-09-02T21:00:00.000Z" });
   });
 });

--- a/src/tests/unit/provider-verified.test.ts
+++ b/src/tests/unit/provider-verified.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { saveEnv } from "@/tests/helpers/env";
 
 /**
  * TASK-583 — `verified` is present on every provider row and null on all of
@@ -19,6 +20,7 @@ vi.mock("@/lib/config-store", () => ({ get: getMock, set: setMock }));
 
 let lib: typeof import("@/lib/provider-verified");
 let hermesHome: string;
+let restoreEnv: () => void;
 
 /** Hermes' pooled credential store, written at `at`. */
 function writeAuthStore(at: Date): void {
@@ -28,11 +30,15 @@ function writeAuthStore(at: Date): void {
 }
 
 afterEach(() => {
-  delete process.env.HERMES_HOME;
-  rmSync(hermesHome, { recursive: true, force: true });
+  // Restored, not deleted: vitest reuses a worker across files, so a variable
+  // DELETED here goes away for every file that follows in it rather than going
+  // back to what it was (src/tests/helpers/env.ts says why).
+  restoreEnv();
+  if (hermesHome) rmSync(hermesHome, { recursive: true, force: true });
 });
 
 beforeEach(async () => {
+  restoreEnv = saveEnv("HERMES_HOME");
   hermesHome = mkdtempSync(path.join(tmpdir(), "clawbox-verified-hermes-"));
   process.env.HERMES_HOME = hermesHome;
   store.clear();


### PR DESCRIPTION
Makes `verified` on the Hermes providers listing mean something, at zero cost (TASK-583).

## Customer-visible symptom

`credentialPresent` says a key is on disk. `verified` is the field that would say the key WORKS, and on every box measured it was present on all 48 provider rows and **null on all 48** — so a revoked key, a rate-limited subscription and a typo'd custom endpoint all rendered exactly like a working provider. Measured on the Hermes box 2026-08-28 and again on beta 419f82c7 on 2026-09-02: `any verified non-null? False`.

## Cause

Nothing on the box ever exercised a credential and wrote the result down. The field was split out of TASK-446 rather than implemented because a real verification probe means credential-bearing traffic from a route the UI polls — latency on every render, a request per provider per poll, bad behaviour on a box with no internet, and it can burn the owner's own quota.

## Fix

**None of that is needed. A completed turn IS the exercise**, and the evidence already exists on the device at zero cost. `/setup-api/hermes/chat` already learns who served each answer from Hermes' OWN billing record — `session_model_usage.billing_provider`, read once per turn by `billedProviderFor`. This only remembers the conclusion, so a polled route never opens the agent's database on a page load (`hermes-turn-record.ts` documents why that must not happen).

- `src/lib/provider-verified.ts` — the marks (provider id → ISO instant), bounded to 32, serialised, and non-throwing on every path: a status mark must never cost an answer or a credential save.
- The mark is taken where the provider is EVIDENCE — the dashboard leg's own frame, or the harness's billing record — deliberately not in `settleTurn`, which the CLI leg also reaches and where the provider can fall back to `hermes config get model.provider`, i.e. what the box is configured with.
- `/setup-api/hermes/models` reports `verified: true` with `verifiedAt` beside it. A provider nothing has exercised stays **null** — "not checked", never `false`.

Against TASK-583's own acceptance:

- *No verification traffic is emitted on any polled route* — **satisfied**. The route reads `data/config.json` and stats one file. Nothing is sent to any provider.
- *`verified` is non-null only where something actually exercised the credential* — **satisfied**, and narrowed further than the first pass: only where the provider came from the harness's record or the transport's own frame.
- *An offline box and a rate-limited subscription both render "not checked", never "not connected"* — the field itself now behaves that way (null, never false). **This PR is payload-only**: nothing renders `verified` yet. The provider strip's dot-and-word comes from `stateFor()` in `src/lib/provider-status.ts`, which decides from `authenticated` alone and is untouched here, so a credentialed-but-never-exercised provider still reads "Connected" on screen. Making the panel say "connected" and "verified" apart is a UI decision with its own strings in ten locales; it is recorded as a follow-up in the fixer queue rather than smuggled in here.

## What it covers, exactly

A turn through ClawBox's own chat route, on the dashboard transport. **Not** a Telegram or Discord turn, not `hermes chat` from the Terminal, and not the CLI leg. This is stated in the module docstring rather than left implied.

## Harness-first

`session_model_usage` holds `billing_provider` and `last_seen` for every session on the box, across every transport, and one grouped query over it would cover them all. It is **not** read here for two stated reasons: that database must not be opened on a page load, and `last_seen`'s epoch and units have never been established on a box (`hermes-turn-record.ts` says the same about reading it as a clock). Establishing that is one on-device read and is the natural next step if this needs to cover channels; it is named in the docstring so the next reader does not have to rediscover it.

Nothing here re-implements a catalogue or a credential store: the evidence comes from the harness's own billing record via the reader that already exists, and staleness comes from the harness's own pooled credential store.

## Sibling call sites — every path that changes a Hermes credential

A rotated key inherits nothing from the one it replaced, so every ClawBox lane that writes or replaces one forgets that provider's mark, **before** the write (a mark lost to a write that then fails is always safe; the next turn earns it back):

- `src/lib/hermes-cloud-provider.ts` — `applyCloudProviderKeyToHermes`
- `src/lib/hermes-clawai.ts` — `applyClawaiToHermes` (account switch, re-pair, rotated device token)
- `src/app/setup-api/hermes/provider-key/route.ts` — the panel's pasted key (openrouter, anthropic, gemini, **zai**, **kimi-coding** — the last two had no covered path at all)
- `src/app/setup-api/hermes/oauth/submit/route.ts` and `.../oauth/poll/route.ts` — the PKCE exchange and the device-code approval, the only lane for openai-codex, nous and copilot
- `src/lib/hermes-local-ai.ts` — the Local AI teardown unsets `providers.clawlocal.api_key`

**ClawBox is not the only writer, though**, and pretending otherwise would be the probe-once class: a key pasted into Hermes' own dashboard, or `hermes auth add` from the Terminal, never passes through this process. So every read also asks the harness's own pooled credential store when it was last written — a stat of `~/.hermes/auth.json`, the file `hermes auth add` rewrites (0600; confirmed on the Hermes box, read-only) — and drops any mark older than that. Deliberately coarse: one file for every provider, so one key change forgets them all. "Not checked" is always a safe answer.

**Cleared, no change needed:** `src/lib/provider-enablement.ts` — the enable/disable switch deliberately KEEPS the credential, so a mark must survive it. `src/app/setup-api/ai-models/configure/route.ts` — its Hermes branch reaches Hermes only through the two lanes above. Factory reset already takes the marks with `data/config.json`.

## Both editions

The OpenClaw edition has no server-side turn completion at all — the browser talks to the gateway socket directly through `OpenClawGatewayAdapter`, so no ClawBox route observes a finished turn and nothing can be recorded there. `/setup-api/hermes/chat` is Hermes-only. On an OpenClaw box `readProviderVerified()` answers `{}` and every route stays 200: the code is inert, not erroring, which the existing "spawns no `hermes` repair on an OpenClaw box" test pins. That the field can never be populated on OpenClaw is a finding, not a gap this PR could close.

## RED

On unmodified `origin/beta`:

```
 × reports a provider that has actually answered as verified, with when
   AssertionError: expected null to be true
 × remembers the provider that answered, so a polled route need never probe
   AssertionError: expected "vi.fn()" to be called with arguments:
     [ 'provider_verified_at', …(1) ]
      Tests  2 failed | 20 passed (22)
```

Both drive the shipped routes and observe the config store directly, so neither is an import-time failure against a tree that lacks the new module.

## GREEN

```
 Test Files  106 passed (106)
      Tests  1723 passed (1723)
```

(every `src/tests/routes/hermes` suite, the new `provider-verified` unit suite, every `hermes-*` and `provider-*` unit suite, plus the three beta guard suites.) `tsc --noEmit` clean, eslint clean on all nine changed files.

## Review

Reviewed at high effort: 3 high, 4 medium, 6 low. All applied except two, both answered in the text above rather than in code: the payload-only scope (stated, not claimed as delivered), and the precedence of a hypothetical Hermes `verified: false` over a newer local mark (documented at the site with the reason and what to revisit if Hermes ever starts populating it). The review also confirmed clean: `provider-enablement`, the configure route, factory reset, the OpenClaw inertness, and that an errored turn cannot mark a provider verified.

## Device proof (read-only)

`~/.hermes/auth.json` exists on the Hermes box, 0600, mtime distinct from `config.yaml`'s — so it is a usable credential-change timestamp and not a file rewritten by every `hermes config set`. `hermes auth --help` lists `add | list | remove | reset | status | logout | spotify`, confirming `auth add` as the write verb. No box was mutated: every command was a read.


## Merge-gate round — the suite was red on a device, green everywhere else

The merge-gate review blocked on one defect this branch would have shipped, and it was in the new
test rather than in the product: `src/tests/routes/hermes/models-refresh-auth.test.ts` asserted on
verification marks written as fixed instants (`2026-09-02T19:53:34Z`) while `readProviderVerified()`
drops any mark older than the mtime of Hermes' own pooled credential store. The suite read that store
from the HOST. On a dev PC and in CI there is no `~/.hermes/auth.json`, so the filter was unreachable
and the case passed; on a Hermes box the file exists and is dated the owner's last key change, so the
mark expired and the case failed against correct code — on the one platform the working rules say to
run the suites on.

RED, reproduced by pointing `HERMES_HOME` at a scratch home holding a fresh `auth.json` (the box
shape), against the previous head:

```
 × reports a provider that has actually answered as verified, with when
   AssertionError: expected null to be true
 ❯ src/tests/routes/hermes/models-refresh-auth.test.ts:176:26
 Tests  1 failed | 9 passed (10)
```

Fixed by isolating the store the suite reads — `HERMES_HOME` at a `mkdtempSync` home, restored
through the repo's `saveEnv` helper rather than deleted — and then by making that home the shape a
device really has: an `auth.json` dated BEFORE the marks, so they travel THROUGH the freshness filter
instead of around it. An empty home would have left `credentialsWrittenAtMs()` at `null` and the
filter unreachable, which is a second way to be green about a state no box is in. One case was added
for the other direction: a store rewritten AFTER the mark (the `hermes auth add` / Hermes-dashboard
lane) puts the row back to `verified: null` with no `verifiedAt`, at the route.

The same `delete process.env.HERMES_HOME` teardown in the two sibling suites this PR touches was
moved onto `saveEnv` as well, and the temp-home teardown now restores the env in a `finally`.

GREEN, on the pushed head, under both host shapes:

```
# HERMES_HOME at a scratch home holding a fresh auth.json (the box shape)
 Test Files  34 passed (34)
      Tests  378 passed (378)

# HERMES_HOME unset (dev PC / CI shape)
 Test Files  2 passed (2)
      Tests  24 passed (24)
```

(`src/tests/routes/hermes/` in full, the `provider-verified` unit suite, and the three guard suites
`openclaw-config-mock-completeness`, `test-timeout-hygiene`, `state-updater-purity`.) `tsc --noEmit`
clean. Rebased onto `origin/beta` `5c7170b8`; `git diff --stat origin/beta...HEAD` lists only the 13
files this PR intends and `--diff-filter=DR` is empty.

### A second round on the same head

CodeRabbit came back on the pushed head with one more actionable point, and it was right in the
direction that matters: `readProviderVerified` kept a mark whose instant EQUALS the credential
store's write time (`Date.parse(at) >= credentialsAt`). A tie says nothing about which came first,
and the two guesses are not equally safe — keeping the mark reports a rotated credential as
verified, which is the one claim this field must never make, while dropping it reports "not
checked", the answer the module is allowed to be wrong with because the next turn earns the mark
straight back. The comparison is now strict, with an equal-timestamp case beside it; put back to
`>=` that case fails (`1 failed | 13 passed`), so it is load-bearing rather than decorative.

Reachability, checked rather than assumed: on ext4 `statSync(...).mtimeMs` normally carries a
sub-millisecond fraction, so `>=` already behaved as `>` on a running box — but a store restored
from a backup or unpacked from an archive lands on a whole second, which a factory-restore path
does.

### Residual, recorded rather than fixed here

`HERMES_HOME` is not in `vitest.config.ts`'s `test.env` floor, which is this repo's own mechanism for
exactly this class — it already floors `CLAWBOX_EDITION`, `CLAWBOX_ROOT`, `OPENCLAW_HOME` and
`OPENCLAW_STATE_DIR`, each added after a measured on-hardware incident of the same shape. Flooring it
would close the hole for every future suite, not just this one, but it changes the default for the 30
test sites that touch the variable and owes a full-suite run of its own, so it is queued as a
separate change rather than folded in here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider verification status is now tracked after successfully completed chat turns.
  * Provider listings display verification status and timestamps when available.

* **Bug Fixes**
  * Verification indicators are cleared when provider credentials or configuration changes, including OAuth updates and removals.
  * Improved handling for providers without confirmed verification data.

* **Tests**
  * Added coverage for verification tracking, invalidation, storage limits, concurrency, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

