### PR TITLE
fix: trailing-slash page paths 308-redirect to themselves in an infinite loop

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -388,8 +388,15 @@ export async function middleware(request: NextRequest) {
   {
     const raw = request.nextUrl.pathname;
     if (raw.length > 1 && raw.endsWith("/") && !isAppProxyPath(raw) && !raw.startsWith("/setup-api/") && !raw.startsWith("/api/") && !raw.startsWith("/_next/")) {
-      const url = request.nextUrl.clone();
-      url.pathname = raw.replace(/\/+$/, "") || "/";
+      // A PLAIN `URL`, never `request.nextUrl.clone()`: `NextURL` records the
+      // trailing slash in a `trailingSlash` flag when it parses the URL, its
+      // `pathname` setter writes the pathname and leaves that flag set, and
+      // `href`/`toString()` — what `NextResponse.redirect` serialises — re-add
+      // the slash from the flag. The Location therefore came back as the path
+      // being redirected AWAY from, i.e. an infinite 308 loop on every page
+      // path typed with a slash. A plain `URL` carries no such flag.
+      const url = new URL(request.nextUrl.href);
+      url.pathname = url.pathname.replace(/\/+$/, "") || "/";
       return NextResponse.redirect(url, 308);
     }
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -395,9 +395,18 @@ export async function middleware(request: NextRequest) {
       // the slash from the flag. The Location therefore came back as the path
       // being redirected AWAY from, i.e. an infinite 308 loop on every page
       // path typed with a slash. A plain `URL` carries no such flag.
-      const url = new URL(request.nextUrl.href);
+      const url = new URL(request.url);
       url.pathname = url.pathname.replace(/\/+$/, "") || "/";
-      return NextResponse.redirect(url, 308);
+      // `no-store`, because a 308 is cacheable by default (RFC 7538 §3) and
+      // browsers treat a permanent redirect as durable. Both shipped boxes
+      // served `/setup/ → /setup/` as a PERMANENT redirect, so a browser that
+      // cached it replays the loop without asking the box and the fix reads as
+      // "did not work". An uncacheable canonical redirect costs one request and
+      // takes the whole class away.
+      return NextResponse.redirect(url, {
+        status: 308,
+        headers: { "cache-control": "no-store" },
+      });
     }
   }
 

--- a/src/tests/middleware/middleware.test.ts
+++ b/src/tests/middleware/middleware.test.ts
@@ -95,6 +95,16 @@ describe("middleware", () => {
       expect(new URL(response.headers.get("location")!, "http://localhost").pathname).toBe("/setup");
     });
 
+    it("is not cacheable, so a browser cannot replay a stale one", async () => {
+      // A 308 is cacheable by default (RFC 7538 §3) and browsers treat a
+      // permanent redirect as durable. Both shipped boxes served the
+      // self-referencing loop AS a permanent redirect, so without this a
+      // browser that cached it stays broken after the box is updated.
+      const response = await middleware(createRequest("/setup/"));
+
+      expect(response.headers.get("cache-control")).toBe("no-store");
+    });
+
     it("keeps the query string", async () => {
       const response = await middleware(createRequest("/login/?next=%2Fportal"));
 

--- a/src/tests/middleware/middleware.test.ts
+++ b/src/tests/middleware/middleware.test.ts
@@ -69,6 +69,42 @@ describe("middleware", () => {
     return `${payload}.${signatureHex}`;
   }
 
+  describe("trailing-slash redirect (step 0)", () => {
+    /**
+     * The redirect has to land on the SLASHLESS path. It did not: `NextURL`
+     * captures `trailingSlash` when it parses the URL, its `pathname` setter
+     * leaves that flag alone, and `href`/`toString()` — which is what
+     * `NextResponse.redirect` serialises — re-adds the slash from it. So every
+     * page path typed with a trailing slash 308'd to itself, forever.
+     */
+    it.each(["/setup/", "/login/", "/portal/", "/updating/", "/app/", "/apps/", "/chat/"])(
+      "sends %s to the same path without the slash, not back to itself",
+      async (pathname) => {
+        const response = await middleware(createRequest(pathname));
+
+        expect(response.status).toBe(308);
+        const target = new URL(response.headers.get("location")!, "http://localhost");
+        expect(target.pathname).toBe(pathname.replace(/\/+$/, ""));
+      },
+    );
+
+    it("collapses repeated trailing slashes in one hop", async () => {
+      const response = await middleware(createRequest("/setup///"));
+
+      expect(response.status).toBe(308);
+      expect(new URL(response.headers.get("location")!, "http://localhost").pathname).toBe("/setup");
+    });
+
+    it("keeps the query string", async () => {
+      const response = await middleware(createRequest("/login/?next=%2Fportal"));
+
+      expect(response.status).toBe(308);
+      const target = new URL(response.headers.get("location")!, "http://localhost");
+      expect(target.pathname).toBe("/login");
+      expect(target.searchParams.get("next")).toBe("/portal");
+    });
+  });
+
   describe("Android captive portal", () => {
     it("redirects /generate_204 to portal", async () => {
       const request = createRequest("/generate_204");


### PR DESCRIPTION
Finding: the trailing-slash 308 loop reported in the run queue by the #675 follow-up fixer (2026-09-05). No board card — the driver attaches it to TASK-631 as a comment.

## Customer-visible symptom

Every page path typed or linked with a trailing slash 308-redirects to itself. A browser gives up with `ERR_TOO_MANY_REDIRECTS`; `/setup/`, `/login/`, `/portal/`, `/updating/`, `/app/`, `/apps/` and `/chat/` are all unreachable. On beta since f14a52b8 (#670), and live on both shipped boxes.

Measured anonymously, read-only, on **both** boxes at beta `d428b044` (the commit this branch is based on; both boxes report `d428b044` on branch `beta`). Host redacted — this repo is public:

```
$ curl -sI -m 8 --path-as-is http://<box>/setup/      # OpenClaw edition
HTTP/1.1 308 Permanent Redirect
location: /setup/

$ curl -sI -m 8 --path-as-is http://<box>/portal/
HTTP/1.1 308 Permanent Redirect
location: /portal/
```

`/apps/`, `/app/` and `/chat/` answer the same way, and the **Hermes** box answers line for line identically:

```
$ curl -sI -m 8 --path-as-is http://<box>/setup/      # Hermes edition
HTTP/1.1 308 Permanent Redirect
location: /setup/

$ curl -sI -m 8 --path-as-is http://<box>/portal/
HTTP/1.1 308 Permanent Redirect
location: /portal/
```

The `location` is the path the redirect was supposed to move *away* from.

## Cause

`src/middleware.ts` step 0 built the redirect target as

```ts
const url = request.nextUrl.clone();
url.pathname = raw.replace(/\/+$/, "") || "/";
return NextResponse.redirect(url, 308);
```

which does not do what it reads like. Verified against the pinned `next@16.3.3` (`package.json`, `bun.lock`) rather than taken on report:

- `next-url.js` → `analyze()`, run from the constructor, calls `getNextPathnameInfo()`, which does **not** strip the slash — it records it: `trailingSlash: pathname !== '/' ? pathname.endsWith('/') : trailingSlash`. The flag is stored in `this[Internal].trailingSlash`.
- `set pathname(value)` writes `this[Internal].url.pathname = value` **and nothing else**. The flag stays set.
- `get href()` renders through `formatPathname()` → `formatNextPathnameInfo()`, whose last line is `!info.buildId && info.trailingSlash ? (!pathname.endsWith('/') ? addPathSuffix(pathname, '/') : pathname) : removeTrailingSlash(pathname)` — it **re-adds** the slash from the flag.
- `toString()` returns `href`, and `NextResponse.redirect` does `headers.set('Location', validateURL(url))` where `validateURL` is `String(new URL(String(url)))`.

So the setter and the serialiser disagree, and the Location comes back with the slash the code had just removed. A plain `URL` has no such flag, which is why `new URL(...)` gets it right — the control the reporter measured.

The reported mechanism ("the setter updates `.pathname` but not `.href`") is confirmed; the precise cause is the sticky `trailingSlash` flag captured at parse time, not a stale `href` string.

## Native mechanism (harness first)

Next's own trailing-slash redirect is the native mechanism, and it is switched **off** on purpose: `next.config.ts` sets `skipTrailingSlashRedirect: true` so `/apps/<id>/` — the base path a proxied Vite app insists on — reaches the proxy as typed. That opt-out is what makes the middleware re-implementation necessary, so this PR keeps it and fixes only how the target is built. The native primitive for building the target is the plain WHATWG `URL` (or `NextURL`'s `href` setter, which re-runs `analyze()`); this uses the former.

## Fix

```ts
const url = new URL(request.url);
url.pathname = url.pathname.replace(/\/+$/, "") || "/";
return NextResponse.redirect(url, {
  status: 308,
  headers: { "cache-control": "no-store" },
});
```

Stripping from the plain URL's **own** pathname rather than from `request.nextUrl.pathname` also keeps a `basePath` on the target, should one ever be configured. `new URL(request.url)` is the form the file's three other redirects already use.

`cache-control: no-store` is the second half of the fix and matters for the rollout. A 308 is cacheable by default (RFC 7538 §3) and browsers treat a permanent redirect as durable — both boxes have been serving the self-referencing loop **as a permanent redirect**, so a browser that stored it replays the loop without asking the box and the fix reads as "did not work". The redirect cannot un-cache what is already stored, but it stops the class here. **Validate on the box in a fresh profile or with a cache-ignoring request, and read the `Location` header — not "the page loads now".**

## RED

`src/tests/middleware/middleware.test.ts`, new `describe("trailing-slash redirect (step 0)")` — drives the real `middleware()` export, no fixture stands in for the URL handling. On unmodified beta `d428b044`:

```
FAIL  |unit| middleware > trailing-slash redirect (step 0) > sends /setup/ to the same path without the slash, not back to itself
AssertionError: expected '/setup/' to be '/setup' // Object.is equality
Expected: "/setup"
Received: "/setup/"

FAIL  |unit| middleware > trailing-slash redirect (step 0) > sends /apps/ to the same path without the slash, not back to itself
AssertionError: expected '/apps/' to be '/apps' // Object.is equality

FAIL  |unit| middleware > trailing-slash redirect (step 0) > collapses repeated trailing slashes in one hop
AssertionError: expected '/setup/' to be '/setup' // Object.is equality

FAIL  |unit| middleware > trailing-slash redirect (step 0) > keeps the query string
AssertionError: expected '/login/' to be '/login' // Object.is equality

 Test Files  1 failed (1)
      Tests  9 failed | 148 skipped (157)
```

## GREEN

```
$ bun run test -- src/tests/middleware/ src/tests/routes/gateway.test.ts \
    src/tests/unit/openclaw-config-mock-completeness.test.ts \
    src/tests/unit/test-timeout-hygiene.test.ts \
    src/tests/unit/state-updater-purity.test.ts
 Test Files  7 passed (7)
      Tests  214 passed (214)

$ npx tsc --noEmit      # clean
$ npx eslint src/middleware.ts src/tests/middleware/middleware.test.ts   # clean
```

The three beta guard suites named above are included and pass. The full `bun run test` run is 12096 passed / 9 failed, and every one of those nine is a 5000 ms timeout in a file this PR does not touch (`chat-spoken-reply`, `telegram/status`, `run-tunnel`, `webapp-icon`); they pass when re-run in isolation on this same branch, so they are load flakes on the dev machine. CI is the suite proof.

## Sibling sweep

Every other `NextResponse.redirect(` and `.pathname =` site in `src/middleware.ts`, `src/**/route.ts` and `src/lib/`, each checked against the actual construct:

| Site | Verdict |
| --- | --- |
| `src/middleware.ts:401` trailing-slash 308 | **the defect — fixed** |
| `src/middleware.ts:407` `NextResponse.redirect(PORTAL_URL, 302)` | clear — `PORTAL_URL` is a plain string from `getPortalUrl()`, never a `NextURL` |
| `src/middleware.ts:551` `NextResponse.redirect(new URL(UPDATING_PAGE, request.url))` | clear — plain `URL`; `UPDATING_PAGE` is the literal `"/updating"` from `src/lib/update-lock.ts` |
| `src/middleware.ts:598` `new URL("/login", request.url)` + `searchParams.set(...)` | clear — plain `URL`; only `searchParams` is mutated, never `pathname` |
| `src/lib/gateway-proxy.ts:129` and `:136` | clear — plain `URL` built from a fully-formed absolute string, no pathname mutation |
| `src/lib/llamacpp.ts:64` `url.pathname = ...` | clear — plain `URL` parsed from a config string, not a `NextURL`; the WHATWG setter behaves |
| `NextResponse.rewrite(` anywhere in `src/` | none exist |
| `Response.redirect` / `redirect()` from `next/navigation` in `src/app/**/route.ts` | none exist |
| hand-built `Location` response headers | none — the only 3xx literal in `src/app` is a `304` Not Modified |

`request.nextUrl.clone()` had exactly one call site in the tree, and it was this one; there are now none.

## Coordination with #695

#695 (`fix/631-apps-root-and-route-guard`) touches `src/lib/clawbox-namespaces.ts`, `src/tests/routes/gateway.test.ts` and `src/tests/unit/clawbox-namespace-coverage.test.ts`. This PR touches `src/middleware.ts` and `src/tests/middleware/middleware.test.ts`. No file is shared and `git merge-tree` of the two heads is clean, so they merge in either order.

Worth noting for #695's benefit: the `/apps/` half of its MEDIUM-1 was **masked** by this loop — `/apps/` never reached the catch-all because it 308'd to itself first. With this merged, `/apps/` reaches `/apps`, which #695 documents as the Control UI's own page.


## Review

One review pass. Two Mediums, two Lows, one Info.

- **MEDIUM "`/apps/` now lands on the gateway shell with the token injected; add `/apps` to `CLAWBOX_PAGE_ROOTS`" — REFUTED**, measured first-hand rather than argued. On the OpenClaw box, at the pinned `OPENCLAW_VERSION=2026.8.1`, the Control UI's own route table has 55 entries and `/apps` **is one of them** — it ships `apps-page-Dze4Pwkv.js` / `apps-page-YnV-N0U5.css` — while `/setup`, `/login`, `/portal`, `/updating` and `/app` are all absent. So the shell is the *right* answer at `/apps`, and claiming the root would 404 a gateway page that works today. This is the same conclusion #695 reached with the same command, and the reason #695 records `/apps` in `UNCLAIMED_ROOTS` instead of claiming it. `/apps/` stays in the test list: the redirect now delivers the user to a real page instead of a loop, which is the whole point.
- **MEDIUM "the 308 carries no `Cache-Control`" — APPLIED**, with a test.
- **LOW "`request.nextUrl.href` where the file's other redirects use `request.url`" — APPLIED** (the reviewer measured the two identical for a `NextRequest`; this is the more legible form).
- **LOW "the step-0 exclusion list is case-sensitive while every gate below decides on the lower-cased path"** — real, **not** folded in. `/SETUP-API/x/` gets a 308 while `/setup-api/x/` correctly gets none. No bypass follows (the target is a path the caller could ask for directly, and the gates lower-case before deciding), but it changes *which* paths get redirected, next to an auth gate, so it wants its own RED rather than a ride on a one-line loop fix. Recorded as a residual in the run queue.
- **INFO** a stale measurement in `src/lib/clawbox-namespaces.ts`'s doc block, pre-existing and in #695's file — left alone, recorded as a residual.

Full findings file: `clawbox-run-scratch-2026-09-03/code-review-trailing-slash.md` (local, not in the repo).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed trailing-slash redirects that could cause redirect loops.
  - Redirects now consistently produce slashless URLs, preserve query parameters, and prevent caching.
  - Repeated trailing slashes are collapsed correctly.

- **Tests**
  - Added coverage for supported page paths, repeated slashes, query strings, redirect status, and cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->