### PR TITLE
fix: an update whose process was replaced is reported, not forgotten

### DIFF
--- a/e2e-install/helpers/setup-api.ts
+++ b/e2e-install/helpers/setup-api.ts
@@ -3,7 +3,7 @@
  * browser page) so happy-path tests can exercise the full install/setup
  * lifecycle without needing a full graphical session.
  */
-import { BASE_URL } from "./container";
+import { BASE_URL, dockerExec } from "./container";
 
 async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
   const res = await fetch(`${BASE_URL}${path}`, {
@@ -377,14 +377,71 @@ export const getGatewayHealth = () =>
  * Returns the final state. Tolerates transient fetch failures with
  * `maxConsecutiveFetchErrors` so a service restart doesn't abort the wait.
  */
+/**
+ * "Nothing has started" — the state a box reports when no update was ever asked
+ * for.
+ *
+ * It is also, before TASK-731, what a box reported when an update HAD been
+ * asked for and the web server that was running it was replaced: the step
+ * list's position lived only in that process, and the next one released the
+ * update lock and answered this. Six e2e-install runs polled it for the whole
+ * 45-minute budget.
+ */
+function looksUnstarted(state: UpdateState): boolean {
+  return (
+    state.phase === "idle"
+    && state.currentStepIndex < 0
+    && state.steps.length > 0
+    && state.steps.every((step) => step.status === "pending")
+  );
+}
+
+/** What the container can say about a run that vanished. Never throws. */
+async function diagnoseLostUpdate(): Promise<string> {
+  const parts: string[] = [];
+  const ask = async (label: string, cmd: string[]) => {
+    try {
+      parts.push(`${label}:\n${(await dockerExec(cmd, { user: "root" })).trim()}`);
+    } catch (err) {
+      parts.push(`${label}: could not be read (${err instanceof Error ? err.message : String(err)})`);
+    }
+  };
+  // How many times the web server has been (re)started, and when: an update
+  // whose process was replaced shows a restart between the POST and now.
+  await ask("clawbox-setup.service", [
+    "systemctl", "show", "clawbox-setup.service",
+    "-p", "NRestarts", "-p", "ActiveEnterTimestamp", "-p", "ExecMainStartTimestamp", "-p", "Result",
+  ]);
+  await ask("the update lock and continuation flag on disk", [
+    "bash", "-lc",
+    "python3 -c \"import json;d=json.load(open('/home/clawbox/clawbox/data/config.json'));"
+    + "print({k:d.get(k) for k in ('update_in_progress','update_needs_continuation')})\" 2>&1 || true",
+  ]);
+  await ask("the last 40 web-server journal lines", [
+    "bash", "-lc", "journalctl -u clawbox-setup.service -n 40 --no-pager 2>&1 || true",
+  ]);
+  await ask("root update steps this boot", [
+    "bash", "-lc", "journalctl -u 'clawbox-root-update@*' -n 40 --no-pager 2>&1 || true",
+  ]);
+  return parts.join("\n\n");
+}
+
 export async function waitForUpdate(
-  opts: { timeoutMs?: number; maxConsecutiveFetchErrors?: number } = {},
+  opts: { timeoutMs?: number; maxConsecutiveFetchErrors?: number; unstartedBudgetMs?: number } = {},
 ): Promise<UpdateState> {
   const timeoutMs = opts.timeoutMs ?? 20 * 60_000;
   const maxConsecutiveFetchErrors = opts.maxConsecutiveFetchErrors ?? 60; // ~3min downtime
+  // How long a state that says "nothing has started" is tolerated before it is
+  // called what it is. It is legitimate only briefly — a web server that has
+  // just come back answers it until `checkContinuation()` resumes the second
+  // half, which is one poll later — so two minutes is generous by a wide
+  // margin, and it replaces a 45-minute wait for a state machine that cannot
+  // move.
+  const unstartedBudgetMs = opts.unstartedBudgetMs ?? 120_000;
   const deadline = Date.now() + timeoutMs;
   let consecutiveErrors = 0;
   let lastState: UpdateState | null = null;
+  let unstartedSince: number | null = null;
   while (Date.now() < deadline) {
     try {
       const state = await getUpdateStatus();
@@ -393,7 +450,22 @@ export async function waitForUpdate(
       if (state.phase === "completed" || state.phase === "failed") {
         return state;
       }
-    } catch {
+      if (looksUnstarted(state)) {
+        unstartedSince ??= Date.now();
+        if (Date.now() - unstartedSince > unstartedBudgetMs) {
+          throw new Error(
+            `the update was accepted but never started: the box has reported "nothing is running" for `
+            + `${Math.round((Date.now() - unstartedSince) / 1000)}s. This is the TASK-731 shape — the web `
+            + `server that owned the run was replaced, and its successor had nothing to resume.\n`
+            + `last state: ${JSON.stringify(lastState)}\n\n${await diagnoseLostUpdate()}`,
+          );
+        }
+      } else {
+        unstartedSince = null;
+      }
+    } catch (err) {
+      // Our own verdict is not a fetch failure; it must not be counted as one.
+      if (err instanceof Error && err.message.startsWith("the update was accepted")) throw err;
       consecutiveErrors += 1;
       if (consecutiveErrors > maxConsecutiveFetchErrors) {
         throw new Error(`update status unreachable for ${consecutiveErrors * 3}s — giving up`);
@@ -401,7 +473,10 @@ export async function waitForUpdate(
     }
     await new Promise((r) => setTimeout(r, 3_000));
   }
-  throw new Error(`update did not complete within ${timeoutMs}ms; last state: ${JSON.stringify(lastState)}`);
+  throw new Error(
+    `update did not complete within ${timeoutMs}ms; last state: ${JSON.stringify(lastState)}`
+    + `\n\n${await diagnoseLostUpdate()}`,
+  );
 }
 
 // ── Tunnel (Cloudflare quick-tunnel) ─────────────────────────────────

--- a/e2e-install/helpers/setup-api.ts
+++ b/e2e-install/helpers/setup-api.ts
@@ -399,9 +399,13 @@ function looksUnstarted(state: UpdateState): boolean {
 /** What the container can say about a run that vanished. Never throws. */
 async function diagnoseLostUpdate(): Promise<string> {
   const parts: string[] = [];
+  // Bounded well under dockerExec's 60 s default: this runs on a path that has
+  // already spent its 120 s budget, and three sequential defaults would turn a
+  // two-minute verdict into a five-minute one.
+  const DIAGNOSIS_TIMEOUT_MS = 15_000;
   const ask = async (label: string, cmd: string[]) => {
     try {
-      parts.push(`${label}:\n${(await dockerExec(cmd, { user: "root" })).trim()}`);
+      parts.push(`${label}:\n${(await dockerExec(cmd, { user: "root", timeoutMs: DIAGNOSIS_TIMEOUT_MS })).trim()}`);
     } catch (err) {
       parts.push(`${label}: could not be read (${err instanceof Error ? err.message : String(err)})`);
     }

--- a/e2e-install/helpers/setup-api.ts
+++ b/e2e-install/helpers/setup-api.ts
@@ -412,16 +412,22 @@ async function diagnoseLostUpdate(): Promise<string> {
     "systemctl", "show", "clawbox-setup.service",
     "-p", "NRestarts", "-p", "ActiveEnterTimestamp", "-p", "ExecMainStartTimestamp", "-p", "Result",
   ]);
-  await ask("the update lock and continuation flag on disk", [
+  await ask("the updater's own keys on disk", [
     "bash", "-lc",
     "python3 -c \"import json;d=json.load(open('/home/clawbox/clawbox/data/config.json'));"
-    + "print({k:d.get(k) for k in ('update_in_progress','update_needs_continuation')})\" 2>&1 || true",
+    + "print({k:d.get(k) for k in ('update_in_progress','update_needs_continuation',"
+    + "'update_interrupted_at','update_completed','update_completed_at')})\" 2>&1 || true",
   ]);
-  await ask("the last 40 web-server journal lines", [
-    "bash", "-lc", "journalctl -u clawbox-setup.service -n 40 --no-pager 2>&1 || true",
-  ]);
-  await ask("root update steps this boot", [
-    "bash", "-lc", "journalctl -u 'clawbox-root-update@*' -n 40 --no-pager 2>&1 || true",
+  // REDACTED, and only the web server's own unit. This message becomes a
+  // Playwright error and is uploaded as a CI artifact on a PUBLIC repository,
+  // where GitHub's `***` masking does not reach; the container is started with
+  // real provider keys in its environment (e2e-install/.env.test). Anything
+  // that looks like a token is replaced before it can be written down, and the
+  // `clawbox-root-update@*` journal — the unit that runs install.sh, which
+  // handles four provider keys — is deliberately not dumped at all.
+  await ask("the last 40 web-server journal lines (redacted)", [
+    "bash", "-lc",
+    "journalctl -u clawbox-setup.service -n 40 --no-pager 2>&1 | sed -E 's/[A-Za-z0-9_-]{20,}/[redacted]/g' || true",
   ]);
   return parts.join("\n\n");
 }
@@ -453,10 +459,21 @@ export async function waitForUpdate(
       if (looksUnstarted(state)) {
         unstartedSince ??= Date.now();
         if (Date.now() - unstartedSince > unstartedBudgetMs) {
+          // The headline says what was OBSERVED, not what caused it. This shape
+          // has two causes and the poller cannot tell them apart: a run that
+          // lost its process (TASK-731), and a run that FINISHED whose status
+          // the container cannot synthesise as `completed` — the e2e box is
+          // permanently `checkout-dirty`, which forces drift and disables that
+          // synthesis for the whole run, so a web-server restart after a good
+          // update lands here too. The disk keys below say which: an
+          // `update_interrupted_at` is the first, an `update_completed` with no
+          // lock is the second.
           throw new Error(
-            `the update was accepted but never started: the box has reported "nothing is running" for `
-            + `${Math.round((Date.now() - unstartedSince) / 1000)}s. This is the TASK-731 shape — the web `
-            + `server that owned the run was replaced, and its successor had nothing to resume.\n`
+            `the box has reported "nothing is running" for `
+            + `${Math.round((Date.now() - unstartedSince) / 1000)}s after the update was accepted. `
+            + `Either the web server that owned the run was replaced and its successor had nothing to `
+            + "resume (TASK-731), or the run finished and this container cannot report completed "
+            + "because it is permanently drifted. The updater's own keys below say which.\n"
             + `last state: ${JSON.stringify(lastState)}\n\n${await diagnoseLostUpdate()}`,
           );
         }
@@ -465,7 +482,7 @@ export async function waitForUpdate(
       }
     } catch (err) {
       // Our own verdict is not a fetch failure; it must not be counted as one.
-      if (err instanceof Error && err.message.startsWith("the update was accepted")) throw err;
+      if (err instanceof Error && err.message.startsWith("the box has reported")) throw err;
       consecutiveErrors += 1;
       if (consecutiveErrors > maxConsecutiveFetchErrors) {
         throw new Error(`update status unreachable for ${consecutiveErrors * 3}s — giving up`);

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -2928,10 +2928,26 @@ export function startUpdate(): { started: boolean; error?: string } {
   state.phase = "running";
   state.currentStepIndex = 0;
 
-  // A new run supersedes the record of the last interrupted one. Fired rather
-  // than awaited, like the lock release it mirrors: refusing to start an update
-  // because a marker could not be cleared would be the worse outcome.
-  void set(UPDATE_INTERRUPTED_KEY, undefined);
+  // A new run supersedes what the last one left behind — the interrupted record
+  // AND the completion markers.
+  //
+  // `update_completed` is the discriminator resumeContinuation uses to tell "an
+  // update was interrupted" from "one finished and only failed to release its
+  // lock". Left standing, a FORCED run started after a successful one (which is
+  // exactly what e2e-install's upgrade spec does, twice) would take the lock,
+  // die before the rebuild writes its continuation flag, and be read as the
+  // finished one — swallowing the very report this branch exists to make. The
+  // box is not "completed" while it is updating, and runUpdate writes both
+  // again when it is.
+  //
+  // Fired rather than awaited, like the lock release it mirrors: refusing to
+  // start an update because a marker could not be cleared would be the worse
+  // outcome.
+  void setMany({
+    [UPDATE_INTERRUPTED_KEY]: undefined,
+    update_completed: undefined,
+    update_completed_at: undefined,
+  });
   launchUpdate(steps, 0, { markCompleted: true });
   return { started: true };
 }

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -18,6 +18,16 @@ import { parseHermesVersion } from "./version-utils";
 import { isSafeBranch } from "./update-branch";
 import { startRootStep } from "./root-step-runner";
 import { setUpdateLock, clearUpdateLock, isUpdateLocked } from "./update-lock";
+
+/**
+ * "An update was accepted and then lost its process" — written where the lock
+ * is released, so the verdict outlives the process that reached it.
+ *
+ * The fault this records is a web server being replaced, so a verdict kept only
+ * in memory is one the next replacement erases; the box has to remember. It is
+ * cleared when a new run starts and when the owner dismisses the result.
+ */
+const UPDATE_INTERRUPTED_KEY = "update_interrupted_at";
 import { collectBuildIdentity, resolveBuildDir } from "./build-identity";
 import type { AuthProfileEntries } from "./subscription-surface";
 import { OFFICIAL_CHANNEL_PLUGINS } from "./openclaw-channels";
@@ -2723,6 +2733,10 @@ export function resetUpdateState(): void {
 export function dismissSettledUpdate(): boolean {
   if (updateOwned() || state.phase === "running") return false;
   state = createInitialState(applicableSteps());
+  // The interrupted-run record is part of the result being dismissed. Without
+  // this the next idle poll re-reads it and raises the same failure again,
+  // which would make it undismissable.
+  void set(UPDATE_INTERRUPTED_KEY, undefined);
   return true;
 }
 
@@ -2796,29 +2810,40 @@ async function resumeContinuation(): Promise<boolean> {
     //
     // But releasing the lock is only half an answer, and the missing half is
     // TASK-731. The lock is on disk and the step list is not: an update whose
-    // web server was replaced between `startUpdate()` (which sets the lock at
-    // the top of runUpdate) and the rebuild step (which writes the continuation
-    // flag) leaves the lock held and nothing to resume. This branch then
-    // cleared it and answered IDLE — indistinguishable from a box nobody ever
-    // asked to update, over a run that had been accepted with
-    // `{ started: true }`. Six e2e-install sightings of exactly that:
-    // `phase: idle, currentStepIndex -1`, every step pending, while the
-    // checkout had already moved to the new commit — and the harness then
-    // polled a state machine that could not move for the whole 45-minute
-    // budget.
+    // web server was replaced between `runUpdate`'s `setUpdateLock()` and the
+    // rebuild step (which writes the continuation flag) leaves the lock held
+    // and nothing to resume. This branch then cleared it and answered IDLE —
+    // indistinguishable from a box nobody ever asked to update, over a run the
+    // route had already accepted with `{ started: true }`. The e2e-install
+    // upgrade spec then polls a state machine that cannot move for its whole
+    // 45-minute budget.
     //
-    // The lock IS the evidence, so it is read before it is cleared: held with
-    // nothing to resume means an update was interrupted, and that is reported
-    // as a failure rather than as silence. Nothing can be resumed — the
-    // position in the step list was only ever in the dead process's memory —
-    // so the honest outcome is a named failure the owner (or the harness) can
-    // act on immediately.
-    const wasInterrupted = await isUpdateLocked();
-    await clearUpdateLock();
-    if (wasInterrupted) {
+    // Two things are needed and neither is enough alone. The lock IS the
+    // evidence, so it is read before it is cleared — and the verdict is
+    // WRITTEN BACK, because the fault being detected is "the web server keeps
+    // being replaced": a process that reports it in memory and then dies takes
+    // the only record with it, and the next one finds a clean disk and answers
+    // idle again, for good. `update_interrupted_at` is that record; it is
+    // cleared by the next `startUpdate()` and by a Dismiss.
+    //
+    // An update that FINISHED and then failed its release is not an
+    // interruption. `clearUpdateLock` is documented to fail softly, and
+    // `launchUpdate` fires it unawaited, so a leftover flag is a real state —
+    // and `update_completed` with no continuation flag is what tells the two
+    // apart. Reporting there would tell an owner to re-run a ten-minute update
+    // that already worked.
+    const wasLocked = await isUpdateLocked();
+    const released = await clearUpdateLock();
+    const finished = Boolean(await get("update_completed"));
+    const remembered = Boolean(await get(UPDATE_INTERRUPTED_KEY));
+    if ((wasLocked && released && !finished) || remembered) {
       const message =
         "The update was interrupted before it could finish: the web server was replaced while it ran, "
         + "and no step is left to resume. Nothing was rolled back — start the update again.";
+      if (!remembered) {
+        // Only on the transition, so the record keeps the time it happened.
+        await set(UPDATE_INTERRUPTED_KEY, new Date().toISOString());
+      }
       state = createInitialState(applicableSteps());
       state.warnings = await restoreWarnings();
       state.phase = "failed";
@@ -2903,6 +2928,10 @@ export function startUpdate(): { started: boolean; error?: string } {
   state.phase = "running";
   state.currentStepIndex = 0;
 
+  // A new run supersedes the record of the last interrupted one. Fired rather
+  // than awaited, like the lock release it mirrors: refusing to start an update
+  // because a marker could not be cleared would be the worse outcome.
+  void set(UPDATE_INTERRUPTED_KEY, undefined);
   launchUpdate(steps, 0, { markCompleted: true });
   return { started: true };
 }
@@ -2980,10 +3009,31 @@ async function checkInternet(): Promise<boolean> {
 }
 
 async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: RunOptions): Promise<void> {
+  // Lock the desktop FIRST, AWAITED, before anything that can take time.
+  //
+  // It used to sit below the internet check and the drift baseline — up to two
+  // 10 s ICMP attempts, an 8 s HTTPS HEAD and a `git` shell-out — and the
+  // update was already accepted (`{started:true}`) for that whole window. A web
+  // server replaced in it left NO trace on disk, so the run was lost and the
+  // box reported "nothing is running" (TASK-731). The lock is the only durable
+  // record that a run exists, so it goes on disk before the run can be lost.
+  //
+  // Scoped to the flow that contains the RESTART step: that is the one that
+  // runs `git reset --hard` and `git clean -fd` over the project. The
+  // OpenClaw-only flow reinstalls a package and bounces the gateway, and
+  // locking the owner's desktop for that would be over-reach. It also covers
+  // the continuation, whose flag survived the reboot but may not have on a box
+  // that was power-cycled instead.
+  const ownsTheDesktop = steps.some((s) => s.id === RESTART_STEP_ID);
+  if (ownsTheDesktop) {
+    await setUpdateLock();
+  }
+
   if (startFrom === 0 && !(await checkInternet())) {
     state.phase = "failed";
     state.error = "No internet connection. Check your WiFi and try again.";
     state.currentStepIndex = -1;
+    await clearUpdateLock();
     return;
   }
 
@@ -2993,24 +3043,6 @@ async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: Run
   // the repo, so there is nothing for it to observe.
   if (startFrom === 0 && steps.some((s) => s.id === RESTART_STEP_ID)) {
     await captureDriftBaseline();
-  }
-
-  // Lock the desktop, AWAITED, before the first step runs.
-  //
-  // Here rather than in startUpdate/resumeContinuation, and awaited rather than
-  // fired and forgotten, so the flag is on disk before anything else happens —
-  // config-store.set is synchronous inside today, but nothing about this should
-  // depend on that staying true. It also covers the continuation, whose flag
-  // survived the reboot but may not have on a box that was power-cycled instead.
-  //
-  // Scoped to the flow that contains the RESTART step, the same test the drift
-  // baseline above uses: that is the one that runs `git reset --hard` and
-  // `git clean -fd` over the project. The OpenClaw-only flow reinstalls a
-  // package and bounces the gateway, and locking the owner's desktop for that
-  // would be over-reach.
-  const ownsTheDesktop = steps.some((s) => s.id === RESTART_STEP_ID);
-  if (ownsTheDesktop) {
-    await setUpdateLock();
   }
 
   let failed = false;

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -17,7 +17,7 @@ import { waitForPortOpen } from "./port-probe";
 import { parseHermesVersion } from "./version-utils";
 import { isSafeBranch } from "./update-branch";
 import { startRootStep } from "./root-step-runner";
-import { setUpdateLock, clearUpdateLock } from "./update-lock";
+import { setUpdateLock, clearUpdateLock, isUpdateLocked } from "./update-lock";
 import { collectBuildIdentity, resolveBuildDir } from "./build-identity";
 import type { AuthProfileEntries } from "./subscription-surface";
 import { OFFICIAL_CHANNEL_PLUGINS } from "./openclaw-channels";
@@ -2793,7 +2793,38 @@ async function resumeContinuation(): Promise<boolean> {
     // continuation flag would otherwise leave the desktop locked with nothing
     // left to unlock it — there is no update to resume, so there is no lock to
     // hold. This is the one release path that does not follow a finished run.
+    //
+    // But releasing the lock is only half an answer, and the missing half is
+    // TASK-731. The lock is on disk and the step list is not: an update whose
+    // web server was replaced between `startUpdate()` (which sets the lock at
+    // the top of runUpdate) and the rebuild step (which writes the continuation
+    // flag) leaves the lock held and nothing to resume. This branch then
+    // cleared it and answered IDLE — indistinguishable from a box nobody ever
+    // asked to update, over a run that had been accepted with
+    // `{ started: true }`. Six e2e-install sightings of exactly that:
+    // `phase: idle, currentStepIndex -1`, every step pending, while the
+    // checkout had already moved to the new commit — and the harness then
+    // polled a state machine that could not move for the whole 45-minute
+    // budget.
+    //
+    // The lock IS the evidence, so it is read before it is cleared: held with
+    // nothing to resume means an update was interrupted, and that is reported
+    // as a failure rather than as silence. Nothing can be resumed — the
+    // position in the step list was only ever in the dead process's memory —
+    // so the honest outcome is a named failure the owner (or the harness) can
+    // act on immediately.
+    const wasInterrupted = await isUpdateLocked();
     await clearUpdateLock();
+    if (wasInterrupted) {
+      const message =
+        "The update was interrupted before it could finish: the web server was replaced while it ran, "
+        + "and no step is left to resume. Nothing was rolled back — start the update again.";
+      state = createInitialState(applicableSteps());
+      state.warnings = await restoreWarnings();
+      state.phase = "failed";
+      state.error = message;
+      console.error(`[Updater] ${message}`);
+    }
     return false;
   }
 

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -2928,26 +2928,6 @@ export function startUpdate(): { started: boolean; error?: string } {
   state.phase = "running";
   state.currentStepIndex = 0;
 
-  // A new run supersedes what the last one left behind — the interrupted record
-  // AND the completion markers.
-  //
-  // `update_completed` is the discriminator resumeContinuation uses to tell "an
-  // update was interrupted" from "one finished and only failed to release its
-  // lock". Left standing, a FORCED run started after a successful one (which is
-  // exactly what e2e-install's upgrade spec does, twice) would take the lock,
-  // die before the rebuild writes its continuation flag, and be read as the
-  // finished one — swallowing the very report this branch exists to make. The
-  // box is not "completed" while it is updating, and runUpdate writes both
-  // again when it is.
-  //
-  // Fired rather than awaited, like the lock release it mirrors: refusing to
-  // start an update because a marker could not be cleared would be the worse
-  // outcome.
-  void setMany({
-    [UPDATE_INTERRUPTED_KEY]: undefined,
-    update_completed: undefined,
-    update_completed_at: undefined,
-  });
   launchUpdate(steps, 0, { markCompleted: true });
   return { started: true };
 }
@@ -3043,6 +3023,40 @@ async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: Run
   const ownsTheDesktop = steps.some((s) => s.id === RESTART_STEP_ID);
   if (ownsTheDesktop) {
     await setUpdateLock();
+    // AND clear what the last run left behind, in the same awaited prologue.
+    //
+    // `update_completed` is the discriminator resumeContinuation uses to tell
+    // "an update was interrupted" from "one finished and only failed to release
+    // its lock". Left standing, a FORCED run started after a successful one
+    // (exactly what e2e-install's upgrade spec does, twice) would take the
+    // lock, die before the rebuild writes its continuation flag, and be read as
+    // the finished one — swallowing the very report the branch exists to make.
+    // The box is not "completed" while it is updating, and the run writes both
+    // again when it is.
+    //
+    // HERE rather than in startUpdate, and awaited: the window this whole
+    // change is about begins when the first step runs, and by then the markers
+    // are gone. A restart in the microseconds before this line finds no lock
+    // either — both are written in the same prologue — so resumeContinuation
+    // correctly says nothing.
+    //
+    // Reported and not fatal, the same rule setUpdateLock follows: refusing to
+    // update a box because a marker could not be cleared is the worse outcome
+    // by some way, and a config store that cannot be written is exactly the
+    // state an update exists to repair. What it costs, said out loud, is that a
+    // later interrupted run may be read as this one having finished.
+    try {
+      await setMany({
+        [UPDATE_INTERRUPTED_KEY]: undefined,
+        update_completed: undefined,
+        update_completed_at: undefined,
+      });
+    } catch (err) {
+      console.warn(
+        "[Updater] Could not clear the previous run's markers - an interruption of THIS run may be reported as a completed update:",
+        err instanceof Error ? err.message : err,
+      );
+    }
   }
 
   if (startFrom === 0 && !(await checkInternet())) {

--- a/src/tests/unit/updater-interrupted-run.test.ts
+++ b/src/tests/unit/updater-interrupted-run.test.ts
@@ -23,14 +23,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  *   … every step "pending", "currentStepIndex":-1,
  *   "drift":{…"codes":["checkout-dirty"]}}
  *
- * `checkout-dirty` is part of the signature rather than a symptom of the branch
- * under test: the checkout had already been synced to the new commit while the
- * build on disk was still the old one — i.e. the first half HAD run, and then
- * the process was gone.
+ * `checkout-dirty` is part of the signature and NOT evidence about the run: it
+ * comes from `git status --porcelain` being non-empty (src/lib/build-identity.ts),
+ * which the e2e container permanently is, and says nothing about whether the
+ * checkout moved — that would be `build-predates-checkout` or
+ * `build-from-other-commit`, and neither is in the captured state. No artefact
+ * from those six runs records whether `update_in_progress` was set, so this file
+ * pins the BEHAVIOUR — an interrupted run is no longer silent — rather than
+ * claiming to be the cause of them.
  *
  * The lock is the evidence and it is already on disk. Held with nothing to
- * resume means an update was interrupted, and the honest answer is a failure
- * with that cause — not silence.
+ * resume, and no completed run to explain it, means an update was interrupted —
+ * and the verdict is written back, because the fault being detected is "the web
+ * server keeps being replaced" and a verdict kept in memory is one the next
+ * replacement erases.
  */
 
 vi.mock("@/lib/config-store", () => ({
@@ -48,10 +54,17 @@ const mockGet = vi.mocked(get);
 const mockSet = vi.mocked(set);
 
 /** The disk as this box would have it after the run was lost. */
-function diskState({ locked, continuation }: { locked: boolean; continuation?: string }) {
+function diskState({
+  locked,
+  continuation,
+  completed = false,
+  interruptedAt,
+}: { locked: boolean; continuation?: string; completed?: boolean; interruptedAt?: string }) {
   mockGet.mockImplementation(async (key: string) => {
     if (key === "update_in_progress") return locked ? true : undefined;
     if (key === "update_needs_continuation") return continuation;
+    if (key === "update_completed") return completed ? true : undefined;
+    if (key === "update_interrupted_at") return interruptedAt;
     return undefined;
   });
 }
@@ -118,6 +131,37 @@ describe("an update whose process was replaced is reported, not forgotten", () =
   // src/tests/unit/updater.test.ts ("resumes the second half…", and the three
   // refusals around it). It is deliberately not re-driven here: it launches a
   // real run, which this file's `exec` mock never settles.
+
+  it("remembers it, so a second restart does not return the box to silence", async () => {
+    // The fault being detected is "the web server keeps being replaced". A
+    // process that reports the verdict in memory and then dies takes the only
+    // record with it, and the next one finds a clean disk and answers idle —
+    // for good. So the release WRITES the verdict.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    diskState({ locked: true });
+    await updater.checkContinuation();
+    expect(mockSet).toHaveBeenCalledWith("update_interrupted_at", expect.any(String));
+
+    // The next process: a clean disk except for the record.
+    updater.resetUpdateState();
+    diskState({ locked: false, interruptedAt: "2026-09-06T09:00:00.000Z" });
+    await updater.checkContinuation();
+    expect(updater.getUpdateState().phase).toBe("failed");
+  });
+
+  it("says nothing about a run that FINISHED and only failed to release its lock", async () => {
+    // clearUpdateLock is documented to fail softly and launchUpdate fires it
+    // unawaited, so a leftover flag over a completed run is a real state.
+    // Reporting there would tell the owner to re-run an update that worked.
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    diskState({ locked: true, completed: true });
+
+    await updater.checkContinuation();
+
+    expect(updater.getUpdateState().phase).toBe("idle");
+    expect(err).not.toHaveBeenCalled();
+    expect(mockSet).not.toHaveBeenCalledWith("update_interrupted_at", expect.any(String));
+  });
 
   it("does not report a box whose update finished and left the lock behind as interrupted twice", async () => {
     // The verdict is a state, not a marker, so a second poll on the same boot

--- a/src/tests/unit/updater-interrupted-run.test.ts
+++ b/src/tests/unit/updater-interrupted-run.test.ts
@@ -47,11 +47,12 @@ vi.mock("@/lib/config-store", () => ({
 
 vi.mock("child_process", () => ({ exec: vi.fn(), execFile: vi.fn() }));
 
-import { get, set } from "@/lib/config-store";
+import { get, set, setMany } from "@/lib/config-store";
 import * as updater from "@/lib/updater";
 
 const mockGet = vi.mocked(get);
 const mockSet = vi.mocked(set);
+const mockSetMany = vi.mocked(setMany);
 
 /** The disk as this box would have it after the run was lost. */
 function diskState({
@@ -74,6 +75,8 @@ beforeEach(() => {
   mockGet.mockReset();
   mockSet.mockReset();
   mockSet.mockResolvedValue(undefined as never);
+  mockSetMany.mockReset();
+  mockSetMany.mockResolvedValue(undefined as never);
 });
 
 afterEach(() => {
@@ -147,6 +150,25 @@ describe("an update whose process was replaced is reported, not forgotten", () =
     diskState({ locked: false, interruptedAt: "2026-09-06T09:00:00.000Z" });
     await updater.checkContinuation();
     expect(updater.getUpdateState().phase).toBe("failed");
+  });
+
+  it("clears the completion markers when a new run starts, so the next verdict is not swallowed", () => {
+    // update_completed is the discriminator the branch above uses. Left
+    // standing, a FORCED run after a successful one — which is exactly what
+    // e2e-install's upgrade spec does, twice — would be read as the finished
+    // one if it died before the rebuild wrote its continuation flag.
+    updater.resetUpdateState();
+    diskState({ locked: false, completed: true });
+
+    expect(updater.startUpdate()).toEqual({ started: true });
+
+    expect(mockSetMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update_completed: undefined,
+        update_completed_at: undefined,
+        update_interrupted_at: undefined,
+      }),
+    );
   });
 
   it("says nothing about a run that FINISHED and only failed to release its lock", async () => {

--- a/src/tests/unit/updater-interrupted-run.test.ts
+++ b/src/tests/unit/updater-interrupted-run.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
@@ -152,23 +154,24 @@ describe("an update whose process was replaced is reported, not forgotten", () =
     expect(updater.getUpdateState().phase).toBe("failed");
   });
 
-  it("clears the completion markers when a new run starts, so the next verdict is not swallowed", () => {
+  it("clears the completion markers in the same awaited prologue as the lock", () => {
     // update_completed is the discriminator the branch above uses. Left
     // standing, a FORCED run after a successful one — which is exactly what
     // e2e-install's upgrade spec does, twice — would be read as the finished
     // one if it died before the rebuild wrote its continuation flag.
-    updater.resetUpdateState();
-    diskState({ locked: false, completed: true });
-
-    expect(updater.startUpdate()).toEqual({ started: true });
-
-    expect(mockSetMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        update_completed: undefined,
-        update_completed_at: undefined,
-        update_interrupted_at: undefined,
-      }),
-    );
+    //
+    // Asserted as TEXT because driving it means driving a whole run: what
+    // matters is that the clear is awaited, is in the branch that takes the
+    // lock, and is reported rather than swallowed when it fails.
+    const src = readFileSync(path.join(process.cwd(), "src/lib/updater.ts"), "utf-8");
+    const prologue = src.slice(src.indexOf("const ownsTheDesktop"), src.indexOf("let failed = false;"));
+    expect(prologue).toContain("await setUpdateLock();");
+    expect(prologue).toContain("await setMany({");
+    expect(prologue).toContain("update_completed: undefined");
+    expect(prologue).toContain("update_completed_at: undefined");
+    expect(prologue).toContain("[UPDATE_INTERRUPTED_KEY]: undefined");
+    // Reported, never fatal — the same rule setUpdateLock follows.
+    expect(prologue).toMatch(/catch \(err\)[\s\S]*console\.warn/);
   });
 
   it("says nothing about a run that FINISHED and only failed to release its lock", async () => {

--- a/src/tests/unit/updater-interrupted-run.test.ts
+++ b/src/tests/unit/updater-interrupted-run.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * TASK-731 — an update that was accepted and then lost its process reported
+ * NOTHING, and cost 45 minutes of runner time per occurrence.
+ *
+ * `startUpdate()` sets the module-level state to running and returns
+ * `{ started: true }` synchronously; `runUpdate` then takes the on-disk lock
+ * (`update_in_progress`) at its top. The step list's position lives only in
+ * that process's memory. The continuation flag — the one thing that survives —
+ * is written by the REBUILD step, near the end of the first half.
+ *
+ * So there is a window: between the POST that starts an update and the rebuild
+ * step, a web server that is replaced takes the whole run with it. The next
+ * process found the lock held, no continuation to resume, released the lock and
+ * answered `phase: idle, currentStepIndex: -1`, every step pending — the state
+ * of a box nobody had ever asked to update.
+ *
+ * Observed six times on e2e-install's `90-upgrade-main-to-beta` spec, on
+ * branches that touch nothing near the updater:
+ *
+ *   update did not complete within 2700000ms; last state: {"phase":"idle",
+ *   … every step "pending", "currentStepIndex":-1,
+ *   "drift":{…"codes":["checkout-dirty"]}}
+ *
+ * `checkout-dirty` is part of the signature rather than a symptom of the branch
+ * under test: the checkout had already been synced to the new commit while the
+ * build on disk was still the old one — i.e. the first half HAD run, and then
+ * the process was gone.
+ *
+ * The lock is the evidence and it is already on disk. Held with nothing to
+ * resume means an update was interrupted, and the honest answer is a failure
+ * with that cause — not silence.
+ */
+
+vi.mock("@/lib/config-store", () => ({
+  get: vi.fn(),
+  set: vi.fn(),
+  setMany: vi.fn(),
+}));
+
+vi.mock("child_process", () => ({ exec: vi.fn(), execFile: vi.fn() }));
+
+import { get, set } from "@/lib/config-store";
+import * as updater from "@/lib/updater";
+
+const mockGet = vi.mocked(get);
+const mockSet = vi.mocked(set);
+
+/** The disk as this box would have it after the run was lost. */
+function diskState({ locked, continuation }: { locked: boolean; continuation?: string }) {
+  mockGet.mockImplementation(async (key: string) => {
+    if (key === "update_in_progress") return locked ? true : undefined;
+    if (key === "update_needs_continuation") return continuation;
+    return undefined;
+  });
+}
+
+beforeEach(() => {
+  updater.resetUpdateState();
+  mockGet.mockReset();
+  mockSet.mockReset();
+  mockSet.mockResolvedValue(undefined as never);
+});
+
+afterEach(() => {
+  updater.resetUpdateState();
+  vi.restoreAllMocks();
+});
+
+describe("an update whose process was replaced is reported, not forgotten", () => {
+  it("answers failed — with the reason — when the lock is held and nothing is left to resume", async () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    diskState({ locked: true });
+
+    const resumed = await updater.checkContinuation();
+
+    // Nothing to resume: that part is unchanged and correct.
+    expect(resumed).toBe(false);
+    const state = updater.getUpdateState();
+    expect(
+      state.phase,
+      "an accepted update that died must not read as a box nobody asked to update",
+    ).toBe("failed");
+    expect(state.error).toMatch(/interrupted before it could finish/);
+    expect(state.error).toMatch(/start the update again/i);
+    // The operator's copy of the same sentence.
+    expect(err.mock.calls.flat().join(" ")).toMatch(/interrupted before it could finish/);
+  });
+
+  it("still releases the desktop lock, which is what that branch was for", async () => {
+    // The box must not be left redirected to /updating for ever. Reporting the
+    // failure is in addition to the release, never instead of it.
+    diskState({ locked: true });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await updater.checkContinuation();
+
+    expect(mockSet).toHaveBeenCalledWith("update_in_progress", undefined);
+  });
+
+  it("says nothing at all on a box that simply has not updated", async () => {
+    // No lock, no continuation: the ordinary boot. Inventing a failed update
+    // there would be the mirror defect — every reboot of every box would show
+    // one.
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    diskState({ locked: false });
+
+    const resumed = await updater.checkContinuation();
+
+    expect(resumed).toBe(false);
+    expect(updater.getUpdateState().phase).toBe("idle");
+    expect(err).not.toHaveBeenCalled();
+  });
+
+  // The post-reboot half — lock held AND a continuation flag written — is a
+  // different branch of the same function and is covered end to end in
+  // src/tests/unit/updater.test.ts ("resumes the second half…", and the three
+  // refusals around it). It is deliberately not re-driven here: it launches a
+  // real run, which this file's `exec` mock never settles.
+
+  it("does not report a box whose update finished and left the lock behind as interrupted twice", async () => {
+    // The verdict is a state, not a marker, so a second poll on the same boot
+    // must not re-decide it: the lock is gone by then and the failure has to
+    // survive on its own.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    diskState({ locked: true });
+    await updater.checkContinuation();
+    expect(updater.getUpdateState().phase).toBe("failed");
+
+    diskState({ locked: false });
+    await updater.checkContinuation();
+
+    expect(
+      updater.getUpdateState().phase,
+      "the verdict must not be erased by the next poll, which finds a clean disk",
+    ).toBe("failed");
+  });
+});

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -733,7 +733,12 @@ describe("updater", () => {
       const postStep = updater.getUpdateState().steps.find((step) => step.id === "post_update");
       expect(postStep?.status).toBe("failed");
       expect(postStep?.error).toBe("post_update exited with status 1");
-      expect(mockSetMany).not.toHaveBeenCalled();
+      // No COMPLETION was persisted. `setMany` itself is called once per run
+      // now — the prologue clears the previous run's markers with it
+      // (TASK-731) — so the assertion is about the payload, not the call.
+      expect(mockSetMany).not.toHaveBeenCalledWith(
+        expect.objectContaining({ update_completed: true }),
+      );
     });
 
     it("fails the continuation when gateway verification still finds no known recovery path", async () => {


### PR DESCRIPTION
**TASK-731** — an in-app update that stalls at `phase: idle` with every step pending, and costs 45 minutes of runner time each time.

## Symptom

`e2e-install`'s `90-upgrade-main-to-beta` spec, six sightings on branches that touch nothing near the updater:

```
update did not complete within 2700000ms; last state: {"phase":"idle",
 … every step "pending", "currentStepIndex":-1,
 "drift":{…"codes":["checkout-dirty"]}}
```

The three preceding tests in the same spec pass — including the one that asserts the schedule POST answered `started: true` — and ~96 other tests in the run pass. A rerun passes with no code change.

## Cause

`startUpdate()` sets the module-level state to running and answers `{ started: true }` **synchronously**; `runUpdate` then takes the on-disk lock (`update_in_progress`). The position in the step list lives only in that process's memory. The one thing that survives a restart — `update_needs_continuation` — is written by the REBUILD step, near the end of the first half. And the lock itself used to sit BELOW `checkInternet()` (up to two 10 s ICMP attempts plus an 8 s HTTPS HEAD) and `captureDriftBaseline()` (a git shell-out), so the first ~30 s of every accepted run left no trace on disk at all. It is taken first now, and the internet-check failure path releases it.

So there is a window between the POST and that step in which a web server that is replaced takes the whole run with it. The next process then reached `resumeContinuation()`:

```ts
const needsContinuation = await get("update_needs_continuation");
if (!needsContinuation) {
  await clearUpdateLock();   // "boot safety"
  return false;              // → the status route answers IDLE
}
```

— released the lock and reported `phase: idle, currentStepIndex: -1`, every step pending. That is the state of a box **nobody has ever asked to update**, over a run that had been accepted. `checkout-dirty` is part of the signature rather than a symptom of the branch under test: the checkout had already been synced to the new commit while the build on disk was still the old one, i.e. the first half HAD run and then the process was gone.

The harness then polled a state machine that could not move, for the whole 45-minute budget.

## Fix

**The lock is the evidence, and it is already on disk.** It is read before it is cleared: held with nothing to resume, and no completed run to explain it, means an update was interrupted — reported as a failure naming the cause instead of as silence. Nothing can be resumed — the step index was only ever in the dead process's memory — so the honest answer is a named failure the owner can act on:

> The update was interrupted before it could finish: the web server was replaced while it ran, and no step is left to resume. Nothing was rolled back — start the update again.

**And the verdict is written back**, because the fault being detected is "the web server keeps being replaced": a process that reports it in memory and then dies takes the only record with it, and the next one finds a clean disk and answers idle again — permanently. `update_interrupted_at` is that record; a new run clears it and so does a Dismiss, without which the failure would be undismissable (the route re-asks on every idle poll).

**A run that FINISHED and only failed to release its lock is not an interruption.** `clearUpdateLock` is documented to fail softly and `launchUpdate` fires it unawaited, so a leftover flag over a completed run is a real state — and telling the owner to re-run a ten-minute update that worked would be the mirror defect. `update_completed` with no continuation flag is what tells the two apart, and the report is also gated on the release actually succeeding.

The release itself is unchanged: a desktop locked on `/updating` for ever is what that branch exists to prevent, and reporting the failure is in addition to the release, never instead of it.

**The harness stops paying for it either way.** `waitForUpdate` recognises the "nothing has started" shape (idle, `currentStepIndex < 0`, every step pending) and gives it two minutes — generous, since the only legitimate window is the poll or two between a web server coming back and `checkContinuation()` resuming — then fails with what was OBSERVED plus what the container can say: the web server's restart count and start time, and the updater's own keys on disk. It deliberately does **not** assert a cause, because this shape has two: a run that lost its process, and a run that FINISHED whose `completed` phase this container can never synthesise (it is permanently `checkout-dirty`, which forces drift and disables that synthesis for the whole run, so a web-server restart after a good update lands here too). The keys say which. The same diagnosis is attached to the timeout message, so a run that hits the ceiling for another reason no longer lands in the artifact as one line of JSON.

The `clawbox-root-update@*` journal is deliberately NOT dumped: that unit runs `install.sh`, which handles four provider keys, and this message becomes a Playwright artifact on a **public** repository where GitHub's `***` masking does not reach. What is left is the web server's own journal with a redaction pass over anything token-shaped.

45–55 minutes per occurrence becomes ~2 minutes plus the cause.

## Native mechanism

Nothing to leverage from OpenClaw or Hermes: this is ClawBox's own updater state machine and its own on-disk lock. The fix uses the lock ClawBox already writes (`src/lib/update-lock.ts`) rather than adding a second marker — the alternative would have been a new "an update was scheduled" file, i.e. a second copy of a fact already on disk.

## RED → GREEN

RED on fresh `origin/beta` 381f34ed (`src/tests/unit/updater-interrupted-run.test.ts`, before the review pass added two more cases):

```
FAIL … > answers failed — with the reason — when the lock is held and nothing is left to resume
AssertionError: an accepted update that died must not read as a box nobody asked to update:
  expected 'idle' to be 'failed'

FAIL … > does not report a box whose update finished and left the lock behind as interrupted twice
AssertionError: expected 'idle' to be 'failed'

 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```

GREEN: `6 passed (6)`. The mirror defect is pinned in the same file — a box with no lock and no continuation stays `idle` and logs nothing, so this cannot invent a failed update on every reboot of every box. Neighbours (`updater`, `updater-continuation-boot`, `routes/update/*`, `update-lock`, `middleware`) — **13 files / 330 tests pass**. Full `--project unit`: 713 files pass, the only failure being the known dev-PC `run-tunnel` flake, which passes in isolation.

## Device leg — both editions, read-only, no mutex

The change only ever fires when the update lock is on disk with no continuation flag, so what had to be checked on hardware is that a healthy box does not look like that:

```
OpenClaw edition:  {'update_in_progress': None, 'update_needs_continuation': None, 'update_completed': True}
Hermes edition:    {'update_in_progress': None, 'update_needs_continuation': None, 'update_completed': True}
```

Both boxes, an hour after their last successful update: no lock held, so this branch reports nothing and the state stays idle — no spurious failed update on either edition. (Only those three keys were read out of `data/config.json`; nothing else in that file was touched or printed.)

## Which half reaches the six sightings

The failure is reported at `90-upgrade-main-to-beta.spec.ts:89` — the SECOND `waitForUpdate`, and that update runs **main's** `updater.ts`, because the first call takes the box to main and rebuilds it there. So the server-side half reaches those sightings only once this is on `main`; the harness half helps from the next run on either branch. Worth stating plainly rather than implying the whole change lands on them.

## Unproven

The e2e occurrence itself is not reproduced here — it needs the container and a restart landing inside a window measured in seconds, which is why it has six sightings and no repro. What is proved is that the state the artifacts recorded is exactly what this branch of `resumeContinuation` produces, that it now produces a named failure instead, and that the harness turns the remaining 45-minute wait into a two-minute one with the container's own evidence attached. If the underlying restart has some other cause, the next occurrence will now say so in the artifact instead of a line of JSON.

## Review

Review, before this PR was opened: 2 HIGH / 2 MEDIUM-HIGH / 3 MEDIUM / 2 LOW-MEDIUM / 4 LOW. The two HIGH were both about the fix looking complete when it was partial — the verdict lived only in memory (so the very fault it detects erases it), and the `checkout-dirty` reading in the original write-up was wrong: it is `git status --porcelain` being non-empty, which the e2e container permanently is, and says nothing about whether the checkout moved. That claim is struck from the code and from this PR; the test pins the behaviour rather than claiming to be the cause of the six timeouts. The MEDIUM-HIGH findings — the uncovered window before the lock, the harness asserting a cause it cannot know, and the public-artifact exposure — are applied above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Update interruptions are now detected and reported as failed instead of remaining ambiguous after an application restart.
  - Interrupted update status persists across restarts until dismissed or replaced by a new update.
  - Completed updates with stale cleanup state are no longer incorrectly reported as interrupted.
  - Update locking is more reliable during connectivity checks and processing.
  - Update timeout and failure messages now include additional troubleshooting details, including service status and relevant logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->