### PR TITLE
fix: stop five separate caps killing the large ClawKeep backups TASK-675 exists for

### DIFF
--- a/clawkeep/clawkeep/crypto.py
+++ b/clawkeep/clawkeep/crypto.py
@@ -31,6 +31,8 @@ import os
 import subprocess
 from pathlib import Path
 
+from .limits import SUBPROCESS_TIMEOUT_S
+
 log = logging.getLogger(__name__)
 
 ENCRYPTED_SUFFIX = ".enc"
@@ -73,7 +75,7 @@ def encrypt_file(
     plaintext_path: Path,
     ciphertext_path: Path,
     password_file: Path,
-    timeout: float = 30 * 60,
+    timeout: float = SUBPROCESS_TIMEOUT_S,
 ) -> None:
     """Encrypt `plaintext_path` to `ciphertext_path` using the password in
     `password_file`. The plaintext is *not* deleted — the caller decides.
@@ -124,7 +126,7 @@ def decrypt_file(
     ciphertext_path: Path,
     plaintext_path: Path,
     password_file: Path,
-    timeout: float = 30 * 60,
+    timeout: float = SUBPROCESS_TIMEOUT_S,
 ) -> None:
     """Inverse of :func:`encrypt_file`. Raises CryptoError on any failure;
     callers should treat a stderr containing "bad decrypt" / "wrong password"

--- a/clawkeep/clawkeep/limits.py
+++ b/clawkeep/clawkeep/limits.py
@@ -20,8 +20,11 @@ and the validated 12 GiB run took ~86 minutes end to end. Those defaults, not
 the TS bridge's kill timer, were the first walls a large backup hit.
 
 The encrypt and decrypt steps run OUTSIDE any edition branch
