### PR TITLE
fix: a missing ClawBox tree no longer reports every binary as absent

### DIFF
--- a/mcp/check-tools.ts
+++ b/mcp/check-tools.ts
@@ -509,11 +509,15 @@ async function check(): Promise<void> {
     // The contract above WAS checked over every posture; what this host could
     // not do is tell you whether these particular probes work.
     const cwd = defaultSpawnCwd();
+    // The POLICY, not a claim about where each probe ran: the fallback to `/`
+    // is also taken on the spawn's own refusal, which this side never sees. A
+    // note that named this directory outright would be wrong about exactly the
+    // host it is written for — one whose root exists and cannot be entered.
     const rootNote = cwd === DEFAULT_CWD
-      ? `CLAWBOX_ROOT=${DEFAULT_CWD}`
-      : `CLAWBOX_ROOT=${DEFAULT_CWD} cannot be entered, so spawns fell back to ${cwd} and were NOT affected by it`;
+      ? `CLAWBOX_ROOT=${DEFAULT_CWD}; a directory refusal retries in /`
+      : `CLAWBOX_ROOT=${DEFAULT_CWD} cannot be entered, so the probes were NOT affected by it`;
     console.log(
-      `\nnote: probes that answered false on this host. Spawns ran in ${cwd} (${rootNote});`
+      `\nnote: probes that answered false on this host. Spawns default to ${cwd} (${rootNote});`
       + `\n      device API probes call ${API_BASE}.`
       + `\n${noteLines.join("\n")}`
       + "\n      The contract and the matrix above come from the declared postures, which are the"

--- a/mcp/check-tools.ts
+++ b/mcp/check-tools.ts
@@ -513,9 +513,19 @@ async function check(): Promise<void> {
     // is also taken on the spawn's own refusal, which this side never sees. A
     // note that named this directory outright would be wrong about exactly the
     // host it is written for — one whose root exists and cannot be entered.
+    // "CLAWBOX_ROOT=<path>" over an UNSET variable is the same kind of false
+    // statement this whole note is being corrected for: on a shipped box the
+    // variable is not set at all (clawbox-setup.service's Environment= carries
+    // NODE_ENV, BUN_ENV, PORT, HOSTNAME and CLAWBOX_EDITION, and nothing else),
+    // so the path being reported is the module's hard-coded fallback and saying
+    // otherwise sends an operator looking for a setting that does not exist.
+    const configured = process.env.CLAWBOX_ROOT;
+    const rootLabel = configured
+      ? `CLAWBOX_ROOT=${configured}`
+      : `CLAWBOX_ROOT is unset, so the default ${DEFAULT_CWD} applies`;
     const rootNote = cwd === DEFAULT_CWD
-      ? `CLAWBOX_ROOT=${DEFAULT_CWD}; a directory refusal retries in /`
-      : `CLAWBOX_ROOT=${DEFAULT_CWD} cannot be entered, so the probes were NOT affected by it`;
+      ? `${rootLabel}; a directory refusal retries in /`
+      : `${rootLabel}, and it cannot be entered — so the probes were NOT affected by it`;
     console.log(
       `\nnote: probes that answered false on this host. Spawns default to ${cwd} (${rootNote});`
       + `\n      device API probes call ${API_BASE}.`

--- a/mcp/check-tools.ts
+++ b/mcp/check-tools.ts
@@ -519,10 +519,17 @@ async function check(): Promise<void> {
     // NODE_ENV, BUN_ENV, PORT, HOSTNAME and CLAWBOX_EDITION, and nothing else),
     // so the path being reported is the module's hard-coded fallback and saying
     // otherwise sends an operator looking for a setting that does not exist.
+    // Three states, not two: set to a path, set to the EMPTY string (which
+    // `DEFAULT_CWD`'s `||` treats as absent, so the fallback applies while the
+    // variable is very much present), and unset. An operator told "unset" about
+    // a variable something exported as empty would go looking in the wrong
+    // place.
     const configured = process.env.CLAWBOX_ROOT;
     const rootLabel = configured
       ? `CLAWBOX_ROOT=${configured}`
-      : `CLAWBOX_ROOT is unset, so the default ${DEFAULT_CWD} applies`;
+      : configured === undefined
+        ? `CLAWBOX_ROOT is unset, so the default ${DEFAULT_CWD} applies`
+        : `CLAWBOX_ROOT is set but empty, so the default ${DEFAULT_CWD} applies`;
     const rootNote = cwd === DEFAULT_CWD
       ? `${rootLabel}; a directory refusal retries in /`
       : `${rootLabel}, and it cannot be entered — so the probes were NOT affected by it`;

--- a/mcp/check-tools.ts
+++ b/mcp/check-tools.ts
@@ -35,7 +35,7 @@ import { z } from "zod";
 import { contractViolations, type RegisteredToolInfo } from "./lib/register";
 // The directory the probes actually spawn in — imported, not restated: a third
 // copy of that path is a third thing to keep in step with the other two.
-import { DEFAULT_CWD } from "./lib/guard";
+import { DEFAULT_CWD, defaultSpawnCwd } from "./lib/guard";
 // The production reader, so the run fixture below cannot drift from it.
 import { runMedia } from "./lib/run-context";
 // The TYPE, so the postures below are checked against the interface they
@@ -116,13 +116,18 @@ function schemaShapeViolations(tool: RegisteredToolInfo, emitted: string): strin
  *
  * The registrars gate whole tool families on a device probe — `du`,
  * `journalctl`, a screen grabber, a readable mailbox, the coding harness, an
- * image backend, the Hermes provider list. Off a real box every probe answers
- * false (mcp/lib/guard.ts spawns in CLAWBOX_ROOT, which exists on a device and
- * nowhere else), so building the server the ordinary way here would examine a
- * FRACTION of the surface and print "Tool contract OK" over the rest: measured
- * on the dev PC, `du` is installed and none of disk_usage, disk_cleanup,
- * logs_tail or screen_capture appeared in this checker's own matrix. That is a
+ * image backend, the Hermes provider list. Off a real box MOST of those answer
+ * false — there is no device API to ask, and a runner has no scrot and no
+ * ImageMagick — so building the server the ordinary way here would examine a
+ * FRACTION of the surface and print "Tool contract OK" over the rest. That is a
  * false success, and the reason CI could not run this job as it stood.
+ *
+ * It used to be every probe, for a reason that was not about this host at all:
+ * the spawns ran in CLAWBOX_ROOT, and a missing directory made `hasBinary()`
+ * answer false for binaries that were installed (TASK-722). That is fixed in
+ * mcp/lib/guard.ts, so `du` and `journalctl` now probe true here — which
+ * narrows what the postures below are covering for, and does not remove the
+ * need for them.
  *
  * So the contract is checked over the DECLARED postures rather than over the
  * probed one alone — the full surface a real box registers, that surface as the
@@ -503,8 +508,12 @@ async function check(): Promise<void> {
   if (noteLines.length) {
     // The contract above WAS checked over every posture; what this host could
     // not do is tell you whether these particular probes work.
+    const cwd = defaultSpawnCwd();
+    const rootNote = cwd === DEFAULT_CWD
+      ? `CLAWBOX_ROOT=${DEFAULT_CWD}`
+      : `CLAWBOX_ROOT=${DEFAULT_CWD} cannot be entered, so spawns fell back to ${cwd} and were NOT affected by it`;
     console.log(
-      `\nnote: probes that answered false on this host. Spawns run in CLAWBOX_ROOT=${DEFAULT_CWD};`
+      `\nnote: probes that answered false on this host. Spawns ran in ${cwd} (${rootNote});`
       + `\n      device API probes call ${API_BASE}.`
       + `\n${noteLines.join("\n")}`
       + "\n      The contract and the matrix above come from the declared postures, which are the"

--- a/mcp/clawbox-mcp.ts
+++ b/mcp/clawbox-mcp.ts
@@ -134,10 +134,12 @@ function instructionsFor(edition: Ed, profile: Profile): string {
  * `overrides` exists for that CHECKER, not for the running server. Several tool
  * families register only when a device probe says the box can do the thing —
  * `du`, `journalctl`, a screen grabber, a readable mailbox, the coding harness.
- * Off a real box every one of those probes answers false (mcp/lib/guard.ts
- * spawns in CLAWBOX_ROOT, which does not exist on a CI runner or a dev PC), so
- * a checker that built the server the ordinary way would examine a fraction of
- * the surface and report the whole thing OK. Nothing else passes it; the
+ * Off a real box most of those probes answer false — there is no device API to
+ * ask, and a runner has neither a screen grabber nor ImageMagick — so a checker
+ * that built the server the ordinary way would examine a fraction of the
+ * surface and report the whole thing OK. (It was ALL of them until TASK-722:
+ * the spawns ran in CLAWBOX_ROOT and a missing directory answered false for
+ * binaries that were installed.) Nothing else passes it; the
  * running server always takes the probes.
  *
  * It may override CAPABILITIES only. The server's identity — `edition`,

--- a/mcp/lib/context.ts
+++ b/mcp/lib/context.ts
@@ -119,7 +119,17 @@ export interface Capabilities {
   screenGrabber: string | null;
   /** ImageMagick `convert`, used to shrink a capture before it is returned. */
   imageConvert: boolean;
-  /** journalctl present AND able to read at least one ClawBox unit. */
+  /**
+   * journalctl present and the journal readable by this process.
+   *
+   * NOT "there are entries for a ClawBox unit": `journalctl -u <absent unit>`
+   * exits 0 over "-- No entries --", so an empty answer is indistinguishable
+   * from a quiet one. Tightening it to require output would make logs_tail
+   * depend on a unit having logged something by startup, and this answer is
+   * kept for the process lifetime — a box whose journal was briefly empty would
+   * lose the tool until the next restart, which is a worse trade than a tool
+   * that answers "nothing yet" on a host that is not a ClawBox.
+   */
   journal: boolean;
   /** `du` present — disk_usage needs it for the cache breakdown. */
   du: boolean;

--- a/mcp/lib/guard.ts
+++ b/mcp/lib/guard.ts
@@ -16,7 +16,7 @@
 // decision is a different one.
 
 import { spawn } from "child_process";
-import { realpathSync } from "fs";
+import { realpathSync, statSync } from "fs";
 import { basename, dirname, join, resolve, isAbsolute, normalize } from "path";
 import { isProtectedFilePath } from "../../src/lib/file-guard";
 // TASK-605's protected-path rule, from the module the OpenClaw hook plugin
@@ -224,6 +224,38 @@ export interface SpawnOptions {
 }
 
 /**
+ * Where a child runs when the caller named no directory.
+ *
+ * `DEFAULT_CWD` is the project root, and it is the right answer for RESOLVING
+ * a relative path (see resolveUserPath). It is NOT a precondition of running a
+ * program: when that directory is absent, `spawn` fails ENOENT before the
+ * binary is ever reached and `spawnArgv` settles at 127 — which `hasBinary()`
+ * reads as "not installed" and `probeJournal()` as "no journal". The whole
+ * capability sweep then answers false at once and the MCP server drops
+ * disk_usage, disk_cleanup, logs_tail and screen_capture from its tool list
+ * with nothing said (TASK-722, the false-failure class). On a box the tree is
+ * normally there; this bites exactly when it briefly is not — mid-update, a
+ * failed mount, a mis-set CLAWBOX_ROOT — which is when those tools are wanted.
+ *
+ * `/` is the fallback because it is the one directory that cannot be missing
+ * and cannot be a surprise: every argument these tools pass is already an
+ * absolute path (`resolveUserPath` guarantees it), so nothing changes meaning.
+ *
+ * Asked per spawn rather than once at import: the tree comes BACK after an
+ * update, and a capability answered once and kept for the process lifetime is
+ * the probe-once class this codebase keeps producing.
+ */
+const FALLBACK_CWD = "/";
+
+function defaultSpawnCwd(): string {
+  try {
+    return statSync(DEFAULT_CWD).isDirectory() ? DEFAULT_CWD : FALLBACK_CWD;
+  } catch {
+    return FALLBACK_CWD;
+  }
+}
+
+/**
  * The ONLY process entry point outside the `bash` tool. Argv array, never a
  * shell string — so no argument, however hostile, can be re-parsed as a
  * command. Output is capped and the child is killed at the cap so a runaway
@@ -234,11 +266,15 @@ export function spawnArgv(
   args: string[],
   options: SpawnOptions = {},
 ): Promise<SpawnResult> {
-  const { timeoutMs = 15_000, maxBytes = 4 * 1024 * 1024, cwd = DEFAULT_CWD, input, extraEnv } = options;
+  const { timeoutMs = 15_000, maxBytes = 4 * 1024 * 1024, cwd, input, extraEnv } = options;
+  // A cwd the CALLER named is honoured exactly as given, missing or not: that
+  // directory is the caller's meaning, and running somewhere else instead
+  // would be the false-success mirror of the bug the fallback above fixes.
+  const effectiveCwd = cwd ?? defaultSpawnCwd();
   return new Promise((resolveP) => {
     let child: ReturnType<typeof spawn>;
     try {
-      child = spawn(bin, args, { cwd, env: { ...process.env, HOME, ...extraEnv }, shell: false });
+      child = spawn(bin, args, { cwd: effectiveCwd, env: { ...process.env, HOME, ...extraEnv }, shell: false });
     } catch (err) {
       resolveP({
         stdout: "",

--- a/mcp/lib/guard.ts
+++ b/mcp/lib/guard.ts
@@ -217,6 +217,12 @@ const DRAIN_MS = 250;
 export interface SpawnOptions {
   timeoutMs?: number;
   maxBytes?: number;
+  /**
+   * Run the child HERE. Omit it and the child runs in the project root, or in
+   * `/` when that root cannot be entered — so an argument that is not an
+   * absolute path does not name a fixed file. A directory named here is used
+   * exactly as given and is never substituted.
+   */
   cwd?: string;
   input?: string;
   /** Extra environment for this child only (e.g. DISPLAY for a screen grab). */
@@ -228,7 +234,7 @@ export interface SpawnOptions {
  *
  * `DEFAULT_CWD` is the project root, and it is the right answer for RESOLVING
  * a relative path (see resolveUserPath). It is NOT a precondition of running a
- * program: when that directory is absent, `spawn` fails ENOENT before the
+ * program: when that directory cannot be entered, `spawn` fails before the
  * binary is ever reached and `spawnArgv` settles at 127 — which `hasBinary()`
  * reads as "not installed" and `probeJournal()` as "no journal". The whole
  * capability sweep then answers false at once and the MCP server drops
@@ -238,8 +244,9 @@ export interface SpawnOptions {
  * failed mount, a mis-set CLAWBOX_ROOT — which is when those tools are wanted.
  *
  * `/` is the fallback because it is the one directory that cannot be missing
- * and cannot be a surprise: every argument these tools pass is already an
- * absolute path (`resolveUserPath` guarantees it), so nothing changes meaning.
+ * and cannot be a surprise. It is safe only because every argument these tools
+ * pass is already an ABSOLUTE path — the rule is restated on `spawnArgv` and on
+ * `SpawnOptions.cwd`, where a caller adding an argument will read it.
  *
  * Asked per spawn rather than once at import: the tree comes BACK after an
  * update, and a capability answered once and kept for the process lifetime is
@@ -247,7 +254,15 @@ export interface SpawnOptions {
  */
 const FALLBACK_CWD = "/";
 
-function defaultSpawnCwd(): string {
+/**
+ * The directory a `spawnArgv` call with no `cwd` will actually use.
+ *
+ * Exported because `check-tools.ts` PRINTS it when a probe answers false: a
+ * note that named `DEFAULT_CWD` there would attach the old, wrong cause ("your
+ * tree is missing") to a probe that failed for a real reason ("scrot is not
+ * installed") — the very misdiagnosis this fix removes.
+ */
+export function defaultSpawnCwd(): string {
   try {
     return statSync(DEFAULT_CWD).isDirectory() ? DEFAULT_CWD : FALLBACK_CWD;
   } catch {
@@ -255,23 +270,60 @@ function defaultSpawnCwd(): string {
   }
 }
 
+/** The spawn failed on the DIRECTORY, before the program was reached. */
+function isCwdRefusal(code: string | undefined): boolean {
+  return code === "ENOENT" || code === "EACCES" || code === "ENOTDIR";
+}
+
+interface Attempt {
+  result: SpawnResult;
+  /** Set when the child never started and the reason could be the directory. */
+  refusedCode?: string;
+}
+
 /**
  * The ONLY process entry point outside the `bash` tool. Argv array, never a
  * shell string — so no argument, however hostile, can be re-parsed as a
  * command. Output is capped and the child is killed at the cap so a runaway
  * producer cannot OOM the stdio server and take every tool down with it.
+ *
+ * EVERY PATH IN `args` MUST BE ABSOLUTE. With no `cwd` the child runs in the
+ * project root, or in `/` when that root cannot be entered, so a relative
+ * argument does not name a fixed file. `resolveUserPath` is what every caller
+ * uses to satisfy this, and `rm -rf --` is one of the callers.
  */
 export function spawnArgv(
   bin: string,
   args: string[],
   options: SpawnOptions = {},
 ): Promise<SpawnResult> {
-  const { timeoutMs = 15_000, maxBytes = 4 * 1024 * 1024, cwd, input, extraEnv } = options;
+  const { cwd } = options;
   // A cwd the CALLER named is honoured exactly as given, missing or not: that
   // directory is the caller's meaning, and running somewhere else instead
   // would be the false-success mirror of the bug the fallback above fixes.
-  const effectiveCwd = cwd ?? defaultSpawnCwd();
-  return new Promise((resolveP) => {
+  if (cwd !== undefined) return spawnAttempt(bin, args, options, cwd).then((a) => a.result);
+  const chosen = defaultSpawnCwd();
+  return spawnAttempt(bin, args, options, chosen).then((a) => {
+    // The stat above answers "does this exist", which is not the same question
+    // as "can this process chdir into it" — a root-owned tree part-way through
+    // an install answers yes and then refuses EACCES — and the two syscalls are
+    // far enough apart for the tree to vanish between them, which is precisely
+    // the mid-update window this fix is about. So the refusal itself, not a
+    // prediction of it, is what selects the fallback.
+    if (chosen === FALLBACK_CWD || !isCwdRefusal(a.refusedCode)) return a.result;
+    return spawnAttempt(bin, args, options, FALLBACK_CWD).then((retry) => retry.result);
+  });
+}
+
+function spawnAttempt(
+  bin: string,
+  args: string[],
+  options: SpawnOptions,
+  effectiveCwd: string,
+): Promise<Attempt> {
+  const { timeoutMs = 15_000, maxBytes = 4 * 1024 * 1024, input, extraEnv } = options;
+  return new Promise((resolveA) => {
+    const resolveP = (result: SpawnResult, refusedCode?: string) => resolveA({ result, refusedCode });
     let child: ReturnType<typeof spawn>;
     try {
       child = spawn(bin, args, { cwd: effectiveCwd, env: { ...process.env, HOME, ...extraEnv }, shell: false });
@@ -282,7 +334,7 @@ export function spawnArgv(
         exitCode: 127,
         timedOut: false,
         truncated: false,
-      });
+      }, (err as NodeJS.ErrnoException | undefined)?.code);
       return;
     }
     let stdout = "";
@@ -291,6 +343,8 @@ export function spawnArgv(
     let timedOut = false;
     let settled = false;
     let drainTimer: ReturnType<typeof setTimeout> | null = null;
+
+    let refusedCode: string | undefined;
 
     const finish = (exitCode: number) => {
       if (settled) return;
@@ -301,7 +355,7 @@ export function spawnArgv(
       // does not accumulate open handles once per hung call.
       child.stdout?.destroy();
       child.stderr?.destroy();
-      resolveP({ stdout, stderr, exitCode, timedOut, truncated });
+      resolveP({ stdout, stderr, exitCode, timedOut, truncated }, refusedCode);
     };
 
     // Kill, then settle on OUR schedule. Killing the direct child does not
@@ -344,6 +398,10 @@ export function spawnArgv(
     });
     child.on("error", (err: Error) => {
       stderr += err.message;
+      // The code travels with the result so the caller above can tell "the
+      // directory refused us" from "the program is not there" — the same
+      // message text serves both.
+      refusedCode = (err as NodeJS.ErrnoException).code;
       finish(127);
     });
 

--- a/mcp/tools/coding.ts
+++ b/mcp/tools/coding.ts
@@ -676,9 +676,11 @@ export function registerCodingTools(reg: Registrar): void {
       assertPathAllowed(target);
 
       // The shared probe, not a second copy of it: this was an inlined
-      // `env which rg` that inherited the same missing-cwd false-failure
-      // hasBinary() was just fixed for (TASK-722), and it degraded a box with
-      // ripgrep installed to `grep -r` silently.
+      // `env which rg` carrying the same missing-cwd false failure hasBinary()
+      // was just fixed for (TASK-722). On a device the tree is there and it
+      // answered correctly; where it is not — a dev PC, a CI runner, the brief
+      // mid-update window — a host with ripgrep silently searched with
+      // `grep -r` instead.
       const useRg = await hasBinary("rg");
       const args: string[] = [];
       if (useRg) {

--- a/mcp/tools/coding.ts
+++ b/mcp/tools/coding.ts
@@ -31,6 +31,7 @@ import {
   assertPathAllowed,
   assertWritePathAllowed,
   commandDeniedByPathGuard,
+  hasBinary,
   resolveUserPath,
   spawnArgv,
 } from "../lib/guard";
@@ -674,7 +675,11 @@ export function registerCodingTools(reg: Registrar): void {
       const target = path ? resolveUserPath(path) : DEFAULT_CWD;
       assertPathAllowed(target);
 
-      const useRg = (await spawnArgv("/usr/bin/env", ["which", "rg"], { timeoutMs: 3_000 })).exitCode === 0;
+      // The shared probe, not a second copy of it: this was an inlined
+      // `env which rg` that inherited the same missing-cwd false-failure
+      // hasBinary() was just fixed for (TASK-722), and it degraded a box with
+      // ripgrep installed to `grep -r` silently.
+      const useRg = await hasBinary("rg");
       const args: string[] = [];
       if (useRg) {
         // --null / -Z make the searcher terminate every printed FILE NAME with a

--- a/src/tests/unit/mcp-probe-cwd.test.ts
+++ b/src/tests/unit/mcp-probe-cwd.test.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it, vi } from "vitest";
 
 /**
  * TASK-722 — a capability probe must not answer "the binary is missing"
@@ -26,9 +26,15 @@ import { describe, expect, it } from "vitest";
  * import time, into DEFAULT_CWD.
  */
 const MISSING_ROOT = path.join(os.tmpdir(), `clawbox-missing-root-${process.pid}`);
+const PREVIOUS_ROOT = process.env.CLAWBOX_ROOT;
 process.env.CLAWBOX_ROOT = MISSING_ROOT;
 
 const { DEFAULT_CWD, hasBinary, spawnArgv } = await import("../../../mcp/lib/guard");
+
+afterAll(() => {
+  if (PREVIOUS_ROOT === undefined) delete process.env.CLAWBOX_ROOT;
+  else process.env.CLAWBOX_ROOT = PREVIOUS_ROOT;
+});
 
 describe("capability probes survive a missing ClawBox tree", () => {
   it("has a root that really is absent, so the rest of this file means what it says", () => {
@@ -55,6 +61,16 @@ describe("capability probes survive a missing ClawBox tree", () => {
     expect(r.exitCode).toBe(0);
   });
 
+  it("runs in the documented fallback, not in some other directory that happens to exist", async () => {
+    // Pinned rather than implied: `/` is what the comment in guard.ts promises,
+    // and it is what makes the fallback safe for callers that pass absolute
+    // paths. A later swap to HOME or os.tmpdir() would still make the tests
+    // above pass while quietly changing where `rm -rf --` runs.
+    const r = await spawnArgv("/usr/bin/env", ["pwd"], { timeoutMs: 3_000 });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe("/");
+  });
+
   it("does NOT silently relocate a working directory the caller asked for", async () => {
     // The fix is about the DEFAULT only. A caller that names a directory means
     // that directory: running somewhere else instead would be the false-success
@@ -62,5 +78,32 @@ describe("capability probes survive a missing ClawBox tree", () => {
     const r = await spawnArgv("/usr/bin/env", ["pwd"], { cwd: MISSING_ROOT, timeoutMs: 3_000 });
     expect(r.exitCode).not.toBe(0);
     expect(r.stdout.trim()).toBe("");
+  });
+
+  it("finds the binary when the root EXISTS but cannot be entered", async () => {
+    // Root ignores the mode bits, so a root runner cannot make this directory
+    // refuse and there is nothing here to prove.
+    if (typeof process.getuid === "function" && process.getuid() === 0) return;
+    // The stat answers "yes, a directory" and the chdir then answers EACCES —
+    // a root-owned tree part-way through an install is exactly that shape. So
+    // predicting the refusal cannot be what selects the fallback; the refusal
+    // itself has to be, which is also what covers a tree that vanishes between
+    // the two syscalls (the mid-update window this whole fix is about).
+    const sealed = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-sealed-root-"));
+    fs.chmodSync(sealed, 0o000);
+    const saved = process.env.CLAWBOX_ROOT;
+    try {
+      vi.resetModules();
+      process.env.CLAWBOX_ROOT = sealed;
+      const guard = await import("../../../mcp/lib/guard");
+      expect(guard.DEFAULT_CWD).toBe(sealed);
+      expect(fs.statSync(sealed).isDirectory()).toBe(true);
+      await expect(guard.hasBinary("sh")).resolves.toBe(true);
+    } finally {
+      process.env.CLAWBOX_ROOT = saved;
+      vi.resetModules();
+      fs.chmodSync(sealed, 0o700);
+      fs.rmSync(sealed, { recursive: true, force: true });
+    }
   });
 });

--- a/src/tests/unit/mcp-probe-cwd.test.ts
+++ b/src/tests/unit/mcp-probe-cwd.test.ts
@@ -1,0 +1,66 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * TASK-722 — a capability probe must not answer "the binary is missing"
+ * because a *working directory* is missing.
+ *
+ * `mcp/lib/guard.ts` gives every spawn a default cwd of `DEFAULT_CWD`
+ * (`CLAWBOX_ROOT` or `/home/clawbox/clawbox`). When that directory is not
+ * there, `spawn` fails ENOENT before the program is ever reached, `spawnArgv`
+ * settles at exit code 127, and `hasBinary()` returns false for a binary that
+ * is installed. `mcp/lib/context.ts` takes those answers once at startup, so
+ * the MCP server then drops `disk_usage`, `disk_cleanup`, `logs_tail` and
+ * `screen_capture` from its tool list with nothing said — the false-failure
+ * class, and the silence that sends an agent to the shell instead.
+ *
+ * On a box the tree is normally there; this bites while it briefly is not
+ * (mid-update, a failed mount, a mis-set CLAWBOX_ROOT), which is exactly when
+ * the tools are wanted. Off a box — every CI runner and every dev machine —
+ * it is the permanent state, which is why `bun run check:mcp-tools` probed
+ * nothing and said so to nobody.
+ *
+ * Set BEFORE the module under test loads: guard.ts reads CLAWBOX_ROOT once, at
+ * import time, into DEFAULT_CWD.
+ */
+const MISSING_ROOT = path.join(os.tmpdir(), `clawbox-missing-root-${process.pid}`);
+process.env.CLAWBOX_ROOT = MISSING_ROOT;
+
+const { DEFAULT_CWD, hasBinary, spawnArgv } = await import("../../../mcp/lib/guard");
+
+describe("capability probes survive a missing ClawBox tree", () => {
+  it("has a root that really is absent, so the rest of this file means what it says", () => {
+    expect(DEFAULT_CWD).toBe(MISSING_ROOT);
+    expect(fs.existsSync(MISSING_ROOT)).toBe(false);
+  });
+
+  it("finds a binary that exists while CLAWBOX_ROOT points at a directory that does not", async () => {
+    // `sh` is on every POSIX host, including every CI runner and both editions
+    // of the device. If this answers false, the probe answered about the
+    // working directory rather than about the binary.
+    await expect(hasBinary("sh")).resolves.toBe(true);
+  });
+
+  it("still answers false for a binary that genuinely is not installed", async () => {
+    await expect(hasBinary("clawbox-no-such-binary-722")).resolves.toBe(false);
+  });
+
+  it("runs a program on the default cwd path, which is what probeJournal and the du/df tools use", async () => {
+    // Same defaulting, one level down: `probeJournal()` and the disk tools
+    // pass no cwd at all, so a missing tree turned every one of them into a
+    // 127 that reads exactly like an absent binary.
+    const r = await spawnArgv("/usr/bin/env", ["true"], { timeoutMs: 3_000 });
+    expect(r.exitCode).toBe(0);
+  });
+
+  it("does NOT silently relocate a working directory the caller asked for", async () => {
+    // The fix is about the DEFAULT only. A caller that names a directory means
+    // that directory: running somewhere else instead would be the false-success
+    // mirror of the bug being fixed here.
+    const r = await spawnArgv("/usr/bin/env", ["pwd"], { cwd: MISSING_ROOT, timeoutMs: 3_000 });
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stdout.trim()).toBe("");
+  });
+});


### PR DESCRIPTION
**TASK-722** — `hasBinary` reports a binary missing when the ClawBox tree is missing.

## Symptom

The MCP server silently drops `disk_usage`, `disk_cleanup`, `logs_tail` and `screen_capture` from its tool list whenever `CLAWBOX_ROOT` cannot be entered — mid-update, a failed mount, a mis-set root. Nothing is said. The agent then has no tool for a question it is asked and reaches for the shell instead, which is the silence that produced the hand-written-SVG incident. Off a device (every CI runner, every dev PC) it is the permanent state, which is why `bun run check:mcp-tools` probed nothing and still printed "Tool contract OK".

## Cause

`mcp/lib/guard.ts` gives every spawn a default `cwd` of `DEFAULT_CWD`. `spawn` fails before the program is reached when that directory cannot be entered, `spawnArgv` settles at exit code 127, and `hasBinary()` reads 127 as "not installed". `buildContext` takes those answers once, at startup, and keeps them for the process lifetime. False failure, with a probe-once amplifier.

## Fix

The project root is where a RELATIVE PATH resolves (`resolveUserPath`, untouched here); it is not a precondition of running a program. With no caller-supplied `cwd` the child now runs in `/` when the root cannot be entered — decided per spawn, so a tree that comes back after an update is seen. The decision is made on the spawn's own refusal (`ENOENT`/`EACCES`/`ENOTDIR` → one retry in `/`), not on a `statSync` prediction: a root-owned tree part-way through an install exists and still refuses, and stat-then-spawn is two syscalls apart, which is the very window this fixes. A `cwd` the caller named is used exactly as given and never substituted — running somewhere else instead would be the false-success mirror of this bug.

## Native mechanism

None to leverage: "is this binary installed on the device" is not something OpenClaw or Hermes answers, and nothing here re-implements a harness model list, session change, credential store or catalog. This is Node `spawn` cwd semantics.

## Sibling call sites

- `mcp/tools/coding.ts` `grep_files` carried its own inlined `env which rg` with the same default and the same defect — a host with ripgrep silently searched with `grep -r`. It now uses the shared `hasBinary`.
- All 11 `spawnArgv` call sites were read: every one passes an absolute path or no path at all, so the fallback changes no argument's meaning. That rule is now stated on `spawnArgv` and on `SpawnOptions.cwd`, where a caller adding an argument will read it.
- `resolveUserPath`, `orientation.ts`'s `FIELD_GUIDE_PATH` and `check-tools.ts`'s path use of `DEFAULT_CWD` are path resolution, not spawning — deliberately unchanged.
- `mcp/lib/jobs.ts` (`bash`, `startJob`, `runShell`) does not go through `spawnArgv`; it defaults to `HOME` and `stat`-validates a caller-named cwd. Cleared, not changed.
- `check-tools.ts` printed `Spawns run in CLAWBOX_ROOT=<root>` above every failed probe; after this change that attaches the old wrong cause to a probe that failed for a real reason, so it now reports where the spawns actually ran. Two rationale comments in `check-tools.ts` and `clawbox-mcp.ts` said "off a real box every probe answers false because the spawn cwd is missing" and are corrected to what is genuinely absent off a box.

## RED → GREEN

RED on unmodified `origin/beta` 8653b118 (`src/tests/unit/mcp-probe-cwd.test.ts`):

```
FAIL |unit| ... > finds a binary that exists while CLAWBOX_ROOT points at a directory that does not
AssertionError: expected false to be true
   43|     await expect(hasBinary("sh")).resolves.toBe(true);

FAIL |unit| ... > runs a program on the default cwd path, which is what probeJournal and the du/df tools use
AssertionError: expected 127 to be +0
   55|     expect(r.exitCode).toBe(0);

 Test Files  1 failed (1)
      Tests  2 failed | 3 passed (5)
```

GREEN on the head: `7 passed (7)`, and the neighbouring suites `src/tests/unit/mcp-*`, `file-guard`, `clawbox-field-guide-edition`, `register-mcp-*` → **37 files / 731 passed, 1 skipped**. `tsc -p mcp/tsconfig.json`, `tsc -p tsconfig.json` and `eslint` clean.

The EACCES case is mutation-proved: forcing `isCwdRefusal` to `false` reddens exactly that test and nothing else.

`bun run check:mcp-tools` on this host, before → after:

```
-      openclaw — spawn probes false: du, journal, screen, imageConvert
+      openclaw — spawn probes false: screen, imageConvert
```

`du` is installed here and `scrot`/`convert` are not, so both the change and what did **not** change are correct.

## Device leg — both editions, read-only, no mutex

The change is spawn-cwd semantics, so the semantics were measured on each box's own Node, read-only, with nothing started, written or mutated:

```
OpenClaw edition
  cwd = a missing project root (the bug)     -> spawn ERROR ENOENT  => spawnArgv exitCode 127, hasBinary("du")=false
  cwd = / (the fallback this PR adds)        -> exit 0 stdout="/usr/bin/du"  => hasBinary("du")=true
  cwd = the real project root                -> exit 0 stdout="/usr/bin/du"  => hasBinary("du")=true

Hermes edition
  cwd = a missing project root (the bug)     -> spawn ERROR ENOENT  => spawnArgv exitCode 127, hasBinary("du")=false
  cwd = / (the fallback this PR adds)        -> exit 0 stdout="/usr/bin/du"  => hasBinary("du")=true
  cwd = the real project root                -> exit 0 stdout="/usr/bin/du"  => hasBinary("du")=true
```

The tool list with the tree PRESENT is unchanged by construction and by that measurement: the fallback is reached only when the root refuses, and with the real root the probe answers exactly as it does today. Both boxes were also read for the units involved; nothing was modified and no lock was taken.

## Residuals, recorded not fixed

- **Probe-once stands.** `buildContext` still takes the capability answers once at startup and keeps them; this PR removes the wrong answer, not the caching. Re-probing means re-registering tools mid-session, which is a different change on both harnesses.
- `Capabilities.journal` documents "able to read at least one ClawBox unit" but `journalctl` exits 0 over `-- No entries --`, so it measures "journalctl is installed and the journal is readable". The doc is corrected rather than the probe: the answer is kept for the process lifetime, so requiring output would cost a box with a briefly-empty journal its `logs_tail` until the next restart — a worse trade than a tool that answers "nothing yet" on a host that is not a ClawBox.

Reviewed before this PR was opened (8 findings: 3 MEDIUM, 3 LOW, 2 NIT); every one is applied in the second commit or answered above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command execution when the configured working directory is unavailable or inaccessible by using a safe fallback directory.
  * Capability checks now more reliably detect available system tools in fallback environments.
  * The `grep` tool continues to detect ripgrep correctly and uses its existing fallback when ripgrep is unavailable.
  * Explicitly configured working directories continue to be honored.
  * Diagnostics now distinguish configured, empty, and unset root-directory settings and report the working directory used.

* **Documentation**
  * Clarified capability requirements, journal access, diagnostics, and behavior outside physical devices.

* **Tests**
  * Added coverage for missing, inaccessible, and explicitly invalid working directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->