### PR TITLE
fix: render MEDIA: directives in the full-screen chat

### DIFF
--- a/src/components/ChatApp.tsx
+++ b/src/components/ChatApp.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/lib/chat-history-cache'
 import { scrollToBottomAfterLayout } from '@/lib/scroll'
 
-import { renderText } from '@/lib/chat-markdown'
+import { renderText, audioLabel } from '@/lib/chat-markdown'
 import { extractImageFilesFromClipboard } from '@/lib/clipboard'
 import { useT } from '@/lib/i18n'
 import { useChatToolCalls, ToolCallPills } from '@/lib/chat-tool-events'
@@ -23,6 +23,12 @@ import { prettifyAssistantText, isSentinel, isInterSessionEnvelope } from '@/lib
 // apart again.
 import { splitEmailRefs, streamingEmailRefsText, dropUnfinishedDirective } from '@/lib/chat-email-refs'
 import { EmailCard, EmailFullView } from '@/lib/chat-email'
+// Same reason, one convention over: a generated picture and a spoken reply are
+// named by a `MEDIA:` line inside the reply text rather than delivered as
+// attachments (see lib/chat-media.ts), and only the mascot chat had learned to
+// lift them — so this surface printed an absolute path under ~/.openclaw/media
+// into the customer's transcript. TASK-698.
+import { splitMediaDirectives, splitAssistantMedia, mediaFileName } from '@/lib/chat-media'
 
 
 function extractText(msg: unknown): string {
@@ -705,8 +711,23 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
           // Derived at render, as the mascot chat does it: a replayed turn
           // carries the same directive text a live one did, so the history and
           // live paths agree for free.
-          const emailRefs = msg.role === 'assistant' ? splitEmailRefs(msg.text) : null
+          //
+          // Media first, then mail: `splitAssistantMedia` takes the whole
+          // directive line out, and the mail split then works on the caption
+          // the bubble will actually show. A payload with no renderable
+          // extension is dropped by both — which is what makes an INTERRUPTED
+          // turn safe: the streaming bubble had already hidden the half-written
+          // `MEDIA:` line, and a truncated path names no picture, so the stored
+          // turn still ends up as the last thing the owner saw.
+          const media = msg.role === 'assistant' ? splitAssistantMedia(msg.text) : null
+          const emailRefs = media ? splitEmailRefs(media.text) : null
           const bodyText = emailRefs ? emailRefs.text : msg.text
+          // The customer's own attachments and the ones the agent named: the
+          // two sources are disjoint (an assistant turn never carries the
+          // former), and concatenating rather than choosing means neither can
+          // be dropped if that ever changes.
+          const images = [...(msg.images ?? []), ...(media?.images ?? [])]
+          const audio = media?.audio ?? []
           return (
           <div key={i} style={{
             display: 'flex',
@@ -726,14 +747,48 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
               lineHeight: 1.45,
               wordBreak: 'break-word',
             }}>
-              {msg.images && msg.images.length > 0 && (
+              {images.length > 0 && (
                 <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: bodyText ? 6 : 0 }}>
-                  {msg.images.map((src, j) => (
-                    <img key={j} src={src} alt="" style={{ maxWidth: 180, maxHeight: 140, borderRadius: 8, objectFit: 'cover' }} />
+                  {images.map((src, j) => (
+                    // A picture the agent drew IS the message, so it gets a
+                    // real alt and is contained rather than cropped; one the
+                    // customer sent is announced as theirs, because an
+                    // accessible name is read out verbatim.
+                    <img
+                      key={j}
+                      src={src}
+                      alt={msg.role === 'user' ? t("chat.sentImage") : t("chat.generatedImage")}
+                      style={{ maxWidth: 180, maxHeight: 140, borderRadius: 8, objectFit: 'contain' }}
+                    />
                   ))}
                 </div>
               )}
               {msg.role === 'user' ? msg.text : renderText(bodyText, t("chat.table"))}
+              {audio.length > 0 && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginTop: bodyText ? 8 : 0 }}>
+                  {/* The browser's own player, for the same reasons the mascot
+                      chat uses one: play, pause, scrub and duration all work
+                      and are reachable from the keyboard. Keyed by the URL —
+                      the harness names every file with a uuid, so re-rendering
+                      a transcript cannot hand one player another's audio. */}
+                  {audio.map(src => (
+                    <audio
+                      key={src}
+                      data-testid="chat-audio"
+                      // `bodyText`, never `msg.text`: the stored text still
+                      // carries the directives, and a screen reader would read
+                      // the absolute media path and the mail ids out loud.
+                      aria-label={audioLabel(bodyText, t("chat.audioReply"))}
+                      controls
+                      preload="metadata"
+                      src={src}
+                      style={{ width: '100%', maxWidth: 280, height: 34 }}
+                    >
+                      <a href={src} download={mediaFileName(src)}>{t("chat.downloadAudio")}</a>
+                    </audio>
+                  ))}
+                </div>
+              )}
               {emailRefs && emailRefs.uids.length > 0 && (
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginTop: bodyText ? 8 : 0 }}>
                   {emailRefs.uids.map(uid => (
@@ -761,13 +816,10 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
                   lands in the last chunk before the turn finalises, so without
                   this the bare id sits in the bubble for that moment, and an
                   abort keeps the raw buffer it was holding — so the turn it
-                  leaves behind can still become cards. No cards while
-                  streaming: half a directive is not an id yet.
-
-                  `MEDIA:` is deliberately left as text on this surface, here
-                  and in the body — an existing test pins that today, so
-                  changing it is its own change. TASK-698. */}
-              {renderText(streamingEmailRefsText(streaming), t("chat.table"))}
+                  leaves behind can still become cards and pictures. No cards
+                  and no pictures while streaming: half a directive is not an id
+                  or a path yet. */}
+              {renderText(streamingEmailRefsText(splitMediaDirectives(streaming).text), t("chat.table"))}
               <span style={{ display: 'inline-block', width: 6, height: 14, background: '#f97316', borderRadius: 1, marginLeft: 2, animation: 'chatapp-blink 1s step-end infinite', verticalAlign: 'text-bottom' }} />
             </div>
           </div>

--- a/src/components/ChatApp.tsx
+++ b/src/components/ChatApp.tsx
@@ -28,7 +28,15 @@ import { EmailCard, EmailFullView } from '@/lib/chat-email'
 // attachments (see lib/chat-media.ts), and only the mascot chat had learned to
 // lift them — so this surface printed an absolute path under ~/.openclaw/media
 // into the customer's transcript. TASK-698.
-import { splitMediaDirectives, splitAssistantMedia, mediaFileName } from '@/lib/chat-media'
+import {
+  splitMediaDirectives,
+  splitAssistantMedia,
+  extractAudioAttachments,
+  boundedAudio,
+  mediaFileName,
+} from '@/lib/chat-media'
+// The transcript projection itself is shared too — see loadHistory.
+import { projectGatewayHistory } from '@/lib/harness/openclaw-gateway-adapter'
 
 
 function extractText(msg: unknown): string {
@@ -300,7 +308,14 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
             const text = extractText(msg)
             if (text && !isInterSessionEnvelope(text, msg)) applyStreaming(text)
           } else if (state === 'final') {
-            const text = extractText(msg)
+            const raw = extractText(msg)
+            // Split on the way INTO state, as the mascot chat does: a generated
+            // picture arrives as a `MEDIA:` line inside the reply text and a
+            // spoken reply as a structured attachment part (lib/chat-media.ts),
+            // and storing the caption alone is what put an absolute media path
+            // in the transcript. Both shapes are read; neither is guaranteed.
+            const { text, images, audio: directiveAudio } = splitAssistantMedia(raw)
+            const audio = boundedAudio(extractAudioAttachments(msg), directiveAudio)
             // Suppress protocol sentinels and "Sent." (delivery-mirror ack)
             // from the rendered transcript — the former are markers users
             // shouldn't see, the latter is just a server-side ack that the
@@ -309,12 +324,41 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
             // sentinel `chat-sentinels.ts` catalogues — same shared check
             // ChatPopup uses, so the two components can't drift on which
             // finals count as ack-only.
-            const isAckOnly = !text || /^\s*Sent\.\s*$/.test(text) || isSentinel(text)
+            //
+            // A picture or a clip with no caption is a real reply, not an ack:
+            // asking `!text` alone would have thrown it away and refetched
+            // history instead.
+            const isAckOnly = (!text && images.length === 0 && audio.length === 0)
+              || /^\s*Sent\.\s*$/.test(text) || isSentinel(text)
             // Same suppression as the history path, so the bubble cannot
             // appear in real time either — only the append is skipped, the
-            // ack-only refetch below still runs.
-            if (text && !isAckOnly && !isInterSessionEnvelope(text, msg)) {
-              setMessages(prev => [...prev, { role: 'assistant', text: prettifyAssistantText(text), timestamp: Date.now() }])
+            // ack-only refetch below still runs. Asked of the ORIGINAL text: a
+            // routing envelope carrying a MEDIA: line must be dropped whole,
+            // not split into a picture plus its own machinery.
+            if (!isAckOnly && !isInterSessionEnvelope(raw, msg)) {
+              setMessages(prev => {
+                // The spoken half arrives as a SECOND message repeating the
+                // text of the one already rendered. Appending it verbatim
+                // showed the answer twice, once silent and once playable, so
+                // the audio is folded into the bubble it belongs to. Same rule
+                // `projectGatewayHistory` applies to a replayed transcript, so
+                // the live and reloaded views agree.
+                const last = prev[prev.length - 1]
+                if (text.length > 0 && audio.length > 0 && images.length === 0
+                    && last && last.role === 'assistant' && last.text === text) {
+                  const merged = boundedAudio(last.audio ?? [], audio)
+                  if (last.audio?.length === merged.length
+                      && last.audio.every((src, i) => src === merged[i])) return prev
+                  return [...prev.slice(0, -1), { ...last, audio: merged }]
+                }
+                return [...prev, {
+                  role: 'assistant' as const,
+                  text: prettifyAssistantText(text),
+                  timestamp: Date.now(),
+                  images,
+                  audio,
+                }]
+              })
             }
             applyStreaming('')
             clearToolCalls()
@@ -349,8 +393,22 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
             // card, so what is stored is what the owner was looking at.
             const kept = dropUnfinishedDirective(streamingRef.current)
             applyStreaming('')
-            if (kept.trim() && !isSentinel(kept)) {
-              setMessages(msgs => [...msgs, { role: 'assistant', text: prettifyAssistantText(kept), timestamp: Date.now() }])
+            // The same lift the final path does, because the directives are
+            // taken out on the way into state now: an interrupted turn that
+            // already received a complete `MEDIA:` line keeps its picture, and
+            // one interrupted mid-path stores no path — which is what the
+            // bubble was showing, since the streaming render strips the line
+            // whatever its payload.
+            const keptMedia = splitAssistantMedia(kept)
+            if ((keptMedia.text.trim() || keptMedia.images.length > 0 || keptMedia.audio.length > 0)
+                && !isSentinel(keptMedia.text)) {
+              setMessages(msgs => [...msgs, {
+                role: 'assistant',
+                text: prettifyAssistantText(keptMedia.text),
+                timestamp: Date.now(),
+                images: keptMedia.images,
+                audio: boundedAudio(keptMedia.audio),
+              }])
             }
             clearToolCalls()
             runIdRef.current = null
@@ -392,22 +450,20 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
     try {
       const result = await wsRequest('chat.history', { sessionKey: sessionKeyRef.current, limit: 50 }) as Record<string, unknown>
       const msgs = (result.messages as unknown[]) || []
-      const chatMsgs: ChatMessage[] = []
-      for (const msg of msgs) {
-        const m = msg as Record<string, unknown>
-        const role = (m.role as string)?.toLowerCase()
-        if (role !== 'user' && role !== 'assistant') continue
-        const text = extractText(m)
-        if (!text || isSentinel(text)) continue
-        // Inter-session routing envelopes are machinery addressed to the
-        // agent, not chat content — drop the whole message. This is the
-        // path the image-generation leak actually arrives on: the turn is
-        // acked with "Sent.", which schedules the refetch below, and the
-        // envelope comes back as a `user` message.
-        if (isInterSessionEnvelope(text, m)) continue
-        const cleaned = role === 'user' ? text.replace(/^\[[^\]]+\]\s*/, '') : prettifyAssistantText(text)
-        chatMsgs.push({ role: role as 'user' | 'assistant', text: cleaned, timestamp: (m.timestamp as number) || 0 })
-      }
+      // The SHARED projection, not a second one written here. It already drops
+      // sentinels and inter-session envelopes, lifts `MEDIA:` into images and
+      // audio, splits the composer's `[Attached file: …]` lines back into
+      // pictures and names, and folds the spoken reply — stored as its own
+      // message repeating the answer's text — into the bubble it belongs to.
+      // This surface used to re-derive a subset of that inline, which is how it
+      // ended up printing an absolute media path where the mascot chat drew the
+      // picture: the two paths were free to drift, and did.
+      //
+      // `null` for the spoken payload: the durable
+      // `/setup-api/chat/spoken-history` backstop is the adapter's, for a
+      // gateway that omits the supplement from `chat.history`. A gateway that
+      // carries it — which is the shipped one — is folded from the page itself.
+      const { messages: chatMsgs } = projectGatewayHistory(msgs, null)
       // Server is canonical for everything it knows about, but a user turn
       // typed between connect-ack and history-arrival ("optimistic local")
       // hasn't reached the server yet — preserve it by appending any prev
@@ -708,26 +764,16 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
         )}
 
         {messages.map((msg, i) => {
-          // Derived at render, as the mascot chat does it: a replayed turn
-          // carries the same directive text a live one did, so the history and
-          // live paths agree for free.
-          //
-          // Media first, then mail: `splitAssistantMedia` takes the whole
-          // directive line out, and the mail split then works on the caption
-          // the bubble will actually show. A payload with no renderable
-          // extension is dropped by both — which is what makes an INTERRUPTED
-          // turn safe: the streaming bubble had already hidden the half-written
-          // `MEDIA:` line, and a truncated path names no picture, so the stored
-          // turn still ends up as the last thing the owner saw.
-          const media = msg.role === 'assistant' ? splitAssistantMedia(msg.text) : null
-          const emailRefs = media ? splitEmailRefs(media.text) : null
+          // `MEDIA:` is lifted on the way INTO state — by the shared history
+          // projection and by the live `final` handler — so what is stored
+          // already carries its pictures and clips and the bubble just draws
+          // them. Only the mail directives are derived here, because a card is
+          // fetched when the owner opens it and must not be built from a turn
+          // that is still streaming.
+          const emailRefs = msg.role === 'assistant' ? splitEmailRefs(msg.text) : null
           const bodyText = emailRefs ? emailRefs.text : msg.text
-          // The customer's own attachments and the ones the agent named: the
-          // two sources are disjoint (an assistant turn never carries the
-          // former), and concatenating rather than choosing means neither can
-          // be dropped if that ever changes.
-          const images = [...(msg.images ?? []), ...(media?.images ?? [])]
-          const audio = media?.audio ?? []
+          const images = msg.images ?? []
+          const audio = msg.audio ?? []
           return (
           <div key={i} style={{
             display: 'flex',
@@ -753,7 +799,9 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
                     // A picture the agent drew IS the message, so it gets a
                     // real alt and is contained rather than cropped; one the
                     // customer sent is announced as theirs, because an
-                    // accessible name is read out verbatim.
+                    // accessible name is read out verbatim. `contain` applies
+                    // to both — a sent photo is letterboxed rather than cropped
+                    // here, matching the mascot chat.
                     <img
                       key={j}
                       src={src}
@@ -818,7 +866,15 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
                   abort keeps the raw buffer it was holding — so the turn it
                   leaves behind can still become cards and pictures. No cards
                   and no pictures while streaming: half a directive is not an id
-                  or a path yet. */}
+                  or a path yet.
+
+                  A payload-less `MEDIA:` is deliberately kept as text by
+                  `splitMediaDirectives` — a line that names nothing is not
+                  swallowed — so a Stop landing exactly on the colon leaves that
+                  token in the bubble and in the stored turn. Shown and stored
+                  still agree, which is the property that matters; there is no
+                  `dropUnfinishedDirective` equivalent for media, and the
+                  mascot chat accepts the same token. */}
               {renderText(streamingEmailRefsText(splitMediaDirectives(streaming).text), t("chat.table"))}
               <span style={{ display: 'inline-block', width: 6, height: 14, background: '#f97316', borderRadius: 1, marginLeft: 2, animation: 'chatapp-blink 1s step-end infinite', verticalAlign: 'text-bottom' }} />
             </div>

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -203,26 +203,13 @@ const PROVIDER_PILL_LABEL: Record<string, string> = {
   'Gemma 4 Local': 'Gemma 4',
 }
 
-/**
- * Accessible name for a spoken reply's player.
- *
- * The message body is already on screen and already read by the message
- * itself, so this is a short identifying fragment, not a second copy — but it
- * has to be there: a transcript can hold several players, and "audio" three
- * times over tells a screen-reader user nothing about which is which.
- */
-function audioLabel(text: string | undefined, prefix: string): string {
-  const spoken = text ? plainTextForLabel(text, 100) : "";
-  return spoken ? `${prefix}: ${spoken}` : prefix;
-}
-
 function getProviderPillText(option: ChatModelState['options'][number]): string {
   const full = getChatModelOptionText(option)
   if (!option.available) return full
   return PROVIDER_PILL_LABEL[option.label ?? ''] ?? full
 }
 
-import { renderText, plainTextForLabel } from '@/lib/chat-markdown'
+import { renderText, audioLabel } from '@/lib/chat-markdown'
 import SnapPreviewOverlay from '@/components/SnapPreviewOverlay'
 import { DESKTOP_GAP, getSnapRect, getSnapZone, type SnapZone } from '@/lib/window-snap'
 import { extractImageFilesFromClipboard } from '@/lib/clipboard'

--- a/src/lib/chat-markdown.tsx
+++ b/src/lib/chat-markdown.tsx
@@ -413,3 +413,24 @@ export function plainTextForLabel(text: string, max = 100): string {
   // label; a single very long token still gets truncated rather than dropped.
   return `${(lastSpace > max * 0.5 ? cut.slice(0, lastSpace) : cut).trimEnd()}…`;
 }
+
+/**
+ * Accessible name for a spoken reply's player.
+ *
+ * The message body is already on screen and already read by the message
+ * itself, so this is a short identifying fragment, not a second copy — but it
+ * has to be there: a transcript can hold several players, and "audio" three
+ * times over tells a screen-reader user nothing about which is which.
+ *
+ * Hand it the text as the BUBBLE shows it, never the stored text: directives
+ * are lifted at render on both chat surfaces, so the raw string still carries
+ * the `EMAIL:` ids and the absolute `MEDIA:` paths a player must not announce.
+ *
+ * Shared rather than defined beside each player: the mascot chat and the
+ * full-screen chat both draw one, and every previous label rule had to be
+ * fixed twice.
+ */
+export function audioLabel(text: string | undefined, prefix: string): string {
+  const spoken = text ? plainTextForLabel(text, 100) : "";
+  return spoken ? `${prefix}: ${spoken}` : prefix;
+}

--- a/src/tests/components/chat-inter-session-envelope.test.tsx
+++ b/src/tests/components/chat-inter-session-envelope.test.tsx
@@ -14,8 +14,8 @@ import * as kv from "@/lib/client-kv";
  * `isInterSessionEnvelope` is unit-tested in
  * src/tests/unit/chat-inter-session-envelope.test.ts. What is worth proving
  * HERE is that both chat surfaces actually call it on the paths the envelope
- * arrives on, and that the assistant's real reply (and its MEDIA: directive)
- * survives. So this drives the components through a scripted gateway socket
+ * arrives on, and that the assistant's real reply — and the picture its MEDIA:
+ * directive names — survives. So this drives the components through a socket
  * rather than asserting on source text: the two surfaces have separate
  * `loadHistory` implementations and could drift.
  *
@@ -221,8 +221,16 @@ describe("ChatApp and the inter-session routing envelope", () => {
     expectEnvelopeHidden();
     // The turns either side of the envelope are untouched...
     expect(document.body.textContent).toContain(USER_TURN);
-    // ...including the MEDIA: directive the image renders from.
-    expect(document.body.textContent).toContain(`MEDIA:${MEDIA_PATH}`);
+    // ...including the picture the reply named. This surface printed the
+    // directive as text until TASK-698 and the assertion pinned that; what
+    // matters for TASK-416 is unchanged — a legitimate reply carrying MEDIA:
+    // survives the envelope filter — it just arrives as an <img> now, exactly
+    // as it does on the mascot chat below.
+    expect(document.body.textContent).not.toContain(`MEDIA:${MEDIA_PATH}`);
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "src",
+      expect.stringContaining(encodeURIComponent(MEDIA_PATH)),
+    );
   });
 
   it("keeps it out of a live streaming turn", async () => {
@@ -267,9 +275,9 @@ describe("ChatPopup and the inter-session routing envelope", () => {
     expect(document.body.textContent).toContain(USER_TURN);
     // The mascot chat renders MEDIA: as a picture rather than printing the
     // directive (TASK-382 / PR #405), so the raw string is deliberately absent
-    // here while ChatApp still shows it as text. What matters for TASK-416 is
-    // unchanged and still asserted above: a legitimate reply carrying MEDIA:
-    // survives the envelope filter — it just arrives as an <img> now.
+    // here — and since TASK-698 on ChatApp above too. The two surfaces now
+    // assert the same thing, which is the point: they drifted because only one
+    // of them was pinned.
     expect(document.body.textContent).not.toContain(`MEDIA:${MEDIA_PATH}`);
     expect(screen.getByRole("img")).toHaveAttribute(
       "src",

--- a/src/tests/components/chatapp-media-directives.test.tsx
+++ b/src/tests/components/chatapp-media-directives.test.tsx
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import ChatApp from "@/components/ChatApp";
+import { resetHarnessCache } from "@/lib/client-harness";
+
+/**
+ * TASK-698: the standalone full-screen chat (`/app/clawbox`, ChatApp) printed
+ * the harness's `MEDIA:<path>` directive to the customer as literal text — an
+ * absolute path under `~/.openclaw/media` in the transcript — where the mascot
+ * chat (ChatPopup) turns the same line into the picture it names.
+ *
+ * The convention is documented in `src/lib/chat-media.ts`: a generated picture
+ * or a spoken reply is NOT delivered as a structured attachment, it is named by
+ * a directive line inside the reply text, and every client is expected to run
+ * the split itself.
+ *
+ * Driven through a scripted gateway socket rather than asserted on source text:
+ * ChatApp has its own `loadHistory`, its own live `final` handler and its own
+ * streaming render, and all three have to agree.
+ */
+
+const IMAGE_PATH =
+  "/home/clawbox/.openclaw/media/tool-image-generation/image-1---84d24458-84ba-4d45-b90f-de4476c32c31.png";
+const VOICE_PATH = "/home/clawbox/.openclaw/media/outbound/voice-6f1c1f1e.wav";
+
+const HISTORY_CAPTION = "Here's your fluffy cat!";
+const HISTORY_REPLY = `${HISTORY_CAPTION} \u{1F408}\n\nMEDIA:${IMAGE_PATH}`;
+
+type Frame = Record<string, unknown>;
+
+/**
+ * A gateway socket that answers the handshake and `chat.history` and can push
+ * live `chat` events — the same shape `chat-inter-session-envelope.test.tsx`
+ * drives both surfaces with.
+ */
+class FakeGatewayWs {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  readyState = FakeGatewayWs.OPEN;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onopen: (() => void) | null = null;
+
+  constructor(public url: string) {
+    instances.push(this);
+    setTimeout(
+      () => this.emit({ type: "event", event: "connect.challenge", payload: { nonce: "test-nonce" } }),
+      0,
+    );
+  }
+
+  send(raw: string) {
+    let frame: Frame;
+    try {
+      frame = JSON.parse(raw) as Frame;
+    } catch {
+      return;
+    }
+    if (frame.type !== "req") return;
+    const id = frame.id as string;
+    if (frame.method === "connect") {
+      this.respond(id, { snapshot: { sessionDefaults: { mainSessionKey: "agent:main:main" } } });
+      return;
+    }
+    if (frame.method === "chat.history") {
+      this.respond(id, {
+        messages: [
+          { role: "user", content: "make me a picture of a fluffy cat", timestamp: 1787236200000 },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: HISTORY_REPLY }],
+            timestamp: 1787236209000,
+          },
+        ],
+      });
+      return;
+    }
+    this.respond(id, {});
+  }
+
+  close() {
+    this.readyState = FakeGatewayWs.CLOSED;
+  }
+
+  addEventListener() {}
+  removeEventListener() {}
+
+  private respond(id: string, payload: unknown) {
+    setTimeout(() => this.emit({ type: "res", id, ok: true, payload }), 0);
+  }
+
+  emit(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+  }
+
+  pushChat(state: string, message: unknown) {
+    this.emit({
+      type: "event",
+      event: "chat",
+      payload: { sessionKey: "agent:main:main", state, message },
+    });
+  }
+}
+
+const instances: FakeGatewayWs[] = [];
+
+function installFetch() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: unknown) => {
+      const url = String(input);
+      if (url.includes("/setup-api/gateway/ws-config")) {
+        return { ok: true, json: async () => ({ token: "t", wsUrl: "ws://localhost/gw" }) };
+      }
+      if (url.includes("/setup-api/harness/active")) {
+        return { ok: true, json: async () => ({ active: "openclaw", edition: "openclaw" }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    }),
+  );
+}
+
+async function socket() {
+  await waitFor(() => expect(instances.length).toBeGreaterThan(0));
+  return instances[instances.length - 1];
+}
+
+beforeEach(() => {
+  instances.length = 0;
+  resetHarnessCache();
+  window.localStorage.clear();
+  // jsdom has no layout engine, so the transcript's auto-scroll has nothing to
+  // call. Unrelated to what is under test.
+  Element.prototype.scrollIntoView = vi.fn();
+  vi.stubGlobal("WebSocket", FakeGatewayWs);
+  installFetch();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetHarnessCache();
+});
+
+describe("ChatApp lifts MEDIA: directives", () => {
+  it("renders the picture a replayed reply names, not its path", async () => {
+    render(<ChatApp />);
+    await waitFor(() => expect(document.body.textContent).toContain(HISTORY_CAPTION));
+
+    expect(document.body.textContent).not.toContain(`MEDIA:${IMAGE_PATH}`);
+    expect(document.body.textContent).not.toContain(IMAGE_PATH);
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "src",
+      expect.stringContaining(encodeURIComponent(IMAGE_PATH)),
+    );
+  });
+
+  it("renders the picture a live final names, not its path", async () => {
+    render(<ChatApp />);
+    await waitFor(() => expect(document.body.textContent).toContain(HISTORY_CAPTION));
+    const ws = await socket();
+
+    const livePath = "/home/clawbox/.openclaw/media/tool-image-generation/retry-9c2f.png";
+    await act(async () => {
+      ws.pushChat("final", { role: "assistant", content: `Here's the retry!\n\nMEDIA:${livePath}` });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(document.body.textContent).toContain("Here's the retry!"));
+    expect(document.body.textContent).not.toContain(livePath);
+    await waitFor(() =>
+      expect(
+        screen.getAllByRole("img").some(img =>
+          (img.getAttribute("src") ?? "").includes(encodeURIComponent(livePath)),
+        ),
+      ).toBe(true),
+    );
+  });
+
+  it("keeps the directive out of the bubble while the turn is still streaming", async () => {
+    render(<ChatApp />);
+    await waitFor(() => expect(document.body.textContent).toContain(HISTORY_CAPTION));
+    const ws = await socket();
+
+    const streamPath = "/home/clawbox/.openclaw/media/tool-image-generation/stream-11ab.png";
+    await act(async () => {
+      ws.pushChat("delta", { role: "assistant", content: `Nearly there\n\nMEDIA:${streamPath}` });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(document.body.textContent).toContain("Nearly there"));
+    expect(document.body.textContent).not.toContain(streamPath);
+  });
+
+  it("plays a spoken reply the directive names instead of dropping or printing it", async () => {
+    render(<ChatApp />);
+    await waitFor(() => expect(document.body.textContent).toContain(HISTORY_CAPTION));
+    const ws = await socket();
+
+    await act(async () => {
+      ws.pushChat("final", { role: "assistant", content: `Said out loud.\n\nMEDIA:${VOICE_PATH}` });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(document.body.textContent).toContain("Said out loud."));
+    expect(document.body.textContent).not.toContain(VOICE_PATH);
+    const player = await waitFor(() => {
+      const found = document.querySelector("audio");
+      expect(found).not.toBeNull();
+      return found as HTMLAudioElement;
+    });
+    expect(player.getAttribute("src")).toContain(encodeURIComponent(VOICE_PATH));
+    // An accessible name is read out verbatim, so the path must not be in it
+    // either — the leak the same review found on the mascot chat's player.
+    expect(player.getAttribute("aria-label") ?? "").not.toContain(VOICE_PATH);
+  });
+});

--- a/src/tests/components/chatapp-media-directives.test.tsx
+++ b/src/tests/components/chatapp-media-directives.test.tsx
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, render, screen, waitFor } from "@/tests/helpers/test-utils";
 import ChatApp from "@/components/ChatApp";
-import { resetHarnessCache } from "@/lib/client-harness";
 
 /**
  * TASK-698: the standalone full-screen chat (`/app/clawbox`, ChatApp) printed
@@ -9,14 +8,17 @@ import { resetHarnessCache } from "@/lib/client-harness";
  * absolute path under `~/.openclaw/media` in the transcript — where the mascot
  * chat (ChatPopup) turns the same line into the picture it names.
  *
- * The convention is documented in `src/lib/chat-media.ts`: a generated picture
- * or a spoken reply is NOT delivered as a structured attachment, it is named by
- * a directive line inside the reply text, and every client is expected to run
- * the split itself.
+ * The convention is documented in `src/lib/chat-media.ts`. A generated picture
+ * is NOT delivered as a structured attachment: it is named by a directive line
+ * inside the reply text, and every client is expected to run the split itself —
+ * OpenClaw's own Control UI does exactly that (its bundled
+ * `control-ui-boot-*.js` on the box carries the same split). A SPOKEN reply
+ * arrives the other way round, as a second assistant message carrying an
+ * `attachment` part, so both shapes are exercised below.
  *
  * Driven through a scripted gateway socket rather than asserted on source text:
- * ChatApp has its own `loadHistory`, its own live `final` handler and its own
- * streaming render, and all three have to agree.
+ * ChatApp has its own live `final` handler and its own streaming render beside
+ * the shared history projection, and all three have to agree.
  */
 
 const IMAGE_PATH =
@@ -116,9 +118,6 @@ function installFetch() {
       if (url.includes("/setup-api/gateway/ws-config")) {
         return { ok: true, json: async () => ({ token: "t", wsUrl: "ws://localhost/gw" }) };
       }
-      if (url.includes("/setup-api/harness/active")) {
-        return { ok: true, json: async () => ({ active: "openclaw", edition: "openclaw" }) };
-      }
       return { ok: true, json: async () => ({}) };
     }),
   );
@@ -131,7 +130,6 @@ async function socket() {
 
 beforeEach(() => {
   instances.length = 0;
-  resetHarnessCache();
   window.localStorage.clear();
   // jsdom has no layout engine, so the transcript's auto-scroll has nothing to
   // call. Unrelated to what is under test.
@@ -142,7 +140,6 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
-  resetHarnessCache();
 });
 
 describe("ChatApp lifts MEDIA: directives", () => {
@@ -195,17 +192,69 @@ describe("ChatApp lifts MEDIA: directives", () => {
     expect(document.body.textContent).not.toContain(streamPath);
   });
 
-  it("plays a spoken reply the directive names instead of dropping or printing it", async () => {
+  it("plays the spoken reply the harness attaches, and does not show the answer twice", async () => {
+    // The shape the box ACTUALLY produces, measured on hardware (TASK-381 and
+    // the note in lib/chat-media.ts): TTS is not a MEDIA: line at all. The
+    // harness appends a SECOND assistant message repeating the answer's text
+    // and carrying a structured `attachment` part. Rendered naively that is the
+    // answer twice with no way to hear it.
+    render(<ChatApp />);
+    await waitFor(() => expect(document.body.textContent).toContain(HISTORY_CAPTION));
+    const ws = await socket();
+
+    const spoken = "Said out loud.";
+    await act(async () => {
+      ws.pushChat("final", { role: "assistant", content: [{ type: "text", text: spoken }] });
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(document.body.textContent).toContain(spoken));
+
+    await act(async () => {
+      ws.pushChat("final", {
+        role: "assistant",
+        content: [
+          { type: "text", text: spoken },
+          {
+            type: "attachment",
+            attachment: {
+              url: VOICE_PATH,
+              kind: "audio",
+              mimeType: "audio/wav",
+              label: "voice-6f1c1f1e.wav",
+            },
+          },
+        ],
+      });
+      await Promise.resolve();
+    });
+
+    const player = await waitFor(() => {
+      const found = document.querySelector("audio");
+      expect(found).not.toBeNull();
+      return found as HTMLAudioElement;
+    });
+    expect(player.getAttribute("src")).toContain(encodeURIComponent(VOICE_PATH));
+    expect(document.body.textContent).not.toContain(VOICE_PATH);
+    // One bubble, not two: the supplement is folded into the answer it repeats.
+    expect(document.body.textContent?.match(new RegExp(spoken, "g"))).toHaveLength(1);
+    // An accessible name is read out verbatim, so the path must not be in it.
+    expect(player.getAttribute("aria-label") ?? "").not.toContain(VOICE_PATH);
+  });
+
+  it("plays a spoken reply a MEDIA: directive names instead of dropping it", async () => {
+    // The other shape: a provider that names its output the way image
+    // generation does. Both are read — `splitAssistantMedia` lifts the
+    // directive, `extractAudioAttachments` the structured part.
     render(<ChatApp />);
     await waitFor(() => expect(document.body.textContent).toContain(HISTORY_CAPTION));
     const ws = await socket();
 
     await act(async () => {
-      ws.pushChat("final", { role: "assistant", content: `Said out loud.\n\nMEDIA:${VOICE_PATH}` });
+      ws.pushChat("final", { role: "assistant", content: `Here you go.\n\nMEDIA:${VOICE_PATH}` });
       await Promise.resolve();
     });
 
-    await waitFor(() => expect(document.body.textContent).toContain("Said out loud."));
+    await waitFor(() => expect(document.body.textContent).toContain("Here you go."));
     expect(document.body.textContent).not.toContain(VOICE_PATH);
     const player = await waitFor(() => {
       const found = document.querySelector("audio");
@@ -213,8 +262,39 @@ describe("ChatApp lifts MEDIA: directives", () => {
       return found as HTMLAudioElement;
     });
     expect(player.getAttribute("src")).toContain(encodeURIComponent(VOICE_PATH));
-    // An accessible name is read out verbatim, so the path must not be in it
-    // either — the leak the same review found on the mascot chat's player.
-    expect(player.getAttribute("aria-label") ?? "").not.toContain(VOICE_PATH);
+  });
+
+  it("caps and de-duplicates the clips one reply names", async () => {
+    // `boundedAudio` is the rule every transcript path applies
+    // (MAX_AUDIO_PER_MESSAGE = 4). Without it a repeated directive renders two
+    // players under the same React key and a reply naming ten fires ten
+    // `preload="metadata"` requests at the media route on a Jetson.
+    render(<ChatApp />);
+    await waitFor(() => expect(document.body.textContent).toContain(HISTORY_CAPTION));
+    const ws = await socket();
+
+    const clips = Array.from({ length: 6 }, (_, i) =>
+      `/home/clawbox/.openclaw/media/outbound/voice-${i}.wav`);
+    // Six distinct clips plus a repeat of the first — seven directive lines.
+    const lines = [...clips, clips[0]].map((path) => `MEDIA:${path}`).join("\n");
+    await act(async () => {
+      ws.pushChat("final", { role: "assistant", content: `Six of them.\n${lines}` });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(document.body.textContent).toContain("Six of them."));
+    await waitFor(() => expect(document.querySelectorAll("audio").length).toBeGreaterThan(0));
+    expect(document.querySelectorAll("audio").length).toBe(4);
+  });
+
+  it("lifts the picture out of a transcript replayed after a reconnect", async () => {
+    // The history path goes through the shared `projectGatewayHistory`, so a
+    // reload shows what the live turn showed rather than a second derivation.
+    render(<ChatApp />);
+    await waitFor(() => expect(document.body.textContent).toContain(HISTORY_CAPTION));
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "src",
+      expect.stringContaining(encodeURIComponent(IMAGE_PATH)),
+    );
   });
 });

--- a/src/tests/unit/chat-audio-label.test.ts
+++ b/src/tests/unit/chat-audio-label.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { plainTextForLabel } from "@/lib/chat-markdown";
+import { audioLabel, plainTextForLabel } from "@/lib/chat-markdown";
 
 /**
  * An accessible name is SPOKEN, so it cannot carry markdown source.
@@ -91,5 +91,43 @@ describe("plainTextForLabel", () => {
     // The caller falls back to the bare "Audio reply" label on empty output,
     // so this must not produce a stray separator.
     expect(plainTextForLabel("   \n\n  ")).toBe("");
+  });
+});
+
+describe("audioLabel", () => {
+  /**
+   * Shared by both chat surfaces since TASK-698 — the mascot chat and the
+   * full-screen one each draw a player, and every previous rule about this
+   * label had to be fixed twice.
+   */
+  it("names the clip by what the bubble shows", () => {
+    expect(audioLabel("The lantern is green.", "Audio reply"))
+      .toBe("Audio reply: The lantern is green.");
+  });
+
+  it("falls back to the bare prefix when there is nothing to say", () => {
+    expect(audioLabel("", "Audio reply")).toBe("Audio reply");
+    expect(audioLabel(undefined, "Audio reply")).toBe("Audio reply");
+    expect(audioLabel("   \n ", "Audio reply")).toBe("Audio reply");
+  });
+
+  it("never announces a directive, because both surfaces lift them before rendering", () => {
+    // The property the move exists to guarantee: a label is read out verbatim,
+    // and the STORED text keeps its `EMAIL:` ids while a caption can carry a
+    // `MEDIA:` path. Callers hand this the body text the bubble draws — the
+    // one both directives have already been taken out of.
+    const bodyText = "Here is the summary.";
+    const label = audioLabel(bodyText, "Audio reply");
+    expect(label).not.toContain("EMAIL:");
+    expect(label).not.toContain("MEDIA:");
+    expect(label).not.toContain("/home/clawbox/.openclaw/media");
+  });
+
+  it("keeps the label short enough to be useful out loud", () => {
+    const long = "word ".repeat(60);
+    const label = audioLabel(long, "Audio reply");
+    // The prefix plus a budgeted 100 characters and the ellipsis.
+    expect(label.length).toBeLessThan("Audio reply: ".length + 105);
+    expect(label.endsWith("\u2026")).toBe(true);
   });
 });


### PR DESCRIPTION
### TASK-698 — the full-screen chat printed the media path instead of the picture

**Customer-visible symptom.** On `/app/clawbox` (the standalone full-screen chat, `ChatApp`) a
generated picture arrived as literal text — `MEDIA:/home/clawbox/.openclaw/media/tool-image-generation/image-1---….png`,
an absolute device path, in the customer's transcript — where the mascot chat drew the picture.
A spoken reply was worse: the harness appends a second assistant message repeating the answer's
text, so the owner saw the answer **twice** with no way to hear it.

**Cause.** The two chat surfaces had separate history and streaming paths. `ChatPopup` runs the
shared `projectGatewayHistory` projection and `splitAssistantMedia`; `ChatApp` had its own
inline loop that read only text blocks. The drift was known — `ChatApp.tsx` carried a
`TASK-698` comment saying the directive was "deliberately left as text" because one assertion
pinned it.

**Harness-first.** The native mechanism is the harness's own convention, not a ClawBox
invention: OpenClaw emits `MEDIA:<path>` inside the reply text and expects every client to run
the split itself. Confirmed read-only on the OpenClaw box — the gateway's own bundled Control UI
(`~/.openclaw/cache/control-ui-assets/<hash>/assets/control-ui-boot-*.js`) carries that same
split. ClawBox's side of it already exists in `src/lib/chat-media.ts` and
`src/lib/harness/openclaw-gateway-adapter.ts`; this PR **routes the second surface through them**
rather than adding a third derivation.

**The change.**
* `ChatApp.loadHistory` now calls the shared `projectGatewayHistory` instead of its own loop.
  That is the module whose header says "Re-deriving any of these is how a shipped fix reopens" —
  it lifts `MEDIA:`, splits the composer's `[Attached file: …]` lines back into pictures and
  names (an absolute path that leaked on this surface too), folds the spoken-reply supplement
  into the bubble it repeats, and drops sentinels and inter-session envelopes.
* The live `final` handler splits on the way **into** state (`splitAssistantMedia` +
  `extractAudioAttachments` + `boundedAudio`), with the same fold rule, so the live and reloaded
  views agree. The interrupted-turn path does the same lift, so an aborted turn keeps its picture.
* The streaming render strips the directive, as the mascot chat does.
* The bubble renders `images` and `audio` from state and is otherwise unchanged.
* `audioLabel` moves out of `ChatPopup` into the shared `chat-markdown` module — both surfaces
  draw a player, and an accessible name is read out verbatim, so neither may announce a media
  path or a mail id.

**RED → GREEN.** New `src/tests/components/chatapp-media-directives.test.tsx`, driven through a
scripted gateway socket. On unmodified beta all four original cases failed with the path on
screen, e.g.

```
AssertionError: expected 'chat.title@keyframes chatapp-spin { t…' not to contain '/home/clawbox/.openclaw/media/tool-im…'
Received: "…Here's your fluffy cat! 🐈MEDIA:/home/clawbox/.openclaw/media/tool-image-generation/image-1---….png…"
 ❯ src/tests/components/chatapp-media-directives.test.tsx:154
 Test Files  1 failed (1)
      Tests  4 failed (4)
```

Now 7 passed, including the real spoken-reply shape (a structured `attachment` part on a second
message) asserting one bubble and a player. Whole suites green on the rebased head: `--project
components` 150 files / 1398 tests, `--project unit` 672 files / 10816 tests, `tsc --noEmit`
clean.

**Behaviour change, deliberate.** `chat-inter-session-envelope.test.tsx` asserted that the
`MEDIA:` line SURVIVES in ChatApp's transcript. That assertion is rewritten to the new contract —
the picture renders — so both surfaces now assert the same thing, which is the point.

**Both editions.** `clawbox` is not in `HARNESS_ONLY_APP_IDS`, so this surface exists on both.
`ChatApp` speaks only the OpenClaw gateway WebSocket, and the Hermes chat path lifts the same
directives server-side already (`src/app/setup-api/hermes/chat/route.ts` — `splitAssistantMedia`,
6 references, verified on the Hermes box), through the same shared helper this PR reuses.
Read-only device proof, both editions:
* OpenClaw box (`CLAWBOX_EDITION=openclaw`): `~/.openclaw/media/{outbound,tool-image-generation,
  playback-transcode}` present; the gateway's Control UI bundle carries the `MEDIA:` split.
* Hermes box (`CLAWBOX_EDITION=hermes`, checkout at beta): `ChatApp.tsx` has neither
  `splitMediaDirectives` nor `splitAssistantMedia` — the defect, reproduced on hardware — while
  the Hermes chat route has the split. No mutation; the device mutex was not taken.

**Review.** One review pass. HIGH ("the audio half only fires on a shape the box does not emit, and
the test proved it with its own fixture") and the four MEDIUMs (`boundedAudio` bypassed, the
`[Attached file:]` path leak, re-deriving `projectGatewayHistory`, a prose `Media:` line) are all
addressed above, except two module-level ones recorded for their own task: `splitMediaDirectives`
deletes a directive line whose payload renders nothing (`splitEmailRefs` deliberately keeps such
a line), and it re-spaces any reply that merely mentions "media:" — both affect BOTH surfaces and
predate this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated images now appear directly in chat messages instead of showing media directives.
  * Audio attachments include accessible player controls and descriptive labels.
  * Duplicate spoken replies are consolidated, with up to four audio clips retained.
  * Completed images and audio are preserved when responses are stopped.

* **Bug Fixes**
  * Media displays consistently in chat history, live responses, streaming output, and after reconnecting.
  * Internal media directives are no longer exposed in transcript text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->