### PR TITLE
fix: end the chat and terminal reconnect ladders when the socket constructor throws

### DIFF
--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -2539,6 +2539,15 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     try {
       ws = new WebSocket(wsUrl)
     } catch {
+      // The same terminal-failure teardown the other three error paths do, and
+      // for the same reason. A wsUrl the browser's parser rejects throws here
+      // on EVERY attempt, so leaving the overlay up left the safety-net retry
+      // effect armed — and that effect resets `retryCountRef` to 0 before it
+      // reconnects, which is the counter both exhaustion branches are gated
+      // on. The ladder could never run out: one doomed attempt every
+      // RETRY_DELAY for as long as the chat window stayed open, behind a
+      // spinner that never came down (TASK-712).
+      tearDownReloadOverlay()
       setStatus('error')
       setErrorMsg('WebSocket creation failed')
       return

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -2112,7 +2112,17 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
           }
         },
         reject: (err: Error) => {
-
+          // The fifth terminal-failure path, and it used to be the one that
+          // forgot both halves. A gateway that REFUSES the connect frame
+          // (protocol skew, a rejected device identity, a denied scope) keeps
+          // the socket open, so without the close below `connect()` returns at
+          // its `readyState === OPEN` guard and even the manual Try again is a
+          // no-op; and without the teardown the reconnect overlay hides the
+          // error panel, which is the TASK-712 spinner-that-never-comes-down
+          // from a far likelier trigger than an unparsable URL.
+          tearDownReloadOverlay()
+          if (wsRef.current === ws) wsRef.current = null
+          try { ws.close() } catch { /* already closing */ }
           setStatus('error')
           setErrorMsg(err.message || 'Auth failed')
         },
@@ -2538,7 +2548,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     // Create WebSocket AFTER all handlers are defined to avoid race conditions
     try {
       ws = new WebSocket(wsUrl)
-    } catch {
+    } catch (err) {
       // The same terminal-failure teardown the other three error paths do, and
       // for the same reason. A wsUrl the browser's parser rejects throws here
       // on EVERY attempt, so leaving the overlay up left the safety-net retry
@@ -2549,7 +2559,13 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       // spinner that never came down (TASK-712).
       tearDownReloadOverlay()
       setStatus('error')
-      setErrorMsg('WebSocket creation failed')
+      // With the reason. The realistic triggers are browser-side refusals —
+      // mixed content (a `ws://` url offered to an HTTPS page behind a proxy
+      // that hid the scheme) and a CSP `connect-src` block — and the bare
+      // message sent the owner looking at the gateway instead. Safe to show:
+      // the token travels in the connect frame, not in `wsUrl`.
+      const reason = err instanceof Error ? err.message : String(err)
+      setErrorMsg(reason ? `WebSocket creation failed: ${reason}` : 'WebSocket creation failed')
       return
     }
     wsRef.current = ws
@@ -4912,9 +4928,11 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     }
   }, [])
   // Tear the reconnect overlay down and reset the reload flags. Called from
-  // every terminal-failure path (both retry-exhaustion branches) so the error
-  // panel — gated on `!reloadingSkill` — can render and the safety-net retry
-  // effect (which fires on `error && reloadingSkill`) stops looping.
+  // every terminal-failure path — the two retry-exhaustion branches, the 1008
+  // auth close, the refused connect frame and the socket constructor that
+  // threw — so the error panel, gated on `!reloadingSkill`, can render and the
+  // safety-net retry effect (which fires on `error && reloadingSkill`) stops
+  // looping.
   const tearDownReloadOverlay = useCallback(() => {
     if (reloadTimerRef.current) {
       clearInterval(reloadTimerRef.current)
@@ -4922,6 +4940,13 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     }
     skillInstalledRef.current = false
     reloadReasonRef.current = 'skill'
+    // The pending switch goes with the overlay it was waiting behind. Its only
+    // consumer is the `hello` resolve branch gated on `skillInstalledRef`,
+    // which the line above clears — so a kept value can never be used for the
+    // switch that stored it, and would instead fire on the NEXT provider
+    // change, resetting the owner's transcript for a switch that ended
+    // minutes ago.
+    pendingModelSwitchResetRef.current = null
     setReloadingSkill(false)
     setReloadProgress(0)
   }, [])