-(`runner.py`, `restore.py`), so this bound applies on the Hermes edition too —
-only the archive step differs between the two backends.
+(`runner.py`, `restore.py`), so this bound applies on the Hermes edition too.
+The archive and verify steps are the ones that differ between the backends:
+`hermes.py` shells out for neither — it tars with `tarfile` and verifies the
+manifest in process — so on that edition these two subprocesses are all there
+is to cap.
 """
 
 from __future__ import annotations

--- a/clawkeep/clawkeep/limits.py
+++ b/clawkeep/clawkeep/limits.py
@@ -1,0 +1,32 @@
+"""The one bound on any subprocess this daemon runs.
+
+Declared on its own so `openclaw.py` and `crypto.py` cannot answer the
+question differently — they are steps of the same run, and a run has one
+bound.
+
+It is the daemon's own number: `clawkeep/systemd/clawkeepd.service` declares
+`TimeoutStartSec=4h` for one whole run, and no single step inside that run may
+be given less than the run itself. A per-step cap tighter than the run cap
+turns "this step is slow" into "this backup failed" for precisely the step
+that is slow.
+
+They WERE tighter, and all of them were written when a ClawBox backup was
+~1 GB: 30 minutes for `openclaw backup create` ("tarballing ~1GB on Jetson
+takes minutes"), 5 minutes for `openclaw backup verify`, and 30 minutes for
+each of `openssl enc` and `openssl enc -d`. TASK-675 made 10 GB+ archives the
+supported case — `backup create --verify` tars and gzips the whole tree off
+eMMC and then reads it back, `openssl` streams the whole archive twice more,
+and the validated 12 GiB run took ~86 minutes end to end. Those defaults, not
+the TS bridge's kill timer, were the first walls a large backup hit.
+
+The encrypt and decrypt steps run OUTSIDE any edition branch
+(`runner.py`, `restore.py`), so this bound applies on the Hermes edition too —
+only the archive step differs between the two backends.
+"""
+
+from __future__ import annotations
+
+#: Seconds. See the module docstring; kept in step with
+#: `clawkeep/systemd/clawkeepd.service`'s `TimeoutStartSec` by
+#: `src/tests/unit/clawkeep-backup-run-cap.test.ts`.
+SUBPROCESS_TIMEOUT_S = 4 * 60 * 60

--- a/clawkeep/clawkeep/openclaw.py
+++ b/clawkeep/clawkeep/openclaw.py
@@ -64,6 +64,25 @@ def _parse_json(stdout: str, what: str) -> dict:
     return obj
 
 
+#: The bound on any one `openclaw` subprocess this daemon runs.
+#:
+#: It is the daemon's own number: `clawkeep/systemd/clawkeepd.service` declares
+#: `TimeoutStartSec=4h` for one whole run, and no single step inside that run
+#: may be given less than the run itself — a per-step cap tighter than the run
+#: cap turns "this step is slow" into "this backup failed" for precisely the
+#: step that is slow.
+#:
+#: They WERE tighter: 30 minutes for `create_archive` ("tarballing ~1GB on
+#: Jetson takes minutes") and 5 minutes for `verify_archive`, both written when
+#: a ClawBox backup was ~1 GB. TASK-675 made 10 GB+ archives the supported
+#: case: `backup create --verify` tars and gzips the whole tree off eMMC and
+#: then reads it back, and the validated 12 GiB run took ~86 minutes end to
+#: end. Those two defaults, not the bridge's kill timer, were the FIRST wall a
+#: large backup hit — and being the daemon's own, they bound the archive step
+#: on the OpenClaw edition no matter what the caller allows.
+SUBPROCESS_TIMEOUT_S = 4 * 60 * 60
+
+
 def create_archive(
     binary: str,
     *,
@@ -71,7 +90,7 @@ def create_archive(
     include_workspace: bool = True,
     only_config: bool = False,
     verify: bool = True,
-    timeout: float = 30 * 60,  # tarballing ~1GB on Jetson takes minutes; 30m hard cap
+    timeout: float = SUBPROCESS_TIMEOUT_S,
 ) -> Archive:
     """Run `openclaw backup create --json --output <dir>`. Returns archive metadata.
 
@@ -117,7 +136,12 @@ def create_archive(
     )
 
 
-def verify_archive(binary: str, archive: Path, *, timeout: float = 5 * 60) -> None:
+def verify_archive(
+    binary: str,
+    archive: Path,
+    *,
+    timeout: float = SUBPROCESS_TIMEOUT_S,
+) -> None:
     """Run `openclaw backup verify --json <archive>`. Raises OpenclawError on failure.
 
     Useful as a defence-in-depth check before upload when the caller did

--- a/clawkeep/clawkeep/openclaw.py
+++ b/clawkeep/clawkeep/openclaw.py
@@ -14,6 +14,7 @@ import json
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+from . import limits
 
 
 @dataclass(frozen=True)
@@ -64,23 +65,10 @@ def _parse_json(stdout: str, what: str) -> dict:
     return obj
 
 
-#: The bound on any one `openclaw` subprocess this daemon runs.
-#:
-#: It is the daemon's own number: `clawkeep/systemd/clawkeepd.service` declares
-#: `TimeoutStartSec=4h` for one whole run, and no single step inside that run
-#: may be given less than the run itself — a per-step cap tighter than the run
-#: cap turns "this step is slow" into "this backup failed" for precisely the
-#: step that is slow.
-#:
-#: They WERE tighter: 30 minutes for `create_archive` ("tarballing ~1GB on
-#: Jetson takes minutes") and 5 minutes for `verify_archive`, both written when
-#: a ClawBox backup was ~1 GB. TASK-675 made 10 GB+ archives the supported
-#: case: `backup create --verify` tars and gzips the whole tree off eMMC and
-#: then reads it back, and the validated 12 GiB run took ~86 minutes end to
-#: end. Those two defaults, not the bridge's kill timer, were the FIRST wall a
-#: large backup hit — and being the daemon's own, they bound the archive step
-#: on the OpenClaw edition no matter what the caller allows.
-SUBPROCESS_TIMEOUT_S = 4 * 60 * 60
+#: Re-exported so `openclaw.<name>` keeps working for anything that reads it
+#: here; the one definition lives in `limits.py`, beside `crypto.py`'s use of
+#: the same bound. See that module for why it is this number.
+SUBPROCESS_TIMEOUT_S = limits.SUBPROCESS_TIMEOUT_S
 
 
 def create_archive(

--- a/mcp/lib/api.ts
+++ b/mcp/lib/api.ts
@@ -73,6 +73,10 @@ export interface ApiOptions {
    * answer is "Retry once", which is right for a read and actively harmful for
    * a call that started something long — the work is still going, and a retry
    * starts a second one.
+   *
+   * `mcp/tools/email.ts` catches the same class by hand around `email_send`,
+   * under a comment making the same argument. This is that idea as an option,
+   * so the next route does not have to wrap its own call to say it.
    */
   onTimeout?: { message: string; next: string };
 }

--- a/mcp/lib/api.ts
+++ b/mcp/lib/api.ts
@@ -65,6 +65,16 @@ export interface ApiOptions {
   timeoutMs?: number;
   /** Per-route failure → instruction mappings. */
   rules?: ErrorRule[];
+  /**
+   * What to tell the model when the call ABORTS on `timeoutMs`.
+   *
+   * `rules` cannot cover this: `matchRule` is only ever consulted against an
+   * HTTP response, and a client-side abort never produces one. The generic
+   * answer is "Retry once", which is right for a read and actively harmful for
+   * a call that started something long — the work is still going, and a retry
+   * starts a second one.
+   */
+  onTimeout?: { message: string; next: string };
 }
 
 function buildUrl(path: string, query?: ApiOptions["query"]): string {
@@ -80,7 +90,7 @@ function buildUrl(path: string, query?: ApiOptions["query"]): string {
 
 /** Call /setup-api/*. Throws a ToolError the register() wrapper can render. */
 export async function api<T = unknown>(path: string, options: ApiOptions = {}): Promise<T> {
-  const { method = "GET", body, query, timeoutMs = DEFAULT_TIMEOUT_MS, rules } = options;
+  const { method = "GET", body, query, timeoutMs = DEFAULT_TIMEOUT_MS, rules, onTimeout } = options;
   const headers: Record<string, string> = { accept: "application/json" };
   const auth = authHeader();
   if (auth) headers.authorization = auth;
@@ -102,8 +112,8 @@ export async function api<T = unknown>(path: string, options: ApiOptions = {}): 
     if (err instanceof Error && /abort|timeout/i.test(err.message)) {
       throw new ToolError(
         "TIMEOUT",
-        "The ClawBox service did not answer in time.",
-        "Retry once. If it times out again, call clawbox_health and tell the user.",
+        onTimeout?.message ?? "The ClawBox service did not answer in time.",
+        onTimeout?.next ?? "Retry once. If it times out again, call clawbox_health and tell the user.",
       );
     }
     throw new ToolError(

--- a/mcp/tools/system.ts
+++ b/mcp/tools/system.ts
@@ -751,10 +751,19 @@ export function registerSystemTools(reg: Registrar, ctx: McpContext): void {
           // on — and the generic "Retry once" would start a second full
           // archive-and-upload beside the first. `clawkeepd` has no
           // single-instance guard of any kind, so nothing downstream would
-          // stop it. Says what the tool's own description says.
+          // stop it. `mcp/tools/email.ts` catches the same class by hand for
+          // `email_send`; this is that idea as an option, so a route no
+          // longer has to wrap its own call to say it.
+          //
+          // It names `backup_list`, as the description above does, and NOT
+          // `backup_status`: that tool answers from `deriveProtection`, which
+          // judges the last COMPLETED backup and knows nothing of a run in
+          // flight — mid-run on a box that has never finished one it would
+          // report "never backed up, unprotected", which is a worse answer
+          // than none.
           onTimeout: {
             message: "The backup is taking longer than this call waits. It is still running.",
-            next: "Do not start another one. Call backup_status to see how it is getting on, and tell the user.",
+            next: "Do not start another one. Tell the user it is still going, and call backup_list later to confirm it landed.",
           },
         },
       );

--- a/mcp/tools/system.ts
+++ b/mcp/tools/system.ts
@@ -743,7 +743,20 @@ export function registerSystemTools(reg: Registrar, ctx: McpContext): void {
       const body = await apiPost<{ ok?: boolean; exitCode?: number }>(
         "/setup-api/clawkeep/backup",
         { ...(label ? { label } : {}) },
-        { timeoutMs: 180_000, rules: BACKUP_RULES },
+        {
+          timeoutMs: 180_000,
+          rules: BACKUP_RULES,
+          // A 12 GB backup runs for well over an hour (TASK-675), so this
+          // abort is the NORMAL outcome for the box this tool matters most
+          // on — and the generic "Retry once" would start a second full
+          // archive-and-upload beside the first. `clawkeepd` has no
+          // single-instance guard of any kind, so nothing downstream would
+          // stop it. Says what the tool's own description says.
+          onTimeout: {
+            message: "The backup is taking longer than this call waits. It is still running.",
+            next: "Do not start another one. Call backup_status to see how it is getting on, and tell the user.",
+          },
+        },
       );
       if (body.ok !== true) {
         throw new ToolError(

--- a/mcp/tools/system.ts
+++ b/mcp/tools/system.ts
@@ -721,7 +721,7 @@ export function registerSystemTools(reg: Registrar, ctx: McpContext): void {
 
   reg.tool(
     "backup_now",
-    "Start a cloud backup of this ClawBox now. It can take several minutes; if this call times out the backup is still running, so do not start another one — call backup_list later to confirm it landed.",
+    "Start a cloud backup of this ClawBox now. It can take several minutes; if this call times out the backup may still be running, so do not start another one — call backup_list later to confirm it landed.",
     { label: zText(64, "Short name for this backup, e.g. \"before update\"").optional() },
     { editions: ["openclaw"], readOnly: false },
     async ({ label }: { label?: string }) => {
@@ -761,9 +761,16 @@ export function registerSystemTools(reg: Registrar, ctx: McpContext): void {
           // flight — mid-run on a box that has never finished one it would
           // report "never backed up, unprotected", which is a worse answer
           // than none.
+          //
+          // All three sentences hedge on purpose. The abort establishes that
+          // THIS CLIENT stopped waiting and nothing else — `clawkeepd` may
+          // have exited, the box may have rebooted, the Next worker may have
+          // been replaced — so stating the run is alive is the same false
+          // certainty as the "Retry once" it replaces, pointing the other
+          // way. The ACTION is right either way, and is the part that matters.
           onTimeout: {
-            message: "The backup is taking longer than this call waits. It is still running.",
-            next: "Do not start another one. Tell the user it is still going, and call backup_list later to confirm it landed.",
+            message: "The backup is taking longer than this call waits. It may still be running.",
+            next: "Do not start another one. Tell the user it may still be running, and call backup_list later to confirm it landed.",
           },
         },
       );

--- a/src/app/setup-api/clawkeep/backup/route.ts
+++ b/src/app/setup-api/clawkeep/backup/route.ts
@@ -11,9 +11,12 @@ export const dynamic = "force-dynamic";
 //
 // On Jetson a real backup can take minutes — the request stays open until the
 // daemon finishes. The UI should call this with no client-side timeout: the
-// bridge's own kill timer (BACKUP_RUN_CAP_MS, 60 minutes) is the real ceiling
-// and now has an owner-facing answer of its own, 504 `timed_out`. The systemd
-// unit's TimeoutStartSec=4h applies to the SCHEDULED run, not to this one.
+// bridge's own kill timer (BACKUP_RUN_CAP_MS) is the real ceiling and has an
+// owner-facing answer of its own, 504 `timed_out`. It is now the same four
+// hours `clawkeep/systemd/clawkeepd.service` declares: those timers are not
+// installed on a ClawBox, so this timer is the only ceiling ANY run gets —
+// scheduled or by hand — and at the old 60 minutes it killed the 12 GB
+// backups TASK-675 exists to support.
 //
 // A box with no pairing is refused with 409 `not_paired` before the daemon is
 // started: `clawkeepd` would have loaded the token, failed and exited 65, and

--- a/src/app/setup-api/clawkeep/backup/route.ts
+++ b/src/app/setup-api/clawkeep/backup/route.ts
@@ -17,8 +17,9 @@ export const dynamic = "force-dynamic";
 // installed on a ClawBox, so this timer is the only ceiling ClawBox ITSELF
 // imposes on a run, scheduled or by hand — and at the old 60 minutes it
 // killed the 12 GB backups TASK-675 exists to support. It is not the only
-// ceiling that exists: the daemon's own per-step caps bind first, whatever
-// this one allows (`clawkeep/clawkeep/limits.py`).
+// ceiling that exists: the daemon's own per-step caps bind independently
+// (`clawkeep/clawkeep/limits.py`), and are what is left if the worker holding
+// this timer is replaced mid-run.
 //
 // A box with no pairing is refused with 409 `not_paired` before the daemon is
 // started: `clawkeepd` would have loaded the token, failed and exited 65, and

--- a/src/app/setup-api/clawkeep/backup/route.ts
+++ b/src/app/setup-api/clawkeep/backup/route.ts
@@ -14,9 +14,11 @@ export const dynamic = "force-dynamic";
 // bridge's own kill timer (BACKUP_RUN_CAP_MS) is the real ceiling and has an
 // owner-facing answer of its own, 504 `timed_out`. It is now the same four
 // hours `clawkeep/systemd/clawkeepd.service` declares: those timers are not
-// installed on a ClawBox, so this timer is the only ceiling ANY run gets —
-// scheduled or by hand — and at the old 60 minutes it killed the 12 GB
-// backups TASK-675 exists to support.
+// installed on a ClawBox, so this timer is the only ceiling ClawBox ITSELF
+// imposes on a run, scheduled or by hand — and at the old 60 minutes it
+// killed the 12 GB backups TASK-675 exists to support. It is not the only
+// ceiling that exists: the daemon's own per-step caps bind first, whatever
+// this one allows (`clawkeep/clawkeep/limits.py`).
 //
 // A box with no pairing is refused with 409 `not_paired` before the daemon is
 // started: `clawkeepd` would have loaded the token, failed and exited 65, and

--- a/src/components/ClawKeepApp.tsx
+++ b/src/components/ClawKeepApp.tsx
@@ -1144,9 +1144,12 @@ function BackupProgressPanel({
           ? t("clawkeep.progress.backupHint")
           : t("clawkeep.progress.restoreHint")}
       </p>
-      {/* "Looks stuck?" recovery link. Surfaces after ~6 minutes on the
-          same heartbeat (real Jetson backups complete in 2-5 min) — gives
-          the user a way out before the 30-minute auto-stale kicks in.
+      {/* "Looks stuck?" recovery link. Surfaces after RESET_HINT_AFTER_MS on
+          the same heartbeat — a way out long before STALE_RUNNING_MS retires
+          the pulse on its own. It is only ever an OFFER: the ~6 minutes was
+          chosen when a Jetson backup took 2-5 min, and a 12 GB archive
+          (TASK-675) legitimately runs for well over an hour, so the link has
+          to sit beside a healthy long run without claiming anything about it.
           Only on backup; restore has its own swap-cant-be-interrupted
           hint above and a reset there would be actively dangerous. */}
       {isBackup && onReset && heartbeatAtMs > 0

--- a/src/lib/clawkeep-protection.ts
+++ b/src/lib/clawkeep-protection.ts
@@ -108,8 +108,18 @@ export const MAX_BACKUP_WINDOW_MS = 7 * DAY_MS + BACKUP_GRACE_MS;
  * It is ClawKeep's own number, not one ClawBox picked: `clawkeep/systemd/
  * clawkeepd.service` declares `TimeoutStartSec=4h` for this very binary, which
  * is the daemon's answer to "how long may one backup take". Because those
- * timers are not installed, this cap is the ONLY ceiling any run on a ClawBox
- * gets, so a shorter one here is the box overruling the daemon.
+ * timers are not installed, this is the only ceiling ClawBox itself imposes on
+ * a run, so a shorter one here is the box overruling the daemon.
+ *
+ * It is not the only ceiling that EXISTS. The daemon carries its own per-step
+ * caps on the OpenClaw edition — `openclaw.py`'s `SUBPROCESS_TIMEOUT_S`, which
+ * bounds `backup create` and `backup verify` — and those bind first, whatever
+ * this constant allows. They were 30 and 5 minutes and are raised to the same
+ * four hours in the same change; `clawkeep-backup-run-cap.test.ts` reads them
+ * back out of the Python and pins them against this value. The Hermes backend
+ * builds its archive in-process with `tarfile` and has no subprocess cap at
+ * all, so the two editions are bounded differently by construction — Hermes by
+ * this timer alone.
  *
  * It was 60 minutes, written when a Jetson backup took 2-5 minutes. TASK-675
  * made 10 GB+ archives the supported case and the validated 12 GiB run took
@@ -122,15 +132,19 @@ export const MAX_BACKUP_WINDOW_MS = 7 * DAY_MS + BACKUP_GRACE_MS;
 export const BACKUP_RUN_CAP_MS = 4 * HOUR_MS;
 
 /**
- * The hard cap on a single RESTORE. Declared beside the backup's for the same
- * reason the module gives above: the two are one number by construction.
+ * The hard cap on a single RESTORE, and on how long a `restoring.flag` may be
+ * believed. Declared beside the backup's for the reason the module gives
+ * above: these are one number by construction, not three that happen to agree.
  *
- * A restore does strictly more work than the backup that produced the archive
- * — multipart download, decrypt, extract, then `openclaw backup verify` — on
- * the same bytes, so a shorter cap is the same false failure with a worse
- * ending: a box SIGKILLed part-way through having its state replaced. It was
- * 30 minutes while the backup had 60, which put a 12 GB restore out of reach
- * before TASK-675's archives existed.
+ * It is the same four hours, and deliberately so — `TimeoutStartSec=4h` is a
+ * bound on one whole ClawKeep run, and a restore is one. What was wrong was
+ * not that the restore lacked a multiplier but that it had HALF the backup's
+ * budget, 30 minutes against 60, for work that is at least symmetric: the
+ * download mirrors the upload, and decrypt, extract and `openclaw backup
+ * verify` all come on top. That put a 12 GB restore out of reach before
+ * TASK-675's archives existed, and being SIGKILLed part-way through a restore
+ * is worse than being killed part-way through a backup, because what is being
+ * rewritten is the box's own state.
  */
 export const RESTORE_RUN_CAP_MS = BACKUP_RUN_CAP_MS;
 
@@ -159,11 +173,20 @@ export const RESTORE_RUN_CAP_MS = BACKUP_RUN_CAP_MS;
  * minutes the shelf went dark on a 12 GB upload that was still going.
  *
  * The remaining looseness is that the heartbeat measures DURATION, not
- * progress: a run SIGKILLed at the cap leaves `"running"` behind and the pulse
- * stays on until the window closes, now four hours rather than one. Measuring
- * it from real progress needs `_on_upload_progress` in `runner.py` to stamp a
- * liveness field — a daemon-side change that has to reach the boxes before
- * this side can read it, so it ships separately.
+ * progress: a run SIGKILLed at the cap — or orphaned by a Next restart, which
+ * takes the kill timer with it — leaves `"running"` behind and the pulse stays
+ * on until the window closes, now four hours rather than one.
+ *
+ * What is missing is NOT a daemon-side stamp. `runner.py`'s
+ * `_on_upload_progress` already persists `upload_bytes_done` on a 250 ms
+ * throttle, `getStatus()` already reads it into `uploadBytesDone`, and the
+ * card already draws a throughput figure from it: a counter that has not moved
+ * across several polls IS the liveness signal, on today's boxes. What is
+ * missing is a consumer — `isBackupRunning` is handed only the two heartbeat
+ * fields, so giving it progress means changing its inputs and every caller
+ * (the shelf, the card, the hook, `backup_status`), and the archive-build
+ * phase still has only `currentStepAtMs` to go on. That is a change with its
+ * own RED, not a line in this one.
  *
  * Two edges this leaves open, neither of which touches the protection verdict —
  * `lastBackupAtMs` stops moving either way, so the age term below still lapses

--- a/src/lib/clawkeep-protection.ts
+++ b/src/lib/clawkeep-protection.ts
@@ -111,15 +111,16 @@ export const MAX_BACKUP_WINDOW_MS = 7 * DAY_MS + BACKUP_GRACE_MS;
  * timers are not installed, this is the only ceiling ClawBox itself imposes on
  * a run, so a shorter one here is the box overruling the daemon.
  *
- * It is not the only ceiling that EXISTS. The daemon carries its own per-step
- * caps on the OpenClaw edition — `openclaw.py`'s `SUBPROCESS_TIMEOUT_S`, which
- * bounds `backup create` and `backup verify` — and those bind first, whatever
- * this constant allows. They were 30 and 5 minutes and are raised to the same
- * four hours in the same change; `clawkeep-backup-run-cap.test.ts` reads them
- * back out of the Python and pins them against this value. The Hermes backend
- * builds its archive in-process with `tarfile` and has no subprocess cap at
- * all, so the two editions are bounded differently by construction — Hermes by
- * this timer alone.
+ * It is not the only ceiling that EXISTS. The daemon shells out for four steps
+ * and carries a cap on each: `backup create` and `backup verify` in
+ * `openclaw.py`, and `openssl enc` / `enc -d` in `crypto.py`. Those bind
+ * first, whatever this constant allows. They were 30, 5, 30 and 30 minutes and
+ * all now take one `limits.SUBPROCESS_TIMEOUT_S`, the same four hours;
+ * `clawkeep-backup-run-cap.test.ts` reads them back out of the Python and pins
+ * them against this value. Only the ARCHIVE step differs by edition — the
+ * Hermes backend builds its tarball in-process with `tarfile` — while the
+ * encrypt and decrypt steps run outside any edition branch, so both SKUs carry
+ * the openssl cap.
  *
  * It was 60 minutes, written when a Jetson backup took 2-5 minutes. TASK-675
  * made 10 GB+ archives the supported case and the validated 12 GiB run took

--- a/src/lib/clawkeep-protection.ts
+++ b/src/lib/clawkeep-protection.ts
@@ -113,14 +113,18 @@ export const MAX_BACKUP_WINDOW_MS = 7 * DAY_MS + BACKUP_GRACE_MS;
  *
  * It is not the only ceiling that EXISTS. The daemon shells out for four steps
  * and carries a cap on each: `backup create` and `backup verify` in
- * `openclaw.py`, and `openssl enc` / `enc -d` in `crypto.py`. Those bind
- * first, whatever this constant allows. They were 30, 5, 30 and 30 minutes and
- * all now take one `limits.SUBPROCESS_TIMEOUT_S`, the same four hours;
+ * `openclaw.py`, and `openssl enc` / `enc -d` in `crypto.py`. They were 30, 5,
+ * 30 and 30 minutes — tighter than this constant, so they, not it, were the
+ * walls a 12 GB backup hit — and all now take one
+ * `limits.SUBPROCESS_TIMEOUT_S`, the same four hours;
  * `clawkeep-backup-run-cap.test.ts` reads them back out of the Python and pins
- * them against this value. Only the ARCHIVE step differs by edition — the
- * Hermes backend builds its tarball in-process with `tarfile` — while the
- * encrypt and decrypt steps run outside any edition branch, so both SKUs carry
- * the openssl cap.
+ * them against this value. At equal values this timer fires first, since it
+ * starts at spawn and a step's does not; the per-step caps bind
+ * INDEPENDENTLY, and are the only ceiling left when the Next worker holding
+ * this one is replaced mid-run. The archive and verify steps differ by
+ * edition — the Hermes backend does both in-process, with `tarfile` and a
+ * manifest check — while encrypt and decrypt shell out outside any edition
+ * branch, so both SKUs carry the openssl cap.
  *
  * It was 60 minutes, written when a Jetson backup took 2-5 minutes. TASK-675
  * made 10 GB+ archives the supported case and the validated 12 GiB run took

--- a/src/lib/clawkeep-protection.ts
+++ b/src/lib/clawkeep-protection.ts
@@ -104,8 +104,35 @@ export const MAX_BACKUP_WINDOW_MS = 7 * DAY_MS + BACKUP_GRACE_MS;
  * in-Next scheduler drives runs instead — and SIGKILLs the daemon at this mark.
  * Declared here, where nothing is imported, so the kill timer and the UI's
  * liveness rule below are the same number by construction.
+ *
+ * It is ClawKeep's own number, not one ClawBox picked: `clawkeep/systemd/
+ * clawkeepd.service` declares `TimeoutStartSec=4h` for this very binary, which
+ * is the daemon's answer to "how long may one backup take". Because those
+ * timers are not installed, this cap is the ONLY ceiling any run on a ClawBox
+ * gets, so a shorter one here is the box overruling the daemon.
+ *
+ * It was 60 minutes, written when a Jetson backup took 2-5 minutes. TASK-675
+ * made 10 GB+ archives the supported case and the validated 12 GiB run took
+ * ~86 minutes — so the box SIGKILLed, around 70% of the upload, the very run
+ * the multipart chunking and the portal's credential-TTL fix had gone to work
+ * to make possible, and answered "backup timed out" over a healthy transfer.
+ * `clawkeep-backup-run-cap.test.ts` reads the unit file and pins the two
+ * together so they cannot drift apart again.
  */
-export const BACKUP_RUN_CAP_MS = 60 * MINUTE_MS;
+export const BACKUP_RUN_CAP_MS = 4 * HOUR_MS;
+
+/**
+ * The hard cap on a single RESTORE. Declared beside the backup's for the same
+ * reason the module gives above: the two are one number by construction.
+ *
+ * A restore does strictly more work than the backup that produced the archive
+ * — multipart download, decrypt, extract, then `openclaw backup verify` — on
+ * the same bytes, so a shorter cap is the same false failure with a worse
+ * ending: a box SIGKILLed part-way through having its state replaced. It was
+ * 30 minutes while the backup had 60, which put a 12 GB restore out of reach
+ * before TASK-675's archives existed.
+ */
+export const RESTORE_RUN_CAP_MS = BACKUP_RUN_CAP_MS;
 
 /**
  * How long a `"running"` status may stand before the run behind it is a corpse
@@ -125,13 +152,18 @@ export const BACKUP_RUN_CAP_MS = 60 * MINUTE_MS;
  * and, on a box whose first backup it was, turning the shelf shield red while
  * the upload was fine.
  *
- * What this deliberately does NOT do is invent a looser window than the cap.
- * TASK-675 made 10 GB+ archives the supported case, and such a run plausibly
- * does not fit in 60 minutes — but that is the cap's problem, not this
- * constant's: pulsing past the cap would be a progress indicator for a process
- * that no longer exists. Raising the cap (and giving `_on_upload_progress` a
- * liveness stamp so the window can be measured from real progress rather than
- * from run duration) belongs with the large-backup work, on hardware.
+ * What this deliberately does NOT do is invent a looser window than the cap:
+ * pulsing past it would be a progress indicator for a process that no longer
+ * exists. It follows the cap instead, which is why raising the cap for
+ * TASK-675's 10 GB+ archives also fixed the other half of that defect — at 60
+ * minutes the shelf went dark on a 12 GB upload that was still going.
+ *
+ * The remaining looseness is that the heartbeat measures DURATION, not
+ * progress: a run SIGKILLed at the cap leaves `"running"` behind and the pulse
+ * stays on until the window closes, now four hours rather than one. Measuring
+ * it from real progress needs `_on_upload_progress` in `runner.py` to stamp a
+ * liveness field — a daemon-side change that has to reach the boxes before
+ * this side can read it, so it ships separately.
  *
  * Two edges this leaves open, neither of which touches the protection verdict —
  * `lastBackupAtMs` stops moving either way, so the age term below still lapses

--- a/src/lib/clawkeep.ts
+++ b/src/lib/clawkeep.ts
@@ -23,7 +23,11 @@ import os from "node:os";
 import path from "node:path";
 import { StringDecoder } from "node:string_decoder";
 
-import { BACKUP_RUN_CAP_MS, expectedBackupWindowMs } from "@/lib/clawkeep-protection";
+import {
+  BACKUP_RUN_CAP_MS,
+  RESTORE_RUN_CAP_MS,
+  expectedBackupWindowMs,
+} from "@/lib/clawkeep-protection";
 import { findOpenclawBin } from "@/lib/openclaw-config";
 import { get as configGet, set as configSet } from "@/lib/config-store";
 import { getEdition } from "@/lib/harness";
@@ -1210,7 +1214,7 @@ export class RestoreNeedsPassphraseError extends ClawKeepError {
   }
 }
 
-const RESTORE_TIMEOUT_MS = 30 * 60 * 1000; // hard cap matches openclaw verify + multipart download
+const RESTORE_TIMEOUT_MS = RESTORE_RUN_CAP_MS;
 // Generous cap for a full backup (openclaw backup create + multipart upload).
 // A hung clawkeepd must not hold a Next.js worker open forever. Shared with
 // the UI's "is this `running` heartbeat still alive" rule, which is only

--- a/src/lib/clawkeep.ts
+++ b/src/lib/clawkeep.ts
@@ -222,7 +222,15 @@ async function ensureDataDir(): Promise<void> {
 // Stale-flag window: if the restoring marker is older than the restore
 // timeout it almost certainly means the Next.js process crashed mid-run
 // and never cleaned up. Treat as not-restoring so the shield stops glowing.
-const RESTORING_FLAG_MAX_AGE_MS = 30 * 60 * 1000;
+//
+// It has to BE the restore timeout, not a number that happens to equal it.
+// The two were both 30 minutes, so the flag could never go stale during a
+// live restore — the run was SIGKILLed at the same instant. Raising the
+// restore cap without this would have had `isRestoring()` DELETE the flag of
+// a restore still in flight (it removes the file, it does not merely report
+// false), dropping the shelf's orange restoring shield back to a calm green
+// verdict while the box's whole state directory was being replaced.
+const RESTORING_FLAG_MAX_AGE_MS = RESTORE_RUN_CAP_MS;
 
 /**
  * "HH:MM", 24-hour, and a time that exists. Kept in step with the memory

--- a/src/tests/unit/clawkeep-backup-run-cap.test.ts
+++ b/src/tests/unit/clawkeep-backup-run-cap.test.ts
@@ -46,11 +46,14 @@ async function declaredDaemonTimeoutMs(): Promise<number> {
 }
 
 describe("the cap a ClawKeep backup run is given", () => {
-  it("is not stricter than the one ClawKeep's own service unit declares", async () => {
-    // The bridge spawns the very binary this unit was written for. Being
-    // stricter than it means the box kills runs the daemon considers normal —
-    // and it is the box, not the daemon, the owner hears from.
-    expect(BACKUP_RUN_CAP_MS).toBeGreaterThanOrEqual(await declaredDaemonTimeoutMs());
+  it("is the one ClawKeep's own service unit declares, to the millisecond", async () => {
+    // Equality rather than "no stricter", because these two describe the SAME
+    // thing — the bound on one whole ClawKeep run — and the argument this
+    // branch makes throughout is that one fact may not be two numbers. It is
+    // also the only form that catches the drift in both directions: a
+    // `TimeoutStartSec` LOWERED to 3h passes a `>=` here while the daemon
+    // kills a four-hour backup the bridge was still waiting on.
+    expect(BACKUP_RUN_CAP_MS).toBe(await declaredDaemonTimeoutMs());
   });
 
   it("outlasts the 12 GB backup this task exists to make work", () => {
@@ -70,6 +73,11 @@ describe("the cap a ClawKeep backup run is given", () => {
     expect(declared, "limits.py must declare SUBPROCESS_TIMEOUT_S").not.toBeNull();
     const seconds = declared![1].split("*").reduce((a, b) => a * Number(b.trim()), 1);
 
+    // "No tighter", not equality, and the difference from the run cap above is
+    // deliberate: these bound a STEP inside the run, and the rule is that no
+    // step may be given less than the run itself. A step allowed more is
+    // harmless — the run cap ends it first — so pinning equality here would
+    // fail a legitimate change for no defect.
     expect(seconds * 1000).toBeGreaterThanOrEqual(BACKUP_RUN_CAP_MS);
     expect(seconds * 1000).toBeGreaterThanOrEqual(RESTORE_RUN_CAP_MS);
 

--- a/src/tests/unit/clawkeep-backup-run-cap.test.ts
+++ b/src/tests/unit/clawkeep-backup-run-cap.test.ts
@@ -137,17 +137,41 @@ describe("the cap a ClawKeep backup run is given", () => {
     expect(protection.RESTORE_RUN_CAP_MS).toBeGreaterThan(MEASURED_12GIB_RUN_MS);
   });
 
-  it("is the cap runBackup actually arms, and no run is killed inside it", async () => {
-    const promise = clawkeep.runBackup({ idle: false });
-    for (let i = 0; i < 50 && !daemon.spawned; i++) {
-      await new Promise((r) => setTimeout(r, 1));
-    }
-    expect(daemon.spawned).toBe(true);
+  it("is not undercut by the daemon's own per-step caps on the OpenClaw edition", async () => {
+    // The bridge cap is the only ceiling CLAWBOX imposes; it is not the only
+    // one that exists. `agent.create_archive()` / `agent.verify_archive()`
+    // pass no timeout, so `openclaw.py`'s defaults bind the archive and the
+    // verify steps first — they were 30 and 5 minutes, so on OpenClaw a 12 GB
+    // backup died half an hour in and never reached the bridge's timer at all.
+    // Read out of the Python rather than restated here, so raising one and
+    // forgetting the other reddens this.
+    const py = await fs.readFile(
+      path.join(process.cwd(), "clawkeep/clawkeep/openclaw.py"),
+      "utf8",
+    );
+    const declared = /^SUBPROCESS_TIMEOUT_S = (.+)$/m.exec(py);
+    expect(declared, "openclaw.py must declare SUBPROCESS_TIMEOUT_S").not.toBeNull();
+    // The expression is a product of integer literals (`4 * 60 * 60`).
+    expect(declared![1]).toMatch(/^[\d\s*]+$/);
+    const seconds = declared![1].split("*").reduce((a, b) => a * Number(b.trim()), 1);
 
-    daemon.finish(0);
-    const result = await promise;
-    expect(daemon.killed).toEqual([]);
-    expect(result.exitCode).toBe(0);
-    expect(result.stderr).not.toContain("backup timed out");
+    expect(seconds * 1000).toBeGreaterThanOrEqual(protection.BACKUP_RUN_CAP_MS);
+    expect(seconds * 1000).toBeGreaterThanOrEqual(protection.RESTORE_RUN_CAP_MS);
+
+    // Both step functions must take that default, not a tighter literal.
+    for (const fn of ["create_archive", "verify_archive"]) {
+      const body = py.slice(py.indexOf(`def ${fn}(`), py.indexOf(`def ${fn}(`) + 400);
+      expect(body, `${fn} must use SUBPROCESS_TIMEOUT_S`).toContain(
+        "timeout: float = SUBPROCESS_TIMEOUT_S",
+      );
+    }
+  });
+
+  it("gives the restoring flag the same window as the restore it marks", () => {
+    // `isRestoring()` DELETES a flag it judges stale, and `restoring` is the
+    // only signal that survives a page reload, so a window shorter than the
+    // restore's own cap drops the shelf's orange shield back to a calm green
+    // verdict while the box's state is still being replaced.
+    expect(protection.RESTORE_RUN_CAP_MS).toBeGreaterThan(MEASURED_12GIB_RUN_MS);
   });
 });

--- a/src/tests/unit/clawkeep-backup-run-cap.test.ts
+++ b/src/tests/unit/clawkeep-backup-run-cap.test.ts
@@ -1,114 +1,40 @@
-import { EventEmitter } from "node:events";
 import fs from "fs/promises";
-import os from "os";
 import path from "path";
 
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
+
+import { BACKUP_RUN_CAP_MS, RESTORE_RUN_CAP_MS } from "@/lib/clawkeep-protection";
 
 /**
  * TASK-675 — a large ClawKeep backup is killed by the box while it is working.
  *
  * The customer case is a 12 GB archive. PR #607 (multipart chunking) and the
- * portal's credential-TTL fix together made that run finish — and the board
- * records the validated 12 GiB run finishing in ~86 minutes. `runBackup()`
- * SIGKILLs the daemon at `BACKUP_RUN_CAP_MS`, which was 60 minutes, so the box
- * destroys the upload around 70% and answers `exitCode: 124`, "backup timed
- * out", over a transfer that was healthy. A false failure delivered onto the
- * one operation whose whole point is that it is long — and the run it kills is
- * precisely the one the rest of TASK-675 went to work to make possible.
+ * portal's credential-TTL fix together made that run finish, and the board
+ * records the validated 12 GiB run finishing in ~86 minutes. Four separate
+ * caps stood in its way, none of them reached by the others:
  *
- * The bound is not something ClawBox has to invent. ClawKeep ships its own
- * service unit for exactly this binary and declares `TimeoutStartSec` there —
- * the daemon's own answer to "how long may one backup take". The bridge that
- * spawns it must not be stricter than the unit written to run it, so the two
- * are pinned together here rather than left as two magic numbers free to
- * drift apart.
+ *   - `openclaw.py`'s `create_archive` default, 30 minutes — the FIRST wall on
+ *     the OpenClaw edition, since `agent.create_archive()` passes no timeout;
+ *   - `runBackup()`'s kill timer, `BACKUP_RUN_CAP_MS`, 60 minutes;
+ *   - on the restore side, `verify_archive`'s 5 minutes, and a
+ *     `RESTORE_TIMEOUT_MS` of 30 — half the backup's.
+ *
+ * Each turns "this step is slow" into "this backup failed" for exactly the
+ * step that is slow. None of the numbers is one ClawBox has to invent:
+ * ClawKeep ships its own unit for this binary and declares `TimeoutStartSec`
+ * there. These tests read that unit and the daemon's own source, so raising
+ * one cap and forgetting another is red here rather than shipped.
  */
-
-const daemon = vi.hoisted(() => ({
-  spawned: false,
-  killed: [] as (string | undefined)[],
-  /** Ends the run the way the daemon exiting would. Replaced at each spawn. */
-  finish: (() => {}) as (code?: number) => void,
-}));
-
-vi.mock("node:child_process", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:child_process")>();
-  const spawn = () => {
-    daemon.spawned = true;
-    const child = new EventEmitter() as EventEmitter & {
-      stdout: EventEmitter;
-      stderr: EventEmitter;
-      kill: (signal?: string) => void;
-    };
-    child.stdout = new EventEmitter();
-    child.stderr = new EventEmitter();
-    let done = false;
-    const close = (code: number | null) => {
-      if (done) return;
-      done = true;
-      child.emit("close", code);
-    };
-    child.kill = (signal?: string) => {
-      daemon.killed.push(signal);
-      setImmediate(() => close(null));
-    };
-    // The daemon works until the test says it has finished. A long upload is
-    // silent on both pipes — `clawkeepd` logs at phase boundaries and
-    // publishes its per-250 ms progress into state.json, not onto stderr — so
-    // nothing on this side can tell a working run from a wedged one except
-    // the cap, which is why the cap has to be the daemon's own.
-    daemon.finish = (code = 0) => close(code);
-    return child;
-  };
-  return { ...actual, spawn, default: { ...actual, spawn } };
-});
-
-const TEST_ROOT = path.join(os.tmpdir(), `clawbox-clawkeep-cap-${process.pid}-${Date.now()}`);
-const DATA_DIR = path.join(TEST_ROOT, "clawkeep");
-
-let clawkeep: typeof import("@/lib/clawkeep");
-let protection: typeof import("@/lib/clawkeep-protection");
-
-beforeAll(async () => {
-  process.env.CLAWKEEP_DATA_DIR = DATA_DIR;
-  process.env.CLAWKEEP_CONFIG_PATH = path.join(DATA_DIR, "config.toml");
-  await fs.mkdir(DATA_DIR, { recursive: true });
-  // `pairedDaemonBin()` refuses an unpaired box before it spawns anything.
-  await fs.writeFile(path.join(DATA_DIR, "token"), "claw_test", { mode: 0o600 });
-  // Point the daemon lookup at a real executable so `getDaemonBin()` takes its
-  // override branch: the PATH probe shells out, and that spawn would come
-  // through the mock below and be mistaken for the backup run.
-  const bin = path.join(TEST_ROOT, "clawkeepd");
-  await fs.writeFile(bin, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
-  process.env.CLAWKEEP_BIN = bin;
-  clawkeep = await import("@/lib/clawkeep");
-  protection = await import("@/lib/clawkeep-protection");
-});
-
-afterAll(async () => {
-  delete process.env.CLAWKEEP_DATA_DIR;
-  delete process.env.CLAWKEEP_CONFIG_PATH;
-  delete process.env.CLAWKEEP_BIN;
-  await fs.rm(TEST_ROOT, { recursive: true, force: true });
-});
-
-beforeEach(() => {
-  daemon.spawned = false;
-  daemon.killed = [];
-  daemon.finish = () => {};
-});
 
 const MINUTE = 60_000;
 /** The board's measured duration of the validated 12 GiB run. */
 const MEASURED_12GIB_RUN_MS = 86 * MINUTE;
 
+const repoFile = (rel: string) => fs.readFile(path.join(process.cwd(), rel), "utf8");
+
 /** What `clawkeepd.service` — ClawKeep's own unit for this binary — allows. */
 async function declaredDaemonTimeoutMs(): Promise<number> {
-  const unit = await fs.readFile(
-    path.join(process.cwd(), "clawkeep/systemd/clawkeepd.service"),
-    "utf8",
-  );
+  const unit = await repoFile("clawkeep/systemd/clawkeepd.service");
   const declared = /^TimeoutStartSec=(\d+)([smh])$/m.exec(unit);
   expect(declared, "clawkeepd.service must declare TimeoutStartSec").not.toBeNull();
   const [, value, unitLetter] = declared!;
@@ -121,57 +47,54 @@ describe("the cap a ClawKeep backup run is given", () => {
     // The bridge spawns the very binary this unit was written for. Being
     // stricter than it means the box kills runs the daemon considers normal —
     // and it is the box, not the daemon, the owner hears from.
-    expect(protection.BACKUP_RUN_CAP_MS).toBeGreaterThanOrEqual(await declaredDaemonTimeoutMs());
+    expect(BACKUP_RUN_CAP_MS).toBeGreaterThanOrEqual(await declaredDaemonTimeoutMs());
   });
 
   it("outlasts the 12 GB backup this task exists to make work", () => {
-    expect(protection.BACKUP_RUN_CAP_MS).toBeGreaterThan(MEASURED_12GIB_RUN_MS);
-  });
-
-  it("gives a restore at least as long as the backup that produced the archive", () => {
-    // The sibling of the same defect: `runRestore` downloads, decrypts,
-    // extracts and verifies the very bytes the backup uploaded, and had HALF
-    // the time to do it in. A restore killed part-way is worse than a backup
-    // killed part-way, because what it was rewriting is the box's own state.
-    expect(protection.RESTORE_RUN_CAP_MS).toBeGreaterThanOrEqual(protection.BACKUP_RUN_CAP_MS);
-    expect(protection.RESTORE_RUN_CAP_MS).toBeGreaterThan(MEASURED_12GIB_RUN_MS);
+    expect(BACKUP_RUN_CAP_MS).toBeGreaterThan(MEASURED_12GIB_RUN_MS);
   });
 
   it("is not undercut by the daemon's own per-step caps on the OpenClaw edition", async () => {
     // The bridge cap is the only ceiling CLAWBOX imposes; it is not the only
-    // one that exists. `agent.create_archive()` / `agent.verify_archive()`
-    // pass no timeout, so `openclaw.py`'s defaults bind the archive and the
-    // verify steps first — they were 30 and 5 minutes, so on OpenClaw a 12 GB
-    // backup died half an hour in and never reached the bridge's timer at all.
-    // Read out of the Python rather than restated here, so raising one and
-    // forgetting the other reddens this.
-    const py = await fs.readFile(
-      path.join(process.cwd(), "clawkeep/clawkeep/openclaw.py"),
-      "utf8",
-    );
-    const declared = /^SUBPROCESS_TIMEOUT_S = (.+)$/m.exec(py);
+    // one that exists. `agent.create_archive()` and `agent.verify_archive()`
+    // pass no timeout, so `openclaw.py`'s defaults bind those steps first —
+    // they were 30 and 5 minutes, so on OpenClaw a 12 GB backup died half an
+    // hour in and never reached the bridge's timer at all. Read out of the
+    // Python rather than restated here.
+    const py = await repoFile("clawkeep/clawkeep/openclaw.py");
+    const declared = /^SUBPROCESS_TIMEOUT_S = ([\d\s*]+)$/m.exec(py);
     expect(declared, "openclaw.py must declare SUBPROCESS_TIMEOUT_S").not.toBeNull();
-    // The expression is a product of integer literals (`4 * 60 * 60`).
-    expect(declared![1]).toMatch(/^[\d\s*]+$/);
     const seconds = declared![1].split("*").reduce((a, b) => a * Number(b.trim()), 1);
 
-    expect(seconds * 1000).toBeGreaterThanOrEqual(protection.BACKUP_RUN_CAP_MS);
-    expect(seconds * 1000).toBeGreaterThanOrEqual(protection.RESTORE_RUN_CAP_MS);
+    expect(seconds * 1000).toBeGreaterThanOrEqual(BACKUP_RUN_CAP_MS);
+    expect(seconds * 1000).toBeGreaterThanOrEqual(RESTORE_RUN_CAP_MS);
 
-    // Both step functions must take that default, not a tighter literal.
+    // And both step functions must take that default, not a tighter literal.
     for (const fn of ["create_archive", "verify_archive"]) {
-      const body = py.slice(py.indexOf(`def ${fn}(`), py.indexOf(`def ${fn}(`) + 400);
-      expect(body, `${fn} must use SUBPROCESS_TIMEOUT_S`).toContain(
-        "timeout: float = SUBPROCESS_TIMEOUT_S",
-      );
+      const at = py.indexOf(`def ${fn}(`);
+      expect(at, `openclaw.py must define ${fn}`).toBeGreaterThan(-1);
+      expect(py.slice(at, at + 400), `${fn} must use SUBPROCESS_TIMEOUT_S`)
+        .toContain("timeout: float = SUBPROCESS_TIMEOUT_S");
     }
   });
+});
 
-  it("gives the restoring flag the same window as the restore it marks", () => {
+describe("the cap a ClawKeep restore is given", () => {
+  it("is at least the backup's, for work that is at least symmetric", () => {
+    // The download mirrors the upload; decrypt, extract and `openclaw backup
+    // verify` come on top. It had HALF the backup's budget.
+    expect(RESTORE_RUN_CAP_MS).toBeGreaterThanOrEqual(BACKUP_RUN_CAP_MS);
+    expect(RESTORE_RUN_CAP_MS).toBeGreaterThan(MEASURED_12GIB_RUN_MS);
+  });
+
+  it("is the same window the restoring flag is believed for", async () => {
     // `isRestoring()` DELETES a flag it judges stale, and `restoring` is the
-    // only signal that survives a page reload, so a window shorter than the
-    // restore's own cap drops the shelf's orange shield back to a calm green
-    // verdict while the box's state is still being replaced.
-    expect(protection.RESTORE_RUN_CAP_MS).toBeGreaterThan(MEASURED_12GIB_RUN_MS);
+    // only signal that survives a page reload, so a shorter window drops the
+    // shelf's orange shield back to a calm green verdict while the box's own
+    // state is still being replaced. One constant, not two numbers that
+    // happen to agree — which is exactly how they came apart.
+    const src = await repoFile("src/lib/clawkeep.ts");
+    expect(src).toContain("const RESTORING_FLAG_MAX_AGE_MS = RESTORE_RUN_CAP_MS;");
+    expect(src).toContain("const RESTORE_TIMEOUT_MS = RESTORE_RUN_CAP_MS;");
   });
 });

--- a/src/tests/unit/clawkeep-backup-run-cap.test.ts
+++ b/src/tests/unit/clawkeep-backup-run-cap.test.ts
@@ -10,14 +10,17 @@ import { BACKUP_RUN_CAP_MS, RESTORE_RUN_CAP_MS } from "@/lib/clawkeep-protection
  *
  * The customer case is a 12 GB archive. PR #607 (multipart chunking) and the
  * portal's credential-TTL fix together made that run finish, and the board
- * records the validated 12 GiB run finishing in ~86 minutes. Four separate
+ * records the validated 12 GiB run finishing in ~86 minutes. FIVE separate
  * caps stood in its way, none of them reached by the others:
  *
  *   - `openclaw.py`'s `create_archive` default, 30 minutes — the FIRST wall on
  *     the OpenClaw edition, since `agent.create_archive()` passes no timeout;
+ *   - `crypto.py`'s `encrypt_file`, 30 minutes — `openssl enc` over the whole
+ *     archive, and it runs OUTSIDE any edition branch, so it bound Hermes too;
  *   - `runBackup()`'s kill timer, `BACKUP_RUN_CAP_MS`, 60 minutes;
- *   - on the restore side, `verify_archive`'s 5 minutes, and a
- *     `RESTORE_TIMEOUT_MS` of 30 — half the backup's.
+ *   - on the restore side, `verify_archive`'s 5 minutes, `crypto.py`'s
+ *     `decrypt_file`'s 30, and a `RESTORE_TIMEOUT_MS` of 30 — half the
+ *     backup's.
  *
  * Each turns "this step is slow" into "this backup failed" for exactly the
  * step that is slow. None of the numbers is one ClawBox has to invent:
@@ -54,26 +57,34 @@ describe("the cap a ClawKeep backup run is given", () => {
     expect(BACKUP_RUN_CAP_MS).toBeGreaterThan(MEASURED_12GIB_RUN_MS);
   });
 
-  it("is not undercut by the daemon's own per-step caps on the OpenClaw edition", async () => {
+  it("is not undercut by the daemon's own per-step caps", async () => {
     // The bridge cap is the only ceiling CLAWBOX imposes; it is not the only
-    // one that exists. `agent.create_archive()` and `agent.verify_archive()`
-    // pass no timeout, so `openclaw.py`'s defaults bind those steps first —
-    // they were 30 and 5 minutes, so on OpenClaw a 12 GB backup died half an
-    // hour in and never reached the bridge's timer at all. Read out of the
-    // Python rather than restated here.
-    const py = await repoFile("clawkeep/clawkeep/openclaw.py");
-    const declared = /^SUBPROCESS_TIMEOUT_S = ([\d\s*]+)$/m.exec(py);
-    expect(declared, "openclaw.py must declare SUBPROCESS_TIMEOUT_S").not.toBeNull();
+    // one that exists. Every step below shells out and passes no timeout from
+    // its caller, so the Python default binds it first — they were 30, 5, 30
+    // and 30 minutes, so a 12 GB backup died half an hour in and never
+    // reached the bridge's timer at all. Read out of the Python rather than
+    // restated here, and swept across BOTH modules: the miss that shipped in
+    // the first version of this branch was a module this test did not read.
+    const limits = await repoFile("clawkeep/clawkeep/limits.py");
+    const declared = /^SUBPROCESS_TIMEOUT_S = ([\d\s*]+)$/m.exec(limits);
+    expect(declared, "limits.py must declare SUBPROCESS_TIMEOUT_S").not.toBeNull();
     const seconds = declared![1].split("*").reduce((a, b) => a * Number(b.trim()), 1);
 
     expect(seconds * 1000).toBeGreaterThanOrEqual(BACKUP_RUN_CAP_MS);
     expect(seconds * 1000).toBeGreaterThanOrEqual(RESTORE_RUN_CAP_MS);
 
-    // And both step functions must take that default, not a tighter literal.
-    for (const fn of ["create_archive", "verify_archive"]) {
+    // And every step must take that default, not a tighter literal of its own.
+    const steps: [string, string][] = [
+      ["clawkeep/clawkeep/openclaw.py", "create_archive"],
+      ["clawkeep/clawkeep/openclaw.py", "verify_archive"],
+      ["clawkeep/clawkeep/crypto.py", "encrypt_file"],
+      ["clawkeep/clawkeep/crypto.py", "decrypt_file"],
+    ];
+    for (const [file, fn] of steps) {
+      const py = await repoFile(file);
       const at = py.indexOf(`def ${fn}(`);
-      expect(at, `openclaw.py must define ${fn}`).toBeGreaterThan(-1);
-      expect(py.slice(at, at + 400), `${fn} must use SUBPROCESS_TIMEOUT_S`)
+      expect(at, `${file} must define ${fn}`).toBeGreaterThan(-1);
+      expect(py.slice(at, at + 500), `${fn} must use SUBPROCESS_TIMEOUT_S`)
         .toContain("timeout: float = SUBPROCESS_TIMEOUT_S");
     }
   });

--- a/src/tests/unit/clawkeep-backup-run-cap.test.ts
+++ b/src/tests/unit/clawkeep-backup-run-cap.test.ts
@@ -1,0 +1,153 @@
+import { EventEmitter } from "node:events";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * TASK-675 — a large ClawKeep backup is killed by the box while it is working.
+ *
+ * The customer case is a 12 GB archive. PR #607 (multipart chunking) and the
+ * portal's credential-TTL fix together made that run finish — and the board
+ * records the validated 12 GiB run finishing in ~86 minutes. `runBackup()`
+ * SIGKILLs the daemon at `BACKUP_RUN_CAP_MS`, which was 60 minutes, so the box
+ * destroys the upload around 70% and answers `exitCode: 124`, "backup timed
+ * out", over a transfer that was healthy. A false failure delivered onto the
+ * one operation whose whole point is that it is long — and the run it kills is
+ * precisely the one the rest of TASK-675 went to work to make possible.
+ *
+ * The bound is not something ClawBox has to invent. ClawKeep ships its own
+ * service unit for exactly this binary and declares `TimeoutStartSec` there —
+ * the daemon's own answer to "how long may one backup take". The bridge that
+ * spawns it must not be stricter than the unit written to run it, so the two
+ * are pinned together here rather than left as two magic numbers free to
+ * drift apart.
+ */
+
+const daemon = vi.hoisted(() => ({
+  spawned: false,
+  killed: [] as (string | undefined)[],
+  /** Ends the run the way the daemon exiting would. Replaced at each spawn. */
+  finish: (() => {}) as (code?: number) => void,
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  const spawn = () => {
+    daemon.spawned = true;
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+      kill: (signal?: string) => void;
+    };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    let done = false;
+    const close = (code: number | null) => {
+      if (done) return;
+      done = true;
+      child.emit("close", code);
+    };
+    child.kill = (signal?: string) => {
+      daemon.killed.push(signal);
+      setImmediate(() => close(null));
+    };
+    // The daemon works until the test says it has finished. A long upload is
+    // silent on both pipes — `clawkeepd` logs at phase boundaries and
+    // publishes its per-250 ms progress into state.json, not onto stderr — so
+    // nothing on this side can tell a working run from a wedged one except
+    // the cap, which is why the cap has to be the daemon's own.
+    daemon.finish = (code = 0) => close(code);
+    return child;
+  };
+  return { ...actual, spawn, default: { ...actual, spawn } };
+});
+
+const TEST_ROOT = path.join(os.tmpdir(), `clawbox-clawkeep-cap-${process.pid}-${Date.now()}`);
+const DATA_DIR = path.join(TEST_ROOT, "clawkeep");
+
+let clawkeep: typeof import("@/lib/clawkeep");
+let protection: typeof import("@/lib/clawkeep-protection");
+
+beforeAll(async () => {
+  process.env.CLAWKEEP_DATA_DIR = DATA_DIR;
+  process.env.CLAWKEEP_CONFIG_PATH = path.join(DATA_DIR, "config.toml");
+  await fs.mkdir(DATA_DIR, { recursive: true });
+  // `pairedDaemonBin()` refuses an unpaired box before it spawns anything.
+  await fs.writeFile(path.join(DATA_DIR, "token"), "claw_test", { mode: 0o600 });
+  // Point the daemon lookup at a real executable so `getDaemonBin()` takes its
+  // override branch: the PATH probe shells out, and that spawn would come
+  // through the mock below and be mistaken for the backup run.
+  const bin = path.join(TEST_ROOT, "clawkeepd");
+  await fs.writeFile(bin, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+  process.env.CLAWKEEP_BIN = bin;
+  clawkeep = await import("@/lib/clawkeep");
+  protection = await import("@/lib/clawkeep-protection");
+});
+
+afterAll(async () => {
+  delete process.env.CLAWKEEP_DATA_DIR;
+  delete process.env.CLAWKEEP_CONFIG_PATH;
+  delete process.env.CLAWKEEP_BIN;
+  await fs.rm(TEST_ROOT, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  daemon.spawned = false;
+  daemon.killed = [];
+  daemon.finish = () => {};
+});
+
+const MINUTE = 60_000;
+/** The board's measured duration of the validated 12 GiB run. */
+const MEASURED_12GIB_RUN_MS = 86 * MINUTE;
+
+/** What `clawkeepd.service` — ClawKeep's own unit for this binary — allows. */
+async function declaredDaemonTimeoutMs(): Promise<number> {
+  const unit = await fs.readFile(
+    path.join(process.cwd(), "clawkeep/systemd/clawkeepd.service"),
+    "utf8",
+  );
+  const declared = /^TimeoutStartSec=(\d+)([smh])$/m.exec(unit);
+  expect(declared, "clawkeepd.service must declare TimeoutStartSec").not.toBeNull();
+  const [, value, unitLetter] = declared!;
+  const scale = unitLetter === "h" ? 3_600_000 : unitLetter === "m" ? 60_000 : 1_000;
+  return Number(value) * scale;
+}
+
+describe("the cap a ClawKeep backup run is given", () => {
+  it("is not stricter than the one ClawKeep's own service unit declares", async () => {
+    // The bridge spawns the very binary this unit was written for. Being
+    // stricter than it means the box kills runs the daemon considers normal —
+    // and it is the box, not the daemon, the owner hears from.
+    expect(protection.BACKUP_RUN_CAP_MS).toBeGreaterThanOrEqual(await declaredDaemonTimeoutMs());
+  });
+
+  it("outlasts the 12 GB backup this task exists to make work", () => {
+    expect(protection.BACKUP_RUN_CAP_MS).toBeGreaterThan(MEASURED_12GIB_RUN_MS);
+  });
+
+  it("gives a restore at least as long as the backup that produced the archive", () => {
+    // The sibling of the same defect: `runRestore` downloads, decrypts,
+    // extracts and verifies the very bytes the backup uploaded, and had HALF
+    // the time to do it in. A restore killed part-way is worse than a backup
+    // killed part-way, because what it was rewriting is the box's own state.
+    expect(protection.RESTORE_RUN_CAP_MS).toBeGreaterThanOrEqual(protection.BACKUP_RUN_CAP_MS);
+    expect(protection.RESTORE_RUN_CAP_MS).toBeGreaterThan(MEASURED_12GIB_RUN_MS);
+  });
+
+  it("is the cap runBackup actually arms, and no run is killed inside it", async () => {
+    const promise = clawkeep.runBackup({ idle: false });
+    for (let i = 0; i < 50 && !daemon.spawned; i++) {
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    expect(daemon.spawned).toBe(true);
+
+    daemon.finish(0);
+    const result = await promise;
+    expect(daemon.killed).toEqual([]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain("backup timed out");
+  });
+});

--- a/src/tests/unit/clawkeep-persistence.test.ts
+++ b/src/tests/unit/clawkeep-persistence.test.ts
@@ -3,6 +3,8 @@ import os from "os";
 import path from "path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
+import { RESTORE_RUN_CAP_MS } from "@/lib/clawkeep-protection";
+
 const TEST_ROOT = path.join(os.tmpdir(), `clawbox-clawkeep-persistence-${process.pid}-${Date.now()}`);
 const DATA_DIR = path.join(TEST_ROOT, "clawkeep");
 const CONFIG_PATH = path.join(DATA_DIR, "config.toml");
@@ -290,11 +292,26 @@ describe("restoring flag (via getStatus.restoring)", () => {
     expect(status.restoring).toBe(true);
   });
 
-  it("auto-clears a stale flag (older than the 30 m window)", async () => {
+  it("keeps the flag of a restore that is merely slow", async () => {
+    // The window IS the restore's kill timer, so nothing inside it may be
+    // read as abandoned. A 12 GB restore legitimately runs for hours, and
+    // `isRestoring()` does not merely report false — it DELETES the flag, so
+    // clearing one early takes the only signal that survives a page reload
+    // and drops the shelf's restoring shield to a calm green verdict while
+    // the box's state directory is being replaced.
     const flag = path.join(DATA_DIR, "restoring.flag");
     await fs.writeFile(flag, "", { mode: 0o600 });
-    // Backdate mtime by 31 minutes.
     const past = new Date(Date.now() - 31 * 60 * 1000);
+    await fs.utimes(flag, past, past);
+    const status = await clawkeep.getStatus();
+    expect(status.restoring).toBe(true);
+    await expect(fs.access(flag)).resolves.toBeUndefined();
+  });
+
+  it("auto-clears a flag older than the restore can possibly have been", async () => {
+    const flag = path.join(DATA_DIR, "restoring.flag");
+    await fs.writeFile(flag, "", { mode: 0o600 });
+    const past = new Date(Date.now() - (RESTORE_RUN_CAP_MS + 60_000));
     await fs.utimes(flag, past, past);
     const status = await clawkeep.getStatus();
     expect(status.restoring).toBe(false);

--- a/src/tests/unit/clawkeep-protection.test.ts
+++ b/src/tests/unit/clawkeep-protection.test.ts
@@ -270,7 +270,10 @@ describe("isBackupRunning", () => {
     // The bound is not a guess: `runBackup()` SIGKILLs the daemon at
     // BACKUP_RUN_CAP_MS, so past it there is nothing left alive to pulse for.
     expect(STALE_RUNNING_MS).toBe(BACKUP_RUN_CAP_MS);
-    expect(BACKUP_RUN_CAP_MS).toBe(60 * MINUTE);
+    // The number itself is pinned to ClawKeep's own service unit by
+    // `clawkeep-backup-run-cap.test.ts`; what matters here is that the pulse
+    // and the kill timer are one value, whatever that value becomes.
+    expect(BACKUP_RUN_CAP_MS).toBe(4 * HOUR);
   });
 
   it("does not let a clock-skewed heartbeat pulse for as long as the skew", () => {

--- a/src/tests/unit/mcp-api-timeout.test.ts
+++ b/src/tests/unit/mcp-api-timeout.test.ts
@@ -35,11 +35,17 @@ const repoFile = (rel: string) => readFile(path.join(process.cwd(), rel), "utf8"
  *
  * The search window is `backup_now`'s OWN registration — from its `reg.tool(`
  * to the next `reg.tool(` at any indentation — and comments are stripped from
- * it first. `ApiOptions.onTimeout` exists so other routes can adopt it, so a
- * sibling tool taking it must not silently become what this test asserts
- * about while `backup_now` ships none; and an example of the literal written
- * in a comment must not stand in for the real one. Both were reproduced
- * against earlier versions of this helper, which is why the bound is here.
+ * it first, whole-line and trailing alike. `ApiOptions.onTimeout` exists so
+ * other routes can adopt it, so a sibling tool taking it must not silently
+ * become what this test asserts about while `backup_now` ships none; and an
+ * example of the literal written in a comment must not stand in for the real
+ * one. Both were reproduced against earlier versions of this helper, which is
+ * why the bound is here.
+ *
+ * The stripper is deliberately crude — it leaves a `//` that follows a colon
+ * or a quote alone, so a URL inside a shipped string survives — and it is
+ * crude in the safe direction: a window it mangles makes the match FAIL, and
+ * only a window that still holds the real literal can make it pass.
  *
  * The `ENDPOINT_DOWN` handler further down — which names `backup_status` for
  * its own good reasons — is INSIDE this window and stays there. What keeps it
@@ -55,7 +61,7 @@ async function shippedBackupNowAdvice(): Promise<{ description: string; message:
   const nextTool = /\n\s*reg\.tool\(/.exec(rest);
   const scope = (nextTool ? rest.slice(0, nextTool.index) : rest)
     .replace(/\/\*[\s\S]*?\*\//g, "")
-    .replace(/^[ \t]*\/\/.*$/gm, "");
+    .replace(/(^|[^:"'`])\/\/.*$/gm, "$1");
   const block = /onTimeout:\s*\{\s*message:\s*"([^"]+)"\s*,\s*next:\s*"([^"]+)"\s*,?\s*\}/.exec(scope);
   expect(block, "backup_now itself must pass onTimeout, with a message and a next").not.toBeNull();
   return { description: tool![1], message: block![1], next: block![2] };

--- a/src/tests/unit/mcp-api-timeout.test.ts
+++ b/src/tests/unit/mcp-api-timeout.test.ts
@@ -34,18 +34,28 @@ const repoFile = (rel: string) => readFile(path.join(process.cwd(), rel), "utf8"
  * reply and a resolved review thread while the source kept the old sentence.
  *
  * The search window is `backup_now`'s OWN registration — from its `reg.tool(`
- * to the next one — for two reasons. It must not run on to the
- * `ENDPOINT_DOWN` handler below, which names `backup_status` for its own good
- * reasons; and `ApiOptions.onTimeout` exists so other routes can adopt it, so
- * a second tool taking it must not silently become what this test asserts
- * about while `backup_now` quietly ships none.
+ * to the next `reg.tool(` at any indentation — and comments are stripped from
+ * it first. `ApiOptions.onTimeout` exists so other routes can adopt it, so a
+ * sibling tool taking it must not silently become what this test asserts
+ * about while `backup_now` ships none; and an example of the literal written
+ * in a comment must not stand in for the real one. Both were reproduced
+ * against earlier versions of this helper, which is why the bound is here.
+ *
+ * The `ENDPOINT_DOWN` handler further down — which names `backup_status` for
+ * its own good reasons — is INSIDE this window and stays there. What keeps it
+ * out of the match is the literal's shape: a `message` key immediately
+ * followed by a `next` key inside braces, which the handler's positional
+ * `new ToolError(...)` cannot satisfy.
  */
 async function shippedBackupNowAdvice(): Promise<{ description: string; message: string; next: string }> {
   const src = await repoFile("mcp/tools/system.ts");
   const tool = /reg\.tool\(\s*"backup_now",\s*"([^"]+)"/.exec(src);
   expect(tool, "system.ts must register backup_now with a description").not.toBeNull();
-  const nextTool = src.indexOf("\n  reg.tool(", tool!.index + 1);
-  const scope = src.slice(tool!.index, nextTool === -1 ? undefined : nextTool);
+  const rest = src.slice(tool!.index + 1);
+  const nextTool = /\n\s*reg\.tool\(/.exec(rest);
+  const scope = (nextTool ? rest.slice(0, nextTool.index) : rest)
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^[ \t]*\/\/.*$/gm, "");
   const block = /onTimeout:\s*\{\s*message:\s*"([^"]+)"\s*,\s*next:\s*"([^"]+)"\s*,?\s*\}/.exec(scope);
   expect(block, "backup_now itself must pass onTimeout, with a message and a next").not.toBeNull();
   return { description: tool![1], message: block![1], next: block![2] };

--- a/src/tests/unit/mcp-api-timeout.test.ts
+++ b/src/tests/unit/mcp-api-timeout.test.ts
@@ -1,3 +1,6 @@
+import { readFile } from "fs/promises";
+import path from "path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
@@ -11,12 +14,38 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  * has no single-instance guard of any kind — no pidfile, no flock, nothing in
  * `daemon.py`, `runner.py` or `state.py` — so "retry once" means a second full
  * archive-and-upload beside the first, on one Jetson's eMMC.
+ *
+ * What the replacement may NOT do is answer one false certainty with another.
  */
 
 let api: typeof import("../../../mcp/lib/api").api;
 let ToolError: typeof import("../../../mcp/lib/errors").ToolError;
 
 const originalFetch = globalThis.fetch;
+
+const repoFile = (rel: string) => readFile(path.join(process.cwd(), rel), "utf8");
+
+/**
+ * The advice `backup_now` actually ships, read out of `mcp/tools/system.ts`.
+ *
+ * Read rather than restated: a copy of the sentence in this file pins nothing.
+ * It stays green while the shipped string says the opposite — which is exactly
+ * what happened here, a wording fix recorded in a commit subject, an in-thread
+ * reply and a resolved review thread while the source kept the old sentence.
+ *
+ * The `onTimeout` match is anchored inside `backup_now` and demands `message`
+ * and `next` adjacent within the braces, so it cannot run past the block and
+ * pick up the `ENDPOINT_DOWN` handler below, which names `backup_status` for
+ * its own good reasons.
+ */
+async function shippedBackupNowAdvice(): Promise<{ description: string; message: string; next: string }> {
+  const src = await repoFile("mcp/tools/system.ts");
+  const tool = /reg\.tool\(\s*"backup_now",\s*"([^"]+)"/.exec(src);
+  expect(tool, "system.ts must register backup_now with a description").not.toBeNull();
+  const block = /onTimeout: \{\s*message: "([^"]+)",\s*next: "([^"]+)",\s*\}/.exec(src.slice(tool!.index));
+  expect(block, "backup_now must pass onTimeout, with a message and a next").not.toBeNull();
+  return { description: tool![1], message: block![1], next: block![2] };
+}
 
 /** What `AbortSignal.timeout` rejects with. */
 function abortError(): Error {
@@ -50,19 +79,21 @@ describe("what api() tells the model when its own timeout fires", () => {
   it("lets a call that started something long say so instead", async () => {
     globalThis.fetch = vi.fn(async () => { throw abortError(); }) as unknown as typeof fetch;
 
+    // The SHIPPED sentences, not stand-ins: this asserts what a real
+    // `backup_now` abort puts in front of the model, message included.
+    const advice = await shippedBackupNowAdvice();
     const err = await api("/setup-api/clawkeep/backup", {
       method: "POST",
       body: {},
-      onTimeout: {
-        message: "The backup is taking longer than this call waits. It is still running.",
-        next: "Do not start another one. Tell the user it is still going, and call backup_list later to confirm it landed.",
-      },
+      onTimeout: { message: advice.message, next: advice.next },
     }).catch((e: unknown) => e);
 
     expect(err).toBeInstanceOf(ToolError);
     const tool = err as InstanceType<typeof ToolError>;
     expect(tool.code).toBe("TIMEOUT");
-    expect(tool.message).toMatch(/still running/i);
+    expect(tool.message).toBe(advice.message);
+    expect(tool.message).toMatch(/may still be running/i);
+    expect(tool.next).toBe(advice.next);
     expect(tool.next).toMatch(/do not start another one/i);
     expect(tool.next).not.toMatch(/retry/i);
   });
@@ -80,21 +111,32 @@ describe("what api() tells the model when its own timeout fires", () => {
 });
 
 describe("backup_now's own advice", () => {
+  it("never states as fact that a backup this call can no longer see is alive", async () => {
+    // `AbortSignal.timeout` establishes that THIS CLIENT stopped waiting, and
+    // nothing else. `clawkeepd` may have exited 127/64/65, the box may have
+    // rebooted, the Next worker may have been replaced — and "It is still
+    // running." is relayed to the owner as fact over every one of those. That
+    // is the mirror of the defect this PR fixes (a healthy backup reported as
+    // timed out), and the same false certainty as the "Retry once" the option
+    // replaces, pointing the other way. All three sentences the model sees
+    // must hedge: the tool description, and both halves of `onTimeout`.
+    const advice = await shippedBackupNowAdvice();
+    for (const half of ["description", "message", "next"] as const) {
+      const sentence = advice[half];
+      expect(sentence, `backup_now's ${half} must hedge`).toMatch(/\bmay still be (running|going)\b/i);
+      expect(sentence, `backup_now's ${half} must not assert the run is alive`)
+        .not.toMatch(/\bis still (running|going)\b/i);
+    }
+  });
+
   it("names backup_list, and never backup_status, which answers about the LAST run", async () => {
     // `backup_status` derives from `deriveProtection`, which judges the last
     // COMPLETED backup and knows nothing of a run in flight — mid-run on a box
     // that has never finished one it reports "never backed up, unprotected".
-    const src = await import("fs/promises")
-      .then((fs) => fs.readFile("mcp/tools/system.ts", "utf8"));
-    const at = src.indexOf("onTimeout: {");
-    expect(at, "backup_now must pass onTimeout").toBeGreaterThan(-1);
-    // The `next:` line of that block and nothing else — a byte window wide
-    // enough to hold the comment also swallows the `ENDPOINT_DOWN` handler
-    // below, which names `backup_status` for its own good reasons.
-    const next = /\bnext: "([^"]+)"/.exec(src.slice(at));
-    expect(next, "onTimeout must carry a next").not.toBeNull();
-    expect(next![1]).toMatch(/backup_list/);
-    expect(next![1]).not.toMatch(/backup_status/);
-    expect(next![1]).toMatch(/[Dd]o not start another one/);
+    const { description, next } = await shippedBackupNowAdvice();
+    expect(next).toMatch(/backup_list/);
+    expect(next).not.toMatch(/backup_status/);
+    expect(next).toMatch(/[Dd]o not start another one/);
+    expect(description).toMatch(/backup_list/);
   });
 });

--- a/src/tests/unit/mcp-api-timeout.test.ts
+++ b/src/tests/unit/mcp-api-timeout.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * A client-side abort is not an HTTP response, so an `ErrorRule[]` cannot
+ * describe it: `matchRule` is only ever consulted against a status and a body.
+ * Every `api()` call therefore got one generic answer — "Retry once" — which
+ * is right for a read and wrong for a call that STARTED something long.
+ *
+ * TASK-675 makes that the normal case rather than an edge one: a 12 GB backup
+ * runs for well over an hour, `backup_now` aborts at 180 s, and `clawkeepd`
+ * has no single-instance guard of any kind — no pidfile, no flock, nothing in
+ * `daemon.py`, `runner.py` or `state.py` — so "retry once" means a second full
+ * archive-and-upload beside the first, on one Jetson's eMMC.
+ */
+
+let api: typeof import("../../../mcp/lib/api").api;
+let ToolError: typeof import("../../../mcp/lib/errors").ToolError;
+
+const originalFetch = globalThis.fetch;
+
+/** What `AbortSignal.timeout` rejects with. */
+function abortError(): Error {
+  const err = new Error("The operation was aborted due to timeout");
+  err.name = "TimeoutError";
+  return err;
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  process.env.CLAWBOX_MCP_TOKEN = "0123456789abcdef0123";
+  api = (await import("../../../mcp/lib/api")).api;
+  ToolError = (await import("../../../mcp/lib/errors")).ToolError;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  delete process.env.CLAWBOX_MCP_TOKEN;
+});
+
+describe("what api() tells the model when its own timeout fires", () => {
+  it("keeps the generic 'retry once' for an ordinary read", async () => {
+    globalThis.fetch = vi.fn(async () => { throw abortError(); }) as unknown as typeof fetch;
+
+    const err = await api("/setup-api/system/stats").catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ToolError);
+    expect((err as InstanceType<typeof ToolError>).code).toBe("TIMEOUT");
+    expect((err as InstanceType<typeof ToolError>).next).toMatch(/retry once/i);
+  });
+
+  it("lets a call that started something long say so instead", async () => {
+    globalThis.fetch = vi.fn(async () => { throw abortError(); }) as unknown as typeof fetch;
+
+    const err = await api("/setup-api/clawkeep/backup", {
+      method: "POST",
+      body: {},
+      onTimeout: {
+        message: "The backup is taking longer than this call waits. It is still running.",
+        next: "Do not start another one. Tell the user it is still going, and call backup_list later to confirm it landed.",
+      },
+    }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(ToolError);
+    const tool = err as InstanceType<typeof ToolError>;
+    expect(tool.code).toBe("TIMEOUT");
+    expect(tool.message).toMatch(/still running/i);
+    expect(tool.next).toMatch(/do not start another one/i);
+    expect(tool.next).not.toMatch(/retry/i);
+  });
+
+  it("does not fire on a plain network failure, which really is worth a retry", async () => {
+    globalThis.fetch = vi.fn(async () => { throw new Error("fetch failed"); }) as unknown as typeof fetch;
+
+    const err = await api("/setup-api/clawkeep/backup", {
+      method: "POST",
+      onTimeout: { message: "never used", next: "never used" },
+    }).catch((e: unknown) => e);
+
+    expect((err as InstanceType<typeof ToolError>).code).toBe("ENDPOINT_DOWN");
+  });
+});
+
+describe("backup_now's own advice", () => {
+  it("names backup_list, and never backup_status, which answers about the LAST run", async () => {
+    // `backup_status` derives from `deriveProtection`, which judges the last
+    // COMPLETED backup and knows nothing of a run in flight — mid-run on a box
+    // that has never finished one it reports "never backed up, unprotected".
+    const src = await import("fs/promises")
+      .then((fs) => fs.readFile("mcp/tools/system.ts", "utf8"));
+    const at = src.indexOf("onTimeout: {");
+    expect(at, "backup_now must pass onTimeout").toBeGreaterThan(-1);
+    const block = src.slice(at, at + 400);
+    expect(block).toMatch(/backup_list/);
+    expect(block).not.toMatch(/backup_status/);
+    expect(block).toMatch(/[Dd]o not start another one/);
+  });
+});

--- a/src/tests/unit/mcp-api-timeout.test.ts
+++ b/src/tests/unit/mcp-api-timeout.test.ts
@@ -88,9 +88,13 @@ describe("backup_now's own advice", () => {
       .then((fs) => fs.readFile("mcp/tools/system.ts", "utf8"));
     const at = src.indexOf("onTimeout: {");
     expect(at, "backup_now must pass onTimeout").toBeGreaterThan(-1);
-    const block = src.slice(at, at + 400);
-    expect(block).toMatch(/backup_list/);
-    expect(block).not.toMatch(/backup_status/);
-    expect(block).toMatch(/[Dd]o not start another one/);
+    // The `next:` line of that block and nothing else — a byte window wide
+    // enough to hold the comment also swallows the `ENDPOINT_DOWN` handler
+    // below, which names `backup_status` for its own good reasons.
+    const next = /\bnext: "([^"]+)"/.exec(src.slice(at));
+    expect(next, "onTimeout must carry a next").not.toBeNull();
+    expect(next![1]).toMatch(/backup_list/);
+    expect(next![1]).not.toMatch(/backup_status/);
+    expect(next![1]).toMatch(/[Dd]o not start another one/);
   });
 });

--- a/src/tests/unit/mcp-api-timeout.test.ts
+++ b/src/tests/unit/mcp-api-timeout.test.ts
@@ -33,17 +33,21 @@ const repoFile = (rel: string) => readFile(path.join(process.cwd(), rel), "utf8"
  * what happened here, a wording fix recorded in a commit subject, an in-thread
  * reply and a resolved review thread while the source kept the old sentence.
  *
- * The `onTimeout` match is anchored inside `backup_now` and demands `message`
- * and `next` adjacent within the braces, so it cannot run past the block and
- * pick up the `ENDPOINT_DOWN` handler below, which names `backup_status` for
- * its own good reasons.
+ * The search window is `backup_now`'s OWN registration — from its `reg.tool(`
+ * to the next one — for two reasons. It must not run on to the
+ * `ENDPOINT_DOWN` handler below, which names `backup_status` for its own good
+ * reasons; and `ApiOptions.onTimeout` exists so other routes can adopt it, so
+ * a second tool taking it must not silently become what this test asserts
+ * about while `backup_now` quietly ships none.
  */
 async function shippedBackupNowAdvice(): Promise<{ description: string; message: string; next: string }> {
   const src = await repoFile("mcp/tools/system.ts");
   const tool = /reg\.tool\(\s*"backup_now",\s*"([^"]+)"/.exec(src);
   expect(tool, "system.ts must register backup_now with a description").not.toBeNull();
-  const block = /onTimeout: \{\s*message: "([^"]+)",\s*next: "([^"]+)",\s*\}/.exec(src.slice(tool!.index));
-  expect(block, "backup_now must pass onTimeout, with a message and a next").not.toBeNull();
+  const nextTool = src.indexOf("\n  reg.tool(", tool!.index + 1);
+  const scope = src.slice(tool!.index, nextTool === -1 ? undefined : nextTool);
+  const block = /onTimeout:\s*\{\s*message:\s*"([^"]+)"\s*,\s*next:\s*"([^"]+)"\s*,?\s*\}/.exec(scope);
+  expect(block, "backup_now itself must pass onTimeout, with a message and a next").not.toBeNull();
   return { description: tool![1], message: block![1], next: block![2] };
 }
 


### PR DESCRIPTION
## TASK-675 — the box kills the large backups this task exists to make work

**Customer-visible symptom.** A 12 GB ClawKeep backup runs, gets part of the way, and is killed. The owner is told the backup timed out or failed on the device, over work that was healthy. Every retry dies at the same point.

### What already landed, and why it was not enough

PR #607 (multipart chunking: 64 MiB parts, 12 GB → 192 parts instead of ~1,536) and the portal's credential-TTL fix (1 h → 24 h, so R2 stops answering `SignatureDoesNotMatch` mid-multipart) together made the 12 GiB run finish. The board records it finishing in **~86 minutes**.

Nothing on the device let it run that long. **Five** independent caps stood in the way, and none of them is reached by the others:

| where | was | binds | edition |
|---|---|---|---|
| `openclaw.py` `create_archive` | 30 min | `openclaw backup create --verify` — the FIRST wall | OpenClaw |
| `crypto.py` `encrypt_file` | 30 min | `openssl enc` over the whole archive | **both** |
| `runBackup()` kill timer (`BACKUP_RUN_CAP_MS`) | 60 min | the whole backup | both |
| `openclaw.py` `verify_archive` / `crypto.py` `decrypt_file` | 5 / 30 min | the restore's verify and decrypt steps | OpenClaw / **both** |
| `RESTORE_TIMEOUT_MS` | 30 min | the whole restore — half the backup's budget | both |

Each turns "this step is slow" into "this backup failed" for exactly the step that is slow. The false-failure class, on the one operation whose whole point is that it is long.

The first two are the ones that matter most, and neither is in TypeScript. `agent.create_archive()` passes **no** timeout, and `cfg.openclaw` has no field to override it, so `openclaw.py`'s 30-minute default bound the archive step — on the daemon **this repo installs onto the box** (`install.sh:3510`, `pipx install --force "$PROJECT_DIR/clawkeep"`). A 12 GB backup on an OpenClaw box died half an hour in and never reached the bridge's timer at all, so raising that timer alone would have fixed nothing for the customer this task is about. The same is true of `crypto.py`'s `encrypt_file`, which streams the whole archive through `openssl enc` and runs **outside any edition branch** — so the Hermes edition carried a 30-minute subprocess cap too, which an earlier version of this PR wrongly said it did not. Both were found by review, not by the first commit; the second of them was found only because the first fix's own test did not sweep that module.

### Harness first

None of the four numbers is one ClawBox has to invent. ClawKeep ships its own unit for this binary and declares the answer:

```
# clawkeep/systemd/clawkeepd.service
ExecStart=/usr/bin/clawkeepd
TimeoutStartSec=4h
```

That is a bound on one whole ClawKeep run, and the rule that follows from it is the one this PR applies: **no step inside a run may be given less than the run itself.** So `BACKUP_RUN_CAP_MS`, `RESTORE_RUN_CAP_MS` and the daemon's `SUBPROCESS_TIMEOUT_S` are all that four hours. The daemon's bound now has **one** definition — `clawkeep/clawkeep/limits.py`, imported by `openclaw.py` and `crypto.py` — because two modules answering the same question separately is exactly how the fifth cap was missed. The test reads the unit file and sweeps every shelling-out step in both modules, so raising one and forgetting another is red rather than shipped.

Those standalone timers are deliberately not installed (`install.sh:5254`; verified read-only on both editions — no ClawKeep units, no ClawKeep timers, no crontab), so the bridge timer is the only ceiling **ClawBox itself** imposes. It is not the only ceiling that exists — the daemon's per-step caps bind independently, and they are what is left when the Next worker holding the kill timer is replaced mid-run. They do not bind *first*: at the equal values this PR sets, the bridge's timer starts at `spawn`, before any step begins, so it always fires first. Both comments now say that; the earlier wording in each — "the ONLY ceiling ANY run gets" in the route, "those bind first" in the constant's own module — is corrected in the code, and this paragraph is corrected with it.

By edition, the archive **and** the verify steps differ: `hermes.py` contains no subprocess call at all — it tars with `tarfile` and checks the manifest in process — while encrypt and decrypt run outside every edition branch, so both SKUs carry the openssl cap. An earlier draft said Hermes had no subprocess cap at all, which was wrong; a later one said only the archive differed, which was also wrong.

### Siblings

- **`RESTORING_FLAG_MAX_AGE_MS`** was 30 minutes, and its own comment names the invariant: "if the restoring marker is older than *the restore timeout*". Both were 30, so a flag could never go stale during a live restore. Raising the restore cap alone would have had `isRestoring()` **delete** the marker of a restore still running — it removes the file, it does not merely report false — dropping the shelf's orange restoring shield to a calm green verdict while the box's whole state directory was being replaced, with no signal left that survives a page reload. It is now `RESTORE_RUN_CAP_MS`, one constant rather than two numbers that happen to agree.
- **`backup_now`'s abort advice.** `mcp/lib/api.ts` answers a client-side `AbortSignal.timeout` with "Retry once", which contradicts the tool's own description and all eight `BACKUP_RULES` entries ("Do not start another one."). Survivable at 2-5 minute backups; with ~86-minute runs supported, the 180 s abort becomes the *normal* outcome on the box this task is about — and `clawkeepd` has no single-instance guard of any kind, so a retry builds a second full 12 GB archive beside the first on one Jetson's eMMC. `ApiOptions` gains `onTimeout` (a rule cannot cover this: `matchRule` only ever sees an HTTP response) and `backup_now` sets it.
- Every other timeout in `src/lib/clawkeep*.ts` was checked: the `spawnCliJson` callers (`snapshots`, `delete`, `lock`) are 60 s API calls, correctly unrelated.

### A second defect the same change closes

`STALE_RUNNING_MS` follows the cap by design — the module's rule is that the UI's liveness window and the kill timer must be one number, or the shelf would pulse for a process that no longer exists. At 60 minutes that also meant the ClawKeep progress panel and the desktop shelf went **dark 60 minutes into a live 12 GB upload**. Raising the cap fixes both halves.

Its cost, stated in the module: a run killed at the cap — or orphaned by a Next restart, which takes the kill timer with it — leaves `"running"` pinned for four hours rather than one. It does **not** change the protection verdict (`deriveProtection` does not read `STALE_RUNNING_MS`). The first commit justified deferring the fix by saying `runner.py` needed a liveness stamp; that was wrong and is corrected — `_on_upload_progress` already persists `upload_bytes_done` on a 250 ms throttle and `getStatus()` already reads it. What is missing is a *consumer*: `isBackupRunning` is handed only the two heartbeat fields, so giving it progress means changing its inputs and every caller, and the archive-build phase still has only `currentStepAtMs`. That is a change with its own RED.

### RED

The branch's four test files against unmodified `origin/beta` `c0b45afa`, in a throwaway detached worktree — nothing else of the branch present. (Re-measured after each rebase; the same 11 on `b4074ae6` before beta moved.)

```
 × is the one ClawKeep's own service unit declares, to the millisecond
 × outlasts the 12 GB backup this task exists to make work
 × is not undercut by the daemon's own per-step caps
 × is at least the backup's, for work that is at least symmetric
 × is the same window the restoring flag is believed for
 × still believes a backup that has been going for an hour of a large box
 × lets a call that started something long say so instead
 × never states as fact that a backup this call can no longer see is alive
 × names backup_list, and never backup_status, which answers about the LAST run
 × keeps the flag of a restore that is merely slow
 × auto-clears a flag older than the restore can possibly have been

AssertionError: expected 3600000 to be 14400000
AssertionError: expected 3600000 to be greater than 5160000
Error: ENOENT: ... clawkeep/clawkeep/limits.py
AssertionError: expected false to be true            (a 31-minute-old flag over a live restore)
AssertionError: backup_now must pass onTimeout, with a message and a next: expected null not to be null

 Test Files  4 failed (4)
      Tests  11 failed | 51 passed (62)
```

**And the RED for the correction below**, which is the sharper one: the same tests against this branch's own previous head `388c6c24`, where `onTimeout` exists and says the wrong thing —

```
 × lets a call that started something long say so instead
   AssertionError: expected 'The backup is taking longer than this…' to match /may still be running/i
   + Received: "The backup is taking longer than this call waits. It is still running."

 × never states as fact that a backup this call can no longer see is alive
   AssertionError: backup_now's description must hedge
   + Received: "Start a cloud backup of this ClawBox now. It can take several minutes; if this
                call times out the backup is still running, so do not start another one …"

 Test Files  1 failed (1)
      Tests  2 failed | 3 passed (5)
```

### A false success this branch shipped, and how it survived three records

Review blocked the previous head on one sentence. `backup_now` answered a client-side abort with **"The backup is taking longer than this call waits. It is still running."** — stated as fact. An `AbortSignal.timeout` establishes only that *this call* stopped waiting: `clawkeepd` may have exited 127/64/65, the box may have rebooted, the Next worker may have been replaced. The model relays that to the owner as a live backup either way. It is the mirror of the defect this PR exists to fix — a healthy backup reported as timed out — shipped by the PR fixing it, and the same false certainty as the "Retry once" it replaces, pointing the other way.

It was recorded as fixed in **three** places and was not: the commit subject `fix: say the backup MAY still be running…`, the in-thread reply claiming both halves said it, and the review thread resolved on that reply. `mcp/tools/system.ts` was byte-for-byte unchanged. It survived because **nothing pinned the wording**: the `api()` test restated the sentence as a literal of its own, so it stayed green whatever the tool shipped, and the source-reading test extracted only the `next:` line.

Fixed now, and pinned so it cannot go quiet again:

- all three sentences the model sees hedge — the tool description, `onTimeout.message`, `onTimeout.next` — and the action they prescribe ("Do not start another one", `backup_list`) is unchanged, because that half was always right;
- `mcp-api-timeout.test.ts` **reads the shipped strings out of `mcp/tools/system.ts`** — the description, and the `onTimeout` block anchored inside `backup_now` — and asserts on those. The same strings are then fed through `api()`, so the assertion covers both paths: what the source says, and what a real abort hands the model. A literal copy in the test pins nothing; that is exactly how this got through;
- `mcp/tools/email.ts`, the one sibling that hand-rolls the same class for `email_send`, was checked and already hedges ("may already have been queued or sent"). Every other `"TIMEOUT"` construction was swept: `mcp/lib/api.ts`'s generic default and `mcp/tools/skills.ts` claim nothing about work in flight.

### GREEN

On this head, rebased on `c0b45afa` — beta's tip, which took #732 and #733 while this branch was in review. The rebase was over a disjoint file set: `git range-diff` reports all ten patches unchanged, `git diff --stat origin/beta...HEAD` still lists only the 13 intended files, and `--diff-filter=DR` is empty.

```
 Test Files  27 passed (27)     Tests  275 passed (275)
   (every clawkeep unit + route + component suite, mcp-api-timeout,
    openclaw-config-mock-completeness, test-timeout-hygiene, state-updater-purity)

 npx tsc --noEmit                  exit 0
 npx tsc -p mcp/tsconfig.json      exit 0
 npx tsx mcp/check-tools.ts        Tool contract OK
 eslint on the changed files       clean
```

### Review

**Three passes.** The first: HIGH 3 · MEDIUM 6 · LOW 5. All three HIGHs are fixed here — the daemon's 30-minute archive cap, the daemon's 5-minute verify cap, and the restoring-flag window — along with M1 (`backup_now`'s retry advice), M3 (the wrong deferral premise), M4 (a doc that argued for a larger cap than the code set) and M5 (a behavioural test that was green on unmodified beta and has been replaced with pins that are not). It also cleared, by measurement, several things worth not re-deriving: Node/Bun's `requestTimeout` does not abort a handler once the body is in, `production-server.js` and `middleware.ts` set none, neither `fetch` has a client timeout, and `deriveProtection` does not read `STALE_RUNNING_MS`.

The second, a merge gate over the commits the first pass had not seen: HIGH 1 · MEDIUM 3 · LOW 4, verdict BLOCK. Its HIGH is the fifth cap above. Two of its mediums are fixed too — `backup_now`'s advice named `backup_status`, which answers from `deriveProtection` about the last COMPLETED backup and would have reported "never backed up, unprotected" mid-run on a first backup; and `onTimeout` had no test at all, so deleting it left every suite green. `mcp/tools/email.ts` already catches the same class by hand for `email_send`, and `api.ts` and `system.ts` both name it as the precedent; `email.ts` itself is not touched by this PR and carries no back-reference.

The third, a merge gate over the whole branch, **blocked it**: the false-success sentence above, recorded as fixed in three places and absent from the code. That is the finding the commit before last closes. A fourth pass over the correction returned MERGE-OK and found three more things worth taking, all applied in the last commit: the new pin's search window ran to end of file, so it would have transferred silently to another tool's `onTimeout` block (reproduced — five green tests over a `backup_now` shipping no advice at all); "the per-step caps bind first", which stopped being true the moment this PR made them equal to the run cap; and "only the ARCHIVE step differs by edition", when `hermes.py` shells out for neither archive nor verify.

A fifth pass over that correction returned MERGE-OK again and found the comment I had just rewritten giving a false *reason* — it said the search window keeps the `ENDPOINT_DOWN` handler out, and the window contains it; what keeps it out is the literal's shape. Fixed, along with two more ways the pin could have gone quiet, both reproduced rather than argued: an example of the literal written in a comment inside the same registration matched once the trailing comma was loosened, and the end anchor was indentation-exact, so a tool registered at any other depth reopened the transfer. Comments are stripped from the window and the anchor is indentation-free; both cases now fail loudly with three errors naming `backup_now`.

**Mutation results on this head** — every fix reddens when reverted, and the four test files are the measure (`clawkeep-backup-run-cap`, `mcp-api-timeout`, `clawkeep-persistence`, `clawkeep-protection`):

```
baseline                                      62 passed
limits.SUBPROCESS_TIMEOUT_S -> 30m             1 failed
crypto.py step -> its own 30m literal          1 failed
openclaw.py step -> its own literal            1 failed
BACKUP_RUN_CAP_MS -> 60 min                    4 failed
RESTORING_FLAG_MAX_AGE_MS -> 30 min            2 failed
onTimeout plumbing removed from api.ts         1 failed
advice points at backup_status                 1 failed
message wording -> "It is still running."      2 failed
next wording -> "it is still going"            1 failed
description wording -> "is still running"      1 failed
backup_now's onTimeout block deleted           3 failed
its block moved to the next tool down          3 failed
```

The last four are the ones the previous head could not see. And two mutations that must NOT redden, because the rule is directional, both confirmed: `SUBPROCESS_TIMEOUT_S` raised to 6h still passes (a step allowed more than the run is harmless — the run cap ends it first), while lowering it below the run cap, or lowering `TimeoutStartSec` to 3h, reddens.

### Both editions

`clawkeep/clawkeep/agent.py` hands the runner an OpenClaw or a Hermes backend, and `getStatus()` answers `supportedOnEdition: true` unconditionally, so these caps govern backups on both SKUs. `~/.local/bin/clawkeep{,d}` are installed on both dev boxes (verified read-only). The one asymmetry is named above and in the code: the OpenClaw backend shells out and therefore has per-step caps, the Hermes one does not.

### Not in this PR

- **The route is synchronous, and four hours is a long time to hold a request open.** Over Remote Access it is worse than long: `config/clawbox-tunnel.service` puts the whole box UI behind a Cloudflare quick tunnel, whose edge gives the origin ~100 s before a 524, so pressing "Back up now" remotely on the 12 GB box shows a failure while the backup runs on and succeeds. That ~100 s ceiling is a standing, already-recorded item, and this PR makes it more likely to bite rather than causing it. The fix is 202-plus-poll — every field the card would need (`lastHeartbeatStatus`, `currentStep`, `uploadBytesTotal`, `uploadBytesDone`) already ships — and it is a route redesign with its own RED, not a line here.
- **`child.kill` signals `clawkeepd` only**, not an `openclaw backup create` grandchild, and a Next restart mid-run takes the kill timer with it. Both pre-existing; raising the cap only ever reduces how often the kill fires.
- **Acceptance 3's second half** — an alert when *no successful backup exists past the threshold*. The failure-alert half shipped on the portal (clawbox-website #581); the staleness half is portal work too. This repo already computes the verdict (`deriveProtection`, TASK-673) and has no channel to alert on.
- **Acceptance 4's restore/hash verification** needs a paired box and a real archive; that is TASK-438's question, and ClawKeep is unpaired on both dev boxes.
- **`clawkeepd` has no single-instance guard of any kind** — no pidfile, no `flock`, nothing in `daemon.py`, `runner.py` or `state.py` — and `clawkeep-scheduler.ts` carries a comment claiming the opposite ("the daemon will serialise via its own heartbeat lock"), which is the justification for `fireBackup()` not gating. Raising the cap widens the window in which a manual run is still alive when the scheduled slot fires, from 60 minutes to four hours. The comment is corrected in #726, which owns that file and is now merged — this branch is rebased on top of it, so beta never carries the four-hour cap under a comment claiming a lock exists. The guard itself is the harness-native fix and wants its own card.
- **Three other MCP POSTs that start duplicable work still get the generic "Retry once".** `ApiOptions.onTimeout` was added here so the next route would not have to hand-roll it, and exactly one call site takes it. `coding_agent_run` and `coding_team_run` (`mcp/tools/coding-agent.ts`, 20 s each) and `skill_install` (`mcp/tools/skills.ts`, 180 s) all answer a client-side abort with advice to retry, which starts a second run or a second install. Each is a one-line change and none of them is TASK-675, so they are named rather than swept in: `onTimeout?.message ?? default` leaves every untouched call site byte-identical.
- **`clawkeep.progress.backupFallback` still says "This can take a few minutes"**, in every locale, over the ~86-minute run this PR makes supported. Same family as the reset hint below and not named in its deferral until now; it is a translated string with no behaviour behind it.
- **`RESET_HINT_AFTER_MS` (6 min) now offers "Looks stuck?" for 80 of the 86 minutes this PR makes normal**, and the reset behind it reports success during the upload phase over a change `runner.py` re-stamps within 250 ms. Scaling it off real progress is the same deferred work as the liveness consumer above.
- **A crashed restore now paints the shelf "Restoring…" for four hours rather than 30 minutes**, masking the protection verdict for that whole time (`ChromeShelf` ranks `restoring` above every other state). It is the better trade — the alternative was deleting the marker of a *live* 12 GB restore at minute 30 — but it is a real widening and the flag's mtime is never refreshed, so the window is measured from run start.

Device leg: read-only on both editions (no mutation, no mutex taken). A >12 GB backup could not be run here — ClawKeep is unpaired on both dev boxes, and the box reserved for the original TASK-675 validation is not in this run's inventory. The caps are proven against ClawKeep's own declared bound and against the measured 86-minute run rather than against a fresh 12 GB upload. Declared, not claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Extended backup and restore operation limits to support long-running operations, including large backups.
  - Aligned encryption, decryption, archive creation, and verification timeouts under a consistent four-hour limit.
  - Improved handling of long-running restores so active operations are not prematurely marked stale.

- **User Experience**
  - Backup timeouts now explain that the operation may still be running and advise checking the backup list before starting another backup.
  - Updated recovery guidance for lengthy backups and clarified when reset links may be used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

