### PR TITLE
fix: ask the core whether a killed consent verb had recorded the consent

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -2651,18 +2651,28 @@ clawbox_plugin_boot_without() {
 # FAILED, not retried — the measured TASK-606 outage — and nothing running as
 # `clawbox` clears a start limit at boot.
 #
-# The one case that changes nothing either way is a plugin the core can see and
-# would load but keeps NO install record for — `clawbox-email-directives` is
-# exactly that on a box today: copied out of the checkout by the block below, so
-# it is in `~/.openclaw/extensions/` with nothing in the installed index to own
-# it. (`deepseek` lives in the same directory and is NOT this case — its ClawHub
+# The one case that changes nothing either way is a plugin the report names but
+# keeps NO install record for — `clawbox-email-directives` is exactly that on a
+# box today: copied out of the checkout by the block below, so it sits in
+# `~/.openclaw/extensions/` with nothing in the installed index to own it.
+# (`deepseek` lives in the same directory and is NOT this case — its ClawHub
 # install does write a record, and the box's own report says `consented`. The
-# directory is not the test; the install record is.) The core cannot emit a
-# consent diagnostic for one, so it can never refuse readiness over its consent:
-# switching it off would be a false failure over a plugin that is working, and
-# calling it accepted/current a false success. The boot says so in one line and
-# leaves the entry and any existing marker exactly as it found them, for the
-# next boot or the Settings Retry to resolve.
+# directory is not the test; the install record is.)
+#
+# WHY IT IS SAFE TO LEAVE THAT ONE ENABLED, and the reason is the install record
+# and nothing else. It is NOT `status: "loaded"` — that field is read here only
+# to withhold evidence, never to grant it, for exactly the reason fifteen lines
+# above. It is that every mechanism in 2026.8.1 which can refuse gateway
+# readiness over a plugin is gated on an install record: both consent emitters
+# (`collectPluginCapabilityConsentDiagnostics`, and the management service's
+# `ownership.ok && installRecord`) and the startup payload verification, which
+# is driven entirely by `loadInstalledPluginIndexInstallRecords`. A plugin the
+# core keeps no record for can therefore neither have its consent reported nor
+# block readiness — so switching it off would be a false failure over a plugin
+# that cannot be the problem, and calling it accepted/current a false success.
+# The boot says which of the two it is in one line and leaves the entry and any
+# existing marker exactly as it found them, for the next boot or the Settings
+# Retry to resolve.
 
 # The consent question is asked at most ONCE per boot, for every id at once:
 # the CLI start is the dominant cost and this runs inside a blocking
@@ -2670,10 +2680,17 @@ clawbox_plugin_boot_without() {
 #
 # ONE SNAPSHOT, TAKEN AT THE FIRST KILL OF THE BOOT, and memoised. A consent
 # recorded by a LATER killed verb is not in it, so that plugin is still named
-# and is switched off — beta's behaviour, conservative, and the reason this
-# reads as a fix for a consent that was ALREADY current before the boot (the
-# common shape: `plugins enable` is idempotent, so it is a slow no-op that gets
-# killed) rather than for one written inside the verb that was then killed.
+# and is switched off — beta's behaviour, and the reason this reads as a fix for
+# a consent that was ALREADY current before the boot (the common shape:
+# `plugins enable` is idempotent, so it is a slow no-op that gets killed) rather
+# than for one written inside the verb that was then killed. The codex verb runs
+# before the managed loop, so on a boot whose codex verb is killed the snapshot
+# predates every managed plugin's own consent write.
+#
+# STALE IN ONE DIRECTION ONLY, which is what makes it safe rather than merely
+# cautious: `plugins enable --accept-capabilities` only ever ADDS consent, so an
+# old snapshot can be wrong by naming a plugin that has since been consented — a
+# false failure, identical to beta — and a stale `consented` is unreachable.
 #
 # The memoisation is not only cost. Measured on a box, this call is ~10 s
 # against its 60 s ceiling, so re-reading it per verb would be affordable on a
@@ -2692,8 +2709,16 @@ CLAWBOX_CONSENT_STATES_READY=0
 # alias-keyed entry would match nothing in the report and be switched off on
 # every killed verb.
 clawbox_plugin_canonical_id() {
-  local id="${1#@openclaw/}"
-  printf '%s' "${id#openclaw-}"
+  # The FIRST matching prefix only, because the reader's `canonical()` below
+  # returns on its first match too: stripping both here would answer `discord`
+  # for `@openclaw/openclaw-discord` where python answers `openclaw-discord`,
+  # and two functions written in one commit to implement one rule must not
+  # disagree about it.
+  case "$1" in
+    @openclaw/*) printf '%s' "${1#@openclaw/}" ;;
+    openclaw-*) printf '%s' "${1#openclaw-}" ;;
+    *) printf '%s' "$1" ;;
+  esac
 }
 
 # What the core's own report says about each plugin, as ` <state>:<id> ` tokens
@@ -2800,7 +2825,7 @@ for pid in pending:
 
 print(" ".join(["ok"] + sorted(f"{state}:{pid}" for pid, state in states.items())))
 PY
-  )" || CLAWBOX_CONSENT_STATES=""
+  )"
   rm -f "$file" 2>/dev/null || true
   case "$CLAWBOX_CONSENT_STATES" in
     ok|"ok "*)
@@ -2817,8 +2842,9 @@ PY
 # What the core's report positively says about one plugin's consent.
 #   0  it adjudicated the plugin and raised no consent diagnostic — recorded
 #   1  it says the plugin still requires consent
-#   2  it can see the plugin and would load it, but keeps no consent record
-#      for it — the question cannot be answered and does not arise
+#   2  it names the plugin but keeps no install record for it — the question
+#      cannot be answered, and cannot arise either (nothing that refuses
+#      readiness applies to a plugin with no record)
 #   3  it does not name the plugin, names it in a state it would not load, or
 #      could not be asked at all
 clawbox_plugin_consent_state() {
@@ -2840,8 +2866,8 @@ CLAWBOX_CONSENT_DETAIL=""
 # The verdict on one consent attempt.
 #   0  consented, or already current — clear any repair marker
 #   1  not established — the caller's existing refusal path, unchanged
-#   2  cannot be established, and the plugin is one the core sees and would
-#      load — change nothing at all and say so
+#   2  cannot be established, and the plugin is one the core keeps no install
+#      record for — change nothing at all and say so
 #
 # Only a kill at the deadline asks the second question, and only a definite
 # "the core has the consent recorded" changes the answer. 124 is `timeout`
@@ -3408,11 +3434,12 @@ elif [ "$CLAWBOX_OPENCLAW_V2" = "1" ] && [ "$CODEX_SHOULD_LOAD" = "1" ]; then
     echo "  Codex runtime plugin capabilities accepted/current$CLAWBOX_CONSENT_DETAIL"
     clawbox_plugin_repair_clear codex
   elif [ "$CODEX_CONSENT_VERDICT" = "2" ]; then
-    # The core sees the plugin and would load it but keeps no install record for
-    # it, so it can neither report the consent nor refuse readiness over it.
-    # Nothing is switched off and nothing is cleared: an existing repair row is
-    # still the truest thing on the screen, and the next boot or the Retry it
-    # offers resolves this.
+    # The core names the plugin but keeps no install record for it, so it can
+    # neither report the consent nor refuse readiness over it — see the block
+    # above for why that, and not anything `status` says, is what makes leaving
+    # it enabled safe. Nothing is switched off and nothing is cleared: an
+    # existing repair row is still the truest thing on the screen, and the next
+    # boot or the Retry it offers resolves this.
     echo "  Codex runtime plugin capabilities are still unknown (the consent verb was killed at its deadline and the core keeps no consent record for this plugin); leaving it as it is"
   else
     echo "  WARN: could not confirm Codex plugin capabilities; booting without Codex"
@@ -3491,12 +3518,12 @@ MANAGEDPY
       continue
     fi
     if [ "$MANAGED_PLUGIN_VERDICT" = "2" ]; then
-      # Same as the codex arm above: the core sees this plugin and would load
-      # it, but keeps no install record for it — `clawbox-email-directives`, the
-      # one this script copies out of the checkout rather than installing, is
-      # exactly this on a box today — so the core can neither report the consent
-      # nor refuse readiness over it. Change nothing, clear nothing, say which
-      # of the two it is.
+      # Same as the codex arm above: the core names this plugin but keeps no
+      # install record for it — `clawbox-email-directives`, the one this script
+      # copies out of the checkout rather than installing, is exactly this on a
+      # box today — so the core can neither report its consent nor refuse
+      # readiness over it. Change nothing, clear nothing, say which of the two
+      # it is.
       echo "  $MANAGED_PLUGIN plugin capabilities are still unknown (the consent verb was killed at its deadline and the core keeps no consent record for this plugin); leaving it as it is"
       continue
     fi

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -2652,10 +2652,13 @@ clawbox_plugin_boot_without() {
 # `clawbox` clears a start limit at boot.
 #
 # The one case that changes nothing either way is a plugin the core can see and
-# would load but keeps NO install record for — a directory-discovered
-# `~/.openclaw/extensions/` plugin, which is what `deepseek` and
-# `clawbox-email-directives` are on a box today. The core cannot emit a consent
-# diagnostic for one, so it can never refuse readiness over its consent either:
+# would load but keeps NO install record for — `clawbox-email-directives` is
+# exactly that on a box today: copied out of the checkout by the block below, so
+# it is in `~/.openclaw/extensions/` with nothing in the installed index to own
+# it. (`deepseek` lives in the same directory and is NOT this case — its ClawHub
+# install does write a record, and the box's own report says `consented`. The
+# directory is not the test; the install record is.) The core cannot emit a
+# consent diagnostic for one, so it can never refuse readiness over its consent:
 # switching it off would be a false failure over a plugin that is working, and
 # calling it accepted/current a false success. The boot says so in one line and
 # leaves the entry and any existing marker exactly as it found them, for the
@@ -2665,12 +2668,20 @@ clawbox_plugin_boot_without() {
 # the CLI start is the dominant cost and this runs inside a blocking
 # ExecStartPre. Empty until the first kill asks for it.
 #
-# ONE SNAPSHOT, TAKEN AT THE FIRST KILL OF THE BOOT. A consent recorded by a
-# LATER killed verb is not in it, so that plugin is still named and is switched
-# off — beta's behaviour, conservative, and the reason this reads as a fix for
-# the first killed verb of a boot. Re-reading per verb would add up to another
-# five 65 s CLI starts to a chain that already spends most of
-# `TimeoutStartSec=600` in the pathological case.
+# ONE SNAPSHOT, TAKEN AT THE FIRST KILL OF THE BOOT, and memoised. A consent
+# recorded by a LATER killed verb is not in it, so that plugin is still named
+# and is switched off — beta's behaviour, conservative, and the reason this
+# reads as a fix for a consent that was ALREADY current before the boot (the
+# common shape: `plugins enable` is idempotent, so it is a slow no-op that gets
+# killed) rather than for one written inside the verb that was then killed.
+#
+# The memoisation is not only cost. Measured on a box, this call is ~10 s
+# against its 60 s ceiling, so re-reading it per verb would be affordable on a
+# HEALTHY box — but the box that reaches this code is one loaded enough to kill
+# `plugins enable` at 60 s, and there the inspect can reach its own deadline
+# too. Per verb that costs 5 x 65 s to produce the same refusal five times;
+# memoised it costs one 65 s attempt and every later verb reuses the answer for
+# free. Bounding the damage on that box is what this is for.
 CLAWBOX_CONSENT_STATES=""
 CLAWBOX_CONSENT_STATES_READY=0
 

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -2595,6 +2595,163 @@ clawbox_plugin_boot_without() {
   clawbox_plugin_repair_mark "$id" "$stage" "$disabled" "$reason" "$spec"
 }
 
+# ── What a capability-consent attempt actually PROVED ───────────────────────
+#
+# TASK-606 follow-up. `timeout -k 5 60 openclaw plugins enable <id>
+# --accept-capabilities` has one failure that says nothing about whether the
+# consent was recorded: the kill at the deadline. The verb writes
+# `plugins.entries.<id>.enabled` FIRST and only then spends seconds loading the
+# gateway SDK, so on a cold Jetson the consent lands and the process is still
+# killed at 60 s. Reading that as a refusal switched the entry OFF — and the box
+# then booted without a channel its owner had correctly consented, permanently,
+# because these loops only ever visit entries that are still `enabled: true`.
+#
+# Re-reading `enabled` cannot separate the two: it is already `true` before the
+# call. NEITHER CAN `plugins inspect --runtime`'s `status`/`activated`, which is
+# the trap this block exists to avoid — in 2026.8.1 both fields are the config's
+# own enablement decision under another name (`status: enabled ? "loaded" :
+# "disabled"` in the loader, `activated: source !== "disabled"` in the
+# activation resolver), and no loader or status module consults the consent
+# record at all. They are true BEFORE the verb runs and stay true when it never
+# landed, so clearing a repair marker on them would be a false success.
+#
+# The core does publish the real answer, from the persisted install record and
+# without loading any plugin runtime: a `diagnostics` entry, emitted for every
+# enabled non-bundled plugin whose accepted surface is not current, reading
+# `Plugin "<id>" requires capability consent; …`. That is the same sentence the
+# updater greps out of the gateway journal (PLUGIN_CAPABILITY_CONSENT_RE), and
+# `plugins inspect <id> --json` carries it WITHOUT `--runtime` — so this costs a
+# CLI start and not a module load of every enabled plugin.
+#
+# WHAT THIS DELIBERATELY DOES NOT DO: it never leaves an unresolved plugin
+# enabled. A gateway that refuses readiness burns `StartLimitBurst=20` inside
+# `StartLimitIntervalSec=3600` and the unit is then FAILED, not retried — the
+# measured TASK-606 outage — and nothing running as `clawbox` clears a start
+# limit at boot. So an answer we cannot get keeps the existing behaviour
+# (switch off, mark, offer the Retry); only a consent PROVED to be recorded
+# changes the outcome. Whether a slow box should instead be allowed to boot
+# with the plugin still on is the same owner ruling D-02 itself was, and is not
+# taken here.
+
+# The consent question is asked at most ONCE per boot, for every id at once:
+# the CLI start is the dominant cost and this runs inside a blocking
+# ExecStartPre. Empty until the first kill asks for it.
+CLAWBOX_CONSENT_PENDING=""
+CLAWBOX_CONSENT_PENDING_READY=0
+
+# The ids the core says are still waiting for capability consent, space-padded
+# for a substring test. Answers 1 when the question could be asked at all, 2
+# when it could not.
+clawbox_consent_pending_load() {
+  local rc=0 file=""
+  [ "$CLAWBOX_CONSENT_PENDING_READY" = "0" ] || return "$CLAWBOX_CONSENT_PENDING_READY"
+  # THROUGH A FILE, not through the environment. Measured on a box: this answer
+  # is 285 KB for 65 plugin reports, and Linux caps a single environment string
+  # at MAX_ARG_STRLEN (131 072), so the `VAR="$out" python3 -` idiom the rest of
+  # this script uses for small payloads dies here with E2BIG. A command
+  # substitution would hold it in the shell too; the reader gets a path.
+  file="$(mktemp 2>/dev/null)" || { CLAWBOX_CONSENT_PENDING_READY=2; return 2; }
+  # `--all --json` and NOT `--runtime`: the consent diagnostics are on the
+  # snapshot path as well, and the runtime flag only adds the hook/tool/service
+  # data this question never reads — it is the module load of every enabled
+  # plugin that makes that call cost tens of seconds on an Orin. One CLI start
+  # answers for every id, which is what keeps this affordable in a blocking
+  # ExecStartPre.
+  timeout -k 5 60 "$OPENCLAW_BIN" plugins inspect --all --json </dev/null >"$file" 2>/dev/null || rc=$?
+  if [ "$rc" != "0" ]; then
+    rm -f "$file" 2>/dev/null || true
+    CLAWBOX_CONSENT_PENDING_READY=2
+    return 2
+  fi
+  # The reader prints `ok` and then the ids, so an answer that could not be
+  # parsed is NOT read as "every plugin is consented" — that would be the exact
+  # false success this whole block exists to remove.
+  CLAWBOX_CONSENT_PENDING="$(python3 - "$file" <<'PY' 2>/dev/null || true
+import json, sys
+
+try:
+    with open(sys.argv[1], encoding="utf-8") as fh:
+        data = json.load(fh)
+except Exception:
+    raise SystemExit(1)
+
+# `--all` answers with a LIST of reports (65 of them on a real box); a single
+# `inspect <id>` answers with one object. Both carry `diagnostics` arrays whose
+# entries name their own pluginId, so walk whatever shape arrives.
+def walk(node, out):
+    if isinstance(node, dict):
+        for entry in node.get("diagnostics") or []:
+            if not isinstance(entry, dict):
+                continue
+            pid = entry.get("pluginId")
+            if isinstance(pid, str) and "requires capability consent" in str(entry.get("message") or ""):
+                out.add(pid)
+        for value in node.values():
+            walk(value, out)
+    elif isinstance(node, list):
+        for value in node:
+            walk(value, out)
+
+pending = set()
+walk(data, pending)
+print(" ".join(["ok"] + sorted(pending)))
+PY
+  )" || CLAWBOX_CONSENT_PENDING=""
+  rm -f "$file" 2>/dev/null || true
+  case "$CLAWBOX_CONSENT_PENDING" in
+    ok|"ok "*)
+      CLAWBOX_CONSENT_PENDING=" ${CLAWBOX_CONSENT_PENDING#ok} "
+      CLAWBOX_CONSENT_PENDING_READY=1
+      return 1
+      ;;
+  esac
+  CLAWBOX_CONSENT_PENDING=""
+  CLAWBOX_CONSENT_PENDING_READY=2
+  return 2
+}
+
+# Is this plugin's capability consent RECORDED, by the core's own account?
+#   0  yes — no consent diagnostic names it
+#   1  no, or the core could not be asked
+clawbox_plugin_consent_recorded() {
+  local id="$1" ready=0
+  clawbox_consent_pending_load || ready=$?
+  [ "$ready" = "1" ] || return 1
+  case "$CLAWBOX_CONSENT_PENDING" in
+    *" $id "*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# Set by clawbox_plugin_consent_outcome for its caller's own message.
+CLAWBOX_CONSENT_DETAIL=""
+
+# The verdict on one consent attempt.
+#   0  consented, or already current — clear any repair marker
+#   1  not established — the caller's existing refusal path, unchanged
+#
+# Only a kill at the deadline asks the second question, and only a definite
+# "the core has the consent recorded" changes the answer. 124 is `timeout`
+# firing at the ceiling; 137 is the SIGKILL `-k 5` sends five seconds later,
+# and is also what the OOM killer sends. Both are asked about rather than
+# assumed, so a CLI that chose 124 as its own exit code is not mis-read either.
+clawbox_plugin_consent_outcome() {
+  local id="$1" rc="$2"
+  CLAWBOX_CONSENT_DETAIL=""
+  if [ "$rc" = "0" ]; then
+    return 0
+  fi
+  case "$rc" in
+    124|137)
+      if clawbox_plugin_consent_recorded "$id"; then
+        CLAWBOX_CONSENT_DETAIL=" (the consent verb was killed at its deadline, and the core reports the consent as recorded)"
+        return 0
+      fi
+      ;;
+  esac
+  return 1
+}
+
 # A `.openclaw` INSIDE the state directory is what the CLI leaves behind when
 # it was run with OPENCLAW_HOME pointing at the state directory (see the pin
 # near the top): a second config, a second empty index, nothing the gateway
@@ -3119,8 +3276,17 @@ elif [ "$CLAWBOX_OPENCLAW_V2" = "1" ] && [ "$CODEX_SHOULD_LOAD" = "1" ]; then
   # A v1 install can leave Codex enabled even after the owner switches primary
   # auth to another provider. V2 verifies every enabled/default-enabled plugin
   # before opening its port, so consent it even when no Codex model is selected.
-  if timeout 60 "$OPENCLAW_BIN" plugins enable codex --accept-capabilities </dev/null >/dev/null 2>&1; then
-    echo "  Codex runtime plugin capabilities accepted/current"
+  # `-k 5` like every other timed CLI call here: plain `timeout` only sends
+  # SIGTERM, and an `openclaw` that ignores it keeps running past the ceiling.
+  # It is also what makes 137 reachable, which the classifier below reads the
+  # same way as 124.
+  CODEX_CONSENT_RC=0
+  timeout -k 5 60 "$OPENCLAW_BIN" plugins enable codex --accept-capabilities </dev/null >/dev/null 2>&1 \
+    || CODEX_CONSENT_RC=$?
+  CODEX_CONSENT_VERDICT=0
+  clawbox_plugin_consent_outcome codex "$CODEX_CONSENT_RC" || CODEX_CONSENT_VERDICT=$?
+  if [ "$CODEX_CONSENT_VERDICT" = "0" ]; then
+    echo "  Codex runtime plugin capabilities accepted/current$CLAWBOX_CONSENT_DETAIL"
     clawbox_plugin_repair_clear codex
   else
     echo "  WARN: could not confirm Codex plugin capabilities; booting without Codex"
@@ -3188,15 +3354,21 @@ for key, entry in entries.items():
 MANAGEDPY
 )"
   for MANAGED_PLUGIN in $MANAGED_ENABLED_PLUGINS; do
-    if MANAGED_PLUGIN_OUT="$(timeout -k 5 60 "$OPENCLAW_BIN" plugins enable "$MANAGED_PLUGIN" --accept-capabilities </dev/null 2>&1)"; then
-      echo "  $MANAGED_PLUGIN plugin capabilities accepted/current"
+    MANAGED_PLUGIN_RC=0
+    MANAGED_PLUGIN_OUT="$(timeout -k 5 60 "$OPENCLAW_BIN" plugins enable "$MANAGED_PLUGIN" --accept-capabilities </dev/null 2>&1)" \
+      || MANAGED_PLUGIN_RC=$?
+    MANAGED_PLUGIN_VERDICT=0
+    clawbox_plugin_consent_outcome "$MANAGED_PLUGIN" "$MANAGED_PLUGIN_RC" || MANAGED_PLUGIN_VERDICT=$?
+    if [ "$MANAGED_PLUGIN_VERDICT" = "0" ]; then
+      echo "  $MANAGED_PLUGIN plugin capabilities accepted/current$CLAWBOX_CONSENT_DETAIL"
       clawbox_plugin_repair_clear "$MANAGED_PLUGIN"
       continue
     fi
-    # `enable` said no. WHY it said no decides what happens next, and the exit
-    # code alone cannot: it is also non-zero for a config lock, a registry
-    # hiccup and — the one that matters on a cold Jetson — the 60 s timeout
-    # above, none of which a 120 s npm install repairs. `Plugin not found: <id>`
+    # The consent is not established — either `enable` refused outright, or it
+    # was killed and the core does not report the consent as recorded. WHY it
+    # said no decides what happens next, and the exit code alone cannot: it is
+    # also non-zero for a config lock, a registry hiccup and the kill above,
+    # none of which a 120 s npm install repairs. `Plugin not found: <id>`
     # is the core's own wording for the package not being on disk (verified
     # against the installed 2026.8.1 CLI), which is the state a core upgrade
     # leaves behind: plugin payloads live in npm project directories keyed to

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -2620,37 +2620,83 @@ clawbox_plugin_boot_without() {
 # enabled non-bundled plugin whose accepted surface is not current, reading
 # `Plugin "<id>" requires capability consent; …`. That is the same sentence the
 # updater greps out of the gateway journal (PLUGIN_CAPABILITY_CONSENT_RE), and
-# `plugins inspect <id> --json` carries it WITHOUT `--runtime` — so this costs a
-# CLI start and not a module load of every enabled plugin.
+# `plugins inspect --all --json` carries it WITHOUT `--runtime` — so this costs
+# a CLI start and not a module load of every enabled plugin.
 #
-# WHAT THIS DELIBERATELY DOES NOT DO: it never leaves an unresolved plugin
-# enabled. A gateway that refuses readiness burns `StartLimitBurst=20` inside
-# `StartLimitIntervalSec=3600` and the unit is then FAILED, not retried — the
-# measured TASK-606 outage — and nothing running as `clawbox` clears a start
-# limit at boot. So an answer we cannot get keeps the existing behaviour
-# (switch off, mark, offer the Retry); only a consent PROVED to be recorded
-# changes the outcome. Whether a slow box should instead be allowed to boot
-# with the plugin still on is the same owner ruling D-02 itself was, and is not
-# taken here.
+# BUT SILENCE IS NOT CONSENT. `collectPluginCapabilityConsentDiagnostics`
+# (2026.8.1) walks the INSTALLED index and skips a plugin that is bundled,
+# index-disabled, or has no install owner and record; a plugin the index does
+# not list at all is never walked. So "no diagnostic names this id" is a
+# statement about consent only for an id the core actually adjudicated, and
+# reading it as one for the rest is the false success this block exists to
+# remove: on a payload stranded by a core generation bump (TASK-602) it would
+# leave an unloadable plugin enabled and clear its repair badge, which IS the
+# TASK-606 outage.
+#
+# So the report is asked what it POSITIVELY says about the id, and there are
+# three answers rather than two:
+#
+#   * adjudicated (the entry carries the install record the `--all` branch
+#     attaches) and not named by a consent diagnostic -> the consent is
+#     recorded: clear the marker, leave the plugin on;
+#   * named by a consent diagnostic -> still unconsented: the existing refusal
+#     path, unchanged;
+#   * the report does not name the id, or names it in a state the core would
+#     not load -> nothing was proved and the plugin cannot be relied on to
+#     load: the same refusal path, because leaving it enabled is the outage.
+#
+# WHAT THIS DELIBERATELY DOES NOT DO: it never leaves a plugin the core would
+# refuse to load enabled. A gateway that refuses readiness burns
+# `StartLimitBurst=20` inside `StartLimitIntervalSec=3600` and the unit is then
+# FAILED, not retried — the measured TASK-606 outage — and nothing running as
+# `clawbox` clears a start limit at boot.
+#
+# The one case that changes nothing either way is a plugin the core can see and
+# would load but keeps NO install record for — a directory-discovered
+# `~/.openclaw/extensions/` plugin, which is what `deepseek` and
+# `clawbox-email-directives` are on a box today. The core cannot emit a consent
+# diagnostic for one, so it can never refuse readiness over its consent either:
+# switching it off would be a false failure over a plugin that is working, and
+# calling it accepted/current a false success. The boot says so in one line and
+# leaves the entry and any existing marker exactly as it found them, for the
+# next boot or the Settings Retry to resolve.
 
 # The consent question is asked at most ONCE per boot, for every id at once:
 # the CLI start is the dominant cost and this runs inside a blocking
 # ExecStartPre. Empty until the first kill asks for it.
-CLAWBOX_CONSENT_PENDING=""
-CLAWBOX_CONSENT_PENDING_READY=0
+#
+# ONE SNAPSHOT, TAKEN AT THE FIRST KILL OF THE BOOT. A consent recorded by a
+# LATER killed verb is not in it, so that plugin is still named and is switched
+# off — beta's behaviour, conservative, and the reason this reads as a fix for
+# the first killed verb of a boot. Re-reading per verb would add up to another
+# five 65 s CLI starts to a chain that already spends most of
+# `TimeoutStartSec=600` in the pathological case.
+CLAWBOX_CONSENT_STATES=""
+CLAWBOX_CONSENT_STATES_READY=0
 
-# The ids the core says are still waiting for capability consent, space-padded
+# `@openclaw/discord`, `openclaw-discord` and `discord` are one plugin: the
+# registry answers to all three and `ensureChannelPlugin` enables whichever one
+# it found, while the core's reports always key on the bare id. Same rule as
+# `canonical()` in the managed-plugin reader below, and without it an
+# alias-keyed entry would match nothing in the report and be switched off on
+# every killed verb.
+clawbox_plugin_canonical_id() {
+  local id="${1#@openclaw/}"
+  printf '%s' "${id#openclaw-}"
+}
+
+# What the core's own report says about each plugin, as ` <state>:<id> ` tokens
 # for a substring test. Answers 1 when the question could be asked at all, 2
 # when it could not.
-clawbox_consent_pending_load() {
+clawbox_consent_states_load() {
   local rc=0 file=""
-  [ "$CLAWBOX_CONSENT_PENDING_READY" = "0" ] || return "$CLAWBOX_CONSENT_PENDING_READY"
+  [ "$CLAWBOX_CONSENT_STATES_READY" = "0" ] || return "$CLAWBOX_CONSENT_STATES_READY"
   # THROUGH A FILE, not through the environment. Measured on a box: this answer
   # is 285 KB for 65 plugin reports, and Linux caps a single environment string
   # at MAX_ARG_STRLEN (131 072), so the `VAR="$out" python3 -` idiom the rest of
   # this script uses for small payloads dies here with E2BIG. A command
   # substitution would hold it in the shell too; the reader gets a path.
-  file="$(mktemp 2>/dev/null)" || { CLAWBOX_CONSENT_PENDING_READY=2; return 2; }
+  file="$(mktemp 2>/dev/null)" || { CLAWBOX_CONSENT_STATES_READY=2; return 2; }
   # `--all --json` and NOT `--runtime`: the consent diagnostics are on the
   # snapshot path as well, and the runtime flag only adds the hook/tool/service
   # data this question never reads — it is the module load of every enabled
@@ -2660,13 +2706,13 @@ clawbox_consent_pending_load() {
   timeout -k 5 60 "$OPENCLAW_BIN" plugins inspect --all --json </dev/null >"$file" 2>/dev/null || rc=$?
   if [ "$rc" != "0" ]; then
     rm -f "$file" 2>/dev/null || true
-    CLAWBOX_CONSENT_PENDING_READY=2
+    CLAWBOX_CONSENT_STATES_READY=2
     return 2
   fi
-  # The reader prints `ok` and then the ids, so an answer that could not be
+  # The reader prints `ok` and then the states, so an answer that could not be
   # parsed is NOT read as "every plugin is consented" — that would be the exact
   # false success this whole block exists to remove.
-  CLAWBOX_CONSENT_PENDING="$(python3 - "$file" <<'PY' 2>/dev/null || true
+  CLAWBOX_CONSENT_STATES="$(python3 - "$file" <<'PY' 2>/dev/null || true
 import json, sys
 
 try:
@@ -2675,52 +2721,105 @@ try:
 except Exception:
     raise SystemExit(1)
 
-# `--all` answers with a LIST of reports (65 of them on a real box); a single
-# `inspect <id>` answers with one object. Both carry `diagnostics` arrays whose
-# entries name their own pluginId, so walk whatever shape arrives.
-def walk(node, out):
+
+def canonical(name):
+    for prefix in ("@openclaw/", "openclaw-"):
+        if name.startswith(prefix):
+            return name[len(prefix):]
+    return name
+
+
+# A consent diagnostic is only ever raised against an id the core adjudicated,
+# so collecting them wherever they sit in the document is safe. What the states
+# below decide is what their ABSENCE is allowed to mean.
+def collect_pending(node, out):
     if isinstance(node, dict):
         for entry in node.get("diagnostics") or []:
             if not isinstance(entry, dict):
                 continue
             pid = entry.get("pluginId")
             if isinstance(pid, str) and "requires capability consent" in str(entry.get("message") or ""):
-                out.add(pid)
+                out.add(canonical(pid))
         for value in node.values():
-            walk(value, out)
+            collect_pending(value, out)
     elif isinstance(node, list):
         for value in node:
-            walk(value, out)
+            collect_pending(value, out)
+
 
 pending = set()
-walk(data, pending)
-print(" ".join(["ok"] + sorted(pending)))
+collect_pending(data, pending)
+
+# `--all` answers with a LIST of per-plugin reports (65 of them on a real box);
+# a single `inspect <id>` answers with one object.
+if isinstance(data, list):
+    reports = [item for item in data if isinstance(item, dict)]
+elif isinstance(data, dict):
+    reports = [data]
+else:
+    reports = []
+
+states = {}
+for report in reports:
+    plugin = report.get("plugin")
+    if not isinstance(plugin, dict):
+        continue
+    pid = plugin.get("id")
+    if not isinstance(pid, str) or not pid:
+        continue
+    pid = canonical(pid)
+    if pid in pending:
+        continue
+    # `status` is NOT evidence of a consent — it is the config's own enablement
+    # bit under another name — and is read here only to WITHHOLD one: a plugin
+    # the core would not load must never be left enabled on a "cannot tell".
+    if plugin.get("status") != "loaded":
+        continue
+    # `install` is the install record the `--all` branch attaches per plugin,
+    # and it is absent exactly when the core could not resolve an install owner
+    # for it — one of the gates in front of every consent diagnostic. Without
+    # one the core CANNOT have an opinion on this plugin's consent, so its
+    # silence is not one.
+    install = report.get("install")
+    states[pid] = "consented" if isinstance(install, dict) and install else "seen"
+
+for pid in pending:
+    states[pid] = "pending"
+
+print(" ".join(["ok"] + sorted(f"{state}:{pid}" for pid, state in states.items())))
 PY
-  )" || CLAWBOX_CONSENT_PENDING=""
+  )" || CLAWBOX_CONSENT_STATES=""
   rm -f "$file" 2>/dev/null || true
-  case "$CLAWBOX_CONSENT_PENDING" in
+  case "$CLAWBOX_CONSENT_STATES" in
     ok|"ok "*)
-      CLAWBOX_CONSENT_PENDING=" ${CLAWBOX_CONSENT_PENDING#ok} "
-      CLAWBOX_CONSENT_PENDING_READY=1
+      CLAWBOX_CONSENT_STATES=" ${CLAWBOX_CONSENT_STATES#ok} "
+      CLAWBOX_CONSENT_STATES_READY=1
       return 1
       ;;
   esac
-  CLAWBOX_CONSENT_PENDING=""
-  CLAWBOX_CONSENT_PENDING_READY=2
+  CLAWBOX_CONSENT_STATES=""
+  CLAWBOX_CONSENT_STATES_READY=2
   return 2
 }
 
-# Is this plugin's capability consent RECORDED, by the core's own account?
-#   0  yes — no consent diagnostic names it
-#   1  no, or the core could not be asked
-clawbox_plugin_consent_recorded() {
-  local id="$1" ready=0
-  clawbox_consent_pending_load || ready=$?
-  [ "$ready" = "1" ] || return 1
-  case "$CLAWBOX_CONSENT_PENDING" in
-    *" $id "*) return 1 ;;
-    *) return 0 ;;
+# What the core's report positively says about one plugin's consent.
+#   0  it adjudicated the plugin and raised no consent diagnostic — recorded
+#   1  it says the plugin still requires consent
+#   2  it can see the plugin and would load it, but keeps no consent record
+#      for it — the question cannot be answered and does not arise
+#   3  it does not name the plugin, names it in a state it would not load, or
+#      could not be asked at all
+clawbox_plugin_consent_state() {
+  local id ready=0
+  id="$(clawbox_plugin_canonical_id "$1")"
+  clawbox_consent_states_load || ready=$?
+  [ "$ready" = "1" ] || return 3
+  case "$CLAWBOX_CONSENT_STATES" in
+    *" pending:$id "*) return 1 ;;
+    *" consented:$id "*) return 0 ;;
+    *" seen:$id "*) return 2 ;;
   esac
+  return 3
 }
 
 # Set by clawbox_plugin_consent_outcome for its caller's own message.
@@ -2729,6 +2828,8 @@ CLAWBOX_CONSENT_DETAIL=""
 # The verdict on one consent attempt.
 #   0  consented, or already current — clear any repair marker
 #   1  not established — the caller's existing refusal path, unchanged
+#   2  cannot be established, and the plugin is one the core sees and would
+#      load — change nothing at all and say so
 #
 # Only a kill at the deadline asks the second question, and only a definite
 # "the core has the consent recorded" changes the answer. 124 is `timeout`
@@ -2736,17 +2837,23 @@ CLAWBOX_CONSENT_DETAIL=""
 # and is also what the OOM killer sends. Both are asked about rather than
 # assumed, so a CLI that chose 124 as its own exit code is not mis-read either.
 clawbox_plugin_consent_outcome() {
-  local id="$1" rc="$2"
+  local id="$1" rc="$2" state=0
   CLAWBOX_CONSENT_DETAIL=""
   if [ "$rc" = "0" ]; then
     return 0
   fi
   case "$rc" in
     124|137)
-      if clawbox_plugin_consent_recorded "$id"; then
-        CLAWBOX_CONSENT_DETAIL=" (the consent verb was killed at its deadline, and the core reports the consent as recorded)"
-        return 0
-      fi
+      clawbox_plugin_consent_state "$id" || state=$?
+      case "$state" in
+        0)
+          CLAWBOX_CONSENT_DETAIL=" (the consent verb was killed at its deadline, and the core reports the consent as recorded)"
+          return 0
+          ;;
+        2)
+          return 2
+          ;;
+      esac
       ;;
   esac
   return 1
@@ -3288,6 +3395,13 @@ elif [ "$CLAWBOX_OPENCLAW_V2" = "1" ] && [ "$CODEX_SHOULD_LOAD" = "1" ]; then
   if [ "$CODEX_CONSENT_VERDICT" = "0" ]; then
     echo "  Codex runtime plugin capabilities accepted/current$CLAWBOX_CONSENT_DETAIL"
     clawbox_plugin_repair_clear codex
+  elif [ "$CODEX_CONSENT_VERDICT" = "2" ]; then
+    # The core sees the plugin and would load it but keeps no install record for
+    # it, so it can neither report the consent nor refuse readiness over it.
+    # Nothing is switched off and nothing is cleared: an existing repair row is
+    # still the truest thing on the screen, and the next boot or the Retry it
+    # offers resolves this.
+    echo "  Codex runtime plugin capabilities are still unknown (the consent verb was killed at its deadline and the core keeps no consent record for this plugin); leaving it as it is"
   else
     echo "  WARN: could not confirm Codex plugin capabilities; booting without Codex"
     clawbox_plugin_boot_without codex consent \
@@ -3362,6 +3476,15 @@ MANAGEDPY
     if [ "$MANAGED_PLUGIN_VERDICT" = "0" ]; then
       echo "  $MANAGED_PLUGIN plugin capabilities accepted/current$CLAWBOX_CONSENT_DETAIL"
       clawbox_plugin_repair_clear "$MANAGED_PLUGIN"
+      continue
+    fi
+    if [ "$MANAGED_PLUGIN_VERDICT" = "2" ]; then
+      # Same as the codex arm above: the core sees this plugin and would load
+      # it, but keeps no install record for it — deepseek and
+      # clawbox-email-directives live in `~/.openclaw/extensions/` and are
+      # exactly this — so it can neither report the consent nor refuse readiness
+      # over it. Change nothing, clear nothing, and say which of the two it is.
+      echo "  $MANAGED_PLUGIN plugin capabilities are still unknown (the consent verb was killed at its deadline and the core keeps no consent record for this plugin); leaving it as it is"
       continue
     fi
     # The consent is not established — either `enable` refused outright, or it

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -2768,8 +2768,6 @@ for report in reports:
     if not isinstance(pid, str) or not pid:
         continue
     pid = canonical(pid)
-    if pid in pending:
-        continue
     # `status` is NOT evidence of a consent — it is the config's own enablement
     # bit under another name — and is read here only to WITHHOLD one: a plugin
     # the core would not load must never be left enabled on a "cannot tell".
@@ -2783,6 +2781,9 @@ for report in reports:
     install = report.get("install")
     states[pid] = "consented" if isinstance(install, dict) and install else "seen"
 
+# LAST, so it overrides: a diagnostic is the core speaking, and it outranks
+# anything read off the same plugin's own entry — including an entry the report
+# does not carry at all.
 for pid in pending:
     states[pid] = "pending"
 

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -3492,10 +3492,11 @@ MANAGEDPY
     fi
     if [ "$MANAGED_PLUGIN_VERDICT" = "2" ]; then
       # Same as the codex arm above: the core sees this plugin and would load
-      # it, but keeps no install record for it — deepseek and
-      # clawbox-email-directives live in `~/.openclaw/extensions/` and are
-      # exactly this — so it can neither report the consent nor refuse readiness
-      # over it. Change nothing, clear nothing, and say which of the two it is.
+      # it, but keeps no install record for it — `clawbox-email-directives`, the
+      # one this script copies out of the checkout rather than installing, is
+      # exactly this on a box today — so the core can neither report the consent
+      # nor refuse readiness over it. Change nothing, clear nothing, say which
+      # of the two it is.
       echo "  $MANAGED_PLUGIN plugin capabilities are still unknown (the consent verb was killed at its deadline and the core keeps no consent record for this plugin); leaving it as it is"
       continue
     fi

--- a/src/tests/helpers/gateway-pre-start.ts
+++ b/src/tests/helpers/gateway-pre-start.ts
@@ -49,3 +49,49 @@ export function repairHelpers(): string {
     "# A `.openclaw` INSIDE the state directory",
   );
 }
+
+/**
+ * One `openclaw plugins inspect --all --json` answer, in the CLI's own shape.
+ *
+ * 2026.8.1 answers `--all --json` with a LIST of per-plugin inspect reports,
+ * each `{plugin, diagnostics, …}` (`buildAllPluginInspectReports`), and the
+ * `--all` branch attaches that plugin's install record as `install` —
+ * `undefined`, so ABSENT from the JSON, whenever the core cannot resolve one
+ * (`resolveInstalledPluginPackageOwnership`).
+ *
+ * That absence is the whole point of this builder. The consent diagnostic is
+ * emitted only for a plugin the core adjudicated — enabled, not bundled, WITH
+ * an install owner and record — so "no diagnostic names this id" is a statement
+ * about consent only for an entry that carries `install`, and says nothing at
+ * all about an entry without one or about an id the report never mentions.
+ */
+export function inspectAllJson(
+  plugins: ReadonlyArray<{
+    id: string;
+    /** The core resolved an install record for it. Default true. */
+    installed?: boolean;
+    /** The core's "requires capability consent" diagnostic names it. */
+    consentRequired?: boolean;
+    /** `plugin.status` as the snapshot reports it. Default "loaded". */
+    status?: "loaded" | "disabled" | "error";
+  }>,
+): string {
+  return JSON.stringify(
+    plugins.map(({ id, installed = true, consentRequired = false, status = "loaded" }) => ({
+      workspaceDir: "/var/lib/clawbox/openclaw/workspace",
+      plugin: { id, name: id, status, origin: "npm" },
+      ...(installed ? { install: { pluginId: id, packagePath: `/var/lib/openclaw/npm/${id}` } } : {}),
+      diagnostics: consentRequired
+        ? [
+            {
+              level: "warn",
+              pluginId: id,
+              // formatPluginCapabilityConsentRequired, verbatim in shape.
+              message: `Plugin "${id}" requires capability consent; disable and re-enable it to review the new surface.`,
+            },
+          ]
+        : [],
+      compatibility: [],
+    })),
+  );
+}

--- a/src/tests/helpers/gateway-pre-start.ts
+++ b/src/tests/helpers/gateway-pre-start.ts
@@ -91,7 +91,6 @@ export function inspectAllJson(
             },
           ]
         : [],
-      compatibility: [],
     })),
   );
 }