--- a/src/components/TerminalApp.tsx
+++ b/src/components/TerminalApp.tsx
@@ -219,6 +219,22 @@ function TerminalInner({ initialCommand, active = true, onTabAction }: TerminalA
     setStatus(s);
   }, []);
 
+  // `connect()` raises the lock on entry and only `onopen`/`onclose` lower it
+  // again, so ANY throw before the socket handlers are installed strands it:
+  // a ChunkLoadError from the three dynamic imports below when an in-app update
+  // replaced the build under an already-open tab, an xterm constructor that
+  // fails, the WebSocket constructor itself. With the lock raised every later
+  // attempt — the 3 s reconnect and the Reconnect button alike — returns at the
+  // guard, silently, as an unhandled rejection, and the window sits on
+  // "Connecting to terminal server…" until it is closed and reopened.
+  const releaseAfterFailedConnect = useCallback((err: unknown) => {
+    connectLockRef.current = false;
+    if (!mountedRef.current) return;
+    updateStatus("error");
+    const reason = err instanceof Error ? err.message : String(err);
+    termRef.current?.writeln(`\r\n\x1b[31mError: could not start the terminal — ${reason}\x1b[0m`);
+  }, [updateStatus]);
+
   const connect = useCallback(async () => {
     if (!mountedRef.current || !containerRef.current) return;
     if (connectLockRef.current) return;
@@ -356,17 +372,22 @@ function TerminalInner({ initialCommand, active = true, onTabAction }: TerminalA
     let ws: WebSocket;
     try {
       ws = new WebSocket(wsUrl);
-    } catch {
-      // The connect lock is released by `onopen` and `onclose`, and a
-      // constructor that throws reaches neither. Left raised, it made every
-      // later connect() return at the guard above — the 3 s auto-reconnect and
-      // the Reconnect button alike — so the terminal could not be revived
-      // without remounting the window (TASK-712's sibling call site).
+    } catch (err) {
+      // The lock is released by `onopen` and `onclose`, and a constructor that
+      // throws reaches neither. Left raised it made the Reconnect button a
+      // no-op (the 3 s auto-reconnect is scheduled inside `onclose`, which this
+      // path never reaches, so the button is the whole of the recovery) and the
+      // window could not be revived without being closed and reopened —
+      // TASK-712's sibling call site.
+      //
+      // The reason, not a guess: what throws here is the BROWSER refusing the
+      // url — mixed content, or a CSP `connect-src` block — and the old text
+      // sent the owner after a PTY server that is running fine.
       connectLockRef.current = false;
       if (!mountedRef.current) return;
       updateStatus("error");
-      term.writeln(`\r\n\x1b[31mError: Cannot connect to ${wsUrl}\x1b[0m`);
-      term.writeln("\x1b[2mTerminal server may not be running.\x1b[0m");
+      const reason = err instanceof Error ? err.message : String(err);
+      term.writeln(`\r\n\x1b[31mError: the browser refused ${wsUrl} — ${reason}\x1b[0m`);
       return;
     }
     wsRef.current = ws;
@@ -441,16 +462,16 @@ function TerminalInner({ initialCommand, active = true, onTabAction }: TerminalA
         if (ev.code !== 1000) {
           term.writeln(`\r\n\x1b[33m[${trRef.current("terminal.retrying", "Disconnected — will retry in 3s…")}]\x1b[0m`);
           reconnectTimerRef.current = setTimeout(() => {
-            if (mountedRef.current) connect();
+            if (mountedRef.current) connect().catch(releaseAfterFailedConnect);
           }, 3000);
         }
       }
     };
-  }, [wsUrl, updateStatus]);
+  }, [wsUrl, updateStatus, releaseAfterFailedConnect]);
 
   useEffect(() => {
     mountedRef.current = true;
-    connect();
+    connect().catch(releaseAfterFailedConnect);
 
     return () => {
       mountedRef.current = false;
@@ -638,8 +659,8 @@ function TerminalInner({ initialCommand, active = true, onTabAction }: TerminalA
       wsRef.current.onclose = null;
       wsRef.current.close(1000);
     }
-    connect();
-  }, [connect]);
+    connect().catch(releaseAfterFailedConnect);
+  }, [connect, releaseAfterFailedConnect]);
 
   return (
     <div

--- a/src/components/TerminalApp.tsx
+++ b/src/components/TerminalApp.tsx
@@ -353,7 +353,22 @@ function TerminalInner({ initialCommand, active = true, onTabAction }: TerminalA
       wsRef.current = null;
     }
 
-    const ws = new WebSocket(wsUrl);
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(wsUrl);
+    } catch {
+      // The connect lock is released by `onopen` and `onclose`, and a
+      // constructor that throws reaches neither. Left raised, it made every
+      // later connect() return at the guard above — the 3 s auto-reconnect and
+      // the Reconnect button alike — so the terminal could not be revived
+      // without remounting the window (TASK-712's sibling call site).
+      connectLockRef.current = false;
+      if (!mountedRef.current) return;
+      updateStatus("error");
+      term.writeln(`\r\n\x1b[31mError: Cannot connect to ${wsUrl}\x1b[0m`);
+      term.writeln("\x1b[2mTerminal server may not be running.\x1b[0m");
+      return;
+    }
     wsRef.current = ws;
     pendingCommandRef.current = initialCommandRef.current?.trim() || null;
     updateStatus("connecting");

