### PR TITLE
fix: drop models the installed core's own catalogue has retired

### DIFF
--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { coreModelLifecycle } from "@/lib/core-model-lifecycle";
+import { coreModelRetired } from "@/lib/core-model-lifecycle";
 import { spawn } from "child_process";
 import { promises as fsp } from "fs";
 import path from "path";
@@ -673,13 +673,49 @@ function isOfferableModelId(provider: string, id: string): boolean {
   // segment is one of these two, and none carries `deprecated: true` — so this
   // is the set doing what it says rather than a change in what is offered.
   if (DEPRECATED_MODEL_IDS.has(lastModelSegment(id))) return false;
-  // And whatever the INSTALLED core says, which is the answer that cannot go
-  // stale: the set above is a hand-kept list, this is the harness's own
-  // catalogue. Fails open — a box with no core, no plugin manifest or a shape
-  // the reader does not recognise answers null and the row is offered, which
-  // is exactly what beta does today.
-  if (coreModelLifecycle(provider, lastModelSegment(id))?.deprecated) return false;
   return true;
+}
+
+/**
+ * The payload as the PICKER should see it: without the models the installed
+ * core has retired.
+ *
+ * Applied when a payload is SERVED, never when one is stored, and that
+ * distinction is the whole of it. `subscription-surface.ts` reads the cache
+ * file back as the set of ids this box will ACCEPT — "a row the picker offers
+ * must be a row that route accepts" — so filtering the stored payload would not
+ * merely stop recommending a retired model, it would start REFUSING one the
+ * customer is already on, with `… is not in the Anthropic model catalogue this
+ * box enumerated`. That sentence would be untrue on both halves: the box did
+ * enumerate it, and the core still routes it by exact reference. What we
+ * recommend and what we accept are two questions, and only the first one has a
+ * new answer.
+ *
+ * The default is re-resolved, because dropping rows can drop the one the
+ * payload named — and a `defaultModelId` outside `models` is a picker with
+ * nothing selected.
+ *
+ * ASYMMETRY, deliberate and worth naming: the lookup is keyed on the CATALOGUE
+ * provider, and the core ships no `codex` extension — so the openai picker
+ * loses `gpt-5.5` while the codex picker keeps it as its default. That is the
+ * same upstream model, hidden on one auth mode and offered on the other, and it
+ * is the behaviour we want today: the core's replacement, `gpt-5.6-sol`, is
+ * plan-gated, and a Free ChatGPT account handed it as the only row AND as the
+ * saved default would 400 on every turn. If a `codex` manifest ever appears, or
+ * the mapping is "fixed" to consult openai's, that default moves silently —
+ * which is what `curated-defaults-offerable.test.ts` is there to notice.
+ */
+function withoutRetiredModels(payload: CatalogResponse): CatalogResponse {
+  const models = payload.models.filter((m) => !coreModelRetired(payload.provider, m.id));
+  if (models.length === payload.models.length) return payload;
+  // Never to empty. If the core has retired everything this box enumerated,
+  // the honest picker is the one the box actually has — an empty one offers
+  // the customer nothing to do.
+  if (models.length === 0) return payload;
+  const defaultModelId = models.some((m) => m.id === payload.defaultModelId)
+    ? payload.defaultModelId
+    : (models.find((m) => m.isDefault)?.id ?? models[0].id);
+  return { ...payload, models, defaultModelId };
 }
 
 function sanitizeCatalogModels(provider: string, models: CatalogModel[]): CatalogModel[] {
@@ -1532,7 +1568,7 @@ export async function GET(req: NextRequest) {
         ? { warming: true }
         : {}),
     };
-    return NextResponse.json(payload, { headers: noStore() });
+    return NextResponse.json(withoutRetiredModels(payload), { headers: noStore() });
   }
 
   // Nothing cached yet — the first picker open after a restart. Serve the
@@ -1542,5 +1578,5 @@ export async function GET(req: NextRequest) {
     ...buildFallbackPayload(provider),
     ...(enumerating ? { warming: true } : {}),
   };
-  return NextResponse.json(payload, { headers: noStore() });
+  return NextResponse.json(withoutRetiredModels(payload), { headers: noStore() });
 }

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { coreModelLifecycle } from "@/lib/core-model-lifecycle";
 import { spawn } from "child_process";
 import { promises as fsp } from "fs";
 import path from "path";
