### PR TITLE
fix: stop the background-job seed block taking the gateway down, and its WARN promising a write that has not happened

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -2289,6 +2289,13 @@ fi
 # refused it, and the WARN below steered the owner at a namespace that no
 # longer exists.
 if [ "$CLAWBOX_OPENCLAW_V2" != "1" ]; then
+# TOTAL, like the reader in the background-job block below and the two
+# assignments above: this is a BLOCKING ExecStartPre under `set -euo
+# pipefail`, so an unhandled shape here is not a bad answer, it is NO
+# GATEWAY. The `except` list catches what was foreseen — and a config whose
+# bytes are not UTF-8 raises `UnicodeDecodeError`, a `ValueError` that is NOT
+# a `json.JSONDecodeError`, so it escapes. The fallback is this site's own
+# documented default, the one its except-branch already prints.
 LEGACY_CODEX_PRIMARY="$(python3 - "$OPENCLAW_CONFIG" <<'PY'
 import json, sys
 try:
@@ -2298,7 +2305,7 @@ except (OSError, json.JSONDecodeError):
 primary = (((cfg.get("agents") or {}).get("defaults") or {}).get("model") or {}).get("primary") or ""
 print(primary if isinstance(primary, str) and primary.lower().startswith("openai-codex/") else "")
 PY
-)"
+)" || LEGACY_CODEX_PRIMARY=""
 if [ -n "$LEGACY_CODEX_PRIMARY" ]; then
   NEW_CODEX_PRIMARY="codex/${LEGACY_CODEX_PRIMARY#*/}"
   if "$OPENCLAW_BIN" config set agents.defaults.model.primary "$NEW_CODEX_PRIMARY" >/dev/null 2>&1; then
@@ -2699,6 +2706,13 @@ else:
     print("0")'
   )" || CODEX_REGISTRY_DEPS_OK=0
 fi
+# TOTAL, like the reader in the background-job block below and the two
+# assignments above: this is a BLOCKING ExecStartPre under `set -euo
+# pipefail`, so an unhandled shape here is not a bad answer, it is NO
+# GATEWAY. The `except` list catches what was foreseen — and a config whose
+# bytes are not UTF-8 raises `UnicodeDecodeError`, a `ValueError` that is NOT
+# a `json.JSONDecodeError`, so it escapes. The fallback is this site's own
+# documented default, the one its except-branch already prints.
 NEEDS_CODEX_PLUGIN="$(python3 - "$OPENCLAW_CONFIG" <<'PY'
 import json, sys
 try:
@@ -2736,13 +2750,20 @@ uses_codex = (
 )
 print("1" if uses_codex else "0")
 PY
-)"
+)" || NEEDS_CODEX_PLUGIN=0
 # OpenClaw 2 loads an installed plugin by default when its config entry is
 # absent. That default-enabled state must participate in BOTH the package
 # health/version checks and capability consent below; otherwise a migrated
 # 2026.7 package can be consented but remain broken against a 2026.8 core.
 CODEX_PLUGIN_ENABLED=0
 if [ "$CLAWBOX_OPENCLAW_V2" = "1" ] && [ -f "$CODEX_PLUGIN_DIR/package.json" ]; then
+  # TOTAL, like the reader in the background-job block below and the two
+  # assignments above: this is a BLOCKING ExecStartPre under `set -euo
+  # pipefail`, so an unhandled shape here is not a bad answer, it is NO
+  # GATEWAY. The `except` list catches what was foreseen — and a config whose
+  # bytes are not UTF-8 raises `UnicodeDecodeError`, a `ValueError` that is NOT
+  # a `json.JSONDecodeError`, so it escapes. The fallback is this site's own
+  # documented default, the one its except-branch already prints.
   CODEX_PLUGIN_ENABLED="$(python3 - "$OPENCLAW_CONFIG" <<'PY'
 import json, sys
 try:
@@ -2755,7 +2776,7 @@ entries = plugins.get("entries", {}) if isinstance(plugins, dict) else {}
 codex = entries.get("codex") if isinstance(entries, dict) else None
 print("0" if isinstance(codex, dict) and codex.get("enabled") is False else "1")
 PY
