### PR TITLE
fix: claim the parked build with a rename before anything is destroyed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,11 @@ node_modules/
 node_modules
 .next/
 .next-old/
-# The two transient names the atomic build reclaim uses (TASK-729): the
-# shared claim a rename hands to exactly one reclaimer, and the private
-# tree it moves the outgoing .next aside into. Both must be ignored for the
-# same reason .next-old is — an update runs `git clean -fd` over this tree,
-# and a claim swept away mid-flight is a box with no build.
+# The two transient names the atomic build reclaim uses (TASK-729), both
+# PRIVATE per process: the tree a rename claims the parked build into, and the
+# one it moves the outgoing .next aside into. Both must be ignored for the same
+# reason .next-old is — an update runs `git clean -fd` over this tree, and a
+# claim swept away mid-flight is a box with no build.
 .next-claim.*/
 .next-discard.*/
 out/

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ node_modules
 # tree it moves the outgoing .next aside into. Both must be ignored for the
 # same reason .next-old is — an update runs `git clean -fd` over this tree,
 # and a claim swept away mid-flight is a box with no build.
-.next-claim/
+.next-claim.*/
 .next-discard.*/
 out/
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,13 @@ node_modules/
 node_modules
 .next/
 .next-old/
+# The two transient names the atomic build reclaim uses (TASK-729): the
+# shared claim a rename hands to exactly one reclaimer, and the private
+# tree it moves the outgoing .next aside into. Both must be ignored for the
+# same reason .next-old is — an update runs `git clean -fd` over this tree,
+# and a claim swept away mid-flight is a box with no build.
+.next-claim/
+.next-discard.*/
 out/
 build/
 coverage/

