### PR TITLE
fix: the failover waits for a route before restarting the gateway

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4974,10 +4974,21 @@ step_nm_dispatcher() {
     echo "  Skipping NM dispatcher: $SRC missing"
     return
   fi
-  mkdir -p "$DISPATCHER_DIR"
-  cp "$SRC" "$DEST"
-  chown root:root "$DEST"
-  chmod 0755 "$DEST"
+  # Every line below claims only what it has just done. step_post_update calls
+  # this step as `step_nm_dispatcher || echo "  Warning: …"`, and bash suspends
+  # `set -e` for the whole dynamic extent of a function run in a condition
+  # context — so on the in-app update path, the one every field box takes, an
+  # unchecked failure here would print "installed" over a file that never
+  # landed, and the `||` warning would never fire because the function still
+  # returned 0 from its last echo. Same rule step_systemd_services states for
+  # itself, for the same reason.
+  if ! mkdir -p "$DISPATCHER_DIR" \
+     || ! cp "$SRC" "$DEST" \
+     || ! chown root:root "$DEST" \
+     || ! chmod 0755 "$DEST"; then
+    echo "  Warning: could not install the NetworkManager failover dispatcher at $DEST" >&2
+    return 1
+  fi
   # The dispatcher is useless without the waiter it defers the gateway restart
   # to, and the waiter must be the ROOT-OWNED copy — root runs it. Installed
   # here as well as in install_root_libexec so an in-app UPDATE, which runs
@@ -4985,10 +4996,20 @@ step_nm_dispatcher() {
   # than a new dispatcher pointing at nothing.
   local WAITER_SRC="$PROJECT_DIR/scripts/gateway-restart-when-online.sh"
   if [ -f "$WAITER_SRC" ]; then
-    install -d -o root -g root -m 0755 "$ROOT_LIBEXEC_DIR"
-    install_root_file "$WAITER_SRC" "$ROOT_LIBEXEC_DIR/gateway-restart-when-online.sh"
-    echo "  Deferred gateway-restart helper installed"
+    # install_root_file returns 1 on both its failure paths and leaves the
+    # PREVIOUS copy in place, so an unreported failure is not "no waiter" but a
+    # STALE one — worse, and invisible until a network event logs the
+    # dispatcher's own "missing or not executable" line.
+    if install -d -o root -g root -m 0755 "$ROOT_LIBEXEC_DIR" \
+       && install_root_file "$WAITER_SRC" "$ROOT_LIBEXEC_DIR/gateway-restart-when-online.sh"; then
+      echo "  Deferred gateway-restart helper installed"
+    else
+      echo "  Warning: could not install the deferred gateway-restart helper — the failover will not restart the gateway" >&2
+      return 1
+    fi
   else
+    # A checkout without the script is degraded, not broken: the dispatcher
+    # still fails over to WiFi. Reported, and not claimed as installed.
     echo "  Warning: $WAITER_SRC missing — the failover will not restart the gateway"
   fi
   echo "  NetworkManager failover dispatcher installed"

--- a/install.sh
+++ b/install.sh
@@ -4982,10 +4982,19 @@ step_nm_dispatcher() {
   # landed, and the `||` warning would never fire because the function still
   # returned 0 from its last echo. Same rule step_systemd_services states for
   # itself, for the same reason.
+  #
+  # install_root_file, not `cp` + `chown` + `chmod`: NetworkManager may execute
+  # this dispatcher at any instant, including mid-update, and `cp` writes the
+  # LIVE inode with O_TRUNC — which on an existing 0755 file means NM can run a
+  # truncated, still-executable dispatcher that silently does less than half its
+  # job. That is the prefix hazard install_root_file was written for (TASK-584).
+  # It stages `$DEST.new` in the same directory and renames, so NM sees either
+  # the whole old file or the whole new one. The staged name is briefly visible
+  # to NM's scan — `.new` is not one of the suffixes it skips — but the worst
+  # that costs is one extra run of a COMPLETE dispatcher, which the waiter's
+  # lock collapses anyway; a truncated one has no such floor.
   if ! mkdir -p "$DISPATCHER_DIR" \
-     || ! cp "$SRC" "$DEST" \
-     || ! chown root:root "$DEST" \
-     || ! chmod 0755 "$DEST"; then
+     || ! install_root_file "$SRC" "$DEST" 0755; then
     echo "  Warning: could not install the NetworkManager failover dispatcher at $DEST" >&2
     record_provision_failure nm_dispatcher
     return 1

--- a/install.sh
+++ b/install.sh
@@ -4474,8 +4474,12 @@ install_root_libexec() {
   done
   # Everything the web server may invoke as root via a NOPASSWD grant. Same
   # rule as above: the copy that runs must not be the one clawbox can rewrite.
+  # gateway-restart-when-online.sh is launched BY ROOT from the NetworkManager
+  # dispatcher on every network event, so it belongs here for exactly the reason
+  # this block exists: the copy that runs must not be the one clawbox can
+  # rewrite. See scripts/nm-dispatcher-failover.sh.
   for src in optimize-ollama.sh clawbox-desktop-mode.sh clawbox-power-mode.sh \
-             clawbox-resource-limits.sh; do
+             clawbox-resource-limits.sh gateway-restart-when-online.sh; do
     if [ -f "$PROJECT_DIR/scripts/$src" ]; then
       install_root_file "$PROJECT_DIR/scripts/$src" "$ROOT_LIBEXEC_DIR/$src"
     fi
@@ -4974,6 +4978,19 @@ step_nm_dispatcher() {
   cp "$SRC" "$DEST"
   chown root:root "$DEST"
   chmod 0755 "$DEST"
+  # The dispatcher is useless without the waiter it defers the gateway restart
+  # to, and the waiter must be the ROOT-OWNED copy — root runs it. Installed
+  # here as well as in install_root_libexec so an in-app UPDATE, which runs
+  # step_nm_dispatcher from step_post_update, gets both halves together rather
+  # than a new dispatcher pointing at nothing.
+  local WAITER_SRC="$PROJECT_DIR/scripts/gateway-restart-when-online.sh"
+  if [ -f "$WAITER_SRC" ]; then
+    install -d -o root -g root -m 0755 "$ROOT_LIBEXEC_DIR"
+    install_root_file "$WAITER_SRC" "$ROOT_LIBEXEC_DIR/gateway-restart-when-online.sh"
+    echo "  Deferred gateway-restart helper installed"
+  else
+    echo "  Warning: $WAITER_SRC missing — the failover will not restart the gateway"
+  fi
   echo "  NetworkManager failover dispatcher installed"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -4987,6 +4987,7 @@ step_nm_dispatcher() {
      || ! chown root:root "$DEST" \
      || ! chmod 0755 "$DEST"; then
     echo "  Warning: could not install the NetworkManager failover dispatcher at $DEST" >&2
+    record_provision_failure nm_dispatcher
     return 1
   fi
   # The dispatcher is useless without the waiter it defers the gateway restart
@@ -5005,6 +5006,7 @@ step_nm_dispatcher() {
       echo "  Deferred gateway-restart helper installed"
     else
       echo "  Warning: could not install the deferred gateway-restart helper — the failover will not restart the gateway" >&2
+      record_provision_failure nm_dispatcher
       return 1
     fi
   else

--- a/scripts/gateway-restart-when-online.sh
+++ b/scripts/gateway-restart-when-online.sh
@@ -180,17 +180,23 @@ mkdir -p "$RUN_DIR" 2>/dev/null || true
 # second before the route lands, having ignored the very event that would have
 # succeeded. So a loser leaves a marker, and the holder re-arms its deadline
 # when it finds one rather than exiting on a request it swallowed.
-if command -v flock >/dev/null 2>&1; then
-  exec 9>"$LOCK_FILE" || exit 0
+# The lock file is OPENED before `exec` is asked to take the descriptor: a failed
+# redirection on `exec` kills a non-interactive bash outright, so `exec 9>… ||
+# exit 0` cannot even reach its fallback — the event would vanish with nothing in
+# the journal, which is the silent-drop shape this script keeps guarding against.
+# `>>` so probing never truncates a lock somebody else holds.
+if command -v flock >/dev/null 2>&1 && : >>"$LOCK_FILE" 2>/dev/null; then
+  exec 9>>"$LOCK_FILE"
   if ! flock -n 9; then
     : > "$REARM_FILE" 2>/dev/null || true
     log "Gateway restart already pending ($REASON) — handed to the waiter holding the lock"
     exit 0
   fi
 else
-  # Without flock there is no mutual exclusion at all, and two waiters could
-  # both restart. Said out loud rather than assumed away.
-  log "WARN: flock unavailable — running without the single-waiter guard"
+  # Without the lock there is no mutual exclusion at all, and two waiters could
+  # both restart. Said out loud rather than assumed away — and the wait still
+  # happens, because dropping the event is the worse of the two failures.
+  log "WARN: no single-waiter guard (flock or $LOCK_FILE unavailable) — a concurrent network event could restart twice"
 fi
 rm -f "$REARM_FILE" 2>/dev/null || true
 

--- a/scripts/gateway-restart-when-online.sh
+++ b/scripts/gateway-restart-when-online.sh
@@ -128,15 +128,27 @@ ONLINE_POLL="$(positive_int "${CLAWBOX_ONLINE_POLL:-}" 3)"
 # "present" on the one edition this guard exists for. Measured read-only on the
 # Hermes box: `clawbox-gateway.service masked enabled`, exit 0.
 #
-# LoadState is the answer that separates them — `loaded` for a unit systemd
-# would act on, `masked` for the Hermes edition's, `not-found` where it was
-# never installed — and it is also right when systemctl is absent entirely,
-# which is equally "no gateway here". Anything but `loaded` means there is
-# nothing to restart: not an error, and not worth a journal line per network
-# event.
-if [ "${CLAWBOX_SKIP_UNIT_CHECK:-0}" != "1" ] \
-   && [ "$(systemctl show -p LoadState --value "$UNIT" 2>/dev/null)" != "loaded" ]; then
-  exit 0
+# LoadState is the answer that separates them: `loaded` for a unit systemd would
+# act on, `masked` for the Hermes edition's, `not-found` where it was never
+# installed. Anything but `loaded` means there is nothing here to restart — not
+# an error, and not worth a journal line per network event. An EMPTY answer is a
+# different thing again and is handled separately below.
+if [ "${CLAWBOX_SKIP_UNIT_CHECK:-0}" != "1" ]; then
+  unit_load_state="$(systemctl show -p LoadState --value "$UNIT" 2>/dev/null)"
+  if [ -z "$unit_load_state" ]; then
+    # systemctl did not answer at all — a `daemon-reexec` (install.sh and the
+    # updater both trigger one), a bus hiccup, or no systemd here. That is NOT
+    # evidence that this edition has no gateway, and exiting silently on it
+    # would drop a network event with no trace anywhere. Say so once, then
+    # stand down: a systemctl that cannot answer cannot restart anything
+    # either, and the next network event starts a fresh wait.
+    # src/lib/gateway-health.ts states the same rule for the same property:
+    # "null means systemctl did not answer, which is not evidence either way."
+    log "WARN: could not read $UNIT load state — standing down for: $REASON"
+    exit 0
+  fi
+  # `loaded` is the only state describing a unit systemd would act on.
+  [ "$unit_load_state" = "loaded" ] || exit 0
 fi
 
 mkdir -p "$RUN_DIR" 2>/dev/null || true

--- a/scripts/gateway-restart-when-online.sh
+++ b/scripts/gateway-restart-when-online.sh
@@ -1,19 +1,26 @@
 #!/usr/bin/env bash
 # Restart the OpenClaw gateway once this box can actually reach the internet.
 #
-# WHY THIS EXISTS (GH #529). `nm-dispatcher-failover.sh` restarted the gateway
-# the moment Ethernet carrier dropped, before anything had proven a replacement
-# route existed. On a headless box with no other uplink the gateway came back
-# into a dead network: Telegram's startup hit ENETUNREACH, the OpenClaw release
-# died three times on the unhandled socket error, and the account supervisor
-# gave up. The gateway kept running with BOTH Telegram accounts stopped, and
-# when Ethernet and DHCP recovered they stayed stopped until someone started
-# them by hand.
+# Installed ROOT-OWNED at /usr/local/libexec/clawbox/gateway-restart-when-online.sh
+# by install.sh::step_nm_dispatcher, and launched from
+# /etc/NetworkManager/dispatcher.d/90-clawbox-failover. It must NOT be executed
+# out of the checkout: NetworkManager runs dispatchers as root, and
+# /home/clawbox/clawbox/scripts is clawbox-owned and group-writable, so root
+# running a script from there is a one-step local root for anything with
+# clawbox-level code execution. Same rule, and the same words, as
+# install.sh's ROOT_LIBEXEC_DIR block (TASK-445).
+#
+# WHY THIS EXISTS (GH #529). The dispatcher restarted the gateway the moment
+# Ethernet carrier dropped, before anything had proven a replacement route
+# existed. On a headless box with no other uplink the gateway came back into a
+# dead network: Telegram's startup hit ENETUNREACH, the OpenClaw release died
+# three times on the unhandled socket error, and the account supervisor gave up.
+# The gateway kept running with BOTH Telegram accounts stopped, and when
+# Ethernet and DHCP recovered they stayed stopped until someone started them by
+# hand.
 #
 # The restart is the point of failure and also the only cure, so it is not
-# cancelled — it is DEFERRED until a route is proven, or abandoned. Restarting
-# into a dead network is what suppresses the accounts; restarting once the
-# network is back is what un-suppresses them (see below).
+# cancelled — it is DEFERRED until a route is proven, or abandoned.
 #
 # WHY A RESTART IS THE WAY TO REVIVE A SUPPRESSED ACCOUNT — asked of the harness
 # first, on the box, read-only, against the installed OpenClaw 2026.8.1:
@@ -29,8 +36,7 @@
 #     it.
 #
 # So a fresh gateway process is the supported way back, and this script is that
-# restart, held until it can succeed. `gateway.channelMaxRestartsPerHour` is the
-# only related knob and it tunes the budget, not the recovery.
+# restart, held until it can succeed.
 #
 # WHY A SEPARATE SCRIPT. NetworkManager runs dispatcher scripts serially and
 # kills a slow one, so the dispatcher must return immediately. It launches this
@@ -41,88 +47,155 @@ set -u
 
 REASON="${1:-network change}"
 LOG_TAG="clawbox-failover"
-UNIT="${CLAWBOX_GATEWAY_UNIT:-clawbox-gateway.service}"
-CLAWBOX_ROOT="${CLAWBOX_ROOT:-/home/clawbox/clawbox}"
 
-# How long a recovering box is given before we stop waiting. Long enough for
-# WiFi association plus DHCP plus a captive-portal-free DNS answer on a slow
-# link; short enough that a genuinely unplugged box is not held for ever. The
-# next NetworkManager event starts a fresh wait, so this is a bound on ONE
-# attempt, not on recovery.
-ONLINE_TIMEOUT="${CLAWBOX_ONLINE_TIMEOUT:-120}"
-ONLINE_POLL="${CLAWBOX_ONLINE_POLL:-3}"
-LOCK_FILE="${CLAWBOX_ONLINE_LOCK:-$CLAWBOX_ROOT/data/gateway-online-restart.lock}"
+# Root-owned tmpfs, not the clawbox-writable data/ directory. This runs as root
+# and opens the lock for writing, so a path the clawbox user can replace with a
+# symlink is root truncating any file that user names. /run is also cleared on
+# boot, which is what a lock wants anyway.
+RUN_DIR="${CLAWBOX_RUN_DIR:-/run/clawbox}"
+LOCK_FILE="$RUN_DIR/gateway-online-restart.lock"
+# The dropped-request marker — see the lock section below.
+REARM_FILE="$RUN_DIR/gateway-online-restart.rearm"
 
 log() { logger -t "$LOG_TAG" -- "$*"; }
 
-# Is there a route to the public internet, not merely a link?
+# Which unit, if any, this box's agent runs as.
 #
-# NetworkManager's own connectivity check is asked FIRST because it is the
-# harness for this layer and it already distinguishes the case that matters:
-# `portal` and `limited` are exactly the "carrier is up, the internet is not"
-# states that make a restart harmful. It answers `unknown` when connectivity
-# checking is disabled — common on an appliance image — so the fallback is the
-# same probe the updater already trusts (`PING_TARGETS` in src/lib/updater.ts),
-# gated on a default route so a box with no route at all does not spend four
-# seconds proving it.
+# The Hermes SKU stops, disables and MASKS clawbox-gateway.service
+# (install.sh's step_edition_gateway_state), and its own agent never has
+# sockets to drop — so on that edition there is nothing here to do and a
+# two-minute wait would be pure noise in the journal. Resolved from the
+# root-owned edition lock, the same authority every other edition decision
+# uses, with the unit's actual presence as the final word.
+UNIT="${CLAWBOX_GATEWAY_UNIT:-clawbox-gateway.service}"
+
+# `full` is NetworkManager's own verdict and the only authoritative yes. Every
+# other value is NOT-YET-DECIDED rather than a no: connectivity checking is
+# ENABLED on the Ubuntu/JetPack base this ships on
+# (/usr/lib/NetworkManager/conf.d/20-connectivity-ubuntu.conf points at
+# connectivity-check.ubuntu.com), so any customer LAN that blocks or hijacks
+# that URL — a corporate egress filter, a Pi-hole, an ISP NXDOMAIN redirector —
+# parks NM at `portal` or `limited` permanently while the box happily reaches
+# Telegram and Anthropic. Treating that as offline would mean the gateway is
+# never restarted again, which is GH #529 back through a different door.
+#
+# So anything short of `full` falls through to a probe of our own, and that
+# probe is the updater's (`PING_TARGETS` and the HTTPS fallback in
+# src/lib/updater.ts) rather than half of it: ICMP is blocked on plenty of real
+# networks, which is exactly why the updater has the second half.
+#
+# `connectivity` and not `connectivity check`: the bare form reads the state NM
+# already maintains, while `check` forces a fresh HTTP fetch on every poll —
+# forty of them per event, each blocking for NM's probe timeout on a dead
+# network, which would overrun the very budget this is meant to bound.
 online() {
   local state
-  state="$(nmcli -t networking connectivity check 2>/dev/null | tr -d '[:space:]')"
-  case "$state" in
-    full) return 0 ;;
-    none|limited|portal) return 1 ;;
-  esac
+  state="$(nmcli -t networking connectivity 2>/dev/null | tr -d '[:space:]')"
+  [ "$state" = "full" ] && return 0
 
+  # No route at all is worth answering without spending four seconds on it.
   ip route show default 2>/dev/null | grep -q . || return 1
+
   local target
   for target in ${CLAWBOX_PING_TARGETS:-8.8.8.8 1.1.1.1}; do
     ping -c 1 -W 2 "$target" >/dev/null 2>&1 && return 0
   done
-  return 1
+  # The updater's own reasoning, verbatim: ICMP is blocked on some networks
+  # (hotel WiFi, corporate egress), and a box that can HEAD github.com is a box
+  # whose gateway will reach its channels.
+  command -v curl >/dev/null 2>&1 \
+    && curl -fsS -I --max-time 8 -o /dev/null "${CLAWBOX_ONLINE_PROBE_URL:-https://github.com/}" 2>/dev/null
 }
+
+# A budget that is not a number must not become an unset `deadline` and a
+# `set -u` death three lines later, with only "Deferring…" in the journal.
+positive_int() {
+  case "${1:-}" in
+    ''|*[!0-9]*) printf '%s' "$2" ;;
+    *) [ "$1" -gt 0 ] 2>/dev/null && printf '%s' "$1" || printf '%s' "$2" ;;
+  esac
+}
+
+# How long a recovering box is given before we stop waiting. Long enough for
+# WiFi association plus DHCP on a slow link; short enough that a genuinely
+# unplugged box is not held for ever. This is a bound on ONE attempt: the
+# dispatcher's connectivity-change and dhcp4-change arms, and the re-arm marker
+# below, are what cover recovery beyond it.
+ONLINE_TIMEOUT="$(positive_int "${CLAWBOX_ONLINE_TIMEOUT:-}" 120)"
+ONLINE_POLL="$(positive_int "${CLAWBOX_ONLINE_POLL:-}" 3)"
+
+if [ "${CLAWBOX_SKIP_UNIT_CHECK:-0}" != "1" ] \
+   && ! systemctl list-unit-files "$UNIT" >/dev/null 2>&1; then
+  # Not an error and not worth a journal line per network event: this edition
+  # simply has no such unit.
+  exit 0
+fi
+
+mkdir -p "$RUN_DIR" 2>/dev/null || true
 
 # One waiter at a time. Overlapping NetworkManager events — a carrier that
 # flaps, or eth down followed by wifi up — would otherwise stack several waits
 # and fire several restarts at the moment the route returned, which is its own
-# way of tripping the supervisor.
-mkdir -p "$(dirname "$LOCK_FILE")" 2>/dev/null || true
+# way of tripping the account supervisor.
+#
+# But `flock -n` alone LOSES the dropped request: the holder can time out one
+# second before the route lands, having ignored the very event that would have
+# succeeded. So a loser leaves a marker, and the holder re-arms its deadline
+# when it finds one rather than exiting on a request it swallowed.
 if command -v flock >/dev/null 2>&1; then
   exec 9>"$LOCK_FILE" || exit 0
   if ! flock -n 9; then
-    log "Gateway restart already pending ($REASON) — leaving it to the waiter that has the lock"
+    : > "$REARM_FILE" 2>/dev/null || true
+    log "Gateway restart already pending ($REASON) — handed to the waiter holding the lock"
     exit 0
   fi
+else
+  # Without flock there is no mutual exclusion at all, and two waiters could
+  # both restart. Said out loud rather than assumed away.
+  log "WARN: flock unavailable — running without the single-waiter guard"
 fi
+rm -f "$REARM_FILE" 2>/dev/null || true
 
 log "Deferring the gateway restart ($REASON) until a public route is proven, up to ${ONLINE_TIMEOUT}s"
 
 deadline=$(( $(date +%s) + ONLINE_TIMEOUT ))
 while :; do
   if online; then
-    # A gateway that is not running is not ours to start: the owner may have
-    # stopped it, and `restart` would start it behind their back.
-    if systemctl is-active --quiet "$UNIT"; then
-      log "Public route is up — restarting $UNIT ($REASON)"
-      if systemctl restart "$UNIT" >/dev/null 2>&1; then
-        # The restart is what revives channel accounts the supervisor gave up
-        # on: their suppression lives in the process that just went away.
-        log "Gateway restarted; suppressed channel accounts start again with it"
-      else
-        log "Gateway restart failed"
-      fi
+    # try-restart, not restart. The probe and the action are two commands and
+    # the gap here is a whole wait long: a unit that is stopped — deliberately
+    # by the owner, or masked by the Hermes edition — must not be STARTED by
+    # this. install.sh states the same rule for the same unit, in the same
+    # words, and `is-active` would be wrong twice over: it also reports
+    # non-zero for `activating`, and this unit's own RestartSec plus a
+    # cold-Jetson TimeoutStartSec make that window minutes long.
+    if systemctl try-restart "$UNIT" >/dev/null 2>&1; then
+      # Asked, not "restarted": try-restart's exit code says the request was
+      # accepted, not that the gateway came back — and certainly not what
+      # OpenClaw did with its channel accounts afterwards.
+      log "Public route is up — asked systemd to restart $UNIT ($REASON); a fresh gateway starts the channel accounts its supervisor gave up on"
     else
-      log "Public route is up but $UNIT is not running — leaving it stopped"
+      log "Public route is up but the restart request for $UNIT failed"
     fi
     exit 0
   fi
-  [ "$(date +%s)" -lt "$deadline" ] || break
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    # A request that arrived while this waiter held the lock is not lost: take
+    # it now and go round again, once per marker.
+    if [ -e "$REARM_FILE" ]; then
+      rm -f "$REARM_FILE" 2>/dev/null || true
+      deadline=$(( $(date +%s) + ONLINE_TIMEOUT ))
+      log "A further network event arrived while waiting — extending the wait ${ONLINE_TIMEOUT}s"
+      continue
+    fi
+    break
+  fi
   sleep "$ONLINE_POLL"
 done
 
 # Deliberately NOT a restart. Bouncing the gateway into a network that still has
 # no route is the exact sequence that suppressed the accounts in the first
 # place, and the sockets it would drop are already dead. The next
-# NetworkManager event — the one that brings a route back — starts a fresh wait
-# and restarts then.
+# NetworkManager event — up, dhcp4-change or connectivity-change — starts a
+# fresh wait and restarts then.
 log "No public route after ${ONLINE_TIMEOUT}s ($REASON) — NOT restarting $UNIT; waiting for the next network event"
 exit 0

--- a/scripts/gateway-restart-when-online.sh
+++ b/scripts/gateway-restart-when-online.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Restart the OpenClaw gateway once this box can actually reach the internet.
+#
+# WHY THIS EXISTS (GH #529). `nm-dispatcher-failover.sh` restarted the gateway
+# the moment Ethernet carrier dropped, before anything had proven a replacement
+# route existed. On a headless box with no other uplink the gateway came back
+# into a dead network: Telegram's startup hit ENETUNREACH, the OpenClaw release
+# died three times on the unhandled socket error, and the account supervisor
+# gave up. The gateway kept running with BOTH Telegram accounts stopped, and
+# when Ethernet and DHCP recovered they stayed stopped until someone started
+# them by hand.
+#
+# The restart is the point of failure and also the only cure, so it is not
+# cancelled — it is DEFERRED until a route is proven, or abandoned. Restarting
+# into a dead network is what suppresses the accounts; restarting once the
+# network is back is what un-suppresses them (see below).
+#
+# WHY A RESTART IS THE WAY TO REVIVE A SUPPRESSED ACCOUNT — asked of the harness
+# first, on the box, read-only, against the installed OpenClaw 2026.8.1:
+#
+#   * `openclaw channels --help` offers add | capabilities | dead-letters |
+#     list | login | logout | logs | remove | resolve | status. There is no
+#     start, resume or restart verb: the CLI cannot revive a stopped account.
+#   * the supervisor that stops it is a `RetrySupervisor(RESTART_POLICY,
+#     MAX_RESTARTS)` held in a Map inside the gateway process
+#     (`dist/server-channels-*.js`), and giving up sets runtime state —
+#     `setRuntime(..., { restartPending: false, reconnectAttempts })` — not
+#     configuration. Nothing on disk records it, so nothing on disk can clear
+#     it.
+#
+# So a fresh gateway process is the supported way back, and this script is that
+# restart, held until it can succeed. `gateway.channelMaxRestartsPerHour` is the
+# only related knob and it tunes the budget, not the recovery.
+#
+# WHY A SEPARATE SCRIPT. NetworkManager runs dispatcher scripts serially and
+# kills a slow one, so the dispatcher must return immediately. It launches this
+# detached; the waiting happens here.
+#
+# Usage: gateway-restart-when-online.sh <reason>
+set -u
+
+REASON="${1:-network change}"
+LOG_TAG="clawbox-failover"
+UNIT="${CLAWBOX_GATEWAY_UNIT:-clawbox-gateway.service}"
+CLAWBOX_ROOT="${CLAWBOX_ROOT:-/home/clawbox/clawbox}"
+
+# How long a recovering box is given before we stop waiting. Long enough for
+# WiFi association plus DHCP plus a captive-portal-free DNS answer on a slow
+# link; short enough that a genuinely unplugged box is not held for ever. The
+# next NetworkManager event starts a fresh wait, so this is a bound on ONE
+# attempt, not on recovery.
+ONLINE_TIMEOUT="${CLAWBOX_ONLINE_TIMEOUT:-120}"
+ONLINE_POLL="${CLAWBOX_ONLINE_POLL:-3}"
+LOCK_FILE="${CLAWBOX_ONLINE_LOCK:-$CLAWBOX_ROOT/data/gateway-online-restart.lock}"
+
+log() { logger -t "$LOG_TAG" -- "$*"; }
+
+# Is there a route to the public internet, not merely a link?
+#
+# NetworkManager's own connectivity check is asked FIRST because it is the
+# harness for this layer and it already distinguishes the case that matters:
+# `portal` and `limited` are exactly the "carrier is up, the internet is not"
+# states that make a restart harmful. It answers `unknown` when connectivity
+# checking is disabled — common on an appliance image — so the fallback is the
+# same probe the updater already trusts (`PING_TARGETS` in src/lib/updater.ts),
+# gated on a default route so a box with no route at all does not spend four
+# seconds proving it.
+online() {
+  local state
+  state="$(nmcli -t networking connectivity check 2>/dev/null | tr -d '[:space:]')"
+  case "$state" in
+    full) return 0 ;;
+    none|limited|portal) return 1 ;;
+  esac
+
+  ip route show default 2>/dev/null | grep -q . || return 1
+  local target
+  for target in ${CLAWBOX_PING_TARGETS:-8.8.8.8 1.1.1.1}; do
+    ping -c 1 -W 2 "$target" >/dev/null 2>&1 && return 0
+  done
+  return 1
+}
+
+# One waiter at a time. Overlapping NetworkManager events — a carrier that
+# flaps, or eth down followed by wifi up — would otherwise stack several waits
+# and fire several restarts at the moment the route returned, which is its own
+# way of tripping the supervisor.
+mkdir -p "$(dirname "$LOCK_FILE")" 2>/dev/null || true
+if command -v flock >/dev/null 2>&1; then
+  exec 9>"$LOCK_FILE" || exit 0
+  if ! flock -n 9; then
+    log "Gateway restart already pending ($REASON) — leaving it to the waiter that has the lock"
+    exit 0
+  fi
+fi
+
+log "Deferring the gateway restart ($REASON) until a public route is proven, up to ${ONLINE_TIMEOUT}s"
+
+deadline=$(( $(date +%s) + ONLINE_TIMEOUT ))
+while :; do
+  if online; then
+    # A gateway that is not running is not ours to start: the owner may have
+    # stopped it, and `restart` would start it behind their back.
+    if systemctl is-active --quiet "$UNIT"; then
+      log "Public route is up — restarting $UNIT ($REASON)"
+      if systemctl restart "$UNIT" >/dev/null 2>&1; then
+        # The restart is what revives channel accounts the supervisor gave up
+        # on: their suppression lives in the process that just went away.
+        log "Gateway restarted; suppressed channel accounts start again with it"
+      else
+        log "Gateway restart failed"
+      fi
+    else
+      log "Public route is up but $UNIT is not running — leaving it stopped"
+    fi
+    exit 0
+  fi
+  [ "$(date +%s)" -lt "$deadline" ] || break
+  sleep "$ONLINE_POLL"
+done
+
+# Deliberately NOT a restart. Bouncing the gateway into a network that still has
+# no route is the exact sequence that suppressed the accounts in the first
+# place, and the sockets it would drop are already dead. The next
+# NetworkManager event — the one that brings a route back — starts a fresh wait
+# and restarts then.
+log "No public route after ${ONLINE_TIMEOUT}s ($REASON) — NOT restarting $UNIT; waiting for the next network event"
+exit 0

--- a/scripts/gateway-restart-when-online.sh
+++ b/scripts/gateway-restart-when-online.sh
@@ -64,9 +64,9 @@ log() { logger -t "$LOG_TAG" -- "$*"; }
 # The Hermes SKU stops, disables and MASKS clawbox-gateway.service
 # (install.sh's step_edition_gateway_state), and its own agent never has
 # sockets to drop — so on that edition there is nothing here to do and a
-# two-minute wait would be pure noise in the journal. Resolved from the
-# root-owned edition lock, the same authority every other edition decision
-# uses, with the unit's actual presence as the final word.
+# two-minute wait would be pure noise in the journal. Decided from the unit's
+# own load state below: systemd's answer about the unit this script would act
+# on, which needs no second source of truth about the edition.
 UNIT="${CLAWBOX_GATEWAY_UNIT:-clawbox-gateway.service}"
 
 # `full` is NetworkManager's own verdict and the only authoritative yes. Every
@@ -124,10 +124,18 @@ positive_int() {
 ONLINE_TIMEOUT="$(positive_int "${CLAWBOX_ONLINE_TIMEOUT:-}" 120)"
 ONLINE_POLL="$(positive_int "${CLAWBOX_ONLINE_POLL:-}" 3)"
 
+# `list-unit-files` is the wrong question: it LISTS a masked unit, so it answers
+# "present" on the one edition this guard exists for. Measured read-only on the
+# Hermes box: `clawbox-gateway.service masked enabled`, exit 0.
+#
+# LoadState is the answer that separates them — `loaded` for a unit systemd
+# would act on, `masked` for the Hermes edition's, `not-found` where it was
+# never installed — and it is also right when systemctl is absent entirely,
+# which is equally "no gateway here". Anything but `loaded` means there is
+# nothing to restart: not an error, and not worth a journal line per network
+# event.
 if [ "${CLAWBOX_SKIP_UNIT_CHECK:-0}" != "1" ] \
-   && ! systemctl list-unit-files "$UNIT" >/dev/null 2>&1; then
-  # Not an error and not worth a journal line per network event: this edition
-  # simply has no such unit.
+   && [ "$(systemctl show -p LoadState --value "$UNIT" 2>/dev/null)" != "loaded" ]; then
   exit 0
 fi
 

--- a/scripts/gateway-restart-when-online.sh
+++ b/scripts/gateway-restart-when-online.sh
@@ -19,11 +19,11 @@
 # Ethernet and DHCP recovered they stayed stopped until someone started them by
 # hand.
 #
-# The restart is the point of failure and also the only cure, so it is not
-# cancelled — it is DEFERRED until a route is proven, or abandoned.
+# The restart is the point of failure, so it is not cancelled — it is DEFERRED
+# until a route is proven, or abandoned.
 #
-# WHY A RESTART IS THE WAY TO REVIVE A SUPPRESSED ACCOUNT — asked of the harness
-# first, on the box, read-only, against the installed OpenClaw 2026.8.1:
+# WHAT THE HARNESS ALREADY DOES — asked of OpenClaw first, on the box,
+# read-only, against the installed 2026.8.1:
 #
 #   * `openclaw channels --help` offers add | capabilities | dead-letters |
 #     list | login | logout | logs | remove | resolve | status. There is no
@@ -34,9 +34,27 @@
 #     `setRuntime(..., { restartPending: false, reconnectAttempts })` — not
 #     configuration. Nothing on disk records it, so nothing on disk can clear
 #     it.
+#   * BUT the gateway ALSO runs its own channel health monitor on every start —
+#     `[health-monitor] started (interval: 300s, startup-grace: 60s,
+#     channel-connect-grace: 120s)`. For a stopped account
+#     `evaluateChannelHealth` returns `not-running`,
+#     `resolveChannelRestartReason` labels that `gave-up` once
+#     reconnectAttempts >= 10, and the monitor restarts THAT ACCOUNT, bounded
+#     by cooldownCycles and maxRestartsPerHour. Three `gateway.*` keys tune it
+#     and ClawBox sets none of them.
 #
-# So a fresh gateway process is the supported way back, and this script is that
-# restart, held until it can succeed.
+# So "a fresh gateway process is the only way back" is TOO STRONG, and this
+# script does not claim it. What the monitor does not do is act on the two
+# reasons it skips outright — `terminal-disconnect` and `blocked` — and
+# `evaluateChannelHealth` tests `terminalDisconnect` BEFORE `not-running`. GH
+# #529's accounts stayed stopped until a human started them, with this monitor
+# running, so one of those skips applied; which one is UNPROVEN, because
+# establishing it means reproducing the outage on a box and losing its live
+# channels.
+#
+# What this script fixes is narrower and certain: the dispatcher used to restart
+# the gateway INTO A DEAD NETWORK, which is the sequence that suppressed the
+# accounts in the first place. Held until it can succeed, or not done at all.
 #
 # WHY A SEPARATE SCRIPT. NetworkManager runs dispatcher scripts serially and
 # kills a slow one, so the dispatcher must return immediately. It launches this

--- a/scripts/nm-dispatcher-failover.sh
+++ b/scripts/nm-dispatcher-failover.sh
@@ -25,6 +25,9 @@ LOG_TAG="clawbox-failover"
 # checkout is clawbox-owned and group-writable. See the waiter's own header and
 # install.sh's ROOT_LIBEXEC_DIR block (TASK-445).
 WAITER="${CLAWBOX_ONLINE_WAITER:-/usr/local/libexec/clawbox/gateway-restart-when-online.sh}"
+# Root-owned tmpfs, the same directory the waiter takes its lock in, and cleared
+# on boot — which is what a "what did we see last time" marker wants anyway.
+RUN_DIR="${CLAWBOX_RUN_DIR:-/run/clawbox}"
 
 log() { logger -t "$LOG_TAG" -- "$*"; }
 
@@ -97,20 +100,43 @@ case "$ACTION" in
     # can SUCCEED, and a LAN that hijacks connectivity-check.ubuntu.com would
     # otherwise veto every restart for ever. This arm decides whether an event
     # is worth ASKING about, and `full` is NM's only positive statement:
-    # `portal`, `limited` and `unknown` mean "not decided". Asking on those
-    # would hand the waiter a request on every flap of a connectivity check
-    # that is already known to be unreliable here — and because the waiter
-    # accepts a working ping whatever NM thinks, each flap on a healthy box
-    # would bounce a healthy gateway mid-conversation. A box whose LAN never
-    # lets NM say `full` still has the arms that do not depend on NM's opinion:
-    # `up`, and the DHCP lease below.
+    # `portal`, `limited` and `unknown` mean "not decided".
+    #
+    # Stated honestly, this HALVES the noise rather than removing it — a check
+    # that flaps still dispatches on each return to `full`. What it buys is that
+    # a LAN permanently parked at `portal`/`limited` cannot ask for a restart on
+    # every transition it makes, and a box that never reaches `full` still has
+    # the arms that do not depend on NM's opinion at all: `up`, and the DHCP
+    # lease below.
     if [ "${CONNECTIVITY_STATE:-}" = "FULL" ]; then
       restart_gateway_when_online "NetworkManager reports full connectivity"
     fi
     exit 0
     ;;
   dhcp4-change)
-    restart_gateway_when_online "DHCP lease on '$IFACE'"
+    # A RENEWAL is not a network change, and this arm must not treat it as one.
+    # NM emits dhcp4-change on every T1 renew and T2 rebind: the office LAN
+    # hands out `dhcp_lease_time = 86400`, so twice a day, and the one- to
+    # two-hour leases consumer routers, guest WiFi and hotel networks give make
+    # it 24-48 times a day. A renewal that keeps the same address moves no
+    # route and drops no socket, so a restart there buys nothing and costs an
+    # in-flight conversation plus a cold-Jetson `gateway-pre-start.sh` — the
+    # exact harm the rest of this script exists to avoid. Beta restarted only on
+    # Ethernet carrier up/down, which is rare; turning that into a routine event
+    # would be a worse bug than the one being fixed.
+    #
+    # So only a lease that actually MOVED the box counts. The address and
+    # gateway are remembered per interface and compared.
+    case "$IFACE" in
+      eth*|en*|"$WIFI_IFACE") ;;
+      *) exit 0 ;;
+    esac
+    lease="${IP4_ADDRESS_0:-}|${IP4_GATEWAY:-}"
+    seen="$RUN_DIR/last-lease.${IFACE//[^A-Za-z0-9._-]/_}"
+    mkdir -p "$RUN_DIR" 2>/dev/null || true
+    [ "$(cat "$seen" 2>/dev/null || true)" = "$lease" ] && exit 0
+    printf '%s' "$lease" > "$seen" 2>/dev/null || true
+    restart_gateway_when_online "DHCP lease on '$IFACE' changed"
     exit 0
     ;;
 esac

