### PR TITLE
fix: coalesce the failover restart to one per route recovery

### DIFF
--- a/scripts/gateway-restart-when-online.sh
+++ b/scripts/gateway-restart-when-online.sh
@@ -74,6 +74,10 @@ RUN_DIR="${CLAWBOX_RUN_DIR:-/run/clawbox}"
 LOCK_FILE="$RUN_DIR/gateway-online-restart.lock"
 # The dropped-request marker — see the lock section below.
 REARM_FILE="$RUN_DIR/gateway-online-restart.rearm"
+# What the last accepted restart request was for — see the coalescing section.
+# In the same root-owned tmpfs, and cleared on boot, which is what this wants:
+# the first event after a boot is never a repeat of one before it.
+STAMP_FILE="$RUN_DIR/gateway-online-restart.stamp"
 
 log() { logger -t "$LOG_TAG" -- "$*"; }
 
@@ -114,8 +118,14 @@ online() {
   # No route at all is worth answering without spending four seconds on it.
   ip route show default 2>/dev/null | grep -q . || return 1
 
+  # Split on whitespace — the value is a LIST, like the updater's PING_TARGETS —
+  # with `read -ra` and not a bare expansion, because an unquoted expansion is a
+  # PATHNAME expansion too: a `*` in the value would turn a filename into a ping
+  # destination. `read` takes one line, which is what a space-separated list is.
   local target
-  for target in ${CLAWBOX_PING_TARGETS:-8.8.8.8 1.1.1.1}; do
+  local -a targets=()
+  read -ra targets <<<"${CLAWBOX_PING_TARGETS:-8.8.8.8 1.1.1.1}"
+  for target in "${targets[@]}"; do
     ping -c 1 -W 2 "$target" >/dev/null 2>&1 && return 0
   done
   # The updater's own reasoning, verbatim: ICMP is blocked on some networks
@@ -141,6 +151,142 @@ positive_int() {
 # below, are what cover recovery beyond it.
 ONLINE_TIMEOUT="$(positive_int "${CLAWBOX_ONLINE_TIMEOUT:-}" 120)"
 ONLINE_POLL="$(positive_int "${CLAWBOX_ONLINE_POLL:-}" 3)"
+
+# ONE RESTART PER ROUTE RECOVERY, not one per NetworkManager event.
+#
+# The flock below stops two waiters WAITING at once. It does nothing about
+# waiters that run one after another, and that is what a recovery actually
+# produces: measured on a box, `up`, `connectivity-change FULL` and
+# `dhcp4-change` all arrived inside one second, NetworkManager ran the
+# dispatchers serially, each waiter proved the same route in well under the time
+# the next took to start, and each asked for its own restart — three requests
+# with no "already pending" line anywhere, for a single recovery. A later boot
+# of the same box produced two requests and one "already pending": the lock
+# catches only the pair that happened to overlap. Every accepted request is a
+# stop and a cold start of a unit that takes ~40 s to come up on this hardware,
+# and each bounce drops the channel accounts the restart exists to revive.
+#
+# So a request is remembered, and a later one for the SAME recovery stands down.
+# Standing down is the dangerous half — a swallowed restart IS GH #529 — so
+# "the same recovery" has to be all three of these, and none of them alone:
+#
+#   * NO ABSENCE SEEN. A waiter that polled and found no route watched the
+#     route go away; whatever returns is a new recovery however familiar it
+#     looks. See saw_route_absent below. The dispatcher clears the stamp on a
+#     `down` of ANY uplink this box routes through — Ethernet or the radio — for
+#     the case where the flap finished before a waiter even started, which is
+#     the one this cannot see. That clear can also land while `try-restart` is
+#     still running, so the stamp is written BEFORE that call and never after
+#     it; see record_restart_asked_for and its call site.
+#   * THE SAME ROUTE, as the kernel selects it — see route_key. A failover to
+#     WiFi, or a lease that moves the box's own address, is a new recovery and
+#     owes its own restart: the sockets are bound to what just died.
+#   * WITHIN THE WINDOW. A cable replugged an hour later comes back on the very
+#     same lease and must still restart. The window covers the measured
+#     one-second burst with room for a `dhcp4-change` or a connectivity check
+#     landing seconds later, and nothing beyond that.
+#
+# The window is measured from BEFORE the restart, because that is when the stamp
+# is written (see the call site), so the time left once the waiter releases the
+# lock is the window MINUS however long the restart took. Said rather than
+# hidden — and left that way on purpose: refreshing the timestamp after
+# `try-restart` would mean writing the stamp again after the restart, which is
+# exactly the write a carrier drop landing during it has to be able to win
+# against. Erring short costs an extra restart; erring the other way costs a
+# swallowed one, and the measured burst arrives inside a second, before the
+# restart has even started.
+COALESCE_WINDOW="$(positive_int "${CLAWBOX_RESTART_COALESCE:-}" 60)"
+
+# Seconds since boot, and NOT `date +%s`: these boards have no RTC, so
+# systemd-timesyncd steps the clock the moment a route comes up — inside the
+# very burst this has to survive. Measured with a stepped clock, a wall-clock
+# window collapses three restarts to two instead of to one. /run is cleared on
+# boot, so the stamp and this counter share a lifetime by construction.
+# Empty (no /proc/uptime) means there is no monotonic clock to compare against.
+monotonic_seconds() {
+  local up=""
+  read -r up _ < /proc/uptime 2>/dev/null || return 1
+  case "$up" in ''|*[!0-9.]*) return 1 ;; esac
+  printf '%s' "${up%%.*}"
+}
+
+# The wait's own clock. A bound on ONE wait is sound on either clock, so this
+# falls back rather than refusing to wait; both ends of every comparison come
+# from this one function, so they can never be read off two different clocks.
+now_seconds() { monotonic_seconds || date +%s; }
+
+# Which recovery this is — asked of the KERNEL rather than parsed out of the
+# routing table. `ip route get` answers with the route it would actually select
+# for that destination and the source address it would use: the interface, the
+# gateway and the local address, which is exactly what the gateway's sockets are
+# bound to. Reading `ip route show default` instead was wrong twice over — a
+# second, higher-metric default route (any box with a saved WiFi profile) read
+# as a new recovery though the traffic path had not moved, and a DHCP NAK that
+# moved only the box's own address read as the same one though every socket had
+# just died.
+#
+# An unanswerable key (no route at all, `ip` missing, a non-IP probe target)
+# is never equal to a recorded one, so it stands down from nothing: this
+# degrades to the unfixed behaviour rather than to a blanket cooldown.
+route_key() {
+  local dest
+  # Same target the probe above uses, so the key describes the path that was
+  # actually proven — and split the same glob-free way, for the same reason: a
+  # `*` reaching `ip route get` as a filename would key the recovery on a route
+  # to something that is not the probe destination at all.
+  local -a targets=()
+  read -ra targets <<<"${CLAWBOX_PING_TARGETS:-8.8.8.8}"
+  dest="${targets[0]:-}"
+  [ -n "$dest" ] || return 0
+  ip -o route get "$dest" 2>/dev/null | awk '
+    {
+      dev = ""; gw = ""; src = "";
+      for (i = 1; i < NF; i++) {
+        if ($i == "via") gw = $(i + 1);
+        if ($i == "dev") dev = $(i + 1);
+        if ($i == "src") src = $(i + 1);
+      }
+      if (dev != "") print dev "/" gw "/" src;
+      exit
+    }'
+}
+
+restart_already_asked_for() {
+  local key="${1:-}" when="" rest="" now=""
+  [ -n "$key" ] || return 1
+  [ -r "$STAMP_FILE" ] || return 1
+  now="$(monotonic_seconds)" || return 1
+  read -r when rest < "$STAMP_FILE" 2>/dev/null || true
+  case "$when" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$rest" = "$key" ] || return 1
+  local age=$(( now - when ))
+  # A stamp from the future is a stamp this boot cannot reason about; treat it
+  # as unusable rather than authoritative and let the restart through, which is
+  # what the unfixed script does on every event anyway.
+  [ "$age" -ge 0 ] && [ "$age" -lt "$COALESCE_WINDOW" ]
+}
+
+# Recorded for a request about to be made, and withdrawn by the caller if
+# systemd rejects it — `try-restart` also answers 0 for a unit that was
+# inactive, where it deliberately did nothing, so this says "asked", never
+# "restarted", exactly like the journal line beside it.
+#
+# Staged and renamed, not truncated in place: without flock two waiters can be
+# here at once, and a half-written line is a guard that quietly is not there.
+# A write that fails is SAID, for the same reason the missing lock is.
+record_restart_asked_for() {
+  local key="${1:-}" now=""
+  [ -n "$key" ] || return 0
+  now="$(monotonic_seconds)" || {
+    log "WARN: no monotonic clock (/proc/uptime) — cannot coalesce, a further network event will restart again"
+    return 0
+  }
+  if ! { printf '%s %s\n' "$now" "$key" > "$STAMP_FILE.new" 2>/dev/null \
+         && mv -f "$STAMP_FILE.new" "$STAMP_FILE" 2>/dev/null; }; then
+    rm -f "$STAMP_FILE.new" 2>/dev/null || true
+    log "WARN: could not record the restart request in $STAMP_FILE — a further network event will restart again"
+  fi
+}
 
 # `list-unit-files` is the wrong question: it LISTS a masked unit, so it answers
 # "present" on the one edition this guard exists for. Measured read-only on the
@@ -172,9 +318,12 @@ fi
 mkdir -p "$RUN_DIR" 2>/dev/null || true
 
 # One waiter at a time. Overlapping NetworkManager events — a carrier that
-# flaps, or eth down followed by wifi up — would otherwise stack several waits
-# and fire several restarts at the moment the route returned, which is its own
-# way of tripping the account supervisor.
+# flaps, or eth down followed by wifi up — would otherwise stack several
+# concurrent waits, each holding the box's fate for two minutes.
+#
+# This is CONCURRENCY only, and it was once claimed to be more: events that do
+# not overlap take the lock one after another and every one of them reached the
+# restart. Collapsing those is the coalescing window above, not this.
 #
 # But `flock -n` alone LOSES the dropped request: the holder can time out one
 # second before the route lands, having ignored the very event that would have
@@ -202,9 +351,25 @@ rm -f "$REARM_FILE" 2>/dev/null || true
 
 log "Deferring the gateway restart ($REASON) until a public route is proven, up to ${ONLINE_TIMEOUT}s"
 
-deadline=$(( $(date +%s) + ONLINE_TIMEOUT ))
+# Did THIS waiter watch the route go away? A waiter that polled and found no
+# route has proven an absence between the last restart and now, so whatever
+# comes back is a new recovery however familiar it looks — a cable pulled and
+# replugged returns on the very same lease, and the sockets it killed are just
+# as dead as ones on a different address. Only a waiter that never saw an
+# absence may stand down.
+saw_route_absent=0
+
+deadline=$(( $(now_seconds) + ONLINE_TIMEOUT ))
 while :; do
   if online; then
+    recovery="$(route_key)"
+    if [ "$saw_route_absent" -eq 0 ] && restart_already_asked_for "$recovery"; then
+      # Not a failure and not a dropped event: the restart this one would ask
+      # for has already been asked for, by a sibling NetworkManager event
+      # describing the same recovery.
+      log "Gateway restart already asked for this route recovery within ${COALESCE_WINDOW}s ($REASON) — standing down"
+      exit 0
+    fi
     # try-restart, not restart. The probe and the action are two commands and
     # the gap here is a whole wait long: a unit that is stopped — deliberately
     # by the owner, or masked by the Hermes edition — must not be STARTED by
@@ -212,22 +377,64 @@ while :; do
     # words, and `is-active` would be wrong twice over: it also reports
     # non-zero for `activating`, and this unit's own RestartSec plus a
     # cold-Jetson TimeoutStartSec make that window minutes long.
+    #
+    # RECORDED BEFORE THE CALL, and withdrawn below if systemd rejects it.
+    #
+    # `try-restart` BLOCKS until the restart job completes, and this unit's cold
+    # start is ~40 s on this hardware — so on a running box that is a wide
+    # window. (At boot it is not: the unit is inactive, `try-restart` is a no-op
+    # on an inactive unit and returns at once, which is why the device journal
+    # shows the whole waiter run in under a tenth of a second.) The record used
+    # to be written after that call returned, keyed on the route read before it,
+    # so a carrier drop inside the window was cleared by the dispatcher and then
+    # put straight back here, stamped for a route that had already died, and the
+    # next recovery stood down on it: GH #529 again, through the mitigation
+    # meant to prevent it. Nothing else could notice — the waiter that drop
+    # dispatches is turned away by the flock this one holds, so no poll ever
+    # proves the absence.
+    #
+    # Writing first inverts it: a clear that lands during the restart is the
+    # last word ON THE RECORD, because nothing here writes again afterwards.
+    # (It is not the last word on the restart: that job is already running, and
+    # this has never been able to recall one.) The dispatcher's clear is a plain
+    # `rm -f` and deliberately takes no lock, so it is never queued behind this
+    # call.
+    record_restart_asked_for "$recovery"
     if systemctl try-restart "$UNIT" >/dev/null 2>&1; then
       # Asked, not "restarted": try-restart's exit code says the request was
       # accepted, not that the gateway came back — and certainly not what
       # OpenClaw did with its channel accounts afterwards.
       log "Public route is up — asked systemd to restart $UNIT ($REASON); a fresh gateway starts the channel accounts its supervisor gave up on"
     else
+      # Nothing was restarted, so nothing may stand down against it. Withdrawing
+      # the record is the safe direction: the worst it costs is one more restart
+      # request, while a record for a restart that never happened is a swallowed
+      # one.
+      #
+      # Only when there was a record to withdraw. An unanswerable route key
+      # records nothing (see record_restart_asked_for), and removing the file on
+      # that path would throw away an EARLIER waiter's good record instead. With
+      # the lock held nothing else can be in here, so a stamp that is still
+      # present now is this waiter's own; without it — the WARN path above —
+      # a sibling's record can still be taken, which costs one extra restart and
+      # never a swallowed one.
+      if [ -n "$recovery" ]; then
+        rm -f "$STAMP_FILE" 2>/dev/null || true
+      fi
       log "Public route is up but the restart request for $UNIT failed"
     fi
     exit 0
   fi
-  if [ "$(date +%s)" -ge "$deadline" ]; then
+  # Reached only when the route is not up: this waiter has now proven an
+  # absence, and no later event may be coalesced away against a restart that
+  # was asked for before it.
+  saw_route_absent=1
+  if [ "$(now_seconds)" -ge "$deadline" ]; then
     # A request that arrived while this waiter held the lock is not lost: take
     # it now and go round again, once per marker.
     if [ -e "$REARM_FILE" ]; then
       rm -f "$REARM_FILE" 2>/dev/null || true
-      deadline=$(( $(date +%s) + ONLINE_TIMEOUT ))
+      deadline=$(( $(now_seconds) + ONLINE_TIMEOUT ))
       log "A further network event arrived while waiting — extending the wait ${ONLINE_TIMEOUT}s"
       continue
     fi

--- a/scripts/nm-dispatcher-failover.sh
+++ b/scripts/nm-dispatcher-failover.sh
@@ -42,7 +42,11 @@ log() { logger -t "$LOG_TAG" -- "$*"; }
 #
 # Detached because NetworkManager runs dispatcher scripts serially and kills a
 # slow one: this script must return at once, and the waiting must not happen in
-# it. The waiter takes its own lock, so overlapping events do not stack.
+# it. Several events arriving for one recovery — `up`, `dhcp4-change` and
+# `connectivity-change` inside a second is the measured shape — are safe to
+# dispatch: the waiter's lock keeps their waits from overlapping, and its
+# record of the route it last asked a restart for collapses the rest of the
+# burst into that one restart.
 #
 # The launch is REPORTED, not fire-and-forget into /dev/null: NM runs
 # dispatchers with a minimal PATH (the reason 99-clawbox-avahi-reload resolves
@@ -141,6 +145,29 @@ case "$ACTION" in
     ;;
 esac
 
+# The carrier really went. Whatever comes back next is a NEW recovery, even on
+# the identical lease, so the waiter's "already asked for this recovery" record
+# must not outlive it: a cable pulled and replugged inside the coalescing window
+# would otherwise be stood down, and that swallowed restart is GH #529 itself.
+# The waiter notices an absence it waits through on its own; this covers the
+# flap that is over before a waiter even runs, which only the event knows about.
+#
+# ABOVE the interface case below, and for EVERY uplink this box routes through:
+# that case returns for the radio on anything but `up`, and a box joined to the
+# customer's WiFi through its own setup AP has no Ethernet arm at all, so a
+# clear only Ethernet reached left exactly that box standing down on the restart
+# its re-association owes. It over-clears by design — a radio dropping while
+# Ethernet still carries the traffic costs one extra restart on the next event,
+# which is bounded by a real `down`, where narrowing it to the interface the
+# record names would cost a swallowed restart the moment the two names disagree.
+if [ "$ACTION" = "down" ]; then
+  case "$IFACE" in
+    eth*|en*|"$WIFI_IFACE")
+      rm -f "$RUN_DIR/gateway-online-restart.stamp" 2>/dev/null || true
+      ;;
+  esac
+fi
+
 # The WiFi arm is the recovery half: after a failover the box's route comes back
 # on the wireless interface, and with only the ethernet arm nothing ever asked
 # for the restart that revives the channel accounts.