--- a/src/tests/components/chat-connect-refused.test.tsx
+++ b/src/tests/components/chat-connect-refused.test.tsx
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import ChatPopup from "@/components/ChatPopup";
+import { resetHarnessCache } from "@/lib/client-harness";
+
+/**
+ * A gateway that REFUSES the connect frame is a terminal failure too.
+ *
+ * It is the likeliest of the lot — a protocol skew after an update, a rejected
+ * device identity, a denied scope — and the socket stays OPEN while it
+ * happens. The reject handler used to set `status: 'error'` and stop there, so
+ * two things went wrong at once: the reconnect overlay stayed up and hid the
+ * error panel (which is gated on `!reloadingSkill`), and the still-open socket
+ * made `connect()` return at its `readyState === OPEN` guard, which killed the
+ * safety-net retry AND the manual Try again. The same permanent spinner
+ * TASK-712 is about, from a far more common trigger.
+ */
+
+const sockets: FakeGatewayWs[] = [];
+
+class FakeGatewayWs {
+  static readonly OPEN = 1;
+  static readonly CLOSED = 3;
+  readyState = FakeGatewayWs.OPEN;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+
+  constructor(public url: string) {
+    sockets.push(this);
+    setTimeout(() => this.emit({ type: "event", event: "connect.challenge", payload: { nonce: "n" } }), 0);
+  }
+
+  send(raw: string) {
+    let frame: Record<string, unknown>;
+    try { frame = JSON.parse(raw) as Record<string, unknown>; } catch { return; }
+    if (frame.type !== "req") return;
+    const id = frame.id as string;
+    if (frame.method === "connect") {
+      // Refused, and the socket is left open — which is what a gateway does.
+      setTimeout(() => this.emit({
+        type: "res",
+        id,
+        ok: false,
+        error: { message: "protocol 4 is newer than this gateway understands" },
+      }), 0);
+      return;
+    }
+    setTimeout(() => this.emit({ type: "res", id, ok: true, payload: {} }), 0);
+  }
+
+  close() { this.closed = true; this.readyState = FakeGatewayWs.CLOSED; }
+
+  emit(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+  }
+}
+
+function installFetch() {
+  vi.stubGlobal("fetch", vi.fn(async (input: unknown) => {
+    const url = String(input);
+    if (url.includes("/setup-api/gateway/ws-config")) {
+      return { ok: true, json: async () => ({ token: "t", wsUrl: "ws://localhost/gw" }) };
+    }
+    if (url.includes("/setup-api/harness/active")) {
+      return { ok: true, json: async () => ({ active: "openclaw", edition: "openclaw" }) };
+    }
+    if (url.includes("/setup-api/chat/model")) {
+      return { ok: true, json: async () => ({ options: [], activeOptionId: "" }) };
+    }
+    if (url.includes("/setup-api/chat/spoken-history")) {
+      return { ok: true, json: async () => ({ items: [] }) };
+    }
+    return { ok: true, json: async () => ({}) };
+  }));
+}
+
+async function settle() {
+  for (let i = 0; i < 4; i++) {
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+  }
+}
+
+describe("a refused connect frame", () => {
+  beforeEach(() => {
+    sockets.length = 0;
+    resetHarnessCache();
+    window.localStorage.clear();
+    Element.prototype.scrollIntoView = vi.fn();
+    vi.stubGlobal("WebSocket", FakeGatewayWs as unknown as typeof WebSocket);
+    installFetch();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetHarnessCache();
+  });
+
+  it("takes the overlay down, shows the reason, and leaves Try again working", async () => {
+    render(<ChatPopup isOpen onClose={() => {}} />);
+    await settle();
+
+    // A provider change raises the reconnect overlay and reconnects — the
+    // window in which the refusal is invisible.
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent("clawbox:primary-ai-configured", { detail: {} }));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    await settle();
+
+    expect(screen.queryByText(/Switching AI provider/i)).toBeNull();
+    await screen.findByText(/newer than this gateway understands/i);
+
+    // The refused socket was let go, so the retry is not swallowed by the
+    // "already open" guard.
+    expect(sockets.every((s) => s.closed)).toBe(true);
+    const before = sockets.length;
+    fireEvent.click(screen.getByText("chat.retry"));
+    await waitFor(() => expect(sockets.length).toBe(before + 1));
+  });
+});