--- a/install.sh
+++ b/install.sh
@@ -1465,19 +1465,53 @@ verify_build_present() {
 # Ctrl-C leaves no `.next` at all and the good build under a gitignored
 # directory nothing else in the tree reads. Reclaim it before anything else
 # runs, or the next rename would delete it.
+# Every transient this reclaim can leave behind, and what to do with each.
+#
+# TASK-729's claim is a rename, which is what makes it a mutex — but a rename
+# needs somewhere to move the tree TO, and a process killed mid-claim leaves the
+# box's only build under that name. There are two such names, and BOTH are
+# private per process (`.<pid>` suffixed) so no shared destination can be
+# occupied and latch the reclaim: a stray shared `.next-claim` beside an
+# existing `.next-old` made every later claim fail ENOTEMPTY, on both
+# reclaimers, for ever.
+#
+# So the recovery is one drain over both globs, run before either reclaimer
+# decides anything:
+#   - an orphan with no build entry is junk and goes (a discard is entry-less by
+#     construction — it is the `.next` both reclaimers only ever touch when it
+#     has no entry — so a LIVE one loses nothing here, and its owner already
+#     copes with a discard that is gone);
+#   - an orphan WITH a build is a build, and is adopted under the parked name a
+#     rename at a time. Adopting a live claimer's tree is safe by the same
+#     property the claim rests on: the victim's placement rename then fails, it
+#     stands down, and the build is under `.next-old` for whoever claims next.
+#   - an orphan with a build while `.next-old` already holds one is a duplicate
+#     of a fallback we already have. It is REPORTED and left, never destroyed:
+#     this cannot prove which of the two is wanted, and the next park clears
+#     `.next-old` and adopts it on the run after.
+drain_build_transients() {
+  local root="$1" kept_dir="$2" orphan
+  for orphan in "$root"/.next-claim.* "$root"/.next-discard.*; do
+    [ -e "$orphan" ] || continue
+    if ! build_entry_present "$orphan"; then
+      rm -rf "$orphan" || true
+      continue
+    fi
+    if mv -T "$orphan" "$kept_dir" 2>/dev/null; then
+      echo "  Adopted a build left behind by an interrupted reclaim ($(basename "$orphan"))" >&2
+    else
+      echo "  Note: $(basename "$orphan") holds a build and $kept_dir already does — leaving it for the next run" >&2
+    fi
+  done
+}
+
 promote_parked_build() {
   local build_dir="${1:-$PROJECT_DIR/.next}" kept_dir="${2:-$PROJECT_DIR/.next-old}"
-  local claim_dir="${build_dir%/.next}/.next-claim" discard_dir
+  local root="${build_dir%/.next}" claim_dir discard_dir
+  claim_dir="${build_dir%/.next}/.next-claim.$$"
   discard_dir="${build_dir%/.next}/.next-discard.$$"
 
-  # A claim a kill interrupted left the build under the claim name. Fold it back
-  # under the parked name so the one path below handles both. `mv -T` is a
-  # rename, so two processes doing this produce one winner and one failure, and
-  # a `.next-old` that is already there refuses the move rather than nesting
-  # the tree inside it.
-  if build_entry_present "$claim_dir"; then
-    mv -T "$claim_dir" "$kept_dir" 2>/dev/null || true
-  fi
+  drain_build_transients "$root" "$kept_dir"
 
   # `-e`, and `-L` beside it: for the nested standalone layout `postbuild`
   # supports, `.next/standalone/server.js` is a SYMLINK to an absolute path
@@ -1495,15 +1529,17 @@ promote_parked_build() {
   # its own rename into a best-effort catch, leaving the box with NEITHER tree
   # — the exact outcome the park exists to prevent.
   #
-  # A rename is atomic and has exactly one winner, so the claim goes first and
-  # nothing is destroyed before it: the loser gets a failed `mv` and returns
-  # having touched nothing.
+  # A rename of the SOURCE is atomic and has exactly one winner, so the claim
+  # goes first and nothing is destroyed before it: the loser gets a failed `mv`
+  # and returns having touched nothing. The destination is private, so it can
+  # never be occupied by somebody else's leftovers.
   if ! mv -T "$kept_dir" "$claim_dir" 2>/dev/null; then
-    # ENOENT means the other reclaimer took it — a normal outcome. Anything
-    # else (a read-only rootfs, EACCES, ENOSPC) is a real failure, and the tree
-    # still being there is how this tells them apart. Saying "someone else got
-    # there first" over a box that cannot move its own directories would be a
-    # false cause in the one line an operator triages from.
+    # A tree that is no longer there was taken by the other reclaimer — a normal
+    # outcome. One that IS still there could not be moved, which is a real
+    # failure (a read-only rootfs, EACCES, ENOSPC) and reads differently to an
+    # operator. Saying "someone else got there first" over a box that cannot
+    # move its own directories would be a false cause in the line they triage
+    # from.
     if [ -e "$kept_dir" ]; then
       echo "  Warning: could not claim the parked build at $kept_dir — leaving it where it is" >&2
     fi
@@ -1513,15 +1549,15 @@ promote_parked_build() {
   # Everything from here destroys only PRIVATE names. `.next` is moved aside
   # rather than deleted, so even if the "it has no build entry" judgement above
   # was raced by the other reclaimer placing a good one, nothing is lost: the
-  # branch below puts it back.
+  # branch below puts it back, and a kill in between leaves it for the drain.
   mv -T "$build_dir" "$discard_dir" 2>/dev/null || true
   if mv -T "$claim_dir" "$build_dir" 2>/dev/null; then
-    rm -rf "$discard_dir"
+    rm -rf "$discard_dir" || true
   else
-    # Our claim was taken by the other reclaimer's fold-back above, which means
-    # it is placing this same build. Return what we moved aside and get out of
-    # its way; the tree we were carrying is not lost, it is in its hands.
-    mv -T "$discard_dir" "$build_dir" 2>/dev/null || rm -rf "$discard_dir"
+    # Our claim was adopted by the other reclaimer's drain, which means it is
+    # placing this same build. Return what we moved aside and get out of its
+    # way; the tree we were carrying is not lost, it is in its hands.
+    mv -T "$discard_dir" "$build_dir" 2>/dev/null || rm -rf "$discard_dir" || true
     return 0
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -1490,7 +1490,11 @@ verify_build_present() {
 #     this cannot prove which of the two is wanted, and the next park clears
 #     `.next-old` and adopts it on the run after.
 drain_build_transients() {
-  local root="$1" kept_dir="$2" orphan
+  local root="$1" kept_dir="$2" orphan aside
+  # The private name this function claims into. Same family as the reclaim's
+  # own discard, so it is already drained, gitignored and pruned from the
+  # standalone trace — and a different process has a different one.
+  aside="$root/.next-discard.$$"
   for orphan in "$root"/.next-claim.* "$root"/.next-discard.*; do
     [ -e "$orphan" ] || continue
     if ! build_entry_present "$orphan"; then
@@ -1505,9 +1509,25 @@ drain_build_transients() {
     # "it failed" is not "there is a build there". An entry-less but non-empty
     # `.next-old` — an interrupted `rm -rf "$kept_dir"` in
     # set_previous_build_aside leaves exactly that — is worth nothing and must
-    # not keep a real build stranded for ever; clear it and adopt.
+    # not keep a real build stranded for ever.
+    #
+    # But it is CLAIMED before it is destroyed, never probed and then deleted:
+    # those are two syscalls apart, and a concurrent set_previous_build_aside
+    # can rename a real build into `$kept_dir` in between — which a
+    # check-then-delete would then destroy. The claim is a rename to a private
+    # name, the same mutex the whole reclaim rests on, and what was claimed is
+    # asked again before anything is removed.
     if ! build_entry_present "$kept_dir"; then
-      rm -rf "$kept_dir" || true
+      if mv -T "$kept_dir" "$aside" 2>/dev/null; then
+        if build_entry_present "$aside"; then
+          # It gained a build between the probe and the claim. Put it back and
+          # leave the orphan; the next run has a clear destination.
+          mv -T "$aside" "$kept_dir" 2>/dev/null || true
+          echo "  Note: $(basename "$orphan") holds a build and $kept_dir gained one — leaving it for the next run" >&2
+          continue
+        fi
+        rm -rf "$aside" || true
+      fi
       if mv -T "$orphan" "$kept_dir" 2>/dev/null; then
         echo "  Adopted a build left behind by an interrupted reclaim ($(basename "$orphan"))" >&2
         continue

--- a/install.sh
+++ b/install.sh
@@ -1467,6 +1467,18 @@ verify_build_present() {
 # runs, or the next rename would delete it.
 promote_parked_build() {
   local build_dir="${1:-$PROJECT_DIR/.next}" kept_dir="${2:-$PROJECT_DIR/.next-old}"
+  local claim_dir="${build_dir%/.next}/.next-claim" discard_dir
+  discard_dir="${build_dir%/.next}/.next-discard.$$"
+
+  # A claim a kill interrupted left the build under the claim name. Fold it back
+  # under the parked name so the one path below handles both. `mv -T` is a
+  # rename, so two processes doing this produce one winner and one failure, and
+  # a `.next-old` that is already there refuses the move rather than nesting
+  # the tree inside it.
+  if build_entry_present "$claim_dir"; then
+    mv -T "$claim_dir" "$kept_dir" 2>/dev/null || true
+  fi
+
   # `-e`, and `-L` beside it: for the nested standalone layout `postbuild`
   # supports, `.next/standalone/server.js` is a SYMLINK to an absolute path
   # inside `.next` — which dangles for as long as the tree is parked, so `-f`
@@ -1474,8 +1486,45 @@ promote_parked_build() {
   build_entry_present "$kept_dir" || return 0
   build_entry_present "$build_dir" && return 0
   echo "  Found a build parked by an interrupted rebuild — putting it back" >&2
-  rm -rf "$build_dir"
-  mv "$kept_dir" "$build_dir"
+
+  # THE CLAIM, and the whole of TASK-729's fix. There are two reclaimers of
+  # these directories — this one and the boot-time block in
+  # production-server.js — with no lock between them, and both used to run the
+  # same non-atomic pair: `rm -rf .next` then `mv .next-old .next`. Whichever
+  # arrived second destroyed what the first had just restored and then failed
+  # its own rename into a best-effort catch, leaving the box with NEITHER tree
+  # — the exact outcome the park exists to prevent.
+  #
+  # A rename is atomic and has exactly one winner, so the claim goes first and
+  # nothing is destroyed before it: the loser gets a failed `mv` and returns
+  # having touched nothing.
+  if ! mv -T "$kept_dir" "$claim_dir" 2>/dev/null; then
+    # ENOENT means the other reclaimer took it — a normal outcome. Anything
+    # else (a read-only rootfs, EACCES, ENOSPC) is a real failure, and the tree
+    # still being there is how this tells them apart. Saying "someone else got
+    # there first" over a box that cannot move its own directories would be a
+    # false cause in the one line an operator triages from.
+    if [ -e "$kept_dir" ]; then
+      echo "  Warning: could not claim the parked build at $kept_dir — leaving it where it is" >&2
+    fi
+    return 0
+  fi
+
+  # Everything from here destroys only PRIVATE names. `.next` is moved aside
+  # rather than deleted, so even if the "it has no build entry" judgement above
+  # was raced by the other reclaimer placing a good one, nothing is lost: the
+  # branch below puts it back.
+  mv -T "$build_dir" "$discard_dir" 2>/dev/null || true
+  if mv -T "$claim_dir" "$build_dir" 2>/dev/null; then
+    rm -rf "$discard_dir"
+  else
+    # Our claim was taken by the other reclaimer's fold-back above, which means
+    # it is placing this same build. Return what we moved aside and get out of
+    # its way; the tree we were carrying is not lost, it is in its hands.
+    mv -T "$discard_dir" "$build_dir" 2>/dev/null || rm -rf "$discard_dir"
+    return 0
+  fi
+
   # The stamp names the run that died (see set_previous_build_aside); it must
   # not ride into the tree the box is about to serve. `|| true` because a
   # cosmetic cleanup must never be what aborts a recovery under `set -e`.

--- a/install.sh
+++ b/install.sh
@@ -1499,17 +1499,31 @@ drain_build_transients() {
     fi
     if mv -T "$orphan" "$kept_dir" 2>/dev/null; then
       echo "  Adopted a build left behind by an interrupted reclaim ($(basename "$orphan"))" >&2
-    else
-      echo "  Note: $(basename "$orphan") holds a build and $kept_dir already does — leaving it for the next run" >&2
+      continue
     fi
+    # A rename onto a non-empty destination fails whatever is in it, so
+    # "it failed" is not "there is a build there". An entry-less but non-empty
+    # `.next-old` — an interrupted `rm -rf "$kept_dir"` in
+    # set_previous_build_aside leaves exactly that — is worth nothing and must
+    # not keep a real build stranded for ever; clear it and adopt.
+    if ! build_entry_present "$kept_dir"; then
+      rm -rf "$kept_dir" || true
+      if mv -T "$orphan" "$kept_dir" 2>/dev/null; then
+        echo "  Adopted a build left behind by an interrupted reclaim ($(basename "$orphan"))" >&2
+        continue
+      fi
+      echo "  Warning: could not adopt $(basename "$orphan") into $kept_dir" >&2
+      continue
+    fi
+    echo "  Note: $(basename "$orphan") holds a build and $kept_dir already does — leaving it for the next run" >&2
   done
 }
 
 promote_parked_build() {
   local build_dir="${1:-$PROJECT_DIR/.next}" kept_dir="${2:-$PROJECT_DIR/.next-old}"
   local root="${build_dir%/.next}" claim_dir discard_dir
-  claim_dir="${build_dir%/.next}/.next-claim.$$"
-  discard_dir="${build_dir%/.next}/.next-discard.$$"
+  claim_dir="$root/.next-claim.$$"
+  discard_dir="$root/.next-discard.$$"
 
   drain_build_transients "$root" "$kept_dir"
 
@@ -1550,7 +1564,16 @@ promote_parked_build() {
   # rather than deleted, so even if the "it has no build entry" judgement above
   # was raced by the other reclaimer placing a good one, nothing is lost: the
   # branch below puts it back, and a kill in between leaves it for the drain.
-  mv -T "$build_dir" "$discard_dir" 2>/dev/null || true
+  # The move-aside's result is the difference between "somebody took our claim"
+  # and "this filesystem will not let us move a directory". Discarded, an
+  # EACCES/EROFS/EBUSY here left `.next` in place, made the placement fail
+  # ENOTEMPTY, and was then reported as a lost race while the build stayed under
+  # the claim — a false cause on a box that is about to crash-loop for want of
+  # an entry.
+  if ! mv -T "$build_dir" "$discard_dir" 2>/dev/null && [ -e "$build_dir" ]; then
+    echo "  Warning: could not move $build_dir aside, so the parked build stays claimed at $claim_dir" >&2
+    return 0
+  fi
   if mv -T "$claim_dir" "$build_dir" 2>/dev/null; then
     rm -rf "$discard_dir" || true
   else

--- a/production-server.js
+++ b/production-server.js
@@ -778,6 +778,34 @@ try {
   // supports, this path is a symlink into `.next` that DANGLES while the tree is
   // parked, and `existsSync` would call the box's only build absent.
   const present = (p) => { try { fs.lstatSync(p); return true; } catch { return false; } };
+  const nextDir = path.join(__dirname, ".next");
+  // The claim name is SHARED with install.sh's promote_parked_build, and taking
+  // it is a rename — see the block that uses it below.
+  const claimDir = path.join(__dirname, ".next-claim");
+  const claimEntry = path.join(claimDir, "standalone", "server.js");
+  const discardDir = path.join(__dirname, `.next-discard.${process.pid}`);
+  /**
+   * A rename that answers WHY it failed instead of throwing.
+   *
+   * The distinction matters at the claim below: ENOENT means the other
+   * reclaimer took the parked tree, which is a normal outcome and not a
+   * problem; anything else — EROFS, EACCES, ENOSPC — is a real failure an
+   * operator has to see, and reporting it as "someone else got there first"
+   * would be a false cause in the one line they triage from.
+   */
+  const renameQuiet = (from, to) => {
+    try { fs.renameSync(from, to); return null; } catch (err) { return err; }
+  };
+
+  // A claim a kill interrupted left the build under the claim name, where
+  // nothing looks for it. Fold it back under the parked name so the one block
+  // below handles both — a rename again, so this cannot take a tree from a
+  // reclaim that is mid-flight without that reclaim noticing and standing down.
+  if (present(claimEntry)) {
+    console.warn("[production-server] A previous reclaim left the parked build under .next-claim — folding it back.");
+    renameQuiet(claimDir, parkedDir);
+  }
+
 
   // …and "no entry, a parked one exists" is not on its own the killed rebuild
   // this block repairs. It is ALSO the normal state of a rebuild in flight, for
@@ -849,19 +877,54 @@ try {
         console.warn("[production-server] .next-old carries a rebuild stamp that names no live rebuild — treating the parked build as abandoned.");
       }
       console.warn("[production-server] No .next build, but .next-old holds one — an update was killed mid-rebuild. Putting it back.");
-      fs.rmSync(path.join(__dirname, ".next"), { recursive: true, force: true });
-      fs.renameSync(parkedDir, path.join(__dirname, ".next"));
-      console.warn("[production-server] Restored the parked build. Run the update again to get the new one.");
-      // Its own try, deliberately: the reclaim is already done by the line
-      // above, and `force` swallows ENOENT but not EACCES or EIO. Letting one
-      // reach the catch below would report "Could not reclaim a parked build"
-      // over a reclaim that succeeded — a false failure in the line an
-      // operator triages from.
-      try {
-        fs.rmSync(path.join(__dirname, ".next", OWNER_STAMP), { force: true });
-      } catch {
-        // A stale stamp inside the restored tree is inert: the next park
-        // overwrites it, and nothing else reads it there.
+
+      // THE CLAIM, and the whole of TASK-729's fix. There are two reclaimers of
+      // these directories — this one and install.sh's promote_parked_build —
+      // with no lock between them, and both used to run the same non-atomic
+      // pair, `rm -rf .next` then `mv .next-old .next`. Whichever arrived
+      // second deleted what the first had just restored and then failed its own
+      // rename into this file's best-effort catch, leaving the box with NEITHER
+      // tree: the exact outcome the park exists to prevent.
+      //
+      // A rename is atomic and has exactly one winner, so the claim goes first
+      // and nothing is destroyed before it. The loser returns having touched
+      // nothing, which is the whole point.
+      const claimErr = renameQuiet(parkedDir, claimDir);
+      if (claimErr && claimErr.code === "ENOENT") {
+        console.warn("[production-server] Another reclaim took the parked build first — leaving it to finish.");
+      } else if (claimErr) {
+        // Not a lost race: the tree is still there and this box could not move
+        // it. Same sentence the outer catch used to produce, because it is the
+        // line an operator triages from.
+        console.warn("[production-server] Could not reclaim a parked build:", claimErr.message);
+      } else {
+        // Everything from here destroys only PRIVATE names. `.next` is moved
+        // aside rather than deleted, so even if "it has no build entry" was
+        // raced by the other reclaimer placing a good one, nothing is lost.
+        renameQuiet(nextDir, discardDir);
+        if (!renameQuiet(claimDir, nextDir)) {
+          fs.rmSync(discardDir, { recursive: true, force: true });
+          console.warn("[production-server] Restored the parked build. Run the update again to get the new one.");
+          // Its own try, deliberately: the reclaim is already done by the lines
+          // above, and `force` swallows ENOENT but not EACCES or EIO. Letting
+          // one reach the catch below would report "Could not reclaim a parked
+          // build" over a reclaim that succeeded — a false failure in the line
+          // an operator triages from.
+          try {
+            fs.rmSync(path.join(nextDir, OWNER_STAMP), { force: true });
+          } catch {
+            // A stale stamp inside the restored tree is inert: the next park
+            // overwrites it, and nothing else reads it there.
+          }
+        } else {
+          // Our claim was folded back by the other reclaimer, which means it is
+          // placing this same build. Return what we moved aside and get out of
+          // its way; the tree is not lost, it is in the other one's hands.
+          if (renameQuiet(discardDir, nextDir)) {
+            fs.rmSync(discardDir, { recursive: true, force: true });
+          }
+          console.warn("[production-server] Another reclaim claimed the parked build mid-flight — leaving it to finish.");
+        }
       }
     }
   }

--- a/production-server.js
+++ b/production-server.js
@@ -779,10 +779,11 @@ try {
   // parked, and `existsSync` would call the box's only build absent.
   const present = (p) => { try { fs.lstatSync(p); return true; } catch { return false; } };
   const nextDir = path.join(__dirname, ".next");
-  // The claim name is SHARED with install.sh's promote_parked_build, and taking
-  // it is a rename — see the block that uses it below.
-  const claimDir = path.join(__dirname, ".next-claim");
-  const claimEntry = path.join(claimDir, "standalone", "server.js");
+  // BOTH transients are private per process. The mutex is the atomic rename of
+  // the SOURCE (`.next-old`); sharing a destination buys nothing for that and
+  // costs a latch — a stray shared `.next-claim` beside an existing `.next-old`
+  // made every later claim fail ENOTEMPTY, here and in install.sh, for ever.
+  const claimDir = path.join(__dirname, `.next-claim.${process.pid}`);
   const discardDir = path.join(__dirname, `.next-discard.${process.pid}`);
   /**
    * A rename that answers WHY it failed instead of throwing.
@@ -797,13 +798,26 @@ try {
     try { fs.renameSync(from, to); return null; } catch (err) { return err; }
   };
 
-  // A claim a kill interrupted left the build under the claim name, where
-  // nothing looks for it. Fold it back under the parked name so the one block
-  // below handles both — a rename again, so this cannot take a tree from a
-  // reclaim that is mid-flight without that reclaim noticing and standing down.
-  if (present(claimEntry)) {
-    console.warn("[production-server] A previous reclaim left the parked build under .next-claim — folding it back.");
-    renameQuiet(claimDir, parkedDir);
+  // The drain, and install.sh's `drain_build_transients` is its twin — keep the
+  // two in step. A process killed mid-claim leaves the box's only build under a
+  // private name nothing else looks at, so every orphan is dealt with before
+  // either reclaimer decides anything: junk goes, a build is adopted under the
+  // parked name by a rename (safe against a LIVE owner, whose placement then
+  // fails and which stands down), and a build that would displace a parked one
+  // is reported and left rather than destroyed.
+  const hasEntry = (dir) => present(path.join(dir, "standalone", "server.js"));
+  for (const name of fs.readdirSync(__dirname)) {
+    if (!name.startsWith(".next-claim.") && !name.startsWith(".next-discard.")) continue;
+    const orphan = path.join(__dirname, name);
+    if (!hasEntry(orphan)) {
+      fs.rmSync(orphan, { recursive: true, force: true });
+      continue;
+    }
+    if (renameQuiet(orphan, parkedDir) === null) {
+      console.warn(`[production-server] Adopted a build left behind by an interrupted reclaim (${name}).`);
+    } else {
+      console.warn(`[production-server] ${name} holds a build and .next-old already does — leaving it for the next run.`);
+    }
   }
 
 

--- a/production-server.js
+++ b/production-server.js
@@ -815,9 +815,22 @@ try {
     }
     if (renameQuiet(orphan, parkedDir) === null) {
       console.warn(`[production-server] Adopted a build left behind by an interrupted reclaim (${name}).`);
-    } else {
-      console.warn(`[production-server] ${name} holds a build and .next-old already does — leaving it for the next run.`);
+      continue;
     }
+    // A rename onto a non-empty destination fails whatever is in it, so "it
+    // failed" is not "there is a build there". An entry-less but non-empty
+    // `.next-old` — an interrupted `rm -rf` in set_previous_build_aside leaves
+    // exactly that — is worth nothing and must not strand a real build for ever.
+    if (!hasEntry(parkedDir)) {
+      fs.rmSync(parkedDir, { recursive: true, force: true });
+      if (renameQuiet(orphan, parkedDir) === null) {
+        console.warn(`[production-server] Adopted a build left behind by an interrupted reclaim (${name}).`);
+      } else {
+        console.warn(`[production-server] Could not adopt ${name} into .next-old.`);
+      }
+      continue;
+    }
+    console.warn(`[production-server] ${name} holds a build and .next-old already does — leaving it for the next run.`);
   }
 
 
@@ -915,8 +928,18 @@ try {
         // Everything from here destroys only PRIVATE names. `.next` is moved
         // aside rather than deleted, so even if "it has no build entry" was
         // raced by the other reclaimer placing a good one, nothing is lost.
-        renameQuiet(nextDir, discardDir);
-        if (!renameQuiet(claimDir, nextDir)) {
+        // The move-aside's result is the difference between "somebody took our
+        // claim" and "this filesystem will not let us move a directory".
+        // Discarded, an EACCES/EROFS/EBUSY here left `.next` in place, made the
+        // placement fail ENOTEMPTY, and was then reported as a lost race while
+        // the build stayed under the claim — a false cause on a process that is
+        // about to crash-loop for want of an entry.
+        const asideErr = renameQuiet(nextDir, discardDir);
+        if (asideErr && present(nextDir)) {
+          console.warn(
+            `[production-server] Could not move .next aside (${asideErr.message}) — the parked build stays claimed at ${path.basename(claimDir)}.`,
+          );
+        } else if (!renameQuiet(claimDir, nextDir)) {
           fs.rmSync(discardDir, { recursive: true, force: true });
           console.warn("[production-server] Restored the parked build. Run the update again to get the new one.");
           // Its own try, deliberately: the reclaim is already done by the lines

--- a/production-server.js
+++ b/production-server.js
@@ -821,8 +821,24 @@ try {
     // failed" is not "there is a build there". An entry-less but non-empty
     // `.next-old` — an interrupted `rm -rf` in set_previous_build_aside leaves
     // exactly that — is worth nothing and must not strand a real build for ever.
+    //
+    // CLAIMED before it is destroyed, never probed and then deleted: those are
+    // two syscalls apart and a concurrent set_previous_build_aside can rename a
+    // real build into `.next-old` in between, which a check-then-delete would
+    // destroy. The claim is a rename to the private discard name — the same
+    // mutex the whole reclaim rests on — and what was claimed is asked again
+    // before anything is removed.
     if (!hasEntry(parkedDir)) {
-      fs.rmSync(parkedDir, { recursive: true, force: true });
+      if (renameQuiet(parkedDir, discardDir) === null) {
+        if (hasEntry(discardDir)) {
+          // It gained a build between the probe and the claim. Put it back and
+          // leave the orphan for the next run.
+          renameQuiet(discardDir, parkedDir);
+          console.warn(`[production-server] ${name} holds a build and .next-old gained one — leaving it for the next run.`);
+          continue;
+        }
+        fs.rmSync(discardDir, { recursive: true, force: true });
+      }
       if (renameQuiet(orphan, parkedDir) === null) {
         console.warn(`[production-server] Adopted a build left behind by an interrupted reclaim (${name}).`);
       } else {

--- a/scripts/postbuild.sh
+++ b/scripts/postbuild.sh
@@ -122,7 +122,13 @@ SDIR="$(dirname "$SRVJS")"
 # refuse a parked entry on its own (that is what its `-prune` is for), and in
 # the nested layout the copy lands beside the entry rather than at the top of
 # the standalone tree, so both places are swept.
-for swept in "$STANDALONE"/.next-old* "$SDIR"/.next-old*; do
+# `.next-claim*` and `.next-discard.*` beside `.next-old*`: the atomic build
+# reclaim (TASK-729) moves the parked tree through those two names, and a build
+# that happened to run while one of them existed would trace it in exactly the
+# way it traces `.next-old`.
+for swept in "$STANDALONE"/.next-old* "$SDIR"/.next-old* \
+             "$STANDALONE"/.next-claim* "$SDIR"/.next-claim* \
+             "$STANDALONE"/.next-discard.* "$SDIR"/.next-discard.*; do
   [ -e "$swept" ] || continue
   echo "postbuild: removing $swept — a parked previous build was traced into the standalone output" >&2
   rm -rf "$swept"

--- a/scripts/postbuild.sh
+++ b/scripts/postbuild.sh
@@ -127,7 +127,7 @@ SDIR="$(dirname "$SRVJS")"
 # that happened to run while one of them existed would trace it in exactly the
 # way it traces `.next-old`.
 for swept in "$STANDALONE"/.next-old* "$SDIR"/.next-old* \
-             "$STANDALONE"/.next-claim* "$SDIR"/.next-claim* \
+             "$STANDALONE"/.next-claim.* "$SDIR"/.next-claim.* \
              "$STANDALONE"/.next-discard.* "$SDIR"/.next-discard.*; do
   [ -e "$swept" ] || continue
   echo "postbuild: removing $swept — a parked previous build was traced into the standalone output" >&2

--- a/scripts/postbuild.sh
+++ b/scripts/postbuild.sh
@@ -102,8 +102,13 @@ if [ -f "$CANDIDATE" ] && [ ! -L "$CANDIDATE" ]; then
 elif [ -f "$STANDALONE/server.js" ] && [ ! -L "$STANDALONE/server.js" ]; then
   SRVJS="$STANDALONE/server.js"
 else
+  # Every parked-tree name is pruned, not just `.next-old*`: the atomic build
+  # reclaim (TASK-729) moves the tree through `.next-claim.*` and
+  # `.next-discard.*`, and a build that traced one of those would otherwise let
+  # this `find` pick the PARKED build's entry — the exact defect the `.next-old*`
+  # prune exists for.
   SRVJS="$(find "$STANDALONE" -maxdepth 3 \
-    \( -name node_modules -o -name '.next-old*' \) -prune \
+    \( -name node_modules -o -name '.next-old*' -o -name '.next-claim.*' -o -name '.next-discard.*' \) -prune \
     -o -type f -name server.js -print -quit)"
   [ -n "$SRVJS" ] || fail "no server.js under $STANDALONE — this build produced nothing the dashboard can load"
 fi
@@ -122,7 +127,7 @@ SDIR="$(dirname "$SRVJS")"
 # refuse a parked entry on its own (that is what its `-prune` is for), and in
 # the nested layout the copy lands beside the entry rather than at the top of
 # the standalone tree, so both places are swept.
-# `.next-claim*` and `.next-discard.*` beside `.next-old*`: the atomic build
+# `.next-claim.*` and `.next-discard.*` beside `.next-old*`: the atomic build
 # reclaim (TASK-729) moves the parked tree through those two names, and a build
 # that happened to run while one of them existed would trace it in exactly the
 # way it traces `.next-old`.

--- a/src/tests/unit/build-reclaim-race.test.ts
+++ b/src/tests/unit/build-reclaim-race.test.ts
@@ -1,0 +1,283 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * TASK-729 — two reclaimers of the same two directories, and no lock between
+ * them.
+ *
+ * `install.sh`'s `promote_parked_build` and the boot-time block in
+ * `production-server.js` both put a build parked by a killed rebuild back, and
+ * both used to run the same non-atomic pair: `rm -rf .next`, then
+ * `mv .next-old .next`. They fire on the same fact — no `.next/standalone/
+ * server.js`, but a `.next-old/standalone/server.js` — and nothing stops them
+ * running together: `do_rebuild` stops clawbox-setup and calls
+ * `promote_parked_build` while a gateway (re)start can pull the web server
+ * straight back up.
+ *
+ * Whichever arrived second destroyed what the first had just restored: its
+ * `rm -rf .next` deleted the build, and its own rename then failed into a
+ * best-effort catch. The box was left with NEITHER tree — and if the build that
+ * follows is OOM-killed, `restore_previous_build` finds nothing to fall back
+ * on and the dashboard stays down. That is the exact outcome the park exists to
+ * prevent (#632).
+ *
+ * The fix is not a second advisory check but an ATOMIC CLAIM: rename the parked
+ * tree to a private name FIRST — a rename has exactly one winner — and destroy
+ * only private names afterwards. The loser's rename fails and it returns having
+ * touched nothing.
+ *
+ * Both implementations are driven here, in one file, because the invariant is
+ * shared and two files would let them drift.
+ */
+
+// Starts a real bash process for the shell half; vitest's 5 s default is not
+// enough on a loaded runner. See src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+const REPO = process.cwd();
+const INSTALL_SH_PATH = path.join(REPO, "install.sh");
+const INSTALL_SH = fs.readFileSync(INSTALL_SH_PATH, "utf-8");
+const SERVER_JS = fs.readFileSync(path.join(REPO, "production-server.js"), "utf-8");
+const NL = String.fromCharCode(10);
+
+function writeBuild(dir: string, buildId: string): void {
+  fs.mkdirSync(path.join(dir, "standalone"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "BUILD_ID"), `${buildId}${NL}`, "utf-8");
+  fs.writeFileSync(path.join(dir, "standalone", "server.js"), "// server\n", "utf-8");
+}
+
+const buildIdAt = (dir: string): string | null => {
+  const p = path.join(dir, "BUILD_ID");
+  return fs.existsSync(p) ? fs.readFileSync(p, "utf-8").trim() : null;
+};
+
+let projectDir: string;
+
+beforeEach(() => {
+  projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "reclaim-race-"));
+});
+
+afterEach(() => {
+  fs.rmSync(projectDir, { recursive: true, force: true });
+});
+
+describe("install.sh's reclaim cannot destroy a build the other reclaimer restored", () => {
+  /**
+   * Run the shipped `promote_parked_build` with the OTHER reclaimer wedged into
+   * it, deterministically.
+   *
+   * `rm` and `mv` are shell functions here, and the first of them to be called
+   * runs the other reclaimer's whole sequence before handing on to the real
+   * command. That is the interleave, made repeatable: whatever the function
+   * reaches for first, it reaches for it one instant after the other reclaimer
+   * has finished.
+   */
+  function runInterleaved() {
+    const script = [
+      // install.sh's own options: a laxer harness would certify a script the
+      // shipped one is not.
+      "set -euo pipefail",
+      `PROJECT_DIR="${projectDir}"`,
+      "wedged=0",
+      // The other reclaimer, as production-server.js ran it before this fix:
+      // destroy .next, then rename the parked tree over it.
+      "other_reclaimer() {",
+      '  command rm -rf "$PROJECT_DIR/.next"',
+      '  command mv "$PROJECT_DIR/.next-old" "$PROJECT_DIR/.next" 2>/dev/null || true',
+      '  printf other >> "$PROJECT_DIR/wedged.log"',
+      "}",
+      "wedge() { if [ \"$wedged\" = 0 ]; then wedged=1; other_reclaimer; fi; }",
+      'rm() { wedge; command rm "$@"; }',
+      'mv() { wedge; command mv "$@"; }',
+      `sed -n '/^build_entry_present() {/,/^}/p' "$1" > "${projectDir}/fns.sh"`,
+      `sed -n '/^promote_parked_build() {/,/^}/p' "$1" >> "${projectDir}/fns.sh"`,
+      `. "${projectDir}/fns.sh"`,
+      'promote_parked_build "$PROJECT_DIR/.next" "$PROJECT_DIR/.next-old" 2>&1',
+    ].join(NL);
+    let code = 0;
+    let out: string;
+    try {
+      out = execFileSync("bash", ["-c", script, "bash", INSTALL_SH_PATH], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (e: unknown) {
+      const err = e as { status?: number; stdout?: string; stderr?: string };
+      code = err.status ?? 1;
+      out = `${err.stdout ?? ""}${err.stderr ?? ""}`;
+    }
+    return { code, out };
+  }
+
+  it("leaves the box with a build when the other reclaimer wins the race", () => {
+    // The state both reclaimers fire on: a rebuild was killed, so `.next` has
+    // no entry and `.next-old` holds the box's only build.
+    writeBuild(path.join(projectDir, ".next-old"), "the-only-build");
+    fs.mkdirSync(path.join(projectDir, ".next"), { recursive: true });
+
+    const r = runInterleaved();
+
+    expect(fs.readFileSync(path.join(projectDir, "wedged.log"), "utf-8"), "the interleave must have fired")
+      .toBe("other");
+    expect(
+      buildIdAt(path.join(projectDir, ".next")),
+      "the box was left with NEITHER tree — the outcome the park exists to prevent",
+    ).toBe("the-only-build");
+    expect(fs.existsSync(path.join(projectDir, ".next", "standalone", "server.js"))).toBe(true);
+    expect(r.code).toBe(0);
+  });
+
+  it("destroys nothing at all when it loses the claim", () => {
+    // The loser's whole contract: it may return empty-handed, it may not take
+    // the winner's build with it.
+    writeBuild(path.join(projectDir, ".next-old"), "the-only-build");
+    fs.mkdirSync(path.join(projectDir, ".next"), { recursive: true });
+
+    runInterleaved();
+
+    // Exactly one live build on disk, and no stray claim or discard left over.
+    const strays = fs
+      .readdirSync(projectDir)
+      .filter((e) => e.startsWith(".next-claim") || e.startsWith(".next-discard"));
+    expect(strays).toEqual([]);
+  });
+
+  it("finishes a claim a kill interrupted, instead of leaving the build hidden", () => {
+    // The cost of claiming under a private name: a SIGKILL between the claim
+    // and the placement leaves the box's only build under a name nothing else
+    // looks at. The next reclaim has to fold it back.
+    writeBuild(path.join(projectDir, ".next-claim"), "the-interrupted-build");
+
+    const script = [
+      "set -euo pipefail",
+      `PROJECT_DIR="${projectDir}"`,
+      `sed -n '/^build_entry_present() {/,/^}/p' "$1" > "${projectDir}/fns.sh"`,
+      `sed -n '/^promote_parked_build() {/,/^}/p' "$1" >> "${projectDir}/fns.sh"`,
+      `. "${projectDir}/fns.sh"`,
+      'promote_parked_build "$PROJECT_DIR/.next" "$PROJECT_DIR/.next-old" 2>&1',
+    ].join(NL);
+    execFileSync("bash", ["-c", script, "bash", INSTALL_SH_PATH], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+
+    expect(buildIdAt(path.join(projectDir, ".next"))).toBe("the-interrupted-build");
+    expect(fs.existsSync(path.join(projectDir, ".next-claim"))).toBe(false);
+  });
+
+  it("claims before it destroys, in the text as well as in the behaviour", () => {
+    // The property in one line, so a refactor that keeps the tests green by
+    // accident cannot lose it: nothing destructive may precede the claim.
+    const start = INSTALL_SH.indexOf("promote_parked_build() {");
+    const body = INSTALL_SH.slice(start, INSTALL_SH.indexOf(`${NL}}`, start));
+    const claim = body.indexOf('mv -T "$kept_dir"');
+    const destroy = body.search(/\brm -rf "\$build_dir"|\bmv -T "\$build_dir"/);
+    expect(claim, "the parked tree must be claimed with a rename").toBeGreaterThan(-1);
+    expect(destroy).toBeGreaterThan(claim);
+  });
+});
+
+describe("production-server.js's reclaim cannot destroy a build install.sh restored", () => {
+  const START = "// A build parked by an update that was killed OUTRIGHT";
+  const END = 'require("./.next/standalone/server.js");';
+
+  function reclaimBlock(): string {
+    const from = SERVER_JS.indexOf(START);
+    const to = SERVER_JS.indexOf(END);
+    if (from < 0) throw new Error("the parked-build reclaim block is gone from production-server.js");
+    return SERVER_JS.slice(from, to).trim();
+  }
+
+  /**
+   * The same wedge, on the Node side: the first `renameSync` or `rmSync` the
+   * block performs runs install.sh's old sequence first.
+   */
+  function runInterleaved(dir: string) {
+    const warnings: string[] = [];
+    let wedged = false;
+    const wedge = () => {
+      if (wedged) return;
+      wedged = true;
+      fs.rmSync(path.join(dir, ".next"), { recursive: true, force: true });
+      try {
+        fs.renameSync(path.join(dir, ".next-old"), path.join(dir, ".next"));
+      } catch { /* the other reclaimer's own best-effort catch */ }
+    };
+    const patched = {
+      ...fs,
+      renameSync: (from: string, to: string) => { wedge(); return fs.renameSync(from, to); },
+      rmSync: (target: string, opts?: object) => { wedge(); return fs.rmSync(target, opts as never); },
+    };
+    try {
+      new Function("fs", "path", "__dirname", "console", reclaimBlock())(
+        patched,
+        path,
+        dir,
+        { warn: (...args: unknown[]) => warnings.push(args.join(" ")) },
+      );
+    } catch (err) {
+      return { warnings, threw: err, wedged };
+    }
+    return { warnings, threw: null as unknown, wedged };
+  }
+
+  it("leaves the box with a build when the other reclaimer wins the race", () => {
+    writeBuild(path.join(projectDir, ".next-old"), "the-only-build");
+    fs.mkdirSync(path.join(projectDir, ".next"), { recursive: true });
+
+    const r = runInterleaved(projectDir);
+
+    expect(r.wedged, "the interleave must have fired").toBe(true);
+    expect(
+      buildIdAt(path.join(projectDir, ".next")),
+      "the box was left with NEITHER tree — the outcome the park exists to prevent",
+    ).toBe("the-only-build");
+    expect(r.threw).toBeNull();
+  });
+
+  it("folds an interrupted claim back and places it", () => {
+    writeBuild(path.join(projectDir, ".next-claim"), "the-interrupted-build");
+
+    const warnings: string[] = [];
+    new Function("fs", "path", "__dirname", "console", reclaimBlock())(
+      fs,
+      path,
+      projectDir,
+      { warn: (...args: unknown[]) => warnings.push(args.join(" ")) },
+    );
+
+    expect(buildIdAt(path.join(projectDir, ".next"))).toBe("the-interrupted-build");
+    expect(fs.existsSync(path.join(projectDir, ".next-claim"))).toBe(false);
+  });
+
+  it("claims before it destroys, in the text as well as in the behaviour", () => {
+    const block = reclaimBlock();
+    const claim = block.indexOf("renameQuiet(parkedDir, claimDir)");
+    const destroy = block.search(/rmSync\(nextDir|renameQuiet\(nextDir, discardDir\)/);
+    expect(claim, "the parked tree must be claimed with a rename").toBeGreaterThan(-1);
+    expect(destroy).toBeGreaterThan(claim);
+    // And `.next` itself is never destroyed outright any more — it is moved to
+    // a private name, so a mistaken judgement about it can be undone.
+    expect(block).not.toMatch(/rmSync\(\s*path\.join\(__dirname, "\.next"\)/);
+  });
+});
+
+describe("the transient names survive the update's own git clean", () => {
+  it("both are gitignored, like .next-old", () => {
+    // An update runs `git clean -fd` over this tree. A claim swept away
+    // mid-flight is a box with no build — the same reason `.next-old/` has an
+    // entry.
+    const ignore = fs.readFileSync(path.join(REPO, ".gitignore"), "utf-8");
+    expect(ignore).toMatch(/^\.next-claim\/$/m);
+    expect(ignore).toMatch(/^\.next-discard\.\*\/$/m);
+  });
+
+  it("postbuild sweeps them out of the standalone output like .next-old", () => {
+    // Next's instrumentation trace copies the whole project root into the
+    // standalone output, which is why `.next-old*` is swept there. A transient
+    // that happened to exist during a build would be copied the same way.
+    const postbuild = fs.readFileSync(path.join(REPO, "scripts", "postbuild.sh"), "utf-8");
+    expect(postbuild).toMatch(/\.next-claim\*/);
+    expect(postbuild).toMatch(/\.next-discard\.\*/);
+  });
+});

--- a/src/tests/unit/build-reclaim-race.test.ts
+++ b/src/tests/unit/build-reclaim-race.test.ts
@@ -242,6 +242,48 @@ describe("install.sh's reclaim cannot destroy a build the other reclaimer restor
     expect(buildIdAt(path.join(projectDir, ".next"))).toBe("the-stranded-build");
   });
 
+  it("claims an entry-less .next-old before destroying it, in both implementations", () => {
+    // The probe and the delete are two syscalls apart, and a concurrent
+    // set_previous_build_aside can rename a real build in between — which a
+    // check-then-delete would destroy. The claim is the same rename mutex the
+    // rest of the reclaim rests on, and what was claimed is asked again.
+    const DRAIN = INSTALL_SH.slice(
+      INSTALL_SH.indexOf("drain_build_transients() {"),
+      INSTALL_SH.indexOf(`${NL}}`, INSTALL_SH.indexOf("drain_build_transients() {")),
+    );
+    const probe = DRAIN.indexOf('if ! build_entry_present "$kept_dir"');
+    const claim = DRAIN.indexOf('mv -T "$kept_dir" "$aside"');
+    const destroy = DRAIN.indexOf('rm -rf "$aside"');
+    expect(probe).toBeGreaterThan(-1);
+    expect(claim).toBeGreaterThan(probe);
+    expect(destroy).toBeGreaterThan(claim);
+    expect(DRAIN).toContain('if build_entry_present "$aside"');
+
+    const block = SERVER_JS.slice(SERVER_JS.indexOf("// A build parked by an update that was killed OUTRIGHT"));
+    const jsClaim = block.indexOf("renameQuiet(parkedDir, discardDir)");
+    const jsDestroy = block.indexOf("fs.rmSync(discardDir, { recursive: true, force: true });");
+    expect(jsClaim).toBeGreaterThan(-1);
+    expect(jsDestroy).toBeGreaterThan(jsClaim);
+    expect(block).toContain("if (hasEntry(discardDir))");
+  });
+
+  it("puts an entry-less .next-old back when it gained a build under the claim", () => {
+    // The revalidation's whole point: the tree that was empty when it was
+    // probed is a build by the time it is claimed, so it goes back and the
+    // orphan waits for the next run rather than displacing it.
+    writeBuild(path.join(projectDir, ".next-claim.999994"), "the-orphan-build");
+    fs.mkdirSync(path.join(projectDir, ".next-old"), { recursive: true });
+
+    const out = runReclaimAlone();
+
+    // Nothing was destroyed and the orphan is still there for the next run, or
+    // it was adopted — either is correct; what must never happen is a build
+    // disappearing.
+    const survivors = fs.readdirSync(projectDir).filter((e) => e.startsWith(".next"));
+    expect(survivors.length).toBeGreaterThan(0);
+    expect(out).not.toMatch(/Warning: could not adopt/);
+  });
+
   it("says a move-aside that FAILED is not a lost race", () => {
     // Discarded, an EACCES/EROFS on `.next` left it in place, made the
     // placement fail ENOTEMPTY, and was reported as "another reclaim took our

--- a/src/tests/unit/build-reclaim-race.test.ts
+++ b/src/tests/unit/build-reclaim-race.test.ts
@@ -228,6 +228,35 @@ describe("install.sh's reclaim cannot destroy a build the other reclaimer restor
     ).toBe("the-only-current-build");
   });
 
+  it("adopts an orphan over an entry-less .next-old rather than calling it a duplicate", () => {
+    // A rename onto a non-empty destination fails whatever is in it, so "it
+    // failed" is not "there is a build there". An interrupted `rm -rf` in
+    // set_previous_build_aside leaves exactly an entry-less but non-empty
+    // `.next-old`, and reading that as a duplicate stranded the real build for
+    // ever.
+    writeBuild(path.join(projectDir, ".next-claim.999995"), "the-stranded-build");
+    fs.mkdirSync(path.join(projectDir, ".next-old", "leftovers"), { recursive: true });
+
+    runReclaimAlone();
+
+    expect(buildIdAt(path.join(projectDir, ".next"))).toBe("the-stranded-build");
+  });
+
+  it("says a move-aside that FAILED is not a lost race", () => {
+    // Discarded, an EACCES/EROFS on `.next` left it in place, made the
+    // placement fail ENOTEMPTY, and was reported as "another reclaim took our
+    // claim" — a false cause on a box about to crash-loop for want of an entry.
+    const PROMOTE = INSTALL_SH.slice(
+      INSTALL_SH.indexOf("promote_parked_build() {"),
+      INSTALL_SH.indexOf(`${NL}}`, INSTALL_SH.indexOf("promote_parked_build() {")),
+    );
+    expect(PROMOTE).toMatch(/if ! mv -T "\$build_dir" "\$discard_dir"[^\n]*\[ -e "\$build_dir" \]/);
+    expect(PROMOTE).toContain("stays claimed at");
+    const block = SERVER_JS.slice(SERVER_JS.indexOf("// A build parked by an update that was killed OUTRIGHT"));
+    expect(block).toContain("const asideErr = renameQuiet(nextDir, discardDir);");
+    expect(block).toContain("Could not move .next aside");
+  });
+
   it("claims before it destroys, in the text as well as in the behaviour", () => {
     // The property in one line, so a refactor that keeps the tests green by
     // accident cannot lose it: nothing destructive may precede the claim.
@@ -333,6 +362,17 @@ describe("the transient names survive the update's own git clean", () => {
     const ignore = fs.readFileSync(path.join(REPO, ".gitignore"), "utf-8");
     expect(ignore).toMatch(/^\.next-claim\.\*\/$/m);
     expect(ignore).toMatch(/^\.next-discard\.\*\/$/m);
+  });
+
+  it("postbuild's entry search prunes them, not only .next-old", () => {
+    // The fallback `find` is what picks the standalone entry when the expected
+    // path is absent. Pruning only `.next-old*` let it choose `server.js`
+    // inside a traced claim or discard — the exact defect the `.next-old*`
+    // prune exists for (#632).
+    const postbuild = fs.readFileSync(path.join(REPO, "scripts", "postbuild.sh"), "utf-8");
+    const find = postbuild.slice(postbuild.indexOf('find "$STANDALONE" -maxdepth 3'));
+    expect(find.slice(0, 300)).toContain("'.next-claim.*'");
+    expect(find.slice(0, 300)).toContain("'.next-discard.*'");
   });
 
   it("postbuild sweeps them out of the standalone output like .next-old", () => {

--- a/src/tests/unit/build-reclaim-race.test.ts
+++ b/src/tests/unit/build-reclaim-race.test.ts
@@ -93,6 +93,7 @@ describe("install.sh's reclaim cannot destroy a build the other reclaimer restor
       'rm() { wedge; command rm "$@"; }',
       'mv() { wedge; command mv "$@"; }',
       `sed -n '/^build_entry_present() {/,/^}/p' "$1" > "${projectDir}/fns.sh"`,
+      `sed -n '/^drain_build_transients() {/,/^}/p' "$1" >> "${projectDir}/fns.sh"`,
       `sed -n '/^promote_parked_build() {/,/^}/p' "$1" >> "${projectDir}/fns.sh"`,
       `. "${projectDir}/fns.sh"`,
       'promote_parked_build "$PROJECT_DIR/.next" "$PROJECT_DIR/.next-old" 2>&1',
@@ -145,16 +146,34 @@ describe("install.sh's reclaim cannot destroy a build the other reclaimer restor
     expect(strays).toEqual([]);
   });
 
+  /** The shipped reclaim, with nothing wedged into it. */
+  function runReclaimAlone() {
+    const script = [
+      "set -euo pipefail",
+      `PROJECT_DIR="${projectDir}"`,
+      `sed -n '/^build_entry_present() {/,/^}/p' "$1" > "${projectDir}/fns.sh"`,
+      `sed -n '/^drain_build_transients() {/,/^}/p' "$1" >> "${projectDir}/fns.sh"`,
+      `sed -n '/^promote_parked_build() {/,/^}/p' "$1" >> "${projectDir}/fns.sh"`,
+      `. "${projectDir}/fns.sh"`,
+      'promote_parked_build "$PROJECT_DIR/.next" "$PROJECT_DIR/.next-old" 2>&1',
+    ].join(NL);
+    return execFileSync("bash", ["-c", script, "bash", INSTALL_SH_PATH], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  }
+
   it("finishes a claim a kill interrupted, instead of leaving the build hidden", () => {
     // The cost of claiming under a private name: a SIGKILL between the claim
     // and the placement leaves the box's only build under a name nothing else
     // looks at. The next reclaim has to fold it back.
-    writeBuild(path.join(projectDir, ".next-claim"), "the-interrupted-build");
+    writeBuild(path.join(projectDir, ".next-claim.999999"), "the-interrupted-build");
 
     const script = [
       "set -euo pipefail",
       `PROJECT_DIR="${projectDir}"`,
       `sed -n '/^build_entry_present() {/,/^}/p' "$1" > "${projectDir}/fns.sh"`,
+      `sed -n '/^drain_build_transients() {/,/^}/p' "$1" >> "${projectDir}/fns.sh"`,
       `sed -n '/^promote_parked_build() {/,/^}/p' "$1" >> "${projectDir}/fns.sh"`,
       `. "${projectDir}/fns.sh"`,
       'promote_parked_build "$PROJECT_DIR/.next" "$PROJECT_DIR/.next-old" 2>&1',
@@ -162,7 +181,51 @@ describe("install.sh's reclaim cannot destroy a build the other reclaimer restor
     execFileSync("bash", ["-c", script, "bash", INSTALL_SH_PATH], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
 
     expect(buildIdAt(path.join(projectDir, ".next"))).toBe("the-interrupted-build");
-    expect(fs.existsSync(path.join(projectDir, ".next-claim"))).toBe(false);
+    expect(fs.existsSync(path.join(projectDir, ".next-claim.999999"))).toBe(false);
+  });
+
+  it("adopts a build stranded under a discard name by a kill", () => {
+    // The cost of moving `.next` aside instead of deleting it: a process killed
+    // between the move-aside and the placement can leave the box's ONLY build
+    // under `.next-discard.<pid>`, which nothing used to read. Same brick,
+    // new name.
+    writeBuild(path.join(projectDir, ".next-discard.999998"), "the-stranded-build");
+
+    runReclaimAlone();
+
+    expect(buildIdAt(path.join(projectDir, ".next"))).toBe("the-stranded-build");
+    expect(fs.existsSync(path.join(projectDir, ".next-discard.999998"))).toBe(false);
+  });
+
+  it("throws away a discard that holds no build, rather than hoarding it", () => {
+    // A discard is entry-less by construction — it is the `.next` both
+    // reclaimers only ever touch when it HAS no entry — so an orphaned one is
+    // junk. Left on disk it is traced into every later standalone build and
+    // eats the `avail < need*2` headroom that decides whether the next park
+    // keeps a fallback at all.
+    fs.mkdirSync(path.join(projectDir, ".next-discard.999997", "standalone"), { recursive: true });
+    writeBuild(path.join(projectDir, ".next-old"), "the-only-build");
+
+    runReclaimAlone();
+
+    expect(fs.existsSync(path.join(projectDir, ".next-discard.999997"))).toBe(false);
+    expect(buildIdAt(path.join(projectDir, ".next"))).toBe("the-only-build");
+  });
+
+  it("is not latched by a stray claim beside an existing parked build", () => {
+    // With a SHARED claim destination this state was stable and fatal: the
+    // fold-back failed ENOTEMPTY, the claim failed ENOTEMPTY, and both
+    // reclaimers were disabled for ever — precisely in the window where they
+    // are needed. Private destinations make it unrepresentable.
+    writeBuild(path.join(projectDir, ".next-claim.999996"), "a-stray-older-build");
+    writeBuild(path.join(projectDir, ".next-old"), "the-only-current-build");
+
+    runReclaimAlone();
+
+    expect(
+      buildIdAt(path.join(projectDir, ".next")),
+      "the reclaim must still place the current build",
+    ).toBe("the-only-current-build");
   });
 
   it("claims before it destroys, in the text as well as in the behaviour", () => {
@@ -170,7 +233,7 @@ describe("install.sh's reclaim cannot destroy a build the other reclaimer restor
     // accident cannot lose it: nothing destructive may precede the claim.
     const start = INSTALL_SH.indexOf("promote_parked_build() {");
     const body = INSTALL_SH.slice(start, INSTALL_SH.indexOf(`${NL}}`, start));
-    const claim = body.indexOf('mv -T "$kept_dir"');
+    const claim = body.indexOf('mv -T "$kept_dir" "$claim_dir"');
     const destroy = body.search(/\brm -rf "\$build_dir"|\bmv -T "\$build_dir"/);
     expect(claim, "the parked tree must be claimed with a rename").toBeGreaterThan(-1);
     expect(destroy).toBeGreaterThan(claim);
@@ -236,7 +299,7 @@ describe("production-server.js's reclaim cannot destroy a build install.sh resto
   });
 
   it("folds an interrupted claim back and places it", () => {
-    writeBuild(path.join(projectDir, ".next-claim"), "the-interrupted-build");
+    writeBuild(path.join(projectDir, ".next-claim.999999"), "the-interrupted-build");
 
     const warnings: string[] = [];
     new Function("fs", "path", "__dirname", "console", reclaimBlock())(
@@ -247,7 +310,7 @@ describe("production-server.js's reclaim cannot destroy a build install.sh resto
     );
 
     expect(buildIdAt(path.join(projectDir, ".next"))).toBe("the-interrupted-build");
-    expect(fs.existsSync(path.join(projectDir, ".next-claim"))).toBe(false);
+    expect(fs.existsSync(path.join(projectDir, ".next-claim.999999"))).toBe(false);
   });
 
   it("claims before it destroys, in the text as well as in the behaviour", () => {
@@ -268,7 +331,7 @@ describe("the transient names survive the update's own git clean", () => {
     // mid-flight is a box with no build — the same reason `.next-old/` has an
     // entry.
     const ignore = fs.readFileSync(path.join(REPO, ".gitignore"), "utf-8");
-    expect(ignore).toMatch(/^\.next-claim\/$/m);
+    expect(ignore).toMatch(/^\.next-claim\.\*\/$/m);
     expect(ignore).toMatch(/^\.next-discard\.\*\/$/m);
   });
 
@@ -277,7 +340,7 @@ describe("the transient names survive the update's own git clean", () => {
     // standalone output, which is why `.next-old*` is swept there. A transient
     // that happened to exist during a build would be copied the same way.
     const postbuild = fs.readFileSync(path.join(REPO, "scripts", "postbuild.sh"), "utf-8");
-    expect(postbuild).toMatch(/\.next-claim\*/);
+    expect(postbuild).toMatch(/\.next-claim\.\*/);
     expect(postbuild).toMatch(/\.next-discard\.\*/);
   });
 });

--- a/src/tests/unit/install-rebuild-build-verify.test.ts
+++ b/src/tests/unit/install-rebuild-build-verify.test.ts
@@ -368,6 +368,9 @@ function run(scenario: Scenario = {}): Run {
     shellFunctions(
       "build_entry_present",
       "verify_build_present",
+      // The drain promote_parked_build calls before it decides anything
+      // (TASK-729). Unsourced it is a 127 inside do_rebuild's first statement.
+      "drain_build_transients",
       "promote_parked_build",
       "set_previous_build_aside",
       "restore_previous_build",


### PR DESCRIPTION
**TASK-729** — two unsynchronised reclaimers of the parked build can leave a box with no build at all.

## Symptom

`install.sh`'s `promote_parked_build` and the boot-time block in `production-server.js` both put a build parked by a killed rebuild back. They fire on the same single fact — no `.next/standalone/server.js`, but a `.next-old/standalone/server.js` — they can run at the same time, and there is no lock between them. Both ran the same non-atomic pair:

```
rm -rf .next
mv .next-old .next
```

Whichever arrived second deleted the build the first had just restored, and its own rename then failed into a best-effort catch. The box ends with **neither tree**; if the build that follows is OOM-killed, `restore_previous_build` has nothing to fall back on and the dashboard stays down — the exact outcome the park exists to prevent (#632).

The window is two renames wide, which is why this is medium and not high. The consequence is a bricked dashboard.

## Fix — an atomic claim, not a second advisory check

A rename has exactly one winner, so the claim goes first and nothing is destroyed before it:

1. `rename(.next-old → .next-claim.<pid>)` — the claim. The loser gets a failed rename and returns having touched nothing. The DESTINATION is private: the mutex is the atomic rename of the source, so sharing a destination buys nothing for exclusion and costs a latch (see below).
2. `rename(.next → .next-discard.<pid>)` — the outgoing tree is moved aside, not deleted, so even a judgement about it that was raced can be undone.
3. `rename(.next-claim → .next)` — the build is placed.
4. `rm -rf .next-discard.<pid>` — and only now, and only a private name.

**Every destroy is of a private name.** That is the property, and it is what makes the interleave harmless rather than merely unlikely.

The cost of claiming under private names is that a kill between steps 1 and 3 leaves the box's only build under a name nothing looks at — under EITHER name, since step 2 can move a good `.next` into the discard. So both reclaimers drain both globs before they decide anything: an orphan with no build entry is junk and goes (a discard is entry-less by construction, so a live one loses nothing and its owner already copes with a discard that is gone); an orphan WITH a build is adopted under the parked name by a rename — safe against a live owner, whose placement then fails and which stands down; and an orphan that would displace a parked build is reported and left, never destroyed, because nothing here can prove which of the two is wanted and the next park clears the way for it.

Two brick states the review reproduced against the first version of this fix, both now closed:

- `.next-discard.<pid>` had no fold-back at all, and an interleave ending in a kill left the only build inside it — spared by `git clean -fd` because this PR gitignored it, traced into every later standalone build, and eating the `avail < need*2` headroom that decides whether the next park keeps a fallback.
- the claim destination was SHARED, and a stray `.next-claim` beside an existing `.next-old` made the fold-back fail ENOTEMPTY and then every claim fail ENOTEMPTY, on both reclaimers, permanently — stable, and fatal precisely in the window where the reclaim is needed.

A claim that fails for a reason other than "someone else took it" is reported as itself: the tree still being there is how the two are told apart, and calling a read-only rootfs "another reclaim got there first" would be a false cause in the one line an operator triages from. On the Node side that is the errno (`ENOENT` = a lost race, anything else = the existing "Could not reclaim a parked build" sentence).

`mv -T` throughout on the shell side, because `mv a b` with `b` an existing directory moves `a` INSIDE it.

## Sibling call sites

- `promote_parked_build`'s second caller (`install.sh:2656`, the argument-less form) takes the same path — the defaults are the same two directories.
- `.gitignore`: both transient names are ignored, for the same reason `.next-old/` is — an update runs `git clean -fd` over this tree, and a claim swept away mid-flight is a box with no build.
- `scripts/postbuild.sh` sweeps `.next-claim*` and `.next-discard.*` out of the standalone output beside `.next-old*`: Next's instrumentation trace copies the whole project root, so a transient that happened to exist during a build would be traced the same way.
- `set_previous_build_aside` / `restore_previous_build` / the `.rebuild-pid` owner stamp are unchanged. The live-rebuild refusal in `production-server.js` still runs BEFORE anything is claimed, so a rebuild in flight is still left alone.

## RED → GREEN

`src/tests/unit/build-reclaim-race.test.ts` drives BOTH implementations with the other reclaimer wedged into them deterministically: the first `rm`/`mv` (shell) or `renameSync`/`rmSync` (Node) that the reclaim performs runs the other reclaimer's whole old sequence first, then hands on. RED on unmodified beta:

```
FAIL … install.sh's reclaim … > leaves the box with a build when the other reclaimer wins the race
AssertionError: the box was left with NEITHER tree — the outcome the park exists to prevent:
  expected null to be 'the-only-build'

FAIL … production-server.js's reclaim … > leaves the box with a build when the other reclaimer wins the race
AssertionError: the box was left with NEITHER tree — the outcome the park exists to prevent:
  expected null to be 'the-only-build'

FAIL … > finishes a claim a kill interrupted, instead of leaving the build hidden
FAIL … > adopts a build stranded under a discard name by a kill
FAIL … > throws away a discard that holds no build, rather than hoarding it
FAIL … > folds an interrupted claim back and places it
FAIL … > claims before it destroys, in the text as well as in the behaviour   (×2)
FAIL … > both are gitignored, like .next-old
FAIL … > postbuild sweeps them out of the standalone output like .next-old

 Test Files  1 failed (1)
      Tests  10 failed | 2 passed (12)
```

GREEN: `12 passed (12)`, and the neighbours — `install-rebuild-build-verify`, `production-server-parked-build`, `postbuild-*`, `install-free-memory-before-build`, `updater`, `tsconfig-excludes-data` — pass. Full `--project unit`: 702 files pass, the only failures being the known dev-PC `routes/telegram/status*` flakes, which fail on unmodified beta on this machine too and pass in isolation.

## Native mechanism

`rename(2)`'s atomicity is the mechanism, and it is the one already in use here — the change is to claim with it before destroying rather than after. Nothing in OpenClaw or Hermes owns a build directory; there is no harness API to leverage.

## Relationship to TASK-728

TASK-728 removes `clawbox-gateway.service`'s `Wants=clawbox-setup.service`, which is what routinely started the web server inside the rebuild window and so what routinely produced the interleave. That reduces the frequency to near zero; it does not close the case (the new unit reaches a box only in `post_update`, an operator can start the web server by hand, and `production-server.js` runs at every restart). The two PRs are independent and both touch `install.sh` and `production-server.js` in different places.

## Unproven

No device leg: reproducing this on hardware means racing two reclaimers on a real box, which needs a killed rebuild and a concurrent web-server start — a mutation a read-only lane may not cause. The failure and the fix are both reproduced deterministically against the shipped code in the test above.

Reviewed before this PR was opened: 3 HIGH / 5 MEDIUM / 5 LOW, with the two HIGH brick states reproduced against this branch's own code. The rework above is the answer, and three new cases pin it — a build stranded under a discard name is placed, an entry-less discard is thrown away, and a stray claim beside a parked build no longer stops the reclaim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery during interrupted or concurrent deployments.
  * Preserved active and competing builds during recovery, reducing the risk of destructive replacement.
  * Cleaned up leftover temporary build directories and improved post-build output handling.

* **Tests**
  * Added coverage for concurrent recovery, interrupted builds, cleanup, and post-build output handling.

* **Chores**
  * Excluded temporary build directories from version-control cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->