--- a/src/tests/unit/gateway-pre-start-codex-runtime.test.ts
+++ b/src/tests/unit/gateway-pre-start-codex-runtime.test.ts
@@ -12,7 +12,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { repairHelpers } from "@/tests/helpers/gateway-pre-start";
+import { inspectAllJson, repairHelpers } from "@/tests/helpers/gateway-pre-start";
 
 // Starts a real process (bash / python3 / node / git): vitest's 5 s test and
 // 10 s hook defaults are not enough on a loaded CI runner. See
@@ -191,7 +191,9 @@ interface PluginFlowOptions {
    * `plugins inspect --all --json` stdout; omitted = the CLI cannot answer.
    *
    * The consent answer is the `diagnostics` array. `status`/`activated` are the
-   * config's own `enabled` bit under another name and cannot carry it.
+   * config's own `enabled` bit under another name and cannot carry it. Built
+   * with `inspectAllJson`, because an answer that never NAMES codex — or names
+   * it without an install record — is the core saying nothing about it.
    */
   inspectJson?: string;
 }
@@ -578,11 +580,13 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh agentRuntime policy", () => {
   const CONSENTED = { v2: true, needsCodex: false, enabledByConfig: true,
     installedVersion: "2026.8.1", peerHealthy: true } as const;
 