--- a/scripts/nm-dispatcher-failover.sh
+++ b/scripts/nm-dispatcher-failover.sh
@@ -52,7 +52,7 @@ restart_gateway_when_online() {
   fi
   # PATH first so a test harness can stand in for it, then the absolute paths,
   # because a dispatcher's PATH is NM's and not a login shell's.
-  local setsid_bin=""
+  local setsid_bin="" candidate
   setsid_bin="$(command -v setsid 2>/dev/null || true)"
   if [ -z "$setsid_bin" ]; then
     for candidate in /usr/bin/setsid /bin/setsid; do
@@ -92,6 +92,18 @@ fi
 # subscribes to both actions in config/99-clawbox-avahi-reload.
 case "$ACTION" in
   connectivity-change)
+    # `FULL` and nothing less — and this is NOT the waiter's rule inverted. The
+    # waiter is lenient about NM's verdict because it decides whether a restart
+    # can SUCCEED, and a LAN that hijacks connectivity-check.ubuntu.com would
+    # otherwise veto every restart for ever. This arm decides whether an event
+    # is worth ASKING about, and `full` is NM's only positive statement:
+    # `portal`, `limited` and `unknown` mean "not decided". Asking on those
+    # would hand the waiter a request on every flap of a connectivity check
+    # that is already known to be unreliable here — and because the waiter
+    # accepts a working ping whatever NM thinks, each flap on a healthy box
+    # would bounce a healthy gateway mid-conversation. A box whose LAN never
+    # lets NM say `full` still has the arms that do not depend on NM's opinion:
+    # `up`, and the DHCP lease below.
     if [ "${CONNECTIVITY_STATE:-}" = "FULL" ]; then
       restart_gateway_when_online "NetworkManager reports full connectivity"
     fi