--- a/src/tests/components/chat-ws-constructor-throw.test.tsx
+++ b/src/tests/components/chat-ws-constructor-throw.test.tsx
@@ -4,17 +4,25 @@ import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 
 /**
- * The reconnect ladder has to be able to run out (TASK-712).
+ * The reconnect ladder has to be able to END (TASK-712).
  *
  * `new WebSocket(wsUrl)` throws synchronously on a malformed URL — a bad
  * `wsUrl` out of `/setup-api/gateway/ws-config` is enough. That catch set
  * `status: 'error'` without tearing the reconnect overlay down, unlike the
- * three other terminal-failure paths, so `reloadingSkill` stayed true, the
+ * other terminal-failure paths, so `reloadingSkill` stayed true, the
  * safety-net retry effect stayed armed, and every 3 s it RESET the retry
  * counter to zero and connected again. The two branches that can end the
  * ladder are both gated on that counter, so it could never be reached: one
  * doomed attempt every three seconds for as long as the chat window is open,
  * behind an overlay that never comes down.
+ *
+ * The first throw is terminal now rather than the start of a budgeted ladder,
+ * and that is deliberate: every trigger that exists today is deterministic —
+ * `/setup-api/gateway/ws-config` always answers `<scheme>://<host>`, so what is
+ * left is mixed content, a CSP `connect-src` block, or a url the browser's own
+ * parser refuses, and a retry fixes none of them. If `wsUrl` ever becomes
+ * proxy-derived or configurable the throw becomes transient, and this path
+ * would then want the retry budget the other three have.
  */
 
 const RETRY_DELAY = 3000;