@@ -614,6 +615,15 @@ function transformOpenclawEntries(
     if (entry.available === false) continue;
     // The only checks that read the ROW rather than the id; everything else is
     // `isOfferableModelId`, shared with the sanitiser.
+    //
+    // The `deprecated` TAG cannot fire on the pinned core and is kept only for
+    // the day it can: `toModelRow` builds `tags` from configured entries and
+    // aliases and never projects a model's lifecycle, so
+    // `anthropic/claude-opus-4-8` — `status: "deprecated"` in the core's own
+    // manifest — arrives here with `tags: []` (measured, 2026.8.1). The
+    // lifecycle is read from where the core actually publishes it, inside
+    // `isOfferableModelId`, so the sanitiser applies the same rule to a payload
+    // an older build cached.
     if (entry.tags?.includes("deprecated")) continue;
     if (!isOfferableModelId(provider, id)) continue;
     out.push({
@@ -663,6 +673,12 @@ function isOfferableModelId(provider: string, id: string): boolean {
   // segment is one of these two, and none carries `deprecated: true` — so this
   // is the set doing what it says rather than a change in what is offered.
   if (DEPRECATED_MODEL_IDS.has(lastModelSegment(id))) return false;
+  // And whatever the INSTALLED core says, which is the answer that cannot go
+  // stale: the set above is a hand-kept list, this is the harness's own
+  // catalogue. Fails open — a box with no core, no plugin manifest or a shape
+  // the reader does not recognise answers null and the row is offered, which
+  // is exactly what beta does today.
+  if (coreModelLifecycle(provider, lastModelSegment(id))?.deprecated) return false;
   return true;
 }
 

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { coreModelRetired } from "@/lib/core-model-lifecycle";
+import { coreRetiredModels } from "@/lib/core-model-lifecycle";
 import { spawn } from "child_process";
 import { promises as fsp } from "fs";
 import path from "path";
@@ -706,7 +706,12 @@ function isOfferableModelId(provider: string, id: string): boolean {
  * which is what `curated-defaults-offerable.test.ts` is there to notice.
  */
 function withoutRetiredModels(payload: CatalogResponse): CatalogResponse {
-  const models = payload.models.filter((m) => !coreModelRetired(payload.provider, m.id));
+  // Resolved ONCE. A payload can run to hundreds of rows (the OpenRouter
+  // catalogue was measured at 423), and asking per row would put one blocking
+  // stat per row on the request thread.
+  const retired = coreRetiredModels(payload.provider);
+  if (retired.size === 0) return payload;
+  const models = payload.models.filter((m) => !retired.has(m.id));
   if (models.length === payload.models.length) return payload;
   // Never to empty. If the core has retired everything this box enumerated,
   // the honest picker is the one the box actually has — an empty one offers

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -621,9 +621,10 @@ function transformOpenclawEntries(
     // aliases and never projects a model's lifecycle, so
     // `anthropic/claude-opus-4-8` — `status: "deprecated"` in the core's own
     // manifest — arrives here with `tags: []` (measured, 2026.8.1). The
-    // lifecycle is read from where the core actually publishes it, inside
-    // `isOfferableModelId`, so the sanitiser applies the same rule to a payload
-    // an older build cached.
+    // lifecycle is read from where the core actually publishes it, at SERVE
+    // time in `withoutRetiredModels` below — never here and never in the
+    // sanitiser, so a payload an older build cached keeps every row this box
+    // will still accept.
     if (entry.tags?.includes("deprecated")) continue;
     if (!isOfferableModelId(provider, id)) continue;
     out.push({

--- a/src/lib/core-model-lifecycle.ts
+++ b/src/lib/core-model-lifecycle.ts
@@ -75,6 +75,16 @@ const cache = new Map<string, CachedManifest>();
  * them: bundled in the core's `dist/extensions`, or beside the config once
  * OpenClaw 2 unbundled the provider into its own installed plugin.
  */
+/**
+ * A provider id that can only ever name a directory, never traverse out of one.
+ *
+ * The id reaches this module from a request query string by way of the catalogue
+ * payload, and it is joined into a filesystem path below. Everything the core
+ * ships is `[a-z0-9-]`, so anything else is not a provider we could have a
+ * manifest for anyway — refusing here costs nothing and closes the class.
+ */
+const SAFE_PROVIDER_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/i;
+
 function manifestPaths(provider: string): string[] {
   const bin = findOpenclawBin();
   const paths: string[] = [];
@@ -146,6 +156,7 @@ function catalogueFor(manifest: unknown, provider: string): unknown {
 }
 
 function retiredFor(provider: string): Set<string> {
+  if (!SAFE_PROVIDER_RE.test(provider)) return new Set();
   const cached = cache.get(provider);
   if (cached) {
     const now = Date.now();
@@ -168,13 +179,32 @@ function retiredFor(provider: string): Set<string> {
     cache.delete(provider);
   }
   for (const file of manifestPaths(provider)) {
+    // Opened ONCE and both stat and read taken from the descriptor. A
+    // `statSync` followed by a `readFileSync` of the same path is two lookups
+    // of a name that can change between them — and the whole point of the stat
+    // is to decide whether the bytes that follow are still the ones it
+    // described. `npm install -g openclaw@latest` renaming `dist/extensions`
+    // underneath is exactly that window, and it is the window this module
+    // exists to survive.
+    let fd: number;
+    try {
+      fd = fsSync.openSync(file, "r");
+    } catch {
+      continue;
+    }
     let stat: fsSync.Stats;
     let raw: string;
     try {
-      stat = fsSync.statSync(file);
-      raw = fsSync.readFileSync(file, "utf-8");
+      stat = fsSync.fstatSync(fd);
+      raw = fsSync.readFileSync(fd, "utf-8");
     } catch {
       continue;
+    } finally {
+      try {
+        fsSync.closeSync(fd);
+      } catch {
+        // Already gone; nothing to release.
+      }
     }
     const retired = new Set<string>();
     try {

--- a/src/lib/core-model-lifecycle.ts
+++ b/src/lib/core-model-lifecycle.ts
@@ -11,44 +11,49 @@ import { findOpenclawBin } from "@/lib/openclaw-config";
  * carries a lifecycle:
  *
  *   { "id": "claude-opus-4-8", "status": "deprecated",
- *     "replacedBy": "claude-opus-5", … }
+ *     "replacedBy": "claude-opus-5",
+ *     "statusReason": "Still available by exact reference; use … for new setups." }
  *
  * WHY THIS FILE EXISTS AT ALL, given `models list --json` is right there.
- * Measured against the pinned core (2026.8.1) with an isolated
- * `OPENCLAW_HOME`:
+ * Measured against the pinned core (2026.8.1) with an isolated `OPENCLAW_HOME`:
  *
  *   $ openclaw models list --provider anthropic --all --json
  *   … { "key": "anthropic/claude-opus-4-8", "name": "Claude Opus 4.8",
  *       "contextWindow": 1000000, "available": null, "tags": [] } …
  *
  * The row is enumerated and its lifecycle is NOT projected — `toModelRow`
- * carries `tags` (which come from configured entries and aliases) and drops
- * `status` / `replacedBy` entirely. So the catalogue route's own
- * `entry.tags?.includes("deprecated")` guard could never fire on this core: a
- * filter that reads as deference to the harness, deferring to nothing. That
- * projection gap is worth reporting upstream; until it closes, the manifest is
- * where the answer lives and this reads it there.
+ * builds `tags` from configured entries and aliases and never carries `status`.
+ * So the catalogue route's own `entry.tags?.includes("deprecated")` guard could
+ * never fire on this core: a filter that reads as deference to the harness,
+ * deferring to nothing. The core DOES model the lifecycle internally and its
+ * gateway `models.list` RPC projects it; ClawBox has no client for that RPC, so
+ * reading the shipped manifest is the cheapest way to ask the same question —
+ * and it is not a new trick here: `scripts/gateway-pre-start.sh` resolves the
+ * same file for deepseek on every boot, from the same two places.
  *
- * Reading the shipped manifest is not a new trick in this repo:
- * `scripts/gateway-pre-start.sh` resolves the same file for deepseek on every
- * boot, from the same two places, and `ai-models/configure` stats it.
+ * THE PREDICATE IS THE CORE'S OWN, not an invention: `deprecated` OR `disabled`
+ * — `catalog.filter(e => … e.status !== "deprecated" && e.status !== "disabled")`
+ * in the installed core's own list probe.
  *
  * FAILS OPEN, everywhere. A box with no core, an unreadable manifest, a plugin
- * that ships none, a shape this does not recognise — all answer "not
- * deprecated", so the picker keeps offering exactly what it offers today. The
- * failure this must never have is the other one: a parse slip that empties a
- * customer's model list.
+ * that ships none, a shape this does not recognise — all answer "not retired",
+ * so the picker keeps offering exactly what it offers today. The failure this
+ * must never have is the other one: a parse slip that empties a model list.
  */
 
-export interface ModelLifecycle {
-  /** The core marks this model retired. */
-  deprecated: boolean;
-  /** What it says to use instead, when it says. */
-  replacedBy: string | null;
+/** What the harness treats as "do not offer this any more". */
+const RETIRED_STATUSES: ReadonlySet<string> = new Set(["deprecated", "disabled"]);
+
+interface CachedManifest {
+  /** Retired ids, indexed under BOTH the raw manifest id and its last segment. */
+  retired: Set<string>;
+  /** The file this was read from, and what it looked like when it was read. */
+  file: string;
+  mtimeMs: number;
+  size: number;
 }
 
-/** Cached per provider for the process: a manifest changes only with a core upgrade, which restarts this server. */
-const cache = new Map<string, Map<string, ModelLifecycle>>();
+const cache = new Map<string, CachedManifest>();
 
 /**
  * The two places the manifest lives, in the order `gateway-pre-start.sh` tries
@@ -64,79 +69,119 @@ function manifestPaths(provider: string): string[] {
       "dist", "extensions", provider, "openclaw.plugin.json",
     ));
   }
-  // Resolved from the environment rather than from `CONFIG_PATH`, which is a
-  // module constant frozen at import: the same shape `harness/credentials.ts`
-  // and `local-ai-token.ts` already use for this directory.
-  const openclawHome = process.env.OPENCLAW_HOME
+  // `CLAWBOX_OPENCLAW_HOME` first, because that is the order every other reader
+  // in this repo spells (`openclaw-config.ts`, `ai-models/configure`,
+  // `gateway-proxy.ts`, `updater.ts`) and the one the test config neutralises.
+  const openclawHome = process.env.CLAWBOX_OPENCLAW_HOME
+    || process.env.OPENCLAW_HOME
     || path.join(process.env.HOME ?? "/home/clawbox", ".openclaw");
   paths.push(path.join(openclawHome, "extensions", provider, "openclaw.plugin.json"));
   return paths;
 }
 
 /**
- * Every `{id, status, replacedBy}` anywhere in the manifest.
+ * Every retired `{id, status}` in one catalogue block.
  *
- * Walked rather than addressed by a fixed path on purpose: the shape has moved
- * between core generations (a provider block, a `modelCatalog`, per-auth-mode
- * variants), the ids are the same in all of them, and a path that goes stale
- * would silently answer "nothing is deprecated" — the exact failure this file
- * replaces. Anything without an `id` string is not a model row and is skipped.
+ * Walked rather than addressed by a fixed path: the shape has moved between
+ * core generations (a provider block, a `modelCatalog`, per-auth-mode variants),
+ * the ids are the same in all of them, and a path that went stale would
+ * silently answer "nothing is retired" — the exact failure this file replaces.
+ *
+ * Indexed under the raw id AND its last segment, because both forms are real:
+ * the anthropic and openai manifests carry bare ids while the nvidia one ships
+ * slashed ones (`z-ai/glm-5.1`), and the caller holds whichever form its
+ * catalogue uses.
  */
-function collect(node: unknown, out: Map<string, ModelLifecycle>): void {
+function collect(node: unknown, out: Set<string>): void {
   if (Array.isArray(node)) {
     for (const item of node) collect(item, out);
     return;
   }
   if (!node || typeof node !== "object") return;
-  const row = node as { id?: unknown; status?: unknown; replacedBy?: unknown };
-  if (typeof row.id === "string" && row.id.trim()) {
-    const deprecated = typeof row.status === "string" && row.status.trim().toLowerCase() === "deprecated";
-    const replacedBy = typeof row.replacedBy === "string" && row.replacedBy.trim() ? row.replacedBy.trim() : null;
-    const id = row.id.trim();
-    const existing = out.get(id);
-    // A manifest names the same model more than once (once per auth mode). Any
-    // occurrence marking it retired retires it — that is the conservative
-    // direction, and the observed manifests agree with themselves anyway.
-    out.set(id, {
-      deprecated: deprecated || (existing?.deprecated ?? false),
-      replacedBy: replacedBy ?? existing?.replacedBy ?? null,
-    });
+  const row = node as { id?: unknown; status?: unknown };
+  if (typeof row.id === "string" && row.id.trim() && typeof row.status === "string") {
+    if (RETIRED_STATUSES.has(row.status.trim().toLowerCase())) {
+      const id = row.id.trim();
+      out.add(id);
+      const slash = id.lastIndexOf("/");
+      if (slash > 0) out.add(id.slice(slash + 1));
+    }
   }
   for (const value of Object.values(node as Record<string, unknown>)) collect(value, out);
 }
 
-function lifecycleFor(provider: string): Map<string, ModelLifecycle> {
+/**
+ * The block that belongs to THIS provider, when the manifest separates them.
+ *
+ * The anthropic manifest ships two catalogues under `modelCatalog.providers` —
+ * `claude-cli` and `anthropic` — and they are genuinely different surfaces, not
+ * copies (`provider-models.ts` documents `claude-cli` as the narrower one). A
+ * flat walk would let a model retired on one route disappear from the other,
+ * where the core still lists and routes it. So the provider's own block is read
+ * when there is one, and the whole manifest only when there is not.
+ */
+function catalogueFor(manifest: unknown, provider: string): unknown {
+  const modelCatalog = (manifest as { modelCatalog?: unknown } | null)?.modelCatalog;
+  const providers = (modelCatalog as { providers?: unknown } | null)?.providers;
+  if (providers && typeof providers === "object" && !Array.isArray(providers)) {
+    const own = (providers as Record<string, unknown>)[provider];
+    if (own !== undefined) return own;
+  }
+  return manifest;
+}
+
+function retiredFor(provider: string): Set<string> {
   const cached = cache.get(provider);
-  if (cached) return cached;
-  const found = new Map<string, ModelLifecycle>();
+  if (cached) {
+    // Re-stat rather than trust the process lifetime. The in-app OpenClaw-only
+    // update (`openclaw_install` → `openclaw_patch` → `gateway_restart`) runs
+    // INSIDE this server and deliberately does not touch ClawBox, so a core
+    // upgrade can and does happen under a live process — and a manifest read
+    // during `npm install -g`, while `dist/extensions` is half-renamed, would
+    // otherwise pin "nothing is retired" for the rest of that process's life.
+    try {
+      const stat = fsSync.statSync(cached.file);
+      if (stat.mtimeMs === cached.mtimeMs && stat.size === cached.size) return cached.retired;
+    } catch {
+      // The file went away: fall through and look again.
+    }
+    cache.delete(provider);
+  }
   for (const file of manifestPaths(provider)) {
+    let stat: fsSync.Stats;
     let raw: string;
     try {
+      stat = fsSync.statSync(file);
       raw = fsSync.readFileSync(file, "utf-8");
     } catch {
       continue;
     }
+    const retired = new Set<string>();
     try {
-      collect(JSON.parse(raw), found);
+      collect(catalogueFor(JSON.parse(raw), provider), retired);
     } catch {
-      // A manifest we cannot parse is a manifest we know nothing from.
+      // A manifest we cannot parse is a manifest we know nothing from — and it
+      // is NOT cached, so a half-written file is re-read rather than believed.
+      return new Set();
     }
-    break;
+    cache.set(provider, { retired, file, mtimeMs: stat.mtimeMs, size: stat.size });
+    return retired;
   }
-  cache.set(provider, found);
-  return found;
+  // Nothing found. Deliberately NOT cached: on a box with no core yet, or one
+  // mid-upgrade, the answer is "ask again", not "there is nothing".
+  return new Set();
 }
 
 /**
- * What the installed core says about this model, or null when it says nothing —
- * which is also the answer on a box with no core installed.
+ * Has the installed core retired this model? False on a box that cannot say —
+ * including one with no core installed.
  *
- * `id` is the BARE id (`claude-opus-4-8`), the same form the catalogue route
- * carries after `modelIdFromKey`.
+ * `id` may be the bare id (`claude-opus-4-8`) or the fully-qualified one
+ * (`z-ai/glm-5.1`); both forms are indexed.
  */
-export function coreModelLifecycle(provider: string, id: string): ModelLifecycle | null {
-  if (!provider || !id) return null;
-  return lifecycleFor(provider).get(id.trim()) ?? null;
+export function coreModelRetired(provider: string, id: string): boolean {
+  if (!provider || !id) return false;
+  return retiredFor(provider).has(id.trim());
 }
 
 /** Test seam: forget the manifests so the next call reads them again. */

--- a/src/lib/core-model-lifecycle.ts
+++ b/src/lib/core-model-lifecycle.ts
@@ -44,6 +44,19 @@ import { findOpenclawBin } from "@/lib/openclaw-config";
 /** What the harness treats as "do not offer this any more". */
 const RETIRED_STATUSES: ReadonlySet<string> = new Set(["deprecated", "disabled"]);
 
+/**
+ * How long a manifest read stands before the file is re-stat'ed.
+ *
+ * The re-stat exists because the in-app OpenClaw update runs inside this server
+ * (see `retiredFor`), and that is a once-in-a-while event — while
+ * `withoutRetiredModels` asks about every row of a payload, and the OpenRouter
+ * catalogue is ~423 rows. One `statSync` per row per request is a blocking
+ * syscall storm on a Jetson for a file that changes when someone taps Update.
+ * Five seconds is far shorter than any update takes and turns the storm into
+ * one stat per provider per five seconds.
+ */
+const STAT_FLOOR_MS = 5_000;
+
 interface CachedManifest {
   /** Retired ids, indexed under BOTH the raw manifest id and its last segment. */
   retired: Set<string>;
@@ -51,6 +64,8 @@ interface CachedManifest {
   file: string;
   mtimeMs: number;
   size: number;
+  /** When the file was last stat'ed, so a burst of lookups costs one syscall. */
+  checkedAt: number;
 }
 
 const cache = new Map<string, CachedManifest>();
@@ -133,6 +148,8 @@ function catalogueFor(manifest: unknown, provider: string): unknown {
 function retiredFor(provider: string): Set<string> {
   const cached = cache.get(provider);
   if (cached) {
+    const now = Date.now();
+    if (now - cached.checkedAt < STAT_FLOOR_MS) return cached.retired;
     // Re-stat rather than trust the process lifetime. The in-app OpenClaw-only
     // update (`openclaw_install` → `openclaw_patch` → `gateway_restart`) runs
     // INSIDE this server and deliberately does not touch ClawBox, so a core
@@ -141,7 +158,10 @@ function retiredFor(provider: string): Set<string> {
     // otherwise pin "nothing is retired" for the rest of that process's life.
     try {
       const stat = fsSync.statSync(cached.file);
-      if (stat.mtimeMs === cached.mtimeMs && stat.size === cached.size) return cached.retired;
+      if (stat.mtimeMs === cached.mtimeMs && stat.size === cached.size) {
+        cached.checkedAt = now;
+        return cached.retired;
+      }
     } catch {
       // The file went away: fall through and look again.
     }
@@ -164,7 +184,7 @@ function retiredFor(provider: string): Set<string> {
       // is NOT cached, so a half-written file is re-read rather than believed.
       return new Set();
     }
-    cache.set(provider, { retired, file, mtimeMs: stat.mtimeMs, size: stat.size });
+    cache.set(provider, { retired, file, mtimeMs: stat.mtimeMs, size: stat.size, checkedAt: Date.now() });
     return retired;
   }
   // Nothing found. Deliberately NOT cached: on a box with no core yet, or one
@@ -181,8 +201,23 @@ function retiredFor(provider: string): Set<string> {
  */
 export function coreModelRetired(provider: string, id: string): boolean {
   if (!provider || !id) return false;
-  return retiredFor(provider).has(id.trim());
+  return coreRetiredModels(provider).has(id.trim());
 }
+
+/**
+ * Every id the installed core has retired for this provider, in both the raw
+ * and last-segment forms.
+ *
+ * For a caller with a LIST to filter: resolve the set once and test against it,
+ * rather than asking per row. `withoutRetiredModels` filters payloads that run
+ * to hundreds of rows.
+ */
+export function coreRetiredModels(provider: string): ReadonlySet<string> {
+  if (!provider) return EMPTY;
+  return retiredFor(provider);
+}
+
+const EMPTY: ReadonlySet<string> = new Set();
 
 /** Test seam: forget the manifests so the next call reads them again. */
 export function resetCoreModelLifecycle(): void {

--- a/src/lib/core-model-lifecycle.ts
+++ b/src/lib/core-model-lifecycle.ts
@@ -1,0 +1,145 @@
+import fsSync from "fs";
+import path from "path";
+import { findOpenclawBin } from "@/lib/openclaw-config";
+
+/**
+ * Which models the INSTALLED core has retired.
+ *
+ * The picker's job is to offer what the box can usefully run, and the one
+ * authority on that is the harness's own catalogue — not a list kept here. The
+ * core publishes it per provider in `openclaw.plugin.json`, and every entry
+ * carries a lifecycle:
+ *
+ *   { "id": "claude-opus-4-8", "status": "deprecated",
+ *     "replacedBy": "claude-opus-5", … }
+ *
+ * WHY THIS FILE EXISTS AT ALL, given `models list --json` is right there.
+ * Measured against the pinned core (2026.8.1) with an isolated
+ * `OPENCLAW_HOME`:
+ *
+ *   $ openclaw models list --provider anthropic --all --json
+ *   … { "key": "anthropic/claude-opus-4-8", "name": "Claude Opus 4.8",
+ *       "contextWindow": 1000000, "available": null, "tags": [] } …
+ *
+ * The row is enumerated and its lifecycle is NOT projected — `toModelRow`
+ * carries `tags` (which come from configured entries and aliases) and drops
+ * `status` / `replacedBy` entirely. So the catalogue route's own
+ * `entry.tags?.includes("deprecated")` guard could never fire on this core: a
+ * filter that reads as deference to the harness, deferring to nothing. That
+ * projection gap is worth reporting upstream; until it closes, the manifest is
+ * where the answer lives and this reads it there.
+ *
+ * Reading the shipped manifest is not a new trick in this repo:
+ * `scripts/gateway-pre-start.sh` resolves the same file for deepseek on every
+ * boot, from the same two places, and `ai-models/configure` stats it.
+ *
+ * FAILS OPEN, everywhere. A box with no core, an unreadable manifest, a plugin
+ * that ships none, a shape this does not recognise — all answer "not
+ * deprecated", so the picker keeps offering exactly what it offers today. The
+ * failure this must never have is the other one: a parse slip that empties a
+ * customer's model list.
+ */
+
+export interface ModelLifecycle {
+  /** The core marks this model retired. */
+  deprecated: boolean;
+  /** What it says to use instead, when it says. */
+  replacedBy: string | null;
+}
+
+/** Cached per provider for the process: a manifest changes only with a core upgrade, which restarts this server. */
+const cache = new Map<string, Map<string, ModelLifecycle>>();
+
+/**
+ * The two places the manifest lives, in the order `gateway-pre-start.sh` tries
+ * them: bundled in the core's `dist/extensions`, or beside the config once
+ * OpenClaw 2 unbundled the provider into its own installed plugin.
+ */
+function manifestPaths(provider: string): string[] {
+  const bin = findOpenclawBin();
+  const paths: string[] = [];
+  if (path.isAbsolute(bin)) {
+    paths.push(path.join(
+      path.dirname(bin), "..", "lib", "node_modules", "openclaw",
+      "dist", "extensions", provider, "openclaw.plugin.json",
+    ));
+  }
+  // Resolved from the environment rather than from `CONFIG_PATH`, which is a
+  // module constant frozen at import: the same shape `harness/credentials.ts`
+  // and `local-ai-token.ts` already use for this directory.
+  const openclawHome = process.env.OPENCLAW_HOME
+    || path.join(process.env.HOME ?? "/home/clawbox", ".openclaw");
+  paths.push(path.join(openclawHome, "extensions", provider, "openclaw.plugin.json"));
+  return paths;
+}
+
+/**
+ * Every `{id, status, replacedBy}` anywhere in the manifest.
+ *
+ * Walked rather than addressed by a fixed path on purpose: the shape has moved
+ * between core generations (a provider block, a `modelCatalog`, per-auth-mode
+ * variants), the ids are the same in all of them, and a path that goes stale
+ * would silently answer "nothing is deprecated" — the exact failure this file
+ * replaces. Anything without an `id` string is not a model row and is skipped.
+ */
+function collect(node: unknown, out: Map<string, ModelLifecycle>): void {
+  if (Array.isArray(node)) {
+    for (const item of node) collect(item, out);
+    return;
+  }
+  if (!node || typeof node !== "object") return;
+  const row = node as { id?: unknown; status?: unknown; replacedBy?: unknown };
+  if (typeof row.id === "string" && row.id.trim()) {
+    const deprecated = typeof row.status === "string" && row.status.trim().toLowerCase() === "deprecated";
+    const replacedBy = typeof row.replacedBy === "string" && row.replacedBy.trim() ? row.replacedBy.trim() : null;
+    const id = row.id.trim();
+    const existing = out.get(id);
+    // A manifest names the same model more than once (once per auth mode). Any
+    // occurrence marking it retired retires it — that is the conservative
+    // direction, and the observed manifests agree with themselves anyway.
+    out.set(id, {
+      deprecated: deprecated || (existing?.deprecated ?? false),
+      replacedBy: replacedBy ?? existing?.replacedBy ?? null,
+    });
+  }
+  for (const value of Object.values(node as Record<string, unknown>)) collect(value, out);
+}
+
+function lifecycleFor(provider: string): Map<string, ModelLifecycle> {
+  const cached = cache.get(provider);
+  if (cached) return cached;
+  const found = new Map<string, ModelLifecycle>();
+  for (const file of manifestPaths(provider)) {
+    let raw: string;
+    try {
+      raw = fsSync.readFileSync(file, "utf-8");
+    } catch {
+      continue;
+    }
+    try {
+      collect(JSON.parse(raw), found);
+    } catch {
+      // A manifest we cannot parse is a manifest we know nothing from.
+    }
+    break;
+  }
+  cache.set(provider, found);
+  return found;
+}
+
+/**
+ * What the installed core says about this model, or null when it says nothing —
+ * which is also the answer on a box with no core installed.
+ *
+ * `id` is the BARE id (`claude-opus-4-8`), the same form the catalogue route
+ * carries after `modelIdFromKey`.
+ */
+export function coreModelLifecycle(provider: string, id: string): ModelLifecycle | null {
+  if (!provider || !id) return null;
+  return lifecycleFor(provider).get(id.trim()) ?? null;
+}
+
+/** Test seam: forget the manifests so the next call reads them again. */
+export function resetCoreModelLifecycle(): void {
+  cache.clear();
+}

--- a/src/tests/routes/ai-models/catalog-deprecated-rows.test.ts
+++ b/src/tests/routes/ai-models/catalog-deprecated-rows.test.ts
@@ -86,8 +86,8 @@ describe("catalog: a model the core's own catalogue has retired", () => {
       () => okChild(ANTHROPIC_LIVE) as unknown as ReturnType<typeof childProcess.spawn>,
     );
     const lifecycle = await import("@/lib/core-model-lifecycle");
-    vi.spyOn(lifecycle, "coreModelRetired").mockImplementation(
-      (provider: string, id: string) => provider === "anthropic" && id === "claude-opus-4-8",
+    vi.spyOn(lifecycle, "coreRetiredModels").mockImplementation(
+      (provider: string) => (provider === "anthropic" ? new Set(["claude-opus-4-8"]) : new Set()),
     );
     ({ GET } = await import("@/app/setup-api/ai-models/catalog/route"));
   });
@@ -141,5 +141,22 @@ describe("catalog: a model the core's own catalogue has retired", () => {
     const body = (await res.json()) as { models: { id: string }[]; defaultModelId: string };
     expect(body.models.map((m) => m.id)).toEqual(["claude-opus-5"]);
     expect(body.defaultModelId).toBe("claude-opus-5");
+  });
+
+  it("never filters the picker empty", async () => {
+    // The one failure this whole module must not have. If the core has retired
+    // everything this box enumerated, the honest picker is the one the box
+    // actually has — an empty one offers the customer nothing to do, and the
+    // lifecycle reader's own header names an emptied model list as the outcome
+    // it fails open to avoid.
+    const lifecycle = await import("@/lib/core-model-lifecycle");
+    vi.mocked(lifecycle.coreRetiredModels).mockImplementation(
+      () => new Set(["claude-opus-5", "claude-opus-4-8", "claude-haiku-4-5"]),
+    );
+    await models();
+    await settle();
+    expect(await models()).toEqual(
+      expect.arrayContaining(["claude-opus-5", "claude-opus-4-8", "claude-haiku-4-5"]),
+    );
   });
 });

--- a/src/tests/routes/ai-models/catalog-deprecated-rows.test.ts
+++ b/src/tests/routes/ai-models/catalog-deprecated-rows.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+import * as childProcess from "child_process";
+import fs from "fs";
+import path from "path";
+import { NextRequest } from "next/server";
+
+/**
+ * TASK-615 — the picker offers a model the harness has retired.
+ *
+ * The card was filed against a hand-maintained Claude list that no longer
+ * exists (`augmentWithStaticCatalog`, `STATIC_MODEL_CONTEXT_WINDOWS` and the
+ * `claude-sonnet-4-6` default were all removed on 2 Sep, and beta's Anthropic
+ * default is `claude-opus-5`). The defect it describes survives the rewrite in
+ * a different place: the route's own guard against a retired model is
+ *
+ *     if (entry.tags?.includes("deprecated")) continue;
+ *
+ * and on the pinned core (2026.8.1) that can never fire. Measured with an
+ * isolated OPENCLAW_HOME:
+ *
+ *     $ openclaw models list --provider anthropic --all --json
+ *     … {"key":"anthropic/claude-opus-4-8","name":"Claude Opus 4.8",
+ *        "contextWindow":1000000,"available":null,"tags":[]} …
+ *
+ * while the core's own manifest for that provider says
+ * `{"id":"claude-opus-4-8","status":"deprecated","replacedBy":"claude-opus-5"}`.
+ * `toModelRow` simply does not project `status`. So a customer picking from a
+ * live enumeration is offered last generation's flagship beside this one, with
+ * nothing on screen to tell them apart — the card's symptom exactly.
+ */
+
+vi.mock("child_process", () => ({ spawn: vi.fn() }));
+
+vi.mock("@/lib/openclaw-config", () => ({
+  findOpenclawBin: () => "openclaw",
+  openclawIsAbsent: () => false,
+}));
+
+const DATA_DIR = "/tmp/clawbox-catalog-deprecated-test";
+vi.mock("@/lib/config-store", () => ({ DATA_DIR: "/tmp/clawbox-catalog-deprecated-test" }));
+
+const mockSpawn = vi.mocked(childProcess.spawn);
+
+/** A child that answers one `models list --json` payload and exits clean. */
+function okChild(payload: unknown) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter; stderr: EventEmitter; kill: () => void;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = () => {};
+  queueMicrotask(() => {
+    child.stdout.emit("data", Buffer.from(JSON.stringify(payload), "utf8"));
+    child.emit("close", 0);
+  });
+  return child;
+}
+
+/**
+ * What the pinned core really answers for anthropic on a bare config: six rows,
+ * every one of them `tags: []`, the retired one indistinguishable from the rest.
+ */
+const ANTHROPIC_LIVE = {
+  count: 3,
+  models: [
+    { key: "anthropic/claude-opus-5", name: "Claude Opus 5", contextWindow: 1_000_000, available: null, tags: [] },
+    { key: "anthropic/claude-opus-4-8", name: "Claude Opus 4.8", contextWindow: 1_000_000, available: null, tags: [] },
+    { key: "anthropic/claude-haiku-4-5", name: "Claude Haiku 4.5", contextWindow: 200_000, available: null, tags: [] },
+  ],
+};
+
+function settle(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 250));
+}
+
+describe("catalog: a model the core's own catalogue has retired", () => {
+  let GET: (req: NextRequest) => Promise<Response>;
+
+  beforeEach(async () => {
+    fs.rmSync(DATA_DIR, { recursive: true, force: true });
+    fs.mkdirSync(path.join(DATA_DIR, "catalog-cache"), { recursive: true });
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockSpawn.mockImplementation(
+      () => okChild(ANTHROPIC_LIVE) as unknown as ReturnType<typeof childProcess.spawn>,
+    );
+    const lifecycle = await import("@/lib/core-model-lifecycle");
+    vi.spyOn(lifecycle, "coreModelLifecycle").mockImplementation((provider, id) =>
+      provider === "anthropic" && id === "claude-opus-4-8"
+        ? { deprecated: true, replacedBy: "claude-opus-5" }
+        : null,
+    );
+    ({ GET } = await import("@/app/setup-api/ai-models/catalog/route"));
+  });
+
+  async function models(): Promise<string[]> {
+    const res = await GET(new NextRequest(
+      "http://clawbox.local/setup-api/ai-models/catalog?provider=anthropic",
+    ));
+    const body = (await res.json()) as { models?: { id: string }[] };
+    return (body.models ?? []).map((m) => m.id);
+  }
+
+  it("does not offer it, and keeps what replaced it", async () => {
+    await models();
+    await settle();
+    const ids = await models();
+    expect(ids).toContain("claude-opus-5");
+    expect(ids).toContain("claude-haiku-4-5");
+    expect(ids).not.toContain("claude-opus-4-8");
+  });
+
+  it("keeps it out of the cached payload it serves later too", async () => {
+    // The sanitiser re-applies the current rules to a payload written by an
+    // older build, so a rule that lived only in the transform would let a
+    // retired row survive a core upgrade in the cache on disk.
+    await models();
+    await settle();
+    const cache = JSON.parse(
+      fs.readFileSync(path.join(DATA_DIR, "catalog-cache", "anthropic.json"), "utf8"),
+    ) as { models: { id: string }[] };
+    expect(cache.models.map((m) => m.id)).not.toContain("claude-opus-4-8");
+  });
+});

--- a/src/tests/routes/ai-models/catalog-deprecated-rows.test.ts
+++ b/src/tests/routes/ai-models/catalog-deprecated-rows.test.ts
@@ -86,10 +86,8 @@ describe("catalog: a model the core's own catalogue has retired", () => {
       () => okChild(ANTHROPIC_LIVE) as unknown as ReturnType<typeof childProcess.spawn>,
     );
     const lifecycle = await import("@/lib/core-model-lifecycle");
-    vi.spyOn(lifecycle, "coreModelLifecycle").mockImplementation((provider, id) =>
-      provider === "anthropic" && id === "claude-opus-4-8"
-        ? { deprecated: true, replacedBy: "claude-opus-5" }
-        : null,
+    vi.spyOn(lifecycle, "coreModelRetired").mockImplementation(
+      (provider: string, id: string) => provider === "anthropic" && id === "claude-opus-4-8",
     );
     ({ GET } = await import("@/app/setup-api/ai-models/catalog/route"));
   });
@@ -111,15 +109,37 @@ describe("catalog: a model the core's own catalogue has retired", () => {
     expect(ids).not.toContain("claude-opus-4-8");
   });
 
-  it("keeps it out of the cached payload it serves later too", async () => {
-    // The sanitiser re-applies the current rules to a payload written by an
-    // older build, so a rule that lived only in the transform would let a
-    // retired row survive a core upgrade in the cache on disk.
+  it("leaves it in the cache the box will still ACCEPT it from", async () => {
+    // The distinction the whole change turns on. `subscription-surface.ts`
+    // reads this file back as the set of ids the box accepts, so filtering it
+    // would not merely stop recommending a retired model — it would start
+    // REFUSING one the customer is already on, with "…is not in the Anthropic
+    // model catalogue this box enumerated", which the box plainly did.
     await models();
     await settle();
     const cache = JSON.parse(
       fs.readFileSync(path.join(DATA_DIR, "catalog-cache", "anthropic.json"), "utf8"),
     ) as { models: { id: string }[] };
-    expect(cache.models.map((m) => m.id)).not.toContain("claude-opus-4-8");
+    expect(cache.models.map((m) => m.id)).toContain("claude-opus-4-8");
+  });
+
+  it("re-resolves the default when the retired row was it", async () => {
+    // Dropping rows can drop the one the payload named, and a defaultModelId
+    // outside `models` is a picker with nothing selected.
+    mockSpawn.mockImplementation(() => okChild({
+      count: 2,
+      models: [
+        { key: "anthropic/claude-opus-4-8", name: "Claude Opus 4.8", contextWindow: 1_000_000, available: null, tags: ["default"] },
+        { key: "anthropic/claude-opus-5", name: "Claude Opus 5", contextWindow: 1_000_000, available: null, tags: [] },
+      ],
+    }) as unknown as ReturnType<typeof childProcess.spawn>);
+    await models();
+    await settle();
+    const res = await GET(new NextRequest(
+      "http://clawbox.local/setup-api/ai-models/catalog?provider=anthropic",
+    ));
+    const body = (await res.json()) as { models: { id: string }[]; defaultModelId: string };
+    expect(body.models.map((m) => m.id)).toEqual(["claude-opus-5"]);
+    expect(body.defaultModelId).toBe("claude-opus-5");
   });
 });

--- a/src/tests/unit/core-model-lifecycle.test.ts
+++ b/src/tests/unit/core-model-lifecycle.test.ts
@@ -71,18 +71,75 @@ const ANTHROPIC = {
   },
 };
 
-describe("coreModelLifecycle", () => {
+describe("coreModelRetired", () => {
   it("reads the retirement the core itself published", async () => {
     writeManifest("anthropic", ANTHROPIC);
-    const { coreModelLifecycle } = await load();
-    expect(coreModelLifecycle("anthropic", "claude-opus-4-8")).toEqual({
-      deprecated: true,
-      replacedBy: "claude-opus-5",
-    });
-    expect(coreModelLifecycle("anthropic", "claude-opus-5")).toEqual({
-      deprecated: false,
-      replacedBy: null,
-    });
+    const { coreModelRetired } = await load();
+    expect(coreModelRetired("anthropic", "claude-opus-4-8")).toBe(true);
+    expect(coreModelRetired("anthropic", "claude-opus-5")).toBe(false);
+  });
+
+  it("honours `disabled` as well as `deprecated`, like the core's own filter", async () => {
+    // `catalog.filter(e => … e.status !== "deprecated" && e.status !== "disabled")`
+    // in the installed core's list probe. `disabled` is the stronger signal;
+    // reading only half the harness's predicate is not deferring to it.
+    writeManifest("google", { models: [
+      { id: "gemini-old", status: "disabled" },
+      { id: "gemini-2.5-flash" },
+    ] });
+    const { coreModelRetired } = await load();
+    expect(coreModelRetired("google", "gemini-old")).toBe(true);
+    expect(coreModelRetired("google", "gemini-2.5-flash")).toBe(false);
+  });
+
+  it("answers for a slashed id under either form", async () => {
+    // The shipped manifests carry both: bare ids for anthropic and openai,
+    // slashed ones for nvidia (`z-ai/glm-5.1`). The caller holds whichever
+    // form its own catalogue uses, and a lookup that only matched one would
+    // fail open — silently, which is this module's stated anti-goal.
+    writeManifest("openrouter", { models: [{ id: "z-ai/glm-5.1", status: "deprecated" }] });
+    const { coreModelRetired } = await load();
+    expect(coreModelRetired("openrouter", "z-ai/glm-5.1")).toBe(true);
+    expect(coreModelRetired("openrouter", "glm-5.1")).toBe(true);
+    expect(coreModelRetired("openrouter", "glm-5.2")).toBe(false);
+  });
+
+  it("reads the provider's OWN catalogue block, not its neighbour's", async () => {
+    // The anthropic manifest ships two under `modelCatalog.providers` —
+    // `claude-cli` and `anthropic` — and they are different surfaces, not
+    // copies. A model retired on the narrower route must not vanish from the
+    // wider one, where the core still lists and routes it.
+    writeManifest("anthropic", { modelCatalog: { providers: {
+      "claude-cli": { models: [{ id: "claude-sonnet-5", status: "deprecated" }] },
+      anthropic: { models: [{ id: "claude-sonnet-5" }, { id: "claude-opus-4-8", status: "deprecated" }] },
+    } } });
+    const { coreModelRetired } = await load();
+    expect(coreModelRetired("anthropic", "claude-sonnet-5")).toBe(false);
+    expect(coreModelRetired("anthropic", "claude-opus-4-8")).toBe(true);
+  });
+
+  it("re-reads a manifest the core replaced under a live process", async () => {
+    // The in-app OpenClaw-only update runs INSIDE this server and deliberately
+    // does not restart it, so "cached for the process lifetime" would keep a
+    // retired model on offer until a reboot — and a read taken while
+    // `npm install -g` is mid-rename would pin "nothing is retired" forever.
+    writeManifest("openai", { models: [{ id: "gpt-5.5" }] });
+    const { coreModelRetired } = await load();
+    expect(coreModelRetired("openai", "gpt-5.5")).toBe(false);
+
+    await new Promise((r) => setTimeout(r, 12));
+    writeManifest("openai", { models: [{ id: "gpt-5.5", status: "deprecated" }, { id: "gpt-5.6-sol" }] });
+    expect(coreModelRetired("openai", "gpt-5.5")).toBe(true);
+  });
+
+  it("does not remember having found no manifest at all", async () => {
+    // "There is no core yet" and "there is nothing retired" are different
+    // answers, and caching the first as the second is how a filter turns
+    // itself off for the life of a process with no log line.
+    const { coreModelRetired } = await load();
+    expect(coreModelRetired("openai", "gpt-5.5")).toBe(false);
+    writeManifest("openai", { models: [{ id: "gpt-5.5", status: "deprecated" }] });
+    expect(coreModelRetired("openai", "gpt-5.5")).toBe(true);
   });
 
   it("finds the row wherever the manifest nests it", async () => {
@@ -96,28 +153,28 @@ describe("coreModelLifecycle", () => {
         oauth: { models: [{ id: "gpt-5.6-sol" }] },
       },
     });
-    const { coreModelLifecycle } = await load();
-    expect(coreModelLifecycle("openai", "gpt-5.5")?.deprecated).toBe(true);
-    expect(coreModelLifecycle("openai", "gpt-5.6-sol")?.deprecated).toBe(false);
+    const { coreModelRetired } = await load();
+    expect(coreModelRetired("openai", "gpt-5.5")).toBe(true);
+    expect(coreModelRetired("openai", "gpt-5.6-sol")).toBe(false);
   });
 
   it("says nothing rather than guessing when it cannot read a manifest", async () => {
     // A box with no core, no plugin, an unreadable file or a shape this does
     // not recognise must leave the picker exactly as it is. The failure this
     // must never have is emptying a customer's model list over a parse slip.
-    const { coreModelLifecycle } = await load();
-    expect(coreModelLifecycle("anthropic", "claude-opus-4-8")).toBeNull();
+    const { coreModelRetired } = await load();
+    expect(coreModelRetired("anthropic", "claude-opus-4-8")).toBe(false);
 
     writeManifest("gemini", "}{ not json" as unknown);
     const broken = await load();
-    expect(broken.coreModelLifecycle("gemini", "anything")).toBeNull();
+    expect(broken.coreModelRetired("gemini", "anything")).toBe(false);
   });
 
   it("never reports a model the manifest does not name", async () => {
     writeManifest("anthropic", ANTHROPIC);
-    const { coreModelLifecycle } = await load();
-    expect(coreModelLifecycle("anthropic", "claude-something-else")).toBeNull();
-    expect(coreModelLifecycle("", "claude-opus-5")).toBeNull();
-    expect(coreModelLifecycle("anthropic", "")).toBeNull();
+    const { coreModelRetired } = await load();
+    expect(coreModelRetired("anthropic", "claude-something-else")).toBe(false);
+    expect(coreModelRetired("", "claude-opus-5")).toBe(false);
+    expect(coreModelRetired("anthropic", "")).toBe(false);
   });
 });

--- a/src/tests/unit/core-model-lifecycle.test.ts
+++ b/src/tests/unit/core-model-lifecycle.test.ts
@@ -22,32 +22,48 @@ vi.mock("@/lib/openclaw-config", () => ({ findOpenclawBin: () => "openclaw" }));
  */
 
 let tmpHome: string;
-let originalHome: string | undefined;
-let originalOpenclawHome: string | undefined;
+
+/**
+ * Every variable the lookup consults, aimed at the fixture.
+ *
+ * `CLAWBOX_OPENCLAW_HOME` is in here because `manifestPaths` reads it FIRST,
+ * ahead of `OPENCLAW_HOME`, and a device carries it — `install-x64.sh` bakes it
+ * into the web-server unit and `updater.ts` exports it into every gateway
+ * pre-start child. `vitest.config.ts` already floors it to `""` for the whole
+ * suite, so this is not a live failure; it is this file no longer depending on
+ * a config-level floor to point its own fixture at itself.
+ */
+const ENV = ["HOME", "OPENCLAW_HOME", "CLAWBOX_OPENCLAW_HOME"] as const;
+const saved: Record<string, string | undefined> = {};
 
 beforeEach(() => {
   vi.resetModules();
   tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "core-lifecycle-"));
-  originalHome = process.env.HOME;
-  originalOpenclawHome = process.env.OPENCLAW_HOME;
+  for (const key of ENV) saved[key] = process.env[key];
   process.env.HOME = tmpHome;
   process.env.OPENCLAW_HOME = path.join(tmpHome, ".openclaw");
+  process.env.CLAWBOX_OPENCLAW_HOME = path.join(tmpHome, ".openclaw");
 });
 
 afterEach(() => {
-  if (originalHome === undefined) delete process.env.HOME;
-  else process.env.HOME = originalHome;
-  if (originalOpenclawHome === undefined) delete process.env.OPENCLAW_HOME;
-  else process.env.OPENCLAW_HOME = originalOpenclawHome;
+  for (const key of ENV) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
   fs.rmSync(tmpHome, { recursive: true, force: true });
   vi.restoreAllMocks();
 });
 
 /** Write a provider manifest where OpenClaw 2 puts it: beside the config. */
 function writeManifest(provider: string, body: unknown): void {
+  writeRawManifest(provider, JSON.stringify(body));
+}
+
+/** The same file, byte for byte — for the bytes `JSON.stringify` would repair. */
+function writeRawManifest(provider: string, raw: string): void {
   const dir = path.join(tmpHome, ".openclaw", "extensions", provider);
   fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(dir, "openclaw.plugin.json"), JSON.stringify(body));
+  fs.writeFileSync(path.join(dir, "openclaw.plugin.json"), raw);
 }
 
 async function load() {
@@ -186,9 +202,56 @@ describe("coreModelRetired", () => {
     const { coreModelRetired } = await load();
     expect(coreModelRetired("anthropic", "claude-opus-4-8")).toBe(false);
 
-    writeManifest("gemini", "}{ not json" as unknown);
+    // Valid JSON, and nothing this module knows how to read.
+    writeManifest("openrouter", "not a catalogue at all");
+    const shape = await load();
+    expect(shape.coreModelRetired("openrouter", "anything")).toBe(false);
+
+    // Not JSON at all, written as RAW BYTES: `JSON.stringify("}{ not json")`
+    // is itself a valid JSON string, so putting this through `writeManifest`
+    // would take the shape path above and leave the `JSON.parse` catch unrun.
+    writeRawManifest("gemini", "}{ not json");
     const broken = await load();
     expect(broken.coreModelRetired("gemini", "anything")).toBe(false);
+  });
+
+  it("remembers a manifest it read but could make nothing of", async () => {
+    // The other half of the contrast the next case rests on, asserted rather
+    // than only asserted ABOUT: a shape this module does not recognise is still
+    // a fair answer about a file it successfully read, so it is cached — which
+    // is what makes the parse branch's refusal to cache a deliberate difference
+    // rather than an accident of where the `return` landed.
+    writeManifest("google", "not a catalogue at all");
+    const { coreModelRetired } = await load();
+    vi.useFakeTimers();
+    try {
+      expect(coreModelRetired("google", "gemini-old")).toBe(false);
+      writeManifest("google", { models: [{ id: "gemini-old", status: "deprecated" }] });
+      expect(coreModelRetired("google", "gemini-old")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not remember a manifest it could not parse", async () => {
+    // Why the two failures above are not interchangeable: an unrecognised
+    // SHAPE caches an empty set — a fair answer about a file that was read —
+    // while a PARSE failure deliberately caches nothing, because the file it
+    // failed on is the one `npm install -g openclaw@latest` is halfway through
+    // writing. Caching that would pin "nothing is retired" for the life of the
+    // process, which is the failure this module exists to survive.
+    writeRawManifest("openai", "}{ not json");
+    const { coreModelRetired } = await load();
+    // Time frozen, so a cached empty set would still be inside the stat floor
+    // and the second answer can only have come from a re-read.
+    vi.useFakeTimers();
+    try {
+      expect(coreModelRetired("openai", "gpt-5.5")).toBe(false);
+      writeManifest("openai", { models: [{ id: "gpt-5.5", status: "deprecated" }] });
+      expect(coreModelRetired("openai", "gpt-5.5")).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("refuses a provider id that could name anything but a directory", async () => {

--- a/src/tests/unit/core-model-lifecycle.test.ts
+++ b/src/tests/unit/core-model-lifecycle.test.ts
@@ -56,17 +56,31 @@ async function load() {
   return mod;
 }
 
-/** The anthropic manifest's real shape on 2026.8.1, cut to what matters. */
+/**
+ * The anthropic manifest's REAL nesting on 2026.8.1, cut to what matters:
+ * `modelCatalog.providers.<route>.models`, with the two routes the core ships.
+ * Copied from the installed file rather than invented, so these cases exercise
+ * the path a real manifest takes.
+ */
 const ANTHROPIC = {
   name: "anthropic",
-  providers: {
-    anthropic: {
-      modelCatalog: [
-        { id: "claude-opus-5", contextWindow: 1_000_000 },
-        { id: "claude-sonnet-5", contextWindow: 1_000_000 },
-        { id: "claude-opus-4-8", contextWindow: 1_000_000, status: "deprecated", replacedBy: "claude-opus-5" },
-        { id: "claude-haiku-4-5", contextWindow: 200_000 },
-      ],
+  modelCatalog: {
+    discovery: { anthropic: "refreshable" },
+    providers: {
+      "claude-cli": {
+        models: [
+          { id: "claude-opus-5", contextWindow: 1_000_000 },
+          { id: "claude-sonnet-5", contextWindow: 1_000_000 },
+        ],
+      },
+      anthropic: {
+        models: [
+          { id: "claude-opus-5", contextWindow: 1_000_000 },
+          { id: "claude-sonnet-5", contextWindow: 1_000_000 },
+          { id: "claude-opus-4-8", contextWindow: 1_000_000, status: "deprecated", replacedBy: "claude-opus-5" },
+          { id: "claude-haiku-4-5", contextWindow: 200_000 },
+        ],
+      },
     },
   },
 };
@@ -127,9 +141,16 @@ describe("coreModelRetired", () => {
     const { coreModelRetired } = await load();
     expect(coreModelRetired("openai", "gpt-5.5")).toBe(false);
 
-    await new Promise((r) => setTimeout(r, 12));
     writeManifest("openai", { models: [{ id: "gpt-5.5", status: "deprecated" }, { id: "gpt-5.6-sol" }] });
-    expect(coreModelRetired("openai", "gpt-5.5")).toBe(true);
+    // Past the stat floor, which exists so a payload of hundreds of rows costs
+    // one syscall rather than hundreds — not to hold an answer for a minute.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(Date.now() + 10_000);
+      expect(coreModelRetired("openai", "gpt-5.5")).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not remember having found no manifest at all", async () => {

--- a/src/tests/unit/core-model-lifecycle.test.ts
+++ b/src/tests/unit/core-model-lifecycle.test.ts
@@ -191,6 +191,20 @@ describe("coreModelRetired", () => {
     expect(broken.coreModelRetired("gemini", "anything")).toBe(false);
   });
 
+  it("refuses a provider id that could name anything but a directory", async () => {
+    // The id reaches this module from a request query string by way of the
+    // catalogue payload and is joined into a filesystem path. Nothing the core
+    // ships is outside `[a-z0-9-]`, so anything else cannot have a manifest —
+    // and refusing here closes the traversal class rather than relying on the
+    // caller to have validated first.
+    writeManifest("anthropic", ANTHROPIC);
+    const { coreModelRetired, coreRetiredModels } = await load();
+    for (const bad of ["../anthropic", "a/b", "..", "anthropic\u0000", "-leading"]) {
+      expect(coreModelRetired(bad, "claude-opus-4-8")).toBe(false);
+      expect(coreRetiredModels(bad).size).toBe(0);
+    }
+  });
+
   it("never reports a model the manifest does not name", async () => {
     writeManifest("anthropic", ANTHROPIC);
     const { coreModelRetired } = await load();

--- a/src/tests/unit/core-model-lifecycle.test.ts
+++ b/src/tests/unit/core-model-lifecycle.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+// The installed core, when there is one, is the FIRST place the module looks —
+// and this machine has one, so a case about "no manifest anywhere" would read
+// the real /usr/lib copy instead. Neutralised to a bare name, which is exactly
+// what `findOpenclawBin` itself answers on a box with no core installed.
+vi.mock("@/lib/openclaw-config", () => ({ findOpenclawBin: () => "openclaw" }));
+
+/**
+ * The picker must not offer what the harness has retired.
+ *
+ * The pinned core (2026.8.1) publishes each model's lifecycle in its provider
+ * manifest — `{"id":"claude-opus-4-8","status":"deprecated","replacedBy":
+ * "claude-opus-5"}` — and does NOT project it through `models list --json`,
+ * whose rows carry `tags: []` for exactly that model. Measured, not assumed.
+ * So the manifest is the only place the answer exists on this core, and these
+ * cases pin that it is read from where the core actually puts it and that
+ * every way of failing to read it is harmless.
+ */
+
+let tmpHome: string;
+let originalHome: string | undefined;
+let originalOpenclawHome: string | undefined;
+
+beforeEach(() => {
+  vi.resetModules();
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "core-lifecycle-"));
+  originalHome = process.env.HOME;
+  originalOpenclawHome = process.env.OPENCLAW_HOME;
+  process.env.HOME = tmpHome;
+  process.env.OPENCLAW_HOME = path.join(tmpHome, ".openclaw");
+});
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalOpenclawHome === undefined) delete process.env.OPENCLAW_HOME;
+  else process.env.OPENCLAW_HOME = originalOpenclawHome;
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+/** Write a provider manifest where OpenClaw 2 puts it: beside the config. */
+function writeManifest(provider: string, body: unknown): void {
+  const dir = path.join(tmpHome, ".openclaw", "extensions", provider);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "openclaw.plugin.json"), JSON.stringify(body));
+}
+
+async function load() {
+  const mod = await import("@/lib/core-model-lifecycle");
+  mod.resetCoreModelLifecycle();
+  return mod;
+}
+
+/** The anthropic manifest's real shape on 2026.8.1, cut to what matters. */
+const ANTHROPIC = {
+  name: "anthropic",
+  providers: {
+    anthropic: {
+      modelCatalog: [
+        { id: "claude-opus-5", contextWindow: 1_000_000 },
+        { id: "claude-sonnet-5", contextWindow: 1_000_000 },
+        { id: "claude-opus-4-8", contextWindow: 1_000_000, status: "deprecated", replacedBy: "claude-opus-5" },
+        { id: "claude-haiku-4-5", contextWindow: 200_000 },
+      ],
+    },
+  },
+};
+
+describe("coreModelLifecycle", () => {
+  it("reads the retirement the core itself published", async () => {
+    writeManifest("anthropic", ANTHROPIC);
+    const { coreModelLifecycle } = await load();
+    expect(coreModelLifecycle("anthropic", "claude-opus-4-8")).toEqual({
+      deprecated: true,
+      replacedBy: "claude-opus-5",
+    });
+    expect(coreModelLifecycle("anthropic", "claude-opus-5")).toEqual({
+      deprecated: false,
+      replacedBy: null,
+    });
+  });
+
+  it("finds the row wherever the manifest nests it", async () => {
+    // The shape has moved between core generations — a provider block, a
+    // modelCatalog, one copy per auth mode — and the ids are the same in all of
+    // them. A fixed path that went stale would answer "nothing is deprecated",
+    // which is the failure this file replaces.
+    writeManifest("openai", {
+      auth: {
+        "api-key": { models: [{ id: "gpt-5.5", status: "deprecated", replacedBy: "gpt-5.6-sol" }] },
+        oauth: { models: [{ id: "gpt-5.6-sol" }] },
+      },
+    });
+    const { coreModelLifecycle } = await load();
+    expect(coreModelLifecycle("openai", "gpt-5.5")?.deprecated).toBe(true);
+    expect(coreModelLifecycle("openai", "gpt-5.6-sol")?.deprecated).toBe(false);
+  });
+
+  it("says nothing rather than guessing when it cannot read a manifest", async () => {
+    // A box with no core, no plugin, an unreadable file or a shape this does
+    // not recognise must leave the picker exactly as it is. The failure this
+    // must never have is emptying a customer's model list over a parse slip.
+    const { coreModelLifecycle } = await load();
+    expect(coreModelLifecycle("anthropic", "claude-opus-4-8")).toBeNull();
+
+    writeManifest("gemini", "}{ not json" as unknown);
+    const broken = await load();
+    expect(broken.coreModelLifecycle("gemini", "anything")).toBeNull();
+  });
+
+  it("never reports a model the manifest does not name", async () => {
+    writeManifest("anthropic", ANTHROPIC);
+    const { coreModelLifecycle } = await load();
+    expect(coreModelLifecycle("anthropic", "claude-something-else")).toBeNull();
+    expect(coreModelLifecycle("", "claude-opus-5")).toBeNull();
+    expect(coreModelLifecycle("anthropic", "")).toBeNull();
+  });
+});

--- a/src/tests/unit/curated-defaults-offerable.test.ts
+++ b/src/tests/unit/curated-defaults-offerable.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import fsSync from "fs";
+import path from "path";
+import { CATALOG_PROVIDERS, PROVIDER_CATALOGS } from "@/lib/provider-models";
+
+/**
+ * A cold-start default the picker would refuse to show is a picker with nothing
+ * selected — and the box writes that default into `agents.defaults.model.primary`.
+ *
+ * This exists because the model-lifecycle filter created an asymmetry that
+ * nothing else would notice: the openai picker loses `gpt-5.5` (the installed
+ * core marks it `status: "deprecated", replacedBy: "gpt-5.6-sol"`) while the
+ * codex picker keeps `gpt-5.5` AS ITS DEFAULT, hinted "Default. Every tier." —
+ * the same upstream model, offered on one auth mode and hidden on the other,
+ * purely because the core ships no `codex` extension directory. That asymmetry
+ * is deliberate today (`gpt-5.6-sol` is plan-gated, and a Free account handed
+ * it as the only row would 400 on every turn), but it is one manifest away from
+ * silently moving the ChatGPT default. This is the assertion that would notice.
+ */
+
+/** Where the installed core keeps a provider's manifest, when there is one. */
+function manifestFor(provider: string): unknown | null {
+  const bases = [
+    "/usr/lib/node_modules/openclaw/dist/extensions",
+    path.join(process.env.HOME ?? "", ".openclaw", "extensions"),
+  ];
+  for (const base of bases) {
+    try {
+      return JSON.parse(fsSync.readFileSync(path.join(base, provider, "openclaw.plugin.json"), "utf-8"));
+    } catch {
+      // Next candidate; absent everywhere is the normal CI shape.
+    }
+  }
+  return null;
+}
+
+function retiredIds(node: unknown, out: Set<string>): void {
+  if (Array.isArray(node)) {
+    for (const item of node) retiredIds(item, out);
+    return;
+  }
+  if (!node || typeof node !== "object") return;
+  const row = node as { id?: unknown; status?: unknown };
+  if (typeof row.id === "string" && typeof row.status === "string"
+    && ["deprecated", "disabled"].includes(row.status.toLowerCase())) {
+    out.add(row.id);
+    const slash = row.id.lastIndexOf("/");
+    if (slash > 0) out.add(row.id.slice(slash + 1));
+  }
+  for (const value of Object.values(node as Record<string, unknown>)) retiredIds(value, out);
+}
+
+describe("every catalog provider's cold-start default is one the picker will show", () => {
+  for (const provider of CATALOG_PROVIDERS) {
+    const catalog = PROVIDER_CATALOGS[provider];
+    const defaultId = catalog?.defaultModelId;
+    if (!defaultId) continue;
+
+    it(`${provider}: the default is in its own curated list`, () => {
+      expect(catalog.models.map((m) => m.id)).toContain(defaultId);
+    });
+
+    it(`${provider}: the installed core has not retired the default`, () => {
+      // Meaningful on a box and on this machine, inert in CI where no core is
+      // installed — stated rather than skipped, so the absence is visible.
+      const manifest = manifestFor(provider);
+      if (!manifest) {
+        expect(manifest).toBeNull();
+        return;
+      }
+      const retired = new Set<string>();
+      retiredIds(manifest, retired);
+      expect(retired.has(defaultId)).toBe(false);
+    });
+  }
+});

--- a/src/tests/unit/curated-defaults-offerable.test.ts
+++ b/src/tests/unit/curated-defaults-offerable.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
-import fsSync from "fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs";
+import os from "os";
 import path from "path";
 import { CATALOG_PROVIDERS, PROVIDER_CATALOGS } from "@/lib/provider-models";
 
@@ -15,39 +16,47 @@ import { CATALOG_PROVIDERS, PROVIDER_CATALOGS } from "@/lib/provider-models";
  * purely because the core ships no `codex` extension directory. That asymmetry
  * is deliberate today (`gpt-5.6-sol` is plan-gated, and a Free account handed
  * it as the only row would 400 on every turn), but it is one manifest away from
- * silently moving the ChatGPT default. This is the assertion that would notice.
+ * silently moving the ChatGPT default.
+ *
+ * WHERE EACH CASE ACTUALLY BITES, because the first version of this file got it
+ * wrong in the way that reports green: it carried its own copy of the lookup
+ * with `/usr/lib/node_modules/openclaw/dist/extensions` hardcoded. That path
+ * exists on this dev machine and on NO box — the openclaw and dual SKUs install
+ * the core under `~/.npm-global`, and Hermes installs none at all — and on no
+ * CI runner, so every case took the "no manifest, assert nothing" branch
+ * everywhere the code actually runs.
+ *
+ *  - The installed-core cases ask `coreRetiredModels`, the same function the
+ *    route serves through, so they read whatever `findOpenclawBin()` resolves.
+ *    Real on a box and on a dev machine; vacuous on CI, which installs no core
+ *    — stated here rather than claimed away.
+ *  - The fixture cases below are the ones that assert EVERYWHERE. They pin the
+ *    asymmetry, both places a manifest can live and the order they are tried
+ *    in, and that the lookup can answer "retired" at all — against manifests
+ *    written into a temporary home, so none of it depends on what the machine
+ *    running the suite happens to have installed.
  */
 
-/** Where the installed core keeps a provider's manifest, when there is one. */
-function manifestFor(provider: string): unknown | null {
-  const bases = [
-    "/usr/lib/node_modules/openclaw/dist/extensions",
-    path.join(process.env.HOME ?? "", ".openclaw", "extensions"),
-  ];
-  for (const base of bases) {
-    try {
-      return JSON.parse(fsSync.readFileSync(path.join(base, provider, "openclaw.plugin.json"), "utf-8"));
-    } catch {
-      // Next candidate; absent everywhere is the normal CI shape.
-    }
-  }
-  return null;
-}
+/**
+ * The binary the lifecycle module resolves from, steerable per case.
+ *
+ * A partial mock over the real module — every other export keeps its own value
+ * — because the fixture cases must neutralise the core's bundled
+ * `dist/extensions` candidate: on a machine that has a core installed it holds
+ * a REAL openai manifest, and it is tried before the fixture's home. A bare
+ * name is exactly what `findOpenclawBin` itself answers where no core is.
+ */
+const bin = vi.hoisted(() => ({ override: null as string | null }));
 
-function retiredIds(node: unknown, out: Set<string>): void {
-  if (Array.isArray(node)) {
-    for (const item of node) retiredIds(item, out);
-    return;
-  }
-  if (!node || typeof node !== "object") return;
-  const row = node as { id?: unknown; status?: unknown };
-  if (typeof row.id === "string" && typeof row.status === "string"
-    && ["deprecated", "disabled"].includes(row.status.toLowerCase())) {
-    out.add(row.id);
-    const slash = row.id.lastIndexOf("/");
-    if (slash > 0) out.add(row.id.slice(slash + 1));
-  }
-  for (const value of Object.values(node as Record<string, unknown>)) retiredIds(value, out);
+vi.mock("@/lib/openclaw-config", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/openclaw-config")>();
+  return { ...actual, findOpenclawBin: () => bin.override ?? actual.findOpenclawBin() };
+});
+
+async function lifecycle() {
+  const mod = await import("@/lib/core-model-lifecycle");
+  mod.resetCoreModelLifecycle();
+  return mod;
 }
 
 describe("every catalog provider's cold-start default is one the picker will show", () => {
@@ -60,17 +69,97 @@ describe("every catalog provider's cold-start default is one the picker will sho
       expect(catalog.models.map((m) => m.id)).toContain(defaultId);
     });
 
-    it(`${provider}: the installed core has not retired the default`, () => {
-      // Meaningful on a box and on this machine, inert in CI where no core is
-      // installed — stated rather than skipped, so the absence is visible.
-      const manifest = manifestFor(provider);
-      if (!manifest) {
-        expect(manifest).toBeNull();
-        return;
-      }
-      const retired = new Set<string>();
-      retiredIds(manifest, retired);
-      expect(retired.has(defaultId)).toBe(false);
+    it(`${provider}: the installed core has not retired the default`, async () => {
+      const { coreRetiredModels } = await lifecycle();
+      expect(coreRetiredModels(provider).has(defaultId)).toBe(false);
     });
   }
+});
+
+describe("against a manifest the module itself resolves", () => {
+  let tmpHome: string;
+  const ENV = ["HOME", "OPENCLAW_HOME", "CLAWBOX_OPENCLAW_HOME"] as const;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "curated-defaults-"));
+    for (const key of ENV) saved[key] = process.env[key];
+    process.env.HOME = tmpHome;
+    // Both spellings, at the same fixture. `manifestPaths` reads
+    // `CLAWBOX_OPENCLAW_HOME` FIRST, so pointing only `OPENCLAW_HOME` would
+    // leave the lookup wherever the surrounding environment aimed it.
+    process.env.OPENCLAW_HOME = path.join(tmpHome, ".openclaw");
+    process.env.CLAWBOX_OPENCLAW_HOME = path.join(tmpHome, ".openclaw");
+    bin.override = "openclaw";
+  });
+
+  afterEach(() => {
+    bin.override = null;
+    for (const key of ENV) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  /** Where OpenClaw 2 puts an unbundled provider's manifest: beside the config. */
+  function writeManifest(provider: string, body: unknown): void {
+    const dir = path.join(tmpHome, ".openclaw", "extensions", provider);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "openclaw.plugin.json"), JSON.stringify(body));
+  }
+
+  it("the codex default survives the openai manifest that retires the same id", async () => {
+    const codexDefault = PROVIDER_CATALOGS.codex.defaultModelId;
+    // The shape the pinned core actually ships: the ChatGPT picker's cold-start
+    // default is the same upstream id the openai extension marks deprecated.
+    writeManifest("openai", { models: [
+      { id: codexDefault, status: "deprecated", replacedBy: "gpt-5.6-sol" },
+      { id: "gpt-5.6-sol" },
+    ] });
+    const { coreRetiredModels } = await lifecycle();
+    expect(coreRetiredModels("openai").has(codexDefault)).toBe(true);
+    // Keyed on the CATALOGUE provider, and the core ships no `codex` extension
+    // — so the ChatGPT picker keeps a default a Free account can actually run.
+    // The day the core ships one, this flips and the case above it fails.
+    expect(coreRetiredModels("codex").has(codexDefault)).toBe(false);
+  });
+
+  it("reads the core's bundled manifest, and prefers it to the one beside the config", async () => {
+    // The `dist/extensions` candidate is the ONLY one that finds anything on a
+    // real box — every manifest measured there is bundled with the core, and
+    // the suite's own `OPENCLAW_HOME` floor puts the second candidate in an
+    // empty tmp dir. Every other case here neutralises it deliberately, so
+    // without this one the segments of that `path.join` could be reordered or
+    // renamed and the whole suite would stay green while a box quietly stopped
+    // filtering. Both candidates are written, with DIFFERENT answers, so the
+    // order is pinned rather than assumed.
+    const dist = path.join(
+      tmpHome, "lib", "node_modules", "openclaw",
+      "dist", "extensions", "anthropic", "openclaw.plugin.json",
+    );
+    fs.mkdirSync(path.dirname(dist), { recursive: true });
+    fs.writeFileSync(dist, JSON.stringify({ models: [{ id: "claude-opus-4-8", status: "deprecated" }] }));
+    writeManifest("anthropic", { models: [{ id: "claude-opus-4-7", status: "deprecated" }] });
+    bin.override = path.join(tmpHome, "bin", "openclaw");
+
+    const { coreRetiredModels } = await lifecycle();
+    const retired = coreRetiredModels("anthropic");
+    expect(retired.has("claude-opus-4-8")).toBe(true);
+    expect(retired.has("claude-opus-4-7")).toBe(false);
+  });
+
+  it("would notice a core that retired a picker's own cold-start default", async () => {
+    // The guard the file exists for, proven capable of failing — for every
+    // catalogue provider, everywhere, and not only where a core happens to be
+    // installed. Without this the cases above pass by reading nothing.
+    const { coreRetiredModels, resetCoreModelLifecycle } = await lifecycle();
+    for (const provider of CATALOG_PROVIDERS) {
+      const defaultId = PROVIDER_CATALOGS[provider]?.defaultModelId;
+      if (!defaultId) continue;
+      writeManifest(provider, { models: [{ id: defaultId, status: "deprecated" }] });
+      resetCoreModelLifecycle();
+      expect(coreRetiredModels(provider).has(defaultId), provider).toBe(true);
+    }
+  });
 });


### PR DESCRIPTION
**TASK-615** — the AI model picker offers a generation-old list. The card's stated premises are **refuted**; a defect of the same shape is live, and this fixes that.

## What the card said, and what beta actually has

The card (2 Sep) named `augmentWithStaticCatalog()`, `STATIC_MODEL_CONTEXT_WINDOWS` at `catalog/route.ts:288` and a `claude-sonnet-4-6` default at `:66`, and said the current Anthropic generation was absent from the catalog.

All three symbols were deleted on 2 Sep (PR #587) and the current generation is present:

| Card claim | On beta `8653b118` |
| --- | --- |
| `STATIC_MODEL_CONTEXT_WINDOWS` | gone — one hit left, in a comment explaining its removal |
| `augmentWithStaticCatalog()` merges a curated list into the live one | gone — `git grep` finds nothing |
| default `claude-sonnet-4-6` | gone |
| current generation absent, catalogue tops out at `claude-opus-4-7` | `provider-models.ts` carries `claude-sonnet-5` and `claude-opus-5` |
| the Anthropic default is a 4.x id | `ANTHROPIC_DEFAULT_MODEL_ID = "claude-opus-5"` (D-03, merged) |
| `models list --provider anthropic` returns ONE model on a claude.ai OAuth device | the pinned core's manifest ships six anthropic rows |

So: **REFUTED as filed.** No hand-written Anthropic list is refreshed here, because adding one is the defect the route's own header exists to prevent.

## The defect that survives the rewrite

The route still has a guard against a retired model:

```ts
if (entry.tags?.includes("deprecated")) continue;
```

and on the pinned core it can never fire. Measured against the installed 2026.8.1 with an isolated `OPENCLAW_HOME` (never a real box, never the dev PC's own state):

```
$ openclaw models list --provider anthropic --all --json
… { "key": "anthropic/claude-opus-4-8",
    "contextWindow": 1000000, "available": null, "tags": [] } …
```

while the core's own `dist/extensions/anthropic/openclaw.plugin.json` says

```
{ "id": "claude-opus-4-8", "status": "deprecated", "replacedBy": "claude-opus-5" }
```

`toModelRow` builds `tags` from configured entries and aliases and never projects `status`. So a customer picking from a live enumeration is offered last generation's flagship beside this one, with nothing on screen to tell them apart — the card's symptom exactly, with different ids than it named. `openai` marks `gpt-5.5` and `gpt-5.5-pro` the same way; `github-copilot`, `nvidia` and `ollama` also ship retired ids, none of them a catalogue provider today.

## The fix

`src/lib/core-model-lifecycle.ts` reads the core's own manifest — the same file `scripts/gateway-pre-start.sh` resolves for deepseek on every boot, from the same two places — and answers one question: has the installed core retired this model?

- **The predicate is the harness's own**, not an invention: `deprecated` OR `disabled`, copied from the core's list probe (`catalog.filter(e => … e.status !== "deprecated" && e.status !== "disabled")`). Reading only half of it would not be deferring to it.
- **The provider's own catalogue block is read** when the manifest separates them. The anthropic manifest ships two under `modelCatalog.providers` — `claude-cli` and `anthropic` — and they are different surfaces, not copies; a flat walk would let a model retired on the narrower route vanish from the wider one, where the core still lists and routes it.
- **Both id forms are indexed.** Shipped manifests carry bare ids (anthropic, openai) and slashed ones (`z-ai/glm-5.1`, nvidia), and the caller holds whichever form its own catalogue uses.
- **The cache re-stats.** The in-app OpenClaw-only update (`openclaw_install` → `openclaw_patch` → `gateway_restart`) runs INSIDE this server and deliberately does not restart it, so "cached for the process lifetime" would keep a retired model on offer until a reboot. And a read taken while `npm install -g` is mid-rename is **not cached at all** — "there is no core yet" and "there is nothing retired" are different answers, and caching the first as the second is how a filter turns itself off for the life of a process with no log line.
- **Fails open, everywhere.** No core, unreadable file, bad JSON, unrecognised shape, a provider with no manifest — all answer "not retired". The failure this must never have is the other one.

### Where the filter is applied, and why that is the whole design

**At SERVE time, never when a payload is stored.** `subscription-surface.ts` reads the catalogue cache file back as the set of ids the box will **accept** — the route's own comment states the invariant, "a row the picker offers must be a row that route accepts". Filtering the stored payload would therefore not merely stop recommending a retired model, it would start REFUSING one the customer is already on: an Anthropic-subscription box sitting on `claude-opus-4-8` (which beta offers) would have a `{"source":"primary"}` restore refused with *"claude-opus-4-8 is not in the Anthropic model catalogue this box enumerated"* — untrue on both halves, since the box did enumerate it and the core still routes it by exact reference (the core's own wording for this status is "Still available by exact reference"). That is this codebase's third bug class, over a choice the previous build offered.

So what we RECOMMEND and what we ACCEPT are two questions, and only the first has a new answer. The cache keeps every enumerated row; `withoutRetiredModels` shapes the response. It also re-resolves `defaultModelId`, because dropping rows can drop the one the payload named, and it never filters to empty.

## Harness-first

The lifecycle is the harness's data and this reads it from the harness. **The native mechanism this does NOT use, named as the rule requires:** the core models the lifecycle internally and its **gateway `models.list` RPC projects `status` / `statusReason` / `replacedBy`** — only the CLI's `toModelRow` drops them. ClawBox has no client for that RPC, so using it would be new work on the picker's render path; reading the shipped manifest asks the same question from the same source at the cost of one `stat`. If the CLI ever projects `status`, this module collapses to one field access, and **that projection gap is worth reporting upstream** — it is recorded in the run's Found list.

## Blast radius — measured, not argued

Driven against the real installed core with enumeration forced to fail, so the curated cold-start list is what is served:

| provider | rows served | default |
| --- | --- | --- |
| openai | `gpt-5.4-pro, gpt-5.4, gpt-5.4-mini` (was 5) | `gpt-5.4`, unchanged |
| codex | unchanged, 6 rows | `gpt-5.5`, unchanged |
| anthropic | unchanged | `claude-opus-5`, unchanged |
| google | unchanged | `gemini-2.5-flash`, unchanged |

No `*_DEFAULT_MODEL_ID` or `PROVIDER_CATALOGS` default becomes unofferable, and no picker empties.

**The codex/openai asymmetry is deliberate and now written down where the lookup happens:** the same upstream `gpt-5.5` is hidden on the openai picker and kept as the codex default, purely because the core ships no `codex` extension. That is what we want today — the core's replacement `gpt-5.6-sol` is plan-gated, and this route's own docblock says what happens if a Free account is handed it as the only row and as the saved default: every turn 400s. It is one manifest away from moving silently, so `src/tests/unit/curated-defaults-offerable.test.ts` pins it two ways, and the difference between them matters:

- **Against FIXTURE manifests, so they assert everywhere** — CI included. One case writes an `openai` manifest that retires the id the codex picker opens on and asserts the openai lookup sees it while the codex lookup does not; a second walks every catalogue provider, retires that provider's own cold-start default, and asserts the guard fires — which is what proves the first case is capable of failing at all; a third writes the core's **bundled** `dist/extensions` manifest and a different one beside the config, and pins that the bundled one is read and preferred. That third candidate is the only one that finds anything on a real box, and every other case here neutralises it deliberately, so without it the segments of that `path.join` could be renamed and the whole suite would stay green while a box quietly stopped filtering.
- **Against the INSTALLED core**, through `coreRetiredModels` — the same function the route serves through, so it resolves the manifest from wherever `findOpenclawBin()` points rather than from a path written into the test. Real on either edition's box and on a dev machine; vacuous on a runner that installs no core, which the docblock says rather than claims away.

## Sibling call sites — swept

- `isOfferableModelId` has exactly two callers (`transformOpenclawEntries`, `sanitizeCatalogModels`) and is left as beta wrote it — that is the point of the serve-time split.
- Both response points in the route go through `withoutRetiredModels`; there are no others.
- `subscription-surface.ts` / `chat/model/route.ts` — the accept-set — deliberately unchanged, and the test now asserts the retired row is still in the cache they read.
- The dead `tags` guard is kept, with a comment saying it cannot fire on this core and why: it costs nothing and starts working the day the CLI projects the field.
- `provider-models.ts`'s curated lists are **not** hand-edited. They are now self-correcting at serve time, which is the card's "how does this stop rotting" answered with the harness's data instead of a date stamp.

## RED → GREEN

RED, on unmodified `origin/beta` (`8653b118`) — the branch's route test against beta's `catalog/route.ts`:

```
     × does not offer it, and keeps what replaced it 341ms
     × re-resolves the default when the retired row was it 258ms

AssertionError: expected [ 'claude-opus-4-8', …(2) ] to not include 'claude-opus-4-8'
AssertionError: expected [ 'claude-opus-4-8', 'claude-opus-5' ] to deeply equal [ 'claude-opus-5' ]

 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
```

The one that passes on beta is the guard: the retired row must still be in the cache the box accepts from. It passes before and after, which is what makes it a guard rather than a claim.

GREEN, on this branch: `src/tests/routes/ai-models/` and the new unit files — `Test Files 20 passed (20)`, `Tests 350 passed (350)`; `curated-defaults-offerable` `12 passed`. Whole unit project green apart from the known dev-PC load flakes in `routes/telegram/status*`, which pass in isolation. `tsc --noEmit` clean.

`core-model-lifecycle.test.ts` is **not** a RED test — it exercises code this PR introduces, on real files on disk rather than a mock. The route test is the RED one.

## Review round 3 — the merge-gate block, and the evidence for each item

The runtime code is unchanged in this round; all three items were a guard that did not guard, and a comment that had gone stale under a later commit.

**1. `curated-defaults-offerable.test.ts` asserted nothing where the code runs.** It carried its own copy of the lookup with `/usr/lib/node_modules/openclaw/dist/extensions` written into it. That path exists on a dev machine and on **no box** — the openclaw and dual SKUs install the core under `~/.npm-global`, which is what `manifestPaths` builds from `findOpenclawBin()`, and Hermes installs no core at all — and on no runner, so all six per-provider cases took the `if (!manifest) { expect(manifest).toBeNull(); return; }` branch and reported green having read nothing. This repo's false-success class, in a file whose docblock claimed "Meaningful on a box".

RED — the assertion the rewrite adds, run against the lookup the file used to ship, with a manifest placed where the PRODUCT resolves it (temporary `HOME`, `openai` retiring the openai picker's own default):

```
 FAIL  src/tests/unit/zz-red-probe.test.ts > the shipped lookup, against a manifest the PRODUCT would read
       > sees the retirement the core published for the openai picker
AssertionError: expected false to be true

 Test Files  1 failed (1)
      Tests  1 failed (1)
```

It reads this machine's `/usr/lib` copy instead of the file the route would read. Fixed by asking `coreRetiredModels`, plus the three fixture cases described above. Proof the fixture cases are not passing on their own fixture: removing the one line that neutralises the bundled `dist/extensions` candidate turns the per-provider fixture case red immediately.

**2. The parse-failure fixture never reached the parse-failure branch.** `writeManifest` put the body through `JSON.stringify`, so `"}{ not json"` was written as a valid JSON *string*: `JSON.parse` succeeded and the assertion passed through the unrecognised-**shape** path instead. The two are not interchangeable — the shape path caches an empty set, and the parse branch deliberately does **not**, which is the whole `npm install -g` mid-rename story this module exists for. So the one branch whose non-caching is load-bearing was the untested one.

RED — the new non-caching assertion against the old `JSON.stringify` fixture:

```
 FAIL  > coreModelRetired > says nothing rather than guessing when it cannot read a manifest
AssertionError: expected false to be true
 195|       expect(broken.coreModelRetired("gemini", "gemini-old")).toBe(true);

 Test Files  1 failed (1)
      Tests  1 failed | 9 passed (10)
```

Fixed with a `writeRawManifest` that writes the bytes as they are, an explicit case for each of the two failure shapes, and a case for **each half** of the contrast, under frozen time so a cached answer would still be inside the 5 s stat floor: a manifest that failed to parse is re-read on the very next call, and one whose shape was not recognised is not. Proof they bite: making the `catch` fall through to `cache.set` reddens the first; deleting the `cache.set` reddens the second.

**3. `CLAWBOX_OPENCLAW_HOME` in the lifecycle suite — REFUTED as a live failure, hardened anyway.** The finding was that an environment exporting it would send every lookup outside `tmpHome` and fail every positive assertion. It cannot today: `vitest.config.ts` (on `beta`, not from this PR) floors `CLAWBOX_OPENCLAW_HOME: ""` for the whole suite, and every reader spells `CLAWBOX_OPENCLAW_HOME || OPENCLAW_HOME || …`, so the empty string falls through. Measured rather than argued:

```
$ CLAWBOX_OPENCLAW_HOME=/nonexistent-openclaw-home ./node_modules/.bin/vitest run \
    --config vitest.config.ts src/tests/unit/core-model-lifecycle.test.ts
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

The file now aims all three variables at its own fixture regardless, because a fixture that depends on a config-level floor to be pointed at itself is one config edit from reading a real box.

**4. The stale comment.** `transformOpenclawEntries`' comment said the lifecycle is read "inside `isOfferableModelId`, so the sanitiser applies the same rule". True in `fd65b013`; `92d83b0a` moved the filter to serve time and the comment stayed, leaving the file with a comment saying the sanitiser applies the rule nine lines above `withoutRetiredModels`' own docblock saying that doing so would start refusing a model the customer is already on. Corrected to name serve time and `withoutRetiredModels`.

GREEN, this round — `src/tests/routes/ai-models/`, both new unit files, and the three guard suites the change could disturb (`openclaw-config-mock-completeness`, `test-timeout-hygiene`, `state-updater-purity`):

```
 Test Files  24 passed (24)
      Tests  398 passed (398)
```

`tsc --noEmit` clean, `eslint` clean on all three changed files.

**Device leg for this round — read-only, both editions, no mutex taken and nothing changed.** The runtime path is byte-identical to the head already confirmed on hardware, so what needed proving is that the rewritten guard now reads something on a box. Walked with the module's own predicate, from the path `findOpenclawBin()` resolves there (`~/.npm-global/lib/node_modules/openclaw/…/dist/extensions`, core 2026.8.1) — the path the deleted lookup could not reach:

```
clawai      NO manifest (fail-open)   default=deepseek-v4-flash          -> not retired
anthropic   scoped=true  retired=[claude-opus-4-8]         default=claude-opus-5             -> not retired
openai      scoped=true  retired=[gpt-5.5, gpt-5.5-pro]    default=gpt-5.4                   -> not retired
codex       NO manifest (fail-open)   default=gpt-5.5                    -> not retired
google      scoped=-     retired=[]                        default=gemini-2.5-flash          -> not retired
openrouter  scoped=-     retired=[]                        default=anthropic/claude-haiku-4.5 -> not retired
```

Four of the six cases now read a real manifest there instead of returning early, the other two fail open, and no catalogue provider's cold-start default is retired — so the case passes on that box for a reason, which is what it did not do before. The asymmetry is live on that hardware exactly as the fixture case describes it: `openai` retires `gpt-5.5`, `codex` ships no manifest, and the ChatGPT picker keeps `gpt-5.5` as its default.

On the **Hermes** box: no `openclaw` binary at any candidate and no `~/.openclaw/extensions` at all, so the bundled candidate is never built, nothing is found and every model stays offerable — the per-provider cases are vacuous there by design, and the fixture cases (which write their own manifest and neutralise the binary lookup) are unaffected.

## Both editions

OpenClaw-only by nature: it reads the OpenClaw core's manifest, and on Hermes there is no core — `findOpenclawBin` answers a bare name, no manifest is found, nothing is cached and every model stays offerable. Hermes gets its model options from its own harness through `src/lib/hermes-model-options.ts`, which this does not touch. The equivalent gap there — whether Hermes publishes a lifecycle at all — is not answered here.

**Device leg:** not run, and the measurements that replace it are named above: the manifests and the CLI's projection were read from the pinned core installed on this machine, with an isolated `OPENCLAW_HOME` for every CLI call, and the blast radius was measured by driving the real route against those real manifests. No box state was touched. CI exercises the route.

## Device leg — read-only, both editions

**OpenClaw box** (`CLAWBOX_EDITION=openclaw`, core **2026.8.1**, installed at `~/.npm-global/lib/node_modules/openclaw`, which is the first path `manifestPaths` builds from `findOpenclawBin()` — so the resolution is confirmed on real hardware, not just on the dev host):

```
$ openclaw models list --provider anthropic --all --json      # 15 rows, every one:
   anthropic/claude-opus-5        tags= []  status= <absent>
   anthropic/claude-opus-4-8      tags= []  status= <absent>
   anthropic/claude-opus-4-7      tags= []  status= <absent>
   anthropic/claude-opus-4-6      tags= []  status= <absent>
   anthropic/claude-opus-4-5      tags= []  status= <absent>
   anthropic/claude-sonnet-4-6    tags= []  status= <absent>
   anthropic/claude-sonnet-4-5    tags= []  status= <absent>
   …
```

That is the card's complaint on hardware: fifteen rows, six of them last generation, nothing on any of them to tell a customer apart. And the same box's manifest, read from the path this fix reads:

```
   anthropic  claude-opus-4-8 -> claude-opus-5
   openai     gpt-5.5         -> gpt-5.6-sol
   openai     gpt-5.5-pro     -> gpt-5.6-sol
```

**The honest size of the fix, stated because the numbers do not flatter it:** of those six old rows the core marks exactly ONE retired, so on that box this removes `claude-opus-4-8` and leaves `claude-opus-4-7`, `-4-6`, `-4-5`, `claude-sonnet-4-6` and `-4-5` on offer. That is the correct behaviour and the point of the change — where the harness has not retired a model, ClawBox has no authority to hide it, and inventing one is the defect the route's header exists to prevent. If those ids should go too, that is a conversation with whoever maintains the core catalogue, not a list to hand-maintain here.

**Hermes box** (`CLAWBOX_EDITION=hermes`): no OpenClaw binary and no `dist/extensions` anywhere on the box, so the reader finds no manifest, caches nothing and answers "not retired" for everything — the fail-open path, confirmed on the edition that has no core rather than argued. **Declared gap:** `clawbox-setup` and `clawbox-hermes-gateway` were both `inactive` on that box at the time, so no route was exercised there; the check above is filesystem-only.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Retired or disabled AI models are now excluded from model picker results.
  - Default models are automatically reassigned when the selected default is retired.
  - Model availability is determined from current lifecycle status rather than outdated catalog labels.
  - Picker results remain available when lifecycle data is missing or would otherwise remove every model.
- **Tests**
  - Added coverage for provider-specific retirement, manifest changes, nested statuses, invalid data, and default-model selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->