--- a/scripts/nm-dispatcher-failover.sh
+++ b/scripts/nm-dispatcher-failover.sh
@@ -12,12 +12,44 @@ ACTION="${2:-}"
 WIFI_IFACE="${NETWORK_INTERFACE:-wlP1p1s0}"
 AP_PROFILE="ClawBox-Setup"
 LOG_TAG="clawbox-failover"
+CLAWBOX_ROOT="${CLAWBOX_ROOT:-/home/clawbox/clawbox}"
 
 log() { logger -t "$LOG_TAG" -- "$*"; }
 
-# Only react to ethernet up/down events.
+# Hand the gateway restart to the waiter, DETACHED.
+#
+# The restart is never immediate any more (GH #529): a gateway bounced into a
+# network with no route loses its Telegram accounts to the account supervisor,
+# which gives up after its restart budget and leaves them stopped for the life
+# of the process — with no CLI verb to start them again. The waiter defers the
+# restart until a public route is proven, and a restart that lands then is also
+# what revives the suppressed accounts. See scripts/gateway-restart-when-online.sh.
+#
+# Detached because NetworkManager runs dispatcher scripts serially and kills a
+# slow one: this script must return at once, and the waiting must not happen in
+# it. The waiter takes its own lock, so overlapping events do not stack.
+restart_gateway_when_online() {
+  local waiter="$CLAWBOX_ROOT/scripts/gateway-restart-when-online.sh"
+  if [ ! -x "$waiter" ]; then
+    log "WARN: $waiter missing — gateway not restarted for: $1"
+    return
+  fi
+  setsid nohup bash "$waiter" "$1" >/dev/null 2>&1 &
+}
+
+# React to ethernet up/down, and to the WiFi radio coming up.
+#
+# The WiFi arm is the recovery half: after a failover the box's route comes back
+# on the wireless interface, and with only the ethernet arm nothing ever asked
+# for the restart that revives the channel accounts.
 case "$IFACE" in
   eth*|en*) ;;
+  "$WIFI_IFACE")
+    if [ "$ACTION" = "up" ]; then
+      restart_gateway_when_online "WiFi '$IFACE' up"
+    fi
+    exit 0
+    ;;
   *) exit 0 ;;
 esac
 
@@ -25,11 +57,9 @@ esac
 # interface. Existing sockets bound to the WiFi IP would otherwise be sent
 # down Eth as asymmetric traffic and silently fail.
 if [ "$ACTION" = "up" ]; then
-  if systemctl is-active --quiet clawbox-gateway.service; then
-    log "Ethernet '$IFACE' up — restarting clawbox-gateway to rebind sockets"
-    systemctl restart clawbox-gateway.service >/dev/null 2>&1 || \
-      log "Gateway restart failed"
-  fi
+  # Carrier is not a route: at `up` the interface may still be waiting on DHCP,
+  # and a restart there is the same mistake as the one below.
+  restart_gateway_when_online "Ethernet '$IFACE' up"
   exit 0
 fi
 
@@ -47,11 +77,11 @@ log "Ethernet '$IFACE' down — attempting WiFi failover"
 # IPs. HTTP/2 keep-alives to OpenAI/Anthropic/Telegram look ESTABLISHED but
 # silently blackhole until TCP times out (~120s). A service restart drops them
 # and forces fresh connections on the surviving interface.
-if systemctl is-active --quiet clawbox-gateway.service; then
-  log "Restarting clawbox-gateway to drop sockets bound to dead $IFACE"
-  systemctl restart clawbox-gateway.service >/dev/null 2>&1 || \
-    log "Gateway restart failed"
-fi
+#
+# Requested here and performed only once a route exists. Those sockets are
+# already dead either way, so nothing is lost by waiting — while restarting
+# into a dead network costs both Telegram accounts until someone notices.
+restart_gateway_when_online "Ethernet '$IFACE' down"
 
 # If the AP is currently active on the WiFi radio, take it down so the radio is free.
 if nmcli -t -f NAME,DEVICE connection show --active | grep -qE "^${AP_PROFILE}:${WIFI_IFACE}$"; then
@@ -92,7 +122,7 @@ log "Failover failed — no saved WiFi profile would connect; starting hotspot a
 # Stranded recovery: no saved WiFi reachable, so bring the captive-portal
 # hotspot back up. start-ap.sh honours the user's configured SSID/password
 # and falls back to ClawBox-Setup if none is set.
-START_AP="/home/clawbox/clawbox/scripts/start-ap.sh"
+START_AP="$CLAWBOX_ROOT/scripts/start-ap.sh"
 if [ -x "$START_AP" ]; then
   bash "$START_AP" >/dev/null 2>&1 &
   log "Recovery AP launch dispatched"

--- a/scripts/nm-dispatcher-failover.sh
+++ b/scripts/nm-dispatcher-failover.sh
@@ -35,10 +35,10 @@ log() { logger -t "$LOG_TAG" -- "$*"; }
 #
 # The restart is never immediate any more (GH #529): a gateway bounced into a
 # network with no route loses its Telegram accounts to OpenClaw's account
-# supervisor, which gives up after its restart budget and leaves them stopped
-# for the life of the process — with no CLI verb to start them again. The
-# waiter defers the restart until a public route is proven, and a restart that
-# lands then is also what revives the suppressed accounts.
+# supervisor, which gives up after its restart budget. The waiter defers the
+# restart until a public route is proven. See the waiter's own header for what
+# OpenClaw's channel health monitor already recovers on its own, and for the
+# part of GH #529 that is still unexplained.
 #
 # Detached because NetworkManager runs dispatcher scripts serially and kills a
 # slow one: this script must return at once, and the waiting must not happen in

--- a/scripts/nm-dispatcher-failover.sh
+++ b/scripts/nm-dispatcher-failover.sh
@@ -9,36 +9,100 @@ set -u
 
 IFACE="${1:-}"
 ACTION="${2:-}"
+# NetworkManager passes no NETWORK_INTERFACE to a dispatcher, and the radio is
+# not always wlP1p1s0 — install.sh auto-detects it and persists the real name
+# here precisely because of that, and documents an operator override. Sourced
+# the way scripts/clawbox-firewall.sh sources it: the file is ROOT-owned, so
+# unlike the clawbox-writable data/*.env it is safe to source as root.
+if [ -r /etc/clawbox/network.env ]; then
+  # shellcheck disable=SC1091
+  . /etc/clawbox/network.env
+fi
 WIFI_IFACE="${NETWORK_INTERFACE:-wlP1p1s0}"
 AP_PROFILE="ClawBox-Setup"
 LOG_TAG="clawbox-failover"
-CLAWBOX_ROOT="${CLAWBOX_ROOT:-/home/clawbox/clawbox}"
+# Root-owned, root-installed: NetworkManager runs this as root, and the
+# checkout is clawbox-owned and group-writable. See the waiter's own header and
+# install.sh's ROOT_LIBEXEC_DIR block (TASK-445).
+WAITER="${CLAWBOX_ONLINE_WAITER:-/usr/local/libexec/clawbox/gateway-restart-when-online.sh}"
 
 log() { logger -t "$LOG_TAG" -- "$*"; }
 
 # Hand the gateway restart to the waiter, DETACHED.
 #
 # The restart is never immediate any more (GH #529): a gateway bounced into a
-# network with no route loses its Telegram accounts to the account supervisor,
-# which gives up after its restart budget and leaves them stopped for the life
-# of the process — with no CLI verb to start them again. The waiter defers the
-# restart until a public route is proven, and a restart that lands then is also
-# what revives the suppressed accounts. See scripts/gateway-restart-when-online.sh.
+# network with no route loses its Telegram accounts to OpenClaw's account
+# supervisor, which gives up after its restart budget and leaves them stopped
+# for the life of the process — with no CLI verb to start them again. The
+# waiter defers the restart until a public route is proven, and a restart that
+# lands then is also what revives the suppressed accounts.
 #
 # Detached because NetworkManager runs dispatcher scripts serially and kills a
 # slow one: this script must return at once, and the waiting must not happen in
 # it. The waiter takes its own lock, so overlapping events do not stack.
+#
+# The launch is REPORTED, not fire-and-forget into /dev/null: NM runs
+# dispatchers with a minimal PATH (the reason 99-clawbox-avahi-reload resolves
+# avahi-daemon absolutely), so a missing setsid or a fork failure would
+# otherwise leave no trace anywhere of a restart that never happened.
 restart_gateway_when_online() {
-  local waiter="$CLAWBOX_ROOT/scripts/gateway-restart-when-online.sh"
-  if [ ! -x "$waiter" ]; then
-    log "WARN: $waiter missing — gateway not restarted for: $1"
+  if [ ! -x "$WAITER" ]; then
+    log "WARN: $WAITER missing or not executable — gateway not restarted for: $1"
     return
   fi
-  setsid nohup bash "$waiter" "$1" >/dev/null 2>&1 &
+  # PATH first so a test harness can stand in for it, then the absolute paths,
+  # because a dispatcher's PATH is NM's and not a login shell's.
+  local setsid_bin=""
+  setsid_bin="$(command -v setsid 2>/dev/null || true)"
+  if [ -z "$setsid_bin" ]; then
+    for candidate in /usr/bin/setsid /bin/setsid; do
+      [ -x "$candidate" ] && setsid_bin="$candidate" && break
+    done
+  fi
+  if [ -n "$setsid_bin" ]; then
+    "$setsid_bin" "$WAITER" "$1" </dev/null >/dev/null 2>&1 &
+  else
+    # Still detached from this shell, but inside the dispatcher's process
+    # group, so NetworkManager's own timeout can take it with it. Said out
+    # loud: a restart that silently never happened is what GH #529 was.
+    log "WARN: setsid not found — the deferred restart may be killed with the dispatcher"
+    "$WAITER" "$1" </dev/null >/dev/null 2>&1 &
+  fi
+  log "Deferred restart dispatched: $1"
 }
 
-# React to ethernet up/down, and to the WiFi radio coming up.
+# The AP is not a network this box got onto — it is the one it is offering.
+# start-ap.sh brings up a `shared` profile with no default route, and
+# ap-watchdog.sh re-raises it every ~20 s while setup is incomplete, so without
+# this every one of those would start a full wait, hold the lock, and drop a
+# genuine Ethernet request in the meantime.
+if [ "${CONNECTION_ID:-}" = "$AP_PROFILE" ]; then
+  exit 0
+fi
+
+# React to ethernet up/down, to the WiFi radio coming up, and — the harness's
+# own answer to the question this script asks — to NetworkManager's
+# connectivity and DHCP events.
 #
