### PR TITLE
fix: decide voice-route ownership by the stamp, not the current proxy url

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -1542,8 +1542,10 @@ def _url_host(_url):
 # install.sh's CLAWBOX_AI_API_KEY branch provisions a RAW DeepSeek key at
 # api.deepseek.com, and admitting that host would make a genuine third party
 # "not foreign". Here that is already true without a test of its own — every
-# reader of this set (`_is_our_image_row`, `_is_foreign`) sits inside the
-# `claw_` gate below, so on a raw-DeepSeek box the set is never consulted.
+# reader of this set (`_is_our_image_row`, `_is_foreign`, `_clawai_host_is_ours`)
+# sits inside the `claw_` gate below — the speech migration through
+# `_clawai_openai_route_is_ours`, which is only set there — so on a raw-DeepSeek
+# box the set is never consulted.
 # clawboxProxyHosts() in src/app/setup-api/ai-models/configure/route.ts DOES
 # test it, because its call site is not gated; the two therefore agree on
 # every box. If a reader of this set is ever moved ABOVE that gate, the
@@ -1860,6 +1862,27 @@ def _same_endpoint(_a, _b):
     return _without_one_trailing_slash(_a) == _without_one_trailing_slash(_b)
 
 
+def _clawai_host_is_ours(_url):
+    """Does this address name a host CLAWBOX ITSELF has written?
+
+    The same `_clawbox_proxy_hosts` the image row's ownership test uses — the
+    live proxy (so a staging box names its staging host) plus the retired ones —
+    rather than a second list, so "is this row mine to repair" and "is this
+    speech route mine" cannot drift into two answers.
+
+    Host, not full address, and deliberately: the arms below that ask this one
+    are looking for a route of OURS that has MOVED, and a move is exactly the
+    case an equality test cannot see. The arms that need the precise address
+    still ask `_same_endpoint`.
+
+    Same gate caveat as the set it reads: every caller must sit inside the
+    `claw_` test above it, or a raw-DeepSeek box would admit api.deepseek.com as
+    ours. This one does — the speech migration runs only when
+    `_clawai_openai_route_is_ours`, which is set inside that gate.
+    """
+    return _url_host(_url) in _clawbox_proxy_hosts if isinstance(_url, str) else False
+
+
 def _clawai_route_is_ours(_base_url, _api_key, _stamped, _proxy_base_url):
     """Is a configured media route OURS — ours to refresh, ours to take back?
 
@@ -1879,12 +1902,16 @@ def _clawai_route_is_ours(_base_url, _api_key, _stamped, _proxy_base_url):
       - our own stamp on the entry (`clawboxManaged`);
       - or a `claw_` portal token on it, which is what survives the proxy URL
         moving;
-      - or the endpoint names our proxy;
+      - or the endpoint names our proxy, or a host of ours it has moved from;
       - or the slot is genuinely EMPTY — no endpoint AND no key. An unset
         endpoint alone says nothing: the canonical way an owner uses the
         generic `openai` slot is their key with no URL at all.
 
-    A PRESENT FOREIGN CREDENTIAL BEATS ALL OF IT, and is asked first. This is
+    FOREIGN EVIDENCE OF EITHER KIND — their credential, or a host that is none
+    of ours — takes the slot back, and is asked first. Their key is the obvious
+    one and was the only one this asked for at first; but a speech server on the
+    LAN needs no key at all, so on the shape an owner is most likely to run, THE
+    ADDRESS IS THE ONLY THING THAT SPEAKS FOR IT. This is
     the only generic OpenAI-compatible speech slot OpenClaw has, so an owner who
     wants their own speech server has to edit the entry we already wrote — which
     `openclaw config set` does in place, leaving our `clawboxManaged` key behind
@@ -1906,6 +1933,14 @@ def _clawai_route_is_ours(_base_url, _api_key, _stamped, _proxy_base_url):
         # Somebody else's credential on the entry: only the endpoint can still
         # say it is ours, and a stale stamp cannot.
         return _has_endpoint and _same_endpoint(_base_url, _proxy_base_url)
+    if _has_endpoint and not _clawai_host_is_ours(_base_url):
+        # Somebody else's HOST. The same kind of evidence as somebody else's
+        # key, and the only kind a KEYLESS speech server ever produces — a
+        # Kokoro or a Piper on the LAN has no credential to speak for it, and
+        # asking only about the key claimed it, overwrote it, and deleted it on
+        # a downgrade. Retired addresses of ours are still ours, so this costs
+        # the repair below nothing.
+        return False
     if _stamped or _key.startswith("claw_"):
         return True
     if not _has_endpoint:
@@ -2155,9 +2190,17 @@ elif _clawai_openai_route_is_ours:
         # token at our own proxy with a model of their choosing, and that entry
         # is theirs (the suite pins it).
         #
-        # `_clawai_route_is_ours` is still asked, for its first arm: a stamped
-        # entry the owner has since re-aimed with a credential of their own is
-        # not ours to take, whatever the stamp says.
+        # `_clawai_route_is_ours` is still asked, for its FOREIGN arms: a
+        # stamped entry the owner has since re-aimed is not ours to take,
+        # whatever the stamp says — and it is re-aimed whether or not they put a
+        # credential of their own on it. The address has to still be one of
+        # OURS, because this is the one place in the file that destroys
+        # configuration.
+        #
+        # Residual, and unchanged either way by this rule: a FOREIGN credential
+        # sitting on our own CURRENT proxy address still reads as ours, so such
+        # an entry is still overwritten and, here, deleted. Narrowing that is a
+        # behaviour change beyond this card.
         if (
             _speech.get(CLAWBOX_SPEECH_MANAGED_KEY) is True
             and isinstance(_speech_base_url, str)

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -1860,6 +1860,46 @@ def _same_endpoint(_a, _b):
     return _without_one_trailing_slash(_a) == _without_one_trailing_slash(_b)
 
 
+def _clawai_route_is_ours(_base_url, _api_key, _stamped, _proxy_base_url):
+    """Is a configured media route OURS — ours to refresh, ours to take back?
+
+    THE CURRENT PROXY URL IS NOT THE QUESTION, and asking it as though it were
+    is what this replaces. `CLAWBOX_AI_PROXY_URL` is env-overridable and moves
+    between releases, so a box we linked under a previous address carries an
+    entry we wrote, pointing at an endpoint that has since been retired — and
+    an equality test reads that as the OWNER'S own speech server and skips it,
+    while the chat provider and the image row are repaired in the same boot.
+    The customer's transcription and voice stay pointed at a dead host and
+    nothing says so: the false-failure class.
+
+    Ownership needs POSITIVE evidence, in the same three shapes the Hermes half
+    of this uses (`hermesCloudRouteIsOurs`, src/lib/hermes-tts.ts — one rule,
+    two editions, and TASK-726 is this half of it):
+
+      - our own stamp on the entry (`clawboxManaged`);
+      - or a `claw_` portal token on it, which is what survives the proxy URL
+        moving;
+      - or the endpoint names our proxy;
+      - or the slot is genuinely EMPTY — no endpoint AND no key. An unset
+        endpoint alone says nothing: the canonical way an owner uses the
+        generic `openai` slot is their key with no URL at all.
+
+    The transcription block above deliberately does NOT use this: nothing it
+    writes carries a stamp or a credential, so its endpoint really is the only
+    evidence it has, and treating its seeded model list as one would claim an
+    owner's own route on our host that happens to serve the same model (two
+    cases in gateway-pre-start-clawai-audio.test.ts pin exactly that). Stamping
+    what it writes, so the same repair becomes possible there, is its own card.
+    """
+    if _stamped:
+        return True
+    if isinstance(_api_key, str) and _api_key.startswith("claw_"):
+        return True
+    if not (isinstance(_base_url, str) and _base_url.strip()):
+        return not (isinstance(_api_key, str) and _api_key.strip())
+    return _same_endpoint(_base_url, _proxy_base_url)
+
+
 if _clawai_openai_route_is_ours:
     # Anything already under tools.media.audio that is not what we would write
     # is the owner's own transcription setup: a self-hosted Whisper, a Deepgram
@@ -2028,10 +2068,11 @@ if _clawai_openai_route_is_ours and _clawai_speech_entitled:
     # same one-trailing-slash rule the transcription migration uses, for the
     # same reason: `.../api/ai//` is a deliberate route, not a typo to tidy.
     _speech_base_url = _speech.get("baseUrl")
-    _speech_route_taken = bool(
-        isinstance(_speech_base_url, str)
-        and _speech_base_url.strip()
-        and not _same_endpoint(_speech_base_url, _clawai_proxy_base_url)
+    _speech_route_taken = not _clawai_route_is_ours(
+        _speech_base_url,
+        _speech.get("apiKey"),
+        _speech.get(CLAWBOX_SPEECH_MANAGED_KEY) is True,
+        _clawai_proxy_base_url,
     )
     if _speech_route_taken:
         print(
@@ -2079,11 +2120,18 @@ elif _clawai_openai_route_is_ours:
     _speech = _tts_providers.get("openai") if isinstance(_tts_providers, dict) else None
     if isinstance(_speech, dict):
         _speech_base_url = _speech.get("baseUrl")
+        # The STAMP is the authorisation, not the address. Requiring the
+        # current proxy URL as well left a downgraded box that had been linked
+        # under a previous address holding our own dead entry for good — every
+        # spoken reply buying a refused round trip, and the panel calling the
+        # cloud voice configured while it did. The stamp still has to be there:
+        # this is the one place in the file that destroys configuration, and an
+        # unstamped entry is somebody's hand-written config whatever it points
+        # at.
         if (
             _speech.get(CLAWBOX_SPEECH_MANAGED_KEY) is True
             and isinstance(_speech_base_url, str)
             and _speech_base_url.strip()
-            and _same_endpoint(_speech_base_url, _clawai_proxy_base_url)
         ):
             del _tts_providers["openai"]
             print(

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -1884,6 +1884,15 @@ def _clawai_route_is_ours(_base_url, _api_key, _stamped, _proxy_base_url):
         endpoint alone says nothing: the canonical way an owner uses the
         generic `openai` slot is their key with no URL at all.
 
+    A PRESENT FOREIGN CREDENTIAL BEATS ALL OF IT, and is asked first. This is
+    the only generic OpenAI-compatible speech slot OpenClaw has, so an owner who
+    wants their own speech server has to edit the entry we already wrote — which
+    `openclaw config set` does in place, leaving our `clawboxManaged` key behind
+    on a route that is now theirs. Trusting a stamp on its own would overwrite
+    their server, their key and their model at the next gateway start, and
+    DELETE the whole entry on a downgrade. `hermesCloudRouteIsOurs` refuses that
+    same entry, and so did the rule this replaces.
+
     The transcription block above deliberately does NOT use this: nothing it
     writes carries a stamp or a credential, so its endpoint really is the only
     evidence it has, and treating its seeded model list as one would claim an
@@ -1891,12 +1900,16 @@ def _clawai_route_is_ours(_base_url, _api_key, _stamped, _proxy_base_url):
     cases in gateway-pre-start-clawai-audio.test.ts pin exactly that). Stamping
     what it writes, so the same repair becomes possible there, is its own card.
     """
