### PR TITLE
fix: report a ClawBox AI credential the portal refused as refused

### DIFF
--- a/src/app/setup-api/ai-models/status/route.ts
+++ b/src/app/setup-api/ai-models/status/route.ts
@@ -198,6 +198,12 @@ async function buildStatusResponse(state: ResolvedAiState): Promise<NextResponse
   // remembered entitlement is a guess, and a guess is what locked a Max owner
   // out of the model he pays for (TASK-691).
   let clawaiAllowedModels: string[] | null = null;
+  // Did the portal REFUSE this device's credential? False until it says so, so
+  // a box that has not asked yet — no token, portal never reached — never
+  // accuses a credential that may be fine. See TASK-419: the answer used to be
+  // thrown away, and the badge went on saying "Connected · Pro" while every
+  // turn came back "HTTP 403: Invalid token".
+  let clawaiTokenRejected = false;
   if (state.hasClawaiProfile) {
     clawaiAccountTier = localTier;
     // Ask the portal whenever a clawai token is paired, regardless
@@ -225,6 +231,8 @@ async function buildStatusResponse(state: ResolvedAiState): Promise<NextResponse
         if (lookup.tier !== localTier) {
           await setConfigValue(CLAWBOX_AI_TIER_CONFIG_KEY, lookup.tier).catch(() => {});
         }
+      } else {
+        clawaiTokenRejected = lookup.rejected;
       }
     }
   }
@@ -254,6 +262,13 @@ async function buildStatusResponse(state: ResolvedAiState): Promise<NextResponse
     // hook needs this to gate ClawKeep / Remote Desktop sign-in
     // prompts independently of paid-tier checks.
     clawaiConfigured: state.hasClawaiProfile,