@@ -165,7 +192,8 @@ if [ "$ACTION" = "up" ]; then
   exit 0
 fi
 
-# Below: handle ethernet DOWN — failover to WiFi and clear stale sockets.
+# Below: handle ethernet DOWN — failover to WiFi and clear stale sockets. The
+# record was already cleared above, before this arm could return.
 [ "$ACTION" = "down" ] || exit 0
 
 # Confirm there is no other ethernet still up before failing over.

--- a/src/tests/unit/failover-waits-for-route.test.ts
+++ b/src/tests/unit/failover-waits-for-route.test.ts
@@ -47,6 +47,9 @@ beforeAll(() => {
 let root: string;
 let bin: string;
 
+/** The shape NetworkManager's DHCP client actually writes for the wired link. */
+const ETH_ROUTE = "default via 192.0.2.1 dev eth0 proto dhcp src 192.0.2.50 metric 100";
+
 interface BoxOptions {
   /** What `nmcli -t networking connectivity check` answers, in order. */
   connectivity?: string[];
@@ -70,8 +73,19 @@ interface BoxOptions {
   unitProbeFails?: boolean;
   /** Whether `curl` is on PATH for the HTTPS half of the probe. */
   curlWorks?: boolean;
+  /** `systemctl try-restart` refuses — nothing was restarted. */
+  tryRestartFails?: boolean;
   /** Drop a re-arm marker once, from inside the poll loop. */
   rearmMidWait?: boolean;
+  /**
+   * The carrier drops WHILE `systemctl try-restart` is running. That call
+   * BLOCKS until the restart job completes — ~40 s on this hardware — so it is
+   * a wide window, and the dispatcher's stamp clear lands inside it. Modelled
+   * by running the real dispatcher's `down` arm from inside the stub.
+   */
+  dropCarrierDuringRestart?: boolean;
+  /** Bring the Ethernet route back once, from inside the poll loop. */
+  restoreRouteMidWait?: boolean;
 }
 
 /** A fake CLAWBOX_ROOT plus a PATH of stubs, so nothing touches a real radio. */
@@ -112,9 +126,40 @@ case "$*" in
   *) exit 0 ;;
 esac`);
 
+  // A routing table in a file rather than baked into the stub, so a test can
+  // move the route between two waiter runs — a failover from Ethernet to WiFi
+  // is a new recovery, and the route is how the waiter tells one from another.
+  writeFileSync(path.join(root, "routes"), opts.defaultRoute ? `${ETH_ROUTE}\n` : "");
   stub("ip", `
 echo "ip $*" >> ${JSON.stringify(calls)}
-${opts.defaultRoute ? 'echo "default via 192.0.2.1 dev eth0"' : "true"}`);
+routes=${JSON.stringify(path.join(root, "routes"))}
+case "$*" in
+  *"route get"*)
+    # The real one answers with the route the KERNEL SELECTED for that one
+    # destination plus the source address it would use — not the table. Modelled
+    # as the first line of the table, which is the order the kernel returns
+    # routes in (by metric), and with the same "unreachable" failure when there
+    # is none.
+    dest="\${@: -1}"
+    answer="$(awk -v d="$dest" 'NR == 1 {
+      gw = ""; dev = ""; src = "";
+      for (i = 1; i < NF; i++) {
+        if ($i == "via") gw = $(i + 1);
+        if ($i == "dev") dev = $(i + 1);
+        if ($i == "src") src = $(i + 1);
+      }
+      if (dev == "") exit;
+      printf "%s", d;
+      if (gw != "") printf " via %s", gw;
+      printf " dev %s", dev;
+      if (src != "") printf " src %s", src;
+      printf " uid 0";
+    }' "$routes" 2>/dev/null)"
+    [ -n "$answer" ] || { echo "RTNETLINK answers: Network is unreachable" >&2; exit 2; }
+    echo "$answer"
+    ;;
+  *) cat "$routes" 2>/dev/null || true ;;
+esac`);
 
   stub("ping", `
 echo "ping $*" >> ${JSON.stringify(calls)}
@@ -133,9 +178,21 @@ exit ${opts.curlWorks ? 0 : 1}`);
   stub("systemctl", `
 echo "systemctl $*" >> ${JSON.stringify(calls)}
 case "$1" in
-  # try-restart is a no-op on a stopped unit and reports success either way —
-  # exactly what the real one does, and why the script uses it.
-  try-restart) exit 0 ;;
+  # try-restart is a no-op on a stopped unit and reports success for it —
+  # exactly what the real one does, and why the script uses it. It does fail on
+  # a masked unit, which is what tryRestartFails models.
+  try-restart)
+    ${opts.dropCarrierDuringRestart
+      ? `m=${JSON.stringify(path.join(root, "carrier-dropped"))}
+    if [ ! -e "$m" ]; then
+      : > "$m"
+      # The carrier really goes, and NetworkManager runs the dispatcher for it
+      # while this restart is still in flight.
+      : > ${JSON.stringify(path.join(root, "routes"))}
+      bash ${JSON.stringify(DISPATCHER)} eth0 down >/dev/null 2>&1 || true
+    fi`
+      : ""}
+    exit ${opts.tryRestartFails ? 1 : 0} ;;
   # Kept, and kept FAITHFUL, although the shipped script no longer asks this:
   # only a unit that is not installed at all goes unlisted, so a regression to
   # this question turns the masked case below red instead of quietly passing.
@@ -166,12 +223,22 @@ echo "log $*" >> ${JSON.stringify(root + "/journal.log")}`);
   // Real `sleep` would make a 120 s wait a 120 s test. It is also the only
   // hook a test has INSIDE the poll loop, which is where a second network
   // event would really arrive.
-  stub("sleep", opts.rearmMidWait
-    ? `f=${JSON.stringify(path.join(root, "run", "gateway-online-restart.rearm"))}
+  stub("sleep", [
+    opts.rearmMidWait
+      ? `f=${JSON.stringify(path.join(root, "run", "gateway-online-restart.rearm"))}
 m=${JSON.stringify(path.join(root, "rearmed"))}
-if [ ! -e "$m" ]; then : > "$m"; : > "$f"; fi
-true`
-    : "true");
+if [ ! -e "$m" ]; then : > "$m"; : > "$f"; fi`
+      : "",
+    // The link comes back while the waiter is polling — the only place a test
+    // can put an event that lands INSIDE the wait, which is where a real
+    // carrier returns.
+    opts.restoreRouteMidWait
+      ? `r=${JSON.stringify(path.join(root, "routes"))}
+m=${JSON.stringify(path.join(root, "route-restored"))}
+if [ ! -e "$m" ]; then : > "$m"; printf '%s\\n' ${JSON.stringify(ETH_ROUTE)} > "$r"; fi`
+      : "",
+    "true",
+  ].filter(Boolean).join("\n"));
   // The dispatcher launches the waiter DETACHED, so a test that let it run
   // would be racing it. Record the request instead: the dispatcher's contract
   // is that it asks and returns, and the waiter's own decisions are exercised