-    if _stamped:
+    _key = _api_key.strip() if isinstance(_api_key, str) else ""
+    _has_endpoint = isinstance(_base_url, str) and bool(_base_url.strip())
+    if _key and not _key.startswith("claw_"):
+        # Somebody else's credential on the entry: only the endpoint can still
+        # say it is ours, and a stale stamp cannot.
+        return _has_endpoint and _same_endpoint(_base_url, _proxy_base_url)
+    if _stamped or _key.startswith("claw_"):
         return True
-    if isinstance(_api_key, str) and _api_key.startswith("claw_"):
-        return True
-    if not (isinstance(_base_url, str) and _base_url.strip()):
-        return not (isinstance(_api_key, str) and _api_key.strip())
+    if not _has_endpoint:
+        return not _key
     return _same_endpoint(_base_url, _proxy_base_url)
 
 
@@ -2062,11 +2075,14 @@ if _clawai_openai_route_is_ours and _clawai_speech_entitled:
     if not isinstance(_speech, dict):
         _speech = {}
 
-    # An entry pointing somewhere that is not our proxy is the owner's own
+    # Whose entry is this? `_clawai_route_is_ours` above holds the whole rule —
+    # a foreign credential takes the slot back whatever else says, then our own
+    # stamp or a `claw_` token claims it wherever it points, then the endpoint,
+    # then an empty slot. An entry that is not ours is the owner's own
     # OpenAI-compatible voice — a self-hosted Kokoro, an OpenAI key of their