-)"
+)" || CODEX_PLUGIN_ENABLED=1
 fi
 # ── OpenClaw 2's three background jobs, opted out of ONCE ───────────────────
 #
@@ -2875,11 +2896,16 @@ record = read_seeded(os.environ["CLAWBOX_OPTOUT_STATE"])
 unusable = record is None
 seeded = set() if unusable else record
 if unusable:
+    # Says what happened on THIS boot. The "recorded as settled" half is
+    # downstream of a `config set` that may still fail, and a WARN that promises
+    # it would be a false success in an operator message: on the failing path
+    # nothing is recorded and every later boot repeats this.
     print("  WARN: the background-job opt-out record exists but cannot be read; the check-ins"
-          " opt-out is being SKIPPED and recorded as settled, so it will not be offered again"
-          " — an absent heartbeat cadence is also what 'switched on' looks like, and re-seeding"
-          " it could undo that. Switch check-ins off in Settings if that is what you want.",
-          file=sys.stderr)
+          " opt-out is being SKIPPED this boot — an absent heartbeat cadence is also what"
+          " 'switched on' looks like, and re-seeding it could undo that. It is recorded as"
+          " settled, and so stops being offered, once this boot's write and its record both"
+          " land; the messages below say whether they did. Switch check-ins off in Settings if"
+          " that is what you want.", file=sys.stderr)
 
 def present(path):
     node = cfg
@@ -2918,10 +2944,28 @@ SEEDPY
     # Non-fatal like every other CLI call here: this is a blocking ExecStartPre,
     # and a box that keeps its noisy defaults is far better than one with no
     # gateway. The next boot tries again, because the keys are still absent.
-    CLAWBOX_OPTOUT_WRITES="$(printf %s "$CLAWBOX_OPTOUT_BATCH" | python3 -c 'import json,sys; print(json.dumps(json.load(sys.stdin)["batch"]))')"
+    # GUARDED like every other Python call in this block (SEEDPY with `|| true`,
+    # STATEPY inside an `if !`), and for the reason stated just above: under
+    # `set -euo pipefail` a failing reader here aborted gateway-pre-start.sh
+    # outright, which as a blocking ExecStartPre means NO GATEWAY — the one
+    # outcome this block's own policy refuses.
+    #
+    # The `|| true` alone is not enough. It removes the invariant that this
+    # variable is `json.dumps` output, and a reader that fails can still have
+    # written to stdout — a `sitecustomize` that prints leaves the banner in the
+    # variable and an emptiness test does not fire. So the SHAPE is what is
+    # checked, not the length: anything that is not a JSON array is "cannot tell
+    # what to write", nothing is recorded, and the next boot tries again.
+    CLAWBOX_OPTOUT_WRITES="$(printf %s "$CLAWBOX_OPTOUT_BATCH" | python3 -c 'import json,sys; print(json.dumps(json.load(sys.stdin)["batch"]))' || true)"
+    case "$CLAWBOX_OPTOUT_WRITES" in
+      "["*"]") ;;
+      *) CLAWBOX_OPTOUT_WRITES="" ;;
+    esac
+    if [ -z "$CLAWBOX_OPTOUT_WRITES" ]; then
+      echo "  WARN: could not read the background-job opt-out batch; leaving the harness keys alone this boot" >&2
     # Nothing to write — every key was already the owner's — so record and move
     # on without paying a CLI start for it.
-    if [ "$CLAWBOX_OPTOUT_WRITES" = "[]" ] \
+    elif [ "$CLAWBOX_OPTOUT_WRITES" = "[]" ] \
       || timeout -k 5 90 "$OPENCLAW_BIN" config set --batch-json "$CLAWBOX_OPTOUT_WRITES" >/dev/null 2>&1; then
       [ "$CLAWBOX_OPTOUT_WRITES" = "[]" ] \
         || echo "  Seeded the OpenClaw 2 background-job opt-outs (heartbeat, memory dreaming, self-learning) — Settings can switch any of them back on"
