### PR TITLE
fix: seed the background-job opt-outs on the Hermes edition too

### DIFF
--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -947,6 +947,348 @@ else
   log "could not disable the built-in browser toolset (exit $BROWSER_DISABLE_RC) — continuing"
 fi
 
+# ── 4b. Hermes' own background jobs, opted out of ONCE per box. ─────────────
+# TASK-609 / owner ruling 2026-09-03: the assistant must not message the owner
+# or spend his tokens on its own initiative unless he asked it to. OpenClaw 2's
+# three such jobs are seeded by `gateway-pre-start.sh`; these are Hermes' two,
+# and they are the harness's own documented keys, read off the installed 0.20.5
+# package on the box:
+#
+#   auxiliary.background_review.enabled  default TRUE — `agent/background_review.py`
+#     (`aux.get("background_review")` -> `is_truthy_value(task.get("enabled"),
+#     default=True)`). The post-turn memory/skill review fork.
+#   curator.enabled                      default TRUE — `hermes_cli/config_defaults.py`
+#     ("curator": {"enabled": True, …}); `agent/curator.py` `is_enabled()`,
+#     "Default ON when no config says otherwise". The background skill pass.
+#
+# Hermes has NO heartbeat: its only `heartbeat` keys are transport-level
+# (`compute_host_heartbeat_secs`, `websocket_heartbeat_ack_max_age_seconds`),
+# so there is no third row to seed. Settings -> System draws the two switches
+# and reports the check-ins row `supported: false` (src/lib/background-jobs.ts).
+#
+# WHY HERE, AND NOT IN THE WEB SERVER. This was first written as a Node boot
+# hook calling `patchHermesConfig`, the comment-preserving writer the Settings
+# toggles use — and that is a SECOND, UNLOCKED writer of config.yaml on a boot
+# path where two already cooperate over `${HERMES_CONFIG}.lock`.
+# `production-server.js` spawns THIS script on every web-server boot (on every
+# edition; §1 above is what makes it a no-op on the OpenClaw SKU), and it holds
+# that lock from §3 to exit while doing a PyYAML read-modify-write plus two CLI
+# calls; `setup-hermes-dashboard-auth.sh` is a third, concurrent, locked writer.
+# `patchHermesConfig` cannot take the lock (it is a Python `filelock`, i.e. a
+# flock, and its own header says so), so a Node seed would win or lose the
+# rename by luck: either recording the keys as seeded and then having them
+# erased — never offered again, both jobs running, and its own read-back cannot
+# see a clobber that lands after it — or erasing `mcp_servers.clawbox`, the
+# protected-path `approvals.deny` table and `skills.disabled`, leaving the agent
+# with no device tools and no path guard. One writer per harness, inside the
+# lock it already holds, is the fix.
+#
+# WHY NOT `hermes config set`, which IS the native surface. §3 above already
+# gives the reason for this file, in this script: the CLI "rewrites the whole
+# config through Hermes' own save_config(), which is a much wider blast radius
+# for a boot-time provisioning step, and it is slow" — two more Python
+# interpreter starts inside a step that already time-boxes its only two CLI
+# calls. It also buys nothing back: `save_config()` re-serialises and drops the
+# comments just as `safe_dump` does. And it has a known failure mode here — the
+# CLI has been seen to exit 0 while storing a STRING, and `agent/curator.py`
+# reads `bool(cfg.get("enabled", True))`, so a stored `"false"` would leave the
+# curator ON with a config that looks right. The read-back below is what makes
+# either writer safe, and this one writes a real YAML boolean.
+#
+# WHAT THIS COSTS, measured rather than assumed: the live config.yaml on the
+# Hermes box carries 36 comment lines (of 275), including Hermes' own
+# "── Security ──" and "── Fallback Model ──" blocks, so the ONE boot that seeds
+# re-serialises them away. It is once per box — the record below means a seeded
+# box never writes again — and the previous revision is kept at
+# `config.yaml.bak`, the same recovery path `hermes-config-yaml.ts` uses for its
+# own writes. §3's "already current, skipping write" means an ALREADY-REGISTERED
+# box pays this on the upgrade boot alone rather than alongside a write it was
+# making anyway; a fresh box pays it with §3's first write.
+#
+# GATED ON THE EDITION, not on the active harness: on a dual box the owner can
+# switch to Hermes at any time without restarting the web server, so a seed that
+# asked which harness was active at boot would leave a switched-over box running
+# both jobs at the harness default until something restarted the server.
+#
+# THE RECORD, and the drift it accepts. `data/background-optouts.json` is
+# ClawBox's own file, shared with the OpenClaw half, and it is a marker for
+# state that lives in `~/.hermes` — the shape §4 above argues against, because a
+# marker and the thing it stands for can drift. Kept anyway, and the difference
+# from §4's case is that re-converging is not free here: `tools disable browser`
+# is idempotent, whereas re-writing an opt-out every boot would put `false` back
+# over a key the owner had unset by hand to mean "back to the default". The
+# accepted residual is the mirror of that: something that restores or reinstalls
+# `~/.hermes` without touching `data/` (a ClawKeep harness restore, a manual
+# reinstall) leaves the record saying "seeded" over a config that no longer
+# carries the keys, and both jobs run at the harness default until the owner
+# uses Settings or the box is factory reset — which empties `data/` and offers
+# the seed again.
+CLAWBOX_OPTOUT_STATE="$PROJECT_DIR/data/background-optouts.json" \
+CLAWBOX_HERMES_CONFIG="$HERMES_CONFIG" \
+python3 - <<'PY' || log "WARNING: the Hermes background-job opt-out seed did not complete; see the note above it for what was and was not written"
+import json, os, sys, tempfile
+
+try:
+    import yaml
+except ImportError:
+    # Defence in depth: §3 above already exits 1 on this, so it cannot be
+    # reached from there — but this block must not be the one that assumes it.
+    print("[register-mcp] NOTE: PyYAML is unavailable; the background-job opt-outs were not seeded",
+          file=sys.stderr)
+    raise SystemExit(0)
+
+# path -> the value ClawBox seeds when the owner has expressed no opinion.
+# Unlike OpenClaw's heartbeat row, BOTH of these are written explicitly in both
+# directions (`true` for on, `false` for off), so an absent value can only mean
+# "no opinion expressed" — there is no key here whose "on" looks like an absence.
+WANTED = [
+    (("auxiliary", "background_review", "enabled"), False),
+    (("curator", "enabled"), False),
+]
+
+state_path = os.environ["CLAWBOX_OPTOUT_STATE"]
+cfg_path = os.environ["CLAWBOX_HERMES_CONFIG"]
+
+
+def read_seeded(path):
+    """The keys this box has already been offered, or None if the record is unusable.
+
+    Absent is the normal first boot. Unusable — unreadable, undecodable, or
+    valid JSON that is not `{"seeded": [<string>, ...]}` — is a third fact, and
+    the difference matters on a DUAL box, where `gateway-pre-start.sh` keeps its
+    own three keys in this same file: rewriting an unusable record would replace
+    it with a valid one naming only these two, and the OpenClaw half would then
+    read a well-formed record that does not mention `heartbeat.every`, find the
+    key absent because the owner had switched check-ins back ON, and write `0m`
+    over his choice. So an unusable record still SEEDS (safe, see WANTED) and
+    records nothing, leaving the file for the half that can repair it safely.
+
+    Total, because the caller cannot tell a raised exception from a real
+    failure: `ValueError` covers JSONDecodeError AND UnicodeDecodeError (a
+    record written in another encoding), `RecursionError` a document nested past
+    the decoder's limit.
+    """
+    try:
+        with open(path, encoding="utf-8") as fh:
+            record = json.load(fh)
+    except FileNotFoundError:
+        return set()
+    except (OSError, ValueError, RecursionError):
+        return None
+    if not isinstance(record, dict):
+        return None
+    rows = record.get("seeded")
+    if not isinstance(rows, list) or not all(isinstance(row, str) for row in rows):
+        return None
+    return set(rows)
+
+
+record = read_seeded(state_path)
+unusable = record is None
+seeded = set() if unusable else record
+if unusable:
+    print("[register-mcp] WARN: the background-job opt-out record exists but cannot be read;"
+          " the Hermes opt-outs are still seeded where the key is absent, and nothing is recorded",
+          file=sys.stderr)
+
+pending = [(path, value) for path, value in WANTED if ".".join(path) not in seeded]
+# A seeded box pays one small file read and nothing else — no YAML load, no
+# write. This runs on every web-server boot.
+if not pending:
+    raise SystemExit(0)
+
+try:
+    with open(cfg_path, encoding="utf-8") as fh:
+        cfg = yaml.safe_load(fh)
+except FileNotFoundError:
+    cfg = {}
+except Exception as exc:  # noqa: BLE001 - any unreadable config defers, never settles
+    # Also defence in depth: §3 exits 1 on an unreadable or unparseable config,
+    # so the script never reaches here with one.
+    print("[register-mcp] NOTE: the Hermes config could not be read (%s); the background-job"
+          " opt-outs will be offered again at the next start" % type(exc).__name__, file=sys.stderr)
+    raise SystemExit(0)
+if cfg is None:
+    cfg = {}
+if not isinstance(cfg, dict):
+    print("[register-mcp] NOTE: the Hermes config is not a mapping; the background-job opt-outs"
+          " were not seeded", file=sys.stderr)
+    raise SystemExit(0)
+
+
+def resolve(path):
+    """'value' (the owner has said something), 'absent', or 'unusable'.
+
+    `None` is an ABSENCE, not an unusable shape. `curator:` written as a bare
+    header with nothing under it loads as `None`, and calling that unusable
+    would refuse the opt-out on every boot for ever over an empty section — the
+    write below replaces a null parent with a mapping exactly as it creates a
+    missing one. Only a parent holding something ELSE (a scalar, a list) is a
+    shape this seed will not reshape.
+    """
+    node = cfg
+    for part in path[:-1]:
+        if node is None:
+            return "absent"
+        if not isinstance(node, dict):
+            return "unusable"
+        if part not in node:
+            # Nothing below an absent parent exists either, and the parents are
+            # ours to create.
+            return "absent"
+        node = node[part]
+    if node is None:
+        return "absent"
+    if not isinstance(node, dict):
+        return "unusable"
+    return "value" if node.get(path[-1]) is not None else "absent"
+
+
+settled = []
+wrote = []
+for path, value in pending:
+    key = ".".join(path)
+    state = resolve(path)
+    if state == "unusable":
+        # A parent written as something other than a mapping. Not ours to
+        # reshape, and not settled either: "we could not look" is not "the owner
+        # has an opinion", and settling it would give up the opt-out for ever.
+        print("[register-mcp] NOTE: %s sits under a key this seed cannot read; it will be"
+              " offered again at the next start" % key, file=sys.stderr)
+        continue
+    # Settled whether it was written or was already the owner's: ClawBox has had
+    # its say about this key, and offering it again could only ever undo him.
+    settled.append(key)
+    if state == "value":
+        continue
+    node = cfg
+    for part in path[:-1]:
+        child = node.get(part)
+        if not isinstance(child, dict):
+            child = {}
+            node[part] = child
+        node = child
+    node[path[-1]] = value
+    wrote.append(key)
+
+if not settled:
+    raise SystemExit(0)
+
+if wrote:
+    directory = os.path.dirname(cfg_path) or "."
+    try:
+        os.makedirs(directory, exist_ok=True)
+        # The previous revision, at the stable name `hermes-config-yaml.ts` uses
+        # for its own writes — this is the one boot that re-serialises the
+        # customer's config, and the comments it drops are recoverable from here.
+        try:
+            with open(cfg_path, "rb") as fh:
+                previous = fh.read()
+        except OSError:
+            previous = None
+        if previous is not None:
+            bfd, btmp = tempfile.mkstemp(dir=directory, prefix=".config.bak.", suffix=".tmp")
+            try:
+                os.fchmod(bfd, 0o600)
+                with os.fdopen(bfd, "wb") as fh:
+                    fh.write(previous)
+                os.replace(btmp, cfg_path + ".bak")
+            except Exception:
+                try:
+                    os.unlink(btmp)
+                except OSError:
+                    pass
+                raise
+        fd, tmp = tempfile.mkstemp(dir=directory, prefix=".config.", suffix=".tmp")
+        try:
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "w") as fh:
+                yaml.safe_dump(cfg, fh, default_flow_style=False, sort_keys=False, allow_unicode=True)
+            os.replace(tmp, cfg_path)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+    except Exception as exc:  # noqa: BLE001
+        # NOT a bare raise: a top-level `python3` under `set -euo pipefail` puts
+        # the whole traceback in the clawbox-setup journal, which is what
+        # TASK-657 took out of §3. Nothing was recorded, so the next boot offers
+        # the seed again.
+        print("[register-mcp] WARN: could not write the Hermes background-job opt-outs (%s);"
+              " the box may spend tokens on background jobs until Settings is used"
+              % type(exc).__name__, file=sys.stderr)
+        raise SystemExit(0)
+    # READ BACK OFF THE FILE, not off `cfg`. A dump that lost a key, a rename
+    # that landed somewhere else, a config a concurrent writer replaced inside
+    # this critical section — all of them leave `cfg` saying the right thing and
+    # the box saying the old one, and recording that as seeded would mean the
+    # keys are never offered again. This block sits AFTER §4 for the same
+    # reason: `hermes tools disable browser` does the CLI's own load ->
+    # save_config on this file, so a read-back above it would not be the last
+    # word on what the boot leaves behind.
+    try:
+        with open(cfg_path, encoding="utf-8") as fh:
+            back = yaml.safe_load(fh) or {}
+    except Exception:  # noqa: BLE001
+        back = None
+    for key in wrote:
+        node = back
+        for part in key.split("."):
+            node = node.get(part) if isinstance(node, dict) else None
+        if node is not False:
+            print("[register-mcp] WARN: %s did not read back as off after the write; nothing was"
+                  " recorded, so the opt-outs are offered again at the next start" % key,
+                  file=sys.stderr)
+            raise SystemExit(0)
+    print("[register-mcp] seeded the Hermes background-job opt-outs (%s) — Settings can switch"
+          " them back on" % ", ".join(wrote))
+
+# RECORDED ONLY AFTER THE WRITE LANDED, and merged rather than replaced: on a
+# dual box `gateway-pre-start.sh` keeps its own three keys in this file, and a
+# wholesale rewrite would drop them and offer that half's seed all over again.
+# Merging is SEQUENTIAL safety only — neither half locks this file, and on a
+# dual box the gateway's ExecStartPre can run beside this script — so the record
+# is re-read here rather than reused from the top, which is as narrow as the
+# window gets. The verdict is re-derived from that second read too: a record
+# that went bad in between must not be laundered into a valid one naming only
+# these two keys, which is the `heartbeat.every` revert `read_seeded` refuses.
+if unusable:
+    raise SystemExit(0)
+again = read_seeded(state_path)
+if again is None:
+    print("[register-mcp] WARN: the background-job opt-out record became unreadable while the"
+          " opt-outs were being written; nothing was recorded", file=sys.stderr)
+    raise SystemExit(0)
+keep = set(again)
+keep.update(settled)
+
+directory = os.path.dirname(state_path) or "."
+try:
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=".background-optouts.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            json.dump({"seeded": sorted(keep)}, fh, indent=2)
+            fh.write("\n")
+        os.replace(tmp, state_path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+except Exception as exc:  # noqa: BLE001
+    # The config IS seeded and verified at this point — only the record is
+    # missing, so the next boot writes the same values over themselves and
+    # records them then. Said precisely, because "the box may spend tokens" is
+    # false on this arm.
+    print("[register-mcp] NOTE: the Hermes background-job opt-outs are in place, but the record"
+          " of them could not be written (%s); the next start will write them again"
+          % type(exc).__name__, file=sys.stderr)
+PY
+
 # ── 5. Prove the EMAIL: hook plugin actually LOADS, every boot. ─────────────
 # `hermes plugins list` would say "enabled" for a plugin that raises on import,
 # has no `register()`, or registers a mistyped hook name: its status is read

--- a/src/lib/background-jobs.ts
+++ b/src/lib/background-jobs.ts
@@ -11,8 +11,11 @@ import { readConfigStrict, restartGateway, runOpenclawConfigSet, runOpenclawConf
 // the journal logged "[heartbeat] started" twice in an evening, and the alerts
 // go to `commands.ownerAllowFrom` — one Telegram user. None of it was asked
 // for, all of it spends the owner's subscription or his ClawBox AI credits, and
-// ClawBox wrote none of the keys. `scripts/gateway-pre-start.sh` seeds the
-// opt-outs once; this module is how the owner changes his mind.
+// ClawBox wrote none of the keys. The opt-outs are seeded once per box by the
+// boot script that owns each harness's config — `scripts/gateway-pre-start.sh`
+// on OpenClaw, `scripts/register-mcp.sh` on Hermes, where the same shared
+// config lock is already held — and this module is how the owner changes his
+// mind afterwards.
 //
 // HARNESS FIRST — every one of these is the harness's own documented key, read
 // and written through the harness's own writer. Nothing here invents a store.

--- a/src/tests/unit/hermes-config-lock.test.ts
+++ b/src/tests/unit/hermes-config-lock.test.ts
@@ -67,14 +67,25 @@ describe("both writers share ONE lock file", () => {
     // matching. Each time the -1 guard below is what caught it, which is the
     // argument for keeping the marker as loose as the ordering claim needs.
     const cliCall = REGISTER_SRC.search(/^.*"\$HERMES_BIN" tools disable browser/m);
+    // The THIRD write: the TASK-609 background-job opt-out seed, which does its
+    // own PyYAML load->safe_dump of the same file. It was first written as a
+    // Node boot hook calling `patchHermesConfig`, which cannot take this lock —
+    // moving it in here is the whole point, and nothing else in CI says it has
+    // to stay. Marked on the env line that carries the record path, at column 0.
+    const optoutSeed = REGISTER_SRC.search(/^CLAWBOX_OPTOUT_STATE=/m);
     // Every marker must have been FOUND before their order means anything: a
     // `search` miss returns -1, and -1 < anything, so an ordering assertion over
     // a moved marker passes while checking nothing.
     expect(call, "register-mcp.sh: no top-level acquire_config_lock call").toBeGreaterThan(-1);
     expect(reconcile, "register-mcp.sh: no PyYAML reconcile block").toBeGreaterThan(-1);
     expect(cliCall, "register-mcp.sh: no `hermes tools disable browser` call").toBeGreaterThan(-1);
+    expect(optoutSeed, "register-mcp.sh: no background-job opt-out seed").toBeGreaterThan(-1);
     expect(call).toBeLessThan(reconcile);
     expect(call).toBeLessThan(cliCall);
+    expect(call).toBeLessThan(optoutSeed);
+    // And AFTER the CLI call, because that one re-saves the whole config: a
+    // read-back above it would not be the last word on what the boot leaves.
+    expect(cliCall).toBeLessThan(optoutSeed);
 
     expect(AUTH_SRC).toContain("flock -w 120 9");
     expect(REGISTER_SRC).toContain("flock -w 120 9");

--- a/src/tests/unit/register-mcp-background-optouts.test.ts
+++ b/src/tests/unit/register-mcp-background-optouts.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { execFileSync, spawnSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+import { testEnv } from "@/tests/helpers/env";
+
+// Starts a real process (bash / python3): vitest's 5 s test and 10 s hook
+// defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+// TASK-609's Hermes half. The OpenClaw half seeds its three opt-outs from
+// `gateway-pre-start.sh`, the ExecStartPre of `clawbox-gateway.service` — a
+// unit the Hermes SKU MASKS, so on that edition the seed never ran at all.
+// Measured on the Hermes box right after the OpenClaw half shipped:
+// `data/background-optouts.json` absent, and `~/.hermes/config.yaml` carrying
+// neither `auxiliary.background_review.enabled` nor `curator.enabled` — both at
+// the harness default of `true`, with Settings drawing switches for two jobs
+// that were still running.
+//
+// `register-mcp.sh` is the repo's own Hermes counterpart of that pre-start
+// (`production-server.js` fire-and-forgets it on every web-server boot on
+// hermes|dual) and it already holds `${HERMES_CONFIG}.lock` while it
+// read-modify-writes the same file, which is why the seed belongs here rather
+// than in a second, unlocked writer.
+//
+// The whole real script is run, with stubs, exactly as
+// `register-mcp-hermes.test.ts` runs it — the section under test writes the
+// customer's config, so a copy of its logic would prove nothing about the
+// shipped one.
+//
+// The three failure shapes pinned:
+//   probe-once    — the seed is offered every boot until it is RECORDED, so a
+//                   box whose write failed is not written off for ever.
+//   false success — nothing is recorded until the keys read back off the file;
+//                   a failed or unverifiable write is offered again.
+//   false failure — a switch the owner turned back on must survive every later
+//                   boot, and the OpenClaw half's rows in the shared record
+//                   must survive this half writing to it.
+
+const REPO = path.resolve(__dirname, "../../..");
+const SCRIPT = path.join(REPO, "scripts", "register-mcp.sh");
+
+const REVIEW_KEY = "auxiliary.background_review.enabled";
+const CURATOR_KEY = "curator.enabled";
+
+function have(bin: string, args: string[]): boolean {
+  return spawnSync(bin, args, { stdio: "ignore" }).status === 0;
+}
+
+const CAN_RUN =
+  process.platform !== "win32"
+  && have("bash", ["-c", "true"])
+  && have("python3", ["-c", "import yaml"]);
+
+const d = CAN_RUN ? describe : describe.skip;
+
+/**
+ * Root writes into a 0500 directory, so the one case that turns on a refused
+ * write would pass there by taking the happy path and prove nothing. CI is
+ * non-root; a `sudo npm test` on a box is not. Same guard, same reason, as
+ * `register-mcp-hermes.test.ts`.
+ */
+const isRoot = typeof process.getuid === "function" && process.getuid() === 0;
+
+let home: string;
+let root: string;
+let configPath: string;
+let statePath: string;
+let lockPath: string;
+
+function run(env: Record<string, string> = {}): { status: number; stdout: string; stderr: string } {
+  const r = spawnSync("bash", [SCRIPT], {
+    encoding: "utf-8",
+    env: testEnv({
+      PATH: process.env.PATH ?? "",
+      HOME: home,
+      CLAWBOX_ROOT: root,
+      HERMES_CONFIG: configPath,
+      HERMES_BIN: path.join(home, "fake-hermes"),
+      BUN_BIN: path.join(home, "fake-bun"),
+      CLAWBOX_EDITION_FILE: lockPath,
+      ...env,
+    }),
+  });
+  return { status: r.status ?? -1, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+/** Read the YAML back as JSON so the assertions are about values, not formatting. */
+function readConfig(): Record<string, unknown> {
+  const out = execFileSync(
+    "python3",
+    ["-c", "import json,sys,yaml; print(json.dumps(yaml.safe_load(open(sys.argv[1])) or {}))", configPath],
+    { encoding: "utf-8" },
+  );
+  return JSON.parse(out);
+}
+
+function at(dotted: string): unknown {
+  let node: unknown = readConfig();
+  for (const part of dotted.split(".")) {
+    if (!node || typeof node !== "object") return undefined;
+    node = (node as Record<string, unknown>)[part];
+  }
+  return node;
+}
+
+function record(): unknown {
+  return JSON.parse(fs.readFileSync(statePath, "utf-8"));
+}
+
+function seededRows(): string[] {
+  return ((record() as { seeded: string[] }).seeded ?? []).slice().sort();
+}
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-optout-home-"));
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-optout-root-"));
+  configPath = path.join(home, ".hermes", "config.yaml");
+  statePath = path.join(root, "data", "background-optouts.json");
+  lockPath = path.join(home, "edition.env");
+
+  fs.mkdirSync(path.join(root, "mcp"), { recursive: true });
+  fs.writeFileSync(path.join(root, "mcp", "clawbox-mcp.ts"), "// stand-in\n");
+  for (const bin of ["fake-hermes", "fake-bun"]) {
+    const p = path.join(home, bin);
+    fs.writeFileSync(p, "#!/bin/sh\nexit 0\n");
+    fs.chmodSync(p, 0o755);
+  }
+  fs.mkdirSync(path.join(home, ".hermes"), { recursive: true });
+  fs.writeFileSync(configPath, "model:\n  default: deepseek-v4-pro\n");
+  fs.writeFileSync(lockPath, "CLAWBOX_EDITION=hermes\n");
+});
+
+afterEach(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+d("register-mcp.sh — the Hermes background-job opt-outs", () => {
+  it("switches both off on a box that has never expressed an opinion", () => {
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(at(REVIEW_KEY)).toBe(false);
+    expect(at(CURATOR_KEY)).toBe(false);
+    expect(r.stdout).toContain("seeded the Hermes background-job opt-outs");
+    expect(seededRows()).toEqual([REVIEW_KEY, CURATOR_KEY].sort());
+  });
+
+  it("keeps the rest of the config", () => {
+    fs.writeFileSync(
+      configPath,
+      "model:\n  default: deepseek-v4-pro\n"
+      + "auxiliary:\n  background_review:\n    model: keep-me\n"
+      + "curator:\n  interval_hours: 168\n",
+    );
+    run();
+    expect(at("model.default")).toBe("deepseek-v4-pro");
+    expect(at("auxiliary.background_review.model")).toBe("keep-me");
+    expect(at("curator.interval_hours")).toBe(168);
+    expect(at(REVIEW_KEY)).toBe(false);
+    expect(at(CURATOR_KEY)).toBe(false);
+  });
+
+  it("leaves a value the owner set alone, and records it as settled", () => {
+    fs.writeFileSync(
+      configPath,
+      "model:\n  default: deepseek-v4-pro\ncurator:\n  enabled: true\n",
+    );
+    const r = run();
+    expect(at(CURATOR_KEY)).toBe(true);
+    expect(at(REVIEW_KEY)).toBe(false);
+    expect(r.stdout).toContain(`opt-outs (${REVIEW_KEY})`);
+    // Settled without being written: ClawBox has had its say about it, so it is
+    // never offered again even if he later unsets it by hand.
+    expect(seededRows()).toEqual([REVIEW_KEY, CURATOR_KEY].sort());
+  });
+
+  it("does not undo a switch the owner turned back on", () => {
+    // THE case this exists for. He switched memory review on in Settings, which
+    // writes `true` explicitly; the next boot must not put `false` back.
+    run();
+    fs.writeFileSync(
+      configPath,
+      "model:\n  default: deepseek-v4-pro\n"
+      + "auxiliary:\n  background_review:\n    enabled: true\ncurator:\n  enabled: false\n",
+    );
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(at(REVIEW_KEY)).toBe(true);
+    expect(seededRows()).toEqual([REVIEW_KEY, CURATOR_KEY].sort());
+  });
+
+  it("costs no config write at all on a box that is already seeded", () => {
+    run();
+    const before = fs.readFileSync(configPath, "utf-8");
+    const stat = fs.statSync(configPath);
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(fs.readFileSync(configPath, "utf-8")).toBe(before);
+    expect(fs.statSync(configPath).mtimeMs).toBe(stat.mtimeMs);
+    expect(r.stdout).not.toContain("seeded the Hermes background-job opt-outs");
+  });
+
+  it("does nothing at all on an OpenClaw-only device", () => {
+    fs.writeFileSync(lockPath, "CLAWBOX_EDITION=openclaw\n");
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(at(REVIEW_KEY)).toBeUndefined();
+    expect(fs.existsSync(statePath)).toBe(false);
+  });
+
+  it("seeds on a dual box too, whichever harness is active", () => {
+    // The web server is not restarted when the owner switches harness, so a
+    // seed that asked which one was active at boot would leave a box switched
+    // to Hermes running both jobs at the harness default.
+    fs.writeFileSync(lockPath, "CLAWBOX_EDITION=dual\n");
+    run();
+    expect(at(REVIEW_KEY)).toBe(false);
+    expect(at(CURATOR_KEY)).toBe(false);
+  });
+});
+
+d("register-mcp.sh — the opt-out record", () => {
+  it("keeps the OpenClaw half's rows when it writes its own", () => {
+    // A dual box: `gateway-pre-start.sh` seeded the three OpenClaw keys first,
+    // and dropping them here would offer that half's seed all over again —
+    // which for `heartbeat.every` is a REVERT, because an absent value there is
+    // also what the owner's "check-ins on" looks like.
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    fs.writeFileSync(statePath, JSON.stringify({ seeded: ["agents.defaults.heartbeat.every"] }));
+    run();
+    expect(seededRows()).toEqual([REVIEW_KEY, CURATOR_KEY, "agents.defaults.heartbeat.every"].sort());
+  });
+
+  it.each([
+    ["not JSON at all", "{{{"],
+    ["not an object", "[1, 2]"],
+    ["a seeded field that is not a list", JSON.stringify({ seeded: 5 })],
+    ["rows that are not strings", JSON.stringify({ seeded: [1, 2] })],
+  ])("still seeds on an unusable record, and does not launder it: %s", (_label, body) => {
+    // Seeding is safe — both keys are written explicitly in both directions, so
+    // an absent value can only mean "no opinion". REPLACING the record is not:
+    // a valid record naming only these two would make the OpenClaw half read
+    // `heartbeat.every` as never seeded and write `0m` over the owner's "on".
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    fs.writeFileSync(statePath, body);
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(at(REVIEW_KEY)).toBe(false);
+    expect(at(CURATOR_KEY)).toBe(false);
+    expect(r.stderr).toContain("cannot be read");
+    expect(fs.readFileSync(statePath, "utf-8")).toBe(body);
+  });
+
+  (isRoot ? it.skip : it)("records nothing when the config write itself fails", () => {
+    // THE false-success guard: a write that did not land must never be recorded
+    // as seeded, or the keys are never offered again and both jobs run for ever.
+    // The registration step above makes its write on the first run, so on the
+    // second it says "already current, skipping write" and this seed is the
+    // only thing left that touches the file — which is what lets a read-only
+    // ~/.hermes reach the seed's own write rather than an earlier one.
+    run();
+    fs.rmSync(statePath);
+    const registered = fs.readFileSync(configPath, "utf-8")
+      .replace(/^curator:\n  enabled: false\n/m, "")
+      .replace(/^ {4}enabled: false\n/m, "");
+    fs.writeFileSync(configPath, registered);
+    fs.chmodSync(path.join(home, ".hermes"), 0o500);
+    try {
+      const r = run();
+      expect(r.stderr + r.stdout).toContain("could not write the Hermes background-job opt-outs");
+      expect(r.stderr + r.stdout).not.toContain("Traceback");
+      expect(fs.existsSync(statePath)).toBe(false);
+    } finally {
+      fs.chmodSync(path.join(home, ".hermes"), 0o700);
+    }
+  });
+
+  it("is never reached, and so records nothing, when the config will not parse", () => {
+    // Named for what it actually pins: a config PyYAML cannot load stops the
+    // script at the registration step ABOVE this seed, so the seed never runs.
+    // That is the right outcome either way — an unreadable config settles
+    // nothing and is offered again — but the guard doing the work is the
+    // earlier step's, not this block's, and the block's own arms for the same
+    // shape are defence in depth. The status is deliberately not asserted.
+    fs.writeFileSync(configPath, "model:\n  default: x\n  : : :\n");
+    const r = run();
+    expect(r.stdout).not.toContain("seeded the Hermes background-job opt-outs");
+    expect(fs.existsSync(statePath)).toBe(false);
+  });
+
+  it("settles neither key when their parents are not mappings", () => {
+    fs.writeFileSync(configPath, "auxiliary: a-string\ncurator: 5\n");
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(at("auxiliary")).toBe("a-string");
+    expect(at("curator")).toBe(5);
+    expect(fs.existsSync(statePath)).toBe(false);
+  });
+
+  it.each([
+    ["one empty section", "model:\n  default: x\ncurator:\n"],
+    ["both empty", "model:\n  default: x\nauxiliary:\ncurator:\n"],
+    ["an empty parent one level down", "model:\n  default: x\nauxiliary:\n  background_review:\ncurator:\n"],
+  ])("treats an empty section as an absence, not as a shape it cannot read: %s", (_label, body) => {
+    // `curator:` with nothing under it loads as `null`. Reading that as "a
+    // parent I must not reshape" would refuse the opt-out on EVERY boot for
+    // ever — a job left running at the harness default with nothing but a
+    // stderr note per boot, which is the outcome this task exists to remove.
+    fs.writeFileSync(configPath, body);
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(at(REVIEW_KEY)).toBe(false);
+    expect(at(CURATOR_KEY)).toBe(false);
+    expect(r.stderr).not.toContain("cannot read");
+    expect(seededRows()).toEqual([REVIEW_KEY, CURATOR_KEY].sort());
+  });
+
+  it("keeps the revision it is about to re-serialise at config.yaml.bak", () => {
+    // The case the .bak is FOR: a box already registered, so the step above
+    // says "already current, skipping write" and this seed is the only thing
+    // that rewrites the config on that boot — taking Hermes' own comment blocks
+    // with it. The revision that had them stays at the name
+    // `hermes-config-yaml.ts` uses for its own writes.
+    run();
+    fs.rmSync(statePath);
+    const withComments = `# ── Security ──\n${fs.readFileSync(configPath, "utf-8")
+      .replace(/^curator:\n  enabled: false\n/m, "")
+      .replace(/^ {4}enabled: false\n/m, "")}`;
+    fs.writeFileSync(configPath, withComments);
+
+    const r = run();
+    expect(r.stdout).not.toContain("registered the ClawBox MCP server");
+    expect(fs.readFileSync(`${configPath}.bak`, "utf-8")).toBe(withComments);
+    expect(fs.statSync(`${configPath}.bak`).mode & 0o777).toBe(0o600);
+    // …and the comment really is gone from the live file, which is why the
+    // backup exists rather than a comment saying it does not matter.
+    expect(fs.readFileSync(configPath, "utf-8")).not.toContain("── Security ──");
+    expect(at(CURATOR_KEY)).toBe(false);
+  });
+});


### PR DESCRIPTION
Follow-up to #707 (TASK-609 / owner decision D-05, merged into `beta` at `c9610f40`). Same finding, residual half.

**Customer-visible symptom.** On a Hermes box the two background jobs #707 was meant to switch off were still running, and Settings drew switches saying so. Measured read-only on the Hermes box right after `c9610f40` was deployed: `data/background-optouts.json` did not exist, and `~/.hermes/config.yaml` carried neither `auxiliary.background_review.enabled` nor `curator.enabled` — both at the harness default of `true`. Nothing had ever been seeded on that edition, so the box kept spending tokens on post-turn review forks and curator passes nobody asked for.

**Cause.** #707's seed lives in `scripts/gateway-pre-start.sh` (~:2520-2710), the `ExecStartPre` of `clawbox-gateway.service`. On the Hermes edition that unit is **masked** — the harness there is `hermes-gateway.service`, which has no pre-start of its own — so the script never runs and neither the keys nor the record were ever written. `src/lib/background-jobs.ts` was the only other reference: it reads and writes those keys on demand for the Settings panel, and was never wired to seed at boot.

## Harness first

Nothing new is invented. Both switches are Hermes' own documented keys, read off the installed 0.20.5 package on the box (read-only):

| Row | Hermes key | Default | Where |
|---|---|---|---|
| Background memory review | `auxiliary.background_review.enabled` | `true` | `agent/background_review.py:220,237-240` — `aux.get("background_review")` → `is_truthy_value(task.get("enabled"), default=True)` |
| Learning new skills by itself | `curator.enabled` (top-level) | `true` | `hermes_cli/config_defaults.py:2116` `"curator": {"enabled": True, …}`; `agent/curator.py:148,150-153` `is_enabled()` — "Default ON when no config says otherwise" |

Hermes has **no heartbeat**: its only `heartbeat` keys are `compute_host_heartbeat_secs` and `websocket_heartbeat_ack_max_age_seconds`, both transport-level. There is no third row to seed, which is why the panel reports that row `supported: false`.

**And the native boot path.** There is no Hermes-side `ExecStartPre` to hang this on. But the repo already has the answer, and already documents it — `production-server.js:274-292`:

> On OpenClaw that registration is written by scripts/gateway-pre-start.sh, an ExecStartPre of clawbox-gateway.service. On the Hermes SKU that unit is masked… **scripts/register-mcp.sh is the Hermes counterpart, and this is where it runs**: clawbox-setup.service is the one unit active on every edition, and both a deploy and an in-app update finish by restarting it.

That is the same script that renders the TASK-605 `approvals.deny` table, reconciles `mcp_servers.clawbox` and `skills.disabled`, and re-arms `image_gen.provider` — a PyYAML read-modify-write of exactly this class of key, on every web-server boot on `hermes|dual`. The seed is one more step in it.

### Why not the Node writer, which keeps comments

The first version of this fix was a Next `register()` boot hook calling `patchHermesConfig` — the comment-preserving writer the Settings toggles use. Review caught it, and it was wrong: it is a **second, unlocked writer** of `config.yaml` on a boot path where two writers already cooperate over an `flock` on `${HERMES_CONFIG}.lock` (`scripts/register-mcp.sh:97,302`, `scripts/setup-hermes-dashboard-auth.sh:72,354`). `register-mcp.sh` takes that lock and holds it to exit while it loads, mutates and `os.replace`s the file — with two 45 s-bounded CLI calls inside the section — and `patchHermesConfig` cannot join that protocol (it is a Python `filelock`; the module header says so). So the rename order was luck:

- the seed writes both keys, reads them back, records them as seeded — and `register-mcp.sh` then `os.replace`s its older snapshot, erasing both. The record says settled for ever, both jobs run, and the read-back structurally cannot see a clobber that lands after it. That is the exact false success the PR exists to prevent;
- or the seed's rename lands last and `mcp_servers.clawbox`, the protected-path `approvals.deny` table and `skills.disabled` are erased — the agent has no device tools and no path guard until the next boot.

One writer per harness, inside the lock it already holds, is the fix.

### Why not `hermes config set`, which is the native surface

Named, and declined, with the reason this script already gives for the same file: §3 above writes `mcp_servers.clawbox` with PyYAML rather than `hermes mcp add` because the CLI *"rewrites the whole config through Hermes' own `save_config()`, which is a much wider blast radius for a boot-time provisioning step, and it is slow"*. Two more Python interpreter starts in a step that already time-boxes its only two CLI calls, and it buys nothing back: `save_config()` re-serialises and drops the comments exactly as `safe_dump` does. It also has a known failure mode here — the CLI has been seen to exit 0 while storing a **string**, and `agent/curator.py:154-157` reads `bool(cfg.get("enabled", True))`, so a stored `"false"` would leave the curator ON over a config that looks right. The read-back below is what makes either writer safe; this one writes a real YAML boolean.

**The measured cost:** this writes through `yaml.safe_dump` like the rest of that script, so the seeding boot re-serialises the document and drops Hermes' own `── Security ──` / `── Fallback Model ──` comment blocks. Measured on the Hermes box: its live `config.yaml` carries **36 comment lines of 275**, so that loss is real and not hypothetical. It is paid **once per box** — the record means a seeded box never writes again, and "already current, skipping write" is what that box's journal shows on every later boot — and the revision it replaces is kept at **`config.yaml.bak`**, the same recovery path `hermes-config-yaml.ts` uses for its own writes. On a fresh box it rides along with §3's own first write; on an already-registered box (the installed base this fix targets) it is a standalone rewrite, which is exactly why the backup is there.

## The change

- `scripts/register-mcp.sh` — new section **4b**, inside the existing `acquire_config_lock` critical section and **after** the `hermes tools disable browser` call, which does the CLI's own `load -> save_config` on the same file — so the seed's read-back is the last word on what the boot leaves behind.
- `src/lib/background-jobs.ts` — a five-line header comment naming both seed scripts. No behaviour change.
- `src/tests/unit/hermes-config-lock.test.ts` — the new writer is added to the ordering assertion that pins every writer of `config.yaml` inside the lock, so nothing can quietly move it back out.

Same first-boot-only semantics as the OpenClaw half, sharing its record file:

- **first boot only, and the RECORD says so** — not the key's absence. Gating on absence alone would re-seed `false` over a key the owner had unset by hand;
- **gated on the EDITION** (`hermes|dual`), not on the active harness: `/setup-api/harness/select` does not restart the web server, so a seed that asked which harness was active at boot would leave a dual box switched to Hermes running both jobs at the harness default until something restarted the server;
- **a key whose parent holds a scalar is deferred, not settled** — while an **empty section** (`curator:` with nothing under it, which loads as `null`) counts as an absence and is seeded, because refusing it would leave that job at the harness default on every boot for ever — "we could not look" is not "the owner has an opinion", and the parent is not ours to reshape;
- **nothing is recorded until the keys read back off the file** — not off the in-memory document. A dump that lost a key, or a config a concurrent writer replaced inside the critical section, leaves the object right and the box wrong;
- **the record is merged, never replaced**, and an **unusable** record still seeds but records nothing. That last one is the one place this deliberately differs from the OpenClaw half, and the reason is the shared file: rewriting an unusable record would replace it with a well-formed one naming only these two keys, and `gateway-pre-start.sh` would then read a valid record that does not mention `agents.defaults.heartbeat.every`, find the key absent *because the owner had switched check-ins back on*, and write `0m` over his choice. Seeding is safe (both Hermes keys are written explicitly in both directions, so an absent value can only mean "no opinion"); laundering the record is not.

## RED → GREEN

RED — the new suite plus the lock-ordering guard, against unmodified `origin/beta`'s `scripts/register-mcp.sh`:

```
 ❯ src/tests/unit/register-mcp-background-optouts.test.ts (19 tests | 15 failed)
     × switches both off on a box that has never expressed an opinion
     × keeps the rest of the config
     × leaves a value the owner set alone, and records it as settled
     × does not undo a switch the owner turned back on
     × seeds on a dual box too, whichever harness is active
     × keeps the OpenClaw half's rows when it writes its own
     × still seeds on an unusable record, and does not launder it: not JSON at all
     × still seeds on an unusable record, and does not launder it: not an object
     × still seeds on an unusable record, and does not launder it: a seeded field that is not a list
     × still seeds on an unusable record, and does not launder it: rows that are not strings
     × records nothing when the config write itself fails
     × treats an empty section as an absence, not as a shape it cannot read: one empty section
     × treats an empty section as an absence, not as a shape it cannot read: both empty
     × treats an empty section as an absence, not as a shape it cannot read: an empty parent one level down
     × keeps the revision it is about to re-serialise at config.yaml.bak
 ❯ src/tests/unit/hermes-config-lock.test.ts (6 tests | 1 failed)
     × both take the lock before they touch config.yaml

AssertionError: expected undefined to be false
      expect(at(REVIEW_KEY)).toBe(false)
```

The four cases that pass on beta are the guards, not the carriers — a script that writes nothing at all satisfies "does nothing on an OpenClaw-only device", "costs no config write on a box that is already seeded", "settles neither key when their parents are not mappings", and "is never reached when the config will not parse" (that last one is the step above aborting, and the test is named for it).

Two of the guards were checked by mutation rather than by argument. Reverting only the two `node is None` lines in `resolve()` turns exactly the three empty-section cases red and leaves the other sixteen green; the lock-ordering case fails the moment the seed is not between `acquire_config_lock` and the end of the script.

GREEN — the new suite plus every neighbour that reads either script, and the three named guards:

```
 Test Files  13 passed (13)
      Tests  282 passed (282)
```

(`register-mcp-background-optouts`, `register-mcp-hermes`, `register-mcp-email-hook`, `hermes-config-lock`, `hermes-dashboard-auth-yaml`, `hermes-image-plugin`, `protected-paths`, `gateway-pre-start-background-optouts`, `routes/background-jobs`, `components/background-jobs-panel`, `openclaw-config-mock-completeness`, `test-timeout-hygiene`, `state-updater-purity`.)

`npx tsc --noEmit` clean, `eslint` clean, `bash -n scripts/register-mcp.sh` clean.

## Device proof, read-only

On the Hermes box, nothing mutated. The unit that runs the new seed path, and evidence that it really runs there:

```
clawbox-setup.service   UnitFileState=enabled  ActiveState=active  SubState=running
clawbox-gateway.service LoadState=masked  UnitFileState=masked  ActiveState=inactive
/etc/clawbox/edition.env: CLAWBOX_EDITION=hermes

journalctl -u clawbox-setup.service | grep '\[register-mcp\]'   (four consecutive boots)
  [register-mcp] added 105 approvals.deny rules — the ClawBox tree and the local-model folders …
  [register-mcp] registered the ClawBox MCP server with Hermes
  [register-mcp] Hermes MCP registration already current, skipping write
  [register-mcp] built-in browser toolset off; browsing goes through the ClawBox browser_* tools
  [register-mcp] clawbox_email_directives loaded and registered its outbound hook

-rw-r--r-- clawbox clawbox    0  /home/clawbox/.hermes/config.yaml.lock
-rw------- clawbox clawbox 9031  /home/clawbox/.hermes/config.yaml
```

So the script the seed is added to runs on that box at every web-server boot, the lock the new section sits inside is real and taken there, the edition gate reads `hermes`, and the OpenClaw seed path is masked — which is the cause. "already current, skipping write" on the later boots is the same short-circuit the seed's record gives it.

Current state on that box, unchanged by this PR: no `data/background-optouts.json`, and neither Hermes key set.

**The seed itself was deliberately NOT run on the owner's box** — it writes the harness's config, a mutation of a device he is using. What is proved on hardware is the boot path and the cause, not the write.

**Owner's click after the next update:** Settings → Background jobs on the Hermes box shows both jobs OFF.

## Siblings

- `scripts/gateway-pre-start.sh` — untouched, and reads the same record. Its `read_seeded` and `STATEPY` both ignore keys they do not own and merge rather than overwrite, so the two halves cannot erase each other's rows; a dual box is covered by a test here ("keeps the OpenClaw half's rows when it writes its own").
- `production-server.js` — already the launcher; nothing to change.
- `src/app/setup-api/background-jobs/route.ts` and `BackgroundJobsPanel` — unchanged: they read the same two keys through the same module, so a seeded box reads back `false` and the switches show OFF.
- `setup-hermes-edition.sh` / `install.sh` — they run `register-mcp.sh` at install time too, so a freshly flashed Hermes box is seeded on its first provisioning rather than one boot later.
- `readHermesJobs` in `src/lib/background-jobs.ts` collapses "could not read" into "both jobs on, not degraded" (it calls `readHermesConfigValue`, which returns `null` for an unreadable file). That is a **separate** residual of #707, in the panel's read rather than in the seed; it is deliberately out of scope here and recorded in the run's queue file. This PR neither depends on it nor makes it worse.

## Unproven

The seed has not been executed on hardware: running it would write the owner's Hermes config. What was proved on the box is the boot path (the unit, its enablement, the `[register-mcp]` journal lines across four boots, the lock file, the edition gate) and the cause (the masked OpenClaw unit, the absent record, the unset keys). The behaviour itself is covered by 19 cases that run the real shipped script.

Two review findings are deliberately **not** taken here and are recorded as residuals rather than fixed silently:

- **the record's drift.** `data/background-optouts.json` is a marker for state that lives in `~/.hermes`, the shape §4 of this same script argues against. It is kept because re-converging is not free for an opt-out — writing `false` back on every boot would undo a key the owner had unset by hand to mean "back to the default", where §4's `tools disable browser` is idempotent. The accepted residual, stated in the code: something that restores or reinstalls `~/.hermes` without touching `data/` leaves the record saying "seeded" over a config that no longer carries the keys, until the owner uses Settings or the box is factory reset. Worth an owner ruling; not worth guessing at inside this PR.
- **the read-back's own arm is not directly covered.** "A write that did not land must not be recorded" is pinned by the new failed-write case; the narrower arm — the write succeeded and the file still disagrees — cannot be driven without a second process racing inside the lock, and is defence in depth against a concurrent writer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Hermes setup now automatically disables selected background jobs on new installations.
  - Existing owner settings and unrelated configuration values are preserved.
  - Opt-out settings are applied once per device and tracked across subsequent boots.

- **Bug Fixes**
  - Configuration updates are written safely with backups and verification.
  - Failed or invalid configuration updates no longer interrupt setup and can be retried later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->