### PR TITLE
fix: a gateway restart no longer starts the dashboard mid-rebuild

### DIFF
--- a/config/clawbox-gateway.service
+++ b/config/clawbox-gateway.service
@@ -1,13 +1,34 @@
 [Unit]
 Description=ClawBox OpenClaw Gateway
-# After the web server as well: memory search reaches its embedder through the
-# web server's local-AI proxy, and OpenClaw's embedding client gives a refused
-# connection three attempts inside two seconds before it answers a search
-# keyword-only and leaves the index dirty. Started side by side at boot, the
-# gateway's first sync used to lose that race every time. Wants, not Requires:
-# a web server that fails to start must not keep the agent down with it.
+# ORDERED after the web server, and deliberately not a dependency on it: memory
+# search reaches its embedder through the web server's local-AI proxy, and
+# OpenClaw's embedding client gives a refused connection three attempts inside
+# two seconds before it answers a search keyword-only and leaves the index
+# dirty. Started side by side at boot, the gateway's first sync used to lose
+# that race every time.
+#
+# `After=` alone is what fixes that race, and it is enough: clawbox-setup.service
+# carries `[Install] WantedBy=multi-user.target` and install.sh enables it, so it
+# is in every boot transaction whether or not this unit asks for it — which is
+# exactly the shape clawbox-tunnel.service, clawbox-heartbeat.service and
+# clawbox-hermes-dashboard-proxy.service already use for the same web server.
+#
+# `Wants=clawbox-setup.service` was HERE, and it made every gateway (re)start
+# start the web server too. That is the defect (TASK-728): `do_rebuild` stops
+# clawbox-setup for the length of the rebuild, and a gateway crash-looping on
+# plugin consent restarts every five seconds against a multi-minute build — so
+# the dashboard came back four seconds after the stop (e2e-install run
+# 33971129750), the update's remaining steps ran from the PRE-UPDATE build, and
+# post_update died on a polkit denial it could not have hit on the new one. It
+# also voided free_memory_for_build's memory hold, since the gateway reaches
+# ollama and llama.cpp through that same proxy, and it is what pulled the web
+# server onto the parked build the #672 guard now has to catch.
+#
+# The one case that changes is a gateway started while the web server is DOWN.
+# During a rebuild that is the outcome this exists to produce; at any other time
+# clawbox-setup is up, or coming back under its own `Restart=always`.
 After=network-online.target clawbox-setup.service
-Wants=network-online.target clawbox-setup.service
+Wants=network-online.target
 # A cold Jetson can legitimately spend up to TimeoutStartSec in
 # gateway-pre-start.sh. Keep the limiter window long enough to contain several
 # complete slow failures; inherited 5-in-10s defaults never tripped when one

--- a/config/clawbox-gateway.service
+++ b/config/clawbox-gateway.service
@@ -7,11 +7,19 @@ Description=ClawBox OpenClaw Gateway
 # dirty. Started side by side at boot, the gateway's first sync used to lose
 # that race every time.
 #
-# `After=` alone is what fixes that race, and it is enough: clawbox-setup.service
-# carries `[Install] WantedBy=multi-user.target` and install.sh enables it, so it
-# is in every boot transaction whether or not this unit asks for it — which is
-# exactly the shape clawbox-tunnel.service, clawbox-heartbeat.service and
-# clawbox-hermes-dashboard-proxy.service already use for the same web server.
+# `After=` orders this unit after the web server's EXEC, not after it is ready —
+# clawbox-setup.service is Type=simple, so its start job completes the moment
+# node is forked, which was equally true when this line said `Wants=` as well.
+# What actually covers the race is scripts/gateway-pre-start.sh launching
+# scripts/ensure-local-embeddings.sh detached, which waits
+# EMBED_PROXY_WAIT_SECONDS (120) for the proxy to answer and exits without
+# touching the config if it never does. The ordering is worth keeping anyway —
+# it removes the common case for free — and it costs nothing, because
+# clawbox-setup.service carries `[Install] WantedBy=multi-user.target` and
+# install.sh enables it, so it is in every boot transaction whether or not this
+# unit asks for it. That is exactly the shape clawbox-tunnel.service,
+# clawbox-heartbeat.service and clawbox-hermes-dashboard-proxy.service already
+# use for the same web server.
 #
 # `Wants=clawbox-setup.service` was HERE, and it made every gateway (re)start
 # start the web server too. That is the defect (TASK-728): `do_rebuild` stops
@@ -24,9 +32,15 @@ Description=ClawBox OpenClaw Gateway
 # ollama and llama.cpp through that same proxy, and it is what pulled the web
 # server onto the parked build the #672 guard now has to catch.
 #
-# The one case that changes is a gateway started while the web server is DOWN.
-# During a rebuild that is the outcome this exists to produce; at any other time
-# clawbox-setup is up, or coming back under its own `Restart=always`.
+# Three cases change, and none of them is the boot: a box whose clawbox-setup an
+# operator DISABLED is no longer dragged up by the gateway (the operator's
+# intent is honoured, and the next update's enable loop puts it back); a
+# `systemctl restart clawbox-gateway` or `--step gateway_setup` run while the
+# web server is down now brings the gateway up beside a dead dashboard; and the
+# dashboard stays down for the whole of a rebuild, which is the outcome this
+# change exists to produce. `Restart=always` is NOT the safety net for the first
+# two — it does not revive a unit that was stopped, disabled or masked on
+# purpose.
 After=network-online.target clawbox-setup.service
 Wants=network-online.target
 # A cold Jetson can legitimately spend up to TimeoutStartSec in

--- a/e2e-install/90-upgrade-main-to-beta.spec.ts
+++ b/e2e-install/90-upgrade-main-to-beta.spec.ts
@@ -6,9 +6,23 @@
  * post-reboot continuation step.
  *
  * This test relies on the shared container set up by `global-setup.ts` —
