### PR TITLE
fix: the Kokoro server reports the phonemiser it actually has

### DIFF
--- a/scripts/kokoro-server.py
+++ b/scripts/kokoro-server.py
@@ -57,11 +57,87 @@ DEFAULT_VOICE = "af_heart"
 pipeline = None
 pipeline_lock = threading.Lock()
 
+# Can THIS process turn a word it has never seen into phonemes?
+#
+# "ok" / "absent" / "unknown", and the distinction is the point: "unknown" is a
+# shape this could not read, never a verdict about the box.
+phonemiser_state = "unknown"
+
+# Nothing any lexicon holds, so a working espeak fallback phonemises all three
+# and a missing one drops all three. The same words install-voice.sh's
+# kokoro_check_phonemiser uses, deliberately: the two must agree about what
+# "working" means.
+PHONEMISER_PROBE_WORDS = ("zorblattic", "frobnicator", "squibbled")
+# misaki's unknown-token marker (U+2753). It also emits nothing at all when the
+# G2P was built with unk='', so both count as dropped.
+UNKNOWN_PHONEME_MARKER = chr(10067)
+
+
+def phonemiser_verdict(g2p):
+    """"ok" when out-of-vocabulary words phonemise, "absent" when they vanish.
+
+    WHY AT RUNTIME, when install-voice.sh already checks it. That check runs in
+    ANOTHER PROCESS, at install time, and this server builds its own KPipeline
+    later — so the install-time verdict is a probe-once for the life of the box.
+    A `pip install --upgrade`, a wiped ~/.local or a python minor bump can lose
+    espeakng-loader while the stamp, `import kokoro, torch` and this server's
+    own health all stay green, and every out-of-vocabulary word — a name, a
+    brand, "ClawBox" itself — is then dropped from every spoken reply with
+    nothing to show for it.
+    kokoro builds the fallback inside a try/except and degrades to
+    `logger.warning('EspeakFallback not Enabled: OOD words will be skipped')`
+    with `fallback=None`; nothing downstream reads that warning.
+
+    BEHAVIOUR, not structure: it asks for SOMETHING back for a word no lexicon
+    has. `kokoro` is installed unpinned, so a check written against today's
+    attribute names would start failing WORKING boxes the day misaki renames
+    one — anything this cannot read is "unknown" and is never graded.
+    """
+    try:
+        dropped = [
+            word for word in PHONEMISER_PROBE_WORDS
+            if not ((g2p(word)[0] or "").replace(UNKNOWN_PHONEME_MARKER, "").strip())
+        ]
+    except Exception as exc:
+        print(
+            f"WARN: could not exercise the phonemiser ({type(exc).__name__}: {exc}) "
+            "-- not treating that as a verdict",
+            flush=True,
+        )
+        return "unknown"
+    return "absent" if dropped else "ok"
+
+
+def health_payload():
+    """What /health answers. Degraded is still SERVING — see load_model."""
+    return {
+        "status": "degraded" if phonemiser_state == "absent" else "ok",
+        "model": "kokoro-82m",
+        "phonemiser": phonemiser_state,
+    }
+
+
 def load_model():
+    global phonemiser_state
     from kokoro import KPipeline
     print("Loading Kokoro model on GPU...", flush=True)
     p = KPipeline(lang_code='a')
     print(f"Model loaded on {next(p.model.parameters()).device}", flush=True)
+    phonemiser_state = phonemiser_verdict(getattr(p, "g2p", None))
+    if phonemiser_state == "absent":
+        # WARNED, never refused. Dropping out-of-vocabulary words beats not
+        # speaking at all, and a box whose only other engine is the cloud voice
+        # would go silent on a refusal. /health says "degraded" so the fact is
+        # readable from outside this journal.
+        print(
+            "WARN: the espeak phonemiser is unavailable — out-of-vocabulary words "
+            "(names, brands, ClawBox itself) will be DROPPED from speech. "
+            "The espeakng-loader wheel kokoro pulls in is missing or broken; "
+            "reinstall it with the box's voice install.",
+            flush=True,
+        )
+    else:
+        print(f"Phonemiser: {phonemiser_state}", flush=True)
     return p
 
 def generate_audio(text, voice=DEFAULT_VOICE):
