### PR TITLE
fix: survive GitHub refusing the updater's anonymous fetches

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,10 @@
 #   CLAWBOX_GIT_RETRIES  — attempts per git network call (default: 3). GitHub
 #                          refuses anonymous fetches from an address that has
 #                          made too many, ~2 in 3 when measured (TASK-655).
-#   CLAWBOX_GIT_RETRY_DELAY — seconds before the first retry, doubling (default: 3)
+#                          A value that is not a whole number is replaced with
+#                          the default and a line is printed saying so.
+#   CLAWBOX_GIT_RETRY_DELAY — seconds before the first retry, doubling (default: 3).
+#                          Same rule for a value that is not a whole number.
 set -euo pipefail
 
 # ── Require root ─────────────────────────────────────────────────────────────
@@ -62,13 +65,21 @@ git_with_retry() {
   local out rc=0 verb
   # Both knobs are operator input and both are used as NUMBERS. A non-numeric
   # `max` makes `[ "$attempt" -ge "$max" ]` fail on every iteration — "integer
-  # expression expected" — so the break is never reached and the loop runs
-  # until something else kills it (8672 attempts, measured). A non-numeric
-  # `delay` makes `$((delay * 2))` an unbound-variable error under `set -u` and
-  # takes install.sh down mid-update. Clamp both to the default rather than
-  # trusting a value nothing in this repository sets.
-  case "$max" in ''|*[!0-9]*) max=3 ;; esac
-  case "$delay" in ''|*[!0-9]*) delay=3 ;; esac
+  # expression expected" — so the break is never reached and the loop does not
+  # end on its own; the regression test has to kill it on a wall clock. A
+  # non-numeric `delay` makes `$((delay * 2))` an unbound-variable error under
+  # `set -u` and takes install.sh down mid-update.
+  #
+  # Replaced with the default rather than trusted, and SAID so: a knob that is
+  # silently ignored is the same class of quiet wrong answer this whole change
+  # is about. Only the shape is checked — `0` is a legitimate "do not retry"
+  # and survives, and a numeric-but-large value is the operator's own call.
+  case "$max" in
+    ''|*[!0-9]*) echo "  CLAWBOX_GIT_RETRIES is not a number, using 3" >&2; max=3 ;;
+  esac
+  case "$delay" in
+    ''|*[!0-9]*) echo "  CLAWBOX_GIT_RETRY_DELAY is not a number, using 3" >&2; delay=3 ;;
+  esac
   # The subcommand, not "$1": every caller here leads with -c/-C, so naming the
   # first argument produced "git -C attempt 1/3 failed" in the journal.
   verb="$(printf '%s\n' "$@" | grep -m1 -E '^(fetch|clone|pull|push|ls-remote)$' || true)"

--- a/install.sh
+++ b/install.sh
@@ -60,6 +60,15 @@ git_retryable_failure() {
 git_with_retry() {
   local attempt=1 max="${CLAWBOX_GIT_RETRIES:-3}" delay="${CLAWBOX_GIT_RETRY_DELAY:-3}"
   local out rc=0 verb
+  # Both knobs are operator input and both are used as NUMBERS. A non-numeric
+  # `max` makes `[ "$attempt" -ge "$max" ]` fail on every iteration — "integer
+  # expression expected" — so the break is never reached and the loop runs
+  # until something else kills it (8672 attempts, measured). A non-numeric
+  # `delay` makes `$((delay * 2))` an unbound-variable error under `set -u` and
+  # takes install.sh down mid-update. Clamp both to the default rather than
+  # trusting a value nothing in this repository sets.
+  case "$max" in ''|*[!0-9]*) max=3 ;; esac
+  case "$delay" in ''|*[!0-9]*) delay=3 ;; esac
   # The subcommand, not "$1": every caller here leads with -c/-C, so naming the
   # first argument produced "git -C attempt 1/3 failed" in the journal.
   verb="$(printf '%s\n' "$@" | grep -m1 -E '^(fetch|clone|pull|push|ls-remote)$' || true)"

--- a/install.sh
+++ b/install.sh
@@ -2239,7 +2239,10 @@ persist_update_branch_pin() {
 # the fact, so the trade is the honest message.
 git_with_retry() {
   local attempt=1 max="${CLAWBOX_GIT_RETRIES:-3}" delay="${CLAWBOX_GIT_RETRY_DELAY:-5}"
-  local out rc=0
+  local out rc=0 verb
+  # The subcommand, not "$1": every caller here leads with -c/-C, so naming the
+  # first argument produced "git -C attempt 1/3 failed" in the journal.
+  verb="$(printf '%s\n' "$@" | grep -m1 -E '^(fetch|clone|pull|push|ls-remote)$' || true)"
   while :; do
     if out="$(GIT_TERMINAL_PROMPT=0 git "$@" 2>&1)"; then
       [ -z "$out" ] || printf '%s\n' "$out"
@@ -2248,7 +2251,7 @@ git_with_retry() {
       rc=$?
     fi
     [ "$attempt" -ge "$max" ] && break
-    echo "  git ${1:-} attempt $attempt/$max failed, retrying in ${delay}s..." >&2
+    echo "  git ${verb:-remote} attempt $attempt/$max failed, retrying in ${delay}s..." >&2
     sleep "$delay"
     attempt=$((attempt + 1))
     delay=$((delay * 2))

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,10 @@
 #                          $PROJECT_DIR/.update-branch, so the device keeps
 #                          updating on the branch it was built with.
 #   NETWORK_INTERFACE    — WiFi interface override (default: auto-detect)
+#   CLAWBOX_GIT_RETRIES  — attempts per git network call (default: 3). GitHub
+#                          refuses anonymous fetches from an address that has
+#                          made too many, ~2 in 3 when measured (TASK-655).
+#   CLAWBOX_GIT_RETRY_DELAY — seconds before the first retry, doubling (default: 3)
 set -euo pipefail
 
 # ── Require root ─────────────────────────────────────────────────────────────
@@ -20,6 +24,72 @@ if [ "$(id -u)" -ne 0 ]; then
   echo "Error: Run this script with sudo" >&2
   exit 1
 fi
+
+# Retry a git call that talks to a remote.
+#
+# Measured on the dev network 2026-09-02 (TASK-655): GitHub answers git's
+# protocol-v2 POST to /git-upload-pack with `HTTP 401` and a body reading
+# "Repository not found." — for a PUBLIC repository — once an address has used
+# up its anonymous allowance. git reports it as
+# `fatal: could not read Username for 'https://github.com'`, which names
+# credentials no ClawBox has, and roughly one attempt in three got through.
+# One in-app update needs three separate fetches to succeed in a row, so a
+# single refusal ended the update at step 0 with a message about a password.
+#
+# git owns no retry of its own — neither 2.34 (the boxes) nor 2.43 has a
+# `fetch.retry`/`http.retry` knob — so it lives here. GIT_TERMINAL_PROMPT=0
+# IS git's own switch and is used rather than reimplemented: without it the
+# same call blocks on a username prompt whenever a tty is attached.
+#
+# Output is captured and re-emitted at the end of each attempt rather than
+# streamed, so the classification below has the text to read. That costs live
+# progress on a long clone; install.sh's output is read from the journal after
+# the fact, so the trade is the honest message.
+# Is this failure worth asking again? Retrying "destination path already
+# exists" three times helps nobody and costs the step's budget.
+git_retryable_failure() {
+  case "$1" in
+    *"could not read Username"*|*"could not read Password"*|*"Repository not found"*) return 0 ;;
+    *"Authentication failed"*|*"terminal prompts disabled"*) return 0 ;;
+    *"Could not resolve host"*|*"Connection timed out"*|*"Connection reset"*) return 0 ;;
+    *"early EOF"*|*"RPC failed"*|*"unable to access"*) return 0 ;;
+  esac
+  return 1
+}
+
+git_with_retry() {
+  local attempt=1 max="${CLAWBOX_GIT_RETRIES:-3}" delay="${CLAWBOX_GIT_RETRY_DELAY:-3}"
+  local out rc=0 verb
+  # The subcommand, not "$1": every caller here leads with -c/-C, so naming the
+  # first argument produced "git -C attempt 1/3 failed" in the journal.
+  verb="$(printf '%s\n' "$@" | grep -m1 -E '^(fetch|clone|pull|push|ls-remote)$' || true)"
+  while :; do
+    # Output is CAPTURED so the classification below has the text to read, then
+    # re-emitted on stderr — where git puts it — so a caller that captures this
+    # function's stdout cannot mistake git's progress for a result.
+    if out="$(GIT_TERMINAL_PROMPT=0 git "$@" 2>&1)"; then
+      [ -z "$out" ] || printf '%s\n' "$out" >&2
+      return 0
+    else
+      rc=$?
+    fi
+    [ "$attempt" -ge "$max" ] && break
+    git_retryable_failure "$out" || break
+    echo "  git ${verb:-remote} attempt $attempt/$max failed, retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+  printf '%s\n' "$out" >&2
+  case "$out" in
+    *"could not read Username"*|*"could not read Password"*|*"Repository not found"*)
+      echo "Error: GitHub refused this ClawBox's anonymous request for the update repository after $attempt attempt(s)." >&2
+      echo "       The repository is public and this device needs no password — GitHub answers 401 to anonymous git" >&2
+      echo "       requests from an address that has made too many. Wait a few minutes and run the update again." >&2
+      ;;
+  esac
+  return "$rc"
+}
 
 # ── Bootstrap: pull latest install.sh and re-exec before parsing constants ───
 # Fixes the race where a stale install.sh (e.g. rsync'd from an out-of-date
@@ -92,13 +162,17 @@ if [ -z "${CLAWBOX_INSTALL_BOOTSTRAPPED:-}" ] \
     echo "[bootstrap] WARN: cannot tell which branch this checkout belongs to; running the on-disk copy."
   else
     echo "[bootstrap] Refreshing install.sh from origin/${_br} before running..."
-    # Tolerated, but no longer silent: the reset below uses whatever refs are on
-    # disk, so a refused fetch means the "refreshing" line above just re-ran the
-    # copy already there. GitHub refuses anonymous fetches from an address that
-    # has made too many, and every ClawBox fetches anonymously (TASK-655).
-    if ! GIT_TERMINAL_PROMPT=0 git -C "$_b" -c safe.directory="$_b" fetch origin --quiet 2>/dev/null; then
-      echo "[bootstrap] WARN: could not fetch origin (GitHub may be refusing anonymous requests from this address); running the refs already on disk."
+    # Fetch #1 of the three an update needs, and the one that decides which
+    # install.sh the rest of the run uses — so it retries like the others.
+    # Still tolerated: the reset below uses whatever refs are on disk. But no
+    # longer SILENT, and no longer 2>/dev/null — the WARN quotes what git said
+    # rather than guessing, because "refreshing install.sh" printed above is
+    # otherwise a claim the run did not keep (TASK-655).
+    if ! _fetchout="$(git_with_retry -C "$_b" -c safe.directory="$_b" fetch origin --quiet 2>&1)"; then
+      echo "[bootstrap] WARN: could not refresh from origin; running the refs already on disk."
+      printf '%s\n' "$_fetchout" | tail -n 3
     fi
+    unset _fetchout
     if git -C "$_b" -c safe.directory="$_b" reset --hard "origin/${_br}" --quiet 2>/dev/null; then
       chown -R clawbox:clawbox "$_b" 2>/dev/null || true
       # Re-record what root is allowed to run, BEFORE re-exec'ing into it. The
