### PR TITLE
fix: rebuild the agent's tool list when the active harness changes

### DIFF
--- a/src/app/setup-api/harness/select/route.ts
+++ b/src/app/setup-api/harness/select/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from "next/server";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import path from "path";
-import { getActiveHarness, setActiveHarness, isHarness, harnessHealthy, isSingleHarnessEdition } from "@/lib/harness";
+import { setActiveHarness, isHarness, harnessHealthy, isSingleHarnessEdition, type Harness } from "@/lib/harness";
 import { refreshHarnessToolsIfSwitched } from "@/lib/harness-mcp-refresh";
 import { CONFIG_ROOT } from "@/lib/config-store";
 
@@ -49,11 +49,6 @@ export async function POST(request: Request) {
     );
   }
 
-  // Read BEFORE the switch, so the refresh below can tell a real flip from a
-  // re-select of the harness already running. Unreadable answers null, which
-  // that guard treats as "not a flip" rather than as a change.
-  const previous = await getActiveHarness().catch(() => null);
-
   // Propagate the canonical identity to both harnesses (OpenClaw real copies +
   // gateway refresh; Hermes FTS5 reindex) BEFORE flipping the active one, so we
   // never complete a switch that leaves the selected harness without its shared
@@ -78,8 +73,15 @@ export async function POST(request: Request) {
   // failure the device is in an uncertain state (synced but maybe not flipped);
   // return the JSON error contract and tell the client to re-read status rather
   // than letting a framework-generated 500 leak through.
+  // The harness this call REPLACED, answered by the write itself so the refresh
+  // below can tell a real flip from a re-select of the one already running.
+  // Read separately up here it was read before the identity sync above, which
+  // has a 60 s budget: two switches in opposite directions both saw the same
+  // predecessor, and the second one persisted its harness and then decided
+  // nothing had moved.
+  let previous: Harness;
   try {
-    await setActiveHarness(harness);
+    previous = await setActiveHarness(harness);
   } catch (err) {
     console.error("[harness/select] failed to persist active harness:", err instanceof Error ? err.message : err);
     return NextResponse.json(

--- a/src/app/setup-api/harness/select/route.ts
+++ b/src/app/setup-api/harness/select/route.ts
@@ -4,7 +4,8 @@ import { NextResponse } from "next/server";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import path from "path";
-import { setActiveHarness, isHarness, harnessHealthy, isSingleHarnessEdition } from "@/lib/harness";
+import { getActiveHarness, setActiveHarness, isHarness, harnessHealthy, isSingleHarnessEdition } from "@/lib/harness";
+import { refreshHarnessToolsIfSwitched } from "@/lib/harness-mcp-refresh";
 import { CONFIG_ROOT } from "@/lib/config-store";
 
 const exec = promisify(execFile);
@@ -48,6 +49,11 @@ export async function POST(request: Request) {
     );
   }
 
+  // Read BEFORE the switch, so the refresh below can tell a real flip from a
+  // re-select of the harness already running. Unreadable answers null, which
+  // that guard treats as "not a flip" rather than as a change.
+  const previous = await getActiveHarness().catch(() => null);
+
   // Propagate the canonical identity to both harnesses (OpenClaw real copies +
   // gateway refresh; Hermes FTS5 reindex) BEFORE flipping the active one, so we
   // never complete a switch that leaves the selected harness without its shared
@@ -81,5 +87,10 @@ export async function POST(request: Request) {
       { status: 500 },
     );
   }
+  // The agent's own tool list is built from a startup probe of which harness is
+  // active, and nothing here bounces it — so ask the harness to rebuild it. Best
+  // effort, after the write: see harness-mcp-refresh.ts for why it is the whole
+  // MCP reload and not a poll in the two handlers whose answer is visible.
+  await refreshHarnessToolsIfSwitched(previous, harness);
   return NextResponse.json({ success: true, active: harness });
 }