@@ -223,6 +290,24 @@ function journal(): string {
 
 function restarts(): number {
   return calls().split("\n").filter((l) => l.startsWith("systemctl try-restart")).length;
+}
+
+/**
+ * The box's routing table from now on, most-preferred route first — which is
+ * the order the kernel returns them in, and therefore the one it selects from.
+ * No lines at all = no route.
+ */
+function moveRoute(...lines: string[]): void {
+  writeFileSync(path.join(root, "routes"), lines.filter(Boolean).map((l) => `${l}\n`).join(""));
+}
+
+/** What `nmcli networking connectivity` answers from now on, one per call. */
+function setConnectivity(...states: string[]): void {
+  writeFileSync(path.join(root, "connectivity"), `${states.join("\n")}\n`);
+}
+
+function journalLines(needle: string): string[] {
+  return journal().split("\n").filter((l) => l.includes(needle));
 }
 
 /**
@@ -435,11 +520,15 @@ describe("Ethernet failover does not restart the gateway into a dead network", (
     expect(journal()).toContain("asked systemd to restart");
   });
 
-  it("lets one waiter hold the wait, so a flapping carrier cannot stack restarts", async () => {
+  it("lets one waiter hold the wait, so overlapping events do not stack two waits", async () => {
     // Overlapping NetworkManager events — a carrier that flaps, or eth down
-    // then wifi up — would otherwise stack several waits and fire several
-    // restarts the moment the route returned, which is its own way of tripping
-    // the account supervisor.
+    // then wifi up — would otherwise run two waits at once, each holding the
+    // box's fate for two minutes.
+    //
+    // CONCURRENCY only, which this test is careful to say: events that do not
+    // overlap take this lock one after another and every one of them used to
+    // reach the restart. Collapsing those is the coalescing describe block that
+    // follows this one, not this lock.
     makeBox({ connectivity: ["full"] });
     const lock = path.join(root, "run", "gateway-online-restart.lock");
     const holder = spawn("flock", ["-n", lock, "-c", "sleep 20"], { stdio: "ignore" });
@@ -466,6 +555,266 @@ describe("Ethernet failover does not restart the gateway into a dead network", (
     } finally {
       holder.kill();
     }
+  });
+});
+
+describe("one restart per route recovery, not one per NetworkManager event", () => {
+  it("collapses a burst of NetworkManager events into a single restart request", () => {
+    // Measured on a box: one boot produced `Ethernet 'enP8p1s0' up`,
+    // `connectivity-change FULL` and `dhcp4-change` inside the SAME SECOND, and
+    // NetworkManager runs dispatchers serially — so three waiters ran one after
+    // another, each proved the same route, and each logged
+    // `asked systemd to restart clawbox-gateway.service`. The `flock` turned
+    // none of them away (no "already pending" line anywhere in that journal):
+    // it stops two waiters waiting AT ONCE, and these did not overlap.
+    //
+    // The unit then went through three stop/start cycles, the first landing one
+    // second after it had finally reached active. The gateway did not serve
+    // until three minutes after boot and churned for five and a half, burning
+    // ~3.5 minutes of CPU re-running gateway-pre-start.sh — and every one of
+    // those bounces drops the channel accounts a restart is supposed to revive.
+    makeBox({ connectivity: ["full"], defaultRoute: true });
+
+    runWaiter("Ethernet 'eth0' up");
+    runWaiter("NetworkManager reports full connectivity");
+    runWaiter("DHCP lease on 'eth0' changed");
+
+    expect(restarts()).toBe(1);
+    // ...and the two that stood down said so, rather than vanishing.
+    expect(journalLines("already asked for this route recovery")).toHaveLength(2);
+  });
+
+  it("does not treat NetworkManager rewriting a route's metric as a new recovery", () => {
+    // NM rewrites `metric` and `proto` on a route that has not moved (a second
+    // profile activating, a renewed lease), so a recovery cannot be keyed on
+    // the raw line: only the device and the gateway say where the traffic goes.
+    makeBox({ connectivity: ["full"], defaultRoute: true });
+
+    runWaiter("Ethernet 'eth0' up");
+    moveRoute("default via 192.0.2.1 dev eth0 proto dhcp src 192.0.2.50 metric 700");
+    runWaiter("DHCP lease on 'eth0' changed");
+
+    expect(restarts()).toBe(1);
+  });
+
+  it("asks again when the route moved, even inside the same window", () => {
+    // A failover from Ethernet to WiFi is a NEW recovery, not a repeat of the
+    // one before it: the sockets the gateway holds are bound to the address
+    // that just died, which is GH #529's own harm. A blanket cooldown would
+    // swallow exactly that restart, so the coalescing is keyed on the route.
+    makeBox({ connectivity: ["full"], defaultRoute: true });
+
+    runWaiter("Ethernet 'eth0' down");
+    moveRoute("default via 198.51.100.1 dev wlan0 proto dhcp src 198.51.100.20 metric 600");
+    runWaiter("WiFi 'wlan0' up");
+
+    expect(restarts()).toBe(2);
+  });
+
+  it("asks again when a lease moved only the box's own address", () => {
+    // Same interface, same gateway, new address — a DHCP NAK and re-DISCOVER,
+    // which consumer routers and guest WiFi do routinely. The dispatcher
+    // already treats it as a real change (see the lease arm below) precisely
+    // because every socket bound to the old address is dead, so the waiter must
+    // not then throw that verdict away for being "the same route".
+    makeBox({ connectivity: ["full"], defaultRoute: true });
+
+    runWaiter("DHCP lease on 'eth0' changed");
+    moveRoute("default via 192.0.2.1 dev eth0 proto dhcp src 192.0.2.77 metric 100");
+    runWaiter("DHCP lease on 'eth0' changed");
+
+    expect(restarts()).toBe(2);
+  });
+
+  it("does not treat a second uplink appearing beside the first as a new recovery", () => {
+    // Any box with a saved WiFi profile brings up a second default route at a
+    // higher metric while Ethernet keeps the traffic. Nothing moved, so nothing
+    // is owed a restart — and a key that read the whole table would have fired
+    // one, mid-cold-start, on the SKU this whole feature exists for.
+    makeBox({ connectivity: ["full"], defaultRoute: true });
+
+    runWaiter("Ethernet 'eth0' up");
+    moveRoute(ETH_ROUTE, "default via 198.51.100.1 dev wlan0 proto dhcp src 198.51.100.20 metric 600");
+    runWaiter("WiFi 'wlan0' up");
+
+    expect(restarts()).toBe(1);
+  });
+
+  it("asks again when it watched the route go away and come back on the same lease", () => {
+    // THE dangerous half of coalescing. A cable pulled and replugged inside the
+    // window returns on the identical lease, so "same route, recently" is true
+    // — and the sockets it killed are just as dead as ones on a new address.
+    // A waiter that polled and found no route has PROVEN an absence since the
+    // last restart, and may never stand down on it.
+    makeBox({
+      connectivity: ["none"],
+      defaultRoute: true,
+      pingWorks: true,
+      restoreRouteMidWait: true,
+    });
+
+    runWaiter("Ethernet 'eth0' up");
+    expect(restarts()).toBe(1);
+
+    // The carrier really drops: no route at all, and NM has no verdict either.
+    moveRoute();
+    // ...and it returns from inside the wait, on the very same lease.
+    runWaiter("Ethernet 'eth0' up");
+
+    expect(restarts()).toBe(2);
+    expect(journalLines("already asked for this route recovery")).toHaveLength(0);
+  });
+
+  it("never coalesces against a route the kernel could not name", () => {
+    // `nmcli` can answer `full` while `ip` cannot answer at all (an IPv6-only
+    // uplink, a transient failure). An empty key matching a recorded empty key
+    // would turn this into the blanket cooldown the route key exists to avoid.
+    makeBox({ connectivity: ["full"] });
+    moveRoute();
+
+    runWaiter("Ethernet 'eth0' up");
+    runWaiter("NetworkManager reports full connectivity");
+
+    expect(restarts()).toBe(2);
+    expect(journalLines("already asked for this route recovery")).toHaveLength(0);
+  });
+
+  it("asks again for a later recovery on the same route, once the window has passed", async () => {
+    // The other side of the same coin: a cable pulled and replugged an hour
+    // later comes back on the very same lease, and that gateway must still be
+    // restarted. The shipped window is 60 s — long enough for the whole event
+    // burst above, short enough that a genuine second recovery is not held
+    // hostage by it — so this shortens the window rather than sleeping for it.
+    makeBox({ connectivity: ["full"], defaultRoute: true });
+    const window = { CLAWBOX_RESTART_COALESCE: "1" };
+
+    runWaiter("Ethernet 'eth0' up", window);
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+    runWaiter("Ethernet 'eth0' up", window);
+
+    expect(restarts()).toBe(2);
+  });
+
+  // The flap the waiter cannot see: down and up again before any waiter runs,
+  // so no waiter ever polls an absence. Only the dispatcher knows the carrier
+  // went, and it is the one that clears the record.
+  //
+  // Parameterised over BOTH uplinks on purpose. A box provisioned through its
+  // own `ClawBox-Setup` AP and joined to the customer's WiFi has no Ethernet
+  // arm to save it — its carrier drop arrives as `<radio> down` — and a clear
+  // that only Ethernet reaches leaves that box standing down on the very
+  // restart its re-association owes, which is GH #529 through the wireless
+  // door. `wlan0` is what NETWORK_INTERFACE is set to in env().
+  it.each([
+    { iface: "eth0", dispatches: 1 },
+    { iface: "wlan0", dispatches: 0 },
+  ])("forgets the last restart request when the carrier actually drops on $iface", async ({ iface, dispatches }) => {
+    makeBox({ connectivity: ["full"], defaultRoute: true });
+    const stamp = path.join(root, "run", "gateway-online-restart.stamp");
+    runWaiter(`'${iface}' up`);
+    expect(existsSync(stamp)).toBe(true);
+
+    runDispatcher(iface, "down");
+
+    expect(existsSync(stamp)).toBe(false);
+    // ...and Ethernet still hands the failover restart to the waiter, as
+    // before. The radio's own `down` never dispatched one and must not start:
+    // the AP/profile failover below is the Ethernet arm's job.
+    if (dispatches > 0) {
+      expect(await deferredEventually(dispatches)).toHaveLength(dispatches);
+    } else {
+      // Nothing to poll FOR — `deferredEventually(0)` returns on its first
+      // iteration and would pass on a launch that simply had not landed yet.
+      // Give the launch that must not happen room to happen, then assert.
+      await new Promise((resolve) => setTimeout(resolve, 750));
+      expect(deferred()).toHaveLength(0);
+    }
+  });
+
+  it("does not forget the record when the box's own recovery AP goes down", () => {
+    // `ap-watchdog.sh` re-raises the setup AP every ~20 s while setup is
+    // incomplete, and that profile is a `shared` one with no default route — so
+    // its transitions are not carrier events and must invalidate nothing. Now
+    // that the clear sits ABOVE the interface case, the AP guard at the top of
+    // the dispatcher is the only thing standing between that watchdog and a
+    // record cleared on every cycle.
+    makeBox({ connectivity: ["full"], defaultRoute: true });
+    const stamp = path.join(root, "run", "gateway-online-restart.stamp");
+    runWaiter("Ethernet 'eth0' up");
+    expect(existsSync(stamp)).toBe(true);
+
+    runDispatcher("wlan0", "down", { CONNECTION_ID: "ClawBox-Setup" });
+
+    expect(existsSync(stamp)).toBe(true);
+  });
+
+  it("never lets a probe target be expanded into a filename", () => {
+    // A bare `${CLAWBOX_PING_TARGETS:-…}` is word-split AND pathname-expanded,
+    // so a `*` in the value made whatever happens to be in the working
+    // directory the ping destination — and therefore the destination
+    // `ip route get` keys the whole recovery on. The waiter runs from the repo
+    // root here, which is never empty, so an expansion would be visible.
+    makeBox({ connectivity: ["portal"], defaultRoute: true, pingWorks: true });
+
+    runWaiter("Ethernet 'eth0' up", { CLAWBOX_PING_TARGETS: "*" });
+
+    const pings = calls().split("\n").filter((l) => l.startsWith("ping "));
+    expect(pings).toEqual(["ping -c 1 -W 2 *"]);
+    expect(calls()).toContain("ip -o route get *");
+    expect(restarts()).toBe(1);
+  });
+
+  it("does not put back a record the carrier drop cleared while the restart was still running", () => {
+    // `systemctl try-restart` BLOCKS for the whole restart — ~40 s on this
+    // hardware — and the record was written after it returned, stamped with the
+    // route key read BEFORE the call. So a carrier drop inside that window was
+    // cleared by the dispatcher and then immediately re-written by the waiter,
+    // and the next recovery stood down on a record for a route that had already
+    // died. Nothing else notices: the waiter the `down` event dispatches is
+    // turned away by the flock this one holds, so no poll ever proves the
+    // absence for it.
+    //
+    // The clear must therefore win over the record whatever the ordering.
+    makeBox({ connectivity: ["full"], defaultRoute: true, dropCarrierDuringRestart: true });
+    const stamp = path.join(root, "run", "gateway-online-restart.stamp");
+
+    runWaiter("Ethernet 'eth0' up");
+
+    expect(restarts()).toBe(1);
+    // The hook really fired — otherwise this test would pass by not testing.
+    expect(existsSync(path.join(root, "carrier-dropped"))).toBe(true);
+    expect(existsSync(stamp)).toBe(false);
+
+    // The carrier returns on the very same lease, well inside the window.
+    moveRoute(ETH_ROUTE);
+    runWaiter("Ethernet 'eth0' up");
+
+    expect(restarts()).toBe(2);
+    expect(journalLines("already asked for this route recovery")).toHaveLength(0);
+  });
+
+  it("keeps the record in the root-owned run directory, beside the lock", () => {
+    // Not under the clawbox-writable data/: this runs as root, so a path that
+    // user can replace with a symlink is root writing wherever it points. /run
+    // is also cleared on boot, which is what "did we already restart for this
+    // recovery" wants — the first event after a boot is never a repeat.
+    makeBox({ connectivity: ["full"], defaultRoute: true });
+
+    runWaiter("Ethernet 'eth0' up");
+
+    expect(existsSync(path.join(root, "run", "gateway-online-restart.stamp"))).toBe(true);
+  });
+
+  it("does not record a restart it failed to ask for", () => {
+    // False success in the other direction: try-restart failing means nothing
+    // was restarted, so the next event must still be allowed to try.
+    makeBox({ connectivity: ["full"], defaultRoute: true, tryRestartFails: true });
+
+    runWaiter("Ethernet 'eth0' up");
+    runWaiter("NetworkManager reports full connectivity");
+
+    expect(restarts()).toBe(2);
+    expect(journalLines("already asked for this route recovery")).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
Follow-up to #702 (TASK-664), from the device lane that verified it. #702 itself stands; this closes a defect the same evidence exposed.

## Customer-visible symptom

Every network recovery bounces the gateway several times over instead of once. On the OpenClaw box, one boot produced three NetworkManager events inside a single second and **three** `asked systemd to restart clawbox-gateway.service` lines; a later boot of the same box produced two requests and one `already pending`. Each accepted request is a stop plus a cold start of a unit that takes ~40 s to come up on this hardware, and each bounce drops exactly the channel accounts the restart exists to revive — so a flapping link makes the box less reachable on Telegram, not more, which is the shape of the outage #702 was written for.

## Cause

`scripts/gateway-restart-when-online.sh` fires one restart per dispatcher EVENT, not one per route recovery.

NetworkManager emits `up`, `connectivity-change FULL` and `dhcp4-change` for one recovery and runs dispatcher scripts **serially**, so the waiters it launches run one after another rather than at the same time. The `flock` only turns away a waiter whose wait would overlap another's: each of these cycles finished well inside the time the next took to start, so none was turned away — no `already pending` line in that journal at all — and every one of them proved the same route and asked for its own restart. #702's own text says the lock is there so "a flapping carrier cannot stack several waits and fire several restarts at the instant the route returns"; it prevents concurrent waits, not sequential repeats, and this PR corrects that claim in the code as well as fixing it.

## Harness-first — what already does this, asked before writing anything

- **systemd merges jobs, but only pending ones.** A `try-restart` requested while a restart job for the same unit is still queued merges into it. It cannot collapse a request that arrives after the previous restart completed — and these requests are not simultaneous: NetworkManager runs the dispatchers serially and a waiter may spend up to 120 s proving a route before it asks. Nor can systemd express "these two requests describe the same route recovery", which is what "once per recovery" means. The measured journal is the proof that it did not save us: three separate requests, and three stop/start cycles of the unit.
- **`systemctl list-jobs <unit>`** is the native way to ask whether a restart is already queued. It answers only for that pending window and is empty the instant the job completes, so it has the same gap; the window used here is a superset of it.
- **`StartLimitIntervalSec` / `StartLimitBurst`** is the wrong tool: it drives the unit to `failed` ("start request repeated too quickly"), a state `src/app/setup-api/gateway/route.ts` already has to explain to the owner.
- **`systemd-run --unit=clawbox-gateway-online-restart --on-active=…`** is the real native candidate and was rejected rather than skipped: a transient unit with a fixed name fails with "Unit … already exists" for the second and third event of a burst, which is coalescing owned by systemd. It also debounces every restart by the delay, and it would collapse a genuine Ethernet→WiFi failover into the same suppression unless the waiter re-checked anyway — so the check has to exist either way, and adding a transient unit on top buys nothing this does not.
- **`ip route get` IS used**, and it is the kernel's own answer to "which route would this box take, and from which address" — replacing a hand-rolled parse of `ip route show default` (see the review section below).
- **`systemctl try-restart --no-block` is the native way to stop the call blocking**, and it is deliberately NOT used. The blocking form is what makes the exit code an OUTCOME: `--no-block` returns 0 the moment the job is enqueued, so a unit that then fails to start would still be recorded as a restart that was asked for and succeeded. That is the false-success class this repo keeps producing, traded for a window that the ordering fix below closes for nothing. The call stays blocking; what changed is that the record no longer depends on surviving it.
- **NetworkManager de-duplicates nothing.** Dispatcher scripts run for every event, serially, each in its own process; there is no "last event" state to read. It does hand the dispatcher `IP4_ADDRESS_0`, `IP4_GATEWAY` and `CONNECTIVITY_STATE`, two of which the `dhcp4-change` arm already uses.

So the memory has to live in this repo. It lives beside the lock this script already keeps, in the same root-owned `/run/clawbox` tmpfs — cleared on boot, which is what "have we already restarted for this recovery" wants.

## Fix

Once the route is proven and before `try-restart`, the waiter checks whether a restart has already been asked for **this** recovery and stands down with a journal line if it has. Standing down is the dangerous half — a swallowed restart is GH #529 itself — so it happens only when all three hold:

1. **This waiter never watched the route go away.** A waiter that polled and found no route has proven an absence since the last restart, so whatever comes back is a new recovery however familiar it looks. The dispatcher additionally clears the record on a `down` of **any uplink this box routes through** — Ethernet or the radio — which covers the flap that is over before a waiter even runs, the one case the waiter cannot see for itself. And because that clear can land while `systemctl try-restart` is still running, the record is written **before** that call and never after it, so the clear is always the last word (see the second review round below).
2. **The kernel selects the same route.** `ip -o route get <probe target>` gives interface, gateway and **source address** — what the gateway's sockets are actually bound to. A second, higher-metric default route (any box with a saved WiFi profile) is therefore not a move, while a DHCP NAK that changes only the box's own address is. A key the kernel cannot answer never equals a recorded one, so it degrades to today's behaviour rather than to a blanket cooldown.
3. **The record is inside a 60 s window** (`CLAWBOX_RESTART_COALESCE`), covering the measured one-second burst with room for a `dhcp4-change` or a connectivity check landing seconds later, and nothing beyond it. A cable replugged an hour later on the same lease still restarts.

The clock is `/proc/uptime`, not `date +%s`: these boards have no RTC and systemd-timesyncd steps the clock the moment a route comes up, inside the very burst this has to survive; `/run` is cleared on boot, so the record and the counter share a lifetime. The record is written for a request about to be made and withdrawn if systemd rejects it, staged and renamed rather than truncated in place, and a write that fails is logged rather than assumed — a guard that silently is not there would show up only as the original symptom.

Everything #702 established is untouched and still covered by its own tests: the wait for a proven default route before any restart, the stand-down on a masked or absent unit (the Hermes edition returns before any of this code), the `dhcp4-change` interface and lease filtering, `try-restart` rather than `restart`, and the installer reporting a helper that did not land.

## Sibling call sites

Every other restarter of `clawbox-gateway.service` was checked, not assumed:

- **`scripts/clawbox-identity-sync.sh:58`** — restarts on an owner action (a harness switch, or the path unit that fires when the canonical identity files change), never on a network event, and there the restart IS the sync: coalescing it would make a requested identity refresh silently not happen, which is the false-success class. Cleared, deliberately not changed.
- **`src/lib/openclaw-config.ts:2786` `restartGateway()`** — a config write by the owner or the updater; not reachable from a network event. Cleared. See the residual below for the one real interaction.
- **`install.sh:5671`, `:5715`, `:6603`** — install and update paths. Cleared.
- **`config/99-clawbox-avahi-reload`** — the repo's other NetworkManager dispatcher; it reloads avahi and restarts no gateway at all. Cleared.
- **The dispatcher's own arms** (`up`, `down`, WiFi `up`, `dhcp4-change`, `connectivity-change`) all go through the waiter, so one change covers them all; the dispatcher needed the `down` arm's record clear, and its comment corrected where it claimed the lock did what the record now does.
- **Every reader and writer of the record file** — `grep -rn gateway-online-restart` over the repo returns the waiter (which defines all three `/run/clawbox` paths) and the dispatcher's one `rm -f`, and nothing else. The `down` clear is the only invalidation site and it is now reached by every uplink.
- **Every consumer of `CLAWBOX_PING_TARGETS`** — `online()` and `route_key()`, both fixed the same way in this round rather than only the line the review flagged. The updater's own `PING_TARGETS` (`src/lib/updater.ts:326`) is a comma split in TypeScript with no shell expansion anywhere near it. Cleared.
- **Every other `systemctl try-restart` of the gateway** — `install.sh:6768` is the install/update path, unreachable from a network event, and it neither reads nor writes the record. Cleared.

### Residual, recorded rather than smuggled in

`gatewayRestartGeneration()` (`src/lib/openclaw-config.ts:2764`) is a counter **inside the web-app process**, bumped at both ends of `restartGateway()` so channel-status memos read before a restart are not served after it. A dispatcher restart is a root `systemctl try-restart` and cannot bump an in-process counter. The exposure is bounded by the memos' own TTLs — `CHANNEL_STATUS_TTL_MS` 15 s, `CHANNEL_STATUS_FAILURE_TTL_MS` 3 s (`src/lib/openclaw-channels.ts:674`, `:690`) — so the worst case is a channel row in Settings up to 15 s out of date after a network recovery. Closing it means moving the generation out of the process into a file every memo holder reads, changing that contract for every reader on both editions; that is not proportional to a 15 s window, so it is recorded here and in the run queue rather than done in this PR.

## RED — round 1, on `origin/beta` (`a6fcc4b6`)

The tests execute the shipped scripts against stubbed `nmcli` / `ip` / `ping` / `systemctl`, as the rest of this suite does.

```
 ❯ src/tests/unit/failover-waits-for-route.test.ts (42 tests | 5 failed)
   × collapses a burst of NetworkManager events into a single restart request
   × does not treat NetworkManager rewriting a route's metric as a new recovery
   × does not treat a second uplink appearing beside the first as a new recovery
   × forgets the last restart request when the carrier actually drops
   × keeps the record in the root-owned run directory, beside the lock

 FAIL > collapses a burst of NetworkManager events into a single restart request
 AssertionError: expected 3 to be 1 // Object.is equality
   - Expected   1
   + Received   3
       expect(restarts()).toBe(1);

 FAIL > does not treat a second uplink appearing beside the first as a new recovery
 AssertionError: expected 2 to be 1 // Object.is equality

 Test Files  1 failed (1)
      Tests  5 failed | 37 passed (42)
```

Three more of the new cases pass on beta by construction and are there to stop the fix over-reaching — a route that moved, a lease that moved only the local address, and a recovery whose route the kernel could not name must all still restart. Each new guard was mutation-tested by disabling it in a scratch copy: dropping the absence rule reddens the flap case, dropping the dispatcher's clear reddens the carrier-drop case, keying on the whole routing table reddens the second-uplink and address-move cases, and removing both empty-key guards reddens the unnamed-route case.

## RED — round 2, on the previous head of this branch (`a8429096`)

The merge-gate review blocked on two reachable paths where a genuine loss-and-recovery still loses its restart. Both now have a test, and both fail on the head that shipped the first fix:

```
 ❯ src/tests/unit/failover-waits-for-route.test.ts (44 tests | 2 failed)
   × forgets the last restart request when the carrier actually drops on 'wlan0'
   × does not put back a record the carrier drop cleared while the restart was still running

 FAIL > forgets the last restart request when the carrier actually drops on 'wlan0'
 AssertionError: expected true to be false      # the stamp survived the radio's own carrier drop
     expect(existsSync(stamp)).toBe(false);

 FAIL > does not put back a record the carrier drop cleared while the restart was still running
 AssertionError: expected true to be false      # the waiter put the record back after the clear
     expect(existsSync(stamp)).toBe(false);

 Tests  2 failed | 42 passed (44)
```

The second case's follow-on symptom is the swallowed restart itself. With that stamp assertion removed so the run reaches the end of the case, on the same unfixed head:

```
 FAIL > does not put back a record the carrier drop cleared while the restart was still running
 AssertionError: expected 1 to be 2
     expect(restarts()).toBe(2);
```

One restart where two were owed, on a real carrier loss and recovery — GH #529, through the mitigation written to prevent it.

## GREEN

```
 ✓ src/tests/unit/failover-waits-for-route.test.ts            46 passed
 ✓ src/tests/unit/openclaw-config-mock-completeness.test.ts
 ✓ src/tests/unit/test-timeout-hygiene.test.ts
 ✓ src/tests/unit/state-updater-purity.test.ts
 ✓ src/tests/unit/root-exec-manifest.test.ts
 ✓ src/tests/unit/root-steps.test.ts                          Tests 116 passed (116)

 tsc --noEmit   exit 0
 bash -n scripts/gateway-restart-when-online.sh scripts/nm-dispatcher-failover.sh   OK
```

## What the review changed

A review pass on this branch found one HIGH and four MEDIUM defects in the first version of the fix, all reproduced by executing the shipped script rather than read off the diff. All are fixed above, and each has a test:

- **HIGH** — the first version asked only "same route, recently?", so a carrier loss and recovery on the same lease inside the window was swallowed: GH #529 through the new door. Fixed by conditions 1 (the absence rule) and the dispatcher's `down` clear.
- **MEDIUM** — keying on every default route made a second uplink appearing read as a new recovery, so a box with a saved WiFi profile still got two restarts per burst.
- **MEDIUM** — the key dropped the local source address, so a DHCP NAK that moved only the box's address was swallowed.
- **MEDIUM** — the window was on the wall clock, which timesyncd steps in exactly the boot window this targets; measured, that degraded three restarts to two rather than to one.
- **MEDIUM** — the harness-first rule: the native candidates were neither used nor named. `ip route get` is now used; `systemd-run`, job merging, `list-jobs` and `StartLimit*` are named above with the reason each was rejected.
- Plus three LOW/nit items: an unanswerable route key must never coalesce, a failed record must be said out loud, and the "systemd ACCEPTED" comment overstated what `try-restart`'s exit code means.

### Second round — the two defects the merge-gate review blocked on

Both were false-failure, both were GH #529 returning through the guard meant to close it, and both were reproduced end-to-end by executing the shipped scripts rather than read off the diff.

- **HIGH — `scripts/nm-dispatcher-failover.sh`: the clear sat below the interface case, so only Ethernet ever reached it.** That case returns for the box's own radio on any action but `up`, so `<radio> down` cleared nothing and dispatched nothing, and nothing else saw the absence either — no waiter is launched on a radio `down`, so no poll ever sets `saw_route_absent`, and the radio re-associates with the route already back on the next waiter's first poll. Measured with the identical event sequence on each uplink (`up` → carrier loss → `down` → `up` on the same lease, inside 60 s): `eth0` → 2 restarts, 0 stand-downs; the radio → 1 restart, 1 "standing down". A box provisioned through its own `ClawBox-Setup` AP and joined to the customer's WiFi has no Ethernet arm to save it — the WiFi arm exists precisely because "after a failover the box's route comes back on the wireless interface". Fixed by hoisting the clear **above** the interface case, gated on `down` for `eth*|en*|$WIFI_IFACE`. It over-clears by design: a radio dropping while Ethernet still carries the traffic costs one extra restart on the next event, bounded by a real `down` event — narrowing it to the interface the record names would buy that back at the price of a swallowed restart the moment the two names disagree, which is the wrong direction.

- **HIGH — `scripts/gateway-restart-when-online.sh`: the in-flight waiter undid the dispatcher's clear, so even the Ethernet path lost the restart.** This is CodeRabbit's Major, and it is real. `systemctl try-restart` **blocks until the restart job completes** — ~40 s for this unit on this hardware — and the record was written after it returned, keyed on the route read before it. Any carrier drop inside that window was cleared by the dispatcher and then immediately re-written by the waiter, stamped with the **pre-drop** route key, so the next recovery stood down on a record for a route that had already died. `saw_route_absent` could not help: the waiter that drop dispatches is turned away by the flock the first one holds and exits without recording anything, so nothing observes the absence. Fixed by writing the record **before** `try-restart` and withdrawing it (`rm -f`) if systemd rejects the request, so a clear landing during the restart is the last word — nothing writes again afterwards. The dispatcher's clear stays a plain `rm -f` that takes no lock, so it is never queued behind the restart it has to invalidate. Serialising the clear behind the same flock, the other shape CodeRabbit offered, would do the opposite: the clear would wait ~40 s for the very call it needs to overtake.

- **LOW (CodeRabbit's Minor) — `CLAWBOX_PING_TARGETS` was word-split by a bare expansion, which is a pathname expansion too.** A `*` in the value made a filename the probe destination and therefore the route key. Split with `read -ra` instead, in **both** consumers — `route_key()`, the line flagged, and `online()`, which has had the identical expansion since #702. Measured in a directory containing a file named `notatarget`, with the value set to `*`: the old split answers `notatarget`, the new one answers `*`. An empty value still falls back to the default and leading whitespace still yields the first real target, as the bare split did.

A second merge-gate pass on the fixed head found no remaining correctness defect — it reverted each of this round's fixes in a scratch tree and confirmed the new tests redden — and its LOW items are applied here too:

- The window is measured from **before** the restart, so what is left once the waiter releases the lock is 60 s minus the restart. Documented beside `COALESCE_WINDOW` rather than corrected: refreshing the timestamp after `try-restart` would mean writing the stamp again after the restart, which is precisely the write a carrier drop landing during it must be able to win against. Erring short costs an extra restart; erring the other way costs a swallowed one, and the measured burst arrives inside a second, before the restart has even started.
- The withdrawal now runs only when there was a record to withdraw. An unanswerable route key records nothing, and an unconditional `rm -f` on that path would take an *earlier* waiter's good record instead.
- Three test gaps closed: the glob fix had no test (`never lets a probe target be expanded into a filename` — mutation-proven, the bare split answers a repo filename); hoisting the clear above the interface case left the recovery-AP guard as the only thing stopping `ap-watchdog.sh` clearing the record every ~20 s, with no `down` case covering it (`does not forget the record when the box's own recovery AP goes down` — mutation-proven by moving the clear above that guard); and the radio's "dispatches nothing" half was asserted with a zero-target poll that returns on its first iteration, so it now waits before asserting.
- The `~40 s` figure in the comment is attributed honestly: it is this unit's cold start on a running box, not what the boot journal shows — at boot the unit is inactive, where `try-restart` is a no-op and returns at once.

## Device evidence — read-only, both boxes, no mutex taken, nothing mutated

Re-read at 09:56 EEST on 2026-09-06, after the rebase. Both boxes are on `beta` at **c3eb1d25** — the same head this branch is rebased on, so neither is behind — and both answer `/login` 200. No network event was triggered, no restart was requested and no mutex was taken; only `edition.env`, `git rev-parse`, the unit's `LoadState` and the journal were read. Addresses redacted.

OpenClaw box, this boot — three events in one second, and the before-state this PR fixes, still present:

```
06:37:29 clawbox-failover[1926]: Deferred restart dispatched: DHCP lease on 'enP8p1s0' changed
06:37:29 clawbox-failover[1956]: Deferring the gateway restart (DHCP lease on 'enP8p1s0' changed) until a public route is proven, up to 120s
06:37:29 clawbox-failover[2005]: Public route is up — asked systemd to restart clawbox-gateway.service (DHCP lease on 'enP8p1s0' changed)
06:37:29 clawbox-failover[2043]: Deferred restart dispatched: Ethernet 'enP8p1s0' up
06:37:30 clawbox-failover[2068]: Deferring the gateway restart (Ethernet 'enP8p1s0' up) until a public route is proven, up to 120s
06:37:30 clawbox-failover[2080]: Deferred restart dispatched: NetworkManager reports full connectivity
06:37:30 clawbox-failover[2091]: Gateway restart already pending (NetworkManager reports full connectivity) — handed to the waiter holding the lock
06:37:30 clawbox-failover[2093]: Public route is up — asked systemd to restart clawbox-gateway.service (Ethernet 'enP8p1s0' up)

  dispatched 3 | asked-restart 2 | already-pending 1 | stood-down 0
  clawbox-gateway.service  LoadState=loaded
```

One recovery, two restart requests — the lock caught only the pair whose waits overlapped. An earlier boot of the same box produced three dispatches, **three** requests and no `already pending` at all.

Hermes box, same boot window — unaffected, and must stay so:

```
  dispatched 3 | asked-restart 0 | already-pending 0 | stood-down 0
  clawbox-gateway.service  LoadState=masked
```

The waiter stands down on the masked unit before it reaches any of this code, so this edition sees no change at all.

`/run/clawbox` is `drwx------ root root` on **both** boxes this boot, i.e. the root-step's `install -d -m 0700` won the boot race against the waiter's and dispatcher's bare `mkdir -p`. That race is pre-existing (the lock and lease files have lived there under the same `mkdir -p` since #702), `/run` is a root-owned tmpfs so nothing unprivileged can pre-create the directory or plant an entry in it at either mode, and the `.stamp.new` → `mv -f` staging therefore cannot be redirected. Recorded in the run queue rather than widened into this PR.

**Declared gap — the device leg for this change is unproven.** The fixed scripts have not run on a box: proving either of them needs a real carrier loss and recovery, which this lane may not cause. What the unit tests do instead is execute the shipped scripts — the same files that are installed, through the same code path the dispatcher takes — against stubbed `nmcli` / `ip` / `ping` / `systemctl` / `logger` / `sleep` / `setsid`, with the drop-during-restart case running the real dispatcher's `down` arm from inside the stubbed `try-restart` so the flock turn-away and the unlocked clear are exercised as they are on a box.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved network failover recovery by preventing duplicate restart requests during repeated recovery events.
  - Ensured recovery retries when the active route changes, connectivity returns after an outage, or a previous restart attempt fails.
  - Ethernet connection losses now reliably begin a fresh recovery cycle, even when network lease details remain unchanged.
  - Improved timeout handling for more reliable recovery during clock adjustments and extended connectivity interruptions.

- **Documentation**
  - Clarified how repeated recovery events are combined during failover processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
