### PR TITLE
fix: factory reset must not read, delete or report through a symlink

### DIFF
--- a/docs-site/technical/filesystem.mdx
+++ b/docs-site/technical/filesystem.mdx
@@ -71,6 +71,13 @@ Rows marked **OpenClaw/dual** or **Hermes/dual** exist only on those editions. C
 
 The update mechanism achieves this with `git reset --hard <release>` + `git clean -fd` (note: no `-x` — gitignored paths like `data/` and `.env` are never cleaned). Details: [Update System](/technical/update-system).
 
+Every ❌ row above assumes the path really is the directory it names. If one of them has been
+replaced by a **symlink**, the factory reset removes the link and leaves whatever it pointed at
+alone — it never deletes through it — and reports the reset as **incomplete**, naming the path,
+without clearing the Wi-Fi, resetting the login password or rebooting. So the box stays reachable
+and the redirected store is still there to deal with. A plain file where a directory belongs is
+simply removed and the reset finishes normally.
+
 <Warning>
 **Do not hand-roll a factory reset over SSH from this table.** `rm -rf ~/.hermes` deletes
 `hermes-agent/` and bricks the Hermes harness; `rm -rf data/*` deletes `network.env` and the

--- a/src/app/setup-api/setup/reset/route.ts
+++ b/src/app/setup-api/setup/reset/route.ts
@@ -156,16 +156,128 @@ async function deleteWifiConnections(): Promise<void> {
   }
 }
 