@@ -94,7 +170,7 @@ class TTSHandler(BaseHTTPRequestHandler):
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
             self.end_headers()
-            self.wfile.write(json.dumps({"status": "ok", "model": "kokoro-82m"}).encode())
+            self.wfile.write(json.dumps(health_payload()).encode())
         else:
             self.send_response(404)
             self.end_headers()

--- a/src/tests/unit/kokoro-server-phonemiser.test.ts
+++ b/src/tests/unit/kokoro-server-phonemiser.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import path from "node:path";
+
+/**
+ * TASK-420 / TASK-686. `scripts/install-voice.sh` checks at INSTALL time that
+ * this box can turn a word no lexicon holds into phonemes, and refuses
+ * `KOKORO=ready` when it cannot. But the process that actually speaks —
+ * `scripts/kokoro-server.py` — builds its own KPipeline later, in another
+ * process, and said nothing about the phonemiser at all: `/health` answered
+ * `{"status":"ok"}` regardless.
+ *
+ * So the install-time check was a PROBE-ONCE for the life of the box. A
+ * `pip install --upgrade`, a wiped `~/.local` or a python minor bump can lose
+ * espeakng-loader while the stamp, `import kokoro, torch` and this server's own
+ * health all stay green — and every out-of-vocabulary word (a name, a brand,
+ * "ClawBox" itself) is then dropped from every spoken reply, silently.
+ *
+ * kokoro builds the espeak fallback inside a try/except and degrades to
+ * `logger.warning('EspeakFallback not Enabled: OOD words will be skipped')`
+ * with `fallback=None`. Nothing downstream reads that warning.
+ *
+ * These EXECUTE the shipped script's own functions with a stand-in G2P, so the
+ * test fails if the real file drifts. `kokoro` and `torch` are never imported:
+ * the verdict and the health payload are pure.
+ */
+
+// Starts a real python3 process: vitest's 5 s default is not enough on a loaded
+// CI runner. See src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+const SERVER = path.resolve(process.cwd(), "scripts/kokoro-server.py");
+const hasPython3 = spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
+
+/**
+ * Pull the phonemiser verdict and the health payload out of the .sh's Python
+ * sibling verbatim, without importing kokoro, torch or soundfile — none of
+ * which exists on a CI runner and none of which the region under test touches.
+ */
+function extractRegion(): string {
+  const src = readFileSync(SERVER, "utf-8");
+  const start = src.indexOf("# Can THIS process turn a word it has never seen into phonemes?");
+  const end = src.indexOf("def load_model():", start);
+  if (start < 0 || end < 0) throw new Error("phonemiser region not found in kokoro-server.py");
+  return src.slice(start, end);
+}
+
+const REGION = hasPython3 ? extractRegion() : "";
+
+/** Run the region with a stand-in `g2p` and report the verdict and the health body. */
+function verdictFor(g2pBody: string): { verdict: string; health: Record<string, unknown>; log: string } {
+  const program = [
+    "import json",
+    REGION,
+    `def g2p(word):\n${g2pBody}`,
+    "verdict = phonemiser_verdict(g2p)",
+    "phonemiser_state = verdict",
+    // health_payload reads the module global, so rebind it the way load_model does.
+    "globals()['phonemiser_state'] = verdict",
+    "print(json.dumps({'verdict': verdict, 'health': health_payload()}))",
+  ].join("\n");
+  const lines = execFileSync("python3", ["-c", program], { encoding: "utf-8" }).trim().split("\n");
+  const parsed = JSON.parse(lines[lines.length - 1]);
+  return { ...parsed, log: lines.slice(0, -1).join("\n") };
+}
+
+describe.skipIf(!hasPython3)("kokoro-server.py — the phonemiser it actually has", () => {
+  it("reports ok when out-of-vocabulary words phonemise", () => {
+    const { verdict, health } = verdictFor("    return ('sɪmˈpleɪ', None)");
+
+    expect(verdict).toBe("ok");
+    expect(health).toMatchObject({ status: "ok", phonemiser: "ok" });
+  });
+
+  it("reports the engine DEGRADED when they come back as the unknown marker", () => {
+    // misaki's unknown token, U+2753 — what it emits with no espeak fallback.
+    const { verdict, health } = verdictFor("    return (chr(10067), None)");
+
+    expect(verdict).toBe("absent");
+    expect(health).toMatchObject({ status: "degraded", phonemiser: "absent" });
+  });
+
+  it("reports it degraded when they come back empty, which is the unk='' shape", () => {
+    const { verdict, health } = verdictFor("    return ('', None)");
+
+    expect(verdict).toBe("absent");
+    expect(health.status).toBe("degraded");
+  });
+
+  it("still says degraded when only SOME words survive", () => {
+    // A missing fallback does not blank a sentence — misaki keeps what it can
+    // phonemise and drops the rest — so a line judged whole reads non-empty
+    // once one of its words survives. One word at a time is the only honest
+    // question.
+    const { verdict } = verdictFor(
+      "    return (('ˈzɔrblætɪk', None) if word == 'zorblattic' else ('', None))",
+    );
+
+    expect(verdict).toBe("absent");
+  });
+
+  it("does not grade a shape it cannot read", () => {
+    // `kokoro` is installed unpinned. A check written against today's attribute
+    // names would start failing WORKING boxes the day misaki renames one, and
+    // "the box speaks badly" is a far worse thing to say wrongly than "we could
+    // not tell".
+    const { verdict, health, log } = verdictFor("    raise TypeError('g2p() takes 2 positional arguments')");
+
+    expect(verdict).toBe("unknown");
+    expect(health.status).toBe("ok");
+    expect(log).toContain("not treating that as a verdict");
+  });
+
+  it("does not grade a missing g2p either", () => {
+    const { verdict } = verdictFor("    raise AssertionError('unreachable')");
+    expect(verdict).toBe("unknown");
+
+    const program = [
+      "import json",
+      REGION,
+      "print(json.dumps({'verdict': phonemiser_verdict(None)}))",
+    ].join("\n");
+    const out = execFileSync("python3", ["-c", program], { encoding: "utf-8" }).trim().split("\n");
+    expect(JSON.parse(out[out.length - 1]).verdict).toBe("unknown");
+  });
+
+  it("probes with words no lexicon holds, and agrees with the installer about them", () => {
+    // The install-time check and this one must mean the same thing by
+    // "working", or a box can be refused at install and call itself healthy at
+    // runtime.
+    const installer = readFileSync(path.resolve(process.cwd(), "scripts/install-voice.sh"), "utf-8");
+    const server = readFileSync(SERVER, "utf-8");
+    for (const word of ["zorblattic", "frobnicator", "squibbled"]) {
+      expect(installer).toContain(word);
+      expect(server).toContain(word);
+    }
+  });
+
+  it("keeps serving while degraded — silence is worse than a dropped name", () => {
+    // The health body says degraded and the response is still a 200 with a
+    // usable payload: a box whose only other engine is the cloud voice would go
+    // quiet on a refusal.
+    const { health } = verdictFor("    return ('', None)");
+
+    expect(health.model).toBe("kokoro-82m");
+    expect(readFileSync(SERVER, "utf-8")).toContain("json.dumps(health_payload())");
+  });
+});


