### PR TITLE
fix: ClawKeep auto-backup that arms nothing while the panel says it is on

### DIFF
--- a/src/app/setup-api/clawkeep/schedule/route.ts
+++ b/src/app/setup-api/clawkeep/schedule/route.ts
@@ -31,7 +31,11 @@ export async function PUT(request: NextRequest) {
   const body = await request.json().catch(() => ({}));
   try {
     const { schedule, armedAtMs } = await writeSchedule(body);
-    await refreshScheduler();
+    // The schedule the write returned, not a re-read of the file it just
+    // renamed: a transient read failure on this path would leave the OLD
+    // cadence armed under a 200, so a box would go on backing up after the
+    // owner switched auto-backup off.
+    await refreshScheduler(schedule);
     // Hand back the arm stamp the write itself produced: the card folds both
     // into its local status, so arming auto-backup cannot lapse the shield on
     // the same click for a run that has not come round yet — and a save that

--- a/src/lib/clawkeep-scheduler.ts
+++ b/src/lib/clawkeep-scheduler.ts
@@ -71,8 +71,16 @@ function fireBackup(): void {
   // "next run" — reports it. Same reason `clawkeep-memory-scheduler.ts`
   // clears at the top of its own `fire()`.
   clear();
-  // Best-effort: if a manual backup is already running the daemon will
-  // serialise via its own heartbeat lock, so we don't gate here.
+  // NOT gated on a run already being in flight, and the reason given here
+  // used to be false: "the daemon will serialise via its own heartbeat lock".
+  // There is no such lock — no pidfile, no flock, nothing in `daemon.py`,
+  // `runner.py` or `state.py` — so two `clawkeepd` processes will happily
+  // stage two multi-GB archives and upload both. It has been survivable
+  // because the window is small; raising the run cap to four hours for
+  // TASK-675's 12 GB archives widens it, since a manual backup started late
+  // in the evening can still be running when the nightly slot fires. Closing
+  // it properly is the daemon's own single-instance guard rather than a
+  // check here, which could only ever narrow the race.
   //
   // A scheduled run must create + upload a REAL backup — `idle: true` only
   // sends a heartbeat ping (and short-circuits within the heartbeat interval),

--- a/src/lib/clawkeep-scheduler.ts
+++ b/src/lib/clawkeep-scheduler.ts
@@ -24,6 +24,30 @@ import {
 
 let armed: NodeJS.Timeout | null = null;
 let armedFor: number = 0;
+/** Re-read timer for an unreadable `schedule.json`. Never a backup slot. */
+let retry: NodeJS.Timeout | null = null;
+/** Serialises overlapping rearms so the older read cannot arm last. */
+let rearmGeneration = 0;
+/**
+ * The last schedule this process could actually READ.
+ *
+ * An unreadable file is evidence of nothing, so the honest thing to keep
+ * running on is the last thing that was evidence of something. Without it the
+ * post-fire rearm — the one that has no live timer to preserve — had nothing
+ * to fall back to and simply stopped.
+ */
+let lastGood: ClawKeepSchedule | null = null;
+
+/**
+ * How long to wait before looking at an unreadable `schedule.json` again.
+ *
+ * "Can I read the schedule?" answered once and believed for the life of the
+ * process is the probe-once class, and on this file it is total: a box that
+ * boots on a root-owned or half-written file would never back up again, on one
+ * log line. Long enough that a genuinely broken file is not a log flood,
+ * short enough that a transient EIO/EMFILE self-heals within the hour.
+ */
+const UNREADABLE_RETRY_MS = 15 * 60 * 1000;
 
 function clear() {
   if (armed) {
@@ -33,7 +57,20 @@ function clear() {
   }
 }
 
+function clearRetry() {
+  if (retry) {
+    clearTimeout(retry);
+    retry = null;
+  }
+}
+
 function fireBackup(): void {
+  // The slot is being consumed now, so stop claiming it is still ahead:
+  // `armed` would otherwise hold an expired handle and `armedFor` a time in
+  // the past, both truthy and neither live — which is what `rearm()` below
+  // and `nextRunAtMs()` are asked about. Same reason
+  // `clawkeep-memory-scheduler.ts` clears at the top of its own `fire()`.
+  clear();
   // Best-effort: if a manual backup is already running the daemon will
   // serialise via its own heartbeat lock, so we don't gate here.
   //
@@ -74,28 +111,61 @@ function fireBackup(): void {
 }
 
 /**
- * Re-read the schedule and re-arm — unless the file could not be read.
+ * Re-read the schedule and re-arm, without letting an unreadable file be read
+ * as the owner switching auto-backup off.
  *
  * An unreadable `schedule.json` sanitises to `DEFAULT_SCHEDULE`, whose
  * `enabled` is false, so this used to tear the nightly timer down and go
- * quiet: a box that had been backing up every night simply stopped, the panel
- * read "auto-backup is off", and the shield sat green on the 7-day
- * no-schedule window (TASK-433). The read already separates "no file" — a box
+ * quiet: a box that had been backing up every night simply stopped, on nothing
+ * but a transient EACCES/EIO/EMFILE or a JSON truncated by a power cut
+ * (TASK-433). `readScheduleSnapshot()` already separates "no file" — a box
  * that has never had a schedule — from "there is a file and it says nothing we
- * can read", which is evidence of nothing and certainly not of the owner
- * switching auto-backup off. Keep what is armed and say so.
+ * can read", which is evidence of nothing.
+ *
+ * What this does NOT do is fix the same symptom on the OWNER's side: `GET
+ * /setup-api/clawkeep/schedule` and `getStatus()` both still flatten
+ * `unreadable` to `DEFAULT_SCHEDULE`, so while the engine keeps backing the
+ * box up the card still reads "auto-backup is off" and `deriveProtection`
+ * still judges it on the 7-day unscheduled window. Carrying `unreadable`
+ * through to a card state is a change with its own copy in ten locales; this
+ * one keeps the backups running.
  */
 async function rearm(): Promise<void> {
+  const generation = ++rearmGeneration;
   const snapshot = await readScheduleSnapshot();
+  // A concurrent rearm — a save landing during boot, or two saves in quick
+  // succession — read after this one did, so its answer is the newer.
+  if (generation !== rearmGeneration) return;
   if (snapshot.unreadable) {
-    console.warn(
-      "[clawkeep-scheduler] schedule.json could not be read — leaving auto-backup as it is"
-        + (armedFor > 0 ? ` (next run still ${new Date(armedFor).toISOString()})` : " (nothing armed)"),
-    );
+    onUnreadableSchedule();
     return;
   }
+  clearRetry();
+  lastGood = snapshot.schedule;
+  applySchedule(snapshot.schedule);
+}
+
+function onUnreadableSchedule(): void {
+  // Keep backing the box up on the last schedule that WAS readable. At boot
+  // there is none, and then there is nothing to arm — but the retry below is
+  // what stops that being permanent.
+  if (lastGood) applySchedule(lastGood);
+  console.warn(
+    "[clawkeep-scheduler] schedule.json could not be read — "
+      + (armedFor > 0
+        ? `keeping the last schedule that was (next run ${new Date(armedFor).toISOString()})`
+        : "nothing is armed")
+      + `; trying again in ${Math.round(UNREADABLE_RETRY_MS / 60_000)} min`,
+  );
+  clearRetry();
+  retry = setTimeout(() => { void rearm(); }, UNREADABLE_RETRY_MS);
+  // A re-read must not be a reason for the process to stay alive.
+  retry.unref?.();
+}
+
+function applySchedule(schedule: ClawKeepSchedule): void {
   clear();
-  arm(snapshot.schedule);
+  arm(schedule);
 }
 
 function arm(schedule: ClawKeepSchedule): void {
@@ -121,10 +191,25 @@ export async function start(): Promise<void> {
   await rearm();
 }
 
-/** Re-read the persisted schedule and rearm. Call after the user saves new
- * schedule settings via /setup-api/clawkeep/schedule. */
-export async function refresh(): Promise<void> {
-  await rearm();
+/**
+ * Re-arm after the owner saves. Call from /setup-api/clawkeep/schedule.
+ *
+ * The route hands over the schedule `writeSchedule()` just returned, because
+ * it is authoritative and re-reading the file it has only now renamed can
+ * fail: a transient error on the save path would otherwise leave the OLD
+ * cadence armed while the PUT answered 200, so a box would keep backing up
+ * after the owner switched auto-backup off. Falls back to a read when no
+ * schedule is supplied.
+ */
+export async function refresh(schedule?: ClawKeepSchedule): Promise<void> {
+  if (!schedule) {
+    await rearm();
+    return;
+  }
+  ++rearmGeneration;
+  clearRetry();
+  lastGood = schedule;
+  applySchedule(schedule);
 }
 
 /** When the next scheduled fire is, in unix ms. 0 means disarmed. Useful

--- a/src/lib/clawkeep-scheduler.ts
+++ b/src/lib/clawkeep-scheduler.ts
@@ -179,6 +179,20 @@ function onUnreadableSchedule(): void {
 function applySchedule(schedule: ClawKeepSchedule): void {
   clear();
   arm(schedule);
+  // The one choke point every arm path goes through, and the last place this
+  // card's own symptom can still hide: `arm()` returns silently when the
+  // schedule is enabled and `computeNextRunMs()` answers 0. The range check on
+  // `timeOfDay` closes the way that used to happen, but two inputs still
+  // reach it — the weekly loop's 9-hop clock/DST guard, and any schedule
+  // handed to `refresh()` that did not come through `sanitiseSchedule()`.
+  // Auto-backup reading as on with no timer armed must never be silent again.
+  if (schedule.enabled && armedFor === 0) {
+    console.warn(
+      "[clawkeep-scheduler] auto-backup is on but the schedule computes no next run"
+        + ` (${schedule.frequency} ${schedule.timeOfDay} weekday ${schedule.weekday})`
+        + " — nothing is armed",
+    );
+  }
 }
 
 function arm(schedule: ClawKeepSchedule): void {

--- a/src/lib/clawkeep-scheduler.ts
+++ b/src/lib/clawkeep-scheduler.ts
@@ -17,7 +17,7 @@
 import {
   backupExitError,
   computeNextRunMs,
-  readSchedule,
+  readScheduleSnapshot,
   runBackup,
   type ClawKeepSchedule,
 } from "@/lib/clawkeep";
@@ -73,10 +73,29 @@ function fireBackup(): void {
     });
 }
 
+/**
+ * Re-read the schedule and re-arm — unless the file could not be read.
+ *
+ * An unreadable `schedule.json` sanitises to `DEFAULT_SCHEDULE`, whose
+ * `enabled` is false, so this used to tear the nightly timer down and go
+ * quiet: a box that had been backing up every night simply stopped, the panel
+ * read "auto-backup is off", and the shield sat green on the 7-day
+ * no-schedule window (TASK-433). The read already separates "no file" — a box
+ * that has never had a schedule — from "there is a file and it says nothing we
+ * can read", which is evidence of nothing and certainly not of the owner
+ * switching auto-backup off. Keep what is armed and say so.
+ */
 async function rearm(): Promise<void> {
+  const snapshot = await readScheduleSnapshot();
+  if (snapshot.unreadable) {
+    console.warn(
+      "[clawkeep-scheduler] schedule.json could not be read — leaving auto-backup as it is"
+        + (armedFor > 0 ? ` (next run still ${new Date(armedFor).toISOString()})` : " (nothing armed)"),
+    );
+    return;
+  }
   clear();
-  const schedule = await readSchedule();
-  arm(schedule);
+  arm(snapshot.schedule);
 }
 
 function arm(schedule: ClawKeepSchedule): void {
@@ -99,9 +118,7 @@ function arm(schedule: ClawKeepSchedule): void {
 
 /** Boot hook — call once at process start. Idempotent. */
 export async function start(): Promise<void> {
-  clear();
-  const schedule = await readSchedule();
-  arm(schedule);
+  await rearm();
 }
 
 /** Re-read the persisted schedule and rearm. Call after the user saves new

--- a/src/lib/clawkeep-scheduler.ts
+++ b/src/lib/clawkeep-scheduler.ts
@@ -66,10 +66,10 @@ function clearRetry() {
 
 function fireBackup(): void {
   // The slot is being consumed now, so stop claiming it is still ahead:
-  // `armed` would otherwise hold an expired handle and `armedFor` a time in
-  // the past, both truthy and neither live — which is what `rearm()` below
-  // and `nextRunAtMs()` are asked about. Same reason
-  // `clawkeep-memory-scheduler.ts` clears at the top of its own `fire()`.
+  // without this, `armedFor` names a time in the past for as long as the
+  // backup runs, and `nextRunAtMs()` — the number an admin surface prints as
+  // "next run" — reports it. Same reason `clawkeep-memory-scheduler.ts`
+  // clears at the top of its own `fire()`.
   clear();
   // Best-effort: if a manual backup is already running the daemon will
   // serialise via its own heartbeat lock, so we don't gate here.
@@ -154,7 +154,12 @@ function onUnreadableSchedule(): void {
     "[clawkeep-scheduler] schedule.json could not be read — "
       + (armedFor > 0
         ? `keeping the last schedule that was (next run ${new Date(armedFor).toISOString()})`
-        : "nothing is armed")
+        // Nothing armed is two different facts and only one is an alarm: a box
+        // whose owner switched auto-backup off is behaving correctly, a box
+        // that has never managed to read the file is not.
+        : lastGood
+          ? "auto-backup was last known to be off"
+          : "nothing is armed and nothing has been read yet")
       + `; trying again in ${Math.round(UNREADABLE_RETRY_MS / 60_000)} min`,
   );
   clearRetry();

--- a/src/lib/clawkeep.ts
+++ b/src/lib/clawkeep.ts
@@ -345,10 +345,6 @@ export async function readScheduleSnapshot(): Promise<ClawKeepScheduleSnapshot> 
   };
 }
 
-export async function readSchedule(): Promise<ClawKeepSchedule> {
-  return (await readScheduleSnapshot()).schedule;
-}
-
 /**
  * The stamp given to a schedule that was armed before stamps existed. Any
  * value above 0 answers "a window has been started on this box"; 1 ms past the
@@ -446,7 +442,7 @@ export async function writeSchedule(next: ClawKeepSchedule): Promise<{
   // Per-call temp name (pid + monotonic counter), like writeStateFile: this is
   // a read-modify-write now, and two saves from the same card must not
   // interleave into one temp file and rename a torn schedule into place —
-  // readSchedule() would then fall back to DEFAULT_SCHEDULE and silently turn
+  // readScheduleSnapshot() would then fall back to DEFAULT_SCHEDULE and silently turn
   // auto-backup off.
   const tmp = `${SCHEDULE_PATH}.tmp.${process.pid}.${++scheduleWriteSeq}`;
   // `armedAtMs` rides alongside the schedule rather than in it: it is not a

--- a/src/lib/clawkeep.ts
+++ b/src/lib/clawkeep.ts
@@ -220,6 +220,13 @@ async function ensureDataDir(): Promise<void> {
 // and never cleaned up. Treat as not-restoring so the shield stops glowing.
 const RESTORING_FLAG_MAX_AGE_MS = 30 * 60 * 1000;
 
+/**
+ * "HH:MM", 24-hour, and a time that exists. Kept in step with the memory
+ * index's own schedule (`clawkeep-memory.ts`): both are read by a scheduler
+ * that arms nothing for an hour outside 00:00-23:59.
+ */
+const TIME_OF_DAY_RE = /^([01]\d|2[0-3]):[0-5]\d$/;
+
 function sanitiseSchedule(input: unknown): ClawKeepSchedule {
   // Coerce-and-default: tolerate a missing/partial schedule file rather than
   // crash the daemon. Only the four well-known fields are honoured; anything
@@ -227,7 +234,14 @@ function sanitiseSchedule(input: unknown): ClawKeepSchedule {
   const r = (input ?? {}) as Record<string, unknown>;
   const frequency: ScheduleFrequency =
     r.frequency === "weekly" ? "weekly" : "daily";
-  const time = typeof r.timeOfDay === "string" && /^\d{2}:\d{2}$/.test(r.timeOfDay)
+  // Range, not just shape. `/^\d{2}:\d{2}$/` accepted "99:99", "24:00" and
+  // "00:60" — and `computeNextRunMs` answers 0 for exactly those, so the file
+  // kept `enabled: true` over a schedule the scheduler could never arm: the
+  // panel said auto-backup was on and no backup ever ran (TASK-433). Same
+  // expression as `clawkeep-memory.ts`, which got this right for the memory
+  // index; a value this rejects falls back to the default, so a box with a
+  // hand-edited or half-written file still backs itself up.
+  const time = typeof r.timeOfDay === "string" && TIME_OF_DAY_RE.test(r.timeOfDay)
     ? r.timeOfDay
     : DEFAULT_SCHEDULE.timeOfDay;
   const weekdayRaw = Number(r.weekday);

--- a/src/tests/routes/clawkeep-schedule.test.ts
+++ b/src/tests/routes/clawkeep-schedule.test.ts
@@ -139,7 +139,12 @@ describe("/setup-api/clawkeep/schedule", () => {
         weekday: 4,
         retentionKeepLast: 7,
       });
+      // WITH the schedule it just wrote, not just "called". Re-reading the
+      // file the PUT has only now renamed can fail, and a failure there leaves
+      // the OLD cadence armed under this 200 — the box goes on backing up
+      // after the owner switched auto-backup off.
       expect(scheduler.refresh).toHaveBeenCalledTimes(1);
+      expect(scheduler.refresh).toHaveBeenCalledWith(body.schedule);
 
       // Round-trip: GET should see the same thing.
       const after = await (await GET()).json();
@@ -158,6 +163,7 @@ describe("/setup-api/clawkeep/schedule", () => {
       expect(body.schedule.timeOfDay).toBe(clawkeep.DEFAULT_SCHEDULE.timeOfDay);
       expect(body.schedule.weekday).toBe(0);
       expect(scheduler.refresh).toHaveBeenCalledTimes(1);
+      expect(scheduler.refresh).toHaveBeenCalledWith(body.schedule);
     });
 
     // TASK-433 — "the ClawKeep cron is not backing up".
@@ -257,7 +263,7 @@ describe("/setup-api/clawkeep/schedule", () => {
     it("does not read an unreadable schedule.json as 'never armed'", async () => {
       const now = Date.now();
       // A truncated write or a power cut mid-rename leaves the file there and
-      // unparseable, and `readSchedule()` falls back to DEFAULT_SCHEDULE —
+      // unparseable, and the read falls back to DEFAULT_SCHEDULE —
       // which says auto-backup is off. But a file nobody can read is evidence
       // of NOTHING, not evidence that this box never armed a schedule, and the
       // owner's re-arming click must not buy 36 h of green on a box whose

--- a/src/tests/routes/clawkeep-schedule.test.ts
+++ b/src/tests/routes/clawkeep-schedule.test.ts
@@ -160,6 +160,51 @@ describe("/setup-api/clawkeep/schedule", () => {
       expect(scheduler.refresh).toHaveBeenCalledTimes(1);
     });
 
+    // TASK-433 — "the ClawKeep cron is not backing up".
+    //
+    // `sanitiseSchedule` checked the SHAPE of `timeOfDay` (`/^\d{2}:\d{2}$/`)
+    // and not its RANGE, so "not-a-time" was correctly coerced to the default
+    // while "99:99" — which matches that regex — was persisted verbatim with
+    // `enabled: true`. `computeNextRunMs` then answers 0 for exactly those
+    // values (it *does* range-check), `arm()` returns on `next <= 0`, and the
+    // box arms nothing: the panel says auto-backup is on, the PUT answered
+    // 200, and no backup ever runs. The false-success class, in the one place
+    // where the cost of it is an unprotected box.
+    //
+    // The range-correct regex already exists one file away, in
+    // `clawkeep-memory.ts` — the memory-index schedule got it right.
+    it.each(["99:99", "24:00", "00:60", "2:5"])(
+      "does not persist an unarmable time of day (%s)",
+      async (timeOfDay) => {
+        const res = await PUT(jsonReq({ ...ARMED_DAILY, timeOfDay }));
+        const body = await res.json();
+
+        // Whatever it stores, it must be a schedule the scheduler can arm:
+        // an enabled schedule that computes no next run is auto-backup that
+        // silently never happens.
+        expect(body.schedule.enabled).toBe(true);
+        expect(clawkeep.computeNextRunMs(body.schedule, new Date())).toBeGreaterThan(0);
+        expect(body.nextRunAtMs).toBeGreaterThan(0);
+
+        // And the persisted file must say the same, so a reboot re-arms it.
+        const persisted = await (await GET()).json();
+        expect(clawkeep.computeNextRunMs(persisted.schedule, new Date())).toBeGreaterThan(0);
+      },
+    );
+
+    it("re-arms a box whose schedule.json was hand-edited to an impossible hour", async () => {
+      // A file written by an older build, a hand edit, or a half-flushed
+      // write. The read path is deliberately tolerant — it must not leave the
+      // box enabled-but-unarmable, which is worse than either extreme.
+      await fs.writeFile(
+        SCHEDULE_FILE,
+        JSON.stringify({ ...ARMED_DAILY, timeOfDay: "27:00", armedAtMs: Date.now() }),
+      );
+      const body = await (await GET()).json();
+      expect(body.schedule.enabled).toBe(true);
+      expect(body.nextRunAtMs).toBeGreaterThan(0);
+    });
+
     it("treats an empty body as a disable + defaults", async () => {
       const res = await PUT(new NextRequest(new URL("http://localhost/setup-api/clawkeep/schedule"), {
         method: "PUT",

--- a/src/tests/unit/clawkeep-persistence.test.ts
+++ b/src/tests/unit/clawkeep-persistence.test.ts
@@ -30,15 +30,15 @@ beforeEach(async () => {
   }
 });
 
-describe("readSchedule / writeSchedule", () => {
+describe("readScheduleSnapshot / writeSchedule", () => {
   it("returns DEFAULT_SCHEDULE when no file exists", async () => {
-    const s = await clawkeep.readSchedule();
+    const s = (await clawkeep.readScheduleSnapshot()).schedule;
     expect(s).toEqual(clawkeep.DEFAULT_SCHEDULE);
   });
 
   it("returns DEFAULT_SCHEDULE when the file is corrupt", async () => {
     await fs.writeFile(path.join(DATA_DIR, "schedule.json"), "{not-json", { mode: 0o600 });
-    const s = await clawkeep.readSchedule();
+    const s = (await clawkeep.readScheduleSnapshot()).schedule;
     expect(s).toEqual(clawkeep.DEFAULT_SCHEDULE);
   });
 
@@ -57,7 +57,7 @@ describe("readSchedule / writeSchedule", () => {
       weekday: 3,
       retentionKeepLast: 5,
     });
-    const reread = await clawkeep.readSchedule();
+    const reread = (await clawkeep.readScheduleSnapshot()).schedule;
     expect(reread).toEqual(written);
   });
 

--- a/src/tests/unit/clawkeep-schedule.test.ts
+++ b/src/tests/unit/clawkeep-schedule.test.ts
@@ -10,6 +10,53 @@ const baseSchedule: ClawKeepSchedule = {
   retentionKeepLast: 10,
 };
 
+/**
+ * The three copies of the time-of-day validator.
+ *
+ * This branch exists because two of them disagreed: `clawkeep.ts` checked the
+ * SHAPE of `HH:MM` while `clawkeep-memory.ts` checked its RANGE, so the backup
+ * schedule stored "99:99" where the memory-index schedule rejected it. They
+ * agree now, and this is what keeps them agreeing.
+ *
+ * A contract test rather than one shared constant, deliberately. The natural
+ * home would be `clawkeep-protection.ts` — the module that exists to be
+ * imported by everything and to import nothing — but `MemoryShardApp.tsx` is a
+ * client component that must never reach `clawkeep.ts` (it opens `fs` at
+ * import), and the same codebase already settles this class the same way:
+ * `voice-output-warning-agreement` asserts that the selector and the privacy
+ * banner agree about which engines are local rather than merging them.
+ */
+describe("the time-of-day validator", () => {
+  const SOURCES = [
+    "src/lib/clawkeep.ts",
+    "src/lib/clawkeep-memory.ts",
+    "src/components/MemoryShardApp.tsx",
+  ];
+
+  it("is the same expression everywhere a schedule is validated", async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    const found: Record<string, string[]> = {};
+    for (const file of SOURCES) {
+      const src = await fs.readFile(path.join(process.cwd(), file), "utf8");
+      // Every `HH:MM`-shaped anchored regex literal the code actually uses.
+      // Comments are dropped first: the modules quote the old expression while
+      // explaining why it was wrong, and a prose mention is not a validator.
+      const code = src
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .split("\n")
+        .map(line => (line.trimStart().startsWith("//") ? "" : line))
+        .join("\n");
+      found[file] = [...code.matchAll(/\/\^[^/\n]*:[^/\n]*\$\//g)].map(m => m[0]);
+      expect(found[file].length, `${file} must validate a time of day`).toBeGreaterThan(0);
+    }
+    const all = Object.values(found).flat();
+    expect(new Set(all).size, `expressions differ: ${JSON.stringify(found, null, 2)}`).toBe(1);
+    // And it must be the range-correct one, not merely a shared shape check.
+    expect(all[0]).toBe("/^([01]\\d|2[0-3]):[0-5]\\d$/");
+  });
+});
+
 describe("computeNextRunMs", () => {
   it("returns 0 when the schedule is disabled", () => {
     const now = new Date("2026-04-29T12:00:00");

--- a/src/tests/unit/clawkeep-schedule.test.ts
+++ b/src/tests/unit/clawkeep-schedule.test.ts
@@ -340,6 +340,32 @@ describe("the ClawKeep backup scheduler", () => {
     expect(runBackup).not.toHaveBeenCalled();
   });
 
+  it("says so when an enabled schedule computes no next run at all", async () => {
+    // The last silent path. `arm()` returns without a word when the schedule
+    // is enabled and `computeNextRunMs()` answers 0 — which after the range
+    // check is the weekly loop's 9-hop clock/DST guard, and anything handed
+    // to `refresh()` that did not come through `sanitiseSchedule()`. That is
+    // this card's symptom exactly: auto-backup on, no timer, nothing said.
+    const runBackup = vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" }));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockClawkeep(runBackup, { schedule: SCHEDULE, armedAtMs: Date.now(), unreadable: false });
+
+    const sched = await import("@/lib/clawkeep-scheduler");
+    await sched.start();
+    warn.mockClear();
+
+    await sched.refresh({ ...SCHEDULE, timeOfDay: "99:99" });
+
+    expect(sched.nextRunAtMs()).toBe(0);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("auto-backup is on but the schedule computes no next run"),
+    );
+
+    await vi.advanceTimersByTimeAsync(24 * 60 * 60_000);
+    expect(runBackup).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it("says nothing when the scheduled backup actually ran", async () => {
     const runBackup = vi.fn(async () => ({ exitCode: 0, stdout: "uploaded", stderr: "" }));
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/src/tests/unit/clawkeep-schedule.test.ts
+++ b/src/tests/unit/clawkeep-schedule.test.ts
@@ -156,10 +156,7 @@ describe("the ClawKeep backup scheduler", () => {
     // `schedule.json` — root-owned after a restore, EIO on failing storage,
     // EMFILE on a loaded Jetson, a JSON truncated by a power cut — resolves to
     // `DEFAULT_SCHEDULE`, whose `enabled` is false. `arm()` then returns, the
-    // nightly timer is torn down, and nothing anywhere says a word: the panel
-    // reads "auto-backup is off" and the shield stays green on the 7-day
-    // no-schedule window. `readScheduleSnapshot` already separates "no file"
-    // from "cannot be read"; the scheduler was throwing that distinction away.
+    // nightly timer is torn down, and nothing anywhere says a word.
     const runBackup = vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" }));
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const snapshot = { schedule: SCHEDULE, armedAtMs: Date.now(), unreadable: false };
@@ -168,7 +165,7 @@ describe("the ClawKeep backup scheduler", () => {
     const sched = await import("@/lib/clawkeep-scheduler");
     await sched.start();
     const armedBefore = sched.nextRunAtMs();
-    expect(armedBefore).toBeGreaterThan(0);
+    expect(armedBefore).toBeGreaterThan(Date.now());
 
     // The next read fails. A transient I/O error must not disarm the box.
     snapshot.schedule = { ...actualDefaultSchedule };
@@ -181,10 +178,66 @@ describe("the ClawKeep backup scheduler", () => {
       expect.stringContaining("schedule.json could not be read"),
     );
 
-    // And the run it was armed for still happens.
+    // The run it was armed for happens...
     await vi.advanceTimersByTimeAsync(61 * 60_000);
     expect(runBackup).toHaveBeenCalledTimes(1);
+
+    // ...and so does the NEXT one. The post-fire rearm has no live timer to
+    // preserve, so "keep what is armed" is not an answer there: a box that
+    // ran once more and then stopped for ever would look identical to a
+    // healthy one for a whole day.
+    expect(sched.nextRunAtMs()).toBeGreaterThan(Date.now());
+    await vi.advanceTimersByTimeAsync(24 * 60 * 60_000);
+    expect(runBackup).toHaveBeenCalledTimes(2);
     warn.mockRestore();
+  });
+
+  it("keeps asking when the box BOOTS on a schedule it cannot read", async () => {
+    // There is no last-known-good at boot, so nothing can be armed — and
+    // answering "can I read the schedule?" once and believing it for the life
+    // of the process is the probe-once class. On this file it is total: the
+    // box would never back up again, on one log line.
+    const runBackup = vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" }));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const snapshot = { schedule: { ...actualDefaultSchedule }, armedAtMs: 0, unreadable: true };
+    mockClawkeep(runBackup, snapshot);
+
+    const sched = await import("@/lib/clawkeep-scheduler");
+    await sched.start();
+    expect(sched.nextRunAtMs()).toBe(0);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("nothing is armed"));
+
+    // The permissions are repaired (or the storage settles). Nobody touches
+    // the panel — the retry is the only thing that can notice.
+    snapshot.schedule = SCHEDULE;
+    snapshot.unreadable = false;
+    await vi.advanceTimersByTimeAsync(16 * 60_000);
+
+    expect(sched.nextRunAtMs()).toBeGreaterThan(Date.now());
+    await vi.advanceTimersByTimeAsync(24 * 60 * 60_000);
+    expect(runBackup).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("honours a save whose schedule the route already holds", async () => {
+    // The owner switches auto-backup OFF. The route hands `refresh` the
+    // schedule `writeSchedule()` returned, so a read that would have failed on
+    // this path cannot leave the old cadence armed under a 200 answer.
+    const runBackup = vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" }));
+    const snapshot = { schedule: SCHEDULE, armedAtMs: Date.now(), unreadable: false };
+    mockClawkeep(runBackup, snapshot);
+
+    const sched = await import("@/lib/clawkeep-scheduler");
+    await sched.start();
+    expect(sched.nextRunAtMs()).toBeGreaterThan(Date.now());
+
+    // The file read would now fail; the route does not need it.
+    snapshot.unreadable = true;
+    await sched.refresh({ ...SCHEDULE, enabled: false });
+
+    expect(sched.nextRunAtMs()).toBe(0);
+    await vi.advanceTimersByTimeAsync(24 * 60 * 60_000);
+    expect(runBackup).not.toHaveBeenCalled();
   });
 
   it("says nothing when the scheduled backup actually ran", async () => {

--- a/src/tests/unit/clawkeep-schedule.test.ts
+++ b/src/tests/unit/clawkeep-schedule.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { computeNextRunMs, type ClawKeepSchedule } from "@/lib/clawkeep";
+import { DEFAULT_SCHEDULE as actualDefaultSchedule, computeNextRunMs, type ClawKeepSchedule } from "@/lib/clawkeep";
 
 const baseSchedule: ClawKeepSchedule = {
   enabled: true,
@@ -102,11 +102,29 @@ describe("the ClawKeep backup scheduler", () => {
     vi.doUnmock("@/lib/clawkeep");
   });
 
-  async function armWith(runBackup: ReturnType<typeof vi.fn>) {
+  /**
+   * Both reads are stubbed on purpose. The real ones resolve
+   * `CLAWKEEP_DATA_DIR` at import time, so a scheduler test that left either
+   * of them real would read — and the write path would write — the developer's
+   * own `~/.clawkeep`.
+   */
+  function mockClawkeep(
+    runBackup: ReturnType<typeof vi.fn>,
+    snapshot: { schedule: ClawKeepSchedule; armedAtMs: number; unreadable: boolean },
+  ) {
     vi.doMock("@/lib/clawkeep", async () => {
       const actual = await vi.importActual<typeof import("@/lib/clawkeep")>("@/lib/clawkeep");
-      return { ...actual, runBackup, readSchedule: vi.fn(async () => SCHEDULE) };
+      return {
+        ...actual,
+        runBackup,
+        readSchedule: vi.fn(async () => snapshot.schedule),
+        readScheduleSnapshot: vi.fn(async () => snapshot),
+      };
     });
+  }
+
+  async function armWith(runBackup: ReturnType<typeof vi.fn>) {
+    mockClawkeep(runBackup, { schedule: SCHEDULE, armedAtMs: Date.now(), unreadable: false });
     const sched = await import("@/lib/clawkeep-scheduler");
     await sched.start();
     return sched;
@@ -130,6 +148,42 @@ describe("the ClawKeep backup scheduler", () => {
       expect.stringContaining("auto-backup failed"),
       expect.stringContaining("127"),
     );
+    warn.mockRestore();
+  });
+
+  it("does not read a schedule.json it cannot open as the owner switching auto-backup off", async () => {
+    // TASK-433, the half that stops a box that WAS backing up. An unreadable
+    // `schedule.json` — root-owned after a restore, EIO on failing storage,
+    // EMFILE on a loaded Jetson, a JSON truncated by a power cut — resolves to
+    // `DEFAULT_SCHEDULE`, whose `enabled` is false. `arm()` then returns, the
+    // nightly timer is torn down, and nothing anywhere says a word: the panel
+    // reads "auto-backup is off" and the shield stays green on the 7-day
+    // no-schedule window. `readScheduleSnapshot` already separates "no file"
+    // from "cannot be read"; the scheduler was throwing that distinction away.
+    const runBackup = vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" }));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const snapshot = { schedule: SCHEDULE, armedAtMs: Date.now(), unreadable: false };
+    mockClawkeep(runBackup, snapshot);
+
+    const sched = await import("@/lib/clawkeep-scheduler");
+    await sched.start();
+    const armedBefore = sched.nextRunAtMs();
+    expect(armedBefore).toBeGreaterThan(0);
+
+    // The next read fails. A transient I/O error must not disarm the box.
+    snapshot.schedule = { ...actualDefaultSchedule };
+    snapshot.armedAtMs = 0;
+    snapshot.unreadable = true;
+    await sched.refresh();
+
+    expect(sched.nextRunAtMs()).toBe(armedBefore);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("schedule.json could not be read"),
+    );
+
+    // And the run it was armed for still happens.
+    await vi.advanceTimersByTimeAsync(61 * 60_000);
+    expect(runBackup).toHaveBeenCalledTimes(1);
     warn.mockRestore();
   });
 

--- a/src/tests/unit/clawkeep-schedule.test.ts
+++ b/src/tests/unit/clawkeep-schedule.test.ts
@@ -103,10 +103,9 @@ describe("the ClawKeep backup scheduler", () => {
   });
 
   /**
-   * Both reads are stubbed on purpose. The real ones resolve
-   * `CLAWKEEP_DATA_DIR` at import time, so a scheduler test that left either
-   * of them real would read — and the write path would write — the developer's
-   * own `~/.clawkeep`.
+   * Stubbed on purpose: the real read resolves `CLAWKEEP_DATA_DIR` at import
+   * time, so a scheduler test that left it real would read the developer's own
+   * `~/.clawkeep`.
    */
   function mockClawkeep(
     runBackup: ReturnType<typeof vi.fn>,
@@ -117,7 +116,6 @@ describe("the ClawKeep backup scheduler", () => {
       return {
         ...actual,
         runBackup,
-        readSchedule: vi.fn(async () => snapshot.schedule),
         readScheduleSnapshot: vi.fn(async () => snapshot),
       };
     });
@@ -214,6 +212,12 @@ describe("the ClawKeep backup scheduler", () => {
     await vi.advanceTimersByTimeAsync(16 * 60_000);
 
     expect(sched.nextRunAtMs()).toBeGreaterThan(Date.now());
+
+    // And it stops asking.
+    warn.mockClear();
+    await vi.advanceTimersByTimeAsync(46 * 60_000);
+    expect(warn).not.toHaveBeenCalled();
+
     await vi.advanceTimersByTimeAsync(24 * 60 * 60_000);
     expect(runBackup).toHaveBeenCalled();
     warn.mockRestore();
@@ -233,7 +237,103 @@ describe("the ClawKeep backup scheduler", () => {
 
     // The file read would now fail; the route does not need it.
     snapshot.unreadable = true;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     await sched.refresh({ ...SCHEDULE, enabled: false });
+
+    expect(sched.nextRunAtMs()).toBe(0);
+    await vi.advanceTimersByTimeAsync(24 * 60 * 60_000);
+    expect(runBackup).not.toHaveBeenCalled();
+    // A save also settles any outstanding re-read: the route's answer is
+    // newer than anything the file could say, so a retry must not survive it
+    // and re-arm the cadence the owner has just switched off.
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("stops re-reading once any successful read gets in first", async () => {
+    // A pending 15-minute retry that a successful read does not cancel keeps
+    // firing for the life of the process, tearing the armed backup timer down
+    // and rebuilding it from `lastGood` — which may be staler than whatever
+    // set the schedule in between. Permanent background churn nothing notices,
+    // so it is pinned on the read itself rather than on a symptom.
+    const runBackup = vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" }));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const snapshot = { schedule: { ...actualDefaultSchedule }, armedAtMs: 0, unreadable: true };
+    const read = vi.fn(async () => snapshot);
+    vi.doMock("@/lib/clawkeep", async () => {
+      const actual = await vi.importActual<typeof import("@/lib/clawkeep")>("@/lib/clawkeep");
+      return { ...actual, runBackup, readScheduleSnapshot: read };
+    });
+    const sched = await import("@/lib/clawkeep-scheduler");
+
+    await sched.start();          // unreadable: arms a retry
+    snapshot.schedule = SCHEDULE;
+    snapshot.unreadable = false;
+    await sched.refresh();        // a good read lands inside the retry window
+    const readsSoFar = read.mock.calls.length;
+
+    // Three retry windows, and deliberately short of 06:00: the scheduled
+    // backup re-reads on its own `.finally(rearm)`, which would mask this.
+    await vi.advanceTimersByTimeAsync(50 * 60_000);
+    expect(read).toHaveBeenCalledTimes(readsSoFar);
+    warn.mockRestore();
+  });
+
+  it("stops re-reading when the route saves inside the retry window", async () => {
+    // The same, through the door the owner actually uses. `refresh(schedule)`
+    // reads nothing at all, so a retry it left behind would re-read and re-arm
+    // over the save that had just replaced it.
+    const runBackup = vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" }));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const snapshot = { schedule: { ...actualDefaultSchedule }, armedAtMs: 0, unreadable: true };
+    const read = vi.fn(async () => snapshot);
+    vi.doMock("@/lib/clawkeep", async () => {
+      const actual = await vi.importActual<typeof import("@/lib/clawkeep")>("@/lib/clawkeep");
+      return { ...actual, runBackup, readScheduleSnapshot: read };
+    });
+    const sched = await import("@/lib/clawkeep-scheduler");
+
+    await sched.start();          // unreadable: arms a retry
+    await sched.refresh(SCHEDULE);
+    const readsSoFar = read.mock.calls.length;
+
+    await vi.advanceTimersByTimeAsync(50 * 60_000);
+    expect(read).toHaveBeenCalledTimes(readsSoFar);
+    expect(sched.nextRunAtMs()).toBeGreaterThan(Date.now());
+    warn.mockRestore();
+  });
+
+  it("lets the newer read win when a save lands during one that is in flight", async () => {
+    // `start()` and `rearm()` no longer clear synchronously before their
+    // await — that is what stops an unreadable read disarming a live timer —
+    // so two rearms can be in flight at once. Without the generation guard the
+    // OLDER read arms last, and the box keeps backing up on the cadence the
+    // owner has already replaced. Silent, and gone by the next reboot, so it
+    // never reproduces on demand.
+    const runBackup = vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" }));
+    let releaseSlowRead: (() => void) | null = null;
+    const slowRead = new Promise<void>((resolve) => { releaseSlowRead = resolve; });
+    const snapshot = { schedule: SCHEDULE, armedAtMs: Date.now(), unreadable: false };
+
+    vi.doMock("@/lib/clawkeep", async () => {
+      const actual = await vi.importActual<typeof import("@/lib/clawkeep")>("@/lib/clawkeep");
+      return {
+        ...actual,
+        runBackup,
+        readScheduleSnapshot: vi.fn(async () => { await slowRead; return snapshot; }),
+      };
+    });
+    const sched = await import("@/lib/clawkeep-scheduler");
+
+    // A boot read that has not answered yet...
+    const booting = sched.start();
+    // ...and the owner saves while it is still out.
+    await sched.refresh({ ...SCHEDULE, enabled: false });
+    expect(sched.nextRunAtMs()).toBe(0);
+
+    // The stale read now answers with the schedule the save replaced.
+    releaseSlowRead!();
+    await booting;
 
     expect(sched.nextRunAtMs()).toBe(0);
     await vi.advanceTimersByTimeAsync(24 * 60 * 60_000);


### PR DESCRIPTION
## TASK-433 — the ClawKeep cron is not backing up

**Customer-visible symptom.** The ClawKeep panel says auto-backup is on and shows a schedule. No backup ever runs, and nothing anywhere says why — not the panel, not the shield, not a log line. The shield stays green until the 7-day no-schedule window catches it.

The card asks to distinguish "cron never fires" from "cron fires and the backup fails" first, because they are different fixes. This is the **never fires** half. Both instances are the false-success class.

### Harness first

ClawKeep ships its own scheduler — `clawkeep/systemd/clawkeepd.timer` (`OnCalendar=daily`, `RandomizedDelaySec=30m`, `Persistent=true`) and `clawkeep-idle.timer` — and `install.sh:5254` states outright that `clawkeep/systemd/` is intentionally not installed. ClawBox owns scheduling instead, through the in-process `clawkeep-scheduler.ts`, so the schedule stays editable from the GUI; `clawkeep-protection.ts` records the same decision. That is the native mechanism, deliberately declined for a stated reason, and this PR does not re-litigate it — it fixes the ClawBox scheduler that took its place.

Confirmed read-only on both editions on beta `8653b118`: `systemctl list-timers` and `list-unit-files` show no ClawKeep units, `crontab -l` is empty, and nothing under `/etc/cron*` mentions ClawKeep. So the in-Next scheduler really is the only thing that can fire a backup on a ClawBox — which is why both of these are total, not partial, failures.

### Cause 1 — a schedule that is stored but can never be armed

`sanitiseSchedule` checked the SHAPE of `timeOfDay` and not its range:

```ts
/^\d{2}:\d{2}$/.test(r.timeOfDay) ? r.timeOfDay : DEFAULT_SCHEDULE.timeOfDay
```

`"not-a-time"` was correctly coerced to the default. `"99:99"`, `"24:00"` and `"00:60"` match that regex and were persisted verbatim with `enabled: true`. `computeNextRunMs` *does* range-check, and answers `0` for exactly those values; `arm()` returns on `next <= 0`. So the file says auto-backup is on, the PUT answered `200`, `getStatus()` reports the schedule as enabled — and no timer exists.

The range-correct expression already existed one file away: `clawkeep-memory.ts:180` uses `/^([01]\d|2[0-3]):[0-5]\d$/` for the memory-index schedule, and `MemoryShardApp.tsx` gates its save on the same one. `clawkeep.ts` now uses it too. A value it rejects still falls back to the default, so a hand-edited or half-written file backs the box up rather than going quiet.

### Cause 2 — an unreadable `schedule.json` read as "the owner switched it off"

`readScheduleSnapshot()` already separates "no file" (a box that never had a schedule) from "there is a file and it says nothing we can read" — EACCES on a file left root-owned by a restore, EIO on failing storage, EMFILE on a loaded Jetson, JSON truncated by a power cut. It publishes that as `unreadable`. The scheduler was throwing the distinction away: an unreadable snapshot sanitises to `DEFAULT_SCHEDULE`, whose `enabled` is false, so `rearm()` tore the nightly timer down and returned without a word. A box that had been backing up every night simply stopped.

`rearm()` no longer reads `unreadable` as "off". It re-arms from the last schedule this process could actually READ, and always arms a bounded re-read (15 min), so a transient failure self-heals within the hour and a persistent one keeps being reported instead of being answered once and believed for the life of the process. `start()` goes through the same path, so boot and save cannot disagree.

Three things fell out of the review pass and are in the second commit, because the first version of this half was not finished:

- `fireBackup()` now `clear()`s at the top, the way `clawkeep-memory-scheduler.ts`'s own `fire()` does and for the same stated reason. Without it, the post-fire `.finally(rearm)` sees an **expired** timer handle and a past `armedFor` — both truthy, neither live — so "keep what is armed" kept nothing: the box ran exactly one more backup and then stopped for ever, and the log line named a slot that had already been consumed.
- A bounded retry, because at boot there is no last-known-good to fall back on. Without it a box that reboots on a root-owned or half-written file never backs up again, on one `console.warn`. That is the probe-once class, and on this file it is total.
- `refresh(schedule?)` — the schedule route hands over the object `writeSchedule()` just returned rather than making the scheduler re-read the file it has only now renamed. A transient failure on the save path would otherwise leave the OLD cadence armed under a `200`, so a box would go on backing up after the owner switched auto-backup off. Plus a rearm generation guard, which `start()` newly needed once it stopped clearing synchronously before its await.

### RED

The seven new cases against the three source files restored to unmodified `origin/beta` `8653b118`, with the branch's tests in place:

```
 × does not persist an unarmable time of day (99:99)
 × does not persist an unarmable time of day (24:00)
 × does not persist an unarmable time of day (00:60)
 × re-arms a box whose schedule.json was hand-edited to an impossible hour
 × does not read a schedule.json it cannot open as the owner switching auto-backup off
 × keeps asking when the box BOOTS on a schedule it cannot read
 × honours a save whose schedule the route already holds

AssertionError: expected 0 to be greater than 0                 (nextRunAtMs over an enabled schedule)
AssertionError: expected +0 to be 1787367600000                 (the armed timer was torn down)
AssertionError: expected "warn" to be called with arguments: [ StringContaining "nothing is armed" ]
AssertionError: expected 1787367600000 to be +0                 (the save was not honoured)

 Test Files  2 failed (2)
      Tests  7 failed | 30 passed (37)
```

The first of the unreadable cases also pins the once-more-then-never behaviour: it advances a further day after the fire and asserts a **second** run, which the first version of this fix did not do.

### GREEN

```
 Test Files  15 passed (15)      Tests  212 passed (212)     (every clawkeep unit + route suite)
 Test Files   7 passed (7)       Tests   30 passed (30)      (clawkeep components)
 Test Files   3 passed (3)       Tests   20 passed (20)      (beta guard tests)
 tsc --noEmit: clean      eslint: clean
```

CI was green on every check on the pre-rebase head, including `e2e-install` (14m51s), and CodeRabbit raised no actionable comments.

### Sibling call sites

- `computeNextRunMs` — three callers (`schedule` GET, `schedule` PUT, `getStatus`); all now receive a schedule that can be armed.
- `sanitiseSchedule` — both the read path (`readScheduleSnapshot`) and the write path (`writeSchedule`); one expression serves both, tolerant on read as its contract says.
- `readSchedule()` — the scheduler was its last production caller and now uses the snapshot; the function stays for its own tests and public shape.
- Every shape-only `HH:MM` regex in `src/` was grepped: there are none left.
- `clawkeep-memory-scheduler.ts` has an **analogous** shape — `readMemorySchedule()` collapses ENOENT and EACCES/EIO into `DEFAULT_MEMORY_SCHEDULE` — but it is not a call site of anything touched here, its time field is already range-checked, and closing it means widening that function's return type through five callers. Cost is a stale index rather than an unprotected box. Recorded in the queue's Found section rather than folded in.

### Both editions

ClawKeep ships on OpenClaw and Hermes, and neither half of this is edition-specific: it is the shared `clawkeep.ts` / `clawkeep-scheduler.ts` pair. Read-only on beta `8653b118`, both boxes show no ClawKeep systemd timers and no crontab, so both depend on this scheduler alone.

### Review

**Two passes.** The first, over commit 1: HIGH 2 · MEDIUM 4 · LOW 6. Both HIGHs and three MEDIUMs are fixed in commit 2 — the post-fire dead timer, the missing boot retry, the save that a failed read could drop, the log line that named a consumed slot, and the test that walked past the first two.

The second, a merge gate over commit 2 (which the first pass had not seen): 0 HIGH · 4 MEDIUM · 4 LOW, verdict BLOCK. It mutation-tested each fix rather than reasoning about it, and found **three that could be reverted with every test still green** — the route handing `refresh()` the schedule, the `rearmGeneration` guard, and both `clearRetry()` calls. Commit 3 pins all three, deletes `readSchedule()` (no production caller left, and it is the exact footgun this branch removes: `DEFAULT_SCHEDULE`, `enabled: false`, for an unreadable file), and corrects two log lines. It also enumerated every interleaving of `start()` / `refresh()` / `refresh(schedule)` / the retry tick / `fireBackup().finally(rearm)` and could not produce zero-timers-with-no-retry, two live timers, or an arming of a replaced schedule.

**Mutation results on the final head** — every fix reddens when reverted:

```
baseline                          40 passed
route drops the schedule arg       2 failed
no rearmGeneration guard           1 failed
no clearRetry() in rearm()         1 failed
no clearRetry() in refresh()       1 failed
no lastGood re-arm                 1 failed
no retry timer                     4 failed
```

### One correction that is not about the schedule

`fireBackup()` did not gate on a run already being in flight, and the stated reason was `"the daemon will serialise via its own heartbeat lock"`. There is no such lock — no pidfile, no `flock`, nothing in `daemon.py`, `runner.py` or `state.py` — so two `clawkeepd` processes stage two multi-GB archives and upload both. Survivable while the window was small; #727 raises the run cap to four hours for 12 GB archives, which widens it, so the false reason is removed here (this PR owns the file) and the comment now says where the fix belongs: the daemon's own single-instance guard, not a check in the scheduler that could only narrow the race.

### Not in this PR

The other half the card names — a scheduled run that FAILS surfacing somewhere the owner can see — is only partly covered today. `fireBackup` writes a `console.warn`; `runner.py` deliberately writes no heartbeat for `EXIT_AUTH_REVOKED` (3), and a daemon that is gone (127) or SIGKILLed (124) never writes one either, so those failures reach the panel only through the age term added for TASK-673. Persisting the classified failure into ClawKeep state is `getStatus()`'s change and belongs with TASK-673.

**MED-1 / L-4, declined with a reason: the owner-facing half of cause 2.** `GET /setup-api/clawkeep/schedule` and `getStatus()` both still flatten `unreadable` to `DEFAULT_SCHEDULE`, so while the engine now keeps backing the box up, the card still reads "auto-backup is off" and `deriveProtection` still judges it on the 7-day unscheduled window. Carrying `unreadable` through to a distinct card state needs copy in ten locales and an owner call on the wording; this PR keeps the backups running and says so in the code rather than claiming the surface too. The gate confirmed the shield does not go falsely *red* — `deriveProtection` gets the disabled schedule and therefore the more lenient 7-day window, while `lastBackupAtMs` keeps advancing because the engine is still running — so this is a false statement, not a false failure. Before this PR the panel and the engine agreed (both off); after it they disagree, and the integrator should merge it knowing that. (Recorded before this run as the #608 review's L4-2.)

Device leg: read-only on both editions (no mutation, no mutex taken). A scheduled run could not be exercised end to end because ClawKeep is unpaired on both dev boxes — no `state.json`, no `schedule.json`. Declared, not claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler reliability when schedule files are temporarily unreadable by preserving active schedules and retrying automatically.
  * Prevented invalid times such as `24:00`, `99:99`, and `00:60` from creating unusable schedules.
  * Ensured newer schedule updates take precedence over older in-progress refreshes.
  * Improved schedule updates so the latest saved configuration is applied immediately.
* **Tests**
  * Expanded coverage for invalid schedules, unreadable files, retries, timer handling, and schedule updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->