+    // The portal answered and refused this device's token. Deliberately NOT
+    // folded into `connected` or `clawaiConfigured`: a rejected credential is
+    // still a configured one, and the gates hanging off those two (ClawKeep,
+    // Remote Desktop, the whole "has this box been linked" question) must not
+    // flip on an auth error. This is the one field that says the credential
+    // does not work, and the surfaces that claim health read it.
+    clawaiTokenRejected,
     tierSource,
   }, {
     headers: {

--- a/src/app/setup-api/ai-models/status/route.ts
+++ b/src/app/setup-api/ai-models/status/route.ts
@@ -292,7 +292,7 @@ export async function GET() {
       {
         connected: false, provider: null, providerLabel: null, mode: null, model: null,
         clawaiTier: null, clawaiAccountTier: null, clawaiAllowedModels: null,
-        clawaiConfigured: false, tierSource: "picker",
+        clawaiConfigured: false, clawaiTokenRejected: false, tierSource: "picker",
       },
       {
         headers: {

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -6239,7 +6239,15 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         // on the type because an older /status response does not carry it, and
         // absent must mean "nobody said", never "rejected". `needsReauth` is
         // the catalogue's existing "Needs sign-in", already in all ten locales.
-        if (aiProvider.clawaiTokenRejected) return { subtitle: t("settings.providers.needsReauth") };
+        // Scoped to the ACTIVE provider, the way the route scopes `clawaiTier`
+        // one field above and for the same reason: `clawaiTokenRejected` is an
+        // ACCOUNT fact (it also breaks images, cloud voice and ClawKeep), while
+        // this line names the provider driving the chat. A box that moved its
+        // chat to Anthropic months ago must keep reading "Anthropic Claude"
+        // here, not "Needs sign-in" over a provider that answers every turn.
+        if (aiProvider.provider === "clawai" && aiProvider.clawaiTokenRejected) {
+          return { subtitle: t("settings.providers.needsReauth") };
+        }
         return { subtitle: aiProvider.providerLabel || (aiProvider.model ? aiProvider.model.split("/").pop() ?? null : null) };
       }
       case "localAi": {

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -1193,7 +1193,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
   };
 
   /* ── AI Provider ── */
-  const [aiProvider, setAiProvider] = useState<{ connected: boolean; provider: string | null; providerLabel: string | null; mode: string | null; model: string | null; clawaiTier: "flash" | "pro" | null } | null>(null);
+  const [aiProvider, setAiProvider] = useState<{ connected: boolean; provider: string | null; providerLabel: string | null; mode: string | null; model: string | null; clawaiTier: "flash" | "pro" | null; clawaiTokenRejected?: boolean } | null>(null);
   useEffect(() => {
     if (section !== "ai" && !isMobile) return;
     const load = () => {
@@ -6233,6 +6233,13 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
       case "ai": {
         if (aiProvider === null) return { subtitle: null };
         if (!aiProvider.connected) return { subtitle: t("settings.notConfigured") || "Not configured" };
+        // The portal has told this box its ClawBox AI credential is refused, so
+        // the provider's NAME is no longer the useful thing to print here: it
+        // reads as health, and every turn is about to fail (TASK-419). Optional
+        // on the type because an older /status response does not carry it, and
+        // absent must mean "nobody said", never "rejected". `needsReauth` is
+        // the catalogue's existing "Needs sign-in", already in all ten locales.
+        if (aiProvider.clawaiTokenRejected) return { subtitle: t("settings.providers.needsReauth") };
         return { subtitle: aiProvider.providerLabel || (aiProvider.model ? aiProvider.model.split("/").pop() ?? null : null) };
       }
       case "localAi": {

--- a/src/lib/chat-error-text.ts
+++ b/src/lib/chat-error-text.ts
@@ -70,14 +70,19 @@ function isRateLimit(raw: string): boolean {
  * the customer has no reason to open. The remedy is a screen they already have.
  *
  * Matched on the wire wording, like the two predicates above, and deliberately
- * NARROW: a bare "token" is an ordinary word in this codebase's errors
- * ("context window exceeded: 403000 tokens" must not match), so the number has
- * to stand alone as a status and the auth words have to be auth words.
+ * NARROW in two directions. A bare "token" is an ordinary word in this
+ * codebase's errors ("context window exceeded: 403000 tokens" must not match),
+ * so the number has to stand alone as a status. And the auth wording has to sit
+ * NEXT TO that status, because a bare "forbidden" anywhere in the line matches
+ * things that have nothing to do with the provider's credential — a web tool
+ * fetching a page that answers "403 Forbidden", or a Cloudflare interstitial,
+ * both of which reach this function through the Hermes adapter. Those used to
+ * fall to the generic "send it again"; turning them into "your sign-in is dead,
+ * reconnect the provider" would be a confident lie.
  */
 function isCredentialRejected(raw: string): boolean {
-  return /\b(?:401|403)\b(?!\s*\d)/.test(raw)
-    && /\b(?:invalid[ _-]?token|missing[ _-]?token|unauthor(?:ized|ised)|forbidden|invalid[ _-]?api[ _-]?key|auth(?:entication|orization)?[ _-]?(?:error|failed))\b/i.test(raw)
-    || /\b(?:401|403)\s+(?:unauthor(?:ized|ised)|forbidden)\b/i.test(raw);
+  return /\b(?:401|403)\b(?!\s*[\d,])[^.\n]{0,24}?\b(?:invalid[ _-]?token|missing[ _-]?token|invalid[ _-]?api[ _-]?key|auth(?:entication|orization)?[ _-]?(?:error|failed)|unauthor(?:ized|ised))\b/i
+    .test(raw);
 }
 
 /** Something went wrong and we will not say what, because we cannot say it safely. */
@@ -97,7 +102,7 @@ const RATE_LIMIT = "That message did not go through — the AI provider is rate-
  * No status number: "403" tells the customer nothing they can act on, and the
  * one thing they can act on is two taps away.
  */
-const CREDENTIAL_REJECTED = "That message did not go through — the AI provider is not accepting this box's sign-in any more. Reconnect the provider in Settings, under AI Models, and send it again.";
+const CREDENTIAL_REJECTED = "That message did not go through — the AI provider is not accepting this box's sign-in any more. Reconnect it in Settings, under Providers, and send it again.";
 
 /** The conversation changed under the turn; retry may work, New chat always does. */
 const TAKEOVER = "That message did not go through. That can happen when this chat is open in another tab or on Telegram — or when the session gets stuck. Send it again, and if it keeps failing, start a New chat — that clears it.";

--- a/src/lib/chat-error-text.ts
+++ b/src/lib/chat-error-text.ts
@@ -61,6 +61,25 @@ function isRateLimit(raw: string): boolean {
     || /(^|[^0-9])429([^0-9]|$)/.test(raw);
 }
 
+/**
+ * The AI provider refused this box's credential.
+ *
+ * The customer-visible shape of a revoked, expired or rotated ClawBox AI token
+ * (TASK-419): Settings shows a healthy paid badge, and the chat answers
+ * "Error: HTTP 403: Invalid token" — true, unactionable, and pointing at a CLI
+ * the customer has no reason to open. The remedy is a screen they already have.
+ *
+ * Matched on the wire wording, like the two predicates above, and deliberately
+ * NARROW: a bare "token" is an ordinary word in this codebase's errors
+ * ("context window exceeded: 403000 tokens" must not match), so the number has
+ * to stand alone as a status and the auth words have to be auth words.
+ */
+function isCredentialRejected(raw: string): boolean {
+  return /\b(?:401|403)\b(?!\s*\d)/.test(raw)
+    && /\b(?:invalid[ _-]?token|missing[ _-]?token|unauthor(?:ized|ised)|forbidden|invalid[ _-]?api[ _-]?key|auth(?:entication|orization)?[ _-]?(?:error|failed))\b/i.test(raw)
+    || /\b(?:401|403)\s+(?:unauthor(?:ized|ised)|forbidden)\b/i.test(raw);
+}
+
 /** Something went wrong and we will not say what, because we cannot say it safely. */
 const GENERIC = "That message did not go through. Send it again — the details stayed in this box's log.";
 
@@ -71,6 +90,14 @@ const GENERIC = "That message did not go through. Send it again — the details 
  * Settings. No "check the log": there is nothing there to act on.
  */
 const RATE_LIMIT = "That message did not go through — the AI provider is rate-limiting this box right now. Nothing is broken. Wait a minute and send it again, or switch to a different provider in Settings.";
+
+/**
+ * The credential is the problem, and re-linking is the fix — so the sentence
+ * names the screen that does it rather than the status code that revealed it.
+ * No status number: "403" tells the customer nothing they can act on, and the
+ * one thing they can act on is two taps away.
+ */
+const CREDENTIAL_REJECTED = "That message did not go through — the AI provider is not accepting this box's sign-in any more. Reconnect the provider in Settings, under AI Models, and send it again.";
 
 /** The conversation changed under the turn; retry may work, New chat always does. */
 const TAKEOVER = "That message did not go through. That can happen when this chat is open in another tab or on Telegram — or when the session gets stuck. Send it again, and if it keeps failing, start a New chat — that clears it.";
@@ -92,6 +119,11 @@ export function describeChatFailure(raw: unknown): string {
   // actionable one — and a 429 buried in an otherwise unsafe string would be
   // dropped to the generic fallback, losing the one fact that explains it.
   if (isRateLimit(text)) return RATE_LIMIT;
+  // Before the sanitizer for the same reason as the rate limit: "HTTP 403:
+  // Invalid token" carries no path or handle, so it would otherwise pass the
+  // leak rules and be relayed verbatim — which is exactly the bubble TASK-419
+  // is about.
+  if (isCredentialRejected(text)) return CREDENTIAL_REJECTED;
   const safe = sanitizeErrorMessage(text);
   // A message that passes the leak rules is worth showing: "Request exceeds the
   // size limit" tells the customer what to change, and replacing it with the

--- a/src/lib/clawbox-ai-portal-tier.ts
+++ b/src/lib/clawbox-ai-portal-tier.ts
@@ -53,7 +53,7 @@ const PORTAL_TIER_CACHE_MAX_ENTRIES = 64;
 const PORTAL_UNREACHABLE_TTL_MS = 30_000;
 // Enough for the service's own error envelope and nothing like enough for an
 // interception page. Only ever parsed, never shown.
-const MAX_ERROR_BODY_CHARS = 4_096;
+const MAX_ERROR_BODY_BYTES = 4_096;
 
 export interface DeviceInfoResponse {
   tier?: string;
@@ -264,7 +264,13 @@ export async function fetchPortalTier(token: string): Promise<PortalLookup> {
         const planTier = mapPortalPlanTier(body);
         const allowedModels = mapPortalAllowedModels(body);
         rememberTier(token, tier, planTier, allowedModels, now);
-        portalUnreachableCache.delete(token);
+        // Every negative verdict, not just this token's. A device holds ONE
+        // ClawBox AI credential at a time, so a 200 for the one it holds now
+        // says the rejection recorded against the one it held a minute ago is
+        // about a credential that no longer exists — and `clawaiTokenRejectedByPortal`
+        // scans, so leaving it would keep the Providers strip in "Needs
+        // sign-in" for the rest of that entry's window after a re-link.
+        portalUnreachableCache.clear();
         return { source: "portal", tier, planTier, allowedModels };
       }
       // 401/403 is ambiguous AS A TIER: it can mean genuinely Free OR token
@@ -338,15 +344,36 @@ export function clawaiTokenRejectedByPortal(): boolean {
  */
 async function portalRefusedTheToken(res: Response): Promise<boolean> {
   if (res.status !== 401 && res.status !== 403) return false;
-  let text: string;
+  const body = res.body;
+  if (!body) return false;
+  // Counted as it arrives. `res.text()` would buffer whatever the far side
+  // sends BEFORE anything could object to its size, and the 4 s timeout above
+  // bounds duration, not bytes — while a 401/403 is exactly the response an
+  // interception appliance answers with a full HTML page, on a device where
+  // memory is the scarce thing. Past the cap this is not the envelope we are
+  // looking for, and draining the rest of it buys nothing.
+  const reader = body.getReader();
+  const chunks: string[] = [];
+  let total = 0;
   try {
-    text = (await res.text()).slice(0, MAX_ERROR_BODY_CHARS);
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (value) {
+        total += value.byteLength;
+        if (total > MAX_ERROR_BODY_BYTES) {
+          await reader.cancel().catch(() => {});
+          return false;
+        }
+        chunks.push(Buffer.from(value).toString("utf8"));
+      }
+      if (done) break;
+    }
   } catch {
     return false;
   }
   let payload: unknown;
   try {
-    payload = JSON.parse(text);
+    payload = JSON.parse(chunks.join(""));
   } catch {
     return false;
   }

--- a/src/lib/clawbox-ai-portal-tier.ts
+++ b/src/lib/clawbox-ai-portal-tier.ts
@@ -118,6 +118,19 @@ const portalUnreachableCache = new Map<string, { until: number; rejected: boolea
 const inFlightPortalLookups = new Map<string, Promise<PortalLookup>>();
 
 /**
+ * How many times a lookup has PROVED a credential works.
+ *
+ * A plain counter, never anything derived from a token. Lookups for two
+ * credentials can overlap — a re-link starts one for the new token while the
+ * old token's is still in flight — and completion order is not arrival order.
+ * Without this, a delayed 403 for the RETIRED token lands after the new one's
+ * 200 and re-arms a rejection that `clawaiTokenRejectedByPortal` then reports
+ * against the credential the box actually holds: Settings says "Needs sign-in"
+ * about a device that was just successfully re-linked.
+ */
+let provenGeneration = 0;
+
+/**
  * Writes a token's resolved tier into the in-memory cache, sweeping
  * expired entries and enforcing the size cap before insertion. Map
  * iteration order is insertion order, so the first key returned by
@@ -245,12 +258,21 @@ export async function fetchPortalTier(token: string): Promise<PortalLookup> {
   const existing = inFlightPortalLookups.get(token);
   if (existing) return existing;
 
+  // Snapshotted before the request: what this lookup learns is about the state
+  // of the world when it was sent.
+  const startedAt = provenGeneration;
   const promise = (async (): Promise<PortalLookup> => {
     const markUnreachable = (rejected: boolean): PortalLookup => {
-      portalUnreachableCache.set(token, {
-        until: now + PORTAL_UNREACHABLE_TTL_MS,
-        rejected,
-      });
+      // A credential has been PROVEN good since this lookup was sent, so this
+      // verdict is about a token the box has moved on from. The caller still
+      // gets it — its own request asked about that token — but nothing is
+      // remembered, so no other reader can be misled by it.
+      if (provenGeneration === startedAt) {
+        portalUnreachableCache.set(token, {
+          until: now + PORTAL_UNREACHABLE_TTL_MS,
+          rejected,
+        });
+      }
       return { source: "unreachable", rejected };
     };
     try {
@@ -271,6 +293,7 @@ export async function fetchPortalTier(token: string): Promise<PortalLookup> {
         // scans, so leaving it would keep the Providers strip in "Needs
         // sign-in" for the rest of that entry's window after a re-link.
         portalUnreachableCache.clear();
+        provenGeneration += 1;
         return { source: "portal", tier, planTier, allowedModels };
       }
       // 401/403 is ambiguous AS A TIER: it can mean genuinely Free OR token
@@ -388,6 +411,7 @@ async function portalRefusedTheToken(res: Response): Promise<boolean> {
  * a clean module-state. Not for production use.
  */
 export function _resetPortalTierCache() {
+  provenGeneration = 0;
   portalUnreachableCache.clear();
   portalTierCache.clear();
   inFlightPortalLookups.clear();

--- a/src/lib/clawbox-ai-portal-tier.ts
+++ b/src/lib/clawbox-ai-portal-tier.ts
@@ -82,7 +82,22 @@ export type PortalLookup =
       /** Entitled model ids, or null when the portal published none. */
       allowedModels: string[] | null;
     }
-  | { source: "unreachable" };
+  | {
+      source: "unreachable";
+      /**
+       * The portal ANSWERED and refused this credential (401/403), as opposed
+       * to not answering at all.
+       *
+       * The tier is preserved either way — see the non-200 branch below, and
+       * TASK-468: a revoked token on a still-paid account must not demote the
+       * badge. But "the portal said no" and "the portal said nothing" are not
+       * the same fact, and collapsing them is what let Settings paint
+       * "Connected · Pro" over a credential the box had just been told was
+       * dead (TASK-419). Callers that report health must read this; callers
+       * that report the TIER must keep ignoring it.
+       */
+      rejected: boolean;
+    };
 
 interface PortalCacheEntry {
   tier: ClawboxAiTier | null;
@@ -92,10 +107,11 @@ interface PortalCacheEntry {
 }
 
 const portalTierCache = new Map<string, PortalCacheEntry>();
-// token → epoch-ms timestamp when its unreachable verdict expires.
+// token → when its unreachable verdict expires, and whether that verdict was
+// the portal REFUSING the credential rather than failing to answer.
 // Separate from portalTierCache because the value is "we tried and
 // it failed, don't try again yet" rather than "the answer is null".
-const portalUnreachableCache = new Map<string, number>();
+const portalUnreachableCache = new Map<string, { until: number; rejected: boolean }>();
 const inFlightPortalLookups = new Map<string, Promise<PortalLookup>>();
 
 /**
@@ -197,11 +213,14 @@ export function mapPortalPlanTier(body: DeviceInfoResponse): ClawboxAiTier | nul
  *
  * 401/403 are deliberately treated the same as 5xx/network errors
  * (unreachable) rather than as a definitive "Free" verdict — see
- * the non-200 branch in the body for the rationale.
+ * the non-200 branch in the body for the rationale. They are still
+ * DISTINGUISHABLE: the unreachable verdict carries `rejected`, which says
+ * whether the portal refused the credential or simply never answered.
  *
  * @param token The bearer token to look up.
  * @returns Either a definitive `{ source: "portal", tier }` answer or
- *   `{ source: "unreachable" }` when the portal couldn't respond.
+ *   `{ source: "unreachable", rejected }` when it couldn't be trusted —
+ *   `rejected` true only when the portal itself refused the credential.
  */
 export async function fetchPortalTier(token: string): Promise<PortalLookup> {
   const now = Date.now();
@@ -215,18 +234,21 @@ export async function fetchPortalTier(token: string): Promise<PortalLookup> {
     };
   }
 
-  const unreachableUntil = portalUnreachableCache.get(token);
-  if (unreachableUntil !== undefined && unreachableUntil > now) {
-    return { source: "unreachable" };
+  const negative = portalUnreachableCache.get(token);
+  if (negative !== undefined && negative.until > now) {
+    return { source: "unreachable", rejected: negative.rejected };
   }
 
   const existing = inFlightPortalLookups.get(token);
   if (existing) return existing;
 
   const promise = (async (): Promise<PortalLookup> => {
-    const markUnreachable = (): PortalLookup => {
-      portalUnreachableCache.set(token, now + PORTAL_UNREACHABLE_TTL_MS);
-      return { source: "unreachable" };
+    const markUnreachable = (rejected: boolean): PortalLookup => {
+      portalUnreachableCache.set(token, {
+        until: now + PORTAL_UNREACHABLE_TTL_MS,
+        rejected,
+      });
+      return { source: "unreachable", rejected };
     };
     try {
       const res = await fetch(PORTAL_DEVICE_INFO_URL, {
@@ -242,15 +264,24 @@ export async function fetchPortalTier(token: string): Promise<PortalLookup> {
         portalUnreachableCache.delete(token);
         return { source: "portal", tier, planTier, allowedModels };
       }
-      // 401/403 is ambiguous: it can mean genuinely Free OR token
+      // 401/403 is ambiguous AS A TIER: it can mean genuinely Free OR token
       // revoked / migrated / corrupted on a still-paid account. We
       // can't tell from the response alone, and treating it as
       // "Free" silently downgrades paid users with broken auth (and
       // fires the downgrade-celebration popup). Mark unreachable
       // instead so callers preserve localTier.
-      return markUnreachable();
+      //
+      // It is NOT ambiguous as a CREDENTIAL: whatever the plan is, the portal
+      // has just refused this token, and a box that says nothing about that
+      // reports itself healthy while every turn 403s. So the verdict carries
+      // the distinction and each caller reads the half it is entitled to.
+      return markUnreachable(res.status === 401 || res.status === 403);
     } catch {
-      return markUnreachable();
+      // A timeout, a dead uplink, a DNS failure: the portal said nothing at
+      // all, so it said nothing about the credential either. Reporting this as
+      // a rejection would tell a customer on a train to re-link a device that
+      // is perfectly fine.
+      return markUnreachable(false);
     }
   })();
 

--- a/src/lib/clawbox-ai-portal-tier.ts
+++ b/src/lib/clawbox-ai-portal-tier.ts
@@ -51,6 +51,9 @@ const PORTAL_TIER_CACHE_MAX_ENTRIES = 64;
 // quickly enough that recovery (token re-pair, portal recovers)
 // shows up on the next poll, not minutes later.
 const PORTAL_UNREACHABLE_TTL_MS = 30_000;
+// Enough for the service's own error envelope and nothing like enough for an
+// interception page. Only ever parsed, never shown.
+const MAX_ERROR_BODY_CHARS = 4_096;
 
 export interface DeviceInfoResponse {
   tier?: string;
@@ -271,11 +274,15 @@ export async function fetchPortalTier(token: string): Promise<PortalLookup> {
       // fires the downgrade-celebration popup). Mark unreachable
       // instead so callers preserve localTier.
       //
-      // It is NOT ambiguous as a CREDENTIAL: whatever the plan is, the portal
-      // has just refused this token, and a box that says nothing about that
-      // reports itself healthy while every turn 403s. So the verdict carries
-      // the distinction and each caller reads the half it is entitled to.
-      return markUnreachable(res.status === 401 || res.status === 403);
+      // It is NOT ambiguous as a CREDENTIAL — but only when the PORTAL is the
+      // one refusing. A corporate proxy, a hotel captive portal, a CDN
+      // anti-bot page or an ISP interception can all answer 403 to this GET,
+      // and calling one of those a rejection would tell an owner with a
+      // perfectly valid token to re-link the device: the same false claim this
+      // change exists to end, pointing the other way. So the body has to look
+      // like the service's own auth error (`{error:{code:"invalid_token"|
+      // "missing_token"}}`, the shape it documents) before the verdict says so.
+      return markUnreachable(await portalRefusedTheToken(res));
     } catch {
       // A timeout, a dead uplink, a DNS failure: the portal said nothing at
       // all, so it said nothing about the credential either. Reporting this as
@@ -291,6 +298,61 @@ export async function fetchPortalTier(token: string): Promise<PortalLookup> {
   } finally {
     inFlightPortalLookups.delete(token);
   }
+}
+
+/**
+ * Has the portal refused this box's ClawBox AI token? Answered WITHOUT asking
+ * it, and without reading the credential.
+ *
+ * For the readers that must not add traffic: `provider-status.ts` is polled and
+ * states in as many words that it probes nothing. This answers only from the
+ * negative cache `fetchPortalTier` has already filled — so on a cold process it
+ * is `false`, meaning "nobody has asked", and the row stays exactly where beta
+ * left it. `/setup-api/ai-models/status` fills that cache every 30 s for as
+ * long as any client is open, which is whenever this strip is on screen.
+ *
+ * Scanned rather than keyed, so the caller needs no token: a device holds one
+ * ClawBox AI credential at a time, entries live 30 s, and a re-link mints a new
+ * key — so a live `rejected` entry is this box's, or is seconds from expiring.
+ */
+export function clawaiTokenRejectedByPortal(): boolean {
+  const now = Date.now();
+  for (const entry of portalUnreachableCache.values()) {
+    if (entry.rejected && entry.until > now) return true;
+  }
+  return false;
+}
+
+/**
+ * Did the PORTAL refuse this token, or did something on the way refuse the
+ * request?
+ *
+ * Only `{ error: { code: "invalid_token" | "missing_token" } }` — the shape the
+ * service documents (see `harness/clawai-images.ts`) — counts. Fails closed:
+ * an HTML interstitial, an empty body, a truncated read or an unrecognised code
+ * all answer false, which leaves the verdict at plain "unreachable" and the
+ * badge exactly where beta left it.
+ *
+ * Bounded, because an interception page can be arbitrarily large and this sits
+ * on the render path of the chat header.
+ */
+async function portalRefusedTheToken(res: Response): Promise<boolean> {
+  if (res.status !== 401 && res.status !== 403) return false;
+  let text: string;
+  try {
+    text = (await res.text()).slice(0, MAX_ERROR_BODY_CHARS);
+  } catch {
+    return false;
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    return false;
+  }
+  const error = (payload as { error?: unknown } | null)?.error;
+  const code = (error as { code?: unknown } | null)?.code;
+  return code === "invalid_token" || code === "missing_token";
 }
 
 /**

--- a/src/lib/provider-status.ts
+++ b/src/lib/provider-status.ts
@@ -17,6 +17,7 @@
 import { getActiveHarness, type Harness } from "@/lib/harness";
 import { isClawboxAiToken } from "@/lib/clawai-token";
 import { hasClawaiToken } from "@/lib/harness/credentials";
+import { clawaiTokenRejectedByPortal } from "@/lib/clawbox-ai-portal-tier";
 import { readConfig } from "@/lib/openclaw-config";
 import { get as getConfigValue } from "@/lib/config-store";
 import {
@@ -204,6 +205,25 @@ interface UnstampedSummary extends Omit<ProviderStatusSummary, "providers"> {
  * Painting "not connected" over a provider we simply failed to ask about is the
  * failure mode most likely to send someone to re-enter a key that was fine.
  */
+/**
+ * Has the portal already refused THIS box's ClawBox AI token?
+ *
+ * CACHE-ONLY, which is the whole point: this reader probes nothing and is
+ * polled, so it answers from what `/setup-api/ai-models/status` has already
+ * asked (every 30 s, while any client is open) and says "nobody has asked" on a
+ * cold process — no request, and not even a credential read. A cold answer
+ * keeps beta's row exactly as it was.
+ *
+ * Why it belongs here at all: `credentialed` is credential PRESENCE, so a
+ * revoked token painted the cyan dot and the word "Connected" on the one screen
+ * the chat's own "reconnect it in Settings" sends the customer to (TASK-419).
+ * `needs-reauth` is the state that was written for exactly this — "the box is
+ * pointed at this provider and cannot authenticate to it".
+ */
+function clawaiTokenRefused(): boolean {
+  return clawaiTokenRejectedByPortal();
+}
+
 function stateFor(
   credentialed: boolean | null,
   isDefault: boolean,
@@ -236,6 +256,7 @@ async function readHermesStatus(): Promise<UnstampedSummary> {
   // Asked once, outside the loop: it reads config and the config store, and the
   // answer is the same for every row that consults it.
   const clawaiLinked = await hasClawaiToken();
+  const clawaiRefused = clawaiTokenRefused();
 
   // Did the live dashboard actually answer? `stale` is set on every fallback
   // path (dashboard down, disk-catalog cold start). It draws the line between
@@ -286,7 +307,9 @@ async function readHermesStatus(): Promise<UnstampedSummary> {
     return {
       id,
       label: hermesProviderLabel(id, byId.get(id)?.name),
-      state: stateFor(credentialed, isDefault, awaitingProbe),
+      state: id === CLAWAI_PROVIDER && clawaiRefused && credentialed === true
+        ? "needs-reauth"
+        : stateFor(credentialed, isDefault, awaitingProbe),
       isDefault,
       section: sectionFor(id),
     };
@@ -331,7 +354,8 @@ async function readOpenclawStatus(): Promise<UnstampedSummary> {
   // The ClawBox AI credential can live in the config store instead of the
   // config file (a box migrated from a Hermes install), and `hasClawaiToken`
   // is the helper that knows both homes.
-  if (await hasClawaiToken()) credentialed.add("clawai");
+  const clawaiRefused = clawaiTokenRefused();
+  if (await hasClawaiToken()) credentialed.add(CLAWAI_PROVIDER);
 
   const primary = config.agents?.defaults?.model?.primary ?? null;
   const defaultProvider = normalizeProviderId(primary ? primary.split("/")[0] : null);
@@ -376,7 +400,9 @@ async function readOpenclawStatus(): Promise<UnstampedSummary> {
       // summary's own doc promises. Same shape of false failure as the one
       // this fix addresses, different reader, and it needs `readConfigStrict`
       // rather than a probe state.
-      state: stateFor(credentialed.has(id), isDefault),
+      state: id === CLAWAI_PROVIDER && clawaiRefused && credentialed.has(id)
+        ? "needs-reauth"
+        : stateFor(credentialed.has(id), isDefault),
       isDefault,
       section: sectionFor(id),
     };

--- a/src/tests/routes/ai-models/status.test.ts
+++ b/src/tests/routes/ai-models/status.test.ts
@@ -311,7 +311,10 @@ describe("/setup-api/ai-models/status", () => {
       // over a credential the box had just been told was dead.
       mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
       mockGetConfigValue.mockResolvedValue("pro");
-      fetchSpy.mockResolvedValue(new Response("invalid_token", { status: 403 }));
+      fetchSpy.mockResolvedValue(new Response(
+        JSON.stringify({ error: { code: "invalid_token", type: "auth_error" } }),
+        { status: 403, headers: { "content-type": "application/json" } },
+      ));
 
       const res = await GET();
       const body = await res.json();
@@ -336,6 +339,39 @@ describe("/setup-api/ai-models/status", () => {
       expect(body.clawaiTokenRejected).toBe(false);
       expect(body.clawaiTier).toBe("pro");
       expect(body.tierSource).toBe("picker");
+    });
+
+    it("does not accuse a credential the portal never refused", async () => {
+      // The healthy direction, and the one that would make this field a
+      // liability if it were wrong: a 200 says the token works, and nothing
+      // downstream may be told otherwise.
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue("flash");
+      fetchSpy.mockResolvedValue(new Response(
+        JSON.stringify({ tier: "max", deviceTier: "pro" }),
+        { status: 200 },
+      ));
+
+      const body = await (await GET()).json();
+      expect(body.clawaiTokenRejected).toBe(false);
+      expect(body.tierSource).toBe("portal");
+    });
+
+    it("does not call an interception page a rejection", async () => {
+      // A corporate proxy, a hotel captive portal or a CDN anti-bot page can
+      // answer 403 to this GET. Only the portal's OWN auth error counts —
+      // otherwise the box tells an owner with a perfectly valid token to
+      // re-link the device, which is this bug pointing the other way.
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue("pro");
+      fetchSpy.mockResolvedValue(new Response(
+        "<html><body>Attention Required! | Cloudflare</body></html>",
+        { status: 403, headers: { "content-type": "text/html" } },
+      ));
+
+      const body = await (await GET()).json();
+      expect(body.clawaiTokenRejected).toBe(false);
+      expect(body.clawaiTier).toBe("pro");
     });
 
     it("surfaces the portal's entitlement list beside the badge", async () => {

--- a/src/tests/routes/ai-models/status.test.ts
+++ b/src/tests/routes/ai-models/status.test.ts
@@ -402,6 +402,39 @@ describe("/setup-api/ai-models/status", () => {
       expect(clawaiTokenRejectedByPortal()).toBe(false);
     });
 
+    it("ignores a rejection that lands after another token was proven good", async () => {
+      // Completion order is not arrival order. A re-link starts a lookup for
+      // the new token while the old one's is still in flight; if the old one
+      // comes back 403 afterwards, remembering it would make the Providers
+      // strip say "Needs sign-in" about a device that was just successfully
+      // re-linked.
+      const portal = await import("@/lib/clawbox-ai-portal-tier");
+      let releaseOld: () => void = () => {};
+      const oldPending = new Promise<void>((resolve) => { releaseOld = resolve; });
+
+      fetchSpy.mockImplementation(async (url: unknown, init?: unknown) => {
+        const auth = (init as { headers?: Record<string, string> } | undefined)?.headers?.Authorization;
+        if (auth?.endsWith("claw_old111")) {
+          await oldPending;
+          return new Response(
+            JSON.stringify({ error: { code: "invalid_token" } }),
+            { status: 403, headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response(JSON.stringify({ tier: "max", deviceTier: "pro" }), { status: 200 });
+      });
+
+      const stale = portal.fetchPortalTier("claw_old111");
+      await portal.fetchPortalTier("claw_new222");
+      expect(portal.clawaiTokenRejectedByPortal()).toBe(false);
+
+      releaseOld();
+      await expect(stale).resolves.toMatchObject({ source: "unreachable", rejected: true });
+      // The caller that asked about the old token is told the truth; nothing
+      // else is.
+      expect(portal.clawaiTokenRejectedByPortal()).toBe(false);
+    });
+
     it("does not buffer an oversized refusal body looking for a code", async () => {
       // An interception appliance can answer 401/403 with a full HTML page, and
       // the 4 s fetch timeout bounds duration, not bytes.

--- a/src/tests/routes/ai-models/status.test.ts
+++ b/src/tests/routes/ai-models/status.test.ts
@@ -374,6 +374,51 @@ describe("/setup-api/ai-models/status", () => {
       expect(body.clawaiTier).toBe("pro");
     });
 
+    it("stops accusing the OLD token once a new one works", async () => {
+      // A device holds one ClawBox AI credential. Re-linking mints a new one,
+      // and the rejection recorded against the retired one must not keep the
+      // Providers strip in "Needs sign-in" for the rest of its cache window —
+      // re-linking is the remedy the failure text prints.
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue("pro");
+      fetchSpy.mockResolvedValue(new Response(
+        JSON.stringify({ error: { code: "invalid_token" } }),
+        { status: 403, headers: { "content-type": "application/json" } },
+      ));
+      expect((await (await GET()).json()).clawaiTokenRejected).toBe(true);
+
+      mockReadConfig.mockResolvedValue({
+        ...clawaiConfigBase,
+        models: { providers: { deepseek: { apiKey: "claw_relinked456" } } },
+      } as never);
+      fetchSpy.mockResolvedValue(new Response(
+        JSON.stringify({ tier: "max", deviceTier: "pro" }),
+        { status: 200 },
+      ));
+
+      const body = await (await GET()).json();
+      expect(body.clawaiTokenRejected).toBe(false);
+      const { clawaiTokenRejectedByPortal } = await import("@/lib/clawbox-ai-portal-tier");
+      expect(clawaiTokenRejectedByPortal()).toBe(false);
+    });
+
+    it("does not buffer an oversized refusal body looking for a code", async () => {
+      // An interception appliance can answer 401/403 with a full HTML page, and
+      // the 4 s fetch timeout bounds duration, not bytes.
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue("pro");
+      fetchSpy.mockResolvedValue(new Response(
+        JSON.stringify({ error: { code: "invalid_token" }, pad: "x".repeat(8192) }),
+        { status: 403, headers: { "content-type": "application/json" } },
+      ));
+
+      const body = await (await GET()).json();
+      // Past the cap it is not the envelope we are looking for: unreachable,
+      // not rejected — the safe direction.
+      expect(body.clawaiTokenRejected).toBe(false);
+      expect(body.clawaiTier).toBe("pro");
+    });
+
     it("surfaces the portal's entitlement list beside the badge", async () => {
       // The badge is the device-pair stamp; the list is what the account may
       // actually run. A Max account paired while it was on the Pro plan reads

--- a/src/tests/routes/ai-models/status.test.ts
+++ b/src/tests/routes/ai-models/status.test.ts
@@ -301,6 +301,43 @@ describe("/setup-api/ai-models/status", () => {
       expect(body.tierSource).toBe("picker");
     });
 
+    it("says the credential was REJECTED, not merely that the portal was quiet", async () => {
+      // TASK-419. The tier must not move — a Max owner whose token was
+      // revoked still pays for Max, and demoting him here is the bug that
+      // reasoning was written to prevent. What the response owes the customer
+      // is the OTHER half: the portal ANSWERED, and what it said was no.
+      // Beta reported exactly the same payload for "portal said no" and
+      // "portal never answered", so Settings painted a healthy paid badge
+      // over a credential the box had just been told was dead.
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue("pro");
+      fetchSpy.mockResolvedValue(new Response("invalid_token", { status: 403 }));
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.clawaiTokenRejected).toBe(true);
+      // Unchanged, on purpose.
+      expect(body.clawaiTier).toBe("pro");
+      expect(body.tierSource).toBe("picker");
+    });
+
+    it("does not call an unreachable portal a rejection", async () => {
+      // The false-failure half. A 500, a timeout or a dead uplink says nothing
+      // about the credential, and telling a customer on a train to re-link a
+      // perfectly good device is the same lie in the other direction.
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue("pro");
+      fetchSpy.mockResolvedValue(new Response("upstream is down", { status: 503 }));
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.clawaiTokenRejected).toBe(false);
+      expect(body.clawaiTier).toBe("pro");
+      expect(body.tierSource).toBe("picker");
+    });
+
     it("surfaces the portal's entitlement list beside the badge", async () => {
       // The badge is the device-pair stamp; the list is what the account may
       // actually run. A Max account paired while it was on the Pro plan reads

--- a/src/tests/routes/providers/status.test.ts
+++ b/src/tests/routes/providers/status.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/lib/hermes-model-options", () => ({
   getModelOptions: vi.fn(),
   probeStillOwed: vi.fn(),
 }));
+vi.mock("@/lib/clawbox-ai-portal-tier", () => ({ clawaiTokenRejectedByPortal: vi.fn() }));
 
 let GET: () => Promise<Response>;
 let getActiveHarness: Mock;
@@ -18,6 +19,7 @@ let readConfig: Mock;
 let getConfigValue: Mock;
 let getModelOptions: Mock;
 let probeStillOwed: Mock;
+let clawaiTokenRejectedByPortal: Mock;
 
 beforeEach(async () => {
   vi.resetModules();
@@ -30,8 +32,13 @@ beforeEach(async () => {
     getModelOptions: Mock;
     probeStillOwed: Mock;
   });
+  ({ clawaiTokenRejectedByPortal } = (await import("@/lib/clawbox-ai-portal-tier")) as unknown as {
+    clawaiTokenRejectedByPortal: Mock;
+  });
   getConfigValue.mockResolvedValue(null);
   hasClawaiToken.mockResolvedValue(false);
+  // Nobody has asked the portal yet: the cold answer, and beta's behaviour.
+  clawaiTokenRejectedByPortal.mockReturnValue(false);
   // The settled box: the dashboard has answered, so nothing is outstanding.
   probeStillOwed.mockResolvedValue(false);
   ({ GET } = await import("@/app/setup-api/providers/status/route"));
@@ -526,5 +533,44 @@ describe("providers/status — needs repair", () => {
     getModelOptions.mockResolvedValue(hermesPayload());
     const body = await (await GET()).json() as { providers: Row[] };
     for (const row of body.providers) expect(row).not.toHaveProperty("needsRepair");
+  });
+});
+
+describe("providers/status — a ClawBox AI token the portal refused", () => {
+  // TASK-419. The strip derives "Connected" from the credential being PRESENT,
+  // so a revoked token painted the cyan dot and the word Connected on the very
+  // screen the chat's own failure text sends the customer to. `needs-reauth`
+  // already exists for this and is already worded in all ten locales.
+  it("shows the ClawBox AI row as needing sign-in on OpenClaw", async () => {
+    getActiveHarness.mockResolvedValue("openclaw");
+    readConfig.mockResolvedValue({
+      agents: { defaults: { model: { primary: "deepseek/deepseek-v4-flash" } } },
+      models: { providers: { deepseek: { apiKey: "claw_x" } } },
+    });
+    hasClawaiToken.mockResolvedValue(true);
+
+    clawaiTokenRejectedByPortal.mockReturnValue(false);
+    const healthy = await (await GET()).json() as { providers: { id: string; state: string }[] };
+    expect(healthy.providers.find((r) => r.id === "clawai")?.state).toBe("connected");
+
+    clawaiTokenRejectedByPortal.mockReturnValue(true);
+    const refused = await (await GET()).json() as { providers: { id: string; state: string }[] };
+    expect(refused.providers.find((r) => r.id === "clawai")?.state).toBe("needs-reauth");
+  });
+
+  it("shows it the same way on Hermes", async () => {
+    // The shared-surface rule: the same fact, the same row, the same word on
+    // the edition whose panel is built from a different reader entirely.
+    getActiveHarness.mockResolvedValue("hermes");
+    getModelOptions.mockResolvedValue(hermesPayload());
+    hasClawaiToken.mockResolvedValue(true);
+
+    clawaiTokenRejectedByPortal.mockReturnValue(false);
+    const healthy = await (await GET()).json() as { providers: { id: string; state: string }[] };
+    expect(healthy.providers.find((r) => r.id === "clawai")?.state).toBe("connected");
+
+    clawaiTokenRejectedByPortal.mockReturnValue(true);
+    const refused = await (await GET()).json() as { providers: { id: string; state: string }[] };
+    expect(refused.providers.find((r) => r.id === "clawai")?.state).toBe("needs-reauth");
   });
 });

--- a/src/tests/unit/chat-error-text.test.ts
+++ b/src/tests/unit/chat-error-text.test.ts
@@ -151,3 +151,36 @@ describe("sanitizeErrorMessage — handles added for TASK-440", () => {
     expect(sanitizeErrorMessage("The model is busy, try again")).toBe("The model is busy, try again");
   });
 });
+
+describe("describeChatFailure — a refused ClawBox AI credential", () => {
+  // TASK-419. The whole customer-visible failure in one line: the box showed a
+  // healthy paid badge and then answered a message with
+  //   "Error: HTTP 403: Invalid token"
+  //   "Error: Agent failed before reply: HTTP 403: Invalid token. Logs: openclaw logs --follow"
+  // Nothing there is wrong, and nothing there is usable. The remedy is a
+  // screen this customer already has open.
+  it("names the reconnect screen instead of relaying the status line", () => {
+    for (const raw of [
+      "HTTP 403: Invalid token",
+      "Agent failed before reply: HTTP 403: Invalid token",
+      "HTTP 401: missing_token",
+      "401 Unauthorized",
+    ]) {
+      const text = describeChatFailure(raw);
+      expect(text).toMatch(/Settings/);
+      expect(text).not.toContain("403");
+      expect(text).not.toContain("401");
+      expect(text).not.toMatch(/openclaw/i);
+    }
+  });
+
+  it("leaves an unrelated failure alone", () => {
+    // Narrow on purpose: "limit" and "token" are ordinary words in this
+    // codebase's error strings, and a greedy match would swallow a message
+    // whose remedy is different.
+    expect(describeChatFailure("Request exceeds the size limit")).toBe(
+      "Error: Request exceeds the size limit",
+    );
+    expect(describeChatFailure("context window exceeded: 403000 tokens")).not.toMatch(/Settings/);
+  });
+});

--- a/src/tests/unit/chat-error-text.test.ts
+++ b/src/tests/unit/chat-error-text.test.ts
@@ -168,9 +168,23 @@ describe("describeChatFailure — a refused ClawBox AI credential", () => {
     ]) {
       const text = describeChatFailure(raw);
       expect(text).toMatch(/Settings/);
+      expect(text).toMatch(/Providers/);
       expect(text).not.toContain("403");
       expect(text).not.toContain("401");
       expect(text).not.toMatch(/openclaw/i);
+    }
+  });
+
+  it("leaves a 403 that is not about the credential alone", () => {
+    // Both reach this function through the Hermes adapter, and both used to
+    // fall to the calm generic line. Turning them into "your sign-in is dead"
+    // would send a customer to re-link a paid account over a web page.
+    for (const raw of [
+      "tool browser_open failed: 403 Forbidden (https://news.example.com)",
+      "web_fetch: the site returned 403 Forbidden",
+      "HTTP 403 — Just a moment…",
+    ]) {
+      expect(describeChatFailure(raw)).not.toMatch(/Settings/);
     }
   });
 


### PR DESCRIPTION
**TASK-419** — Settings reports ClawBox AI as Connected on the Pro tier while the stored token is invalid.

## Customer-visible symptom

Leave a revoked, expired or rotated ClawBox AI token on a box and it tells the customer everything is fine:

```
GET /setup-api/ai-models/status
  -> {"connected":true,"clawaiConfigured":true,"clawaiTier":"pro","providerLabel":"ClawBox AI",...}
```

Settings paints the cyan dot and the word **Connected** next to the paid plan card, and then the first chat message answers:

```
Error: HTTP 403: Invalid token
Error: Agent failed before reply: HTTP 403: Invalid token. Logs: openclaw logs --follow
```

Both lines are true and neither is usable. This is the shape of every "my ClawBox stopped working" ticket after a token is revoked.

## Cause

The box **already asks** the right question and then throws the answer away.

`fetchPortalTier` (`src/lib/clawbox-ai-portal-tier.ts`) calls the portal's own `GET /api/clawbox-ai/device-info` with the device bearer — the native mechanism, already wired, already cached. On a non-200 it returned `{ source: "unreachable" }`, with a comment explaining, correctly, that 401/403 is ambiguous **as a tier**: it can mean genuinely Free or a revoked token on a still-paid account, and treating it as Free silently demotes a Max owner and fires the downgrade celebration (TASK-468 / TASK-691).

That reasoning is right, and it was applied one field too wide. 401/403 is not ambiguous as a **credential**: whatever the plan is, the service has just refused this token. Collapsing "the portal said no" into "the portal said nothing" is what let three surfaces keep claiming health:

- `/setup-api/ai-models/status` — `connected` is `!!normalizedProvider` and `clawaiConfigured` is "an auth profile exists": presence, both of them.
- `src/lib/provider-status.ts` — the Settings → Providers strip, whose `credentialed` set is built from config file reads and `hasClawaiToken()`, so a refused token still renders `state: "connected"`.
- `describeChatFailure` — no auth branch, so `"HTTP 403: Invalid token"` passed the leak rules and was relayed verbatim.

## The fix

Stop discarding the distinction; change nothing about the tier.

1. **`clawbox-ai-portal-tier.ts`** — the unreachable verdict carries `rejected`, and the negative cache remembers it. `rejected` is set **only when the body is the service's own auth envelope** (`{error:{code:"invalid_token"|"missing_token"}}`, the shape documented in `harness/clawai-images.ts`), bounded at 4 KB and never shown. A corporate proxy, a hotel captive portal, a CDN anti-bot page or an ISP interception can all answer 403 to that GET, and calling one of those a rejection would tell an owner with a valid token to re-link the device — this bug pointing the other way. Anything unparseable stays plain `unreachable`, which is beta's behaviour.
2. **`/setup-api/ai-models/status`** — emits `clawaiTokenRejected`. `connected`, `clawaiConfigured`, `clawaiTier`, `clawaiAccountTier` and `tierSource` are untouched.
3. **`src/lib/provider-status.ts`** — a ClawBox AI row whose token the portal refused reports the strip's existing `needs-reauth` state instead of `connected`. Both legs, OpenClaw and Hermes.
4. **`SettingsApp`** — the AI section subtitle says "Needs sign-in" instead of the provider name, **only when ClawBox AI is the active provider**.
5. **`chat-error-text.ts`** — a narrow auth branch answers "the AI provider is not accepting this box's sign-in any more. Reconnect it in Settings, under Providers, and send it again." instead of relaying a status line and a CLI hint.

### Why `connected` and `clawaiConfigured` did not change

`src/lib/use-clawbox-login.ts` derives `loggedIn` from `clawaiConfigured`, and that gates ClawKeep and Remote Desktop. A refused credential is still a configured one; flipping those would un-link the box, which is a bigger lie than the one being fixed. `clawaiTokenRejected` is the one field that means "the credential does not work", and the surfaces that claim health read it.

### Why the Providers strip did not get a probe

`provider-status.ts` states in as many words that it probes nothing, and it is polled. `clawaiTokenRejectedByPortal()` is **cache-only**: it reads the negative cache `fetchPortalTier` has already filled and makes no request — not even a credential read. On a cold process it answers `false` ("nobody has asked") and the row is exactly beta's. `/setup-api/ai-models/status` fills that cache every 30 s for as long as any client is open, which is whenever this strip is on screen.

## Harness-first

The native mechanism is the portal's own `device-info` endpoint, and it was **already being called on every status poll** — nothing new is built here, an answer the box already receives simply stops being discarded. On the display side the fix reuses the vocabulary that exists rather than inventing a flag: `needs-reauth` is a `ProviderConnectionState` whose own doc describes this exact case ("the box is pointed at this provider as its default and cannot authenticate to it"), and `settings.providers.needsReauth` — "Needs sign-in" — is already translated in all ten locales, so no new string ships. Hermes carries an adjacent native notion (`HermesProviderRow.verified`, "whether a credential was actually exercised"); it is fed by Hermes' dashboard rather than by the portal, so it is named here as the right long-term home for this on that edition rather than duplicated.

## Sibling call sites — swept

- `fetchPortalTier` has exactly two consumers. `ai-models/configure/route.ts:2031` reads only `lookup.source === "portal" && lookup.tier`, so adding a field to the other union member changes nothing there; nothing else anywhere constructs a `PortalLookup`.
- Every surface that claims ClawBox AI health from presence: `/setup-api/ai-models/status` (fixed), `provider-status.ts` both legs → `AiProviderList` / `AIModelsStep` / `HermesProviderConfig`, which all render from `useProviderStatus` (fixed at the source), `SettingsApp`'s subtitle (fixed, provider-scoped), `describeChatFailure` (fixed).
- The `GET` catch-path fallback now carries `clawaiTokenRejected: false`, so the endpoint that owns the field cannot answer without it.
- **Explicitly cleared:** `src/app/setup-api/hermes/clawai/route.ts` `hasToken` stays presence — it answers "is a token stored", which is what its caller asks, and the health claim it feeds is the strip, already fixed above.
- **Known boundary, pre-existing:** the portal lookup only runs for a token starting with `claw_`, while the Hermes paste path deliberately accepts any well-formed token. A box paired with a differently-shaped token gets no lookup and so can never be reported rejected. The tier badge has had the identical gap since it shipped; not widened, not closed here.
- **Stated windows:** a token revoked one second after a successful lookup reads healthy for up to the 120 s positive TTL (the chat branch covers that window); recovery lags by at most the 30 s negative TTL; a re-link is immediate because it produces a new cache key.

## RED → GREEN

RED, on unmodified `origin/beta` (`8653b118`):

```
 FAIL  … status.test.ts > clawai tier resolution from portal
       > says the credential was REJECTED, not merely that the portal was quiet
AssertionError: expected undefined to be true // Object.is equality
 ❯ src/tests/routes/ai-models/status.test.ts:319:40

 FAIL  … status.test.ts > clawai tier resolution from portal
       > does not call an unreachable portal a rejection
AssertionError: expected undefined to be false // Object.is equality

 FAIL  … chat-error-text.test.ts > describeChatFailure — a refused ClawBox AI credential
       > names the reconnect screen instead of relaying the status line
AssertionError: expected 'Error: HTTP 403: Invalid token' to match /Settings/

 Test Files  2 failed (2)
      Tests  3 failed | 45 passed (48)
```

GREEN, on this branch: `Test Files 859 passed (859)`, `Tests 12920 passed | 1 skipped (12921)` — the whole suite, unit and components. `tsc --noEmit` clean. (A later full run showed the known dev-PC load flakes — `routes/telegram/status*`, `chat-email-route-endings`, `chat-spoken-reply` — all four pass in isolation: `Test Files 4 passed (4)`, `Tests 46 passed (46)`.)

New cases pin both directions, not just the failing one: a 200 must answer `rejected:false`, an HTML interception page answering 403 must answer `rejected:false` with the tier intact, a web tool's "403 Forbidden" must not become "your sign-in is dead", and the Providers strip must read `connected` before and `needs-reauth` after — on **both** editions.

## Both editions

`/setup-api/ai-models/status` funnels both legs through one `buildStatusResponse`, so the flag is reachable on Hermes as well as OpenClaw, and the Providers strip is fixed in both of its readers with a test for each. No device mutation and no hardware behaviour is touched, so there is no device leg for this change; CI exercises it fully.

## The gate, measured against production

`rejected` is set only when the portal names the credential. Verified from the office against the live endpoint with a deliberately invalid token:

```
$ curl https://clawbox.com/api/clawbox-ai/device-info -H "Authorization: Bearer claw_0000…"
HTTP 403  {"error":{"message":"Token not found","type":"auth_error","code":"invalid_token"}}

$ curl https://clawbox.com/api/clawbox-ai/device-info                  # no bearer
HTTP 401  {"error":{"message":"Missing X-ClawBox-Token header or Authorization: Bearer token",
                    "type":"auth_error","code":"missing_token"}}
```

So the portal answers the same envelope the AI proxy does, `portalRefusedTheToken` accepts exactly those two codes, and both bodies are ~80-130 bytes — well under the 4 KB bounded read. A verdict is only ever "rejected" when the service itself said so; an interception page, a 5xx or a timeout all stay "unreachable", which is beta's behaviour and the safe direction.