-  it.each([124, 137])("keeps Codex on when a killed verb had recorded the consent (exit %i)", (code) => {
+  it.each([124, 137])("keeps Codex on when the core positively reports the consent (exit %i)", (code) => {
+    // Named, adjudicated (it carries its install record), and no consent
+    // diagnostic: the one shape that means the consent is recorded.
     const { argv, stdout, marker } = runPluginFlowFull({
       ...CONSENTED,
       consentExit: code,
-      inspectJson: '{"diagnostics":[]}',
+      inspectJson: inspectAllJson([{ id: "codex" }]),
     });
     expect(argv).toContain("plugins inspect --all --json");
     expect(stdout).toContain("Codex runtime plugin capabilities accepted/current");
@@ -590,13 +594,43 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh agentRuntime policy", () => {
     expect(marker).toEqual({});
   });
 
+  it("does not read silence about Codex as Codex's consent", () => {
+    // `collectPluginCapabilityConsentDiagnostics` never walks a plugin its
+    // installed index does not list, which is what a core generation bump
+    // leaves behind — so an answer that does not mention codex is the core
+    // having nothing to say, not the core reporting a recorded consent.
+    const { stdout, marker } = runPluginFlowFull({
+      ...CONSENTED,
+      consentExit: 124,
+      inspectJson: inspectAllJson([{ id: "discord" }]),
+    });
+    expect(stdout).not.toContain("Codex runtime plugin capabilities accepted/current");
+    expect(stdout).toContain("booting without Codex");
+    expect(marker.codex?.stage).toBe("consent");
+  });
+
+  it("leaves Codex exactly as it is when the core keeps no consent record for it", () => {
+    // Named and loading, but with no install record the core can never emit a
+    // consent diagnostic for it — so it can never refuse readiness for consent
+    // either. Switching it off would be a false failure and calling it
+    // accepted/current a false success; say so and change nothing.
+    const { argv, stdout, marker } = runPluginFlowFull({
+      ...CONSENTED,
+      consentExit: 124,
+      inspectJson: inspectAllJson([{ id: "codex", installed: false }]),
+    });
+    expect(stdout).not.toContain("Codex runtime plugin capabilities accepted/current");
+    expect(stdout).not.toContain("booting without Codex");
+    expect(stdout).toContain("Codex runtime plugin capabilities are still unknown");
+    expect(argv.some((line) => line.startsWith("config set"))).toBe(false);
+    expect(marker).toEqual({});
+  });
+
   it("still boots without Codex when a killed verb had NOT recorded the consent", () => {
     const { stdout, marker } = runPluginFlowFull({
       ...CONSENTED,
       consentExit: 124,
-      inspectJson:
-        '{"diagnostics":[{"level":"warn","pluginId":"codex",'
-        + '"message":"Plugin codex requires capability consent; run openclaw plugins enable"}]}',
+      inspectJson: inspectAllJson([{ id: "codex", consentRequired: true }]),
     });
     expect(stdout).toContain("booting without Codex");
     expect(marker.codex?.stage).toBe("consent");

--- a/src/tests/unit/gateway-pre-start-codex-runtime.test.ts
+++ b/src/tests/unit/gateway-pre-start-codex-runtime.test.ts
@@ -180,10 +180,40 @@ interface PluginFlowOptions {
   peerHealthy?: boolean;
   layout?: "flat-managed" | "project-managed" | "registry";
   registryDependenciesOk?: boolean;
+  /**
+   * Exit code for `plugins enable codex --accept-capabilities`.
+   *
+   * 124/137 are the kill at the deadline — the one failure that says nothing
+   * about whether the consent was written.
+   */
+  consentExit?: number;
+  /**
+   * `plugins inspect --all --json` stdout; omitted = the CLI cannot answer.
+   *
+   * The consent answer is the `diagnostics` array. `status`/`activated` are the
+   * config's own `enabled` bit under another name and cannot carry it.
+   */
+  inspectJson?: string;
 }
 
 /** Execute the shipped shell command flow against a fake OpenClaw binary. */
 function runPluginFlow(options: PluginFlowOptions): string[] {
+  return runPluginFlowFull(options).argv;
+}
+
+/**
+ * The same run, with everything it said and everything it recorded.
+ *
+ * The consent arm now has a third outcome that is defined by what it does NOT
+ * do — no switch-off, no marker — so a case for it has to see the marker file
+ * and stderr, not only the argv log.
+ */
+function runPluginFlowFull(options: PluginFlowOptions): {
+  argv: string[];
+  stdout: string;
+  stderr: string;
+  marker: Record<string, { stage?: string; disabled?: boolean }>;
+} {
   const pluginDir = path.join(dir, "plugin", "node_modules", "@openclaw", "codex");
   if (options.installedVersion) {
     mkdirSync(pluginDir, { recursive: true });
@@ -200,10 +230,25 @@ function runPluginFlow(options: PluginFlowOptions): string[] {
 
   const log = path.join(dir, "openclaw-commands.log");
   const fakeOpenClaw = path.join(dir, "openclaw");
-  writeFileSync(fakeOpenClaw, '#!/usr/bin/env bash\nprintf \'%s\\n\' "$*" >> "$CODEX_TEST_LOG"\n');
+  writeFileSync(
+    fakeOpenClaw,
+    [
+      "#!/usr/bin/env bash",
+      'printf \'%s\\n\' "$*" >> "$CODEX_TEST_LOG"',
+      ...(options.consentExit
+        ? [`if [ "$2" = "enable" ]; then exit ${options.consentExit}; fi`]
+        : []),
+      'if [ "$2" = "inspect" ]; then',
+      ...(options.inspectJson
+        ? [`  printf '%s' '${options.inspectJson}'; exit 0`]
+        : ["  exit 1"]),
+      "fi",
+    ].join("\n"),
+  );
   chmodSync(fakeOpenClaw, 0o755);
 
-  execFileSync("bash", ["-c", `set -euo pipefail\n${PLUGIN_FLOW}`], {
+  const result = spawnSync("bash", ["-c", `set -euo pipefail\n${PLUGIN_FLOW}`], {
+    encoding: "utf-8",
     env: {
       ...process.env,
       // The prepended repair helpers write `$CLAWBOX_ROOT/data/plugin-repair.json`:
@@ -222,10 +267,22 @@ function runPluginFlow(options: PluginFlowOptions): string[] {
     },
     stdio: "pipe",
   });
+  if (result.status !== 0) throw new Error(`plugin flow exited ${result.status}: ${result.stderr}`);
 
-  return existsSync(log)
-    ? readFileSync(log, "utf-8").trim().split("\n").filter(Boolean)
-    : [];
+  let marker: Record<string, { stage?: string; disabled?: boolean }> = {};
+  try {
+    marker = JSON.parse(readFileSync(path.join(dir, "data", "plugin-repair.json"), "utf-8"));
+  } catch {
+    /* no marker was written */
+  }
+  return {
+    argv: existsSync(log)
+      ? readFileSync(log, "utf-8").trim().split("\n").filter(Boolean)
+      : [],
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    marker,
+  };
 }
 
 /**
@@ -509,6 +566,59 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh agentRuntime policy", () => {
       installedVersion: "2026.8.1",
       peerHealthy: true,
     })).toEqual(["plugins enable codex --accept-capabilities"]);
+  });
+
+  // ── The consent verb killed at its deadline (TASK-606 follow-up) ─────────
+  //
+  // The codex twin of the managed loop's cases in
+  // gateway-pre-start-managed-plugin-payload.test.ts. Same verb, same ceiling,
+  // same sibling defect: every non-zero exit was read as a refusal, so a kill
+  // at the deadline switched Codex off over a consent that may well have been
+  // written — `plugins enable` records it and only then loads the gateway SDK.
+  const CONSENTED = { v2: true, needsCodex: false, enabledByConfig: true,
+    installedVersion: "2026.8.1", peerHealthy: true } as const;
+
+  it.each([124, 137])("keeps Codex on when a killed verb had recorded the consent (exit %i)", (code) => {
+    const { argv, stdout, marker } = runPluginFlowFull({
+      ...CONSENTED,
+      consentExit: code,
+      inspectJson: '{"diagnostics":[]}',
+    });
+    expect(argv).toContain("plugins inspect --all --json");
+    expect(stdout).toContain("Codex runtime plugin capabilities accepted/current");
+    expect(stdout).not.toContain("booting without Codex");
+    expect(marker).toEqual({});
+  });
+
+  it("still boots without Codex when a killed verb had NOT recorded the consent", () => {
+    const { stdout, marker } = runPluginFlowFull({
+      ...CONSENTED,
+      consentExit: 124,
+      inspectJson:
+        '{"diagnostics":[{"level":"warn","pluginId":"codex",'
+        + '"message":"Plugin codex requires capability consent; run openclaw plugins enable"}]}',
+    });
+    expect(stdout).toContain("booting without Codex");
+    expect(marker.codex?.stage).toBe("consent");
+  });
+
+  it("still boots without Codex when the core cannot be asked at all", () => {
+    // Never leaves an unresolved plugin enabled: readiness refusal burns
+    // StartLimitBurst=20 and the unit is then FAILED, not retried.
+    const { stdout, marker } = runPluginFlowFull({ ...CONSENTED, consentExit: 137 });
+    expect(stdout).toContain("booting without Codex");
+    expect(marker.codex?.stage).toBe("consent");
+  });
+
+  it("still boots without Codex when the core actually refused the consent", () => {
+    const { argv, stdout, marker } = runPluginFlowFull({ ...CONSENTED, consentExit: 1 });
+    expect(stdout).toContain("booting without Codex");
+    // The marker is what Settings renders the Retry from. The switch-off half
+    // needs an openclaw.json this fragment's environment does not set, and is
+    // pinned in gateway-pre-start-managed-plugin-payload.test.ts.
+    expect(marker.codex?.stage).toBe("consent");
+    // A refusal the core chose never pays for the second question.
+    expect(argv.some((line) => line.startsWith("plugins inspect"))).toBe(false);
   });
 
   it("leaves an explicitly disabled unused plugin alone", () => {

--- a/src/tests/unit/gateway-pre-start-managed-plugin-payload.test.ts
+++ b/src/tests/unit/gateway-pre-start-managed-plugin-payload.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { testEnv } from "@/tests/helpers/env";
-import { repairHelpers } from "@/tests/helpers/gateway-pre-start";
+import { inspectAllJson, repairHelpers } from "@/tests/helpers/gateway-pre-start";
 import { OFFICIAL_CHANNEL_PLUGINS } from "@/lib/openclaw-channels";
 
 // Starts a real process (bash / python3): vitest's 5 s test and 10 s hook
@@ -80,9 +80,13 @@ interface RunOptions {
    *
    * The consent answer is the `diagnostics` array, not `status`/`activated` —
    * those two are the config's own `enabled` bit under another name and are
-   * true before the consent verb has run.
+   * true before the consent verb has run. Build it with `inspectAllJson`: an
+   * answer that does not NAME the id, or names it without an install record,
+   * is the core saying nothing about it rather than reporting its consent.
    */
   inspectJson?: string;
+  /** A `data/plugin-repair.json` the boot starts with. */
+  existingMarker?: Record<string, Record<string, unknown>>;
   /** Install specs (argv[3]) the fake CLI refuses. */
   installFails?: string[];
   /** The INSTALLED core's release as the script resolved it; "" = unknown. */
@@ -97,6 +101,11 @@ function run(opts: RunOptions): {
 } {
   const config = path.join(dir, "openclaw.json");
   writeFileSync(config, JSON.stringify({ plugins: { entries: opts.entries } }));
+
+  if (opts.existingMarker) {
+    mkdirSync(path.join(dir, "data"), { recursive: true });
+    writeFileSync(path.join(dir, "data", "plugin-repair.json"), JSON.stringify(opts.existingMarker));
+  }
 
   const log = path.join(dir, "argv.log");
   const bin = path.join(dir, "openclaw");
@@ -221,20 +230,80 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
   // separate a landed consent from a lost one — and neither can `status` /
   // `activated`, which are that same bit under another name. The core's consent
   // DIAGNOSTIC is the only field that carries the answer.
-  const CONSENT_DIAGNOSTIC = (id: string) =>
-    `Plugin \"${id}\" requires capability consent; disable and re-enable it or run ...`;
+  //
+  // AND IT ONLY CARRIES IT FOR AN ID THE CORE ADJUDICATED.
+  // `collectPluginCapabilityConsentDiagnostics` (2026.8.1) walks the installed
+  // index and skips every plugin that is bundled, index-disabled, or has no
+  // install owner/record — and a plugin the index does not list at all is never
+  // walked. So silence has four meanings and only one of them is consent, which
+  // is why every case below asks what the report POSITIVELY says about the id.
 
-  it.each([124, 137])("switches nothing off when a killed verb had recorded the consent (exit %i)", (code) => {
-    // No diagnostic names discord, so the core has its consent.
+  it.each([124, 137])("clears nothing off a consent the core positively reports (exit %i)", (code) => {
+    // The core names discord, carries its install record — so it DID adjudicate
+    // it — and emits no consent diagnostic for it. That is the one shape that
+    // means "the consent is recorded".
     const { argv, stdout, marker } = run({
       entries: { discord: { enabled: true } },
       enableKilled: { discord: code },
-      inspectJson: '{"diagnostics":[]}',
+      inspectJson: inspectAllJson([{ id: "discord" }]),
     });
     expect(argv).toContain("plugins inspect --all --json");
     expect(stdout).toContain("discord plugin capabilities accepted/current");
     expect(argv.some((line) => line.includes("enabled false"))).toBe(false);
     expect(marker).toEqual({});
+  });
+
+  it("does not read silence about a plugin as that plugin's consent", () => {
+    // The reproduction: a real `--all` answer that simply never mentions
+    // discord. That is what the core emits for a plugin its installed index
+    // does not list — the state a core generation bump leaves behind (TASK-602)
+    // — and reading it as "consented" left an unloadable plugin enabled, which
+    // is the readiness refusal, the burnt StartLimitBurst and the TASK-606
+    // outage.
+    const { argv, stdout, marker } = run({
+      entries: { discord: { enabled: true } },
+      enableKilled: { discord: 124 },
+      inspectJson: inspectAllJson([{ id: "whatsapp" }]),
+    });
+    expect(stdout).not.toContain("discord plugin capabilities accepted/current");
+    expect(argv).toContain('config set plugins.entries["discord"].enabled false --strict-json');
+    expect(stdout).toContain("booting without it");
+    expect(marker.discord?.stage).toBe("consent");
+  });
+
+  it("switches a plugin the core cannot load off, whatever it says about consent", () => {
+    // Named, but not in a state the core would load: never left enabled, or the
+    // gateway refuses readiness over it and the unit burns its start limit.
+    const { argv, stdout } = run({
+      entries: { discord: { enabled: true } },
+      enableKilled: { discord: 124 },
+      inspectJson: inspectAllJson([{ id: "discord", status: "error" }]),
+    });
+    expect(argv).toContain('config set plugins.entries["discord"].enabled false --strict-json');
+    expect(stdout).toContain("booting without it");
+  });
+
+  it("leaves a plugin the core keeps no consent record for exactly as it is", () => {
+    // deepseek and clawbox-email-directives on the box today: enabled, live in
+    // `~/.openclaw/extensions/`, and have no install record — so the core emits
+    // no consent diagnostic for them and CANNOT. Switching them off would be a
+    // false failure over a plugin that is loading fine and can never refuse
+    // readiness for consent; calling it "accepted/current" and clearing the
+    // badge would be the false success. Neither: say so and change nothing.
+    const { argv, stdout, marker } = run({
+      entries: { deepseek: { enabled: true } },
+      enableKilled: { deepseek: 137 },
+      inspectJson: inspectAllJson([{ id: "deepseek", installed: false }]),
+      existingMarker: {
+        deepseek: { id: "deepseek", stage: "install", disabled: false, reason: "earlier boot", atMs: 1 },
+      },
+    });
+    expect(stdout).not.toContain("deepseek plugin capabilities accepted/current");
+    expect(stdout).not.toContain("booting without it");
+    expect(stdout).toContain("deepseek plugin capabilities are still unknown");
+    expect(argv.some((line) => line.includes("enabled false"))).toBe(false);
+    // The marker it started with is still there: not cleared, and not replaced.
+    expect(marker.deepseek?.stage).toBe("install");
   });
 
   it("still switches off when a killed verb had NOT recorded the consent", () => {
@@ -243,7 +312,7 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
     const { argv, stdout, marker } = run({
       entries: { discord: { enabled: true } },
       enableKilled: { discord: 124 },
-      inspectJson: `{"diagnostics":[{"level":"warn","pluginId":"discord","message":"${CONSENT_DIAGNOSTIC("discord")}"}]}`,
+      inspectJson: inspectAllJson([{ id: "discord", consentRequired: true }]),
     });
     expect(argv).toContain('config set plugins.entries["discord"].enabled false --strict-json');
     expect(stdout).toContain("booting without it");
@@ -265,21 +334,31 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
 
   it("reads the diagnostic PER ID, not as one verdict for the boot", () => {
     // The discriminating case: both verbs were killed and both plugins are
-    // enabled, and the core names only one of them. Without this, "the core
-    // said no" and "the core could not be asked" are indistinguishable, because
-    // both end in a switch-off.
+    // enabled and adjudicated, and the core names only one of them.
     const { argv, stdout } = run({
       entries: { discord: { enabled: true }, whatsapp: { enabled: true } },
       enableKilled: { discord: 124, whatsapp: 124 },
-      inspectJson:
-        '{"diagnostics":[{"level":"warn","pluginId":"whatsapp",'
-        + '"message":"Plugin whatsapp requires capability consent; run openclaw plugins enable"}]}',
+      inspectJson: inspectAllJson([{ id: "discord" }, { id: "whatsapp", consentRequired: true }]),
     });
     // whatsapp is named, so it is still unconsented and must go off.
     expect(argv).toContain('config set plugins.entries["whatsapp"].enabled false --strict-json');
-    // discord is NOT named, so its consent landed inside the killed verb.
+    // discord is adjudicated and NOT named, so its consent landed.
     expect(argv.some((line) => line.includes('entries["discord"].enabled false'))).toBe(false);
     expect(stdout).toContain("discord plugin capabilities accepted/current");
+  });
+
+  it("matches the core's own plugin id when the entry is keyed by an alias", () => {
+    // `ensureChannelPlugin` can enable the plugin as `openclaw-whatsapp`, and
+    // the core's reports always key on the bare `whatsapp`. Comparing the two
+    // literally would find the id in neither set and switch a consented channel
+    // off on every killed verb.
+    const { argv, stdout } = run({
+      entries: { "openclaw-whatsapp": { enabled: true } },
+      enableKilled: { "openclaw-whatsapp": 124 },
+      inspectJson: inspectAllJson([{ id: "whatsapp" }]),
+    });
+    expect(stdout).toContain("openclaw-whatsapp plugin capabilities accepted/current");
+    expect(argv.some((line) => line.includes("enabled false"))).toBe(false);
   });
 
   it("asks the core once per boot, not once per plugin", () => {
@@ -287,7 +366,7 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
     const { argv } = run({
       entries: { discord: { enabled: true }, whatsapp: { enabled: true } },
       enableKilled: { discord: 124, whatsapp: 124 },
-      inspectJson: '{"diagnostics":[]}',
+      inspectJson: inspectAllJson([{ id: "discord" }, { id: "whatsapp" }]),
     });
     expect(argv.filter((line) => line.startsWith("plugins inspect"))).toEqual([
       "plugins inspect --all --json",

--- a/src/tests/unit/gateway-pre-start-managed-plugin-payload.test.ts
+++ b/src/tests/unit/gateway-pre-start-managed-plugin-payload.test.ts
@@ -135,6 +135,28 @@ function run(opts: RunOptions): {
         ? ["  exit 1"]
         : [`  printf '%s' '${opts.inspectJson}'; exit 0`]),
       "fi",
+      // `config set plugins.entries["<id>"].enabled <bool>` must REALLY write
+      // the file. `clawbox_plugin_disable` proves its result by re-reading the
+      // config, so a fake that only logged the call sent every switch-off case
+      // through "could not switch the plugin off" — and any assertion that
+      // reads the config back could not fail.
+      'if [ "$1" = "config" ] && [ "$2" = "set" ]; then',
+      `  CFG_KEY="$3" CFG_VALUE="$4" python3 - "${config}" <<'CFGPY'`,
+      "import json, os, sys",
+      "",
+      "PREFIX, SUFFIX = 'plugins.entries[\"', '\"].enabled'",
+      "key = os.environ['CFG_KEY']",
+      "if not (key.startswith(PREFIX) and key.endswith(SUFFIX)):",
+      "    raise SystemExit(0)",
+      "with open(sys.argv[1], encoding='utf-8') as fh:",
+      "    doc = json.load(fh)",
+      "entries = doc.setdefault('plugins', {}).setdefault('entries', {})",
+      "entries.setdefault(key[len(PREFIX):-len(SUFFIX)], {})['enabled'] = os.environ['CFG_VALUE'] == 'true'",
+      "with open(sys.argv[1], 'w', encoding='utf-8') as fh:",
+      "    json.dump(doc, fh)",
+      "CFGPY",
+      "  exit 0",
+      "fi",
       'if [ "$2" = "install" ]; then',
       `  for r in ${(opts.installFails ?? []).map((s) => `'${s}'`).join(" ")}; do`,
       '    if [ "$3" = "$r" ]; then exit 1; fi',
@@ -265,7 +287,7 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
     // — and reading it as "consented" left an unloadable plugin enabled, which
     // is the readiness refusal, the burnt StartLimitBurst and the TASK-606
     // outage.
-    const { argv, stdout, marker } = run({
+    const { argv, stdout, marker, entries } = run({
       entries: { discord: { enabled: true } },
       enableKilled: { discord: 124 },
       inspectJson: inspectAllJson([{ id: "whatsapp" }]),
@@ -273,6 +295,10 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
     expect(stdout).not.toContain("discord plugin capabilities accepted/current");
     expect(argv).toContain('config set plugins.entries["discord"].enabled false --strict-json');
     expect(stdout).toContain("booting without it");
+    // The write LANDED, not just the call: the entry is off in the file the
+    // next boot's loop selects on, and the marker says ClawBox did it.
+    expect(entries.discord?.enabled).toBe(false);
+    expect(marker.discord?.disabled).toBe(true);
     expect(marker.discord?.stage).toBe("consent");
   });
 
@@ -325,7 +351,10 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
       inspectJson: inspectAllJson([{ id: "deepseek", installed: false }]),
     } as const;
     const first = run(opts);
+    // A real assertion: the suite's fake CLI honours `config set … .enabled`,
+    // so a boot that took the refusal path leaves `false` here.
     expect(first.entries.deepseek?.enabled).toBe(true);
+    expect(first.argv.some((line) => line.startsWith("config set"))).toBe(false);
     // The same directory, so this argv log carries BOTH boots.
     const second = run(opts);
     expect(second.argv.filter((line) => line === "plugins enable deepseek --accept-capabilities"))

--- a/src/tests/unit/gateway-pre-start-managed-plugin-payload.test.ts
+++ b/src/tests/unit/gateway-pre-start-managed-plugin-payload.test.ts
@@ -66,13 +66,35 @@ interface RunOptions {
   payloadMissing?: string[];
   /** Plugin ids whose `plugins enable` fails for some OTHER reason. */
   enableFails?: string[];
+  /**
+   * Plugin ids whose `plugins enable` is KILLED at the deadline, by exit code.
+   *
+   * 124 is `timeout` firing at the ceiling; 137 is the SIGKILL `-k 5` sends
+   * five seconds later. Neither says anything about whether the consent was
+   * written: `plugins enable` writes `plugins.entries.<id>.enabled` and THEN
+   * spends seconds loading the gateway SDK.
+   */
+  enableKilled?: Record<string, number>;
+  /**
+   * `plugins inspect --all --json` stdout; omitted = the CLI cannot answer.
+   *
+   * The consent answer is the `diagnostics` array, not `status`/`activated` —
+   * those two are the config's own `enabled` bit under another name and are
+   * true before the consent verb has run.
+   */
+  inspectJson?: string;
   /** Install specs (argv[3]) the fake CLI refuses. */
   installFails?: string[];
   /** The INSTALLED core's release as the script resolved it; "" = unknown. */
   effective?: string;
 }
 
-function run(opts: RunOptions): { argv: string[]; stdout: string } {
+function run(opts: RunOptions): {
+  argv: string[];
+  stdout: string;
+  stderr: string;
+  marker: Record<string, { disabled?: boolean; stage?: string }>;
+} {
   const config = path.join(dir, "openclaw.json");
   writeFileSync(config, JSON.stringify({ plugins: { entries: opts.entries } }));
 
@@ -88,9 +110,19 @@ function run(opts: RunOptions): { argv: string[]; stdout: string } {
       `  for r in ${(opts.payloadMissing ?? []).map((s) => `'${s}'`).join(" ")}; do`,
       '    if [ "$3" = "$r" ]; then echo "Plugin not found: $3. Run \`openclaw plugins list\` to see installed plugins." >&2; exit 1; fi',
       "  done",
+      // A refusal the core CHOSE to make: it ran, it answered, it said no.
       `  for r in ${(opts.enableFails ?? []).map((s) => `'${s}'`).join(" ")}; do`,
-      '    if [ "$3" = "$r" ]; then echo "timeout" >&2; exit 124; fi',
+      '    if [ "$3" = "$r" ]; then echo "refused" >&2; exit 1; fi',
       "  done",
+      // Killed. The process never got to say anything.
+      ...Object.entries(opts.enableKilled ?? {}).map(
+        ([id, code]) => `  if [ "$3" = '${id}' ]; then exit ${code}; fi`,
+      ),
+      "fi",
+      'if [ "$2" = "inspect" ]; then',
+      ...(opts.inspectJson === undefined
+        ? ["  exit 1"]
+        : [`  printf '%s' '${opts.inspectJson}'; exit 0`]),
       "fi",
       'if [ "$2" = "install" ]; then',
       `  for r in ${(opts.installFails ?? []).map((s) => `'${s}'`).join(" ")}; do`,
@@ -125,7 +157,13 @@ function run(opts: RunOptions): { argv: string[]; stdout: string } {
   } catch {
     /* the CLI was never run */
   }
-  return { argv, stdout: result.stdout };
+  let marker: Record<string, { disabled?: boolean; stage?: string }> = {};
+  try {
+    marker = JSON.parse(readFileSync(path.join(dir, "data", "plugin-repair.json"), "utf-8"));
+  } catch {
+    /* no marker was written */
+  }
+  return { argv, stdout: result.stdout, stderr: result.stderr, marker };
 }
 
 describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin payload repair", () => {
@@ -147,9 +185,11 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
   });
 
   it("does NOT reinstall when the consent verb failed for any other reason", () => {
-    // A cold-Jetson `plugins enable` that overran its 60 s budget, a config
-    // lock, a registry hiccup: none of them is a missing payload, and a 120 s
-    // npm install on a BLOCKING ExecStartPre is not their repair.
+    // A config lock, a registry hiccup, a surface the core would not accept:
+    // none of them is a missing payload, and a 120 s npm install on a BLOCKING
+    // ExecStartPre is not their repair. A verb KILLED at its deadline is not in
+    // this family at all and has its own cases below — it is the one failure
+    // that says nothing about whether the consent was recorded.
     const { argv, stdout } = run({
       entries: { discord: { enabled: true }, whatsapp: { enabled: true } },
       enableFails: ["discord", "whatsapp"],
@@ -164,6 +204,106 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
     // (TASK-606): the refusal is real, it is just not one an install repairs.
     expect(argv).toContain('config set plugins.entries["discord"].enabled false --strict-json');
     expect(stdout).toContain("booting without it");
+  });
+
+  // ── A consent verb KILLED at its deadline (TASK-606 follow-up) ───────────
+  //
+  // `timeout -k 5 60 openclaw plugins enable <id> --accept-capabilities` has one
+  // failure that says NOTHING about whether the consent landed: the kill at the
+  // deadline. The verb writes `plugins.entries.<id>.enabled` and THEN spends
+  // seconds loading the gateway SDK, so on a cold Jetson the consent is recorded
+  // and the process is still killed. The loop read every non-zero exit as a
+  // refusal and switched the entry OFF for it — so a box booted without a
+  // correctly consented Discord, and it did NOT heal, because the loop only
+  // visits entries that are already `enabled: true`.
+  //
+  // The entry is already `true` before the call, so re-reading `enabled` cannot
+  // separate a landed consent from a lost one — and neither can `status` /
+  // `activated`, which are that same bit under another name. The core's consent
+  // DIAGNOSTIC is the only field that carries the answer.
+  const CONSENT_DIAGNOSTIC = (id: string) =>
+    `Plugin \"${id}\" requires capability consent; disable and re-enable it or run ...`;
+
+  it.each([124, 137])("switches nothing off when a killed verb had recorded the consent (exit %i)", (code) => {
+    // No diagnostic names discord, so the core has its consent.
+    const { argv, stdout, marker } = run({
+      entries: { discord: { enabled: true } },
+      enableKilled: { discord: code },
+      inspectJson: '{"diagnostics":[]}',
+    });
+    expect(argv).toContain("plugins inspect --all --json");
+    expect(stdout).toContain("discord plugin capabilities accepted/current");
+    expect(argv.some((line) => line.includes("enabled false"))).toBe(false);
+    expect(marker).toEqual({});
+  });
+
+  it("still switches off when a killed verb had NOT recorded the consent", () => {
+    // The core names discord, so readiness really would be refused over it and
+    // the gateway would burn its start limit. Unchanged behaviour.
+    const { argv, stdout, marker } = run({
+      entries: { discord: { enabled: true } },
+      enableKilled: { discord: 124 },
+      inspectJson: `{"diagnostics":[{"level":"warn","pluginId":"discord","message":"${CONSENT_DIAGNOSTIC("discord")}"}]}`,
+    });
+    expect(argv).toContain('config set plugins.entries["discord"].enabled false --strict-json');
+    expect(stdout).toContain("booting without it");
+    expect(marker.discord?.stage).toBe("consent");
+  });
+
+  it("keeps the existing behaviour when the core cannot be asked at all", () => {
+    // NEVER leaves an unresolved plugin enabled: a gateway that refuses
+    // readiness burns StartLimitBurst=20 inside an hour and the unit is then
+    // FAILED, not retried, and nothing running as clawbox clears a start limit.
+    const { argv, stdout, marker } = run({
+      entries: { discord: { enabled: true } },
+      enableKilled: { discord: 137 },
+    });
+    expect(argv).toContain('config set plugins.entries["discord"].enabled false --strict-json');
+    expect(stdout).toContain("booting without it");
+    expect(marker.discord?.stage).toBe("consent");
+  });
+
+  it("reads the diagnostic PER ID, not as one verdict for the boot", () => {
+    // The discriminating case: both verbs were killed and both plugins are
+    // enabled, and the core names only one of them. Without this, "the core
+    // said no" and "the core could not be asked" are indistinguishable, because
+    // both end in a switch-off.
+    const { argv, stdout } = run({
+      entries: { discord: { enabled: true }, whatsapp: { enabled: true } },
+      enableKilled: { discord: 124, whatsapp: 124 },
+      inspectJson:
+        '{"diagnostics":[{"level":"warn","pluginId":"whatsapp",'
+        + '"message":"Plugin whatsapp requires capability consent; run openclaw plugins enable"}]}',
+    });
+    // whatsapp is named, so it is still unconsented and must go off.
+    expect(argv).toContain('config set plugins.entries["whatsapp"].enabled false --strict-json');
+    // discord is NOT named, so its consent landed inside the killed verb.
+    expect(argv.some((line) => line.includes('entries["discord"].enabled false'))).toBe(false);
+    expect(stdout).toContain("discord plugin capabilities accepted/current");
+  });
+
+  it("asks the core once per boot, not once per plugin", () => {
+    // The CLI start is the dominant cost and this is a blocking ExecStartPre.
+    const { argv } = run({
+      entries: { discord: { enabled: true }, whatsapp: { enabled: true } },
+      enableKilled: { discord: 124, whatsapp: 124 },
+      inspectJson: '{"diagnostics":[]}',
+    });
+    expect(argv.filter((line) => line.startsWith("plugins inspect"))).toEqual([
+      "plugins inspect --all --json",
+    ]);
+  });
+
+  it("still switches the plugin off when the core actually refused", () => {
+    // A refusal the core CHOSE to make never pays for the second question.
+    const { argv, stdout, marker } = run({
+      entries: { discord: { enabled: true } },
+      enableFails: ["discord"],
+    });
+    expect(argv).toContain('config set plugins.entries["discord"].enabled false --strict-json');
+    expect(stdout).toContain("booting without it");
+    expect(marker.discord?.stage).toBe("consent");
+    expect(argv.some((line) => line.startsWith("plugins inspect"))).toBe(false);
   });
 
   it("repairs the payload under the alias the registry answers to", () => {

--- a/src/tests/unit/gateway-pre-start-managed-plugin-payload.test.ts
+++ b/src/tests/unit/gateway-pre-start-managed-plugin-payload.test.ts
@@ -98,6 +98,8 @@ function run(opts: RunOptions): {
   stdout: string;
   stderr: string;
   marker: Record<string, { disabled?: boolean; stage?: string }>;
+  /** `plugins.entries` as the boot left it — what the NEXT boot's loop selects on. */
+  entries: Record<string, { enabled?: boolean }>;
 } {
   const config = path.join(dir, "openclaw.json");
   writeFileSync(config, JSON.stringify({ plugins: { entries: opts.entries } }));
@@ -172,7 +174,10 @@ function run(opts: RunOptions): {
   } catch {
     /* no marker was written */
   }
-  return { argv, stdout: result.stdout, stderr: result.stderr, marker };
+  const entries = (JSON.parse(readFileSync(config, "utf-8")) as {
+    plugins?: { entries?: Record<string, { enabled?: boolean }> };
+  }).plugins?.entries ?? {};
+  return { argv, stdout: result.stdout, stderr: result.stderr, marker, entries };
 }
 
 describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin payload repair", () => {
@@ -304,6 +309,28 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
     expect(argv.some((line) => line.includes("enabled false"))).toBe(false);
     // The marker it started with is still there: not cleared, and not replaced.
     expect(marker.deepseek?.stage).toBe("install");
+  });
+
+  it("has the next boot ask again about a plugin it could not tell about", () => {
+    // The device lane measured the 60 s kill hitting 4 of 4 managed plugins on
+    // ONE boot, at an exact 60 s cadence — this is the common path, not an
+    // edge, so "cannot tell" has to heal itself without an owner. It does, by
+    // construction and only by construction: the loop selects on
+    // `enabled: true`, so leaving the entry alone IS the retry. The two the
+    // lane found still off two boots later were switched off, which is what
+    // takes a plugin out of this loop's reach for good.
+    const opts = {
+      entries: { deepseek: { enabled: true } },
+      enableKilled: { deepseek: 124 },
+      inspectJson: inspectAllJson([{ id: "deepseek", installed: false }]),
+    } as const;
+    const first = run(opts);
+    expect(first.entries.deepseek?.enabled).toBe(true);
+    // The same directory, so this argv log carries BOTH boots.
+    const second = run(opts);
+    expect(second.argv.filter((line) => line === "plugins enable deepseek --accept-capabilities"))
+      .toHaveLength(2);
+    expect(second.entries.deepseek?.enabled).toBe(true);
   });
 
   it("still switches off when a killed verb had NOT recorded the consent", () => {


### PR DESCRIPTION
**TASK-606 / D-02** — the regression #706 shipped and deferred on the reviewer's own recommendation, because it needed a design decision rather than a patch.

## Symptom

A box boots **without Discord** (or WhatsApp, DeepSeek, Codex) over a plugin whose capabilities were consented perfectly well. Settings shows a "Needs repair" badge and a Retry the owner has to press. It does not heal on its own: these loops only ever visit entries that are still `enabled: true`, and this one has just been set to `false`.

## Cause

Both consent call sites in `scripts/gateway-pre-start.sh` ran

```
timeout -k 5 60 "$OPENCLAW_BIN" plugins enable <id> --accept-capabilities
```

and read **every** non-zero exit as a refusal, ending in `clawbox_plugin_boot_without`, which switches `plugins.entries.<id>.enabled` off.

The kill at the deadline is the one failure that says nothing about whether the consent landed: `plugins enable` writes `plugins.entries.<id>.enabled` **first** and only then spends seconds loading the gateway SDK, so on a cold Jetson the consent is recorded and the process is still killed at 60 s. Exit 124 is `timeout` firing; 137 is the SIGKILL `-k 5` sends five seconds later.

New in #706 — beta before it only logged `WARN: could not confirm … capabilities`.

## Harness first — and the two traps that had to be avoided

**Trap 1: `status` / `activated`.** The obvious discriminator does not work: the entry is already `true` before the call, so re-reading `enabled` cannot separate a landed consent from a lost one. Neither can `plugins inspect --runtime`'s `status` / `activated`, which is what this fix first used and what the first review caught. Verified read-only against the pinned core 2026.8.1:

```
loader-shared-Bufryvge.js:46          status: params.enabled ? "loaded" : "disabled"
config-normalization-shared-…js:71-73 enabled: source !== "disabled", activated: source !== "disabled"
```

and no loader or status module imports `capability-consent` / `capability-summary` at all. Both fields are the config's own enablement bit under another name — true **before** the consent verb runs, and still true when it never landed.

The core does publish the real answer, from the persisted install record and without loading any plugin runtime — a `diagnostics` entry emitted for every enabled non-bundled plugin whose accepted surface is not current (`collectPluginCapabilityConsentDiagnostics`), reading

```
Plugin "<id>" requires capability consent; disable and re-enable it or run
`openclaw plugins enable <id> --accept-capabilities`.
```

That is the same sentence `src/lib/updater.ts` already greps out of the gateway journal (`PLUGIN_CAPABILITY_CONSENT_RE`), and it rides on the **snapshot** path too — so `plugins inspect --all --json` answers it **without** `--runtime`, the flag that costs a module load of every enabled plugin.

**Trap 2, and the reason for this revision: silence is not consent.** The second review found the first version of this fix reading *"the core did not name this id"* as *"the core has this id's consent"*. It is not the same statement. Verified in the pinned bundle, `status-snapshot-ReEyIkDQ.js:13`:

```js
for (const plugin of params.index.plugins) {
  if (!plugin.enabled || plugin.origin === "bundled") continue;
  const installOwner  = resolveInstalledPluginIndexInstallOwner(plugin);
  const installRecord = installOwner ? params.index.installRecords[installOwner] : undefined;
  if (!installOwner || !installRecord) continue;
  …
}
```

so the core emits **no consent diagnostic at all** for a plugin that is

1. not in the installed index — the state a core **generation bump** leaves behind (TASK-602), the one the same loop's `"Plugin not found"` branch exists to repair;
2. without an install owner / record — a directory-discovered `~/.openclaw/extensions/` plugin. **`deepseek` and `clawbox-email-directives` are exactly this on a box today**, both `MANAGED`, both enabled, both visited every boot;
3. bundled;
4. index-disabled.

Reading (1) as consent leaves an **unloadable plugin enabled** and clears its repair badge — readiness refused, `Restart=always`, `StartLimitBurst=20` inside `StartLimitIntervalSec=3600`, unit **failed, not retried**. That is the TASK-606 outage, on a path beta currently gets right, printed to the operator as *"the core reports the consent as recorded"*. A false success in the repo's own named class, on the one path this card exists to make honest.

## The fix

The report is asked what it **positively says** about the id, and there are three answers rather than two. `plugins inspect --all --json` attaches each plugin's install record to its own entry (`plugins-inspect-command-NO8n6USt.js`: `install: resolveInstallRecord(inspect.plugin.id)`, absent from the JSON when the core cannot resolve one) — which is the same gate the consent emitter puts in front of every diagnostic, so it is exactly the set of ids the core adjudicated.

| `plugins enable` exit | what the core's report says about the id | what happens |
|---|---|---|
| `0` | — | consented — clear the repair marker (unchanged) |
| `124` / `137` | names it, carries its install record, no consent diagnostic | consented — clear the marker, switch nothing off |
| `124` / `137` | names it with a consent diagnostic | the existing refusal path, unchanged |
| `124` / `137` | names it, would load it, but keeps **no install record** for it | **new**: change nothing at all — one line in the boot log, entry left on, marker left exactly as it was |
| `124` / `137` | does not name it, or names it in a state it would not load (`status: "error"`) | the existing refusal path — the plugin cannot be relied on to load |
| `124` / `137` | cannot be asked, or answers unreadably | the existing refusal path, unchanged |
| any other non-zero | — | the existing refusal path, unchanged |

**It still never leaves a plugin the core would refuse to load enabled.** Report-absence and `status: "error"` are what identify that plugin, and both end in the refusal path.

**The third outcome cannot cause the outage it declines to prevent, and the reason is the install record — not `status`.** Every mechanism in 2026.8.1 that can refuse gateway readiness over a plugin is gated on one: both consent emitters (`collectPluginCapabilityConsentDiagnostics`, and the management service's `ownership.ok && installRecord`) and the startup payload verification, which is driven entirely by `loadInstalledPluginIndexInstallRecords`. A plugin the core keeps no record for can therefore neither have its consent reported nor block readiness. `status: "loaded"` is read only to **withhold** evidence, never to grant it — the block's own header spends fifteen lines refusing that field as proof of anything, and the code does not quietly rely on it here.

So: switching such a plugin off would be a false failure over something that cannot be the problem, and calling it accepted/current would be the false success. It says which of the two it is and changes nothing, and the next boot or the Settings Retry resolves it.

**No second CLI start.** The brief for this revision asked for a `plugins inspect --runtime --json` on the cannot-tell path to prove the plugin loads. That call is not made, deliberately: (a) verdict 3 — report-absent, or named with `status: "error"` — is **already** the refusal path, which is beta's behaviour, so a `--runtime` answer could only ever *rescue* a plugin from a switch-off; it can never prevent an outage and its absence cannot cause one; (b) `--runtime` module-loads every enabled plugin, the cost this whole design exists to avoid, in a blocking `ExecStartPre` whose budget is spent below; (c) a `--runtime` inspect timed at 60 s can itself be killed at its deadline, reintroducing the same "cannot tell" one layer down. The only outcome where a runtime answer would have changed an *action* rather than a message is verdict 2 — and there the safety is the install-record invariant above, not anything `status` proves.

**Aliases.** The id is canonicalised (`@openclaw/discord`, `openclaw-discord`, `discord`) before it is looked up, the same rule the managed-plugin reader already uses. The core's reports always key on the bare id, so without this an alias-keyed entry would match nothing and be switched off on every killed verb — the very failure this PR removes.

The question is asked **once per boot** for every id at once, and only after a kill actually happens, so a healthy boot pays nothing. An unparseable answer is **not** read as "everything is consented": the reader prints an `ok` sentinel first, and anything else falls back to the refusal path.

**What this fix does NOT claim.** The snapshot is taken at the **first** killed verb of a boot and reused, and the codex verb runs before the managed loop — so on a boot whose codex verb is killed, the snapshot predates every managed plugin's own consent write. This head therefore fixes the case where the consent was **already current before the boot** (the common shape: `plugins enable` is idempotent, so it is a slow no-op that gets killed), not one written for the first time inside the verb that is then killed.

It is stale in one direction only, which is what makes it safe rather than merely cautious: `plugins enable --accept-capabilities` only ever **adds** consent, so an old snapshot can be wrong by naming a plugin that has since been consented — a false failure, identical to beta — and a stale `consented` is unreachable.

The per-verb reload CodeRabbit proposed was not taken, and **not for the cost reason the first review gave**. Measured on the box (below), one `plugins inspect --all --json` costs **9.6 s**, not its 60 s ceiling, so five of them would be ~50 s and not the 325 s that figure assumed. The reason is the pathological box: one loaded enough to kill `plugins enable` at 60 s can push the inspect to its deadline too, and then a per-verb reload spends 5 × 65 s to produce the same refusal five times, while the memoised failure costs one 65 s attempt and every later verb reuses it for free. The memoisation is what bounds the damage on exactly the box that needs it bounded. Recorded as a follow-up with the measured numbers rather than argued from a ceiling.

## RED → GREEN

RED, on this PR's own previous head — the code the second review blocked, `c5bf3de4`, rebased unchanged onto current beta as `bd939b1e` — driven by the reviewer's reproduction: a real `--all` answer that simply never mentions the plugin.

```
× does not read silence about Codex as Codex's consent
× leaves Codex exactly as it is when the core keeps no consent record for it
× does not read silence about a plugin as that plugin's consent
× switches a plugin the core cannot load off, whatever it says about consent
× leaves a plugin the core keeps no consent record for exactly as it is

AssertionError: expected '  discord plugin capabilities accepte…' not to contain 'discord plugin capabilities accepted/…'
- discord plugin capabilities accepted/current
+   discord plugin capabilities accepted/current (the consent verb was killed at its deadline, and the core reports the consent as recorded)

 Test Files  2 failed (2)
      Tests  5 failed | 56 passed (61)
```

That is the defect verbatim: *"the core reports the consent as recorded"* printed against a report that never mentions the plugin, the marker cleared, the entry left enabled.

GREEN — every `gateway-pre-start-*` suite (21) plus `openclaw-config-mock-completeness`, `test-timeout-hygiene` and `state-updater-purity`:

```
 Test Files  24 passed (24)
      Tests  493 passed (493)
```

and the whole unit project, because this head also changes a shared test helper:

```
 Test Files  700 passed (700)
      Tests  11420 passed | 1 skipped (11421)
```

`bash -n scripts/gateway-pre-start.sh` clean; `npx tsc --noEmit -p tsconfig.json` exit 0; `npx eslint` on the three touched TypeScript files exit 0.

## Device proof (read-only), on THIS head

Re-run for this revision, because the previous run proved the previous classifier. OpenClaw box, core `OpenClaw 2026.8.1 (ea80657)`. The consent block is extracted **verbatim from the shipped script** and driven against the box's **own real** `plugins inspect --all --json` answer:

```
real payload bytes=285875
-- the two MANAGED ids that are enabled on this box, killed verb (124) --
  deepseek                  -> verdict=0 consented (clear the marker, leave it enabled)
                               (the consent verb was killed at its deadline, and the core
                                reports the consent as recorded)
  clawbox-email-directives  -> verdict=2 unknown (change nothing, say so)
-- an id the real report does not name at all (the reviewer's reproduction) --
  discord                   -> verdict=1 refusal (switch off, mark, offer the Retry)
-- unchanged paths --
  deepseek, clean exit 0              -> verdict=0
  deepseek, core refused outright (1) -> verdict=1
  deepseek, core unreachable          -> verdict=1
bash=5.1.16(1)-release python3=3.10.12
```

All three outcomes on real data, and the middle one is why the third outcome exists. The box's enabled managed plugins are `deepseek` and `clawbox-email-directives`; both live in `~/.openclaw/extensions/`, but they are **not** the same case:

```
deepseek                  -> consented:deepseek                  (ClawHub install wrote an install record)
clawbox-email-directives  -> seen:clawbox-email-directives       (copied out of the checkout; no install record)
counts over the whole real answer:  consented=1  seen=42  pending=0   sentinel=ok
```

So on the previous head a killed verb on `clawbox-email-directives` was told "the core reports the consent as recorded" on no evidence at all, and the simple "absent means refuse" fix would have switched a working plugin off. Neither happens now.

**Cost, measured rather than assumed:** `plugins inspect --all --json` on this box is **9.6 s** for 285,874 bytes, against its 60 s ceiling. That is the whole price of the second question, once per boot, only after a kill.

**An earlier device claim is withdrawn.** The previous run reported `PASS  same payload, deepseek not named -> consented (verdict=0)` as evidence. It was not evidence: a plugin not being named cannot distinguish "consented" from "the core has nothing to say", which is the defect this revision fixes. (It also happens to be wrong about `deepseek` specifically — the box does carry an install record for it, as the run above shows.)

**The box caught a defect the unit tests could not**, in the first revision: the payload was handed to the reader through an environment variable, the idiom the rest of this script uses for small payloads. The real answer is ~285 KB and Linux caps a single environment string at `MAX_ARG_STRLEN` (131,072), so it died with `Argument list too long` while every mocked test passed. The reader gets a path to a spooled file, and the size and the reason are in the comment.

Nothing on the box was changed: no service restarted, no config written, no marker touched, the device mutex not taken (nothing mutating). Gateway `active` before and after; `openclaw.json` mtime unchanged; the two temp files removed.

## What the device lane measured, and what this fix does about it

The lane found the 60 s kill firing on **4 of 4** managed plugins on one boot, at an exact 60 s cadence — a timeout, not a capability refusal. `codex` and `deepseek` recovered through their own installer blocks further down the script; **`discord` and `whatsapp` have none and were switched off, and are still off two boots later** with the Retry badge up. So this is the common path, not an edge.

| the lane's finding | what this head does |
|---|---|
| the kill is common, so the new outcome must be cheap | one ~10 s inspect per boot, memoised, only after a kill; a healthy boot pays nothing |
| the new outcome must not burn `StartLimitBurst` | verdict 2 switches nothing off and writes no marker, so it cannot add a readiness refusal; and a plugin the core would not load never reaches it |
| an unresolved row must be retried **automatically on the next boot**, not only via Settings Retry | verdict 2 leaves the entry `enabled: true`, and the loop selects on exactly that — so the next boot asks again by construction. Pinned by *"has the next boot ask again about a plugin it could not tell about"*, which runs the loop twice and asserts the second boot re-issues `plugins enable` |
| `discord` / `whatsapp` were switched off by a slow CLI | that is the case this PR exists to stop: an already-consented plugin whose verb is a slow no-op is now named `consented` by the report and stays on. It does **not** cover a consent that has to be written for the first time inside the verb that is then killed — see "What this fix does NOT claim" |

The plugin that is **switched off** still never returns on the boot path (the loop only visits `enabled: true`): that is #706's own known limit, unchanged here, and recorded as a follow-up. This head makes it much rarer; it does not close it.

The 60 s per-call budget is also untouched. With this change the lane's worst boot costs 4 × 60 s of killed enables plus one ~10 s inspect ≈ 250 s of `TimeoutStartSec=600`, and the ceiling case 5 × 65 s + 65 s = 390 s — inside the window either way. Whether 60 s is the right per-call budget is D-02's own ruling, not a fixer's.

## Sibling sweep — every other consumer of the enable deadline

| site | verdict |
|---|---|
| `scripts/gateway-pre-start.sh` codex consent branch | **fixed here** |
| `scripts/gateway-pre-start.sh` managed-plugin consent loop | **fixed here** |
| `src/lib/openclaw-channels.ts:335` | clear — already reads the config back after this exact kill |
| `src/app/setup-api/plugins/repair/route.ts:191` | a failure returns `repair_failed` and the marker stays up; it never switches anything off — but see below |
| `src/lib/updater.ts` `repairPluginsBlockingReadiness` | clear — it acts only on plugins the journal **positively names**; it never infers anything from silence |
| `src/lib/updater.ts` `clearRepairMarkerAfterPayloadRepair` | clear — a timeout warns and leaves the marker; never disables |
| `src/lib/updater.ts` `recordPluginCapabilityConsent` | clear — same: warns, does not clear the marker, never disables |

Both callers of `clawbox_plugin_consent_outcome` handle the new third verdict; there are no others, and the previous helper names (`clawbox_plugin_consent_recorded`, `clawbox_consent_pending_load`, `CLAWBOX_CONSENT_PENDING`) appear nowhere in the tree.

The codex branch also gains `-k 5` on its `timeout`, which every other timed CLI call in this file already carries.

**Recorded, not fixed here:**

1. `src/app/setup-api/plugins/repair/route.ts:116` (`harnessSaysLoaded`), and **an earlier note about it in this PR was too strong**. It is *not* "the same unsound predicate one layer up": it demands positive `status === "loaded" && activated === true` from a **`--runtime`** inspect, where modules really are loaded and `pushPluginValidationError` can set `status: "error"` — so it is neither reading silence nor tautological there. It is a **weaker** signal than the consent diagnostic (it cannot see an unaccepted surface), not an unsound one. Recorded so a future change aims at the right defect; it does not belong in this one.
2. The three `plugins install` deadlines that end in `clawbox_plugin_boot_without` share the "a kill says nothing about whether it landed" property. Different verb, different meaning — an install cut short is a genuine reason to boot without the plugin — so it wants its own card.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plugin consent handling during gateway startup.
  - Consent commands that time out or are terminated are now accepted when consent was successfully recorded.
  - Unconfirmed consent continues to trigger the existing disable-and-repair flow.
  - Startup diagnostics now better distinguish confirmed consent, unavailable verification, and explicit refusals.
  - Added safeguards to ensure consent verification remains bounded and occurs only once per startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->