### PR DESCRIPTION
Closes the honesty half of TASK-420, with the owner-mandated measurement done first.

## Measurement first: the Jetson Kokoro install path, measured read-only on BOTH boxes, 2026-09-05

Required by the owner's ruling before any installer code ("measure the Jetson install
path on a box read-only first — wheel availability, model size, boot cost"). Every
command below is a read; neither box was mutated and no mutex was taken.

| What | OpenClaw edition | Hermes edition |
|---|---|---|
| `CLAWBOX_EDITION` | `openclaw` | `hermes` |
| Arch / OS | aarch64, Ubuntu 22.04.5 | aarch64, Ubuntu 22.04.5 |
| JetPack / L4T | R36 rev 5.0 (2026-01-16) | R36 rev 5.0 (2026-01-16) |
| Python | 3.10.12 (system) | 3.10.12 (system) |
| `kokoro` wheel | **0.9.4 installed** | **0.9.4 installed** |
| Wheel availability | resolves from PyPI, `kokoro-0.9.4-py3-none-any.whl`, **32 KB**, pure-python | same |
| `misaki` | 0.9.4 | 0.9.4 |
| `torch` | 2.5.0a0+872d972e41.nv24.08 (NVIDIA Jetson wheel) | same |
| `numpy` | 1.26.4 (above the `>=1.24,<2` floor) | same |
| `soundfile` / `transformers` | 0.14.0 / 4.57.6 | same |
| `espeakng-loader` | 0.2.4 | 0.2.4 |
| `espeak-ng` apt package/binary | **absent** (not needed — the loader ships the .so) | **absent** |
| Phonemiser library | `…/site-packages/espeakng_loader/libespeak-ng.so` present | present |
| Model on disk | `models--hexgrad--Kokoro-82M` **314 MB** (455 MB total HF cache) | **313 MB** (457 MB) |
| `/etc/clawbox/tts-status` | `KOKORO=ready` (2026-09-05T20:03Z) | `KOKORO=ready` (2026-09-05T19:59Z) |
| `kokoro-server.service` (user unit) | present, disabled, inactive | present, **enabled**, inactive |
| Piper fallback | present | **absent** — Kokoro is the only local engine |
| Disk headroom | 402 GB free of 467 GB | 388 GB free of 467 GB |
| RAM | 7,607 MB total, 4,624 MB available | 7,607 MB total, 5,223 MB available |
| `nvcc` | absent (runtime CUDA 12.6 present; nothing is built from source) | same |