@@ -2215,56 +2289,6 @@ persist_update_branch_pin() {
   fi
   chown "$CLAWBOX_USER:$CLAWBOX_USER" "$pin_file"
   chmod 644 "$pin_file"
-}
-
-# Retry a git call that talks to a remote.
-#
-# Measured on the dev network 2026-09-02 (TASK-655): GitHub answers git's
-# protocol-v2 POST to /git-upload-pack with `HTTP 401` and a body reading
-# "Repository not found." — for a PUBLIC repository — once an address has used
-# up its anonymous allowance. git reports it as
-# `fatal: could not read Username for 'https://github.com'`, which names
-# credentials no ClawBox has, and roughly one attempt in three got through.
-# One in-app update needs three separate fetches to succeed in a row, so a
-# single refusal ended the update at step 0 with a message about a password.
-#
-# git owns no retry of its own — neither 2.34 (the boxes) nor 2.43 has a
-# `fetch.retry`/`http.retry` knob — so it lives here. GIT_TERMINAL_PROMPT=0
-# IS git's own switch and is used rather than reimplemented: without it the
-# same call blocks on a username prompt whenever a tty is attached.
-#
-# Output is captured and re-emitted at the end of each attempt rather than
-# streamed, so the classification below has the text to read. That costs live
-# progress on a long clone; install.sh's output is read from the journal after
-# the fact, so the trade is the honest message.
-git_with_retry() {
-  local attempt=1 max="${CLAWBOX_GIT_RETRIES:-3}" delay="${CLAWBOX_GIT_RETRY_DELAY:-5}"
-  local out rc=0 verb
-  # The subcommand, not "$1": every caller here leads with -c/-C, so naming the
-  # first argument produced "git -C attempt 1/3 failed" in the journal.
-  verb="$(printf '%s\n' "$@" | grep -m1 -E '^(fetch|clone|pull|push|ls-remote)$' || true)"
-  while :; do
-    if out="$(GIT_TERMINAL_PROMPT=0 git "$@" 2>&1)"; then
-      [ -z "$out" ] || printf '%s\n' "$out"
-      return 0
-    else
-      rc=$?
-    fi
-    [ "$attempt" -ge "$max" ] && break
-    echo "  git ${verb:-remote} attempt $attempt/$max failed, retrying in ${delay}s..." >&2
-    sleep "$delay"
-    attempt=$((attempt + 1))
-    delay=$((delay * 2))
-  done
-  printf '%s\n' "$out" >&2
-  case "$out" in
-    *"could not read Username"*|*"could not read Password"*|*"Repository not found"*|*"Authentication failed"*|*"terminal prompts disabled"*)
-      echo "Error: GitHub refused this ClawBox's anonymous request for the update repository after $max attempts." >&2
-      echo "       The repository is public and this device needs no password — GitHub answers 401 to anonymous git" >&2
-      echo "       requests from an address that has made too many. Wait a few minutes and run the update again." >&2
-      ;;
-  esac
-  return "$rc"
 }
 
 sync_repo_to_update_target() {

--- a/install.sh
+++ b/install.sh
@@ -92,7 +92,13 @@ if [ -z "${CLAWBOX_INSTALL_BOOTSTRAPPED:-}" ] \
     echo "[bootstrap] WARN: cannot tell which branch this checkout belongs to; running the on-disk copy."
   else
     echo "[bootstrap] Refreshing install.sh from origin/${_br} before running..."
-    git -C "$_b" -c safe.directory="$_b" fetch origin --quiet 2>/dev/null || true
+    # Tolerated, but no longer silent: the reset below uses whatever refs are on
+    # disk, so a refused fetch means the "refreshing" line above just re-ran the
+    # copy already there. GitHub refuses anonymous fetches from an address that
+    # has made too many, and every ClawBox fetches anonymously (TASK-655).
+    if ! GIT_TERMINAL_PROMPT=0 git -C "$_b" -c safe.directory="$_b" fetch origin --quiet 2>/dev/null; then
+      echo "[bootstrap] WARN: could not fetch origin (GitHub may be refusing anonymous requests from this address); running the refs already on disk."
+    fi
     if git -C "$_b" -c safe.directory="$_b" reset --hard "origin/${_br}" --quiet 2>/dev/null; then
       chown -R clawbox:clawbox "$_b" 2>/dev/null || true
       # Re-record what root is allowed to run, BEFORE re-exec'ing into it. The
@@ -2211,6 +2217,53 @@ persist_update_branch_pin() {
   chmod 644 "$pin_file"
 }
 
+# Retry a git call that talks to a remote.
+#
+# Measured on the dev network 2026-09-02 (TASK-655): GitHub answers git's
+# protocol-v2 POST to /git-upload-pack with `HTTP 401` and a body reading
+# "Repository not found." — for a PUBLIC repository — once an address has used
+# up its anonymous allowance. git reports it as
+# `fatal: could not read Username for 'https://github.com'`, which names
+# credentials no ClawBox has, and roughly one attempt in three got through.
+# One in-app update needs three separate fetches to succeed in a row, so a
+# single refusal ended the update at step 0 with a message about a password.
+#
+# git owns no retry of its own — neither 2.34 (the boxes) nor 2.43 has a
+# `fetch.retry`/`http.retry` knob — so it lives here. GIT_TERMINAL_PROMPT=0
+# IS git's own switch and is used rather than reimplemented: without it the
+# same call blocks on a username prompt whenever a tty is attached.
+#
+# Output is captured and re-emitted at the end of each attempt rather than
+# streamed, so the classification below has the text to read. That costs live
+# progress on a long clone; install.sh's output is read from the journal after
+# the fact, so the trade is the honest message.
+git_with_retry() {
+  local attempt=1 max="${CLAWBOX_GIT_RETRIES:-3}" delay="${CLAWBOX_GIT_RETRY_DELAY:-5}"
+  local out rc=0
+  while :; do
+    if out="$(GIT_TERMINAL_PROMPT=0 git "$@" 2>&1)"; then
+      [ -z "$out" ] || printf '%s\n' "$out"
+      return 0
+    else
+      rc=$?
+    fi
+    [ "$attempt" -ge "$max" ] && break
+    echo "  git ${1:-} attempt $attempt/$max failed, retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+  printf '%s\n' "$out" >&2
+  case "$out" in
+    *"could not read Username"*|*"could not read Password"*|*"Repository not found"*|*"Authentication failed"*|*"terminal prompts disabled"*)
+      echo "Error: GitHub refused this ClawBox's anonymous request for the update repository after $max attempts." >&2
+      echo "       The repository is public and this device needs no password — GitHub answers 401 to anonymous git" >&2
+      echo "       requests from an address that has made too many. Wait a few minutes and run the update again." >&2
+      ;;
+  esac
+  return "$rc"
+}
+
 sync_repo_to_update_target() {
   local target_branch="$1"
   local upstream_branch="$2"
@@ -2220,7 +2273,7 @@ sync_repo_to_update_target() {
     exit 1
   fi
 
-  git -c safe.directory="$PROJECT_DIR" -C "$PROJECT_DIR" fetch origin
+  git_with_retry -c safe.directory="$PROJECT_DIR" -C "$PROJECT_DIR" fetch origin
   # Discard local working-tree changes before switching branches. The later
   # `reset --hard` would blow them away anyway; doing it up-front avoids
   # `git checkout` aborting with "local changes would be overwritten" when
@@ -2262,7 +2315,7 @@ step_git_pull() {
   local fresh_clone=0
   if [ ! -d "$PROJECT_DIR/.git" ]; then
     echo "  Cloning from $REPO_URL (branch: $REPO_BRANCH)..."
-    git clone --branch "$REPO_BRANCH" "$REPO_URL" "$PROJECT_DIR"
+    git_with_retry clone --branch "$REPO_BRANCH" "$REPO_URL" "$PROJECT_DIR"
     chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$PROJECT_DIR"
     fresh_clone=1
   fi

--- a/mcp/lib/versions.ts
+++ b/mcp/lib/versions.ts
@@ -31,6 +31,17 @@ export interface VersionsPayload {
    * whose software predates the field.
    */
   edition?: string;
+  /**
+   * Whether the device actually reached GitHub for this check.
+   *
+   * Declared here because `updateAvailable: false` is unfalsifiable without
+   * it: GitHub refuses anonymous git-upload-pack POSTs from an address that
+   * has made too many, the device then compares HEAD against the STALE refs
+   * its last successful fetch left, and every component reads "current"
+   * (TASK-655). Absent on a device whose software predates the field, which is
+   * "not known" — never "unreachable".
+   */
+  remote?: { reachable: boolean; refusedAnonymously?: boolean; reason?: string };
 }
 
 /**

--- a/mcp/tools/orientation.ts
+++ b/mcp/tools/orientation.ts
@@ -410,9 +410,20 @@ export function registerOrientationTools(reg: Registrar, ctx: McpContext): void 
               // one — and a model with no answer states one from training
               // memory. It never carries a target: see updater.ts.
               ...(versions.hermes ? { hermes: versions.hermes } : {}),
+              // "unknown", not false, when the device could not reach GitHub.
+              // This is the tool the server's instructions tell every model to
+              // call FIRST, so `waiting: false` here is how the owner asking
+              // "am I on the latest version?" gets told yes by a box that never
+              // managed to ask (TASK-655). The reason travels with it so the
+              // model can say what actually happened.
               waiting:
-                versions.clawbox?.updateAvailable === true
-                || (shipsOpenclaw(versions, ctx) && versions.openclaw?.updateAvailable === true),
+                versions.remote?.reachable === false
+                  ? "unknown"
+                  : versions.clawbox?.updateAvailable === true
+                    || (shipsOpenclaw(versions, ctx) && versions.openclaw?.updateAvailable === true),
+              ...(versions.remote?.reachable === false
+                ? { check_failed: versions.remote.reason ?? "could not reach the update repository" }
+                : {}),
             }
           : "unknown",
       });

--- a/mcp/tools/system.ts
+++ b/mcp/tools/system.ts
@@ -369,7 +369,7 @@ export function registerSystemTools(reg: Registrar, ctx: McpContext): void {
 
   reg.tool(
     "update_check",
-    "Check whether a newer ClawBox software version is available, and report the installed version. This only reports — it never installs anything. If an update is waiting, tell the user to install it from Settings -> System Update.",
+    "Check whether a newer ClawBox software version is available, and report the installed version. This only reports — it never installs anything. If an update is waiting, tell the user to install it from Settings -> System Update. If `remote.reachable` is false the device could not reach GitHub for this check, so say the check failed and quote `remote.reason` — do NOT report the device as up to date.",
     {},
     { editions: ["openclaw", "hermes"], readOnly: true, openWorld: true, profile: "core" },
     // Shaped, not raw: the route always carries an `openclaw` component and

--- a/scripts/force-update.sh
+++ b/scripts/force-update.sh
@@ -60,18 +60,39 @@ run_as_clawbox() {
   fi
 }
 
+# Same list, same reason, as install.sh's git_retryable_failure: asking again
+# only helps a refusal that is about the moment, not about the remote. This is
+# the script an owner runs when they are already stuck, so 3 s + 6 s of backoff
+# over a broken origin is time taken from someone waiting at the box.
+git_retryable_failure() {
+  case "$1" in
+    *"could not read Username"*|*"could not read Password"*|*"Repository not found"*) return 0 ;;
+    *"Authentication failed"*|*"terminal prompts disabled"*) return 0 ;;
+    *"Could not resolve host"*|*"Connection timed out"*|*"Connection reset"*) return 0 ;;
+    *"early EOF"*|*"RPC failed"*|*"unable to access"*) return 0 ;;
+  esac
+  return 1
+}
+
 # One attempt is a coin flip: GitHub refuses anonymous git-upload-pack POSTs
 # from an address that has made too many, ~2 in 3 when measured (TASK-655).
 # install.sh's git_with_retry is not sourceable from here (that file is an
 # installer, not a library), so this is the same three-attempt shape inline.
 fetch_with_retry() {
   local attempt=1 max="${CLAWBOX_GIT_RETRIES:-3}" delay="${CLAWBOX_GIT_RETRY_DELAY:-3}" out
+  # Both knobs are operator input and both are used as numbers — see
+  # install.sh's git_with_retry: a non-numeric `max` makes the break
+  # unreachable and a non-numeric `delay` is an unbound-variable error under
+  # `set -u`.
+  case "$max" in ''|*[!0-9]*) max=3 ;; esac
+  case "$delay" in ''|*[!0-9]*) delay=3 ;; esac
   while :; do
     if out="$(run_as_clawbox "$GIT fetch origin" 2>&1)"; then
       [ -z "$out" ] || printf '%s\n' "$out" >&2
       return 0
     fi
     [ "$attempt" -ge "$max" ] && break
+    git_retryable_failure "$out" || break
     echo "[force-update] fetch attempt $attempt/$max failed, retrying in ${delay}s..." >&2
     sleep "$delay"
     attempt=$((attempt + 1))

--- a/scripts/force-update.sh
+++ b/scripts/force-update.sh
@@ -71,6 +71,16 @@ run_as_clawbox() {
 # only helps a refusal that is about the moment, not about the remote. This is
 # the script an owner runs when they are already stuck, so 3 s + 6 s of backoff
 # over a broken origin is time taken from someone waiting at the box.
+#
+# The list must stay byte-identical to install.sh's — a test asserts it — so
+# any change belongs in both.
+#
+# `Could not resolve host` is DELIBERATELY retryable here and deliberately not
+# in src/lib/updater.ts, which is the only case where the three classifiers
+# disagree. A run of this script or of install.sh happens once, with someone
+# waiting, and can race NetworkManager still coming up — one more ask can land.
+# The version check in updater.ts is polled by four surfaces, where the same
+# retry is dead time on every poll over a question already answered.
 git_retryable_failure() {
   case "$1" in
     *"could not read Username"*|*"could not read Password"*|*"Repository not found"*) return 0 ;;

--- a/scripts/force-update.sh
+++ b/scripts/force-update.sh
@@ -20,6 +20,13 @@
 
 set -euo pipefail
 
+# Environment:
+#   CLAWBOX_ROOT / CLAWBOX_BRANCH — as below.
+#   CLAWBOX_GIT_RETRIES     — attempts for the fetch (default: 3).
+#   CLAWBOX_GIT_RETRY_DELAY — seconds before the first retry, doubling (default: 3).
+#   A value that is not a whole number is replaced with the default and a line
+#   is printed saying so. Same two knobs, same rule, as install.sh.
+
 PROJECT_DIR="${CLAWBOX_ROOT:-/home/clawbox/clawbox}"
 TARGET_BRANCH="${CLAWBOX_BRANCH:-main}"
 UPSTREAM="origin/${TARGET_BRANCH}"
@@ -83,9 +90,13 @@ fetch_with_retry() {
   # Both knobs are operator input and both are used as numbers — see
   # install.sh's git_with_retry: a non-numeric `max` makes the break
   # unreachable and a non-numeric `delay` is an unbound-variable error under
-  # `set -u`.
-  case "$max" in ''|*[!0-9]*) max=3 ;; esac
-  case "$delay" in ''|*[!0-9]*) delay=3 ;; esac
+  # `set -u`. Replaced with the default, and said out loud.
+  case "$max" in
+    ''|*[!0-9]*) echo "[force-update] CLAWBOX_GIT_RETRIES is not a number, using 3" >&2; max=3 ;;
+  esac
+  case "$delay" in
+    ''|*[!0-9]*) echo "[force-update] CLAWBOX_GIT_RETRY_DELAY is not a number, using 3" >&2; delay=3 ;;
+  esac
   while :; do
     if out="$(run_as_clawbox "$GIT fetch origin" 2>&1)"; then
       [ -z "$out" ] || printf '%s\n' "$out" >&2

--- a/scripts/force-update.sh
+++ b/scripts/force-update.sh
@@ -44,11 +44,48 @@ if [ ! -d "$PROJECT_DIR/.git" ]; then
 fi
 
 run_as_clawbox() {
+  # GIT_TERMINAL_PROMPT=0 is git's own switch, and it is load-bearing HERE more
+  # than anywhere else: this script is run by hand over SSH, so git HAS a tty
+  # and a refused anonymous fetch blocks on `Username for 'https://github.com':`
+  # instead of failing — the recovery script hanging on the box it is recovering
+  # (TASK-655). The updater sets the same variable for the same reason.
+  # The export goes INSIDE the command string, not in front of `sudo`'s target:
+  # sudo resets the environment, so `sudo -u x VAR=1 cmd` needs a `setenv` the
+  # sudoers drop-in does not grant — and it would change the argv shape
+  # scripts/check-sudoers-coverage.sh resolves this call site by.
   if [ "$(id -un)" = "$CLAWBOX_USER" ]; then
-    bash -c "$1"
+    bash -c "export GIT_TERMINAL_PROMPT=0; $1"
   else
-    sudo -u "$CLAWBOX_USER" bash -c "$1"
+    sudo -u "$CLAWBOX_USER" bash -c "export GIT_TERMINAL_PROMPT=0; $1"
   fi
+}
+
+# One attempt is a coin flip: GitHub refuses anonymous git-upload-pack POSTs
+# from an address that has made too many, ~2 in 3 when measured (TASK-655).
+# install.sh's git_with_retry is not sourceable from here (that file is an
+# installer, not a library), so this is the same three-attempt shape inline.
+fetch_with_retry() {
+  local attempt=1 max="${CLAWBOX_GIT_RETRIES:-3}" delay="${CLAWBOX_GIT_RETRY_DELAY:-3}" out
+  while :; do
+    if out="$(run_as_clawbox "$GIT fetch origin" 2>&1)"; then
+      [ -z "$out" ] || printf '%s\n' "$out" >&2
+      return 0
+    fi
+    [ "$attempt" -ge "$max" ] && break
+    echo "[force-update] fetch attempt $attempt/$max failed, retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+  printf '%s\n' "$out" >&2
+  case "$out" in
+    *"could not read Username"*|*"could not read Password"*|*"Repository not found"*)
+      echo "[force-update] GitHub refused this device's anonymous request for the repository." >&2
+      echo "[force-update] It is public and needs no password — GitHub answers 401 to anonymous git" >&2
+      echo "[force-update] requests from an address that has made too many. Wait a few minutes and re-run." >&2
+      ;;
+  esac
+  return 1
 }
 
 GIT="git -c safe.directory=$PROJECT_DIR -C $PROJECT_DIR"
@@ -57,7 +94,7 @@ echo "[force-update] Fixing .git ownership (any root-owned bits left by install.
 sudo chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$PROJECT_DIR/.git"
 
 echo "[force-update] Hard-syncing $PROJECT_DIR to $UPSTREAM..."
-run_as_clawbox "$GIT fetch origin"
+fetch_with_retry
 run_as_clawbox "$GIT reset --hard HEAD"
 run_as_clawbox "$GIT checkout $TARGET_BRANCH 2>/dev/null || $GIT checkout -b $TARGET_BRANCH $UPSTREAM"
 run_as_clawbox "$GIT reset --hard $UPSTREAM"

--- a/src/app/setup-api/update/status/route.ts
+++ b/src/app/setup-api/update/status/route.ts
@@ -55,7 +55,12 @@ export async function GET() {
       // "completed" must not describe. `drift` travels with every response so
       // the surfaces that render it can say WHY the update is being offered.
       const completed = await isUpdateCompleted();
-      if (completed && !drift && !needsUpdate(versions.clawbox) && !needsUpdate(versions.openclaw)) {
+      // `remote.reachable === false` outranks the flag for the same reason drift
+      // does: "nothing to do" derived from a check that never reached GitHub is
+      // not a fact, and this is the payload the setup wizard reads before it
+      // decides whether to auto-advance past the update step (TASK-655).
+      const remoteAnswered = versions.remote?.reachable !== false;
+      if (completed && remoteAnswered && !drift && !needsUpdate(versions.clawbox) && !needsUpdate(versions.openclaw)) {
         return NextResponse.json({
           ...state,
           phase: "completed",

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -6034,7 +6034,16 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         // never offers an update the page then denies (a `v` prefix, a
         // target older than current).
         const needs = componentNeedsUpdate(cb);
-        return { subtitle: needs && cb.target ? `${cleanVersion(cb.current) ?? cb.current} → ${cleanVersion(cb.target) ?? cb.target}` : t("settings.upToDate") };
+        if (needs && cb.target) {
+          return { subtitle: `${cleanVersion(cb.current) ?? cb.current} → ${cleanVersion(cb.target) ?? cb.target}` };
+        }
+        // A device that could not reach its update remote compared HEAD against
+        // the STALE refs the last successful fetch left, so "no delta" is not
+        // evidence of anything. Say nothing rather than repeat the claim the
+        // Update page has already stopped making (TASK-655) — no subtitle needs
+        // no string in ten locales, and the page beside it gives the reason.
+        if (versionInfo?.remote && !versionInfo.remote.reachable) return { subtitle: null };
+        return { subtitle: t("settings.upToDate") };
       }
       case "about":
         return { subtitle: versionInfo?.clawbox?.current ? cleanVersion(versionInfo.clawbox.current) : null };

--- a/src/components/SystemUpdateApp.tsx
+++ b/src/components/SystemUpdateApp.tsx
@@ -22,6 +22,13 @@ export interface VersionInfo {
   // present only on the SKUs that ship Hermes.
   hermes?: ComponentVersion;
   edition?: "openclaw" | "hermes" | "dual";
+  /**
+   * Whether the device actually reached its update remote. Optional for the
+   * same reason as the two above — a payload from a server that predates the
+   * field must keep rendering exactly as it did, so ABSENT means "not known",
+   * never "unreachable".
+   */
+  remote?: { reachable: boolean; refusedAnonymously?: boolean; reason?: string };
 }
 
 /**
@@ -315,6 +322,19 @@ export default function SystemUpdateApp({ embedded = false }: { embedded?: boole
     // realign" (hwtest-round1, 2026-08-24). Drift offers the update instead,
     // and the banner below says which drift.
     if (driftDetected) return "drift";
+    // Last, and only where the screen would otherwise say "You're up to date".
+    //
+    // A device GitHub refused produces the same payload as a current one: the
+    // fetch fails, HEAD is compared against the STALE `origin/<branch>` the
+    // last successful fetch left, and there is no delta. Reporting that as
+    // "Every component is on the latest release" is the lie TASK-655 was filed
+    // for, and a box behind a refused address can sit on it for weeks.
+    //
+    // Below the two tests above on purpose: an offer and a drift are LOCAL
+    // evidence that there is something to do, and they stay actionable — a
+    // refused remote must not take the Update button away from a box that
+    // already knows it needs one.
+    if (versions.remote && !versions.remote.reachable) return "fetch-error";
     return "up-to-date";
   }, [updateStarted, updateError, updateState, versions, versionsError, driftDetected]);
 
@@ -330,7 +350,10 @@ export default function SystemUpdateApp({ embedded = false }: { embedded?: boole
       case "fetch-error":
         return {
           icon: "cloud_off", iconClass: "text-amber-300",
-          headline: "Couldn't reach the update server", subhead: versionsError ?? "Check the device's internet connection and try again.",
+          headline: "Couldn't reach the update server",
+          subhead: versionsError
+            ?? versions?.remote?.reason
+            ?? "Check the device's internet connection and try again.",
           tone: "warn" as const,
         };
       case "up-to-date":

--- a/src/components/SystemUpdateApp.tsx
+++ b/src/components/SystemUpdateApp.tsx
@@ -427,6 +427,14 @@ export default function SystemUpdateApp({ embedded = false }: { embedded?: boole
   // hero used to make, one card further down.
   const clawboxAvail = (!!versions && componentNeedsUpdate(versions.clawbox)) || driftDetected;
 
+  // "CURRENT" / "Up to date" on the card is derived from a comparison against
+  // the STALE refs a refused fetch left behind, so on a box whose remote could
+  // not be reached it is the same denial the hero has just stopped making, one
+  // card further down. `unknown` makes the card say so instead. Only where
+  // there is no local evidence: a drifted or genuinely-behind box keeps its
+  // offer, because that fact was established without the remote.
+  const clawboxUnknown = !clawboxAvail && versions?.remote?.reachable === false;
+
   return (
     <div className={embedded ? "relative w-full text-gray-200" : "relative h-full w-full overflow-y-auto bg-[var(--bg-app)] text-gray-200"} data-testid="system-update-app">
       <div className={embedded ? "w-full" : "min-h-full w-full flex items-start justify-center p-6 pt-10 bg-[var(--bg-deep)]"}>
@@ -511,6 +519,7 @@ export default function SystemUpdateApp({ embedded = false }: { embedded?: boole
                 current={versions.clawbox.current}
                 target={versions.clawbox.target}
                 available={clawboxAvail}
+                unknown={clawboxUnknown}
                 onUpdate={() => void triggerUpdate()}
               />
             </div>
@@ -605,10 +614,14 @@ export default function SystemUpdateApp({ embedded = false }: { embedded?: boole
 
                   {/* Force full update — recovery for a device left with a stale
                       OpenClaw/system unit by force-update.sh (restores the UI but
-                      not the full update). Only offered when otherwise up to date
-                      (the recovery scenario) so it can't fire during loading or a
-                      failed version fetch. */}
-                  {status === "up-to-date" && (
+                      not the full update). Offered when there is no update to
+                      run — up to date, or a box whose remote could not be
+                      reached — and never while loading, so it can't fire before
+                      the payload is in. The refused case is the one that most
+                      needs it: install.sh retries the fetch, so the update has a
+                      real chance of getting through where the version check did
+                      not, and this is the only control that starts it. */}
+                  {(status === "up-to-date" || (status === "fetch-error" && !!versions)) && (
                     <div className="border-t border-[var(--border-subtle)] pt-4">
                       <div className="text-sm text-gray-100 inline-flex items-center gap-2">
                         <span className="material-symbols-rounded text-amber-400" style={{ fontSize: 18 }} aria-hidden="true">restart_alt</span>
@@ -812,6 +825,7 @@ function ComponentCard({
   current,
   target,
   available,
+  unknown = false,
   onUpdate,
 }: {
   name: string;
@@ -819,6 +833,8 @@ function ComponentCard({
   current: string | null;
   target: string | null;
   available: boolean;
+  /** The remote could not be reached, so "current" is not a fact. */
+  unknown?: boolean;
   onUpdate: () => void;
 }) {
   return (
@@ -829,7 +845,7 @@ function ComponentCard({
           <p className="text-xs text-[var(--text-muted)] mt-0.5">{description}</p>
         </div>
         <span className={`shrink-0 px-2 py-0.5 rounded-full border text-[10px] font-semibold tracking-wider ${available ? "bg-emerald-500/15 text-emerald-300 border-emerald-500/30" : "bg-white/5 text-[var(--text-muted)] border-[var(--border-subtle)]"}`}>
-          {available ? "UPDATE" : "CURRENT"}
+          {available ? "UPDATE" : unknown ? "UNKNOWN" : "CURRENT"}
         </span>
       </div>
       <div className="mt-4 grid grid-cols-2 gap-2 text-xs">
@@ -840,7 +856,7 @@ function ComponentCard({
         <div>
           <div className="uppercase tracking-wider text-[10px] text-[var(--text-muted)]">Latest</div>
           <div className={`mt-1 font-mono truncate ${available ? "text-emerald-300" : "text-gray-100"}`}>
-            {cleanVersion(target ?? "") || target || "—"}
+            {unknown ? "—" : cleanVersion(target ?? "") || target || "—"}
           </div>
         </div>
       </div>
@@ -850,7 +866,7 @@ function ComponentCard({
         disabled={!available}
         className="mt-4 px-3 py-1.5 rounded-md text-xs font-semibold border cursor-pointer disabled:cursor-default disabled:opacity-50 transition-colors bg-emerald-500/15 border-emerald-500/40 text-emerald-200 hover:bg-emerald-500/25"
       >
-        {available ? `Update ${name}` : "Up to date"}
+        {available ? `Update ${name}` : unknown ? "Couldn't check" : "Up to date"}
       </button>
     </div>
   );

--- a/src/components/UpdateStep.tsx
+++ b/src/components/UpdateStep.tsx
@@ -203,6 +203,9 @@ export default function UpdateStep({ onNext }: UpdateStepProps) {
   const [versions, setVersions] = useState<{
     clawbox: { current: string; target: string | null; updateAvailable?: boolean };
     openclaw: { current: string | null; target: string | null; updateAvailable?: boolean };
+    // Optional: a payload from a server that predates the field must keep
+    // behaving exactly as before, so ABSENT is "not known", never "unreachable".
+    remote?: { reachable: boolean; refusedAnonymously?: boolean; reason?: string };
   } | null>(null);
   const [fetchError, setFetchError] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -368,7 +371,17 @@ export default function UpdateStep({ onNext }: UpdateStepProps) {
   const isIdle = !state || state.phase === "idle";
   const clawboxNeedsUpdate = !!versions && (versions.clawbox.updateAvailable ?? !!versions.clawbox.target);
   const openclawNeedsUpdate = !!versions && (versions.openclaw.updateAvailable ?? !!versions.openclaw.target);
-  const isUpToDateEarly = !loading && isIdle && !starting && versions && !clawboxNeedsUpdate && !openclawNeedsUpdate;
+  // GitHub refuses anonymous git-upload-pack POSTs from an address that has
+  // made too many, so a box being set up behind such an address compares HEAD
+  // against the STALE refs its image shipped with and finds no delta. On this
+  // screen that was worse than a wrong label: the wizard printed "System Up to
+  // Date" and AUTO-ADVANCED after 1.5 s, onboarding the customer onto whatever
+  // was in the image with no update attempted and nothing said (TASK-655).
+  // Routed into the existing check-failed branch, which already offers Retry
+  // and Skip — the owner decides, and setup is never blocked.
+  const remoteUnreachable = versions?.remote?.reachable === false;
+  const isUpToDateEarly = !loading && isIdle && !starting && versions
+    && !remoteUnreachable && !clawboxNeedsUpdate && !openclawNeedsUpdate;
 
   // Auto-advance if already up to date — show brief flash then continue
   const autoAdvancedRef = useRef(false);
@@ -406,7 +419,7 @@ export default function UpdateStep({ onNext }: UpdateStepProps) {
     );
   }
 
-  if (fetchError) {
+  if (fetchError || (remoteUnreachable && isIdle && !starting)) {
     return (
       <Card>
         <h1 className="font-bold font-display mb-[var(--s-2)]" style={T_H1}>
@@ -415,6 +428,14 @@ export default function UpdateStep({ onNext }: UpdateStepProps) {
         <p className="text-red-400 mb-[var(--s-6)]" style={T_LEDE}>
           {t("update.failedToCheck")}
         </p>
+        {/* Server-authored, in the owner's words rather than git's — the same
+            sentence the System Update screen shows. Rendered only when the
+            server sent one, so nothing here depends on a new locale key. */}
+        {!fetchError && versions?.remote?.reason && (
+          <p className="text-[var(--text-secondary)] mb-[var(--s-6)]" style={T_LEDE}>
+            {versions.remote.reason}
+          </p>
+        )}
         <div className="flex flex-col sm:flex-row sm:items-center gap-[var(--s-3)]">
           <button
             type="button"
@@ -433,7 +454,7 @@ export default function UpdateStep({ onNext }: UpdateStepProps) {
   }
 
   // Idle state — show trigger button or "up to date"
-  const isUpToDate = versions && !clawboxNeedsUpdate && !openclawNeedsUpdate;
+  const isUpToDate = versions && !remoteUnreachable && !clawboxNeedsUpdate && !openclawNeedsUpdate;
 
   const isDowngrade = versions?.clawbox.target
     ? compareVersions(versions.clawbox.current, versions.clawbox.target) > 0

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -198,8 +198,29 @@ const REMOTE_CHECK_ATTEMPTS = 2;
  * matters, because the refusal being retried is caused by too many of them.
  */
 const REMOTE_ADVISORY_ATTEMPTS = 1;
-const REMOTE_RETRY_DELAY_MS = Number(process.env.UPDATER_REMOTE_RETRY_DELAY_MS || "4000");
-const REMOTE_CHECK_RETRY_DELAY_MS = Number(process.env.UPDATER_REMOTE_CHECK_RETRY_DELAY_MS || "1200");
+/**
+ * An override that is not a non-negative number of milliseconds is replaced
+ * with the default, and said out loud.
+ *
+ * `Number("garbage")` is NaN and a negative value stays negative; `setTimeout`
+ * treats both as 0, so the retries would still run but back-to-back — removing
+ * the one thing the policy depends on, and sending the anonymous requests in a
+ * burst, which is the condition the refusal is caused by. The shell knobs are
+ * clamped the same way, in install.sh and scripts/force-update.sh.
+ */
+function retryDelayMsFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    console.warn(`[Updater] ${name}="${raw}" is not a number of milliseconds, using ${fallback}`);
+    return fallback;
+  }
+  return parsed;
+}
+
+const REMOTE_RETRY_DELAY_MS = retryDelayMsFromEnv("UPDATER_REMOTE_RETRY_DELAY_MS", 4000);
+const REMOTE_CHECK_RETRY_DELAY_MS = retryDelayMsFromEnv("UPDATER_REMOTE_CHECK_RETRY_DELAY_MS", 1200);
 
 const ANONYMOUS_REFUSAL_REASON =
   "GitHub refused this ClawBox's anonymous request for the update repository. "

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -102,8 +102,11 @@ const REMOTE_REACHABLE: RemoteReachability = { reachable: true };
  * Measured on the dev network, 2026-09-02 (TASK-655): GitHub answers git's
  * protocol-v2 POST to `/git-upload-pack` with `HTTP 401` and a body reading
  * "Repository not found." — for a PUBLIC repository — once an address has used
- * up its anonymous allowance. The GET to `/info/refs` keeps answering, so
- * `ls-remote` succeeds while `fetch` does not.
+ * up its anonymous allowance. On the day it was measured the GET to
+ * `/info/refs` kept answering while the POST did not, which is why the fetch
+ * failed and `ls-remote` did not. That was the state that afternoon, NOT a
+ * property of the endpoint: the GET is refused too, which is why it is retried
+ * and why getTargetVersion has a branch for it being unreachable.
  *
  * git reports it as `fatal: could not read Username for 'https://github.com'`.
  * That sentence points at credentials; the cause is an anonymous-access

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -57,13 +57,131 @@ const execFile = promisify(execFileCb);
 function execGit(
   projectDir: string,
   args: string[],
-  options: { timeout: number; maxBuffer?: number },
+  options: { timeout: number; maxBuffer?: number; env?: NodeJS.ProcessEnv },
 ) {
   return execFile(
     "git",
     ["-c", `safe.directory=${projectDir}`, "-C", projectDir, ...args],
     options,
   );
+}
+
+/**
+ * git's own switch for "never ask a human for a credential".
+ *
+ * Every ClawBox fetches this repository anonymously and has no credential to
+ * offer. Without this, a git run that inherits a tty — a support engineer's
+ * `install.sh` in a terminal, a root unit started from one — blocks on a
+ * username prompt nobody is there to type, and the update hangs instead of
+ * failing. With it the refusal is deterministic and immediate.
+ */
+const GIT_NO_PROMPT_ENV: Record<string, string> = { GIT_TERMINAL_PROMPT: "0" };
+
+/**
+ * How this device's network reach to the update remote actually went.
+ *
+ * `reachable: false` is the fact /update/versions used to lose: the fetch was
+ * swallowed, HEAD was compared against a STALE `origin/<branch>` and the box
+ * told its owner "You're up to date" while it had not managed to ask.
+ */
+export interface RemoteReachability {
+  reachable: boolean;
+  /**
+   * GitHub answered a public repository's anonymous `git-upload-pack` with
+   * 401. git words that as "could not read Username", which names credentials
+   * a ClawBox never has — so it is classified here rather than shown raw.
+   */
+  refusedAnonymously?: boolean;
+  /** One owner-facing sentence. Absent when the remote answered. */
+  reason?: string;
+}
+
+const REMOTE_REACHABLE: RemoteReachability = { reachable: true };
+
+/**
+ * Measured on the dev network, 2026-09-02 (TASK-655): GitHub answers git's
+ * protocol-v2 POST to `/git-upload-pack` with `HTTP 401` and a body reading
+ * "Repository not found." — for a PUBLIC repository — once an address has used
+ * up its anonymous allowance. The GET to `/info/refs` keeps answering, so
+ * `ls-remote` succeeds while `fetch` does not.
+ *
+ * git reports it as `fatal: could not read Username for 'https://github.com'`.
+ * That sentence points at credentials; the cause is an anonymous-access
+ * refusal, and no ClawBox has a credential to add. Two people lost an
+ * afternoon to that wording before it was measured.
+ */
+function isAnonymousFetchRefusal(text: string): boolean {
+  return /could not read Username|could not read Password|Repository not found|Authentication failed|terminal prompts disabled/i
+    .test(text);
+}
+
+/** A refusal or a transient network fault — both are worth asking again. */
+function isRetryableRemoteFailure(text: string): boolean {
+  return isAnonymousFetchRefusal(text)
+    || /Could not resolve host|Connection (?:timed out|refused|reset)|early EOF|RPC failed|The requested URL returned error: 5\d\d|unable to access/i
+      .test(text);
+}
+
+function errorText(err: unknown): string {
+  const e = err as { stderr?: string; stdout?: string; message?: string } | undefined;
+  return [e?.stderr, e?.stdout, e?.message].filter(Boolean).join("\n").trim();
+}
+
+/**
+ * Attempts and backoff for a refused fetch.
+ *
+ * Measured (TASK-655, 19:27): with GitHub letting roughly one anonymous fetch
+ * in three through, and one in-app update needing three separate fetches to
+ * succeed in a row, an update had a few percent chance of completing. git has
+ * no retry of its own — neither 2.34 (the boxes) nor 2.43 (the dev PC) carries
+ * a `fetch.retry`/`http.retry` knob — so it lives here.
+ */
+const REMOTE_FETCH_ATTEMPTS = 3;
+const REMOTE_RETRY_DELAY_MS = Number(process.env.UPDATER_REMOTE_RETRY_DELAY_MS || "4000");
+
+const ANONYMOUS_REFUSAL_REASON =
+  "GitHub refused this ClawBox's anonymous request for the update repository. "
+  + "The repository is public and the device needs no password — GitHub answers 401 to anonymous git "
+  + "requests from an address that has made too many. Try again in a few minutes.";
+
+/**
+ * Run a git network command, retrying a refused or transient attempt.
+ *
+ * Returns how it went rather than throwing: every caller here wants to carry
+ * on and SAY the remote could not be reached, which is the whole point — the
+ * old `.catch(() => {})` is what turned a refusal into "up to date".
+ */
+async function reachOrigin(
+  projectDir: string,
+  args: string[],
+  options: { timeout: number; maxBuffer?: number },
+): Promise<RemoteReachability> {
+  let lastText = "";
+  for (let attempt = 1; attempt <= REMOTE_FETCH_ATTEMPTS; attempt++) {
+    try {
+      await execGit(projectDir, args, {
+        ...options,
+        env: { ...process.env, ...GIT_NO_PROMPT_ENV },
+      });
+      return REMOTE_REACHABLE;
+    } catch (err) {
+      lastText = errorText(err);
+      if (attempt === REMOTE_FETCH_ATTEMPTS || !isRetryableRemoteFailure(lastText)) break;
+      console.warn(
+        `[Updater] git ${args[0]} attempt ${attempt}/${REMOTE_FETCH_ATTEMPTS} failed, retrying: `
+        + lastText.split("\n").pop(),
+      );
+      await delay(REMOTE_RETRY_DELAY_MS * attempt);
+    }
+  }
+  const refusedAnonymously = isAnonymousFetchRefusal(lastText);
+  return {
+    reachable: false,
+    refusedAnonymously,
+    reason: refusedAnonymously
+      ? ANONYMOUS_REFUSAL_REASON
+      : `Could not reach the update repository: ${lastText.split("\n").pop() || "unknown error"}`,
+  };
 }
 
 const VALID_HOST = /^[A-Za-z0-9.\-:]+$/;
@@ -776,7 +894,26 @@ async function updateClawBoxAndReboot(): Promise<void> {
   //      are preserved so we don't nuke user state or force a multi-
   //      minute rebuild.
   const gitOptions = { timeout: 60_000, maxBuffer: 2 * 1024 * 1024 };
-  await execGit(PROJECT_DIR, ["fetch", "origin"], gitOptions);
+  const fetched = await reachOrigin(PROJECT_DIR, ["fetch", "origin"], gitOptions);
+  if (!fetched.reachable) {
+    // This is the THIRD anonymous fetch of one update — the Node updater's own,
+    // step 0's (`bootstrap_updater` → install.sh `sync_repo_to_update_target`)
+    // and this one, which asks for ALL refs and is the heaviest. Step 0 has
+    // already fetched origin AND hard-reset this tree to `upstream`, so the ref
+    // this step needs is on disk; failing the run here paints "Update failed"
+    // over a checkout that is already at the target (TASK-655: an attempt got
+    // through the first two fetches, ran steps 1-8, and died on this one).
+    //
+    // So: proceed on the refs already fetched, but only after PROVING the ref
+    // exists. Without that proof this would be a false success — a reset to a
+    // ref that was never fetched fails, and one that resolves to a stale commit
+    // would rebuild the box onto the wrong code without saying so.
+    await execGit(PROJECT_DIR, ["rev-parse", "--verify", `${upstream}^{commit}`], gitOptions);
+    warnUpdate(
+      "remote-fetch-refused",
+      `${fetched.reason} Continuing with the refs this update already fetched.`,
+    );
+  }
   await execGit(PROJECT_DIR, ["reset", "--hard", "HEAD"], gitOptions);
   try {
     await execGit(PROJECT_DIR, ["checkout", local], gitOptions);
@@ -1673,7 +1810,23 @@ interface VersionInfo {
    * before.
    */
   edition: EditionName;
+  /**
+   * Whether this check could actually reach the update remote.
+   *
+   * Without it "no update available" is unfalsifiable: a device GitHub is
+   * refusing produces exactly the same payload as a device that is genuinely
+   * current, and the one screen whose job is "should I update?" answers
+   * "You're up to date" (TASK-655, fleet-wide, measured 2026-09-02).
+   */
+  remote: RemoteReachability;
 }
+
+/**
+ * How the last real tag lookup went. Kept beside `cachedTargetVersion` and
+ * invalidated with it, so a cached version and the reachability that produced
+ * it can never disagree.
+ */
+let lastTagRemote: RemoteReachability = REMOTE_REACHABLE;
 
 let cachedVersionInfo: VersionInfo | null = null;
 let versionInfoCacheTime = 0;
@@ -1686,6 +1839,7 @@ export function invalidateVersionCache(): void {
   // memoized result of the last lookup.
   cachedTargetVersion = null;
   targetVersionCacheTime = 0;
+  lastTagRemote = REMOTE_REACHABLE;
 }
 
 /**
@@ -1757,31 +1911,42 @@ async function readHermesVersion(): Promise<string | null> {
   }
 }
 
-async function getPinnedBranchTarget(projectDir: string): Promise<{
-  branch: string;
-  currentSha: string;
-  targetSha: string;
-} | null> {
+interface PinnedBranchCheck {
+  target: { branch: string; currentSha: string; targetSha: string } | null;
+  remote: RemoteReachability;
+}
+
+/**
+ * Compare the device against its pinned branch on origin.
+ *
+ * The fetch outcome is RETURNED, not swallowed. It used to be
+ * `.catch(() => {})`, after which HEAD was compared against whatever
+ * `origin/<branch>` the last successful fetch had left: on a box GitHub was
+ * refusing, that is HEAD itself, so the answer was "no update" and the About
+ * screen said "You're up to date" about a check that never happened
+ * (TASK-655).
+ */
+async function getPinnedBranchTarget(projectDir: string): Promise<PinnedBranchCheck> {
   let branch: string;
   try {
     branch = (await readFile(path.join(projectDir, ".update-branch"), "utf-8")).trim();
   } catch {
-    return null;
+    return { target: null, remote: REMOTE_REACHABLE };
   }
-  if (!branch || !isSafeBranch(branch)) return null;
+  if (!branch || !isSafeBranch(branch)) return { target: null, remote: REMOTE_REACHABLE };
 
+  const remote = await reachOrigin(projectDir, ["fetch", "--quiet", "origin", branch], { timeout: 20_000 });
   try {
-    await execGit(projectDir, ["fetch", "--quiet", "origin", branch], { timeout: 20_000 }).catch(() => {});
     const [{ stdout: currentOut }, { stdout: targetOut }] = await Promise.all([
       execGit(projectDir, ["rev-parse", "HEAD"], { timeout: 10_000 }),
       execGit(projectDir, ["rev-parse", `origin/${branch}`], { timeout: 10_000 }),
     ]);
     const currentSha = currentOut.trim();
     const targetSha = targetOut.trim();
-    if (!currentSha || !targetSha || currentSha === targetSha) return null;
-    return { branch, currentSha, targetSha };
+    if (!currentSha || !targetSha || currentSha === targetSha) return { target: null, remote };
+    return { target: { branch, currentSha, targetSha }, remote };
   } catch {
-    return null;
+    return { target: null, remote };
   }
 }
 
@@ -1821,7 +1986,12 @@ export async function getVersionInfo(): Promise<VersionInfo> {
     // hermes binary, so this must never spawn there.
     hasHermes ? readHermesVersion() : Promise.resolve(null),
   ]);
-  const pinnedBranchTarget = await getPinnedBranchTarget(PROJECT_DIR);
+  const { target: pinnedBranchTarget, remote: pinnedRemote } = await getPinnedBranchTarget(PROJECT_DIR);
+  // Two independent reads of the same remote — the tag list (getTargetVersion,
+  // an `ls-remote` over the GET that keeps answering) and the pinned branch's
+  // fetch (the POST GitHub refuses). Either failing means this check did not
+  // see the remote, so the worse of the two is what the device reports.
+  const remote = !pinnedRemote.reachable ? pinnedRemote : lastTagRemote;
 
   // rawVersion is the installed release (e.g. "v3.1.0"); extract the base tag
   // so it compares cleanly against the target tag.
@@ -1858,6 +2028,7 @@ export async function getVersionInfo(): Promise<VersionInfo> {
       ? { hermes: { current: hermesCurrent, target: null, updateAvailable: false } }
       : {}),
     edition,
+    remote,
   };
   versionInfoCacheTime = Date.now();
   return cachedVersionInfo;
@@ -1866,15 +2037,18 @@ export async function getVersionInfo(): Promise<VersionInfo> {
 export async function getTargetVersion(): Promise<string | null> {
   if (Date.now() - targetVersionCacheTime < TARGET_VERSION_CACHE_TTL) return cachedTargetVersion;
   try {
-    await execGit(
+    // The tag fetch is advisory — `ls-remote` below asks origin directly — but
+    // its refusal is still evidence about the remote, so it is recorded rather
+    // than dropped. `ls-remote` failing is recorded by the catch.
+    lastTagRemote = await reachOrigin(
       PROJECT_DIR,
       ["fetch", "--quiet", "--tags", "origin"],
       { timeout: 20_000 },
-    ).catch(() => {});
+    );
     const { stdout } = await execGit(
       PROJECT_DIR,
       ["ls-remote", "--tags", "--refs", "origin"],
-      { timeout: 10_000 },
+      { timeout: 10_000, env: { ...process.env, ...GIT_NO_PROMPT_ENV } },
     );
     const tags = stdout
       .trim()
@@ -1897,7 +2071,15 @@ export async function getTargetVersion(): Promise<string | null> {
     cachedTargetVersion = semverTags[semverTags.length - 1];
     targetVersionCacheTime = Date.now();
     return cachedTargetVersion;
-  } catch {
+  } catch (err) {
+    const text = errorText(err);
+    lastTagRemote = {
+      reachable: false,
+      refusedAnonymously: isAnonymousFetchRefusal(text),
+      reason: isAnonymousFetchRefusal(text)
+        ? ANONYMOUS_REFUSAL_REASON
+        : `Could not reach the update repository: ${text.split("\n").pop() || "unknown error"}`,
+    };
     cachedTargetVersion = null;
     targetVersionCacheTime = Date.now();
     return null;

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -202,18 +202,29 @@ const REMOTE_ADVISORY_ATTEMPTS = 1;
  * An override that is not a non-negative number of milliseconds is replaced
  * with the default, and said out loud.
  *
- * `Number("garbage")` is NaN and a negative value stays negative; `setTimeout`
- * treats both as 0, so the retries would still run but back-to-back — removing
- * the one thing the policy depends on, and sending the anonymous requests in a
- * burst, which is the condition the refusal is caused by. The shell knobs are
- * clamped the same way, in install.sh and scripts/force-update.sh.
+ * `Number("garbage")` is NaN, `Number(" ")` is 0, and a negative value stays
+ * negative; `setTimeout` treats all three as 0, so the retries would still run
+ * but back-to-back — removing the one thing the policy depends on, and sending
+ * the anonymous requests in the burst that causes the refusal being retried.
+ *
+ * The upper bound is here for the opposite reason, and it is why this clamps a
+ * RANGE where the shell knobs deliberately do not: `setTimeout` above
+ * 2^31 - 1 ms does not wait longer, it fires on the next tick with a
+ * `TimeoutOverflowWarning`. A huge value would therefore be INVERTED into no
+ * delay at all rather than honoured, and `reachOrigin` multiplies by the
+ * attempt number on top. Ten minutes is far past any sane version-check
+ * backoff and leaves the product three orders of magnitude clear of the limit.
  */
+const MAX_RETRY_DELAY_MS = 600_000;
+
 function retryDelayMsFromEnv(name: string, fallback: number): number {
   const raw = process.env[name];
-  if (!raw) return fallback;
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0) {
-    console.warn(`[Updater] ${name}="${raw}" is not a number of milliseconds, using ${fallback}`);
+  if (raw === undefined) return fallback;
+  const trimmed = raw.trim();
+  const parsed = trimmed === "" ? Number.NaN : Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > MAX_RETRY_DELAY_MS) {
+    console.warn(`[Updater] ${name}="${raw}" is not a number of milliseconds `
+      + `between 0 and ${MAX_RETRY_DELAY_MS}, using ${fallback}`);
     return fallback;
   }
   return parsed;

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -109,17 +109,57 @@ const REMOTE_REACHABLE: RemoteReachability = { reachable: true };
  * That sentence points at credentials; the cause is an anonymous-access
  * refusal, and no ClawBox has a credential to add. Two people lost an
  * afternoon to that wording before it was measured.
+ *
+ * Narrow on purpose. `Authentication failed` and `terminal prompts disabled`
+ * are the same 401 seen through another git version, but they ALSO fire on a
+ * QA box pointed at a private fork — where "the repository is public and the
+ * device needs no password" would be a false diagnosis. Only the measured
+ * signature earns that sentence; see refusalReason().
  */
 function isAnonymousFetchRefusal(text: string): boolean {
-  return /could not read Username|could not read Password|Repository not found|Authentication failed|terminal prompts disabled/i
-    .test(text);
+  return /could not read Username|could not read Password|Repository not found/i.test(text);
 }
 
-/** A refusal or a transient network fault — both are worth asking again. */
-function isRetryableRemoteFailure(text: string): boolean {
+/** The same 401 in a spelling that does not prove the remote is public. */
+function isCredentialRefusal(text: string): boolean {
   return isAnonymousFetchRefusal(text)
-    || /Could not resolve host|Connection (?:timed out|refused|reset)|early EOF|RPC failed|The requested URL returned error: 5\d\d|unable to access/i
-      .test(text);
+    || /Authentication failed|terminal prompts disabled/i.test(text);
+}
+
+/**
+ * No DNS — this box is not on the network at all.
+ *
+ * Told apart from a refusal because the answers differ: a refusal is worth
+ * asking again in a moment; "there is no network" is not, and retrying it only
+ * spends the owner's time on a question already answered.
+ */
+function isOffline(text: string): boolean {
+  return /Could not resolve host|Temporary failure in name resolution|Network is unreachable/i.test(text);
+}
+
+/**
+ * The remote answered, and what it said is that this ref does not exist.
+ *
+ * A CONFIGURATION answer, not a network one: an operator who pinned Settings →
+ * System Update → Advanced to a branch that has since been deleted has a pin
+ * problem, and reporting it as "could not reach GitHub" sends them to the
+ * router instead of to the setting.
+ */
+function isMissingRef(text: string): boolean {
+  return /couldn't find remote ref|Remote branch .* not found/i.test(text);
+}
+
+/** A refusal, a timeout or a transient fault — all worth asking again. */
+function isRetryableRemoteFailure(err: unknown, text: string): boolean {
+  if (isOffline(text) || isMissingRef(text)) return false;
+  if (isCredentialRefusal(text)) return true;
+  // A git killed by execFile's own timeout has usually printed nothing, so
+  // there is no text to classify — and a stalled connection is the case a
+  // retry helps most. `killed`/`signal` is the only evidence there is.
+  const e = err as { killed?: boolean; signal?: string } | undefined;
+  if (e?.killed || e?.signal) return true;
+  return /Connection (?:timed out|refused|reset)|early EOF|RPC failed|The requested URL returned error: 5\d\d|unable to access/i
+    .test(text);
 }
 
 function errorText(err: unknown): string {
@@ -135,14 +175,47 @@ function errorText(err: unknown): string {
  * succeed in a row, an update had a few percent chance of completing. git has
  * no retry of its own — neither 2.34 (the boxes) nor 2.43 (the dev PC) carries
  * a `fetch.retry`/`http.retry` knob — so it lives here.
+ *
+ * TWO budgets, because the callers pay different prices for the wrong one. The
+ * UPDATE path is a one-shot operation the owner is watching and losing it costs
+ * a whole run, so it gets the full three attempts. The VERSION CHECK is polled
+ * by four surfaces: a long retry there is dead time on every poll, and the
+ * refusal it is answering is caused by too many anonymous requests from this
+ * address — which a blanket 3x would feed. It asks twice, briefly.
  */
 const REMOTE_FETCH_ATTEMPTS = 3;
+const REMOTE_CHECK_ATTEMPTS = 2;
 const REMOTE_RETRY_DELAY_MS = Number(process.env.UPDATER_REMOTE_RETRY_DELAY_MS || "4000");
+const REMOTE_CHECK_RETRY_DELAY_MS = Number(process.env.UPDATER_REMOTE_CHECK_RETRY_DELAY_MS || "1200");
 
 const ANONYMOUS_REFUSAL_REASON =
   "GitHub refused this ClawBox's anonymous request for the update repository. "
   + "The repository is public and the device needs no password — GitHub answers 401 to anonymous git "
   + "requests from an address that has made too many. Try again in a few minutes.";
+
+/** One owner-facing sentence for a failed reach. */
+function refusalReason(err: unknown, text: string): string {
+  if (isAnonymousFetchRefusal(text)) return ANONYMOUS_REFUSAL_REASON;
+  if (isCredentialRefusal(text)) {
+    return "The update repository refused this device's request for credentials it does not have. "
+      + "If this box is pointed at a private fork, it needs a remote it can read anonymously.";
+  }
+  if (isOffline(text)) {
+    return "This ClawBox could not look up github.com — check the network connection and try again.";
+  }
+  if (isMissingRef(text)) {
+    return "The update branch this ClawBox is pinned to no longer exists on GitHub. "
+      + "Choose a different branch in System Update → Advanced options.";
+  }
+  const e = err as { killed?: boolean; signal?: string } | undefined;
+  if (e?.killed || e?.signal) {
+    return "The update repository did not answer in time — the connection may be slow or blocked. Try again.";
+  }
+  // Last resort. errorText() on a spawn failure is Node's own
+  // `Command failed: git -c safe.directory=…`: an argv is not an explanation,
+  // so only its last line goes out, and only when there is nothing better.
+  return `Could not reach the update repository: ${text.split("\n").pop() || "unknown error"}`;
+}
 
 /**
  * Run a git network command, retrying a refused or transient attempt.
@@ -154,33 +227,35 @@ const ANONYMOUS_REFUSAL_REASON =
 async function reachOrigin(
   projectDir: string,
   args: string[],
-  options: { timeout: number; maxBuffer?: number },
+  options: { timeout: number; maxBuffer?: number; attempts?: number; retryDelayMs?: number },
 ): Promise<RemoteReachability> {
+  const attempts = options.attempts ?? REMOTE_FETCH_ATTEMPTS;
+  const retryDelayMs = options.retryDelayMs ?? REMOTE_RETRY_DELAY_MS;
   let lastText = "";
-  for (let attempt = 1; attempt <= REMOTE_FETCH_ATTEMPTS; attempt++) {
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
     try {
       await execGit(projectDir, args, {
-        ...options,
+        timeout: options.timeout,
+        maxBuffer: options.maxBuffer,
         env: { ...process.env, ...GIT_NO_PROMPT_ENV },
       });
       return REMOTE_REACHABLE;
     } catch (err) {
+      lastErr = err;
       lastText = errorText(err);
-      if (attempt === REMOTE_FETCH_ATTEMPTS || !isRetryableRemoteFailure(lastText)) break;
+      if (attempt === attempts || !isRetryableRemoteFailure(err, lastText)) break;
       console.warn(
-        `[Updater] git ${args[0]} attempt ${attempt}/${REMOTE_FETCH_ATTEMPTS} failed, retrying: `
+        `[Updater] git ${args[0]} attempt ${attempt}/${attempts} failed, retrying: `
         + lastText.split("\n").pop(),
       );
-      await delay(REMOTE_RETRY_DELAY_MS * attempt);
+      await delay(retryDelayMs * attempt);
     }
   }
-  const refusedAnonymously = isAnonymousFetchRefusal(lastText);
   return {
     reachable: false,
-    refusedAnonymously,
-    reason: refusedAnonymously
-      ? ANONYMOUS_REFUSAL_REASON
-      : `Could not reach the update repository: ${lastText.split("\n").pop() || "unknown error"}`,
+    refusedAnonymously: isAnonymousFetchRefusal(lastText),
+    reason: refusalReason(lastErr, lastText),
   };
 }
 
@@ -894,24 +969,25 @@ async function updateClawBoxAndReboot(): Promise<void> {
   //      are preserved so we don't nuke user state or force a multi-
   //      minute rebuild.
   const gitOptions = { timeout: 60_000, maxBuffer: 2 * 1024 * 1024 };
-  const fetched = await reachOrigin(PROJECT_DIR, ["fetch", "origin"], gitOptions);
-  if (!fetched.reachable) {
-    // This is the THIRD anonymous fetch of one update — the Node updater's own,
-    // step 0's (`bootstrap_updater` → install.sh `sync_repo_to_update_target`)
-    // and this one, which asks for ALL refs and is the heaviest. Step 0 has
-    // already fetched origin AND hard-reset this tree to `upstream`, so the ref
-    // this step needs is on disk; failing the run here paints "Update failed"
-    // over a checkout that is already at the target (TASK-655: an attempt got
-    // through the first two fetches, ran steps 1-8, and died on this one).
-    //
-    // So: proceed on the refs already fetched, but only after PROVING the ref
-    // exists. Without that proof this would be a false success — a reset to a
-    // ref that was never fetched fails, and one that resolves to a stale commit
-    // would rebuild the box onto the wrong code without saying so.
+  // NO fetch here. This used to be the THIRD anonymous fetch of one update —
+  // after the Node updater's own and step 0's (`bootstrap_updater` →
+  // install.sh `sync_repo_to_update_target`) — and the heaviest, because it
+  // asked for ALL refs. Step 0 is `failFast` and has already fetched origin AND
+  // hard-reset this tree to `upstream`, so this one could only ever re-fetch
+  // refs the run already has, while giving GitHub a third chance to refuse the
+  // whole update: an attempt on 2026-09-02 got through the first two, ran
+  // steps 1-8 for three and a half minutes, and died here (TASK-655).
+  //
+  // What replaces it is the question the reset actually depends on — is the ref
+  // on this device? — asked of the refs already on disk. Dropping the fetch
+  // without asking that would be a false success: `reset --hard` to a ref that
+  // was never fetched fails with git's own argv, and nothing would say why.
+  try {
     await execGit(PROJECT_DIR, ["rev-parse", "--verify", `${upstream}^{commit}`], gitOptions);
-    warnUpdate(
-      "remote-fetch-refused",
-      `${fetched.reason} Continuing with the refs this update already fetched.`,
+  } catch {
+    throw new Error(
+      `This ClawBox has no local copy of ${upstream}. Step 1 of this update was supposed to fetch it — `
+      + "run the update again, and if it keeps failing, GitHub may be refusing this address's anonymous requests.",
     );
   }
   await execGit(PROJECT_DIR, ["reset", "--hard", "HEAD"], gitOptions);
@@ -1544,7 +1620,12 @@ const UPDATE_STEPS: UpdateStepDef[] = [
   {
     id: "bootstrap_updater",
     label: "Refreshing updater scripts",
-    timeoutMs: 120_000,
+    // 180 s, raised from 120: this step's fetch now retries (install.sh
+    // `git_with_retry`, up to 3 attempts with 3 s + 6 s of backoff). A retry
+    // that gets the fetch through on attempt 3 only to be killed by the budget
+    // it needed would turn an intermittent refusal into a hard failure, which
+    // is the retry paying for itself and then being billed for it. TASK-655.
+    timeoutMs: 180_000,
     requiresRoot: true,
     failFast: true,
   },
@@ -1935,7 +2016,11 @@ async function getPinnedBranchTarget(projectDir: string): Promise<PinnedBranchCh
   }
   if (!branch || !isSafeBranch(branch)) return { target: null, remote: REMOTE_REACHABLE };
 
-  const remote = await reachOrigin(projectDir, ["fetch", "--quiet", "origin", branch], { timeout: 20_000 });
+  const remote = await reachOrigin(projectDir, ["fetch", "--quiet", "origin", branch], {
+    timeout: 20_000,
+    attempts: REMOTE_CHECK_ATTEMPTS,
+    retryDelayMs: REMOTE_CHECK_RETRY_DELAY_MS,
+  });
   try {
     const [{ stdout: currentOut }, { stdout: targetOut }] = await Promise.all([
       execGit(projectDir, ["rev-parse", "HEAD"], { timeout: 10_000 }),
@@ -2037,19 +2122,24 @@ export async function getVersionInfo(): Promise<VersionInfo> {
 export async function getTargetVersion(): Promise<string | null> {
   if (Date.now() - targetVersionCacheTime < TARGET_VERSION_CACHE_TTL) return cachedTargetVersion;
   try {
-    // The tag fetch is advisory — `ls-remote` below asks origin directly — but
-    // its refusal is still evidence about the remote, so it is recorded rather
-    // than dropped. `ls-remote` failing is recorded by the catch.
-    lastTagRemote = await reachOrigin(
+    // The tag fetch is ADVISORY: `ls-remote` below asks origin directly, so the
+    // answer is not read from the local tag refs this call updates. Its refusal
+    // is logged, never promoted — reporting the remote unreachable because an
+    // advisory call was refused while the authoritative one answered is the
+    // false-failure half of the same bug.
+    const tagFetch = await reachOrigin(
       PROJECT_DIR,
       ["fetch", "--quiet", "--tags", "origin"],
-      { timeout: 20_000 },
+      { timeout: 20_000, attempts: REMOTE_CHECK_ATTEMPTS, retryDelayMs: REMOTE_CHECK_RETRY_DELAY_MS },
     );
+    if (!tagFetch.reachable) console.warn(`[Updater] advisory tag fetch did not land: ${tagFetch.reason}`);
     const { stdout } = await execGit(
       PROJECT_DIR,
       ["ls-remote", "--tags", "--refs", "origin"],
       { timeout: 10_000, env: { ...process.env, ...GIT_NO_PROMPT_ENV } },
     );
+    // origin answered, on the call the tag answer depends on.
+    lastTagRemote = REMOTE_REACHABLE;
     const tags = stdout
       .trim()
       .split("\n")
@@ -2076,9 +2166,7 @@ export async function getTargetVersion(): Promise<string | null> {
     lastTagRemote = {
       reachable: false,
       refusedAnonymously: isAnonymousFetchRefusal(text),
-      reason: isAnonymousFetchRefusal(text)
-        ? ANONYMOUS_REFUSAL_REASON
-        : `Could not reach the update repository: ${text.split("\n").pop() || "unknown error"}`,
+      reason: refusalReason(err, text),
     };
     cachedTargetVersion = null;
     targetVersionCacheTime = Date.now();

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -181,7 +181,10 @@ function errorText(err: unknown): string {
  * a whole run, so it gets the full three attempts. The VERSION CHECK is polled
  * by four surfaces: a long retry there is dead time on every poll, and the
  * refusal it is answering is caused by too many anonymous requests from this
- * address — which a blanket 3x would feed. It asks twice, briefly.
+ * address — which a blanket 3x would feed. It asks twice, briefly, and it
+ * spends those two asks on the call it reads the answer from rather than
+ * splitting them: hence the third budget below, which is what the advisory tag
+ * fetch gets so the check's total stays where it was.
  */
 const REMOTE_FETCH_ATTEMPTS = 3;
 const REMOTE_CHECK_ATTEMPTS = 2;
@@ -2096,10 +2099,11 @@ export async function getVersionInfo(): Promise<VersionInfo> {
     hasHermes ? readHermesVersion() : Promise.resolve(null),
   ]);
   const { target: pinnedBranchTarget, remote: pinnedRemote } = await getPinnedBranchTarget(PROJECT_DIR);
-  // Two independent reads of the same remote — the tag list (getTargetVersion,
-  // an `ls-remote` over the GET that keeps answering) and the pinned branch's
-  // fetch (the POST GitHub refuses). Either failing means this check did not
-  // see the remote, so the worse of the two is what the device reports.
+  // Two independent reads of the same remote — the tag list (getTargetVersion's
+  // `ls-remote`, a GET to /info/refs) and the pinned branch's fetch (a POST to
+  // /git-upload-pack). BOTH can be refused; the POST far more often, which is
+  // what the card measured. Either failing means this check did not see the
+  // remote, so the worse of the two is what the device reports.
   const remote = !pinnedRemote.reachable ? pinnedRemote : lastTagRemote;
 
   // rawVersion is the installed release (e.g. "v3.1.0"); extract the base tag
@@ -2154,7 +2158,10 @@ export async function getTargetVersion(): Promise<string | null> {
     const tagFetch = await reachOrigin(
       PROJECT_DIR,
       ["fetch", "--quiet", "--tags", "origin"],
-      { timeout: 20_000, attempts: REMOTE_ADVISORY_ATTEMPTS },
+      // The delay is explicit even at one attempt: dropping it would fall back
+      // to the UPDATE path's 4 s budget, so raising REMOTE_ADVISORY_ATTEMPTS
+      // later would silently put a 4 s sleep on every polled version check.
+      { timeout: 20_000, attempts: REMOTE_ADVISORY_ATTEMPTS, retryDelayMs: REMOTE_CHECK_RETRY_DELAY_MS },
     );
     if (!tagFetch.reachable) console.warn(`[Updater] advisory tag fetch did not land: ${tagFetch.reason}`);
     // The AUTHORITATIVE call, and so the one that is retried. It used to get a

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -185,6 +185,13 @@ function errorText(err: unknown): string {
  */
 const REMOTE_FETCH_ATTEMPTS = 3;
 const REMOTE_CHECK_ATTEMPTS = 2;
+/**
+ * The advisory tag fetch asks ONCE, and the retry it used to hold is spent on
+ * the `ls-remote` the tag answer is actually read from. That keeps the number
+ * of anonymous requests a version check can make exactly where it was — which
+ * matters, because the refusal being retried is caused by too many of them.
+ */
+const REMOTE_ADVISORY_ATTEMPTS = 1;
 const REMOTE_RETRY_DELAY_MS = Number(process.env.UPDATER_REMOTE_RETRY_DELAY_MS || "4000");
 const REMOTE_CHECK_RETRY_DELAY_MS = Number(process.env.UPDATER_REMOTE_CHECK_RETRY_DELAY_MS || "1200");
 
@@ -229,18 +236,32 @@ async function reachOrigin(
   args: string[],
   options: { timeout: number; maxBuffer?: number; attempts?: number; retryDelayMs?: number },
 ): Promise<RemoteReachability> {
+  return (await readFromOrigin(projectDir, args, options)).remote;
+}
+
+/**
+ * The same policy, for a call whose OUTPUT is the answer.
+ *
+ * `RemoteReachability` travels into the /update/versions payload, so git's
+ * stdout is returned beside it rather than added to it.
+ */
+async function readFromOrigin(
+  projectDir: string,
+  args: string[],
+  options: { timeout: number; maxBuffer?: number; attempts?: number; retryDelayMs?: number },
+): Promise<{ remote: RemoteReachability; stdout: string }> {
   const attempts = options.attempts ?? REMOTE_FETCH_ATTEMPTS;
   const retryDelayMs = options.retryDelayMs ?? REMOTE_RETRY_DELAY_MS;
   let lastText = "";
   let lastErr: unknown;
   for (let attempt = 1; attempt <= attempts; attempt++) {
     try {
-      await execGit(projectDir, args, {
+      const { stdout } = await execGit(projectDir, args, {
         timeout: options.timeout,
         maxBuffer: options.maxBuffer,
         env: { ...process.env, ...GIT_NO_PROMPT_ENV },
       });
-      return REMOTE_REACHABLE;
+      return { remote: REMOTE_REACHABLE, stdout: String(stdout ?? "") };
     } catch (err) {
       lastErr = err;
       lastText = errorText(err);
@@ -253,9 +274,12 @@ async function reachOrigin(
     }
   }
   return {
-    reachable: false,
-    refusedAnonymously: isAnonymousFetchRefusal(lastText),
-    reason: refusalReason(lastErr, lastText),
+    remote: {
+      reachable: false,
+      refusedAnonymously: isAnonymousFetchRefusal(lastText),
+      reason: refusalReason(lastErr, lastText),
+    },
+    stdout: "",
   };
 }
 
@@ -2130,14 +2154,25 @@ export async function getTargetVersion(): Promise<string | null> {
     const tagFetch = await reachOrigin(
       PROJECT_DIR,
       ["fetch", "--quiet", "--tags", "origin"],
-      { timeout: 20_000, attempts: REMOTE_CHECK_ATTEMPTS, retryDelayMs: REMOTE_CHECK_RETRY_DELAY_MS },
+      { timeout: 20_000, attempts: REMOTE_ADVISORY_ATTEMPTS },
     );
     if (!tagFetch.reachable) console.warn(`[Updater] advisory tag fetch did not land: ${tagFetch.reason}`);
-    const { stdout } = await execGit(
+    // The AUTHORITATIVE call, and so the one that is retried. It used to get a
+    // single attempt: one refused ls-remote then made every surface say the
+    // update server could not be reached, and TARGET_VERSION_CACHE_TTL held
+    // that answer for 60 s over a refusal that clears in seconds.
+    const lsRemote = await readFromOrigin(
       PROJECT_DIR,
       ["ls-remote", "--tags", "--refs", "origin"],
-      { timeout: 10_000, env: { ...process.env, ...GIT_NO_PROMPT_ENV } },
+      { timeout: 10_000, attempts: REMOTE_CHECK_ATTEMPTS, retryDelayMs: REMOTE_CHECK_RETRY_DELAY_MS },
     );
+    if (!lsRemote.remote.reachable) {
+      lastTagRemote = lsRemote.remote;
+      cachedTargetVersion = null;
+      targetVersionCacheTime = Date.now();
+      return null;
+    }
+    const stdout = lsRemote.stdout;
     // origin answered, on the call the tag answer depends on.
     lastTagRemote = REMOTE_REACHABLE;
     const tags = stdout

--- a/src/tests/components/update-remote-refusal.test.tsx
+++ b/src/tests/components/update-remote-refusal.test.tsx
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@/tests/helpers/test-utils";
+import { translations } from "@/lib/translations";
+import SystemUpdateApp from "@/components/SystemUpdateApp";
+import SettingsApp, { type UISettings } from "@/components/SettingsApp";
+
+vi.mock("@/lib/i18n", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/i18n")>()),
+  useT: () => ({
+    locale: "en",
+    setLocale: () => {},
+    t: (key: string, params?: Record<string, string | number>) => {
+      let str = translations.en[key] ?? key;
+      if (params) for (const [k, v] of Object.entries(params)) str = str.replaceAll(`{${k}}`, String(v));
+      return str;
+    },
+  }),
+}));
+vi.mock("next/image", () => ({ default: (props: Record<string, unknown>) => <img alt="" {...props} /> }));
+vi.mock("@/components/TelegramConfiguringOverlay", () => ({ default: () => null }));
+
+/**
+ * TASK-655. GitHub refuses anonymous `git-upload-pack` POSTs from an address
+ * that has used up its allowance — 401, "Repository not found.", for a PUBLIC
+ * repo — and every ClawBox fetches anonymously.
+ *
+ * The device then compares HEAD against the STALE `origin/<branch>` the last
+ * successful fetch left, finds no delta, and the one screen whose job is
+ * "should I update?" answers "You're up to date. Every component is on the
+ * latest release." A box that cannot reach its update remote is told it is
+ * current, indefinitely and with a green tick.
+ */
+
+const REFUSAL_REASON =
+  "GitHub refused this ClawBox's anonymous request for the update repository. "
+  + "The repository is public and the device needs no password — GitHub answers 401 to anonymous git "
+  + "requests from an address that has made too many. Try again in a few minutes.";
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return { ok, status, json: async () => body } as unknown as Response;
+}
+
+const HEALTHY_IDENTITY = {
+  build: { shortCommit: "1dc29ef", branch: "beta", builtAt: "2026-08-24T15:12:02.000Z" },
+  deployedBuildId: "6lvAbUpp0QIu",
+  checkout: { commit: "1dc29ef0", shortCommit: "1dc29ef", branch: "beta", dirty: false, committedAt: null },
+  pin: { branch: "beta", source: "pin-file", commit: null, pinned: true },
+  drift: { buildVsCheckout: "match", checkoutVsPin: "match", detected: false, reasons: [], codes: [] },
+};
+
+function mountWith(remote: unknown) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/setup-api/update/versions")) {
+        return jsonResponse({
+          clawbox: { current: "v3.9.0", target: null, updateAvailable: false },
+          openclaw: { current: "2026.8.1", target: null, updateAvailable: false },
+          edition: "openclaw",
+          ...(remote === undefined ? {} : { remote }),
+        });
+      }
+      if (url.includes("/setup-api/system/build-identity")) return jsonResponse(HEALTHY_IDENTITY);
+      if (url.includes("/setup-api/system/update-branch")) return jsonResponse({ branch: "beta" });
+      if (url.includes("/setup-api/update/status")) return jsonResponse({ phase: "idle", steps: [] });
+      return jsonResponse({});
+    }),
+  );
+}
+
+describe("SystemUpdateApp — a remote it could not reach is not 'up to date'", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("says the check failed instead of claiming every component is current", async () => {
+    mountWith({ reachable: false, refusedAnonymously: true, reason: REFUSAL_REASON });
+    const { findByText, queryByText } = render(<SystemUpdateApp />);
+
+    await findByText("Couldn't reach the update server");
+    expect(queryByText("You're up to date")).toBeNull();
+    expect(queryByText("Every component is on the latest release.")).toBeNull();
+  });
+
+  it("tells the owner GitHub refused the anonymous request, not that a password is missing", async () => {
+    mountWith({ reachable: false, refusedAnonymously: true, reason: REFUSAL_REASON });
+    const { findByText } = render(<SystemUpdateApp />);
+
+    await findByText(REFUSAL_REASON);
+  });
+
+  it("still says 'up to date' when the remote answered", async () => {
+    mountWith({ reachable: true });
+    const { findByText } = render(<SystemUpdateApp />);
+
+    await findByText("You're up to date");
+  });
+
+  it("keeps offering the update to a drifted box the remote refused", async () => {
+    // Drift is LOCAL evidence — the build on disk disagrees with the checkout —
+    // and it stays actionable whatever GitHub is doing. Hiding the button
+    // behind an unreachable remote would take the one repair the owner can run
+    // away from the box that needs it.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/setup-api/update/versions")) {
+          return jsonResponse({
+            clawbox: { current: "v3.9.0", target: null, updateAvailable: false },
+            openclaw: { current: "2026.8.1", target: null, updateAvailable: false },
+            edition: "openclaw",
+            remote: { reachable: false, refusedAnonymously: true, reason: REFUSAL_REASON },
+          });
+        }
+        if (url.includes("/setup-api/system/build-identity")) {
+          return jsonResponse({
+            ...HEALTHY_IDENTITY,
+            checkout: { commit: "d285cfd8", shortCommit: "d285cfd", branch: "beta", dirty: false, committedAt: null },
+            drift: {
+              buildVsCheckout: "drift",
+              checkoutVsPin: "unknown",
+              detected: true,
+              reasons: ["This box is running a build made from 1dc29ef but the code on disk is d285cfd — run Update to realign."],
+              codes: ["build-from-other-commit"],
+            },
+          });
+        }
+        if (url.includes("/setup-api/system/update-branch")) return jsonResponse({ branch: "beta" });
+        if (url.includes("/setup-api/update/status")) return jsonResponse({ phase: "idle", steps: [] });
+        return jsonResponse({});
+      }),
+    );
+    const { findByRole } = render(<SystemUpdateApp />);
+
+    await findByRole("button", { name: "Update everything" });
+  });
+
+  it("still says 'up to date' for a device whose server predates the field", async () => {
+    // An older /update/versions payload carries no `remote` at all. Absent is
+    // not "unreachable" — treating it as one would alarm every box mid-fleet
+    // update.
+    mountWith(undefined);
+    const { findByText } = render(<SystemUpdateApp />);
+
+    await findByText("You're up to date");
+  });
+});
+
+/**
+ * The same claim, one screen over. Settings' sidebar puts "Up to date" under
+ * the System Update entry from the same payload, so a box GitHub was refusing
+ * carried the lie in two places at once — and the sidebar's copy sits beside a
+ * page that has stopped making it.
+ */
+const settingsUi: UISettings = {
+  wallpaperId: "default",
+  wpFit: "fill",
+  wpBgColor: "#000000",
+  wpOpacity: 100,
+  mascotHidden: false,
+  wallpapers: [{ id: "default", name: "Default" }],
+  customWallpapers: [],
+  onWallpaperChange: vi.fn(),
+  onWpFitChange: vi.fn(),
+  onWpBgColorChange: vi.fn(),
+  onWpOpacityChange: vi.fn(),
+  onMascotToggle: vi.fn(),
+  onWallpaperUpload: vi.fn(),
+  onCustomWallpaperDelete: vi.fn(),
+};
+
+function stubSettingsFetch(remote: unknown): void {
+  vi.stubGlobal("fetch", vi.fn((input: string | URL | undefined) => {
+    const url = String(input ?? "");
+    if (url.startsWith("/setup-api/update/versions")) {
+      return Promise.resolve(jsonResponse({
+        clawbox: { current: "v4.0.0", target: null, updateAvailable: false },
+        openclaw: { current: "2026.8.1", target: null, updateAvailable: false },
+        edition: "openclaw",
+        ...(remote === undefined ? {} : { remote }),
+      }));
+    }
+    if (url === "/setup-api/update/status") return Promise.resolve(jsonResponse({ phase: "idle", steps: [] }));
+    if (url === "/setup-api/system/update-branch") return Promise.resolve(jsonResponse({ branch: "beta" }));
+    if (url === "/setup-api/providers/status") {
+      return Promise.resolve(jsonResponse({ harness: "openclaw", defaultProvider: "clawai", degraded: false, providers: [] }));
+    }
+    return Promise.resolve(jsonResponse({}));
+  }));
+}
+
+describe("Settings sidebar — the same claim, one screen over", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("drops the 'Up to date' subtitle when the device could not reach the remote", async () => {
+    stubSettingsFetch({ reachable: false, refusedAnonymously: true, reason: REFUSAL_REASON });
+    render(<SettingsApp ui={settingsUi} />);
+
+    const nav = await screen.findByRole("navigation");
+    await waitFor(() => expect(nav.textContent).toContain(translations.en["settings.systemUpdate"]));
+    expect(nav.textContent).not.toContain(translations.en["settings.upToDate"]);
+  });
+
+  it("keeps it for a device that did reach the remote", async () => {
+    stubSettingsFetch({ reachable: true });
+    render(<SettingsApp ui={settingsUi} />);
+
+    const nav = await screen.findByRole("navigation");
+    await waitFor(() => expect(nav.textContent).toContain(translations.en["settings.upToDate"]));
+  });
+});

--- a/src/tests/components/update-remote-refusal.test.tsx
+++ b/src/tests/components/update-remote-refusal.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "@/tests/helpers/test-utils";
 import { translations } from "@/lib/translations";
 import SystemUpdateApp from "@/components/SystemUpdateApp";
 import SettingsApp, { type UISettings } from "@/components/SettingsApp";
+import UpdateStep from "@/components/UpdateStep";
 
 vi.mock("@/lib/i18n", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/i18n")>()),
@@ -212,4 +213,69 @@ describe("Settings sidebar — the same claim, one screen over", () => {
     const nav = await screen.findByRole("navigation");
     await waitFor(() => expect(nav.textContent).toContain(translations.en["settings.upToDate"]));
   });
+});
+
+/**
+ * The onboarding wizard, where the same claim also SKIPS WORK.
+ *
+ * `UpdateStep` reads /setup-api/update/status, whose `versions` object is the
+ * whole `getVersionInfo()` payload. On a first boot behind an address GitHub is
+ * refusing, HEAD matched the stale refs the image shipped with, the step
+ * printed "Up to date" and auto-advanced after 1.5 s — the customer onboarded
+ * onto whatever was in the image, with no update attempted and nothing said.
+ */
+function stubWizardStatus(remote: unknown) {
+  vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+    const url = input.toString();
+    if (url === "/setup-api/update/status") {
+      return jsonResponse({
+        phase: "idle",
+        steps: [],
+        currentStepIndex: -1,
+        versions: {
+          clawbox: { current: "v4.0.0", target: null, updateAvailable: false },
+          openclaw: { current: "2026.8.1", target: null, updateAvailable: false },
+          ...(remote === undefined ? {} : { remote }),
+        },
+      });
+    }
+    return jsonResponse({ error: "Not found" }, false, 404);
+  }));
+}
+
+describe("SetupWizard update step — a refused check does not skip the step", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("does not auto-advance past the update step on a box that could not check", async () => {
+    stubWizardStatus({ reachable: false, refusedAnonymously: true, reason: REFUSAL_REASON });
+    const onNext = vi.fn();
+
+    const { findByText } = render(<UpdateStep onNext={onNext} />);
+
+    await findByText(REFUSAL_REASON);
+    // The auto-advance fires 1.5 s after the step decides it is up to date.
+    await new Promise((r) => setTimeout(r, 2_000));
+    expect(onNext).not.toHaveBeenCalled();
+  }, 20_000);
+
+  it("still auto-advances a box that reached GitHub and is current", async () => {
+    stubWizardStatus({ reachable: true });
+    const onNext = vi.fn();
+
+    render(<UpdateStep onNext={onNext} />);
+
+    await waitFor(() => expect(onNext).toHaveBeenCalled(), { timeout: 6_000 });
+  }, 20_000);
+
+  it("still auto-advances a device whose server predates the field", async () => {
+    stubWizardStatus(undefined);
+    const onNext = vi.fn();
+
+    render(<UpdateStep onNext={onNext} />);
+
+    await waitFor(() => expect(onNext).toHaveBeenCalled(), { timeout: 6_000 });
+  }, 20_000);
 });

--- a/src/tests/routes/update/status.test.ts
+++ b/src/tests/routes/update/status.test.ts
@@ -78,7 +78,7 @@ describe("GET /setup-api/update/status", () => {
     mockGetVersionInfo.mockResolvedValue({
       clawbox: { current: "1.0.0", target: "1.1.0" },
       openclaw: { current: "0.5.0", target: "0.5.1" },
-      edition: "openclaw",
+      edition: "openclaw", remote: { reachable: true },
     });
     mockCollectBuildIdentity.mockResolvedValue(buildIdentity(NO_DRIFT));
 
@@ -105,7 +105,7 @@ describe("GET /setup-api/update/status", () => {
     mockGetVersionInfo.mockResolvedValue({
       clawbox: { current: "1.1.0", target: null, updateAvailable: false },
       openclaw: { current: "0.5.1", target: null, updateAvailable: false },
-      edition: "openclaw",
+      edition: "openclaw", remote: { reachable: true },
     });
 
     const res = await updateStatusGet();
@@ -122,7 +122,7 @@ describe("GET /setup-api/update/status", () => {
     mockGetVersionInfo.mockResolvedValue({
       clawbox: { current: "1.0.0", target: "1.1.0", updateAvailable: true },
       openclaw: { current: "0.5.1", target: null, updateAvailable: false },
-      edition: "openclaw",
+      edition: "openclaw", remote: { reachable: true },
     });
 
     const res = await updateStatusGet();
@@ -219,7 +219,7 @@ describe("GET /setup-api/update/status", () => {
       mockGetVersionInfo.mockResolvedValue({
         clawbox: { current: "3.9.0", target: null, updateAvailable: false },
         openclaw: { current: "2026.7.1-2", target: null, updateAvailable: false },
-        edition: "hermes",
+        edition: "hermes", remote: { reachable: true },
       });
     });
 

--- a/src/tests/routes/update/versions.test.ts
+++ b/src/tests/routes/update/versions.test.ts
@@ -23,7 +23,7 @@ describe("GET /setup-api/update/versions", () => {
     mockGetVersionInfo.mockResolvedValue({
       clawbox: { current: "v2.2.2", target: "v2.2.3" },
       openclaw: { current: "2026.4.5", target: "2026.4.6" },
-      edition: "openclaw",
+      edition: "openclaw", remote: { reachable: true },
     });
 
     const mod = await import("@/app/setup-api/update/versions/route");
@@ -37,7 +37,7 @@ describe("GET /setup-api/update/versions", () => {
     await expect(response.json()).resolves.toEqual({
       clawbox: { current: "v2.2.2", target: "v2.2.3" },
       openclaw: { current: "2026.4.5", target: "2026.4.6" },
-      edition: "openclaw",
+      edition: "openclaw", remote: { reachable: true },
     });
     expect(mockInvalidateVersionCache).not.toHaveBeenCalled();
   });
@@ -49,7 +49,7 @@ describe("GET /setup-api/update/versions", () => {
       clawbox: { current: "v3.1.0", target: null },
       openclaw: { current: null, target: null },
       hermes: { current: "v0.20.5", target: null, updateAvailable: false },
-      edition: "hermes",
+      edition: "hermes", remote: { reachable: true },
     });
 
     const response = await getVersions(makeRequest());
@@ -57,7 +57,7 @@ describe("GET /setup-api/update/versions", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
       hermes: { current: "v0.20.5", target: null, updateAvailable: false },
-      edition: "hermes",
+      edition: "hermes", remote: { reachable: true },
     });
   });
 

--- a/src/tests/unit/install-git-fetch-retry.test.ts
+++ b/src/tests/unit/install-git-fetch-retry.test.ts
@@ -104,18 +104,46 @@ function runFetch(refusals: number): { status: number; output: string; attempts:
   return { status: r.status ?? -1, output: `${r.stdout ?? ""}${r.stderr ?? ""}`, attempts };
 }
 
-/**
- * The retry knobs as an operator may actually have exported them.
- *
- * `git` always refuses here, so a loop that never breaks never returns — which
- * is why this runs under `timeout`: rc 124 is the DEFECT being measured, not a
- * hung suite.
- */
-function runFetchWithKnobs(knobs: Record<string, string>): {
+/** Run one extracted-function script under a wall-clock bound, and report what stopped it. */
+function runBounded(script: string, knobs: Record<string, string>): {
   status: number;
   output: string;
   attempts: number;
+  harnessError: string | null;
 } {
+  const r = spawnSync("timeout", ["10", "bash", "-c", script], {
+    encoding: "utf-8",
+    // Far above what the runaway loop writes in ten seconds (~200 KB/s
+    // measured), so spawnSync's 1 MB default cannot be what ends the run.
+    maxBuffer: 64 * 1024 * 1024,
+    env: testEnv({ PATH: process.env.PATH ?? "", ...knobs }),
+  });
+  const attempts = fs
+    .readFileSync(attemptLog, "utf-8")
+    .split("\n")
+    .filter(Boolean).length;
+  return {
+    status: r.status ?? -1,
+    output: `${r.stdout ?? ""}${r.stderr ?? ""}`,
+    attempts,
+    // `timeout` missing, or the buffer blown after all: either would otherwise
+    // read as a clean run with an unexpected status.
+    harnessError: r.error ? String(r.error) : null,
+  };
+}
+
+/**
+ * The retry knobs as an operator may actually have exported them.
+ *
+ * `git` always refuses here, so a loop that never breaks never returns on its
+ * own and something has to stop it. `maxBuffer` is raised well past what the
+ * runaway loop can produce in the window so that the thing which stops it is
+ * `timeout` — rc 124 — and not spawnSync's 1 MB default cutting the child off
+ * with `ENOBUFS` and a null status. That distinction is the whole reason the
+ * "never exited" assertion below can fail at all: with the default buffer it
+ * passes on the defective code.
+ */
+function runFetchWithKnobs(knobs: Record<string, string>): ReturnType<typeof runBounded> {
   const script = [
     "set -euo pipefail",
     `ATTEMPTS=${JSON.stringify(attemptLog)}`,
@@ -130,23 +158,11 @@ function runFetchWithKnobs(knobs: Record<string, string>): {
     `git_with_retry -C ${JSON.stringify(tmp)} fetch origin || echo "rc=$?"`,
   ].join("\n");
 
-  const r = spawnSync("timeout", ["10", "bash", "-c", script], {
-    encoding: "utf-8",
-    env: testEnv({ PATH: process.env.PATH ?? "", ...knobs }),
-  });
-  const attempts = fs
-    .readFileSync(attemptLog, "utf-8")
-    .split("\n")
-    .filter(Boolean).length;
-  return { status: r.status ?? -1, output: `${r.stdout ?? ""}${r.stderr ?? ""}`, attempts };
+  return runBounded(script, knobs);
 }
 
 /** force-update.sh's inline twin, with `run_as_clawbox` and `sleep` stubbed. */
-function runForceFetch(gitSays: string, knobs: Record<string, string> = {}): {
-  status: number;
-  output: string;
-  attempts: number;
-} {
+function runForceFetch(gitSays: string, knobs: Record<string, string> = {}): ReturnType<typeof runBounded> {
   const script = [
     "set -euo pipefail",
     `ATTEMPTS=${JSON.stringify(attemptLog)}`,
@@ -162,15 +178,7 @@ function runForceFetch(gitSays: string, knobs: Record<string, string> = {}): {
     'fetch_with_retry || echo "rc=$?"',
   ].join("\n");
 
-  const r = spawnSync("timeout", ["10", "bash", "-c", script], {
-    encoding: "utf-8",
-    env: testEnv({ PATH: process.env.PATH ?? "", ...knobs }),
-  });
-  const attempts = fs
-    .readFileSync(attemptLog, "utf-8")
-    .split("\n")
-    .filter(Boolean).length;
-  return { status: r.status ?? -1, output: `${r.stdout ?? ""}${r.stderr ?? ""}`, attempts };
+  return runBounded(script, knobs);
 }
 
 d("a retry knob an operator got wrong cannot hang the update", () => {
@@ -181,7 +189,8 @@ d("a retry knob an operator got wrong cannot hang the update", () => {
     // refusal that will not clear. rc 124 below is `timeout` killing it.
     const r = runFetchWithKnobs({ CLAWBOX_GIT_RETRIES: "invalid" });
 
-    expect(r.status, "the retry loop never exited").not.toBe(124);
+    expect(r.harnessError).toBeNull();
+    expect(r.status, "`timeout` had to kill the retry loop").not.toBe(124);
     expect(r.attempts).toBe(3);
     expect(r.output).toContain("attempt 1/3");
     expect(r.output).not.toMatch(/integer expression expected/);
@@ -192,8 +201,9 @@ d("a retry knob an operator got wrong cannot hang the update", () => {
     // garbage delay makes `sleep` fail and takes the whole install.sh down.
     const r = runFetchWithKnobs({ CLAWBOX_GIT_RETRY_DELAY: "soon" });
 
-    expect(r.status).not.toBe(124);
+    expect(r.harnessError).toBeNull();
     expect(r.output).toContain("retrying in 3s");
+    expect(r.output).not.toMatch(/unbound variable/);
   });
 
   it("keeps a deliberate override working", () => {
@@ -209,8 +219,19 @@ d("scripts/force-update.sh retries the same way, or does not retry at all", () =
   it("clamps a non-numeric attempt count instead of looping for ever", () => {
     const r = runForceFetch(ANON_REFUSAL, { CLAWBOX_GIT_RETRIES: "invalid" });
 
-    expect(r.status, "the retry loop never exited").not.toBe(124);
+    expect(r.harnessError).toBeNull();
+    expect(r.status, "`timeout` had to kill the retry loop").not.toBe(124);
     expect(r.attempts).toBe(3);
+  });
+
+  it("classifies with the SAME list install.sh uses, character for character", () => {
+    // Two copies exist because install.sh is an installer, not a library, and
+    // cannot be sourced from a standalone recovery script. Nothing else stops
+    // them drifting: each is extracted separately by the tests above, so either
+    // could be edited alone and stay green while the two scripts disagreed
+    // about which failures are worth asking again.
+    expect(extractShellFunctionFrom(FORCE_UPDATE_SH, "git_retryable_failure"))
+      .toBe(extractShellFunction("git_retryable_failure"));
   });
 
   it("retries GitHub's anonymous refusal", () => {

--- a/src/tests/unit/install-git-fetch-retry.test.ts
+++ b/src/tests/unit/install-git-fetch-retry.test.ts
@@ -80,8 +80,8 @@ function runFetch(refusals: number): { status: number; output: string; attempts:
     "  return 0",
     "}",
     "sleep() { :; }",
-    extractShellFunction("git_fetch_with_retry"),
-    `git_fetch_with_retry ${JSON.stringify(tmp)} origin`,
+    extractShellFunction("git_with_retry"),
+    `git_with_retry -C ${JSON.stringify(tmp)} fetch origin`,
   ].join("\n");
 
   const r = spawnSync("bash", ["-c", script], {
@@ -123,7 +123,7 @@ d("install.sh survives GitHub refusing an anonymous fetch", () => {
   it("is what sync_repo_to_update_target fetches through", () => {
     const sync = extractShellFunction("sync_repo_to_update_target");
 
-    expect(sync).toContain("git_fetch_with_retry");
+    expect(sync).toContain("git_with_retry");
     // The bare one-shot fetch is what step 0 died on; it must not survive
     // beside the retrying one.
     expect(sync).not.toMatch(/^\s*git -c safe\.directory=.*fetch origin\s*$/m);

--- a/src/tests/unit/install-git-fetch-retry.test.ts
+++ b/src/tests/unit/install-git-fetch-retry.test.ts
@@ -224,16 +224,6 @@ d("scripts/force-update.sh retries the same way, or does not retry at all", () =
     expect(r.attempts).toBe(3);
   });
 
-  it("classifies with the SAME list install.sh uses, character for character", () => {
-    // Two copies exist because install.sh is an installer, not a library, and
-    // cannot be sourced from a standalone recovery script. Nothing else stops
-    // them drifting: each is extracted separately by the tests above, so either
-    // could be edited alone and stay green while the two scripts disagreed
-    // about which failures are worth asking again.
-    expect(extractShellFunctionFrom(FORCE_UPDATE_SH, "git_retryable_failure"))
-      .toBe(extractShellFunction("git_retryable_failure"));
-  });
-
   it("retries GitHub's anonymous refusal", () => {
     const r = runForceFetch(ANON_REFUSAL);
 
@@ -248,6 +238,21 @@ d("scripts/force-update.sh retries the same way, or does not retry at all", () =
     const r = runForceFetch("fatal: 'origin' does not appear to be a git repository");
 
     expect(r.attempts).toBe(1);
+  });
+});
+
+// A plain `describe`, NOT the bash-gated `d`: this is a string comparison of two
+// files, and the one assertion holding the two classifiers together is exactly
+// the thing that must not disappear on a runner that cannot spawn bash.
+describe("the two shell retry classifiers cannot drift apart", () => {
+  it("are the same list, character for character", () => {
+    // Two copies exist because install.sh is an installer, not a library, and
+    // cannot be sourced from a standalone recovery script. Nothing else stops
+    // them drifting: each is extracted separately by the tests below, so either
+    // could be edited alone and stay green while the two scripts disagreed
+    // about which failures are worth asking again.
+    expect(extractShellFunctionFrom(FORCE_UPDATE_SH, "git_retryable_failure"))
+      .toBe(extractShellFunction("git_retryable_failure"));
   });
 });
 

--- a/src/tests/unit/install-git-fetch-retry.test.ts
+++ b/src/tests/unit/install-git-fetch-retry.test.ts
@@ -161,8 +161,15 @@ function runFetchWithKnobs(knobs: Record<string, string>): ReturnType<typeof run
   return runBounded(script, knobs);
 }
 
-/** force-update.sh's inline twin, with `run_as_clawbox` and `sleep` stubbed. */
-function runForceFetch(gitSays: string, knobs: Record<string, string> = {}): ReturnType<typeof runBounded> {
+/**
+ * force-update.sh's inline twin, with `run_as_clawbox` and `sleep` stubbed.
+ * `rc` is what the stub returns; 0 drives the success path.
+ */
+function runForceFetch(
+  gitSays: string,
+  knobs: Record<string, string> = {},
+  rc = 128,
+): ReturnType<typeof runBounded> {
   const script = [
     "set -euo pipefail",
     `ATTEMPTS=${JSON.stringify(attemptLog)}`,
@@ -170,12 +177,16 @@ function runForceFetch(gitSays: string, knobs: Record<string, string> = {}): Ret
     "run_as_clawbox() {",
     "  printf 'fetch\\n' >> \"$ATTEMPTS\"",
     `  printf '%s\\n' ${JSON.stringify(gitSays)} >&2`,
-    "  return 128",
+    `  return ${rc}`,
     "}",
     "sleep() { :; }",
     extractShellFunctionFrom(FORCE_UPDATE_SH, "git_retryable_failure"),
     extractShellFunctionFrom(FORCE_UPDATE_SH, "fetch_with_retry"),
-    'fetch_with_retry || echo "rc=$?"',
+    // stdout is captured apart from stderr so the success case can assert that
+    // git's own output does NOT reach a caller reading this function's stdout —
+    // the guarantee the install.sh twin is already pinned on.
+    'out="$(fetch_with_retry)" || echo "rc=$?"',
+    'printf "STDOUT[%s]\\n" "$out"',
   ].join("\n");
 
   return runBounded(script, knobs);
@@ -229,6 +240,20 @@ d("scripts/force-update.sh retries the same way, or does not retry at all", () =
 
     expect(r.attempts).toBe(3);
     expect(r.output).toMatch(/GitHub refused this device's anonymous request/);
+  });
+
+  it("does not retry a fetch that succeeded, and keeps git's output off stdout", () => {
+    // Every other case here drives the failure path, so the two behaviours the
+    // install.sh twin is pinned on were unasserted in this copy: one attempt on
+    // success, and git's chatter re-emitted on stderr — a caller reading this
+    // function's stdout must not mistake progress output for a result.
+    const r = runForceFetch("Fetching origin", {}, 0);
+
+    expect(r.status).toBe(0);
+    expect(r.attempts).toBe(1);
+    expect(r.output).toContain("STDOUT[]");
+    expect(r.output).not.toMatch(/rc=/);
+    expect(r.output).toContain("Fetching origin");
   });
 
   it("does not retry a failure asking again cannot fix", () => {

--- a/src/tests/unit/install-git-fetch-retry.test.ts
+++ b/src/tests/unit/install-git-fetch-retry.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { spawnSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+import { testEnv } from "@/tests/helpers/env";
+
+// Starts a real bash: vitest's 5 s test and 10 s hook defaults are not enough
+// on a loaded CI runner. See src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+/**
+ * Measured on the dev network 2026-09-02 (TASK-655): GitHub answers git's
+ * protocol-v2 POST to /git-upload-pack with `HTTP 401` and a body reading
+ * "Repository not found." — for a PUBLIC repository — from an address that has
+ * used up its anonymous allowance. git reports it as
+ * `fatal: could not read Username for 'https://github.com'`.
+ *
+ * Roughly one attempt in three got through, and step 0 of an in-app update
+ * (`bootstrap_updater` → `sync_repo_to_update_target`) fetches exactly once. So
+ * a box behind such an address cannot update, and the failure text sends its
+ * owner looking for a password nobody has.
+ *
+ * git itself has no retry: 2.34 (the boxes) and 2.43 (the dev PC) both lack any
+ * `fetch.retry` / `http.retry` knob, so the retry has to live in install.sh.
+ * `GIT_TERMINAL_PROMPT=0` IS git's own switch and is used rather than
+ * reimplemented — without it the same fetch blocks on a credential prompt when
+ * a tty is attached instead of failing.
+ */
+
+const REPO = path.resolve(__dirname, "../../..");
+const INSTALL_SH = fs.readFileSync(path.join(REPO, "install.sh"), "utf-8");
+
+const CAN_RUN =
+  process.platform !== "win32"
+  && spawnSync("bash", ["-c", "true"], { stdio: "ignore" }).status === 0;
+const d = CAN_RUN ? describe : describe.skip;
+
+function extractShellFunction(name: string): string {
+  const start = INSTALL_SH.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found in install.sh`);
+  const end = INSTALL_SH.indexOf("\n}", start);
+  if (end < 0) throw new Error(`${name} has no closing brace`);
+  return `${INSTALL_SH.slice(start, end)}\n}`;
+}
+
+const ANON_REFUSAL = "fatal: could not read Username for 'https://github.com': No such device or address";
+
+let tmp: string;
+let attemptLog: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-fetch-retry-"));
+  attemptLog = path.join(tmp, "attempts");
+  fs.writeFileSync(attemptLog, "");
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+/**
+ * Drive the shipped function against a stub `git` that refuses the first
+ * `refusals` attempts exactly the way github.com does, then succeeds.
+ * `sleep` is stubbed so the backoff is observable without being waited out.
+ */
+function runFetch(refusals: number): { status: number; output: string; attempts: number } {
+  const script = [
+    "set -euo pipefail",
+    `ATTEMPTS=${JSON.stringify(attemptLog)}`,
+    `REFUSALS=${refusals}`,
+    "git() {",
+    "  printf 'git %s\\n' \"$*\" >> \"$ATTEMPTS\"",
+    "  local n; n=$(wc -l < \"$ATTEMPTS\")",
+    "  if [ \"$n\" -le \"$REFUSALS\" ]; then",
+    `    printf '%s\\n' ${JSON.stringify(ANON_REFUSAL)} >&2`,
+    "    return 128",
+    "  fi",
+    "  return 0",
+    "}",
+    "sleep() { :; }",
+    extractShellFunction("git_fetch_with_retry"),
+    `git_fetch_with_retry ${JSON.stringify(tmp)} origin`,
+  ].join("\n");
+
+  const r = spawnSync("bash", ["-c", script], {
+    encoding: "utf-8",
+    env: testEnv({ PATH: process.env.PATH ?? "" }),
+  });
+  const attempts = fs
+    .readFileSync(attemptLog, "utf-8")
+    .split("\n")
+    .filter(Boolean).length;
+  return { status: r.status ?? -1, output: `${r.stdout ?? ""}${r.stderr ?? ""}`, attempts };
+}
+
+d("install.sh survives GitHub refusing an anonymous fetch", () => {
+  it("retries a refused fetch instead of failing the update on the first attempt", () => {
+    const r = runFetch(2);
+
+    expect(r.status).toBe(0);
+    expect(r.attempts).toBe(3);
+  });
+
+  it("does not retry a fetch that succeeded", () => {
+    const r = runFetch(0);
+
+    expect(r.status).toBe(0);
+    expect(r.attempts).toBe(1);
+  });
+
+  it("names GitHub's anonymous refusal rather than a missing password", () => {
+    const r = runFetch(99);
+
+    expect(r.status).not.toBe(0);
+    // The owner is told what actually happened. "could not read Username"
+    // alone sent two people looking for credentials a ClawBox never has.
+    expect(r.output).toMatch(/anonymous/i);
+    expect(r.output).toMatch(/GitHub/);
+  });
+
+  it("is what sync_repo_to_update_target fetches through", () => {
+    const sync = extractShellFunction("sync_repo_to_update_target");
+
+    expect(sync).toContain("git_fetch_with_retry");
+    // The bare one-shot fetch is what step 0 died on; it must not survive
+    // beside the retrying one.
+    expect(sync).not.toMatch(/^\s*git -c safe\.directory=.*fetch origin\s*$/m);
+  });
+});

--- a/src/tests/unit/install-git-fetch-retry.test.ts
+++ b/src/tests/unit/install-git-fetch-retry.test.ts
@@ -31,18 +31,26 @@ vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const REPO = path.resolve(__dirname, "../../..");
 const INSTALL_SH = fs.readFileSync(path.join(REPO, "install.sh"), "utf-8");
+// force-update.sh carries its own copy of the same shape: it is the recovery
+// script an owner runs when the in-app update cannot, so it must not be able to
+// hang on the box it is recovering either.
+const FORCE_UPDATE_SH = fs.readFileSync(path.join(REPO, "scripts", "force-update.sh"), "utf-8");
 
 const CAN_RUN =
   process.platform !== "win32"
   && spawnSync("bash", ["-c", "true"], { stdio: "ignore" }).status === 0;
 const d = CAN_RUN ? describe : describe.skip;
 
-function extractShellFunction(name: string): string {
-  const start = INSTALL_SH.indexOf(`${name}() {`);
-  if (start < 0) throw new Error(`${name} not found in install.sh`);
-  const end = INSTALL_SH.indexOf("\n}", start);
+function extractShellFunctionFrom(source: string, name: string): string {
+  const start = source.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found`);
+  const end = source.indexOf("\n}", start);
   if (end < 0) throw new Error(`${name} has no closing brace`);
-  return `${INSTALL_SH.slice(start, end)}\n}`;
+  return `${source.slice(start, end)}\n}`;
+}
+
+function extractShellFunction(name: string): string {
+  return extractShellFunctionFrom(INSTALL_SH, name);
 }
 
 const ANON_REFUSAL = "fatal: could not read Username for 'https://github.com': No such device or address";
@@ -95,6 +103,132 @@ function runFetch(refusals: number): { status: number; output: string; attempts:
     .filter(Boolean).length;
   return { status: r.status ?? -1, output: `${r.stdout ?? ""}${r.stderr ?? ""}`, attempts };
 }
+
+/**
+ * The retry knobs as an operator may actually have exported them.
+ *
+ * `git` always refuses here, so a loop that never breaks never returns — which
+ * is why this runs under `timeout`: rc 124 is the DEFECT being measured, not a
+ * hung suite.
+ */
+function runFetchWithKnobs(knobs: Record<string, string>): {
+  status: number;
+  output: string;
+  attempts: number;
+} {
+  const script = [
+    "set -euo pipefail",
+    `ATTEMPTS=${JSON.stringify(attemptLog)}`,
+    "git() {",
+    "  printf 'git %s\\n' \"$*\" >> \"$ATTEMPTS\"",
+    `  printf '%s\\n' ${JSON.stringify(ANON_REFUSAL)} >&2`,
+    "  return 128",
+    "}",
+    "sleep() { :; }",
+    extractShellFunction("git_retryable_failure"),
+    extractShellFunction("git_with_retry"),
+    `git_with_retry -C ${JSON.stringify(tmp)} fetch origin || echo "rc=$?"`,
+  ].join("\n");
+
+  const r = spawnSync("timeout", ["10", "bash", "-c", script], {
+    encoding: "utf-8",
+    env: testEnv({ PATH: process.env.PATH ?? "", ...knobs }),
+  });
+  const attempts = fs
+    .readFileSync(attemptLog, "utf-8")
+    .split("\n")
+    .filter(Boolean).length;
+  return { status: r.status ?? -1, output: `${r.stdout ?? ""}${r.stderr ?? ""}`, attempts };
+}
+
+/** force-update.sh's inline twin, with `run_as_clawbox` and `sleep` stubbed. */
+function runForceFetch(gitSays: string, knobs: Record<string, string> = {}): {
+  status: number;
+  output: string;
+  attempts: number;
+} {
+  const script = [
+    "set -euo pipefail",
+    `ATTEMPTS=${JSON.stringify(attemptLog)}`,
+    'GIT="git"',
+    "run_as_clawbox() {",
+    "  printf 'fetch\\n' >> \"$ATTEMPTS\"",
+    `  printf '%s\\n' ${JSON.stringify(gitSays)} >&2`,
+    "  return 128",
+    "}",
+    "sleep() { :; }",
+    extractShellFunctionFrom(FORCE_UPDATE_SH, "git_retryable_failure"),
+    extractShellFunctionFrom(FORCE_UPDATE_SH, "fetch_with_retry"),
+    'fetch_with_retry || echo "rc=$?"',
+  ].join("\n");
+
+  const r = spawnSync("timeout", ["10", "bash", "-c", script], {
+    encoding: "utf-8",
+    env: testEnv({ PATH: process.env.PATH ?? "", ...knobs }),
+  });
+  const attempts = fs
+    .readFileSync(attemptLog, "utf-8")
+    .split("\n")
+    .filter(Boolean).length;
+  return { status: r.status ?? -1, output: `${r.stdout ?? ""}${r.stderr ?? ""}`, attempts };
+}
+
+d("a retry knob an operator got wrong cannot hang the update", () => {
+  it("clamps a non-numeric attempt count instead of looping for ever", () => {
+    // `[ "$attempt" -ge "$max" ]` with a non-numeric `max` makes `[` itself
+    // fail — "integer expression expected" — every iteration, so the loop
+    // never reaches its break and the step burns its whole budget on a
+    // refusal that will not clear. rc 124 below is `timeout` killing it.
+    const r = runFetchWithKnobs({ CLAWBOX_GIT_RETRIES: "invalid" });
+
+    expect(r.status, "the retry loop never exited").not.toBe(124);
+    expect(r.attempts).toBe(3);
+    expect(r.output).toContain("attempt 1/3");
+    expect(r.output).not.toMatch(/integer expression expected/);
+  });
+
+  it("clamps a non-numeric delay, so the backoff stays a number of seconds", () => {
+    // `sleep` is stubbed here, but on a box it is real and `set -e` is on: a
+    // garbage delay makes `sleep` fail and takes the whole install.sh down.
+    const r = runFetchWithKnobs({ CLAWBOX_GIT_RETRY_DELAY: "soon" });
+
+    expect(r.status).not.toBe(124);
+    expect(r.output).toContain("retrying in 3s");
+  });
+
+  it("keeps a deliberate override working", () => {
+    const r = runFetchWithKnobs({ CLAWBOX_GIT_RETRIES: "2", CLAWBOX_GIT_RETRY_DELAY: "7" });
+
+    expect(r.attempts).toBe(2);
+    expect(r.output).toContain("attempt 1/2");
+    expect(r.output).toContain("retrying in 7s");
+  });
+});
+
+d("scripts/force-update.sh retries the same way, or does not retry at all", () => {
+  it("clamps a non-numeric attempt count instead of looping for ever", () => {
+    const r = runForceFetch(ANON_REFUSAL, { CLAWBOX_GIT_RETRIES: "invalid" });
+
+    expect(r.status, "the retry loop never exited").not.toBe(124);
+    expect(r.attempts).toBe(3);
+  });
+
+  it("retries GitHub's anonymous refusal", () => {
+    const r = runForceFetch(ANON_REFUSAL);
+
+    expect(r.attempts).toBe(3);
+    expect(r.output).toMatch(/GitHub refused this device's anonymous request/);
+  });
+
+  it("does not retry a failure asking again cannot fix", () => {
+    // The recovery script is run by an owner who is already stuck. Spending
+    // 3 s + 6 s of backoff on a broken remote before saying so is time taken
+    // from someone waiting at the box.
+    const r = runForceFetch("fatal: 'origin' does not appear to be a git repository");
+
+    expect(r.attempts).toBe(1);
+  });
+});
 
 d("install.sh survives GitHub refusing an anonymous fetch", () => {
   it("retries a refused fetch instead of failing the update on the first attempt", () => {

--- a/src/tests/unit/install-git-fetch-retry.test.ts
+++ b/src/tests/unit/install-git-fetch-retry.test.ts
@@ -80,6 +80,7 @@ function runFetch(refusals: number): { status: number; output: string; attempts:
     "  return 0",
     "}",
     "sleep() { :; }",
+    extractShellFunction("git_retryable_failure"),
     extractShellFunction("git_with_retry"),
     `git_with_retry -C ${JSON.stringify(tmp)} fetch origin`,
   ].join("\n");
@@ -118,6 +119,64 @@ d("install.sh survives GitHub refusing an anonymous fetch", () => {
     // alone sent two people looking for credentials a ClawBox never has.
     expect(r.output).toMatch(/anonymous/i);
     expect(r.output).toMatch(/GitHub/);
+  });
+
+  it("does not retry a failure asking again cannot fix", () => {
+    // "destination path already exists" is not a refusal; three attempts and
+    // 9 s of sleeps spend the root step's budget to reach the same answer.
+    const script = [
+      "set -euo pipefail",
+      `ATTEMPTS=${JSON.stringify(attemptLog)}`,
+      "git() {",
+      "  printf 'git %s\\n' \"$*\" >> \"$ATTEMPTS\"",
+      "  echo \"fatal: destination path 'x' already exists and is not an empty directory.\" >&2",
+      "  return 128",
+      "}",
+      "sleep() { :; }",
+      extractShellFunction("git_retryable_failure"),
+      extractShellFunction("git_with_retry"),
+      `git_with_retry clone --branch beta https://example.invalid/x ${JSON.stringify(tmp)} || true`,
+    ].join("\n");
+    spawnSync("bash", ["-c", script], {
+      encoding: "utf-8",
+      env: testEnv({ PATH: process.env.PATH ?? "" }),
+    });
+
+    expect(fs.readFileSync(attemptLog, "utf-8").split("\n").filter(Boolean)).toHaveLength(1);
+  });
+
+  it("leaves git's own output on stderr, so a caller capturing stdout gets none of it", () => {
+    // The function captures git's stderr to classify it. Re-emitting it on
+    // STDOUT would make it indistinguishable from a result to any future caller
+    // that reads this function's stdout.
+    const script = [
+      "set -euo pipefail",
+      "git() { echo 'Fetching origin' >&2; return 0; }",
+      extractShellFunction("git_retryable_failure"),
+      extractShellFunction("git_with_retry"),
+      "out=$(git_with_retry -C /tmp fetch origin 2>/dev/null)",
+      'printf "[%s]" "$out"',
+    ].join("\n");
+    const r = spawnSync("bash", ["-c", script], {
+      encoding: "utf-8",
+      env: testEnv({ PATH: process.env.PATH ?? "" }),
+    });
+
+    expect(r.status).toBe(0);
+    expect(r.stdout?.trim()).toBe("[]");
+  });
+
+  it("is defined before the bootstrap block that runs the FIRST of the three fetches", () => {
+    // bash defines a function when execution reaches it. The bootstrap block
+    // decides which install.sh the rest of the update runs, so a definition
+    // below it would leave that fetch — the one that matters most — unretried.
+    const defined = INSTALL_SH.indexOf("git_with_retry() {");
+    const bootstrap = INSTALL_SH.indexOf("# ── Bootstrap: pull latest install.sh");
+    const used = INSTALL_SH.indexOf("git_with_retry -C \"$_b\"");
+
+    expect(defined).toBeGreaterThan(-1);
+    expect(bootstrap).toBeGreaterThan(defined);
+    expect(used).toBeGreaterThan(bootstrap);
   });
 
   it("is what sync_repo_to_update_target fetches through", () => {

--- a/src/tests/unit/mcp-update-remote-refusal.test.ts
+++ b/src/tests/unit/mcp-update-remote-refusal.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+/**
+ * TASK-655. The same "up to date" claim, told to the model instead of the owner.
+ *
+ * GitHub refuses anonymous `git-upload-pack` POSTs from an address that has
+ * made too many, so the device compares HEAD against the STALE refs its last
+ * successful fetch left and finds no delta. `device_status` — the tool the MCP
+ * server's own instructions tell every model to call FIRST for anything about
+ * this device — turned that into `update.waiting: false`, and the owner asking
+ * the assistant "am I on the latest version?" was told yes by a box that never
+ * managed to ask.
+ */
+
+const { apiGet, apiTry } = vi.hoisted(() => ({ apiGet: vi.fn(), apiTry: vi.fn() }));
+
+vi.mock("../../../mcp/lib/api", () => ({
+  apiGet: (...a: unknown[]) => apiGet(...a),
+  apiPost: vi.fn(),
+  apiTry: (...a: unknown[]) => apiTry(...a),
+  API_BASE: "http://127.0.0.1:80",
+  CLAWBOX_ROOT: "/home/clawbox/clawbox",
+}));
+
+import type { McpContext } from "../../../mcp/lib/context";
+import { captureRegistrar } from "../helpers/mcp-registrar";
+import { registerOrientationTools } from "../../../mcp/tools/orientation";
+import { registerSystemTools } from "../../../mcp/tools/system";
+
+const REFUSAL_REASON =
+  "GitHub refused this ClawBox's anonymous request for the update repository. "
+  + "The repository is public and the device needs no password — GitHub answers 401 to anonymous git "
+  + "requests from an address that has made too many. Try again in a few minutes.";
+
+const ctx = (edition: "openclaw" | "hermes"): McpContext => ({
+  edition,
+  install: edition,
+  appHarness: edition,
+  profile: "full",
+  capabilities: { screenGrabber: null, imageConvert: false, journal: false, du: false },
+  providers: [],
+  emailCanRead: false,
+  codingAgent: false,
+  canGenerateImages: true,
+});
+
+/** What a refused box's /update/versions really answers: no delta anywhere. */
+const refusedPayload = (edition: "openclaw" | "hermes") => ({
+  clawbox: { current: "v4.0.0", target: null, updateAvailable: false },
+  openclaw: { current: "2026.8.1", target: null, updateAvailable: false },
+  ...(edition === "hermes" ? { hermes: { current: "0.20.5", target: null, updateAvailable: false } } : {}),
+  edition,
+  remote: { reachable: false, refusedAnonymously: true, reason: REFUSAL_REASON },
+});
+
+async function deviceStatus(edition: "openclaw" | "hermes", payload: unknown) {
+  apiTry.mockImplementation(async (path: string) =>
+    path.includes("/setup-api/update/versions") ? payload : null,
+  );
+  const h = captureRegistrar(edition);
+  registerOrientationTools(h.reg, ctx(edition));
+  const out = await h.call("device_status", {});
+  if (out.isError) throw new Error("device_status failed");
+  return JSON.parse(out.text) as { update: Record<string, unknown> | string };
+}
+
+beforeEach(() => {
+  apiGet.mockReset();
+  apiTry.mockReset().mockResolvedValue(null);
+});
+
+describe("device_status does not tell the model an unreachable box is current", () => {
+  for (const edition of ["openclaw", "hermes"] as const) {
+    it(`answers "unknown", not false, on the ${edition} edition`, async () => {
+      const body = await deviceStatus(edition, refusedPayload(edition));
+      const update = body.update as Record<string, unknown>;
+
+      expect(update.waiting).toBe("unknown");
+      expect(String(update.check_failed)).toContain("anonymous");
+    });
+  }
+
+  it("still answers false on a box that reached GitHub and is current", async () => {
+    const body = await deviceStatus("openclaw", {
+      ...refusedPayload("openclaw"),
+      remote: { reachable: true },
+    });
+    const update = body.update as Record<string, unknown>;
+
+    expect(update.waiting).toBe(false);
+    expect(update).not.toHaveProperty("check_failed");
+  });
+
+  it("still answers false for a device whose software predates the field", async () => {
+    // Absent is "not known", never "unreachable" — a mid-fleet update must not
+    // make every older box start reporting a failed check.
+    const payload = { ...refusedPayload("openclaw") } as Record<string, unknown>;
+    delete payload.remote;
+
+    const body = await deviceStatus("openclaw", payload);
+    const update = body.update as Record<string, unknown>;
+
+    expect(update.waiting).toBe(false);
+  });
+});
+
+describe("update_check names the field so the model cannot ignore it", () => {
+  it("passes remote through and tells the model what to do with it", async () => {
+    apiGet.mockResolvedValue(refusedPayload("openclaw"));
+    const h = captureRegistrar("openclaw");
+    registerSystemTools(h.reg, ctx("openclaw"));
+
+    const out = await h.call("update_check", {});
+    if (out.isError) throw new Error(`update_check failed: ${JSON.stringify(out.error)}`);
+    const body = JSON.parse(out.text) as Record<string, unknown>;
+
+    expect(body.remote).toEqual({ reachable: false, refusedAnonymously: true, reason: REFUSAL_REASON });
+    const described = h.tools.get("update_check")?.description ?? "";
+    expect(described).toMatch(/remote\.reachable/);
+  });
+});

--- a/src/tests/unit/updater-remote-refusal.test.ts
+++ b/src/tests/unit/updater-remote-refusal.test.ts
@@ -258,6 +258,37 @@ describe("a refused anonymous fetch is not 'up to date'", () => {
   });
 });
 
+describe("a retry delay an operator got wrong", () => {
+  it("is replaced with the default, and said out loud", async () => {
+    // `Number("soon")` is NaN and a negative value stays negative; `setTimeout`
+    // treats both as 0, so the retries would still run — back to back, removing
+    // the spacing the policy depends on and sending the anonymous requests in a
+    // burst, which is the condition the refusal is caused by. The shell knobs
+    // are clamped the same way in install.sh and scripts/force-update.sh.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.UPDATER_REMOTE_CHECK_RETRY_DELAY_MS = "soon";
+    process.env.UPDATER_REMOTE_RETRY_DELAY_MS = "-1";
+
+    await import("@/lib/updater");
+    const said = warn.mock.calls.map((c) => c.join(" ")).join("\n");
+
+    expect(said).toMatch(/UPDATER_REMOTE_CHECK_RETRY_DELAY_MS="soon".*using 1200/);
+    expect(said).toMatch(/UPDATER_REMOTE_RETRY_DELAY_MS="-1".*using 4000/);
+    warn.mockRestore();
+  });
+
+  it("keeps a deliberate override", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.UPDATER_REMOTE_CHECK_RETRY_DELAY_MS = "0";
+
+    await import("@/lib/updater");
+
+    expect(warn.mock.calls.map((c) => c.join(" ")).join("\n"))
+      .not.toMatch(/UPDATER_REMOTE_CHECK_RETRY_DELAY_MS/);
+    warn.mockRestore();
+  });
+});
+
 describe("the call the answer depends on is the one that is retried", () => {
   /**
    * `ls-remote` is the AUTHORITATIVE half of the version check: the tag list is

--- a/src/tests/unit/updater-remote-refusal.test.ts
+++ b/src/tests/unit/updater-remote-refusal.test.ts
@@ -277,6 +277,34 @@ describe("a retry delay an operator got wrong", () => {
     warn.mockRestore();
   });
 
+  it("refuses a blank value, which Number() reads as zero", async () => {
+    // `Number(" ")` is 0, not NaN — so whitespace slipped past a plain
+    // finite/negative check and became exactly the no-delay burst the guard
+    // exists to prevent.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.UPDATER_REMOTE_CHECK_RETRY_DELAY_MS = "  ";
+
+    await import("@/lib/updater");
+
+    expect(warn.mock.calls.map((c) => c.join(" ")).join("\n"))
+      .toMatch(/UPDATER_REMOTE_CHECK_RETRY_DELAY_MS.*using 1200/);
+    warn.mockRestore();
+  });
+
+  it("refuses a value so large the timer would invert it into no delay", async () => {
+    // `setTimeout` above 2^31-1 ms does not wait longer, it fires on the next
+    // tick with a TimeoutOverflowWarning — and reachOrigin multiplies by the
+    // attempt number on top, so the ceiling has to leave room for that.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.UPDATER_REMOTE_RETRY_DELAY_MS = "800000000";
+
+    await import("@/lib/updater");
+
+    expect(warn.mock.calls.map((c) => c.join(" ")).join("\n"))
+      .toMatch(/UPDATER_REMOTE_RETRY_DELAY_MS="800000000".*using 4000/);
+    warn.mockRestore();
+  });
+
   it("keeps a deliberate override", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     process.env.UPDATER_REMOTE_CHECK_RETRY_DELAY_MS = "0";

--- a/src/tests/unit/updater-remote-refusal.test.ts
+++ b/src/tests/unit/updater-remote-refusal.test.ts
@@ -53,6 +53,7 @@ vi.mock("@/lib/port-probe", async (orig) => ({
 const { mockRunHermesCli } = vi.hoisted(() => ({ mockRunHermesCli: vi.fn() }));
 vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: mockRunHermesCli }));
 
+import { saveEnv } from "@/tests/helpers/env";
 import { get, set, setMany } from "@/lib/config-store";
 import { waitForPortOpen } from "@/lib/port-probe";
 
@@ -75,10 +76,17 @@ type Answer = Result | Result[];
 let argvLog: string[] = [];
 
 function install(results: Record<string, Answer>): void {
+  // Sequences are consumed by `shift`, so each `install()` gets its OWN copy.
+  // Sharing one array with the caller's literal would hand a second `install()`
+  // in the same case an already-drained queue that then silently repeats its
+  // last entry — a passing test measuring a scenario other than the one it reads
+  // as. Every fixture helper in this file is a candidate for exactly that.
+  const queues = new Map<string, Result[]>();
+  for (const [k, v] of Object.entries(results)) if (Array.isArray(v)) queues.set(k, [...v]);
   const answer = (key: string): Result | undefined => {
     for (const k of Object.keys(results)) {
       if (!key.includes(k)) continue;
-      const value = results[k];
+      const value = queues.get(k) ?? results[k];
       if (!Array.isArray(value)) return value;
       return value.length > 1 ? value.shift() : value[0];
     }
@@ -137,10 +145,21 @@ function countArgv(fragment: string): number {
   return argvLog.filter((line) => line.includes(fragment)).length;
 }
 
+/** Restores every knob below to what it was, rather than deleting it. */
+let restoreEnv: () => void = () => {};
+
 beforeEach(() => {
   vi.resetModules();
   vi.clearAllMocks();
   argvLog = [];
+  restoreEnv = saveEnv(
+    "CLAWBOX_EDITION",
+    "GATEWAY_HEALTH_WAIT_MS",
+    "GATEWAY_RECOVERY_WAIT_MS",
+    "GATEWAY_WAIT_INTERVAL_MS",
+    "UPDATER_REMOTE_RETRY_DELAY_MS",
+    "UPDATER_REMOTE_CHECK_RETRY_DELAY_MS",
+  );
   process.env.CLAWBOX_EDITION = "openclaw";
   process.env.GATEWAY_HEALTH_WAIT_MS = "1";
   process.env.GATEWAY_RECOVERY_WAIT_MS = "1";
@@ -169,20 +188,23 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  delete process.env.CLAWBOX_EDITION;
-  delete process.env.GATEWAY_HEALTH_WAIT_MS;
-  delete process.env.GATEWAY_RECOVERY_WAIT_MS;
-  delete process.env.GATEWAY_WAIT_INTERVAL_MS;
-  delete process.env.UPDATER_REMOTE_RETRY_DELAY_MS;
-  delete process.env.UPDATER_REMOTE_CHECK_RETRY_DELAY_MS;
+  // Restored, not deleted: vitest reuses a worker across files, so a `delete`
+  // takes the variable away from every file that runs after this one in the
+  // same worker. See src/tests/helpers/env.ts.
+  restoreEnv();
 });
 
 describe("a refused anonymous fetch is not 'up to date'", () => {
   /**
-   * The exact field state the box was in on 2026-09-02: `git ls-remote`'s GET
-   * to /info/refs still answers (the card measured that it "always succeeds"),
-   * while the fetch's POST is refused — so the refs on disk are whatever the
-   * last successful fetch left, and HEAD equals the STALE origin/beta.
+   * The field state the box was in on 2026-09-02: the fetch's POST to
+   * /git-upload-pack is refused while `ls-remote`'s GET to /info/refs answers —
+   * so the refs on disk are whatever the last successful fetch left, and HEAD
+   * equals the STALE origin/beta.
+   *
+   * The GET answering is what the card measured that day, NOT a property of the
+   * endpoint: it is refused too, which is why it is retried and why
+   * "still says the remote is unreachable when every ls-remote is refused"
+   * exists below.
    */
   function boxWithRefusedFetch(): void {
     install({

--- a/src/tests/unit/updater-remote-refusal.test.ts
+++ b/src/tests/unit/updater-remote-refusal.test.ts
@@ -68,13 +68,20 @@ const ANON_REFUSAL = "fatal: could not read Username for 'https://github.com': N
 const SHA = "1111111111111111111111111111111111111111";
 
 type Result = { stdout: string; stderr: string } | Error;
+/** A sequence answers successive calls in order, then repeats its last entry. */
+type Answer = Result | Result[];
 
 /** Every `execFile` argv this run issued, joined for matching. */
 let argvLog: string[] = [];
 
-function install(results: Record<string, Result>): void {
+function install(results: Record<string, Answer>): void {
   const answer = (key: string): Result | undefined => {
-    for (const k of Object.keys(results)) if (key.includes(k)) return results[k];
+    for (const k of Object.keys(results)) {
+      if (!key.includes(k)) continue;
+      const value = results[k];
+      if (!Array.isArray(value)) return value;
+      return value.length > 1 ? value.shift() : value[0];
+    }
     return undefined;
   };
 
@@ -138,8 +145,14 @@ beforeEach(() => {
   process.env.GATEWAY_HEALTH_WAIT_MS = "1";
   process.env.GATEWAY_RECOVERY_WAIT_MS = "1";
   process.env.GATEWAY_WAIT_INTERVAL_MS = "1";
-  // The retry backoff must not turn a unit test into a wall-clock wait.
+  // The retry backoff must not turn a unit test into a wall-clock wait. BOTH
+  // knobs: the version-check delay defaults to 1200 ms and two of these cases
+  // sleep on it twice, which spent over half of vitest's 5 s default before any
+  // test work — the flake class src/tests/unit/test-timeout-hygiene.test.ts
+  // exists to prevent, and which it cannot see here because this file mocks
+  // child_process instead of spawning one.
   process.env.UPDATER_REMOTE_RETRY_DELAY_MS = "1";
+  process.env.UPDATER_REMOTE_CHECK_RETRY_DELAY_MS = "1";
   vi.mocked(get).mockResolvedValue(undefined);
   vi.mocked(set).mockResolvedValue();
   vi.mocked(setMany).mockResolvedValue();
@@ -161,6 +174,7 @@ afterEach(() => {
   delete process.env.GATEWAY_RECOVERY_WAIT_MS;
   delete process.env.GATEWAY_WAIT_INTERVAL_MS;
   delete process.env.UPDATER_REMOTE_RETRY_DELAY_MS;
+  delete process.env.UPDATER_REMOTE_CHECK_RETRY_DELAY_MS;
 });
 
 describe("a refused anonymous fetch is not 'up to date'", () => {
@@ -219,6 +233,72 @@ describe("a refused anonymous fetch is not 'up to date'", () => {
 
     expect(info.remote?.reachable).toBe(true);
     expect(countArgv("fetch --quiet origin beta")).toBe(1);
+  });
+});
+
+describe("the call the answer depends on is the one that is retried", () => {
+  /**
+   * `ls-remote` is the AUTHORITATIVE half of the version check: the tag list is
+   * read from origin's answer, not from the local refs the tag fetch updates.
+   * It got one attempt while the advisory fetch above it got two, so a single
+   * refused `ls-remote` made every surface say "couldn't reach the update
+   * server" — and `TARGET_VERSION_CACHE_TTL` kept that answer for 60 s.
+   */
+  it("retries a refused ls-remote instead of reporting no target version", async () => {
+    install({
+      "fetch --quiet origin beta": { stdout: "", stderr: "" },
+      "fetch --quiet --tags origin": { stdout: "", stderr: "" },
+      "ls-remote": [new Error(ANON_REFUSAL), { stdout: `${SHA}\trefs/tags/v1.2.3\n`, stderr: "" }],
+      "rev-parse HEAD": { stdout: `${SHA}\n`, stderr: "" },
+      "rev-parse origin/beta": { stdout: `${SHA}\n`, stderr: "" },
+      openclaw: { stdout: "1.0.0", stderr: "" },
+    });
+    const updater = await import("@/lib/updater");
+
+    const target = await updater.getTargetVersion();
+
+    expect(target).toBe("v1.2.3");
+    expect(countArgv("ls-remote")).toBe(2);
+  });
+
+  it("spends the retry on ls-remote rather than on the advisory tag fetch", async () => {
+    // The anonymous allowance is what is being refused, so the budget stays
+    // where it was: the discarded call asks once, the one the answer is read
+    // from asks twice.
+    install({
+      "fetch --quiet origin beta": { stdout: "", stderr: "" },
+      "fetch --quiet --tags origin": new Error(ANON_REFUSAL),
+      "ls-remote": { stdout: `${SHA}\trefs/tags/v1.2.3\n`, stderr: "" },
+      "rev-parse HEAD": { stdout: `${SHA}\n`, stderr: "" },
+      "rev-parse origin/beta": { stdout: `${SHA}\n`, stderr: "" },
+      openclaw: { stdout: "1.0.0", stderr: "" },
+    });
+    const updater = await import("@/lib/updater");
+
+    const target = await updater.getTargetVersion();
+
+    expect(target).toBe("v1.2.3");
+    expect(countArgv("fetch --quiet --tags origin")).toBe(1);
+    expect(countArgv("ls-remote")).toBe(1);
+  });
+
+  it("still says the remote is unreachable when every ls-remote is refused", async () => {
+    install({
+      "fetch --quiet origin beta": { stdout: "", stderr: "" },
+      "fetch --quiet --tags origin": { stdout: "", stderr: "" },
+      "ls-remote": new Error(ANON_REFUSAL),
+      "rev-parse HEAD": { stdout: `${SHA}\n`, stderr: "" },
+      "rev-parse origin/beta": { stdout: `${SHA}\n`, stderr: "" },
+      openclaw: { stdout: "1.0.0", stderr: "" },
+    });
+    const updater = await import("@/lib/updater");
+
+    const info = await updater.getVersionInfo();
+
+    expect(await updater.getTargetVersion()).toBeNull();
+    expect(info.remote?.reachable).toBe(false);
+    expect(info.remote?.refusedAnonymously).toBe(true);
+    expect(countArgv("ls-remote")).toBe(2);
   });
 });
 
@@ -343,5 +423,6 @@ describe("what the refusal is called", () => {
     await updater.getVersionInfo();
 
     expect(countArgv("fetch --quiet origin beta")).toBe(1);
+    expect(countArgv("ls-remote")).toBe(1);
   });
 });

--- a/src/tests/unit/updater-remote-refusal.test.ts
+++ b/src/tests/unit/updater-remote-refusal.test.ts
@@ -222,25 +222,34 @@ describe("a refused anonymous fetch is not 'up to date'", () => {
   });
 });
 
-describe("the restart step does not fail an update over a redundant fetch", () => {
+describe("the restart step spends no anonymous fetch of its own", () => {
   /**
    * By the time the `restart` step runs, step 0 (`bootstrap_updater` →
    * install.sh `sync_repo_to_update_target`) has already fetched origin and
-   * hard-reset the tree to it. Its own `git fetch origin` is the THIRD
-   * anonymous fetch of one update and the heaviest (all refs); a refusal
-   * there ends the run on a box whose tree is already at the target.
+   * hard-reset the tree to it — and step 0 is `failFast`, so a run that reaches
+   * here is a run where that happened. Its own `git fetch origin` was therefore
+   * the THIRD anonymous fetch of one update and the heaviest (all refs), and it
+   * could only ever cost the run: an attempt on 2026-09-02 got through the
+   * first two, ran steps 1-8, and died on this one.
    */
-  it("hard-resets to the upstream refs already on disk when the fetch is refused", async () => {
+  function boxAtTheRestartStep(overrides: Record<string, Result> = {}): void {
     install({
       // Ends the run right after the tree work, so the case does not sit in
       // waitForRebuildToTakeOver's 15-minute window.
       "clawbox-run-root-step.sh rebuild_reboot": new Error("rebuild not launched"),
-      "fetch origin": new Error(ANON_REFUSAL),
+      // The rebuild unit reports a failure, so waitForRebuildToTakeOver breaks
+      // on its first poll instead of holding the case for fifteen minutes.
+      "show clawbox-root-update@rebuild_reboot.service": { stdout: "failed\n", stderr: "" },
       "rev-parse --verify origin/beta": { stdout: `${SHA}\n`, stderr: "" },
       "rev-parse HEAD": { stdout: `${SHA}\n`, stderr: "" },
       "symbolic-ref": { stdout: "beta\n", stderr: "" },
       openclaw: { stdout: "1.0.0", stderr: "" },
+      ...overrides,
     });
+  }
+
+  it("resets to the refs step 1 already fetched, without asking GitHub again", async () => {
+    boxAtTheRestartStep();
     const updater = await import("@/lib/updater");
 
     updater.resetUpdateState();
@@ -252,5 +261,87 @@ describe("the restart step does not fail an update over a redundant fetch", () =
       },
       { timeout: 15_000, interval: 20 },
     );
+    // The whole point: no third anonymous fetch. `fetch --quiet …` belongs to
+    // the version check, which this run does not perform.
+    expect(argvLog.filter((l) => /\bfetch origin\b/.test(l))).toEqual([]);
   }, 20_000);
+
+  it("names the missing ref instead of printing a git command line", async () => {
+    // Dropping the fetch without asking whether the ref is here would be a
+    // false success: `reset --hard` to a ref nobody fetched fails with Node's
+    // `Command failed: git -c safe.directory=…`, which explains nothing.
+    boxAtTheRestartStep({
+      "rev-parse --verify origin/beta": new Error(
+        "Command failed: git -c safe.directory=/home/clawbox/clawbox -C /home/clawbox/clawbox rev-parse --verify origin/beta^{commit}",
+      ),
+    });
+    const updater = await import("@/lib/updater");
+
+    updater.resetUpdateState();
+    updater.startUpdate();
+
+    await vi.waitFor(
+      () => {
+        const step = updater.getUpdateState().steps.find((s) => s.id === "restart");
+        expect(step?.status).toBe("failed");
+        expect(step?.error).toContain("no local copy of origin/beta");
+        expect(step?.error).not.toContain("safe.directory");
+      },
+      { timeout: 15_000, interval: 20 },
+    );
+  }, 20_000);
+});
+
+describe("what the refusal is called", () => {
+  /**
+   * "Could not reach GitHub" is the wrong sentence for two of these, and a
+   * wrong sentence sends the owner to the router or to a password field.
+   */
+  const cases: [string, string, RegExp][] = [
+    [
+      "a deleted update branch",
+      "fatal: couldn't find remote ref fix/gone",
+      /branch this ClawBox is pinned to/i,
+    ],
+    ["no network at all", "fatal: unable to access 'https://github.com/': Could not resolve host: github.com", /look up github\.com/i],
+  ];
+
+  for (const [name, gitSays, expected] of cases) {
+    it(`calls ${name} what it is`, async () => {
+      install({
+        "fetch --quiet origin beta": new Error(gitSays),
+        "fetch --quiet --tags origin": new Error(gitSays),
+        "ls-remote": new Error(gitSays),
+        "rev-parse HEAD": { stdout: `${SHA}\n`, stderr: "" },
+        "rev-parse origin/beta": { stdout: `${SHA}\n`, stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+      });
+      const updater = await import("@/lib/updater");
+
+      const info = await updater.getVersionInfo();
+
+      expect(info.remote?.reachable).toBe(false);
+      expect(info.remote?.refusedAnonymously).toBeFalsy();
+      expect(info.remote?.reason).toMatch(expected);
+    });
+  }
+
+  it("asks only once when there is no network to ask over", async () => {
+    // Retrying "there is no DNS" spends the owner's time on a question already
+    // answered — and the refusal this retry exists for is caused by an address
+    // making too many anonymous requests, so a blanket retry feeds it.
+    install({
+      "fetch --quiet origin beta": new Error("fatal: unable to access 'https://github.com/': Could not resolve host: github.com"),
+      "fetch --quiet --tags origin": new Error("fatal: unable to access 'https://github.com/': Could not resolve host: github.com"),
+      "ls-remote": new Error("Could not resolve host: github.com"),
+      "rev-parse HEAD": { stdout: `${SHA}\n`, stderr: "" },
+      "rev-parse origin/beta": { stdout: `${SHA}\n`, stderr: "" },
+      openclaw: { stdout: "1.0.0", stderr: "" },
+    });
+    const updater = await import("@/lib/updater");
+
+    await updater.getVersionInfo();
+
+    expect(countArgv("fetch --quiet origin beta")).toBe(1);
+  });
 });

--- a/src/tests/unit/updater-remote-refusal.test.ts
+++ b/src/tests/unit/updater-remote-refusal.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import * as childProcess from "child_process";
+import * as fs from "fs/promises";
+
+/**
+ * GitHub refuses anonymous `git-upload-pack` POSTs from an address that has
+ * used up its anonymous allowance — with `HTTP 401` and a body reading
+ * "Repository not found.", for a PUBLIC repository. git surfaces that as
+ * `fatal: could not read Username for 'https://github.com'`, which names
+ * CREDENTIALS while the cause is an anonymous-access refusal.
+ *
+ * Every ClawBox fetches anonymously and a customer box has no credential to
+ * offer, so the three things this file pins are the three ways that refusal
+ * currently reaches the owner as something else:
+ *
+ *  - FALSE SUCCESS: /update/versions swallows the failed fetch, compares HEAD
+ *    against a STALE `origin/<branch>` and answers "You're up to date".
+ *  - NO RETRY: one refused attempt ends the check, though the refusal is
+ *    intermittent (measured ~1 in 3 getting through, TASK-655).
+ *  - FALSE FAILURE: the `restart` step re-fetches refs step 0 already
+ *    fetched and hard-reset the tree to, so a refusal there paints
+ *    "Update failed" over a tree that is already at the target.
+ */
+
+vi.mock("child_process", () => ({
+  exec: vi.fn(),
+  execFile: vi.fn(),
+}));
+
+vi.mock("fs/promises", () => ({
+  readFile: vi.fn(),
+  realpath: vi.fn(),
+  rm: vi.fn(),
+  // collectBuildIdentity stats the build tree before the sync. It is caught
+  // and warned about, but leaving it off the mock makes every case in this
+  // file log a mock error that has nothing to do with what it asks.
+  stat: vi.fn(async () => {
+    throw new Error("ENOENT");
+  }),
+}));
+
+vi.mock("@/lib/config-store", () => ({
+  get: vi.fn(),
+  set: vi.fn(),
+  setMany: vi.fn(),
+}));
+
+vi.mock("@/lib/port-probe", async (orig) => ({
+  ...(await orig<typeof import("@/lib/port-probe")>()),
+  waitForPortOpen: vi.fn(),
+}));
+
+const { mockRunHermesCli } = vi.hoisted(() => ({ mockRunHermesCli: vi.fn() }));
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: mockRunHermesCli }));
+
+import { get, set, setMany } from "@/lib/config-store";
+import { waitForPortOpen } from "@/lib/port-probe";
+
+const mockExec = vi.mocked(childProcess.exec);
+const mockExecFile = vi.mocked(childProcess.execFile);
+const mockReadFile = vi.mocked(fs.readFile);
+const mockRealpath = vi.mocked(fs.realpath);
+const mockRm = vi.mocked(fs.rm);
+
+/** git's own words for GitHub's 401 on an anonymous upload-pack POST. */
+const ANON_REFUSAL = "fatal: could not read Username for 'https://github.com': No such device or address";
+
+const SHA = "1111111111111111111111111111111111111111";
+
+type Result = { stdout: string; stderr: string } | Error;
+
+/** Every `execFile` argv this run issued, joined for matching. */
+let argvLog: string[] = [];
+
+function install(results: Record<string, Result>): void {
+  const answer = (key: string): Result | undefined => {
+    for (const k of Object.keys(results)) if (key.includes(k)) return results[k];
+    return undefined;
+  };
+
+  const settle = (result: Result | undefined) => {
+    const obj = {
+      then: (resolve: (v: { stdout: string; stderr: string }) => void, reject: (e: Error) => void) => {
+        if (result instanceof Error) reject(result);
+        else resolve(result ?? { stdout: "", stderr: "" });
+        return obj;
+      },
+      catch: (reject: (e: Error) => void) => {
+        if (result instanceof Error) reject(result);
+        return obj;
+      },
+    };
+    return obj;
+  };
+
+  mockExecFile.mockImplementation(((
+    cmd: string,
+    args: string[],
+    optsOrCb?: unknown,
+    maybeCb?: unknown,
+  ) => {
+    const key = `${cmd} ${args.join(" ")}`;
+    argvLog.push(key);
+    const result = answer(key);
+    const cb = (typeof optsOrCb === "function" ? optsOrCb : maybeCb) as
+      | ((e: Error | null, r: { stdout: string; stderr: string }) => void)
+      | undefined;
+    if (cb) {
+      if (result instanceof Error) cb(result, { stdout: "", stderr: "" });
+      else cb(null, result ?? { stdout: "", stderr: "" });
+    }
+    return settle(result) as unknown as ReturnType<typeof childProcess.execFile>;
+  }) as unknown as typeof childProcess.execFile);
+
+  mockExec.mockImplementation(((cmd: string, optsOrCb?: unknown, maybeCb?: unknown) => {
+    argvLog.push(cmd);
+    const result = answer(cmd);
+    const cb = (typeof optsOrCb === "function" ? optsOrCb : maybeCb) as
+      | ((e: Error | null, r: { stdout: string; stderr: string }) => void)
+      | undefined;
+    if (cb) {
+      if (result instanceof Error) cb(result, { stdout: "", stderr: "" });
+      else cb(null, result ?? { stdout: "", stderr: "" });
+    }
+    return settle(result) as unknown as ReturnType<typeof childProcess.exec>;
+  }) as unknown as typeof childProcess.exec);
+}
+
+function countArgv(fragment: string): number {
+  return argvLog.filter((line) => line.includes(fragment)).length;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  argvLog = [];
+  process.env.CLAWBOX_EDITION = "openclaw";
+  process.env.GATEWAY_HEALTH_WAIT_MS = "1";
+  process.env.GATEWAY_RECOVERY_WAIT_MS = "1";
+  process.env.GATEWAY_WAIT_INTERVAL_MS = "1";
+  // The retry backoff must not turn a unit test into a wall-clock wait.
+  process.env.UPDATER_REMOTE_RETRY_DELAY_MS = "1";
+  vi.mocked(get).mockResolvedValue(undefined);
+  vi.mocked(set).mockResolvedValue();
+  vi.mocked(setMany).mockResolvedValue();
+  vi.mocked(waitForPortOpen).mockResolvedValue(true);
+  mockRealpath.mockImplementation((async (p: unknown) => String(p)) as never);
+  mockRm.mockResolvedValue(undefined);
+  mockReadFile.mockImplementation(async (file) => {
+    const p = String(file);
+    if (p.endsWith(".update-branch")) return "beta\n";
+    if (p.endsWith("BUILD_ID")) return "rebuilt-build-id\n";
+    if (p.endsWith("package.json")) return JSON.stringify({ version: "1.0.0" });
+    throw new Error("ENOENT");
+  });
+});
+
+afterEach(() => {
+  delete process.env.CLAWBOX_EDITION;
+  delete process.env.GATEWAY_HEALTH_WAIT_MS;
+  delete process.env.GATEWAY_RECOVERY_WAIT_MS;
+  delete process.env.GATEWAY_WAIT_INTERVAL_MS;
+  delete process.env.UPDATER_REMOTE_RETRY_DELAY_MS;
+});
+
+describe("a refused anonymous fetch is not 'up to date'", () => {
+  /**
+   * The exact field state the box was in on 2026-09-02: `git ls-remote`'s GET
+   * to /info/refs still answers (the card measured that it "always succeeds"),
+   * while the fetch's POST is refused — so the refs on disk are whatever the
+   * last successful fetch left, and HEAD equals the STALE origin/beta.
+   */
+  function boxWithRefusedFetch(): void {
+    install({
+      "fetch --quiet origin beta": new Error(ANON_REFUSAL),
+      "fetch --quiet --tags origin": new Error(ANON_REFUSAL),
+      "ls-remote": { stdout: "abc123\trefs/tags/v1.0.0\n", stderr: "" },
+      "rev-parse HEAD": { stdout: `${SHA}\n`, stderr: "" },
+      "rev-parse origin/beta": { stdout: `${SHA}\n`, stderr: "" },
+      openclaw: { stdout: "1.0.0", stderr: "" },
+    });
+  }
+
+  it("says the update remote could not be reached instead of reporting no update", async () => {
+    boxWithRefusedFetch();
+    const updater = await import("@/lib/updater");
+
+    const info = await updater.getVersionInfo();
+
+    // The lie today: `updateAvailable: false` with nothing anywhere in the
+    // payload saying the device never managed to ask.
+    expect(info.clawbox.updateAvailable).toBe(false);
+    expect(info.remote).toBeDefined();
+    expect(info.remote?.reachable).toBe(false);
+    expect(info.remote?.refusedAnonymously).toBe(true);
+  });
+
+  it("retries the refused fetch instead of giving up on the first attempt", async () => {
+    boxWithRefusedFetch();
+    const updater = await import("@/lib/updater");
+
+    await updater.getVersionInfo();
+
+    expect(countArgv("fetch --quiet origin beta")).toBeGreaterThan(1);
+  });
+
+  it("reports a reachable remote on a box whose fetch succeeds", async () => {
+    install({
+      "fetch --quiet origin beta": { stdout: "", stderr: "" },
+      "fetch --quiet --tags origin": { stdout: "", stderr: "" },
+      "ls-remote": { stdout: "abc123\trefs/tags/v1.0.0\n", stderr: "" },
+      "rev-parse HEAD": { stdout: `${SHA}\n`, stderr: "" },
+      "rev-parse origin/beta": { stdout: `${SHA}\n`, stderr: "" },
+      openclaw: { stdout: "1.0.0", stderr: "" },
+    });
+    const updater = await import("@/lib/updater");
+
+    const info = await updater.getVersionInfo();
+
+    expect(info.remote?.reachable).toBe(true);
+    expect(countArgv("fetch --quiet origin beta")).toBe(1);
+  });
+});
+
+describe("the restart step does not fail an update over a redundant fetch", () => {
+  /**
+   * By the time the `restart` step runs, step 0 (`bootstrap_updater` →
+   * install.sh `sync_repo_to_update_target`) has already fetched origin and
+   * hard-reset the tree to it. Its own `git fetch origin` is the THIRD
+   * anonymous fetch of one update and the heaviest (all refs); a refusal
+   * there ends the run on a box whose tree is already at the target.
+   */
+  it("hard-resets to the upstream refs already on disk when the fetch is refused", async () => {
+    install({
+      // Ends the run right after the tree work, so the case does not sit in
+      // waitForRebuildToTakeOver's 15-minute window.
+      "clawbox-run-root-step.sh rebuild_reboot": new Error("rebuild not launched"),
+      "fetch origin": new Error(ANON_REFUSAL),
+      "rev-parse --verify origin/beta": { stdout: `${SHA}\n`, stderr: "" },
+      "rev-parse HEAD": { stdout: `${SHA}\n`, stderr: "" },
+      "symbolic-ref": { stdout: "beta\n", stderr: "" },
+      openclaw: { stdout: "1.0.0", stderr: "" },
+    });
+    const updater = await import("@/lib/updater");
+
+    updater.resetUpdateState();
+    updater.startUpdate();
+
+    await vi.waitFor(
+      () => {
+        expect(countArgv("reset --hard origin/beta")).toBe(1);
+      },
+      { timeout: 15_000, interval: 20 },
+    );
+  }, 20_000);
+});


### PR DESCRIPTION
**TASK-655 (M-06)** — box updates fail when GitHub refuses anonymous git v2 fetches (401 "Repository not found"), fleet-wide.

## Customer-visible symptom
A ClawBox behind an address GitHub is rate-limiting is told **"You're up to date — every component is on the latest release"**, in four places at once, for weeks. It has not managed to ask: the fetch is refused, the device compares `HEAD` against the *stale* `origin/<branch>` its last successful fetch left, finds no delta, and reports that as news. When an update *is* started it dies at step 0 with `fatal: could not read Username for 'https://github.com'` — a sentence about credentials no ClawBox has.

## Cause
GitHub answers git's protocol-v2 POST to `/git-upload-pack` with `HTTP 401` + body "Repository not found." — for a **public** repository — once an address has used up its anonymous allowance (measured 2026-09-02, ~2 attempts in 3 refused; on that afternoon the GET to `/info/refs` kept answering while the POST did not, so `ls-remote` succeeded where `fetch` failed — that was the state measured, **not** a property of the endpoint, and the GET is refused too). Every ClawBox fetches anonymously and one in-app update needed **three** separate anonymous fetches to succeed in a row.

Three defects, one per bug class:
- **False success** — `getPinnedBranchTarget` swallowed the fetch with `.catch(() => {})`, then compared against stale refs. `/update/versions` had no field in which the refusal could be said.
- **False failure** — the `restart` step re-fetched *all* refs that step 0 had already fetched **and hard-reset the tree to**, so a refusal there painted "Update failed" over a checkout already at the target. (Measured: one attempt got through the first two fetches, ran steps 1-8 for 3.5 min, and died on the third.)
- **No retry anywhere** — one refused attempt ended the operation.

## Harness first
This is git's own territory, not OpenClaw's or Hermes' — neither harness owns the ClawBox updater, and the card says so ("leverage git, do not build a downloader"). What is used rather than reimplemented:
- **`GIT_TERMINAL_PROMPT=0`** — git's own switch for "never ask a human". Without it a fetch that inherits a tty (a support engineer running `install.sh` or `force-update.sh`) **blocks on a username prompt** instead of failing. Now set on every network git call in `updater.ts`, `install.sh` and `scripts/force-update.sh`.
- **`git rev-parse --verify <ref>^{commit}`** — asks whether the ref the reset needs is already on disk, instead of re-fetching to find out.
- **`git ls-remote`** — already the authority for the tag list, so its success is now what decides reachability rather than an advisory fetch beside it.
- **Retry: git has none.** Neither 2.34 (the boxes) nor 2.43 (the dev PC) carries a `fetch.retry`/`http.retry` knob. That absence is the finding; the retry lives in `install.sh`'s `git_with_retry` and `updater.ts`'s `reachOrigin`.
- The repo already has the escalation for a persistently refused address — the maintainer's local bundle-update script, which scp's a thin bundle instead of fetching. This PR does not touch it; it makes the ordinary path survive an intermittent refusal.

## What changed
1. **Reachability is a fact the payload carries.** `VersionInfo.remote = { reachable, refusedAnonymously?, reason? }`, produced by `reachOrigin()`. Four surfaces stopped repeating the claim: the System Update hero (reuses the existing "Couldn't reach the update server" state — no new locale strings), its component card ("UNKNOWN"/"Couldn't check" instead of "CURRENT"/"Up to date"), Settings' sidebar subtitle (no claim rather than a false one), and the setup wizard's update step — which not only said "Up to date" but **auto-advanced past itself after 1.5 s**, onboarding a customer onto whatever shipped in the image.
2. **Both MCP tools.** `device_status` — the tool the server's instructions tell every model to call first — answered `update.waiting: false`; it now answers `"unknown"` with a `check_failed` reason. `update_check` declares `remote` and its description tells the model not to report the device as up to date without it. Both `editions: ["openclaw","hermes"]`.
3. **The third fetch is gone.** The `restart` step no longer fetches at all; step 0 is `failFast` and has already fetched **and** hard-reset the tree to `upstream`, so the step asks the only question the reset depends on — is the ref here? — and names the branch if it is not, instead of printing a git argv.
4. **Retries, classified and budgeted.** `git_with_retry` (install.sh) and `reachOrigin` (updater.ts) retry only what asking again can fix: a refusal, a timeout, a transient fault — never "no DNS", never a deleted branch, never "destination path already exists". Two budgets: 3 attempts on the one-shot update path, 2 short ones on the version check that four surfaces poll (a blanket 3× would feed the very limit it is answering). `bootstrap_updater`'s step budget went 120 s → 180 s so the retry cannot be killed by the budget it needs to pay off.
5. **All three fetches, plus the recovery script.** `git_with_retry` is defined **above** install.sh's bootstrap block — bash defines a function when execution reaches it, and that block decides which `install.sh` the rest of the run uses. `scripts/force-update.sh` (the script the failure text sends people to) got the retry and the no-prompt switch; it previously hung at a credential prompt on the box it was recovering.
6. **Honest words.** A 401 on a public repo, a private-fork refusal, no DNS, a deleted pin branch and a timeout now get five different sentences instead of one wrong one — and never a raw `Command failed: git -c safe.directory=…` as the hero subhead.

## RED → GREEN
RED on unmodified beta `3ee0e2ce` (a detached worktree with only the new test files added): **11 failures, 4 control cases passing.**

```
FAIL  install-git-fetch-retry.test.ts > retries a refused fetch instead of failing the update on the first attempt
  Error: git_with_retry not found in install.sh
FAIL  install-git-fetch-retry.test.ts > is what sync_repo_to_update_target fetches through
  AssertionError: expected 'sync_repo_to_update_target() {…' to contain 'git_with_retry'
FAIL  updater-remote-refusal.test.ts > says the update remote could not be reached instead of reporting no update
  AssertionError: expected undefined to be defined
FAIL  updater-remote-refusal.test.ts > retries the refused fetch instead of giving up on the first attempt
  AssertionError: expected 1 to be greater than 1
FAIL  updater-remote-refusal.test.ts > reports a reachable remote on a box whose fetch succeeds
  AssertionError: expected undefined to be true
FAIL  updater-remote-refusal.test.ts > the restart step … reset --hard origin/beta
  AssertionError: expected +0 to be 1
FAIL  update-remote-refusal.test.tsx > says the check failed instead of claiming every component is current
FAIL  update-remote-refusal.test.tsx > tells the owner GitHub refused the anonymous request, not that a password is missing
FAIL  update-remote-refusal.test.tsx > drops the 'Up to date' subtitle when the device could not reach the remote
  AssertionError: expected 'paletteAppearance…' not to contain 'Up to date'
Tests  8 failed (unit) · 3 failed | 4 passed (components)
```

GREEN on this branch: `vitest run --project unit` → **669 files, 10 773 passed, 1 skipped**; `--project components` → **150 files, 1 398 passed**; `tsc --noEmit` clean for both `tsconfig.json` and `mcp/tsconfig.json`; `scripts/check-sudoers-coverage.sh` → `OK — 47 grants, 43 resolved sudo invocations, 0 gaps`.

## Device proof — read-only, both editions, nothing mutated
Both boxes at beta `3ee0e2ce`, git 2.34.1, bash 5.1.16:
- The defect's site on the shipped code: `install.sh:2223  git -c safe.directory=… fetch origin` — the bare one-shot fetch, on both.
- Both still carry `protocol.version=0`, the hand-applied 2026-09-02 mitigation; anonymous `ls-remote` answers today on both.
- The **shipped** `git_with_retry` was executed on each box against a stub `git` that refuses twice then succeeds:
```
bash=5.1.16(1)-release git=git version 2.34.1
  git fetch attempt 1/3 failed, retrying in 3s...
  git fetch attempt 2/3 failed, retrying in 6s...
RETRY-RECOVERED attempts=3
Error: GitHub refused this ClawBox's anonymous request for the update repository after 2 attempt(s).
```

## Review
One `clawbox-review` pass: 4 HIGH, 9 MEDIUM, 8 LOW → `(review findings kept locally)`. All four HIGH applied (unpersisted warning — removed with the fetch that raised it; the wizard's auto-advance; both MCP tools; the bootstrap fetch's missing retry), plus M1-M9 and L3-L7. Deferred with reasons: `install-x64.sh`'s bare clone/fetch (a separate SKU installer, own card), and llama.cpp's `|| echo Warning` clone (a different remote).

## Known limit, worth saying
The first post-merge update on a box still starts from the `install.sh` already on disk, which has no retry — so that one run is still a coin flip on fetch #1. Deploying beta head to the boxes via `box-update.sh` (or the bundle path) is the way to get the retry onto them; from the second update on, it carries itself.


## Second round — the four review threads, answered on this head

All four were valid. Each got a failing test on the previous head first.

| Where | What it was | Class |
|---|---|---|
| `install.sh:61` | A non-numeric `CLAWBOX_GIT_RETRIES` makes `[ "$attempt" -ge "$max" ]` fail every iteration, so the break is never reached — **8672 attempts** before the harness cut the measurement off. A non-numeric `CLAWBOX_GIT_RETRY_DELAY` makes `$((delay * 2))` an unbound-variable error under `set -u`, which takes install.sh down mid-update. | hang · crash |
| `scripts/force-update.sh:74` | `fetch_with_retry` had no classifier, so a permanent failure paid 3 s + 6 s of backoff before saying so. Both knobs reach it too. | wasted budget · hang |
| `src/lib/updater.ts` | `ls-remote` is the call the tag answer is **read from**, and it got one attempt while the advisory fetch above it got two. One refusal made every surface say the update server could not be reached — cached for 60 s. | false failure |
| `src/tests/unit/updater-remote-refusal.test.ts` | `UPDATER_REMOTE_CHECK_RETRY_DELAY_MS` was not overridden: 2738 ms and 2410 ms of real sleep against vitest's 5 s default. | CI flake |

**Both knobs are clamped to digits** at the top of `git_with_retry` and of `force-update.sh`'s `fetch_with_retry` — a grep for both names shows those are the only two readers in the tree. A deliberate `CLAWBOX_GIT_RETRIES=0` still means one attempt; only non-digits are replaced.

**`force-update.sh` got the classifier** rather than an explanation of why it does not need one. It is the script an owner runs when the in-app update has already failed them, so 9 s of backoff over a remote that will refuse every time is time taken from someone standing at the box.

**`ls-remote` is now retried, and the budget did not grow.** `reachOrigin` is split so a call whose *output* is the answer runs under the same bounded policy; the stdout is returned beside `RemoteReachability` rather than added to it, because that type travels into the `/update/versions` payload and a tag listing has no business there. The advisory tag fetch moved from `REMOTE_CHECK_ATTEMPTS` (2) to `REMOTE_ADVISORY_ATTEMPTS` (1), so `getTargetVersion`'s worst case stays at three anonymous requests (1 + 2, previously 2 + 1) — which matters, because the refusal being retried is *caused* by too many anonymous requests from one address. The advisory call's result is discarded either way: the tag list is read from origin's answer, not from the local refs that fetch updates.

RED on the previous head `8985bb52`:

```
 ❯ unit/install-git-fetch-retry.test.ts
     × clamps a non-numeric attempt count instead of looping for ever
       AssertionError: expected 8672 to be 3
     × clamps a non-numeric delay, so the backoff stays a number of seconds
       Expected '  git fetch attempt 1/3 failed, retrying in soons...
                  environment: line 39: soon: unbound variable' to contain 'retrying in 3s'
     × scripts/force-update.sh … does not retry a failure asking again cannot fix
 ❯ unit/updater-remote-refusal.test.ts
     × retries a refused ls-remote instead of reporting no target version   expected null to be 'v1.2.3'
     × spends the retry on ls-remote rather than on the advisory tag fetch  expected 2 to be 1
     × still says the remote is unreachable when every ls-remote is refused expected 1 to be 2
```

GREEN on this head: `updater-remote-refusal`, `install-git-fetch-retry`, `mcp-update-remote-refusal`, `update-remote-refusal` (components), `update/status`, `update/versions`, `openclaw-config-mock-completeness`, `test-timeout-hygiene`, `state-updater-purity`, `root-steps` → **10 files, 91 tests**, plus all five `updater*` suites → 121 tests. `tsc --noEmit` clean; `bash -n install.sh scripts/*.sh` clean; `scripts/check-sudoers-coverage.sh` → `OK — 47 grants, 0 gaps`.

The flake measurement, same machine, `--reporter=verbose`:

```
before  ✓ says the update remote could not be reached …   2738ms
        ✓ retries the refused fetch …                     2410ms
after   ✓ says the update remote could not be reached …    341ms
        ✓ retries the refused fetch …                       13ms
```

### What reviewing the fix found

- **The regression test's own headline assertion could not fail.** `expect(status).not.toBe(124)` never saw 124, because spawnSync's 1 MB default buffer cut the child off first with a null status — at 8672 attempts in 5.1 s. So the "8672 attempts" figure was the buffer limit, not anything the loop chose to do, and the only assertion actually going RED was the attempt count. The harness now gives the child a buffer far larger than the window can fill and reports whether the harness itself had to intervene, so `timeout` is what stops a loop that does not end. The honest measurement: **`` `timeout` had to kill the retry loop: expected 124 not to be 124 `` after a full ten seconds.**
- **The clamp says out loud when it replaces a value.** A knob silently ignored is the same class of quiet wrong answer this PR is about. Only the *shape* is checked — `0` is a legitimate "do not retry" and survives; a large but numeric value is the operator's own call, so no range cap was invented.
- **The two shell classifiers are byte-identical copies and nothing held them together.** Each is extracted separately by the tests, so either could be edited alone and stay green while the two scripts disagreed about which failures are worth asking again. A test now asserts they are the same string.
- **Three comments contradicted the code above them:** `getVersionInfo` still called `ls-remote` "the GET that keeps answering" — the exact claim this change's retry and early return refute, and an invitation to delete them; the budgets docblock said "TWO budgets" above three constants; and the advisory fetch had lost its explicit version-check delay, so raising its attempt count later would have put the update path's 4 s backoff on every polled check.
- **Test hygiene:** the sequenced fake results are copied per `install()` rather than shifted out of the caller's literal, and the environment knobs are restored through `saveEnv` instead of deleted — a `delete` takes the variable away from every file that runs after this one in the same vitest worker.

### Still deferred, with the reason sharpened

`install-x64.sh:384,391` — `step_git_pull`'s bare `git clone` and `git fetch origin` against this same public repository. The deferral stands (a separate x86-64 SKU installer, not driven by the in-app updater), but the symptom there is worse than "no retry": **`GIT_TERMINAL_PROMPT=0` appears nowhere in that file**, so run as documented from a terminal it does not fail on GitHub's 401 — it blocks on `Username for 'https://github.com':`, which is the hang `scripts/force-update.sh` calls out as "the recovery script hanging on the box it is recovering". Run headless it dies on the first refusal under `set -e`. The right fix is one sourceable retry helper read by all three scripts rather than a third copy, which is why it is not folded in here.


### Third round — the comments, and two threads answered without a commit

- The docblock above `isAnonymousFetchRefusal` carried a third copy of the "the GET keeps answering" claim — the first thing a maintainer reads before touching the classifier, and an argument for deleting the very retry and unreachable-branch this PR adds. Corrected, along with the same sentence in the "Cause" paragraph above.
- `Could not resolve host` is retryable in the two shell classifiers and deliberately **not** in the TypeScript one, and nothing in the code said so — `force-update.sh`'s own comment argued the opposite for its own case. The reason now lives where the divergence does: an install or recovery run happens once, with someone waiting, and can race NetworkManager still coming up; the version check is polled by four surfaces, where the same retry is dead time on every poll.
- The drift guard holding the two shell copies byte-identical sat inside the bash-gated `describe`, so the one assertion keeping them together vanished on a runner that cannot spawn bash. It is a string comparison of two files and now runs unconditionally.

Two threads were **refuted with measurements rather than patched**, both answered in-thread:

- *Quote `$PROJECT_DIR` in `force-update.sh`* — `PROJECT_DIR` is validated against `^[A-Za-z0-9._/-]+$` at `:39-42` and the script exits before `GIT` is built, so neither a space nor a metacharacter can reach `bash -c` (`/a b/c`, `/a$(id)/b`, `/a;touch …`, `/a'b` all REJECTED; `/home/clawbox/clawbox` ACCEPTED). That class also covers the single-quote residual the comment itself raises, which single-quoting would not have.
- *`Repository not found` also matches a private or deleted remote* — true in general, but not on a ClawBox: with no credential helper an unreadable repo answers `could not read Username`, and `remote: Repository not found.` requires an **authenticated** request. The proposed narrowing would therefore not separate the case it names, and would risk losing the measured signature. The residual it points at is real and stated: `could not read Username` alone does not prove the remote is public either, so the sentence can still be wrong on a box pointed at a private fork. git's text carries no signal that separates them.


### Fourth round — the sibling knobs, and the recovery fetch's success path

- **The TypeScript delay knobs were the sibling this PR missed.** `CLAWBOX_GIT_RETRIES` and `CLAWBOX_GIT_RETRY_DELAY` were clamped in the same round while `UPDATER_REMOTE_RETRY_DELAY_MS` and `UPDATER_REMOTE_CHECK_RETRY_DELAY_MS` stayed bare `Number()` calls. `Number("soon")` is NaN and a negative override stays negative; `setTimeout` treats both as 0, so the retries still run — **back to back**, removing the spacing the policy depends on and sending the anonymous requests in exactly the burst that causes the refusal being retried. Both now fall back to their default and say so, in the same words the two scripts use. A deliberate `0` is a number and survives.
- **`force-update.sh`'s `fetch_with_retry` was only ever driven through its failure path.** Two behaviours its `install.sh` twin is pinned on were unasserted here: a successful fetch runs exactly one attempt, and git's own output is re-emitted on **stderr** so a caller reading the function's stdout cannot mistake progress for a result. The two shell copies are held together by a byte-equality assertion for the *classifier* only, so anything the twin tests and this one does not is where they can quietly diverge.

```
 ❯ unit/updater-remote-refusal.test.ts
     × is replaced with the default, and said out loud
       AssertionError: expected '' to match /UPDATER_REMOTE_CHECK_RETRY_DELAY_MS="…/
 ❯ unit/install-git-fetch-retry.test.ts   (with the shipped function's `>&2` removed)
     × does not retry a fetch that succeeded, and keeps git's output off stdout
       AssertionError: expected 'STDOUT[Fetching origin]\n' to contain 'STDOUT[]'
```

GREEN on this head: 14 suites, **205 tests**. All eight review threads answered in-thread and resolved.


### Fifth round — two holes in the guard the fourth round added

- **`Number(" ")` is 0, not NaN.** A whitespace-only override sailed past the finite/negative check and became exactly the no-delay burst the guard exists to prevent — and the docblock claimed parity with the shell knobs, which was untrue for that input: `case "$max" in ''|*[!0-9]*)` matches a space, so install.sh rejects it out loud. Trimmed now, and an empty value is refused like any other non-number.
- **A very large value was inverted rather than honoured.** `setTimeout` above 2^31−1 ms fires on the next tick with a `TimeoutOverflowWarning`, and `reachOrigin` multiplies by the attempt number on top — `800000000 × 3` schedules at **1 ms**. So a huge delay means no backoff at all, the same failure as a blank one from the opposite direction. This is the one place a **range** cap is right where the shell knobs deliberately have none: there a large number is honoured and simply sleeps, so how long to wait is the operator's call; here the platform silently turns it into its opposite. Ten minutes is far past any sane version-check backoff and leaves three orders of magnitude of headroom.

Neither variable has a writer anywhere in the tree — the only hits are the two declarations and the test file — so this guards a hand-set knob rather than a live defect.

```
 ❯ unit/updater-remote-refusal.test.ts
     × refuses a blank value, which Number() reads as zero
     × refuses a value so large the timer would invert it into no delay
```

GREEN on this head: 14 suites, **207 tests**. All nine review threads answered in-thread and resolved. CI on the previous head was 11/11 green, `e2e-install` included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic retries with exponential backoff for temporary update-connection failures, including authentication, rate limits, DNS, and connectivity issues.
  - Update checks now report remote availability and provide relevant failure reasons.
  - Added GitHub-specific guidance when anonymous access is refused.

- **Bug Fixes**
  - Prevented unreachable remotes from being incorrectly reported as “Up to date.”
  - Update screens, settings, onboarding, and device status now distinguish unavailable checks from successful checks.
  - Preserved recovery options when version information cannot be retrieved.
  - Prevented interactive prompts during automated update operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



