### PR TITLE
fix: stop re-asking ClawBox AI for a picture once it refused the credential

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -80,6 +80,7 @@ import {
   openaiAuthOrder,
 } from "@/lib/chatgpt-subscription";
 import { fetchPortalTier } from "@/lib/clawbox-ai-portal-tier";
+import { forgetClawaiCredentialRefusal } from "@/lib/harness/credentials";
 import {
   isValidModelId,
   GOOGLE_MODELS,
@@ -2042,7 +2043,14 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
         console.warn("[configure] ClawBox AI portal tier probe failed:", err);
       }
     }
-    const resolvedClawboxTier: ClawboxAiTier | null = isClawAI
+    // The credential is about to be rewritten, so any memory that the PROXY
+  // refused the previous one is now about a token this box no longer holds.
+  // Dropped here — before the writes, like `forgetProviderVerified` on the
+  // Hermes side — so "re-link the device", which is what every refusal tells
+  // the customer to do, takes effect on the very next call rather than after a
+  // timer. See src/lib/harness/credentials.ts.
+  if (isClawAI) forgetClawaiCredentialRefusal();
+  const resolvedClawboxTier: ClawboxAiTier | null = isClawAI
       ? (portalConfirmedTier
           ?? requestedClawboxAiTier
           ?? normalizeClawboxAiTier(configStore[CLAWBOX_AI_TIER_CONFIG_KEY])

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -1190,6 +1190,13 @@ async function configureClawboxAi(
   // the CLI so the credential lands in the auth store of the running
   // generation (see pasteAuthApiKey).
   await pasteAuthApiKey(CLAWBOX_AI_PROVIDER, CLAWBOX_AI_PROFILE_KEY, clawboxAiToken);
+  // The credential is now on disk, so any memory that the PROXY refused the
+  // previous one is about a token this box no longer holds. AFTER the write,
+  // not before it: a paste that threw would otherwise have re-enabled requests
+  // against the very token that was refused. This is what makes "re-link the
+  // device" — the instruction every refusal prints — take effect on the next
+  // call rather than after a timer. See src/lib/harness/credentials.ts.
+  forgetClawaiCredentialRefusal();
 
   let snapshot: OpenClawConfig | null = null;
   try {
@@ -2043,13 +2050,6 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
         console.warn("[configure] ClawBox AI portal tier probe failed:", err);
       }
     }
-    // The credential is about to be rewritten, so any memory that the PROXY
-  // refused the previous one is now about a token this box no longer holds.
-  // Dropped here — before the writes, like `forgetProviderVerified` on the
-  // Hermes side — so "re-link the device", which is what every refusal tells
-  // the customer to do, takes effect on the very next call rather than after a
-  // timer. See src/lib/harness/credentials.ts.
-  if (isClawAI) forgetClawaiCredentialRefusal();
   const resolvedClawboxTier: ClawboxAiTier | null = isClawAI
       ? (portalConfirmedTier
           ?? requestedClawboxAiTier

--- a/src/app/setup-api/chat/capabilities/route.ts
+++ b/src/app/setup-api/chat/capabilities/route.ts
@@ -122,7 +122,10 @@ export async function GET() {
   // `hasClawaiImageRoute` is deliberately NOT counted. Its probe caches a plain
   // `false` for a minute whether the proxy answered "no" or did not answer at
   // all — it draws no answer/failure distinction to report — so folding it in
-  // would mean claiming a precision that module does not have.
+  // would mean claiming a precision that module does not have. (It answers
+  // false for a third reason too: the proxy has named this device's credential
+  // invalid, remembered for fifteen minutes. That one is not pending either —
+  // it is settled until the device is re-linked.)
   const factsPending =
     harness === "hermes" &&
     (hermesFeatureProbePending()

--- a/src/app/setup-api/chat/transcribe/route.ts
+++ b/src/app/setup-api/chat/transcribe/route.ts
@@ -5,6 +5,7 @@ import {
   CLAWBOX_AI_PROXY_URL,
   clawaiCredentialRefused,
   noteClawaiCredentialRefused,
+  proxyRefusedClawaiCredential,
   resolveClawaiToken,
 } from "@/lib/harness/credentials";
 import { localSttInstalled, transcribeLocally } from "@/lib/stt-local";
@@ -271,26 +272,6 @@ async function readAudio(req: NextRequest): Promise<{ file: Blob; name: string }
 type Audio = { file: Blob; name: string };
 type Transcript = { text: string };
 
-/**
- * Did the proxy identify THIS DEVICE'S CREDENTIAL as the reason it refused?
- *
- * Same rule and same reason as the image path's copy: `error.code` decides
- * whether the refusal is worth remembering, and nothing read here is ever
- * shown to the customer, so the never-relay-the-body rule below is intact.
- * Fails closed — an unreadable or unrecognised refusal is not remembered.
- */
-async function proxyRefusedTheCredential(res: Response): Promise<boolean> {
-  if (res.status !== 401 && res.status !== 403) return false;
-  let payload: unknown;
-  try {
-    payload = await res.clone().json();
-  } catch {
-    return false;
-  }
-  const error = (payload as { error?: unknown } | null)?.error;
-  const code = (error as { code?: unknown } | null)?.code;
-  return code === "invalid_token" || code === "missing_token";
-}
 
 /** The cloud engine: the recording goes to the ClawBox AI proxy. */
 async function transcribeInCloud(req: NextRequest, audio: Audio): Promise<Transcript | Failure> {
@@ -350,7 +331,7 @@ async function transcribeInCloud(req: NextRequest, audio: Audio): Promise<Transc
     // `missing_token` / `invalid_token`; a bare 401/403 can be an edge rule or
     // a plan gate, and remembering one of those would mute the microphone on a
     // box whose credential is fine. Only the proxy's own verdict is recorded.
-    if (await proxyRefusedTheCredential(res)) noteClawaiCredentialRefused(res.status);
+    if (await proxyRefusedClawaiCredential(res)) noteClawaiCredentialRefused(res.status);
     const status = res.status === 401 || res.status === 403
       ? 503
       : res.status >= 400 && res.status < 500 ? 400 : 502;

--- a/src/app/setup-api/chat/transcribe/route.ts
+++ b/src/app/setup-api/chat/transcribe/route.ts
@@ -4,6 +4,7 @@ import { Readable } from "stream";
 import {
   CLAWBOX_AI_PROXY_URL,
   clawaiCredentialRefused,
+  clawaiCredentialGeneration,
   noteClawaiCredentialRefused,
   proxyRefusedClawaiCredential,
   resolveClawaiToken,
@@ -298,6 +299,11 @@ async function transcribeInCloud(req: NextRequest, audio: Audio): Promise<Transc
     };
   }
 
+  // Snapshotted BEFORE the upload, for the reason the image path documents: a
+  // re-link that lands mid-request makes the answer a verdict on a credential
+  // the box no longer holds.
+  const generation = clawaiCredentialGeneration();
+
   const upstream = new FormData();
   upstream.set("file", audio.file, audio.name);
   upstream.set("model", TRANSCRIBE_MODEL);
@@ -331,7 +337,7 @@ async function transcribeInCloud(req: NextRequest, audio: Audio): Promise<Transc
     // `missing_token` / `invalid_token`; a bare 401/403 can be an edge rule or
     // a plan gate, and remembering one of those would mute the microphone on a
     // box whose credential is fine. Only the proxy's own verdict is recorded.
-    if (await proxyRefusedClawaiCredential(res)) noteClawaiCredentialRefused(res.status);
+    if (await proxyRefusedClawaiCredential(res)) noteClawaiCredentialRefused(res.status, generation);
     const status = res.status === 401 || res.status === 403
       ? 503
       : res.status >= 400 && res.status < 500 ? 400 : 502;

--- a/src/app/setup-api/chat/transcribe/route.ts
+++ b/src/app/setup-api/chat/transcribe/route.ts
@@ -1,7 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import Busboy from "busboy";
 import { Readable } from "stream";
-import { CLAWBOX_AI_PROXY_URL, resolveClawaiToken } from "@/lib/harness/credentials";
+import {
+  CLAWBOX_AI_PROXY_URL,
+  clawaiCredentialRefused,
+  noteClawaiCredentialRefused,
+  resolveClawaiToken,
+} from "@/lib/harness/credentials";
 import { localSttInstalled, transcribeLocally } from "@/lib/stt-local";
 import { getSttPrimary, sttEngineOrder, TRANSCRIBE_MODEL } from "@/lib/stt-preference";
 
@@ -266,6 +271,27 @@ async function readAudio(req: NextRequest): Promise<{ file: Blob; name: string }
 type Audio = { file: Blob; name: string };
 type Transcript = { text: string };
 
+/**
+ * Did the proxy identify THIS DEVICE'S CREDENTIAL as the reason it refused?
+ *
+ * Same rule and same reason as the image path's copy: `error.code` decides
+ * whether the refusal is worth remembering, and nothing read here is ever
+ * shown to the customer, so the never-relay-the-body rule below is intact.
+ * Fails closed — an unreadable or unrecognised refusal is not remembered.
+ */
+async function proxyRefusedTheCredential(res: Response): Promise<boolean> {
+  if (res.status !== 401 && res.status !== 403) return false;
+  let payload: unknown;
+  try {
+    payload = await res.clone().json();
+  } catch {
+    return false;
+  }
+  const error = (payload as { error?: unknown } | null)?.error;
+  const code = (error as { code?: unknown } | null)?.code;
+  return code === "invalid_token" || code === "missing_token";
+}
+
 /** The cloud engine: the recording goes to the ClawBox AI proxy. */
 async function transcribeInCloud(req: NextRequest, audio: Audio): Promise<Transcript | Failure> {
   const token = await resolveClawaiToken();
@@ -275,6 +301,19 @@ async function transcribeInCloud(req: NextRequest, audio: Audio): Promise<Transc
     return {
       status: 503,
       error: "This ClawBox is not linked to ClawBox AI yet, so it cannot transcribe audio.",
+    };
+  }
+
+  // The proxy has already told this box it will not accept this credential,
+  // and a recording is ~9 MB. Uploading it to be refused again costs the
+  // customer their uplink and the box its time, and answers nothing the first
+  // refusal did not already answer — so the same sentence is returned here,
+  // without the upload. Cleared the moment the device is re-linked.
+  const refused = clawaiCredentialRefused(token);
+  if (refused !== null) {
+    return {
+      status: 503,
+      error: "ClawBox AI rejected this device's credentials. Re-link the device and try again.",
     };
   }
 
@@ -307,6 +346,11 @@ async function transcribeInCloud(req: NextRequest, audio: Audio): Promise<Transc
     // request carried a bearer token. Only the status is relayed, never the
     // body, so a proxy that echoes cannot leak the device credential into a
     // browser console.
+    // The proxy names the credential as the problem with its own
+    // `missing_token` / `invalid_token`; a bare 401/403 can be an edge rule or
+    // a plan gate, and remembering one of those would mute the microphone on a
+    // box whose credential is fine. Only the proxy's own verdict is recorded.
+    if (await proxyRefusedTheCredential(res)) noteClawaiCredentialRefused(token, res.status);
     const status = res.status === 401 || res.status === 403
       ? 503
       : res.status >= 400 && res.status < 500 ? 400 : 502;

--- a/src/app/setup-api/chat/transcribe/route.ts
+++ b/src/app/setup-api/chat/transcribe/route.ts
@@ -309,7 +309,7 @@ async function transcribeInCloud(req: NextRequest, audio: Audio): Promise<Transc
   // customer their uplink and the box its time, and answers nothing the first
   // refusal did not already answer — so the same sentence is returned here,
   // without the upload. Cleared the moment the device is re-linked.
-  const refused = clawaiCredentialRefused(token);
+  const refused = clawaiCredentialRefused();
   if (refused !== null) {
     return {
       status: 503,
@@ -350,7 +350,7 @@ async function transcribeInCloud(req: NextRequest, audio: Audio): Promise<Transc
     // `missing_token` / `invalid_token`; a bare 401/403 can be an edge rule or
     // a plan gate, and remembering one of those would mute the microphone on a
     // box whose credential is fine. Only the proxy's own verdict is recorded.
-    if (await proxyRefusedTheCredential(res)) noteClawaiCredentialRefused(token, res.status);
+    if (await proxyRefusedTheCredential(res)) noteClawaiCredentialRefused(res.status);
     const status = res.status === 401 || res.status === 403
       ? 503
       : res.status >= 400 && res.status < 500 ? 400 : 502;

--- a/src/app/setup-api/hermes/clawai/route.ts
+++ b/src/app/setup-api/hermes/clawai/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { get, setMany } from "@/lib/config-store";
+import { forgetClawaiCredentialRefusal } from "@/lib/harness/credentials";
 import { hermesConfigGet } from "@/lib/hermes-config-cache";
 import { getActiveHarness } from "@/lib/harness";
 import { getCodingAgentStatus } from "@/lib/coding-agent";
@@ -121,6 +122,10 @@ export async function POST(request: Request) {
       .then((status) => status.ready)
       .catch(() => undefined);
     await setMany({ clawai_token: suppliedToken });
+    // A refusal the proxy gave the token being replaced is about that token,
+    // not this one. Dropped here as well as in `applyClawaiToHermes`, because a
+    // paste that never reaches the apply still changed the credential.
+    forgetClawaiCredentialRefusal();
   }
 
   const token = suppliedToken || (await readToken());

--- a/src/lib/harness/capabilities.ts
+++ b/src/lib/harness/capabilities.ts
@@ -64,8 +64,10 @@ export interface HarnessFacts {
    *
    * They cannot be collapsed the other way round either: the proxy's discovery
    * endpoint is UNAUTHENTICATED, so it answers "is there an image service" and
-   * says nothing whatever about whether this device's token still works. See
-   * `clawaiImageRouteReachable`.
+   * says nothing whatever about whether this device's token still works. The
+   * one exception is a token the proxy has ALREADY named as invalid on a real
+   * generation — `clawaiImageRouteReachable` reports false for that, because by
+   * then it is a measured fact rather than a guess. See that function.
    */
   hasClawaiImageRoute: boolean;
   /**
@@ -162,8 +164,9 @@ export function capabilitiesFor(id: HarnessId, facts: HarnessFacts): HarnessCapa
       // plain words and the agent draws it — the same shape as OpenClaw. The
       // composer path: no backend yet, but a credential to spend
       // (`hasClawaiToken`) AND somewhere to spend it (`hasClawaiImageRoute`,
-      // probed against the proxy's own discovery endpoint) put a picture
-      // button in the composer instead.
+      // probed against the proxy's own discovery endpoint, and false while the
+      // proxy has named this device's credential invalid) put a picture button
+      // in the composer instead.
       //
       // This was FALSE outright until these two paths landed. On OpenClaw a
       // picture is made by the AGENT reaching for its own image tool — the

--- a/src/lib/harness/clawai-images.ts
+++ b/src/lib/harness/clawai-images.ts
@@ -217,9 +217,8 @@ export async function clawaiImageRouteReachable(fetchImpl: FetchLike = fetch): P
   // Ahead of the probe cache, not behind it: a 403 that lands a second after a
   // successful probe would otherwise keep the button for the ten minutes that
   // answer is good for, which is the whole window a customer spends pressing
-  // it.
-  const token = await resolveClawaiToken();
-  if (token && clawaiCredentialRefused(token) !== null) return false;
+  // it. It costs nothing — no request, and no credential read.
+  if (clawaiCredentialRefused() !== null) return false;
   const now = Date.now();
   if (probeCache && now < probeCache.expiresAt) return probeCache.promise;
   // Seeded with the SHORT ttl so concurrent callers during the probe share one
@@ -314,7 +313,7 @@ export async function generateClawaiImageBytes(
     );
   }
 
-  const refused = clawaiCredentialRefused(token);
+  const refused = clawaiCredentialRefused();
   if (refused !== null) {
     // Refused WITHOUT asking again. The customer is still told, in the same
     // words and with the same status as the request that established this, so
@@ -381,7 +380,7 @@ export async function generateClawaiImageBytes(
     // can come from an edge rule, a rate-limit page, an interception proxy or
     // a plan gate, and remembering one of those would hide the button and tell
     // a customer with a perfectly good credential to re-pair the device.
-    if (await proxyRefusedTheCredential(res)) noteClawaiCredentialRefused(token, res.status);
+    if (await proxyRefusedTheCredential(res)) noteClawaiCredentialRefused(res.status);
     // The STATUS decides what is SAID, never the body. An upstream error body is allowed to
     // quote the request that caused it, and this request carried a bearer
     // token — the same reason the transcription route relays a status and

--- a/src/lib/harness/clawai-images.ts
+++ b/src/lib/harness/clawai-images.ts
@@ -1,6 +1,6 @@
 import fsp from "fs/promises";
 import path from "path";
-import { randomUUID } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import { CLAWBOX_AI_IMAGE_MODEL_ID } from "@/lib/clawbox-ai-models";
 import { mediaUrl } from "@/lib/chat-media";
 import { CLAWBOX_AI_PROXY_URL, resolveClawaiToken } from "./credentials";
@@ -162,6 +162,67 @@ const PROBE_TTL_FAIL_MS = 60_000;
 let probeCache: { promise: Promise<boolean>; expiresAt: number } | null = null;
 
 /**
+ * How long a refusal of THIS device's credential is believed.
+ *
+ * A 401/403 from our own proxy means the credential is not accepted, and
+ * nothing the box can do makes the next identical request succeed — so the
+ * honest number here is "until the credential changes", which is what the
+ * fingerprint below actually keys on. The timer exists only for the one case
+ * the box cannot observe: a token the PORTAL restores (a mis-revocation put
+ * back, a plan reinstated) without the device being re-linked. Fifteen minutes
+ * is short enough that such a box heals on its own and long enough that the
+ * cost of being wrong is four requests an hour instead of two thousand.
+ */
+const CREDENTIAL_REFUSAL_TTL_MS = 15 * 60_000;
+
+/**
+ * The credential the proxy last refused, by fingerprint, and until when.
+ *
+ * The FINGERPRINT is what makes this a memory of one credential rather than a
+ * flag on the box: re-linking is the fix the error message tells the customer
+ * to apply, so a different token has to be tried at once — no restart, no
+ * waiting out the timer. It is a hash and never the token: this value is
+ * compared, never logged, but a bare secret sitting in module state is one
+ * stack trace away from a log line.
+ */
+let credentialRefusal: { fingerprint: string; status: number; until: number } | null = null;
+
+function fingerprintOf(token: string): string {
+  return createHash("sha256").update(token).digest("hex").slice(0, 16);
+}
+
+/** Is this exact credential inside a live refusal? Expired ones are dropped. */
+function refusalFor(token: string): { status: number } | null {
+  if (!credentialRefusal) return null;
+  if (Date.now() >= credentialRefusal.until) {
+    credentialRefusal = null;
+    return null;
+  }
+  if (credentialRefusal.fingerprint !== fingerprintOf(token)) return null;
+  return credentialRefusal;
+}
+
+/**
+ * Note that the proxy refused this credential, so the next caller does not
+ * spend a request finding out again.
+ *
+ * Only 401 and 403 — the two the proxy answers with when the credential itself
+ * is the problem (`missing_token` / `invalid_token`). NOT 429: a spent daily
+ * allowance is refused for the same reason every time too, but it is refused
+ * for a whole plan rather than for a credential, it resets on a clock this
+ * module cannot see, and the icon pipeline already pauses the box for it
+ * (`BOX_WIDE_STATUSES` in webapp-icon.ts). Widening this to cover it would be
+ * a second, worse implementation of that.
+ */
+function rememberCredentialRefusal(token: string, status: number): void {
+  credentialRefusal = {
+    fingerprint: fingerprintOf(token),
+    status,
+    until: Date.now() + CREDENTIAL_REFUSAL_TTL_MS,
+  };
+}
+
+/**
  * Does the proxy serve image generation, for the model this box would ask for?
  *
  * A PROBED fact, for the reason every other fact in the capability table is
@@ -189,16 +250,28 @@ let probeCache: { promise: Promise<boolean>; expiresAt: number } | null = null;
  * — verified: it returns the same 200 with no token and with a wrong one — so
  * it cannot tell a live credential from a revoked one. That half of the answer
  * is `hasClawaiToken`, and the two are combined by the capability rather than
- * conflated here. A token that is present but revoked therefore still shows the
- * button, and fails at generate time with the proxy's 403 surfaced as "re-link
- * this device". That is the right way round: hiding the button on every box
- * whose token MIGHT be stale would hide it on every box.
+ * conflated here. A token that is present but MIGHT be stale therefore still
+ * shows the button: hiding it on every box whose token might be stale would
+ * hide it on every box.
+ *
+ * A token the proxy HAS refused is a different fact, and this does answer it.
+ * Once a generate came back 401/403 for the credential this box currently
+ * holds, the button is an offer to draw that ends in an error bubble every
+ * time, so it goes away until the device is re-linked — see
+ * `rememberCredentialRefusal`. Might-be-stale stays a button; proven-dead does
+ * not.
  *
  * Fails CLOSED. Anything other than a clean, parseable, model-listing 200 is
  * false, because a wrong `true` is an offer to draw that ends in an error
  * bubble — the same lie the microphone used to tell.
  */
 export async function clawaiImageRouteReachable(fetchImpl: FetchLike = fetch): Promise<boolean> {
+  // Ahead of the probe cache, not behind it: a 403 that lands a second after a
+  // successful probe would otherwise keep the button for the ten minutes that
+  // answer is good for, which is the whole window a customer spends pressing
+  // it.
+  const token = await resolveClawaiToken();
+  if (token && refusalFor(token)) return false;
   const now = Date.now();
   if (probeCache && now < probeCache.expiresAt) return probeCache.promise;
   // Seeded with the SHORT ttl so concurrent callers during the probe share one
@@ -216,9 +289,10 @@ export async function clawaiImageRouteReachable(fetchImpl: FetchLike = fetch): P
   return entry.promise;
 }
 
-/** Test seam: forget the cached answer so the next call asks again. */
+/** Test seam: forget every remembered answer so the next call asks again. */
 export function resetClawaiImageProbe(): void {
   probeCache = null;
+  credentialRefusal = null;
 }
 
 async function askProxyForImageModels(fetchImpl: FetchLike): Promise<boolean> {
@@ -288,6 +362,17 @@ export async function generateClawaiImageBytes(
     );
   }
 
+  const refused = refusalFor(token);
+  if (refused) {
+    // Refused WITHOUT asking again. The customer is still told, in the same
+    // words and with the same status as the request that established this, so
+    // nothing is hidden — what stops is the traffic. Beta sent one POST per
+    // trigger for as long as the box stayed up: 6,554 of them from a single
+    // device in twelve hours, every one a 403 that was knowable in advance.
+    const [status, message] = messageForStatus(refused.status);
+    throw new ClawaiImageError(status, message);
+  }
+
   let res: Response;
   try {
     // CodeQL `js/file-access-to-http` ("file data in outbound network request")
@@ -336,6 +421,9 @@ export async function generateClawaiImageBytes(
   }
 
   if (!res.ok) {
+    // A credential the proxy will not accept is the one failure here that
+    // CANNOT come right on its own, so it is remembered rather than re-tried.
+    if (res.status === 401 || res.status === 403) rememberCredentialRefusal(token, res.status);
     // The STATUS decides, never the body. An upstream error body is allowed to
     // quote the request that caused it, and this request carried a bearer
     // token — the same reason the transcription route relays a status and

--- a/src/lib/harness/clawai-images.ts
+++ b/src/lib/harness/clawai-images.ts
@@ -7,6 +7,7 @@ import {
   CLAWBOX_AI_PROXY_URL,
   clawaiCredentialRefused,
   noteClawaiCredentialRefused,
+  proxyRefusedClawaiCredential,
   resetClawaiCredentialRefusals,
   resolveClawaiToken,
 } from "./credentials";
@@ -380,7 +381,7 @@ export async function generateClawaiImageBytes(
     // can come from an edge rule, a rate-limit page, an interception proxy or
     // a plan gate, and remembering one of those would hide the button and tell
     // a customer with a perfectly good credential to re-pair the device.
-    if (await proxyRefusedTheCredential(res)) noteClawaiCredentialRefused(res.status);
+    if (await proxyRefusedClawaiCredential(res)) noteClawaiCredentialRefused(res.status);
     // The STATUS decides what is SAID, never the body. An upstream error body is allowed to
     // quote the request that caused it, and this request carried a bearer
     // token — the same reason the transcription route relays a status and
@@ -419,30 +420,6 @@ export async function generateClawaiImageBytes(
   return { bytes, extension };
 }
 
-/**
- * Did the proxy identify THIS DEVICE'S CREDENTIAL as the reason it refused?
- *
- * The proxy answers `401 {code:"missing_token"}` / `403 {code:"invalid_token"}`
- * for a credential and other codes for everything else, and those two are the
- * only answers that mean "asking again with this token is pointless".
- *
- * Reading `error.code` is not a breach of the never-relay-the-body rule below:
- * that rule is about what reaches the CUSTOMER, and nothing read here is ever
- * shown. Fails closed — an unreadable, bodiless or unrecognised refusal is
- * treated as not-the-credential, which costs a retry rather than a feature.
- */
-async function proxyRefusedTheCredential(res: Response): Promise<boolean> {
-  if (res.status !== 401 && res.status !== 403) return false;
-  let payload: unknown;
-  try {
-    payload = await res.clone().json();
-  } catch {
-    return false;
-  }
-  const error = (payload as { error?: unknown } | null)?.error;
-  const code = (error as { code?: unknown } | null)?.code;
-  return code === "invalid_token" || code === "missing_token";
-}
 
 /**
  * What a failing status is allowed to say.

--- a/src/lib/harness/clawai-images.ts
+++ b/src/lib/harness/clawai-images.ts
@@ -6,6 +6,7 @@ import { mediaUrl } from "@/lib/chat-media";
 import {
   CLAWBOX_AI_PROXY_URL,
   clawaiCredentialRefused,
+  clawaiCredentialGeneration,
   noteClawaiCredentialRefused,
   proxyRefusedClawaiCredential,
   resetClawaiCredentialRefusals,
@@ -327,6 +328,10 @@ export async function generateClawaiImageBytes(
     throw new ClawaiImageError(status, message);
   }
 
+  // Snapshotted BEFORE the request. A re-link that lands while this is in
+  // flight makes the answer a verdict on a credential the box no longer holds.
+  const generation = clawaiCredentialGeneration();
+
   let res: Response;
   try {
     // CodeQL `js/file-access-to-http` ("file data in outbound network request")
@@ -381,7 +386,7 @@ export async function generateClawaiImageBytes(
     // can come from an edge rule, a rate-limit page, an interception proxy or
     // a plan gate, and remembering one of those would hide the button and tell
     // a customer with a perfectly good credential to re-pair the device.
-    if (await proxyRefusedClawaiCredential(res)) noteClawaiCredentialRefused(res.status);
+    if (await proxyRefusedClawaiCredential(res)) noteClawaiCredentialRefused(res.status, generation);
     // The STATUS decides what is SAID, never the body. An upstream error body is allowed to
     // quote the request that caused it, and this request carried a bearer
     // token — the same reason the transcription route relays a status and

--- a/src/lib/harness/clawai-images.ts
+++ b/src/lib/harness/clawai-images.ts
@@ -1,9 +1,15 @@
 import fsp from "fs/promises";
 import path from "path";
-import { createHash, randomUUID } from "crypto";
+import { randomUUID } from "crypto";
 import { CLAWBOX_AI_IMAGE_MODEL_ID } from "@/lib/clawbox-ai-models";
 import { mediaUrl } from "@/lib/chat-media";
-import { CLAWBOX_AI_PROXY_URL, resolveClawaiToken } from "./credentials";
+import {
+  CLAWBOX_AI_PROXY_URL,
+  clawaiCredentialRefused,
+  noteClawaiCredentialRefused,
+  resetClawaiCredentialRefusals,
+  resolveClawaiToken,
+} from "./credentials";
 import { chatGeneratedImageDir, GENERATED_IMAGE_RETENTION, pruneMediaDir } from "./media-root";
 import type { FetchLike } from "./transport";
 
@@ -162,67 +168,6 @@ const PROBE_TTL_FAIL_MS = 60_000;
 let probeCache: { promise: Promise<boolean>; expiresAt: number } | null = null;
 
 /**
- * How long a refusal of THIS device's credential is believed.
- *
- * A 401/403 from our own proxy means the credential is not accepted, and
- * nothing the box can do makes the next identical request succeed — so the
- * honest number here is "until the credential changes", which is what the
- * fingerprint below actually keys on. The timer exists only for the one case
- * the box cannot observe: a token the PORTAL restores (a mis-revocation put
- * back, a plan reinstated) without the device being re-linked. Fifteen minutes
- * is short enough that such a box heals on its own and long enough that the
- * cost of being wrong is four requests an hour instead of two thousand.
- */
-const CREDENTIAL_REFUSAL_TTL_MS = 15 * 60_000;
-
-/**
- * The credential the proxy last refused, by fingerprint, and until when.
- *
- * The FINGERPRINT is what makes this a memory of one credential rather than a
- * flag on the box: re-linking is the fix the error message tells the customer
- * to apply, so a different token has to be tried at once — no restart, no
- * waiting out the timer. It is a hash and never the token: this value is
- * compared, never logged, but a bare secret sitting in module state is one
- * stack trace away from a log line.
- */
-let credentialRefusal: { fingerprint: string; status: number; until: number } | null = null;
-
-function fingerprintOf(token: string): string {
-  return createHash("sha256").update(token).digest("hex").slice(0, 16);
-}
-
-/** Is this exact credential inside a live refusal? Expired ones are dropped. */
-function refusalFor(token: string): { status: number } | null {
-  if (!credentialRefusal) return null;
-  if (Date.now() >= credentialRefusal.until) {
-    credentialRefusal = null;
-    return null;
-  }
-  if (credentialRefusal.fingerprint !== fingerprintOf(token)) return null;
-  return credentialRefusal;
-}
-
-/**
- * Note that the proxy refused this credential, so the next caller does not
- * spend a request finding out again.
- *
- * Only 401 and 403 — the two the proxy answers with when the credential itself
- * is the problem (`missing_token` / `invalid_token`). NOT 429: a spent daily
- * allowance is refused for the same reason every time too, but it is refused
- * for a whole plan rather than for a credential, it resets on a clock this
- * module cannot see, and the icon pipeline already pauses the box for it
- * (`BOX_WIDE_STATUSES` in webapp-icon.ts). Widening this to cover it would be
- * a second, worse implementation of that.
- */
-function rememberCredentialRefusal(token: string, status: number): void {
-  credentialRefusal = {
-    fingerprint: fingerprintOf(token),
-    status,
-    until: Date.now() + CREDENTIAL_REFUSAL_TTL_MS,
-  };
-}
-
-/**
  * Does the proxy serve image generation, for the model this box would ask for?
  *
  * A PROBED fact, for the reason every other fact in the capability table is
@@ -254,12 +199,15 @@ function rememberCredentialRefusal(token: string, status: number): void {
  * shows the button: hiding it on every box whose token might be stale would
  * hide it on every box.
  *
- * A token the proxy HAS refused is a different fact, and this does answer it.
- * Once a generate came back 401/403 for the credential this box currently
- * holds, the button is an offer to draw that ends in an error bubble every
- * time, so it goes away until the device is re-linked — see
- * `rememberCredentialRefusal`. Might-be-stale stays a button; proven-dead does
- * not.
+ * A token the proxy HAS NAMED as the problem is a different fact, and this does
+ * answer it. Once a generate came back 401/403 with the proxy's own
+ * `invalid_token` / `missing_token`, the button is an offer to draw that ends
+ * in an error bubble every time, so it goes away — until the device is
+ * re-linked, or fifteen minutes pass, whichever comes first. The timer is
+ * there so a box the portal healed without a re-link gets its button back on
+ * its own; the consequence, stated plainly, is that a still-dead credential
+ * shows the button again every fifteen minutes and one press re-hides it.
+ * Might-be-stale stays a button; proven-dead does not.
  *
  * Fails CLOSED. Anything other than a clean, parseable, model-listing 200 is
  * false, because a wrong `true` is an offer to draw that ends in an error
@@ -271,7 +219,7 @@ export async function clawaiImageRouteReachable(fetchImpl: FetchLike = fetch): P
   // answer is good for, which is the whole window a customer spends pressing
   // it.
   const token = await resolveClawaiToken();
-  if (token && refusalFor(token)) return false;
+  if (token && clawaiCredentialRefused(token) !== null) return false;
   const now = Date.now();
   if (probeCache && now < probeCache.expiresAt) return probeCache.promise;
   // Seeded with the SHORT ttl so concurrent callers during the probe share one
@@ -289,10 +237,14 @@ export async function clawaiImageRouteReachable(fetchImpl: FetchLike = fetch): P
   return entry.promise;
 }
 
-/** Test seam: forget every remembered answer so the next call asks again. */
+/**
+ * Test seam: forget every remembered answer so the next call asks again —
+ * including the shared credential refusal, which is what makes the status
+ * table below able to walk 401 and 403 without poisoning the cases after them.
+ */
 export function resetClawaiImageProbe(): void {
   probeCache = null;
-  credentialRefusal = null;
+  resetClawaiCredentialRefusals();
 }
 
 async function askProxyForImageModels(fetchImpl: FetchLike): Promise<boolean> {
@@ -362,14 +314,16 @@ export async function generateClawaiImageBytes(
     );
   }
 
-  const refused = refusalFor(token);
-  if (refused) {
+  const refused = clawaiCredentialRefused(token);
+  if (refused !== null) {
     // Refused WITHOUT asking again. The customer is still told, in the same
     // words and with the same status as the request that established this, so
     // nothing is hidden — what stops is the traffic. Beta sent one POST per
-    // trigger for as long as the box stayed up: 6,554 of them from a single
-    // device in twelve hours, every one a 403 that was knowable in advance.
-    const [status, message] = messageForStatus(refused.status);
+    // trigger, per process, for as long as the box stayed up, every one of them
+    // a 403 that was knowable in advance. (The fleet-wide 15k/day on TASK-727
+    // is the sum of every image caller on the box; how much of it came through
+    // here rather than through the agent's own image tool was not separated.)
+    const [status, message] = messageForStatus(refused);
     throw new ClawaiImageError(status, message);
   }
 
@@ -421,10 +375,14 @@ export async function generateClawaiImageBytes(
   }
 
   if (!res.ok) {
-    // A credential the proxy will not accept is the one failure here that
-    // CANNOT come right on its own, so it is remembered rather than re-tried.
-    if (res.status === 401 || res.status === 403) rememberCredentialRefusal(token, res.status);
-    // The STATUS decides, never the body. An upstream error body is allowed to
+    // A credential the proxy itself names as the problem is the one failure
+    // here that CANNOT come right on its own, so it is remembered rather than
+    // re-tried. It has to be the PROXY saying so: a bare 401/403 on the wire
+    // can come from an edge rule, a rate-limit page, an interception proxy or
+    // a plan gate, and remembering one of those would hide the button and tell
+    // a customer with a perfectly good credential to re-pair the device.
+    if (await proxyRefusedTheCredential(res)) noteClawaiCredentialRefused(token, res.status);
+    // The STATUS decides what is SAID, never the body. An upstream error body is allowed to
     // quote the request that caused it, and this request carried a bearer
     // token — the same reason the transcription route relays a status and
     // nothing else.
@@ -460,6 +418,31 @@ export async function generateClawaiImageBytes(
   }
 
   return { bytes, extension };
+}
+
+/**
+ * Did the proxy identify THIS DEVICE'S CREDENTIAL as the reason it refused?
+ *
+ * The proxy answers `401 {code:"missing_token"}` / `403 {code:"invalid_token"}`
+ * for a credential and other codes for everything else, and those two are the
+ * only answers that mean "asking again with this token is pointless".
+ *
+ * Reading `error.code` is not a breach of the never-relay-the-body rule below:
+ * that rule is about what reaches the CUSTOMER, and nothing read here is ever
+ * shown. Fails closed — an unreadable, bodiless or unrecognised refusal is
+ * treated as not-the-credential, which costs a retry rather than a feature.
+ */
+async function proxyRefusedTheCredential(res: Response): Promise<boolean> {
+  if (res.status !== 401 && res.status !== 403) return false;
+  let payload: unknown;
+  try {
+    payload = await res.clone().json();
+  } catch {
+    return false;
+  }
+  const error = (payload as { error?: unknown } | null)?.error;
+  const code = (error as { code?: unknown } | null)?.code;
+  return code === "invalid_token" || code === "missing_token";
 }
 
 /**

--- a/src/lib/harness/credentials.ts
+++ b/src/lib/harness/credentials.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import { CLAWBOX_AI_PROVIDER } from "@/lib/clawbox-ai-models";
 import { get } from "@/lib/config-store";
 import { readConfig } from "@/lib/openclaw-config";
@@ -62,4 +63,92 @@ export async function resolveClawaiToken(): Promise<string | null> {
 /** Whether this box holds a ClawBox AI credential at all. */
 export async function hasClawaiToken(): Promise<boolean> {
   return (await resolveClawaiToken()) !== null;
+}
+
+/* ---------------------------------------------------------------------------
+ * A credential the proxy has already refused
+ * ------------------------------------------------------------------------ */
+
+/**
+ * How long a refusal of a given credential is believed.
+ *
+ * A 401/403 from our own proxy, identified as such by the proxy (see
+ * `noteClawaiCredentialRefused`), means the credential is not accepted, and
+ * nothing the box can do makes the next identical request succeed — so the
+ * honest expiry is "until the credential changes", which is what the
+ * fingerprint keys on. The timer covers only the case the box cannot observe:
+ * a token the PORTAL restores (a mis-revocation put back, a plan reinstated)
+ * without the device being re-linked. Fifteen minutes is short enough that
+ * such a box heals on its own and long enough that being wrong costs four
+ * requests an hour instead of two thousand.
+ */
+const CREDENTIAL_REFUSAL_TTL_MS = 15 * 60_000;
+
+/**
+ * Bounded, and keyed by FINGERPRINT rather than a single slot.
+ *
+ * One slot would be silently disabled by two credentials in alternation, which
+ * is reachable: `resolveClawaiToken` falls through to the Hermes store whenever
+ * `readConfig()` cannot read `openclaw.json` — a permission error, or a file
+ * caught half-written by a concurrent `openclaw config set` — so a box whose
+ * two stores hold different strings flips per read. Four entries is more than
+ * any real box has and the map is pruned on every write.
+ */
+const MAX_REMEMBERED_REFUSALS = 4;
+const refusals = new Map<string, { status: number; until: number }>();
+
+/**
+ * A hash, never the token. The value is only ever compared, and a bare secret
+ * sitting in module state is one stack trace away from a log line.
+ */
+function fingerprintOf(token: string): string {
+  return createHash("sha256").update(token).digest("hex").slice(0, 16);
+}
+
+/**
+ * Has the ClawBox AI proxy already refused THIS credential? Returns the status
+ * it refused with, so the caller words the failure exactly as it would have
+ * worded the real one. Expired entries are dropped on the way past.
+ */
+export function clawaiCredentialRefused(token: string): number | null {
+  const entry = refusals.get(fingerprintOf(token));
+  if (!entry) return null;
+  if (Date.now() >= entry.until) {
+    refusals.delete(fingerprintOf(token));
+    return null;
+  }
+  return entry.status;
+}
+
+/**
+ * Note that the proxy refused this credential, so the next caller does not
+ * spend a request — or an upload — finding out again.
+ *
+ * ONLY the caller may decide this: a bare 401/403 on the wire can come from an
+ * edge rule, an interception proxy or a plan gate, and treating one of those as
+ * "your device is unlinked" would hide a working feature and send a customer to
+ * re-pair a healthy box. Callers arm this from the proxy's OWN identification
+ * of the credential as the problem (`error.code` = `missing_token` /
+ * `invalid_token`), never from the status alone.
+ *
+ * NOT 429: a spent daily allowance is refused for the same reason every time
+ * too, but it belongs to a plan rather than to a credential and it resets on a
+ * clock this module cannot see.
+ */
+export function noteClawaiCredentialRefused(token: string, status: number): void {
+  const now = Date.now();
+  for (const [key, entry] of refusals) {
+    if (entry.until <= now) refusals.delete(key);
+  }
+  while (refusals.size >= MAX_REMEMBERED_REFUSALS) {
+    const oldest = refusals.keys().next().value;
+    if (oldest === undefined) break;
+    refusals.delete(oldest);
+  }
+  refusals.set(fingerprintOf(token), { status, until: now + CREDENTIAL_REFUSAL_TTL_MS });
+}
+
+/** Test seam: forget every remembered refusal. */
+export function resetClawaiCredentialRefusals(): void {
+  refusals.clear();
 }

--- a/src/lib/harness/credentials.ts
+++ b/src/lib/harness/credentials.ts
@@ -106,6 +106,24 @@ const CREDENTIAL_REFUSAL_TTL_MS = 15 * 60_000;
 let refusal: { status: number; until: number } | null = null;
 
 /**
+ * How many times this box's ClawBox AI credential has been rewritten.
+ *
+ * A plain counter, and deliberately nothing derived from the secret. It exists
+ * because a request made with the OLD credential can still be in flight when
+ * the new one is written: without this, that request's 403 lands after the
+ * rewrite and arms a refusal against a credential that was never refused,
+ * muting the microphone and the picture button on a device the customer has
+ * just successfully re-linked. Callers snapshot it before the request and hand
+ * it back with the verdict; a verdict from a superseded generation is dropped.
+ */
+let credentialGeneration = 0;
+
+/** The generation to snapshot before a request whose refusal may be recorded. */
+export function clawaiCredentialGeneration(): number {
+  return credentialGeneration;
+}
+
+/**
  * Has the ClawBox AI proxy refused this box's credential? Returns the status it
  * refused with, so the caller words the failure exactly as it would have worded
  * the real one.
@@ -134,7 +152,10 @@ export function clawaiCredentialRefused(): number | null {
  * too, but it belongs to a plan rather than to a credential and it resets on a
  * clock this module cannot see.
  */
-export function noteClawaiCredentialRefused(status: number): void {
+export function noteClawaiCredentialRefused(status: number, generation: number): void {
+  // The credential was rewritten while this request was in flight, so what came
+  // back is a verdict on a token this box no longer holds.
+  if (generation !== credentialGeneration) return;
   refusal = { status, until: Date.now() + CREDENTIAL_REFUSAL_TTL_MS };
 }
 
@@ -148,12 +169,14 @@ export function noteClawaiCredentialRefused(status: number): void {
  * whether this box is OpenClaw or Hermes.
  */
 export function forgetClawaiCredentialRefusal(): void {
+  credentialGeneration += 1;
   refusal = null;
 }
 
 /** Test seam: forget every remembered refusal. */
 export function resetClawaiCredentialRefusals(): void {
   refusal = null;
+  credentialGeneration = 0;
 }
 
 /**

--- a/src/lib/harness/credentials.ts
+++ b/src/lib/harness/credentials.ts
@@ -155,3 +155,69 @@ export function forgetClawaiCredentialRefusal(): void {
 export function resetClawaiCredentialRefusals(): void {
   refusal = null;
 }
+
+/**
+ * The most a refusal body may be read before it is parsed.
+ *
+ * Enough for the service's own error envelope and nothing like enough for an
+ * interception page. `res.json()` and `res.text()` both buffer whatever the far
+ * side sends before anything can object to its size, and a 401/403 is exactly
+ * the response an edge appliance answers with a full HTML page — on a device
+ * where memory is the scarce thing.
+ */
+const MAX_REFUSAL_BODY_BYTES = 8 * 1024;
+
+/**
+ * Did the ClawBox AI proxy identify THIS DEVICE'S CREDENTIAL as the reason it
+ * refused?
+ *
+ * The proxy answers `401 {code:"missing_token"}` / `403 {code:"invalid_token"}`
+ * for a credential and other codes for everything else, and those two are the
+ * only answers that mean "asking again with this token is pointless". A bare
+ * 401/403 on the wire can come from an edge rule, a rate-limit page, an
+ * interception proxy or a plan gate.
+ *
+ * Reading `error.code` is not a breach of the never-relay-the-body rule the
+ * callers follow: that rule is about what reaches the CUSTOMER, and nothing
+ * read here is ever shown. Bounded, and it FAILS CLOSED — an unreadable,
+ * oversized, bodiless or unrecognised refusal is treated as not-the-credential,
+ * which costs a retry rather than a feature.
+ *
+ * One copy, shared by every ClawBox caller of the proxy, so the accepted
+ * contract cannot drift between the picture path and the voice path.
+ */
+export async function proxyRefusedClawaiCredential(res: Response): Promise<boolean> {
+  if (res.status !== 401 && res.status !== 403) return false;
+  const body = res.body;
+  if (!body) return false;
+  const reader = body.getReader();
+  const chunks: Buffer[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (value) {
+        total += value.byteLength;
+        // Past the cap this is not the envelope we are looking for, and
+        // draining the rest of it buys nothing.
+        if (total > MAX_REFUSAL_BODY_BYTES) {
+          await reader.cancel().catch(() => {});
+          return false;
+        }
+        chunks.push(Buffer.from(value));
+      }
+      if (done) break;
+    }
+  } catch {
+    return false;
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch {
+    return false;
+  }
+  const error = (payload as { error?: unknown } | null)?.error;
+  const code = (error as { code?: unknown } | null)?.code;
+  return code === "invalid_token" || code === "missing_token";
+}

--- a/src/lib/harness/credentials.ts
+++ b/src/lib/harness/credentials.ts
@@ -1,4 +1,3 @@
-import { createHash } from "crypto";
 import { CLAWBOX_AI_PROVIDER } from "@/lib/clawbox-ai-models";
 import { get } from "@/lib/config-store";
 import { readConfig } from "@/lib/openclaw-config";
@@ -70,59 +69,59 @@ export async function hasClawaiToken(): Promise<boolean> {
  * ------------------------------------------------------------------------ */
 
 /**
- * How long a refusal of a given credential is believed.
+ * How long a refusal of this box's ClawBox AI credential is believed.
  *
  * A 401/403 from our own proxy, identified as such by the proxy (see
  * `noteClawaiCredentialRefused`), means the credential is not accepted, and
- * nothing the box can do makes the next identical request succeed — so the
- * honest expiry is "until the credential changes", which is what the
- * fingerprint keys on. The timer covers only the case the box cannot observe:
- * a token the PORTAL restores (a mis-revocation put back, a plan reinstated)
- * without the device being re-linked. Fifteen minutes is short enough that
- * such a box heals on its own and long enough that being wrong costs four
- * requests an hour instead of two thousand.
+ * nothing the box can do makes the next identical request succeed. The honest
+ * expiry is therefore "until the credential changes" — which is not a timer at
+ * all, and is why every ClawBox writer of that credential clears this on the
+ * way past (`forgetClawaiCredentialRefusal`), exactly as they already clear
+ * `provider_verified_at`.
+ *
+ * The timer is the backstop for the one case the box cannot observe: a token
+ * the PORTAL restores (a mis-revocation put back, a plan reinstated) with
+ * nothing on the device changing. Fifteen minutes is short enough that such a
+ * box heals on its own and long enough that being wrong costs four requests an
+ * hour instead of two thousand.
  */
 const CREDENTIAL_REFUSAL_TTL_MS = 15 * 60_000;
 
 /**
- * Bounded, and keyed by FINGERPRINT rather than a single slot.
+ * When the proxy's refusal of this box's ClawBox AI credential expires, and
+ * what it refused with.
  *
- * One slot would be silently disabled by two credentials in alternation, which
- * is reachable: `resolveClawaiToken` falls through to the Hermes store whenever
- * `readConfig()` cannot read `openclaw.json` — a permission error, or a file
- * caught half-written by a concurrent `openclaw config set` — so a box whose
- * two stores hold different strings flips per read. Four entries is more than
- * any real box has and the map is pruned on every write.
+ * One slot, because a box holds ONE ClawBox AI credential: it is minted per
+ * device by the portal and written to both stores by the same hand-off. What
+ * makes "re-link the device" — the instruction the failure prints — take effect
+ * at once is not a per-credential key but `forgetClawaiCredentialRefusal`,
+ * called by every path that writes the credential.
+ *
+ * Nothing derived from the token is kept here. An earlier draft stored a
+ * SHA-256 of it as a comparison key; CodeQL reads a credential reaching a bare
+ * digest as a password hashed without a KDF, and it is right to — the fix is
+ * not a stronger hash on the render path of a polled route, it is not deriving
+ * anything from the secret in the first place.
  */
-const MAX_REMEMBERED_REFUSALS = 4;
-const refusals = new Map<string, { status: number; until: number }>();
+let refusal: { status: number; until: number } | null = null;
 
 /**
- * A hash, never the token. The value is only ever compared, and a bare secret
- * sitting in module state is one stack trace away from a log line.
+ * Has the ClawBox AI proxy refused this box's credential? Returns the status it
+ * refused with, so the caller words the failure exactly as it would have worded
+ * the real one.
  */
-function fingerprintOf(token: string): string {
-  return createHash("sha256").update(token).digest("hex").slice(0, 16);
-}
-
-/**
- * Has the ClawBox AI proxy already refused THIS credential? Returns the status
- * it refused with, so the caller words the failure exactly as it would have
- * worded the real one. Expired entries are dropped on the way past.
- */
-export function clawaiCredentialRefused(token: string): number | null {
-  const entry = refusals.get(fingerprintOf(token));
-  if (!entry) return null;
-  if (Date.now() >= entry.until) {
-    refusals.delete(fingerprintOf(token));
+export function clawaiCredentialRefused(): number | null {
+  if (!refusal) return null;
+  if (Date.now() >= refusal.until) {
+    refusal = null;
     return null;
   }
-  return entry.status;
+  return refusal.status;
 }
 
 /**
- * Note that the proxy refused this credential, so the next caller does not
- * spend a request — or an upload — finding out again.
+ * Note that the proxy refused this box's credential, so the next caller does
+ * not spend a request — or an upload — finding out again.
  *
  * ONLY the caller may decide this: a bare 401/403 on the wire can come from an
  * edge rule, an interception proxy or a plan gate, and treating one of those as
@@ -135,20 +134,24 @@ export function clawaiCredentialRefused(token: string): number | null {
  * too, but it belongs to a plan rather than to a credential and it resets on a
  * clock this module cannot see.
  */
-export function noteClawaiCredentialRefused(token: string, status: number): void {
-  const now = Date.now();
-  for (const [key, entry] of refusals) {
-    if (entry.until <= now) refusals.delete(key);
-  }
-  while (refusals.size >= MAX_REMEMBERED_REFUSALS) {
-    const oldest = refusals.keys().next().value;
-    if (oldest === undefined) break;
-    refusals.delete(oldest);
-  }
-  refusals.set(fingerprintOf(token), { status, until: now + CREDENTIAL_REFUSAL_TTL_MS });
+export function noteClawaiCredentialRefused(status: number): void {
+  refusal = { status, until: Date.now() + CREDENTIAL_REFUSAL_TTL_MS };
+}
+
+/**
+ * The credential changed — forget that it was refused, so the very next call
+ * asks again.
+ *
+ * The same shape, and the same call sites, as `forgetProviderVerified`: a mark
+ * about a credential is dropped by whoever rewrites that credential. Kept
+ * synchronous and dependency-free so a writer can call it without caring
+ * whether this box is OpenClaw or Hermes.
+ */
+export function forgetClawaiCredentialRefusal(): void {
+  refusal = null;
 }
 
 /** Test seam: forget every remembered refusal. */
 export function resetClawaiCredentialRefusals(): void {
-  refusals.clear();
+  refusal = null;
 }

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -28,6 +28,7 @@ import {
 } from "@/lib/clawbox-ai-models";
 import { isClawboxAiVisionId, resolveVisionModelId } from "@/lib/clawbox-ai-vision";
 import { forgetProviderVerified } from "@/lib/provider-verified";
+import { forgetClawaiCredentialRefusal } from "@/lib/harness/credentials";
 
 // Applying ClawBox AI to a HERMES device, in one place.
 //
@@ -130,6 +131,11 @@ export async function applyClawaiToHermes(
   // token on disk beside a mark asserting the old one worked. A mark lost to a
   // failed apply is always safe. See src/lib/provider-verified.ts.
   await forgetProviderVerified(CLAWAI_PROVIDER);
+  // And the other mark ABOUT this credential, for the same reason and at the
+  // same moment: a refusal the proxy gave the OLD token says nothing about the
+  // new one, and leaving it would make the picture button and the microphone
+  // stay away from a device that was just re-linked to fix exactly that.
+  forgetClawaiCredentialRefusal();
 
   // Read BEFORE anything is written, because the refresh at the bottom needs to
   // know whether this call is what turned drawing on. `hermesConfigGet` is keyed

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -131,11 +131,6 @@ export async function applyClawaiToHermes(
   // token on disk beside a mark asserting the old one worked. A mark lost to a
   // failed apply is always safe. See src/lib/provider-verified.ts.
   await forgetProviderVerified(CLAWAI_PROVIDER);
-  // And the other mark ABOUT this credential, for the same reason and at the
-  // same moment: a refusal the proxy gave the OLD token says nothing about the
-  // new one, and leaving it would make the picture button and the microphone
-  // stay away from a device that was just re-linked to fix exactly that.
-  forgetClawaiCredentialRefusal();
 
   // Read BEFORE anything is written, because the refresh at the bottom needs to
   // know whether this call is what turned drawing on. `hermesConfigGet` is keyed
@@ -274,6 +269,16 @@ export async function applyClawaiToHermes(
 
   for (const args of steps) {
     const r = await runHermesCli(args, { timeoutMs: 15_000 });
+    // The other mark ABOUT this credential, dropped the moment the new one is
+    // actually ON DISK — not before the loop, where a step that failed first
+    // would have re-enabled requests against the very token the proxy refused.
+    // The polarity is the opposite of `forgetProviderVerified` above, and so is
+    // the safe moment: that mark asserts something WORKED, so losing it early
+    // costs nothing; this one asserts something FAILED, so dropping it early
+    // costs traffic.
+    if (r.code === 0 && args[2] === `providers.${CLAWAI_PROVIDER}.api_key`) {
+      forgetClawaiCredentialRefusal();
+    }
     // `unset` of an absent key is a no-op; only a failing `set` is fatal.
     if (r.code !== 0 && args[1] === "set") {
       // This message is rendered verbatim in the Settings save banner (the

--- a/src/tests/unit/clawai-images.test.ts
+++ b/src/tests/unit/clawai-images.test.ts
@@ -368,6 +368,27 @@ describe("generateClawaiImage", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps asking when the 403 did not come from the proxy", async () => {
+    // The false-failure guard, and the reason the memo reads `error.code` at
+    // all. An edge rule, a rate-limit page or an interception proxy can answer
+    // 403 to a box whose credential is perfectly good — remembering one of
+    // those would hide the picture button and tell that customer to re-pair a
+    // working device. Only the proxy's own `invalid_token` / `missing_token`
+    // is proof, so anything else costs a retry rather than a feature.
+    const edge = vi.fn(async () => new Response("<html>403 Forbidden</html>", { status: 403 }));
+    for (let i = 0; i < 3; i++) {
+      await expect(generateClawaiImage("x", { fetchImpl: edge })).rejects.toMatchObject({ status: 503 });
+    }
+    expect(edge).toHaveBeenCalledTimes(3);
+
+    // A 403 the proxy DID attribute to the credential still stops the loop,
+    // and a plan gate that answers some other code still does not.
+    const gated = vi.fn(async () => jsonResponse({ error: { code: "model_not_allowed" } }, 403));
+    await expect(generateClawaiImage("x", { fetchImpl: gated })).rejects.toMatchObject({ status: 503 });
+    await expect(generateClawaiImage("x", { fetchImpl: gated })).rejects.toMatchObject({ status: 503 });
+    expect(gated).toHaveBeenCalledTimes(2);
+  });
+
   it("asks again the moment the device is re-linked", async () => {
     // The other half, and the reason this is a memory of ONE credential rather
     // than a flag on the box: re-linking is the fix the error tells the

--- a/src/tests/unit/clawai-images.test.ts
+++ b/src/tests/unit/clawai-images.test.ts
@@ -328,6 +328,10 @@ describe("generateClawaiImage", () => {
       { upstream: 502, body: {}, status: 502, says: /Generating the picture failed/ },
     ];
     for (const c of cases) {
+      // Each case is its own box: the 401/403 arms leave a remembered refusal
+      // behind (see "stops asking once the proxy has refused…"), and the point
+      // here is what each STATUS is translated to.
+      resetClawaiImageProbe();
       const fetchImpl = vi.fn(async () => jsonResponse(c.body, c.upstream));
       const err = await generateClawaiImage("x", { fetchImpl }).catch((e) => e);
       expect(err).toBeInstanceOf(ClawaiImageError);
@@ -337,6 +341,66 @@ describe("generateClawaiImage", () => {
       expect(err.message).not.toContain("Invalid token");
       expect(err.message).not.toContain("gpt-image-1-mini");
     }
+  });
+
+  it("stops asking once the proxy has refused this device's credential", async () => {
+    // TASK-727. The proxy answers 403 `invalid_token` to a credential it no
+    // longer accepts, and that answer cannot change while the credential does
+    // not: nothing the box can do makes the next identical request succeed.
+    // Beta asked anyway, on every trigger, forever — 6,554 refused POSTs from
+    // one box in twelve hours and ~68 per e2e-install run, all of them
+    // guaranteed 403 before they were sent.
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({ error: { message: "Invalid token", code: "invalid_token" } }, 403),
+    );
+    await expect(generateClawaiImage("x", { fetchImpl })).rejects.toMatchObject({ status: 503 });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    // Every later attempt still FAILS, with the same actionable sentence — the
+    // customer is told the truth each time. What must not happen is another
+    // request going out to be refused again.
+    for (let i = 0; i < 20; i++) {
+      await expect(generateClawaiImage("x", { fetchImpl })).rejects.toMatchObject({
+        status: 503,
+        message: expect.stringContaining("Re-link the device"),
+      });
+    }
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("asks again the moment the device is re-linked", async () => {
+    // The other half, and the reason this is a memory of ONE credential rather
+    // than a flag on the box: re-linking is the fix the error tells the
+    // customer to apply, so it has to work without a restart and without
+    // waiting out any timer.
+    const refuse = vi.fn(async () => jsonResponse({ error: { code: "invalid_token" } }, 403));
+    await expect(generateClawaiImage("x", { fetchImpl: refuse })).rejects.toMatchObject({ status: 503 });
+    await expect(generateClawaiImage("x", { fetchImpl: refuse })).rejects.toMatchObject({ status: 503 });
+    expect(refuse).toHaveBeenCalledTimes(1);
+
+    linkDevice("claw_freshtoken000000000000000000");
+    const accept = vi.fn(async () => jsonResponse(imageResponse()));
+    const result = await generateClawaiImage("x", { fetchImpl: accept });
+    expect(accept).toHaveBeenCalledTimes(1);
+    expect(result.media).toContain("/setup-api/chat/media");
+  });
+
+  it("stops offering the picture button while the credential is refused", async () => {
+    // The capability is `route is up` AND `credential works`, and beta could
+    // only ever answer the first half, so a box with a dead token kept showing
+    // a button whose every press ends in the same error bubble.
+    const refuse = vi.fn(async () => jsonResponse({ error: { code: "invalid_token" } }, 403));
+    await expect(generateClawaiImage("x", { fetchImpl: refuse })).rejects.toMatchObject({ status: 503 });
+
+    const probe = vi.fn(async () =>
+      jsonResponse({ status: "ok", models: [IMAGE_MODEL], defaultModel: IMAGE_MODEL }),
+    );
+    await expect(clawaiImageRouteReachable(probe)).resolves.toBe(false);
+    expect(probe).not.toHaveBeenCalled();
+
+    // And it comes back with a working credential, without a restart.
+    linkDevice("claw_freshtoken000000000000000000");
+    await expect(clawaiImageRouteReachable(probe)).resolves.toBe(true);
   });
 
   it("gives up rather than hanging, and says which kind of failure it was", async () => {

--- a/src/tests/unit/clawai-images.test.ts
+++ b/src/tests/unit/clawai-images.test.ts
@@ -390,16 +390,18 @@ describe("generateClawaiImage", () => {
   });
 
   it("asks again the moment the device is re-linked", async () => {
-    // The other half, and the reason this is a memory of ONE credential rather
-    // than a flag on the box: re-linking is the fix the error tells the
-    // customer to apply, so it has to work without a restart and without
-    // waiting out any timer.
+    // The other half, and the reason the memo has a way to be cleared at all:
+    // re-linking is the fix the error message tells the customer to apply, so
+    // it has to work without a restart and without waiting out any timer. The
+    // writers call `forgetClawaiCredentialRefusal` — the same shape, and the
+    // same call sites, as `forgetProviderVerified`.
     const refuse = vi.fn(async () => jsonResponse({ error: { code: "invalid_token" } }, 403));
     await expect(generateClawaiImage("x", { fetchImpl: refuse })).rejects.toMatchObject({ status: 503 });
     await expect(generateClawaiImage("x", { fetchImpl: refuse })).rejects.toMatchObject({ status: 503 });
     expect(refuse).toHaveBeenCalledTimes(1);
 
     linkDevice("claw_freshtoken000000000000000000");
+    (await import("@/lib/harness/credentials")).forgetClawaiCredentialRefusal();
     const accept = vi.fn(async () => jsonResponse(imageResponse()));
     const result = await generateClawaiImage("x", { fetchImpl: accept });
     expect(accept).toHaveBeenCalledTimes(1);
@@ -421,6 +423,7 @@ describe("generateClawaiImage", () => {
 
     // And it comes back with a working credential, without a restart.
     linkDevice("claw_freshtoken000000000000000000");
+    (await import("@/lib/harness/credentials")).forgetClawaiCredentialRefusal();
     await expect(clawaiImageRouteReachable(probe)).resolves.toBe(true);
   });
 

--- a/src/tests/unit/clawai-images.test.ts
+++ b/src/tests/unit/clawai-images.test.ts
@@ -381,6 +381,17 @@ describe("generateClawaiImage", () => {
     }
     expect(edge).toHaveBeenCalledTimes(3);
 
+    // Nor does an oversized body: an edge appliance can answer a 401/403 with a
+    // full HTML page, and buffering it to look for a code we are not going to
+    // find would spend the device's memory on the answer "no".
+    const huge = vi.fn(async () => new Response(
+      JSON.stringify({ error: { code: "invalid_token" }, padding: "x".repeat(16 * 1024) }),
+      { status: 403, headers: { "content-type": "application/json" } },
+    ));
+    await expect(generateClawaiImage("x", { fetchImpl: huge })).rejects.toMatchObject({ status: 503 });
+    await expect(generateClawaiImage("x", { fetchImpl: huge })).rejects.toMatchObject({ status: 503 });
+    expect(huge).toHaveBeenCalledTimes(2);
+
     // A 403 the proxy DID attribute to the credential still stops the loop,
     // and a plan gate that answers some other code still does not.
     const gated = vi.fn(async () => jsonResponse({ error: { code: "model_not_allowed" } }, 403));

--- a/src/tests/unit/harness-credentials.test.ts
+++ b/src/tests/unit/harness-credentials.test.ts
@@ -199,32 +199,49 @@ describe("a credential the ClawBox AI proxy has refused", () => {
   }
 
   it("remembers the status, so the next caller says the same thing", async () => {
-    const { clawaiCredentialRefused, noteClawaiCredentialRefused } = await memo();
-    expect(clawaiCredentialRefused()).toBeNull();
-    noteClawaiCredentialRefused(403);
-    expect(clawaiCredentialRefused()).toBe(403);
+    const mod = await memo();
+    expect(mod.clawaiCredentialRefused()).toBeNull();
+    mod.noteClawaiCredentialRefused(403, mod.clawaiCredentialGeneration());
+    expect(mod.clawaiCredentialRefused()).toBe(403);
   });
 
   it("is dropped the moment the credential is rewritten", async () => {
     // What makes "re-link the device" — the instruction every refusal prints —
-    // an instruction that works. It is a call, not a derived key: nothing about
-    // the token is kept, so nothing has to be compared against it.
-    const { clawaiCredentialRefused, noteClawaiCredentialRefused, forgetClawaiCredentialRefusal } = await memo();
-    noteClawaiCredentialRefused(401);
-    expect(clawaiCredentialRefused()).toBe(401);
-    forgetClawaiCredentialRefusal();
-    expect(clawaiCredentialRefused()).toBeNull();
+    // an instruction that works.
+    const mod = await memo();
+    mod.noteClawaiCredentialRefused(401, mod.clawaiCredentialGeneration());
+    expect(mod.clawaiCredentialRefused()).toBe(401);
+    mod.forgetClawaiCredentialRefusal();
+    expect(mod.clawaiCredentialRefused()).toBeNull();
   });
 
-  it("keeps nothing derived from the credential", async () => {
-    // An earlier draft stored a SHA-256 of the token as a comparison key, and
-    // CodeQL was right to read a credential reaching a bare digest as a
-    // password hashed without a KDF. The answer is not a stronger hash on a
-    // polled route: it is deriving nothing from the secret at all.
+  it("ignores a verdict that arrives after the credential changed", async () => {
+    // The interleaving: a request sent with the OLD token is still in flight
+    // when the owner re-links, and its 403 lands afterwards. Recording it would
+    // mute the microphone and hide the picture button on a device that was just
+    // successfully re-linked — over a credential it no longer holds.
     const mod = await memo();
-    mod.noteClawaiCredentialRefused(403);
-    const state = JSON.stringify(mod);
-    expect(state).not.toContain(OPENCLAW_TOKEN);
-    expect(state).not.toContain(HERMES_TOKEN);
+    const inFlight = mod.clawaiCredentialGeneration();
+    mod.forgetClawaiCredentialRefusal();
+    mod.noteClawaiCredentialRefused(403, inFlight);
+    expect(mod.clawaiCredentialRefused()).toBeNull();
+
+    // A verdict from the CURRENT credential is still recorded.
+    mod.noteClawaiCredentialRefused(403, mod.clawaiCredentialGeneration());
+    expect(mod.clawaiCredentialRefused()).toBe(403);
+  });
+
+  it("asks for no credential to answer, and is handed none", async () => {
+    // The security property, expressed as the shape of the API rather than by
+    // rummaging in module state: nothing here takes, returns or stores the
+    // token or anything derived from it. An earlier draft keyed the memory on a
+    // SHA-256 of it, and CodeQL was right to read a credential reaching a bare
+    // digest as a password hashed without a KDF.
+    const mod = await memo();
+    expect(mod.clawaiCredentialRefused.length).toBe(0);
+    expect(mod.clawaiCredentialGeneration.length).toBe(0);
+    expect(mod.forgetClawaiCredentialRefusal.length).toBe(0);
+    // status + generation, both non-secret.
+    expect(mod.noteClawaiCredentialRefused.length).toBe(2);
   });
 });

--- a/src/tests/unit/harness-credentials.test.ts
+++ b/src/tests/unit/harness-credentials.test.ts
@@ -183,3 +183,49 @@ describe("the credential module stays on the server", () => {
     }
   });
 });
+
+describe("a credential the ClawBox AI proxy has refused", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    readConfig.mockReset();
+    configStoreGet.mockReset();
+  });
+
+  /** The memory, freshly imported so each case starts with none. */
+  async function memo() {
+    const mod = await import("@/lib/harness/credentials");
+    mod.resetClawaiCredentialRefusals();
+    return mod;
+  }
+
+  it("remembers by credential, so a re-link is believed at once", async () => {
+    const { clawaiCredentialRefused, noteClawaiCredentialRefused } = await memo();
+    noteClawaiCredentialRefused(OPENCLAW_TOKEN, 403);
+    expect(clawaiCredentialRefused(OPENCLAW_TOKEN)).toBe(403);
+    // A different credential is a different question, and it has not been
+    // asked. This is what makes "re-link the device" an instruction that works
+    // rather than one the box then ignores for a quarter of an hour.
+    expect(clawaiCredentialRefused(HERMES_TOKEN)).toBeNull();
+  });
+
+  it("holds more than one, so two stores in alternation cannot disable it", async () => {
+    // `resolveClawaiToken` falls through to the Hermes store whenever
+    // `openclaw.json` cannot be read — a permission error, or a file caught
+    // half-written by a concurrent `openclaw config set` — so a box whose two
+    // stores hold different strings flips per read. A single slot would be
+    // overwritten on every flip and the box would be back to asking forever.
+    const { clawaiCredentialRefused, noteClawaiCredentialRefused } = await memo();
+    noteClawaiCredentialRefused(OPENCLAW_TOKEN, 403);
+    noteClawaiCredentialRefused(HERMES_TOKEN, 401);
+    expect(clawaiCredentialRefused(OPENCLAW_TOKEN)).toBe(403);
+    expect(clawaiCredentialRefused(HERMES_TOKEN)).toBe(401);
+  });
+
+  it("never keeps the credential itself", async () => {
+    // The value is only ever compared, and a bare secret in module state is one
+    // stack trace away from a log line.
+    const mod = await memo();
+    mod.noteClawaiCredentialRefused(OPENCLAW_TOKEN, 403);
+    expect(JSON.stringify(mod)).not.toContain(OPENCLAW_TOKEN);
+  });
+});

--- a/src/tests/unit/harness-credentials.test.ts
+++ b/src/tests/unit/harness-credentials.test.ts
@@ -198,34 +198,33 @@ describe("a credential the ClawBox AI proxy has refused", () => {
     return mod;
   }
 
-  it("remembers by credential, so a re-link is believed at once", async () => {
+  it("remembers the status, so the next caller says the same thing", async () => {
     const { clawaiCredentialRefused, noteClawaiCredentialRefused } = await memo();
-    noteClawaiCredentialRefused(OPENCLAW_TOKEN, 403);
-    expect(clawaiCredentialRefused(OPENCLAW_TOKEN)).toBe(403);
-    // A different credential is a different question, and it has not been
-    // asked. This is what makes "re-link the device" an instruction that works
-    // rather than one the box then ignores for a quarter of an hour.
-    expect(clawaiCredentialRefused(HERMES_TOKEN)).toBeNull();
+    expect(clawaiCredentialRefused()).toBeNull();
+    noteClawaiCredentialRefused(403);
+    expect(clawaiCredentialRefused()).toBe(403);
   });
 
-  it("holds more than one, so two stores in alternation cannot disable it", async () => {
-    // `resolveClawaiToken` falls through to the Hermes store whenever
-    // `openclaw.json` cannot be read — a permission error, or a file caught
-    // half-written by a concurrent `openclaw config set` — so a box whose two
-    // stores hold different strings flips per read. A single slot would be
-    // overwritten on every flip and the box would be back to asking forever.
-    const { clawaiCredentialRefused, noteClawaiCredentialRefused } = await memo();
-    noteClawaiCredentialRefused(OPENCLAW_TOKEN, 403);
-    noteClawaiCredentialRefused(HERMES_TOKEN, 401);
-    expect(clawaiCredentialRefused(OPENCLAW_TOKEN)).toBe(403);
-    expect(clawaiCredentialRefused(HERMES_TOKEN)).toBe(401);
+  it("is dropped the moment the credential is rewritten", async () => {
+    // What makes "re-link the device" — the instruction every refusal prints —
+    // an instruction that works. It is a call, not a derived key: nothing about
+    // the token is kept, so nothing has to be compared against it.
+    const { clawaiCredentialRefused, noteClawaiCredentialRefused, forgetClawaiCredentialRefusal } = await memo();
+    noteClawaiCredentialRefused(401);
+    expect(clawaiCredentialRefused()).toBe(401);
+    forgetClawaiCredentialRefusal();
+    expect(clawaiCredentialRefused()).toBeNull();
   });
 
-  it("never keeps the credential itself", async () => {
-    // The value is only ever compared, and a bare secret in module state is one
-    // stack trace away from a log line.
+  it("keeps nothing derived from the credential", async () => {
+    // An earlier draft stored a SHA-256 of the token as a comparison key, and
+    // CodeQL was right to read a credential reaching a bare digest as a
+    // password hashed without a KDF. The answer is not a stronger hash on a
+    // polled route: it is deriving nothing from the secret at all.
     const mod = await memo();
-    mod.noteClawaiCredentialRefused(OPENCLAW_TOKEN, 403);
-    expect(JSON.stringify(mod)).not.toContain(OPENCLAW_TOKEN);
+    mod.noteClawaiCredentialRefused(403);
+    const state = JSON.stringify(mod);
+    expect(state).not.toContain(OPENCLAW_TOKEN);
+    expect(state).not.toContain(HERMES_TOKEN);
   });
 });

--- a/src/tests/unit/hermes-voice-writes-once.test.ts
+++ b/src/tests/unit/hermes-voice-writes-once.test.ts
@@ -52,6 +52,9 @@ vi.mock("@/lib/local-models", async (importOriginal) => ({
 vi.mock("@/lib/harness/credentials", () => ({
   CLAWBOX_AI_PROXY_URL: "https://clawbox.test/api/ai",
   resolveClawaiToken: vi.fn(async () => null),
+  // Dropped by the link path beside `forgetProviderVerified`: a refusal the
+  // proxy gave the token being replaced says nothing about the new one.
+  forgetClawaiCredentialRefusal: vi.fn(),
 }));
 // The link path's neighbours, none of which this file is about. The vision
 // resolver is mocked because it performs network I/O against the proxy.


### PR DESCRIPTION
**TASK-727** — image generation retries a permanent 403 forever (~15k refused calls/day since 09-04).

## Customer-visible symptom

A box whose ClawBox AI credential the proxy no longer accepts kept asking anyway. Every trigger — a chat composer press, a coding run's `generate_image`, a new web app's icon, a new project's favicon — opened its own `POST /api/ai/images/generations`, got the same `403 invalid_token`, showed the same error, and left nothing behind that would stop the next one. Measured from Cloudflare over 12 h: 6,554 refused image calls from one device at up to ~34/min, and ~68 per `e2e-install` run on the CI credential. Fleet-wide refused image calls went 0 → 6,700 (09-04) → 14,700 (09-05) per day. No customer generation failed in that window; the traffic was self-inflicted.

## Cause

`src/lib/harness/clawai-images.ts` is the one module every ClawBox-side image request goes through, and it kept **no memory of the outcome**. `messageForStatus` turned an upstream 401/403 into a correct, customer-readable `503 "Re-link the device"` — and the next caller started from scratch. A refusal of the credential is the one failure on that path that cannot come right by itself: the request is fully determined by two module constants and the device credential, so re-sending it byte-for-byte is guaranteed to be refused again.

Two things made it look bounded when it is not:

- `webapp-icon.ts` does have failure cooldowns (5 min per app, 15 min box-wide on `ClawaiImageError.status` ∈ {429, 503}) — but they only ever guarded the ICON pipeline. The chat composer, the coding-agent media tool and the capability probe never saw them.
- `clawaiImageRouteReachable()` answers "is there an image service" from an **unauthenticated** discovery GET, so it kept returning `true` on a box whose credential was dead — a button that could only ever produce an error bubble.

## The fix

One remembered fact, in `src/lib/harness/credentials.ts` beside `resolveClawaiToken` — because the fact is about the CREDENTIAL, not about pictures:

- When the proxy refuses and **says the credential is why**, remember that, with a 15-minute expiry.
- A later caller fails **without a request**, with the identical status and sentence the first refusal produced. The customer is told every time; only the traffic stops.
- Every ClawBox path that WRITES the ClawBox AI credential drops the memory on the way past — `forgetClawaiCredentialRefusal()`, called from `ai-models/configure`, `hermes/clawai` and `applyClawaiToHermes`, at the same moment and for the same reason those already call `forgetProviderVerified`. That is what makes "re-link the device", which every refusal prints, an instruction that works on the very next call rather than after a timer.

**Nothing derived from the token is kept.** The first draft stored a SHA-256 of it as a comparison key; CodeQL read that as a credential reaching a bare digest — a password hashed without a KDF — and it was right to. The answer is not a stronger hash on the render path of a polled route: it is not deriving anything from the secret at all. A box holds ONE ClawBox AI credential (the portal mints it per device and the same hand-off writes both stores), so a single slot plus an explicit invalidation on write says everything a per-credential key would have said, and says it without a secret in module state.
- `clawaiImageRouteReachable()` consults it **ahead of its own probe cache**, so the picture button goes away instead of staying for the ten minutes a successful probe is good for.
- `/setup-api/chat/transcribe` — the sibling that spends the same credential against the same proxy and translates 401/403 into the same 503 — consults and arms the same memory. On a refused box a microphone press no longer uploads a ~9 MB recording to be refused.

**Only the proxy's own verdict arms it.** A bare 401/403 on the wire can come from an edge rule, a rate-limit page, an interception proxy or a plan gate. Arming on the status alone would hide the picture button and tell a customer with a perfectly good credential to re-pair a working device — the same false claim this PR exists to end, pointing the other way. So the memo is armed only on `{error:{code:"invalid_token"|"missing_token"}}`, the envelope this module has documented since it was written. Reading `error.code` to DECIDE is not a breach of "the status decides, never the body": that rule is about what reaches the customer, and nothing read here is ever shown. It fails closed — an unreadable, bodiless or unrecognised refusal costs a retry rather than a feature.

Two properties keep it from becoming a probe-once bug:

- **Re-linking clears it instantly**, through the writers above. Pinned by `asks again the moment the device is re-linked` and by `is dropped the moment the credential is rewritten`.
- **The timer covers the one case the box cannot observe**: the portal restoring a credential with nothing on the device changing. Stated plainly, the consequence is that a still-dead credential shows the button again every fifteen minutes and one press re-hides it. That is the trade, and the doc comment says so rather than claiming the button stays away until a re-link.

**Deliberately only 401/403, not 429.** A spent daily allowance is refused for the same reason every time too, but it belongs to a plan rather than to a credential, it resets on a clock this module cannot see, and `webapp-icon.ts`'s `BOX_WIDE_STATUSES` already pauses the box for it.

## Harness-first

There is **no native OpenClaw or Hermes mechanism to reuse here**, and naming that is the point of the rule. This module exists precisely because the harness does not make the call: on Hermes `image_gen.provider` dispatches to a plugin slot that ships empty, and on both editions the surfaces in this PR (chat composer, the coding-agent media MCP tool, the web-app and project icon pipelines, the transcribe route) are ClawBox's own `fetch` calls to ClawBox's own proxy. The adjacent native mechanisms — Hermes' `image_gen` registry and its `image.generate {probe:true}`, OpenClaw's provider/auth store — govern the AGENT's image tool, not these, and that tool is deliberately untouched (below).

## Sibling call sites — swept

| Caller | Status |
| --- | --- |
| `src/app/setup-api/chat/images/route.ts` | covered (chat composer) |
| `src/app/setup-api/coding-agent/media/image/route.ts` | covered (the `generate_image` MCP tool — its own comment already imagines "a run that met a refused upstream twenty times") |
| `src/lib/webapp-icon.ts` → `ensureIconFile` | covered; its app/box cooldowns are unchanged and still fire one layer up, cheaper. Verified: `ensureIconFile` admitting N generations before the first failure no longer lets N requests out — the slot serialises them, the first arms the memo, the rest short-circuit |
| `src/lib/project-icon.ts` → `ensureIconFile` | covered |
| `src/lib/code-projects.ts`, `src/lib/webapp-registry.ts`, `src/lib/pending-actions.ts`, `src/lib/coding-agent.ts` | covered — they reach the proxy only through the two functions above |
| `src/app/setup-api/chat/capabilities/route.ts` → `clawaiImageRouteReachable` | changed: `false` while this box's credential is known-refused; its contract comments and `harness/capabilities.ts`'s two are updated to match |
| `src/app/setup-api/chat/transcribe/route.ts` | changed: consults and arms the same memo |
| `src/app/setup-api/ai-models/configure/route.ts`, `src/app/setup-api/hermes/clawai/route.ts`, `src/lib/hermes-clawai.ts` | changed: every writer of the ClawBox AI credential drops the memo, beside the `forgetProviderVerified` they already call |

Explicitly cleared rather than covered:

- `scripts/hermes-plugins/image_gen/clawai/__init__.py` — the Hermes `image_gen` backend, in the Hermes agent process, so this memo cannot reach it. Checked and it is not a storm: one `client.images.generate` per `image_generate` call, and the OpenAI Python SDK's default retry policy covers 408/409/429/5xx, never 401/403. Its 429 arm does retry twice, worth a look next time that file is opened.
- The OpenClaw agent's own image tool on `agents.defaults.mediaModels.image` → `models.providers.openai`. That is the credential the card's item 2 names, and it holds a non-`claw_` token on the affected box. **Not taken here on purpose**: it is the `models.providers.openai.apiKey` pairing owned by the D-05 / TASK-661 ChatGPT-blocker work; moving it needs a provider id of ClawBox's own for the image row plus `mediaModels.image` and the `tools.media.audio` pointers moved with it, and a previous pass killed the one-line version because with the image row left behind it would send an OpenAI OAuth credential to `clawbox.com/api/ai`. That change needs a box; this one does not.

Card item 3 ("e2e-install should not fire ~68 refused image calls per CI run") is answered by the same change rather than by touching the workflow: the run forwards `CLAWBOX_AI_API_KEY` through `/setup-api/ai-models/configure`, and one Next server serves the run, so a refused key costs one POST per 15 minutes instead of one per app.

## Stated boundaries

- The memory is **per process**. A `clawbox-setup.service` restart forgets it, and `e2e-install` restarts the server mid-run, so the per-run count is "small and bounded", not asserted as exactly one.
- It is **box-wide, not per credential**, and it is cleared by ClawBox's own writers. A credential rotated by something other than those writers — the portal re-minting it into `openclaw.json` behind the box's back — is covered only by the 15-minute timer.
- **File overlap:** the two-hunk change to `src/app/setup-api/ai-models/configure/route.ts` (an import and one `forgetClawaiCredentialRefusal()` call) touches the same file as PR #730 (TASK-730), which changes the `models auth …` helpers near the top. Whichever merges second should rebase.
- `clawaiImageRouteReachable` now resolves the credential ahead of its cache — two small file reads on a polled route. Accepted for now: the alternative is threading the token through the capabilities route, which the caller does not currently hold.
- The in-code comment no longer attributes the 6,554 POSTs to this path. The proxy logs were not separated by caller, so the honest claim is "one POST per trigger, per process, all knowable in advance".

## Found while here, not fixed (needs its own card)

`resolveClawaiToken()` returns `models.providers.deepseek.apiKey` without asking whether it is a ClawBox credential at all, and `install.sh` writes a **raw DeepSeek key** into that same slot (`{baseUrl:"https://api.deepseek.com", …}`) with a comment saying so. On such a box `hasClawaiToken()` is true and the box sends a third party's API key to `clawbox.com` in an `Authorization` header. The codebase already owns the predicate (`isClawboxAiToken`, used by `canOwnOpenAiImageApiKey`, `voice-output`'s cloud-credential check and the boot migration); gating the resolver on it — only when the row's `baseUrl` is not a ClawBox proxy — would take the CI number to zero rather than to one per 15 minutes. Not taken here because it flips `hasClawaiToken()` on those boxes, which gates the microphone, images and ClawKeep, and that blast radius wants its own RED.

## RED → GREEN

RED, on unmodified `origin/beta` (`8653b118`):

```
 ❯ |unit| src/tests/unit/clawai-images.test.ts (21 tests | 3 failed) 477ms
     × stops asking once the proxy has refused this device's credential 12ms
     × asks again the moment the device is re-linked 6ms
     × stops offering the picture button while the credential is refused 9ms

 FAIL  … > stops asking once the proxy has refused this device's credential
AssertionError: expected "vi.fn()" to be called 1 times, but got 21 times
 ❯ src/tests/unit/clawai-images.test.ts:368:23

 FAIL  … > asks again the moment the device is re-linked
AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times

 FAIL  … > stops offering the picture button while the credential is refused
AssertionError: expected true to be false // Object.is equality

 Test Files  1 failed (1)
      Tests  3 failed | 18 passed (21)
```

Twenty-one identical POSTs where one carries all the information there is — the defect in one number.

GREEN, on this branch: the whole suite, unit and components — `Tests 12921 passed | 1 skipped (12924)`, with only the two known dev-PC load flakes (`routes/telegram/status*`, which pass in isolation). `tsc --noEmit` clean.

The reworked memory adds its own cases: the status is remembered and re-worded identically, it is dropped the moment the credential is rewritten, a 403 the proxy did NOT attribute to the credential keeps the loop asking (three requests, not one), and nothing derived from either store's token survives in module state.

## Both editions

The changed modules are edition-agnostic by construction: the credential is resolved through `resolveClawaiToken`, which knows both stores. `clawaiImageRouteReachable` is consumed only on Hermes today (`onHermes && linked` in the capabilities route), so the button-hiding half is visible there; the generate-side and transcribe-side breakers apply on both. Scope note for the record: on a LINKED Hermes box the agent draws (the plugin slot is filled at link time, so `imageGenerationTrigger` is `agent` and the composer button is already absent), and on OpenClaw the drawer is the gateway — so what this PR covers is the composer path on an empty-slot Hermes box, the coding-agent media route, the icon pipelines and the voice path on both. No device mutation and no hardware behaviour is touched, so there is no device leg; CI exercises it fully.

## The gate, measured against production

The arming condition is that the proxy names the credential. Verified from the office, unauthenticated and with a deliberately invalid token — a refusal costs no generation and no allowance:

```
$ curl -X POST https://clawbox.com/api/ai/images/generations -H "Authorization: Bearer claw_0000…"
HTTP 403  {"error":{"message":"Invalid token","type":"auth_error","code":"invalid_token"}}

$ curl -X POST https://clawbox.com/api/ai/images/generations          # no bearer
HTTP 401  {"error":{"message":"Missing X-ClawBox-Token header or Authorization: Bearer token",
                    "type":"auth_error","code":"missing_token"}}
```

Both are exactly the two codes `proxyRefusedClawaiCredential` accepts, and both bodies are ~80-130 bytes — three orders of magnitude under the 8 KB cap, so the bounded read never truncates a real refusal. The contract this fix arms on is the one production actually answers with, not one taken from the module's documentation.

## Device leg — read-only, both editions

**Hermes box** (`CLAWBOX_EDITION=hermes`), the edition whose composer path this PR covers. Credential shape read without printing anything (length and prefix only):

```
data/config.json    clawai_token          present, len 37, claw_ prefix
~/.openclaw/openclaw.json  models.providers.deepseek.apiKey   absent
```

So on that box `resolveClawaiToken` takes its documented second branch — the OpenClaw read finds no key and falls through to the config store — and there is exactly one credential, which is the shape the single-slot memory assumes. **Declared gap:** `clawbox-setup` and `clawbox-hermes-gateway` were both `inactive` on that box at the time, so no route was exercised on it; the check is filesystem-only.

**OpenClaw box**: `CLAWBOX_EDITION=openclaw`, core 2026.8.1. Nothing in this PR mutates a box, and the two facts it turns on — the proxy's refusal envelope and the credential store layout — are measured above rather than reasoned about.
