### PR TITLE
fix: let the core resolve which agent store the ClawBox AI credential goes to

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -115,86 +115,21 @@ const OPENCLAW_HOME_DIR =
   || path.join(process.env.HOME ?? "/home/clawbox", ".openclaw");
 const CLAWBOX_HOME_DIR = process.env.HOME ?? "/home/clawbox";
 /**
- * The core's implicit agent, for a config that declares no roster at all.
+ * The agent whose LEGACY credential file ClawBox writes, pre-v2.
  *
- * `LEGACY_IMPLICIT_AGENT_ID` in the installed core
- * (`dist/session-key-*.js`), and what `listAgentIds` answers when
- * `agents.entries` / `agents.list` are both absent — which is every stock box.
+ * `main` is the core's implicit agent (`LEGACY_IMPLICIT_AGENT_ID`) and the
+ * directory it resolves for a config with no roster, which is every box that
+ * still has a legacy `auth-profiles.json` to write. Deliberately NOT used for
+ * the `models auth …` calls any more — see `pasteAuthApiKey`.
  */
-const IMPLICIT_AGENT_ID = "main";
-
-/**
- * The agent whose store ClawBox writes to, resolved the way the CLI would.
- *
- * ONE id is computed and passed explicitly to BOTH the credential path and
- * every `models auth …` call, because those commands do not resolve alike when
- * `--agent` is omitted: `resolveModelsTargetAgent` sends a WRITE through
- * `resolveSoleAgentId` and a READ (`auth list`) through
- * `resolveAmbientOwnerAgentId`, so a guard that read one store while the paste
- * wrote another would be no guard at all.
- *
- * What it must NOT be is a constant. `main` was pinned here, and on a box whose
- * roster declares another agent that wrote the device's ClawBox AI credential
- * into a store the gateway never reads — leaving whatever was in the real store
- * to keep serving turns, however stale. That is TASK-730: two credentials on
- * one box, the revoked one preferred, and every ClawBox surface reporting on
- * the good one.
- *
- * The rule is the core's own `tryResolveSoleAgentId`, not an invention:
- *
- *   - no roster property at all  → `main` (the implicit agent)
- *   - exactly one declared agent → that agent, whatever it is called
- *   - more than one              → the core cannot pick either, and neither do
- *                                  we: `main` is passed on, and the CLI
- *                                  answers `Unknown agent id "main"` when it is
- *                                  not one of them. That is today's behaviour
- *                                  and it is loud; guessing would not be.
- *
- * Both roster shapes are read because the core reads both
- * (`readAgentRosterProperty`: `agents.entries` as a record, `agents.list` as an
- * array).
- */
-function resolveAgentIdFrom(config: unknown): string {
-  const agents = (config as { agents?: Record<string, unknown> } | null)?.agents;
-  if (!agents || typeof agents !== "object" || Array.isArray(agents)) return IMPLICIT_AGENT_ID;
-  const ids = rosterAgentIds(agents);
-  // `undefined` is "no roster declared"; an empty roster IS declared, and there
-  // the implicit agent is not implied — pass `main` on and let the CLI object.
-  if (ids === undefined) return IMPLICIT_AGENT_ID;
-  return ids.length === 1 ? ids[0] : IMPLICIT_AGENT_ID;
-}
-
-/** The declared agent ids, or undefined when no roster property is present. */
-function rosterAgentIds(agents: Record<string, unknown>): string[] | undefined {
-  const entries = Object.hasOwn(agents, "entries") ? agents.entries : undefined;
-  if (entries !== undefined) {
-    if (!entries || typeof entries !== "object" || Array.isArray(entries)) return [];
-    return Object.keys(entries).map((id) => id.trim()).filter(Boolean);
-  }
-  const list = Object.hasOwn(agents, "list") ? agents.list : undefined;
-  if (list === undefined) return undefined;
-  if (!Array.isArray(list)) return [];
-  return list
-    .map((entry) => (entry && typeof entry === "object" ? (entry as { id?: unknown }).id : undefined))
-    .map((id) => (typeof id === "string" ? id.trim() : ""))
-    .filter(Boolean);
-}
-
-/**
- * The resolved agent for THIS request.
- *
- * Read per call rather than cached in a module constant: the roster is owned by
- * the owner and by `openclaw agents add`, and a value captured at import time
- * would keep addressing yesterday's store for the lifetime of the server.
- */
-async function clawboxAgentId(): Promise<string> {
-  return resolveAgentIdFrom(await readOpenClawConfig().catch(() => null));
-}
-
-/** Where that agent keeps the pre-v2 credential file. */
-function authProfilesPathFor(agentId: string): string {
-  return path.join(OPENCLAW_HOME_DIR, "agents", agentId, "agent", "auth-profiles.json");
-}
+const LEGACY_AGENT_ID = "main";
+const AUTH_PROFILES_PATH = path.join(
+  OPENCLAW_HOME_DIR,
+  "agents",
+  LEGACY_AGENT_ID,
+  "agent",
+  "auth-profiles.json",
+);
 const CLAWBOX_UID = process.getuid?.() ?? 1000;
 const CLAWBOX_GID = process.getgid?.() ?? 1000;
 const CLAWBOX_AI_PROXY_URL = process.env.CLAWBOX_AI_PROXY_URL?.trim() || "https://clawbox.com/api/ai";
@@ -412,9 +347,9 @@ async function applyConfigSetGroups(groups: (ConfigSetGroup | null)[]): Promise<
   }
 }
 