+/** ENOENT, the one errno every step of this wipe reads as "already gone". */
+function isEnoent(err: unknown): boolean {
+  return Boolean(err && typeof err === "object" && "code" in err && err.code === "ENOENT");
+}
+
+/**
+ * What `removeDirectoryContents` is allowed to do with `dir`.
+ *
+ * `directory` — it really is one; readdir it.
+ * `gone`      — there was nothing there, or what was there was not a directory
+ *               and has been removed. Nothing was hidden behind it.
+ * `failure`   — say so through the failure list. NEVER a throw: everything else
+ *               in this wipe returns its failures, and the handler's outer catch
+ *               is a 500 taken AFTER data/, ~/.openclaw, ~/.clawkeep and the
+ *               home paths are gone and BEFORE the password reset, the WiFi
+ *               clear and the reboot — the un-resettable box this whole guard
+ *               exists to prevent, reached by a different errno.
+ */
+type DirectoryGuard =
+  | { kind: "directory" }
+  | { kind: "gone" }
+  | { kind: "failure"; failure: string };
+
+/**
+ * Check what `dir` actually is before anything readdirs it.
+ *
+ * Nothing may `readdir` a path this wipe is about to empty entry-by-entry until
+ * this has answered `directory`. A previous owner with a shell (the Terminal
+ * app, or SSH before the key wipe — the adversary the keep-lists are written
+ * against) can leave two things in the way:
+ *
+ *   - A SYMLINK. `readdir` follows it and `fs.rm` then deletes THROUGH it:
+ *     `rm -rf ~/.hermes && ln -s /home/clawbox ~/.hermes` turned the next
+ *     owner's factory reset into a wipe of everything in the home directory
+ *     that is not a keep-list NAME — the checkout, `.bun`, `.local/bin`, the
+ *     `~/.cache/huggingface` voice models. A reflash, caused by pressing
+ *     Factory reset.
+ *   - A PLAIN FILE. `readdir` raises ENOTDIR, which used to escape to the
+ *     handler's outer catch and answer 500 half-way through the wipe,
+ *     identically on every retry.
+ *
+ * Both are answered by removing THAT PATH — `fs.rm` on a symlink removes the
+ * link, never its target — but they are not the same outcome and must not be
+ * reported as one:
+ *
+ *   - A plain file (or socket, or fifo) hid nothing: there is no directory of
+ *     owner state behind it, so removing it finishes the job (`gone`) and the
+ *     reset completes, which is the ENOTDIR half of the defect.
+ *   - A SYMLINK hid everything. Its target still holds whatever the wipe was
+ *     sent to erase — and it may not even be on this disk. Deleting through it
+ *     is the reflash above; keeping quiet about it would hand the next owner a
+ *     box that answered "factory reset complete" over a `~/Documents` still
+ *     full of the previous owner's files, browsable in the Files app. So the
+ *     link goes and the path is REPORTED: the handler's aggregate gate then
+ *     answers "factory reset incomplete" with the path named, WITHOUT clearing
+ *     the WiFi, resetting the password or rebooting, so the owner still has a
+ *     reachable box and something to act on.
+ *
+ * That also covers a directory that is a symlink for a good reason — a
+ * `data/llamacpp` moved to another disk, say. Its `keep` list (the 3.2 GB Gemma
+ * GGUF) is unreachable through a removed link, so "nothing inside a
+ * non-directory can be a keep-list member" is true of a plain file and NOT of a
+ * symlink; reporting is what stops that becoming a silent loss on a box that
+ * reboots into AP mode with no internet.
+ *
+ * Not TOCTOU-proof, deliberately: Node exposes no readdir-at-fd (`fs.opendir`
+ * takes a path, there is no `fdopendir`), so a shell racing this between the
+ * lstat and the readdir could still swap a directory for a link. That needs a
+ * live adversary on the box DURING the reset; the planted-link case closed here
+ * needs a shell once, at any time before it.
+ */
+async function guardDirectory(dir: string): Promise<DirectoryGuard> {
+  let stats;
+  try {
+    stats = await fs.lstat(dir);
+  } catch (err: unknown) {
+    if (isEnoent(err)) return { kind: "gone" };
+    return { kind: "failure", failure: `${dir}: ${err}` };
+  }
+  if (stats.isDirectory()) return { kind: "directory" };
+
+  const wasSymlink = stats.isSymbolicLink();
+  try {
+    await fs.rm(dir, { recursive: true, force: true });
+  } catch (err: unknown) {
+    return { kind: "failure", failure: `${dir}: ${err}` };
+  }
+  if (!wasSymlink) return { kind: "gone" };
+  return {
+    kind: "failure",
+    failure: `${dir}: a symlink, not a directory — the link was removed and whatever it pointed at was left untouched, so this factory reset did not erase it`,
+  };
+}
+
+/**
+ * Name a failure from `removeDirectoryContents` for the aggregate list.
+ *
+ * An ENTRY failure is a bare name (`auth.json: EACCES…`) and is read relative to
+ * the directory it came from; a WHOLE-DIRECTORY failure from `guardDirectory`
+ * already carries its absolute path, and prefixing that again would read as a
+ * child of itself.
+ */
+function labelFailure(rel: string, failure: string): string {
+  return failure.startsWith("/") ? failure : `${rel}/${failure}`;
+}
+
 async function removeDirectoryContents(dir: string, keep?: ReadonlySet<string>): Promise<string[]> {
   // Background processes (npm install, plugin runtimes) can recreate files
   // between readdir and rm; one retry catches that.
   for (let attempt = 0; attempt < 2; attempt++) {
+    // Re-asked on every attempt, not hoisted: the retry exists because things
+    // move under this wipe, and a path that became a link between the passes
+    // must not be read through — or reported clean — on the second one either.
+    const guard = await guardDirectory(dir);
+    if (guard.kind === "gone") return [];
+    if (guard.kind === "failure") return [guard.failure];
     let entries: string[];
     try {
       entries = await fs.readdir(dir);
       if (keep) entries = entries.filter((entry) => !keep.has(entry));
     } catch (err: unknown) {
-      if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") return [];
+      if (isEnoent(err)) return [];
       throw err;
     }
     if (entries.length === 0) return [];
@@ -372,11 +484,11 @@ async function wipeHomeUserState(): Promise<string[]> {
   );
   for (const rel of HOME_CONTENT_WIPE_DIRS) {
     const dirFailures = await removeDirectoryContents(path.join(HOME_DIR, rel));
-    failures.push(...dirFailures.map((f) => `${rel}/${f}`));
+    failures.push(...dirFailures.map((f) => labelFailure(rel, f)));
   }
   for (const { rel, keep } of HOME_CONTENT_WIPE_KEEP) {
     const dirFailures = await removeDirectoryContents(path.join(HOME_DIR, rel), keep);
-    failures.push(...dirFailures.map((f) => `${rel}/${f}`));
+    failures.push(...dirFailures.map((f) => labelFailure(rel, f)));
   }
   // Agent-scheduled cron jobs. `crontab -r` exits non-zero when there is no
   // crontab — that's the desired end state, not a failure; anything else
@@ -492,24 +604,32 @@ export async function POST(request: Request) {
     await maskAndStopGateway();
 
     const dataFailures: string[] = [];
-    try {
-      const entries = await fs.readdir(DATA_DIR);
-      const results = await Promise.allSettled(
-        entries
-          .filter(entry => !DATA_KEEP_NAMES.has(entry))
-          .map(entry => fs.rm(path.join(DATA_DIR, entry), { recursive: true, force: true }))
-      );
-      for (const r of results) {
-        if (r.status === "rejected") dataFailures.push(String(r.reason));
+    // The top of data/ is wiped by a readdir + rm pass of its own rather than
+    // through removeDirectoryContents (it keeps no retry, so a survivor is
+    // reported on the first pass), so it needs the same guard: a link planted
+    // at data/ would point this rm at whatever it names.
+    const dataGuard = await guardDirectory(DATA_DIR);
+    if (dataGuard.kind === "failure") dataFailures.push(dataGuard.failure);
+    if (dataGuard.kind === "directory") {
+      try {
+        const entries = await fs.readdir(DATA_DIR);
+        const results = await Promise.allSettled(
+          entries
+            .filter(entry => !DATA_KEEP_NAMES.has(entry))
+            .map(entry => fs.rm(path.join(DATA_DIR, entry), { recursive: true, force: true }))
+        );
+        for (const r of results) {
+          if (r.status === "rejected") dataFailures.push(String(r.reason));
+        }
+      } catch (err: unknown) {
+        if (!isEnoent(err)) throw err;
       }
-    } catch (err: unknown) {
-      if (!(err && typeof err === "object" && "code" in err && err.code === "ENOENT")) throw err;
     }
     // …then take each container keep down to its exception list.
     for (const { rel, keep } of DATA_KEEP) {
       if (!keep) continue;
       dataFailures.push(
-        ...(await removeDirectoryContents(path.join(DATA_DIR, rel), keep)).map((f) => `${rel}/${f}`),
+        ...(await removeDirectoryContents(path.join(DATA_DIR, rel), keep)).map((f) => labelFailure(rel, f)),
       );
     }
 

--- a/src/tests/routes/setup/reset-confirmation.test.ts
+++ b/src/tests/routes/setup/reset-confirmation.test.ts
@@ -24,6 +24,11 @@ vi.mock("child_process", () => ({
 
 vi.mock("fs/promises", () => ({
   default: {
+    // The wipe lstats every directory before it reads one (a symlink or a
+    // plain file planted in the way is removed rather than read through — see
+    // reset.test.ts). This file is about the gate, so everything it points at
+    // is a plain directory.
+    lstat: vi.fn(async () => ({ isDirectory: () => true })),
     readdir: vi.fn(async () => []),
     rm: vi.fn(async () => {}),
     mkdir: vi.fn(async () => undefined),

--- a/src/tests/routes/setup/reset.test.ts
+++ b/src/tests/routes/setup/reset.test.ts
@@ -14,6 +14,7 @@ vi.mock("child_process", () => ({
 
 vi.mock("fs/promises", () => ({
   default: {
+    lstat: vi.fn(),
     readdir: vi.fn(),
     rm: vi.fn(),
     mkdir: vi.fn(),
@@ -118,6 +119,9 @@ describe("POST /setup-api/setup/reset", () => {
       getgid: () => 1000,
     });
 
+    // Everything the wipe is pointed at really is a directory unless a case
+    // says otherwise — that is what the route checks before it reads one.
+    mockFs.lstat.mockResolvedValue({ isDirectory: () => true } as unknown as Awaited<ReturnType<typeof fs.lstat>>);
     mockFs.readdir.mockResolvedValue([]);
     mockFs.rm.mockResolvedValue();
     mockFs.mkdir.mockResolvedValue(undefined);
@@ -550,6 +554,7 @@ describe("POST /setup-api/setup/reset — Hermes agent + offline model survive",
       if (p === "/test/data/llamacpp") return Promise.resolve(["models", "server.pid", "server.log"]);
       return Promise.resolve([]);
     }) as unknown as typeof fs.readdir);
+    mockFs.lstat.mockResolvedValue({ isDirectory: () => true } as unknown as Awaited<ReturnType<typeof fs.lstat>>);
     mockFs.rm.mockResolvedValue();
     mockFs.mkdir.mockResolvedValue(undefined);
     mockFs.writeFile.mockResolvedValue();
@@ -737,5 +742,248 @@ describe("POST /setup-api/setup/reset — Hermes agent + offline model survive",
     // execFile — asserting on the exec transcript here would always pass.
     expect(vi.mocked(startRootStep)).not.toHaveBeenCalledWith("chpasswd", expect.anything());
     expect(calls.some((c) => c.includes("systemctl reboot"))).toBe(false);
+  });
+});
+
+/**
+ * What the entry-by-entry wipe does when the thing it is pointed at is NOT a
+ * directory.
+ *
+ * `removeDirectoryContents(dir, keep)` is used wherever the reset has to keep
+ * something — ~/.hermes, data/llamacpp, data/embed, Documents/Downloads/Desktop
+ * — and it used to `readdir` `dir` and `rm -rf` the entries without ever asking
+ * what `dir` was. Both halves of that are reachable by a previous owner with a
+ * shell, which is the adversary the whole keep-list is written against (the
+ * Terminal app, or SSH before the key wipe):
+ *
+ *   1. `rm -rf ~/.hermes && ln -s /home/clawbox ~/.hermes` made the next
+ *      owner's factory reset readdir the LINK TARGET and delete every entry in
+ *      it that is not a keep-list name — the ClawBox checkout, the running web
+ *      server, `.bun`, `.local/bin`, the `~/.cache/huggingface` voice models.
+ *      Pressing Factory reset would have cost a reflash.
+ *   2. A plain FILE where a directory is expected made `readdir` raise ENOTDIR,
+ *      which the helper rethrew and `wipeHomeUserState` did not catch — so the
+ *      reset answered 500 AFTER data/, ~/.openclaw, ~/.clawkeep and the home
+ *      paths were gone and BEFORE the password reset, the WiFi clear and the
+ *      reboot. Every retry failed at the same place: the box is unusable and
+ *      un-resettable without a shell.
+ *
+ * One `lstat` closes both, for all four call-site families — but the two cases
+ * do not end the same way, and the difference is the point of these tests. A
+ * plain file hid nothing, so removing it finishes the job and the reset
+ * completes. A SYMLINK hid everything: its target still holds what the wipe was
+ * sent to erase, so the link is removed (never its target) and the path is
+ * REPORTED, which takes the reset down its own abort path — no WiFi clear, no
+ * password reset, no reboot, the owner told what was not erased. A reset that
+ * answered "complete" over a ~/Documents still full of the previous owner's
+ * files, browsable in the Files app, would be the worse defect of the two.
+ */
+describe("POST /setup-api/setup/reset — a non-directory where a directory belongs", () => {
+  let resetPost: () => Promise<Response>;
+  let session: SessionFixture;
+  const HOME = process.env.HOME || "/home/clawbox";
+  const HERMES = `${HOME}/.hermes`;
+
+  const rmTargets = () =>
+    mockFs.rm.mock.calls.map(([p]) => p).filter((p): p is string => typeof p === "string");
+
+  /** Everything a readdir of the LINK TARGET would have offered up for deletion. */
+  const LINK_TARGET_ENTRIES = ["clawbox", ".bun", ".local", ".cache", "Documents"];
+
+  /** lstat that reports every path as a directory except `notADir`. */
+  function lstatExcept(notADir: string, kind: "symlink" | "file") {
+    mockFs.lstat.mockImplementation(((p: string) =>
+      Promise.resolve({
+        isDirectory: () => p !== notADir,
+        isSymbolicLink: () => p === notADir && kind === "symlink",
+      })) as unknown as typeof fs.lstat);
+  }
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ models: [] }),
+    }));
+    vi.stubGlobal("process", { ...process, getuid: () => 1000, getgid: () => 1000 });
+
+    mockFs.lstat.mockResolvedValue({
+      isDirectory: () => true,
+      isSymbolicLink: () => false,
+    } as unknown as Awaited<ReturnType<typeof fs.lstat>>);
+    mockFs.readdir.mockResolvedValue([] as unknown as ReaddirResult);
+    mockFs.rm.mockResolvedValue();
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.writeFile.mockResolvedValue();
+    mockFs.chown.mockResolvedValue();
+    mockFs.unlink.mockResolvedValue();
+    mockResetUpdateState.mockReturnValue();
+    setupExecFileMock({ nmcli: { stdout: "", stderr: "" }, systemctl: { stdout: "", stderr: "" } });
+
+    session = installSessionFixture();
+    const mod = await import("@/app/setup-api/setup/reset/route");
+    resetPost = () => mod.POST(new Request("http://localhost/setup-api/setup/reset", {
+      method: "POST",
+      headers: { Cookie: session.cookie, "Content-Type": "application/json" },
+      body: JSON.stringify({ password: "hunter2", confirm: "RESET" }),
+    }));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    session.cleanup();
+  });
+
+  it("removes a symlink planted at ~/.hermes instead of deleting through it", async () => {
+    lstatExcept(HERMES, "symlink");
+    // What the link points at. If anything readdirs the link, these are what it
+    // hands to `rm -rf`.
+    mockFs.readdir.mockImplementation(((p: string) =>
+      Promise.resolve(p === HERMES ? LINK_TARGET_ENTRIES : [])) as unknown as typeof fs.readdir);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const res = await resetPost();
+    const body = await res.json();
+    const targets = rmTargets();
+    warnSpy.mockRestore();
+
+    // The link itself goes…
+    expect(targets).toContain(HERMES);
+    // …and nothing inside the target it pointed at.
+    for (const entry of LINK_TARGET_ENTRIES) {
+      expect(targets, `factory reset deleted through the ~/.hermes symlink into ${entry}`)
+        .not.toContain(`${HERMES}/${entry}`);
+    }
+    // And the reset does not claim to have erased what is still at the target.
+    expect(res.status).toBe(500);
+    expect(JSON.stringify(body.failures)).toContain(HERMES);
+    expect(JSON.stringify(body.failures)).toContain("symlink");
+  });
+
+  it("leaves the box reachable when it reports a redirected directory", async () => {
+    // The abort path, and why the symlink case takes it: the AP only comes back
+    // on a reboot, so a reset that already cleared the WiFi and reset the login
+    // password without rebooting would strand a WiFi-only box.
+    lstatExcept(HERMES, "symlink");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const res = await resetPost();
+    await vi.advanceTimersByTimeAsync(2_000);
+    warnSpy.mockRestore();
+
+    expect(res.status).toBe(500);
+    const commands = mockExecFile.mock.calls.map(([cmd, args]) => `${cmd} ${(args ?? []).join(" ")}`);
+    expect(commands.some((c) => c.startsWith("nmcli connection delete"))).toBe(false);
+    expect(commands.some((c) => c.includes("reboot"))).toBe(false);
+    expect(vi.mocked(startRootStep).mock.calls.map(([step]) => step)).not.toContain("chpasswd");
+  });
+
+  it("finishes the reset when a plain file sits where ~/.hermes should be", async () => {
+    lstatExcept(HERMES, "file");
+    // readdir on a file is ENOTDIR — the error that used to abort the whole
+    // reset half-way through, on every retry. Nothing reads it now, and a plain
+    // file hid no directory of owner state, so the reset completes.
+    mockFs.readdir.mockImplementation(((p: string) => {
+      if (p === HERMES) {
+        const err = new Error("ENOTDIR: not a directory") as Error & { code: string };
+        err.code = "ENOTDIR";
+        return Promise.reject(err);
+      }
+      return Promise.resolve([]);
+    }) as unknown as typeof fs.readdir);
+
+    const res = await resetPost();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(rmTargets()).toContain(HERMES);
+
+    // And it really did get all the way to the end: the reboot is armed only
+    // after the password reset and the WiFi clear.
+    await vi.advanceTimersByTimeAsync(1_000);
+    const reboot = mockExecFile.mock.calls.find(
+      ([cmd, args]) => cmd === "/usr/bin/sudo" && args?.join(" ").includes("reboot"),
+    );
+    expect(reboot, "the reset never reached the reboot").toBeDefined();
+  });
+
+  it("reports a non-directory it cannot remove instead of aborting the whole reset", async () => {
+    // A previous owner had the sudo password, so the thing in the way can be
+    // undeletable: a bind mount over the file (EBUSY), `chattr +i` (EPERM), a
+    // read-only mount. A throw here would land in the handler's outer catch —
+    // the same half-wiped, un-resettable box, one errno over.
+    lstatExcept(HERMES, "file");
+    mockFs.rm.mockImplementation(((p: unknown) =>
+      p === HERMES
+        ? Promise.reject(new Error("EACCES: permission denied"))
+        : Promise.resolve()) as unknown as typeof fs.rm);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const res = await resetPost();
+    const body = await res.json();
+    warnSpy.mockRestore();
+
+    expect(res.status).toBe(500);
+    // Reported through the failure list, with the path — not as a bare
+    // "Factory reset failed" from the outer catch.
+    expect(body.error).toContain("incomplete");
+    expect(JSON.stringify(body.failures)).toContain(HERMES);
+    // …and the rest of the wipe still ran: ~/.ssh went before the report.
+    expect(rmTargets()).toContain(`${HOME}/.ssh`);
+  });
+
+  it("does not readdir the top of data/ through a symlink either", async () => {
+    // Same shape one directory over: DATA_DIR is wiped by a readdir + rm pass
+    // of its own, and a link planted there points the same rm -rf at whatever
+    // it names.
+    lstatExcept("/test/data", "symlink");
+    mockFs.readdir.mockImplementation(((p: string) =>
+      Promise.resolve(p === "/test/data" ? LINK_TARGET_ENTRIES : [])) as unknown as typeof fs.readdir);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const res = await resetPost();
+    const body = await res.json();
+    const targets = rmTargets();
+    warnSpy.mockRestore();
+
+    expect(targets).toContain("/test/data");
+    for (const entry of LINK_TARGET_ENTRIES) {
+      expect(targets, `factory reset deleted through the data/ symlink into ${entry}`)
+        .not.toContain(`/test/data/${entry}`);
+    }
+    expect(res.status).toBe(500);
+    expect(JSON.stringify(body.failures)).toContain("/test/data");
+  });
+
+  /**
+   * The one assumption the whole guard rests on, checked against the real
+   * filesystem rather than a mock: every case above passes `fs.rm` a path and
+   * asserts the STRING, so they would all pass just as happily on a runtime
+   * where `rm -rf <link>` erased the target.
+   */
+  it("fs.rm removes a symlink itself, never what it points at", async () => {
+    const realFs = await vi.importActual<typeof import("fs/promises")>("fs/promises");
+    const os = await vi.importActual<typeof import("os")>("os");
+    const nodePath = await vi.importActual<typeof import("path")>("path");
+    const tmp = await realFs.mkdtemp(nodePath.join(os.tmpdir(), "clawbox-reset-link-"));
+    try {
+      const target = nodePath.join(tmp, "target");
+      await realFs.mkdir(target);
+      await realFs.writeFile(nodePath.join(target, "keepme.txt"), "previous owner\n");
+      const link = nodePath.join(tmp, "link");
+      await realFs.symlink(target, link);
+
+      await realFs.rm(link, { recursive: true, force: true });
+
+      await expect(realFs.lstat(link)).rejects.toThrow();
+      expect((await realFs.readdir(target))).toEqual(["keepme.txt"]);
+    } finally {
+      await realFs.rm(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/src/tests/unit/gateway-pre-start-email-hook.test.ts
+++ b/src/tests/unit/gateway-pre-start-email-hook.test.ts
@@ -294,11 +294,11 @@ d("gateway-pre-start.sh — the outbound EMAIL: directive hook plugin", () => {
   });
 
   it("re-verifies after a factory reset empties ~/.openclaw", () => {
-    // `removeDirectoryContents(OPENCLAW_DIR)` (setup/reset/route.ts:508) reads
+    // `removeDirectoryContents(OPENCLAW_DIR)` (setup/reset/route.ts) reads
     // the directory with `fs.readdir`, which lists dot-entries — so the stamp
     // beside `extensions/` goes with the plugin it describes, exactly as it did
     // when it lived inside `extensions/`. The route then writes a fresh
-    // openclaw.json back (:541), which is why this does too.
+    // openclaw.json back (the openclaw.json seed), which is why this does too.
     run();
     for (const entry of readdirSync(openclawHome)) {
       rmSync(path.join(openclawHome, entry), { recursive: true, force: true });


### PR DESCRIPTION
**TASK-676** — factory reset reads and deletes through a planted symlink, and a non-directory bricks it half-way.

## Symptom

`removeDirectoryContents(dir, keep)` is the entry-by-entry wipe the reset uses wherever it has to
keep something — `~/.hermes` (keep `hermes-agent`, `bin`), `data/llamacpp` and `data/embed` (keep
`models`), `Documents`/`Downloads`/`Desktop` — and it never asked what `dir` was:

```ts
entries = await fs.readdir(dir);                                  // FOLLOWS a symlink
fs.rm(path.join(dir, entry), { recursive: true, force: true });   // deletes THROUGH it
```

Both halves are reachable by a previous owner with a shell — the Terminal app, or SSH before the key
wipe, which is exactly the adversary the keep-lists are written against.

1. **Deletes through a symlink.** `rm -rf ~/.hermes && ln -s /home/clawbox ~/.hermes` makes the next
   owner's factory reset readdir the link TARGET and `rm -rf` every entry in it that is not a
   keep-list NAME: the ClawBox checkout, the running web server, `.bun`, `.local/bin`, the
   `~/.cache/huggingface` voice models. A reflash, caused by pressing Factory reset. Same shape for
   `data/llamacpp` and for the three home content directories.
2. **A plain file bricks the reset.** `readdir` on a file raises ENOTDIR; the helper swallows only
   ENOENT and rethrows the rest, and `wipeHomeUserState` awaits it with no `try`. The throw reaches
   the handler's outer catch and answers 500 "Factory reset failed" — AFTER `data/`, `~/.openclaw`,
   `~/.clawkeep`, `HOME_REMOVE_PATHS` and Documents/Downloads/Desktop are wiped and BEFORE the
   password reset, the WiFi clear and the reboot. Identically on every retry: the box is unusable
   and un-resettable without a shell.

## The fix, and the part that is not just an `lstat`

One `lstat` before anything reads a directory, for all four call-site families plus the
top-of-`data/` pass (which has its own readdir rather than going through the helper). A path that is
not a real directory is removed AS ITSELF — `fs.rm` on a symlink removes the link, never its target.

The two cases then end **differently**, and that is the substance of this PR:

* **A plain file** (or socket, or fifo) hid nothing — there is no directory of owner state behind
  it — so removing it finishes the job and the reset completes. That is half 2 of the card, closed.
* **A symlink hid everything.** Its target still holds what the wipe was sent to erase, and it may
  not even be on this disk. So the link goes and the path is **reported**: the handler's existing
  aggregate gate answers "Factory reset incomplete" with the path named, and — by that gate's own
  design — *without* clearing the WiFi, resetting the login password or rebooting, so the owner
  still has a reachable box and something to act on.

  Simply unlinking and reporting success was the first draft of this PR and it is worse than the
  bug: `rm -rf ~/Documents && ln -s ~/stash ~/Documents`, press Factory reset, resell the box —
  `~/stash` survives, `{"success":true}` is returned, and the Files app's browse root is `$HOME`
  with `~/stash` not in `PROTECTED_HOME_DIRS`, so the **next owner browses the previous owner's
  files**. Reporting is also what makes a legitimately relocated `data/llamacpp` (the 3.2 GB Gemma
  GGUF moved to another disk) a named line rather than a silent loss on a box that reboots into AP
  mode with no internet.

The guard **never throws**. `removeDirectoryContents` is built so it cannot abort — readdir errors
are filtered, entry removals go through `Promise.allSettled`, failures are returned — and an
undeletable file in the way (a bind mount → EBUSY, `chattr +i` → EPERM, a read-only mount; all
available to someone who had the sudo password) would otherwise have reached the outer catch and
rebuilt the identical half-wiped, un-resettable box one errno over. The guard returns a
`DirectoryGuard` and its failures join the list the rest of the wipe already fills.

## Harness first

Nothing in OpenClaw or Hermes owns this — it is ClawBox's own reset route and Node's filesystem
API. Node exposes no readdir-at-fd (`fs.opendir` takes a path; there is no `fdopendir`), so
`O_NOFOLLOW`/`O_DIRECTORY` buy nothing here and `lstat` is the available answer. That leaves a TOCTOU
window, stated in the code: closing it needs a live adversary racing the reset, while the planted-link
case closed here needs a shell once, at any time before it.

## RED → GREEN

RED on unmodified `origin/beta` (d428b044) — 5 of the 6 new cases fail:

```
 × removes a symlink planted at ~/.hermes instead of deleting through it
 × leaves the box reachable when it reports a redirected directory
 × finishes the reset when a plain file sits where ~/.hermes should be
 × reports a non-directory it cannot remove instead of aborting the whole reset
 × does not readdir the top of data/ through a symlink either
      Tests  5 failed | 35 passed (40)
```

GREEN with the fix, plus the neighbouring suites and the three beta guards:

```
 Test Files  11 passed (11)
      Tests  173 passed (173)
```

`tsc --noEmit` clean; `eslint` clean apart from one pre-existing unused-import warning in this file.

The sixth new case is deliberately not RED: it pins the assumption the whole guard rests on —
`fs.rm` on a symlink removes the link and leaves the target's contents — against the **real**
filesystem, because every other case mocks `fs.rm` and so asserts only which path string was
passed. It would pass just as happily on a runtime where `rm -rf <link>` erased the target.

## Sibling call sites

* `removeDirectoryContents` has four call-site families (`HOME_CONTENT_WIPE_DIRS`,
  `HOME_CONTENT_WIPE_KEEP`, `DATA_KEEP`, `~/.openclaw` and `~/.clawkeep`); the guard is inside the
  function, so all of them get it.
* The **top-of-`data/`** pass does its own `readdir` + `rm` one screen away with the same hazard —
  a link at `data/` would have pointed the same `rm -rf` at whatever it named — and is guarded too.
  It keeps its own no-retry shape.
* `wipeHomeUserState`'s `HOME_REMOVE_PATHS` use `fs.rm` on single named paths, which does not follow
  a top-level symlink; the other readdir-then-delete sweeps in `src/lib/harness/` already `lstat`
  every entry and skip non-files.
* `src/tests/routes/setup/reset-confirmation.test.ts` mocks `fs/promises` and reaches this route, so
  it needed the `lstat` entry — without it 1 of its 7 cases (the one that gets past the gate into
  the wipe) failed.

## Both editions

The `~/.hermes` keep-list runs on every edition: on an OpenClaw-only box the path is absent, `lstat`
answers ENOENT and the result is `[]`, exactly as on beta. The guard adds no edition-specific path
and `readEdition()` still gates only the gateway mask.

## Docs

`docs-site/technical/filesystem.mdx` — the "What survives what" table's ❌ rows assume the path is
the directory it names; a note under it now states the symlink outcome.

## Review

One review pass, which is why this PR looks the way it does. Its two HIGH findings were both against
the first draft and both were reproduced against the real route: the draft made previous-owner data
*survive* a reset while reporting `{"success":true}`, and its `fs.rm` had no `try`, so an EACCES on
the planted file threw into the outer catch and rebuilt the very brick this card is about. Also
applied: the retry's re-check now reports a mid-retry symlink swap instead of returning `[]`; the
comment claiming "nothing inside a non-directory can be a keep-list member" is corrected (true of a
plain file, false of a symlink to a directory); the docs table; the real-filesystem case; and the
stale `setup/reset/route.ts:508` citations in `gateway-pre-start-email-hook.test.ts` now name the
symbol instead of a line this diff moves.

Not taken, recorded in the fixer queue: `src/lib/file-guard.ts` already owns "resolve symlinks
before trusting a path" for the Files API, so if resolve-and-wipe is ever preferred over
report-and-stop, the resolve helper belongs there rather than as a third copy in a route file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Factory reset now safely handles symbolic links without deleting their destinations.
  * Reset reports incomplete cleanup when protected paths cannot be removed and prevents password, Wi‑Fi, and reboot actions from proceeding.
  * Unexpected files blocking required directories are removed so reset can continue normally.
  * Cleanup failures are reported while allowing other eligible reset operations to continue.
  * Reset preserves required installation components and offline model data while removing secrets and runtime data.

* **Documentation**
  * Documented factory-reset behavior for redirected paths and cleanup outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->