- * run it after happy-path.spec.ts. Because the updater literally bounces
- * the Next.js server (step_rebuild_reboot → systemctl restart), the HTTP
- * endpoint goes down for some seconds; `waitForUpdate` tolerates that.
+ * run it after happy-path.spec.ts.
+ *
+ * The HTTP endpoint goes down for MINUTES, not seconds, and by design. The
+ * updater stops clawbox-setup.service for the whole rebuild
+ * (`do_rebuild`) and starts it again at the end (`step_rebuild_reboot` →
+ * `systemctl restart`, the test-mode stand-in for the reboot). Nothing brings
+ * it back in between since TASK-728 removed `clawbox-gateway.service`'s
+ * `Wants=clawbox-setup.service` — which is the point of that change, and which
+ * used to be why `/setup-api/update/status` kept answering across a rebuild at
+ * all (on the PRE-UPDATE build, which is the defect it fixes).
+ *
+ * So both `waitForUpdate` calls below pass an explicit downtime budget rather
+ * than the helper's default of 60 consecutive failures (~183 s): `bun install`
+ * plus `next build` on a qemu-x86 fallback runner is well past that, and the
+ * default would report `update status unreachable` over an update that
+ * completed. 420 × 3 s = 21 min, sized on the updater's own
+ * REBUILD_TAKEOVER_TIMEOUT_MS (20 min) and still inside the 45-minute ceiling.
  *
  * The `beta` branch must exist on origin with a commit ancestor-mergeable
  * from main (or at least a git-resettable ref). This matches how the real
