### PR TITLE
install: let a test point the container markers at its own sandbox

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -701,7 +701,15 @@ in_container() {
   if command -v systemd-detect-virt >/dev/null 2>&1; then
     systemd-detect-virt --container --quiet && return 0
   fi
-  [ -f /.dockerenv ] || [ -f /run/.containerenv ]
+  # The marker paths are a variable so a test can point them at its own
+  # sandbox: read from the real filesystem, this probe answers "container" for
+  # every suite that itself runs in one, and the cases it would then skip are
+  # the ones worth exercising.
+  local marker
+  for marker in ${CLAWBOX_CONTAINER_MARKERS:-/.dockerenv /run/.containerenv}; do
+    [ -f "$marker" ] && return 0
+  done
+  return 1
 }
 
 harness_has_no_gpu() {

--- a/src/tests/unit/install-swapfile.test.ts
+++ b/src/tests/unit/install-swapfile.test.ts
@@ -48,6 +48,24 @@ const STEP = extractShellFunction("step_swapfile");
 const FSTAB_FN = extractShellFunction("ensure_swapfile_fstab");
 const IN_CONTAINER = extractShellFunction("in_container");
 
+/**
+ * The real binaries the step shells out to, resolved ONCE against this
+ * machine's PATH. The sandbox's PATH is built from these rather than
+ * inherited, so the only `systemd-detect-virt` a case can reach is the stub it
+ * asked for — and `spawnSync` resolves the shell itself through the CHILD's
+ * PATH, which is why bash is on the list too.
+ */
+const REAL_TOOLS: Record<string, string> = (() => {
+  const found: Record<string, string> = {};
+  for (const tool of ["bash", "sh", "grep", "awk", "tail", "tr", "dd", "chmod", "chown", "rm", "wc", "cat"]) {
+    const probe = spawnSync("/usr/bin/env", ["sh", "-c", `command -v ${tool}`], { encoding: "utf-8" });
+    const real = probe.stdout.trim();
+    if (real) found[tool] = real;
+  }
+  return found;
+})();
+const BASH = REAL_TOOLS.bash ?? "/bin/bash";
+
 let tmp: string;
 
 /**
@@ -60,6 +78,13 @@ function runStep(opts: {
   swaponFails?: boolean;
   testMode?: boolean;
   container?: boolean;
+  /**
+   * Which of the configured marker paths actually exists. Default: both.
+   * A case that writes every marker cannot tell a probe that reads the whole
+   * list from one that stops at the first path, so the fallback cases name
+   * one marker each.
+   */
+  containerMarkers?: number[];
   detectVirtMissing?: boolean;
   readOnlyFstab?: boolean;
   fstab?: string;
@@ -92,8 +117,24 @@ function runStep(opts: {
   const markerDir = path.join(tmp, "markers");
   fs.mkdirSync(markerDir, { recursive: true });
   const markers = [path.join(markerDir, "dockerenv"), path.join(markerDir, "containerenv")];
-  if (opts.container) for (const m of markers) fs.writeFileSync(m, "");
+  if (opts.container) {
+    const present = opts.containerMarkers ?? markers.map((_, i) => i);
+    for (const i of present) fs.writeFileSync(markers[i], "");
+  }
   if (opts.readOnlyFstab) fs.chmodSync(fstab, 0o444);
+
+  // A PATH of exactly two directories: the stubs, and symlinks to the real
+  // tools the step shells out to. The inherited PATH is deliberately NOT on it
+  // — with it, `detectVirtMissing` only removed our stub while the box's own
+  // systemd-detect-virt stayed reachable, so the marker fallback the case is
+  // named for was never the branch that answered.
+  const sysbin = path.join(tmp, "sysbin");
+  fs.mkdirSync(sysbin, { recursive: true });
+  // One test calls runStep twice against the same sandbox.
+  for (const [tool, real] of Object.entries(REAL_TOOLS)) {
+    const link = path.join(sysbin, tool);
+    if (!fs.existsSync(link)) fs.symlinkSync(real, link);
+  }
 
   const script = [
     "set -uo pipefail",
@@ -112,9 +153,9 @@ function runStep(opts: {
     "step_swapfile",
   ].join(NL);
 
-  const res = spawnSync("bash", ["-c", script], {
+  const res = spawnSync(BASH, ["-c", script], {
     encoding: "utf-8",
-    env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+    env: { ...process.env, PATH: `${bin}:${sysbin}` },
   });
   return {
     status: res.status,
@@ -194,13 +235,26 @@ describe("step_swapfile stands down rather than harming the box", () => {
     expect(r.calls).toMatch(/fallocate -l 4G/);
   });
 
-  it("answers the marker files as well as systemd-detect-virt", () => {
-    // The fallback path is what a box without systemd-detect-virt uses; the
-    // probe must not depend on the one binary.
-    const r = runStep({ availGb: 400, container: true, detectVirtMissing: true });
+  it.each([[0, "the docker marker"], [1, "the podman marker"]])(
+    "answers marker %i (%s) on its own, with no systemd-detect-virt to ask",
+    (index) => {
+      // The fallback path is what a box without systemd-detect-virt uses; the
+      // probe must not depend on the one binary, and it must read the whole
+      // marker list rather than stopping at the first path.
+      const r = runStep({ availGb: 400, container: true, containerMarkers: [index], detectVirtMissing: true });
+      expect(r.status).toBe(0);
+      expect(r.out).toMatch(/Skipping swapfile: running in a container/);
+      expect(r.calls).toBe("");
+    },
+  );
+
+  it("provisions normally when neither marker is there and the probe is missing", () => {
+    // The other half of the fallback: no binary and no marker is a real box,
+    // and the step must go on to make the file rather than skip on a doubt.
+    const r = runStep({ availGb: 400, detectVirtMissing: true });
     expect(r.status).toBe(0);
-    expect(r.out).toMatch(/Skipping swapfile: running in a container/);
-    expect(r.calls).toBe("");
+    expect(r.out).toMatch(/Creating a 8G swapfile/);
+    expect(r.calls).toMatch(/swapon --priority 1/);
   });
 
   it("skips a container BEFORE writing anything, test flag or not", () => {

--- a/src/tests/unit/install-swapfile.test.ts
+++ b/src/tests/unit/install-swapfile.test.ts
@@ -60,6 +60,7 @@ function runStep(opts: {
   swaponFails?: boolean;
   testMode?: boolean;
   container?: boolean;
+  detectVirtMissing?: boolean;
   readOnlyFstab?: boolean;
   fstab?: string;
 }) {
@@ -84,12 +85,20 @@ function runStep(opts: {
   stub("free", `echo "Swap: 11Gi 1Gi 10Gi"`);
   stub("fallocate", `echo "fallocate $*" >> "${tmp}/calls"; : > "\${!#}"; exit 0`);
   // The container probe answers through systemd-detect-virt on a real box.
-  stub("systemd-detect-virt", `exit ${opts.container ? 0 : 1}`);
+  if (!opts.detectVirtMissing) stub("systemd-detect-virt", `exit ${opts.container ? 0 : 1}`);
+  // …and falls back to marker files. Point those at the sandbox: read from the
+  // real filesystem, every case here would answer "container" whenever the
+  // suite itself runs in one, and skip the provisioning it is meant to prove.
+  const markerDir = path.join(tmp, "markers");
+  fs.mkdirSync(markerDir, { recursive: true });
+  const markers = [path.join(markerDir, "dockerenv"), path.join(markerDir, "containerenv")];
+  if (opts.container) for (const m of markers) fs.writeFileSync(m, "");
   if (opts.readOnlyFstab) fs.chmodSync(fstab, 0o444);
 
   const script = [
     "set -uo pipefail",
     `CLAWBOX_TEST_MODE=${opts.testMode ? 1 : 0}`,
+    `CLAWBOX_CONTAINER_MARKERS=${JSON.stringify(markers.join(" "))}`,
     "is_test_mode() { [ \"$CLAWBOX_TEST_MODE\" = \"1\" ]; }",
     'SWAPFILE_SIZE_GB=8',
     'SWAPFILE_DISK_RESERVE_GB=20',
@@ -183,6 +192,15 @@ describe("step_swapfile stands down rather than harming the box", () => {
     const r = runStep({ availGb: 25 });
     expect(r.status).toBe(0);
     expect(r.calls).toMatch(/fallocate -l 4G/);
+  });
+
+  it("answers the marker files as well as systemd-detect-virt", () => {
+    // The fallback path is what a box without systemd-detect-virt uses; the
+    // probe must not depend on the one binary.
+    const r = runStep({ availGb: 400, container: true, detectVirtMissing: true });
+    expect(r.status).toBe(0);
+    expect(r.out).toMatch(/Skipping swapfile: running in a container/);
+    expect(r.calls).toBe("");
   });
 
   it("skips a container BEFORE writing anything, test flag or not", () => {


### PR DESCRIPTION
Follow-up to #715, from its review.

`in_container()`'s fallback read the real `/.dockerenv` and `/run/.containerenv`. A test suite that itself runs in a container therefore answered "container" for every case, and the swapfile tests would skip the creation and persistence they exist to prove rather than exercise them.

The marker paths are a variable now (`CLAWBOX_CONTAINER_MARKERS`, defaulting to the two real ones, and `systemd-detect-virt` is still asked first on a real box). The tests point it at their own sandbox and create the markers only for the container case, so provisioning is exercised wherever the suite runs. A new case covers the box the fallback exists for: no `systemd-detect-virt` at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Fz3uZVzYQzcNAkw1cQ8ff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Container detection now supports configurable marker file paths through `CLAWBOX_CONTAINER_MARKERS`.
  - Defaults include standard Docker and container environment markers.

- **Bug Fixes**
  - Improved behavior in environments where virtualization detection tools are unavailable.
  - Prevents swap creation or activation when a container is identified through marker files.
  - Supports reliable detection when either configured container marker is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->