### PR TITLE
fix: repair the plugin payloads a core upgrade orphans, and say which plugin refused

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3061,6 +3061,25 @@ for p in d.get("plugins", []):
       case "$pkg" in
         @openclaw/*) spec="$pkg@$TARGET" ;;
       esac
+      # Matched on the NORMALISED id: the registry can key a plugin as
+      # `openclaw-discord` or `@openclaw/discord`. Hoisted above the refresh so
+      # the pin repair below and the consent whitelist further down ask about
+      # the same name.
+      local PLUGIN_KEY="${plugin#@openclaw/}"
+      PLUGIN_KEY="${PLUGIN_KEY#openclaw-}"
+      # Rebuild the pin when the package could not be derived (TASK-602). A
+      # plugin whose payload a core upgrade orphaned is listed by `plugins list
+      # --json` with no rootDir/source, so `$pkg` is empty, `$spec` stays the
+      # BARE id and npm resolves it as @latest — the exact drift this block was
+      # written to prevent, on the boxes that most need the refresh. For the
+      # plugins ClawBox installs from the @openclaw scope the package name IS
+      # the id, so the pinned spec can be rebuilt from it; anything else keeps
+      # the bare id, which is the caller's own plugin and its owner's business.
+      if [ "$spec" = "$plugin" ] && [ -n "$TARGET" ]; then
+        case "$PLUGIN_KEY" in
+          codex|discord|whatsapp) spec="@openclaw/$PLUGIN_KEY@$TARGET" ;;
+        esac
+      fi
       echo "    - $spec"
       # --accept-capabilities, for the plugins CLAWBOX installs and only those.
       #
@@ -3089,8 +3108,6 @@ for p in d.get("plugins", []):
       # silently, behind the WARN below. `$spec` keeps the raw name, which is
       # what the CLI has to be given.
       local CAP_ARGS=()
-      local PLUGIN_KEY="${plugin#@openclaw/}"
-      PLUGIN_KEY="${PLUGIN_KEY#openclaw-}"
       case "$PLUGIN_KEY" in
         codex|deepseek|discord|whatsapp|clawbox-email-directives)
           openclaw_is_v2 && CAP_ARGS=(--accept-capabilities)

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -2654,47 +2654,62 @@ for key, entry in entries.items():
 MANAGEDPY
 )"
   for MANAGED_PLUGIN in $MANAGED_ENABLED_PLUGINS; do
-    if timeout 60 "$OPENCLAW_BIN" plugins enable "$MANAGED_PLUGIN" --accept-capabilities </dev/null >/dev/null 2>&1; then
+    if MANAGED_PLUGIN_OUT="$(timeout -k 5 60 "$OPENCLAW_BIN" plugins enable "$MANAGED_PLUGIN" --accept-capabilities </dev/null 2>&1)"; then
       echo "  $MANAGED_PLUGIN plugin capabilities accepted/current"
       continue
     fi
-    # `enable` could not answer, so the package is very likely not on disk to be
-    # consented to (TASK-602). Plugin payloads live in npm project directories
-    # keyed to the core GENERATION, so a core upgrade strands everything
-    # installed under the old one; `enable` then says "Plugin not found" and
-    # this loop used to warn and let the gateway try again with nothing
-    # changed. The codex block above already reinstalls its own payload pinned
-    # to the core target for exactly this state — this is the same repair for
-    # the channel plugins the Settings panel installs, and the reason a REBOOT
-    # now heals a box the 2026-09-01 outage left dead (src/lib/updater.ts does
-    # it during an update; an owner reboots long before he updates).
-    #
-    # Only where ClawBox knows the npm package AND the core pin: an unpinned
-    # `@openclaw/<id>` resolves @latest, which is how the codex plugin drifted
-    # ahead of the pinned core and crashed every chat. deepseek comes from
-    # ClawHub and clawbox-email-directives is copied out of the checkout — both
-    # have their own block in this script, and an `@openclaw/<id>` guess would
-    # fetch a package that is not the plugin. Same list as
-    # OFFICIAL_CHANNEL_PLUGINS in src/lib/openclaw-channels.ts, which
-    # gateway-pre-start-managed-plugin-payload.test.ts holds it to.
-    #
-    # Time-boxed at the codex install's own 120 s, and reachable for at most
-    # the two ids below, so this adds at most 4 minutes to a BLOCKING
-    # ExecStartPre and only on a box whose gateway would not come up at all.
-    MANAGED_PLUGIN_KEY="${MANAGED_PLUGIN#@openclaw/}"
-    MANAGED_PLUGIN_KEY="${MANAGED_PLUGIN_KEY#openclaw-}"
-    MANAGED_PLUGIN_SPEC=""
-    case "$MANAGED_PLUGIN_KEY" in
-      discord|whatsapp)
-        [ -n "$OPENCLAW_TARGET" ] \
-          && MANAGED_PLUGIN_SPEC="@openclaw/$MANAGED_PLUGIN_KEY@$OPENCLAW_TARGET"
+    # `enable` said no. WHY it said no decides what happens next, and the exit
+    # code alone cannot: it is also non-zero for a config lock, a registry
+    # hiccup and — the one that matters on a cold Jetson — the 60 s timeout
+    # above, none of which a 120 s npm install repairs. `Plugin not found: <id>`
+    # is the core's own wording for the package not being on disk (verified
+    # against the installed 2026.8.1 CLI), which is the state a core upgrade
+    # leaves behind: plugin payloads live in npm project directories keyed to
+    # the core GENERATION, so a bump strands everything installed under the old
+    # one (TASK-602). The codex block above asks the same question of the
+    # filesystem rather than of an exit code, for the same reason.
+    case "$MANAGED_PLUGIN_OUT" in
+      *"Plugin not found"*) ;;
+      *)
+        echo "  WARN: could not confirm $MANAGED_PLUGIN plugin capabilities; gateway readiness may remain blocked"
+        continue
         ;;
     esac
-    if [ -n "$MANAGED_PLUGIN_SPEC" ] \
-      && timeout 120 "$OPENCLAW_BIN" plugins install "$MANAGED_PLUGIN_SPEC" --force --accept-capabilities </dev/null >/dev/null 2>&1; then
+    # The payload is gone, and only ClawBox's own npm packages may be replaced
+    # here: deepseek comes from ClawHub and clawbox-email-directives is copied
+    # out of the checkout — both have their own block in this script, and an
+    # `@openclaw/<id>` guess would fetch a package that is not the plugin. Same
+    # list as OFFICIAL_CHANNEL_PLUGINS in src/lib/openclaw-channels.ts, which
+    # gateway-pre-start-managed-plugin-payload.test.ts holds it to.
+    MANAGED_PLUGIN_KEY="${MANAGED_PLUGIN#@openclaw/}"
+    MANAGED_PLUGIN_KEY="${MANAGED_PLUGIN_KEY#openclaw-}"
+    MANAGED_PLUGIN_PKG=""
+    case "$MANAGED_PLUGIN_KEY" in
+      discord|whatsapp) MANAGED_PLUGIN_PKG="@openclaw/$MANAGED_PLUGIN_KEY" ;;
+    esac
+    if [ -z "$MANAGED_PLUGIN_PKG" ]; then
+      echo "  WARN: the $MANAGED_PLUGIN payload is missing and ClawBox has no npm package of its own for it; its own installer owns that repair"
+      continue
+    fi
+    # Pinned to the INSTALLED core, like the deepseek block below and unlike the
+    # codex one above: this script never installs the core, so on a box that
+    # pulled new ClawBox code before its core update landed the pin file names a
+    # release the running runtime cannot load. `CLAWBOX_OPENCLAW_EFFECTIVE` is
+    # already normalised to MAJOR.MINOR.PATCH above, so an npm republish
+    # (2026.7.1 -> 2026.7.1-2) cannot turn into a 404 here. The unpinned spec is
+    # the fallback for a core whose release could not be read at all, never a
+    # second attempt: this is a BLOCKING ExecStartPre, so ONE 120 s install per
+    # plugin is the whole budget — at most 6 minutes for the two ids above, and
+    # only on a box whose gateway would not come up at all.
+    if [ -n "$CLAWBOX_OPENCLAW_EFFECTIVE" ]; then
+      MANAGED_PLUGIN_SPEC="$MANAGED_PLUGIN_PKG@$CLAWBOX_OPENCLAW_EFFECTIVE"
+    else
+      MANAGED_PLUGIN_SPEC="$MANAGED_PLUGIN_PKG"
+    fi
+    if timeout -k 5 120 "$OPENCLAW_BIN" plugins install "$MANAGED_PLUGIN_SPEC" --force --accept-capabilities </dev/null >/dev/null 2>&1; then
       echo "  $MANAGED_PLUGIN plugin payload reinstalled ($MANAGED_PLUGIN_SPEC)"
     else
-      echo "  WARN: could not confirm $MANAGED_PLUGIN plugin capabilities; gateway readiness may remain blocked"
+      echo "  WARN: could not reinstall the $MANAGED_PLUGIN plugin payload ($MANAGED_PLUGIN_SPEC); gateway readiness may remain blocked"
     fi
   done
 fi

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -2656,6 +2656,43 @@ MANAGEDPY
   for MANAGED_PLUGIN in $MANAGED_ENABLED_PLUGINS; do
     if timeout 60 "$OPENCLAW_BIN" plugins enable "$MANAGED_PLUGIN" --accept-capabilities </dev/null >/dev/null 2>&1; then
       echo "  $MANAGED_PLUGIN plugin capabilities accepted/current"
+      continue
+    fi
+    # `enable` could not answer, so the package is very likely not on disk to be
+    # consented to (TASK-602). Plugin payloads live in npm project directories
+    # keyed to the core GENERATION, so a core upgrade strands everything
+    # installed under the old one; `enable` then says "Plugin not found" and
+    # this loop used to warn and let the gateway try again with nothing
+    # changed. The codex block above already reinstalls its own payload pinned
+    # to the core target for exactly this state — this is the same repair for
+    # the channel plugins the Settings panel installs, and the reason a REBOOT
+    # now heals a box the 2026-09-01 outage left dead (src/lib/updater.ts does
+    # it during an update; an owner reboots long before he updates).
+    #
+    # Only where ClawBox knows the npm package AND the core pin: an unpinned
+    # `@openclaw/<id>` resolves @latest, which is how the codex plugin drifted
+    # ahead of the pinned core and crashed every chat. deepseek comes from
+    # ClawHub and clawbox-email-directives is copied out of the checkout — both
+    # have their own block in this script, and an `@openclaw/<id>` guess would
+    # fetch a package that is not the plugin. Same list as
+    # OFFICIAL_CHANNEL_PLUGINS in src/lib/openclaw-channels.ts, which
+    # gateway-pre-start-managed-plugin-payload.test.ts holds it to.
+    #
+    # Time-boxed at the codex install's own 120 s, and reachable for at most
+    # the two ids below, so this adds at most 4 minutes to a BLOCKING
+    # ExecStartPre and only on a box whose gateway would not come up at all.
+    MANAGED_PLUGIN_KEY="${MANAGED_PLUGIN#@openclaw/}"
+    MANAGED_PLUGIN_KEY="${MANAGED_PLUGIN_KEY#openclaw-}"
+    MANAGED_PLUGIN_SPEC=""
+    case "$MANAGED_PLUGIN_KEY" in
+      discord|whatsapp)
+        [ -n "$OPENCLAW_TARGET" ] \
+          && MANAGED_PLUGIN_SPEC="@openclaw/$MANAGED_PLUGIN_KEY@$OPENCLAW_TARGET"
+        ;;
+    esac
+    if [ -n "$MANAGED_PLUGIN_SPEC" ] \
+      && timeout 120 "$OPENCLAW_BIN" plugins install "$MANAGED_PLUGIN_SPEC" --force --accept-capabilities </dev/null >/dev/null 2>&1; then
+      echo "  $MANAGED_PLUGIN plugin payload reinstalled ($MANAGED_PLUGIN_SPEC)"
     else
       echo "  WARN: could not confirm $MANAGED_PLUGIN plugin capabilities; gateway readiness may remain blocked"
     fi

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1071,8 +1071,9 @@ const CLAWBOX_MANAGED_PLUGIN_IDS: ReadonlySet<string> = new Set([
  * finished: `scripts/gateway-pre-start.sh` reinstalls `@openclaw/codex` when
  * its package directory is missing, installs the pinned DeepSeek provider from
  * ClawHub (not npm, and not a `<pkg>@<version>` spec), and copies
- * `clawbox-email-directives` out of the checkout. Codex is still listed here
- * because its repair below is the one this file already owns.
+ * `clawbox-email-directives` out of the checkout. Codex IS listed: its own
+ * pinned reinstall is the repair this file has always run for it, for a
+ * migrated-v1 project as well as for an orphaned payload.
  */
 const MANAGED_PLUGIN_NPM_PACKAGES: ReadonlyMap<string, string> = new Map([
   ["codex", "@openclaw/codex"],
@@ -1212,8 +1213,12 @@ async function repairPluginsBlockingReadiness(journal: string): Promise<void> {
   }
   for (const pluginId of consent.managed) {
     if (repaired.has(normalizeManagedPluginId(pluginId))) continue;
+    // Codex answers a consent refusal with the same pinned force-install it
+    // answers a missing payload with: a v1 migration can leave that ONE plugin
+    // as a project declaration with no `node_modules`, where `enable` says
+    // "Plugin not found".
     if (normalizeManagedPluginId(pluginId) === "codex") {
-      if (await codexCapabilityRepairIsAllowed()) await repairCodexCapabilityConsent();
+      await repairManagedPluginPayload(pluginId);
       continue;
     }
     if (!(await pluginConsentRepairIsAllowed(pluginId))) continue;
@@ -1231,11 +1236,6 @@ async function repairPluginsBlockingReadiness(journal: string): Promise<void> {
  */
 async function repairManagedPluginPayload(pluginId: string): Promise<boolean> {
   const key = normalizeManagedPluginId(pluginId);
-  if (key === "codex") {
-    if (!(await codexCapabilityRepairIsAllowed())) return false;
-    await repairCodexCapabilityConsent();
-    return true;
-  }
   const npmPackage = MANAGED_PLUGIN_NPM_PACKAGES.get(key);
   if (!npmPackage) {
     // The pre-start owns this one, and `runCurrentGatewayPreStart()` has just
@@ -1246,14 +1246,15 @@ async function repairManagedPluginPayload(pluginId: string): Promise<boolean> {
     );
     return false;
   }
-  if (!(await pluginConsentRepairIsAllowed(pluginId))) return false;
+  // Codex has its own opt-out test, which also asks whether Codex is in use at
+  // all — an owner who moved to another provider must not have a stale journal
+  // line buy him a six-minute npm install on every update.
+  const allowed = key === "codex"
+    ? await codexCapabilityRepairIsAllowed()
+    : await pluginConsentRepairIsAllowed(pluginId);
+  if (!allowed) return false;
   await reinstallManagedPluginPayload(npmPackage);
   return true;
-}
-
-/** The pinned force-install that repairs a partial Codex project AND consents it. */
-async function repairCodexCapabilityConsent(): Promise<void> {
-  await reinstallManagedPluginPayload("@openclaw/codex");
 }
 
 /**

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1268,12 +1268,23 @@ async function repairPluginsBlockingReadiness(
     // as a project declaration with no `node_modules`, where `enable` says
     // "Plugin not found".
     if (normalizeManagedPluginId(pluginId) === "codex") {
+      // Codex has its own opt-out test, which also asks whether Codex is in
+      // use at all.
+      if (!(await codexCapabilityRepairIsAllowed())) continue;
+      if (options.consentOnly) {
+        // After a FAILED pre-start, the local verb — like every other managed
+        // plugin here. Codex's pinned reinstall exists because a migrated v1
+        // project can leave the declaration without `node_modules`, where
+        // `enable` answers "Plugin not found"; that is worth minutes of npm on
+        // the path that can restart the gateway afterwards, and not on the one
+        // that is about to report the pre-start's failure either way.
+        await recordPluginCapabilityConsent(pluginId);
+        continue;
+      }
       // One spec, not two: the unpinned fallback exists for a payload that is
       // GONE and may not be published under the pin's build suffix. Here the
-      // package is on disk — only its consent record is stale — and this path
-      // also runs after a FAILED pre-start, where every extra npm minute is
-      // spent on an update that is going to report that failure anyway.
-      await repairManagedPluginPayload(pluginId, { fallbackToUnpinned: false });
+      // package is on disk and only its consent record is stale.
+      await reinstallManagedPluginPayload("@openclaw/codex", false);
       continue;
     }
     if (!(await pluginConsentRepairIsAllowed(pluginId))) continue;

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -20,6 +20,7 @@ import { startRootStep } from "./root-step-runner";
 import { setUpdateLock, clearUpdateLock } from "./update-lock";
 import { collectBuildIdentity, resolveBuildDir } from "./build-identity";
 import type { AuthProfileEntries } from "./subscription-surface";
+import { OFFICIAL_CHANNEL_PLUGINS } from "./openclaw-channels";
 import {
   CHATGPT_AGENT_RUNTIME_ID,
   hasChatgptOauthProfile,
@@ -815,6 +816,21 @@ const LEGACY_GATEWAY_BLOCKER_RE =
 // for. Not global: `.match()` and `.test()` share this object.
 const PLUGIN_CAPABILITY_CONSENT_RE =
   /Plugin\s+["']?([A-Za-z0-9@._/-]+?)["']?\s+requires capability consent/i;
+// The OTHER refusal, and the one a core upgrade produces (TASK-602). Plugin
+// payloads live under `~/.openclaw/npm/projects/openclaw-<id>-<hash>__
+// openclaw-generation__g-<generation>`, keyed to the core that installed them,
+// so a core bump leaves them unreachable. The core's startup verification then
+// refuses readiness with its own sentence — `formatStartupPluginSmokeFailure`
+// in the installed 2026.8.1 bundle prints
+//
+//     - Plugin "discord": configured plugin payload verification failed
+//       (<reason>): <detail>. Run `openclaw update repair` to retry plugin repair.
+//
+// — and consent is not what is missing: the package is not on disk to consent
+// to. Matched on the core's own words rather than on the reason code, which is
+// an internal enum. Not global, for the same reason as the pattern above.
+const PLUGIN_PAYLOAD_VERIFICATION_RE =
+  /Plugin\s+["']?([A-Za-z0-9@._/-]+?)["']?\s*:\s*configured plugin payload verification failed/i;
 const CURRENT_GATEWAY_PRE_START = path.join(PROJECT_DIR, "scripts", "gateway-pre-start.sh");
 const GATEWAY_QUIESCED_ROOT_STEPS = new Set(["openclaw_install", "post_update"]);
 
@@ -1040,6 +1056,30 @@ const CLAWBOX_MANAGED_PLUGIN_IDS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * The npm package behind each managed plugin whose payload this file may
+ * reinstall, keyed by the normalised plugin id.
+ *
+ * Only the plugins that come from npm AND are pinned to the core, because a
+ * payload repair is `plugins install <pkg>@<core target>`: the core generation
+ * is what orphaned the payload, so the replacement has to be built for the
+ * core now on the box. `OFFICIAL_CHANNEL_PLUGINS` is the same map the Settings
+ * panel installs from, imported rather than copied — a second list here would
+ * be one more place to forget when a channel is added.
+ *
+ * The two managed plugins deliberately absent both have a repair that runs
+ * BEFORE this one, in the pre-start `runCurrentGatewayPreStart()` has just
+ * finished: `scripts/gateway-pre-start.sh` reinstalls `@openclaw/codex` when
+ * its package directory is missing, installs the pinned DeepSeek provider from
+ * ClawHub (not npm, and not a `<pkg>@<version>` spec), and copies
+ * `clawbox-email-directives` out of the checkout. Codex is still listed here
+ * because its repair below is the one this file already owns.
+ */
+const MANAGED_PLUGIN_NPM_PACKAGES: ReadonlyMap<string, string> = new Map([
+  ["codex", "@openclaw/codex"],
+  ...Object.entries(OFFICIAL_CHANNEL_PLUGINS),
+]);
+
+/**
  * `@openclaw/discord` and `openclaw-discord` are the same plugin as `discord`.
  *
  * The core names its own normalised plugin id in the refusal, which on a
@@ -1052,8 +1092,11 @@ function normalizeManagedPluginId(id: string): string {
   return id.replace(/^@openclaw\//, "").replace(/^openclaw-/, "");
 }
 
-/** Every plugin a consent refusal in this journal names, split by who owns it. */
-function pluginsNeedingConsent(journal: string): { managed: string[]; unmanaged: string[] } {
+/** Every plugin a refusal of one shape in this journal names, split by who owns it. */
+function pluginsNamedInRefusals(
+  journal: string,
+  pattern: RegExp,
+): { managed: string[]; unmanaged: string[] } {
   // A GLOBAL copy of the shared pattern, built here so the shared one keeps a
   // stable `lastIndex` for its `.test()` callers. Reading only the FIRST match
   // was a live dead end: the journal tail spans the whole boot (`-b`) and the
@@ -1061,7 +1104,7 @@ function pluginsNeedingConsent(journal: string): { managed: string[]; unmanaged:
   // ahead of a live `discord` one had the repair fix codex while
   // `getGatewayFailureDetail` — which scans in REVERSE — handed the owner the
   // discord sentence.
-  const namesRe = new RegExp(PLUGIN_CAPABILITY_CONSENT_RE.source, "gi");
+  const namesRe = new RegExp(pattern.source, "gi");
   // KEYED by the normalised id, VALUED by the first raw id seen for it. One
   // boot's journal can name the same plugin twice under different spellings —
   // `codex` from one start, `@openclaw/codex` from another — and a set of raw
@@ -1115,7 +1158,7 @@ async function pluginConsentRepairIsAllowed(pluginId: string): Promise<boolean> 
 }
 
 /**
- * Accept every ClawBox-managed plugin a concrete gateway error names.
+ * Repair every ClawBox-managed plugin a concrete gateway refusal names.
  *
  * WHY THIS IS NOT CODEX-ONLY ANY MORE (TASK-603). The gateway refuses readiness
  * for ANY enabled plugin whose declared capability surface has not been
@@ -1126,18 +1169,49 @@ async function pluginConsentRepairIsAllowed(pluginId: string): Promise<boolean> 
  * owner the core's own sentence: "rerun with --accept-capabilities". That is
  * advice about a CLI he never ran, over a box that will not come back until
  * somebody runs it for him. This is the tool doing the thing itself.
+ *
+ * WHY THERE ARE TWO REFUSALS (TASK-602). Consent is the refusal a plugin gets
+ * when its package is on disk and its reviewed surface is stale. A CORE UPGRADE
+ * produces the other one: plugin payloads live in npm project directories keyed
+ * to the core generation, so a bump strands the packages installed under the
+ * old one and the core's startup verification refuses over a payload that is
+ * not there. `plugins enable` cannot answer that, which is why the outage of
+ * 2026-09-01 survived a repair that only knew the consent sentence — the
+ * gateway then failed 21 times, systemd gave up, and the owner was left on
+ * "Connecting to gateway…" with no route back short of a hand-run CLI.
+ *
+ * WHY NOT `openclaw update repair --accept-capabilities`, which IS the harness's
+ * own post-core convergence and DOES take that flag on the pinned 2026.8.1: it
+ * consents for everything blocked, the owner's own plugins included. The
+ * whitelist is the point, so ClawBox drives the same underlying verbs per
+ * plugin instead. The core runs that convergence itself at startup
+ * (`runStartupUpgradeConvergence`), and it is exactly the capability-consent
+ * callback it has no way to answer there; the installed bundle exposes no
+ * config key and no environment variable for it, only the CLI flag.
  */
-async function repairPluginCapabilityConsent(journal: string): Promise<void> {
-  const { managed, unmanaged } = pluginsNeedingConsent(journal);
-  for (const pluginId of unmanaged) {
+async function repairPluginsBlockingReadiness(journal: string): Promise<void> {
+  const payload = pluginsNamedInRefusals(journal, PLUGIN_PAYLOAD_VERIFICATION_RE);
+  const consent = pluginsNamedInRefusals(journal, PLUGIN_CAPABILITY_CONSENT_RE);
+  for (const pluginId of [...payload.unmanaged, ...consent.unmanaged]) {
     // Said out loud rather than skipped in silence: this is the one case where
     // the owner still has to run the CLI himself, and the update log is where
     // he or a support session will look for why nothing happened.
     console.info(
-      `[Updater] "${pluginId}" needs capability consent and is not a ClawBox-managed plugin — leaving it to its owner`,
+      `[Updater] "${pluginId}" is blocking gateway readiness and is not a ClawBox-managed plugin — leaving it to its owner`,
     );
   }
-  for (const pluginId of managed) {
+  // Payloads FIRST, and the plugins they repaired are then skipped by the
+  // consent pass below: `plugins install --accept-capabilities` puts the
+  // package back AND records the reviewed surface, so a following `enable`
+  // would be a second ~12 s CLI cold start for a question already answered.
+  const repaired = new Set<string>();
+  for (const pluginId of payload.managed) {
+    if (await repairManagedPluginPayload(pluginId)) {
+      repaired.add(normalizeManagedPluginId(pluginId));
+    }
+  }
+  for (const pluginId of consent.managed) {
+    if (repaired.has(normalizeManagedPluginId(pluginId))) continue;
     if (normalizeManagedPluginId(pluginId) === "codex") {
       if (await codexCapabilityRepairIsAllowed()) await repairCodexCapabilityConsent();
       continue;
@@ -1147,8 +1221,54 @@ async function repairPluginCapabilityConsent(journal: string): Promise<void> {
   }
 }
 
+/**
+ * Put a managed plugin's payload back, pinned to the core now on the box.
+ *
+ * Returns whether the reinstall was ATTEMPTED, not whether it worked — the
+ * clean restart and the port probe decide that, as everywhere else in this
+ * recovery. False means nothing was tried: the owner switched the plugin off,
+ * Codex is not in use, or the payload is not this file's to replace.
+ */
+async function repairManagedPluginPayload(pluginId: string): Promise<boolean> {
+  const key = normalizeManagedPluginId(pluginId);
+  if (key === "codex") {
+    if (!(await codexCapabilityRepairIsAllowed())) return false;
+    await repairCodexCapabilityConsent();
+    return true;
+  }
+  const npmPackage = MANAGED_PLUGIN_NPM_PACKAGES.get(key);
+  if (!npmPackage) {
+    // The pre-start owns this one, and `runCurrentGatewayPreStart()` has just
+    // run it. Saying so beats a silent skip: if the refusal survived that, the
+    // update log is where the reason will be looked for.
+    console.info(
+      `[Updater] "${pluginId}" failed payload verification; its install is the gateway pre-start's, which has already run`,
+    );
+    return false;
+  }
+  if (!(await pluginConsentRepairIsAllowed(pluginId))) return false;
+  await reinstallManagedPluginPayload(npmPackage);
+  return true;
+}
+
 /** The pinned force-install that repairs a partial Codex project AND consents it. */
 async function repairCodexCapabilityConsent(): Promise<void> {
+  await reinstallManagedPluginPayload("@openclaw/codex");
+}
+
+/**
+ * `plugins install <pkg>@<core target> --force --accept-capabilities`.
+ *
+ * Pinned to the core the box is on, because both states this repairs are about
+ * the core: a migrated v1 install can leave only the managed-project
+ * declaration without node_modules, and a core BUMP re-keys the npm project
+ * directories so the payloads built for the old generation are unreachable
+ * (TASK-602). `enable` answers neither — it says "Plugin not found" — while a
+ * pinned force-install rebuilds the project and records consent in one
+ * idempotent operation. OpenClaw state leases live for five minutes after a
+ * killed startup, so this budget must outlast that bounded stale lease.
+ */
+async function reinstallManagedPluginPayload(npmPackage: string): Promise<void> {
   let target = OPENCLAW_VERSION_FALLBACK;
   try {
     target = (await readFile(OPENCLAW_TARGET_FILE, "utf-8")).trim().split(/\s+/)[0] || target;
@@ -1156,17 +1276,12 @@ async function repairCodexCapabilityConsent(): Promise<void> {
     // The compiled fallback is the same pin used by the installer.
   }
   try {
-    // A migrated v1 install can leave only the managed-project declaration,
-    // without node_modules. `enable` then says "Plugin not found"; a pinned
-    // force-install repairs that partial project and records consent in one
-    // idempotent operation. OpenClaw state leases live for five minutes after
-    // a killed startup, so this budget must outlast that bounded stale lease.
     await execFile(
       OPENCLAW_BIN,
       [
         "plugins",
         "install",
-        `@openclaw/codex@${target}`,
+        `${npmPackage}@${target}`,
         "--force",
         "--accept-capabilities",
       ],
@@ -1176,7 +1291,7 @@ async function repairCodexCapabilityConsent(): Promise<void> {
     // Best effort: the clean restart and positive port probe below decide the
     // result. This must not replace a preceding pre-start failure either.
     console.warn(
-      "[Updater] Codex capability repair did not complete:",
+      `[Updater] payload repair for "${npmPackage}" did not complete:`,
       err instanceof Error ? err.message : err,
     );
   }
@@ -1321,7 +1436,16 @@ function getGatewayFailureDetail(logText: string): string | null {
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean);
-  for (const pattern of [PLUGIN_CAPABILITY_CONSENT_RE, /SQLite transaction lock wait failed/i]) {
+  // Order is priority, not chronology: the FIRST pattern with a match wins.
+  // A payload that is not on disk outranks a consent question about it, and
+  // both outrank systemd's own "Start request repeated too quickly", which is
+  // what `lines.at(-1)` hands back once the unit has hit its start limit —
+  // true, and nothing the owner can act on (TASK-602).
+  for (const pattern of [
+    PLUGIN_PAYLOAD_VERIFICATION_RE,
+    PLUGIN_CAPABILITY_CONSENT_RE,
+    /SQLite transaction lock wait failed/i,
+  ]) {
     const match = [...lines].reverse().find((line) => pattern.test(line));
     if (match) return match;
   }
@@ -1363,10 +1487,10 @@ async function ensureGatewayHealthy(options: { restartFirst?: boolean } = {}): P
       // If an earlier pre-start migration fails, still record the narrowly
       // scoped consent named by the existing journal. Do not restart after a
       // partial pre-start; propagate its failure once the repair is recorded.
-      await repairPluginCapabilityConsent(journal);
+      await repairPluginsBlockingReadiness(journal);
       throw err;
     }
-    await repairPluginCapabilityConsent(journal);
+    await repairPluginsBlockingReadiness(journal);
     await runOpenclawDoctorFix();
   });
   // `awaitReady: false` on both restarts in this function, and only here: the

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -998,9 +998,25 @@ async function withGatewayQuiesced<T>(operation: () => Promise<T>): Promise<T> {
   return outcome.value;
 }
 
+/**
+ * Every plugin id the pre-start says it put back, normalised.
+ *
+ * The script prints `  <id> plugin payload reinstalled (<spec>)` for each one.
+ * Reading its own report is what stops this file re-issuing the identical npm
+ * install a moment later for a package that is already back on disk.
+ */
+function pluginPayloadsRepairedByPreStart(preStartOutput: string): Set<string> {
+  const repaired = new Set<string>();
+  const re = /^\s*(\S+) plugin payload reinstalled \(/gim;
+  for (const match of preStartOutput.matchAll(re)) {
+    repaired.add(normalizeManagedPluginId(match[1]));
+  }
+  return repaired;
+}
+
 /** Run the newly checked-out pre-start repair while the gateway is stopped. */
-async function runCurrentGatewayPreStart(): Promise<void> {
-  if (!existsSync(CURRENT_GATEWAY_PRE_START)) return;
+async function runCurrentGatewayPreStart(): Promise<string> {
+  if (!existsSync(CURRENT_GATEWAY_PRE_START)) return "";
   const home = process.env.CLAWBOX_HOME_DIR || process.env.HOME || "/home/clawbox";
   const openclawHome = process.env.CLAWBOX_OPENCLAW_HOME
     || process.env.OPENCLAW_HOME
@@ -1023,7 +1039,7 @@ async function runCurrentGatewayPreStart(): Promise<void> {
     OPENCLAW_CONFIG_PATH: path.join(openclawHome, "openclaw.json"),
   };
   delete env.OPENCLAW_HOME;
-  await execFile("/bin/bash", [CURRENT_GATEWAY_PRE_START], {
+  const { stdout } = await execFile("/bin/bash", [CURRENT_GATEWAY_PRE_START], {
     // Match the unit's 600s TimeoutStartSec with a little process overhead.
     // Killing this halfway through a plugin migration recreates the lock race
     // this maintenance path exists to avoid.
@@ -1031,6 +1047,7 @@ async function runCurrentGatewayPreStart(): Promise<void> {
     maxBuffer: 4 * 1024 * 1024,
     env,
   });
+  return stdout ?? "";
 }
 
 /**
@@ -1048,32 +1065,34 @@ async function runCurrentGatewayPreStart(): Promise<void> {
  * consents for everything blocked, including his.
  */
 const CLAWBOX_MANAGED_PLUGIN_IDS: ReadonlySet<string> = new Set([
+  // The ones `scripts/gateway-pre-start.sh` installs and owns the repair for.
   "codex",
   "deepseek",
-  "discord",
-  "whatsapp",
   "clawbox-email-directives",
+  // …and every channel the Settings panel can install, read from the map it
+  // installs from rather than copied: a channel added there and forgotten here
+  // would be classified as the OWNER's plugin and logged as one ClawBox may
+  // not answer for, over a package ClawBox itself put on the box.
+  ...Object.keys(OFFICIAL_CHANNEL_PLUGINS),
 ]);
 
 /**
  * The npm package behind each managed plugin whose payload this file may
  * reinstall, keyed by the normalised plugin id.
  *
- * Only the plugins that come from npm AND are pinned to the core, because a
- * payload repair is `plugins install <pkg>@<core target>`: the core generation
- * is what orphaned the payload, so the replacement has to be built for the
- * core now on the box. `OFFICIAL_CHANNEL_PLUGINS` is the same map the Settings
- * panel installs from, imported rather than copied — a second list here would
- * be one more place to forget when a channel is added.
+ * Only the plugins that are an npm `<package>@<version>` spec, because that is
+ * what the repair is: the core generation is what orphaned the payload, so the
+ * replacement has to be built for the core now on the box.
+ * `OFFICIAL_CHANNEL_PLUGINS` is the same map the Settings panel installs from,
+ * imported rather than copied — a second list here would be one more place to
+ * forget when a channel is added.
  *
- * The two managed plugins deliberately absent both have a repair that runs
- * BEFORE this one, in the pre-start `runCurrentGatewayPreStart()` has just
- * finished: `scripts/gateway-pre-start.sh` reinstalls `@openclaw/codex` when
- * its package directory is missing, installs the pinned DeepSeek provider from
- * ClawHub (not npm, and not a `<pkg>@<version>` spec), and copies
- * `clawbox-email-directives` out of the checkout. Codex IS listed: its own
- * pinned reinstall is the repair this file has always run for it, for a
- * migrated-v1 project as well as for an orphaned payload.
+ * The two managed plugins deliberately absent are absent for their SHAPE, not
+ * for who repairs them: `deepseek` is a ClawHub spec (`clawhub:@openclaw/…`)
+ * and `clawbox-email-directives` is copied out of the checkout, so an
+ * `@openclaw/<id>@<version>` guess would fetch a package that is not the
+ * plugin. `scripts/gateway-pre-start.sh` owns both, and
+ * `runCurrentGatewayPreStart()` has just run it.
  */
 const MANAGED_PLUGIN_NPM_PACKAGES: ReadonlyMap<string, string> = new Map([
   ["codex", "@openclaw/codex"],
@@ -1190,8 +1209,29 @@ async function pluginConsentRepairIsAllowed(pluginId: string): Promise<boolean> 
  * callback it has no way to answer there; the installed bundle exposes no
  * config key and no environment variable for it, only the CLI flag.
  */
-async function repairPluginsBlockingReadiness(journal: string): Promise<void> {
-  const payload = pluginsNamedInRefusals(journal, PLUGIN_PAYLOAD_VERIFICATION_RE);
+interface PluginRepairOptions {
+  /**
+   * Consent only — no npm install.
+   *
+   * For the path where the pre-start FAILED: a payload reinstall is up to six
+   * minutes per plugin (`gateway_verify` is a `customRun` step, so its
+   * `timeoutMs` is unenforced and nothing bounds the total), spent after a
+   * pre-start that just died — possibly mid plugin migration, with OpenClaw's
+   * five-minute state leases held — and ending in that pre-start's failure
+   * anyway. `plugins enable` is local, ~12 s and safe there.
+   */
+  consentOnly?: boolean;
+  /** Normalised ids whose payload the gateway pre-start has already put back. */
+  alreadyRepaired?: Iterable<string>;
+}
+
+async function repairPluginsBlockingReadiness(
+  journal: string,
+  options: PluginRepairOptions = {},
+): Promise<void> {
+  const payload = options.consentOnly
+    ? { managed: [], unmanaged: [] }
+    : pluginsNamedInRefusals(journal, PLUGIN_PAYLOAD_VERIFICATION_RE);
   const consent = pluginsNamedInRefusals(journal, PLUGIN_CAPABILITY_CONSENT_RE);
   for (const pluginId of [...payload.unmanaged, ...consent.unmanaged]) {
     // Said out loud rather than skipped in silence: this is the one case where
@@ -1205,11 +1245,21 @@ async function repairPluginsBlockingReadiness(journal: string): Promise<void> {
   // consent pass below: `plugins install --accept-capabilities` puts the
   // package back AND records the reviewed surface, so a following `enable`
   // would be a second ~12 s CLI cold start for a question already answered.
-  const repaired = new Set<string>();
+  // Only a reinstall that SUCCEEDED counts: `plugins enable` is the one repair
+  // here that touches no registry, and skipping it because a network install
+  // was attempted would drop the repair that could still have worked on a box
+  // whose network is why the update is being repaired.
+  const repaired = new Set<string>(options.alreadyRepaired ?? []);
   for (const pluginId of payload.managed) {
-    if (await repairManagedPluginPayload(pluginId)) {
-      repaired.add(normalizeManagedPluginId(pluginId));
+    const key = normalizeManagedPluginId(pluginId);
+    // The pre-start reinstalls the channel payloads too, and it ran a moment
+    // ago against this same box. Re-issuing the byte-identical install would
+    // pay a second npm fetch per plugin for a package already back on disk.
+    if (repaired.has(key)) {
+      console.info(`[Updater] "${pluginId}" payload was already reinstalled by the gateway pre-start`);
+      continue;
     }
+    if (await repairManagedPluginPayload(pluginId)) repaired.add(key);
   }
   for (const pluginId of consent.managed) {
     if (repaired.has(normalizeManagedPluginId(pluginId))) continue;
@@ -1218,7 +1268,12 @@ async function repairPluginsBlockingReadiness(journal: string): Promise<void> {
     // as a project declaration with no `node_modules`, where `enable` says
     // "Plugin not found".
     if (normalizeManagedPluginId(pluginId) === "codex") {
-      await repairManagedPluginPayload(pluginId);
+      // One spec, not two: the unpinned fallback exists for a payload that is
+      // GONE and may not be published under the pin's build suffix. Here the
+      // package is on disk — only its consent record is stale — and this path
+      // also runs after a FAILED pre-start, where every extra npm minute is
+      // spent on an update that is going to report that failure anyway.
+      await repairManagedPluginPayload(pluginId, { fallbackToUnpinned: false });
       continue;
     }
     if (!(await pluginConsentRepairIsAllowed(pluginId))) continue;
@@ -1229,12 +1284,15 @@ async function repairPluginsBlockingReadiness(journal: string): Promise<void> {
 /**
  * Put a managed plugin's payload back, pinned to the core now on the box.
  *
- * Returns whether the reinstall was ATTEMPTED, not whether it worked — the
- * clean restart and the port probe decide that, as everywhere else in this
- * recovery. False means nothing was tried: the owner switched the plugin off,
- * Codex is not in use, or the payload is not this file's to replace.
+ * Returns whether the package is believed to be back. False covers both
+ * "nothing was tried" — the owner switched the plugin off, Codex is not in
+ * use, the payload is not this file's to replace — and "the install failed",
+ * because both leave the consent repair below worth attempting.
  */
-async function repairManagedPluginPayload(pluginId: string): Promise<boolean> {
+async function repairManagedPluginPayload(
+  pluginId: string,
+  options: { fallbackToUnpinned?: boolean } = {},
+): Promise<boolean> {
   const key = normalizeManagedPluginId(pluginId);
   const npmPackage = MANAGED_PLUGIN_NPM_PACKAGES.get(key);
   if (!npmPackage) {
@@ -1253,8 +1311,7 @@ async function repairManagedPluginPayload(pluginId: string): Promise<boolean> {
     ? await codexCapabilityRepairIsAllowed()
     : await pluginConsentRepairIsAllowed(pluginId);
   if (!allowed) return false;
-  await reinstallManagedPluginPayload(npmPackage);
-  return true;
+  return reinstallManagedPluginPayload(npmPackage, options.fallbackToUnpinned !== false);
 }
 
 /**
@@ -1269,33 +1326,45 @@ async function repairManagedPluginPayload(pluginId: string): Promise<boolean> {
  * idempotent operation. OpenClaw state leases live for five minutes after a
  * killed startup, so this budget must outlast that bounded stale lease.
  */
-async function reinstallManagedPluginPayload(npmPackage: string): Promise<void> {
+async function reinstallManagedPluginPayload(
+  npmPackage: string,
+  fallbackToUnpinned: boolean,
+): Promise<boolean> {
   let target = OPENCLAW_VERSION_FALLBACK;
   try {
     target = (await readFile(OPENCLAW_TARGET_FILE, "utf-8")).trim().split(/\s+/)[0] || target;
   } catch {
     // The compiled fallback is the same pin used by the installer.
   }
-  try {
-    await execFile(
-      OPENCLAW_BIN,
-      [
-        "plugins",
-        "install",
-        `${npmPackage}@${target}`,
-        "--force",
-        "--accept-capabilities",
-      ],
-      { timeout: 360_000, maxBuffer: 4 * 1024 * 1024 },
-    );
-  } catch (err) {
-    // Best effort: the clean restart and positive port probe below decide the
-    // result. This must not replace a preceding pre-start failure either.
-    console.warn(
-      `[Updater] payload repair for "${npmPackage}" did not complete:`,
-      err instanceof Error ? err.message : err,
-    );
+  // Pinned first, then unpinned — the shape `deepseekPluginSpecs` already uses
+  // in this repo, and for its reason: npm republishes a release under a build
+  // suffix (2026.7.1 -> 2026.7.1-2), and a plugin published only under the base
+  // version 404s on a pin carrying one. The unpinned spec is safe as a LAST
+  // resort because the core checks the plugin's own `compat.pluginApi` against
+  // the running host and refuses a mismatch.
+  const specs = fallbackToUnpinned
+    ? [`${npmPackage}@${target}`, npmPackage]
+    : [`${npmPackage}@${target}`];
+  let lastError: unknown;
+  for (const spec of specs) {
+    try {
+      await execFile(
+        OPENCLAW_BIN,
+        ["plugins", "install", spec, "--force", "--accept-capabilities"],
+        { timeout: 360_000, maxBuffer: 4 * 1024 * 1024 },
+      );
+      return true;
+    } catch (err) {
+      lastError = err;
+    }
   }
+  // Best effort: the clean restart and positive port probe below decide the
+  // result. This must not replace a preceding pre-start failure either.
+  console.warn(
+    `[Updater] payload repair for "${npmPackage}" did not complete:`,
+    lastError instanceof Error ? lastError.message : lastError,
+  );
+  return false;
 }
 
 /**
@@ -1482,16 +1551,20 @@ async function ensureGatewayHealthy(options: { restartFirst?: boolean } = {}): P
   // is fatal here: restarting after killing a migration midway is unsafe.
   await withGatewayQuiesced(async () => {
     const journal = await readGatewayJournalTail();
+    let preStartOutput: string;
     try {
-      await runCurrentGatewayPreStart();
+      preStartOutput = await runCurrentGatewayPreStart();
     } catch (err) {
       // If an earlier pre-start migration fails, still record the narrowly
       // scoped consent named by the existing journal. Do not restart after a
       // partial pre-start; propagate its failure once the repair is recorded.
-      await repairPluginsBlockingReadiness(journal);
+      // Consent only here — see PluginRepairOptions.
+      await repairPluginsBlockingReadiness(journal, { consentOnly: true });
       throw err;
     }
-    await repairPluginsBlockingReadiness(journal);
+    await repairPluginsBlockingReadiness(journal, {
+      alreadyRepaired: pluginPayloadsRepairedByPreStart(preStartOutput),
+    });
     await runOpenclawDoctorFix();
   });
   // `awaitReady: false` on both restarts in this function, and only here: the

--- a/src/tests/unit/gateway-pre-start-managed-plugin-payload.test.ts
+++ b/src/tests/unit/gateway-pre-start-managed-plugin-payload.test.ts
@@ -59,12 +59,14 @@ afterEach(() => {
 interface RunOptions {
   /** `plugins.entries` as openclaw.json carries it. */
   entries: Record<string, { enabled: boolean }>;
-  /** Plugin ids whose `plugins enable` the fake CLI refuses. */
+  /** Plugin ids whose `plugins enable` answers the core's "Plugin not found". */
+  payloadMissing?: string[];
+  /** Plugin ids whose `plugins enable` fails for some OTHER reason. */
   enableFails?: string[];
   /** Install specs (argv[3]) the fake CLI refuses. */
   installFails?: string[];
-  /** The core target as the script resolved it; "" = unknown. */
-  target?: string;
+  /** The INSTALLED core's release as the script resolved it; "" = unknown. */
+  effective?: string;
 }
 
 function run(opts: RunOptions): { argv: string[]; stdout: string } {
@@ -79,8 +81,12 @@ function run(opts: RunOptions): { argv: string[]; stdout: string } {
       "#!/usr/bin/env bash",
       `echo "$*" >> "${log}"`,
       'if [ "$2" = "enable" ]; then',
+      // The core's own sentence for a package that is not on disk, verbatim.
+      `  for r in ${(opts.payloadMissing ?? []).map((s) => `'${s}'`).join(" ")}; do`,
+      '    if [ "$3" = "$r" ]; then echo "Plugin not found: $3. Run \`openclaw plugins list\` to see installed plugins." >&2; exit 1; fi',
+      "  done",
       `  for r in ${(opts.enableFails ?? []).map((s) => `'${s}'`).join(" ")}; do`,
-      '    if [ "$3" = "$r" ]; then exit 1; fi',
+      '    if [ "$3" = "$r" ]; then echo "timeout" >&2; exit 124; fi',
       "  done",
       "fi",
       'if [ "$2" = "install" ]; then',
@@ -93,14 +99,16 @@ function run(opts: RunOptions): { argv: string[]; stdout: string } {
   );
   chmodSync(bin, 0o755);
 
-  const result = spawnSync("bash", ["-c", BLOCK], {
+  // Under the shipped script's own options, so an `&&` list or a failing
+  // pipeline in the extracted block fails here the way it would on a box.
+  const result = spawnSync("bash", ["-c", "set -euo pipefail\n" + BLOCK], {
     encoding: "utf-8",
     env: testEnv({
       PATH: process.env.PATH ?? "/usr/bin:/bin",
       CLAWBOX_OPENCLAW_V2: "1",
       OPENCLAW_CONFIG: config,
       OPENCLAW_BIN: bin,
-      OPENCLAW_TARGET: opts.target ?? "2026.8.1",
+      CLAWBOX_OPENCLAW_EFFECTIVE: opts.effective ?? "2026.8.1",
     }),
   });
   if (result.status !== 0) throw new Error(`block exited ${result.status}: ${result.stderr}`);
@@ -120,10 +128,10 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
     expect(argv).toEqual(["plugins enable discord --accept-capabilities"]);
   });
 
-  it("reinstalls the pinned payload when the consent verb cannot find the plugin", () => {
+  it("reinstalls the pinned payload when the core says the package is not there", () => {
     const { argv, stdout } = run({
       entries: { discord: { enabled: true } },
-      enableFails: ["discord"],
+      payloadMissing: ["discord"],
     });
     expect(argv).toEqual([
       "plugins enable discord --accept-capabilities",
@@ -132,12 +140,27 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
     expect(stdout).toContain("discord plugin payload reinstalled");
   });
 
+  it("does NOT reinstall when the consent verb failed for any other reason", () => {
+    // A cold-Jetson `plugins enable` that overran its 60 s budget, a config
+    // lock, a registry hiccup: none of them is a missing payload, and a 120 s
+    // npm install on a BLOCKING ExecStartPre is not their repair.
+    const { argv, stdout } = run({
+      entries: { discord: { enabled: true }, whatsapp: { enabled: true } },
+      enableFails: ["discord", "whatsapp"],
+    });
+    expect(argv).toEqual([
+      "plugins enable discord --accept-capabilities",
+      "plugins enable whatsapp --accept-capabilities",
+    ]);
+    expect(stdout).toContain("WARN: could not confirm discord plugin capabilities");
+  });
+
   it("repairs the payload under the alias the registry answers to", () => {
     // `ensureChannelPlugin` can enable the plugin as `openclaw-whatsapp`, and
     // the npm package is `@openclaw/whatsapp` either way.
     const { argv } = run({
       entries: { "openclaw-whatsapp": { enabled: true } },
-      enableFails: ["openclaw-whatsapp"],
+      payloadMissing: ["openclaw-whatsapp"],
     });
     expect(argv).toEqual([
       "plugins enable openclaw-whatsapp --accept-capabilities",
@@ -145,24 +168,27 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
     ]);
   });
 
-  it("warns and keeps booting when the reinstall fails too", () => {
+  it("says the reinstall failed, not that capabilities are unconfirmed", () => {
+    // The boot log is the primary evidence for this failure mode; "could not
+    // confirm capabilities" would send whoever reads it after the wrong thing.
     const { stdout } = run({
       entries: { discord: { enabled: true } },
-      enableFails: ["discord"],
+      payloadMissing: ["discord"],
       installFails: ["@openclaw/discord@2026.8.1"],
     });
-    expect(stdout).toContain("WARN: could not confirm discord plugin capabilities");
+    expect(stdout).toContain("could not reinstall the discord plugin payload");
   });
 
   it("leaves a managed plugin with no npm package of ours to its own installer", () => {
     // deepseek comes from ClawHub and clawbox-email-directives is copied out of
     // the checkout; both have their own block in this script, and an
     // `@openclaw/<id>` guess would fetch a package that is not the plugin.
-    const { argv } = run({
+    const { argv, stdout } = run({
       entries: { deepseek: { enabled: true } },
-      enableFails: ["deepseek"],
+      payloadMissing: ["deepseek"],
     });
     expect(argv).toEqual(["plugins enable deepseek --accept-capabilities"]);
+    expect(stdout).toContain("ClawBox has no npm package of its own for it");
   });
 
   it("repairs exactly the channel plugins the Settings panel installs", () => {
@@ -171,7 +197,7 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
     // loses that channel — and its gateway — on the next core bump, with no
     // reboot that heals it.
     const src = readFileSync(SCRIPT, "utf-8");
-    const shellCase = /\n\s+([a-z|-]+)\)\n\s+\[ -n "\$OPENCLAW_TARGET" \]/.exec(src);
+    const shellCase = /\n\s+([a-z|-]+)\)\s+MANAGED_PLUGIN_PKG="@openclaw\/\$MANAGED_PLUGIN_KEY"/.exec(src);
     expect(shellCase, "the payload-repair case arm was not found").not.toBeNull();
     expect(shellCase?.[1].split("|").sort())
       .toEqual(Object.keys(OFFICIAL_CHANNEL_PLUGINS).sort());
@@ -182,14 +208,18 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
     }
   });
 
-  it("does not guess a spec when the core target is unknown", () => {
-    // An unpinned `@openclaw/discord` resolves @latest, which is how the codex
-    // plugin drifted ahead of the pinned core and crashed every chat.
+  it("falls back to the unpinned spec only when the installed core is unknown", () => {
+    // Pinned to the INSTALLED core, not to the checkout's pin file: this script
+    // never installs the core, so a box that pulled new ClawBox code before its
+    // core update landed would otherwise install a plugin its runtime refuses.
     const { argv } = run({
       entries: { discord: { enabled: true } },
-      enableFails: ["discord"],
-      target: "",
+      payloadMissing: ["discord"],
+      effective: "",
     });
-    expect(argv).toEqual(["plugins enable discord --accept-capabilities"]);
+    expect(argv).toEqual([
+      "plugins enable discord --accept-capabilities",
+      "plugins install @openclaw/discord --force --accept-capabilities",
+    ]);
   });
 });

--- a/src/tests/unit/gateway-pre-start-managed-plugin-payload.test.ts
+++ b/src/tests/unit/gateway-pre-start-managed-plugin-payload.test.ts
@@ -4,6 +4,7 @@ import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { testEnv } from "@/tests/helpers/env";
+import { OFFICIAL_CHANNEL_PLUGINS } from "@/lib/openclaw-channels";
 
 // Starts a real process (bash / python3): vitest's 5 s test and 10 s hook
 // defaults are not enough on a loaded CI runner. See
@@ -162,6 +163,23 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
       enableFails: ["deepseek"],
     });
     expect(argv).toEqual(["plugins enable deepseek --accept-capabilities"]);
+  });
+
+  it("repairs exactly the channel plugins the Settings panel installs", () => {
+    // The shell `case` and OFFICIAL_CHANNEL_PLUGINS are one list in two
+    // languages: a channel added to the panel and forgotten here is a box that
+    // loses that channel — and its gateway — on the next core bump, with no
+    // reboot that heals it.
+    const src = readFileSync(SCRIPT, "utf-8");
+    const shellCase = /\n\s+([a-z|-]+)\)\n\s+\[ -n "\$OPENCLAW_TARGET" \]/.exec(src);
+    expect(shellCase, "the payload-repair case arm was not found").not.toBeNull();
+    expect(shellCase?.[1].split("|").sort())
+      .toEqual(Object.keys(OFFICIAL_CHANNEL_PLUGINS).sort());
+    for (const [id, npmPackage] of Object.entries(OFFICIAL_CHANNEL_PLUGINS)) {
+      // The shell builds the spec as `@openclaw/<id>`, so a package that is not
+      // named after its plugin id would be silently mis-installed.
+      expect(npmPackage).toBe(`@openclaw/${id}`);
+    }
   });
 
   it("does not guess a spec when the core target is unknown", () => {

--- a/src/tests/unit/gateway-pre-start-managed-plugin-payload.test.ts
+++ b/src/tests/unit/gateway-pre-start-managed-plugin-payload.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { testEnv } from "@/tests/helpers/env";
+
+// Starts a real process (bash / python3): vitest's 5 s test and 10 s hook
+// defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+// TASK-602. Plugin payloads live under `~/.openclaw/npm/projects/openclaw-<id>-
+// <hash>__openclaw-generation__g-<generation>`, keyed to the core that
+// installed them, so a core bump strands the packages built for the old
+// generation and the gateway refuses readiness over a payload that is not
+// there. `plugins enable` — the consent verb this loop has always run — cannot
+// answer that: it says "Plugin not found" and exits non-zero, and the loop
+// warned and let the gateway try again with nothing changed.
+//
+// This is the BOOT path, and it is the one that matters here: a box that is
+// already down gets a reboot from its owner long before it gets an update, and
+// `src/lib/updater.ts` only repairs the same state during an update. The Codex
+// block a few lines above already reinstalls its own payload pinned to the
+// core; the channel plugins the Settings panel installs did not.
+//
+// The real block is run out of the shipped script against a fake `openclaw`
+// that records its argv, so what is pinned is the code that boots the gateway
+// and not a copy of it.
+
+const SCRIPT = path.resolve(process.cwd(), "scripts/gateway-pre-start.sh");
+const hasBash = spawnSync("bash", ["--version"], { stdio: "ignore" }).status === 0;
+const hasPython3 = spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
+
+/** The managed-plugin consent loop, verbatim, from its guard to its closing `fi`. */
+function extractBlock(): string {
+  const src = readFileSync(SCRIPT, "utf-8");
+  const marker = src.indexOf('  MANAGED_ENABLED_PLUGINS="$(python3 - "$OPENCLAW_CONFIG"');
+  if (marker < 0) throw new Error("managed plugin block not found in gateway-pre-start.sh");
+  const start = src.lastIndexOf('if [ "$CLAWBOX_OPENCLAW_V2" = "1" ]; then', marker);
+  const end = src.indexOf("\n  done\nfi\n", marker);
+  if (start < 0 || end < 0) throw new Error("managed plugin block boundaries not found");
+  return src.slice(start, end + "\n  done\nfi\n".length);
+}
+
+const BLOCK = hasBash && hasPython3 ? extractBlock() : "";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "pre-start-managed-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+interface RunOptions {
+  /** `plugins.entries` as openclaw.json carries it. */
+  entries: Record<string, { enabled: boolean }>;
+  /** Plugin ids whose `plugins enable` the fake CLI refuses. */
+  enableFails?: string[];
+  /** Install specs (argv[3]) the fake CLI refuses. */
+  installFails?: string[];
+  /** The core target as the script resolved it; "" = unknown. */
+  target?: string;
+}
+
+function run(opts: RunOptions): { argv: string[]; stdout: string } {
+  const config = path.join(dir, "openclaw.json");
+  writeFileSync(config, JSON.stringify({ plugins: { entries: opts.entries } }));
+
+  const log = path.join(dir, "argv.log");
+  const bin = path.join(dir, "openclaw");
+  writeFileSync(
+    bin,
+    [
+      "#!/usr/bin/env bash",
+      `echo "$*" >> "${log}"`,
+      'if [ "$2" = "enable" ]; then',
+      `  for r in ${(opts.enableFails ?? []).map((s) => `'${s}'`).join(" ")}; do`,
+      '    if [ "$3" = "$r" ]; then exit 1; fi',
+      "  done",
+      "fi",
+      'if [ "$2" = "install" ]; then',
+      `  for r in ${(opts.installFails ?? []).map((s) => `'${s}'`).join(" ")}; do`,
+      '    if [ "$3" = "$r" ]; then exit 1; fi',
+      "  done",
+      "fi",
+      "exit 0",
+    ].join("\n"),
+  );
+  chmodSync(bin, 0o755);
+
+  const result = spawnSync("bash", ["-c", BLOCK], {
+    encoding: "utf-8",
+    env: testEnv({
+      PATH: process.env.PATH ?? "/usr/bin:/bin",
+      CLAWBOX_OPENCLAW_V2: "1",
+      OPENCLAW_CONFIG: config,
+      OPENCLAW_BIN: bin,
+      OPENCLAW_TARGET: opts.target ?? "2026.8.1",
+    }),
+  });
+  if (result.status !== 0) throw new Error(`block exited ${result.status}: ${result.stderr}`);
+
+  let argv: string[] = [];
+  try {
+    argv = readFileSync(log, "utf-8").trim().split("\n").filter(Boolean);
+  } catch {
+    /* the CLI was never run */
+  }
+  return { argv, stdout: result.stdout };
+}
+
+describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin payload repair", () => {
+  it("consents and stops there while the payload is intact", () => {
+    const { argv } = run({ entries: { discord: { enabled: true } } });
+    expect(argv).toEqual(["plugins enable discord --accept-capabilities"]);
+  });
+
+  it("reinstalls the pinned payload when the consent verb cannot find the plugin", () => {
+    const { argv, stdout } = run({
+      entries: { discord: { enabled: true } },
+      enableFails: ["discord"],
+    });
+    expect(argv).toEqual([
+      "plugins enable discord --accept-capabilities",
+      "plugins install @openclaw/discord@2026.8.1 --force --accept-capabilities",
+    ]);
+    expect(stdout).toContain("discord plugin payload reinstalled");
+  });
+
+  it("repairs the payload under the alias the registry answers to", () => {
+    // `ensureChannelPlugin` can enable the plugin as `openclaw-whatsapp`, and
+    // the npm package is `@openclaw/whatsapp` either way.
+    const { argv } = run({
+      entries: { "openclaw-whatsapp": { enabled: true } },
+      enableFails: ["openclaw-whatsapp"],
+    });
+    expect(argv).toEqual([
+      "plugins enable openclaw-whatsapp --accept-capabilities",
+      "plugins install @openclaw/whatsapp@2026.8.1 --force --accept-capabilities",
+    ]);
+  });
+
+  it("warns and keeps booting when the reinstall fails too", () => {
+    const { stdout } = run({
+      entries: { discord: { enabled: true } },
+      enableFails: ["discord"],
+      installFails: ["@openclaw/discord@2026.8.1"],
+    });
+    expect(stdout).toContain("WARN: could not confirm discord plugin capabilities");
+  });
+
+  it("leaves a managed plugin with no npm package of ours to its own installer", () => {
+    // deepseek comes from ClawHub and clawbox-email-directives is copied out of
+    // the checkout; both have their own block in this script, and an
+    // `@openclaw/<id>` guess would fetch a package that is not the plugin.
+    const { argv } = run({
+      entries: { deepseek: { enabled: true } },
+      enableFails: ["deepseek"],
+    });
+    expect(argv).toEqual(["plugins enable deepseek --accept-capabilities"]);
+  });
+
+  it("does not guess a spec when the core target is unknown", () => {
+    // An unpinned `@openclaw/discord` resolves @latest, which is how the codex
+    // plugin drifted ahead of the pinned core and crashed every chat.
+    const { argv } = run({
+      entries: { discord: { enabled: true } },
+      enableFails: ["discord"],
+      target: "",
+    });
+    expect(argv).toEqual(["plugins enable discord --accept-capabilities"]);
+  });
+});

--- a/src/tests/unit/install-plugin-capability-consent.test.ts
+++ b/src/tests/unit/install-plugin-capability-consent.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { OFFICIAL_CHANNEL_PLUGINS } from "@/lib/openclaw-channels";
 
 /**
  * TASK-603 — the plugin refresh inside `step_openclaw_install` records consent.
@@ -101,7 +102,14 @@ describe("install.sh plugin refresh", () => {
     expect(install).toBeGreaterThan(loopStart);
     const region = LINES.slice(loopStart, install).join("\n");
     expect(region).toContain('if [ "$spec" = "$plugin" ] && [ -n "$TARGET" ]; then');
-    expect(region).toContain('codex|discord|whatsapp) spec="@openclaw/$PLUGIN_KEY@$TARGET" ;;');
+    // The arm is a fourth copy of a list that lives in TypeScript, so it is
+    // held to it: every channel the Settings panel can install, plus codex,
+    // whose package is `@openclaw/codex` for the same reason. A channel added
+    // there and forgotten here leaves its spec bare and npm resolves @latest.
+    const arm = /\n\s+([a-z|-]+)\) spec="@openclaw\/\$PLUGIN_KEY@\$TARGET" ;;/.exec(region);
+    expect(arm, "the pin-repair case arm was not found").not.toBeNull();
+    expect(arm?.[1].split("|").sort())
+      .toEqual(["codex", ...Object.keys(OFFICIAL_CHANNEL_PLUGINS)].sort());
   });
 
   it("has no `plugins install` or `plugins enable` that skips consent entirely", () => {

--- a/src/tests/unit/install-plugin-capability-consent.test.ts
+++ b/src/tests/unit/install-plugin-capability-consent.test.ts
@@ -72,10 +72,36 @@ describe("install.sh plugin refresh", () => {
     // default arm and be refreshed without consent — silently, behind the WARN
     // — while `$spec` still has to carry the raw name for the CLI.
     const built = LINES.findIndex((l) => l.includes("CAP_ARGS=(--accept-capabilities)"));
-    const region = LINES.slice(Math.max(0, built - 8), built).join("\n");
+    // The whole loop body, not a fixed window above the guard: `PLUGIN_KEY` is
+    // hoisted to the top of the iteration because the pin repair reads it too,
+    // so a window would only pin where the assignment happens to sit today.
+    const loopStart = LINES.findIndex((l) => l.includes("read -r plugin pkg; do"));
+    expect(loopStart).toBeGreaterThanOrEqual(0);
+    expect(loopStart).toBeLessThan(built);
+    const region = LINES.slice(loopStart, built).join("\n");
     expect(region).toContain("${plugin#@openclaw/}");
     expect(region).toContain("${PLUGIN_KEY#openclaw-}");
-    expect(region).toContain('case "$PLUGIN_KEY" in');
+    // Still adjacent to the guard: the whitelist is matched on the normalised
+    // id, never on the raw one.
+    expect(LINES[built - 2]).toContain('case "$PLUGIN_KEY" in');
+  });
+
+  it("never refreshes a ClawBox plugin at @latest because its payload is gone", () => {
+    // TASK-602. A core upgrade re-keys the npm project directories, so
+    // `plugins list --json` lists the orphaned plugin with no rootDir/source;
+    // the package derivation above then yields "" and `$spec` stays the BARE
+    // id, which npm resolves as @latest — on the very boxes this refresh
+    // exists for. The pin has to be rebuilt from the id for the @openclaw
+    // packages ClawBox installs, and left alone for anyone else's plugin.
+    const loopStart = LINES.findIndex((l) => l.includes("read -r plugin pkg; do"));
+    const install = LINES.findIndex(
+      (l, i) => i > loopStart && l.includes('plugins install "$spec" --force'),
+    );
+    expect(loopStart).toBeGreaterThanOrEqual(0);
+    expect(install).toBeGreaterThan(loopStart);
+    const region = LINES.slice(loopStart, install).join("\n");
+    expect(region).toContain('if [ "$spec" = "$plugin" ] && [ -n "$TARGET" ]; then');
+    expect(region).toContain('codex|discord|whatsapp) spec="@openclaw/$PLUGIN_KEY@$TARGET" ;;');
   });
 
   it("has no `plugins install` or `plugins enable` that skips consent entirely", () => {

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -1101,7 +1101,10 @@ describe("updater", () => {
 
     it("continues to doctor and restart when the targeted Codex repair fails", async () => {
       setupExecFileMock({
-        "plugins install @openclaw/codex@2026.8.1 --force --accept-capabilities": new Error(
+        // BOTH specs: the pinned one and the unpinned fallback behind it. With
+        // only the pinned one refused this would exercise the fallback path
+        // succeeding, not the failure this case is about.
+        "plugins install @openclaw/codex": new Error(
           "Codex repair timed out",
         ),
         "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
@@ -1139,11 +1142,195 @@ describe("updater", () => {
         "[Updater] payload repair for \"@openclaw/codex\" did not complete:",
         "Codex repair timed out",
       );
+      // ONE spec for a consent refusal: the package is on disk, only its
+      // consent record is stale, so the unpinned fallback (which exists for a
+      // payload that is gone) would be a second npm minute for nothing.
+      expect(calls.filter((call) => call.includes("plugins install @openclaw/codex")))
+        .toHaveLength(1);
       expect(calls.some((call) => call.includes("openclaw doctor --fix --yes --non-interactive")))
         .toBe(true);
       expect(calls.some((call) => call.includes("systemctl restart clawbox-gateway.service")))
         .toBe(true);
       warnSpy.mockRestore();
+    });
+
+    it("falls back to the unpinned spec when the pinned payload is not published", async () => {
+      // npm republishes a release under a build suffix (2026.7.1 -> 2026.7.1-2)
+      // and a plugin published only under the base version 404s on a pin
+      // carrying one. `deepseekPluginSpecs` already answers this the same way.
+      setupExecFileMock({
+        "plugins install @openclaw/whatsapp@2026.8.1": new Error("404 Not Found"),
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
+        "/usr/bin/journalctl -u clawbox-gateway.service": {
+          stdout: '- Plugin "whatsapp": configured plugin payload verification failed '
+            + "(missing-install-path): install path is missing.\n",
+          stderr: "",
+        },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+        "/bin/bash": { stdout: "", stderr: "" },
+      });
+
+      vi.resetModules();
+      mockGet.mockResolvedValue(true);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockRebuiltBox();
+      mockGatewayUp.mockImplementation(async () =>
+        mockExecFile.mock.calls.some(([cmd, args]) =>
+          `${cmd} ${(args as string[]).join(" ")}`
+            .includes("plugins install @openclaw/whatsapp --force --accept-capabilities"),
+        ),
+      );
+      updater = await import("@/lib/updater");
+
+      updater.resetUpdateState();
+      expect(await updater.checkContinuation()).toBe(true);
+      await vi.waitFor(() => expect(updater.getUpdateState().phase).toBe("completed"));
+
+      const calls = mockExecFile.mock.calls.map(([cmd, args]) =>
+        `${cmd} ${(args as string[]).join(" ")}`,
+      );
+      expect(calls.filter((call) => call.includes("plugins install @openclaw/whatsapp")))
+        .toEqual([
+          expect.stringContaining("plugins install @openclaw/whatsapp@2026.8.1 --force --accept-capabilities"),
+          expect.stringContaining("plugins install @openclaw/whatsapp --force --accept-capabilities"),
+        ]);
+    });
+
+    it("still records local consent when the payload install could not run", async () => {
+      // `plugins enable` is the one repair here that touches no registry, and
+      // the network is often exactly why the update is being repaired. Treating
+      // an ATTEMPTED reinstall as a repair would drop it.
+      setupExecFileMock({
+        "plugins install @openclaw/discord": new Error("getaddrinfo ENOTFOUND registry.npmjs.org"),
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
+        "/usr/bin/journalctl -u clawbox-gateway.service": {
+          stdout: [
+            '- Plugin "discord": configured plugin payload verification failed '
+              + "(missing-install-path): install path is missing.",
+            'Plugin "discord" requires capability consent; rerun with --accept-capabilities.',
+            "",
+          ].join("\n"),
+          stderr: "",
+        },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+        "/bin/bash": { stdout: "", stderr: "" },
+      });
+
+      vi.resetModules();
+      mockGet.mockResolvedValue(true);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockRebuiltBox();
+      mockGatewayUp.mockImplementation(async () =>
+        mockExecFile.mock.calls.some(([cmd, args]) =>
+          `${cmd} ${(args as string[]).join(" ")}`
+            .includes("plugins enable discord --accept-capabilities"),
+        ),
+      );
+      updater = await import("@/lib/updater");
+
+      updater.resetUpdateState();
+      expect(await updater.checkContinuation()).toBe(true);
+      await vi.waitFor(() => expect(updater.getUpdateState().phase).toBe("completed"));
+
+      const calls = mockExecFile.mock.calls.map(([cmd, args]) =>
+        `${cmd} ${(args as string[]).join(" ")}`,
+      );
+      expect(calls.some((call) => call.includes("plugins enable discord --accept-capabilities")))
+        .toBe(true);
+    });
+
+    it("does not re-install a payload the gateway pre-start just put back", async () => {
+      // The pre-start reinstalls the channel payloads too, and it runs a moment
+      // before this. Re-issuing the identical install would pay a second npm
+      // fetch per plugin for a package already back on disk.
+      setupExecFileMock({
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
+        "/usr/bin/journalctl -u clawbox-gateway.service": {
+          stdout: '- Plugin "discord": configured plugin payload verification failed '
+            + "(missing-install-path): install path is missing.\n",
+          stderr: "",
+        },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+        // The pre-start's own report, in its own words.
+        "/bin/bash": {
+          stdout: "  discord plugin payload reinstalled (@openclaw/discord@2026.8.1)\n",
+          stderr: "",
+        },
+      });
+
+      // The pre-start has to actually RUN for its report to exist.
+      const priorRoot = process.env.CLAWBOX_ROOT;
+      process.env.CLAWBOX_ROOT = process.cwd();
+      vi.resetModules();
+      mockGet.mockResolvedValue(true);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockRebuiltBox();
+      mockGatewayUp.mockImplementation(async () =>
+        mockExecFile.mock.calls.some(([cmd, args]) =>
+          `${cmd} ${(args as string[]).join(" ")}`
+            .includes("systemctl restart clawbox-gateway.service"),
+        ),
+      );
+      updater = await import("@/lib/updater");
+      if (priorRoot === undefined) delete process.env.CLAWBOX_ROOT;
+      else process.env.CLAWBOX_ROOT = priorRoot;
+
+      updater.resetUpdateState();
+      expect(await updater.checkContinuation()).toBe(true);
+      await vi.waitFor(() => expect(updater.getUpdateState().phase).toBe("completed"));
+
+      const calls = mockExecFile.mock.calls.map(([cmd, args]) =>
+        `${cmd} ${(args as string[]).join(" ")}`,
+      );
+      expect(calls.some((call) => call.includes("scripts/gateway-pre-start.sh"))).toBe(true);
+      expect(calls.some((call) => call.includes("plugins install @openclaw/discord"))).toBe(false);
+    });
+
+    it("spends no npm install after the pre-start itself failed", async () => {
+      // A payload reinstall is minutes per plugin on a `customRun` step whose
+      // timeoutMs is unenforced, spent after a pre-start that just died — and
+      // the update reports that failure either way. Consent only there.
+      setupExecFileMock({
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
+        "/usr/bin/journalctl -u clawbox-gateway.service": {
+          stdout: '- Plugin "discord": configured plugin payload verification failed '
+            + "(missing-install-path): install path is missing.\n",
+          stderr: "",
+        },
+        "/bin/bash": new Error("pre-start failed"),
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+      });
+
+      const priorRoot = process.env.CLAWBOX_ROOT;
+      process.env.CLAWBOX_ROOT = process.cwd();
+      vi.resetModules();
+      mockGet.mockResolvedValue(true);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockRebuiltBox();
+      updater = await import("@/lib/updater");
+      if (priorRoot === undefined) delete process.env.CLAWBOX_ROOT;
+      else process.env.CLAWBOX_ROOT = priorRoot;
+
+      updater.resetUpdateState();
+      expect(await updater.checkContinuation()).toBe(true);
+      await vi.waitFor(() => expect(updater.getUpdateState().phase).toBe("failed"));
+
+      const calls = mockExecFile.mock.calls.map(([cmd, args]) =>
+        `${cmd} ${(args as string[]).join(" ")}`,
+      );
+      expect(calls.some((call) => call.includes("plugins install @openclaw/discord"))).toBe(false);
     });
 
     it("retries a failed maintenance unmask and surfaces the cleanup failure", async () => {

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -1445,9 +1445,13 @@ describe("updater", () => {
         `${cmd} ${(args as string[]).join(" ")}`,
       );
       const preStartIndex = calls.findIndex((call) => call.includes("scripts/gateway-pre-start.sh"));
+      // The LOCAL consent verb, not the pinned reinstall: after a pre-start
+      // that just died, minutes of npm buy nothing on an update that is about
+      // to report that failure.
       const consentIndex = calls.findIndex((call) =>
-        call.includes("plugins install @openclaw/codex@2026.8.1 --force --accept-capabilities"),
+        call.includes("plugins enable codex --accept-capabilities"),
       );
+      expect(calls.some((call) => call.includes("plugins install @openclaw/codex"))).toBe(false);
       const finalUnmaskIndex = calls
         .map((call, index) => call.includes("systemctl --runtime unmask clawbox-gateway.service") ? index : -1)
         .filter((index) => index >= 0)

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -1136,7 +1136,7 @@ describe("updater", () => {
         `${cmd} ${(args as string[]).join(" ")}`,
       );
       expect(warnSpy).toHaveBeenCalledWith(
-        "[Updater] Codex capability repair did not complete:",
+        "[Updater] payload repair for \"@openclaw/codex\" did not complete:",
         "Codex repair timed out",
       );
       expect(calls.some((call) => call.includes("openclaw doctor --fix --yes --non-interactive")))

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -994,6 +994,111 @@ describe("updater", () => {
       expect(calls.some((call) => call.includes("plugins enable weatherbot"))).toBe(false);
     });
 
+    it("reinstalls a managed plugin whose payload a core upgrade orphaned", async () => {
+      // TASK-602. A core bump re-keys `~/.openclaw/npm/projects/` by the new
+      // generation, so the payloads installed against the old one are no longer
+      // reachable. The core then refuses readiness with a DIFFERENT sentence
+      // from the consent one — `configured plugin payload verification failed`
+      // — and `plugins enable` cannot answer it: the package is not on disk to
+      // be consented to. The repair that works is the pinned reinstall, the
+      // same one the Codex arm already runs.
+      setupExecFileMock({
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
+        "/usr/bin/journalctl -u clawbox-gateway.service": {
+          stdout: [
+            "OpenClaw plugin verification failed; refusing to report the gateway ready.",
+            '- Plugin "discord": configured plugin payload verification failed '
+              + "(missing-install-path): install path is missing. "
+              + "Run `openclaw update repair` to retry plugin repair.",
+            "Resolve the plugin verification errors above, then restart the Gateway.",
+            "clawbox-gateway.service: Start request repeated too quickly.",
+            "",
+          ].join("\n"),
+          stderr: "",
+        },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+        "/bin/bash": { stdout: "", stderr: "" },
+      });
+
+      vi.resetModules();
+      mockGet.mockResolvedValue(true);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockRebuiltBox();
+      // Only the reinstall can make this box healthy: consenting to a package
+      // that is not on disk changes nothing.
+      mockGatewayUp.mockImplementation(async () => {
+        const calls = mockExecFile.mock.calls.map(([cmd, args]) =>
+          `${cmd} ${(args as string[]).join(" ")}`,
+        );
+        const repairIndex = calls.findIndex((call) =>
+          call.includes("plugins install @openclaw/discord@2026.8.1 --force --accept-capabilities"),
+        );
+        const restartIndex = calls.findIndex((call) =>
+          call.includes("systemctl restart clawbox-gateway.service"),
+        );
+        return repairIndex >= 0 && restartIndex > repairIndex;
+      });
+      updater = await import("@/lib/updater");
+
+      updater.resetUpdateState();
+      expect(await updater.checkContinuation()).toBe(true);
+      await vi.waitFor(() => expect(updater.getUpdateState().phase).toBe("completed"));
+
+      const calls = mockExecFile.mock.calls.map(([cmd, args]) =>
+        `${cmd} ${(args as string[]).join(" ")}`,
+      );
+      expect(calls.some((call) =>
+        call.includes("plugins install @openclaw/discord@2026.8.1 --force --accept-capabilities"),
+      )).toBe(true);
+    });
+
+    it("names the plugin the core refused, not the systemd start-limit line", async () => {
+      // TASK-602's customer-visible half. systemd gives up after the core has
+      // exited 21 times, so the LAST journal line on the box is its own
+      // start-limit message. With no pattern for the verification refusal the
+      // owner was handed that line — nothing about a plugin, nothing to act on
+      // — while the sentence naming the plugin sat a few lines above it.
+      setupExecFileMock({
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
+        "/usr/bin/journalctl -u clawbox-gateway.service": {
+          stdout: [
+            "OpenClaw plugin verification failed; refusing to report the gateway ready.",
+            '- Plugin "whatsapp": configured plugin payload verification failed '
+              + "(missing-install-path): install path is missing. "
+              + "Run `openclaw update repair` to retry plugin repair.",
+            "clawbox-gateway.service: Start request repeated too quickly.",
+            "clawbox-gateway.service: Failed with result 'exit-code'.",
+            "",
+          ].join("\n"),
+          stderr: "",
+        },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+        "/bin/bash": { stdout: "", stderr: "" },
+      });
+
+      vi.resetModules();
+      mockGet.mockResolvedValue(true);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockRebuiltBox();
+      mockGatewayUp.mockResolvedValue(false);
+      updater = await import("@/lib/updater");
+
+      updater.resetUpdateState();
+      expect(await updater.checkContinuation()).toBe(true);
+      await vi.waitFor(() => expect(updater.getUpdateState().phase).toBe("failed"));
+
+      const error = updater.getUpdateState().error ?? "";
+      expect(error).toContain('Plugin "whatsapp"');
+      expect(error).toContain("configured plugin payload verification failed");
+      expect(error).not.toContain("Start request repeated too quickly");
+    });
+
     it("continues to doctor and restart when the targeted Codex repair fails", async () => {
       setupExecFileMock({
         "plugins install @openclaw/codex@2026.8.1 --force --accept-capabilities": new Error(


### PR DESCRIPTION
## TASK-602 — a core upgrade orphans the plugins ClawBox installs at configure time and leaves the gateway dead

**What the owner sees.** The chat window sits on "Connecting to gateway…" forever. Nothing explains why. Every OpenClaw box with Discord or WhatsApp configured — the setup we tell customers to use — loses its gateway on the next core bump, with no in-product recovery.

**Cause.** Plugin payloads live in npm project directories keyed to the core GENERATION (`~/.openclaw/npm/projects/openclaw-<id>-<hash>__openclaw-generation__g-<gen>/`, three of them on the OpenClaw box today: codex, discord, whatsapp). A core upgrade re-keys them, so the packages built under the old generation are unreachable. The core's startup verification then refuses readiness with a sentence ClawBox did not know:

```
OpenClaw plugin verification failed; refusing to report the gateway ready.
- Plugin "discord": configured plugin payload verification failed (<reason>): <detail>. Run `openclaw update repair` to retry plugin repair.
```

`src/lib/updater.ts` matched only the OTHER refusal — `Plugin "<id>" requires capability consent` — so nothing was repaired, and `getGatewayFailureDetail` fell through to the last journal line, which after systemd's start limit is `Start request repeated too quickly`. The owner was handed a systemd message over a plugin problem. And `plugins enable`, the consent verb both the updater and `scripts/gateway-pre-start.sh` ran, cannot answer a missing payload: the core replies `Plugin not found: <id>`.

### Harness first

* **`openclaw update repair`** IS the native post-core convergence (`runPostCorePluginConvergence` → `repairMissingConfiguredPluginInstalls` + `repairInstalledNpmOpenClawHostLinks` in the installed 2026.8.1 bundle), and the core runs it itself at every gateway start (`runStartupUpgradeConvergence`). What it cannot do at startup is answer the capability-consent callback, and the installed bundle exposes **no config key and no environment variable** for that — the `--accept-capabilities` CLI flag is the only non-interactive consent. That absence is the finding: ClawBox has to drive the flag itself.
* `openclaw update repair --accept-capabilities` **does** exist on the pinned core (the card was written against an older one), but it consents for every blocked plugin including ones the owner installed himself. That is why the repair stays per plugin against `CLAWBOX_MANAGED_PLUGIN_IDS` — the same reason the existing codex arm gives.
* Detection is the core's own wording throughout: the payload-refusal sentence in the journal, and `Plugin not found:` from the CLI on the boot path.

### The change

1. **`src/lib/updater.ts`** — recognise the payload refusal, reinstall the ClawBox-managed plugin pinned to the core (`plugins install <pkg>@<target> --force --accept-capabilities`, unpinned as the last resort the way `deepseekPluginSpecs` already does it), and rank that sentence ahead of the systemd line in `getGatewayFailureDetail`. A reinstall that FAILED still falls through to the network-free `plugins enable`. After a failed pre-start the repair is consent-only — a payload reinstall there is minutes on a step whose budget is unenforced, spent on an update that reports that failure anyway.
2. **`scripts/gateway-pre-start.sh`** — the boot path is the one that matters for a box already down: an owner reboots long before he updates. It now reinstalls a channel payload, but **only when the core says `Plugin not found`** — never on a 60 s timeout, a config lock or a registry hiccup, none of which a 120 s npm install repairs on a blocking `ExecStartPre`. Pinned to the INSTALLED core (`CLAWBOX_OPENCLAW_EFFECTIVE`, already normalised past npm republish suffixes), because this script never installs the core.
3. **`install.sh`** — the post-core refresh that should have prevented all of this derived the npm package from `plugins list --json`'s `rootDir`. An orphaned plugin has none, so the spec fell back to the bare id and npm resolved **@latest** — the exact drift that block exists to prevent, on the boxes that most need it. The pin is now rebuilt from the id for the `@openclaw` packages ClawBox installs, and left alone for anyone else's plugin.

Sibling call sites swept: `repairPluginCapabilityConsent` (renamed, both callers updated), `pluginsNeedingConsent` (generalised to `pluginsNamedInRefusals`, the only caller), `getGatewayFailureDetail` (the only reader of the gateway journal), the pre-start's managed-plugin loop, and the `install.sh` refresh above. `CLAWBOX_MANAGED_PLUGIN_IDS` is now built from `OFFICIAL_CHANNEL_PLUGINS` so a channel added to the Settings panel cannot silently lose the repair; a unit test holds the shell `case` arm to the same map. The updater no longer re-issues an install the pre-start just did: it reads the pre-start's own report line.

### RED → GREEN

RED, on unmodified beta (`b8eeb335`):

```
 FAIL  |unit| src/tests/unit/updater.test.ts > updater > startUpdate > reinstalls a managed plugin whose payload a core upgrade orphaned
AssertionError: expected 'failed' to be 'completed'
[Updater] Failed: Verifying gateway health — OpenClaw gateway is not listening on port 18789: clawbox-gateway.service: Start request repeated too quickly.

 FAIL  |unit| src/tests/unit/updater.test.ts > updater > startUpdate > names the plugin the core refused, not the systemd start-limit line
AssertionError: expected 'OpenClaw gateway is not listening on …' to contain 'Plugin "whatsapp"'
Received: "OpenClaw gateway is not listening on port 18789: clawbox-gateway.service: Failed with result 'exit-code'."

 FAIL  |unit| src/tests/unit/gateway-pre-start-managed-plugin-payload.test.ts > reinstalls the pinned payload when the consent verb cannot find the plugin
AssertionError: expected [ Array(1) ] to deeply equal [ …(2) ]
  [
    "plugins enable discord --accept-capabilities",
-   "plugins install @openclaw/discord@2026.8.1 --force --accept-capabilities",
  ]
```

GREEN, after the fix and the review round:

```
 Test Files  465 passed (465)
      Tests  8087 passed | 1 skipped (8088)
```

plus `tsc --noEmit` clean. The three beta guard suites (`openclaw-config-mock-completeness`, `test-timeout-hygiene`, `state-updater-purity`) are in that run.

### Both editions, proven read-only on both boxes

* **OpenClaw box** (`CLAWBOX_EDITION=openclaw`): the three generation-keyed payload directories are there (`openclaw-codex-…__openclaw-generation__g-…`, and the same for discord and whatsapp), the pre-start's own Python reports the four managed enabled plugins (`deepseek discord whatsapp clawbox-email-directives`), and the core pin is `2026.8.1`. `openclaw plugins enable <absent id>` answers `Plugin not found: <id>. Run \`openclaw plugins list\`…` and exits 1 — the gate this PR keys the boot repair on.
* **Hermes box** (`CLAWBOX_EDITION=hermes`): no `openclaw` binary, `clawbox-gateway.service` masked and inactive. The pre-start block stays inside `[ "$CLAWBOX_OPENCLAW_V2" = "1" ]` and is the gateway unit's own `ExecStartPre`, and the updater's `gateway_verify` step already carries `applies: () => !gatewayIsAbsent()`. The change is inert there.

Nothing was mutated on either box; every command above is a read or a CLI query that fails.

### Reviewed and deliberately not taken here

* `getGatewayFailureDetail` scans the whole boot (`journalctl -b`), so a payload line from an earlier failed start can outlive its repair and be shown over an unrelated later failure. Pre-existing in shape for the consent pattern; bounding the scan to the last restart marker is its own change.
* `timeout` without `-k` on the pre-existing codex install a few lines above the new arm — the new call carries `-k 5`; the codex one is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery for managed OpenClaw plugins with missing or invalid payloads.
  * Automatically reinstalls affected Discord and WhatsApp plugins using the correct core-version package.
  * Directs DeepSeek and ClawBox email plugin issues to their required installers.
  * Prevents duplicate repairs and avoids reinstalling plugins users have intentionally disabled.
  * Improves capability-consent failure handling and preserves pinned plugin versions during refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->