--- a/src/tests/components/chat-ws-constructor-throw.test.tsx
+++ b/src/tests/components/chat-ws-constructor-throw.test.tsx
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@/tests/helpers/test-utils";
+import ChatPopup from "@/components/ChatPopup";
+import { resetHarnessCache } from "@/lib/client-harness";
+
+/**
+ * The reconnect ladder has to be able to run out (TASK-712).
+ *
+ * `new WebSocket(wsUrl)` throws synchronously on a malformed URL — a bad
+ * `wsUrl` out of `/setup-api/gateway/ws-config` is enough. That catch set
+ * `status: 'error'` without tearing the reconnect overlay down, unlike the
+ * three other terminal-failure paths, so `reloadingSkill` stayed true, the
+ * safety-net retry effect stayed armed, and every 3 s it RESET the retry
+ * counter to zero and connected again. The two branches that can end the
+ * ladder are both gated on that counter, so it could never be reached: one
+ * doomed attempt every three seconds for as long as the chat window is open,
+ * behind an overlay that never comes down.
+ */
+
+const RETRY_DELAY = 3000;
+
+const ctorUrls: string[] = [];
+
+class ThrowingWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  constructor(url: string) {
+    ctorUrls.push(url);
+    // What a browser throws for a URL its WebSocket parser rejects.
+    throw new SyntaxError("The URL's scheme must be either 'ws' or 'wss'.");
+  }
+}
+
+function installFetch() {
+  vi.stubGlobal("fetch", vi.fn(async (input: unknown) => {
+    const url = String(input);
+    if (url.includes("/setup-api/gateway/ws-config")) {
+      // Answered on a later tick, as a real network call is. It matters: the
+      // `connecting` render has to land BEFORE the constructor throws, or the
+      // status never leaves `error` from React's point of view and the retry
+      // effect would look bounded here while looping on a real box.
+      await new Promise((r) => setTimeout(r, 10));
+      return { ok: true, json: async () => ({ token: "t", wsUrl: "ws://localhost/gw" }) };
+    }
+    if (url.includes("/setup-api/harness/active")) {
+      return { ok: true, json: async () => ({ active: "openclaw", edition: "openclaw" }) };
+    }
+    if (url.includes("/setup-api/chat/model")) {
+      return { ok: true, json: async () => ({ options: [], activeOptionId: "" }) };
+    }
+    if (url.includes("/setup-api/chat/spoken-history")) {
+      return { ok: true, json: async () => ({ items: [] }) };
+    }
+    return { ok: true, json: async () => ({}) };
+  }));
+}
+
+/** Raises the reconnect overlay the way a provider change does, then reconnects. */
+async function raiseOverlayAndReconnect() {
+  await act(async () => {
+    window.dispatchEvent(new CustomEvent("clawbox:primary-ai-configured", { detail: {} }));
+    await vi.advanceTimersByTimeAsync(50);
+  });
+}
+
+describe("a WebSocket constructor that throws ends the reconnect ladder", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    ctorUrls.length = 0;
+    resetHarnessCache();
+    window.localStorage.clear();
+    Element.prototype.scrollIntoView = vi.fn();
+    vi.stubGlobal("WebSocket", ThrowingWebSocket as unknown as typeof WebSocket);
+    installFetch();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    resetHarnessCache();
+  });
+
+  it("stops trying instead of reconnecting every 3 s forever", async () => {
+    render(<ChatPopup isOpen onClose={() => {}} />);
+    await act(async () => { await vi.advanceTimersByTimeAsync(50); });
+    await raiseOverlayAndReconnect();
+
+    const attemptsBefore = ctorUrls.length;
+    expect(attemptsBefore).toBeGreaterThan(0);
+
+    // Ten retry windows, one `act` each so every re-render lands and the
+    // safety-net effect gets its chance to re-arm. The ladder's budget is far
+    // smaller than ten, so a ladder that can exhaust stopped long before this.
+    for (let i = 0; i < 10; i++) {
+      // Two `act`s per window: one to fire the retry timer (which renders
+      // `connecting`), one to let the ws-config answer arrive and the
+      // constructor throw (which renders `error` again, re-arming the effect).
+      await act(async () => { await vi.advanceTimersByTimeAsync(RETRY_DELAY); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(50); });
+    }
+
+    expect(ctorUrls.length).toBe(attemptsBefore);
+  });
+
+  it("takes the overlay down so the owner gets the error and a Try again", async () => {
+    render(<ChatPopup isOpen onClose={() => {}} />);
+    await act(async () => { await vi.advanceTimersByTimeAsync(50); });
+    await raiseOverlayAndReconnect();
+
+    // The overlay hides the error panel while it is up, so a stuck overlay is
+    // what the owner actually sees: a spinner that never resolves.
+    expect(screen.queryByText(/Switching AI provider/i)).toBeNull();
+    expect(screen.getByText(/WebSocket creation failed/i)).toBeTruthy();
+  });
+});

--- a/src/tests/components/terminal-connect-lock-release.test.tsx
+++ b/src/tests/components/terminal-connect-lock-release.test.tsx
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import TerminalApp from "@/components/TerminalApp";
+
+/**
+ * The connect lock comes back down for EVERY throw, not only the socket's.
+ *
+ * `connect()` raises `connectLockRef` on entry and only `onopen`/`onclose`
+ * lower it again, and it does a lot before either can run: three dynamic
+ * `import()`s, a font wait, `new Terminal(...)`, `term.open()`. A throw
+ * anywhere in there — the realistic one being a ChunkLoadError when an in-app
+ * update replaces the build under an already-open tab — left the lock raised
+ * as an unhandled rejection, and from then on every attempt returned at the
+ * guard: the window sat on "Connecting to terminal server…" with a Reconnect
+ * button that did nothing.
+ */
+
+const h = vi.hoisted(() => ({ terminals: 0 }));
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class {
+    constructor() {
+      h.terminals += 1;
+      throw new Error("ChunkLoadError: Loading chunk @xterm/xterm failed");
+    }
+  },
+}));
+vi.mock("@xterm/addon-fit", () => ({ FitAddon: class { fit() {} } }));
+vi.mock("@xterm/addon-web-links", () => ({ WebLinksAddon: class {} }));
+vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
+
+describe("a terminal that cannot even be constructed", () => {
+  beforeEach(() => {
+    h.terminals = 0;
+    vi.stubGlobal("WebSocket", class { static readonly OPEN = 1; });
+    vi.stubGlobal("ResizeObserver", class { observe() {} unobserve() {} disconnect() {} });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reports the failure and can be retried", async () => {
+    render(<TerminalApp />);
+
+    await screen.findByText("Error");
+    await waitFor(() => expect(h.terminals).toBe(1));
+
+    // The lock is down: Reconnect reaches the constructor again. It fails
+    // again — the chunk is still gone — but on beta this second attempt never
+    // happened, and the window stayed on "Connecting…" for good.
+    fireEvent.click(screen.getByText("Reconnect"));
+    await waitFor(() => expect(h.terminals).toBe(2));
+  });
+});