+# `connectivity-change` carries CONNECTIVITY_STATE and is what NM emits when an
+# upstream router reboots with the box's carrier intact: the most common real
+# shape of "the accounts got suppressed and never came back", and one that
+# produces no up/down at all. `dhcp4-change` is the lease landing a second
+# after an association, which the up event is too early for. This repo already
+# subscribes to both actions in config/99-clawbox-avahi-reload.
+case "$ACTION" in
+  connectivity-change)
+    if [ "${CONNECTIVITY_STATE:-}" = "FULL" ]; then
+      restart_gateway_when_online "NetworkManager reports full connectivity"
+    fi
+    exit 0
+    ;;
+  dhcp4-change)
+    restart_gateway_when_online "DHCP lease on '$IFACE'"
+    exit 0
+    ;;
+esac
+
 # The WiFi arm is the recovery half: after a failover the box's route comes back
 # on the wireless interface, and with only the ethernet arm nothing ever asked
 # for the restart that revives the channel accounts.
@@ -122,7 +186,7 @@ log "Failover failed — no saved WiFi profile would connect; starting hotspot a
 # Stranded recovery: no saved WiFi reachable, so bring the captive-portal
 # hotspot back up. start-ap.sh honours the user's configured SSID/password
 # and falls back to ClawBox-Setup if none is set.
-START_AP="$CLAWBOX_ROOT/scripts/start-ap.sh"
+START_AP="${CLAWBOX_ROOT:-/home/clawbox/clawbox}/scripts/start-ap.sh"
 if [ -x "$START_AP" ]; then
   bash "$START_AP" >/dev/null 2>&1 &
   log "Recovery AP launch dispatched"

--- a/src/tests/unit/failover-waits-for-route.test.ts
+++ b/src/tests/unit/failover-waits-for-route.test.ts
@@ -54,8 +54,14 @@ interface BoxOptions {
   defaultRoute?: boolean;
   /** Whether `ping` succeeds. */
   pingWorks?: boolean;
-  /** Whether the gateway unit exists at all (false = the Hermes edition). */
-  unitExists?: boolean;
+  /**
+   * What `systemctl` reports for the gateway unit's LoadState:
+   * `loaded` (the OpenClaw edition), `masked` (the Hermes edition, which stops,
+   * disables and MASKS it), or `not-found` (no such unit at all). A boolean
+   * could not tell the middle case from the first, which is exactly how the
+   * Hermes edition went untested.
+   */
+  unitLoadState?: "loaded" | "masked" | "not-found";
   /** Whether `curl` is on PATH for the HTTPS half of the probe. */
   curlWorks?: boolean;
   /** Drop a re-arm marker once, from inside the poll loop. */
@@ -113,13 +119,25 @@ exit ${opts.pingWorks ? 0 : 1}`);
 echo "curl $*" >> ${JSON.stringify(calls)}
 exit ${opts.curlWorks ? 0 : 1}`);
 
+  // Modelled on the real systemctl for BOTH questions, because the difference
+  // between them is the defect: a masked unit is still LISTED, so
+  // `list-unit-files` answers "present" on the Hermes edition, and only
+  // LoadState tells a masked unit from a live one.
+  const loadState = opts.unitLoadState ?? "loaded";
   stub("systemctl", `
 echo "systemctl $*" >> ${JSON.stringify(calls)}
 case "$1" in
   # try-restart is a no-op on a stopped unit and reports success either way —
   # exactly what the real one does, and why the script uses it.
   try-restart) exit 0 ;;
-  list-unit-files) exit ${opts.unitExists === false ? 1 : 0} ;;
+  # Only a unit that is not installed at all goes unlisted. Verbatim shape of
+  # what the Hermes box prints: "clawbox-gateway.service masked enabled".
+  list-unit-files)
+    ${loadState === "not-found"
+      ? "exit 1"
+      : `echo "clawbox-gateway.service ${loadState === "masked" ? "masked" : "enabled"} enabled"`}
+    ;;
+  show) echo ${JSON.stringify(loadState)} ;;
   *) exit 0 ;;
 esac`);
 
@@ -161,8 +179,8 @@ function env(extra: Record<string, string> = {}): NodeJS.ProcessEnv {
   };
 }
 
