### PR TITLE
fix: paint the wallpaper fallback locally instead of writing it box-wide

### DIFF
--- a/src/app/app/[id]/page.tsx
+++ b/src/app/app/[id]/page.tsx
@@ -128,6 +128,11 @@ function useAppearance(enabled: boolean, activeHarness: string | null) {
   // probe is a same-origin call that answers long before a card can be opened
   // and a picture deleted on it.
   const harnessDefaultWallpaperId = activeHarness === "hermes" ? "hermes" : "clawbox";
+  // Painted vs persisted, exactly as on the desktop: this route answers
+  // `d?.active || "unknown"` on a probe that failed, and "unknown" reads as
+  // OpenClaw above. Null means the delete writes no fallback at all.
+  const persistableDefaultWallpaperId =
+    activeHarness === "hermes" || activeHarness === "openclaw" ? harnessDefaultWallpaperId : null;
   const [wallpaperId, setWallpaperId] = useState("clawbox");
   const [wpFit, setWpFit] = useState<WpFit>("fill");
   const [wpBgColor, setWpBgColor] = useState("#000000");
@@ -263,7 +268,7 @@ function useAppearance(enabled: boolean, activeHarness: string | null) {
         // captured before the store above advances the ref to the shortened
         // one — not the list the saved id was originally chosen against, which
         // may have been another browser's entirely.
-        setWallpaperId(wallpaperIdAfterDelete(wallpaperId, idx, before, harnessDefaultWallpaperId));
+        setWallpaperId(wallpaperIdAfterDelete(wallpaperId, idx, before, persistableDefaultWallpaperId));
       },
     },
   };

--- a/src/app/app/[id]/page.tsx
+++ b/src/app/app/[id]/page.tsx
@@ -6,6 +6,7 @@ import dynamic from "next/dynamic";
 import Image from "next/image";
 import Link from "next/link";
 import { fetchHarness } from "@/lib/client-harness";
+import { wallpaperIdAfterDelete } from "@/lib/custom-wallpapers";
 import { apps } from "@/lib/desktop-apps";
 import { I18nProvider, useT } from "@/lib/i18n";
 import { handoffSettingsSection, STANDALONE_SETTINGS_SECTION_PARAM } from "@/lib/ui-events";
@@ -115,7 +116,10 @@ function usePreferenceSaver(loadedRef: { current: boolean }) {
  * `ui_mascot_hidden`) and the same uploaded-wallpaper list, so a change made
  * from a phone is the change the desktop would have made.
  */
-function useAppearance(enabled: boolean) {
+function useAppearance(enabled: boolean, activeHarness: string | null) {
+  // What a box with no custom wallpaper selected shows. `null` — the harness
+  // is still being resolved — keeps the neutral default rather than guessing.
+  const harnessDefaultWallpaperId = activeHarness === "hermes" ? "hermes" : "clawbox";
   const [wallpaperId, setWallpaperId] = useState("clawbox");
   const [wpFit, setWpFit] = useState<WpFit>("fill");
   const [wpBgColor, setWpBgColor] = useState("#000000");
@@ -213,16 +217,12 @@ function useAppearance(enabled: boolean) {
         const next = customRef.current.filter((_, i) => i !== idx);
         applyCustomWallpapers(next);
         // `custom-<n>` is an INDEX into that list, so deleting one renumbers
-        // every picture after it. Clearing only the exact match left a
-        // selection past the hole pointing at its neighbour — the wallpaper
-        // silently became a different picture, or none once the last entry
-        // went. The same rule is in src/app/page.tsx's own handler; keep the
-        // two in step, as with the list above it.
-        const selected = wallpaperId.startsWith("custom-")
-          ? Number.parseInt(wallpaperId.slice("custom-".length), 10)
-          : NaN;
-        if (selected === idx) setWallpaperId("clawbox");
-        else if (Number.isInteger(selected) && selected > idx) setWallpaperId(`custom-${selected - 1}`);
+        // every picture after it. Through the SHARED rule, not a fourth
+        // spelling of it: this handler and the desktop's write the same
+        // box-wide `wp_id`, and the fallback is the harness's own art — a
+        // Hermes box whose only custom wallpaper is deleted must not land on
+        // the ClawBox one (TASK-719).
+        setWallpaperId(wallpaperIdAfterDelete(wallpaperId, idx, harnessDefaultWallpaperId));
       },
     },
   };