-    # own, a different route on our host. Leave every field of it alone. The
-    # same one-trailing-slash rule the transcription migration uses, for the
-    # same reason: `.../api/ai//` is a deliberate route, not a typo to tidy.
+    # own, a different route on our host — and every field of it is left alone.
+    # The endpoint arm keeps the one-trailing-slash rule the transcription
+    # migration uses: `.../api/ai//` is a deliberate route, not a typo to tidy.
     _speech_base_url = _speech.get("baseUrl")
     _speech_route_taken = not _clawai_route_is_ours(
         _speech_base_url,
@@ -2083,9 +2099,10 @@ if _clawai_openai_route_is_ours and _clawai_speech_entitled:
         _speech["baseUrl"] = _clawai_proxy_base_url
         _speech["model"] = CLAWBOX_SPEECH_MODEL_ID
         _speech["apiKey"] = _clawai_token
-        # Adopt and normalise an unmarked entry that already points at us — a
-        # hand repair, or one written before this stamp existed — rather than
-        # leave a box with a half-configured voice. Writing is recoverable and
+        # Adopt and normalise an unmarked entry that is ours by any of the other
+        # arms — a hand repair, one written before this stamp existed, or one
+        # still naming an address we have since retired — rather than leave a
+        # box with a half-configured voice. Writing is recoverable and
         # deleting is not, which is why only the delete below insists on it.
         _speech[CLAWBOX_SPEECH_MANAGED_KEY] = True
         if _speech != _speech_before:
@@ -2103,11 +2120,13 @@ elif _clawai_openai_route_is_ours:
     # A box that was Max and is not any more keeps an entry pointing at an
     # endpoint that now answers 403, so every spoken reply buys a refused round
     # trip before falling back — and the panel calls the cloud voice configured
-    # while it does it. Take back only what we wrote, and "what we wrote" means
-    # our own stamp plus our own proxy, not the proxy alone: an entry pointing
-    # at this host that we did not stamp is somebody's hand-written config, and
-    # this is the one place in the file that destroys configuration. An owner's
-    # own voice is theirs whatever their ClawBox AI plan says.
+    # while it does it. Take back only what we wrote: our own STAMP — whatever
+    # address it names, which is the half this fixes — and not an entry the
+    # owner has since re-aimed with a credential of their own. An entry
+    # pointing at this host that we did not stamp is somebody's hand-written
+    # config, and this is the one place in the file that destroys
+    # configuration. An owner's own voice is theirs whatever their ClawBox AI
+    # plan says.
     #
     # `messages.tts.provider` is deliberately NOT touched here either. If the
     # customer had explicitly chosen the cloud voice, the panel's job is to show
@@ -2128,10 +2147,27 @@ elif _clawai_openai_route_is_ours:
         # this is the one place in the file that destroys configuration, and an
         # unstamped entry is somebody's hand-written config whatever it points
         # at.
+        # THE STAMP, and only the stamp, opens this door — narrower than the
+        # adopt path above on purpose, and the difference is that this one
+        # cannot be undone. A `claw_` token is enough to REFRESH an entry
+        # because the worst case is our own fields rewritten to our own values;
+        # it is not enough to DELETE one, because an owner can point our own
+        # token at our own proxy with a model of their choosing, and that entry
+        # is theirs (the suite pins it).
+        #
+        # `_clawai_route_is_ours` is still asked, for its first arm: a stamped
+        # entry the owner has since re-aimed with a credential of their own is
+        # not ours to take, whatever the stamp says.
         if (
             _speech.get(CLAWBOX_SPEECH_MANAGED_KEY) is True
             and isinstance(_speech_base_url, str)
             and _speech_base_url.strip()
+            and _clawai_route_is_ours(
+                _speech_base_url,
+                _speech.get("apiKey"),
+                True,
+                _clawai_proxy_base_url,
+            )
         ):
             del _tts_providers["openai"]
             print(

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -1895,9 +1895,15 @@ def _clawai_route_is_ours(_base_url, _api_key, _stamped, _proxy_base_url):
     The customer's transcription and voice stay pointed at a dead host and
     nothing says so: the false-failure class.
 
-    Ownership needs POSITIVE evidence, in the same three shapes the Hermes half
-    of this uses (`hermesCloudRouteIsOurs`, src/lib/hermes-tts.ts — one rule,
-    two editions, and TASK-726 is this half of it):
+    Ownership needs POSITIVE evidence, in the four shapes below. The Hermes half
+    (`hermesCloudRouteIsOurs`, src/lib/hermes-tts.ts — TASK-726 is this half of
+    it) asks the same question with the arms IT has: it writes no stamp, so it
+    has three, and it needs no delete arm at all because it HAS no destructive
+    path — `writeHermesCloudTarget` is the only writer of `tts.openai.*` and a
+    downgrade there just stops exposing the endpoint. The consequence is one
+    real divergence, and it is deliberate: our own `claw_` token at an address
+    of the owner's reads as OURS on Hermes and as THEIRS here, which is what
+    beta did and what the suite pins.
 
       - our own stamp on the entry (`clawboxManaged`);
       - or a `claw_` portal token on it, which is what survives the proxy URL
@@ -1907,11 +1913,15 @@ def _clawai_route_is_ours(_base_url, _api_key, _stamped, _proxy_base_url):
         endpoint alone says nothing: the canonical way an owner uses the
         generic `openai` slot is their key with no URL at all.
 
-    FOREIGN EVIDENCE OF EITHER KIND — their credential, or a host that is none
-    of ours — takes the slot back, and is asked first. Their key is the obvious
-    one and was the only one this asked for at first; but a speech server on the
-    LAN needs no key at all, so on the shape an owner is most likely to run, THE
-    ADDRESS IS THE ONLY THING THAT SPEAKS FOR IT. This is
+    FOREIGN EVIDENCE IS ASKED FIRST, and it comes in two kinds. A host that is
+    none of ours is decisive on its own: no stamp and no token of ours outranks
+    it. Their CREDENTIAL is weighed against the address rather than over it — an
+    `sk-` key on one of our own addresses still reads as ours, which is what beta
+    did and what this deliberately does not change (see the delete arm below).
+
+    The key was the only evidence this asked for at first. But a speech server on
+    the LAN needs no key at all, so on the shape an owner is most likely to run,
+    THE ADDRESS IS THE ONLY THING THAT SPEAKS FOR IT. This is
     the only generic OpenAI-compatible speech slot OpenClaw has, so an owner who
     wants their own speech server has to edit the entry we already wrote — which
     `openclaw config set` does in place, leaving our `clawboxManaged` key behind
@@ -1919,6 +1929,16 @@ def _clawai_route_is_ours(_base_url, _api_key, _stamped, _proxy_base_url):
     their server, their key and their model at the next gateway start, and
     DELETE the whole entry on a downgrade. `hermesCloudRouteIsOurs` refuses that
     same entry, and so did the rule this replaces.
+
+    ONE WIDENING, recorded rather than hidden: an entry carrying our stamp or our
+    token on a DIFFERENT PATH of one of our own hosts (`clawbox.com/api/ai-2025`)
+    reads as ours here, where the equality test called it theirs. That is the
+    card — it is how an entry we wrote under a moved proxy is recognised — and it
+    needs TWO pieces of our-ness at once, which a customer serving from their own
+    machine cannot produce. It does sit against the premise
+    gateway-pre-start-clawai-audio.test.ts:167 pins for the transcription block,
+    where another route on our own host IS the owner's; the difference is that
+    that block has no stamp and no credential to ask about.
 
     The transcription block above deliberately does NOT use this: nothing it
     writes carries a stamp or a credential, so its endpoint really is the only

--- a/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
@@ -47,6 +47,14 @@ function slice(from: string, to: string): string {
  * block precisely so both migrations answer that question the same way, so
  * this test takes it from there rather than restating the rule.
  */
+/**
+ * The hosts ClawBox has ever written as its AI proxy — the live one plus the
+ * retired ones — and the URL normaliser that builds them, taken from the
+ * shipped script rather than restated here. `_clawai_host_is_ours` is the arm
+ * that decides whether a route the owner did not key is theirs, and a second
+ * copy of that list would let the two answers drift.
+ */
+const PROXY_HOSTS = hasPython3 ? slice("from urllib.parse import urlsplit", "def _is_our_image_row(_row):") : "";
 const SAME_ENDPOINT = hasPython3 ? slice("def _same_endpoint(_a, _b):", "if _clawai_openai_route_is_ours:") : "";
 const POLICY = hasPython3
   ? slice("# Migration: ClawBox AI cloud voice (text to speech).", "if isinstance(ds_models, list):")
@@ -95,6 +103,10 @@ function migrate(cfg: Config, opts: Options = {}): { cfg: Config; changed: boole
     `_clawai_openai_route_is_ours = ${routeIsOurs ? "True" : "False"}`,
     `_clawai_proxy_base_url = ${JSON.stringify(PROXY)}`,
     `_clawai_token = ${JSON.stringify(TOKEN)}`,
+    // The ClawBox AI provider entry the image migration read the live proxy
+    // off; the only binding the host set above needs.
+    `deepseek_provider = {"baseUrl": ${JSON.stringify(PROXY)}}`,
+    PROXY_HOSTS,
     SAME_ENDPOINT,
     ...(v2 ? ["CLAWBOX_OPENCLAW_V2 = True"] : []),
     POLICY,

--- a/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
@@ -298,6 +298,66 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
     });
   });
 