## Boot / first-synthesis cost (OpenClaw box, measured)

Run with exactly the `LD_LIBRARY_PATH` the shipped `kokoro-server.service` sets:

```
torch import        2.72 s   (cuda available: True)
kokoro import       5.44 s
KPipeline build     4.49 s
first synthesis     1.57 s   -> 56,400 samples of real audio
```

Total cold cost ≈ 13 s, which matches the 13–19 s cold start `clawbox-tts.sh` and the
`tts/warm` route are already written around.

## The finding this settles

`python3 -c "import kokoro"` fails on BOTH boxes with
`ImportError: libcusparseLt.so.0: cannot open shared object file` — the 2026-08-21
diagnosis on the card. It is **not** a defect: that library ships inside the
`nvidia-cusparselt-cu12` wheel under user-site, and every shipped path already puts it
on the linker path —

* `scripts/install-voice.sh` computes it and bakes it into the unit;
* `kokoro-server.service` carries `Environment=LD_LIBRARY_PATH=…/nvidia/cusparselt/lib:…`;
* `scripts/openclaw/clawbox-tts.sh` computes `KOKORO_LD_PATH` and passes it;
* `scripts/kokoro-server.py` sets it itself.

A bare interactive `import` is the one caller that does not, which is why it looks
broken from a shell and works in service.

## Conclusion for the card

The owner's ruling — "Kokoro MUST be installed on both editions … the installer claim
becomes true, Piper stays only as the fallback" — is **already satisfied on beta**, on
both editions: `install.sh:3661` runs `install-voice.sh --tts-only`, which runs
`install_kokoro_tts`, and both boxes carry the wheel, the 313–314 MB model, the unit and
a phonemiser, and synthesise real audio in ~13 s cold / 1.6 s warm. Nothing further needs
installing. What was still open is the HONESTY half, which is what the accompanying PR
fixes: the process that speaks never checked the phonemiser it had, and its `/health`
said `ok` regardless.

---

## Customer-visible symptom

A box whose phonemiser has gone missing goes on saying it is healthy. `KOKORO=ready` stays in `/etc/clawbox/tts-status`, `import kokoro, torch` still succeeds, `/health` answers `{"status":"ok"}` — and every out-of-vocabulary word (a name, a brand, **"ClawBox" itself**) is dropped from every spoken reply. Nothing anywhere says so. On the Hermes edition there is no Piper at all, so Kokoro is the only local engine and there is nothing behind it.

## Cause