@@ -263,10 +263,10 @@ export default function StandaloneAppPage() {
   const { id } = useParams<{ id: string }>();
   // Only /app/settings reads the appearance preferences — every other page
   // here would be paying for a request it never renders.
-  const appearance = useAppearance(id === "settings");
   // null while unresolved — a harness-only app must not paint before we know
   // which harness this device actually runs.
   const [harness, setHarness] = useState<string | null>(null);
+  const appearance = useAppearance(id === "settings", harness);
 
   useEffect(() => {
     let alive = true;

--- a/src/app/app/[id]/page.tsx
+++ b/src/app/app/[id]/page.tsx
@@ -6,7 +6,12 @@ import dynamic from "next/dynamic";
 import Image from "next/image";
 import Link from "next/link";
 import { fetchHarness } from "@/lib/client-harness";
-import { wallpaperIdAfterDelete } from "@/lib/custom-wallpapers";
+import {
+  customWallpaperId,
+  customWallpaperIndex,
+  isCustomWallpaperInRange,
+  wallpaperIdAfterDelete,
+} from "@/lib/custom-wallpapers";
 import { apps } from "@/lib/desktop-apps";
 import { I18nProvider, useT } from "@/lib/i18n";
 import { handoffSettingsSection, STANDALONE_SETTINGS_SECTION_PARAM } from "@/lib/ui-events";
@@ -117,8 +122,11 @@ function usePreferenceSaver(loadedRef: { current: boolean }) {
  * from a phone is the change the desktop would have made.
  */
 function useAppearance(enabled: boolean, activeHarness: string | null) {
-  // What a box with no custom wallpaper selected shows. `null` — the harness
-  // is still being resolved — keeps the neutral default rather than guessing.
+  // What a box with no custom wallpaper selected shows: the harness's own art,
+  // the same default the desktop opens a first boot on. An unresolved harness
+  // reads as ClawBox, which is also this page's initial `wallpaperId` — the
+  // probe is a same-origin call that answers long before a card can be opened
+  // and a picture deleted on it.
   const harnessDefaultWallpaperId = activeHarness === "hermes" ? "hermes" : "clawbox";
   const [wallpaperId, setWallpaperId] = useState("clawbox");
   const [wpFit, setWpFit] = useState<WpFit>("fill");
@@ -140,8 +148,23 @@ function useAppearance(enabled: boolean, activeHarness: string | null) {
   const applyCustomWallpapers = useCallback((next: string[]) => {
     customRef.current = next;
     setCustomWallpapers(next);
-    try { localStorage.setItem(CUSTOM_WPS_KEY, JSON.stringify(next)); } catch {}
   }, []);
+  // The STORED list is the OUTCOME of an upload or a delete, so it is written
+  // first and its failure is the whole operation's — the desktop's rule, and
+  // the same reasoning: it is what the next load paints and `wp_id` is a
+  // box-wide position into it, so moving the card over a list that never
+  // changed leaves a DIFFERENT picture on screen after a reload. There is no
+  // toast surface on this route (ToastHost is the desktop's), and the picture
+  // staying put is the honest answer: the operation did not happen.
+  const storeCustomWallpapers = useCallback((next: string[]) => {
+    try {
+      localStorage.setItem(CUSTOM_WPS_KEY, JSON.stringify(next));
+    } catch {
+      return false;
+    }
+    applyCustomWallpapers(next);
+    return true;
+  }, [applyCustomWallpapers]);
 
   useEffect(() => {
     if (!enabled) return;
@@ -164,6 +187,12 @@ function useAppearance(enabled: boolean, activeHarness: string | null) {
       .finally(() => { if (alive) setHydrated(true); });
     return () => { alive = false; };
   }, [enabled]);
+
+  const renderedWallpaperId =
+    customWallpaperIndex(wallpaperId) !== null
+      && !isCustomWallpaperInRange(wallpaperId, customWallpapers.length)
+      ? harnessDefaultWallpaperId
+      : wallpaperId;
 
   const save = usePreferenceSaver(loaded);
   useEffect(() => {
@@ -188,19 +217,25 @@ function useAppearance(enabled: boolean, activeHarness: string | null) {
     const reader = new FileReader();
     reader.onload = () => {
       const next = [...customRef.current, reader.result as string];
-      applyCustomWallpapers(next);
-      setWallpaperId(`custom-${next.length - 1}`);
+      // The picture is not there to be selected unless it was stored.
+      if (!storeCustomWallpapers(next)) return;
+      setWallpaperId(customWallpaperId(next.length - 1));
       setWpOpacity(100);
     };
     reader.readAsDataURL(file);
     e.target.value = "";
-  }, [applyCustomWallpapers]);
+  }, [storeCustomWallpapers]);
 
   return {
     uploadRef,
     onUploadFile,
     ui: {
-      wallpaperId,
+      // What is on screen, not what the box holds. `wp_id` is box-wide and the
+      // pictures are this browser's, so a `custom-<n>` a phone cannot answer
+      // is the laptop's selection, still valid there — the card shows the
+      // fallback and leaves the box's own value alone. Only an explicit choice
+      // below ever writes it.
+      wallpaperId: renderedWallpaperId,
       wpFit,
       wpBgColor,
       wpOpacity,
@@ -215,7 +250,8 @@ function useAppearance(enabled: boolean, activeHarness: string | null) {
       onWallpaperUpload: () => uploadRef.current?.click(),
       onCustomWallpaperDelete: (idx: number) => {
         const next = customRef.current.filter((_, i) => i !== idx);
-        applyCustomWallpapers(next);
+        // Nothing was removed, so nothing is renumbered.
+        if (!storeCustomWallpapers(next)) return;
         // `custom-<n>` is an INDEX into that list, so deleting one renumbers
         // every picture after it. Through the SHARED rule, not a fourth
         // spelling of it: this handler and the desktop's write the same

--- a/src/app/app/[id]/page.tsx
+++ b/src/app/app/[id]/page.tsx
@@ -249,7 +249,8 @@ function useAppearance(enabled: boolean, activeHarness: string | null) {
       onMascotToggle: setMascotHidden,
       onWallpaperUpload: () => uploadRef.current?.click(),
       onCustomWallpaperDelete: (idx: number) => {
-        const next = customRef.current.filter((_, i) => i !== idx);
+        const before = customRef.current;
+        const next = before.filter((_, i) => i !== idx);
         // Nothing was removed, so nothing is renumbered.
         if (!storeCustomWallpapers(next)) return;
         // `custom-<n>` is an INDEX into that list, so deleting one renumbers
@@ -258,7 +259,11 @@ function useAppearance(enabled: boolean, activeHarness: string | null) {
         // box-wide `wp_id`, and the fallback is the harness's own art — a
         // Hermes box whose only custom wallpaper is deleted must not land on
         // the ClawBox one (TASK-719).
-        setWallpaperId(wallpaperIdAfterDelete(wallpaperId, idx, harnessDefaultWallpaperId));
+        // `before` is the list as it stood immediately ahead of THIS delete,
+        // captured before the store above advances the ref to the shortened
+        // one — not the list the saved id was originally chosen against, which
+        // may have been another browser's entirely.
+        setWallpaperId(wallpaperIdAfterDelete(wallpaperId, idx, before, harnessDefaultWallpaperId));
       },
     },
   };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,6 +46,8 @@ import type { InstalledMeta } from "@/lib/store-categories";
 import { SKILL_CHANGE_EVENT, announceSkillChange, installedAppRemovedDetail } from "@/lib/skill-change-message";
 import { apps, type AppDef } from "@/lib/desktop-apps";
 import { hiddenAppIdsForHarness, isInstalledAppVisible } from "@/lib/desktop-app-editions";
+import { customWallpaperIndex, wallpaperIdAfterDelete } from "@/lib/custom-wallpapers";
+import { TOAST_EVENT } from "@/components/ToastHost";
 import {
   layoutIcons,
   layoutsEqual,
@@ -591,6 +593,13 @@ function ChromeDesktopInner() {
   // the mirror behind. A mirror kept in step by convention is an invisible LOST
   // write, and the purity rule cannot see one: it reports side effects INSIDE
   // an updater, never a missing ref advance outside one.
+  // What a box with no custom wallpaper selected shows — the harness's own
+  // art, the same default the mount path above picks for a first boot.
+  const harnessDefaultWallpaperId = activeHarness === "hermes" ? "hermes" : "clawbox";
+  // The repair effect below has to be able to tell "no custom wallpapers" from
+  // "not read yet": firing against the empty initial state would reset a
+  // perfectly good `custom-<n>` selection on every load.
+  const [customWallpapersLoaded, setCustomWallpapersLoaded] = useState(false);
   const customWallpapersRef = useRef<string[]>([]);
   const applyCustomWallpapers = useCallback((next: string[]) => {
     customWallpapersRef.current = next;
@@ -601,11 +610,29 @@ function ChromeDesktopInner() {
   useEffect(() => {
     try {
       const saved = localStorage.getItem(CUSTOM_WPS_KEY);
-      if (!saved) return;
-      const parsed: string[] = JSON.parse(saved);
-      applyCustomWallpapers(parsed);
+      if (saved) {
+        const parsed: string[] = JSON.parse(saved);
+        applyCustomWallpapers(parsed);
+      }
     } catch {}
+    setCustomWallpapersLoaded(true);
   }, [applyCustomWallpapers]);
+  // A selection that names a picture this browser does not have.
+  //
+  // `wp_id` is box-wide (SQLite, read by every browser that opens the desktop)
+  // while the pictures are per-browser `localStorage`, so a delete on the
+  // laptop leaves the box's own screen holding a position past the end of its
+  // own list — and so does every box that hit TASK-719 before it was fixed.
+  // The desktop already paints the default there; without this, Settings goes
+  // on claiming a slot that does not exist and the stale id is written back on
+  // every preference save. Reset to what is actually on screen and let the
+  // existing debounced write persist the repair.
+  useEffect(() => {
+    if (!customWallpapersLoaded || !prefsLoaded.current) return;
+    const index = customWallpaperIndex(wallpaperId);
+    if (index === null || index < customWallpapers.length) return;
+    setWallpaperId(harnessDefaultWallpaperId);
+  }, [customWallpapersLoaded, customWallpapers, wallpaperId, harnessDefaultWallpaperId]);
   const wallpaperInputRef = useRef<HTMLInputElement>(null);
   const handleWallpaperUpload = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -1954,20 +1981,29 @@ function ChromeDesktopInner() {
                 // Same as the upload above: outside the updater, and off the
                 // ref rather than off `prev`.
                 const next = customWallpapersRef.current.filter((_, i) => i !== idx);
+                // The stored list FIRST, because it is what the next load
+                // paints and what `wp_id` is a position into. A swallowed
+                // write (site data blocked, a locked-down profile) with the
+                // other two already moved would leave the three disagreeing
+                // and a DIFFERENT picture on screen after a reload, with
+                // nothing said. So the delete simply does not happen, and the
+                // owner is told why.
+                try {
+                  localStorage.setItem(CUSTOM_WPS_KEY, JSON.stringify(next));
+                } catch {
+                  window.dispatchEvent(new CustomEvent(TOAST_EVENT, {
+                    detail: { message: "Could not remove that wallpaper — this browser is not letting the page store them." },
+                  }));
+                  return;
+                }
                 applyCustomWallpapers(next);
-                try { localStorage.setItem(CUSTOM_WPS_KEY, JSON.stringify(next)); } catch {}
-                // `custom-<n>` is an INDEX into that list (see the wallpaper
-                // background below, which reads it with parseInt), so deleting
-                // one renumbers every picture after it. Clearing only the exact
-                // match left a selection past the hole pointing at its
-                // neighbour — the desktop drew a different wallpaper than the
-                // one that was chosen, or none once the last entry went. The
-                // same rule is in src/app/app/[id]/page.tsx's handler.
-                const selected = wallpaperId.startsWith("custom-")
-                  ? Number.parseInt(wallpaperId.slice("custom-".length), 10)
-                  : NaN;
-                if (selected === idx) setWallpaperId("clawbox");
-                else if (Number.isInteger(selected) && selected > idx) setWallpaperId(`custom-${selected - 1}`);
+                // `custom-<n>` is an INDEX into that list, so deleting one
+                // renumbers every picture after it. Through the SHARED rule,
+                // which is also what src/app/app/[id]/page.tsx's handler and
+                // the background below now use — and the fallback is the
+                // harness's own art, so a Hermes box does not land on the
+                // ClawBox wallpaper.
+                setWallpaperId(wallpaperIdAfterDelete(wallpaperId, idx, harnessDefaultWallpaperId));
               },
             }} />
           </div>
@@ -2469,8 +2505,8 @@ function ChromeDesktopInner() {
       )}
       {/* Desktop wallpaper background */}
       {(() => {
-        const customIdx = wallpaperId.startsWith("custom-") ? parseInt(wallpaperId.split("-")[1]) : -1;
-        const customWp = customIdx >= 0 ? customWallpapers[customIdx] : undefined;
+        const customIdx = customWallpaperIndex(wallpaperId);
+        const customWp = customIdx === null ? undefined : customWallpapers[customIdx];
         return customWp ? (
           <>
             <div className="absolute inset-0 z-0 pointer-events-none" style={{ backgroundColor: wpBgColor }} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2010,7 +2010,8 @@ function ChromeDesktopInner() {
               onCustomWallpaperDelete: (idx: number) => {
                 // Same as the upload above: outside the updater, and off the
                 // ref rather than off `prev`.
-                const next = customWallpapersRef.current.filter((_, i) => i !== idx);
+                const before = customWallpapersRef.current;
+                const next = before.filter((_, i) => i !== idx);
                 // Nothing was removed, so nothing is renumbered.
                 if (!storeCustomWallpapers(next, "Could not remove that wallpaper — this browser is not letting the page store them.")) return;
                 // `custom-<n>` is an INDEX into that list, so deleting one
@@ -2021,8 +2022,12 @@ function ChromeDesktopInner() {
                 // ClawBox wallpaper.
                 // Off the STORED id, not the rendered one: this is the write
                 // that goes to the box, and it must renumber what the box
-                // actually holds.
-                setWallpaperId(wallpaperIdAfterDelete(wallpaperId, idx, harnessDefaultWallpaperId));
+                // actually holds. `before` is the list as it stood immediately
+                // ahead of THIS delete — captured before the store above, which
+                // advances the ref to the shortened one — and it is what tells
+                // the rule whether the saved id was an index into this
+                // browser's list at all.
+                setWallpaperId(wallpaperIdAfterDelete(wallpaperId, idx, before, harnessDefaultWallpaperId));
               },
             }} />
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -630,8 +630,12 @@ function ChromeDesktopInner() {
     try {
       const saved = localStorage.getItem(CUSTOM_WPS_KEY);
       if (saved) {
-        const parsed: string[] = JSON.parse(saved);
-        applyCustomWallpapers(parsed);
+        // Whatever is under this key is not necessarily a list: another tab,
+        // an older build, a hand-edited profile. A non-array reached the grid
+        // as `.map is not a function` — the standalone route already checks,
+        // and the two read the same key.
+        const parsed: unknown = JSON.parse(saved);
+        if (Array.isArray(parsed)) applyCustomWallpapers(parsed as string[]);
       }
     } catch {}
     setCustomWallpapersLoaded(true);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,7 +46,7 @@ import type { InstalledMeta } from "@/lib/store-categories";
 import { SKILL_CHANGE_EVENT, announceSkillChange, installedAppRemovedDetail } from "@/lib/skill-change-message";
 import { apps, type AppDef } from "@/lib/desktop-apps";
 import { hiddenAppIdsForHarness, isInstalledAppVisible } from "@/lib/desktop-app-editions";
-import { customWallpaperIndex, wallpaperIdAfterDelete } from "@/lib/custom-wallpapers";
+import { customWallpaperId, customWallpaperIndex, isCustomWallpaperInRange, wallpaperIdAfterDelete } from "@/lib/custom-wallpapers";
 import { TOAST_EVENT } from "@/components/ToastHost";
 import {
   layoutIcons,
@@ -470,7 +470,6 @@ function ChromeDesktopInner() {
   // one a device that has never chosen starts on. A Hermes box opens on the
   // Hermes art; OpenClaw is untouched.
   const [wallpaperId, setWallpaperId] = useState("clawbox");
-  const currentWallpaper = wallpapers.find(w => w.id === wallpaperId) || wallpapers[0];
   type WpFit = "fill" | "fit" | "center";
   const [wpFit, setWpFit] = useState<WpFit>("fill");
   const [wpBgColor, setWpBgColor] = useState("#000000");
@@ -596,15 +595,34 @@ function ChromeDesktopInner() {
   // What a box with no custom wallpaper selected shows — the harness's own
   // art, the same default the mount path above picks for a first boot.
   const harnessDefaultWallpaperId = activeHarness === "hermes" ? "hermes" : "clawbox";
-  // The repair effect below has to be able to tell "no custom wallpapers" from
-  // "not read yet": firing against the empty initial state would reset a
-  // perfectly good `custom-<n>` selection on every load.
+  // The fallback below has to be able to tell "no custom wallpapers" from "not
+  // read yet": an empty initial state puts every `custom-<n>` out of range, so
+  // without this a perfectly good selection flashes the default on every load.
   const [customWallpapersLoaded, setCustomWallpapersLoaded] = useState(false);
   const customWallpapersRef = useRef<string[]>([]);
   const applyCustomWallpapers = useCallback((next: string[]) => {
     customWallpapersRef.current = next;
     setCustomWallpapersState(next);
   }, []);
+  // The STORED list is the OUTCOME of an upload or a delete, so it is written
+  // first and its failure is the whole operation's.
+  //
+  // It is what the next load paints, and `wp_id` — box-wide, in SQLite — is a
+  // position into it. Moving the state and the id over a list that never
+  // actually changed (site data blocked, a locked-down profile, quota) leaves
+  // the three disagreeing and a DIFFERENT picture on screen after a reload,
+  // with nothing said. So the operation simply does not happen and the owner
+  // is told why. The same rule is in src/app/app/[id]/page.tsx.
+  const storeCustomWallpapers = useCallback((next: string[], failure: string) => {
+    try {
+      localStorage.setItem(CUSTOM_WPS_KEY, JSON.stringify(next));
+    } catch {
+      window.dispatchEvent(new CustomEvent(TOAST_EVENT, { detail: { message: failure } }));
+      return false;
+    }
+    applyCustomWallpapers(next);
+    return true;
+  }, [applyCustomWallpapers]);
   // Wallpapers are large base64 blobs — keep in localStorage to avoid
   // bloating the KV JSON file that gets read/written on every state save.
   useEffect(() => {
@@ -617,22 +635,25 @@ function ChromeDesktopInner() {
     } catch {}
     setCustomWallpapersLoaded(true);
   }, [applyCustomWallpapers]);
-  // A selection that names a picture this browser does not have.
+  // What is PAINTED, which is not always what the box holds.
   //
   // `wp_id` is box-wide (SQLite, read by every browser that opens the desktop)
-  // while the pictures are per-browser `localStorage`, so a delete on the
-  // laptop leaves the box's own screen holding a position past the end of its
-  // own list — and so does every box that hit TASK-719 before it was fixed.
-  // The desktop already paints the default there; without this, Settings goes
-  // on claiming a slot that does not exist and the stale id is written back on
-  // every preference save. Reset to what is actually on screen and let the
-  // existing debounced write persist the repair.
-  useEffect(() => {
-    if (!customWallpapersLoaded || !prefsLoaded.current) return;
-    const index = customWallpaperIndex(wallpaperId);
-    if (index === null || index < customWallpapers.length) return;
-    setWallpaperId(harnessDefaultWallpaperId);
-  }, [customWallpapersLoaded, customWallpapers, wallpaperId, harnessDefaultWallpaperId]);
+  // while the pictures are per-browser `localStorage`. So a `custom-<n>` this
+  // browser cannot answer is not a wrong selection to be repaired — it is
+  // almost always ANOTHER browser's, still resolving perfectly on the laptop
+  // that chose it. This browser has no standing to overwrite it: healing it
+  // box-wide would mean the box's own screen, or a phone, silently destroying
+  // the owner's wallpaper by being opened.
+  //
+  // So the fallback lives here, in the render, and nowhere else. `wallpaperId`
+  // — the value the debounced write sends — only ever changes on an explicit
+  // choice: picking a tile, uploading, or deleting the picture in use.
+  const renderedWallpaperId =
+    customWallpapersLoaded && customWallpaperIndex(wallpaperId) !== null
+      && !isCustomWallpaperInRange(wallpaperId, customWallpapers.length)
+      ? harnessDefaultWallpaperId
+      : wallpaperId;
+  const currentWallpaper = wallpapers.find(w => w.id === renderedWallpaperId) || wallpapers[0];
   const wallpaperInputRef = useRef<HTMLInputElement>(null);
   const handleWallpaperUpload = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -651,14 +672,16 @@ function ChromeDesktopInner() {
       // (or an upload and a delete) can both run before React commits, and both
       // would otherwise read the same list and the second would discard the
       // first — from the state AND from localStorage.
-      applyCustomWallpapers(next);
-      try { localStorage.setItem(CUSTOM_WPS_KEY, JSON.stringify(next)); } catch {}
-      setWallpaperId(`custom-${next.length - 1}`);
+      // Nothing was stored, so there is no picture to select: showing it and
+      // pointing the box-wide `wp_id` at it would put a slot on the card that
+      // the next load cannot paint.
+      if (!storeCustomWallpapers(next, "Could not save that wallpaper — this browser is not letting the page store them.")) return;
+      setWallpaperId(customWallpaperId(next.length - 1));
       setWpOpacity(100);
     };
     reader.readAsDataURL(file);
     e.target.value = "";
-  }, [applyCustomWallpapers]);
+  }, [storeCustomWallpapers]);
 
   // ─── Chat (mascot click toggles chat popup) ───
   const [chatOpen, setChatOpen] = useState(false);
@@ -1964,7 +1987,9 @@ function ChromeDesktopInner() {
         return (
           <div className="h-full overflow-y-auto">
             <SettingsApp ui={{
-              wallpaperId,
+              // What is on screen, not what the box holds: the panel must not
+              // highlight — or name — a slot this browser cannot show.
+              wallpaperId: renderedWallpaperId,
               wpFit,
               wpBgColor,
               wpOpacity,
@@ -1981,28 +2006,17 @@ function ChromeDesktopInner() {
                 // Same as the upload above: outside the updater, and off the
                 // ref rather than off `prev`.
                 const next = customWallpapersRef.current.filter((_, i) => i !== idx);
-                // The stored list FIRST, because it is what the next load
-                // paints and what `wp_id` is a position into. A swallowed
-                // write (site data blocked, a locked-down profile) with the
-                // other two already moved would leave the three disagreeing
-                // and a DIFFERENT picture on screen after a reload, with
-                // nothing said. So the delete simply does not happen, and the
-                // owner is told why.
-                try {
-                  localStorage.setItem(CUSTOM_WPS_KEY, JSON.stringify(next));
-                } catch {
-                  window.dispatchEvent(new CustomEvent(TOAST_EVENT, {
-                    detail: { message: "Could not remove that wallpaper — this browser is not letting the page store them." },
-                  }));
-                  return;
-                }
-                applyCustomWallpapers(next);
+                // Nothing was removed, so nothing is renumbered.
+                if (!storeCustomWallpapers(next, "Could not remove that wallpaper — this browser is not letting the page store them.")) return;
                 // `custom-<n>` is an INDEX into that list, so deleting one
                 // renumbers every picture after it. Through the SHARED rule,
                 // which is also what src/app/app/[id]/page.tsx's handler and
                 // the background below now use — and the fallback is the
                 // harness's own art, so a Hermes box does not land on the
                 // ClawBox wallpaper.
+                // Off the STORED id, not the rendered one: this is the write
+                // that goes to the box, and it must renumber what the box
+                // actually holds.
                 setWallpaperId(wallpaperIdAfterDelete(wallpaperId, idx, harnessDefaultWallpaperId));
               },
             }} />
@@ -2505,7 +2519,7 @@ function ChromeDesktopInner() {
       )}
       {/* Desktop wallpaper background */}
       {(() => {
-        const customIdx = customWallpaperIndex(wallpaperId);
+        const customIdx = customWallpaperIndex(renderedWallpaperId);
         const customWp = customIdx === null ? undefined : customWallpapers[customIdx];
         return customWp ? (
           <>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -588,8 +588,9 @@ function ChromeDesktopInner() {
   // `[].filter(…)` and write an empty list over every saved wallpaper.
   //
   // The raw setter is renamed out of reach and all three writers go through
-  // `applyCustomWallpapers`, so a fourth cannot advance the state while leaving
-  // the mirror behind. A mirror kept in step by convention is an invisible LOST
+  // `applyCustomWallpapers` — the two that CHANGE the list by way of
+  // `storeCustomWallpapers`, which stores it first — so a fourth cannot advance
+  // the state while leaving the mirror behind. A mirror kept in step by convention is an invisible LOST
   // write, and the purity rule cannot see one: it reports side effects INSIDE
   // an updater, never a missing ref advance outside one.
   // What a box with no custom wallpaper selected shows — the harness's own

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -596,6 +596,14 @@ function ChromeDesktopInner() {
   // What a box with no custom wallpaper selected shows — the harness's own
   // art, the same default the mount path above picks for a first boot.
   const harnessDefaultWallpaperId = activeHarness === "hermes" ? "hermes" : "clawbox";
+  // The same answer, but only once the probe has actually given one. The line
+  // above has to name a wallpaper to PAINT while `activeHarness` is still null,
+  // and guessing there is free — the paint corrects itself when the probe
+  // lands. Guessing in a value that gets PERSISTED box-wide is not free: an
+  // unresolved harness reads as OpenClaw, so it would write the ClawBox art
+  // over a Hermes box's selection for good. Null means "do not write one".
+  const persistableDefaultWallpaperId =
+    activeHarness === "hermes" || activeHarness === "openclaw" ? harnessDefaultWallpaperId : null;
   // The fallback below has to be able to tell "no custom wallpapers" from "not
   // read yet": an empty initial state puts every `custom-<n>` out of range, so
   // without this a perfectly good selection flashes the default on every load.
@@ -2027,7 +2035,7 @@ function ChromeDesktopInner() {
                 // advances the ref to the shortened one — and it is what tells
                 // the rule whether the saved id was an index into this
                 // browser's list at all.
-                setWallpaperId(wallpaperIdAfterDelete(wallpaperId, idx, before, harnessDefaultWallpaperId));
+                setWallpaperId(wallpaperIdAfterDelete(wallpaperId, idx, before, persistableDefaultWallpaperId));
               },
             }} />
           </div>

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -6222,18 +6222,15 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         return { subtitle: null };
       }
       case "appearance": {
+        // `ui.wallpaperId` is what the page is PAINTING, so a slot named here
+        // is one the grid below can highlight — the row used to print
+        // "Custom 3" over a grid of two with nothing selected. Through `t()`,
+        // like the tile it names: this was the last name on the card that
+        // never followed the UI language.
         const customIdx = customWallpaperIndex(ui.wallpaperId);
-        // A slot number is only printable when the slot EXISTS. `wp_id` is
-        // box-wide while the pictures are this browser's `localStorage`, so an
-        // id can name a position the list no longer holds — and printing
-        // "Custom 3" beside a grid of two, with none of them highlighted, is
-        // the panel asserting a selection it never checked. The desktop paints
-        // the first built-in there, so that is what the row says.
         const sub = customIdx === null
           ? ui.wallpaperId
-          : customIdx < ui.customWallpapers.length
-            ? `Custom ${customIdx + 1}`
-            : (ui.wallpapers[0]?.name ?? ui.wallpaperId);
+          : t("settings.customWallpaper", { n: customIdx + 1 });
         return { subtitle: sub };
       }
       case "wifi":

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -43,6 +43,7 @@ import BackgroundJobsPanel from "./BackgroundJobsPanel";
 // marker file and would pull `fs` into the browser bundle.
 import { canonicalPluginId } from "@/lib/plugin-repair-id";
 import PluginRepairNotice, { type PluginRepairInfo } from "./PluginRepairNotice";
+import { customWallpaperId, customWallpaperIndex } from "@/lib/custom-wallpapers";
 
 /* ── Types ── */
 
@@ -3291,7 +3292,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                   );
                 })}
                 {ui.customWallpapers.map((dataUrl, i) => {
-                  const selected = ui.wallpaperId === `custom-${i}`;
+                  const selected = ui.wallpaperId === customWallpaperId(i);
                   // The last two names on this card that never followed the UI
                   // language: an uploaded wallpaper announced itself as
                   // "Custom 1" beside tiles whose names were translated.
@@ -3305,7 +3306,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                         type="button"
                         aria-pressed={selected}
                         aria-label={customName}
-                        onClick={() => ui.onWallpaperChange(`custom-${i}`)}
+                        onClick={() => ui.onWallpaperChange(customWallpaperId(i))}
                         className={`relative w-full h-full rounded-xl overflow-hidden transition-all cursor-pointer border-none p-0 ${
                           selected ? "ring-2 ring-orange-400 ring-offset-2 ring-offset-[#0d1117] scale-[1.02]" : "hover:scale-[1.02]"
                         }`}
@@ -6221,9 +6222,18 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         return { subtitle: null };
       }
       case "appearance": {
-        const sub = ui.wallpaperId.startsWith("custom-")
-          ? `Custom ${parseInt(ui.wallpaperId.split("-")[1] || "0") + 1}`
-          : ui.wallpaperId;
+        const customIdx = customWallpaperIndex(ui.wallpaperId);
+        // A slot number is only printable when the slot EXISTS. `wp_id` is
+        // box-wide while the pictures are this browser's `localStorage`, so an
+        // id can name a position the list no longer holds — and printing
+        // "Custom 3" beside a grid of two, with none of them highlighted, is
+        // the panel asserting a selection it never checked. The desktop paints
+        // the first built-in there, so that is what the row says.
+        const sub = customIdx === null
+          ? ui.wallpaperId
+          : customIdx < ui.customWallpapers.length
+            ? `Custom ${customIdx + 1}`
+            : (ui.wallpapers[0]?.name ?? ui.wallpaperId);
         return { subtitle: sub };
       }
       case "wifi":

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -6229,7 +6229,9 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         // never followed the UI language.
         const customIdx = customWallpaperIndex(ui.wallpaperId);
         const sub = customIdx === null
-          ? ui.wallpaperId
+          // A built-in's NAME, not its id — the row printed the raw slug
+          // `deep-space` beside a tile labelled "Deep Space".
+          ? (ui.wallpapers.find((w) => w.id === ui.wallpaperId)?.name ?? ui.wallpaperId)
           : t("settings.customWallpaper", { n: customIdx + 1 });
         return { subtitle: sub };
       }

--- a/src/lib/custom-wallpapers.ts
+++ b/src/lib/custom-wallpapers.ts
@@ -1,0 +1,64 @@
+/**
+ * The desktop's custom wallpapers are addressed by POSITION: the pictures live
+ * in one browser's `localStorage`, and the selection is the string
+ * `custom-<n>` naming an index into that list.
+ *
+ * That format was spelled out four different ways across two files — a
+ * `startsWith` compare, a template literal, a radix-less `parseInt` on
+ * `split("-")[1]`, and a `slice`. None of them ever asked the question that
+ * actually matters, which is whether the position still EXISTS: a list that
+ * has shrunk (or a `wp_id` saved by a different browser, which holds a
+ * different list) leaves the id pointing past the end, and the desktop then
+ * paints the default while Settings goes on claiming the slot. One parser, so
+ * the range check has a single place to live.
+ */
+
+export const CUSTOM_WALLPAPER_PREFIX = "custom-";
+
+/** The index a `custom-<n>` id names, or null for any other wallpaper id. */
+export function customWallpaperIndex(wallpaperId: string): number | null {
+  if (!wallpaperId.startsWith(CUSTOM_WALLPAPER_PREFIX)) return null;
+  const raw = wallpaperId.slice(CUSTOM_WALLPAPER_PREFIX.length);
+  // Digits only: `parseInt` would read "2abc" as 2 and "" as NaN, and neither
+  // is an id this app ever wrote.
+  if (!/^\d+$/.test(raw)) return null;
+  const index = Number.parseInt(raw, 10);
+  return Number.isSafeInteger(index) ? index : null;
+}
+
+/** The id for the picture at `index`. */
+export function customWallpaperId(index: number): string {
+  return `${CUSTOM_WALLPAPER_PREFIX}${index}`;
+}
+
+/** Whether `wallpaperId` names a picture a list of `count` entries still holds. */
+export function isCustomWallpaperInRange(wallpaperId: string, count: number): boolean {
+  const index = customWallpaperIndex(wallpaperId);
+  return index !== null && index >= 0 && index < count;
+}
+
+/**
+ * Which wallpaper should be selected once the picture at `deletedIndex` is
+ * removed from the list.
+ *
+ * The positions RENUMBER: deleting an earlier entry moves every later one down
+ * a slot, so a selection that is not re-indexed ends up naming a different
+ * picture — or, in the common case, none at all, and the desktop falls back to
+ * the default. The owner deletes one wallpaper and a different one disappears
+ * (TASK-719).
+ *
+ * `fallbackId` is what to select when the deleted one WAS the selected one —
+ * the harness's own art, the same default a box that has never chosen one
+ * opens on, so a Hermes box does not land on the ClawBox wallpaper.
+ */
+export function wallpaperIdAfterDelete(
+  wallpaperId: string,
+  deletedIndex: number,
+  fallbackId: string,
+): string {
+  const active = customWallpaperIndex(wallpaperId);
+  // A built-in is selected: a custom one going away cannot change it.
+  if (active === null) return wallpaperId;
+  if (active === deletedIndex) return fallbackId;
+  return active > deletedIndex ? customWallpaperId(active - 1) : wallpaperId;
+}

--- a/src/lib/custom-wallpapers.ts
+++ b/src/lib/custom-wallpapers.ts
@@ -51,6 +51,16 @@ export function isCustomWallpaperInRange(wallpaperId: string, count: number): bo
  * the harness's own art, the same default a box that has never chosen one
  * opens on, so a Hermes box does not land on the ClawBox wallpaper.
  *
+ * `null` there means the edition is NOT KNOWN YET, and then this returns the id
+ * unchanged rather than guessing. The guess would be persisted box-wide and is
+ * wrong half the time: `activeHarness` unresolved reads as OpenClaw everywhere
+ * it is turned into a wallpaper, so a Hermes box whose probe was slow or failed
+ * would write the ClawBox art over the owner's selection, permanently, on a
+ * delete that had nothing to do with the edition. The desktop already refuses
+ * that write on the MOUNT path; this is the same refusal on the delete path.
+ * What the owner sees meanwhile is the render fallback, which costs nothing and
+ * corrects itself the moment the probe lands.
+ *
  * `before` is the list as it stood BEFORE the removal, and it is what decides
  * whether the rule applies at all: renumbering only makes sense for a selection
  * that was an index into this very list. The range check lives here rather than
@@ -71,7 +81,7 @@ export function wallpaperIdAfterDelete(
   wallpaperId: string,
   deletedIndex: number,
   before: readonly string[],
-  fallbackId: string,
+  fallbackId: string | null,
 ): string {
   const active = customWallpaperIndex(wallpaperId);
   // A built-in is selected: a custom one going away cannot change it.
@@ -83,6 +93,6 @@ export function wallpaperIdAfterDelete(
   // browser's shorter list over a choice it cannot even paint — the same write
   // the mount path already refuses to make (TASK-719).
   if (!isCustomWallpaperInRange(wallpaperId, before.length)) return wallpaperId;
-  if (active === deletedIndex) return fallbackId;
+  if (active === deletedIndex) return fallbackId ?? wallpaperId;
   return active > deletedIndex ? customWallpaperId(active - 1) : wallpaperId;
 }

--- a/src/lib/custom-wallpapers.ts
+++ b/src/lib/custom-wallpapers.ts
@@ -50,15 +50,39 @@ export function isCustomWallpaperInRange(wallpaperId: string, count: number): bo
  * `fallbackId` is what to select when the deleted one WAS the selected one —
  * the harness's own art, the same default a box that has never chosen one
  * opens on, so a Hermes box does not land on the ClawBox wallpaper.
+ *
+ * `before` is the list as it stood BEFORE the removal, and it is what decides
+ * whether the rule applies at all: renumbering only makes sense for a selection
+ * that was an index into this very list. The range check lives here rather than
+ * at the two callers for the reason the whole module exists — a caller that
+ * forgets it writes the corruption box-wide. The list rather than its length
+ * for the same reason: `(id, deletedIndex, count, fallback)` is two adjacent
+ * numbers that transpose silently, and a caller that swapped them would disable
+ * the guard and renumber against the wrong pivot.
+ *
+ * In the other direction the check is a HEURISTIC, and knowingly so: an
+ * IN-range `custom-<n>` is ASSUMED to be this browser's, because a positional
+ * id carries nothing that could prove whose it is. A phone holding three of its
+ * own pictures and the laptop's `custom-2` still renumbers it. Only a
+ * non-positional id closes that half; the range check closes the half a
+ * position can actually answer.
  */
 export function wallpaperIdAfterDelete(
   wallpaperId: string,
   deletedIndex: number,
+  before: readonly string[],
   fallbackId: string,
 ): string {
   const active = customWallpaperIndex(wallpaperId);
   // A built-in is selected: a custom one going away cannot change it.
   if (active === null) return wallpaperId;
+  // A `custom-<n>` this list never held is not ours to renumber. `wp_id` is
+  // box-wide and the pictures are per-browser, so a selection past the end of
+  // the list being deleted from is almost always ANOTHER browser's, still
+  // resolving perfectly there. Shifting it down a slot would write this
+  // browser's shorter list over a choice it cannot even paint — the same write
+  // the mount path already refuses to make (TASK-719).
+  if (!isCustomWallpaperInRange(wallpaperId, before.length)) return wallpaperId;
   if (active === deletedIndex) return fallbackId;
   return active > deletedIndex ? customWallpaperId(active - 1) : wallpaperId;
 }

--- a/src/tests/components/desktop-wallpaper-delete.test.tsx
+++ b/src/tests/components/desktop-wallpaper-delete.test.tsx
@@ -176,18 +176,47 @@ describe("deleting a custom wallpaper", () => {
     expect(wallpaperUrls().some((u) => u.includes("clawbox-wallpaper"))).toBe(false);
   });
 
-  it("heals a selection this browser's list can no longer answer", async () => {
-    // What a delete on the OWNER'S LAPTOP leaves on the box's own screen, and
-    // what every box that hit this bug before the fix is still holding: the
-    // box-wide `wp_id` names a slot past the end of this browser's list.
-    window.localStorage.setItem("clawbox-custom-wallpapers", JSON.stringify([WP[0]]));
+  it("never writes this browser's missing pictures back over the box's selection", async () => {
+    // The box's own screen, or the owner's phone: `wp_id` is box-wide (SQLite)
+    // and the pictures are per-browser `localStorage`, so a browser that never
+    // uploaded anything cannot answer ANY `custom-<n>` — including the one the
+    // owner's laptop chose and still resolves perfectly.
+    //
+    // Opening the desktop is not a statement about that selection. The
+    // fallback below is what THIS browser paints; the box keeps what it holds.
+    window.localStorage.removeItem("clawbox-custom-wallpapers");
     savedWallpaperId = "custom-2";
-    render(<ChromeDesktop />);
-    await waitFor(() => expect(screen.getByTestId("desktop-root")).toBeTruthy());
+    await mountDesktop("clawbox-wallpaper");
 
-    // Repaired rather than left dangling — and the repair is persisted, so it
-    // is not re-done on every load and Settings stops claiming "Custom 3".
-    await waitFor(() => expect(lastSavedWallpaperId()).toBe("clawbox"));
-    expect(wallpaperUrls().some((u) => u.includes("clawbox-wallpaper"))).toBe(true);
+    // Well past the 500 ms preference debounce.
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    expect(lastSavedWallpaperId()).not.toBe("clawbox");
+    expect(saved.some((body) => "wp_id" in body && body.wp_id !== "custom-2")).toBe(false);
+  });
+
+  it("paints the HERMES art for a selection this browser cannot answer", async () => {
+    // Same browser, Hermes box. The local fallback follows the edition, and it
+    // is still only a local fallback — nothing about it reaches the box.
+    activeHarness = "hermes";
+    window.localStorage.removeItem("clawbox-custom-wallpapers");
+    savedWallpaperId = "custom-2";
+    await mountDesktop("hermes-wallpaper");
+
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    expect(wallpaperUrls().some((u) => u.includes("clawbox-wallpaper"))).toBe(false);
+    expect(saved.some((body) => "wp_id" in body && body.wp_id !== "custom-2")).toBe(false);
+  });
+
+  it("does not offer a phantom slot for a picture this browser does not have", async () => {
+    // Settings used to claim "Custom 3" over a grid of none, with no tile
+    // highlighted. The panel is handed what is ON SCREEN, so the fallback tile
+    // is the selected one and the row names it.
+    window.localStorage.removeItem("clawbox-custom-wallpapers");
+    savedWallpaperId = "custom-2";
+    await mountDesktop("clawbox-wallpaper");
+
+    await openAppearanceSettings();
+    const tile = await screen.findByRole("button", { name: /^ClawBox$/i });
+    expect(tile.getAttribute("aria-pressed")).toBe("true");
   });
 });

--- a/src/tests/components/desktop-wallpaper-delete.test.tsx
+++ b/src/tests/components/desktop-wallpaper-delete.test.tsx
@@ -44,6 +44,8 @@ const WP = [
 let savedWallpaperId = "custom-2";
 /** Which harness the box reports — the fallback wallpaper follows it. */
 let activeHarness = "openclaw";
+/** Milliseconds the harness probe takes to answer, so a case can run inside the window where it has not. */
+let harnessDelayMs = 0;
 /** Every preference body the desktop POSTed, in order. */
 const saved: Record<string, unknown>[] = [];
 
@@ -66,6 +68,7 @@ function installFetch() {
     }
     if (url.includes("/setup-api/setup/status")) return answer({ setup_complete: true });
     if (url.includes("/setup-api/harness/active")) {
+      if (harnessDelayMs > 0) await new Promise((resolve) => setTimeout(resolve, harnessDelayMs));
       return answer({ active: activeHarness, edition: activeHarness });
     }
     if (url.includes("/setup-api/preferences?all=1")) {
@@ -111,6 +114,7 @@ describe("deleting a custom wallpaper", () => {
     window.localStorage.setItem("clawbox-custom-wallpapers", JSON.stringify(WP));
     savedWallpaperId = "custom-2";
     activeHarness = "openclaw";
+    harnessDelayMs = 0;
     saved.length = 0;
     resetHarnessCache();
     // jsdom does not implement it at all, so `vi.spyOn` cannot be used and
@@ -233,6 +237,30 @@ describe("deleting a custom wallpaper", () => {
     // Nothing moved: not the stored list, not what is on screen, not the box.
     expect(JSON.parse(window.localStorage.getItem("clawbox-custom-wallpapers") || "[]")).toEqual(WP);
     expect(wallpaperUrls().some((u) => u.includes(WP[2]))).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    expect(saved.some((body) => "wp_id" in body && body.wp_id !== "custom-2")).toBe(false);
+  });
+
+  it("writes nothing while the harness probe has not answered, and lands on the Hermes art", async () => {
+    // The preferences call and the harness probe race, and until the probe
+    // answers the desktop cannot know which edition's art the fallback is. The
+    // repair this replaced ran in that window and PERSISTED "clawbox" — on a
+    // Hermes box, box-wide and for good, since the later Hermes answer found a
+    // selection already made. Nothing is written now, so the paint simply
+    // catches up when the probe lands.
+    activeHarness = "hermes";
+    harnessDelayMs = 900;
+    window.localStorage.removeItem("clawbox-custom-wallpapers");
+    savedWallpaperId = "custom-2";
+
+    render(<ChromeDesktop />);
+    await waitFor(() => expect(screen.getByTestId("desktop-root")).toBeTruthy());
+    // Inside the window: the preferences have landed, the probe has not.
+    await waitFor(() => expect(wallpaperUrls().some((u) => u.includes("clawbox-wallpaper"))).toBe(true));
+    expect(saved.some((body) => "wp_id" in body && body.wp_id !== "custom-2")).toBe(false);
+
+    // And once it does answer, the paint follows the edition.
+    await waitFor(() => expect(wallpaperUrls().some((u) => u.includes("hermes-wallpaper"))).toBe(true));
     await new Promise((resolve) => setTimeout(resolve, 900));
     expect(saved.some((body) => "wp_id" in body && body.wp_id !== "custom-2")).toBe(false);
   });

--- a/src/tests/components/desktop-wallpaper-delete.test.tsx
+++ b/src/tests/components/desktop-wallpaper-delete.test.tsx
@@ -291,6 +291,38 @@ describe("deleting a custom wallpaper", () => {
     expect(saved.some((body) => "wp_id" in body && body.wp_id !== "custom-2")).toBe(false);
   });
 
+  it("writes no edition fallback when the in-use picture is deleted before the probe answers", async () => {
+    // The mount path already refuses to persist a fallback it cannot compute
+    // ("writes nothing while the harness probe has not answered"). The DELETE
+    // path is the sibling call site of the very same value, and it was writing
+    // it: `activeHarness` is null until the probe lands and null reads as
+    // OpenClaw, so deleting the wallpaper in use on a Hermes box whose probe is
+    // slow — or has failed for good, after three attempts — persisted
+    // "clawbox" box-wide. Permanent, and nothing to do with the edition.
+    activeHarness = "hermes";
+    harnessDelayMs = 3_000;
+    savedWallpaperId = "custom-2";
+
+    render(<ChromeDesktop />);
+    await waitFor(() => expect(screen.getByTestId("desktop-root")).toBeTruthy());
+    // Inside the window: preferences have landed, the probe has not.
+    await waitFor(() => expect(wallpaperUrls().some((u) => u.includes(WP[2]))).toBe(true));
+
+    await openAppearanceSettings();
+    fireEvent.click(await screen.findByRole("button", { name: /Remove custom 3/i }));
+
+    // The delete itself is not blocked — a local operation must not wait on a
+    // remote probe. Only the box-wide guess is withheld.
+    await waitFor(() => {
+      expect(JSON.parse(window.localStorage.getItem("clawbox-custom-wallpapers") || "[]"))
+        .toEqual([WP[0], WP[1]]);
+    });
+    // Well past the 500 ms debounce, still inside the probe delay.
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    expect(saved.some((body) => "wp_id" in body && body.wp_id === "clawbox")).toBe(false);
+    expect(saved.some((body) => "wp_id" in body && body.wp_id !== "custom-2")).toBe(false);
+  });
+
   it("does not offer a phantom slot for a picture this browser does not have", async () => {
     // Settings used to claim "Custom 3" over a grid of none, with no tile
     // highlighted. The panel is handed what is ON SCREEN, so the fallback tile

--- a/src/tests/components/desktop-wallpaper-delete.test.tsx
+++ b/src/tests/components/desktop-wallpaper-delete.test.tsx
@@ -198,6 +198,32 @@ describe("deleting a custom wallpaper", () => {
     expect(saved.some((body) => "wp_id" in body && body.wp_id !== "custom-2")).toBe(false);
   });
 
+  it("does not renumber a selection that is not this browser's to renumber", async () => {
+    // The same cross-browser numbering, on the DELETE path. `wp_id` is
+    // box-wide and the pictures are per-browser, so the laptop's `custom-5`
+    // can arrive at a browser holding three of its own — and deleting one of
+    // those three renumbers a list the saved id was never an index into. The
+    // handler would have written `custom-4` over the laptop's choice, from a
+    // list it has no standing to renumber, which is the very write the mount
+    // path above refuses to make.
+    savedWallpaperId = "custom-5";
+    await mountDesktop("clawbox-wallpaper");
+
+    await openAppearanceSettings();
+    fireEvent.click(await screen.findByRole("button", { name: /Remove custom 1/i }));
+
+    // This browser's own list did shrink — the delete is not being refused.
+    await waitFor(() => {
+      expect(JSON.parse(window.localStorage.getItem("clawbox-custom-wallpapers") || "[]"))
+        .toEqual([WP[1], WP[2]]);
+    });
+    // Rendered locally, persisted nowhere: still the local fallback, and the
+    // box still holds the selection it held. Well past the 500 ms debounce.
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    expect(wallpaperUrls().some((u) => u.includes("clawbox-wallpaper"))).toBe(true);
+    expect(saved.some((body) => "wp_id" in body && body.wp_id !== "custom-5")).toBe(false);
+  });
+
   it("paints the HERMES art for a selection this browser cannot answer", async () => {
     // Same browser, Hermes box. The local fallback follows the edition, and it
     // is still only a local fallback — nothing about it reaches the box.

--- a/src/tests/components/desktop-wallpaper-delete.test.tsx
+++ b/src/tests/components/desktop-wallpaper-delete.test.tsx
@@ -207,6 +207,36 @@ describe("deleting a custom wallpaper", () => {
     expect(saved.some((body) => "wp_id" in body && body.wp_id !== "custom-2")).toBe(false);
   });
 
+  it("does not select an UPLOAD it could not store", async () => {
+    // The upload had the delete's bug the other way round: the list moved in
+    // memory, the `setItem` failure was swallowed, and the box-wide `wp_id`
+    // was then pointed at a slot the next load cannot paint — the owner's
+    // wallpaper replaced, box-wide, by one that does not exist. Both writers
+    // now go through the same store-first rule.
+    await mountDesktop(WP[2]);
+    saved.length = 0;
+
+    const input = document.querySelector<HTMLInputElement>("input[type='file'][accept='image/*']");
+    expect(input).toBeTruthy();
+    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("quota", "QuotaExceededError");
+    });
+    try {
+      fireEvent.change(input!, {
+        target: { files: [new File([new Uint8Array([1, 2, 3])], "wp.png", { type: "image/png" })] },
+      });
+      await screen.findByText(/not letting the page store them/i);
+    } finally {
+      setItem.mockRestore();
+    }
+
+    // Nothing moved: not the stored list, not what is on screen, not the box.
+    expect(JSON.parse(window.localStorage.getItem("clawbox-custom-wallpapers") || "[]")).toEqual(WP);
+    expect(wallpaperUrls().some((u) => u.includes(WP[2]))).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    expect(saved.some((body) => "wp_id" in body && body.wp_id !== "custom-2")).toBe(false);
+  });
+
   it("does not offer a phantom slot for a picture this browser does not have", async () => {
     // Settings used to claim "Custom 3" over a grid of none, with no tile
     // highlighted. The panel is handed what is ON SCREEN, so the fallback tile

--- a/src/tests/components/desktop-wallpaper-delete.test.tsx
+++ b/src/tests/components/desktop-wallpaper-delete.test.tsx
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import ChromeDesktop from "@/app/page";
+import { resetHarnessCache } from "@/lib/client-harness";
+
+// The desktop is the whole shell, and this suite is about ONE handler in it.
+// Mounting the mascot (a rAF walk loop) and the chat popup (6 500 lines, a
+// gateway socket, a history round-trip) for every case made this file slow
+// enough to starve the worker pool — four unrelated component files timed out
+// beside it. Neither draws a wallpaper.
+vi.mock("@/components/Mascot", () => ({ default: () => null }));
+vi.mock("@/components/ChatPopup", () => ({
+  default: () => null,
+  CHAT_PANEL_GAP: 12,
+  noticeColumnInset: () => 0,
+}));
+
+/**
+ * Deleting a custom wallpaper must not change which one is on screen (TASK-719).
+ *
+ * `custom-<n>` is a POSITION in the saved list, so removing an entry renumbers
+ * every entry after it. The delete handler only reset the selection when the
+ * deleted one WAS the selected one; delete an earlier picture and the id the
+ * desktop still held pointed one slot too far — off the end of the list in the
+ * common case — and the desktop silently fell back to the default. The
+ * customer's wallpaper changed because they deleted a different one.
+ */
+
+// Mounts the WHOLE desktop shell three times — every mount runs the preference
+// load, the harness probe, the app grid and a full SettingsApp render before
+// the case can click anything. Measured ~0.9 s per case idle here; on a
+// four-worker runner that is several sub-5 s waits in series and vitest's
+// default `testTimeout` fires. See src/tests/unit/test-timeout-hygiene.test.ts,
+// which lists this file so the ceiling cannot quietly go away again.
+vi.setConfig({ testTimeout: 20_000, hookTimeout: 20_000 });
+
+const WP = [
+  "data:image/png;base64,AAAA",
+  "data:image/png;base64,BBBB",
+  "data:image/png;base64,CCCC",
+];
+
+/** The saved `wp_id` the box answers with on mount. */
+let savedWallpaperId = "custom-2";
+/** Which harness the box reports — the fallback wallpaper follows it. */
+let activeHarness = "openclaw";
+/** Every preference body the desktop POSTed, in order. */
+const saved: Record<string, unknown>[] = [];
+
+/** A complete-enough `Response`: `ok`, `status`, `json` and `text`. */
+function answer(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+function installFetch() {
+  vi.stubGlobal("fetch", vi.fn(async (input: unknown, init?: RequestInit) => {
+    const url = String(input);
+    if (url.includes("/setup-api/preferences") && init?.method === "POST") {
+      try { saved.push(JSON.parse(String(init.body)) as Record<string, unknown>); } catch { /* not ours */ }
+      return answer({ ok: true });
+    }
+    if (url.includes("/setup-api/setup/status")) return answer({ setup_complete: true });
+    if (url.includes("/setup-api/harness/active")) {
+      return answer({ active: activeHarness, edition: activeHarness });
+    }
+    if (url.includes("/setup-api/preferences?all=1")) {
+      return answer({ wp_id: savedWallpaperId, wp_opacity: 100 });
+    }
+    return answer({});
+  }));
+}
+
+/** The most recent `wp_id` the desktop sent to the box. */
+function lastSavedWallpaperId(): unknown {
+  for (let i = saved.length - 1; i >= 0; i--) {
+    if ("wp_id" in saved[i]) return saved[i].wp_id;
+  }
+  return undefined;
+}
+
+/** The desktop paints the wallpaper as a background-image on a full-bleed div. */
+function wallpaperUrls(): string[] {
+  return Array.from(document.querySelectorAll<HTMLElement>("div[style*='background-image']"))
+    .map((el) => el.style.backgroundImage);
+}
+
+async function mountDesktop(expected: string) {
+  render(<ChromeDesktop />);
+  await waitFor(() => expect(screen.getByTestId("desktop-root")).toBeTruthy());
+  await waitFor(() => expect(wallpaperUrls().some((u) => u.includes(expected))).toBe(true));
+}
+
+async function openAppearanceSettings() {
+  fireEvent.contextMenu(screen.getByTestId("desktop-surface"));
+  const menu = await screen.findByTestId("desktop-context-menu");
+  const settings = Array.from(menu.querySelectorAll("button"))
+    .find((b) => /settings/i.test(b.textContent || ""));
+  expect(settings).toBeTruthy();
+  fireEvent.click(settings!);
+  fireEvent.click(await screen.findByRole("button", { name: /appearance/i }));
+}
+
+describe("deleting a custom wallpaper", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.localStorage.setItem("clawbox-custom-wallpapers", JSON.stringify(WP));
+    savedWallpaperId = "custom-2";
+    activeHarness = "openclaw";
+    saved.length = 0;
+    resetHarnessCache();
+    // jsdom does not implement it at all, so `vi.spyOn` cannot be used and
+    // `restoreMocks` has nothing to restore — put it back by hand below.
+    Element.prototype.scrollIntoView = vi.fn();
+    // The shared `matchMedia` from `src/tests/setup.ts` is a `vi.fn()`, and
+    // `mockReset: true` (vitest.config.ts) empties every mock's implementation
+    // after each test — so from the SECOND case in any file it answers
+    // `undefined` and the mascot's reduced-motion effect throws on `.matches`.
+    // A plain function has no implementation to reset.
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener() {},
+        removeListener() {},
+        addEventListener() {},
+        removeEventListener() {},
+        dispatchEvent: () => false,
+      }),
+    });
+    installFetch();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetHarnessCache();
+    delete (Element.prototype as { scrollIntoView?: unknown }).scrollIntoView;
+    window.localStorage.clear();
+  });
+
+  it("keeps the picture the owner is actually looking at", async () => {
+    await mountDesktop(WP[2]);
+
+    await openAppearanceSettings();
+    fireEvent.click(await screen.findByRole("button", { name: /Remove custom 1/i }));
+
+    // It is now Custom 2 of two, but it is the same picture.
+    await waitFor(() => {
+      expect(JSON.parse(window.localStorage.getItem("clawbox-custom-wallpapers") || "[]"))
+        .toEqual([WP[1], WP[2]]);
+    });
+    expect(wallpaperUrls().some((u) => u.includes(WP[2]))).toBe(true);
+    // And the box hears about it — the selection is SQLite-backed, so a
+    // re-index that never left the tab would come back wrong on the next boot.
+    await waitFor(() => expect(lastSavedWallpaperId()).toBe("custom-1"));
+  });
+
+  it("falls back to the HERMES art on a Hermes box", async () => {
+    // A shared surface has to be right on both editions: the mount path
+    // deliberately opens a Hermes box on the Hermes wallpaper, and deleting
+    // the picture in use must land on the same one.
+    activeHarness = "hermes";
+    await mountDesktop(WP[2]);
+
+    await openAppearanceSettings();
+    fireEvent.click(await screen.findByRole("button", { name: /Remove custom 3/i }));
+
+    await waitFor(() => expect(wallpaperUrls().some((u) => u.includes("hermes-wallpaper"))).toBe(true));
+    expect(wallpaperUrls().some((u) => u.includes("clawbox-wallpaper"))).toBe(false);
+  });
+
+  it("heals a selection this browser's list can no longer answer", async () => {
+    // What a delete on the OWNER'S LAPTOP leaves on the box's own screen, and
+    // what every box that hit this bug before the fix is still holding: the
+    // box-wide `wp_id` names a slot past the end of this browser's list.
+    window.localStorage.setItem("clawbox-custom-wallpapers", JSON.stringify([WP[0]]));
+    savedWallpaperId = "custom-2";
+    render(<ChromeDesktop />);
+    await waitFor(() => expect(screen.getByTestId("desktop-root")).toBeTruthy());
+
+    // Repaired rather than left dangling — and the repair is persisted, so it
+    // is not re-done on every load and Settings stops claiming "Custom 3".
+    await waitFor(() => expect(lastSavedWallpaperId()).toBe("clawbox"));
+    expect(wallpaperUrls().some((u) => u.includes("clawbox-wallpaper"))).toBe(true);
+  });
+});

--- a/src/tests/components/standalone-app-appearance.test.tsx
+++ b/src/tests/components/standalone-app-appearance.test.tsx
@@ -231,6 +231,42 @@ describe("/app/settings — Appearance", () => {
     expect(posts.some((body) => "wp_id" in body)).toBe(false);
   });
 
+  it("does not renumber a selection that is not an index into this browser's list", async () => {
+    // The phone is the surface most likely to be holding a `wp_id` it did not
+    // choose. Two pictures of its own, the laptop's `custom-5` from the box:
+    // deleting one of ITS two must not shift that id down a slot and write it
+    // back — this handler is a second copy of the desktop's, and this is the
+    // case that catches the two drifting apart.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (init?.method === "POST") {
+          posts.push(JSON.parse(String(init.body)) as Record<string, unknown>);
+          return { ok: true, json: async () => ({ ok: true }) };
+        }
+        if (url.includes("keys=wp_id")) return { ok: true, json: async () => ({ ...SAVED, wp_id: "custom-5" }) };
+        return { ok: true, json: async () => ({}) };
+      }),
+    );
+    localStorage.setItem("clawbox-custom-wallpapers", JSON.stringify(["data:image/png;base64,AAAA", "data:image/png;base64,BBBB"]));
+
+    render(<StandaloneAppPage />);
+    // `wp_fit` proves the box's answer landed, as above.
+    await waitFor(() => expect(screen.getByTestId("ui-fit").textContent).toBe("center"));
+    expect(screen.getByTestId("ui-custom").textContent).toBe("2");
+    posts.length = 0;
+
+    fireEvent.click(screen.getByTestId("delete-custom-0"));
+    // This browser's own list did shrink — the delete is not being refused.
+    expect(screen.getByTestId("ui-custom").textContent).toBe("1");
+    // Rendered locally, persisted nowhere: the card shows the fallback and the
+    // box keeps the selection it holds. Well past the 500 ms debounce.
+    expect(screen.getByTestId("ui-wallpaper").textContent).toBe("clawbox");
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    expect(posts.some((body) => "wp_id" in body)).toBe(false);
+  });
+
   it("does not move the selection when the shortened list cannot be stored", async () => {
     // Site data blocked, or a locked-down profile. The list is what the next
     // load paints and `wp_id` is a position into it — moving the id over a

--- a/src/tests/components/standalone-app-appearance.test.tsx
+++ b/src/tests/components/standalone-app-appearance.test.tsx
@@ -204,6 +204,59 @@ describe("/app/settings — Appearance", () => {
     expect(screen.getByTestId("ui-wallpaper").textContent).toBe("clawbox");
   });
 
+  it("shows the fallback for a selection this browser's uploads cannot answer, and leaves the box's own alone", async () => {
+    // `wp_id` is box-wide, the pictures are this browser's `localStorage`: a
+    // phone that never uploaded anything cannot answer the laptop's
+    // `custom-2`. What the card shows is the fallback; what the box holds is
+    // untouched, because opening a page is not a choice.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (init?.method === "POST") {
+          posts.push(JSON.parse(String(init.body)) as Record<string, unknown>);
+          return { ok: true, json: async () => ({ ok: true }) };
+        }
+        if (url.includes("keys=wp_id")) return { ok: true, json: async () => ({ ...SAVED, wp_id: "custom-2" }) };
+        return { ok: true, json: async () => ({}) };
+      }),
+    );
+
+    render(<StandaloneAppPage />);
+    // `wp_fit` proves the box's answer LANDED — "clawbox" is also this page's
+    // initial state, so asserting it alone would pass before the fetch.
+    await waitFor(() => expect(screen.getByTestId("ui-fit").textContent).toBe("center"));
+    expect(screen.getByTestId("ui-wallpaper").textContent).toBe("clawbox");
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    expect(posts.some((body) => "wp_id" in body)).toBe(false);
+  });
+
+  it("does not move the selection when the shortened list cannot be stored", async () => {
+    // Site data blocked, or a locked-down profile. The list is what the next
+    // load paints and `wp_id` is a position into it — moving the id over a
+    // list that never shrank leaves a DIFFERENT picture on screen after a
+    // reload, with nothing said. So the delete does not happen at all.
+    localStorage.setItem("clawbox-custom-wallpapers", JSON.stringify(["data:image/png;base64,AAAA", "data:image/png;base64,BBBB"]));
+    render(<StandaloneAppPage />);
+    await waitFor(() => expect(screen.getByTestId("ui-custom").textContent).toBe("2"));
+
+    fireEvent.click(screen.getByTestId("pick-custom-1"));
+    expect(screen.getByTestId("ui-wallpaper").textContent).toBe("custom-1");
+
+    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("quota", "QuotaExceededError");
+    });
+    try {
+      fireEvent.click(screen.getByTestId("delete-custom-0"));
+    } finally {
+      setItem.mockRestore();
+    }
+
+    expect(screen.getByTestId("ui-custom").textContent).toBe("2");
+    expect(screen.getByTestId("ui-wallpaper").textContent).toBe("custom-1");
+    expect(JSON.parse(localStorage.getItem("clawbox-custom-wallpapers") || "[]")).toHaveLength(2);
+  });
+
   it("offers the wallpapers this browser already uploaded, and asks the file input for a new one", async () => {
     localStorage.setItem("clawbox-custom-wallpapers", JSON.stringify(["data:image/png;base64,AAAA"]));
     render(<StandaloneAppPage />);

--- a/src/tests/components/standalone-app-appearance.test.tsx
+++ b/src/tests/components/standalone-app-appearance.test.tsx
@@ -24,7 +24,10 @@ vi.mock("next/link", () => ({
   default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
 }));
 vi.mock("next/image", () => ({ default: () => null }));
-vi.mock("@/lib/client-harness", () => ({ fetchHarness: vi.fn(async () => ({ active: "openclaw" })) }));
+// Hoisted so a case can decide what the probe answers — including answering
+// without an `active`, which is what a failed probe looks like to this route.
+const harnessMock = vi.hoisted(() => vi.fn(async (): Promise<{ active?: string }> => ({ active: "openclaw" })));
+vi.mock("@/lib/client-harness", () => ({ fetchHarness: harnessMock }));
 
 interface StubUi {
   wallpaperId: string;
@@ -79,6 +82,7 @@ let posts: Record<string, unknown>[];
 beforeEach(() => {
   posts = [];
   localStorage.clear();
+  harnessMock.mockResolvedValue({ active: "openclaw" });
   vi.stubGlobal(
     "fetch",
     vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -291,6 +295,31 @@ describe("/app/settings — Appearance", () => {
     expect(screen.getByTestId("ui-custom").textContent).toBe("2");
     expect(screen.getByTestId("ui-wallpaper").textContent).toBe("custom-1");
     expect(JSON.parse(localStorage.getItem("clawbox-custom-wallpapers") || "[]")).toHaveLength(2);
+  });
+
+  it("writes no edition fallback when the probe never said which edition this is", async () => {
+    // This route answers `d?.active || "unknown"` on a failed probe, and
+    // "unknown" reads as OpenClaw wherever it is turned into a wallpaper. So
+    // deleting the picture in use on a Hermes box whose probe failed persisted
+    // "clawbox" box-wide — permanently, from a delete that had nothing to do
+    // with the edition. The guess is fine to PAINT and not fine to WRITE.
+    harnessMock.mockResolvedValue({});
+    localStorage.setItem("clawbox-custom-wallpapers", JSON.stringify(["data:image/png;base64,AAAA"]));
+    render(<StandaloneAppPage />);
+    await waitFor(() => expect(screen.getByTestId("ui-custom").textContent).toBe("1"));
+
+    fireEvent.click(screen.getByTestId("pick-custom-0"));
+    await waitFor(() => expect(posts.at(-1)).toMatchObject({ wp_id: "custom-0" }), SAVED_SOON);
+    posts.length = 0;
+
+    // The delete is not blocked — a local operation must not wait on a probe.
+    fireEvent.click(screen.getByTestId("delete-custom-0"));
+    expect(screen.getByTestId("ui-custom").textContent).toBe("0");
+    // Painted locally…
+    expect(screen.getByTestId("ui-wallpaper").textContent).toBe("clawbox");
+    // …and not written. Well past the 500 ms debounce.
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    expect(posts.some((body) => body.wp_id === "clawbox")).toBe(false);
   });
 
   it("offers the wallpapers this browser already uploaded, and asks the file input for a new one", async () => {

--- a/src/tests/unit/custom-wallpapers.test.ts
+++ b/src/tests/unit/custom-wallpapers.test.ts
@@ -32,25 +32,41 @@ describe("custom wallpaper ids", () => {
   });
 });
 
+/** A pre-delete list of `n` pictures — only its LENGTH matters to the rule. */
+function listOf(n: number): string[] {
+  return Array.from({ length: n }, (_, i) => `data:image/png;base64,${i}`);
+}
+
 describe("the selection after a custom wallpaper is deleted", () => {
   it("follows the same picture down a slot when an EARLIER one goes", () => {
     // The whole defect: on beta this stayed "custom-2" against a two-entry
     // list, so the desktop painted the default instead.
-    expect(wallpaperIdAfterDelete("custom-2", 0, "clawbox")).toBe("custom-1");
-    expect(wallpaperIdAfterDelete("custom-1", 0, "clawbox")).toBe("custom-0");
+    expect(wallpaperIdAfterDelete("custom-2", 0, listOf(3), "clawbox")).toBe("custom-1");
+    expect(wallpaperIdAfterDelete("custom-1", 0, listOf(2), "clawbox")).toBe("custom-0");
   });
 
   it("leaves it alone when a LATER one goes", () => {
-    expect(wallpaperIdAfterDelete("custom-0", 2, "clawbox")).toBe("custom-0");
+    expect(wallpaperIdAfterDelete("custom-0", 2, listOf(3), "clawbox")).toBe("custom-0");
   });
 
   it("falls back to the harness's own art when the selected one goes", () => {
-    expect(wallpaperIdAfterDelete("custom-1", 1, "clawbox")).toBe("clawbox");
+    expect(wallpaperIdAfterDelete("custom-1", 1, listOf(2), "clawbox")).toBe("clawbox");
     // A Hermes box opens on the Hermes wallpaper and must land back on it.
-    expect(wallpaperIdAfterDelete("custom-1", 1, "hermes")).toBe("hermes");
+    expect(wallpaperIdAfterDelete("custom-1", 1, listOf(2), "hermes")).toBe("hermes");
   });
 
   it("does not touch a built-in selection", () => {
-    expect(wallpaperIdAfterDelete("clawbox", 0, "hermes")).toBe("clawbox");
+    expect(wallpaperIdAfterDelete("clawbox", 0, listOf(3), "hermes")).toBe("clawbox");
+  });
+
+  it("does not renumber a selection this list never held", () => {
+    // `wp_id` is box-wide and the pictures are per-browser, so a browser with
+    // three of its own can be holding the laptop's "custom-5". Deleting one of
+    // ITS three renumbered that id to "custom-4" and wrote it box-wide — the
+    // laptop's wallpaper destroyed out of a list it was never an index into.
+    expect(wallpaperIdAfterDelete("custom-5", 0, listOf(3), "clawbox")).toBe("custom-5");
+    // Including the boundary, and including a list this browser has none of.
+    expect(wallpaperIdAfterDelete("custom-3", 0, listOf(3), "clawbox")).toBe("custom-3");
+    expect(wallpaperIdAfterDelete("custom-2", 0, listOf(0), "clawbox")).toBe("custom-2");
   });
 });

--- a/src/tests/unit/custom-wallpapers.test.ts
+++ b/src/tests/unit/custom-wallpapers.test.ts
@@ -59,6 +59,18 @@ describe("the selection after a custom wallpaper is deleted", () => {
     expect(wallpaperIdAfterDelete("clawbox", 0, listOf(3), "hermes")).toBe("clawbox");
   });
 
+  it("writes NO fallback while the edition is still unknown", () => {
+    // `null` is "the harness probe has not answered". The deleted picture was
+    // the selected one, so a fallback would be persisted box-wide — and an
+    // unresolved harness reads as OpenClaw everywhere it becomes a wallpaper,
+    // so the guess would put the ClawBox art on a Hermes box for good. The id
+    // is left alone; the render fallback is what the owner sees meanwhile.
+    expect(wallpaperIdAfterDelete("custom-1", 1, listOf(2), null)).toBe("custom-1");
+    // Everything that is NOT edition-specific still happens: renumbering an
+    // earlier delete needs no harness at all.
+    expect(wallpaperIdAfterDelete("custom-2", 0, listOf(3), null)).toBe("custom-1");
+  });
+
   it("does not renumber a selection this list never held", () => {
     // `wp_id` is box-wide and the pictures are per-browser, so a browser with
     // three of its own can be holding the laptop's "custom-5". Deleting one of

--- a/src/tests/unit/custom-wallpapers.test.ts
+++ b/src/tests/unit/custom-wallpapers.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  customWallpaperId,
+  customWallpaperIndex,
+  isCustomWallpaperInRange,
+  wallpaperIdAfterDelete,
+} from "@/lib/custom-wallpapers";
+
+describe("custom wallpaper ids", () => {
+  it("reads the position out of an id this app wrote", () => {
+    expect(customWallpaperIndex("custom-0")).toBe(0);
+    expect(customWallpaperIndex("custom-12")).toBe(12);
+    expect(customWallpaperId(3)).toBe("custom-3");
+  });
+
+  it("answers null for anything else, rather than a plausible number", () => {
+    // The built-ins.
+    expect(customWallpaperIndex("clawbox")).toBeNull();
+    expect(customWallpaperIndex("hermes")).toBeNull();
+    // What a radix-less `parseInt` on `split("-")[1]` used to make of these.
+    expect(customWallpaperIndex("custom-")).toBeNull();
+    expect(customWallpaperIndex("custom-2abc")).toBeNull();
+    expect(customWallpaperIndex("custom--1")).toBeNull();
+  });
+
+  it("knows a position the list no longer holds", () => {
+    expect(isCustomWallpaperInRange("custom-1", 2)).toBe(true);
+    // The state a delete in another browser leaves behind: the selection is
+    // box-wide, the list is not.
+    expect(isCustomWallpaperInRange("custom-2", 2)).toBe(false);
+    expect(isCustomWallpaperInRange("clawbox", 2)).toBe(false);
+  });
+});
+
+describe("the selection after a custom wallpaper is deleted", () => {
+  it("follows the same picture down a slot when an EARLIER one goes", () => {
+    // The whole defect: on beta this stayed "custom-2" against a two-entry
+    // list, so the desktop painted the default instead.
+    expect(wallpaperIdAfterDelete("custom-2", 0, "clawbox")).toBe("custom-1");
+    expect(wallpaperIdAfterDelete("custom-1", 0, "clawbox")).toBe("custom-0");
+  });
+
+  it("leaves it alone when a LATER one goes", () => {
+    expect(wallpaperIdAfterDelete("custom-0", 2, "clawbox")).toBe("custom-0");
+  });
+
+  it("falls back to the harness's own art when the selected one goes", () => {
+    expect(wallpaperIdAfterDelete("custom-1", 1, "clawbox")).toBe("clawbox");
+    // A Hermes box opens on the Hermes wallpaper and must land back on it.
+    expect(wallpaperIdAfterDelete("custom-1", 1, "hermes")).toBe("hermes");
+  });
+
+  it("does not touch a built-in selection", () => {
+    expect(wallpaperIdAfterDelete("clawbox", 0, "hermes")).toBe("clawbox");
+  });
+});

--- a/src/tests/unit/test-timeout-hygiene.test.ts
+++ b/src/tests/unit/test-timeout-hygiene.test.ts
@@ -264,6 +264,14 @@ const MIN_TIMEOUT_MS = 15_000;
  */
 const ALSO_REQUIRED = [
   "src/tests/routes/chat/capabilities-parallel.test.ts",
+  // Starts no process either: it mounts the whole desktop shell — the
+  // preference load, the harness probe, the app grid and a full SettingsApp
+  // render — once per case, and then waits on a 500 ms debounced preference
+  // POST. ~0.9 s per case on an idle dev machine; under four workers that is
+  // several sub-5 s waits in series, which is exactly what `testTimeout`
+  // governs. Seen taking the whole components project's other files down with
+  // it before the mascot and the chat popup were mocked out of the mount.
+  "src/tests/components/desktop-wallpaper-delete.test.tsx",
   "src/tests/components/hermes-oauth-inline.test.tsx",
   "src/tests/components/chat-spoken-reply.test.tsx",
   // Starts its processes through @/lib/coding-agent rather than importing


### PR DESCRIPTION
**TASK-719** — the custom-wallpaper selection, after the positional re-index landed.

## What changed under this card while it was being fixed

The card's headline defect — deleting an earlier custom wallpaper left the selected
`custom-<n>` pointing a slot too far, so the desktop silently fell back to the default — is
**already fixed on `beta`** by #720, in both `src/app/page.tsx` and `src/app/app/[id]/page.tsx`.
It reproduced on `8653b118` and no longer reproduces on `381f34ed`. Verified by running the
regression test in this PR against the current beta: the case that pins it now **passes** there.

So this PR is the residue that #720's fix did not cover, each half reproduced on current beta:

## 1. A Hermes box lands on the ClawBox wallpaper

Both delete handlers hard-code `setWallpaperId("clawbox")` when the picture being deleted is the
one in use. The mount path deliberately opens a Hermes device on the Hermes art
(`page.tsx`, "A Hermes device that has never picked a wallpaper opens on the Hermes art"), so
deleting the only custom wallpaper on a Hermes box moved it to the other edition's branding. The
fallback is now the harness's own default on both surfaces. Standing rule: a shared surface has to
be right on both editions.

## 2. A selection this browser cannot answer is shown honestly — and never written back

`wp_id` is box-wide — SQLite, read by every browser that opens the desktop — while the pictures are
per-browser `localStorage`. A delete on the owner's laptop therefore leaves the box's own screen
holding a position past the end of *its* list, and so does every box that hit this bug before #720.
The desktop already painted the default there, but Settings went on printing "Custom 3" beside a
grid of two with none of them highlighted — the false-success class at the reporting layer.

**An earlier head of this PR healed that by writing the fallback back to the box, and that was
wrong.** It answered a per-browser question with a box-wide write: a browser that never uploaded
anything cannot resolve *any* `custom-<n>`, including the one the owner's laptop chose and still
resolves perfectly — so merely opening the desktop on the box's own screen, or on a phone,
destroyed the owner's wallpaper permanently. `origin/beta` preserves it. That head did not.

So the fallback now lives **in the render and nowhere else**. `renderedWallpaperId` is what gets
painted and what `SettingsApp` is handed, so the panel highlights the tile that is actually on
screen and names it; `wallpaperId` — the value the debounced writer sends to the box — changes only
on an explicit owner action: picking a tile, uploading, or deleting the picture in use. Both
surfaces do it the same way.

That also removes the harness race for free. The fallback follows the edition, and while the
`/setup-api/harness/active` probe is still in flight nothing is persisted at all — so a Hermes box
can no longer be healed onto the ClawBox branding and have it written box-wide, decided by which of
two concurrent fetches answers first. (That claim held for the mount path only until section 2c
below; it now holds for the delete path too.)

## 2b. …and the DELETE path was writing exactly what the mount path refuses to

Found by review after the sections above were already written, and it is the same defect one screen
along. The fallback had been taken out of the mount path, but both delete handlers still called
`wallpaperIdAfterDelete(wallpaperId, idx, …)` unconditionally — including when the saved id was not
an index into *this* browser's list at all.

Three pictures in this browser, the box holding the laptop's `wp_id: custom-5`, delete this
browser's first picture. What went to the box:

```
[ 'custom-5', 'custom-4' ]
```

`custom-4` is the laptop's wallpaper destroyed box-wide, by renumbering a list `custom-5` was never
an index into. A browser has no more standing to renumber another browser's selection than it has to
heal it.

The guard lives in the shared rule, not in the two handlers, and it takes the pre-delete **list**
rather than its length so that two adjacent `number` parameters cannot be silently transposed:

```ts
export function wallpaperIdAfterDelete(
  wallpaperId: string,
  deletedIndex: number,
  before: readonly string[],
  fallbackId: string,
): string {
  const active = customWallpaperIndex(wallpaperId);
  if (active === null) return wallpaperId;              // a built-in: untouched, as before
  if (!isCustomWallpaperInRange(wallpaperId, before.length)) return wallpaperId;
  ...
```

Both handlers read that list *before* `storeCustomWallpapers`, which advances the ref to the
shortened one in the same turn. An out-of-range selection now renders locally and persists nothing,
which is the rule the whole PR is built on.

## 2c. The same handler's OTHER unresolvable value: the edition

`wp_id` was not the only thing the delete path persisted from state it could not resolve. When the
deleted picture is the selected one, the handler writes the harness's default art — and
`activeHarness === "hermes" ? "hermes" : "clawbox"` reads an **unresolved** probe as OpenClaw. The
desktop retries `/setup-api/harness/active` three times and then leaves it `null` for good;
`/app/settings` makes one attempt and stores `d?.active || "unknown"`. So on a Hermes box whose
probe was slow or failed, deleting the wallpaper in use wrote `wp_id: "clawbox"` to SQLite
permanently, out of an operation that had nothing to do with the edition.

That is the probe-once class, and it falsified this PR's own claim above that nothing is persisted
while the probe is in flight — true on the mount path, and the delete path is the sibling call site
of the very same value.

The delete is **not** gated on the probe: removing a picture from this browser's `localStorage` is a
local operation and must not fail or hang on a remote answer. The rule is the one already
established here — *the guess is fine to paint and not fine to persist*:

```ts
const harnessDefaultWallpaperId = activeHarness === "hermes" ? "hermes" : "clawbox";
// Null means "do not write one".
const persistableDefaultWallpaperId =
  activeHarness === "hermes" || activeHarness === "openclaw" ? harnessDefaultWallpaperId : null;
```

`fallbackId` is now `string | null` and a `null` returns the id unchanged instead of guessing. Only
the branch that would have written a guess changes — an edition-independent renumber still works
with no harness at all — and the stale id heals on the owner's next explicit choice, exactly as the
mount path already leaves it.

## 3. One parser instead of five, and the STORE is the outcome

`custom-<n>` was spelled out five ways across three files — a `startsWith` compare, a template
literal, a radix-less `parseInt` on `split("-")[1]`, a `slice`, and now two copies of the re-index
rule that #720 asked to be kept in step by hand. `src/lib/custom-wallpapers.ts` is the one parser,
with the range check the code never actually asked anywhere, and both delete handlers call the same
`wallpaperIdAfterDelete`.

Both files also now share one `storeCustomWallpapers` rule: the stored list is written **first**, and
its failure is the whole operation's. A swallowed `localStorage` failure (site data blocked, a
locked-down profile, quota) with the list and the box-wide id already moved would leave a *different*
picture on screen after a reload with nothing said — so the operation simply does not happen. That
rule now covers **four** writers, not one: it was on the desktop's delete only, and the desktop's
UPLOAD had the same fault in the other direction — the list moved in memory, the `setItem` failure
was swallowed, and the box-wide `wp_id` was then pointed at a slot the next load cannot paint.

## Harness-first

Nothing here belongs to OpenClaw or Hermes: neither harness has a wallpaper or desktop-asset store.
The box-side stores that do exist — `/setup-api/preferences` via `usePreferenceWriter`, and
`src/lib/client-kv.ts` — already hold `wp_id`, and the images are deliberately kept out of them
(`page.tsx`: "large base64 blobs … avoid bloating the KV JSON file"). No native mechanism is being
re-implemented, and that absence is exactly why `wp_id` and the picture list can disagree at all.

## Sibling call sites

- `src/app/app/[id]/page.tsx` — the standalone `/app/settings` window, whose own handler #720 added
  and asked to be kept in step. **Fixed**: the shared parser, the harness fallback, the render-only
  fallback, and the store-is-the-outcome rule. There is no `ToastHost` on that route (it is the
  desktop's surface, and every other toast in the app is dispatched from there), so a refused write
  is a silent no-op with the picture still on the card — honest, and strictly better than beta,
  which moved the id anyway.
- **The desktop's UPLOAD handler — a defect found while sweeping this fix, not by the card.** It
  swallowed the `setItem` failure and then persisted `custom-<n>` box-wide. **Fixed**, same rule,
  same toast.
- The desktop's wallpaper background and SettingsApp's grid and Appearance subtitle — every reader
  of the positional id. **Fixed**: all through the one parser, all reading the rendered id.
- The `localStorage` load path now checks `Array.isArray` before handing the value to the grid, as
  the standalone route already did — the two read the same key, and a non-array reached the grid as
  `.map is not a function`.

## RED → GREEN

### The card's own RED, against unmodified `origin/beta`

```
 ❯ src/tests/components/desktop-wallpaper-delete.test.tsx (3 tests | 2 failed)
   × falls back to the HERMES art on a Hermes box
   × keeps the picture the owner is actually looking at   [passes on beta — #720 fixed it]
```

### The regression the review pass found, against the FIRST head of this PR (`b8f774c2`)

Empty `localStorage` (the box's own screen, or the owner's phone), box holding `wp_id: "custom-2"`
that the owner's laptop legitimately chose. Mount the desktop, change nothing, read the last `wp_id`
POSTed:

```
 ❯ desktop-wallpaper-delete.test.tsx
   × never writes this browser's missing pictures back over the box's selection
     AssertionError: expected 'clawbox' not to be 'clawbox'
   × paints the HERMES art for a selection this browser cannot answer
     AssertionError: expected true to be false        // it had POSTed a wp_id of its own
```

`origin/beta` round-trips `custom-2`; `b8f774c2` POSTed `clawbox` and destroyed the selection
box-wide. Six new cases pin the rework, and every one of them fails on unmodified beta:

- the two above, on both editions;
- **the delayed-harness case CodeRabbit asked for** — the probe answers 900 ms late on a Hermes box:
  nothing is written inside the window, and the paint follows the edition once it lands;
- Settings offers no phantom slot for a picture this browser does not have;
- an UPLOAD that could not be stored selects nothing and tells the owner;
- and, on `/app/settings`, the card shows the fallback while the box keeps its own value, and a
  delete whose store fails moves nothing.

### GREEN on this head

```
$ npx vitest run desktop-wallpaper-delete standalone-app-appearance custom-wallpapers \
    settings-appearance-a11y standalone-app-settings-section standalone-app-i18n \
    standalone-app-installed standalone-back-link settings-app \
    openclaw-config-mock-completeness test-timeout-hygiene state-updater-purity
 Test Files  12 passed (12)
      Tests  86 passed (86)

$ npx tsc --noEmit          # exit 0
```

### The delete-path RED (section 2b), against the previous head of this PR

Three pictures seeded in this browser, box answering `wp_id: custom-5`, delete the first picture:

```
 ❯ desktop-wallpaper-delete.test.tsx
   × does not renumber a selection that is not this browser's to renumber
     AssertionError: expected true to be false     // it POSTed [ 'custom-5', 'custom-4' ]

 ❯ custom-wallpapers.test.ts
   × does not renumber a selection this list never held
     AssertionError: expected 'custom-4' to be 'custom-5'
```

Green on this head, with the case added on **both** surfaces — `/app/settings` is the phone, i.e.
the surface most likely to be holding a `wp_id` it did not choose, and its copy of the handler had
no component-level coverage of the guard at all.

## Residuals — recorded, not fixed here

- **`custom-<n>` is still a POSITION**, so the range check can only answer the half a position
  makes answerable. An id *past the end* of this browser's list is provably not an index into it and
  is now left alone (section 2b); an *in-range* id is still ASSUMED to be this browser's, because a
  positional id carries nothing that could prove whose it is — a phone holding three pictures and the
  laptop's `custom-2` still renumbers it. The real fix is a stable `custom:<uuid>` per upload, which
  makes "this id is not mine" answerable instead of guessable — its own card. Now stated plainly in
  the module docstring rather than left to be inferred from the guard.
- **The desktop's toast surface is untranslated as a whole.** The two toasts here are hardcoded
  English, like the six others already dispatched from `page.tsx`. Translating one pair and not the
  rest would be worse than the residual; the surface wants one pass.
- **`/app/settings` has no toast surface**, so a refused store there is silent. The picture staying
  on the card is the feedback.

## Notes

The new desktop suite mounts the whole shell, so it declares its own `testTimeout`/`hookTimeout` and
is listed in `test-timeout-hygiene.test.ts` — the first cut of it, without that and without mocking
the mascot and the chat popup out of the mount, took four unrelated component files down with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed custom wallpaper deletion so displayed wallpapers remain stable when earlier wallpapers are removed.
  - Deleted wallpapers now select the appropriate default when necessary.
  - Invalid or unavailable saved selections display a supported fallback without overwriting preferences.
  - Improved wallpaper behavior across supported app appearances and harnesses.
  - Added feedback when wallpaper preferences cannot be saved.
  - Prevented wallpaper changes when saving fails, preserving the current selection and list.

- **Tests**
  - Expanded coverage for deletion, fallback, reindexing, invalid selections, and storage failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