+  describe("a box we linked under a previous proxy address (TASK-726)", () => {
+    // CLAWBOX_AI_PROXY_URL is env-overridable and moves between releases, so
+    // an entry WE wrote can name an endpoint that has since been retired. The
+    // rule used to be equality with the CURRENT url, which reads our own entry
+    // as the owner's own speech server: the box was skipped and left on a dead
+    // route for the life of that address, while the chat provider and the
+    // image row were repaired in the same boot.
+    const RETIRED = "https://clawbox.com/api/ai-2025";
+
+    it("re-points our own stamped entry at the address that serves today", () => {
+      const { cfg, changed, log } = migrate({
+        messages: { tts: { providers: { openai: { baseUrl: RETIRED, model: SPEECH_MODEL, apiKey: TOKEN, ...MANAGED } } } },
+      });
+
+      expect(changed).toBe(true);
+      expect(speech(cfg)).toEqual({ baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN, ...MANAGED });
+      expect(log).not.toContain("already names its own speech route");
+    });
+
+    it("recognises one by its claw_ token even without the stamp", () => {
+      // What a box carries when it was written before the stamp existed. The
+      // portal token is ours whatever address it was pointed at.
+      const { cfg, changed } = migrate({
+        messages: { tts: { providers: { openai: { baseUrl: RETIRED, model: "gpt-4o-mini-tts", apiKey: TOKEN } } } },
+      });
+
+      expect(changed).toBe(true);
+      expect(speech(cfg)?.baseUrl).toBe(PROXY);
+      expect(speech(cfg)).toMatchObject(MANAGED);
+    });
+
+    it("takes its own entry back on a downgrade even though the address moved", () => {
+      // The mirror image, and the worse half: a box that was Max and is not
+      // any more kept OUR dead entry for good, so every spoken reply bought a
+      // refused round trip and the panel called the cloud voice configured
+      // while it did.
+      const { cfg, changed, log } = migrate(
+        { messages: { tts: { providers: { openai: { baseUrl: RETIRED, model: SPEECH_MODEL, apiKey: TOKEN, ...MANAGED } } } } },
+        { deviceTier: "free" },
+      );
+
+      expect(changed).toBe(true);
+      expect(speech(cfg)).toBeUndefined();
+      expect(log).toContain("no longer includes it");
+    });
+
+    it("still refuses to take an UNSTAMPED entry on a moved address", () => {
+      // The destructive path keeps its positive evidence: the stamp is the
+      // authorisation, and an entry we did not write is somebody's own.
+      const own = { baseUrl: RETIRED, model: "tts-1", apiKey: "sk-owner" };
+      const { cfg, changed } = migrate(
+        { messages: { tts: { providers: { openai: own } } } },
+        { deviceTier: "free" },
+      );
+
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toEqual(own);
+    });
+  });
+
   it("does not touch a box whose openai slot belongs to its owner", () => {
     // Same handover the transcription migration uses: when the image migration
     // decided the slot is not ours, our token must not be written anywhere
@@ -321,6 +381,16 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
       // A host-only match would stamp over a deliberate path. Same rule the
       // transcription migration applies, from the same helper.
       const own = { baseUrl: "https://clawbox.com/their-own-route", model: "tts-1" };
+      const { cfg, changed } = migrate({ messages: { tts: { providers: { openai: own } } } });
+
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toEqual(own);
+    });
+
+    it("is left alone when it carries the owner's own key on a route of ours that has moved", () => {
+      // The credential is what decides after the stamp, and `sk-` is not ours
+      // however the endpoint reads.
+      const own = { baseUrl: "https://clawbox.com/api/ai-2025", model: "tts-1", apiKey: "sk-owner" };
       const { cfg, changed } = migrate({ messages: { tts: { providers: { openai: own } } } });
 
       expect(changed).toBe(false);

--- a/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
@@ -344,6 +344,23 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
       expect(log).toContain("no longer includes it");
     });
 