-async function readAuthProfiles(agentId: string): Promise<AuthProfilesFile> {
+async function readAuthProfiles(): Promise<AuthProfilesFile> {
   try {
-    const raw = await fs.readFile(authProfilesPathFor(agentId), "utf-8");
+    const raw = await fs.readFile(AUTH_PROFILES_PATH, "utf-8");
     return JSON.parse(raw) as AuthProfilesFile;
   } catch (err) {
     // Only a genuinely absent file means "no profiles yet" (first run). Any
@@ -430,15 +365,14 @@ async function readAuthProfiles(agentId: string): Promise<AuthProfilesFile> {
   }
 }
 
-async function writeAuthProfiles(agentId: string, authProfiles: AuthProfilesFile) {
-  const target = authProfilesPathFor(agentId);
-  await fs.mkdir(path.dirname(target), { recursive: true });
-  const tmpPath = target + `.tmp.${Date.now()}.${process.pid}`;
+async function writeAuthProfiles(authProfiles: AuthProfilesFile) {
+  await fs.mkdir(path.dirname(AUTH_PROFILES_PATH), { recursive: true });
+  const tmpPath = AUTH_PROFILES_PATH + `.tmp.${Date.now()}.${process.pid}`;
   await fs.writeFile(tmpPath, JSON.stringify(authProfiles, null, 2), {
     mode: 0o600,
   });
-  await fs.rename(tmpPath, target);
-  await fs.chown(target, CLAWBOX_UID, CLAWBOX_GID);
+  await fs.rename(tmpPath, AUTH_PROFILES_PATH);
+  await fs.chown(AUTH_PROFILES_PATH, CLAWBOX_UID, CLAWBOX_GID);
 }
 
 /**
@@ -461,12 +395,26 @@ async function pasteAuthApiKey(provider: string, profileId: string, key: string)
   await spawnOpenclawCli(
     [
       "models", "auth", "paste-api-key",
-      // `--agent` omitted means "the configured default agent", which is not
-      // necessarily the one ClawBox operates on — and a WRITE and a READ do not
-      // even resolve it the same way. `applyOpenAiAuthOrder` and
-      // `assertNoSignInAt` pass the SAME resolved id, so the guard, the order
-      // and the paste all address one store.
-      "--agent", await clawboxAgentId(),
+      // NO `--agent`. ClawBox used to pin `main` here — and in the sign-in
+      // guard and the order write — on the argument that the CLI resolves a
+      // READ and a WRITE differently, so an unpinned pair could address two
+      // stores. Measured against the installed core (2026.8.1) with a sole
+      // `pro-agent` roster and the flag omitted, that is not what happens:
+      //
+      //   models auth list --json     -> "agentId": "pro-agent"
+      //   paste-api-key …             -> agents/pro-agent/agent/openclaw-agent.sqlite
+      //
+      // The two resolvers only diverge on a roster with SEVERAL agents, and
+      // there `main` was never the right answer either. What the pin actually
+      // did was write this device's ClawBox AI credential into an agent store
+      // the gateway does not read — leaving whatever the real store held,
+      // however stale, to keep serving turns, which is TASK-730 — or, when
+      // `main` is not in the roster at all, fail the whole save outright:
+      //
+      //   $ openclaw models auth paste-api-key --agent main …
+      //   Unknown agent id "main". Use "openclaw agents list" to see configured agents.
+      //
+      // So the target is the harness's to choose, and this asks it to.
       "--provider", provider,
       "--profile-id", profileId,
     ],
@@ -533,10 +481,21 @@ async function assertNoSignInAt(profileId: string): Promise<void> {
   if (openclawIsAbsent()) return;
   let raw: string;
   try {
-    // Same agent as the paste this guards and as the auth order beside it: the
-    // store `--agent` selects is the whole subject of the question.
+    // Unpinned, like the paste this guards and the auth order beside it: all
+    // three let the core pick the agent, so all three address one store on
+    // every box where a save can succeed (see `pasteAuthApiKey`). The response
+    // names the agent it answered for (`agentId`, `agentDir`), so a box that
+    // disagrees can still be told apart in a log.
+    //
+    // KNOWN LIMIT, measured: before an agent has a store of its own the core
+    // answers from the shared one (`authStatePath` pointed at `agents/main/`
+    // while `agentId` was `pro-agent`), so this can see an inherited profile
+    // the paste would only have shadowed. It refuses in that case, which is
+    // the safe direction — and strictly better than what it replaces, since
+    // the same box previously failed the whole save with
+    // `Unknown agent id "main"`.
     raw = await spawnOpenclawCli(
-      ["models", "auth", "list", "--agent", await clawboxAgentId(), "--json"],
+      ["models", "auth", "list", "--json"],
       { captureStdout: true, timeoutMs: 60_000 },
     );
   } catch (err) {
@@ -615,9 +574,6 @@ async function applyOpenAiAuthOrder(
   config: OpenClawConfig | null,
   clawboxWroteOrder: boolean,
 ): Promise<string | undefined> {
-  // From the SAME config the caller already read, so the order and the
-  // credential cannot end up in different agents' stores.
-  const agentId = resolveAgentIdFrom(config);
   const order = openaiAuthOrder(
     config?.auth?.profiles,
     preferred,
@@ -626,8 +582,8 @@ async function applyOpenAiAuthOrder(
   const shouldSet = order.length > 1;
   if (!shouldSet && !clawboxWroteOrder) return undefined;
   const args = shouldSet
-    ? ["models", "auth", "order", "set", "--agent", agentId, "--provider", CHATGPT_PROVIDER, ...order]
-    : ["models", "auth", "order", "clear", "--agent", agentId, "--provider", CHATGPT_PROVIDER];
+    ? ["models", "auth", "order", "set", "--provider", CHATGPT_PROVIDER, ...order]
+    : ["models", "auth", "order", "clear", "--provider", CHATGPT_PROVIDER];
   try {
     await spawnOpenclawCli(args, { timeoutMs: 60_000 });
     // The marker follows the write that succeeded, so a later save knows
@@ -2470,11 +2426,7 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
       }
       await pasteAuthApiKey(ocProvider, config.profileKey, apiKeyValue);
     } else {
-      // Same resolution as the paste above, so the legacy file and the CLI
-      // that migrates it address one agent's store.
-      const legacyAgentId = await clawboxAgentId();
-      const legacyProfilesPath = authProfilesPathFor(legacyAgentId);
-      const authProfiles = await readAuthProfiles(legacyAgentId);
+      const authProfiles = await readAuthProfiles();
       if (authMode === "subscription") {
         // OAuth credential format expected by OpenClaw:
         // { type: "oauth", provider, access, id?, refresh, expires, projectId? }
@@ -2494,7 +2446,7 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
           ...(projectId ? { projectId } : {}),
         };
       }
-      await writeAuthProfiles(legacyAgentId, authProfiles);
+      await writeAuthProfiles(authProfiles);
       // OpenClaw 2 refuses to hydrate this LEGACY file: run the doctor
       // migration IMMEDIATELY, before the config-set batch, catalog refresh
       // and session sweep execute against a poisoned shared auth store (it
@@ -2510,7 +2462,7 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
       try {
         await runOpenclawDoctorFix();
       } catch (doctorErr) {
-        const siblings = await fs.readdir(path.dirname(legacyProfilesPath)).catch(() => [] as string[]);
+        const siblings = await fs.readdir(path.dirname(AUTH_PROFILES_PATH)).catch(() => [] as string[]);
         const migratedStore = siblings.some((name) => name.startsWith("auth-profiles.json.migrated-"));
         console.error(
           "[configure] doctor --fix failed after the OAuth store write:",
@@ -2533,7 +2485,7 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
         }
         if (mustRollBack) {
           const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-          await fs.rename(legacyProfilesPath, `${legacyProfilesPath}.failed-${stamp}`).catch(() => {});
+          await fs.rename(AUTH_PROFILES_PATH, `${AUTH_PROFILES_PATH}.failed-${stamp}`).catch(() => {});
           return NextResponse.json(
             { error: "Credential migration failed. The subscription sign-in was rolled back — try again, or run 'openclaw doctor --fix' from the Terminal." },
             { status: 502 },
@@ -3252,13 +3204,13 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
           error: "This box is signed in to that provider, and the sign-in is stored in the same "
             + `credential slot (${err.profileId}). Saving an API key here would delete it. `
             + "Remove the sign-in first — in the Terminal: "
-            // The same `--agent` the guard read with and the paste writes to.
-            // Without it the CLI takes the configured default agent, so on a
-            // multi-agent box the owner's command clears a different store and
-            // the refusal never goes away. Argument order is the command's own
+            // Unpinned, exactly as the guard read and the paste wrote: the
+            // core resolves the same agent for all three, and naming one here
+            // would send the owner at a store none of them touched. Argument
+            // order is the command's own
             // (`models auth logout [options] <profileId>`, read from its
             // --help on 2026.8.1).
-            + `openclaw models auth logout --agent ${await clawboxAgentId()} ${err.profileId}`
+            + `openclaw models auth logout ${err.profileId}`
             + " — then paste the key.",
           code: "sign_in_would_be_lost",
           profileId: err.profileId,

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -115,25 +115,86 @@ const OPENCLAW_HOME_DIR =
   || path.join(process.env.HOME ?? "/home/clawbox", ".openclaw");
 const CLAWBOX_HOME_DIR = process.env.HOME ?? "/home/clawbox";
 /**
- * The agent whose store ClawBox owns.
+ * The core's implicit agent, for a config that declares no roster at all.
  *
- * Named once and used for BOTH the credential path below and every `models
- * auth …` call, because the CLI resolves its own target when `--agent` is
- * omitted: `resolveModelsTargetAgent` → `resolveSoleAgentId`, which throws
- * "Pass --agent <id>." on a box with more than one configured agent and
- * otherwise resolves whichever sole agent is declared. Either way the order
- * write could address a different store than this path — and did, silently.
- * `main` is the core's own implicit agent id (LEGACY_IMPLICIT_AGENT_ID) and
- * the directory it resolves for a config with no agent roster.
+ * `LEGACY_IMPLICIT_AGENT_ID` in the installed core
+ * (`dist/session-key-*.js`), and what `listAgentIds` answers when
+ * `agents.entries` / `agents.list` are both absent — which is every stock box.
  */
-const CLAWBOX_AGENT_ID = "main";
-const AUTH_PROFILES_PATH = path.join(
-  OPENCLAW_HOME_DIR,
-  "agents",
-  CLAWBOX_AGENT_ID,
-  "agent",
-  "auth-profiles.json",
-);
+const IMPLICIT_AGENT_ID = "main";
+
+/**
+ * The agent whose store ClawBox writes to, resolved the way the CLI would.
+ *
+ * ONE id is computed and passed explicitly to BOTH the credential path and
+ * every `models auth …` call, because those commands do not resolve alike when
+ * `--agent` is omitted: `resolveModelsTargetAgent` sends a WRITE through
+ * `resolveSoleAgentId` and a READ (`auth list`) through
+ * `resolveAmbientOwnerAgentId`, so a guard that read one store while the paste
+ * wrote another would be no guard at all.
+ *
+ * What it must NOT be is a constant. `main` was pinned here, and on a box whose
+ * roster declares another agent that wrote the device's ClawBox AI credential
+ * into a store the gateway never reads — leaving whatever was in the real store
+ * to keep serving turns, however stale. That is TASK-730: two credentials on
+ * one box, the revoked one preferred, and every ClawBox surface reporting on
+ * the good one.
+ *
+ * The rule is the core's own `tryResolveSoleAgentId`, not an invention:
+ *
+ *   - no roster property at all  → `main` (the implicit agent)
+ *   - exactly one declared agent → that agent, whatever it is called
+ *   - more than one              → the core cannot pick either, and neither do
+ *                                  we: `main` is passed on, and the CLI
+ *                                  answers `Unknown agent id "main"` when it is
+ *                                  not one of them. That is today's behaviour
+ *                                  and it is loud; guessing would not be.
+ *
+ * Both roster shapes are read because the core reads both
+ * (`readAgentRosterProperty`: `agents.entries` as a record, `agents.list` as an
+ * array).
+ */
+function resolveAgentIdFrom(config: unknown): string {
+  const agents = (config as { agents?: Record<string, unknown> } | null)?.agents;
+  if (!agents || typeof agents !== "object" || Array.isArray(agents)) return IMPLICIT_AGENT_ID;
+  const ids = rosterAgentIds(agents);
+  // `undefined` is "no roster declared"; an empty roster IS declared, and there
+  // the implicit agent is not implied — pass `main` on and let the CLI object.
+  if (ids === undefined) return IMPLICIT_AGENT_ID;
+  return ids.length === 1 ? ids[0] : IMPLICIT_AGENT_ID;
+}
+
+/** The declared agent ids, or undefined when no roster property is present. */
+function rosterAgentIds(agents: Record<string, unknown>): string[] | undefined {
+  const entries = Object.hasOwn(agents, "entries") ? agents.entries : undefined;
+  if (entries !== undefined) {
+    if (!entries || typeof entries !== "object" || Array.isArray(entries)) return [];
+    return Object.keys(entries).map((id) => id.trim()).filter(Boolean);
+  }
+  const list = Object.hasOwn(agents, "list") ? agents.list : undefined;
+  if (list === undefined) return undefined;
+  if (!Array.isArray(list)) return [];
+  return list
+    .map((entry) => (entry && typeof entry === "object" ? (entry as { id?: unknown }).id : undefined))
+    .map((id) => (typeof id === "string" ? id.trim() : ""))
+    .filter(Boolean);
+}
+
+/**
+ * The resolved agent for THIS request.
+ *
+ * Read per call rather than cached in a module constant: the roster is owned by
+ * the owner and by `openclaw agents add`, and a value captured at import time
+ * would keep addressing yesterday's store for the lifetime of the server.
+ */
+async function clawboxAgentId(): Promise<string> {
+  return resolveAgentIdFrom(await readOpenClawConfig().catch(() => null));
+}
+
+/** Where that agent keeps the pre-v2 credential file. */
+function authProfilesPathFor(agentId: string): string {
+  return path.join(OPENCLAW_HOME_DIR, "agents", agentId, "agent", "auth-profiles.json");
+}
 const CLAWBOX_UID = process.getuid?.() ?? 1000;
 const CLAWBOX_GID = process.getgid?.() ?? 1000;
 const CLAWBOX_AI_PROXY_URL = process.env.CLAWBOX_AI_PROXY_URL?.trim() || "https://clawbox.com/api/ai";
@@ -351,9 +412,9 @@ async function applyConfigSetGroups(groups: (ConfigSetGroup | null)[]): Promise<
   }
 }
 
-async function readAuthProfiles(): Promise<AuthProfilesFile> {
+async function readAuthProfiles(agentId: string): Promise<AuthProfilesFile> {
   try {
-    const raw = await fs.readFile(AUTH_PROFILES_PATH, "utf-8");
+    const raw = await fs.readFile(authProfilesPathFor(agentId), "utf-8");
     return JSON.parse(raw) as AuthProfilesFile;
   } catch (err) {
     // Only a genuinely absent file means "no profiles yet" (first run). Any
@@ -369,14 +430,15 @@ async function readAuthProfiles(): Promise<AuthProfilesFile> {
   }
 }
 
-async function writeAuthProfiles(authProfiles: AuthProfilesFile) {
-  await fs.mkdir(path.dirname(AUTH_PROFILES_PATH), { recursive: true });
-  const tmpPath = AUTH_PROFILES_PATH + `.tmp.${Date.now()}.${process.pid}`;
+async function writeAuthProfiles(agentId: string, authProfiles: AuthProfilesFile) {
+  const target = authProfilesPathFor(agentId);
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  const tmpPath = target + `.tmp.${Date.now()}.${process.pid}`;
   await fs.writeFile(tmpPath, JSON.stringify(authProfiles, null, 2), {
     mode: 0o600,
   });
-  await fs.rename(tmpPath, AUTH_PROFILES_PATH);
-  await fs.chown(AUTH_PROFILES_PATH, CLAWBOX_UID, CLAWBOX_GID);
+  await fs.rename(tmpPath, target);
+  await fs.chown(target, CLAWBOX_UID, CLAWBOX_GID);
 }
 
 /**
@@ -400,11 +462,11 @@ async function pasteAuthApiKey(provider: string, profileId: string, key: string)
     [
       "models", "auth", "paste-api-key",
       // `--agent` omitted means "the configured default agent", which is not
-      // necessarily the one ClawBox operates on. `applyOpenAiAuthOrder` already
-      // pins CLAWBOX_AGENT_ID for the order over these same profiles, and
-      // `assertNoSignInAt` reads with the same pin — a guard that read one
-      // store while the paste wrote another would be no guard at all.
-      "--agent", CLAWBOX_AGENT_ID,
+      // necessarily the one ClawBox operates on — and a WRITE and a READ do not
+      // even resolve it the same way. `applyOpenAiAuthOrder` and
+      // `assertNoSignInAt` pass the SAME resolved id, so the guard, the order
+      // and the paste all address one store.
+      "--agent", await clawboxAgentId(),
       "--provider", provider,
       "--profile-id", profileId,
     ],
@@ -474,7 +536,7 @@ async function assertNoSignInAt(profileId: string): Promise<void> {
     // Same agent as the paste this guards and as the auth order beside it: the
     // store `--agent` selects is the whole subject of the question.
     raw = await spawnOpenclawCli(
-      ["models", "auth", "list", "--agent", CLAWBOX_AGENT_ID, "--json"],
+      ["models", "auth", "list", "--agent", await clawboxAgentId(), "--json"],
       { captureStdout: true, timeoutMs: 60_000 },
     );
   } catch (err) {
@@ -553,6 +615,9 @@ async function applyOpenAiAuthOrder(
   config: OpenClawConfig | null,
   clawboxWroteOrder: boolean,
 ): Promise<string | undefined> {
+  // From the SAME config the caller already read, so the order and the
+  // credential cannot end up in different agents' stores.
+  const agentId = resolveAgentIdFrom(config);
   const order = openaiAuthOrder(
     config?.auth?.profiles,
     preferred,
@@ -561,8 +626,8 @@ async function applyOpenAiAuthOrder(
   const shouldSet = order.length > 1;
   if (!shouldSet && !clawboxWroteOrder) return undefined;
   const args = shouldSet
-    ? ["models", "auth", "order", "set", "--agent", CLAWBOX_AGENT_ID, "--provider", CHATGPT_PROVIDER, ...order]
-    : ["models", "auth", "order", "clear", "--agent", CLAWBOX_AGENT_ID, "--provider", CHATGPT_PROVIDER];
+    ? ["models", "auth", "order", "set", "--agent", agentId, "--provider", CHATGPT_PROVIDER, ...order]
+    : ["models", "auth", "order", "clear", "--agent", agentId, "--provider", CHATGPT_PROVIDER];
   try {
     await spawnOpenclawCli(args, { timeoutMs: 60_000 });
     // The marker follows the write that succeeded, so a later save knows
@@ -2405,7 +2470,11 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
       }
       await pasteAuthApiKey(ocProvider, config.profileKey, apiKeyValue);
     } else {
-      const authProfiles = await readAuthProfiles();
+      // Same resolution as the paste above, so the legacy file and the CLI
+      // that migrates it address one agent's store.
+      const legacyAgentId = await clawboxAgentId();
+      const legacyProfilesPath = authProfilesPathFor(legacyAgentId);
+      const authProfiles = await readAuthProfiles(legacyAgentId);
       if (authMode === "subscription") {
         // OAuth credential format expected by OpenClaw:
         // { type: "oauth", provider, access, id?, refresh, expires, projectId? }
@@ -2425,7 +2494,7 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
           ...(projectId ? { projectId } : {}),
         };
       }
-      await writeAuthProfiles(authProfiles);
+      await writeAuthProfiles(legacyAgentId, authProfiles);
       // OpenClaw 2 refuses to hydrate this LEGACY file: run the doctor
       // migration IMMEDIATELY, before the config-set batch, catalog refresh
       // and session sweep execute against a poisoned shared auth store (it
@@ -2441,7 +2510,7 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
       try {
         await runOpenclawDoctorFix();
       } catch (doctorErr) {
-        const siblings = await fs.readdir(path.dirname(AUTH_PROFILES_PATH)).catch(() => [] as string[]);
+        const siblings = await fs.readdir(path.dirname(legacyProfilesPath)).catch(() => [] as string[]);
         const migratedStore = siblings.some((name) => name.startsWith("auth-profiles.json.migrated-"));
         console.error(
           "[configure] doctor --fix failed after the OAuth store write:",
@@ -2464,7 +2533,7 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
         }
         if (mustRollBack) {
           const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-          await fs.rename(AUTH_PROFILES_PATH, `${AUTH_PROFILES_PATH}.failed-${stamp}`).catch(() => {});
+          await fs.rename(legacyProfilesPath, `${legacyProfilesPath}.failed-${stamp}`).catch(() => {});
           return NextResponse.json(
             { error: "Credential migration failed. The subscription sign-in was rolled back — try again, or run 'openclaw doctor --fix' from the Terminal." },
             { status: 502 },
@@ -3189,7 +3258,7 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
             // the refusal never goes away. Argument order is the command's own
             // (`models auth logout [options] <profileId>`, read from its
             // --help on 2026.8.1).
-            + `openclaw models auth logout --agent ${CLAWBOX_AGENT_ID} ${err.profileId}`
+            + `openclaw models auth logout --agent ${await clawboxAgentId()} ${err.profileId}`
             + " — then paste the key.",
           code: "sign_in_would_be_lost",
           profileId: err.profileId,

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -825,11 +825,11 @@ describe("POST /setup-api/ai-models/configure over an existing sign-in", () => {
     // The sentence has to be followable literally: it names the slot and the
     // native verb that clears it.
     expect(body.error).toContain(profileId);
-    // Followable literally, against the SAME store the guard read: without the
-    // selector the CLI takes the configured default agent, so on a
-    // multi-agent box the owner clears a different store and the refusal
-    // never goes away.
-    expect(body.error).toContain(`openclaw models auth logout --agent main ${profileId}`);
+    // Followable literally, against the SAME store the guard read: all three
+    // let the core resolve the agent, so naming one here would point the owner
+    // at a store none of them touched.
+    expect(body.error).toContain(`openclaw models auth logout ${profileId}`);
+    expect(body.error).not.toContain("--agent");
     // A refusal is not a failure: nothing may have been written on the way to it.
     expect(pasteWasSpawned()).toBe(false);
     expectNoSideEffects();
@@ -859,10 +859,12 @@ describe("POST /setup-api/ai-models/configure over an existing sign-in", () => {
     const args = vi.mocked(spawnOpenclawCli).mock.calls.map(([a]) => a as string[]);
     const read = args.find((a) => a.includes("auth") && a.includes("list"));
     const paste = args.find((a) => a.includes("paste-api-key"));
+    // Neither pins an agent: the core resolves the same one for the READ that
+    // guards and the WRITE that pastes, so the guard cannot end up inspecting
+    // a different store from the one being written.
     for (const call of [read, paste]) {
       expect(call).toBeDefined();
-      expect(call).toContain("--agent");
-      expect(call?.[(call?.indexOf("--agent") ?? -1) + 1]).toBe("main");
+      expect(call).not.toContain("--agent");
     }
   });
 

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -840,6 +840,54 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(orderCall?.[0]).toEqual(expect.arrayContaining(["--agent", "main"]));
   });
 
+  it("writes the ClawBox AI credential to the agent the box actually runs", async () => {
+    // TASK-730. A customer was dead for two days on HTTP 403 because his box
+    // held TWO ClawBox AI credentials and the gateway served the revoked one:
+    //   deepseek:default = claw_bd1…  <- sent, revoked, 403
+    //   models.json      = claw_c98…  <- present, ignored
+    // with the profile read out of `agents/main/agent/…` while the box's own
+    // models.json lived under `agents/pro-agent/`. ClawBox pinned `--agent
+    // main` for every `models auth …` call, so on a box whose roster names a
+    // different agent the credential is written into a store the gateway never
+    // reads — and whatever was in the real store, however stale, keeps
+    // serving turns. The core's own rule for a WRITE is
+    // `resolveSoleAgentId`: a declared sole agent wins, and `main` is only
+    // the answer when no roster is declared at all
+    // (agent-scope-config: listAgentIds → LEGACY_IMPLICIT_AGENT_ID = "main").
+    mockReadOpenClawConfig.mockResolvedValue({
+      agents: { list: [{ id: "pro-agent" }] },
+      auth: { profiles: {} },
+    } as never);
+
+    await configurePost(jsonRequest({
+      provider: "clawai",
+      apiKey: "claw_c98000000000000000000000000000",
+      authMode: "subscription",
+    }));
+
+    const paste = pasteCallFor("deepseek:default");
+    expect(paste?.[0]).toEqual(expect.arrayContaining(["--agent", "pro-agent"]));
+  });
+
+  it("still says `main` when the box declares no agent roster at all", async () => {
+    // The other half, and the reason this is a resolution rather than a
+    // rename: a stock box has no `agents.entries`/`agents.list`, and there the
+    // core's implicit agent IS `main`. Guessing anything else would move every
+    // existing box's credential into a store nothing reads — the same defect,
+    // pointed the other way.
+    mockReadOpenClawConfig.mockResolvedValue({ auth: { profiles: {} } } as never);
+
+    await configurePost(jsonRequest({
+      provider: "clawai",
+      apiKey: "claw_c98000000000000000000000000000",
+      authMode: "subscription",
+    }));
+
+    expect(pasteCallFor("deepseek:default")?.[0]).toEqual(
+      expect.arrayContaining(["--agent", "main"]),
+    );
+  });
+
   it("names both OpenAI profiles, the sign-in first, when the box holds an API key too", async () => {
     // An explicit order REPLACES the core's candidate list rather than
     // reordering it, so a one-entry order written here made a later

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -808,16 +808,15 @@ describe("POST /setup-api/ai-models/configure", () => {
     }));
 
     expect(vi.mocked(spawnOpenclawCli)).toHaveBeenCalledWith(
-      ["models", "auth", "order", "clear", "--agent", "main", "--provider", "openai"],
+      ["models", "auth", "order", "clear", "--provider", "openai"],
       expect.anything(),
     );
   });
 
   // The order write and the credential write must address the SAME agent
-  // store. `models auth order` resolves its own target when `--agent` is
-  // omitted (resolveSoleAgentId), which throws on a box with more than one
-  // configured agent and otherwise resolves whichever sole agent is declared
-  // — not necessarily `main`, the directory the credential was written into.
+  // store. Both now let the core resolve it, which is the only answer that is
+  // right on a box whose roster names something other than `main` — see
+  // "lets the core pick the agent…" below for the measurement.
   it("addresses the same agent store the credential was written to", async () => {
     // Two openai profiles, so an order IS written — and it must name the agent
     // whose store the credential went to.
@@ -837,55 +836,63 @@ describe("POST /setup-api/ai-models/configure", () => {
     const orderCall = vi.mocked(spawnOpenclawCli).mock.calls.find(
       ([args]) => Array.isArray(args) && args[2] === "order",
     );
-    expect(orderCall?.[0]).toEqual(expect.arrayContaining(["--agent", "main"]));
+    expect(orderCall?.[0]).not.toContain("--agent");
+    expect(pasteCallFor("openai:chatgpt")?.[0] ?? []).not.toContain("--agent");
   });
 
-  it("writes the ClawBox AI credential to the agent the box actually runs", async () => {
+  it("lets the core pick the agent when it writes the ClawBox AI credential", async () => {
     // TASK-730. A customer was dead for two days on HTTP 403 because his box
     // held TWO ClawBox AI credentials and the gateway served the revoked one:
     //   deepseek:default = claw_bd1…  <- sent, revoked, 403
     //   models.json      = claw_c98…  <- present, ignored
     // with the profile read out of `agents/main/agent/…` while the box's own
     // models.json lived under `agents/pro-agent/`. ClawBox pinned `--agent
-    // main` for every `models auth …` call, so on a box whose roster names a
-    // different agent the credential is written into a store the gateway never
-    // reads — and whatever was in the real store, however stale, keeps
-    // serving turns. The core's own rule for a WRITE is
-    // `resolveSoleAgentId`: a declared sole agent wins, and `main` is only
-    // the answer when no roster is declared at all
-    // (agent-scope-config: listAgentIds → LEGACY_IMPLICIT_AGENT_ID = "main").
+    // main` on every `models auth …` call, so the credential it wrote went
+    // into a store the gateway does not read — and on a box whose roster does
+    // not name `main` at all, the save fails outright:
+    //
+    //   $ openclaw models auth paste-api-key --agent main …
+    //   Unknown agent id "main". Use "openclaw agents list" to see configured agents.
+    //
+    // Measured on the pinned core (2026.8.1) with a sole `pro-agent` roster
+    // and NO flag: `models auth list --json` answers `"agentId":"pro-agent"`
+    // and the paste lands in `agents/pro-agent/agent/openclaw-agent.sqlite`.
+    // So the agent is the harness's to resolve, and ClawBox asks it to.
+    await configurePost(jsonRequest({
+      provider: "clawai",
+      apiKey: "claw_c98000000000000000000000000000",
+      authMode: "subscription",
+    }));
+
+    expect(pasteCallFor("deepseek:default")?.[0]).not.toContain("--agent");
+  });
+
+  it("lets it pick for the guard and the order too, so all three address one store", async () => {
+    // The invariant the old pin existed to protect, and the reason this is one
+    // change rather than three: `models auth list` is a READ and resolves
+    // through a different path from a WRITE, so an unpinned pair COULD have
+    // addressed two stores. Measured, on every box where a save can succeed,
+    // it does not — and where the two would diverge (several agents declared)
+    // the write refuses loudly rather than picking one.
+    mockGetAll.mockResolvedValue({ openai_auth_order_written: true } as never);
     mockReadOpenClawConfig.mockResolvedValue({
-      agents: { list: [{ id: "pro-agent" }] },
-      auth: { profiles: {} },
+      auth: { profiles: { "openai:default": { provider: "openai", mode: "api_key" } } },
     } as never);
 
     await configurePost(jsonRequest({
-      provider: "clawai",
-      apiKey: "claw_c98000000000000000000000000000",
+      provider: "openai",
+      apiKey: "access.token.jwt",
+      idToken: "id.token.jwt",
       authMode: "subscription",
+      refreshToken: "refresh-token",
+      expiresIn: 3600,
     }));
 
-    const paste = pasteCallFor("deepseek:default");
-    expect(paste?.[0]).toEqual(expect.arrayContaining(["--agent", "pro-agent"]));
-  });
-
-  it("still says `main` when the box declares no agent roster at all", async () => {
-    // The other half, and the reason this is a resolution rather than a
-    // rename: a stock box has no `agents.entries`/`agents.list`, and there the
-    // core's implicit agent IS `main`. Guessing anything else would move every
-    // existing box's credential into a store nothing reads — the same defect,
-    // pointed the other way.
-    mockReadOpenClawConfig.mockResolvedValue({ auth: { profiles: {} } } as never);
-
-    await configurePost(jsonRequest({
-      provider: "clawai",
-      apiKey: "claw_c98000000000000000000000000000",
-      authMode: "subscription",
-    }));
-
-    expect(pasteCallFor("deepseek:default")?.[0]).toEqual(
-      expect.arrayContaining(["--agent", "main"]),
-    );
+    const calls = vi.mocked(spawnOpenclawCli).mock.calls
+      .map(([args]) => args)
+      .filter((args): args is string[] => Array.isArray(args) && args[0] === "models" && args[1] === "auth");
+    expect(calls.length).toBeGreaterThan(0);
+    for (const args of calls) expect(args).not.toContain("--agent");
   });
 
   it("names both OpenAI profiles, the sign-in first, when the box holds an API key too", async () => {
@@ -907,7 +914,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     }));
 
     expect(vi.mocked(spawnOpenclawCli)).toHaveBeenCalledWith(
-      ["models", "auth", "order", "set", "--agent", "main", "--provider", "openai",
+      ["models", "auth", "order", "set", "--provider", "openai",
         "openai:chatgpt", "openai:default"],
       expect.anything(),
     );
@@ -926,7 +933,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     }));
 
     expect(vi.mocked(spawnOpenclawCli)).toHaveBeenCalledWith(
-      ["models", "auth", "order", "set", "--agent", "main", "--provider", "openai",
+      ["models", "auth", "order", "set", "--provider", "openai",
         "openai:default", "openai:chatgpt"],
       expect.anything(),
     );
@@ -1070,7 +1077,7 @@ describe("POST /setup-api/ai-models/configure", () => {
 
     expect(res.status).toBe(200);
     expect(body.success).toBe(true);
-    expect(body.warning).toMatch(/models auth order set --agent main --provider openai/);
+    expect(body.warning).toMatch(/models auth order set --provider openai/);
   });
 
   // A Pro account used to land on gpt-5.5 after sign-in and had to know to


### PR DESCRIPTION
**TASK-730** — a box can hold two ClawBox AI keys and silently prefer the revoked one.

## Customer-visible symptom

A Max customer was dead for two days on `HTTP 403 "Invalid token"`. His box held two ClawBox AI credentials and served the wrong one:

```
deepseek effective = profiles: ~/.openclaw/agents/main/agent/openclaw-agent.sqlite
         deepseek:default = claw_bd1…   <- sent, revoked, 403
         models.json      = claw_c98…   <- present, ignored
         source = models.json: ~/.openclaw/agents/pro-agent/agent/models.json
```

Every ClawBox surface reported the good key. The gateway sent the revoked one. Nothing on the box could tell him which — the truth came out of a hand-written probe an engineer composed in an email.

## Cause

`src/app/setup-api/ai-models/configure/route.ts` pinned the agent it writes credentials for:

```ts
const CLAWBOX_AGENT_ID = "main";
```

and passed `--agent main` to `models auth paste-api-key`, to the `models auth list` sign-in guard, to `models auth order set/clear`, and into the remedy sentence the refusal prints. Its docblock argued the pin was necessary: the CLI resolves a WRITE through `resolveSoleAgentId` and a READ through `resolveAmbientOwnerAgentId`, so an unpinned pair could address two stores.

The reasoning was sound and the constant was not. On a box whose roster names something other than `main`, the pin writes this device's credential into an agent store the gateway does not read — and whatever the real store holds, however stale, keeps serving turns. That is the customer's box.

## Measured on the installed core (2026.8.1)

All of the following was run with an isolated `OPENCLAW_HOME` / `OPENCLAW_STATE_DIR` / `OPENCLAW_CONFIG_PATH` / `HOME` under a scratch directory — never against a real box or a real config.

With a sole `pro-agent` roster and **no `--agent` flag at all**, the core resolves the same agent for the read and for the write:

```
$ openclaw models auth list --json
{ "agentId": "pro-agent",
  "agentDir": "…/agents/pro-agent/agent",
  "authStatePath": "…/agents/main/agent/openclaw-agent.sqlite",   <- inherited, see below
  "profiles": [] }

$ printf '…' | openclaw models auth paste-api-key --provider openai --profile-id openai:default
Auth profile: openai:default (openai/api_key)
  -> …/agents/pro-agent/agent/openclaw-agent.sqlite

$ openclaw models auth list --json
{ "agentId": "pro-agent",
  "authStatePath": "…/agents/pro-agent/agent/openclaw-agent.sqlite",
  "profiles": [ { "id": "openai:default", "provider": "openai", "type": "api_key" } ] }
```

And the same box, with the pin this PR removes:

```
$ openclaw models auth list --agent main --json
{ "ok": false, "error": { "message": "Unknown agent id \"main\". Use \"openclaw agents list\" to see configured agents." } }

$ openclaw models auth paste-api-key --agent main --provider openai --profile-id openai:probe
Unknown agent id "main". Use "openclaw agents list" to see configured agents.
```

So on that box beta cannot save a ClawBox AI credential at all, and on a box that declares `main` alongside the agent it actually runs, it saves it into the wrong store — silently, with a `200`.

## The fix (harness-first: **delete the pin**)

`--agent` is dropped from all three `models auth …` calls and from the remedy sentence. The agent is the harness's to resolve, and ClawBox now asks it to.

The read/write asymmetry the old docblock invoked is real but only bites on a roster with SEVERAL agents — and there `main` was never the right answer either: the write refuses with `Multiple agents are configured … Pass --agent <id>.`, which is a clearer failure than `Unknown agent id "main"`. On every box where a save can succeed, the guard, the paste and the order address one store, which is exactly the invariant the pin existed to protect.

The alternative — parsing `agents.entries` / `agents.list` in ClawBox and re-implementing `tryResolveSoleAgentId` — was written first and thrown away. It duplicated a rule this repo does not own (and got several roster shapes wrong: the core keeps a `list` element that is any object, keeps an `entries` key only when its value is a record, and runs every id through `normalizeAgentId`, which lowercases and rewrites punctuation), it read `openclaw.json` four separate times per request through a reader that returns `{}` on an unreadable file, and it answered a question the CLI answers correctly for free. `openclaw agents list --json` is named here as the native mechanism for the one thing a parser would still be needed for — an agent's resolved **directory** — and is not used, because after this change nothing needs one.

## Sibling call sites — swept

- The three `models auth …` calls and the remedy string in `configure/route.ts`: all unpinned, in one change, so they cannot drift apart.
- `AUTH_PROFILES_PATH` — the pre-v2 legacy `auth-profiles.json` — still resolves under `agents/main/`, renamed `LEGACY_AGENT_ID` to say why: the builds that wrote that file hardcoded `main`, and `doctor --fix` migrates it from wherever it finds it (`listAuthProfileRepairCandidates` enumerates every existing `agents/*/agent`). Unchanged from beta, deliberately.
- `src/lib/local-ai-token.ts:38` — **cleared, not a defect.** It reads `agents/main/agent/auth-profiles.json` only to hunt the `llamacpp-local` / `ollama-local` sentinels a pre-`b0c6e452` build wrote, and those builds hardcoded `main`, so that is exactly the right place to look. Read-only, fail-closed, no `claw_` key.
- `scripts/codex-auth-mirror.js` — **cleared.** It already enumerates every directory under `<stateDir>/agents` and models the shared-store ownership row; its `agents/main` mention is prose about the core's default.
- `src/lib/clawkeep-memory.ts:356` (`memory status --agent main --deep --json`) and `:827` (`memory index --agent main`) — **the same latent defect, different subsystem** (ClawKeep memory, not credentials), so not widened into this PR. Recorded as a residual for the ClawKeep lane rather than fixed here.

## What this PR deliberately does NOT take

The card names three problems. This is the second, and it is the only one that lives in ClawBox's own code:

1. **"The profile store silently wins over models.json."** That is the core's own documented precedence — a usable auth profile outranks `models.providers.<p>.apiKey`, recorded in this repo already — not something to override from here.
3. **"`doctor --fix` reports healthy over a revoked key."** That is `openclaw doctor`'s health rule; it belongs upstream. The ClawBox-side answer to "the box says it is fine while every turn 403s" is TASK-419, which is a separate PR in this batch.

## Residuals found while measuring (named, not fixed)

- **The revoked credential survives, shadowed.** A sole non-main agent INHERITS the shared/main store until it has one of its own — visible above as `authStatePath` pointing at `agents/main/` while `agentId` is `pro-agent`. Writing the agent's own profile shadows the inherited one, which is what stops the box serving the revoked key; it does not remove it. `openclaw models auth logout <profileId>` exists, is quoted as advice in this file, and is never invoked from anywhere in ClawBox — so a stale profile is never retired. That is the honest answer to "why did the box hold two credentials", and it wants its own card.
- **ClawBox's own reader uses the opposite precedence to the core's.** `resolveClawaiToken` (`src/lib/harness/credentials.ts`) reads `models.providers.<clawai>.apiKey` and never opens the profile store — so every ClawBox surface reported the good key for two days while the gateway sent the revoked one. Making that reader agree with the core (or at minimum report a mismatch) turns a silent outage into a visible one. In-repo, harness-native, and the next card after this one.
- **Known limit, measured and documented in the code:** because a fresh agent inherits the shared store, the sign-in guard can see a profile the paste would only have shadowed and refuse the save. That is the safe direction, and it is strictly better than what it replaces — the same box previously failed the whole save with `Unknown agent id "main"`.

## RED → GREEN

RED, on unmodified `origin/beta` (`8653b118`) — the branch's tests against beta's `configure/route.ts`:

```
     × refuses an anthropic API key that would replace the sign-in at anthropic:default
     × refuses an openai API key that would replace the sign-in at openai:default
     × reads and writes the SAME agent's credential store
     × clears an order ClawBox itself wrote once the box is down to one profile
     × addresses the same agent store the credential was written to
     × lets the core pick the agent when it writes the ClawBox AI credential
     × lets it pick for the guard and the order too, so all three address one store
     × names both OpenAI profiles, the sign-in first, when the box holds an API key too
     × revises the preference to the API key when THAT is the save
     × names a failed auth-order preference in the answer instead of hiding it

 Test Files  2 failed | 16 passed (18)
```

The headline one:

```
 FAIL  … > lets the core pick the agent when it writes the ClawBox AI credential
AssertionError: expected [ 'models', 'auth', …(7) ] to not include '--agent'
 ❯ src/tests/routes/ai-models/configure.test.ts:867:55
```

GREEN, on this branch: `src/tests/routes/ai-models/` `Test Files 18 passed (18)`, `Tests 340 passed (340)`. Whole unit project `Test Files 703 passed (703)`, `Tests 11480 passed | 1 skipped (11481)`. `tsc --noEmit` clean.

Eight pre-existing cases asserted `--agent main` and now assert that no agent is pinned; the one that documented "the order write and the credential write must address the SAME agent store" keeps its subject and gets a stronger assertion — both calls, and the paste beside them.

## Both editions

Hermes is unaffected and cannot reach the changed code: `assertNoSignInAt` returns early on `openclawIsAbsent()`, and a Hermes box has no `~/.openclaw/openclaw.json` and never runs `paste-api-key` — its ClawBox AI credential goes to the config store and `~/.hermes/config.yaml` through `applyClawaiToHermes`. Nothing new runs there and nothing throws.

**Device leg:** not run, and not applicable. The change is entirely in which arguments ClawBox passes to a CLI, the CLI's own resolution was measured against the pinned core in an isolated home (above) rather than reasoned about, and no box state was mutated. CI exercises the route.

## Device leg — read-only, both editions

**OpenClaw box** (`CLAWBOX_EDITION=openclaw`, core 2026.8.1):

```
$ openclaw agents list --json
[ { "id": "main",
    "agentDir": "/home/clawbox/.openclaw/agents/main/agent",
    "model": "deepseek/deepseek-v4-pro",
    "isDefault": true } ]
```

One agent, and it is `main` — so **this change is a no-op on our own boxes**: with `--agent` dropped the core resolves the same `main` the pin named, the credential lands in the same store, and nothing about those boxes moves. That is the "never worse" half proved on hardware rather than argued. What it fixes is the box shape the customer had, where the roster names something else and the pin either writes into a store the gateway does not read or fails the save outright.

**Hermes box** (`CLAWBOX_EDITION=hermes`): no OpenClaw binary and no `dist` on the box at all, so `paste-api-key` is unreachable there and `openclawIsAbsent()` short-circuits the guard — the edition leg confirmed by absence rather than by reasoning. **Declared gap:** `clawbox-setup` and `clawbox-hermes-gateway` were both `inactive` on that box at the time, so no route was exercised there.