`scripts/install-voice.sh` added a real phonemiser check (#619): it builds the G2P and asks for phonemes for three words no lexicon holds, and refuses `KOKORO=ready` when they come back empty. But that check runs **in another process, at install time**, and `scripts/kokoro-server.py` — the process that actually speaks — builds its own `KPipeline` later and never asked. So the verdict was a probe-once for the life of the box: a `pip install --upgrade`, a wiped `~/.local` or a python minor bump can lose `espeakng-loader` while the stamp, the imports and the server's own health all stay green.

kokoro builds the espeak fallback inside a `try/except` and degrades to `logger.warning('EspeakFallback not Enabled: OOD words will be skipped')` with `fallback=None`. Nothing downstream reads that warning.

## Fix

`load_model()` exercises the G2P it has just built with the same three words `kokoro_check_phonemiser` uses — deliberately the same words, so install time and run time cannot mean different things by "working" (pinned by a test). Then:

- **absent** → a loud WARN in the journal naming what is lost and how to repair it, and `/health` answers `{"status":"degraded","phonemiser":"absent"}`.
- **Warned, never refused.** Dropping a name beats not speaking at all, and on the Hermes edition — no Piper — a refusal would take the box's voice away entirely. `/health` stays HTTP 200 with a usable body, so a liveness probe is unaffected.
- **unknown** for any shape the check cannot read. `kokoro` is installed unpinned; a check written against today's attribute names would start failing WORKING boxes the day misaki renames one, and "this box speaks badly" is a far worse thing to say wrongly than "we could not tell".

## Harness-first

Nothing here re-implements anything OpenClaw or Hermes owns: the question is about a python package this repo installs, asked of the object that package just built, and the answer is published on the server's own existing endpoint. The repo's own install-time check is the authority for what "working" means, and this reuses its probe words rather than inventing a second definition.

## Sibling call sites

- `scripts/install-voice.sh` — `kokoro_check_phonemiser` is the install-time twin; the shared probe words are asserted identical by a test, so the two cannot drift apart silently.
- `/health` has **no consumer in this repo** (grepped): `clawbox-tts.sh` talks to the unix socket, OpenClaw's OpenAI TTS provider posts to `/v1/audio/speech`. Nothing reads `status`, so the new value breaks no caller and the response stays a 200.
- `scripts/openclaw/clawbox-tts.sh` and the unit both already put the cusparselt directory on the linker path (see the measurement above) — cleared, unchanged.
- The `scripts/openclaw/kokoro-server.py` duplicate the earlier round flagged is already gone from beta; there is one file.

## RED

On unmodified `origin/beta` the server has no notion of a phonemiser at all:

```
$ git show origin/beta:scripts/kokoro-server.py | grep -n "status.*ok"
97:            self.wfile.write(json.dumps({"status": "ok", "model": "kokoro-82m"}).encode())

$ git show origin/beta:scripts/kokoro-server.py | grep -ci "phonem\|espeak"
0

phonemiser working : {"status": "ok", "model": "kokoro-82m"}
phonemiser MISSING : {"status": "ok", "model": "kokoro-82m"}   <-- identical; nothing can tell
```

The new suite is written against functions that do not exist on beta, which is the point: the beta file has nowhere for this check to live.

## GREEN

```
 Test Files  3 passed (3)
      Tests  60 passed (60)   (the new suite + install-tts-no-engine + the timeout-hygiene guard)
```

The new suite runs the shipped `kokoro-server.py`'s own functions under python3 with a stand-in G2P — `kokoro`, `torch` and `soundfile` are never imported, so it runs on a CI runner — and covers ok / unknown-marker / empty / partially-dropped / unreadable-shape / missing-g2p.

## Device proof (read-only, both editions)

The whole measurement table above. Both boxes were only read: no install, no mutex, no unit started or stopped, nothing written.

## What this does NOT do

It does not install Kokoro, because Kokoro is already installed on both editions and works — that is what the measurement establishes, and it is why the installing half of TASK-420 needs no code. Piper remains the fallback on the OpenClaw edition and remains absent on Hermes, both unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added phonemiser status information to the health endpoint.
  * The service now reports degraded health when phonemisation is unavailable or uncertain.
  * The server can continue starting and serving requests when phonemisation is degraded.

* **Tests**
  * Added coverage for phonemisation outcomes, health reporting, partial failures, and degraded operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->