--- a/src/tests/components/terminal-ws-constructor-throw.test.tsx
+++ b/src/tests/components/terminal-ws-constructor-throw.test.tsx
@@ -14,20 +14,9 @@ import TerminalApp from "@/components/TerminalApp";
  * until the owner closed and reopened it.
  */
 
-let throwOnNextConstruct = false;
-const sockets: FakeWs[] = [];
-
-class FakeWs {
-  static readonly OPEN = 1;
-  readyState = 0;
-  onopen: (() => void) | null = null;
-  onmessage: ((event: MessageEvent) => void) | null = null;
-  onclose: ((event: { code: number }) => void) | null = null;
-  onerror: (() => void) | null = null;
-  constructor(public url: string) { sockets.push(this); }
-  send() {}
-  close() { this.readyState = 3; }
-}
+/** Every attempt, because `wsUrl` is derived once from `window.location` and
+ *  cannot change: a url the browser refuses is refused again on the retry. */
+let constructions = 0;
 
 const writes: string[] = [];
 function makeTerm() {
@@ -51,17 +40,13 @@ vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
 
 describe("a terminal socket constructor that throws", () => {
   beforeEach(() => {
-    sockets.length = 0;
+    constructions = 0;
     writes.length = 0;
-    throwOnNextConstruct = true;
-    const WebSocketStub = function (url: string) {
-      if (throwOnNextConstruct) {
-        throwOnNextConstruct = false;
-        throw new SyntaxError("The URL's scheme must be either 'ws' or 'wss'.");
-      }
-      return new FakeWs(url);
+    const WebSocketStub = function () {
+      constructions += 1;
+      throw new SyntaxError("The URL's scheme must be either 'ws' or 'wss'.");
     } as unknown as typeof WebSocket;
-    (WebSocketStub as unknown as { OPEN: number }).OPEN = FakeWs.OPEN;
+    (WebSocketStub as unknown as { OPEN: number }).OPEN = 1;
     vi.stubGlobal("WebSocket", WebSocketStub);
     vi.stubGlobal("ResizeObserver", class { observe() {} unobserve() {} disconnect() {} });
   });
@@ -70,16 +55,20 @@ describe("a terminal socket constructor that throws", () => {
     vi.unstubAllGlobals();
   });
 
-  it("says so and leaves Reconnect working", async () => {
+  it("says why, and lets Reconnect try again", async () => {
     render(<TerminalApp />);
 
-    // The failure is reported rather than swallowed behind "Connecting…".
+    // The failure is reported rather than swallowed behind "Connecting…", and
+    // it names what actually refused: the browser, not the PTY server.
     await screen.findByText("Error");
-    expect(writes.some((line) => line.includes("Cannot connect to"))).toBe(true);
-    expect(sockets).toHaveLength(0);
+    await waitFor(() => expect(constructions).toBe(1));
+    expect(writes.some((line) => line.includes("the browser refused"))).toBe(true);
+    expect(writes.some((line) => line.includes("scheme must be either"))).toBe(true);
 
-    // And the button in the status bar can still open one.
+    // The lock came back down, so the button in the status bar reaches the
+    // constructor a second time. It throws again — the url cannot change — but
+    // the attempt is the proof, and on beta there was none.
     fireEvent.click(screen.getByText("Reconnect"));
-    await waitFor(() => expect(sockets).toHaveLength(1));
+    await waitFor(() => expect(constructions).toBe(2));
   });
 });

--- a/src/tests/components/terminal-ws-constructor-throw.test.tsx
+++ b/src/tests/components/terminal-ws-constructor-throw.test.tsx
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import TerminalApp from "@/components/TerminalApp";
+
+/**
+ * The Terminal's connect lock has to come back down when the socket
+ * constructor throws (TASK-712's sibling call site).
+ *
+ * `connect()` raises `connectLockRef` on entry and only `onopen` and `onclose`
+ * lower it again — neither of which a constructor that threw will ever call.
+ * With the flag stuck raised every later `connect()` returned at its own
+ * guard, so the 3 s auto-reconnect AND the Reconnect button in the status bar
+ * both became no-ops: the window sat on "Connecting to terminal server…"
+ * until the owner closed and reopened it.
+ */
+
+let throwOnNextConstruct = false;
+const sockets: FakeWs[] = [];
+
+class FakeWs {
+  static readonly OPEN = 1;
+  readyState = 0;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: { code: number }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  constructor(public url: string) { sockets.push(this); }
+  send() {}
+  close() { this.readyState = 3; }
+}
+
+const writes: string[] = [];
+function makeTerm() {
+  return {
+    cols: 80, rows: 24,
+    loadAddon: () => {}, open: () => {}, focus: () => {}, write: () => {},
+    writeln: (line: string) => { writes.push(line); },
+    dispose: () => {}, clear: () => {}, selectAll: () => {}, paste: () => {},
+    getSelection: () => "",
+    onData: () => ({ dispose: () => {} }),
+    attachCustomKeyEventHandler: () => {},
+  };
+}
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class { constructor() { return makeTerm() as unknown as object; } },
+}));
+vi.mock("@xterm/addon-fit", () => ({ FitAddon: class { fit() {} } }));
+vi.mock("@xterm/addon-web-links", () => ({ WebLinksAddon: class {} }));
+vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
+
+describe("a terminal socket constructor that throws", () => {
+  beforeEach(() => {
+    sockets.length = 0;
+    writes.length = 0;
+    throwOnNextConstruct = true;
+    const WebSocketStub = function (url: string) {
+      if (throwOnNextConstruct) {
+        throwOnNextConstruct = false;
+        throw new SyntaxError("The URL's scheme must be either 'ws' or 'wss'.");
+      }
+      return new FakeWs(url);
+    } as unknown as typeof WebSocket;
+    (WebSocketStub as unknown as { OPEN: number }).OPEN = FakeWs.OPEN;
+    vi.stubGlobal("WebSocket", WebSocketStub);
+    vi.stubGlobal("ResizeObserver", class { observe() {} unobserve() {} disconnect() {} });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("says so and leaves Reconnect working", async () => {
+    render(<TerminalApp />);
+
+    // The failure is reported rather than swallowed behind "Connecting…".
+    await screen.findByText("Error");
+    expect(writes.some((line) => line.includes("Cannot connect to"))).toBe(true);
+    expect(sockets).toHaveLength(0);
+
+    // And the button in the status bar can still open one.
+    fireEvent.click(screen.getByText("Reconnect"));
+    await waitFor(() => expect(sockets).toHaveLength(1));
+  });
+});


### PR DESCRIPTION
**TASK-712** — the chat's reconnect ladder could never exhaust, and neither could the Terminal's.

## Symptom

Open the chat on a box where the browser refuses the gateway socket URL — mixed content behind a
proxy that hid the scheme, or a CSP `connect-src` block — and the window sits behind
"Switching AI provider… / This may take up to 30 seconds" for as long as it stays open, quietly
opening one doomed connection every three seconds. The error panel and its Try again button are
hidden while that overlay is up, so there is nothing the owner can do but reload the page.

The Terminal had the same shape from the same construct: a throwing `new WebSocket(...)` left the
connect lock raised, and the Reconnect button in the status bar became a no-op.

## Cause

`src/components/ChatPopup.tsx` — the `new WebSocket(wsUrl)` catch set `status: 'error'` without
calling `tearDownReloadOverlay()`, unlike the other terminal-failure paths. `reloadingSkill` stayed
true, so the safety-net retry effect stayed armed — and that effect RESETS `retryCountRef` to 0
before reconnecting, which is the counter both exhaustion branches are gated on. The ladder could
never reach its own end.

`src/components/TerminalApp.tsx` — `connect()` raises `connectLockRef` on entry and only
`onopen`/`onclose` lower it. A constructor that throws reaches neither, so every later attempt
returned at the guard.

## Harness-first

Nothing here belongs to OpenClaw or Hermes. The gateway socket, its reconnect ladder and the
`/terminal-ws` PTY socket are ClawBox's own browser code; no harness CLI, RPC or config owns a
browser reconnect policy, and no model list, session store or catalogue is touched. The change is a
`try/catch` around a DOM constructor plus the teardown the sibling paths already do.

## Both editions

The chat surface is shared. The gateway socket exists only on OpenClaw (a Hermes box runs no
gateway and `hasLiveConnection` is false, so `connect()` returns at its first line), which is why
the RED tests stub the harness to `openclaw` — the code path under test does not exist on Hermes.
The Terminal window is edition-independent and its fix applies to both.

## Sibling call sites

Every `new WebSocket(` in the tree was checked:

- `src/components/ChatApp.tsx:437` — already catches, and has no overlay, connect lock or retry
  ladder to strand. **Cleared, not changed.**
- `src/components/TerminalApp.tsx` — had no catch at all. **Fixed here**, plus every throw between
  the lock going up and the socket handlers being installed (the three dynamic `import()`s and the
  xterm construction) now releases the lock and reports, instead of stranding it as an unhandled
  rejection. That is the ChunkLoadError an in-app update produces under an already-open tab.
- `src/lib/hermes-dashboard-rpc.ts:100`, `src/lib/hermes-dashboard-turn.ts:795`,
  `src/app/setup-api/hermes/chat/clarify/route.ts:157` — server-side `ws`, already wrapped.
  **Cleared.**

The review pass then found a fourth terminal-failure path in the same component that had the same
omission and is a far more likely trigger: the connect-request `reject` (`ChatPopup.tsx`), which a
gateway takes when it REFUSES the connect frame — a protocol skew after an update, a rejected
device identity, a denied scope — while leaving the socket open. It now tears the overlay down and
lets the refused socket go, so `connect()`'s `readyState === OPEN` guard can no longer swallow both
the automatic retry and the manual Try again. Also from that pass: `tearDownReloadOverlay` now
clears `pendingModelSwitchResetRef`, which could otherwise survive an abandoned reload and reset the
owner's transcript during an unrelated provider change minutes later.

## RED → GREEN

RED, against unmodified `origin/beta` (`8653b118`):

```
 ❯ src/tests/components/chat-ws-constructor-throw.test.tsx (2 tests | 2 failed)
   × stops trying instead of reconnecting every 3 s forever
     AssertionError: expected 12 to be 2   // ten retry windows, ten more attempts
   × takes the overlay down so the owner gets the error and a Try again
     AssertionError: expected <span>Switching AI provider...</span> to be null

 ❯ src/tests/components/terminal-ws-constructor-throw.test.tsx (1 test | 1 failed)
   × says why, and lets Reconnect try again
     Error: Test timed out in 5000ms
   Unhandled Rejection: SyntaxError: The URL's scheme must be either 'ws' or 'wss'.
     ❯ src/components/TerminalApp.tsx:349

 ❯ src/tests/components/terminal-connect-lock-release.test.tsx (1 test | 1 failed)
   × reports the failure and can be retried
     Error: Test timed out in 5000ms          // never even reaches the error state

 ❯ src/tests/components/chat-connect-refused.test.tsx (1 test | 1 failed)
   × takes the overlay down, shows the reason, and leaves Try again working
     AssertionError: expected <span>Switching AI provider...</span> to be null
```

GREEN on this head, whole components project:

```
 Test Files  160 passed (160)
      Tests  1443 passed (1443)
```

`npx tsc --noEmit` exits 0.

## Notes

Found by the review pass and NOT fixed here, because it is not in this diff and wants its own card:
on the Hermes SKU the same "Switching AI provider…" overlay is raised by a provider change in
Settings and nothing can ever take it down — the two places that clear `reloadingSkill` both live
inside the gateway `onMessage` that edition never runs, so the transcript stays hidden until a page
reload. Recorded for the queue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved failure handling for chat and terminal connections.
  - Refused or unavailable connections now close cleanly, dismiss reconnect overlays, release connection locks, and display the underlying error.
  - Reconnect actions remain available after failed connection attempts.
  - Prevented repeated automatic retries after terminal connection setup failures.

- **Tests**
  - Added coverage for refused connections, socket creation errors, overlay cleanup, retry behavior, and terminal lock recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->