-function runDispatcher(iface: string, action: string): void {
-  const r = spawnSync("bash", [DISPATCHER, iface, action], { env: env(), encoding: "utf-8", timeout: 25_000 });
+function runDispatcher(iface: string, action: string, extraEnv: Record<string, string> = {}): void {
+  const r = spawnSync("bash", [DISPATCHER, iface, action], { env: env(extraEnv), encoding: "utf-8", timeout: 25_000 });
   expect(r.status).toBe(0);
 }
 
@@ -268,15 +286,49 @@ describe("Ethernet failover does not restart the gateway into a dead network", (
     expect(restarts()).toBe(0);
   });
 
-  it("does nothing at all on an edition with no gateway unit", () => {
-    // Hermes stops, disables and MASKS clawbox-gateway.service, and its agent
-    // never has sockets to drop. A two-minute wait there is pure journal noise.
-    makeBox({ connectivity: ["none"], unitExists: false });
+  it("does nothing at all on an edition where the unit was never installed", () => {
+    makeBox({ connectivity: ["none"], unitLoadState: "not-found" });
 
     runWaiter("Ethernet 'eth0' down", { CLAWBOX_SKIP_UNIT_CHECK: "0" });
 
     expect(restarts()).toBe(0);
     expect(journal()).toBe("");
+  });
+
+  it("does nothing at all on the Hermes edition, where the unit is MASKED rather than absent", () => {
+    // The Hermes SKU stops, disables and MASKS clawbox-gateway.service, and its
+    // agent never has sockets to drop — so there is nothing here to do.
+    //
+    // But a masked unit is still LISTED. Measured read-only on the Hermes box:
+    // `systemctl list-unit-files clawbox-gateway.service` prints
+    // "clawbox-gateway.service masked enabled" and exits 0. A guard reading
+    // that exit status therefore fires on no edition at all: every
+    // NetworkManager event on Hermes — eth up/down, WiFi up, dhcp4-change,
+    // connectivity-change — started a waiter that ended either in a
+    // `try-restart` on a masked unit and a "restart request … failed" journal
+    // line about a box where nothing is wrong, or in a full 120 s wait. The
+    // false-failure class, on the edition the shared-tools rule says this must
+    // work on.
+    //
+    // `full` connectivity, so a guard that does not fire restarts immediately
+    // rather than after a wait — the failure is the restart, not the delay.
+    makeBox({ connectivity: ["full"], unitLoadState: "masked" });
+
+    runWaiter("Ethernet 'eth0' up", { CLAWBOX_SKIP_UNIT_CHECK: "0" });
+
+    expect(restarts()).toBe(0);
+    expect(journal()).toBe("");
+  });
+
+  it("still restarts on the edition that does have a live gateway unit", () => {
+    // The other half of the guard, and the reason it reads LoadState rather
+    // than simply refusing: a check that skipped every edition would silence
+    // GH #529's fix on the edition that needs it.
+    makeBox({ connectivity: ["full"], unitLoadState: "loaded" });
+
+    runWaiter("Ethernet 'eth0' up", { CLAWBOX_SKIP_UNIT_CHECK: "0" });
+
+    expect(restarts()).toBe(1);
   });
 
   it("takes a request that arrived while it was waiting rather than losing it", () => {
@@ -403,5 +455,164 @@ describe("the dispatcher hands the restart to the waiter rather than firing it",
     await new Promise((resolve) => setTimeout(resolve, 300));
     expect(restarts()).toBe(0);
     expect(deferred()).toHaveLength(0);
+  });
+
+  it("ignores every transition of the box's own recovery AP", async () => {
+    // The AP is not a network this box got onto — it is the one it is
+    // offering, with no default route. ap-watchdog.sh re-raises it every ~20 s
+    // while setup is incomplete, so without this skip each of those would start
+    // a full wait, take the lock, and drop a genuine Ethernet request meanwhile.
+    makeBox({ connectivity: ["full"] });
+
+    runDispatcher("wlan0", "up", { CONNECTION_ID: "ClawBox-Setup" });
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(deferred()).toHaveLength(0);
+    expect(restarts()).toBe(0);
+  });
+
+  it("asks for the restart when a DHCP lease lands after an association", async () => {
+    // The lease arrives a second or two after the `up` the interface arm sees,
+    // which is precisely why `up` alone was not enough.
+    makeBox({ connectivity: ["full"] });
+
+    runDispatcher("wlan0", "dhcp4-change");
+
+    const asked = await deferredEventually(1);
+    expect(asked).toHaveLength(1);
+    expect(asked[0]).toContain("DHCP lease on 'wlan0'");
+  });
+
+  it("asks for the restart when NetworkManager itself confirms full connectivity", async () => {
+    // The upstream-router-reboot shape: carrier never drops, so there is no
+    // up/down and no new lease, and this is the only event that fires.
+    makeBox({ connectivity: ["full"] });
+
+    runDispatcher("eth0", "connectivity-change", { CONNECTIVITY_STATE: "FULL" });
+
+    const asked = await deferredEventually(1);
+    expect(asked).toHaveLength(1);
+    expect(asked[0]).toContain("full connectivity");
+  });
+
+  it("does not ask on a connectivity state NetworkManager has not resolved", async () => {
+    // Deliberate, and not the waiter's rule inverted. The waiter is lenient
+    // about NM's verdict because it decides whether a restart can SUCCEED. This
+    // arm decides whether an event is worth ASKING about, and `full` is NM's
+    // only positive statement — `portal`, `limited` and `unknown` mean "not
+    // decided". Since the waiter accepts a working ping whatever NM thinks,
+    // dispatching on those would bounce a healthy gateway mid-conversation
+    // every time a flaky connectivity check flapped.
+    makeBox({ connectivity: ["full"] });
+
+    runDispatcher("eth0", "connectivity-change", { CONNECTIVITY_STATE: "LIMITED" });
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(deferred()).toHaveLength(0);
+  });
+});
+
+/**
+ * The installer half of the same feature. The dispatcher is inert without the
+ * root-owned waiter it defers the restart to, so `step_nm_dispatcher` installs
+ * both — and it is called from `step_post_update`, the path every field box
+ * takes on an in-app update, as
+ *
+ *     step_nm_dispatcher || echo "  Warning: nm_dispatcher step failed (non-fatal)"
+ *
+ * Bash suspends `set -e` for the whole dynamic extent of a function run in a
+ * condition context, so on that path a failed install is not fatal and not even
+ * visible unless the step says so itself. These run the REAL function out of
+ * install.sh in both shapes.
+ */
+describe("the installer reports what it actually installed", () => {
+  const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
+
+  /** The house pattern: lift the real function out of install.sh and run it. */
+  function shellFunction(name: string): string {
+    const start = INSTALL_SH.indexOf(`${name}() {`);
+    if (start < 0) throw new Error(`${name} not found in install.sh`);
+    const end = INSTALL_SH.indexOf("\n}", start);
+    if (end < 0) throw new Error(`${name} has no closing brace`);
+    return INSTALL_SH.slice(start, end + 2);
+  }
+
+  function runStep(opts: { waiterInstallFails?: boolean; shape: "update" | "fresh" }) {
+    const project = path.join(root, "project");
+    const dispatcherDir = path.join(root, "dispatcher.d");
+    const libexec = path.join(root, "root-libexec");
+    mkdirSync(path.join(project, "scripts"), { recursive: true });
+    copyFileSync(DISPATCHER, path.join(project, "scripts", "nm-dispatcher-failover.sh"));
+    copyFileSync(WAITER, path.join(project, "scripts", "gateway-restart-when-online.sh"));
+
+    const body = shellFunction("step_nm_dispatcher")
+      .replace("/etc/NetworkManager/dispatcher.d", dispatcherDir);
+
+    const script = [
+      // install.sh's own options, which are half of what this is about.
+      "set -euo pipefail",
+      `PROJECT_DIR=${JSON.stringify(project)}`,
+      `ROOT_LIBEXEC_DIR=${JSON.stringify(libexec)}`,
+      // Not root in a test: ownership is not what is under test here.
+      "chown() { :; }",
+      // The step's only `install` call is `install -d … "$ROOT_LIBEXEC_DIR"`.
+      "install() { for a; do :; done; mkdir -p \"$a\"; }",
+      opts.waiterInstallFails
+        ? "install_root_file() { return 1; }"
+        : "install_root_file() { cp \"$1\" \"$2\"; }",
+      body,
+      opts.shape === "update"
+        // Verbatim from step_post_update.
+        ? 'step_nm_dispatcher || echo "  Warning: nm_dispatcher step failed (non-fatal)"'
+        : "step_nm_dispatcher",
+    ].join("\n");
+
+    const r = spawnSync("bash", ["-c", script], { encoding: "utf-8", timeout: 25_000 });
+    return { status: r.status, out: `${r.stdout}${r.stderr}`, libexec };
+  }
+
+  it("does not claim the deferred-restart helper is installed when it is not", () => {
+    // The false-success class. `install_root_file` returns 1 on both of its
+    // failure paths — a full or read-only /usr — and leaves the PREVIOUS copy
+    // in place, so the operator is told a new waiter landed while a stale one,
+    // or none, is what the dispatcher will call.
+    makeBox();
+
+    const r = runStep({ waiterInstallFails: true, shape: "update" });
+
+    expect(r.out).not.toContain("Deferred gateway-restart helper installed");
+    expect(r.out).toContain("could not install the deferred gateway-restart helper");
+  });
+
+  it("reports the failed step to step_post_update instead of returning success", () => {
+    // Without this the `|| echo "Warning: nm_dispatcher step failed"` in
+    // step_post_update can never fire: the function returned 0 from its last
+    // echo, so the update path reported a clean step over a missing waiter.
+    makeBox();
+
+    const r = runStep({ waiterInstallFails: true, shape: "update" });
+
+    expect(r.out).toContain("nm_dispatcher step failed");
+    expect(r.out).not.toContain("NetworkManager failover dispatcher installed");
+  });
+
+  it("still aborts the fresh install, where a failure is fatal by design", () => {
+    makeBox();
+
+    const r = runStep({ waiterInstallFails: true, shape: "fresh" });
+
+    expect(r.status).not.toBe(0);
+  });
+
+  it("installs both halves and says so when the install really succeeds", () => {
+    makeBox();
+
+    const r = runStep({ shape: "update" });
+
+    expect(r.status).toBe(0);
+    expect(r.out).toContain("Deferred gateway-restart helper installed");
+    expect(r.out).toContain("NetworkManager failover dispatcher installed");
+    expect(r.out).not.toContain("Warning");
+    expect(existsSync(path.join(r.libexec, "gateway-restart-when-online.sh"))).toBe(true);
   });
 });

--- a/src/tests/unit/failover-waits-for-route.test.ts
+++ b/src/tests/unit/failover-waits-for-route.test.ts
@@ -443,6 +443,13 @@ describe("Ethernet failover does not restart the gateway into a dead network", (
     makeBox({ connectivity: ["full"] });
     const lock = path.join(root, "run", "gateway-online-restart.lock");
     const holder = spawn("flock", ["-n", lock, "-c", "sleep 20"], { stdio: "ignore" });
+    // `spawn` reports a missing executable asynchronously, and a ChildProcess
+    // with no `error` listener turns that into an uncaught exception that fails
+    // the entire run rather than this one case. flock is util-linux and is not
+    // guaranteed on every runner image.
+    holder.on("error", (err) => {
+      throw new Error(`flock is required for this test: ${err.message}`);
+    });
     try {
       await new Promise((resolve) => setTimeout(resolve, 500));
       const r = spawnSync("bash", [path.join(root, "libexec", "gateway-restart-when-online.sh"), "second"], {
@@ -629,7 +636,18 @@ describe("the installer reports what it actually installed", () => {
     if (start < 0) throw new Error(`${name} not found in install.sh`);
     const end = INSTALL_SH.indexOf("\n}", start);
     if (end < 0) throw new Error(`${name} has no closing brace`);
-    return INSTALL_SH.slice(start, end + 2);
+    const body = INSTALL_SH.slice(start, end + 2);
+    // The terminator is the first line starting with `}`, which is how every
+    // top-level function in install.sh closes — but a heredoc or an awk program
+    // inside the step could contain one and silently cut the body short. A
+    // truncated body is worse than a broken test: bash would fail to parse it,
+    // and every `not.toContain(...)` assertion below would then pass vacuously.
+    const opens = (body.match(/\{/g) ?? []).length;
+    const closes = (body.match(/\}/g) ?? []).length;
+    if (opens !== closes) {
+      throw new Error(`${name} was extracted truncated from install.sh (${opens} { vs ${closes} })`);
+    }
+    return body;
   }
 
   function runStep(opts: { waiterInstallFails?: boolean; dispatcherInstallFails?: boolean; shape: "update" | "fresh" }) {
@@ -641,7 +659,13 @@ describe("the installer reports what it actually installed", () => {
     copyFileSync(WAITER, path.join(project, "scripts", "gateway-restart-when-online.sh"));
 
     const body = shellFunction("step_nm_dispatcher")
-      .replace("/etc/NetworkManager/dispatcher.d", dispatcherDir);
+      .replaceAll("/etc/NetworkManager/dispatcher.d", dispatcherDir);
+    // Fail fast rather than write into the developer's or the runner's real
+    // dispatcher directory: `replace` with a string pattern rewrites only the
+    // first match, so a second literal added later would escape the sandbox.
+    if (body.includes("/etc/NetworkManager")) {
+      throw new Error("step_nm_dispatcher still references a real system path after redirection");
+    }
 
     const script = [
       // install.sh's own options, which are half of what this is about.

--- a/src/tests/unit/failover-waits-for-route.test.ts
+++ b/src/tests/unit/failover-waits-for-route.test.ts
@@ -62,6 +62,12 @@ interface BoxOptions {
    * Hermes edition went untested.
    */
   unitLoadState?: "loaded" | "masked" | "not-found";
+  /**
+   * `systemctl` itself cannot answer — a `daemon-reexec`, a bus hiccup, or no
+   * systemd at all. Distinct from every value above: it is not evidence that
+   * this edition has no gateway.
+   */
+  unitProbeFails?: boolean;
   /** Whether `curl` is on PATH for the HTTPS half of the probe. */
   curlWorks?: boolean;
   /** Drop a re-arm marker once, from inside the poll loop. */
@@ -130,14 +136,26 @@ case "$1" in
   # try-restart is a no-op on a stopped unit and reports success either way —
   # exactly what the real one does, and why the script uses it.
   try-restart) exit 0 ;;
-  # Only a unit that is not installed at all goes unlisted. Verbatim shape of
-  # what the Hermes box prints: "clawbox-gateway.service masked enabled".
+  # Kept, and kept FAITHFUL, although the shipped script no longer asks this:
+  # only a unit that is not installed at all goes unlisted, so a regression to
+  # this question turns the masked case below red instead of quietly passing.
+  # Verbatim shape of what the Hermes box prints:
+  # "clawbox-gateway.service masked enabled".
   list-unit-files)
     ${loadState === "not-found"
       ? "exit 1"
       : `echo "clawbox-gateway.service ${loadState === "masked" ? "masked" : "enabled"} enabled"`}
     ;;
-  show) echo ${JSON.stringify(loadState)} ;;
+  # Matched on the PROPERTY, not just the verb, so a change to some other
+  # 'systemctl show -p ...' cannot keep passing on this answer.
+  show)
+    case "$*" in
+      *"-p LoadState"*) ${opts.unitProbeFails
+        ? 'echo "Failed to connect to bus" >&2; exit 1'
+        : `echo ${JSON.stringify(loadState)}`} ;;
+      *) exit 0 ;;
+    esac
+    ;;
   *) exit 0 ;;
 esac`);
 
@@ -320,6 +338,21 @@ describe("Ethernet failover does not restart the gateway into a dead network", (
     expect(journal()).toBe("");
   });
 
+  it("says so, rather than standing down silently, when systemctl cannot answer", () => {
+    // `2>/dev/null` plus a `!= loaded` test would read "the question could not
+    // be asked" as "this edition has no gateway", and drop the network event
+    // with no trace anywhere — including the `dhcp4-change` that would have
+    // revived the suppressed accounts. src/lib/gateway-health.ts states the
+    // rule for the same property: systemctl not answering "is not evidence
+    // either way".
+    makeBox({ connectivity: ["full"], unitProbeFails: true });
+
+    runWaiter("Ethernet 'eth0' up", { CLAWBOX_SKIP_UNIT_CHECK: "0" });
+
+    expect(restarts()).toBe(0);
+    expect(journal()).toContain("could not read");
+  });
+
   it("still restarts on the edition that does have a live gateway unit", () => {
     // The other half of the guard, and the reason it reads LoadState rather
     // than simply refusing: a check that skipped every edition would silence
@@ -483,6 +516,49 @@ describe("the dispatcher hands the restart to the waiter rather than firing it",
     expect(asked[0]).toContain("DHCP lease on 'wlan0'");
   });
 
+  it("ignores a DHCP lease that renews the same address", async () => {
+    // NM emits dhcp4-change on every T1/T2 renew. Measured on the office LAN:
+    // `dhcp_lease_time = 86400`, so twice a day on a box where nothing at all
+    // has happened — and 24-48 times a day on the one- to two-hour leases
+    // consumer routers and hotel networks hand out. Restarting there bounces a
+    // healthy gateway and drops an in-flight conversation, which is the harm
+    // the rest of this script exists to avoid.
+    makeBox({ connectivity: ["full"] });
+    const lease = { IP4_ADDRESS_0: "192.0.2.50/24 192.0.2.1", IP4_GATEWAY: "192.0.2.1" };
+
+    runDispatcher("eth0", "dhcp4-change", lease);
+    expect(await deferredEventually(1)).toHaveLength(1);
+
+    runDispatcher("eth0", "dhcp4-change", lease);
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(deferred()).toHaveLength(1);
+  });
+
+  it("asks again when a lease actually moves the box", async () => {
+    // The other half: a lease that changes the address or the gateway IS a
+    // network change, and the sockets bound to the old address are dead.
+    makeBox({ connectivity: ["full"] });
+
+    runDispatcher("eth0", "dhcp4-change", { IP4_ADDRESS_0: "192.0.2.50/24 192.0.2.1", IP4_GATEWAY: "192.0.2.1" });
+    expect(await deferredEventually(1)).toHaveLength(1);
+
+    runDispatcher("eth0", "dhcp4-change", { IP4_ADDRESS_0: "198.51.100.7/24 198.51.100.1", IP4_GATEWAY: "198.51.100.1" });
+
+    expect(await deferredEventually(2)).toHaveLength(2);
+  });
+
+  it("ignores a DHCP lease on an interface this box does not route through", async () => {
+    // The arm ran before the interface filter, so a docker or veth lease asked
+    // for a gateway restart too.
+    makeBox({ connectivity: ["full"] });
+
+    runDispatcher("docker0", "dhcp4-change");
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(deferred()).toHaveLength(0);
+  });
+
   it("asks for the restart when NetworkManager itself confirms full connectivity", async () => {
     // The upstream-router-reboot shape: carrier never drops, so there is no
     // up/down and no new lease, and this is the only event that fires.
@@ -537,13 +613,20 @@ describe("the installer reports what it actually installed", () => {
     return INSTALL_SH.slice(start, end + 2);
   }
 
-  function runStep(opts: { waiterInstallFails?: boolean; shape: "update" | "fresh" }) {
+  function runStep(opts: { waiterInstallFails?: boolean; dispatcherDirReadOnly?: boolean; shape: "update" | "fresh" }) {
     const project = path.join(root, "project");
     const dispatcherDir = path.join(root, "dispatcher.d");
     const libexec = path.join(root, "root-libexec");
     mkdirSync(path.join(project, "scripts"), { recursive: true });
     copyFileSync(DISPATCHER, path.join(project, "scripts", "nm-dispatcher-failover.sh"));
     copyFileSync(WAITER, path.join(project, "scripts", "gateway-restart-when-online.sh"));
+
+    if (opts.dispatcherDirReadOnly) {
+      // A full or read-only /etc is the likelier failure of the two, and it is
+      // the half `install_root_file` does not cover.
+      mkdirSync(dispatcherDir, { recursive: true });
+      chmodSync(dispatcherDir, 0o555);
+    }
 
     const body = shellFunction("step_nm_dispatcher")
       .replace("/etc/NetworkManager/dispatcher.d", dispatcherDir);
@@ -560,6 +643,10 @@ describe("the installer reports what it actually installed", () => {
       opts.waiterInstallFails
         ? "install_root_file() { return 1; }"
         : "install_root_file() { cp \"$1\" \"$2\"; }",
+      // The real one stamps $PROVISION_STATUS_FILE, which the dashboard and the
+      // flash host read. A step that only warns leaves the update's own verdict
+      // saying it was clean.
+      'record_provision_failure() { echo "provision-failure: $1"; }',
       body,
       opts.shape === "update"
         // Verbatim from step_post_update.
@@ -582,6 +669,7 @@ describe("the installer reports what it actually installed", () => {
 
     expect(r.out).not.toContain("Deferred gateway-restart helper installed");
     expect(r.out).toContain("could not install the deferred gateway-restart helper");
+    expect(r.out).toContain("provision-failure: nm_dispatcher");
   });
 
   it("reports the failed step to step_post_update instead of returning success", () => {
@@ -594,6 +682,21 @@ describe("the installer reports what it actually installed", () => {
 
     expect(r.out).toContain("nm_dispatcher step failed");
     expect(r.out).not.toContain("NetworkManager failover dispatcher installed");
+  });
+
+  it("does not claim the dispatcher is installed when the copy failed", () => {
+    // The other half of the same function, and the one that fires on a full or
+    // read-only /etc: `cp`, `chown` and `chmod` were unchecked too, so the
+    // update path printed "NetworkManager failover dispatcher installed" over
+    // a dispatcher that never landed.
+    makeBox();
+
+    const r = runStep({ dispatcherDirReadOnly: true, shape: "update" });
+
+    expect(r.out).not.toContain("NetworkManager failover dispatcher installed");
+    expect(r.out).toContain("could not install the NetworkManager failover dispatcher");
+    expect(r.out).toContain("provision-failure: nm_dispatcher");
+    expect(r.out).toContain("nm_dispatcher step failed");
   });
 
   it("still aborts the fresh install, where a failure is fatal by design", () => {
@@ -613,6 +716,7 @@ describe("the installer reports what it actually installed", () => {
     expect(r.out).toContain("Deferred gateway-restart helper installed");
     expect(r.out).toContain("NetworkManager failover dispatcher installed");
     expect(r.out).not.toContain("Warning");
+    expect(r.out).not.toContain("provision-failure");
     expect(existsSync(path.join(r.libexec, "gateway-restart-when-online.sh"))).toBe(true);
   });
 });

--- a/src/tests/unit/failover-waits-for-route.test.ts
+++ b/src/tests/unit/failover-waits-for-route.test.ts
@@ -364,6 +364,26 @@ describe("Ethernet failover does not restart the gateway into a dead network", (
     expect(restarts()).toBe(1);
   });
 
+  it("says so, rather than dropping the event, when the lock file cannot be opened", () => {
+    // `exec 9>"$LOCK_FILE" || exit 0` cannot do what it looks like it does: a
+    // failed redirection on `exec` kills a non-interactive bash outright, so
+    // the `||` fallback never runs and the network event vanishes with nothing
+    // in the journal. Same silent-drop shape as reading a failed systemctl
+    // probe as "this edition has no gateway".
+    makeBox({ connectivity: ["full"] });
+    const runDir = path.join(root, "run");
+    chmodSync(runDir, 0o555);
+    try {
+      runWaiter("Ethernet 'eth0' up");
+
+      expect(journal()).toContain("no single-waiter guard");
+      // ...and the wait still happens: dropping the event is the worse failure.
+      expect(restarts()).toBe(1);
+    } finally {
+      chmodSync(runDir, 0o755);
+    }
+  });
+
   it("takes a request that arrived while it was waiting rather than losing it", () => {
     // `flock -n` turns an overlapping event into a no-op with no memory of it,
     // so a waiter could time out one second before the route landed having
@@ -636,13 +656,17 @@ describe("the installer reports what it actually installed", () => {
       "set -euo pipefail",
       `PROJECT_DIR=${JSON.stringify(project)}`,
       `ROOT_LIBEXEC_DIR=${JSON.stringify(libexec)}`,
-      // Not root in a test: ownership is not what is under test here.
-      "chown() { :; }",
       // The step's only `install` call is `install -d … "$ROOT_LIBEXEC_DIR"`.
       "install() { for a; do :; done; mkdir -p \"$a\"; }",
-      opts.waiterInstallFails
-        ? "install_root_file() { return 1; }"
-        : "install_root_file() { cp \"$1\" \"$2\"; }",
+      // Modelled on the real install_root_file: stage "$dst.new", then rename,
+      // so the test exercises the atomicity the dispatcher now depends on. Not
+      // root in a test, so ownership is dropped rather than faked.
+      'install_root_file() { cp "$1" "$2.new" && mv -f "$2.new" "$2"; }',
+      // The dispatcher goes through install_root_file too, so a blanket failure
+      // would fire on the wrong half — fail only the waiter's destination.
+      ...(opts.waiterInstallFails
+        ? ['install_root_file() { case "$2" in *gateway-restart-when-online.sh) return 1 ;; esac; cp "$1" "$2.new" && mv -f "$2.new" "$2"; }']
+        : []),
       // The real one stamps $PROVISION_STATUS_FILE, which the dashboard and the
       // flash host read. A step that only warns leaves the update's own verdict
       // saying it was clean.
@@ -655,7 +679,7 @@ describe("the installer reports what it actually installed", () => {
     ].join("\n");
 
     const r = spawnSync("bash", ["-c", script], { encoding: "utf-8", timeout: 25_000 });
-    return { status: r.status, out: `${r.stdout}${r.stderr}`, libexec };
+    return { status: r.status, out: `${r.stdout}${r.stderr}`, libexec, dispatcherDir };
   }
 
   it("does not claim the deferred-restart helper is installed when it is not", () => {
@@ -718,5 +742,8 @@ describe("the installer reports what it actually installed", () => {
     expect(r.out).not.toContain("Warning");
     expect(r.out).not.toContain("provision-failure");
     expect(existsSync(path.join(r.libexec, "gateway-restart-when-online.sh"))).toBe(true);
+    // The staged copy is renamed, never left behind for NetworkManager to find.
+    expect(existsSync(path.join(r.dispatcherDir, "90-clawbox-failover"))).toBe(true);
+    expect(existsSync(path.join(r.dispatcherDir, "90-clawbox-failover.new"))).toBe(false);
   });
 });

--- a/src/tests/unit/failover-waits-for-route.test.ts
+++ b/src/tests/unit/failover-waits-for-route.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync, copyFileSync, chmodSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/**
+ * GH #529 / TASK-664. `scripts/nm-dispatcher-failover.sh` restarted the OpenClaw
+ * gateway the moment Ethernet carrier dropped, before anything had proven a
+ * replacement route existed.
+ *
+ * On a headless box with no other uplink the gateway came back into a dead
+ * network: Telegram's startup hit ENETUNREACH, the release died three times on
+ * the unhandled socket error, and OpenClaw's account supervisor gave up. The
+ * gateway kept running with BOTH Telegram accounts stopped — and when Ethernet
+ * and DHCP recovered they stayed stopped until someone started them by hand.
+ *
+ * The restart is both the cause and the cure, so it is deferred rather than
+ * dropped: the suppression lives in the gateway PROCESS (a RetrySupervisor in a
+ * Map; `openclaw channels` has no start/resume verb), so a fresh process is the
+ * only way back, and it has to land after the route does.
+ *
+ * These EXECUTE the shipped scripts against stubbed nmcli / ip / ping /
+ * systemctl and assert on what was actually invoked. Grepping the source would
+ * pass on a rewrite that kept the words and dropped the deferral.
+ */
+
+// Starts real processes (bash, and a helper that sleeps between polls): vitest's
+// 5 s test and 10 s hook defaults are not enough. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+const REPO = process.cwd();
+const DISPATCHER = path.join(REPO, "scripts", "nm-dispatcher-failover.sh");
+const WAITER = path.join(REPO, "scripts", "gateway-restart-when-online.sh");
+const hasBash = spawnSync("bash", ["--version"], { stdio: "ignore" }).status === 0;
+
+// Unconditional, not skipIf: a runner without bash would report green while
+// proving nothing about the one script standing between a carrier blip and a
+// box that stops answering on Telegram until somebody notices.
+beforeAll(() => {
+  if (!hasBash) {
+    throw new Error("bash is required: these tests execute the shipped scripts rather than reading them");
+  }
+});
+
+let root: string;
+let bin: string;
+
+interface BoxOptions {
+  /** What `nmcli -t networking connectivity check` answers, in order. */
+  connectivity?: string[];
+  /** Whether `ip route show default` prints a route. */
+  defaultRoute?: boolean;
+  /** Whether `ping` succeeds. */
+  pingWorks?: boolean;
+  /** Whether the gateway unit is active. */
+  gatewayActive?: boolean;
+}
+
+/** A fake CLAWBOX_ROOT plus a PATH of stubs, so nothing touches a real radio. */
+function makeBox(opts: BoxOptions = {}): void {
+  root = mkdtempSync(path.join(tmpdir(), "clawbox-failover-"));
+  bin = path.join(root, "bin");
+  mkdirSync(path.join(root, "data"), { recursive: true });
+  mkdirSync(path.join(root, "scripts"), { recursive: true });
+  mkdirSync(bin, { recursive: true });
+
+  // The shipped waiter, where the dispatcher looks for it.
+  copyFileSync(WAITER, path.join(root, "scripts", "gateway-restart-when-online.sh"));
+  chmodSync(path.join(root, "scripts", "gateway-restart-when-online.sh"), 0o755);
+
+  const stub = (name: string, body: string) => {
+    const file = path.join(bin, name);
+    writeFileSync(file, `#!/usr/bin/env bash\n${body}\n`, { mode: 0o755 });
+  };
+
+  const calls = path.join(root, "calls.log");
+  writeFileSync(calls, "");
+
+  // A queue of connectivity answers, consumed one per call, last one repeating
+  // — so a test can say "none, none, then full" and watch the waiter wait.
+  writeFileSync(path.join(root, "connectivity"), (opts.connectivity ?? ["none"]).join("\n") + "\n");
+  stub("nmcli", `
+echo "nmcli $*" >> ${JSON.stringify(calls)}
+case "$*" in
+  *"networking connectivity check"*)
+    q=${JSON.stringify(path.join(root, "connectivity"))}
+    head -n 1 "$q"
+    if [ "$(wc -l < "$q")" -gt 1 ]; then tail -n +2 "$q" > "$q.next" && mv "$q.next" "$q"; fi
+    ;;
+  *) exit 0 ;;
+esac`);
+
+  stub("ip", `
+echo "ip $*" >> ${JSON.stringify(calls)}
+${opts.defaultRoute ? 'echo "default via 192.0.2.1 dev eth0"' : "true"}`);
+
+  stub("ping", `
+echo "ping $*" >> ${JSON.stringify(calls)}
+exit ${opts.pingWorks ? 0 : 1}`);
+
+  stub("systemctl", `
+echo "systemctl $*" >> ${JSON.stringify(calls)}
+case "$1" in
+  is-active) exit ${opts.gatewayActive === false ? 1 : 0} ;;
+  *) exit 0 ;;
+esac`);
+
+  stub("logger", `
+shift 2 2>/dev/null || true
+echo "log $*" >> ${JSON.stringify(root + "/journal.log")}`);
+
+  // Real `sleep` would make a 120 s wait a 120 s test.
+  stub("sleep", "true");
+  // The dispatcher launches the waiter DETACHED, so a test that let it run
+  // would be racing it. Record the request instead: the dispatcher's contract
+  // is that it asks and returns, and the waiter's own decisions are exercised
+  // directly above.
+  stub("setsid", `echo "detached $*" >> ${JSON.stringify(calls)}`);
+}
+
+afterEach(() => { rmSync(root, { recursive: true, force: true }); });
+
+function env(extra: Record<string, string> = {}): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    PATH: `${bin}:${process.env.PATH}`,
+    CLAWBOX_ROOT: root,
+    CLAWBOX_ONLINE_TIMEOUT: "2",
+    CLAWBOX_ONLINE_POLL: "1",
+    NETWORK_INTERFACE: "wlan0",
+    ...extra,
+  };
+}
+
+function runDispatcher(iface: string, action: string): void {
+  const r = spawnSync("bash", [DISPATCHER, iface, action], { env: env(), encoding: "utf-8", timeout: 25_000 });
+  expect(r.status).toBe(0);
+}
+
+function runWaiter(reason = "test"): { stdout: string } {
+  const r = spawnSync("bash", [path.join(root, "scripts", "gateway-restart-when-online.sh"), reason], {
+    env: env(),
+    encoding: "utf-8",
+    timeout: 25_000,
+  });
+  expect(r.status).toBe(0);
+  return { stdout: r.stdout };
+}
+
+function calls(): string {
+  return existsSync(path.join(root, "calls.log")) ? readFileSync(path.join(root, "calls.log"), "utf-8") : "";
+}
+
+function journal(): string {
+  const f = path.join(root, "journal.log");
+  return existsSync(f) ? readFileSync(f, "utf-8") : "";
+}
+
+function restarts(): number {
+  return calls().split("\n").filter((l) => l.startsWith("systemctl restart")).length;
+}
+
+/**
+ * Detached waiter launches the dispatcher asked for, with their reasons.
+ *
+ * Polled: the dispatcher backgrounds the launch and returns without waiting for
+ * it, which is the property under test — so the assertion has to allow for the
+ * child landing a moment after the parent exits.
+ */
+async function deferredEventually(expected: number): Promise<string[]> {
+  const deadline = Date.now() + 5_000;
+  for (;;) {
+    const seen = deferred();
+    if (seen.length >= expected || Date.now() > deadline) return seen;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+function deferred(): string[] {
+  return calls()
+    .split("\n")
+    .filter((l) => l.startsWith("detached ") && l.includes("gateway-restart-when-online.sh"));
+}
+
+describe("Ethernet failover does not restart the gateway into a dead network", () => {
+  it("does not restart while no public route exists", () => {
+    // The whole defect: the restart landed here, and the accounts never came
+    // back from it.
+    makeBox({ connectivity: ["none"], defaultRoute: false });
+
+    runWaiter("Ethernet 'eth0' down");
+
+    expect(restarts()).toBe(0);
+    expect(journal()).toContain("NOT restarting");
+  });
+
+  it("does not restart on a captive portal or a link with no internet", () => {
+    // `portal` and `limited` are precisely "carrier is up, the internet is
+    // not" — the state that makes a restart harmful rather than useless.
+    for (const state of ["portal", "limited"]) {
+      makeBox({ connectivity: [state], defaultRoute: true, pingWorks: true });
+      runWaiter(`Ethernet 'eth0' down (${state})`);
+      expect(restarts()).toBe(0);
+      rmSync(root, { recursive: true, force: true });
+      makeBox();
+    }
+  });
+
+  it("restarts as soon as the route returns, which is what revives the suppressed accounts", () => {
+    // The suppression lives in the gateway process — OpenClaw's channel
+    // RetrySupervisor, with no CLI verb to start an account again — so the
+    // restart IS the recovery, and it has to land after the route.
+    makeBox({ connectivity: ["none", "none", "full"], defaultRoute: false });
+
+    runWaiter("Ethernet 'eth0' down");
+
+    expect(restarts()).toBe(1);
+    expect(calls()).toContain("systemctl restart clawbox-gateway.service");
+    expect(journal()).toContain("suppressed channel accounts start again");
+  });
+
+  it("accepts a route NetworkManager itself cannot judge, when the box can really reach out", () => {
+    // Connectivity checking is often disabled on an appliance image, and
+    // `unknown` must not be read as "offline" for ever.
+    makeBox({ connectivity: ["unknown"], defaultRoute: true, pingWorks: true });
+
+    runWaiter("Ethernet 'eth0' up");
+
+    expect(restarts()).toBe(1);
+  });
+
+  it("does not start a gateway the owner stopped", () => {
+    makeBox({ connectivity: ["full"], gatewayActive: false });
+
+    runWaiter("Ethernet 'eth0' up");
+
+    expect(restarts()).toBe(0);
+    expect(journal()).toContain("is not running");
+  });
+
+  it("lets one waiter hold the wait, so a flapping carrier cannot stack restarts", async () => {
+    // Overlapping NetworkManager events — a carrier that flaps, or eth down
+    // then wifi up — would otherwise stack several waits and fire several
+    // restarts the moment the route returned, which is its own way of tripping
+    // the account supervisor.
+    makeBox({ connectivity: ["full"] });
+    const lock = path.join(root, "data", "gateway-online-restart.lock");
+    const holder = spawn("flock", ["-n", lock, "-c", "sleep 20"], { stdio: "ignore" });
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      const r = spawnSync("bash", [path.join(root, "scripts", "gateway-restart-when-online.sh"), "second"], {
+        env: env(),
+        encoding: "utf-8",
+        timeout: 25_000,
+      });
+      expect(r.status).toBe(0);
+      expect(journal()).toContain("already pending");
+      expect(restarts()).toBe(0);
+    } finally {
+      holder.kill();
+    }
+  });
+});
+
+describe("the dispatcher hands the restart to the waiter rather than firing it", () => {
+  it("never restarts the gateway itself on an Ethernet down", async () => {
+    makeBox({ connectivity: ["none"], defaultRoute: false });
+
+    runDispatcher("eth0", "down");
+
+    // It ASKS, and returns. Nothing it did itself touched the gateway.
+    const asked = await deferredEventually(1);
+    expect(asked).toHaveLength(1);
+    expect(asked[0]).toContain("Ethernet 'eth0' down");
+    expect(restarts()).toBe(0);
+  });
+
+  it("never restarts the gateway itself on an Ethernet up either", async () => {
+    // Carrier is not a route: at `up` the interface may still be on DHCP.
+    makeBox({ connectivity: ["none"], defaultRoute: false });
+
+    runDispatcher("eth0", "up");
+
+    const asked = await deferredEventually(1);
+    expect(asked).toHaveLength(1);
+    expect(asked[0]).toContain("Ethernet 'eth0' up");
+    expect(restarts()).toBe(0);
+  });
+
+  it("asks for the restart when the WiFi radio comes up after a failover", async () => {
+    // The recovery half. With only the Ethernet arm, a box that failed over to
+    // WiFi never asked for the restart that revives its channel accounts.
+    makeBox({ connectivity: ["full"] });
+
+    runDispatcher("wlan0", "up");
+
+    const asked = await deferredEventually(1);
+    expect(asked).toHaveLength(1);
+    expect(asked[0]).toContain("WiFi 'wlan0' up");
+  });
+
+  it("ignores an interface that is neither Ethernet nor this box's radio", async () => {
+    makeBox({ connectivity: ["full"] });
+
+    runDispatcher("docker0", "up");
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(restarts()).toBe(0);
+    expect(deferred()).toHaveLength(0);
+  });
+});

--- a/src/tests/unit/failover-waits-for-route.test.ts
+++ b/src/tests/unit/failover-waits-for-route.test.ts
@@ -371,17 +371,16 @@ describe("Ethernet failover does not restart the gateway into a dead network", (
     // in the journal. Same silent-drop shape as reading a failed systemctl
     // probe as "this edition has no gateway".
     makeBox({ connectivity: ["full"] });
-    const runDir = path.join(root, "run");
-    chmodSync(runDir, 0o555);
-    try {
-      runWaiter("Ethernet 'eth0' up");
+    // A DIRECTORY at the lock path, not a read-only parent: root bypasses DAC
+    // write checks, so a 0555 directory stops nobody in a root CI container,
+    // while no uid at all can open a directory for writing.
+    mkdirSync(path.join(root, "run", "gateway-online-restart.lock"), { recursive: true });
 
-      expect(journal()).toContain("no single-waiter guard");
-      // ...and the wait still happens: dropping the event is the worse failure.
-      expect(restarts()).toBe(1);
-    } finally {
-      chmodSync(runDir, 0o755);
-    }
+    runWaiter("Ethernet 'eth0' up");
+
+    expect(journal()).toContain("no single-waiter guard");
+    // ...and the wait still happens: dropping the event is the worse failure.
+    expect(restarts()).toBe(1);
   });
 
   it("takes a request that arrived while it was waiting rather than losing it", () => {
@@ -633,20 +632,13 @@ describe("the installer reports what it actually installed", () => {
     return INSTALL_SH.slice(start, end + 2);
   }
 
-  function runStep(opts: { waiterInstallFails?: boolean; dispatcherDirReadOnly?: boolean; shape: "update" | "fresh" }) {
+  function runStep(opts: { waiterInstallFails?: boolean; dispatcherInstallFails?: boolean; shape: "update" | "fresh" }) {
     const project = path.join(root, "project");
     const dispatcherDir = path.join(root, "dispatcher.d");
     const libexec = path.join(root, "root-libexec");
     mkdirSync(path.join(project, "scripts"), { recursive: true });
     copyFileSync(DISPATCHER, path.join(project, "scripts", "nm-dispatcher-failover.sh"));
     copyFileSync(WAITER, path.join(project, "scripts", "gateway-restart-when-online.sh"));
-
-    if (opts.dispatcherDirReadOnly) {
-      // A full or read-only /etc is the likelier failure of the two, and it is
-      // the half `install_root_file` does not cover.
-      mkdirSync(dispatcherDir, { recursive: true });
-      chmodSync(dispatcherDir, 0o555);
-    }
 
     const body = shellFunction("step_nm_dispatcher")
       .replace("/etc/NetworkManager/dispatcher.d", dispatcherDir);
@@ -662,10 +654,15 @@ describe("the installer reports what it actually installed", () => {
       // so the test exercises the atomicity the dispatcher now depends on. Not
       // root in a test, so ownership is dropped rather than faked.
       'install_root_file() { cp "$1" "$2.new" && mv -f "$2.new" "$2"; }',
-      // The dispatcher goes through install_root_file too, so a blanket failure
-      // would fire on the wrong half — fail only the waiter's destination.
+      // Both halves go through install_root_file, so a blanket failure would
+      // fire on the wrong one — each case fails only its own destination.
+      // Keyed on the path rather than on directory permissions, because root
+      // bypasses DAC write checks and CI may well run as root.
       ...(opts.waiterInstallFails
         ? ['install_root_file() { case "$2" in *gateway-restart-when-online.sh) return 1 ;; esac; cp "$1" "$2.new" && mv -f "$2.new" "$2"; }']
+        : []),
+      ...(opts.dispatcherInstallFails
+        ? ['install_root_file() { case "$2" in *90-clawbox-failover) return 1 ;; esac; cp "$1" "$2.new" && mv -f "$2.new" "$2"; }']
         : []),
       // The real one stamps $PROVISION_STATUS_FILE, which the dashboard and the
       // flash host read. A step that only warns leaves the update's own verdict
@@ -710,12 +707,12 @@ describe("the installer reports what it actually installed", () => {
 
   it("does not claim the dispatcher is installed when the copy failed", () => {
     // The other half of the same function, and the one that fires on a full or
-    // read-only /etc: `cp`, `chown` and `chmod` were unchecked too, so the
-    // update path printed "NetworkManager failover dispatcher installed" over
-    // a dispatcher that never landed.
+    // read-only /etc: the copy was unchecked too, so the update path printed
+    // "NetworkManager failover dispatcher installed" over a dispatcher that
+    // never landed.
     makeBox();
 
-    const r = runStep({ dispatcherDirReadOnly: true, shape: "update" });
+    const r = runStep({ dispatcherInstallFails: true, shape: "update" });
 
     expect(r.out).not.toContain("NetworkManager failover dispatcher installed");
     expect(r.out).toContain("could not install the NetworkManager failover dispatcher");

--- a/src/tests/unit/failover-waits-for-route.test.ts
+++ b/src/tests/unit/failover-waits-for-route.test.ts
@@ -54,8 +54,12 @@ interface BoxOptions {
   defaultRoute?: boolean;
   /** Whether `ping` succeeds. */
   pingWorks?: boolean;
-  /** Whether the gateway unit is active. */
-  gatewayActive?: boolean;
+  /** Whether the gateway unit exists at all (false = the Hermes edition). */
+  unitExists?: boolean;
+  /** Whether `curl` is on PATH for the HTTPS half of the probe. */
+  curlWorks?: boolean;
+  /** Drop a re-arm marker once, from inside the poll loop. */
+  rearmMidWait?: boolean;
 }
 
 /** A fake CLAWBOX_ROOT plus a PATH of stubs, so nothing touches a real radio. */
@@ -66,9 +70,13 @@ function makeBox(opts: BoxOptions = {}): void {
   mkdirSync(path.join(root, "scripts"), { recursive: true });
   mkdirSync(bin, { recursive: true });
 
-  // The shipped waiter, where the dispatcher looks for it.
-  copyFileSync(WAITER, path.join(root, "scripts", "gateway-restart-when-online.sh"));
-  chmodSync(path.join(root, "scripts", "gateway-restart-when-online.sh"), 0o755);
+  // The shipped waiter. On a box it is installed ROOT-OWNED under
+  // /usr/local/libexec/clawbox and the dispatcher is pointed there; the sandbox
+  // stands in for that path through CLAWBOX_ONLINE_WAITER.
+  mkdirSync(path.join(root, "libexec"), { recursive: true });
+  mkdirSync(path.join(root, "run"), { recursive: true });
+  copyFileSync(WAITER, path.join(root, "libexec", "gateway-restart-when-online.sh"));
+  chmodSync(path.join(root, "libexec", "gateway-restart-when-online.sh"), 0o755);
 
   const stub = (name: string, body: string) => {
     const file = path.join(bin, name);
@@ -84,7 +92,7 @@ function makeBox(opts: BoxOptions = {}): void {
   stub("nmcli", `
 echo "nmcli $*" >> ${JSON.stringify(calls)}
 case "$*" in
-  *"networking connectivity check"*)
+  *"networking connectivity"*)
     q=${JSON.stringify(path.join(root, "connectivity"))}
     head -n 1 "$q"
     if [ "$(wc -l < "$q")" -gt 1 ]; then tail -n +2 "$q" > "$q.next" && mv "$q.next" "$q"; fi
@@ -100,10 +108,18 @@ ${opts.defaultRoute ? 'echo "default via 192.0.2.1 dev eth0"' : "true"}`);
 echo "ping $*" >> ${JSON.stringify(calls)}
 exit ${opts.pingWorks ? 0 : 1}`);
 
+  // The updater's own second half: ICMP is blocked on plenty of real networks.
+  stub("curl", `
+echo "curl $*" >> ${JSON.stringify(calls)}
+exit ${opts.curlWorks ? 0 : 1}`);
+
   stub("systemctl", `
 echo "systemctl $*" >> ${JSON.stringify(calls)}
 case "$1" in
-  is-active) exit ${opts.gatewayActive === false ? 1 : 0} ;;
+  # try-restart is a no-op on a stopped unit and reports success either way —
+  # exactly what the real one does, and why the script uses it.
+  try-restart) exit 0 ;;
+  list-unit-files) exit ${opts.unitExists === false ? 1 : 0} ;;
   *) exit 0 ;;
 esac`);
 
@@ -111,8 +127,15 @@ esac`);
 shift 2 2>/dev/null || true
 echo "log $*" >> ${JSON.stringify(root + "/journal.log")}`);
 
-  // Real `sleep` would make a 120 s wait a 120 s test.
-  stub("sleep", "true");
+  // Real `sleep` would make a 120 s wait a 120 s test. It is also the only
+  // hook a test has INSIDE the poll loop, which is where a second network
+  // event would really arrive.
+  stub("sleep", opts.rearmMidWait
+    ? `f=${JSON.stringify(path.join(root, "run", "gateway-online-restart.rearm"))}
+m=${JSON.stringify(path.join(root, "rearmed"))}
+if [ ! -e "$m" ]; then : > "$m"; : > "$f"; fi
+true`
+    : "true");
   // The dispatcher launches the waiter DETACHED, so a test that let it run
   // would be racing it. Record the request instead: the dispatcher's contract
   // is that it asks and returns, and the waiter's own decisions are exercised
@@ -127,8 +150,12 @@ function env(extra: Record<string, string> = {}): NodeJS.ProcessEnv {
     ...process.env,
     PATH: `${bin}:${process.env.PATH}`,
     CLAWBOX_ROOT: root,
+    CLAWBOX_ONLINE_WAITER: path.join(root, "libexec", "gateway-restart-when-online.sh"),
+    CLAWBOX_RUN_DIR: path.join(root, "run"),
     CLAWBOX_ONLINE_TIMEOUT: "2",
     CLAWBOX_ONLINE_POLL: "1",
+    // The unit-existence gate is the Hermes arm; the cases that care set it.
+    CLAWBOX_SKIP_UNIT_CHECK: "1",
     NETWORK_INTERFACE: "wlan0",
     ...extra,
   };
@@ -139,9 +166,9 @@ function runDispatcher(iface: string, action: string): void {
   expect(r.status).toBe(0);
 }
 
-function runWaiter(reason = "test"): { stdout: string } {
-  const r = spawnSync("bash", [path.join(root, "scripts", "gateway-restart-when-online.sh"), reason], {
-    env: env(),
+function runWaiter(reason = "test", extraEnv: Record<string, string> = {}): { stdout: string } {
+  const r = spawnSync("bash", [path.join(root, "libexec", "gateway-restart-when-online.sh"), reason], {
+    env: env(extraEnv),
     encoding: "utf-8",
     timeout: 25_000,
   });
@@ -159,7 +186,7 @@ function journal(): string {
 }
 
 function restarts(): number {
-  return calls().split("\n").filter((l) => l.startsWith("systemctl restart")).length;
+  return calls().split("\n").filter((l) => l.startsWith("systemctl try-restart")).length;
 }
 
 /**
@@ -196,16 +223,71 @@ describe("Ethernet failover does not restart the gateway into a dead network", (
     expect(journal()).toContain("NOT restarting");
   });
 
-  it("does not restart on a captive portal or a link with no internet", () => {
-    // `portal` and `limited` are precisely "carrier is up, the internet is
-    // not" — the state that makes a restart harmful rather than useless.
+  it("does not restart on a captive portal that really has no way out", () => {
+    // `portal` and `limited` are "carrier is up, the internet is not" — the
+    // state that makes a restart harmful rather than merely useless.
     for (const state of ["portal", "limited"]) {
-      makeBox({ connectivity: [state], defaultRoute: true, pingWorks: true });
+      makeBox({ connectivity: [state], defaultRoute: true, pingWorks: false, curlWorks: false });
       runWaiter(`Ethernet 'eth0' down (${state})`);
       expect(restarts()).toBe(0);
       rmSync(root, { recursive: true, force: true });
-      makeBox();
     }
+    makeBox();
+  });
+
+  it("does NOT take NetworkManager's word for it when the box can really reach out", () => {
+    // Connectivity checking is ENABLED on the Ubuntu/JetPack base, pointed at
+    // connectivity-check.ubuntu.com. Any LAN that blocks or hijacks that URL —
+    // a corporate egress filter, a Pi-hole, an ISP NXDOMAIN redirector — parks
+    // NM at `portal` or `limited` permanently while the box reaches Telegram
+    // and Anthropic perfectly well. Treating that as offline would mean the
+    // gateway is never restarted again: GH #529 back through another door.
+    makeBox({ connectivity: ["portal"], defaultRoute: true, pingWorks: true });
+
+    runWaiter("Ethernet 'eth0' up behind a captive-portal check");
+
+    expect(calls()).toContain("ping");
+    expect(restarts()).toBe(1);
+  });
+
+  it("falls back to HTTPS when ICMP is blocked, as the updater does", () => {
+    makeBox({ connectivity: ["limited"], defaultRoute: true, pingWorks: false, curlWorks: true });
+
+    runWaiter("Ethernet 'eth0' up on an ICMP-filtered network");
+
+    expect(calls()).toContain("curl");
+    expect(restarts()).toBe(1);
+  });
+
+  it("does not spend a probe when there is no default route at all", () => {
+    makeBox({ connectivity: ["none"], defaultRoute: false, pingWorks: true });
+
+    runWaiter("Ethernet 'eth0' down");
+
+    expect(calls()).not.toContain("ping");
+    expect(restarts()).toBe(0);
+  });
+
+  it("does nothing at all on an edition with no gateway unit", () => {
+    // Hermes stops, disables and MASKS clawbox-gateway.service, and its agent
+    // never has sockets to drop. A two-minute wait there is pure journal noise.
+    makeBox({ connectivity: ["none"], unitExists: false });
+
+    runWaiter("Ethernet 'eth0' down", { CLAWBOX_SKIP_UNIT_CHECK: "0" });
+
+    expect(restarts()).toBe(0);
+    expect(journal()).toBe("");
+  });
+
+  it("takes a request that arrived while it was waiting rather than losing it", () => {
+    // `flock -n` turns an overlapping event into a no-op with no memory of it,
+    // so a waiter could time out one second before the route landed having
+    // ignored the very event that would have succeeded.
+    makeBox({ connectivity: ["none"], defaultRoute: false, rearmMidWait: true });
+
+    runWaiter("Ethernet 'eth0' down");
+
+    expect(journal()).toContain("extending the wait");
   });
 
   it("restarts as soon as the route returns, which is what revives the suppressed accounts", () => {
@@ -217,8 +299,8 @@ describe("Ethernet failover does not restart the gateway into a dead network", (
     runWaiter("Ethernet 'eth0' down");
 
     expect(restarts()).toBe(1);
-    expect(calls()).toContain("systemctl restart clawbox-gateway.service");
-    expect(journal()).toContain("suppressed channel accounts start again");
+    expect(calls()).toContain("systemctl try-restart clawbox-gateway.service");
+    expect(journal()).toContain("channel accounts its supervisor gave up on");
   });
 
   it("accepts a route NetworkManager itself cannot judge, when the box can really reach out", () => {
@@ -231,13 +313,22 @@ describe("Ethernet failover does not restart the gateway into a dead network", (
     expect(restarts()).toBe(1);
   });
 
-  it("does not start a gateway the owner stopped", () => {
-    makeBox({ connectivity: ["full"], gatewayActive: false });
+  it("asks with try-restart, which cannot start a gateway the owner stopped", () => {
+    // The probe and the action are two commands and the gap is a whole wait
+    // long. `restart` would START a unit that is stopped — deliberately by the
+    // owner, or masked by the Hermes edition — which install.sh forbids in
+    // writing for this same unit. `is-active` would be wrong twice over: it
+    // also reports non-zero for `activating`, and this unit's RestartSec plus a
+    // cold-Jetson TimeoutStartSec make that window minutes long.
+    makeBox({ connectivity: ["full"] });
 
     runWaiter("Ethernet 'eth0' up");
 
-    expect(restarts()).toBe(0);
-    expect(journal()).toContain("is not running");
+    expect(calls()).toContain("systemctl try-restart clawbox-gateway.service");
+    expect(calls()).not.toContain("systemctl restart ");
+    expect(calls()).not.toContain("systemctl is-active");
+    // Asked, not "restarted": the exit code says the request was accepted.
+    expect(journal()).toContain("asked systemd to restart");
   });
 
   it("lets one waiter hold the wait, so a flapping carrier cannot stack restarts", async () => {
@@ -246,17 +337,20 @@ describe("Ethernet failover does not restart the gateway into a dead network", (
     // restarts the moment the route returned, which is its own way of tripping
     // the account supervisor.
     makeBox({ connectivity: ["full"] });
-    const lock = path.join(root, "data", "gateway-online-restart.lock");
+    const lock = path.join(root, "run", "gateway-online-restart.lock");
     const holder = spawn("flock", ["-n", lock, "-c", "sleep 20"], { stdio: "ignore" });
     try {
       await new Promise((resolve) => setTimeout(resolve, 500));
-      const r = spawnSync("bash", [path.join(root, "scripts", "gateway-restart-when-online.sh"), "second"], {
+      const r = spawnSync("bash", [path.join(root, "libexec", "gateway-restart-when-online.sh"), "second"], {
         env: env(),
         encoding: "utf-8",
         timeout: 25_000,
       });
       expect(r.status).toBe(0);
       expect(journal()).toContain("already pending");
+      // ...and the dropped request is REMEMBERED, so the holder does not time
+      // out one second before the route lands having ignored it.
+      expect(existsSync(path.join(root, "run", "gateway-online-restart.rearm"))).toBe(true);
       expect(restarts()).toBe(0);
     } finally {
       holder.kill();


### PR DESCRIPTION
Closes GH #529 / TASK-664. Reference: https://github.com/ID-Robots/clawbox/issues/529

## Customer-visible symptom

An external ClawBox user's Ethernet cable came out. When it went back in, the box answered nobody on Telegram — **both accounts stopped, and they stayed stopped until someone started them by hand**. Nothing on the box said so; the gateway itself was up and the chat worked.

## Cause

`scripts/nm-dispatcher-failover.sh` restarted `clawbox-gateway.service` the moment Ethernet carrier dropped, **before anything had proven a replacement route existed** — and again on carrier `up`, before DHCP had finished. On a headless box with no other uplink the gateway came back into a dead network: Telegram's startup hit `ENETUNREACH`, the OpenClaw release died three times on the unhandled socket error, and OpenClaw's account supervisor gave up on both accounts. The gateway kept running without them.

The restart is both the cause and the cure, which is what makes the ordering the whole fix.

## Harness-first — asked of OpenClaw before writing anything

Read-only on the box, against the installed **2026.8.1**:

- `openclaw channels --help` offers `add | capabilities | dead-letters | list | login | logout | logs | remove | resolve | status`. **There is no `start`, `resume` or `restart` verb** — the CLI cannot revive a stopped account, so "use the channels CLI to start the suppressed accounts", as the card suggests, is not available.
- The supervisor that stops one is a `RetrySupervisor(RESTART_POLICY, MAX_RESTARTS)` held in a `Map` inside the gateway process (`dist/server-channels-*.js`), and giving up sets **runtime** state — `setRuntime(…, { restartPending: false, reconnectAttempts })` — not configuration. Nothing on disk records the suppression, so nothing on disk can clear it. `gateway.channelMaxRestartsPerHour` tunes the budget, not the recovery.

### Correction after review — OpenClaw DOES ship a channel health monitor, and this section was too strong

The paragraph above asked only the CLI, and concluded from its verb list that a fresh gateway process is the only way back. That conclusion does not hold, and the merge record should say so rather than carry it.

Measured read-only on the OpenClaw box against the same installed **2026.8.1**: the gateway starts `startChannelHealthMonitor` on **every** start — 56 occurrences in the retained journal —

```
[health-monitor] started (interval: 300s, startup-grace: 60s, channel-connect-grace: 120s)
```

and `dist/worker/worker.mjs` shows what it does. `evaluateChannelHealth` returns `not-running` for `lifecycle === "stopped" || !running`; `resolveChannelRestartReason` labels exactly that case **`gave-up`** when `reconnectAttempts >= 10`; the monitor then logs `health-monitor: restarting (reason: gave-up)` and does `stopChannel` → `startChannel` for that one account, bounded by `cooldownCycles` and `maxRestartsPerHour`. Three documented `gateway.*` keys tune it (`channelHealthCheckMinutes`, `channelStaleEventThresholdMinutes`, `channelMaxRestartsPerHour`) and ClawBox sets none of them — on the box, `openclaw.json`'s `gateway` object holds only `auth`, `bind`, `controlUi`, `mode`.

So for a *plainly* gave-up account the harness recovers on its own within ~300 s, and "a fresh gateway process is the only supported way back" is wrong as a general statement.

What is **not** known is which state GH #529's accounts actually ended in. The monitor skips two reasons outright —

```js
if (reason === 'terminal-disconnect' || reason === 'blocked') { log('skipping restart, ' + reason); continue }
```

— and `evaluateChannelHealth` tests `terminalDisconnect` **first**, before `not-running`; it also skips an account that is `isManuallyStopped` or under autostart suppression. The customer's two accounts stayed stopped until a human started them, with this monitor running on that build, which is evidence that one of those skip paths applied — but *which* cannot be established without reproducing the outage on a box, i.e. pulling the uplink and killing two live Telegram accounts, which the working rules do not allow for a fix.

**Recorded, not resolved — and recorded in the script, not only here.** `scripts/gateway-restart-when-online.sh`'s own header now carries this finding, so the next reader of the code is not left with the claim the first draft made. It does not change what this PR's core fix does — beta restarted the gateway *into a dead network*, and that is wrong however the accounts are revived afterwards — but it does mean the "the restart is the only cure" framing is unproven. The cheapest next step is a reproduction with the gateway journal grepped for `health-monitor:` around the failure: if the monitor skipped the account, that skip is the real finding; if it restarted it, the native fix is those `gateway.*` keys ClawBox already writes config for, and the dispatcher work shrinks to the WiFi-recovery and no-restart-into-a-dead-network halves.

For the network half the native mechanism is NetworkManager's own dispatcher **events**, not a poll of its state — and this repo already subscribes to them (`config/99-clawbox-avahi-reload` lists `connectivity-change` among its actions). The dispatcher therefore handles `connectivity-change` (acting when `CONNECTIVITY_STATE=FULL`) and `dhcp4-change` alongside up/down, which is also the only way it can see the case that produces **no** up/down at all: an upstream router rebooting with the box's carrier intact, the most common real shape of "the accounts got suppressed and never came back". The bounded poll is the safety net behind those events, not the mechanism.

## Fix

`scripts/gateway-restart-when-online.sh` (new, installed **root-owned** under `/usr/local/libexec/clawbox`) waits for a **proven public route**, then asks once:

1. `nmcli networking connectivity` — `full` is NetworkManager's own verdict and the only authoritative yes. Everything else is *not yet decided*, **not** a no: connectivity checking is enabled on the Ubuntu/JetPack base (`connectivity-check.ubuntu.com`), so any LAN that blocks or hijacks that URL — a corporate egress filter, a Pi-hole, an ISP NXDOMAIN redirector — parks NM at `portal` or `limited` permanently while the box reaches Telegram and Anthropic perfectly well. Treating that as offline would mean the gateway is never restarted again.
2. So anything short of `full` falls through to a probe of our own, gated on a default route (a box with none is answered without spending four seconds on it): the updater's own `PING_TARGETS`, **and** its HTTPS fallback, because ICMP is blocked on plenty of real networks — which is exactly why `src/lib/updater.ts` has the second half.
3. No route inside the window → **no restart**, and it says so in the journal. Bouncing into a dead network is the sequence that suppressed the accounts.
4. `systemctl try-restart`, never `restart`: the probe and the action are two commands and the gap here is a whole wait long, so a unit that is stopped — deliberately by the owner, or masked by the Hermes edition — must not be *started* by this. `install.sh` states the same rule for the same unit in the same words, and `is-active` would be wrong twice over (it reports non-zero for `activating`, which this unit's `RestartSec` plus a cold-Jetson `TimeoutStartSec` make minutes long). The journal says **asked**, not "restarted": an exit code cannot speak for what OpenClaw then did with its accounts.
5. On an edition with no unit systemd would act on, the waiter exits before starting a two-minute wait. The Hermes SKU **masks** `clawbox-gateway.service`, and a masked unit is still *listed*, so the test is `systemctl show -p LoadState --value` = `loaded` and not `list-unit-files` — see the round-2 section below, where this was a defect.

The dispatcher launches it **detached** — NetworkManager runs dispatcher scripts serially and kills a slow one — and the waiter takes an `flock`, so a flapping carrier cannot stack several waits and fire several restarts at the instant the route returns. A request the lock turns away is **remembered**: `flock -n` alone loses it, and the holder could time out one second before the route landed having ignored the very event that would have succeeded.

### Privilege

NetworkManager runs dispatchers as **root**, and `/home/clawbox/clawbox/scripts` is clawbox-owned and group-writable. The first draft had root `bash`ing the waiter out of the checkout on every network event and truncating a lock under clawbox-owned `data/` with `exec 9>` — which follows symlinks; reproduced, a symlinked lock path took a victim file from 26 bytes to 0 while the waiter logged a clean success. `install.sh` already forbids exactly this by name (`ROOT_LIBEXEC_DIR`, TASK-445), so the waiter is installed `root:root 0755` under `/usr/local/libexec/clawbox` — from `install_root_libexec` **and** from `step_nm_dispatcher`, so an in-app update gets the dispatcher and the waiter together rather than a new dispatcher pointing at nothing — and the lock lives in root-owned `/run/clawbox`.

## Sibling call sites

- **The dispatcher only ever reacted to the ethernet interface.** After a failover to WiFi the box's route comes back on the radio, and nothing asked for the restart that revives the accounts — the recovery half was missing entirely. It now reacts to `$WIFI_IFACE` coming up too.
- **Both** of the dispatcher's own restarts are deferred: `up` as well as `down`. Carrier is not a route.
- The original comment's reason for restarting on `down` — dropping TCP sockets bound to a dead interface, which look ESTABLISHED and blackhole for ~120 s — is unaffected: those sockets are already dead, so nothing is lost by waiting, while restarting early costs both Telegram accounts.
- `grep`ped for every other restarter of the gateway on a network event: `install.sh`, `config/*.service` and `src/lib` have none — the only other restarts are the owner's own (Settings), the updater's, and `restartGateway()` from a config write, none of which is triggered by carrier.
- `CLAWBOX_ROOT` now backs the `start-ap.sh` path too, which was hardcoded beside a variable that meant the same thing.
- **`NETWORK_INTERFACE` is resolved from root-owned `/etc/clawbox/network.env`**, the way `scripts/clawbox-firewall.sh` does it. NetworkManager passes no such variable to a dispatcher, and `install.sh` auto-detects the radio and persists the real name there precisely because it is not always `wlP1p1s0` — without this the new WiFi recovery arm would be silently dead on any box with a different radio. (Confirmed the flagship box *is* `wlP1p1s0`, so this bites other hardware rather than that one.)
- **The AP's own transitions are skipped** (`CONNECTION_ID` = the AP profile). `start-ap.sh` raises a `shared` profile with no default route and `ap-watchdog.sh` re-raises it every ~20 s while setup is incomplete, so without this every one of those would hold the lock for a full wait — and bounce the gateway mid-onboarding when the owner joined their home WiFi.
- **The detached launch no longer swallows its own failure**: it resolves `setsid` by PATH and then absolutely (a dispatcher's PATH is NM's, not a login shell's — the reason `99-clawbox-avahi-reload` resolves `avahi-daemon` absolutely), logs the dispatch, and redirects stdin.
- **Both editions:** `clawbox-gateway.service` **does** exist on the Hermes SKU — `setup-hermes-edition.sh` removes the unit file and then `systemctl mask`s the name, so systemd still lists it, as `masked`. Measured read-only on the Hermes box: `clawbox-gateway.service masked enabled`, `LoadState=masked`. The waiter therefore decides on `LoadState`, not on `is-active` (which it deliberately never calls — see point 4) and not on `list-unit-files`, and on that edition it exits silently with **no** journal line at all. An earlier revision of this bullet claimed the unit was absent and that the waiter used `is-active`; both were wrong, and the round-2 section below is what closed it.
- `install.sh`'s `step_nm_dispatcher` copies the dispatcher to `/etc/NetworkManager/dispatcher.d/90-clawbox-failover` and is already on the `step_post_update` list, so a box that only UPDATES gets the new behaviour. The waiter ships in the git tree the dispatcher reads it from, mode 0755.

## Merge-gate round 2 — two defects in this PR's own new code

A merge-gate review blocked the previous head on two findings, both in this PR's new code and both in
this repo's named bug classes. Both are closed here, each with a RED test that fails on the previous
head.

### 1. False failure on the Hermes edition — the "no gateway unit" guard fired on no edition at all

The waiter guarded on `systemctl list-unit-files "$UNIT"`, which **lists a masked unit**. The Hermes
SKU stops, disables and *masks* `clawbox-gateway.service`, so the guard's exit status was 0 there and
the waiter ran anyway: every NetworkManager event the new dispatcher reacts to — `eth` up/down, WiFi
`up`, `dhcp4-change`, `connectivity-change FULL` — either spent the full 120 s wait or reached
`systemctl try-restart` on a masked unit, which fails, and logged

```
Public route is up but the restart request for clawbox-gateway.service failed
```

— a failure line about a box where nothing is wrong, on the edition the shared-tools rule says this
must work on. Measured read-only on both boxes (systemd 249, nothing written, no mutex):

```
BOX_OPENCLAW   CLAWBOX_EDITION=openclaw
  systemctl list-unit-files clawbox-gateway.service -> clawbox-gateway.service enabled enabled   exit=0
  LoadState=loaded   UnitFileState=enabled   ActiveState=activating
  new guard -> proceed: a live unit, the waiter defers a restart to it

BOX_HERMES     CLAWBOX_EDITION=hermes
  systemctl list-unit-files clawbox-gateway.service -> clawbox-gateway.service masked  enabled   exit=0
  LoadState=masked   UnitFileState=masked    ActiveState=inactive
  new guard -> exit 0: no gateway to restart, no waiter, no journal line

control, both boxes: a unit that really does not exist
  systemctl list-unit-files definitely-not-real-xyz.service -> exit=1
  LoadState=not-found
```

The guard now decides on `LoadState`, which separates all three states — `loaded`, `masked`,
`not-found` — and is also correct when `systemctl` does not answer at all. That is not a new
mechanism: **`src/lib/gateway-health.ts` already decides this exact question for this exact unit the
same way**, and says why in its own comment ("`false` for masked and not-found … read off the DEVICE
rather than inferred from the edition"). The shell waiter was the one place using the weaker probe.

The suite could not catch this because its `systemctl` stub modelled only present/absent:

```ts
list-unit-files) exit ${opts.unitExists === false ? 1 : 0} ;;
```

so the masked case took the *other* branch on a real Hermes box while the test passed. The stub now
answers both questions the way the real one does — a masked unit is still listed, and only
`LoadState` tells it apart — and the option is `unitLoadState: "loaded" | "masked" | "not-found"`.

The comment above `UNIT` claimed the verdict was "resolved from the root-owned edition lock … with
the unit's actual presence as the final word". Nothing read the edition lock; that comment is
corrected rather than left to mislead the next reader.

### 2. False success in the installer — "helper installed" printed over a failed install

`step_nm_dispatcher` discarded `install_root_file`'s result and printed `Deferred gateway-restart
helper installed` regardless. On the **fresh-install** path (bare call) `set -euo pipefail` aborted,
so that path was honest. But `step_post_update` — the path every field box takes on an in-app
update — calls it as

```bash
step_nm_dispatcher || echo "  Warning: nm_dispatcher step failed (non-fatal)"
```

and bash suspends errexit for the **whole dynamic extent** of a function run in a condition context.
So on the update path a failed install printed success, went on to claim the dispatcher itself was
installed, and the `||` warning never fired because the function still returned 0 from its last
`echo`. `install_root_file` leaves the *previous* copy in place on failure, so the operator was told
a new waiter had landed while a stale one — or none — is what the dispatcher would call; the only
other trace is the dispatcher's runtime `WARN: … missing or not executable`, and only when a network
event happens.

Every line in the step now claims only what it has just done, and the step returns non-zero when the
waiter did not land. The dispatcher's own `cp`/`chown`/`chmod` are checked the same way, because
`NetworkManager failover dispatcher installed` was the second false claim in the same function.

### Sibling call sites of both fixes

- **`install_root_file`, every other call site.** `install.sh:4472`, `:4484`, `:4490` and `:4503`
  (all in `install_root_libexec`) also discard the result — but none of them **prints** anything, so
  they do not assert success and are not the false-success class. Cleared, not fixed.
  `step_polkit_rules` (`install.sh:5336`) *does* print `Polkit rules installed` over an unchecked
  `install_root_file`; it is reachable only from bare calls (`step_system_config:4322`,
  `step_rebuild_reboot:6623`), never behind a `||` or in a condition, so errexit aborts before the
  line prints and it is not a live false success today. Cleared here as out of this PR's scope and
  recorded as a residual rather than smuggled in.
- **`systemctl list-unit-files` as a presence probe, everywhere else.** `scripts/optimize-ollama.sh:53`
  (`ollama.service`), `scripts/clawbox-firewall.sh:237` (`rpcbind.service`) and
  `scripts/clawbox-desktop-mode.sh:98-99,192` (display managers) have the same masked-unit blindness.
  None of them is this PR's unit and none is on the failover path; cleared here and recorded as a
  residual.
- **Other consumers of the gateway unit's state.** `src/lib/gateway-health.ts` already reads
  `LoadState` (correct, and now the shell agrees with it); `src/lib/openclaw-config.ts` and
  `scripts/clawbox-identity-sync.sh` restart the unit on an owner action rather than a network event,
  so neither is reached by this change.

### RED, on the previous head `ee9c27f2`

```
 ❯ src/tests/unit/failover-waits-for-route.test.ts (25 tests | 3 failed)
   × does nothing at all on the Hermes edition, where the unit is MASKED rather than absent
   × does not claim the deferred-restart helper is installed when it is not
   × reports the failed step to step_post_update instead of returning success

 FAIL > does nothing at all on the Hermes edition, where the unit is MASKED rather than absent
 AssertionError: expected 1 to be +0 // Object.is equality
   - Expected   0
   + Received   1
       expect(restarts()).toBe(0);

 FAIL > does not claim the deferred-restart helper is installed when it is not
 AssertionError: expected '  Deferred gateway-restart helper ins…' not to contain
                          'Deferred gateway-restart helper insta…'
   +   Deferred gateway-restart helper installed
   +   NetworkManager failover dispatcher installed

 FAIL > reports the failed step to step_post_update instead of returning success
 AssertionError: expected '  Deferred gateway-restart helper ins…' to contain 'nm_dispatcher step failed'
   - nm_dispatcher step failed
   +   Deferred gateway-restart helper installed
   +   NetworkManager failover dispatcher installed

 Tests  3 failed | 22 passed (25)
```

The first is the Hermes false failure: with the unit masked and connectivity `full`, the old guard
let the waiter through and it restarted. The other two are the installer false success, run against
the **real** `step_nm_dispatcher` lifted out of `install.sh` in the `step_post_update` shape.

A fourth new case — "still aborts the fresh install, where a failure is fatal by design" — passes on
both heads on purpose: it pins the errexit behaviour the fix must not change.

## RED

The shipped dispatcher from `origin/beta`, run against stubbed `nmcli`/`ip`/`ping`/`systemctl`:

```
=== beta dispatcher, ethernet down, NO route anywhere ===
systemctl is-active --quiet clawbox-gateway.service
systemctl restart clawbox-gateway.service
restarts=1

=== beta dispatcher, ethernet UP before DHCP ===
systemctl is-active --quiet clawbox-gateway.service
systemctl restart clawbox-gateway.service
restarts=1

=== beta dispatcher, WiFi comes up after failover (recovery) ===
restarts=0 (nothing asks for the restart that revives the accounts)
```

All three are the defect: a restart into a network with no route, twice, and no restart at all at the one moment it would have worked.

## GREEN

On the final head, rebased onto `origin/beta`:

```
 Test Files  8 passed (8)
      Tests  110 passed (110)
```

(the new suite — **31** cases — plus `openclaw-config-mock-completeness`, `test-timeout-hygiene`, `state-updater-purity`, `install-post-update-units`, `clawbox-firewall-policy`, `ap-watchdog-honours-disable` and `root-steps`.) `npx tsc --noEmit`: clean. `bash -n install.sh scripts/*.sh`: clean. `scripts/check-sudoers-coverage.sh`: `OK — 47 grants, 43 resolved sudo invocations, 0 gaps`.

The suite EXECUTES the shipped scripts — and the real `step_nm_dispatcher` lifted out of `install.sh` — against stubs, and asserts on what was actually invoked: no route → no restart; a captive portal with genuinely no way out → no restart; a portal NM is *wrong* about → the probe runs and the restart lands; ICMP blocked → the HTTPS fallback carries it; no default route → no probe spent; the unit `not-found` → nothing at all; the unit **masked** → nothing at all, and an empty journal; the unit `loaded` → the restart still happens; `systemctl` unable to answer → a warning rather than a silent stand-down; a request dropped by the lock → the wait is extended rather than lost; the route returns → exactly one `try-restart` and never a `restart` or an `is-active`; a held lock → the second waiter stands down and leaves its marker. On the dispatcher side: it asks and returns without touching the gateway itself; the AP's own transitions, a same-address DHCP renewal, a lease on an unrouted interface and a `connectivity-change` short of `FULL` all ask for nothing; a moved lease and a `FULL` transition do. On the installer side: a failed waiter install prints no success line, records a provision failure and lets `step_post_update`'s warning fire; a failed dispatcher copy does the same; the fresh-install path still aborts; and a real success installs both halves and says so.

## Review

Three review rounds, each with the harness facts checked on the box.

**Round 1 (the PR's own draft).** Two highs, both defects in the first draft and both closed: root `bash`ing a clawbox-writable script on every network event, and a lock under clawbox-owned `data/` opened with `exec 9>` (reproduced — a symlinked lock path took a victim file from 26 bytes to 0 while the waiter logged a clean success).

**Round 2 (merge gate).** BLOCKED on the two findings in the round-2 section above — the Hermes false failure and the installer false success — both measured rather than argued. Both are closed here.

**Round 3 (this delta).** Confirmed both round-2 blockers closed on hardware, and found two more, both now fixed: the `dhcp4-change` over-restart (above), and the harness-first section being too strong — OpenClaw's own `startChannelHealthMonitor` is real, runs on this box, and restarts a `gave-up` account. That one is **recorded rather than resolved**: see the harness-first correction above. It is the honest state of the merge record, and a reviewer should weigh it before merging.

Also from round 3, applied: the unit guard no longer stands down *silently* when `systemctl` cannot answer at all (an empty `LoadState` is not evidence that the edition has no gateway — `src/lib/gateway-health.ts` states the same rule for the same property); a failed dispatcher or waiter install now calls `record_provision_failure nm_dispatcher`, so the update's own verdict stops reporting a clean run over a missing or stale waiter; the `mkdir`/`cp`/`chown`/`chmod` half of the step got the test it never had; the `systemctl` stub matches the property it answers and can express a failed probe; and the `connectivity-change` comment no longer claims an invariant the file does not hold.

**Round 4 (CodeRabbit on the round-3 head).** Two more, both applied:

* **The dispatcher was installed with `cp`,** which truncates the *live* inode — and that inode is already `0755` from the previous install, so NetworkManager, which may run the dispatcher at any instant including mid-update, could execute a **truncated but still executable** dispatcher. That is the prefix hazard `install_root_file` exists for (TASK-584); it now goes through it, staged and renamed. The staged `$DEST.new` is briefly visible to NM's scan (1.36.6 skips `~`, `.rpmsave`, `.rpmorig`, `.rpmnew`, `.swp` — not `.new`), but the worst that costs is one extra run of a *complete* dispatcher, which the waiter's lock collapses; a truncated one has no such floor. Recorded in the comment rather than left to be re-derived.
* **`exec 9>"$LOCK_FILE" || exit 0` could not do what it read like.** `exec` is a special builtin, so a failed redirection kills a non-interactive bash outright — the `||` branch never runs and the network event vanishes with nothing in the journal. The lock file is now opened before `exec` takes the descriptor, and a lock that cannot be taken is logged and the wait proceeds without the single-waiter guard: the same choice, and now the same wording, as the `flock`-unavailable branch beside it, because two restarts is a bounded cost and a dropped event is GH #529 again. Regression test: a read-only run directory, which produced an empty journal on the previous head.

Declined, with reasons: hard-coding `CLAWBOX_ONLINE_WAITER` (the suite executes the shipped script through it, and NetworkManager owns a dispatcher's environment, so it is not reachable in the field); and CodeRabbit's `!= NONE` connectivity gate, answered in-thread.

## Proven on hardware, and what is not

**Proven, read-only on both boxes** (systemd 249, no mutex taken, nothing written): the edition guard's verdict on each SKU — `LoadState=loaded` on the OpenClaw box and `masked` on the Hermes box, `not-found` for a control unit that does not exist, and the old `list-unit-files` question returning exit 0 for *both* real cases, which is the defect. Also read-only: `/etc/clawbox/network.env` is root-owned (so the dispatcher may source it as root) while the checkout's `data/network.env` is clawbox-owned; `/run/clawbox` is `drwx------ root root`; the office LAN's `dhcp_lease_time = 86400`, which is what makes the `dhcp4-change` arm's cost concrete; `nmcli -t networking connectivity` = `full` on both boxes; and OpenClaw 2026.8.1's channel health monitor, its skip list and its restart reasons.

**Not proven:** the end-to-end outage itself. Exercising it for real means pulling the uplink on a shared box and watching two Telegram accounts die, which mutates that box's network and channels, and the working rules forbid changing a channel or a box's state for anything but the task. That is also why the harness-first question above is left open rather than answered — see that section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Gateway services now wait for confirmed network connectivity before restarting after Ethernet or Wi‑Fi failover.
  - Connectivity checks support default-route detection, configurable ping targets, and HTTPS fallback.
  - DHCP and connectivity events trigger recovery only when relevant network changes occur.
  - Overlapping network events are coordinated to prevent duplicate restarts.

- **Bug Fixes**
  - Improved handling of captive, limited, or temporarily unavailable connections.
  - Unrelated interfaces and recovery access-point events no longer trigger recovery actions.
  - Gateway recovery is skipped safely when the service is unavailable.
  - Installation now reports dispatcher and connectivity-helper setup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