@@ -4166,6 +4210,13 @@ fi
 # (the marker file check), consent given explicitly, non-fatal — a failed
 # install leaves the gateway refusing readiness with its own clear message.
 if [ "$CLAWBOX_OPENCLAW_V2" = "1" ] && [ ! -f "$OPENCLAW_HOME_DIR/extensions/deepseek/openclaw.plugin.json" ]; then
+  # TOTAL, like the reader in the background-job block below and the two
+  # assignments above: this is a BLOCKING ExecStartPre under `set -euo
+  # pipefail`, so an unhandled shape here is not a bad answer, it is NO
+  # GATEWAY. The `except` list catches what was foreseen — and a config whose
+  # bytes are not UTF-8 raises `UnicodeDecodeError`, a `ValueError` that is NOT
+  # a `json.JSONDecodeError`, so it escapes. The fallback is this site's own
+  # documented default, the one its except-branch already prints.
   NEEDS_DEEPSEEK_PLUGIN="$(python3 - "$OPENCLAW_CONFIG" <<'PY'
 import json, sys
 try:
@@ -4177,7 +4228,7 @@ deepseek = providers.get("deepseek")
 key = deepseek.get("apiKey") if isinstance(deepseek, dict) else None
 print("1" if isinstance(key, str) and key.strip() else "0")
 PY
-)"
+)" || NEEDS_DEEPSEEK_PLUGIN=0
   if [ "$NEEDS_DEEPSEEK_PLUGIN" = "1" ]; then
     # Pinned to the INSTALLED core, like @openclaw/codex above. The plugin is
     # cut from the openclaw/openclaw tree with the core's own version number
@@ -4223,6 +4274,13 @@ fi
 # falls back to ~/.openclaw/workspace when unset, handles absolute vs
 # tilde-relative vs bare-name values, and is safe when the file is
 # missing (fresh factory-reset state).
+# TOTAL, like the reader in the background-job block below and the two
+# assignments above: this is a BLOCKING ExecStartPre under `set -euo
+# pipefail`, so an unhandled shape here is not a bad answer, it is NO
+# GATEWAY. The `except` list catches what was foreseen — and a config whose
+# bytes are not UTF-8 raises `UnicodeDecodeError`, a `ValueError` that is NOT
+# a `json.JSONDecodeError`, so it escapes. The fallback is this site's own
+# documented default, the one its except-branch already prints.
 CLAWBOX_WORKSPACE="$(python3 - "$OPENCLAW_CONFIG" <<'PY'
 import json, os, sys
 default = os.path.expanduser("~/.openclaw/workspace")
@@ -4238,7 +4296,7 @@ if isinstance(ws, str) and ws.strip():
 else:
     print(default)
 PY
-)"
+)" || CLAWBOX_WORKSPACE="$HOME/.openclaw/workspace"
 # --- clawbox bootstrap seed ---
 # ClawBox's own first-conversation ritual.
 #

--- a/src/tests/unit/gateway-pre-start-background-optouts.test.ts
+++ b/src/tests/unit/gateway-pre-start-background-optouts.test.ts
@@ -141,6 +141,20 @@ afterEach(() => {
   rmSync(dir, { recursive: true, force: true });
 });
 