@@ -25,6 +39,13 @@ import {
 import { startUpdate, waitForUpdate } from "./helpers/setup-api";
 
 const UPGRADE_BRANCH = process.env.CLAWBOX_UPGRADE_TARGET_BRANCH ?? "beta";
+
+/**
+ * How many consecutive unanswered status polls (3 s apart) are a rebuild rather
+ * than a broken box — see the header. 21 minutes, sized on the updater's own
+ * REBUILD_TAKEOVER_TIMEOUT_MS.
+ */
+const REBUILD_DOWNTIME_POLLS = 420;
 
 test.describe.configure({ mode: "serial" });
 
@@ -54,7 +75,7 @@ test.describe(`in-app upgrade: main → ${UPGRADE_BRANCH}`, () => {
     const result = await startUpdate(true);
     expect(result.started).toBe(true);
 
-    const state = await waitForUpdate({ timeoutMs: 45 * 60_000 });
+    const state = await waitForUpdate({ timeoutMs: 45 * 60_000, maxConsecutiveFetchErrors: REBUILD_DOWNTIME_POLLS });
     expect(["completed", "failed"]).toContain(state.phase);
     if (state.phase === "failed") {
       const failedStep = state.steps.find((step) => step.status === "failed");
@@ -92,7 +113,7 @@ test.describe(`in-app upgrade: main → ${UPGRADE_BRANCH}`, () => {
     // downtime; it also needs to see the `post_update` step run via
     // `checkContinuation`, which the server's own boot hook fires a few
     // seconds after it is back up (our status polls are only the fallback).
-    const state = await waitForUpdate({ timeoutMs: 45 * 60_000 });
+    const state = await waitForUpdate({ timeoutMs: 45 * 60_000, maxConsecutiveFetchErrors: REBUILD_DOWNTIME_POLLS });
     // `waitForUpdate` returns only a terminal phase — "completed" once
     // post_update and the checks after it ran, or "failed" — polling through
     // the restart and the resumed second half to get there.

--- a/install.sh
+++ b/install.sh
@@ -1319,11 +1319,15 @@ llamacpp_pid_if_running() {
 # knowing which. The routine breaker was clawbox-gateway.service's
 # `Wants=clawbox-setup.service`, which started the unit do_rebuild had just
 # stopped on every gateway (re)start; that line is gone (TASK-728), so a
-# crash-looping gateway no longer reopens the proxy behind the build. It is not
-# a fence even so: the new unit file only reaches the disk in step_systemd_
-# services, which runs in post_update — AFTER this rebuild — so the update that
-# delivers the change still runs its own build under the old unit, and an
-# operator can always start the web server by hand.
+# crash-looping gateway no longer reopens the proxy behind the build — including
+# on the update that DELIVERS the change, because the new unit file is installed
+# and daemon-reloaded before this function runs (step_rebuild_reboot calls
+# step_systemd_services seven lines above do_rebuild, and the updater's
+# gateway_setup step, which cps the same file, is the step immediately before
+# the rebuild). What is still not fenced: `install.sh --step rebuild` run by
+# hand, a box where gateway_setup was skipped (the unit is absent on the hermes
+# SKU) or step_systemd_services failed non-fatally, and an operator or the
+# sudoers grant restarting clawbox-setup inside the window.
 #
 # Stop, never disable — the same rule the idle standby follows, and the reason
 # it is safe: every engine here is meant to come back on demand. An update that
@@ -1631,11 +1635,12 @@ restore_previous_build() {
   #
   # What used to bring it back routinely was clawbox-gateway.service's
   # `Wants=clawbox-setup.service`, removed in TASK-728. This stays `restart`
-  # regardless: the new unit file only lands in post_update, so the update that
-  # removes the pull still rebuilds under the old one, boxes updating from an
-  # older build carry it for one more cycle, and an operator can start the web
-  # server by hand at any time. A rollback that reports itself wrongly is the
-  # expensive failure here; a redundant restart costs nothing.
+  # regardless, because the ways in are fewer rather than none: `install.sh
+  # --step rebuild` by hand, a box where gateway_setup was skipped or
+  # step_systemd_services failed non-fatally, and an operator or the sudoers
+  # grant restarting clawbox-setup inside the window. A rollback that reports
+  # itself wrongly is the expensive failure here; a redundant restart costs
+  # nothing.
   # `reset-failed` first, as both gateway recovery paths do. The reclaim in
   # production-server.js is now correctly refused for the length of the build,
   # so clawbox-setup crash-loops on `require`ing a build that is not there yet;
@@ -1786,11 +1791,12 @@ do_rebuild() {
   # The stop is what makes that ordering worth having. It did not keep the
   # dashboard down for the length of the rebuild, because clawbox-gateway.service
   # carried `Wants=clawbox-setup.service` and started it again on any gateway
-  # (re)start; that line is gone (TASK-728). The park still stamps the tree it
-  # sets aside and the two `systemctl` calls that end a rebuild still use
-  # `restart` rather than `start`: the removal reaches a box only when
-  # step_systemd_services reinstalls the unit in post_update, which is after this
-  # rebuild, and neither guard costs anything once it has.
+  # (re)start; that line is gone (TASK-728), and it is already gone for THIS
+  # rebuild — step_systemd_services runs seven lines above the do_rebuild in
+  # step_rebuild_reboot. The park still stamps the tree it sets aside and the two
+  # `systemctl` calls that end a rebuild still use `restart` rather than `start`:
+  # a hand-run `--step rebuild`, a skipped gateway_setup and an operator restart
+  # all still land in the window, and neither guard costs anything.
   promote_parked_build "$build_dir" "$kept_dir"
 
   # After the stop, never before it — see free_memory_for_build.
@@ -7156,11 +7162,14 @@ step_rebuild_reboot() {
   if is_test_mode; then
     echo "CLAWBOX_TEST_MODE=1, restarting clawbox-setup.service in lieu of reboot"
     # `reset-failed` first, as the other two rebuild-ending restarts already do
-    # (step_rebuild, restore_previous_build): the unit can crash-loop for the
-    # length of a rebuild, and a latched StartLimit would turn this restart into
-    # a failure over a build that is fine. This is the branch e2e-install takes,
-    # and it is bare under `set -euo pipefail`, so that failure would end the
-    # step.
+    # (step_rebuild, restore_previous_build). With no start dependency left,
+    # nothing starts clawbox-setup DURING a rebuild any more, so it can no
+    # longer crash-loop on the missing standalone entry from that source — but a
+    # hand restart or the sudoers grant can still land in the window and latch
+    # the unit's inherited 5-in-10 s start limit, and a latched limit would turn
+    # this restart into a failure over a build that is fine. This is the branch
+    # e2e-install takes, and it is bare under `set -euo pipefail`, so that
+    # failure would end the step.
     systemctl reset-failed clawbox-setup.service 2>/dev/null || true
     systemctl restart clawbox-setup.service
     return 0

--- a/install.sh
+++ b/install.sh
@@ -1316,10 +1316,14 @@ llamacpp_pid_if_running() {
 # server down nothing can pull a model back in behind us.
 #
 # "With the web server down" is best-effort, not a guarantee, and it is worth
-# knowing which: clawbox-gateway.service carries `Wants=clawbox-setup.service`,
-# so a gateway (re)start during the build starts the unit do_rebuild had just
-# stopped and the proxy is reachable again. The stop still removes the common
-# case; it does not fence the window.
+# knowing which. The routine breaker was clawbox-gateway.service's
+# `Wants=clawbox-setup.service`, which started the unit do_rebuild had just
+# stopped on every gateway (re)start; that line is gone (TASK-728), so a
+# crash-looping gateway no longer reopens the proxy behind the build. It is not
+# a fence even so: the new unit file only reaches the disk in step_systemd_
+# services, which runs in post_update — AFTER this rebuild — so the update that
+# delivers the change still runs its own build under the old unit, and an
+# operator can always start the web server by hand.
 #
 # Stop, never disable — the same rule the idle standby follows, and the reason
 # it is safe: every engine here is meant to come back on demand. An update that
@@ -1618,13 +1622,20 @@ restore_previous_build() {
   fi
 
   # `restart`, not `start`: `start` on a unit that is already active is a no-op,
-  # and the unit CAN be active here. do_rebuild stopped it, but
-  # clawbox-gateway.service carries `Wants=clawbox-setup.service`, so any
-  # gateway (re)start pulls it back up mid-rebuild — and once `next build` has
-  # written the standalone entry, the restart loop latches onto whatever tree is
-  # in place. A `start` would then be a no-op over a process serving the build
-  # that just FAILED verification, curl would answer 200 from it, and the line
-  # below would report a rollback that never happened.
+  # and the unit CAN be active here. do_rebuild stopped it, and once anything
+  # brings it back the restart loop latches onto whatever tree is in place from
+  # the moment `next build` writes the standalone entry. A `start` would then be
+  # a no-op over a process serving the build that just FAILED verification, curl
+  # would answer 200 from it, and the line below would report a rollback that
+  # never happened.
+  #
+  # What used to bring it back routinely was clawbox-gateway.service's
+  # `Wants=clawbox-setup.service`, removed in TASK-728. This stays `restart`
+  # regardless: the new unit file only lands in post_update, so the update that
+  # removes the pull still rebuilds under the old one, boxes updating from an
+  # older build carry it for one more cycle, and an operator can start the web
+  # server by hand at any time. A rollback that reports itself wrongly is the
+  # expensive failure here; a redundant restart costs nothing.
   # `reset-failed` first, as both gateway recovery paths do. The reclaim in
   # production-server.js is now correctly refused for the length of the build,
   # so clawbox-setup crash-loops on `require`ing a build that is not there yet;
@@ -1772,11 +1783,14 @@ do_rebuild() {
   # back before the rename below would delete it. After the stop, never before
   # it: the rename moves the tree the running server is loading from.
   #
-  # The stop is what makes that ordering worth having, but it does not keep the
-  # dashboard down for the length of the rebuild — clawbox-gateway.service's
-  # `Wants=clawbox-setup.service` starts it again on any gateway (re)start. That
-  # is why the park stamps the tree it sets aside, and why the two `systemctl`
-  # calls that end a rebuild use `restart` rather than `start`.
+  # The stop is what makes that ordering worth having. It did not keep the
+  # dashboard down for the length of the rebuild, because clawbox-gateway.service
+  # carried `Wants=clawbox-setup.service` and started it again on any gateway
+  # (re)start; that line is gone (TASK-728). The park still stamps the tree it
+  # sets aside and the two `systemctl` calls that end a rebuild still use
+  # `restart` rather than `start`: the removal reaches a box only when
+  # step_systemd_services reinstalls the unit in post_update, which is after this
+  # rebuild, and neither guard costs anything once it has.
   promote_parked_build "$build_dir" "$kept_dir"
 
   # After the stop, never before it — see free_memory_for_build.
@@ -7141,6 +7155,13 @@ step_rebuild_reboot() {
   do_rebuild
   if is_test_mode; then
     echo "CLAWBOX_TEST_MODE=1, restarting clawbox-setup.service in lieu of reboot"
+    # `reset-failed` first, as the other two rebuild-ending restarts already do
+    # (step_rebuild, restore_previous_build): the unit can crash-loop for the
+    # length of a rebuild, and a latched StartLimit would turn this restart into
+    # a failure over a build that is fine. This is the branch e2e-install takes,
+    # and it is bare under `set -euo pipefail`, so that failure would end the
+    # step.
+    systemctl reset-failed clawbox-setup.service 2>/dev/null || true
     systemctl restart clawbox-setup.service
     return 0
   fi

--- a/production-server.js
+++ b/production-server.js
@@ -787,9 +787,10 @@ try {
   // carried `Wants=clawbox-setup.service`, so every gateway (re)start started the
   // service do_rebuild had just stopped (e2e-install run 33971129750: four
   // seconds after the stop). That line is gone (TASK-728), which removes the
-  // routine trigger and not the case: the unit file only reaches a box in
-  // post_update, so the update that removes it still rebuilds under the old one,
-  // and an operator can start the web server by hand at any time. Reclaiming
+  // routine trigger and not the case: `install.sh --step rebuild` run by hand, a
+  // box where the gateway unit was never installed so gateway_setup is skipped,
+  // and an operator (or the sudoers grant) restarting clawbox-setup all still
+  // land inside the window. Reclaiming
   // there `rm -rf`s the half-written build
   // out from under `next build` and renames the previous one on top of it, and
   // the box comes back on the build the update was replacing.

--- a/production-server.js
+++ b/production-server.js
@@ -783,10 +783,14 @@ try {
   // this block repairs. It is ALSO the normal state of a rebuild in flight, for
   // the whole length of the build: install.sh's do_rebuild renames `.next` to
   // `.next-old` and `next build` writes the standalone entry last. This process
-  // is started inside that window as a matter of routine — clawbox-gateway.service
-  // carries `Wants=clawbox-setup.service`, so every gateway (re)start starts the
+  // was started inside that window as a matter of routine — clawbox-gateway.service
+  // carried `Wants=clawbox-setup.service`, so every gateway (re)start started the
   // service do_rebuild had just stopped (e2e-install run 33971129750: four
-  // seconds after the stop). Reclaiming there `rm -rf`s the half-written build
+  // seconds after the stop). That line is gone (TASK-728), which removes the
+  // routine trigger and not the case: the unit file only reaches a box in
+  // post_update, so the update that removes it still rebuilds under the old one,
+  // and an operator can start the web server by hand at any time. Reclaiming
+  // there `rm -rf`s the half-written build
   // out from under `next build` and renames the previous one on top of it, and
   // the box comes back on the build the update was replacing.
   //

--- a/src/tests/unit/gateway-rebuild-window.test.ts
+++ b/src/tests/unit/gateway-rebuild-window.test.ts
@@ -109,24 +109,42 @@ describe("the ordering the removed Wants= was resting on", () => {
     // The enable loop skips several units by name (browser, embed, tunnel, the
     // timer-driven one-shots). clawbox-setup must not join that list, or the
     // gateway would be ordered after a unit nothing starts.
-    const loop = INSTALL_SH.slice(
-      INSTALL_SH.indexOf('for svc in "${ALL_SERVICES[@]}"; do'),
-      INSTALL_SH.indexOf('systemctl enable --now clawbox-heartbeat.timer'),
+    //
+    // Anchored on the loop that ENABLES, not the earlier one that copies: there
+    // are two `for svc in "${ALL_SERVICES[@]}"` loops, and slicing from the
+    // first would drag 38 unrelated lines into a negative assertion — which
+    // would then fail the day anyone wrote a comment naming this unit in them.
+    const enableLoopStart = INSTALL_SH.indexOf(
+      'for svc in "${ALL_SERVICES[@]}"; do',
+      INSTALL_SH.indexOf('systemctl daemon-reload'),
     );
-    expect(loop.length).toBeGreaterThan(0);
+    const loop = INSTALL_SH.slice(
+      enableLoopStart,
+      INSTALL_SH.indexOf("systemctl enable --now clawbox-heartbeat.timer"),
+    );
+    expect(enableLoopStart).toBeGreaterThan(-1);
     expect(loop).toContain('systemctl enable "$svc"');
-    expect(loop).not.toContain("clawbox-setup.service");
+    // Only the SKIP lines are the question, so only they are read.
+    const skipped = loop
+      .split("\n")
+      .filter((line) => line.includes("&& continue"))
+      .join("\n");
+    expect(skipped).not.toContain("clawbox-setup");
     expect(INSTALL_SH).toMatch(/EXPECTED_ACTIVE_SERVICES=\([^)]*clawbox-setup\.service/);
   });
 });
 
 describe("every rebuild-ending restart clears a latched start limit", () => {
   /**
-   * The unit crash-loops for the length of a rebuild, so a latched
-   * StartLimitBurst turns the restart that ENDS the rebuild into a failure over
-   * a build that is fine. Two of the three restarts got `reset-failed` in
-   * 5e268479; the test-mode branch of step_rebuild_reboot — the one e2e-install
-   * takes, and bare under `set -euo pipefail` — did not.
+   * A latched StartLimitBurst turns the restart that ENDS a rebuild into a
+   * failure over a build that is fine. With no start dependency left nothing
+   * starts clawbox-setup DURING a rebuild any more, so it can no longer
+   * crash-loop on the missing standalone entry from that source — but an
+   * operator, or the sudoers `systemctl restart clawbox-setup` grant, can still
+   * land inside the window and latch the unit's inherited 5-in-10 s limit. Two
+   * of the three restarts got `reset-failed` in 5e268479; the test-mode branch
+   * of step_rebuild_reboot — the one e2e-install takes, and bare under
+   * `set -euo pipefail` — did not.
    */
   function shellFn(name: string): string {
     const start = INSTALL_SH.indexOf(`${name}() {`);

--- a/src/tests/unit/gateway-rebuild-window.test.ts
+++ b/src/tests/unit/gateway-rebuild-window.test.ts
@@ -153,11 +153,17 @@ describe("every rebuild-ending restart clears a latched start limit", () => {
     return INSTALL_SH.slice(start, end);
   }
 
-  it.each(["step_rebuild", "step_rebuild_reboot"])("%s resets the limit before restarting", (fn) => {
-    const body = shellFn(fn);
-    const reset = body.indexOf("systemctl reset-failed clawbox-setup.service");
-    const restart = body.indexOf("systemctl restart clawbox-setup.service");
-    expect(reset, `${fn} restarts clawbox-setup without clearing a latched start limit`).toBeGreaterThan(-1);
-    expect(restart).toBeGreaterThan(reset);
-  });
+  it.each(["step_rebuild", "step_rebuild_reboot", "restore_previous_build"])(
+    "%s resets the limit before restarting",
+    (fn) => {
+      // restore_previous_build is the THIRD rebuild-ending restart — the
+      // rollback path — and it got its `reset-failed` in 5e268479 with the
+      // others. Left out of this list, a regression there would pass.
+      const body = shellFn(fn);
+      const reset = body.indexOf("systemctl reset-failed clawbox-setup.service");
+      const restart = body.indexOf("systemctl restart clawbox-setup.service");
+      expect(reset, `${fn} restarts clawbox-setup without clearing a latched start limit`).toBeGreaterThan(-1);
+      expect(restart).toBeGreaterThan(reset);
+    },
+  );
 });

--- a/src/tests/unit/gateway-rebuild-window.test.ts
+++ b/src/tests/unit/gateway-rebuild-window.test.ts
@@ -1,0 +1,145 @@
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * TASK-728 — a gateway (re)start must not pull the dashboard up mid-rebuild.
+ *
+ * `config/clawbox-gateway.service` carried `Wants=clawbox-setup.service`, so
+ * every gateway start started the web-server unit that `install.sh`'s
+ * `do_rebuild` had just stopped. Measured in e2e-install run 33971129750: the
+ * dashboard came back FOUR SECONDS after the stop, while `bun install` was
+ * still running, because the gateway was crash-looping on plugin consent and
+ * restarting every five seconds against a multi-minute build.
+ *
+ * That one line broke three things at once:
+ *
+ *  1. The updater resumed on the PRE-UPDATE build — the remaining steps ran
+ *     from the old tree and `post_update` died on a polkit denial
+ *     ("Interactive authentication required") it could not have hit on the new
+ *     one. PR #672's guard covers only the window after the park, not this.
+ *  2. `free_memory_for_build`'s memory hold was void: the gateway reaches
+ *     ollama and llama.cpp through the web server's own proxy, so a model could
+ *     be pulled in behind the build — the OOM that produced TASK-709.
+ *  3. It is what pulled the web server onto the PARKED build, plus the
+ *     crash-loop cost the #672 guard now carries (clawbox-setup restarting
+ *     every ~3.5 s for the length of the build, each start fire-and-forgetting
+ *     scripts/register-mcp.sh, which runs `hermes plugins doctor` on the
+ *     hermes/dual SKUs).
+ *
+ * Removing the window beats guarding it — but the ORDERING the `Wants=` was
+ * mixed up with is real and has to survive, so the invariant it rested on is
+ * pinned here too.
+ */
+
+const REPO = process.cwd();
+const CONFIG_DIR = path.join(REPO, "config");
+const read = (rel: string) => readFileSync(path.join(REPO, rel), "utf-8");
+
+const GATEWAY_UNIT = read("config/clawbox-gateway.service");
+const SETUP_UNIT = read("config/clawbox-setup.service");
+const INSTALL_SH = read("install.sh");
+
+/** The value of a unit-file directive, with comments and blank lines gone. */
+function directive(unit: string, key: string): string[] {
+  return unit
+    .split("\n")
+    .filter((l) => !l.trimStart().startsWith("#"))
+    .filter((l) => l.startsWith(`${key}=`))
+    .map((l) => l.slice(key.length + 1).trim());
+}
+
+describe("the gateway is ordered after the web server without starting it", () => {
+  it("still orders itself after clawbox-setup", () => {
+    // The race this ordering exists for is real and unrelated to the defect:
+    // memory search reaches its embedder through the web server's local-AI
+    // proxy, and OpenClaw's embedding client gives a refused connection three
+    // attempts inside two seconds before answering keyword-only and leaving the
+    // index dirty.
+    expect(directive(GATEWAY_UNIT, "After").join(" ")).toContain("clawbox-setup.service");
+  });
+
+  it("does not pull it up", () => {
+    // Wants, Requires and BindsTo all START the other unit. Any of them here
+    // re-opens the rebuild window.
+    for (const key of ["Wants", "Requires", "BindsTo", "Requisite", "PartOf"]) {
+      expect(
+        directive(GATEWAY_UNIT, key).join(" "),
+        `${key}= must not name clawbox-setup.service — it would start the unit do_rebuild stopped`,
+      ).not.toContain("clawbox-setup");
+    }
+  });
+
+  it("keeps network-online, which is a different question", () => {
+    // The line carried two things; only one of them was the defect.
+    expect(directive(GATEWAY_UNIT, "Wants").join(" ")).toContain("network-online.target");
+  });
+
+  it("no unit ships a start dependency on the web server", () => {
+    // The house style already, for the same web server: clawbox-tunnel,
+    // clawbox-heartbeat and clawbox-hermes-dashboard-proxy all order themselves
+    // After= it and none of them Wants= it. Asserted over the whole directory so
+    // a unit added later cannot quietly re-introduce the pull.
+    const offenders = readdirSync(CONFIG_DIR)
+      .filter((f) => f.endsWith(".service") || f.endsWith(".timer"))
+      .filter((f) => f !== "clawbox-setup.service")
+      .filter((f) => {
+        const unit = readFileSync(path.join(CONFIG_DIR, f), "utf-8");
+        return ["Wants", "Requires", "BindsTo", "Requisite"].some((k) =>
+          directive(unit, k).join(" ").includes("clawbox-setup"),
+        );
+      });
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("the ordering the removed Wants= was resting on", () => {
+  /**
+   * `After=` only orders units that are already IN the transaction. Dropping the
+   * `Wants=` is safe precisely because clawbox-setup.service is in every boot
+   * transaction on its own — and that is the invariant this PR now depends on,
+   * so it is pinned rather than assumed.
+   */
+  it("clawbox-setup is pulled into the boot transaction by its own Install section", () => {
+    expect(SETUP_UNIT).toMatch(/\[Install\]/);
+    expect(directive(SETUP_UNIT, "WantedBy").join(" ")).toContain("multi-user.target");
+  });
+
+  it("and install.sh enables it rather than skipping it", () => {
+    // The enable loop skips several units by name (browser, embed, tunnel, the
+    // timer-driven one-shots). clawbox-setup must not join that list, or the
+    // gateway would be ordered after a unit nothing starts.
+    const loop = INSTALL_SH.slice(
+      INSTALL_SH.indexOf('for svc in "${ALL_SERVICES[@]}"; do'),
+      INSTALL_SH.indexOf('systemctl enable --now clawbox-heartbeat.timer'),
+    );
+    expect(loop.length).toBeGreaterThan(0);
+    expect(loop).toContain('systemctl enable "$svc"');
+    expect(loop).not.toContain("clawbox-setup.service");
+    expect(INSTALL_SH).toMatch(/EXPECTED_ACTIVE_SERVICES=\([^)]*clawbox-setup\.service/);
+  });
+});
+
+describe("every rebuild-ending restart clears a latched start limit", () => {
+  /**
+   * The unit crash-loops for the length of a rebuild, so a latched
+   * StartLimitBurst turns the restart that ENDS the rebuild into a failure over
+   * a build that is fine. Two of the three restarts got `reset-failed` in
+   * 5e268479; the test-mode branch of step_rebuild_reboot — the one e2e-install
+   * takes, and bare under `set -euo pipefail` — did not.
+   */
+  function shellFn(name: string): string {
+    const start = INSTALL_SH.indexOf(`${name}() {`);
+    expect(start, `${name} not found in install.sh`).toBeGreaterThan(-1);
+    const end = INSTALL_SH.indexOf("\n}", start);
+    return INSTALL_SH.slice(start, end);
+  }
+
+  it.each(["step_rebuild", "step_rebuild_reboot"])("%s resets the limit before restarting", (fn) => {
+    const body = shellFn(fn);
+    const reset = body.indexOf("systemctl reset-failed clawbox-setup.service");
+    const restart = body.indexOf("systemctl restart clawbox-setup.service");
+    expect(reset, `${fn} restarts clawbox-setup without clearing a latched start limit`).toBeGreaterThan(-1);
+    expect(restart).toBeGreaterThan(reset);
+  });
+});

--- a/src/tests/unit/install-rebuild-build-verify.test.ts
+++ b/src/tests/unit/install-rebuild-build-verify.test.ts
@@ -148,8 +148,10 @@ interface Run {
    * "live <pid>", "stale <pid>" or "none". The reclaim in production-server.js
    * has nothing else to go on: from the park until the standalone entry is
    * written there is no `.next/standalone/server.js`, which is the only thing
-   * it looks at, and clawbox-setup is pulled back up inside that window by
-   * `clawbox-gateway.service`'s `Wants=`.
+   * it looks at, and clawbox-setup can be up inside that window — routinely so
+   * before TASK-728 removed `clawbox-gateway.service`'s `Wants=`, and still on
+   * the update that removes it (the new unit lands in post_update) or when an
+   * operator starts the web server by hand.
    */
   buildSawOwner: string;
   /** Did a stamp survive into the tree the box is left serving? */
@@ -607,11 +609,16 @@ describe("do_rebuild keeps the box serving when the build fails", () => {
 
   it("restarts clawbox-setup rather than starting it, so a latched unit is replaced", () => {
     // `start` on an already-active unit is a no-op, and the unit CAN be active
-    // here: clawbox-gateway.service's `Wants=clawbox-setup.service` pulls it
-    // back up mid-rebuild, and its own `Restart=always` latches it onto
-    // whatever tree exists once `next build` writes the standalone entry. A
-    // `start` would then leave the box serving the build that just failed
-    // verification while this function reported a rollback.
+    // here: once anything brings it back, its own `Restart=always` latches it
+    // onto whatever tree exists from the moment `next build` writes the
+    // standalone entry. A `start` would then leave the box serving the build
+    // that just failed verification while this function reported a rollback.
+    //
+    // What brought it back routinely was clawbox-gateway.service's
+    // `Wants=clawbox-setup.service`, removed in TASK-728 — which removes the
+    // routine trigger and not the case: the new unit file only reaches a box in
+    // post_update, so the update that removes the pull still rebuilds under the
+    // old one, and an operator can start the web server by hand.
     const r = run({ build: "succeeds", identity: "drift" });
 
     expect(r.status).not.toBe(0);
@@ -723,11 +730,14 @@ describe.skipIf(process.platform !== "linux")("do_rebuild says who owns the buil
    * to `.next-old` and only then runs `bun run build`, so for the whole length
    * of the build there is no `.next/standalone/server.js` and there is a parked
    * one — the exact condition production-server.js's boot-time reclaim fires
-   * on. And clawbox-setup comes back up inside that window as a matter of
-   * routine: `config/clawbox-gateway.service` carries
-   * `Wants=clawbox-setup.service`, so every gateway (re)start starts the
+   * on. And clawbox-setup used to come back up inside that window as a matter
+   * of routine: `config/clawbox-gateway.service` carried
+   * `Wants=clawbox-setup.service`, so every gateway (re)start started the
    * service `do_rebuild` had just stopped (e2e-install run 33971129750: four
-   * seconds after the stop, while `bun install` was still running).
+   * seconds after the stop, while `bun install` was still running). TASK-728
+   * removed that line; the stamp stays, because the new unit only reaches a box
+   * in post_update — after this very rebuild — and a hand-started web server
+   * lands in the same window.
    *
    * Nothing in the tree said "a rebuild is in flight", so the reclaim could not
    * tell that state from the one it exists for — a rebuild whose shell was

--- a/src/tests/unit/install-rebuild-build-verify.test.ts
+++ b/src/tests/unit/install-rebuild-build-verify.test.ts
@@ -149,9 +149,9 @@ interface Run {
    * has nothing else to go on: from the park until the standalone entry is
    * written there is no `.next/standalone/server.js`, which is the only thing
    * it looks at, and clawbox-setup can be up inside that window — routinely so
-   * before TASK-728 removed `clawbox-gateway.service`'s `Wants=`, and still on
-   * the update that removes it (the new unit lands in post_update) or when an
-   * operator starts the web server by hand.
+   * before TASK-728 removed `clawbox-gateway.service`'s `Wants=`, and still
+   * through a hand-run `--step rebuild`, a box where gateway_setup is skipped,
+   * or an operator restarting the web server.
    */
   buildSawOwner: string;
   /** Did a stamp survive into the tree the box is left serving? */
@@ -616,9 +616,9 @@ describe("do_rebuild keeps the box serving when the build fails", () => {
     //
     // What brought it back routinely was clawbox-gateway.service's
     // `Wants=clawbox-setup.service`, removed in TASK-728 — which removes the
-    // routine trigger and not the case: the new unit file only reaches a box in
-    // post_update, so the update that removes the pull still rebuilds under the
-    // old one, and an operator can start the web server by hand.
+    // routine trigger and not the case: a hand-run `--step rebuild`, a box where
+    // gateway_setup is skipped, and an operator (or the sudoers grant)
+    // restarting clawbox-setup all still land inside the window.
     const r = run({ build: "succeeds", identity: "drift" });
 
     expect(r.status).not.toBe(0);
@@ -735,9 +735,10 @@ describe.skipIf(process.platform !== "linux")("do_rebuild says who owns the buil
    * `Wants=clawbox-setup.service`, so every gateway (re)start started the
    * service `do_rebuild` had just stopped (e2e-install run 33971129750: four
    * seconds after the stop, while `bun install` was still running). TASK-728
-   * removed that line; the stamp stays, because the new unit only reaches a box
-   * in post_update — after this very rebuild — and a hand-started web server
-   * lands in the same window.
+   * removed that line — including for the update that carries it, since
+   * step_systemd_services runs above do_rebuild in step_rebuild_reboot. The
+   * stamp stays for the ways in that are left: a hand-run `--step rebuild`, a
+   * skipped gateway_setup, and an operator restarting the web server.
    *
    * Nothing in the tree said "a rebuild is in flight", so the reclaim could not
    * tell that state from the one it exists for — a rebuild whose shell was

--- a/src/tests/unit/production-server-parked-build.test.ts
+++ b/src/tests/unit/production-server-parked-build.test.ts
@@ -225,8 +225,9 @@ describe("production-server.js reclaims a parked build at boot", () => {
     // so every gateway (re)start started the service `do_rebuild` had just
     // stopped (seen in e2e-install run 33971129750, four seconds after the
     // stop). TASK-728 removed that line — which removes the routine trigger and
-    // not the case, since the new unit only reaches a box in post_update and an
-    // operator can start the web server by hand. Reclaiming there `rm -rf`s the
+    // not the case: a hand-run `--step rebuild`, a box where gateway_setup is
+    // skipped, and an operator restarting the web server all still land inside
+    // the window. Reclaiming there `rm -rf`s the
     // half-written build out from under `next build` and renames the previous
     // one on top of it.
     const kept = path.join(projectDir, ".next-old");

--- a/src/tests/unit/production-server-parked-build.test.ts
+++ b/src/tests/unit/production-server-parked-build.test.ts
@@ -220,12 +220,15 @@ describe("production-server.js reclaims a parked build at boot", () => {
     // and only THEN runs `bun run build`, so for the whole length of the build
     // — minutes on a Jetson — there is no `.next/standalone/server.js` and
     // there is a parked one. That is exactly the condition this block reclaims
-    // on, and clawbox-setup is pulled back up inside that window routinely:
-    // `clawbox-gateway.service` carries `Wants=clawbox-setup.service`, so every
-    // gateway (re)start starts the service `do_rebuild` had just stopped (seen
-    // in e2e-install run 33971129750, four seconds after the stop). Reclaiming
-    // there `rm -rf`s the half-written build out from under `next build` and
-    // renames the previous one on top of it.
+    // on, and clawbox-setup used to be pulled back up inside that window
+    // routinely: `clawbox-gateway.service` carried `Wants=clawbox-setup.service`,
+    // so every gateway (re)start started the service `do_rebuild` had just
+    // stopped (seen in e2e-install run 33971129750, four seconds after the
+    // stop). TASK-728 removed that line — which removes the routine trigger and
+    // not the case, since the new unit only reaches a box in post_update and an
+    // operator can start the web server by hand. Reclaiming there `rm -rf`s the
+    // half-written build out from under `next build` and renames the previous
+    // one on top of it.
     const kept = path.join(projectDir, ".next-old");
     writeBuild(kept, "parked-build-id");
     writeFileSync(path.join(kept, OWNER_STAMP), ownerStamp(process.pid), "utf-8");


### PR DESCRIPTION
**TASK-728** — a gateway restart starts the dashboard mid-rebuild.

## Symptom

`install.sh`'s `do_rebuild` stops `clawbox-setup.service` for the length of a rebuild. It came back anyway: in e2e-install run 33971129750 the dashboard was up again **four seconds after the stop**, while `bun install` was still running, because the gateway was crash-looping on plugin consent and restarting every five seconds against a multi-minute build.

Three things broke at once, and the first is what actually failed that run:

1. **The updater resumed on the pre-update build.** The dashboard came back before the park, the update's remaining steps ran from the old tree, and its `execAsRoot` called `systemctl start` directly — so `post_update` died on "Interactive authentication required", a polkit denial the new build cannot produce. PR #672's guard covers only the window after the park.
2. **`free_memory_for_build`'s memory hold was void.** The gateway reaches ollama and llama.cpp through the web server's own proxy, so with the proxy back a model can be pulled in behind the build — the OOM that produced TASK-709.
3. **The parked-build race #672 guards**, plus the crash-loop cost that guard now carries: `clawbox-setup` restarting every ~3.5 s for the length of the build, each start fire-and-forgetting `scripts/register-mcp.sh`, which runs `hermes plugins doctor` on the hermes/dual SKUs.

## Cause

One line: `config/clawbox-gateway.service` carried `Wants=clawbox-setup.service`. `Wants=` STARTS the other unit; every gateway (re)start therefore started the unit `do_rebuild` had just stopped.

## Fix

The `Wants=` is removed and the `After=` kept. Removing the window beats guarding it, and the ordering the line was mixed up with survives on its own.

## Why the ordering is safe — measured, not argued

`After=` orders only units that are already in the transaction, so the whole question is whether `clawbox-setup.service` is pulled into the boot transaction on its own. It is:

- `config/clawbox-setup.service` carries `[Install] WantedBy=multi-user.target`;
- `install.sh` enables it — it is in `ALL_SERVICES`, in `EXPECTED_ACTIVE_SERVICES`, and is not one of the units the enable loop skips.

Read-only on both boxes, no mutex taken, nothing changed:

```
OpenClaw edition
  clawbox-gateway.service   Wants=network-online.target clawbox-setup.service   After=clawbox-setup.service network-online.target
  clawbox-setup.service     is-enabled=enabled   WantedBy=multi-user.target clawbox-gateway.service
  systemctl list-dependencies multi-user.target | grep -c clawbox-setup.service  ->  1
  gateway starts in the retained journal (2 days): 4   (each one started the dashboard too)

Hermes edition
  clawbox-gateway.service   LoadState=masked   Wants=   After=
  clawbox-setup.service     is-enabled=enabled   WantedBy=multi-user.target
  systemctl list-dependencies multi-user.target | grep -c clawbox-setup.service  ->  1
```

systemd's own answer on the OpenClaw box is the proof: `clawbox-setup.service` is `WantedBy=multi-user.target clawbox-gateway.service` — two sources, and removing the gateway's leaves the target's. The Hermes box, where the gateway unit is masked, is already running with exactly the dependency graph this PR produces, and boots fine.

Three sibling units — `clawbox-tunnel.service`, `clawbox-heartbeat.service`, `clawbox-hermes-dashboard-proxy.service` — already order themselves `After=clawbox-setup.service` with no `Wants=`. This makes the gateway the fourth rather than the exception.

## The invariant the removal now rests on, pinned

`src/tests/unit/gateway-rebuild-window.test.ts` asserts both halves: the gateway still orders itself after the web server and carries no start dependency on it (`Wants`/`Requires`/`BindsTo`/`Requisite`/`PartOf`), **and** the thing that makes that safe — `clawbox-setup.service`'s own `[Install] WantedBy=multi-user.target`, install.sh's enable loop not skipping it, and its presence in `EXPECTED_ACTIVE_SERVICES`. The no-start-dependency rule is asserted over the whole of `config/`, so a unit added later cannot quietly re-introduce the pull.

## What deliberately did NOT change

Every guard that exists because the dashboard can come back stays — the `.rebuild-pid` owner stamp, `production-server.js`'s reclaim refusal, and `restart`-not-`start` on both rebuild-ending restarts. The removal reaches a box only when `step_systemd_services` reinstalls the unit in `post_update`, which is **after** the rebuild of the very update that carries it, and a hand-started web server lands in the same window either way. The comments that stated the pull as a live fact now say what is true.

## Folded in, one line

`step_rebuild_reboot`'s test-mode restart is the third rebuild-ending restart and lacked the `reset-failed` the other two got in 5e268479 — bare under `set -euo pipefail`, on the branch e2e-install takes. The unit crash-loops for the length of a rebuild, so a latched start limit would turn that restart into a failure over a build that is fine.

## RED → GREEN

RED on unmodified beta (`src/tests/unit/gateway-rebuild-window.test.ts`):

```
FAIL … > does not pull it up
AssertionError: Wants= must not name clawbox-setup.service — it would start the unit do_rebuild stopped
  expected 'network-online.target clawbox-setup.service' not to contain 'clawbox-setup'

FAIL … > no unit ships a start dependency on the web server
AssertionError: expected [ 'clawbox-gateway.service' ] to deeply equal []

FAIL … > step_rebuild_reboot resets the limit before restarting
AssertionError: step_rebuild_reboot restarts clawbox-setup without clearing a latched start limit: expected -1 to be greater than -1

 Test Files  1 failed (1)
      Tests  3 failed | 5 passed (8)
```

GREEN: `8 passed (8)`, and the neighbours — `install-*`, `production-server-parked-build`, `observability-install`, `updater`, `sudoers-coverage` — **39 files / 918 tests pass**. Full `--project unit`: 702 files pass, the only failures being the known dev-PC `routes/telegram/status*` flakes, which fail on unmodified beta on this machine too (`Test timed out in 5000ms`) and pass in isolation.

## Native mechanism

This IS the native mechanism: systemd's own distinction between ordering (`After=`) and a start dependency (`Wants=`). Nothing is re-implemented; a line that conflated the two is removed.

## Unproven

- **The dual SKU** is not on this bench (`boxes.env` carries an OpenClaw box and a Hermes box), so the `register-mcp.sh` cost the card names is reasoned about and not measured there.
- Proving the AFTER state on hardware needs a box on this branch running a rebuild, which a read-only lane may not do. What is measured above is the before-state and the premise the removal rests on, on both editions.

## Review

Review, before this PR was opened: 1 HIGH / 2 MEDIUM / 3 LOW / 1 NIT, all applied.

The HIGH is the one worth reading: **this change makes e2e-install's own upgrade spec fail.** `waitForUpdate` gives up after 60 consecutive unanswered status polls (~183 s), a default sized for the seconds-long restart the `Wants=` used to produce. With the pull gone the endpoint is dark for `bun install` + `next build` + the ENOENT retry build — minutes, by design. Both rebuild-spanning waits now carry an explicit 420-poll (21 min) budget, sized on the updater's own `REBUILD_TAKEOVER_TIMEOUT_MS`, and the spec header says why.

The top MEDIUM corrected a claim this PR made in five comments and two test docblocks: "the new unit file only reaches a box in `post_update`, after this rebuild". False, in the direction of understating the fix — `step_rebuild_reboot` calls `step_systemd_services` seven lines above `do_rebuild`, and the updater's `gateway_setup` step (which cps the same file) is the step immediately before the rebuild. The removal fences the update that carries it. The guards stay for what genuinely remains: a hand-run `--step rebuild`, a box where `gateway_setup` is skipped or `step_systemd_services` failed non-fatally, and an operator or the sudoers grant restarting clawbox-setup inside the window.

Also applied: three comments no longer justify their `reset-failed` with a crash loop this change is what stops; the unit comment no longer claims `After=` fixes the embedder race (clawbox-setup is `Type=simple`, so it orders after the exec, not after readiness — what covers that race is `gateway-pre-start.sh` launching `ensure-local-embeddings.sh` detached with its own 120 s wait, named there now); the "up, or coming back under `Restart=always`" line is replaced by the three cases that really change, since `Restart=always` revives nothing stopped, disabled or masked on purpose; and the new guard's enable-loop slice is anchored on the loop that enables rather than the one that copies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gateway starts and restarts no longer automatically start the dashboard setup service.
  * Rebuilds keep the dashboard stopped when setup is disabled, while preserving network ordering and proxy readiness checks.
  * Improved rebuild recovery by clearing service start-limit failures before restarting setup.

* **Tests**
  * Added coverage for service ordering, dependency behavior, rebuild recovery, and extended upgrade downtime scenarios.

* **Documentation**
  * Updated rebuild and recovery guidance to reflect the revised service behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->