### PR TITLE
fix: fill every channel-status memo from one CLI start

### DIFF
--- a/src/app/setup-api/discord/status/route.ts
+++ b/src/app/setup-api/discord/status/route.ts
@@ -250,9 +250,9 @@ export async function GET() {
     // `tokenStatus` and `lastError`, which is exactly the vocabulary the Hermes
     // branch above maps. So the card was blank on a box whose bot was
     // answering in Discord.
-    // Through the shared memo in openclaw-channels: one CLI cold start per
-    // channel per window, concurrent callers coalesced, failures remembered
-    // too. This route used to hold a private copy of that cache — which is why
+    // Through the shared memo in openclaw-channels: ONE CLI cold start per
+    // window for every channel at once (the read is un-filtered, TASK-671),
+    // concurrent callers coalesced, failures remembered too. This route used to hold a private copy of that cache — which is why
     // /whatsapp/status, reading the same command with no memo at all, cost 3.6 s
     // a poll where this one cost 20 ms.
     const channel = await readCachedChannelStatus(DISCORD_CHANNEL_ID);

--- a/src/app/setup-api/telegram/status/route.ts
+++ b/src/app/setup-api/telegram/status/route.ts
@@ -179,9 +179,11 @@ export async function GET() {
     const { token, known } = await readActiveTelegramBot(harness);
     if (!token) return NextResponse.json({ configured: false, unknown: !known });
     // Whether anything is LISTENING, asked of the harness's own answer rather
-    // than inferred: `openclaw channels status --channel telegram --json`
-    // through the ONE shared memo `readCachedChannelStatus` owns (15 s success
-    // / 3 s failure, in-flight coalesced, invalidated by every channel write) —
+    // than inferred: `openclaw channels status --json` through the ONE shared
+    // memo `readCachedChannelStatus` owns (15 s success / 3 s failure, in-flight
+    // coalesced, invalidated by every channel write and by a gateway restart) —
+    // one un-filtered read that answers for every channel, so opening the
+    // Channels hub costs one CLI start rather than one per card —
     // the same mechanism the Discord route one file over already uses, and the
     // reason this costs ~20 ms rather than a CLI boot.
     //

--- a/src/lib/openclaw-channels.ts
+++ b/src/lib/openclaw-channels.ts
@@ -600,6 +600,15 @@ async function readChannelRowResult(
 // /discord/status grew the first one and /whatsapp/status never got it, which
 // is why one panel answered in 20 ms and the other in three and a half seconds
 // from the same command.
+//
+// One memo AND one CLI start (TASK-671). The first shape of this cache still
+// filled it one channel per start, so a cold Channels hub — or Settings on a
+// phone, which reads every channel on one mount — paid the cold start twice
+// over. `--channel` is optional and the un-filtered payload is keyed by channel
+// id, so one process start answers about all of them; measured on the box,
+// three runs each, 3.72/3.25/3.19 s un-filtered against 3.17/3.15/3.10 s
+// filtered. The whole cost is the CLI start, and one read now serves what two
+// used to.
 
 /**
  * How long one gateway ANSWER about a channel stands — including the answer

--- a/src/lib/openclaw-channels.ts
+++ b/src/lib/openclaw-channels.ts
@@ -473,28 +473,52 @@ export interface ChannelRowResult {
   row: Record<string, unknown> | null;
 }
 
-async function readChannelRowResult(
-  channelId: string,
+/** One `channels status --json` payload, as much of it as this module reads. */
+interface ChannelStatusPayload {
+  channelAccounts?: Record<string, unknown>;
+  channels?: Record<string, unknown>;
+}
+
+/**
+ * Run `channels status` and parse what came back.
+ *
+ * `channelId` narrows the read to ONE channel; `null` asks about every channel,
+ * which is what the memo below does. `--channel` is optional on this command —
+ * checked against the installed CLI, openclaw 2026.8.1 — and the un-filtered
+ * payload is keyed by channel id, so one process start answers about all of
+ * them. Measured on the OpenClaw box, three runs each: un-filtered 3.72/3.25/
+ * 3.19 s against 3.17/3.15/3.10 s for a filtered read. The whole cost is the
+ * CLI cold start; walking every channel adds about a quarter of a second, so
+ * one un-filtered read is far cheaper than two filtered ones.
+ *
+ * `null` back means "could not read the gateway" — a spawn failure, or output
+ * that is not a payload — and is deliberately kept apart from an EMPTY payload,
+ * which is a gateway answering about a box with nothing configured.
+ */
+async function readChannelStatusPayload(
+  channelId: string | null,
   // `captureStdout` is deliberately not offerable: this function's whole job is
   // to parse the CLI's `--json`, and a caller that turned stdout off would get
   // an empty string and a silent `null` — "the gateway said nothing" — for a
   // channel that is perfectly healthy.
   options: Omit<SpawnOpenclawOptions, "captureStdout"> = {},
-): Promise<ChannelRowResult> {
+): Promise<ChannelStatusPayload | null> {
   // No CLI to ask on a Hermes box. Not an answer: the edition is read per call,
   // so this must not be remembered as one.
-  if (openclawIsAbsent()) return { answered: false, row: null };
+  if (openclawIsAbsent()) return null;
   let parsed: unknown;
   try {
     const out = await spawnOpenclawCli(
       [
         "channels",
         "status",
-        "--channel",
-        channelId,
+        ...(channelId === null ? [] : ["--channel", channelId]),
         "--json",
         // Bounds the gateway round trip the command makes. Without it a wedged
         // gateway is only stopped by the spawn timeout, which is much longer.
+        // It bounds the un-filtered read too, which is what keeps one wedged
+        // channel from making the shared read slower than the per-channel ones
+        // it replaced.
         "--timeout",
         String(CHANNEL_STATUS_GATEWAY_TIMEOUT_MS),
       ],
@@ -503,10 +527,10 @@ async function readChannelRowResult(
     parsed = JSON.parse(out);
   } catch (err) {
     console.warn(
-      `[openclaw-channels] could not read ${channelId} status:`,
+      `[openclaw-channels] could not read ${channelId ?? "channel"} status:`,
       err instanceof Error ? err.message : err,
     );
-    return { answered: false, row: null };
+    return null;
   }
 
   // The CLI exited fine but what came back is not a payload — the same class of
@@ -519,33 +543,46 @@ async function readChannelRowResult(
   // `channels` key would be the same mistake inverted: a gateway with nothing
   // configured is entitled to answer `{}`, and calling that a failed read would
   // put exactly the box this change is for back on the 3 s window.
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return { answered: false, row: null };
-  }
-  const payload = parsed as {
-    channelAccounts?: Record<string, unknown>;
-    channels?: Record<string, unknown>;
-  };
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  return parsed as ChannelStatusPayload;
+}
 
-  // Prefer the per-ACCOUNT row: it is the only one that carries `connected`
-  // and `tokenStatus`. The channel-level row — which has neither — is the
-  // fallback for a payload that has no accounts yet.
+/**
+ * One channel's row out of a payload, or `null` when the payload does not
+ * mention it — which, for a payload the gateway actually answered, means that
+ * channel was never set up.
+ *
+ * Prefer the per-ACCOUNT row: it is the only one that carries `connected` and
+ * `tokenStatus`. The channel-level row — which has neither — is the fallback
+ * for a payload that has no accounts yet.
+ */
+function rowFromPayload(
+  payload: ChannelStatusPayload,
+  channelId: string,
+): Record<string, unknown> | null {
   const accounts = payload.channelAccounts?.[channelId];
   if (Array.isArray(accounts) && accounts.length > 0) {
     const first = accounts[0];
-    if (first && typeof first === "object") {
-      return { answered: true, row: first as Record<string, unknown> };
-    }
+    if (first && typeof first === "object") return first as Record<string, unknown>;
   }
 
   const channel = payload.channels?.[channelId];
-  if (channel && typeof channel === "object") {
-    return { answered: true, row: channel as Record<string, unknown> };
-  }
+  if (channel && typeof channel === "object") return channel as Record<string, unknown>;
 
-  // The gateway answered and this channel is simply not in the payload — it was
-  // never set up. A real answer, and it stands for a full window.
-  return { answered: true, row: null };
+  return null;
+}
+
+/** {@link ChannelRowResult} for one channel out of one payload read. */
+function resultFor(payload: ChannelStatusPayload | null, channelId: string): ChannelRowResult {
+  if (!payload) return { answered: false, row: null };
+  return { answered: true, row: rowFromPayload(payload, channelId) };
+}
+
+async function readChannelRowResult(
+  channelId: string,
+  options: Omit<SpawnOpenclawOptions, "captureStdout"> = {},
+): Promise<ChannelRowResult> {
+  return resultFor(await readChannelStatusPayload(channelId, options), channelId);
 }
 
 // ── One memo for `channels status`, shared by every channel ─────────────────
@@ -592,22 +629,84 @@ interface CachedRow {
   answered: boolean;
   at: number;
 }
-interface InFlightRow {
-  /** The channel's invalidation count when this read started. */
-  epoch: number;
-  promise: Promise<ChannelRowResult>;
+interface InFlightPayload {
+  /**
+   * Every channel's invalidation count when this read started — the whole map,
+   * not one channel's, because one read now answers about all of them and each
+   * has to be judged on its own.
+   */
+  epochs: Map<string, number>;
+  promise: Promise<ChannelStatusPayload | null>;
 }
 
 const cachedRows = new Map<string, CachedRow>();
-const inFlightRows = new Map<string, InFlightRow>();
+/**
+ * The ONE read in flight. There is no per-channel variant: a read without
+ * `--channel` answers about every channel, so two of them would be the same
+ * CLI start twice.
+ */
+let inFlightPayload: InFlightPayload | null = null;
 /** Per channel, so one channel's mutation never discards another's fresh read. */
 const epochs = new Map<string, number>();
+/**
+ * The channels ClawBox has a status panel for.
+ *
+ * A payload the gateway answered lists the channels it knows; a channel it does
+ * NOT list was never set up, and a read that failed says nothing about any of
+ * them. Both are answers that have to be stored for every channel a panel will
+ * ask about, or the un-configured box — the common one — pays a CLI start per
+ * channel on the first cold open instead of one for all of them.
+ *
+ * Deliberately a short, explicit list rather than a scrape of the CLI's own
+ * `--channel` enumeration, for the same reason {@link OFFICIAL_CHANNEL_PLUGINS}
+ * is one: this is what the Settings panel can show, and a channel ClawBox has
+ * no UI for has no business occupying a memo slot. {@link askedChannelIds}
+ * covers anything asked for beyond it.
+ */
+const MEMOISED_CHANNEL_IDS = ["telegram", "whatsapp", "discord"] as const;
 
 /**
- * {@link readChannelRow}, but at most one CLI start per channel per window, with
- * concurrent callers sharing the one in flight. This is what a status route
- * should call; {@link readChannelRow} stays the uncached "ask right now" read
- * that {@link waitForChannelConnected} polls a transition with.
+ * Channel ids some caller has asked the memo about, beyond the list above.
+ *
+ * Kept so a channel ClawBox learns about later still gets its negative answer
+ * stored rather than re-asked on every poll, without that list having to be
+ * edited in two places.
+ */
+const askedChannelIds = new Set<string>(MEMOISED_CHANNEL_IDS);
+
+/**
+ * Store one payload read against every channel it can speak for.
+ *
+ * `startedEpochs` is the snapshot taken when the read began: a channel whose
+ * epoch moved since then had a change land mid-flight, so this answer predates
+ * it and is dropped — for THAT channel only, which is the whole reason the
+ * epochs are per channel rather than one counter.
+ */
+function storeChannelPayload(
+  payload: ChannelStatusPayload | null,
+  startedEpochs: Map<string, number>,
+): void {
+  const at = Date.now();
+  const answered = payload !== null;
+  const ids = new Set<string>(startedEpochs.keys());
+  for (const id of askedChannelIds) ids.add(id);
+  if (payload) {
+    for (const id of Object.keys(payload.channelAccounts ?? {})) ids.add(id);
+    for (const id of Object.keys(payload.channels ?? {})) ids.add(id);
+  }
+  for (const id of ids) {
+    if ((epochs.get(id) ?? 0) !== (startedEpochs.get(id) ?? 0)) continue;
+    cachedRows.set(id, { row: payload ? rowFromPayload(payload, id) : null, answered, at });
+  }
+}
+
+/**
+ * {@link readChannelRow}, but at most one CLI start per WINDOW — for every
+ * channel at once, not one channel per start — with concurrent callers sharing
+ * the one in flight. This is what a status route should call;
+ * {@link readChannelRow} stays the uncached "ask right now" read that
+ * {@link waitForChannelConnected} polls a transition with, where filtering to
+ * one channel is right because that is what the caller is watching.
  *
  * The returned row is SHARED with every other caller in the window — read it,
  * never mutate it.
@@ -617,6 +716,7 @@ const epochs = new Map<string, number>();
  * disproved.
  */
 export function readCachedChannelRowResult(channelId: string): Promise<ChannelRowResult> {
+  askedChannelIds.add(channelId);
   const epoch = epochs.get(channelId) ?? 0;
   const cached = cachedRows.get(channelId);
   if (cached) {
@@ -628,30 +728,37 @@ export function readCachedChannelRowResult(channelId: string): Promise<ChannelRo
       return Promise.resolve({ answered: cached.answered, row: cached.row });
     }
   }
-  // Join a read in flight — but only one started since the last invalidation.
-  // An older one is answering a question the owner has already changed the
-  // answer to: it is what would hand a poll made AFTER the QR was scanned the
-  // "not linked" row that a read started before it is about to return.
-  const existing = inFlightRows.get(channelId);
-  if (existing && existing.epoch === epoch) return existing.promise;
+  // Join a read in flight — but only one started since THIS channel's last
+  // invalidation. An older one is answering a question the owner has already
+  // changed the answer to: it is what would hand a poll made AFTER the QR was
+  // scanned the "not linked" row that a read started before it is about to
+  // return. Judged per channel, because the shared read is still perfectly
+  // current for every other channel in it.
+  const existing = inFlightPayload;
+  if (existing && (existing.epochs.get(channelId) ?? 0) === epoch) {
+    return existing.promise.then((payload) => resultFor(payload, channelId));
+  }
 
-  const promise = readChannelRowResult(channelId)
-    .then(({ answered, row }) => {
-      // Same rule for storing: an invalidation that landed while this was in
-      // flight means the answer predates the change that caused it.
-      if ((epochs.get(channelId) ?? 0) === epoch) {
-        cachedRows.set(channelId, { row, answered, at: Date.now() });
-      }
-      return { answered, row };
+  // Snapshot BOTH sets: a channel that has been invalidated but never read
+  // through this memo has an epoch and no entry in `askedChannelIds`, and
+  // missing it would make this read's own fresh answer look stale.
+  const startedEpochs = new Map<string, number>(epochs);
+  for (const id of askedChannelIds) {
+    if (!startedEpochs.has(id)) startedEpochs.set(id, 0);
+  }
+  const promise = readChannelStatusPayload(null)
+    .then((payload) => {
+      storeChannelPayload(payload, startedEpochs);
+      return payload;
     })
     .finally(() => {
       // Only ever clear our OWN entry: an abandoned read must not evict the
       // replacement that an invalidation started, or the next caller pays for a
       // third CLI start.
-      if (inFlightRows.get(channelId)?.epoch === epoch) inFlightRows.delete(channelId);
+      if (inFlightPayload?.promise === promise) inFlightPayload = null;
     });
-  inFlightRows.set(channelId, { epoch, promise });
-  return promise;
+  inFlightPayload = { epochs: startedEpochs, promise };
+  return promise.then((payload) => resultFor(payload, channelId));
 }
 
 /**

--- a/src/lib/openclaw-channels.ts
+++ b/src/lib/openclaw-channels.ts
@@ -33,6 +33,7 @@
 import {
   type SpawnOpenclawOptions,
   OpenclawSpawnTimeoutError,
+  gatewayRestartGeneration,
   openclawIsAbsent,
   readConfig,
   spawnOpenclawCli,
@@ -477,6 +478,10 @@ export interface ChannelRowResult {
 interface ChannelStatusPayload {
   channelAccounts?: Record<string, unknown>;
   channels?: Record<string, unknown>;
+  /** The CLI's own word for "I could not reach the gateway". */
+  gatewayReachable?: unknown;
+  /** Set when the answer was assembled from the config file alone. */
+  configOnly?: unknown;
 }
 
 /**
@@ -544,7 +549,21 @@ async function readChannelStatusPayload(
   // configured is entitled to answer `{}`, and calling that a failed read would
   // put exactly the box this change is for back on the 3 s window.
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
-  return parsed as ChannelStatusPayload;
+  const payload = parsed as ChannelStatusPayload;
+  // The CLI SAYS when it could not reach the gateway, and that is not an
+  // answer about any channel. Measured on the OpenClaw box with the unit
+  // stopped: `channels status --json` exits 0 and prints a perfectly valid
+  // object — `{ gatewayReachable: false, configOnly: true, error: "Gateway not
+  // reachable at ws://127.0.0.1:18789 (ECONNREFUSED)…", configuredChannels:
+  // [...] }` — with no `channelAccounts` and no `channels` key at all. Read as
+  // a payload it says "every channel was never set up", and that answer stood
+  // for the full 15 s window instead of the 3 s a failed read gets. A gateway
+  // restart is the commonest thing on this box, so the panel reported a paired,
+  // connected WhatsApp as "Not configured" for a quarter of a minute after
+  // every one of them. Ask the harness's own field rather than guessing from
+  // the absence of keys, which a box with nothing configured is entitled to.
+  if (payload.gatewayReachable === false || payload.configOnly === true) return null;
+  return payload;
 }
 
 /**
@@ -637,6 +656,12 @@ interface CachedRow {
   /** See {@link ChannelRowResult} — picks which of the two TTLs applies. */
   answered: boolean;
   at: number;
+  /** When the read that produced this row STARTED. Two shared reads can be out
+   *  at once, and the one that started first is free to finish last; without
+   *  this the older answer overwrites the newer one and is stamped fresh. */
+  startedAt: number;
+  /** {@link gatewayRestartGeneration} when that read started. */
+  restarts: number;
 }
 interface InFlightPayload {
   /**
@@ -645,6 +670,10 @@ interface InFlightPayload {
    * has to be judged on its own.
    */
   epochs: Map<string, number>;
+  /** Wall clock when the spawn began; see {@link CachedRow.startedAt}. */
+  startedAt: number;
+  /** {@link gatewayRestartGeneration} when the spawn began. */
+  restarts: number;
   promise: Promise<ChannelStatusPayload | null>;
 }
 
@@ -691,21 +720,47 @@ const askedChannelIds = new Set<string>(MEMOISED_CHANNEL_IDS);
  * it and is dropped — for THAT channel only, which is the whole reason the
  * epochs are per channel rather than one counter.
  */
-function storeChannelPayload(
-  payload: ChannelStatusPayload | null,
-  startedEpochs: Map<string, number>,
-): void {
+function storeChannelPayload(payload: ChannelStatusPayload | null, read: InFlightPayload): void {
   const at = Date.now();
   const answered = payload !== null;
-  const ids = new Set<string>(startedEpochs.keys());
+  const restarts = read.restarts;
+  const ids = new Set<string>(read.epochs.keys());
   for (const id of askedChannelIds) ids.add(id);
   if (payload) {
-    for (const id of Object.keys(payload.channelAccounts ?? {})) ids.add(id);
-    for (const id of Object.keys(payload.channels ?? {})) ids.add(id);
+    // `payload` is an unchecked cast of whatever the CLI printed, and
+    // `Object.keys("abc")` is `["0","1","2"]` — junk ids in the memo for a
+    // malformed answer. The same plain-object test `rowFromPayload` applies per
+    // value, applied once to the container.
+    for (const group of [payload.channelAccounts, payload.channels]) {
+      if (!group || typeof group !== "object" || Array.isArray(group)) continue;
+      for (const id of Object.keys(group)) ids.add(id);
+    }
   }
   for (const id of ids) {
-    if ((epochs.get(id) ?? 0) !== (startedEpochs.get(id) ?? 0)) continue;
-    cachedRows.set(id, { row: payload ? rowFromPayload(payload, id) : null, answered, at });
+    // An invalidation that landed while this was in flight means the answer
+    // predates the change that caused it — for THAT channel only, which is the
+    // whole reason the epochs are per channel rather than one counter.
+    if ((epochs.get(id) ?? 0) !== (read.epochs.get(id) ?? 0)) continue;
+    const held = cachedRows.get(id);
+    if (held) {
+      // Two shared reads can overlap: whichever STARTED last owns the entry,
+      // whatever order they finish in. Without this the slower, older read
+      // lands second and its stale rows are stamped with a fresh `at`.
+      if (held.startedAt > read.startedAt) continue;
+      // A read that could not reach the gateway says nothing about a channel
+      // some other read has just answered for. Downgrading a live answer to a
+      // failure because a DIFFERENT channel's poll happened to fail is a false
+      // failure this memo did not have while each channel had its own read.
+      if (!answered && held.answered && held.restarts === restarts
+          && Date.now() - held.at < CHANNEL_STATUS_TTL_MS) continue;
+    }
+    cachedRows.set(id, {
+      row: payload ? rowFromPayload(payload, id) : null,
+      answered,
+      at,
+      startedAt: read.startedAt,
+      restarts,
+    });
   }
 }
 
@@ -727,8 +782,17 @@ function storeChannelPayload(
 export function readCachedChannelRowResult(channelId: string): Promise<ChannelRowResult> {
   askedChannelIds.add(channelId);
   const epoch = epochs.get(channelId) ?? 0;
+  const restarts = gatewayRestartGeneration();
   const cached = cachedRows.get(channelId);
-  if (cached) {
+  // A row from before a gateway restart is not an answer about the gateway that
+  // is up now. `restartGateway()` has ~14 callers — a model save, an STT
+  // change, a browser install, the updater, boot — and none of them knows what
+  // a channel is, so none can be taught to invalidate this. One poll of ANY
+  // channel now seeds every channel's entry, so without this the exposure
+  // covers channels the owner never even opened: the Telegram card would report
+  // a receiving bot from a row read before the restart that stopped it, which
+  // is the very thing that route says it exists to prevent.
+  if (cached && cached.restarts === restarts) {
     const age = Date.now() - cached.at;
     const ttl = cached.answered ? CHANNEL_STATUS_TTL_MS : CHANNEL_STATUS_FAILURE_TTL_MS;
     // `age >= 0` because the clock is wall-clock: a Jetson whose RTC is corrected
@@ -744,7 +808,8 @@ export function readCachedChannelRowResult(channelId: string): Promise<ChannelRo
   // return. Judged per channel, because the shared read is still perfectly
   // current for every other channel in it.
   const existing = inFlightPayload;
-  if (existing && (existing.epochs.get(channelId) ?? 0) === epoch) {
+  if (existing && (existing.epochs.get(channelId) ?? 0) === epoch
+      && existing.restarts === restarts) {
     return existing.promise.then((payload) => resultFor(payload, channelId));
   }
 
@@ -755,19 +820,26 @@ export function readCachedChannelRowResult(channelId: string): Promise<ChannelRo
   for (const id of askedChannelIds) {
     if (!startedEpochs.has(id)) startedEpochs.set(id, 0);
   }
-  const promise = readChannelStatusPayload(null)
+  const read: InFlightPayload = {
+    epochs: startedEpochs,
+    startedAt: Date.now(),
+    restarts,
+    // Assigned on the next line; the callbacks below cannot run before it is.
+    promise: null as unknown as Promise<ChannelStatusPayload | null>,
+  };
+  read.promise = readChannelStatusPayload(null)
     .then((payload) => {
-      storeChannelPayload(payload, startedEpochs);
+      storeChannelPayload(payload, read);
       return payload;
     })
     .finally(() => {
       // Only ever clear our OWN entry: an abandoned read must not evict the
       // replacement that an invalidation started, or the next caller pays for a
       // third CLI start.
-      if (inFlightPayload?.promise === promise) inFlightPayload = null;
+      if (inFlightPayload === read) inFlightPayload = null;
     });
-  inFlightPayload = { epochs: startedEpochs, promise };
-  return promise.then((payload) => resultFor(payload, channelId));
+  inFlightPayload = read;
+  return read.promise.then((payload) => resultFor(payload, channelId));
 }
 
 /**

--- a/src/lib/openclaw-channels.ts
+++ b/src/lib/openclaw-channels.ts
@@ -574,6 +574,18 @@ async function readChannelStatusPayload(
  * Prefer the per-ACCOUNT row: it is the only one that carries `connected` and
  * `tokenStatus`. The channel-level row — which has neither — is the fallback
  * for a payload that has no accounts yet.
+ *
+ * The un-filtered read does NOT change what this means. Captured on the
+ * OpenClaw box, gateway up, WhatsApp never linked and Discord never
+ * configured: `channels status --json` and `channels status --channel whatsapp
+ * --json` carry the SAME `channelAccounts.whatsapp[0]` and the SAME
+ * `channels.whatsapp` object, field for field. Only the SET of channels
+ * listed differs — the un-filtered form lists every channel the gateway knows,
+ * the filtered form lists the one it was asked about. So a channel absent from
+ * an un-filtered payload is one that would have been absent from its own
+ * filtered read too, and every memoised caller reads exactly the row it read
+ * before. Pinned from those captures in
+ * `src/tests/routes/channels/status-payload-shapes.test.ts`.
  */
 function rowFromPayload(
   payload: ChannelStatusPayload,

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -2730,8 +2730,33 @@ async function awaitGatewayReady(options: RestartGatewayOptions): Promise<void> 
   throw new GatewayNotReadyError();
 }
 
+/**
+ * How many times this process has bounced the gateway.
+ *
+ * A monotonic counter, exported so anything holding a memo of something the
+ * GATEWAY told us can tell whether its answer predates a restart. A restart
+ * takes every channel, every provider and every session down at once, while the
+ * ~14 callers of {@link restartGateway} — a model save, an STT change, a
+ * browser install, the updater, boot — know nothing about any of them and
+ * cannot each be taught to invalidate the right caches.
+ *
+ * Deliberately in this direction: this module imports nothing from the memo
+ * holders, so they read the counter and there is no cycle. (A previous note
+ * claimed one; it was wrong.)
+ */
+let gatewayRestartCount = 0;
+
+/** @see gatewayRestartCount */
+export function gatewayRestartGeneration(): number {
+  return gatewayRestartCount;
+}
+
 export async function restartGateway(options: RestartGatewayOptions = {}): Promise<void> {
   if (gatewayIsAbsent()) return;
+  // Bumped BEFORE the restart, not after: the systemctl call is awaited and a
+  // read that starts while it is in flight is already reading a gateway on its
+  // way down, so its answer must not be stored against the old generation.
+  gatewayRestartCount += 1;
   // Best effort, before the restart: a unit that crash-looped through its
   // StartLimitBurst (20/hour — one bad config during an update is enough)
   // refuses every restart for the rest of the window with "Start request

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -2740,6 +2740,20 @@ async function awaitGatewayReady(options: RestartGatewayOptions): Promise<void> 
  * browser install, the updater, boot — know nothing about any of them and
  * cannot each be taught to invalidate the right caches.
  *
+ * Bumped TWICE per restart, at both ends, and one bump is not enough: with only
+ * the first, a read that STARTS after the bump and lands while the gateway is
+ * on its way down carries the new generation already, so the row it caches —
+ * read from the dying process — is accepted for a full window after the new one
+ * is up. The second bump makes every read that overlapped the restart older
+ * than the generation that follows it.
+ *
+ * What it cannot cover is the sub-second window between `systemctl restart`
+ * being issued and the old process actually closing its socket, on a caller
+ * that did not wait for readiness (`awaitReady: false`) and so has no "after"
+ * to bump at. A read landing exactly there is bounded instead by the memo's own
+ * short failure window, because the moment the socket is gone the CLI answers
+ * `gatewayReachable: false` and that is not stored as an answer at all.
+ *
  * Deliberately in this direction: this module imports nothing from the memo
  * holders, so they read the counter and there is no cycle. (A previous note
  * claimed one; it was wrong.)
@@ -2753,9 +2767,8 @@ export function gatewayRestartGeneration(): number {
 
 export async function restartGateway(options: RestartGatewayOptions = {}): Promise<void> {
   if (gatewayIsAbsent()) return;
-  // Bumped BEFORE the restart, not after: the systemctl call is awaited and a
-  // read that starts while it is in flight is already reading a gateway on its
-  // way down, so its answer must not be stored against the old generation.
+  // The FIRST of the two bumps — see gatewayRestartCount. Before the restart,
+  // so a row read from the gateway that is about to go down is already stale.
   gatewayRestartCount += 1;
   // Best effort, before the restart: a unit that crash-looped through its
   // StartLimitBurst (20/hour — one bad config during an update is enough)
@@ -2774,6 +2787,9 @@ export async function restartGateway(options: RestartGatewayOptions = {}): Promi
       timeout: 60000,
     });
     await awaitGatewayReady(options);
+    // The SECOND bump: everything read while this restart was in flight belongs
+    // to the generation that is now behind us.
+    gatewayRestartCount += 1;
     return;
   } catch (err) {
     if (err instanceof GatewayNotReadyError) throw err;
@@ -2797,6 +2813,7 @@ export async function restartGateway(options: RestartGatewayOptions = {}): Promi
         });
         // The legacy user unit serves the same port, so it owes the same proof.
         await awaitGatewayReady(options);
+        gatewayRestartCount += 1;
         return;
       } catch (fallbackErr) {
         // A gateway that was restarted but never came back must not be reported

--- a/src/tests/routes/channels/status-one-spawn.test.ts
+++ b/src/tests/routes/channels/status-one-spawn.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * TASK-671 (split from F-28 / PR #594): one `openclaw channels status` start
+ * must fill the memo for EVERY channel, not one channel per start.
+ *
+ * `--channel` is optional on that command — measured against the installed CLI
+ * (openclaw 2026.8.1) on the OpenClaw box, where the un-filtered payload keys
+ * `channelAccounts` and `channels` by `discord`/`telegram`/`whatsapp` even on a
+ * box that has only Telegram configured — and `readChannelRow`'s parser already
+ * indexes into a multi-channel payload. So the CLI has always handed back every
+ * channel in one process start and this module threw all but one row away.
+ *
+ * It matters because a cold Channels hub, and Settings on a phone (the panels'
+ * `!isMobile` escapes never return early there), read several channel statuses
+ * on one mount. Measured on the box, three runs each:
+ *   un-filtered  `channels status --json`                 3.72 / 3.25 / 3.19 s
+ *   filtered     `channels status --channel <id> --json`  3.17 / 3.15 / 3.10 s
+ * — the whole cost is the CLI cold start, and walking every channel adds about
+ * a quarter of a second. Two filtered reads are ~6.3 s where one un-filtered
+ * read is ~3.4 s.
+ *
+ * The CLI is mocked at `spawnOpenclawCli`, below every layer this touches, so
+ * the count is of real would-be process starts.
+ */
+
+vi.mock("@/lib/openclaw-config", () => ({
+  openclawIsAbsent: vi.fn(() => false),
+  readConfig: vi.fn(async () => ({})),
+  restartGateway: vi.fn(async () => {}),
+  spawnOpenclawCli: vi.fn(),
+}));
+
+import { spawnOpenclawCli } from "@/lib/openclaw-config";
+
+const mockSpawn = vi.mocked(spawnOpenclawCli);
+
+/** What one mocked `channels status` start costs, standing in for the seconds. */
+const CLI_MS = 100;
+
+let statusStarts = 0;
+/** Every `channels status` argv the module actually spawned. */
+let statusArgs: string[][] = [];
+let cliFails = false;
+
+/** The gateway's answer for a box with all three channels present. */
+function payload() {
+  return JSON.stringify({
+    channelAccounts: {
+      telegram: [{ configured: true, enabled: true, connected: true }],
+      whatsapp: [{ configured: true, enabled: true, linked: true, connected: true }],
+      discord: [{ configured: true, enabled: true, connected: false }],
+    },
+  });
+}
+
+let channels: typeof import("@/lib/openclaw-channels");
+
+beforeEach(async () => {
+  // The memo is module-level; a cache carried between cases would answer the
+  // next one.
+  vi.resetModules();
+  vi.clearAllMocks();
+  statusStarts = 0;
+  statusArgs = [];
+  cliFails = false;
+  // A failed read is logged; the failure case below is deliberate.
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  mockSpawn.mockImplementation(async (args: string[]) => {
+    if (args[0] === "channels" && args[1] === "status") {
+      statusStarts += 1;
+      statusArgs.push(args);
+      await new Promise((resolve) => setTimeout(resolve, CLI_MS));
+      if (cliFails) throw new Error("gateway unreachable");
+      return payload();
+    }
+    return "{}";
+  });
+  channels = await import("@/lib/openclaw-channels");
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("one CLI start fills every channel's memo", () => {
+  it("serves a Settings mount that reads three channels from one start", async () => {
+    const [telegram, whatsapp, discord] = await Promise.all([
+      channels.readCachedChannelRow("telegram"),
+      channels.readCachedChannelRow("whatsapp"),
+      channels.readCachedChannelRow("discord"),
+    ]);
+
+    expect(statusStarts).toBe(1);
+    // The one start must be the UN-filtered read, or it could only have
+    // answered about the channel it named.
+    expect(statusArgs[0]).not.toContain("--channel");
+    expect(telegram).toMatchObject({ connected: true });
+    expect(whatsapp).toMatchObject({ linked: true });
+    expect(discord).toMatchObject({ connected: false });
+  });
+
+  it("answers the second and third channel from memory, sequentially too", async () => {
+    // The concurrent case above shares one in-flight promise. This is the other
+    // half: a panel that reads its channels one after the other must find the
+    // rest of the payload already stored rather than starting the CLI again.
+    await channels.readCachedChannelRow("whatsapp");
+    expect(statusStarts).toBe(1);
+    await channels.readCachedChannelRow("discord");
+    await channels.readCachedChannelRow("telegram");
+    expect(statusStarts).toBe(1);
+  });
+
+  it("caches a channel absent from the payload as 'no row', not as unasked", async () => {
+    // The gateway answered; a channel it did not mention was never set up. That
+    // is a real answer and stands for a full window — leaving it unset would
+    // re-spawn the CLI on every poll for exactly the un-configured box this
+    // change is for.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    mockSpawn.mockImplementation(async (args: string[]) => {
+      if (args[0] === "channels" && args[1] === "status") {
+        statusStarts += 1;
+        statusArgs.push(args);
+        return JSON.stringify({ channelAccounts: { telegram: [{ configured: true }] } });
+      }
+      return "{}";
+    });
+
+    expect(await channels.readCachedChannelRow("telegram")).toMatchObject({ configured: true });
+    expect(await channels.readCachedChannelRow("whatsapp")).toBeNull();
+    expect(await channels.readCachedChannelRow("discord")).toBeNull();
+    expect(statusStarts).toBe(1);
+
+    vi.setSystemTime(Date.now() + 4_000);
+    expect(await channels.readCachedChannelRow("whatsapp")).toBeNull();
+    expect(statusStarts).toBe(1);
+  });
+
+  it("keeps a failed read on the short window, for every channel", async () => {
+    // "The gateway could not be asked" is not an answer about any channel, so
+    // it must not be pinned for a whole answer window — on the channel that
+    // asked or on the ones the same payload would have covered.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    cliFails = true;
+    expect(await channels.readCachedChannelRow("whatsapp")).toBeNull();
+    expect(await channels.readCachedChannelRow("discord")).toBeNull();
+    expect(statusStarts).toBe(1);
+
+    cliFails = false;
+    vi.setSystemTime(Date.now() + 5_000);
+    expect(await channels.readCachedChannelRow("discord")).toMatchObject({ connected: false });
+    expect(statusStarts).toBe(2);
+  });
+
+  it("never lets one channel's invalidation discard another's fresh row", async () => {
+    // The epochs are per channel and one read now covers many of them, so the
+    // shared read has to store per channel: a pairing that invalidates WhatsApp
+    // while the read is out must drop only WhatsApp's answer.
+    const inFlight = channels.readCachedChannelRow("whatsapp");
+    channels.invalidateChannelStatus("whatsapp");
+    await inFlight;
+
+    // Discord's row came from the same payload and nothing invalidated it.
+    expect(await channels.readCachedChannelRow("discord")).toMatchObject({ connected: false });
+    expect(statusStarts).toBe(1);
+
+    // WhatsApp's was dropped, so it is asked again.
+    expect(await channels.readCachedChannelRow("whatsapp")).toMatchObject({ linked: true });
+    expect(statusStarts).toBe(2);
+  });
+
+  it("never answers a poll made after a change from the read that started before it", async () => {
+    // The guard PR #594 added, kept across the shape change: a read still out
+    // when the owner's scan lands must neither answer the poll that follows it
+    // nor be stored, and its cleanup must not evict the read that replaced it.
+    const stale = channels.readCachedChannelRow("whatsapp");
+    channels.invalidateChannelStatus("whatsapp");
+    const fresh = channels.readCachedChannelRow("whatsapp");
+    expect(await fresh).toMatchObject({ linked: true });
+    await stale;
+    expect(statusStarts).toBe(2);
+    await channels.readCachedChannelRow("whatsapp");
+    expect(statusStarts).toBe(2);
+  });
+
+  it("still asks about one channel only when the caller wants a read right now", async () => {
+    // `readChannelRow` is the uncached "ask the gateway now" read that
+    // `waitForChannelConnected` polls a transition with. Filtering there is
+    // right: it is about one channel and pays no memo.
+    await channels.readChannelRow("whatsapp");
+    expect(statusStarts).toBe(1);
+    expect(statusArgs[0]).toContain("--channel");
+    expect(statusArgs[0]).toContain("whatsapp");
+  });
+});

--- a/src/tests/routes/channels/status-one-spawn.test.ts
+++ b/src/tests/routes/channels/status-one-spawn.test.ts
@@ -26,14 +26,16 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("@/lib/openclaw-config", () => ({
   openclawIsAbsent: vi.fn(() => false),
+  gatewayRestartGeneration: vi.fn(() => 0),
   readConfig: vi.fn(async () => ({})),
   restartGateway: vi.fn(async () => {}),
   spawnOpenclawCli: vi.fn(),
 }));
 
-import { spawnOpenclawCli } from "@/lib/openclaw-config";
+import { gatewayRestartGeneration, spawnOpenclawCli } from "@/lib/openclaw-config";
 
 const mockSpawn = vi.mocked(spawnOpenclawCli);
+const mockRestarts = vi.mocked(gatewayRestartGeneration);
 
 /** What one mocked `channels status` start costs, standing in for the seconds. */
 const CLI_MS = 100;
@@ -42,6 +44,14 @@ let statusStarts = 0;
 /** Every `channels status` argv the module actually spawned. */
 let statusArgs: string[][] = [];
 let cliFails = false;
+/**
+ * Per-start answers, consumed in order: `{ ms }` is how long that start takes
+ * and `{ out }` what it prints (or `fail` for a spawn that throws). Two reads
+ * can be in flight at once now, so a mock that answers every start with the
+ * same latency and the same payload cannot exercise either the ordering or the
+ * content divergence between them.
+ */
+let script: { ms: number; out?: string; fail?: boolean }[] = [];
 
 /** The gateway's answer for a box with all three channels present. */
 function payload() {
@@ -64,15 +74,18 @@ beforeEach(async () => {
   statusStarts = 0;
   statusArgs = [];
   cliFails = false;
+  script = [];
   // A failed read is logged; the failure case below is deliberate.
   vi.spyOn(console, "warn").mockImplementation(() => {});
+  mockRestarts.mockReturnValue(0);
   mockSpawn.mockImplementation(async (args: string[]) => {
     if (args[0] === "channels" && args[1] === "status") {
+      const step = script.shift();
       statusStarts += 1;
       statusArgs.push(args);
-      await new Promise((resolve) => setTimeout(resolve, CLI_MS));
-      if (cliFails) throw new Error("gateway unreachable");
-      return payload();
+      await new Promise((resolve) => setTimeout(resolve, step?.ms ?? CLI_MS));
+      if (step?.fail || (!step && cliFails)) throw new Error("gateway unreachable");
+      return step?.out ?? payload();
     }
     return "{}";
   });
@@ -180,6 +193,100 @@ describe("one CLI start fills every channel's memo", () => {
     await stale;
     expect(statusStarts).toBe(2);
     await channels.readCachedChannelRow("whatsapp");
+    expect(statusStarts).toBe(2);
+  });
+
+  it("treats a gateway the CLI could not reach as a failed read, not as 'no channels'", async () => {
+    // Measured on the OpenClaw box with `clawbox-gateway.service` stopped:
+    // `channels status --json` exits 0 and prints a valid object —
+    // `{ gatewayReachable: false, configOnly: true, error: "Gateway not
+    // reachable at ws://…(ECONNREFUSED)…", configuredChannels: ["telegram"] }`
+    // — with no `channelAccounts` and no `channels` key at all. Read as a
+    // payload that is "the gateway answered and none of these channels exists",
+    // which is pinned for the full 15 s answer window instead of the 3 s a
+    // failed read gets. A gateway restart is the commonest event on this box.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    script = [{
+      ms: 0,
+      out: JSON.stringify({
+        gatewayReachable: false,
+        configOnly: true,
+        error: "Gateway not reachable at ws://127.0.0.1:18789 (ECONNREFUSED).",
+        configuredChannels: ["telegram"],
+      }),
+    }];
+
+    expect(await channels.readCachedChannelRow("telegram")).toBeNull();
+    expect(statusStarts).toBe(1);
+
+    // The short window, because this was not an answer about any channel.
+    vi.setSystemTime(Date.now() + 5_000);
+    expect(await channels.readCachedChannelRow("telegram")).toMatchObject({ connected: true });
+    expect(statusStarts).toBe(2);
+  });
+
+  it("does not downgrade a channel's fresh answer because another channel's read failed", async () => {
+    // One read now speaks for every channel, so a failure has to be careful in
+    // a way a per-channel read never had to be: WhatsApp's poll failing must
+    // not turn Telegram's two-second-old emerald dot into "could not ask".
+    vi.useFakeTimers({ toFake: ["Date"] });
+    script = [{ ms: 0 }, { ms: 0, fail: true }];
+
+    expect(await channels.readCachedChannelRow("telegram")).toMatchObject({ connected: true });
+    channels.invalidateChannelStatus("whatsapp");
+    vi.setSystemTime(Date.now() + 2_000);
+    expect(await channels.readCachedChannelRow("whatsapp")).toBeNull();
+    expect(statusStarts).toBe(2);
+
+    // Telegram's answer is still inside its window and still an answer.
+    const telegram = await channels.readCachedChannelRowResult("telegram");
+    expect(telegram).toEqual({ answered: true, row: expect.objectContaining({ connected: true }) });
+    expect(statusStarts).toBe(2);
+  });
+
+  it("lets the read that STARTED last own the row, whatever order they finish in", async () => {
+    // Two shared reads overlap whenever a change lands mid-flight. The older
+    // one is slower here — two CLI cold starts competing on a Jetson is exactly
+    // how that happens — so without a guard it lands second and stamps its
+    // pre-restart rows as fresh.
+    const stale = JSON.stringify({
+      channelAccounts: { telegram: [{ configured: true, connected: true }] },
+    });
+    const fresh = JSON.stringify({
+      channelAccounts: { telegram: [{ configured: true, connected: false }] },
+    });
+    script = [{ ms: 80, out: stale }, { ms: 10, out: fresh }];
+
+    const first = channels.readCachedChannelRow("telegram");
+    channels.invalidateChannelStatus("telegram");
+    const second = channels.readCachedChannelRow("telegram");
+
+    expect(await second).toMatchObject({ connected: false });
+    await first;
+    expect(statusStarts).toBe(2);
+    // The slow first read has now settled. It must not have overwritten the
+    // newer answer with the connection state it captured before the change.
+    expect(await channels.readCachedChannelRow("telegram")).toMatchObject({ connected: false });
+    expect(statusStarts).toBe(2);
+  });
+
+  it("drops every channel's row when the gateway is restarted by something that knows nothing about channels", async () => {
+    // `restartGateway()` has ~14 callers — a model save, an STT change, a
+    // browser install, the updater, boot — and none of them invalidates a
+    // channel. On beta a channel held a row only if that channel had been
+    // polled; now ONE poll seeds all three, so the stale answer covers channels
+    // the owner never opened. The monotonic restart counter is what closes it.
+    expect(await channels.readCachedChannelRow("telegram")).toMatchObject({ connected: true });
+    expect(statusStarts).toBe(1);
+
+    mockRestarts.mockReturnValue(1);
+    script = [{ ms: 0, out: JSON.stringify({
+      channelAccounts: { telegram: [{ configured: true, connected: false }] },
+    }) }];
+    expect(await channels.readCachedChannelRow("telegram")).toMatchObject({ connected: false });
+    expect(statusStarts).toBe(2);
+    // And the channels that were only seeded by the first read are re-asked too.
+    expect(await channels.readCachedChannelRow("discord")).toBeNull();
     expect(statusStarts).toBe(2);
   });
 

--- a/src/tests/routes/channels/status-one-spawn.test.ts
+++ b/src/tests/routes/channels/status-one-spawn.test.ts
@@ -290,6 +290,30 @@ describe("one CLI start fills every channel's memo", () => {
     expect(statusStarts).toBe(2);
   });
 
+  it("drops a row read from the gateway that was on its way down", async () => {
+    // The counter is bumped at BOTH ends of a restart, and one bump is not
+    // enough: a read that STARTS after the first bump carries the new
+    // generation already, so with only that bump the row it took from the dying
+    // process would be accepted for a full window after the new gateway is up.
+    // Here the read begins during the restart (generation 1) and the restart
+    // finishes (generation 2).
+    mockRestarts.mockReturnValue(1);
+    script = [{ ms: 20, out: JSON.stringify({
+      channelAccounts: { telegram: [{ configured: true, connected: true }] },
+    }) }, { ms: 0, out: JSON.stringify({
+      channelAccounts: { telegram: [{ configured: true, connected: false }] },
+    }) }];
+
+    const during = channels.readCachedChannelRow("telegram");
+    expect(await during).toMatchObject({ connected: true });
+    expect(statusStarts).toBe(1);
+
+    // `restartGateway` returns; the generation moves past the read.
+    mockRestarts.mockReturnValue(2);
+    expect(await channels.readCachedChannelRow("telegram")).toMatchObject({ connected: false });
+    expect(statusStarts).toBe(2);
+  });
+
   it("still asks about one channel only when the caller wants a read right now", async () => {
     // `readChannelRow` is the uncached "ask the gateway now" read that
     // `waitForChannelConnected` polls a transition with. Filtering there is

--- a/src/tests/routes/channels/status-payload-shapes.test.ts
+++ b/src/tests/routes/channels/status-payload-shapes.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+/**
+ * TASK-671 — the un-filtered `channels status` payload says the SAME thing
+ * about a channel as the filtered one.
+ *
+ * Swapping the memo from `--channel <id>` to one un-filtered read is only safe
+ * if `rowFromPayload` reads the same row out of either shape; if the un-filtered
+ * form stubbed a channel the filtered form omits, every memoised caller would
+ * change what it reports on an un-configured box — the WhatsApp card would stop
+ * saying "Not configured" and start offering a QR flow that cannot complete.
+ *
+ * So these are not invented fixtures. They are the two payloads captured
+ * verbatim from the OpenClaw box (openclaw 2026.8.1) with the gateway up,
+ * WhatsApp configured but never linked and Discord never configured — the exact
+ * state that would expose the difference. The Telegram entries are left out
+ * because that channel IS configured on that box and its rows are not this
+ * test's subject.
+ *
+ * What the capture shows: the two payloads differ ONLY in which channels they
+ * list. Every field of the channel they both name is identical.
+ */
+
+vi.mock("@/lib/openclaw-config", () => ({
+  openclawIsAbsent: vi.fn(() => false),
+  gatewayRestartGeneration: vi.fn(() => 0),
+  readConfig: vi.fn(async () => ({})),
+  restartGateway: vi.fn(async () => {}),
+  spawnOpenclawCli: vi.fn(),
+}));
+
+import { spawnOpenclawCli } from "@/lib/openclaw-config";
+
+const mockSpawn = vi.mocked(spawnOpenclawCli);
+
+/** `channelAccounts.whatsapp[0]`, identical in both captures. */
+const WHATSAPP_ACCOUNT = {
+  accountId: "default",
+  enabled: true,
+  lastStartAt: null,
+  lastStopAt: null,
+  restartPending: false,
+  reconnectAttempts: 0,
+  healthState: "stopped",
+  lifecycle: "stopped",
+  busy: false,
+  lastInboundAt: null,
+  lastOutboundAt: null,
+  lastConnectedAt: null,
+  lastDisconnect: null,
+  lastMessageAt: null,
+  lastEventAt: null,
+  lastRunActivityAt: null,
+  configured: true,
+  linked: false,
+  running: false,
+  stateReason: "not linked",
+  lastError: null,
+};
+
+/** `channels.whatsapp`, identical in both captures. */
+const WHATSAPP_CHANNEL = {
+  configured: true,
+  statusState: "not-linked",
+  linked: false,
+  authAgeMs: null,
+  self: { e164: null, jid: null, lid: null },
+  running: false,
+  connected: false,
+  lastConnectedAt: null,
+  lastDisconnect: null,
+  reconnectAttempts: 0,
+  lastInboundAt: null,
+  lastMessageAt: null,
+  lastEventAt: null,
+  busy: false,
+  lastRunActivityAt: null,
+  lastError: null,
+  healthState: "stopped",
+  lifecycle: "stopped",
+};
+
+/** Discord, never configured on that box — only the un-filtered read names it. */
+const DISCORD_ACCOUNT = {
+  accountId: "default",
+  enabled: true,
+  lastStartAt: null,
+  lastStopAt: null,
+  restartPending: false,
+  reconnectAttempts: 0,
+  lastInboundAt: null,
+  lastOutboundAt: null,
+  tokenSource: "none",
+  tokenStatus: "missing",
+  lastConnectedAt: null,
+  lastDisconnect: null,
+  lastEventAt: null,
+  configured: false,
+  running: false,
+  stateReason: "not configured",
+  lastError: null,
+};
+
+const UNFILTERED = JSON.stringify({
+  channelAccounts: { whatsapp: [WHATSAPP_ACCOUNT], discord: [DISCORD_ACCOUNT] },
+  channels: {
+    whatsapp: WHATSAPP_CHANNEL,
+    discord: { configured: false, running: false, lastStartAt: null, lastStopAt: null, lastError: null, tokenSource: "none", lastProbeAt: null },
+  },
+});
+
+const FILTERED_WHATSAPP = JSON.stringify({
+  channelAccounts: { whatsapp: [WHATSAPP_ACCOUNT] },
+  channels: { whatsapp: WHATSAPP_CHANNEL },
+});
+
+let channels: typeof import("@/lib/openclaw-channels");
+
+async function loadWith(stdout: string) {
+  vi.resetModules();
+  vi.clearAllMocks();
+  mockSpawn.mockImplementation(async (args: string[]) =>
+    args[0] === "channels" && args[1] === "status" ? stdout : "{}",
+  );
+  channels = await import("@/lib/openclaw-channels");
+}
+
+beforeEach(() => {
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+describe("the un-filtered payload reads the same as the filtered one", () => {
+  it("gives WhatsApp byte-for-byte the row its own filtered read gives", async () => {
+    await loadWith(UNFILTERED);
+    const shared = await channels.readCachedChannelRow("whatsapp");
+
+    await loadWith(FILTERED_WHATSAPP);
+    const perChannel = await channels.readChannelRow("whatsapp");
+
+    expect(shared).toEqual(perChannel);
+    // And it is the ACCOUNT row, the only one carrying `linked` — the field
+    // `readOpenclawWhatsappStatus` decides "is a device paired" from.
+    expect(shared).toMatchObject({ configured: true, linked: false, stateReason: "not linked" });
+  });
+
+  it("parses the same status out of either payload", async () => {
+    await loadWith(UNFILTERED);
+    const shared = await channels.readCachedChannelStatus("whatsapp");
+
+    await loadWith(FILTERED_WHATSAPP);
+    const perChannel = await channels.readChannelStatus("whatsapp");
+
+    expect(shared).toEqual(perChannel);
+  });
+
+  it("still reports a channel the gateway does not name at all as no row", async () => {
+    // The invariant the memo's TTL split rests on: an ANSWERED payload that
+    // does not mention a channel means that channel was never set up, and that
+    // stands for a full window. `slack` is on no box here.
+    await loadWith(UNFILTERED);
+    expect(await channels.readCachedChannelRow("slack")).toBeNull();
+    expect(await channels.readCachedChannelRowResult("slack")).toEqual({
+      answered: true,
+      row: null,
+    });
+  });
+
+  it("reads Discord's un-configured row rather than inventing a configured one", async () => {
+    // The other half of the same worry: a channel the un-filtered payload DOES
+    // name must not read as configured just because it is present.
+    await loadWith(UNFILTERED);
+    expect(await channels.readCachedChannelRow("discord")).toMatchObject({
+      configured: false,
+      running: false,
+      tokenStatus: "missing",
+    });
+  });
+});

--- a/src/tests/routes/telegram/status-openclaw-receiving.test.ts
+++ b/src/tests/routes/telegram/status-openclaw-receiving.test.ts
@@ -9,9 +9,10 @@
  * remove (TASK-693).
  *
  * The answer comes from the harness, not from an inference: `openclaw channels
- * status --channel telegram --json` through `readCachedChannelStatus`, the one
- * shared memo the Discord route already uses (15 s success / 3 s failure,
- * in-flight coalesced, invalidated by every channel write).
+ * status --json` through `readCachedChannelStatus`, the one shared memo the
+ * Discord route already uses (15 s success / 3 s failure, in-flight coalesced,
+ * invalidated by every channel write and by a gateway restart). The read is
+ * un-filtered and fills every channel's entry in one CLI start (TASK-671).
  *
  * And it is TRI-STATE. `null` means the gateway could not be asked — every
  * Telegram save restarts it, so the read right after one lands in that window —

--- a/src/tests/routes/whatsapp/status-cache.test.ts
+++ b/src/tests/routes/whatsapp/status-cache.test.ts
@@ -29,6 +29,7 @@ vi.mock("@/lib/hermes-whatsapp", () => ({ readHermesWhatsappStatus: vi.fn() }));
 vi.mock("@/lib/whatsapp-pairing", () => ({ getPairingManager: vi.fn() }));
 vi.mock("@/lib/openclaw-config", () => ({
   openclawIsAbsent: vi.fn(() => false),
+  gatewayRestartGeneration: vi.fn(() => 0),
   readConfig: vi.fn(async () => ({})),
   restartGateway: vi.fn(async () => {}),
   spawnOpenclawCli: vi.fn(),


### PR DESCRIPTION
### TASK-671 (and the OpenClaw half of TASK-694) — one CLI start fills every channel's memo

**Customer-visible symptom.** Opening the Channels hub, or Settings on a phone (where the panels'
`!isMobile` escapes never return early), reads several channel statuses on one mount. PR #594 put
one shared memo in front of `openclaw channels status`, but still filled it **one channel per CLI
start** — so that mount paid two or three OpenClaw cold starts on a Jetson instead of one.

**Harness first.** `--channel` is OPTIONAL on that command and the un-filtered payload is keyed by
channel id, which `readChannelRow`'s parser already indexes into. So the CLI has always handed back
every channel in one process start and this module threw all but one row away. Nothing new is
built; the change is to stop discarding what the harness already sends.

**Measured on the OpenClaw box (read-only, openclaw 2026.8.1, gateway up), the card's own
acceptance criterion:**

```
UNFILTERED  channels status --json                3.72 / 3.25 / 3.19 s
FILTERED    channels status --channel <id> --json 3.17 / 3.15 / 3.10 / 3.17 / 3.16 / 3.08 s
```

The whole cost is the CLI cold start; walking every channel adds about a quarter of a second. One
un-filtered read (~3.4 s) against two filtered ones (~6.3 s) — clearly cheaper, so the card is
ACCEPTED rather than measured-and-rejected. Also measured, for TASK-694's open question: a **cold
Channels-hub open is 4.18 s** on that box today (the four status GETs concurrently; Telegram 4.13 s
and WhatsApp 4.16 s each paying their own start, Discord 26 ms because it short-circuits before the
CLI, e-mail 34 ms), against **0.06 s** warm. Because the GETs are concurrent the wall-clock win is
the difference between two competing Node cold starts and one; on the sequential mobile path it is
the full 2x.

**Three defects found while doing it, two of them live on beta.**

1. **A gateway that cannot be reached was cached as "this channel was never set up", for the full
   15 s answer window.** Captured on the box with `clawbox-gateway.service` stopped: `channels
   status --json` exits 0 and prints a valid object — `{ gatewayReachable: false, configOnly: true,
   error: "Gateway not reachable at ws://127.0.0.1:18789 (ECONNREFUSED)…" }` — with no
   `channelAccounts` and no `channels` key at all. Beta reads that as an ANSWER, so after every
   gateway restart the panel called a paired, connected WhatsApp "Not configured" for a quarter of
   a minute, on the 15 s window instead of the 3 s a failed read gets. Now the harness's own field
   is consulted. (This is a beta defect; the RED below covers it.)
2. **A gateway restart invalidated at most one channel.** `restartGateway()` takes every channel
   down and has ~14 callers — a model save, an STT change, a browser install, the updater, boot —
   none of which knows what a channel is. Beta's exposure was limited to channels that had been
   polled; one shared read would have widened it to every channel. `openclaw-config` now exports a
   monotonic `gatewayRestartGeneration()` (the pull direction — that module imports nothing from
   `openclaw-channels`, so there is no cycle) and a row from an older generation is stale.
3. **A failed shared read must not downgrade another channel's fresh answer, and the read that
   STARTED last owns the row** whatever order two overlapping reads finish in.

**RED → GREEN.** New `src/tests/routes/channels/status-one-spawn.test.ts`, counting real
would-be process starts at `spawnOpenclawCli`. On unmodified beta:

```
 × serves a Settings mount that reads three channels from one start
   AssertionError: expected 3 to be 1
 × answers the second and third channel from memory, sequentially too
   AssertionError: expected 3 to be 1
 × treats a gateway the CLI could not reach as a failed read, not as 'no channels'
   AssertionError: expected null to match object { connected: true }
 Tests  5 failed | 2 passed (7)
```

Now 11 passed there and 4 in the new payload-shape suite. Whole suites green on the rebased head:
`--project unit` 676 files / 10888 tests, `--project components` 149 files / 1391 tests, `tsc
--noEmit` clean.

**The review's HIGH, refuted with a capture.** The concern was that the un-filtered payload might
stub channels the filtered one omits, changing what "no row" means. Captured both payloads on the
box with WhatsApp configured-but-never-linked and Discord never configured — the exact state that
would expose it — and they carry the SAME `channelAccounts.whatsapp[0]` and the SAME
`channels.whatsapp`, field for field. Only the SET of channels listed differs. Both captures are
pinned verbatim as fixtures in `src/tests/routes/channels/status-payload-shapes.test.ts`, which
asserts the shared read and the filtered read produce an identical row and status.

**Siblings.** `readChannelRow` / `readChannelStatus` keep the FILTERED read — that is
`waitForChannelConnected`'s uncached "ask right now" poll about one channel, where filtering is
correct — and a test pins it. The three memo consumers (`openclaw-whatsapp.ts`, the Discord and
Telegram status routes) need no change: the signatures and the per-channel invalidation epochs are
unchanged. Three prose call sites that described the filtered command are corrected. Two test files
that mock `@/lib/openclaw-config` with a factory needed the new export; a missing one fails loudly
("No `gatewayRestartGeneration` export is defined on the mock"), which is a different failure mode
from the silent `instanceof undefined` the mock-completeness guard exists for, so that guard is
left alone.

**Both editions.** `openclawIsAbsent()` still short-circuits the whole read, so this path is inert
on the Hermes SKU and none of it is remembered there — the edition is read per call. Hermes' own
channel statuses go through `hermesGatewayStatus()`, which PR #602 already reduced to one shared
gateway spawn (the Hermes half of TASK-694); this is the OpenClaw half of the same card. Read-only
device proof, both editions: OpenClaw box `CLAWBOX_EDITION=openclaw`, every measurement above taken
there; Hermes box `CLAWBOX_EDITION=hermes`, no `openclaw` binary, so the memo never spawns. No
mutation on either box; the device mutex was not taken.

**Review.** One review pass, 1 HIGH / 4 MEDIUM / 4 LOW. The HIGH is refuted above with the capture
and a fixture test. The MEDIUMs are fixed here (the failed-read downgrade, the overlapping-read
ordering, the restart granularity, the object guards on `Object.keys`) except the wedged-channel
timeout question, which cannot be settled without stopping a channel plugin on a box the owner is
using: `--timeout 8000` is passed on the un-filtered read exactly as it was on the filtered one and
the 30 s spawn ceiling is unchanged, so the worst case is bounded the same way it was, but whether
the CLI applies that budget once per command or once per channel is NOT measured and is recorded as
such rather than asserted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Channel status checks now retrieve and cache information for all channels in a shared read, reducing repeated lookups and improving consistency.
  - Status results now correctly reflect gateway restarts, unreachable gateways, empty responses, unconfigured channels, and missing channels.
  - Telegram status checks continue to report receiving status using shared channel-status data.
- **Bug Fixes**
  - Prevented stale or failed status responses from overwriting newer channel information.
  - Ensured cached status data is refreshed appropriately after gateway restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->