+const UNUSABLE: [string, string | Buffer][] = [
+  ["a document that is not an object", "[1, 2]"],
+  ["a `seeded` that is not a list", JSON.stringify({ seeded: 5 })],
+  ["rows that are not strings", JSON.stringify({ seeded: [1, 2] })],
+  ["rows that are not even hashable", JSON.stringify({ seeded: [[1]] })],
+  ["a file that is not JSON at all", "{ broken"],
+  // REAL BYTES. `"\uFFFD"` in a source file is written out as EF BF BD, which
+  // is valid UTF-8 and decodes fine — so a case named for the decode guard was
+  // passing through `JSONDecodeError`, the branch that was already there.
+  // These are the shapes a power cut mid-write actually leaves.
+  ["a file that is not even UTF-8", Buffer.from([0xff, 0xfe, 0x00, 0x67, 0x61, 0x72, 0x62])],
+  ["a document nested past the decoder's limit", "[".repeat(200_000)],
+];
+
 d("gateway-pre-start.sh — the OpenClaw 2 background-job opt-outs", () => {
   it("seeds all three on a box that has never expressed an opinion", () => {
     const r = run();
@@ -264,19 +278,7 @@ d("gateway-pre-start.sh — the OpenClaw 2 background-job opt-outs", () => {
     expect(readFileSync(configPath, "utf-8")).toBe("{ broken");
     expect(calls()).toBe("");
   });
-  it.each<[string, string | Buffer]>([
-    ["a document that is not an object", "[1, 2]"],
-    ["a `seeded` that is not a list", JSON.stringify({ seeded: 5 })],
-    ["rows that are not strings", JSON.stringify({ seeded: [1, 2] })],
-    ["rows that are not even hashable", JSON.stringify({ seeded: [[1]] })],
-    ["a file that is not JSON at all", "{ broken"],
-    // REAL BYTES. `"\uFFFD"` in a source file is written out as EF BF BD, which
-    // is valid UTF-8 and decodes fine — so a case named for the decode guard
-    // was passing through `JSONDecodeError`, the branch that was already there.
-    // These are the shapes a power cut mid-write actually leaves.
-    ["a file that is not even UTF-8", Buffer.from([0xff, 0xfe, 0x00, 0x67, 0x61, 0x72, 0x62])],
-    ["a document nested past the decoder's limit", "[".repeat(200_000)],
-  ])("leaves the AMBIGUOUS key alone when the record is there but unusable: %s", (_name, body) => {
+  it.each(UNUSABLE)("leaves the AMBIGUOUS key alone when the record is there but unusable: %s", (_name, body) => {
     // Only STATEPY writes this file and it always writes `{"seeded": [...]}`,
     // so this needs a hand edit or a corrupted filesystem — but every one of
     // these shapes used to raise out of the Python, which `|| true` swallowed:
@@ -313,8 +315,12 @@ d("gateway-pre-start.sh — the OpenClaw 2 background-job opt-outs", () => {
     ]);
   });
 
-  it("does not offer the ambiguous key again on the boot after an unusable record", () => {
-    writeFileSync(statePath, "[1, 2]");
+  it.each(UNUSABLE)("does not offer the ambiguous key again on the boot after: %s", (_name, body) => {
+    // THE PROPERTY THE WHOLE ROUND IS ABOUT. Boot 1 replaces the unusable record
+    // with a well-formed one; boot 2 must then be silent — otherwise the revert
+    // this guards against simply arrives one boot later, which is the shape the
+    // recorder's own narrow guard used to produce for ever.
+    writeFileSync(statePath, body);
     run();
     rmSync(path.join(dir, "calls.log"), { force: true });
     // The owner's "on" is still an absence, and the record is well-formed now.
@@ -322,6 +328,95 @@ d("gateway-pre-start.sh — the OpenClaw 2 background-job opt-outs", () => {
     expect(r.status).toBe(0);
     expect(at("agents.defaults.heartbeat.every")).toBeUndefined();
     expect(calls()).toBe("");
+    expect(r.stderr).not.toContain("cannot be read");
+  });
+
+  it("does not promise the check-ins opt-out is settled when the write has not happened", () => {
+    // FALSE SUCCESS IN AN OPERATOR MESSAGE. The recording is downstream of the
+    // `config set` below, so on the failing path NOTHING is written to the
+    // record and every later boot repeats this — while the WARN has already
+    // told the operator the key was "recorded as settled, so it will not be
+    // offered again". Its own boot contradicts it two lines down.
+    writeFileSync(statePath, "[1, 2]");
+    const r = run({ OC_EXIT: "1" });
+    expect(r.status).toBe(0);
+    expect(r.stderr).toContain("cannot be read");
+    // The same boot says the seed did not happen.
+    expect(r.stderr).toContain("could not seed");
+    expect(r.stderr).not.toContain("recorded as settled, so it will not be offered again");
+    // THE PROPERTY, not just the absence of the old sentence: the message has
+    // to scope itself to the boot it is describing, and make the settling
+    // conditional on the write that earns it.
+    expect(r.stderr).toContain("SKIPPED this boot");
+    expect(r.stderr).toContain("once this boot's write and its record both land");
+    // And nothing was recorded, which is what makes the promise false.
+    expect(readFileSync(statePath, "utf-8")).toBe("[1, 2]");
+  });
+
+  it("keeps the gateway starting when the batch reader fails", () => {
+    // NO GATEWAY, the one outcome this block's own comment says its design
+    // refuses. The batch reader was the one Python call in the block that was
+    // not guarded at all — SEEDPY carries `|| true`, STATEPY runs inside an
+    // `if !` — so under `set -euo pipefail` a failure here aborted
+    // gateway-pre-start.sh outright, and this runs as a BLOCKING ExecStartPre:
+    // the box comes up with no gateway at all rather than with noisy defaults.
+    //
+    // The realistic trigger is stdout pollution from a `sitecustomize`, which
+    // leaves the reader an unparseable stdin. (NOT PYTHONSTARTUP: CPython reads
+    // that only for an interactive interpreter, never for `-c` or `-`.) The
+    // failure is injected AT the guarded call rather than modelled through its
+    // cause — `python3 -c` is the reader's shape and nothing else in this block
+    // uses it — so this pins the guard, not one way of reaching it. The
+    // polluted-but-NON-EMPTY shape, which an emptiness test would miss, is
+    // pinned by the case below.
+    const real = spawnSync("bash", ["-c", "command -v python3"], { encoding: "utf-8" })
+      .stdout.trim();
+    const py = path.join(binDir, "python3");
+    writeFileSync(
+      py,
+      "#!/usr/bin/env bash\n"
+      + 'if [ "$1" = "-c" ]; then exit 1; fi\n'
+      + `exec ${JSON.stringify(real)} "$@"\n`,
+    );
+    chmodSync(py, 0o755);
+
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(r.stderr).toContain("could not read the background-job opt-out batch");
+    // Nothing guessed at either: no CLI start, no config write, and no record,
+    // so the next boot tries the whole thing again.
+    expect(calls()).toBe("");
+    expect(at("agents.defaults.heartbeat.every")).toBeUndefined();
+    expect(existsSync(statePath)).toBe(false);
+  });
+
+  it("never hands the CLI what a FAILED batch reader left on stdout", () => {
+    // The shape an emptiness test cannot catch, and the one the realistic cause
+    // actually produces. A `sitecustomize` that prints pollutes EVERY python3 in
+    // the block: SEEDPY's stdout is then unparseable, so the reader raises — but
+    // the reader's own banner is already on ITS stdout, so the variable is
+    // non-empty garbage. `|| true` alone would walk that straight into
+    // `openclaw config set --batch-json "sitecustomize: hello"`, which is the
+    // harness's own config writer being handed unvalidated text. So the SHAPE is
+    // what is checked, not the length.
+    const real = spawnSync("bash", ["-c", "command -v python3"], { encoding: "utf-8" })
+      .stdout.trim();
+    const py = path.join(binDir, "python3");
+    writeFileSync(
+      py,
+      "#!/usr/bin/env bash\n"
+      + 'echo "sitecustomize: hello"\n'
+      + `exec ${JSON.stringify(real)} "$@"\n`,
+    );
+    chmodSync(py, 0o755);
+
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(r.stderr).toContain("could not read the background-job opt-out batch");
+    // Nothing was handed to the config writer at all.
+    expect(calls()).toBe("");
+    expect(at("agents.defaults.heartbeat.every")).toBeUndefined();
+    expect(existsSync(statePath)).toBe(false);
   });
 
   it("records a well-formed set on a normal first boot", () => {

--- a/src/tests/unit/gateway-pre-start-corrupt-config.test.ts
+++ b/src/tests/unit/gateway-pre-start-corrupt-config.test.ts
@@ -269,3 +269,113 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh config write block", () => {
     expect(readdirSync(dir)).toEqual(["openclaw.json"]);
   });
 });
+
+/**
+ * Every OTHER `VAR="$(python3 … "$OPENCLAW_CONFIG" …)"` in the same script.
+ *
+ * Same class as the loader above and as the background-job batch reader: these
+ * are plain assignments in a BLOCKING `ExecStartPre` under `set -euo pipefail`,
+ * so a Python that exits non-zero does not produce a bad answer — it takes the
+ * gateway down. Each program has an `except` branch that prints a deliberate
+ * default, but the list is narrower than the failures a real box produces:
+ * `UnicodeDecodeError` is a `ValueError`, NOT a `json.JSONDecodeError`, so a
+ * config whose bytes are not UTF-8 — the shape a power cut mid-write leaves,
+ * and the shape `gateway-pre-start-background-optouts.test.ts` already fixtures
+ * — escapes every one of them.
+ *
+ * Pinned as a property of the SHIPPED assignments rather than of the Python, so
+ * the guard cannot be dropped without this failing.
+ */
+const READERS: [string, string, string][] = [
+  // [variable, the default its own except-branch prints, why it is that value]
+  ["LEGACY_CODEX_PRIMARY", "", "no legacy codex primary could be read"],
+  ["NEEDS_CODEX_PLUGIN", "0", "assume codex is not needed"],
+  ["CODEX_PLUGIN_ENABLED", "1", "assume it is enabled, so consent is still attempted"],
+  ["NEEDS_DEEPSEEK_PLUGIN", "0", "assume no deepseek key is configured"],
+];
+
+describe.skipIf(!hasPython3)("gateway-pre-start.sh — the other openclaw.json readers", () => {
+  /** One shipped assignment, verbatim, including its `)" || VAR=default` tail. */
+  function extractAssignment(variable: string): string {
+    const src = readFileSync(SCRIPT, "utf-8");
+    const marker = `${variable}="$(python3 - "$OPENCLAW_CONFIG" <<'PY'`;
+    const start = src.indexOf(marker);
+    if (start < 0) throw new Error(`${variable} assignment not found in gateway-pre-start.sh`);
+    const bodyEnd = src.indexOf('\nPY\n)"', start);
+    if (bodyEnd < 0) throw new Error(`${variable} assignment has no closing heredoc`);
+    const lineEnd = src.indexOf("\n", bodyEnd + '\nPY\n)"'.length);
+    return src.slice(start, lineEnd);
+  }
+
+  it.each(READERS)(
+    "%s survives a config whose bytes are not UTF-8 and answers its own default",
+    (variable, fallback) => {
+      const dir = mkdtempSync(path.join(os.tmpdir(), "prestart-readers-"));
+      try {
+        const cfg = path.join(dir, "openclaw.json");
+        // REAL BYTES, the same shape the background-job suite fixtures.
+        writeFileSync(cfg, Buffer.from([0xff, 0xfe, 0x00, 0x7b, 0x7d]));
+        const program = [
+          "set -euo pipefail",
+          `OPENCLAW_CONFIG=${JSON.stringify(cfg)}`,
+          extractAssignment(variable),
+          `printf '%s' "$${variable}"`,
+        ].join("\n");
+        const r = spawnSync("bash", ["-c", program], { encoding: "utf-8", timeout: 30_000 });
+        // The gateway still starts. That is the whole point.
+        expect(r.status).toBe(0);
+        expect(r.stdout).toBe(fallback);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("CLAWBOX_WORKSPACE survives it too, and answers the harness's own default", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "prestart-readers-ws-"));
+    try {
+      const cfg = path.join(dir, "openclaw.json");
+      writeFileSync(cfg, Buffer.from([0xff, 0xfe, 0x00, 0x7b, 0x7d]));
+      const program = [
+        "set -euo pipefail",
+        `OPENCLAW_CONFIG=${JSON.stringify(cfg)}`,
+        extractAssignment("CLAWBOX_WORKSPACE"),
+        'printf %s "$CLAWBOX_WORKSPACE"',
+      ].join("\n");
+      const r = spawnSync("bash", ["-c", program], {
+        encoding: "utf-8",
+        timeout: 30_000,
+        env: { ...process.env, HOME: dir },
+      });
+      expect(r.status).toBe(0);
+      expect(r.stdout).toBe(path.join(dir, ".openclaw", "workspace"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("also survives a config whose `agents` is null", () => {
+    // `cfg.get("agents", {}).get(...)` raises AttributeError on an explicit
+    // null, which no except list here mentions.
+    const dir = mkdtempSync(path.join(os.tmpdir(), "prestart-readers-null-"));
+    try {
+      const cfg = path.join(dir, "openclaw.json");
+      writeFileSync(cfg, JSON.stringify({ agents: null }));
+      const program = [
+        "set -euo pipefail",
+        `OPENCLAW_CONFIG=${JSON.stringify(cfg)}`,
+        extractAssignment("CLAWBOX_WORKSPACE"),
+        'printf %s "$CLAWBOX_WORKSPACE"',
+      ].join("\n");
+      const r = spawnSync("bash", ["-c", program], {
+        encoding: "utf-8",
+        timeout: 30_000,
+        env: { ...process.env, HOME: dir },
+      });
+      expect(r.status).toBe(0);
+      expect(r.stdout).toBe(path.join(dir, ".openclaw", "workspace"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
**TASK-609 / D-05 follow-up** — two residuals in the background-job opt-out seed block of `scripts/gateway-pre-start.sh`, found while finishing #707 and written after it had merged.

Both live in a **blocking `ExecStartPre`**, which is what makes the second one serious.

## 1. A false success in an operator message

The WARN printed for an unusable opt-out record told the operator the check-ins opt-out was

> "being SKIPPED **and recorded as settled, so it will not be offered again**"

but the recording is downstream of an `openclaw config set` that can still fail. On the failing path nothing is recorded and every later boot repeats the whole thing — and the very same boot prints, two lines further down, "could not seed the OpenClaw 2 background-job opt-outs". The message contradicted its own boot.

Reworded to describe **this** boot and to defer the settling to the write that earns it.

## 2. No gateway at all

```
CLAWBOX_OPTOUT_WRITES="$(printf %s "$CLAWBOX_OPTOUT_BATCH" | python3 -c '…json.load(sys.stdin)["batch"]…')"
```

was the only Python call in the block **without** `|| true`. Under the script's `set -euo pipefail` an unparseable stdout aborts `gateway-pre-start.sh` outright — and as a blocking `ExecStartPre` that is a box with **no gateway**, the one outcome the comment three lines above says the design refuses ("a box that keeps its noisy defaults is far better than one with no gateway").

Pre-existing and close to unreachable — the realistic trigger is stdout pollution from a `sitecustomize`. Now guarded like its neighbours (SEEDPY carries `|| true`, STATEPY runs inside an `if !`).

**`|| true` alone is not enough, and review caught that.** It removes the invariant that the variable holds `json.dumps` output, and a reader that fails can still have written to stdout — a `sitecustomize` banner leaves the variable *non-empty garbage*, which an emptiness test does not catch, and `openclaw config set --batch-json "sitecustomize: hello"` then runs. So the **shape** is checked, not the length: anything that is not a JSON array is "cannot tell what to write", nothing is recorded, and the next boot tries again.

## Harness first

No new mechanism, and none needed: the three opt-outs remain the core's own documented keys written through the core's own `config set --batch-json`. This PR only changes how the block behaves when its own plumbing fails.

## RED → GREEN

RED 1 — the operator message, on unmodified beta. The failure output shows both contradicting lines on one boot:

```
FAIL  gateway-pre-start.sh — the OpenClaw 2 background-job opt-outs >
      does not promise the check-ins opt-out is settled when the write has not happened
AssertionError: expected '  WARN: the background-job opt-out re…' not to contain 'will not be offered again'

+   WARN: the background-job opt-out record exists but cannot be read; the check-ins opt-out
+         is being SKIPPED and recorded as settled, so it will not be offered again — …
+   WARN: could not seed the OpenClaw 2 background-job opt-outs; the box may send unprompted
+         check-ins and spend tokens on background jobs until Settings is used
```

RED 2 — the boot, on unmodified beta:

```
FAIL  gateway-pre-start.sh — the OpenClaw 2 background-job opt-outs >
      keeps the gateway starting when the batch reader fails
AssertionError: expected 1 to be +0 // Object.is equality

- Expected
+ Received

- 0
+ 1

 ❯ src/tests/unit/gateway-pre-start-background-optouts.test.ts:376:22
    376|     expect(r.status).toBe(0);
```

Exit 1 out of a blocking `ExecStartPre` is the gateway not starting.

GREEN, with the fix — every `gateway-pre-start-*` suite plus the three standing guards:

```
Test Files  24 passed (24)
     Tests  466 passed (466)
```

`bash -n scripts/gateway-pre-start.sh` clean; `npx tsc --noEmit -p tsconfig.json` clean.

Also widens the existing "boot after an unusable record" property from the single `[1, 2]` shape to an `it.each` over every unusable shape the recorder can meet.

## Device proof (read-only)

The shipped block, run verbatim on the OpenClaw box (beta `5b49df65`) against a stub CLI in a temp directory, with a `python3` that fails exactly where the batch reader runs:

```
reader fails, empty stdout     exit0 warned no-cli unrecorded
reader fails, polluted stdout  exit0 warned no-cli unrecorded
bash=5.1.16(1)-release python3=3.10.12
```

Both shapes: the reader failing silently, and the reader failing with a banner already on its stdout.

The box's toolchain is older than the development machine's (5.2.21 / 3.12.3), which is the reason to run it there. Nothing on the box was changed; no service was touched.

## Sibling sweep

Every other Python call **in this block** is already guarded: `SEEDPY` carries `|| true`, `STATEPY` is wrapped in `if ! … then WARN`. Both clear.

**And the five siblings are fixed here too, because review was right that leaving them contradicts this PR's own thesis.** Every other `VAR="$(python3 … "$OPENCLAW_CONFIG" …)"` in the same `set -euo pipefail` script caught only `(OSError, json.JSONDecodeError)`:

```
gateway-pre-start.sh  LEGACY_CODEX_PRIMARY   NEEDS_CODEX_PLUGIN   CODEX_PLUGIN_ENABLED
                      NEEDS_DEEPSEEK_PLUGIN  CLAWBOX_WORKSPACE
```

A non-UTF-8 `openclaw.json` raises `UnicodeDecodeError` — a `ValueError` but **not** a `JSONDecodeError` — so it escaped and aborted the same blocking `ExecStartPre`. `NEEDS_CODEX_PLUGIN` is **unconditional and runs every boot**, ~105 lines *before* the seed block, so the box never even reached the code this PR started out fixing. `CLAWBOX_WORKSPACE` additionally died with `AttributeError` on `{"agents": null}`.

Each now carries `)" || VAR=<its own documented default>` — the total guard, matching the shape already used at two other assignments in this file, and preserving exactly the default each program's own `except` branch prints. RED for all six, on unmodified beta:

```
× LEGACY_CODEX_PRIMARY survives a config whose bytes are not UTF-8 …
× NEEDS_CODEX_PLUGIN survives …
× CODEX_PLUGIN_ENABLED survives …
× NEEDS_DEEPSEEK_PLUGIN survives …
× CLAWBOX_WORKSPACE survives it too …
× also survives a config whose `agents` is null
AssertionError: expected 1 to be +0     // exit 1 out of a blocking ExecStartPre
      Tests  6 failed | 8 passed (14)
```

## Compatibility

The Hermes edition's own seed path is a separate branch (`fix/609-hermes-background-optout-seed`, `src/lib/background-jobs.ts` + `src/instrumentation.ts`). No file overlap with this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved gateway startup reliability when configuration files are malformed, unreadable, or contain invalid text.
  - Added safe fallback behavior for missing or invalid workspace, agent, and integration settings.
  - Prevented invalid background opt-out data from being sent to command-line tools.
  - Ensured incomplete configuration updates are retried rather than incorrectly marked as completed.
  - Improved handling of corrupted opt-out records so startup can continue safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->