### PR TITLE
fix: keep the interrupted reply on the adapter chat path

### DIFF
--- a/src/components/ChatApp.tsx
+++ b/src/components/ChatApp.tsx
@@ -400,8 +400,13 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
             // bubble was showing, since the streaming render strips the line
             // whatever its payload.
             const keptMedia = splitAssistantMedia(kept)
+            // `streamingEmailRefsText` first: `SENTINEL_RE` anchors the whole
+            // string, so a Stop landing between `NO_REPLY` and an `EMAIL:` line
+            // the reply had begun leaves a value that no longer looks like a
+            // sentinel and would be appended verbatim. The same question the
+            // bubble asks, and the same one the popup's two branches now ask.
             if ((keptMedia.text.trim() || keptMedia.images.length > 0 || keptMedia.audio.length > 0)
-                && !isSentinel(keptMedia.text)) {
+                && !isSentinel(streamingEmailRefsText(keptMedia.text))) {
               setMessages(msgs => [...msgs, {
                 role: 'assistant',
                 text: prettifyAssistantText(keptMedia.text),

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -4071,7 +4071,19 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       // Nothing is coming on either path, so the run ends here.
       sendingRef.current = false
       setSending(false)
+      // What the box managed to write is the OWNER'S, and it survives here for
+      // the same reason it survives on the gateway path's `aborted`/`error`
+      // branch: pressing Stop mid-answer keeps the fragment rather than wiping
+      // it. This path — the adapter's, i.e. the one a Hermes box and a dual
+      // box on Hermes run — used to clear the buffer and append nothing, so
+      // the same Stop lost the reply on one edition and kept it on the other
+      // (TASK-721). Read, clear, THEN append, all outside any updater, and
+      // before the failure line below so the answer stays above it.
+      const kept = dropUnfinishedDirective(streamingRef.current)
       applyStreaming('')
+      if (kept.trim() && !isSentinel(kept)) {
+        setMessages(prev => [...prev, { role: 'assistant', text: kept, timestamp: Date.now() }])
+      }
       clearToolCalls()
       // The agent is no longer parked on anything, so neither is the customer.
       // A card outliving its turn is a control with nowhere to post to.

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -2446,7 +2446,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
             // saw.
             const kept = dropUnfinishedDirective(streamingRef.current)
             applyStreaming('')
-            if (kept.trim() && !isSentinel(kept)) {
+            if (kept.trim() && !isSentinel(streamingEmailRefsText(kept))) {
               setMessages(msgs => [...msgs, { role: 'assistant', text: kept, timestamp: Date.now() }])
             }
             clearToolCalls()
@@ -4074,14 +4074,31 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       // What the box managed to write is the OWNER'S, and it survives here for
       // the same reason it survives on the gateway path's `aborted`/`error`
       // branch: pressing Stop mid-answer keeps the fragment rather than wiping
-      // it. This path — the adapter's, i.e. the one a Hermes box and a dual
-      // box on Hermes run — used to clear the buffer and append nothing, so
-      // the same Stop lost the reply on one edition and kept it on the other
-      // (TASK-721). Read, clear, THEN append, all outside any updater, and
-      // before the failure line below so the answer stays above it.
+      // it. This catch serves BOTH adapters — the gateway one rejects here too
+      // when a `chat.send` ack fails — but only the Hermes one ever reaches it
+      // with a non-empty buffer, because on the gateway edition the socket's
+      // own terminal event owns that buffer and every entry to `dispatchTurn`
+      // clears it first. It used to clear and append nothing, so the same Stop
+      // lost the reply on one edition and kept it on the other (TASK-721).
+      // Read, clear, THEN append, all outside any updater, and before the
+      // failure line below so the answer stays above it.
+      //
+      // `streamingEmailRefsText` first, not the raw buffer: `SENTINEL_RE`
+      // anchors the whole string, so a Stop landing between `NO_REPLY` and an
+      // `EMAIL:` line the reply had begun leaves a value that is no longer
+      // recognisable as a sentinel — and it would be appended verbatim and
+      // minted into an email card off text the bubble never showed. The
+      // gateway path asks the same question the same way.
+      //
+      // Stored RAW, without the `splitAssistantMedia` the full-screen chat's
+      // abort branch applies: a `MEDIA:` line is something the Hermes route
+      // ADDS when it settles a turn, so an interrupted stream has not got one.
+      // What an interrupted Hermes answer can carry is prose naming a file it
+      // just wrote, which the settle path's own clean-up handles and which no
+      // split here would improve.
       const kept = dropUnfinishedDirective(streamingRef.current)
       applyStreaming('')
-      if (kept.trim() && !isSentinel(kept)) {
+      if (kept.trim() && !isSentinel(streamingEmailRefsText(kept))) {
         setMessages(prev => [...prev, { role: 'assistant', text: kept, timestamp: Date.now() }])
       }
       clearToolCalls()

--- a/src/lib/harness/hermes-adapter.ts
+++ b/src/lib/harness/hermes-adapter.ts
@@ -459,10 +459,12 @@ export class HermesAdapter implements HarnessAdapter {
         ? await readStreamedTurn(res, onEvent)
         : await readJsonBody(res);
       // Reading the body is where a Stop most often lands — it is the long
-      // part of the turn on both paths. A failed parse and an abandoned stream
-      // both come back as an empty object, which would otherwise sail on and
-      // be returned as a successful turn with no text; the run has to end as
-      // the abort it was.
+      // part of the turn on both paths. On the JSON path a failed parse comes
+      // back as an empty object, which would otherwise sail on and be returned
+      // as a successful turn with no text; the run has to end as the abort it
+      // was. The STREAMED path never reaches here after a Stop — it throws out
+      // of `readStreamedTurn` — so the same question is asked again in the
+      // catch below, which is what covers both.
       if (controller.signal.aborted) throw new HarnessError("aborted", "Stopped.");
       if (!res.ok) {
         throw new HarnessError(
@@ -498,6 +500,17 @@ export class HermesAdapter implements HarnessAdapter {
         ...(typeof data.provider === "string" && data.provider ? { provider: data.provider } : {}),
       };
     } catch (err) {
+      // A STOP IS NOT AN UPSTREAM FAILURE, whichever way the body ended.
+      //
+      // An abandoned stream does not come back as an empty object: it throws —
+      // on an `error` frame, and on a stream that ends without `done` — so the
+      // check above the parse is reached only on the JSON path. A Stop whose
+      // stream closed cleanly first (the route's own `controller.close()`
+      // racing the client's abort, a proxy dropping the SSE body) therefore
+      // arrived here as `upstream` + "The reply was cut off before it
+      // finished.", and the surface put a red error line under the answer the
+      // owner had just asked it to stop writing.
+      if (controller.signal.aborted) throw new HarnessError("aborted", "Stopped.");
       throw asHarnessError(err, "upstream");
     } finally {
       req.signal?.removeEventListener("abort", abortFromCaller);

--- a/src/tests/components/chat-hermes-stop-keeps-partial.test.tsx
+++ b/src/tests/components/chat-hermes-stop-keeps-partial.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { StrictMode } from "react";
 import { fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
 import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
@@ -19,10 +20,9 @@ import { resetHarnessCache } from "@/lib/client-harness";
  */
 
 const REPLY = "Half an answer before the owner pressed Stop.";
-const HERMES_SESSION = "20260906_104200_a1b2c3";
 
 let releaseChunk: ((chunk: string | null) => void) | null = null;
-/** A Hermes box runs no gateway; this must stay 0. */
+/** A Hermes box runs no gateway; asserted, not merely counted. */
 let socketsOpened = 0;
 
 class ForbiddenWs {
@@ -37,8 +37,19 @@ function frame(event: string, data: unknown): string {
   return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
 }
 
-/** An SSE Response whose chunks are handed out one `releaseChunk` at a time. */
-function pacedStream(): Response {
+/**
+ * An SSE Response whose chunks are handed out one `releaseChunk` at a time —
+ * and which HONOURS the abort signal.
+ *
+ * That second half is the whole fixture. A fake reader that ignores the signal
+ * turns Stop into "the stream ended without a `done` frame", which the adapter
+ * reports as an UPSTREAM failure, not an abort — so a test written against it
+ * exercises the error branch while claiming to test the abort branch, and a
+ * "shows no error line" assertion passes over a DOM that contains one. A real
+ * browser rejects the pending `read()` with an `AbortError` the moment the
+ * fetch is aborted, and that is what this does.
+ */
+function pacedStream(signal?: AbortSignal | null): Response {
   const encoder = new TextEncoder();
   return {
     ok: true,
@@ -48,7 +59,14 @@ function pacedStream(): Response {
       getReader() {
         return {
           read: () =>
-            new Promise<{ done: boolean; value?: Uint8Array }>((resolve) => {
+            new Promise<{ done: boolean; value?: Uint8Array }>((resolve, reject) => {
+              const abort = () => {
+                const err = new Error("The operation was aborted.");
+                err.name = "AbortError";
+                reject(err);
+              };
+              if (signal?.aborted) { abort(); return; }
+              signal?.addEventListener("abort", abort, { once: true });
               releaseChunk = (chunk) =>
                 chunk === null ? resolve({ done: true }) : resolve({ done: false, value: encoder.encode(chunk) });
             }),
@@ -59,7 +77,7 @@ function pacedStream(): Response {
 }
 
 function installFetch() {
-  vi.stubGlobal("fetch", vi.fn(async (input: unknown) => {
+  vi.stubGlobal("fetch", vi.fn(async (input: unknown, init?: RequestInit) => {
     const url = String(input);
     if (url.includes("/setup-api/harness/active")) {
       return { ok: true, json: async () => ({ active: "hermes", edition: "hermes" }) };
@@ -99,7 +117,7 @@ function installFetch() {
     if (url.includes("/setup-api/chat/history")) {
       return { ok: true, json: async () => ({ messages: [{ role: "assistant", text: "Earlier.", timestamp: 1 }] }) };
     }
-    if (url.includes("/setup-api/hermes/chat")) return pacedStream();
+    if (url.includes("/setup-api/hermes/chat")) return pacedStream(init?.signal);
     return { ok: true, json: async () => ({}) };
   }));
 }
@@ -110,7 +128,14 @@ function occurrences(needle: string): number {
 }
 
 async function mount() {
-  render(<ChatPopup isOpen onClose={() => {}} />);
+  // Under StrictMode, so the "exactly once" case below actually pins the
+  // TASK-703 regression: React double-invokes updaters there, and an append
+  // moved back inside one would put the fragment on screen twice.
+  render(
+    <StrictMode>
+      <ChatPopup isOpen onClose={() => {}} />
+    </StrictMode>,
+  );
   const textarea = await screen.findByRole("textbox");
   await waitFor(() => expect(textarea).not.toBeDisabled());
   return textarea;
@@ -152,16 +177,19 @@ describe("Stop on a Hermes box", () => {
     await push(frame("delta", { text: REPLY }));
     await waitFor(() => expect(occurrences(REPLY)).toBe(1));
 
-    // The Stop button, which is only on screen while a turn is running.
+    // The Stop button, which is only on screen while a turn is running. It
+    // aborts the adapter's fetch, the body's pending read rejects with an
+    // `AbortError` exactly as a browser's does, and the turn ends as
+    // `HarnessError('aborted')` — no `push` needed, and none given: a stream
+    // this test ended by hand would be the OTHER failure (see the case below).
     fireEvent.click(screen.getByTitle("chat.stop"));
-    // The route kills the child and closes the body; the adapter then sees its
-    // controller aborted and rejects the turn with `HarnessError('aborted')`.
-    await push(null);
 
     // The turn is over — the streaming bubble is gone, so anything still on
     // screen is a transcript entry.
     await waitFor(() => expect(screen.queryByTitle("chat.stop")).toBeNull());
     expect(occurrences(REPLY)).toBe(1);
+    // A Hermes box runs no gateway, and this surface must not have opened one.
+    expect(socketsOpened).toBe(0);
   });
 
   it("keeps it above the failure line when the turn dies instead", async () => {
@@ -175,14 +203,17 @@ describe("Stop on a Hermes box", () => {
     await push(null);
 
     await waitFor(() => expect(screen.queryByTitle("chat.stop")).toBeNull());
-    const rendered = document.body.textContent ?? "";
-    const reply = rendered.indexOf(REPLY);
-    // The failure notice, whatever its wording — the surface sanitises the
-    // harness's own text rather than rendering it (TASK-440).
-    const notice = rendered.search(/Error:|did not go through|could not|failed|try again/i);
-    expect(reply, `the interrupted answer was not kept:\n${rendered}`).toBeGreaterThan(-1);
-    expect(notice, `no failure notice was shown:\n${rendered}`).toBeGreaterThan(-1);
-    expect(reply, `the notice came before the answer:\n${rendered}`).toBeLessThan(notice);
+    // Against the BUBBLES, not `document.body.textContent`: the popup ships a
+    // large inline <style> block and a row of control labels, and a substring
+    // search over the whole document would match "failed" in chrome — before
+    // the transcript (a spurious ordering failure) or after it (a pass with no
+    // notice ever appended, which is the shape this file exists to catch).
+    const answer = await screen.findByText(REPLY);
+    const notice = await screen.findByText(/^Error: /);
+    expect(
+      answer.compareDocumentPosition(notice) & Node.DOCUMENT_POSITION_FOLLOWING,
+      "the failure notice came before the answer it interrupted",
+    ).toBeTruthy();
   });
 
   it("shows no error line for a Stop the owner asked for", async () => {
@@ -190,9 +221,27 @@ describe("Stop on a Hermes box", () => {
     await send(textarea, "Tell me a story");
     await push(frame("delta", { text: REPLY }));
     fireEvent.click(screen.getByTitle("chat.stop"));
+
+    await waitFor(() => expect(screen.queryByTitle("chat.stop")).toBeNull());
+    // No notice of ANY wording. The first cut of this file ended the stream by
+    // hand instead of letting the abort reject the read, so the adapter
+    // reported "The reply was cut off before it finished." and this assertion
+    // passed straight over it.
+    expect(screen.queryByText(/^Error: /)).toBeNull();
+    expect(screen.queryByText(/did not go through|Stopped\./i)).toBeNull();
+  });
+
+  it("still says so when the stream ends without finishing and no Stop was pressed", async () => {
+    // The case the abort fixture used to stand in for, kept as its own: a body
+    // that closes with no `done` frame is a genuine failure and must still be
+    // reported.
+    const textarea = await mount();
+    await send(textarea, "Tell me a story");
+    await push(frame("delta", { text: REPLY }));
     await push(null);
 
     await waitFor(() => expect(screen.queryByTitle("chat.stop")).toBeNull());
-    expect(document.body.textContent).not.toMatch(/did not go through|Stopped\./i);
+    expect(await screen.findByText(/^Error: /)).toBeTruthy();
+    expect(occurrences(REPLY)).toBe(1);
   });
 });

--- a/src/tests/components/chat-hermes-stop-keeps-partial.test.tsx
+++ b/src/tests/components/chat-hermes-stop-keeps-partial.test.tsx
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import ChatPopup from "@/components/ChatPopup";
+import { resetHarnessCache } from "@/lib/client-harness";
+
+/**
+ * Stop keeps what the box had already written — on BOTH editions (TASK-721).
+ *
+ * The gateway path keeps it: its `aborted`/`error` branch reads
+ * `dropUnfinishedDirective(streamingRef.current)` and appends it before
+ * anything else. The ADAPTER path — the one a Hermes box runs, and the one the
+ * dual SKU runs while Hermes is active — cleared the same buffer in
+ * `dispatchTurn`'s catch and appended nothing, so pressing Stop mid-answer
+ * threw the half-written reply away on one edition and kept it on the other.
+ *
+ * The behavioural test that pinned this for TASK-703 stubs the harness to
+ * `openclaw`, so the Hermes half of "the interrupted turn is kept" was neither
+ * implemented nor pinned. This is that half.
+ */
+
+const REPLY = "Half an answer before the owner pressed Stop.";
+const HERMES_SESSION = "20260906_104200_a1b2c3";
+
+let releaseChunk: ((chunk: string | null) => void) | null = null;
+/** A Hermes box runs no gateway; this must stay 0. */
+let socketsOpened = 0;
+
+class ForbiddenWs {
+  static readonly OPEN = 1;
+  readyState = ForbiddenWs.OPEN;
+  constructor() { socketsOpened += 1; }
+  send() {}
+  close() {}
+}
+
+function frame(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+/** An SSE Response whose chunks are handed out one `releaseChunk` at a time. */
+function pacedStream(): Response {
+  const encoder = new TextEncoder();
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: (n: string) => (n.toLowerCase() === "content-type" ? "text/event-stream" : null) },
+    body: {
+      getReader() {
+        return {
+          read: () =>
+            new Promise<{ done: boolean; value?: Uint8Array }>((resolve) => {
+              releaseChunk = (chunk) =>
+                chunk === null ? resolve({ done: true }) : resolve({ done: false, value: encoder.encode(chunk) });
+            }),
+        };
+      },
+    },
+  } as unknown as Response;
+}
+
+function installFetch() {
+  vi.stubGlobal("fetch", vi.fn(async (input: unknown) => {
+    const url = String(input);
+    if (url.includes("/setup-api/harness/active")) {
+      return { ok: true, json: async () => ({ active: "hermes", edition: "hermes" }) };
+    }
+    if (url.includes("/setup-api/chat/capabilities")) {
+      return {
+        ok: true,
+        json: async () => ({
+          harness: "hermes",
+          facts: {
+            hasClawaiToken: false,
+            hermesSupportsImages: false,
+            hermesHasVisionRoute: false,
+            hermesStreamsTurns: true,
+            hasClawaiImageRoute: false,
+          },
+        }),
+      };
+    }
+    if (url.includes("/setup-api/hermes/models")) {
+      return {
+        ok: true,
+        json: async () => ({
+          providers: [{ id: "clawai", name: "ClawBox AI", authenticated: true }],
+          models: [{ id: "deepseek-v4-flash", name: "Flash" }],
+          provider: "clawai",
+          current: "deepseek-v4-flash",
+          defaultModel: "deepseek-v4-flash",
+          reasoning: "off",
+        }),
+      };
+    }
+    if (url.includes("/setup-api/chat/model")) return { ok: true, json: async () => ({ options: [], activeOptionId: "" }) };
+    if (url.includes("/setup-api/chat/spoken-history")) return { ok: true, json: async () => ({ items: [] }) };
+    // A non-empty history: an empty one makes the popup auto-greet, and that
+    // turn would take the paced stream this test is pacing by hand.
+    if (url.includes("/setup-api/chat/history")) {
+      return { ok: true, json: async () => ({ messages: [{ role: "assistant", text: "Earlier.", timestamp: 1 }] }) };
+    }
+    if (url.includes("/setup-api/hermes/chat")) return pacedStream();
+    return { ok: true, json: async () => ({}) };
+  }));
+}
+
+/** How many times `needle` appears in what is on screen. */
+function occurrences(needle: string): number {
+  return (document.body.textContent ?? "").split(needle).length - 1;
+}
+
+async function mount() {
+  render(<ChatPopup isOpen onClose={() => {}} />);
+  const textarea = await screen.findByRole("textbox");
+  await waitFor(() => expect(textarea).not.toBeDisabled());
+  return textarea;
+}
+
+async function send(textarea: HTMLElement, text: string) {
+  fireEvent.change(textarea, { target: { value: text } });
+  fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+  await waitFor(() => expect(releaseChunk).not.toBeNull());
+}
+
+async function push(chunk: string | null) {
+  await waitFor(() => expect(releaseChunk).not.toBeNull());
+  const release = releaseChunk!;
+  releaseChunk = null;
+  release(chunk);
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+describe("Stop on a Hermes box", () => {
+  beforeEach(() => {
+    releaseChunk = null;
+    socketsOpened = 0;
+    resetHarnessCache();
+    window.localStorage.clear();
+    Element.prototype.scrollIntoView = vi.fn();
+    installFetch();
+    vi.stubGlobal("WebSocket", ForbiddenWs as unknown as typeof WebSocket);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetHarnessCache();
+  });
+
+  it("keeps the half-written reply, exactly once", async () => {
+    const textarea = await mount();
+    await send(textarea, "Tell me a story");
+    await push(frame("delta", { text: REPLY }));
+    await waitFor(() => expect(occurrences(REPLY)).toBe(1));
+
+    // The Stop button, which is only on screen while a turn is running.
+    fireEvent.click(screen.getByTitle("chat.stop"));
+    // The route kills the child and closes the body; the adapter then sees its
+    // controller aborted and rejects the turn with `HarnessError('aborted')`.
+    await push(null);
+
+    // The turn is over — the streaming bubble is gone, so anything still on
+    // screen is a transcript entry.
+    await waitFor(() => expect(screen.queryByTitle("chat.stop")).toBeNull());
+    expect(occurrences(REPLY)).toBe(1);
+  });
+
+  it("keeps it above the failure line when the turn dies instead", async () => {
+    // The same buffer, the other half of the gateway branch this now mirrors:
+    // a turn that fails mid-answer keeps what was written and puts the notice
+    // UNDER it, rather than losing the fragment and showing only the notice.
+    const textarea = await mount();
+    await send(textarea, "Tell me a story");
+    await push(frame("delta", { text: REPLY }));
+    await push(frame("error", { error: "hermes said no" }));
+    await push(null);
+
+    await waitFor(() => expect(screen.queryByTitle("chat.stop")).toBeNull());
+    const rendered = document.body.textContent ?? "";
+    const reply = rendered.indexOf(REPLY);
+    // The failure notice, whatever its wording — the surface sanitises the
+    // harness's own text rather than rendering it (TASK-440).
+    const notice = rendered.search(/Error:|did not go through|could not|failed|try again/i);
+    expect(reply, `the interrupted answer was not kept:\n${rendered}`).toBeGreaterThan(-1);
+    expect(notice, `no failure notice was shown:\n${rendered}`).toBeGreaterThan(-1);
+    expect(reply, `the notice came before the answer:\n${rendered}`).toBeLessThan(notice);
+  });
+
+  it("shows no error line for a Stop the owner asked for", async () => {
+    const textarea = await mount();
+    await send(textarea, "Tell me a story");
+    await push(frame("delta", { text: REPLY }));
+    fireEvent.click(screen.getByTitle("chat.stop"));
+    await push(null);
+
+    await waitFor(() => expect(screen.queryByTitle("chat.stop")).toBeNull());
+    expect(document.body.textContent).not.toMatch(/did not go through|Stopped\./i);
+  });
+});


### PR DESCRIPTION
**TASK-721** — pressing Stop on a Hermes box threw the half-written reply away.

## Symptom

Mid-answer on a Hermes box (or a dual box running Hermes), the owner presses Stop. Everything the
box had already written vanishes from the transcript. On an OpenClaw box the same Stop keeps it.

## Cause

`src/components/ChatPopup.tsx`. The gateway path's `aborted`/`error` branch reads
`dropUnfinishedDirective(streamingRef.current)` and appends it before anything else. The **adapter**
path — the one a Hermes box runs — did `applyStreaming('')` in `dispatchTurn`'s catch and appended
nothing. TASK-703's fix, which made the interrupted turn appear exactly once instead of twice, only
put it there at all on one of the two editions, and the behavioural test that pinned it stubs the
harness to `openclaw`.

A second cause found by the review pass, in `src/lib/harness/hermes-adapter.ts`: the abort check
sits **after** the body parse, and an abandoned *stream* never reaches it — `readStreamedTurn`
throws on an `error` frame and on a stream that ends without `done`, so control leaves for the
catch. The check was live only for the JSON path, and its comment said the opposite. A Stop whose
stream closed cleanly first (the route's own `controller.close()` racing the client's abort, a
proxy dropping the SSE body) therefore came back as `upstream` + "The reply was cut off before it
finished." — and with this PR keeping the fragment, that red line would now sit *under* the answer
and read as though the answer had failed. The check moved into the catch, which covers both paths.

## Harness-first

There is no native mechanism to reclaim here: what the surface keeps on screen after an interrupt is
ClawBox's own transcript state on both editions, and the two harnesses already answer this the same
way at the protocol level — the OpenClaw gateway emits an `aborted` chat event, the Hermes route
answers 499 and the adapter turns it into `HarnessError('aborted')`. The defect was that only one of
the two client paths acted on it.

## Both editions

The mascot chat (`ChatPopup`) is the shared surface and it is the one fixed. `ChatApp`, the
full-screen chat, is gateway-only — it opens `/setup-api/gateway/ws-config` and drives
`wsRequest('chat.send')` with no harness branch — so it has no adapter path to fix; its own abort
branch already keeps the fragment. **Cleared, not changed**, except for the sentinel guard below.

## Sibling call sites

Every place either surface clears the streaming buffer on an abort was read:

- `ChatPopup.tsx` — the gateway `aborted`/`error` branch already kept it. The adapter catch is what
  this PR fixes.
- `ChatApp.tsx` — its `aborted`/`error` branch already keeps it.
- Every other `applyStreaming('')` in both files is a run START or a transcript clear, not an
  abort. **Cleared.**

The review pass then found that all three keeps asked `isSentinel(kept)` on the raw buffer.
`SENTINEL_RE` anchors the whole string, so a Stop landing between `NO_REPLY` and an `EMAIL:` line
the reply had begun leaves a value that no longer looks like a sentinel — it would be appended
verbatim and an email card minted off text the bubble never showed. All three now ask the question
the bubble asks, through `streamingEmailRefsText`.

## RED → GREEN

RED, against unmodified `origin/beta` (`381f34ed`):

```
 ❯ src/tests/components/chat-hermes-stop-keeps-partial.test.tsx (4 tests | 3 failed)
   × keeps the half-written reply, exactly once
     AssertionError: expected +0 to be 1        // the fragment is gone
   × keeps it above the failure line when the turn dies instead
     Error: Test timed out in 5000ms            // no answer bubble to order against
   × still says so when the stream ends without finishing and no Stop was pressed
```

GREEN on this head — the new file plus the neighbouring chat suites and the purity guard:

```
 Test Files  7 passed (7)
      Tests  71 passed (71)
```

`npx tsc --noEmit` exits 0.

The first cut of that suite was wrong in a way worth naming, because the review caught it and not
the assertions: its fake stream reader ignored the fetch signal, so Stop changed nothing and the
test ended the body by hand — which the adapter reports as an upstream failure, not an abort. All
three cases ran the *error* branch while claiming to test the abort branch, and the "shows no error
line" case passed over a DOM containing a full error line. The reader now rejects the pending
`read()` with an `AbortError` exactly as a browser does, the stream-ends-without-`done` case is its
own test, and the "exactly once" case renders under `StrictMode` so it actually pins the
updater-purity regression it names.

## Not fixed here, and stated rather than left implied

The kept fragment is **live-session only on Hermes**. The Hermes route records no assistant row for
an aborted or failed turn — only the question, plus a system `Error:` row on failure — and
`loadHistory` replaces the transcript with the box's copy, preserving only un-echoed *user* turns.
So switching chat tabs, reloading, or any reconcile drops the fragment again, and one screen later
the two editions still disagree. Closing that means recording the partial server-side on the abort
and error arms of the Hermes route's `streamTurn` (through `appendTranscript`, which that route
already calls three times a turn) — a route-level change to what the box deliberately does *not*
record on a 499, with its own regression surface, and outside this card's stated scope. Recorded for
the queue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Interrupted assistant responses are now preserved instead of discarded.
  - Stopping a streamed response no longer displays an incorrect upstream error.
  - Partial responses remain visible when a stream fails, with the relevant error shown beneath them.
  - Prevented incomplete control messages and email-related content from appearing in chat transcripts.
  - Improved handling of interrupted or incomplete streamed replies to avoid duplicate or misleading messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->