--- a/src/app/setup-api/harness/select/route.ts
+++ b/src/app/setup-api/harness/select/route.ts
@@ -73,12 +73,14 @@ export async function POST(request: Request) {
   // failure the device is in an uncertain state (synced but maybe not flipped);
   // return the JSON error contract and tell the client to re-read status rather
   // than letting a framework-generated 500 leak through.
-  // The harness this call REPLACED, answered by the write itself so the refresh
+  // The harness this call REPLACED, answered by the write itself, so the refresh
   // below can tell a real flip from a re-select of the one already running.
-  // Read separately up here it was read before the identity sync above, which
-  // has a 60 s budget: two switches in opposite directions both saw the same
-  // predecessor, and the second one persisted its harness and then decided
-  // nothing had moved.
+  //
+  // It has to come from the persist rather than from a read of our own: a read
+  // would sit above the identity sync and its 60 s budget, and two switches in
+  // opposite directions inside that window both see the same predecessor — the
+  // second persists its harness, concludes nothing moved, and leaves the box on
+  // one harness with the agent's whole tool list built for the other.
   let previous: Harness;
   try {
     previous = await setActiveHarness(harness);

--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -129,12 +129,25 @@ export async function set(key: string, value: unknown): Promise<void> {
  * land a config write between them. It says nothing about another process
  * writing the same file — the rename in `writeConfig` is what covers that.
  *
- * Replaces only. To delete a key, `set` it to `undefined`.
+ * Replaces only, and REFUSES a value JSON would drop rather than treating it as
+ * `set` does. `JSON.stringify` omits a key whose value is `undefined`, and a
+ * function or a symbol identically, so accepting one would rename a config
+ * WITHOUT the key over the one that had it — and the caller, handed the
+ * predecessor and no error, would read that as the switch having been made.
+ * The test is `JSON.stringify(value) === undefined`, which is the property that
+ * actually matters, rather than an enumeration of the values that have it. To
+ * delete a key, `set` it to `undefined`.
  *
  * Same strict read as `set`, for the same reason: a write over a store nobody
  * can read must throw rather than replace it with the one key being saved.
  */
 export async function swap(key: string, value: unknown): Promise<unknown> {
+  // Ahead of the read, so a value that cannot be stored costs no file access.
+  // `JSON.stringify` throws on a BigInt or a cycle, which `writeConfig` would
+  // have done anyway — here it happens before anything is opened.
+  if (JSON.stringify(value) === undefined) {
+    throw new TypeError(`config-store: swap(${key}) replaces, it cannot delete — use set()`);
+  }
   const config = readConfigStrict();
   const previous = config[key];
   config[key] = value;

--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -138,6 +138,13 @@ export async function set(key: string, value: unknown): Promise<void> {
  * actually matters, rather than an enumeration of the values that have it. To
  * delete a key, `set` it to `undefined`.
  *
+ * The VALUE half only. A `__proto__` KEY produces the same outcome by a
+ * different mechanism — `config[key] = value` hits `Object.prototype`'s setter,
+ * so the key never lands — and is NOT covered here, because it is identical in
+ * `set` and `setMany` and belongs with a store-wide fix rather than a third
+ * copy of one. Unreachable from the only caller, which passes a module
+ * constant.
+ *
  * Same strict read as `set`, for the same reason: a write over a store nobody
  * can read must throw rather than replace it with the one key being saved.
  */

--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -119,6 +119,29 @@ export async function set(key: string, value: unknown): Promise<void> {
   writeConfig(config);
 }
 
+/**
+ * Set `key` and return what it held — read and written in ONE synchronous step.
+ *
+ * `get` then `set` is not the same thing. The `await` between them is a point
+ * where another request can land its own write, and the caller then reasons
+ * about a predecessor its call never actually replaced. There is no await
+ * between the read and the write here, so nothing can interleave.
+ *
+ * Same strict read as `set`, for the same reason: a write over a store nobody
+ * can read must throw rather than replace it with the one key being saved.
+ */
+export async function swap(key: string, value: unknown): Promise<unknown> {
+  const config = readConfigStrict();
+  const previous = config[key];
+  if (value === undefined) {
+    delete config[key];
+  } else {
+    config[key] = value;
+  }
+  writeConfig(config);
+  return previous;
+}
+
 export async function setMany(entries: Record<string, unknown>): Promise<void> {
   const config = readConfigStrict();
   for (const [key, value] of Object.entries(entries)) {

--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -124,8 +124,12 @@ export async function set(key: string, value: unknown): Promise<void> {
  *
  * `get` then `set` is not the same thing. The `await` between them is a point
  * where another request can land its own write, and the caller then reasons
- * about a predecessor its call never actually replaced. There is no await
- * between the read and the write here, so nothing can interleave.
+ * about a predecessor its call never actually replaced. Here the read and the
+ * write are in the same event-loop turn, so no other caller IN THIS PROCESS can
+ * land a config write between them. It says nothing about another process
+ * writing the same file — the rename in `writeConfig` is what covers that.
+ *
+ * Replaces only. To delete a key, `set` it to `undefined`.
  *
  * Same strict read as `set`, for the same reason: a write over a store nobody
  * can read must throw rather than replace it with the one key being saved.
@@ -133,11 +137,7 @@ export async function set(key: string, value: unknown): Promise<void> {
 export async function swap(key: string, value: unknown): Promise<unknown> {
   const config = readConfigStrict();
   const previous = config[key];
-  if (value === undefined) {
-    delete config[key];
-  } else {
-    config[key] = value;
-  }
+  config[key] = value;
   writeConfig(config);
   return previous;
 }

--- a/src/lib/harness-mcp-refresh.ts
+++ b/src/lib/harness-mcp-refresh.ts
@@ -49,20 +49,19 @@ import { reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reloa
  * succeeded into an error. A box that cannot be asked catches up at the next
  * restart, which is what every box did before this existed.
  *
- * @param before the harness that was active, or null when it could not be read
+ * @param before the harness this switch REPLACED, as answered by the write
  * @param after  the harness now active
  * @returns true when the box's MCP children were respawned for this change
  */
 export async function refreshHarnessToolsIfSwitched(
-  before: string | null,
+  before: string,
   after: string,
 ): Promise<boolean> {
   // A re-select of the harness already running changes nothing the agent can
-  // see, and must cost nothing. An unreadable "before" is NOT treated as a
-  // change either: it would ask for a reload on every save on a box whose
-  // harness store is unreadable, which is the one state where the answer is
-  // least likely to have moved.
-  if (before === null || before === after) return false;
+  // see, and must cost nothing. `before` comes back from the persist itself, so
+  // this compares what was actually replaced — not a value read earlier that
+  // another request may have moved in between.
+  if (before === after) return false;
 
   const moved = `the active harness moved from ${before} to ${after}`;
   // `.catch` even though `reloadMcpServers` documents that it never throws: the

--- a/src/lib/harness-mcp-refresh.ts
+++ b/src/lib/harness-mcp-refresh.ts
@@ -45,8 +45,10 @@ import { reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reloa
  * Hermes' own MCP children, which is worth having: they answer truthfully for
  * the next switch back. The OpenClaw side is not asked and does not need to be —
  * it spawns the ClawBox MCP server per session and reaps it after ten idle
- * minutes, so it self-heals. `reportMcpReloadRefused` is for the box where there
- * is no dashboard up at all.
+ * minutes, so it self-heals. `reportMcpReloadRefused` is for the box that has no
+ * dashboard up, or has one that said no — a `confirm_required` or an error
+ * frame is a refusal too, and the line it writes is the one an operator can act
+ * on.
  *
  * Never throws and never reports to the caller: the selection is PERSISTED by
  * the time this runs, and a best-effort refresh must not turn a switch that

--- a/src/lib/harness-mcp-refresh.ts
+++ b/src/lib/harness-mcp-refresh.ts
@@ -1,0 +1,77 @@
+import { reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reload";
+
+/**
+ * Ask the agent to rebuild its tool list when the ACTIVE HARNESS moved under it.
+ *
+ * WHY THIS EXISTS — the fifth of five, and the biggest of them. The ClawBox MCP
+ * server probes this device ONCE, while its stdio child boots
+ * (`mcp/lib/context.ts` / `mcp/lib/edition.ts`), and the answer decides more
+ * than any other snapshot in that file: on the `dual` SKU it settles which
+ * harness's built-in APPS `ui_open_app` and `ui_list_apps` offer, which TOOL SET
+ * is registered at all (`resolveEdition` — the skills family on Hermes, the app
+ * store on OpenClaw), what `device_status` calls the agent, and which field
+ * guide `clawbox_context` serves.
+ *
+ * `/setup-api/harness/select` deliberately does not bounce the other gateway, so
+ * nothing told that child anything. The owner switched to Hermes in Settings and
+ * `ui_open_app("hermes")` went on answering "There is no such app on this
+ * ClawBox" for the box's own dashboard — TASK-541's exact symptom — while
+ * `clawbox app open hermes` from the same agent's shell succeeded, because a CLI
+ * run IS its own startup. It cleared at the next MCP restart, and nothing on the
+ * box caused one (TASK-715).
+ *
+ * THE MECHANISM IS THE HARNESS'S OWN, not a poll bolted onto the two handlers
+ * whose answer happens to be visible. `reload.mcp` respawns the child and
+ * re-probes EVERYTHING, so the app list, the registered tool set, the tool
+ * descriptions and the orientation answers move together — a per-call re-read
+ * of the app list alone would leave one surface fresh and the rest of the
+ * session stale, which is the harder bug to see: `ui_list_apps` would name
+ * `hermes-skills` in the same session where `skill_list` is not registered and
+ * `device_status` still says OpenClaw.
+ *
+ * IT IS NOT FREE — the reload kills and respawns every MCP child and
+ * invalidates the model's prompt cache — so, like all four siblings
+ * (`email-mcp-refresh`, `coding-agent-mcp-refresh`, `provider-mcp-refresh`,
+ * `hermes-image-refresh`), it is asked for only on a real flip.
+ */
+
+/**
+ * Reload the MCP servers iff this request actually changed the active harness.
+ *
+ * Both directions. Switching TO Hermes gives its dashboard the reload directly;
+ * switching AWAY leaves an OpenClaw box, where `reportMcpReloadRefused` says the
+ * true sentence for that edition — OpenClaw spawns the ClawBox MCP server per
+ * session and reaps it after ten idle minutes, so it self-heals and needs no
+ * repair.
+ *
+ * Never throws and never reports to the caller: the selection is PERSISTED by
+ * the time this runs, and a best-effort refresh must not turn a switch that
+ * succeeded into an error. A box that cannot be asked catches up at the next
+ * restart, which is what every box did before this existed.
+ *
+ * @param before the harness that was active, or null when it could not be read
+ * @param after  the harness now active
+ * @returns true when the box's MCP children were respawned for this change
+ */
+export async function refreshHarnessToolsIfSwitched(
+  before: string | null,
+  after: string,
+): Promise<boolean> {
+  // A re-select of the harness already running changes nothing the agent can
+  // see, and must cost nothing. An unreadable "before" is NOT treated as a
+  // change either: it would ask for a reload on every save on a box whose
+  // harness store is unreadable, which is the one state where the answer is
+  // least likely to have moved.
+  if (before === null || before === after) return false;
+
+  const moved = `the active harness moved from ${before} to ${after}`;
+  // `.catch` even though `reloadMcpServers` documents that it never throws: the
+  // promise it makes is to the OWNER'S SWITCH, which is already persisted, and
+  // it must not depend on a neighbouring module keeping its own.
+  if (!(await reloadMcpServers().catch(() => false))) {
+    await reportMcpReloadRefused("harness/select", moved);
+    return false;
+  }
+  console.log(`[harness/select] ${moved}; asked the agent to reload its MCP servers`);
+  return true;
+}

--- a/src/lib/harness-mcp-refresh.ts
+++ b/src/lib/harness-mcp-refresh.ts
@@ -38,11 +38,15 @@ import { reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reloa
 /**
  * Reload the MCP servers iff this request actually changed the active harness.
  *
- * Both directions. Switching TO Hermes gives its dashboard the reload directly;
- * switching AWAY leaves an OpenClaw box, where `reportMcpReloadRefused` says the
- * true sentence for that edition — OpenClaw spawns the ClawBox MCP server per
- * session and reaps it after ten idle minutes, so it self-heals and needs no
- * repair.
+ * Both directions, and the reload goes to HERMES either way — it is the only
+ * harness here with a dashboard to ask. On the licensed dual SKU that dashboard
+ * runs whichever harness is active (`install.sh` enables it for "hermes + dual"),
+ * so switching AWAY from Hermes normally succeeds too. What it respawns is
+ * Hermes' own MCP children, which is worth having: they answer truthfully for
+ * the next switch back. The OpenClaw side is not asked and does not need to be —
+ * it spawns the ClawBox MCP server per session and reaps it after ten idle
+ * minutes, so it self-heals. `reportMcpReloadRefused` is for the box where there
+ * is no dashboard up at all.
  *
  * Never throws and never reports to the caller: the selection is PERSISTED by
  * the time this runs, and a best-effort refresh must not turn a switch that
@@ -51,7 +55,8 @@ import { reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reloa
  *
  * @param before the harness this switch REPLACED, as answered by the write
  * @param after  the harness now active
- * @returns true when the box's MCP children were respawned for this change
+ * @returns true when HERMES' MCP children were respawned for this change — not
+ *          a claim about the OpenClaw child, which is never asked
  */
 export async function refreshHarnessToolsIfSwitched(
   before: string,
@@ -71,6 +76,11 @@ export async function refreshHarnessToolsIfSwitched(
     await reportMcpReloadRefused("harness/select", moved);
     return false;
   }
-  console.log(`[harness/select] ${moved}; asked the agent to reload its MCP servers`);
+  // Names WHO was asked. "the agent" read as "whichever harness now serves the
+  // owner", which is wrong in the away direction: on dual, Hermes answers this
+  // call after the box has moved to OpenClaw, and an operator reading the
+  // journal for "the agent still thinks it is on Hermes" must not be told the
+  // OpenClaw child was reloaded.
+  console.log(`[harness/select] ${moved}; asked Hermes to reload its MCP servers`);
   return true;
 }

--- a/src/lib/harness.ts
+++ b/src/lib/harness.ts
@@ -9,7 +9,7 @@
 
 import fs from "fs";
 import path from "path";
-import { get, set } from "@/lib/config-store";
+import { get, swap } from "@/lib/config-store";
 import { envPort } from "@/lib/port-probe";
 import { verifyDualLicense } from "@/lib/edition-license";
 import { readEdition, readEditionSource, type EditionSource } from "@/lib/edition-source";
@@ -133,13 +133,29 @@ export async function getActiveHarness(): Promise<Harness> {
   }
 }
 
-export async function setActiveHarness(harness: Harness): Promise<void> {
+/**
+ * Make `harness` the active one, and answer with THE ONE IT REPLACED.
+ *
+ * The predecessor comes back from the write rather than from a read the caller
+ * made earlier, because the caller's question — did this actually change
+ * anything — can only be answered by the write itself. `/setup-api/harness/select`
+ * used to read it before an identity sync with a 60 s budget, so two switches in
+ * opposite directions both saw the same predecessor: the second persisted its
+ * harness and then concluded nothing had moved, leaving the box on one harness
+ * with the agent's whole tool list built for the other.
+ */
+export async function setActiveHarness(harness: Harness): Promise<Harness> {
   // Refuse to persist a switch on a locked device (defense-in-depth — the
   // /harness/select route also rejects, and the UI hides the switcher).
   if (isSingleHarnessEdition()) {
     throw new Error("Harness switching is disabled on this edition");
   }
-  await set(HARNESS_CONFIG_KEY, harness);
+  const previous = await swap(HARNESS_CONFIG_KEY, harness);
+  // A store that has never held one, or holds something that is not a harness,
+  // reads as the default — the same answer `getActiveHarness` gives it. Not
+  // locked: `isSingleHarnessEdition()` above is the same test `lockedHarness()`
+  // makes, so the edition cannot be overriding the stored value here.
+  return isHarness(previous) ? previous : DEFAULT_HARNESS;
 }
 
 /**

--- a/src/tests/routes/harness-select-mcp-reload.test.ts
+++ b/src/tests/routes/harness-select-mcp-reload.test.ts
@@ -13,7 +13,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
  */
 
 const getActiveHarness = vi.fn(async () => "openclaw" as string);
-const setActiveHarness = vi.fn(async (_harness: string) => {});
+const setActiveHarness = vi.fn(async (_harness: string) => "openclaw" as string);
 const harnessHealthy = vi.fn(async () => true);
 vi.mock("@/lib/harness", () => ({
   getActiveHarness: () => getActiveHarness(),
@@ -27,6 +27,16 @@ const dashboardRpc = vi.fn(async (_method: string, _params?: unknown) => ({ stat
 vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: (m: string, p: unknown) => dashboardRpc(m, p) }));
 
 const execFile = vi.fn();
+/**
+ * The identity sync, held open on demand.
+ *
+ * It runs `clawbox-identity-sync.sh` with a 60 s budget, and that is the window
+ * two concurrent switches overlap in — so the interleaving case below has to be
+ * able to stand two requests inside it at once and finish them in a chosen
+ * order. Everything else runs it to completion immediately, as before.
+ */
+let holdSync = false;
+const pendingSyncs: (() => void)[] = [];
 vi.mock("child_process", () => ({
   execFile: (
     _cmd: string,
@@ -35,7 +45,9 @@ vi.mock("child_process", () => ({
     cb: (err: Error | null, out: { stdout: string; stderr: string }) => void,
   ) => {
     execFile();
-    cb(null, { stdout: "", stderr: "" });
+    const finish = () => cb(null, { stdout: "", stderr: "" });
+    if (holdSync) pendingSyncs.push(finish);
+    else finish();
   },
 }));
 
@@ -50,7 +62,10 @@ function post(harness: string) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  holdSync = false;
+  pendingSyncs.length = 0;
   getActiveHarness.mockResolvedValue("openclaw");
+  setActiveHarness.mockResolvedValue("openclaw");
   harnessHealthy.mockResolvedValue(true);
   dashboardRpc.mockResolvedValue({ status: "ok" });
   vi.spyOn(console, "log").mockImplementation(() => {});
@@ -73,6 +88,42 @@ describe("POST /setup-api/harness/select", () => {
 
     expect(res.status).toBe(200);
     expect(dashboardRpc).not.toHaveBeenCalled();
+  });
+
+  it("still asks for the reload when two opposite switches overlap", async () => {
+    // `previous` used to be read at the top of the handler, BEFORE an identity
+    // sync with a 60 s budget. Two switches in opposite directions therefore
+    // both saw the same predecessor: the second one persisted its harness and
+    // then decided nothing had moved, so the box ended on one harness with the
+    // agent still holding the other one's tools — for the rest of the session,
+    // since nothing else restarts it. Reading the predecessor FROM THE WRITE
+    // closes the window.
+    let stored = "openclaw";
+    getActiveHarness.mockImplementation(async () => stored);
+    setActiveHarness.mockImplementation(async (harness: string) => {
+      const replaced = stored;
+      stored = harness;
+      return replaced;
+    });
+
+    // Both requests are inside their identity sync before either persists.
+    holdSync = true;
+    const toHermes = post("hermes");
+    const toOpenclaw = post("openclaw");
+    await vi.waitFor(() => expect(pendingSyncs).toHaveLength(2));
+
+    // Hermes lands first and really does flip the box.
+    pendingSyncs[0]();
+    await toHermes;
+    // Then OpenClaw lands, and it flips it back — a real change, from hermes.
+    pendingSyncs[1]();
+    await toOpenclaw;
+
+    expect(stored).toBe("openclaw");
+    expect(setActiveHarness.mock.calls.map(([h]) => h)).toEqual(["hermes", "openclaw"]);
+    // One reload for each real flip. The second is the one that used to be
+    // skipped, and it is the one that leaves the agent matching the box.
+    expect(dashboardRpc).toHaveBeenCalledTimes(2);
   });
 
   it("still reports the switch when the box has no dashboard to ask", async () => {

--- a/src/tests/routes/harness-select-mcp-reload.test.ts
+++ b/src/tests/routes/harness-select-mcp-reload.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Switching the harness has to reach the agent's own tool list (TASK-715).
+ *
+ * The ClawBox MCP server resolves which harness is active ONCE, when its stdio
+ * child boots, and registers whole tool families and the built-in app list off
+ * that answer. This route deliberately does not bounce the other gateway, so on
+ * the dual SKU nothing told that child the harness had moved: `ui_open_app`
+ * answered "There is no such app on this ClawBox" for the box's own dashboard
+ * until the next MCP restart, while `clawbox app open` from the same agent's
+ * shell succeeded — a CLI run is its own startup.
+ */
+
+const getActiveHarness = vi.fn(async () => "openclaw" as string);
+const setActiveHarness = vi.fn(async (_harness: string) => {});
+const harnessHealthy = vi.fn(async () => true);
+vi.mock("@/lib/harness", () => ({
+  getActiveHarness: () => getActiveHarness(),
+  setActiveHarness: (h: string) => setActiveHarness(h),
+  harnessHealthy: () => harnessHealthy(),
+  isHarness: (h: unknown) => h === "openclaw" || h === "hermes",
+  isSingleHarnessEdition: () => false,
+}));
+
+const dashboardRpc = vi.fn(async (_method: string, _params?: unknown) => ({ status: "ok" }) as unknown);
+vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: (m: string, p: unknown) => dashboardRpc(m, p) }));
+
+const execFile = vi.fn();
+vi.mock("child_process", () => ({
+  execFile: (
+    _cmd: string,
+    _args: string[],
+    _opts: unknown,
+    cb: (err: Error | null, out: { stdout: string; stderr: string }) => void,
+  ) => {
+    execFile();
+    cb(null, { stdout: "", stderr: "" });
+  },
+}));
+
+import { POST } from "@/app/setup-api/harness/select/route";
+
+function post(harness: string) {
+  return POST(new Request("http://localhost/setup-api/harness/select", {
+    method: "POST",
+    body: JSON.stringify({ harness }),
+  }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getActiveHarness.mockResolvedValue("openclaw");
+  harnessHealthy.mockResolvedValue(true);
+  dashboardRpc.mockResolvedValue({ status: "ok" });
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+describe("POST /setup-api/harness/select", () => {
+  it("asks the harness to rebuild its MCP tool list after a real switch", async () => {
+    const res = await post("hermes");
+
+    expect(res.status).toBe(200);
+    expect(setActiveHarness).toHaveBeenCalledWith("hermes");
+    expect(dashboardRpc).toHaveBeenCalledWith("reload.mcp", { confirm: true });
+  });
+
+  it("asks for nothing when the owner re-selects the harness already running", async () => {
+    // The reload respawns every MCP child and invalidates the model's prompt
+    // cache; a save that moved nothing must not buy that.
+    const res = await post("openclaw");
+
+    expect(res.status).toBe(200);
+    expect(dashboardRpc).not.toHaveBeenCalled();
+  });
+
+  it("still reports the switch when the box has no dashboard to ask", async () => {
+    // The selection is persisted before the refresh runs, and a best-effort
+    // reload must never turn a switch that succeeded into an error.
+    dashboardRpc.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const res = await post("hermes");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true, active: "hermes" });
+  });
+});

--- a/src/tests/unit/config-store.test.ts
+++ b/src/tests/unit/config-store.test.ts
@@ -150,6 +150,51 @@ describe("config-store", () => {
       await expect(configStore.swap("telegram_bot_token", "111:x")).rejects.toThrow();
       expect(await fs.readFile(CONFIG_PATH, "utf-8")).toBe("{ half written");
     });
+
+    it("refuses `undefined` instead of quietly REMOVING the key", async () => {
+      // `swap` replaces; it does not delete. `JSON.stringify` drops a key whose
+      // value is `undefined`, so the rename would have written a config without
+      // it — and the caller, handed the predecessor and no error, would read
+      // that as a successful switch. `setActiveHarness` losing `active_harness`
+      // that way leaves the box with no recorded harness while the route
+      // reports the change made.
+      await fs.writeFile(CONFIG_PATH, JSON.stringify({ active_harness: "hermes", keep: "kept" }), "utf-8");
+
+      await expect(configStore.swap("active_harness", undefined)).rejects.toThrow(TypeError);
+      const content = JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8"));
+      expect(content).toEqual({ active_harness: "hermes", keep: "kept" });
+    });
+
+    it("refuses every OTHER value JSON drops the same way", async () => {
+      // `undefined` is not special — a function and a symbol are omitted by
+      // `JSON.stringify` identically, with the identical outcome: the key gone
+      // from the file, the predecessor returned, no error. The guard tests the
+      // property, so this list is what the property covers rather than a second
+      // enumeration to keep in step.
+      await fs.writeFile(CONFIG_PATH, JSON.stringify({ active_harness: "hermes" }), "utf-8");
+
+      await expect(configStore.swap("active_harness", () => "hermes")).rejects.toThrow(TypeError);
+      await expect(configStore.swap("active_harness", Symbol("hermes"))).rejects.toThrow(TypeError);
+      expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8"))).toEqual({ active_harness: "hermes" });
+    });
+
+    it("lets neither of two overlapping swaps read a predecessor the other replaced", async () => {
+      // The property the whole fix rests on, and the one nothing else pins: the
+      // read and the write are in the SAME event-loop turn, so the second call
+      // cannot see the value the first one started from. Move this module to
+      // `fs/promises` — a natural cleanup, since it is already `async` — and an
+      // `await` appears between them, both swaps answer "openclaw", the route
+      // concludes nothing moved and skips the reload. That is TASK-715 exactly.
+      await fs.writeFile(CONFIG_PATH, JSON.stringify({ active_harness: "openclaw" }), "utf-8");
+
+      // Deliberately NOT awaited in between.
+      const first = configStore.swap("active_harness", "hermes");
+      const second = configStore.swap("active_harness", "openclaw");
+
+      expect(await first).toBe("openclaw");
+      expect(await second).toBe("hermes");
+      expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8")).active_harness).toBe("openclaw");
+    });
   });
 
   describe("setMany", () => {

--- a/src/tests/unit/config-store.test.ts
+++ b/src/tests/unit/config-store.test.ts
@@ -125,6 +125,33 @@ describe("config-store", () => {
     });
   });
 
+  describe("swap", () => {
+    it("writes the new value and answers with the one it replaced", async () => {
+      await fs.writeFile(CONFIG_PATH, JSON.stringify({ active_harness: "openclaw", keep: "kept" }), "utf-8");
+
+      await expect(configStore.swap("active_harness", "hermes")).resolves.toBe("openclaw");
+      const content = JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8"));
+      expect(content.active_harness).toBe("hermes");
+      expect(content.keep).toBe("kept");
+    });
+
+    it("answers undefined for a key the store did not hold", async () => {
+      await expect(configStore.swap("neverSet", "first")).resolves.toBeUndefined();
+      expect(await configStore.get("neverSet")).toBe("first");
+    });
+
+    it("throws over a store it could not read, like `set`", async () => {
+      // The invariant this shares with `set`: `swap` is a second write path
+      // into the file holding the mailbox password and both bot tokens, and a
+      // forgiving read would rebuild it from `{}` and REPLACE it with the one
+      // key being written. Pinned here because the caller cannot see it.
+      await fs.writeFile(CONFIG_PATH, "{ half written", "utf-8");
+
+      await expect(configStore.swap("telegram_bot_token", "111:x")).rejects.toThrow();
+      expect(await fs.readFile(CONFIG_PATH, "utf-8")).toBe("{ half written");
+    });
+  });
+
   describe("setMany", () => {
     it("sets multiple keys atomically", async () => {
       await configStore.setMany({ x: 1, y: 2, z: 3 });

--- a/src/tests/unit/harness-edition.test.ts
+++ b/src/tests/unit/harness-edition.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 // config-store backs the stored active_harness; mock it so we control the value.
 const mockGet = vi.fn();
-const mockSet = vi.fn();
+const mockSwap = vi.fn();
 vi.mock("@/lib/config-store", () => ({
   get: (...a: unknown[]) => mockGet(...a),
-  set: (...a: unknown[]) => mockSet(...a),
+  swap: (...a: unknown[]) => mockSwap(...a),
 }));
 
 // Control the dual-license verdict directly (the real module verifies an
@@ -30,7 +30,7 @@ async function loadHarness(edition?: string) {
 describe("harness edition lock", () => {
   beforeEach(() => {
     mockGet.mockReset();
-    mockSet.mockReset();
+    mockSwap.mockReset();
     licenseValid = false;
   });
   afterEach(() => {
@@ -45,7 +45,7 @@ describe("harness edition lock", () => {
     mockGet.mockResolvedValue("hermes"); // stale config ignored on a locked device
     expect(await h.getActiveHarness()).toBe("openclaw");
     await expect(h.setActiveHarness("hermes")).rejects.toThrow(LOCKED);
-    expect(mockSet).not.toHaveBeenCalled();
+    expect(mockSwap).not.toHaveBeenCalled();
   });
 
   it("locks to hermes on the hermes edition", async () => {
@@ -55,7 +55,7 @@ describe("harness edition lock", () => {
     mockGet.mockResolvedValue("openclaw");
     expect(await h.getActiveHarness()).toBe("hermes");
     await expect(h.setActiveHarness("openclaw")).rejects.toThrow(LOCKED);
-    expect(mockSet).not.toHaveBeenCalled();
+    expect(mockSwap).not.toHaveBeenCalled();
   });
 
   it("dual WITHOUT a valid license degrades to locked single (default harness)", async () => {
@@ -64,7 +64,7 @@ describe("harness edition lock", () => {
     expect(h.isSingleHarnessEdition()).toBe(true);
     expect(h.lockedHarness()).toBe("openclaw");
     await expect(h.setActiveHarness("hermes")).rejects.toThrow(LOCKED);
-    expect(mockSet).not.toHaveBeenCalled();
+    expect(mockSwap).not.toHaveBeenCalled();
   });
 
   it("stays locked on dual when the licence verdict is unavailable", async () => {
@@ -77,7 +77,7 @@ describe("harness edition lock", () => {
     expect(h.isDualUnlocked()).toBe(false);
     expect(h.isSingleHarnessEdition()).toBe(true);
     await expect(h.setActiveHarness("hermes")).rejects.toThrow(LOCKED);
-    expect(mockSet).not.toHaveBeenCalled();
+    expect(mockSwap).not.toHaveBeenCalled();
   });
 
   it("dual WITH a valid license unlocks the switcher", async () => {
@@ -87,8 +87,23 @@ describe("harness edition lock", () => {
     expect(h.lockedHarness()).toBeNull();
     mockGet.mockResolvedValue("hermes");
     expect(await h.getActiveHarness()).toBe("hermes"); // honors stored value
-    await h.setActiveHarness("openclaw");
-    expect(mockSet).toHaveBeenCalledWith("active_harness", "openclaw");
+    mockSwap.mockResolvedValue("hermes");
+    // The write answers with what it REPLACED — the caller's "did this change
+    // anything" cannot be answered by a read it made earlier.
+    expect(await h.setActiveHarness("openclaw")).toBe("hermes");
+    expect(mockSwap).toHaveBeenCalledWith("active_harness", "openclaw");
+  });
+
+  it("reports the default as the predecessor when the store held no harness", async () => {
+    // A box that has never switched, or one whose stored value is not a
+    // harness at all: the same answer `getActiveHarness` gives it, so a
+    // re-select of the default is still correctly read as "nothing moved".
+    licenseValid = true;
+    const h = await loadHarness("dual");
+    mockSwap.mockResolvedValue(undefined);
+    expect(await h.setActiveHarness("hermes")).toBe("openclaw");
+    mockSwap.mockResolvedValue("nonsense");
+    expect(await h.setActiveHarness("hermes")).toBe("openclaw");
   });
 
   it("treats an unknown edition value as the native openclaw edition", async () => {

--- a/src/tests/unit/harness-mcp-refresh.test.ts
+++ b/src/tests/unit/harness-mcp-refresh.test.ts
@@ -64,13 +64,6 @@ describe("the agent's tool list, after the owner switches harness", () => {
     expect(rpcMock).not.toHaveBeenCalled();
   });
 
-  it("costs nothing when the previous harness could not be read", async () => {
-    // "I could not tell" is not evidence of a flip, and treating it as one
-    // would buy a reload on every save on the one box least likely to need it.
-    await expect(refreshHarnessToolsIfSwitched(null, "hermes")).resolves.toBe(false);
-    expect(rpcMock).not.toHaveBeenCalled();
-  });
-
   it("says so rather than reporting a reload the dashboard refused", async () => {
     // `confirm_required` is an ordinary non-error reply that means NOTHING
     // HAPPENED — the false-success shape the shared helper exists to catch.

--- a/src/tests/unit/harness-mcp-refresh.test.ts
+++ b/src/tests/unit/harness-mcp-refresh.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The fifth boot-time snapshot, and the biggest: WHICH HARNESS IS ACTIVE.
+ *
+ * `mcp/lib/edition.ts` resolves it once while the ClawBox MCP stdio child
+ * boots, and that one answer decides which harness's built-in apps
+ * `ui_open_app`/`ui_list_apps` offer, which tool families are registered at
+ * all, what `device_status` calls the agent and which field guide
+ * `clawbox_context` serves. `/setup-api/harness/select` deliberately does not
+ * bounce the other gateway, so on the dual SKU nothing told that child — and
+ * `ui_open_app("hermes")` went on answering "There is no such app on this
+ * ClawBox" for the box's own dashboard until the next MCP restart (TASK-715,
+ * TASK-541's symptom returning through the switch).
+ *
+ * The mechanism is the harness's own `reload.mcp`, shared with the four
+ * siblings; what is pinned here is the RULE for when it is worth paying for.
+ */
+
+const rpcMock = vi.hoisted(() => vi.fn());
+const activeHarnessMock = vi.hoisted(() => vi.fn(async () => "hermes" as string));
+
+vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: rpcMock }));
+vi.mock("@/lib/harness", () => ({ getActiveHarness: activeHarnessMock }));
+
+import { refreshHarnessToolsIfSwitched } from "@/lib/harness-mcp-refresh";
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  rpcMock.mockReset();
+  activeHarnessMock.mockReset();
+  activeHarnessMock.mockResolvedValue("hermes");
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  warnSpy.mockRestore();
+});
+
+describe("the agent's tool list, after the owner switches harness", () => {
+  it("asks the harness to rebuild it when the harness really moved", async () => {
+    rpcMock.mockResolvedValue({ status: "ok" });
+
+    await expect(refreshHarnessToolsIfSwitched("openclaw", "hermes")).resolves.toBe(true);
+    expect(rpcMock).toHaveBeenCalledWith("reload.mcp", { confirm: true });
+  });
+
+  it("asks in the other direction too", async () => {
+    rpcMock.mockResolvedValue({ status: "ok" });
+
+    await expect(refreshHarnessToolsIfSwitched("hermes", "openclaw")).resolves.toBe(true);
+    expect(rpcMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("costs nothing when the owner re-selects the harness already running", async () => {
+    // A reload respawns every MCP child and invalidates the model's prompt
+    // cache, so the next turn re-pays for a system prompt that was cached. A
+    // save that changed nothing the agent can see must not buy that.
+    await expect(refreshHarnessToolsIfSwitched("hermes", "hermes")).resolves.toBe(false);
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it("costs nothing when the previous harness could not be read", async () => {
+    // "I could not tell" is not evidence of a flip, and treating it as one
+    // would buy a reload on every save on the one box least likely to need it.
+    await expect(refreshHarnessToolsIfSwitched(null, "hermes")).resolves.toBe(false);
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it("says so rather than reporting a reload the dashboard refused", async () => {
+    // `confirm_required` is an ordinary non-error reply that means NOTHING
+    // HAPPENED — the false-success shape the shared helper exists to catch.
+    rpcMock.mockResolvedValue({ status: "confirm_required" });
+
+    await expect(refreshHarnessToolsIfSwitched("openclaw", "hermes")).resolves.toBe(false);
+  });
+
+  it("never throws when there is no dashboard to ask", async () => {
+    rpcMock.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    await expect(refreshHarnessToolsIfSwitched("openclaw", "hermes")).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
**TASK-715** — the MCP server kept the harness it found at boot.

## Symptom

On the `dual` SKU the owner switches harness in Settings. `ui_open_app("hermes")` answers
"There is no such app on this ClawBox" for the box's own dashboard — TASK-541's exact symptom —
while `clawbox app open hermes` from the same agent's shell succeeds. It clears at the next MCP
restart, and nothing on the box causes one.

## Cause

The ClawBox MCP server resolves which harness is active ONCE, while its stdio child boots
(`mcp/lib/edition.ts`), and that one answer decides more than the app list: which tool families are
registered at all (`resolveEdition` — the skills family on Hermes, the app store on OpenClaw), the
tool descriptions the agent reads to choose an id, what `device_status` calls the agent, and which
field guide `clawbox_context` serves. `/setup-api/harness/select` deliberately does not bounce the
other gateway, so nothing told that child. The CLI is right by accident: a CLI run IS its own
startup.

## Harness-first — and it changed the fix

The first cut of this branch re-resolved the harness per call inside `ui_open_app` / `ui_list_apps`.
The review pass rejected it, correctly: the native mechanism for exactly this staleness class already
ships in this repo. `reloadMcpServers()` (`src/lib/hermes-mcp-reload.ts`) wraps Hermes' own
`reload.mcp` dashboard RPC, and `mcp/README.md` describes the class in its own words — "Because the
probe is startup-only, a mode or credential change would otherwise leave a long-lived server with the
tool list it built at boot". Four call sites already follow the pattern (`email-mcp-refresh`,
`coding-agent-mcp-refresh`, `provider-mcp-refresh`, `hermes-image-refresh`), each with the same
"only on a flip, it is not free" rule. A harness switch is the same shape and a bigger change than
any of them, and the select route — the one place that knows it happened — did not call it.

`src/lib/harness-mcp-refresh.ts` is the fifth sibling.

Why the per-call read was the wrong shape, not merely a second-best one: it would have made the app
list fresh while the registered tool set, the tool descriptions and the orientation answers stayed
on the boot snapshot — `ui_list_apps` naming `hermes-skills` in the same session where `skill_list`
is not registered and `device_status` still says OpenClaw. A reload re-probes everything, so they
move together.

MCP's own `tools/list_changed` is **not** the missing piece: the stdio child has no inbound event
source, so it would still have to poll to learn the switch happened. `list_changed` is what a server
emits once it knows; `reload.mcp` is how the box tells it.

## Both editions

Switching TO Hermes hands its dashboard the reload directly. Switching AWAY leaves an OpenClaw box,
which has no dashboard by design — `reportMcpReloadRefused` already says the true sentence for that
edition, and the README documents the self-heal: OpenClaw spawns the ClawBox MCP server lazily per
session and reaps it after ten idle minutes.

## Sibling call sites

- `mcp/clawbox-cli.ts` — **cleared, not changed.** It resolves the harness per invocation already,
  because a CLI run is its own startup.
- The four existing `*-mcp-refresh.ts` helpers — the pattern this follows; each keeps its own
  guard, and the shared `alreadyReloaded` option is not needed here because the select route moves
  one family and returns.
- `mcp/lib/edition.ts` / `mcp/lib/context.ts` — untouched. The snapshot is right again once the
  child is respawned, so nothing there needs a second source of truth.
- `active_harness` has exactly **one** writer in the tree (`setActiveHarness`), so changing its
  return type reaches one call site. Every test that mocks `@/lib/config-store` was checked for the
  new `swap` export; only `harness-edition.test.ts` reaches it.

## The predecessor comes from the write

Review found a race on the original head: `previous` was read at the top of the handler, **above** an
identity sync with a 60 s budget. Two switches in opposite directions inside that window both read
the same predecessor — the second persists its harness, concludes nothing moved, skips its reload,
and leaves the box on one harness with the agent's whole tool list built for the other.

`setActiveHarness` now returns the harness it replaced, read and written in one synchronous step by a
new `swap` in `config-store.ts` (`readConfigStrict()` then `writeConfig()`, both `fs.*Sync`, nothing
awaited between them, and the same strict read `set` uses — this is a second write path into the file
holding the mailbox password and both bot tokens). The route no longer reads the harness at all.

**What that does and does not close.** It makes the reload *decision* correct whatever order two
requests interleave in, so the last reload always post-dates the last persist. It does **not**
serialise the transaction: two concurrent switches still run two unlocked
`clawbox-identity-sync.sh` invocations, unchanged by this PR. One residual remains and it is beta's
documented self-heal case — if the last-persisting request's own reload is refused, the tool list
catches up at the next MCP restart.

Also removed: `refreshHarnessToolsIfSwitched`'s `before: string | null` branch. `getActiveHarness`
swallows its own read failure and returns `DEFAULT_HARNESS`, so `null` was never reachable and the
comment describing it was an inherited premise. The predecessor is now always a real harness.

## RED → GREEN

RED, against unmodified `origin/beta` (`381f34ed`):

```
 ❯ src/tests/routes/harness-select-mcp-reload.test.ts (3 tests | 1 failed)
   × asks the harness to rebuild its MCP tool list after a real switch
     AssertionError: expected "vi.fn()" to be called with arguments:
       [ 'reload.mcp', { confirm: true } ]
     Number of calls: 0
```

RED for the race, two requests held inside their identity syncs and released in order:

```
 ❯ src/tests/routes/harness-select-mcp-reload.test.ts
   × still asks for the reload when two opposite switches overlap
     AssertionError: expected "vi.fn()" to be called 2 times, but got 1 times
```

GREEN on this head — the new suites, the four sibling refresh suites, `config-store`, the edition
lock and the hygiene guards:

```
$ npx vitest run config-store harness-edition harness-select-mcp-reload harness-mcp-refresh \
    install-hermes-tts email-mcp-refresh coding-agent-mcp-refresh provider-mcp-refresh \
    hermes-image-refresh openclaw-config-mock-completeness test-timeout-hygiene state-updater-purity
 Test Files  13 passed (13)
      Tests  169 passed (169)

$ npx tsc --noEmit          # exit 0
```

`swap` has direct coverage of every promise it makes, each verified by mutating that behaviour away
and confirming the suite fails:

- it returns the value it replaced;
- it throws over a store it could not read, like `set`;
- **it refuses a value it cannot store.** `JSON.stringify` omits a key whose value is `undefined` —
  and a function or a symbol identically — so the rename wrote a config *without* the key while the
  caller was handed the predecessor and no error, and would read that as the switch having been
  made. The false-success class, inside the function added to close a race. The guard is
  `JSON.stringify(value) === undefined`, the property itself rather than an enumeration of the
  values that have it, and it sits ahead of the read so an unstorable value costs no file access.
  Not reachable from `setActiveHarness(harness: Harness)`, which is the point of fixing it while
  there is one caller rather than ten;
- **the read and the write are in the same event-loop turn** — the property the whole fix rests on
  and the one nothing else pinned. Two swaps started without awaiting between them: the second must
  see the first's value. Insert `await Promise.resolve()` between the read and the write, which is
  the natural shape of a future `fs/promises` cleanup, and it reddens with
  `expected 'openclaw' to be 'hermes'` — TASK-715's race, returned.

Still open, deliberately: `swap("__proto__", x)` also fails to store, because `config[key] = value`
hits `Object.prototype`'s setter. That is identical in `set` and `setMany`, so guarding it only here
would reproduce the one-call-site-guarded shape this PR is otherwise avoiding; it belongs with the
store-wide follow-up recorded on the review thread.

## Not proven on hardware

The reload needs a licensed `dual` box to switch on; neither test box is one (the OpenClaw box is
`CLAWBOX_EDITION=openclaw`, the Hermes box `hermes`, and on a locked edition the select route
answers 403 before reaching this code). Whoever next has a dual box on the bench should switch the
harness in Settings and then ask the agent to open the newly-active harness's dashboard — it should
open, without an MCP restart, and the journal should carry one
`[harness/select] the active harness moved from … to …; asked Hermes to reload its MCP servers`.

That line names **Hermes** deliberately, in both directions. On the licensed dual SKU the Hermes
dashboard runs whichever harness is active, so a `hermes → openclaw` switch also succeeds at
`reload.mcp` — what it respawns is Hermes' own MCP children, which is worth having for the next
switch back. The OpenClaw side is never asked and does not need to be: it spawns the ClawBox MCP
server per session and reaps it after ten idle minutes. The line used to say "asked the agent",
which read as "whichever harness now serves the owner" and was wrong in exactly that direction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Harness tools now refresh automatically when switching to a different harness.
  * Re-selecting the active harness avoids unnecessary tool refreshes.
  * Harness switching continues successfully when dashboard tool refresh is unavailable.

* **Bug Fixes**
  * Refused or failed tool refresh requests no longer interrupt harness selection.
  * Harness settings are updated atomically to prevent partial configuration changes.

* **Tests**
  * Added coverage for harness switching, re-selection, refresh failures, and configuration updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

