### PR TITLE
fix: let a rebuild survive a file that vanished from its own build trace

### DIFF
--- a/install-x64.sh
+++ b/install-x64.sh
@@ -422,7 +422,43 @@ step_build() {
     echo "  Rebuilding native modules (node-pty)..."
     as_user_login "cd \"$PROJECT_DIR\" && npm_config_python=/usr/bin/python3 npm rebuild node-pty --foreground-scripts"
   fi
-  as_user_login "cd \"$PROJECT_DIR\" && \"$BUN\" run build"
+  # ONE retry, and only for the mid-build file-trace race — the same guard
+  # `run_next_build` carries in install.sh, copied rather than shared because
+  # this installer is standalone by design and has its own helper names. See
+  # that function for why the race exists and why one rebuild is the whole
+  # repair.
+  #
+  # This SKU needs it at least as much: there is no `do_rebuild` here, so this
+  # is the only build path on x64 — for a fresh install and for the documented
+  # `--step build` on a live box alike — and it parks no previous build, while
+  # `next build` wipes `.next/standalone` before it copies anything.
+  local build_log build_rc build_attempt
+  build_log="${TMPDIR:-/tmp}/clawbox-x64-build.log"
+  : > "$build_log" 2>/dev/null || build_log=""
+  build_rc=0
+  for build_attempt in 1 2; do
+    if [ -n "$build_log" ]; then
+      if as_user_login "cd \"$PROJECT_DIR\" && \"$BUN\" run build" 2>&1 | tee "$build_log"; then
+        build_rc=0
+        break
+      fi
+      # The BUILD's status, never the pipeline's.
+      build_rc=${PIPESTATUS[0]}
+      if [ "$build_rc" -eq 0 ]; then break; fi
+    else
+      if as_user_login "cd \"$PROJECT_DIR\" && \"$BUN\" run build"; then build_rc=0; else build_rc=$?; fi
+      break
+    fi
+    if [ "$build_attempt" -eq 2 ]; then break; fi
+    # One awk, not two greps in a pipe — see run_next_build in install.sh.
+    awk '/ENOENT.*copyfile/ && !/Failed to copy traced files for/ { hit = 1 } END { exit hit ? 0 : 1 }' "$build_log" || break
+    echo "  A file this build was tracing changed while it ran — building once more"
+  done
+  if [ -n "$build_log" ]; then rm -f "$build_log"; fi
+  if [ "$build_rc" -ne 0 ]; then
+    echo "Error: Build failed (exit $build_rc)"
+    exit "$build_rc"
+  fi
   if [ ! -f "$PROJECT_DIR/.next/standalone/server.js" ]; then
     echo "Error: Build failed — .next/standalone/server.js not found"
     exit 1

--- a/install-x64.sh
+++ b/install-x64.sh
@@ -432,9 +432,13 @@ step_build() {
   # is the only build path on x64 — for a fresh install and for the documented
   # `--step build` on a live box alike — and it parks no previous build, while
   # `next build` wipes `.next/standalone` before it copies anything.
-  local build_log build_rc build_attempt
-  build_log="${TMPDIR:-/tmp}/clawbox-x64-build.log"
-  : > "$build_log" 2>/dev/null || build_log=""
+  # A private `mktemp -d` directory, never a predictable path — this installer
+  # runs as root and a fixed name under TMPDIR is a symlink a local user can
+  # plant. See run_next_build in install.sh.
+  local build_log build_log_dir build_rc build_attempt
+  build_log_dir="$(mktemp -d "${TMPDIR:-/tmp}/clawbox-x64-build-XXXXXX" 2>/dev/null || true)"
+  build_log=""
+  if [ -n "$build_log_dir" ]; then build_log="$build_log_dir/build.log"; fi
   build_rc=0
   for build_attempt in 1 2; do
     if [ -n "$build_log" ]; then
@@ -454,7 +458,7 @@ step_build() {
     awk '/ENOENT.*copyfile/ && !/Failed to copy traced files for/ { hit = 1 } END { exit hit ? 0 : 1 }' "$build_log" || break
     echo "  A file this build was tracing changed while it ran — building once more"
   done
-  if [ -n "$build_log" ]; then rm -f "$build_log"; fi
+  if [ -n "$build_log_dir" ]; then rm -rf "$build_log_dir"; fi
   if [ "$build_rc" -ne 0 ]; then
     echo "Error: Build failed (exit $build_rc)"
     exit "$build_rc"

--- a/install.sh
+++ b/install.sh
@@ -1540,6 +1540,47 @@ restore_previous_build() {
 
 # Stop the setup service, free memory, reinstall, and rebuild — without ever
 # leaving the box with no build at all.
+# `bun run build`, with ONE retry and only for the mid-build file-trace race.
+#
+# WHAT RACES. Next writes a `.nft.json` beside every server entry and then
+# copies every file it lists into `.next/standalone`. The page and app-page
+# copies are `.catch`-wrapped; the MIDDLEWARE and INSTRUMENTATION ones are not
+# (node_modules/next/dist/build/utils.js, still true on 16.3.3), so one
+# `fs.copyFile` ENOENT there aborts `next build` outright. And those two traces
+# carry the project root as an asset directory — data/webapps,
+# data/code-projects, data/coding-agent-artifacts and .git among them, measured
+# on the OpenClaw box. So a web app the agent creates or removes, a coding run
+# writing a screenshot, or the update's own `git reset --hard` between the trace
+# and the copy kills the build over a file the dashboard never needed.
+#
+# WHY NOT A CONFIG. `outputFileTracingExcludes` is applied per ROUTE entry
+# (next/dist/build/collect-build-traces.js iterates the chunk trace's entry
+# map), which is why the `data/**` exclude in next.config.ts cleans the route
+# traces and leaves these two untouched — and Next exposes no other tracing
+# knob: `outputFileTracingRoot`, `-Excludes` and `-Includes` are the whole
+# surface in its config schema.
+#
+# WHY A RETRY IS THE RIGHT ANSWER. The failure is transient by construction: the
+# next trace cannot list a file that is gone. One retry, gated on the ENOENT the
+# copy throws, so a build that is broken for any other reason still fails on the
+# first attempt and is reported as such rather than hidden behind a second
+# five-minute build. Both attempts stream to the step log as before; the copy
+# here only exists so the gate can read what was printed.
+run_next_build() {
+  local log rc attempt
+  log="$(mktemp "${TMPDIR:-/tmp}/clawbox-build-XXXXXX.log")"
+  for attempt in 1 2; do
+    as_clawbox_login "cd $PROJECT_DIR && $BUN run build" 2>&1 | tee "$log"
+    rc=${PIPESTATUS[0]}
+    [ "$rc" -eq 0 ] && break
+    [ "$attempt" -eq 2 ] && break
+    grep -Eq "ENOENT.*copyfile" "$log" || break
+    echo "  A file this build was tracing changed while it ran (ENOENT during the standalone copy) — building once more"
+  done
+  rm -f "$log"
+  return "$rc"
+}
+
 do_rebuild() {
   local build_dir="$PROJECT_DIR/.next"
   local kept_dir="$PROJECT_DIR/.next-old"
@@ -1579,7 +1620,7 @@ do_rebuild() {
     set_previous_build_aside "$build_dir" "$kept_dir"
     echo "Running bun build..."
     built=1
-    as_clawbox_login "cd $PROJECT_DIR && $BUN run build" || rc=$?
+    run_next_build || rc=$?
     if [ "$rc" -eq 0 ] && ! verify_build_present "$PROJECT_DIR"; then
       rc=1
     fi

--- a/install.sh
+++ b/install.sh
@@ -1566,14 +1566,27 @@ restore_previous_build() {
 # first attempt and is reported as such rather than hidden behind a second
 # five-minute build. Both attempts stream to the step log as before; the copy
 # here only exists so the gate can read what was printed.
+#
+# Every branch below is written the long way — `if`, never `[ … ] && …` — and
+# the build runs as an `if` CONDITION. Both are about errexit: this file is
+# `set -euo pipefail`, `do_rebuild` calls this in a `||` context (errexit
+# suspended for the whole body) and `step_build` calls it bare (errexit live),
+# so a failing pipeline or a false `[ … ] &&` test outside a condition would
+# kill the script on the first attempt in one caller and not the other.
 run_next_build() {
   local log rc attempt
   log="$(mktemp "${TMPDIR:-/tmp}/clawbox-build-XXXXXX.log")"
+  rc=0
   for attempt in 1 2; do
-    as_clawbox_login "cd $PROJECT_DIR && $BUN run build" 2>&1 | tee "$log"
+    if as_clawbox_login "cd $PROJECT_DIR && $BUN run build" 2>&1 | tee "$log"; then
+      rc=0
+      break
+    fi
+    # The BUILD's status, not tee's. A pipeline that only failed in tee still
+    # has to be reported as a failure, or a full disk would pass for a build.
     rc=${PIPESTATUS[0]}
-    [ "$rc" -eq 0 ] && break
-    [ "$attempt" -eq 2 ] && break
+    if [ "$rc" -eq 0 ]; then rc=1; fi
+    if [ "$attempt" -eq 2 ]; then break; fi
     grep -Eq "ENOENT.*copyfile" "$log" || break
     echo "  A file this build was tracing changed while it ran (ENOENT during the standalone copy) — building once more"
   done
@@ -2350,7 +2363,10 @@ step_build() {
   promote_parked_build
   as_clawbox_login "cd $PROJECT_DIR && $BUN install"
   ensure_node_pty
-  as_clawbox_login "cd $PROJECT_DIR && $BUN run build"
+  # Through do_rebuild's helper, for do_rebuild's reason: `--step build` is
+  # dispatchable on a live box, where the agent can create or remove a web app
+  # while the trace is being copied.
+  run_next_build
   # The same two questions do_rebuild asks, through the same helper: an install
   # that leaves a box unable to load the server is the defect this file already
   # tested for, and the identity half is the one the box already owns.

--- a/install.sh
+++ b/install.sh
@@ -1538,62 +1538,97 @@ restore_previous_build() {
   return 1
 }
 
-# Stop the setup service, free memory, reinstall, and rebuild — without ever
-# leaving the box with no build at all.
 # `bun run build`, with ONE retry and only for the mid-build file-trace race.
 #
 # WHAT RACES. Next writes a `.nft.json` beside every server entry and then
-# copies every file it lists into `.next/standalone`. The page and app-page
-# copies are `.catch`-wrapped; the MIDDLEWARE and INSTRUMENTATION ones are not
-# (node_modules/next/dist/build/utils.js, still true on 16.3.3), so one
-# `fs.copyFile` ENOENT there aborts `next build` outright. And those two traces
-# carry the project root as an asset directory — data/webapps,
-# data/code-projects, data/coding-agent-artifacts and .git among them, measured
-# on the OpenClaw box. So a web app the agent creates or removes, a coding run
-# writing a screenshot, or the update's own `git reset --hard` between the trace
-# and the copy kills the build over a file the dashboard never needed.
+# copies every file it lists into `.next/standalone` — after wiping that
+# directory first. The page and app-page copies are `.catch`-wrapped; the
+# MIDDLEWARE and INSTRUMENTATION ones are not (node_modules/next/dist/build/
+# utils.js, still true on 16.3.3), so one `fs.copyFile` ENOENT there aborts
+# `next build` outright. And those two traces carry the project root as an
+# asset directory — measured on the OpenClaw box, beta build of 2026-09-05:
+# every ROUTE trace has 0 entries under data/ and .git/, while
+# middleware.js.nft.json has 27 under data/ and instrumentation.js.nft.json has
+# 32 under data/ plus 701 under .git/. So a web app the agent creates or
+# removes, a coding run writing a screenshot, or the update's own
+# `git reset --hard` between the trace and the copy kills the build over a file
+# the dashboard never needed.
 #
-# WHY NOT A CONFIG. `outputFileTracingExcludes` is applied per ROUTE entry
-# (next/dist/build/collect-build-traces.js iterates the chunk trace's entry
-# map), which is why the `data/**` exclude in next.config.ts cleans the route
-# traces and leaves these two untouched — and Next exposes no other tracing
-# knob: `outputFileTracingRoot`, `-Excludes` and `-Includes` are the whole
-# surface in its config schema.
+# WHY NOT A CONFIG. `outputFileTracingExcludes` reaches route entries only — the
+# same measurement is what proves it, and it is why next.config.ts's own
+# `.git/**` key is inoperative for the instrumentation trace. Next exposes no
+# other tracing knob: `outputFileTracingRoot`, `-Excludes` and `-Includes` are
+# the whole surface in its config schema.
 #
 # WHY A RETRY IS THE RIGHT ANSWER. The failure is transient by construction: the
 # next trace cannot list a file that is gone. One retry, gated on the ENOENT the
 # copy throws, so a build that is broken for any other reason still fails on the
 # first attempt and is reported as such rather than hidden behind a second
-# five-minute build. Both attempts stream to the step log as before; the copy
-# here only exists so the gate can read what was printed.
+# five-minute build. `REBUILD_TAKEOVER_TIMEOUT_MS` in src/lib/updater.ts carries
+# the budget for that second build.
 #
-# Every branch below is written the long way — `if`, never `[ … ] && …` — and
-# the build runs as an `if` CONDITION. Both are about errexit: this file is
+# The log copy exists ONLY so the gate can read what was printed, and it is
+# best-effort: a `/tmp` that is full or unwritable — a Jetson tmpfs under the
+# memory pressure `free_memory_for_build` exists for — must cost the retry, not
+# the build. The build's own status is the verdict, never the pipeline's, so
+# `tee` can never turn a build that worked into a failed update;
+# `verify_build_present` in both callers is what catches a build that exited 0
+# without producing anything. Output now carries the build's stderr on stdout so
+# the gate can see it, which is the one thing about the step log that changed.
+#
+# Every branch is written the long way — `if`, never `[ … ] && …` — and the
+# build runs as an `if` CONDITION. Both are about errexit: this file is
 # `set -euo pipefail`, `do_rebuild` calls this in a `||` context (errexit
 # suspended for the whole body) and `step_build` calls it bare (errexit live),
 # so a failing pipeline or a false `[ … ] &&` test outside a condition would
 # kill the script on the first attempt in one caller and not the other.
 run_next_build() {
   local log rc attempt
-  log="$(mktemp "${TMPDIR:-/tmp}/clawbox-build-XXXXXX.log")"
+  # A fixed path, overwritten rather than accumulated: this shell is a
+  # documented OOM-kill target (TASK-709), and the cleanup below is only
+  # reachable on a normal return.
+  log="${TMPDIR:-/tmp}/clawbox-next-build.log"
+  : > "$log" 2>/dev/null || log=""
+  if [ -z "$log" ]; then
+    echo "  Note: could not open a build log; a mid-build trace race will not be retried"
+  fi
   rc=0
   for attempt in 1 2; do
-    if as_clawbox_login "cd $PROJECT_DIR && $BUN run build" 2>&1 | tee "$log"; then
-      rc=0
+    if [ -n "$log" ]; then
+      if as_clawbox_login "cd $PROJECT_DIR && $BUN run build" 2>&1 | tee "$log"; then
+        rc=0
+        break
+      fi
+      # The BUILD's status, full stop. `pipefail` makes the pipeline non-zero
+      # for a tee that could not write too, and a log this function could not
+      # keep must never be the reason an update is reported failed.
+      rc=${PIPESTATUS[0]}
+      if [ "$rc" -eq 0 ]; then break; fi
+    else
+      if as_clawbox_login "cd $PROJECT_DIR && $BUN run build"; then
+        rc=0
+      else
+        rc=$?
+      fi
       break
     fi
-    # The BUILD's status, not tee's. A pipeline that only failed in tee still
-    # has to be reported as a failure, or a full disk would pass for a build.
-    rc=${PIPESTATUS[0]}
-    if [ "$rc" -eq 0 ]; then rc=1; fi
     if [ "$attempt" -eq 2 ]; then break; fi
-    grep -Eq "ENOENT.*copyfile" "$log" || break
+    # The FATAL shape only. Next prints the identical `ENOENT … copyfile` node
+    # message inside the `.catch` it wraps the page and app-page copies in,
+    # prefixed with `Failed to copy traced files for` — a warning over a build
+    # that carried on, and no reason to spend a second build. ONE awk rather
+    # than two greps in a pipe: `grep -q` exits on its first match and can
+    # SIGPIPE the producer, which under `pipefail` reads as "no match" and
+    # would silently drop the retry this whole function exists for.
+    awk '/ENOENT.*copyfile/ && !/Failed to copy traced files for/ { hit = 1 } END { exit hit ? 0 : 1 }' "$log" || break
     echo "  A file this build was tracing changed while it ran (ENOENT during the standalone copy) — building once more"
   done
-  rm -f "$log"
+  if [ -n "$log" ]; then rm -f "$log"; fi
   return "$rc"
 }
 
+# Stop the setup service, free memory, reinstall, and rebuild — without ever
+# leaving the box with no build at all.
 do_rebuild() {
   local build_dir="$PROJECT_DIR/.next"
   local kept_dir="$PROJECT_DIR/.next-old"

--- a/install.sh
+++ b/install.sh
@@ -1583,12 +1583,18 @@ restore_previous_build() {
 # so a failing pipeline or a false `[ … ] &&` test outside a condition would
 # kill the script on the first attempt in one caller and not the other.
 run_next_build() {
-  local log rc attempt
-  # A fixed path, overwritten rather than accumulated: this shell is a
-  # documented OOM-kill target (TASK-709), and the cleanup below is only
-  # reachable on a normal return.
-  log="${TMPDIR:-/tmp}/clawbox-next-build.log"
-  : > "$log" 2>/dev/null || log=""
+  local log log_dir rc attempt
+  # A PRIVATE directory from `mktemp -d`, never a predictable path. This script
+  # runs as root: `: > "$TMPDIR/<fixed name>"` follows a symlink a local user
+  # planted there, so root truncates and then `tee`s a build log into whatever
+  # it pointed at. `mktemp -d` creates a 0700 directory with an unguessable
+  # name atomically, so nothing can be waiting inside it. The cost is that an
+  # OOM kill — which this shell is a documented target of (TASK-709) — leaves an
+  # empty directory rather than nothing; a stale 0700 directory in /tmp is the
+  # cheaper of the two problems by a wide margin.
+  log_dir="$(mktemp -d "${TMPDIR:-/tmp}/clawbox-build-XXXXXX" 2>/dev/null || true)"
+  log=""
+  if [ -n "$log_dir" ]; then log="$log_dir/next-build.log"; fi
   if [ -z "$log" ]; then
     echo "  Note: could not open a build log; a mid-build trace race will not be retried"
   fi
@@ -1623,7 +1629,7 @@ run_next_build() {
     awk '/ENOENT.*copyfile/ && !/Failed to copy traced files for/ { hit = 1 } END { exit hit ? 0 : 1 }' "$log" || break
     echo "  A file this build was tracing changed while it ran (ENOENT during the standalone copy) — building once more"
   done
-  if [ -n "$log" ]; then rm -f "$log"; fi
+  if [ -n "$log_dir" ]; then rm -rf "$log_dir"; fi
   return "$rc"
 }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -75,28 +75,28 @@ const nextConfig: NextConfig = {
   // system-profile.ts resolves scripts/ from the process cwd).
   //
   // `.git` is in that 6186-file list too — 88 MB of it on the OpenClaw box,
-  // measured 2026-09-05 — and unlike the middleware half it CAN be excluded
-  // here. Read out of the installed next@16.3.3 in this checkout (TASK-692),
-  // because the paragraph above led a review to the opposite conclusion:
+  // measured 2026-09-05. TASK-692 read next@16.3.3's own source and concluded
+  // the `.git/**` key below reaches the instrumentation trace
+  // (next-trace-entrypoints-plugin.js keys `entryNameFilesMap` by
+  // `entrypoint.name` for every server-compiler entrypoint, collect-build-
+  // traces.js iterates that map, and `picomatch("*", {dot,contains})` matches
+  // "instrumentation"), while flagging that a real device build with the line
+  // in place was NOT measured.
   //
-  //   * next-trace-entrypoints-plugin.js keys `entryNameFilesMap` by
-  //     `entrypoint.name` for EVERY server-compiler entrypoint, not only route
-  //     entries, so `instrumentation` has an entry in it.
-  //   * collect-build-traces.js iterates that map and applies these globs to
-  //     each `.nft.json`, skipping only static pages and `edgeRuntimeRoutes` —
-  //     which is exactly why MIDDLEWARE keeps its `data/` entry and the
-  //     server-compiler traces do not.
-  //   * `picomatch("*", { dot: true, contains: true })("instrumentation")` is
-  //     `true`, and `.git/**` matches `.git/objects/...` under the same
-  //     options. Both checked with the vendored matcher.
-  //   * build/utils.js copies the standalone tree FROM those lists, so an
-  //     entry dropped here is a file never copied.
+  // It has been measured now (TASK-670), on a box building THIS branch's own
+  // beta head, with the key below already in the checked-out config:
   //
-  // So `.git` is excluded at the source rather than deleted afterwards. What
-  // is NOT measured: a real `next build` on a box with this line in place —
-  // that is device work. scripts/postbuild.sh therefore still sweeps `.git`
-  // and still FAILS the build if a copy survives, which is the post-condition
-  // the suites pin; this line is meant to make that sweep find nothing.
+  //   every `.next/server/app/**/*.nft.json`   data 0   .git 0
+  //   .next/server/middleware.js.nft.json      data 27  .git 0
+  //   .next/server/instrumentation.js.nft.json data 32  .git 701
+  //
+  // So the key reaches ROUTE entries and nothing else, exactly as the
+  // paragraph above says, and the source reading does not survive contact with
+  // a real build. `.git` is NOT excluded at the source: scripts/postbuild.sh
+  // sweeping it afterwards — and failing the build when a copy survives — is
+  // what actually keeps it out of the artifact, and is load-bearing rather
+  // than belt-and-braces. The key stays because it does its job for the route
+  // traces; do not read it as covering the other two.
   //
   // Its companion, the checkout's own `.env`, genuinely has no switch: Next
   // copies `.env` and `.env.production` ITSELF, AFTER the trace, in

--- a/scripts/force-update.sh
+++ b/scripts/force-update.sh
@@ -72,7 +72,44 @@ if [ ! -x "$BUN_BIN" ]; then
   BUN_BIN="$(command -v bun || echo bun)"
 fi
 run_as_clawbox "cd $PROJECT_DIR && $BUN_BIN install"
-run_as_clawbox "cd $PROJECT_DIR && $BUN_BIN run build"
+
+# ONE retry, and only for the mid-build file-trace race — the same guard
+# `run_next_build` carries in install.sh, copied rather than shared because
+# this script is standalone by design (it is what an operator runs when the
+# in-app updater is already broken) and has its own helper names. See that
+# function for why the race exists and why one rebuild is the whole repair.
+#
+# It matters MORE here than there: `git reset --hard` and `git clean -fd` run
+# a few lines above, `next build` wipes `.next/standalone` before it copies
+# anything, and this path parks NO previous build — so a mid-copy ENOENT
+# leaves the box with no standalone entry and nothing to fall back on.
+BUILD_LOG="${TMPDIR:-/tmp}/clawbox-force-update-build.log"
+: > "$BUILD_LOG" 2>/dev/null || BUILD_LOG=""
+BUILD_RC=0
+for BUILD_ATTEMPT in 1 2; do
+  if [ -n "$BUILD_LOG" ]; then
+    if run_as_clawbox "cd $PROJECT_DIR && $BUN_BIN run build" 2>&1 | tee "$BUILD_LOG"; then
+      BUILD_RC=0
+      break
+    fi
+    # The BUILD's status, never the pipeline's: a log this script could not
+    # write must not turn a build that worked into a failed recovery.
+    BUILD_RC=${PIPESTATUS[0]}
+    if [ "$BUILD_RC" -eq 0 ]; then break; fi
+  else
+    if run_as_clawbox "cd $PROJECT_DIR && $BUN_BIN run build"; then BUILD_RC=0; else BUILD_RC=$?; fi
+    break
+  fi
+  if [ "$BUILD_ATTEMPT" -eq 2 ]; then break; fi
+  # One awk, not two greps in a pipe — see run_next_build in install.sh.
+  awk '/ENOENT.*copyfile/ && !/Failed to copy traced files for/ { hit = 1 } END { exit hit ? 0 : 1 }' "$BUILD_LOG" || break
+  echo "[force-update] A file the build was tracing changed while it ran — building once more"
+done
+if [ -n "$BUILD_LOG" ]; then rm -f "$BUILD_LOG"; fi
+if [ "$BUILD_RC" -ne 0 ]; then
+  echo "[force-update] Build failed (exit $BUILD_RC)." >&2
+  exit "$BUILD_RC"
+fi
 
 echo "[force-update] Restarting clawbox-setup..."
 sudo systemctl restart clawbox-setup

--- a/scripts/force-update.sh
+++ b/scripts/force-update.sh
@@ -83,8 +83,12 @@ run_as_clawbox "cd $PROJECT_DIR && $BUN_BIN install"
 # a few lines above, `next build` wipes `.next/standalone` before it copies
 # anything, and this path parks NO previous build — so a mid-copy ENOENT
 # leaves the box with no standalone entry and nothing to fall back on.
-BUILD_LOG="${TMPDIR:-/tmp}/clawbox-force-update-build.log"
-: > "$BUILD_LOG" 2>/dev/null || BUILD_LOG=""
+# A private `mktemp -d` directory, never a predictable path — this script runs
+# as root and a fixed name under TMPDIR is a symlink a local user can plant.
+# See run_next_build in install.sh.
+BUILD_LOG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/clawbox-force-update-XXXXXX" 2>/dev/null || true)"
+BUILD_LOG=""
+if [ -n "$BUILD_LOG_DIR" ]; then BUILD_LOG="$BUILD_LOG_DIR/build.log"; fi
 BUILD_RC=0
 for BUILD_ATTEMPT in 1 2; do
   if [ -n "$BUILD_LOG" ]; then
@@ -105,7 +109,7 @@ for BUILD_ATTEMPT in 1 2; do
   awk '/ENOENT.*copyfile/ && !/Failed to copy traced files for/ { hit = 1 } END { exit hit ? 0 : 1 }' "$BUILD_LOG" || break
   echo "[force-update] A file the build was tracing changed while it ran — building once more"
 done
-if [ -n "$BUILD_LOG" ]; then rm -f "$BUILD_LOG"; fi
+if [ -n "$BUILD_LOG_DIR" ]; then rm -rf "$BUILD_LOG_DIR"; fi
 if [ "$BUILD_RC" -ne 0 ]; then
   echo "[force-update] Build failed (exit $BUILD_RC)." >&2
   exit "$BUILD_RC"

--- a/src/app/updating/page.tsx
+++ b/src/app/updating/page.tsx
@@ -39,7 +39,7 @@ import ReconnectStage from "@/components/ReconnectStage";
  */
 
 /** The rebuild's own budget (REBUILD_TAKEOVER_TIMEOUT_MS) plus room to reboot. */
-const STUCK_AFTER_MS = 20 * 60 * 1000;
+const STUCK_AFTER_MS = 25 * 60 * 1000;
 const POLL_MS = 2000;
 
 interface Step { id: string; label: string; status: string }

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -156,7 +156,15 @@ import { RESTART_STEP_ID } from "./update-constants";
 
 // Ceiling for the rebuild/restart hand-off: bun build alone runs minutes on a
 // Jetson, plus the config/redeploy steps before it and the reboot after.
-const REBUILD_TAKEOVER_TIMEOUT_MS = 900_000;
+//
+// 20 min, raised from 15 (TASK-670). `do_rebuild` may now run `next build` a
+// SECOND time when the first died on a file that changed under its own file
+// trace, and nothing extends this deadline once the wait has started: past it
+// `waitForRebuildToTakeOver` throws AND clears `update_needs_continuation`, so
+// a rebuild that actually worked would be reported red and post_update,
+// hermes_edition and gateway_verify would never run. One extra build is 2-4
+// min on a Jetson; this covers it with the same margin the original carried.
+const REBUILD_TAKEOVER_TIMEOUT_MS = 1_200_000;
 
 // The root unit that performs the rebuild + restart. Distinct from
 // RESTART_STEP_ID ("restart"), which is the UI step's identity — querying

--- a/src/tests/unit/install-free-memory-before-build.test.ts
+++ b/src/tests/unit/install-free-memory-before-build.test.ts
@@ -60,11 +60,17 @@ const FREE_MEMORY = shellCode(extractShellFunction("free_memory_for_build"));
 
 describe("do_rebuild frees memory in the one place it can hold", () => {
   it("frees memory before the build", () => {
+    // `run_next_build` IS the build here — it is the only caller of
+    // `$BUN run build` in do_rebuild's path, and it exists because Next's
+    // standalone copy can die on a file that changed mid-build (TASK-670).
+    // Both halves are asserted, so neither the call nor the command can move
+    // ahead of the free without this failing.
     const freeIdx = DO_REBUILD.indexOf("free_memory_for_build");
-    const buildIdx = DO_REBUILD.indexOf("$BUN run build");
+    const buildIdx = DO_REBUILD.indexOf("run_next_build");
     expect(freeIdx).toBeGreaterThan(-1);
     expect(buildIdx).toBeGreaterThan(-1);
     expect(freeIdx).toBeLessThan(buildIdx);
+    expect(shellCode(extractShellFunction("run_next_build"))).toContain("$BUN run build");
   });
 
   it("frees memory AFTER the web server is stopped, not before", () => {

--- a/src/tests/unit/install-rebuild-build-verify.test.ts
+++ b/src/tests/unit/install-rebuild-build-verify.test.ts
@@ -128,6 +128,8 @@ interface Scenario {
    */
   diskHeadroom?: "ample" | "tight";
   bunInstall?: "succeeds" | "fails";
+  /** Can `run_next_build` open its build log at all? */
+  buildLog?: "writable" | "unwritable";
   nodePty?: "succeeds" | "fails";
   /** Which shipped function to run. */
   entry?: "do_rebuild" | "step_build";
@@ -161,6 +163,7 @@ let systemctlLog: string;
 let projectDir: string;
 let ownerProbe: string;
 let buildAttempts: string;
+let unwritableTmp: string;
 
 function writeBuild(dir: string, buildId: string, withEntry = true): void {
   mkdirSync(path.join(dir, "standalone"), { recursive: true });
@@ -179,6 +182,7 @@ function run(scenario: Scenario = {}): Run {
     diskHeadroom = "ample",
     bunInstall = "succeeds",
     nodePty = "succeeds",
+    buildLog = "writable",
     entry = "do_rebuild",
   } = scenario;
 
@@ -279,6 +283,9 @@ function run(scenario: Scenario = {}): Run {
     "set -euo pipefail",
     "",
     "PROJECT_DIR=" + JSON.stringify(projectDir),
+    // A /tmp the box cannot write — a Jetson tmpfs under exactly the memory
+    // pressure free_memory_for_build exists for, or a full eMMC.
+    "TMPDIR=" + JSON.stringify(buildLog === "unwritable" ? unwritableTmp : sandbox),
     "CLAWBOX_USER=clawbox",
     "BUN=/nonexistent/bun",
     "FAKE_BUILD=" + JSON.stringify(fakeBuild),
@@ -402,6 +409,8 @@ beforeEach(() => {
   projectDir = path.join(sandbox, "clawbox");
   ownerProbe = path.join(sandbox, "parked-owner.txt");
   buildAttempts = path.join(sandbox, "build-attempts.txt");
+  unwritableTmp = path.join(sandbox, "no-write");
+  mkdirSync(unwritableTmp, { recursive: true, mode: 0o500 });
 });
 
 afterEach(() => {
@@ -496,6 +505,34 @@ describe("do_rebuild verifies the build it produced", () => {
     const r = run({ build: "trace-race-then-succeeds", entry: "step_build" });
     expect(r.status).toBe(0);
     expect(r.attempts).toBe(2);
+    expect(r.hasEntry).toBe(true);
+  });
+
+  it("runs the build exactly once when it works", () => {
+    // The other half of the retry cases: a loop that always ran twice would
+    // satisfy every one of them and double every healthy update.
+    expect(run({ build: "succeeds" }).attempts).toBe(1);
+  });
+
+  it("still succeeds when it cannot open a build log at all", () => {
+    // The log is a debugging convenience for the retry gate, not a
+    // precondition of building. A /tmp the box cannot write must cost the
+    // RETRY, never the build — `tee`'s status is not the build's, and
+    // verify_build_present is what catches a build that produced nothing.
+    const r = run({ build: "succeeds", buildLog: "unwritable" });
+    expect(r.status).toBe(0);
+    expect(r.attempts).toBe(1);
+    expect(r.buildId).toBe("new-build-id");
+    expect(r.hasEntry).toBe(true);
+    expect(r.stdout).toContain("could not open a build log");
+  });
+
+  it("still runs the build at all when it cannot open a build log", () => {
+    // `step_build` calls the helper BARE, with errexit live: a failure while
+    // opening the log there would abort the script before the build ran.
+    const r = run({ build: "succeeds", buildLog: "unwritable", entry: "step_build" });
+    expect(r.status).toBe(0);
+    expect(r.attempts).toBe(1);
     expect(r.hasEntry).toBe(true);
   });
 

--- a/src/tests/unit/install-rebuild-build-verify.test.ts
+++ b/src/tests/unit/install-rebuild-build-verify.test.ts
@@ -87,7 +87,11 @@ type BuildOutcome =
   /** Exit 0, nothing written at all. */
   | "exits-zero-without-output"
   /** Exit 0 with BUILD_ID but no standalone entry: the half-run postbuild. */
-  | "no-standalone-entry";
+  | "no-standalone-entry"
+  /** Next's unwrapped standalone copy hits a file that vanished; the retry works. */
+  | "trace-race-then-succeeds"
+  /** The same ENOENT every time — a file that is gone for good, not a race. */
+  | "trace-race-always";
 
 interface Scenario {
   build?: BuildOutcome;
@@ -148,12 +152,15 @@ interface Run {
   buildSawOwner: string;
   /** Did a stamp survive into the tree the box is left serving? */
   ownerLeftBehind: boolean;
+  /** How many times `bun run build` was actually invoked. */
+  attempts: number;
 }
 
 let sandbox: string;
 let systemctlLog: string;
 let projectDir: string;
 let ownerProbe: string;
+let buildAttempts: string;
 
 function writeBuild(dir: string, buildId: string, withEntry = true): void {
   mkdirSync(path.join(dir, "standalone"), { recursive: true });
@@ -175,6 +182,9 @@ function run(scenario: Scenario = {}): Run {
     entry = "do_rebuild",
   } = scenario;
 
+  // Per RUN, not per test: a case that calls this twice must not read the
+  // first build's attempts as the second's.
+  rmSync(buildAttempts, { force: true });
   mkdirSync(projectDir, { recursive: true });
   if (previousBuild === "servable") writeBuild(path.join(projectDir, ".next"), "old-build-id");
   if (parkedBuild === "servable") {
@@ -215,6 +225,20 @@ function run(scenario: Scenario = {}): Run {
     "oom-killed": 'echo "Killed" >&2; exit 137',
     "exits-zero-without-output": "exit 0",
     "no-standalone-entry": 'mkdir -p "$1/.next" && printf "new-build-id\\n" > "$1/.next/BUILD_ID" && exit 0',
+    // The message node throws out of `fs.promises.copyFile`, which Next's
+    // standalone copy does NOT catch for the middleware and instrumentation
+    // traces. Verbatim, because the retry is gated on recognising it.
+    "trace-race-then-succeeds": [
+      'if [ "$ATTEMPT" = "1" ]; then',
+      `  echo "Error: ENOENT: no such file or directory, copyfile '$1/data/webapps/demo/index.html' -> '$1/.next/standalone/data/webapps/demo/index.html'" >&2`,
+      "  exit 1",
+      "fi",
+      'mkdir -p "$1/.next/standalone" && printf "new-build-id\\n" > "$1/.next/BUILD_ID" && printf "// server\\n" > "$1/.next/standalone/server.js" && exit 0',
+    ].join("\n"),
+    "trace-race-always": [
+      `echo "Error: ENOENT: no such file or directory, copyfile '$1/data/webapps/demo/index.html' -> '$1/.next/standalone/data/webapps/demo/index.html'" >&2`,
+      "exit 1",
+    ].join("\n"),
   };
   // Sampled from inside the build, because that is the only moment the
   // question matters: the reclaim fires on a box whose `bun run build` is
@@ -236,7 +260,19 @@ function run(scenario: Scenario = {}): Run {
     '  printf "none\\n" > ' + JSON.stringify(ownerProbe),
     "fi",
   ].join("\n");
-  writeFileSync(fakeBuild, "#!/usr/bin/env bash\n" + probeOwner + "\n" + bodies[build] + "\n", "utf-8");
+  // Counts its own invocations, because "was the build run twice?" is the
+  // whole question for the retry cases — and the guard that a build which
+  // failed for any other reason is still run exactly once.
+  const countAttempt = [
+    "ATTEMPTS_FILE=" + JSON.stringify(buildAttempts),
+    'ATTEMPT=$(( $(cat "$ATTEMPTS_FILE" 2>/dev/null || echo 0) + 1 ))',
+    'printf "%s\\n" "$ATTEMPT" > "$ATTEMPTS_FILE"',
+  ].join("\n");
+  writeFileSync(
+    fakeBuild,
+    "#!/usr/bin/env bash\n" + countAttempt + "\n" + probeOwner + "\n" + bodies[build] + "\n",
+    "utf-8",
+  );
   spawnSync("chmod", ["+x", fakeBuild]);
 
   const lines = [
@@ -353,6 +389,9 @@ function run(scenario: Scenario = {}): Run {
     parked: existsSync(path.join(projectDir, ".next-old")),
     buildSawOwner: existsSync(ownerProbe) ? readFileSync(ownerProbe, "utf-8").trim() : "not-run",
     ownerLeftBehind: existsSync(path.join(projectDir, ".next", ".rebuild-pid")),
+    attempts: existsSync(buildAttempts)
+      ? Number(readFileSync(buildAttempts, "utf-8").trim())
+      : 0,
   };
 }
 
@@ -361,6 +400,7 @@ beforeEach(() => {
   systemctlLog = path.join(sandbox, "systemctl.log");
   projectDir = path.join(sandbox, "clawbox");
   ownerProbe = path.join(sandbox, "parked-owner.txt");
+  buildAttempts = path.join(sandbox, "build-attempts.txt");
 });
 
 afterEach(() => {
@@ -420,6 +460,40 @@ describe("do_rebuild verifies the build it produced", () => {
     const r = run({ build: "succeeds", identity: "drift" });
     expect(r.status).not.toBe(0);
     expect(r.buildId).toBe("old-build-id");
+  });
+
+  it("rebuilds once when a file the build was tracing vanished under it", () => {
+    // TASK-670. Next copies the middleware and instrumentation file traces
+    // with NO error handling — the page and app-page copies are `.catch`
+    // wrapped, those two are not (node_modules/next/dist/build/utils.js on
+    // 16.3.3) — and both traces carry the project root as an asset directory,
+    // data/webapps and data/code-projects included (measured on the OpenClaw
+    // box). So a web app the agent creates or removes while the build runs
+    // kills `next build` with ENOENT during the standalone copy, and the whole
+    // update dies on a file nobody needed. The next trace cannot list a file
+    // that is gone, so one rebuild is the whole repair.
+    const r = run({ build: "trace-race-then-succeeds" });
+    expect(r.status).toBe(0);
+    expect(r.attempts).toBe(2);
+    expect(r.buildId).toBe("new-build-id");
+    expect(r.hasEntry).toBe(true);
+  });
+
+  it("gives up after ONE retry when the same file is still missing", () => {
+    // A file that is gone for good is not a race, and a second five-minute
+    // build is all this may ever spend finding that out.
+    const r = run({ build: "trace-race-always" });
+    expect(r.status).not.toBe(0);
+    expect(r.attempts).toBe(2);
+    // The box keeps serving what it was serving.
+    expect(r.buildId).toBe("old-build-id");
+  });
+
+  it("does not retry a build that failed for any other reason", () => {
+    // A retry over a real failure buys the owner a second wait and the same
+    // answer, and hides which attempt the error came from.
+    expect(run({ build: "oom-killed" }).attempts).toBe(1);
+    expect(run({ build: "no-standalone-entry" }).attempts).toBe(1);
   });
 
   it("warns rather than failing when the identity script is not on disk", () => {

--- a/src/tests/unit/install-rebuild-build-verify.test.ts
+++ b/src/tests/unit/install-rebuild-build-verify.test.ts
@@ -409,8 +409,12 @@ beforeEach(() => {
   projectDir = path.join(sandbox, "clawbox");
   ownerProbe = path.join(sandbox, "parked-owner.txt");
   buildAttempts = path.join(sandbox, "build-attempts.txt");
+  // A regular FILE, not a 0500 directory: mode bits do not stop UID 0, so a
+  // suite running as root would create the log inside it and skip the very
+  // fallback these cases exist for. A file makes `mktemp -d` under it fail
+  // with ENOTDIR whoever runs the tests.
   unwritableTmp = path.join(sandbox, "no-write");
-  mkdirSync(unwritableTmp, { recursive: true, mode: 0o500 });
+  writeFileSync(unwritableTmp, "", "utf-8");
 });
 
 afterEach(() => {

--- a/src/tests/unit/install-rebuild-build-verify.test.ts
+++ b/src/tests/unit/install-rebuild-build-verify.test.ts
@@ -490,6 +490,15 @@ describe("do_rebuild verifies the build it produced", () => {
     expect(r.buildId).toBe("old-build-id");
   });
 
+  it("gives the full-install build the same retry", () => {
+    // `install.sh --step build` is dispatchable on a live box, so it races the
+    // same writers do_rebuild does.
+    const r = run({ build: "trace-race-then-succeeds", entry: "step_build" });
+    expect(r.status).toBe(0);
+    expect(r.attempts).toBe(2);
+    expect(r.hasEntry).toBe(true);
+  });
+
   it("does not retry a build that failed for any other reason", () => {
     // A retry over a real failure buys the owner a second wait and the same
     // answer, and hides which attempt the error came from.

--- a/src/tests/unit/install-rebuild-build-verify.test.ts
+++ b/src/tests/unit/install-rebuild-build-verify.test.ts
@@ -364,6 +364,7 @@ function run(scenario: Scenario = {}): Run {
       "promote_parked_build",
       "set_previous_build_aside",
       "restore_previous_build",
+      "run_next_build",
     ),
     "",
     shellFunction(entry),
@@ -412,7 +413,7 @@ describe("the shipped function bodies these tests run", () => {
   // of every function it reads today, and silently wrong the day one grows a
   // heredoc or an indented closing brace at column 0 — the tests would then
   // assert against a fragment and pass for the wrong reason.
-  it.each(["do_rebuild", "step_build", "verify_build_present", "restore_previous_build"])(
+  it.each(["do_rebuild", "step_build", "verify_build_present", "restore_previous_build", "run_next_build"])(
     "%s is extracted whole",
     (name) => {
       const body = shellFunction(name);


### PR DESCRIPTION
## TASK-670 — a rebuild can still die on a file that changed under it, and the update dies with it

**What the owner sees.** The in-app update fails on a box that was healthy, over a file nothing needed. `do_rebuild` has already stopped `clawbox-setup.service` by then; it puts the previous build back (F-27, #592, #672), so the dashboard returns — but the update is dead and the owner has to start again, and on the boxes where this bites, one of the writers that trips it is the agent the owner is talking to.

**Cause, measured rather than assumed.** Next writes a `.nft.json` beside every server entry and then copies every file it lists into `.next/standalone`. In Next 16.3.3 (`node_modules/next/dist/build/utils.js`, `copyTracedFiles`) the page and app-page copies are `.catch`-wrapped; the middleware copy (`:1089`), the instrumentation copy (`:1104`) and `next-server` are **not**, so one `fs.promises.copyFile` ENOENT there aborts the whole build.

And those two traces carry the project root as an asset directory. Read-only on both boxes, beta build of 2026-09-05:

| trace | OpenClaw box | Hermes box |
|---|---|---|
| `middleware.js.nft.json` | 2022 files, 27 under `data/` | 2053 files, 57 under `data/` |
| `instrumentation.js.nft.json` | 7024 files, 32 under `data/` | 6715 files, 60 under `data/` |
| `next-server` / `next-minimal-server` | 0 under `data/` | 0 under `data/` |

So `data/webapps/**`, `data/code-projects/**`, `data/coding-agent-artifacts/**` and `.git/**` are all inside an unwrapped copy: a web app the agent creates or removes, a coding run writing a screenshot, or the update's own `git reset --hard` between the trace and the copy kills `next build`.

### Harness first — and a correction to the card

* `outputFileTracingExcludes` **cannot** reach those two traces. `outputFileTracingRoot`, `-Excludes` and `-Includes` are the only tracing keys in Next's config schema, and the exclude keys reach route entries only. That was contested — reading `collect-build-traces.js` and `next-trace-entrypoints-plugin.js` suggests `entryNameFilesMap` should carry the `middleware` and `instrumentation` entrypoints too — so it was settled on a box building this repo's own beta head, with the exclude already in the checked-out config:

```
every .next/server/app/**/*.nft.json    data 0    .git 0
.next/server/middleware.js.nft.json     data 27   .git 0
.next/server/instrumentation.js.nft.json data 32  .git 701
```

  So the source reading does not survive contact with a real build. That absence of a reachable knob is the finding — and it has a second consequence this PR also corrects: **#694's `.git/**` exclude is inoperative for the instrumentation trace.** `next.config.ts` claimed `.git` was "excluded at the source rather than deleted afterwards" while flagging that a real device build had not been measured; 701 `.git/` entries say otherwise, so `scripts/postbuild.sh` sweeping `.git` afterwards is load-bearing rather than belt-and-braces. The comment now says so, with the measurement.
* **The card's stated cause is wrong, and its fix direction with it.** It says the traces carry `data/webapps/*` "because the modules `middleware.ts` and `instrumentation.ts` pull in resolve `path.join(CONFIG_ROOT, "data", …)` statically", so breaking that static resolution would clear them. The measured traces list `bench/tasks/…`, `public/sw.js`, `scripts/access-log.js` and `production-server.js` too — the whole project root, which no data-path expression explains. (Also measured: those traces come from turbopack's own module-graph trace, not from nft over `.next/server/middleware.js`, which is a five-line turbopack stub that traces to 3 files — so a local nft experiment on the source does not model them.) Narrowing that sweep is a separate change with an open prerequisite; it is not what this PR does.
* The failure IS transient by construction: the next trace cannot list a file that is already gone. So the repair is one rebuild, gated on the signature.

### The change

`install.sh` gains `run_next_build`: it runs `bun run build`, and only when the build failed **and** its output carries the `ENOENT … copyfile` signature does it run once more. A build that failed for any other reason still fails on the first attempt and is reported as such, never hidden behind a second five-minute build. Both attempts stream to the step log exactly as before; the copy exists only so the gate can read what was printed.

`do_rebuild` and `step_build` both go through it — `install.sh --step build` is dispatchable on a live box, so it races the same writers. The helper is written to be errexit-safe in both call contexts (`do_rebuild` calls it in a `||` context, `step_build` bare), which is why the build runs as an `if` condition and every branch is spelled out rather than written as an `[ … ] && …` list.

The log copy is **best-effort**: a `/tmp` that is full or unwritable — a Jetson tmpfs under exactly the memory pressure `free_memory_for_build` exists for — costs the retry, never the build. That was a defect in the first cut of this PR and is now a case of its own: `tee`'s status is not the build's, and `verify_build_present` in both callers is what catches a build that exited 0 having produced nothing. The gate is one `awk` rather than two greps in a pipe, because `grep -q` exits on its first match and can SIGPIPE the producer, which under `pipefail` reads as "no match" and would drop the retry silently. It also excludes the `Failed to copy traced files for` lines, which carry the identical node message from the copies Next DOES wrap — a warning over a build that carried on is no reason to spend a second one.

**The other two `bun run build` call sites get the same guard**, copied rather than shared because both scripts are standalone by design and have their own helper names: `scripts/force-update.sh` (the manual recovery an operator runs when the in-app updater is already broken — and the path where this matters most, since `git reset --hard` + `git clean -fd` run a few lines above, `next build` wipes `.next/standalone` before it copies anything, and nothing parks a previous build there) and `install-x64.sh step_build` (the x64 SKU has no `do_rebuild` at all, so that is its only build path, for a fresh install and for the documented `--step build` on a live box alike, again with no park).

`REBUILD_TAKEOVER_TIMEOUT_MS` goes 15 min → 20 min with it, and the `/updating` page's stuck threshold with that: nothing extends that deadline once the wait has started, and past it `waitForRebuildToTakeOver` throws AND clears `update_needs_continuation` — so a retried, successful rebuild would have been reported red with `post_update`, `hermes_edition` and `gateway_verify` silently dropped.

### RED → GREEN

RED, on unmodified beta (`b8eeb335`):

```
 FAIL  |unit| src/tests/unit/install-rebuild-build-verify.test.ts > do_rebuild verifies the build it produced > rebuilds once when a file the build was tracing vanished under it
AssertionError: expected 1 to be +0
    expect(r.status).toBe(0);

 FAIL  |unit| src/tests/unit/install-rebuild-build-verify.test.ts > do_rebuild verifies the build it produced > gives up after ONE retry when the same file is still missing
AssertionError: expected 1 to be 2
    expect(r.attempts).toBe(2);
```

The fake build fails its first invocation with the message node throws out of `fs.promises.copyFile`, verbatim, and succeeds on the second; the shipped function bodies are extracted from `install.sh` and run under real bash, so the assertions see the script.

GREEN, after the fix and the review round:

```
 Test Files  465 passed (465)
      Tests  8115 passed | 1 skipped (8116)
```

plus `tsc --noEmit` clean. The three beta guard suites are in that run. The neighbouring shell suites are green too, including `install-free-memory-before-build`, whose ordering guard now names the build helper and asserts the helper is what runs `$BUN run build` — so neither the call nor the command can move ahead of `free_memory_for_build` without failing.

### Both editions

`do_rebuild` is not edition-gated and neither is this: the Hermes box shows the same Next 16.3.3, the same two unwrapped copies at the same lines, and a WIDER volatile sweep than the OpenClaw box (57 and 60 `data/` entries against 27 and 32). Proven read-only on both; nothing was mutated on either box.


### Reviewed, reproduced, and fixed here rather than filed

The review round found that the first cut turned a SUCCESSFUL build into a failed update whenever the log could not be written. Reproduced against that commit's own function body, with the build stubbed to succeed and `TMPDIR` pointed at a `chmod 500` directory:

```
tee: '': No such file or directory
BUILD RAN
grep: : No such file or directory
do_rebuild would see rc=1
```

`do_rebuild` would then have printed `Error: rebuild failed (exit 1)` and rolled the new build back — on every update, on that box, for a build that worked. In `step_build`, which calls the helper bare with errexit live, the script died before the build ran at all. Both are covered by cases now.

### Note for the integrator

This branch touches `src/lib/updater.ts` (one constant, `REBUILD_TAKEOVER_TIMEOUT_MS`) and #710 touches the same file in a different region. Merging either first should be clean; the second may want a trivial rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved update and rebuild reliability by retrying once after temporary file-copy build failures.
  - Build failures now correctly stop service restarts and preserve the original failure status.
  - Builds continue without retry detection if temporary logging is unavailable.
  - Updates allow more time before being marked as stuck, and rebuild takeovers allow an additional attempt.

- **Documentation**
  - Clarified which application traces exclude repository metadata and confirmed cleanup validation for standalone builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->