+    it("leaves a pre-stamp entry alone on a downgrade, narrower than the adopt path on purpose", () => {
+      // A `claw_` token is enough to REFRESH an entry — the worst case is our
+      // own fields rewritten to our own values — and deliberately not enough to
+      // DELETE one: an owner can point our own token at our own proxy with a
+      // model of their choosing, and the case above pins that entry as theirs.
+      // The narrow residue is a box written before the stamp existed that is
+      // ALSO downgraded; it keeps a dead entry, as it did before this change.
+      const preStamp = { baseUrl: RETIRED, model: SPEECH_MODEL, apiKey: TOKEN };
+      const { cfg, changed } = migrate(
+        { messages: { tts: { providers: { openai: preStamp } } } },
+        { deviceTier: "free" },
+      );
+
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toEqual(preStamp);
+    });
+
     it("still refuses to take an UNSTAMPED entry on a moved address", () => {
       // The destructive path keeps its positive evidence: the stamp is the
       // authorisation, and an entry we did not write is somebody's own.
@@ -382,6 +399,38 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
       // transcription migration applies, from the same helper.
       const own = { baseUrl: "https://clawbox.com/their-own-route", model: "tts-1" };
       const { cfg, changed } = migrate({ messages: { tts: { providers: { openai: own } } } });
+
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toEqual(own);
+    });
+
+    it("is left alone when the owner has repointed OUR OWN stamped entry at their server", () => {
+      // `messages.tts.providers.openai` is the only generic OpenAI-compatible
+      // speech slot OpenClaw has, so an owner who runs their own has to edit
+      // the entry we wrote — and `openclaw config set` edits in place, leaving
+      // our `clawboxManaged` key behind on a route that is now theirs.
+      const own = {
+        baseUrl: "https://kokoro.local/v1",
+        model: "kokoro",
+        apiKey: "sk-owner",
+        voice: "af",
+        clawboxManaged: true,
+      };
+      const { cfg, changed, log } = migrate({ messages: { tts: { providers: { openai: own } } } });
+
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toEqual(own);
+      expect(log).toContain("already names its own speech route");
+    });
+
+    it("does not delete that entry on a downgrade either", () => {
+      // The one irreversible action in the file, and a stale stamp must not be
+      // enough to fire it over live owner configuration.
+      const own = { baseUrl: "https://kokoro.local/v1", model: "kokoro", apiKey: "sk-owner", clawboxManaged: true };
+      const { cfg, changed } = migrate(
+        { messages: { tts: { providers: { openai: own } } } },
+        { deviceTier: "free" },
+      );
 
       expect(changed).toBe(false);
       expect(speech(cfg)).toEqual(own);

--- a/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
@@ -436,6 +436,46 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
       expect(speech(cfg)).toEqual(own);
     });
 
+    it("is left alone when the owner has repointed it at a KEYLESS server of their own", () => {
+      // The keyed case above is the easy one. A local speech server — Kokoro,
+      // Piper — needs NO credential, so the address is the only thing that
+      // speaks for it. `openclaw config set` edits in place, which is why our
+      // `clawboxManaged` stamp is still sitting on an entry that has been
+      // theirs since the day they pointed it at their box.
+      const own = { baseUrl: "https://kokoro.local/v1", model: "kokoro", clawboxManaged: true };
+      const { cfg, changed, log } = migrate({ messages: { tts: { providers: { openai: own } } } });
+
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toEqual(own);
+      expect(log).toContain("already names its own speech route");
+    });
+
+    it("does not delete that KEYLESS entry on a downgrade either", () => {
+      // The one irreversible action in the file. A stamp on an address that
+      // was never ours is not a licence to destroy the owner's configuration —
+      // and this is the case the keyed pair above cannot see.
+      const own = { baseUrl: "https://kokoro.local/v1", model: "kokoro", clawboxManaged: true };
+      const { cfg, changed } = migrate(
+        { messages: { tts: { providers: { openai: own } } } },
+        { deviceTier: "free" },
+      );
+
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toEqual(own);
+    });
+
+    it("still repairs our own stamped entry left on a RETIRED proxy address", () => {
+      // The reason the rule stopped being an equality test against the current
+      // URL: a box linked under a previous address carries an entry WE wrote,
+      // pointing at an endpoint that no longer answers. That address is still
+      // one of ours, so it is still ours to repair.
+      const own = { baseUrl: "https://openclawhardware.dev/api/ai", model: SPEECH_MODEL, apiKey: TOKEN, ...MANAGED };
+      const { cfg, changed } = migrate({ messages: { tts: { providers: { openai: own } } } });
+
+      expect(changed).toBe(true);
+      expect(speech(cfg)).toEqual({ baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN, ...MANAGED });
+    });
+
     it("is left alone when it carries the owner's own key on a route of ours that has moved", () => {
       // The credential is what decides after the stamp, and `sk-` is not ours
       // however the endpoint reads.


### PR DESCRIPTION
**TASK-726** — the OpenClaw half of the ownership rule PR #647 landed on Hermes.

## Symptom

A box we linked under a previous ClawBox AI proxy address keeps its cloud voice pointed at an
endpoint that has been retired — in the same boot in which the chat provider and the image row are
repaired. The Voice panel calls the cloud voice configured; every spoken reply buys a refused round
trip before falling back. And the mirror image is worse: a box that was Max and is not any more
keeps OUR OWN dead entry for good, because the downgrade path refuses to take it back.

## Cause

`scripts/gateway-pre-start.sh` decided whether `messages.tts.providers.openai` was ours by equality
with the CURRENT `CLAWBOX_AI_PROXY_URL`. That variable is env-overridable and moves between
releases, so an entry we wrote reads as the owner's own speech server and is skipped — the
false-failure class. The entry already carries the `clawboxManaged` stamp the rule needed.

## Harness-first

The rule itself is ClawBox's own — no harness owns "is this ClawBox AI route mine" — but it already
HAS one home in this tree: `hermesCloudRouteIsOurs` (`src/lib/hermes-tts.ts`), which PR #647 wrote
for exactly this defect on the Hermes edition. This PR is the OpenClaw half, arm for arm, and the
new `_clawai_route_is_ours` docstring names it so the two cannot drift into two rules.

## The rule

Positive evidence, in four arms, asked in this order:

**Foreign evidence is asked first, and it comes in two kinds.**

1. **A host that is none of ours is decisive on its own** — no stamp and no token of ours outranks
   it. `messages.tts.providers.openai` is the only generic OpenAI-compatible speech slot OpenClaw
   has, so an owner who runs their own has to edit the entry we wrote, and `openclaw config set`
   edits in place: our `clawboxManaged` key is left behind on a route that has been theirs ever
   since. A speech server on the LAN — Kokoro, Piper — needs **no credential at all**, so on the
   shape an owner is most likely to run, the address is the only thing that speaks for it.
   "Ours" here means one of `_clawbox_proxy_hosts` — the same set the image row's ownership test
   uses, the live proxy plus the **retired** ones — so a route of ours that has moved is still ours
   and the repair above still happens.
2. **A present foreign credential** is weighed against the address rather than over it: an `sk-`
   key on an address that is not ours takes the slot back, while one on an address of ours does
   not. That is what beta did, and this deliberately does not change it — see Residuals.

Then the positive arms, in order: our own stamp or a `claw_` portal token (what survives the proxy
URL moving); the endpoint naming our proxy (the same one-trailing-slash rule as before); or a
genuinely empty slot — no endpoint AND no key.

The downgrade path is deliberately **narrower**: only the stamp opens it, on top of both foreign
arms. A `claw_` token is enough to refresh an entry, because the worst case is our own fields
rewritten to our own values; it is not enough to delete one, because an owner can point our own
token at our own proxy with a model of their choosing, and the suite pins that entry as theirs.

## Sibling call sites

- **The speech-to-text block above it: cleared, not changed.** `tools.media.audio` carries no stamp
  and no credential — only a `baseUrl` and our seeded model list — and two cases in
  `gateway-pre-start-clawai-audio.test.ts` deliberately pin that an owner's own route on our host
  serving the same model is THEIRS, so the model list cannot stand in for a stamp. A box linked
  under a previous address therefore keeps channel transcription pointed at a retired endpoint;
  closing that means stamping what the transcription migration writes, which is forward-only and its
  own card. Recorded for the queue, and stated in the helper's docstring.
- **The image migration's `_key_is_ours`: cleared.** It already decides on the credential (`claw_`
  or absent) plus a foreign-route check, which is this rule.
- **The Hermes side: cleared, and for a stronger reason than symmetry.** `hermesCloudRouteIsOurs`
  has no stamp arm, so a keyless `kokoro.local` falls to its equality test and is correctly the
  owner's. More decisively, Hermes has **no destructive path at all**: `writeHermesCloudTarget` is
  the only writer of `tts.openai.*` and a downgrade there simply stops exposing the endpoint. The
  two rules therefore diverge in one place, deliberately — our own `claw_` token at an address of
  the owner's reads as OURS on Hermes and as THEIRS here, which is what beta did and what the suite
  pins.

## Residuals — recorded, not fixed here

- **A foreign credential on our own CURRENT proxy address still reads as ours**, so such an entry is
  overwritten and, on a downgrade, deleted. This is CodeRabbit's Major on this PR. It behaves
  **identically on `origin/beta` and on this head** — verified by execution on both trees — so it is
  a pre-existing residual, not something this merge introduces. Narrowing it is a behaviour change
  beyond this card.
- **One widening, from the card itself:** an entry carrying our stamp or our token on a different
  *path* of one of our own hosts (`clawbox.com/api/ai-2025`) now reads as ours, where the equality
  test called it theirs. That is how an entry written under a moved proxy is recognised at all. It
  needs two pieces of our-ness at once — stamp-or-token **and** one of our hosts — which a customer
  serving from their own machine cannot produce. Recorded in the docstring.
- **The transcription block still carries no stamp**, so a box linked under a previous address keeps
  channel transcription pointed at a retired endpoint. Forward-only, and its own card.

## RED → GREEN

### The card's own RED, against unmodified `origin/beta`

```
 ❯ src/tests/unit/gateway-pre-start-clawai-speech.test.ts (33 tests | 3 failed)
   × re-points our own stamped entry at the address that serves today
     AssertionError: expected false to be true      // skipped as "the owner's own route"
   × recognises one by its claw_ token even without the stamp
   × takes its own entry back on a downgrade even though the address moved
```

### The regression the review pass found, against the FIRST head of this PR (`e31932e5`)

That head widened the downgrade path far enough to delete a stamped entry the owner had re-aimed at
their own **keyless** speech server — which `origin/beta` preserves. The keyed variant of exactly
that scenario was already pinned and passing, which is what let it through: `sk-owner` fires the
foreign-credential arm, and a local Kokoro or Piper has no key to fire it with.

```
 ❯ src/tests/unit/gateway-pre-start-clawai-speech.test.ts
   × does not delete that KEYLESS entry on a downgrade either
     AssertionError: expected true to be false      // `changed` — the entry was deleted
   × is left alone when the owner has repointed it at a KEYLESS server of their own
```

Both preserve the entry on `origin/beta` and on this head; only `e31932e5` deleted it. A third new
case pins the other direction — our own stamped entry on a **retired** host is still repaired — so
the fix cannot be "put the equality test back".

### GREEN on this head

```
$ npx vitest run gateway-pre-start-clawai-speech gateway-pre-start-clawai-audio \
    gateway-pre-start-clawai-images openclaw-config-mock-completeness \
    test-timeout-hygiene state-updater-purity
 Test Files  6 passed (6)
      Tests  131 passed (131)

$ npx tsc --noEmit          # exit 0
$ bash -n scripts/gateway-pre-start.sh   # clean
```

The suite runs the migration block sliced out of the shipped `.sh`, so these cases exercise the real
script. The preamble now also slices the real proxy-host set rather than restating it, so the arm
that decides whose address this is cannot drift from the one the image row uses.

## Device leg (read-only)

Read on the OpenClaw box on 2026-09-06, no mutex taken and nothing changed: it carries exactly the
entry this reasons about — `messages.tts.providers.openai` with `clawboxManaged: true`, our model,
and a `baseUrl` equal to today's default proxy. So today it is recognised; the moment the address
moves, beta's rule reads it as the owner's own and skips it while this one keeps it ours. The Hermes
box is `CLAWBOX_EDITION=hermes` and does not run this migration — its half is #647's.

Re-read on 2026-09-06 after this fix, same way: the entry is `baseUrl: https://clawbox.com/api/ai`,
`model: gpt-4o-mini-tts`, `clawboxManaged: true`, `apiKey` a `claw_` token — still classified as
ours by the new rule (our host, our token, our stamp), so the added arm changes nothing on a real
box.

Not proven on hardware: the repair itself, which needs a box whose stored entry names a retired
address. That state cannot be created read-only, and creating it means writing a customer-shaped
config onto a test box.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Cloud speech route migration when proxy endpoints change.
  - Preserved credentials belonging to other services during migration and cleanup.
  - Ensured configured ClawBox speech routes are refreshed, adopted, or removed according to ownership.
  - Prevented unrelated speech entries from being modified or deleted.

- **Tests**
  - Added coverage for moved proxy routes, legacy entries, ownership changes, migration, repointing, and downgrade cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
