### PR TITLE
fix: silence the Hermes update check on ClawBox's own version probe

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3147,7 +3147,22 @@ step_hermes_install() {
     # right here — before the reachability check, before any repair, printing
     # nothing — taking `install.sh --step hermes_install` (the documented
     # repair command) and every later step of a full install down with it.
-    installed=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
+    # TASK-613: remove once hermes-agent#104275 lands
+    # (HERMES_DISABLE_UPDATE_CHECK / updates.check). `hermes --version` also
+    # runs the agent's passive update check — `git fetch origin main` plus an
+    # unauthenticated GitHub compare, 10 s each — and on a box being installed
+    # or repaired that six-hour cache is always cold, so both probes in this
+    # step pay for a network round trip whose only output `head -1` throws
+    # away. Upstream's own printer takes `check_updates=False`
+    # (hermes_cli/_startup_fast.py) and no CLI flag or env var reaches it, so
+    # ask the interpreter the shim execs. Fails OPEN: anything wrong here
+    # leaves `installed` empty and the shim probe below answers exactly as it
+    # always did.
+    installed=$(runuser -u "$CLAWBOX_USER" -- env -u PYTHONHOME HOME="$CLAWBOX_HOME" \
+      PYTHONPATH="$agent_dir" "$venv_python" -c \
+      'from hermes_cli._startup_fast import print_fast_version_info as v; v(check_updates=False)' \
+      2>/dev/null | head -1) || installed=""
+    [ -n "$installed" ] || installed=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
       "$shim" --version 2>/dev/null | head -1) || installed=""
   fi
 
@@ -3270,7 +3285,16 @@ step_hermes_install() {
   # the owner as a crash-looping dashboard. `|| installed=""` for the same
   # errexit reason as the first probe: when the install laid down nothing, this
   # runs a shim that does not exist and exits 127.
-  installed=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
+  #
+  # Silenced the same way as the probe above, and for the same reason: this one
+  # runs seconds after a fresh checkout, when the update check has nothing
+  # cached and everything to fetch. TASK-613: remove once
+  # hermes-agent#104275 lands (HERMES_DISABLE_UPDATE_CHECK / updates.check).
+  installed=$(runuser -u "$CLAWBOX_USER" -- env -u PYTHONHOME HOME="$CLAWBOX_HOME" \
+    PYTHONPATH="$agent_dir" "$venv_python" -c \
+    'from hermes_cli._startup_fast import print_fast_version_info as v; v(check_updates=False)' \
+    2>/dev/null | head -1) || installed=""
+  [ -n "$installed" ] || installed=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
     "$shim" --version 2>/dev/null | head -1) || installed=""
   if [ -n "$installed" ]; then
     at_commit=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \

--- a/install.sh
+++ b/install.sh
@@ -3147,23 +3147,38 @@ step_hermes_install() {
     # right here — before the reachability check, before any repair, printing
     # nothing — taking `install.sh --step hermes_install` (the documented
     # repair command) and every later step of a full install down with it.
-    # TASK-613: remove once hermes-agent#104275 lands
-    # (HERMES_DISABLE_UPDATE_CHECK / updates.check). `hermes --version` also
-    # runs the agent's passive update check — `git fetch origin main` plus an
-    # unauthenticated GitHub compare, 10 s each — and on a box being installed
-    # or repaired that six-hour cache is always cold, so both probes in this
-    # step pay for a network round trip whose only output `head -1` throws
-    # away. Upstream's own printer takes `check_updates=False`
-    # (hermes_cli/_startup_fast.py) and no CLI flag or env var reaches it, so
-    # ask the interpreter the shim execs. Fails OPEN: anything wrong here
-    # leaves `installed` empty and the shim probe below answers exactly as it
-    # always did.
-    installed=$(runuser -u "$CLAWBOX_USER" -- env -u PYTHONHOME HOME="$CLAWBOX_HOME" \
-      PYTHONPATH="$agent_dir" "$venv_python" -c \
-      'from hermes_cli._startup_fast import print_fast_version_info as v; v(check_updates=False)' \
-      2>/dev/null | head -1) || installed=""
-    [ -n "$installed" ] || installed=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
-      "$shim" --version 2>/dev/null | head -1) || installed=""
+    #
+    # Runnability stays THE SHIM'S to prove, and is asked first. `--help` goes
+    # through the same shim -> `<agent_dir>/hermes` -> `hermes_cli.main` path
+    # `--version` does, so a shim whose interpreter or entry script is gone
+    # still fails it — but unlike `--version` it runs no update check
+    # (`banner.check_for_updates()` has two call sites in 0.20.5:
+    # `print_fast_version_info` and the interactive welcome banner). Asking the
+    # venv interpreter directly instead would only prove the PACKAGE IMPORTS,
+    # which is not the question this guard exists to answer: a box whose
+    # `hermes` command is dead would read as "already installed" and the
+    # documented repair would do nothing. Measured on a Hermes box: 0.82 s.
+    if runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
+      "$shim" --help >/dev/null 2>&1; then
+      # The agent runs; this is only the version STRING for the log line.
+      # TASK-613: remove once hermes-agent#104275 lands
+      # (HERMES_DISABLE_UPDATE_CHECK / updates.check). `hermes --version` also
+      # runs that update check — `git fetch origin main` plus an
+      # unauthenticated GitHub compare, 10 s each — and on a box being
+      # installed or repaired the six-hour cache is always cold, so this step
+      # paid for a network round trip whose only output `head -1` throws away.
+      # Upstream's own printer takes `check_updates=False`
+      # (hermes_cli/_startup_fast.py) and no CLI flag or env var reaches it, so
+      # ask the interpreter the shim just proved it execs. Fails OPEN: anything
+      # wrong here leaves `installed` empty and the `--version` probe below
+      # answers exactly as it always did.
+      installed=$(runuser -u "$CLAWBOX_USER" -- env -u PYTHONHOME HOME="$CLAWBOX_HOME" \
+        PYTHONSAFEPATH=1 PYTHONPATH="$agent_dir" "$venv_python" -c \
+        'from hermes_cli._startup_fast import print_fast_version_info as v; v(check_updates=False)' \
+        2>/dev/null | head -1) || installed=""
+      [ -n "$installed" ] || installed=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
+        "$shim" --version 2>/dev/null | head -1) || installed=""
+    fi
   fi
 
   # A version string cannot answer "is this the pinned build?": upstream prints
@@ -3286,16 +3301,21 @@ step_hermes_install() {
   # errexit reason as the first probe: when the install laid down nothing, this
   # runs a shim that does not exist and exits 127.
   #
-  # Silenced the same way as the probe above, and for the same reason: this one
-  # runs seconds after a fresh checkout, when the update check has nothing
-  # cached and everything to fetch. TASK-613: remove once
+  # Shaped like the probe above and for the same reasons: the SHIM answers
+  # whether the agent this install just laid down actually runs, and only then
+  # is the version string read without the update check — which here has
+  # nothing cached and everything to fetch. TASK-613: remove once
   # hermes-agent#104275 lands (HERMES_DISABLE_UPDATE_CHECK / updates.check).
-  installed=$(runuser -u "$CLAWBOX_USER" -- env -u PYTHONHOME HOME="$CLAWBOX_HOME" \
-    PYTHONPATH="$agent_dir" "$venv_python" -c \
-    'from hermes_cli._startup_fast import print_fast_version_info as v; v(check_updates=False)' \
-    2>/dev/null | head -1) || installed=""
-  [ -n "$installed" ] || installed=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
-    "$shim" --version 2>/dev/null | head -1) || installed=""
+  installed=""
+  if runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
+    "$shim" --help >/dev/null 2>&1; then
+    installed=$(runuser -u "$CLAWBOX_USER" -- env -u PYTHONHOME HOME="$CLAWBOX_HOME" \
+      PYTHONSAFEPATH=1 PYTHONPATH="$agent_dir" "$venv_python" -c \
+      'from hermes_cli._startup_fast import print_fast_version_info as v; v(check_updates=False)' \
+      2>/dev/null | head -1) || installed=""
+    [ -n "$installed" ] || installed=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
+      "$shim" --version 2>/dev/null | head -1) || installed=""
+  fi
   if [ -n "$installed" ]; then
     at_commit=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
       git -C "$agent_dir" rev-parse HEAD 2>/dev/null) || at_commit=""

--- a/src/lib/hermes-cli.ts
+++ b/src/lib/hermes-cli.ts
@@ -16,6 +16,13 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 // A config/auth command's output is tiny; cap the buffer so a misbehaving
 // child can't grow it unbounded.
 const MAX_OUTPUT_BYTES = 1_000_000;
+// One name each, because the silenced version probe below has to tell "the
+// child could not be started" (retry the supported call) from "the child said
+// far too much" (asking again would overflow the same buffer).
+const OUTPUT_LIMIT_MESSAGE = "hermes output exceeded the size limit";
+const ERROR_OUTPUT_LIMIT_MESSAGE = "hermes error output exceeded the size limit";
+const isOutputLimitError = (e: unknown) =>
+  e instanceof Error && (e.message === OUTPUT_LIMIT_MESSAGE || e.message === ERROR_OUTPUT_LIMIT_MESSAGE);
 
 /**
  * Console width for the CLI's `rich` output.
@@ -56,15 +63,44 @@ const WIDE_CONSOLE_COLUMNS = "400";
 // is the opposite of a silence: it selects the `git ls-remote` branch and is
 // part of the cache key, so it would force a miss on every ClawBox probe AND on
 // the owner's next banner.)
-const HERMES_AGENT_DIR = path.join(HOME_DIR, ".hermes", "hermes-agent");
-// The shim is four lines: unset PYTHONPATH, unset PYTHONHOME, exec this
-// interpreter on `<agent_dir>/hermes`. install.sh already treats the pair as
-// the install's identity (step_hermes_install's `venv_python` guard).
-const HERMES_VENV_PYTHON = path.join(HERMES_AGENT_DIR, "venv", "bin", "python");
+//
+// The shim is four lines: unset PYTHONPATH, unset PYTHONHOME, exec
+// `<agent_dir>/venv/bin/python <agent_dir>/hermes`. Where that agent dir is
+// resolves the way the rest of this repo resolves it — `hermesHome()` in
+// hermes-env.ts, `whatsappBridgeInstallDir()` in hermes-whatsapp.ts — so both
+// documented overrides move BOTH halves of the probe together and the silent
+// form can never answer for a different install than the fallback runs. Read
+// per call rather than at import, and copied rather than imported: this block
+// is meant to be deleted whole, and a new module edge out of hermes-cli.ts
+// would have to be added to every suite that mocks that module.
+const hermesAgentDir = () =>
+  process.env.HERMES_AGENT_DIR ||
+  path.join(process.env.HERMES_HOME || path.join(HOME_DIR, ".hermes"), "hermes-agent");
 const SILENT_VERSION_PY =
   "from hermes_cli._startup_fast import print_fast_version_info as v; v(check_updates=False)";
 /** The one argv this file knows a silent equivalent for. */
 const isSilenceableVersionCall = (args: string[]) => args.length === 1 && args[0] === "--version";
+/**
+ * The silent attempt's own ceiling, spent ON TOP of the caller's budget.
+ *
+ * Deliberately not a slice of `timeoutMs`: the supported call has to keep
+ * every millisecond it had before this workaround existed, or a cold, loaded
+ * Orin where `hermes --version` answers in eight seconds would start reporting
+ * no version at all — the workaround causing the very failure it removes. The
+ * silent form does no network and measured 853-870 ms on a Hermes box; 5 s is
+ * headroom for a cold interpreter start, and it is time added at most once.
+ */
+const SILENT_VERSION_TIMEOUT_MS = 5_000;
+/**
+ * A banner ClawBox can actually use.
+ *
+ * `parseHermesVersion` falls back to SHOWING an unrecognised first line, so
+ * anything the interpreter happens to print (a sitecustomize notice, a future
+ * upstream banner) would become "the Hermes version" on the About screen and
+ * the supported call that prints the real one would never be made.
+ */
+const looksLikeVersionBanner = (stdout: string) =>
+  /\bv?\d+\.\d+/.test(stdout.split("\n", 1)[0] ?? "");
 
 export interface HermesCliResult {
   code: number | null;
@@ -75,10 +111,7 @@ export interface HermesCliResult {
 export interface HermesCliOptions {
   timeoutMs?: number;
   input?: string;
-  // `undefined` REMOVES a variable the server inherited, which is what the
-  // silenced version probe needs for PYTHONHOME (see below) — the shim
-  // unsets it for the same reason.
-  env?: Record<string, string | undefined>;
+  env?: Record<string, string>;
   /**
    * Kill the child when the caller gives up (a browser that navigated away
    * aborts its fetch, but that alone would leave the process running to its
@@ -130,41 +163,54 @@ export async function runHermesCli(
   const argv = opts.sudo ? ["-n", HERMES_BIN, ...args] : args;
 
   if (opts.silenceUpdateCheck && !opts.sudo && isSilenceableVersionCall(args)) {
-    const budgetMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-    const started = Date.now();
+    const agentDir = hermesAgentDir();
     try {
-      const quiet = await spawnHermes(HERMES_VENV_PYTHON, ["-c", SILENT_VERSION_PY], {
-        ...opts,
-        // Half the budget, never more. The silent form does no network at all
-        // (measured 853-857 ms on a Hermes box), and whatever it does spend
-        // has to leave the fallback enough of the CALLER's deadline to answer
-        // — a fix that turns one timeout into two would be worse than the
-        // defect it removes.
-        timeoutMs: Math.max(1, Math.floor(budgetMs / 2)),
-        // The package IS the checkout — there is no pip dist to import — so
-        // the checkout goes on the path the shim's `exec <dir>/hermes` would
-        // have put there. PYTHONHOME is removed rather than set: an inherited
-        // one would send this interpreter at a different stdlib.
-        env: { PYTHONPATH: HERMES_AGENT_DIR, PYTHONHOME: undefined, ...opts.env },
-      });
-      if (quiet.code === 0 && quiet.stdout) return quiet;
-    } catch {
-      // Fall through to the supported call. Not swallowing an outcome: this
-      // path has produced nothing yet, and the call below is the answer.
+      const quiet = await spawnHermes(
+        path.join(agentDir, "venv", "bin", "python"),
+        ["-c", SILENT_VERSION_PY],
+        {
+          ...opts,
+          timeoutMs: Math.min(opts.timeoutMs ?? DEFAULT_TIMEOUT_MS, SILENT_VERSION_TIMEOUT_MS),
+          // The package IS the checkout — there is no pip dist to import — so
+          // the checkout goes on the path the shim's `exec <dir>/hermes` puts
+          // there. PYTHONSAFEPATH keeps the CWD off sys.path[0], where `-c`
+          // would otherwise put it and the shim never does; Python 3.11+ reads
+          // it and older interpreters ignore an unknown PYTHON* variable.
+          env: { ...opts.env, PYTHONPATH: agentDir, PYTHONSAFEPATH: "1" },
+        },
+        // PYTHONHOME goes the way the shim takes it — removed, not set: an
+        // inherited one aims this interpreter at a different stdlib. And no
+        // console line for a speculative spawn that has a supported call
+        // behind it, or a box with no venv logs every probe twice.
+        { unsetEnv: ["PYTHONHOME"], logSpawnFailure: false },
+      );
+      if (quiet.code === 0 && looksLikeVersionBanner(quiet.stdout)) return quiet;
+    } catch (e) {
+      // Fall through to the supported call — except for the one failure that
+      // says the CHILD misbehaved rather than that it could not be started:
+      // asking the same question again would overflow the same buffer.
+      if (isOutputLimitError(e)) throw e;
     }
-    return spawnHermes(bin, argv, {
-      ...opts,
-      timeoutMs: Math.max(1, budgetMs - (Date.now() - started)),
-    });
   }
 
   return spawnHermes(bin, argv, opts);
+}
+
+interface SpawnExtras {
+  /** Variables to REMOVE from the child's environment — the shim's `unset`. */
+  unsetEnv?: readonly string[];
+  /**
+   * Whether a child that could not be started is worth a console line. Off for
+   * a speculative attempt that has a supported call behind it.
+   */
+  logSpawnFailure?: boolean;
 }
 
 function spawnHermes(
   bin: string,
   argv: string[],
   opts: HermesCliOptions,
+  extras: SpawnExtras = {},
 ): Promise<HermesCliResult> {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   // Already aborted BEFORE the call: nothing may be started. `abort` fires
@@ -178,7 +224,7 @@ function spawnHermes(
   // install is precisely the thing to avoid. Same rejection as `onAbort`, so
   // callers have one message to recognise.
   if (opts.signal?.aborted) return Promise.reject(new Error("hermes call cancelled"));
-  const env: Record<string, string | undefined> = {
+  const env: NodeJS.ProcessEnv = {
     ...process.env,
     HOME: HOME_DIR,
     PATH: `${path.dirname(HERMES_BIN)}:${process.env.PATH || ""}`,
@@ -192,15 +238,14 @@ function spawnHermes(
     COLUMNS: WIDE_CONSOLE_COLUMNS,
     ...opts.env,
   };
-  // An `undefined` from `opts.env` means REMOVE, not "leave as inherited":
-  // deleted here rather than relied on inside `spawn`, so the contract is the
-  // one this file states.
-  for (const [key, value] of Object.entries(env)) if (value === undefined) delete env[key];
+  // Removals are applied AFTER the defaults, so HOME/PATH/COLUMNS stay the
+  // guarantee this function makes and only this file can take one away.
+  for (const key of extras.unsetEnv ?? []) delete env[key];
   return new Promise<HermesCliResult>((resolve, reject) => {
     const child = spawn(bin, argv, {
       stdio: [opts.input !== undefined ? "pipe" : "ignore", "pipe", "pipe"],
       cwd: HOME_DIR,
-      env: env as NodeJS.ProcessEnv,
+      env,
     });
 
     let out = "";
@@ -230,7 +275,7 @@ function spawnHermes(
     child.stdout!.on("data", (chunk: Buffer) => {
       outBytes += chunk.length;
       if (outBytes > MAX_OUTPUT_BYTES) {
-        finish(() => { child.kill("SIGKILL"); reject(new Error("hermes output exceeded the size limit")); });
+        finish(() => { child.kill("SIGKILL"); reject(new Error(OUTPUT_LIMIT_MESSAGE)); });
         return;
       }
       out += chunk.toString();
@@ -238,7 +283,7 @@ function spawnHermes(
     child.stderr!.on("data", (chunk: Buffer) => {
       errBytes += chunk.length;
       if (errBytes > MAX_OUTPUT_BYTES) {
-        finish(() => { child.kill("SIGKILL"); reject(new Error("hermes error output exceeded the size limit")); });
+        finish(() => { child.kill("SIGKILL"); reject(new Error(ERROR_OUTPUT_LIMIT_MESSAGE)); });
         return;
       }
       err += chunk.toString();
@@ -255,7 +300,7 @@ function spawnHermes(
         // out raw. That matters MORE here — eleven setup-api routes reject-path
         // this straight into their JSON `error` — so the sanitising belongs at
         // the spawn, not at each caller.
-        console.error("[hermes cli] spawn failed", e);
+        if (extras.logSpawnFailure !== false) console.error("[hermes cli] spawn failed", e);
         reject(new Error(spawnFailureMessage(e)));
       });
     });

--- a/src/lib/hermes-cli.ts
+++ b/src/lib/hermes-cli.ts
@@ -26,50 +26,147 @@ const MAX_OUTPUT_BYTES = 1_000_000;
  */
 const WIDE_CONSOLE_COLUMNS = "400";
 
+// ── TASK-613: remove once hermes-agent#104275 lands (HERMES_DISABLE_UPDATE_CHECK
+// / updates.check) ───────────────────────────────────────────────────────────
+//
+// `hermes --version` is the only non-interactive hermes call that runs the
+// agent's passive update check: in 0.20.5 `banner.check_for_updates()` has
+// exactly two call sites — `_startup_fast.py:238`, inside
+// `print_fast_version_info`, and `banner.py:646`, the interactive welcome
+// banner. Every `config`/`skills`/`plugins`/`approvals` call this file makes is
+// already silent, so the silence belongs on that one call and nowhere else.
+//
+// What the check costs a version probe: an `Update available: N commits behind
+// — run 'hermes update'` line appended to the banner we parse (advice that is
+// wrong on a device pinned to a commit, whose update path is not `hermes
+// update`), and — on every six-hourly cache miss — a synchronous `git fetch
+// origin main --depth 1` plus an unauthenticated GitHub compare, each with its
+// own 10 s ceiling inside the 10 s budget the probe gives the WHOLE call.
+//
+// Upstream already has the switch: `print_fast_version_info(*, check_updates:
+// bool = True)` returns early at `_startup_fast.py:228-229`. Nothing can reach
+// it — all five call sites hard-code True, `banner.py` reads only
+// `HERMES_REVISION`, and there is no `updates.*` key for it — so until
+// NousResearch/hermes-agent#104275 lands, ask the agent's own printer directly
+// through the interpreter the `hermes` shim execs.
+//
+// Nothing is written by this: `check_for_updates` never runs, so the shared
+// ~/.hermes/.update_check cache the OWNER's interactive banner reads is left
+// exactly as it was. (Pre-setting `HERMES_REVISION` was the other candidate and
+// is the opposite of a silence: it selects the `git ls-remote` branch and is
+// part of the cache key, so it would force a miss on every ClawBox probe AND on
+// the owner's next banner.)
+const HERMES_AGENT_DIR = path.join(HOME_DIR, ".hermes", "hermes-agent");
+// The shim is four lines: unset PYTHONPATH, unset PYTHONHOME, exec this
+// interpreter on `<agent_dir>/hermes`. install.sh already treats the pair as
+// the install's identity (step_hermes_install's `venv_python` guard).
+const HERMES_VENV_PYTHON = path.join(HERMES_AGENT_DIR, "venv", "bin", "python");
+const SILENT_VERSION_PY =
+  "from hermes_cli._startup_fast import print_fast_version_info as v; v(check_updates=False)";
+/** The one argv this file knows a silent equivalent for. */
+const isSilenceableVersionCall = (args: string[]) => args.length === 1 && args[0] === "--version";
+
 export interface HermesCliResult {
   code: number | null;
   stdout: string;
   stderr: string;
 }
 
-export function runHermesCli(
+export interface HermesCliOptions {
+  timeoutMs?: number;
+  input?: string;
+  // `undefined` REMOVES a variable the server inherited, which is what the
+  // silenced version probe needs for PYTHONHOME (see below) — the shim
+  // unsets it for the same reason.
+  env?: Record<string, string | undefined>;
+  /**
+   * Kill the child when the caller gives up (a browser that navigated away
+   * aborts its fetch, but that alone would leave the process running to its
+   * timeout). Optional — callers that don't pass one behave exactly as before.
+   *
+   * A route may hand this its `request.signal` for a probe, or for the FIRST
+   * durable write of the request — cancelling either leaves NOTHING ELSE of
+   * that request half-done. It is not a rollback: an abort that lands after
+   * the child has already written keeps that write, because all this does is
+   * refuse to start (see the guard below) or kill the process. What it buys
+   * is that the box is left in one of the two states the request began and
+   * ended in, rather than between them.
+   *
+   * So it must NOT be handed to work that FOLLOWS a durable write: a browser
+   * that locked its screen would then leave the token in ClawBox's store and
+   * not in Hermes', or a saved channel with a gateway nobody started. Past
+   * the first write, finish the job.
+   */
+  signal?: AbortSignal;
+  /**
+   * Run the call through `sudo -n`. Only for the handful of subcommands that
+   * genuinely need root (`gateway install --system`, which writes a
+   * /etc/systemd/system unit). `-n` means a box without a passwordless rule
+   * fails immediately instead of blocking on a password prompt — a route
+   * handler must never be able to hang on a prompt.
+   */
+  sudo?: boolean;
+  /**
+   * TASK-613: remove once hermes-agent#104275 lands
+   * (HERMES_DISABLE_UPDATE_CHECK / updates.check).
+   *
+   * Ask for the call WITHOUT the agent's passive update check. Only
+   * `--version` runs one, so this is a no-op for any other argv, and it is
+   * ignored under `sudo` — silencing a privileged call by running the
+   * interpreter directly would drop the privilege.
+   *
+   * Fails OPEN: anything that stops the silent form answering (no venv, a
+   * renamed module, a changed signature) falls through to the plain call,
+   * which behaves exactly as it does on a box without this.
+   */
+  silenceUpdateCheck?: boolean;
+}
+
+export async function runHermesCli(
   args: string[],
-  opts: {
-    timeoutMs?: number;
-    input?: string;
-    env?: Record<string, string>;
-    /**
-     * Kill the child when the caller gives up (a browser that navigated away
-     * aborts its fetch, but that alone would leave the process running to its
-     * timeout). Optional — callers that don't pass one behave exactly as before.
-     *
-     * A route may hand this its `request.signal` for a probe, or for the FIRST
-     * durable write of the request — cancelling either leaves NOTHING ELSE of
-     * that request half-done. It is not a rollback: an abort that lands after
-     * the child has already written keeps that write, because all this does is
-     * refuse to start (see the guard below) or kill the process. What it buys
-     * is that the box is left in one of the two states the request began and
-     * ended in, rather than between them.
-     *
-     * So it must NOT be handed to work that FOLLOWS a durable write: a browser
-     * that locked its screen would then leave the token in ClawBox's store and
-     * not in Hermes', or a saved channel with a gateway nobody started. Past
-     * the first write, finish the job.
-     */
-    signal?: AbortSignal;
-    /**
-     * Run the call through `sudo -n`. Only for the handful of subcommands that
-     * genuinely need root (`gateway install --system`, which writes a
-     * /etc/systemd/system unit). `-n` means a box without a passwordless rule
-     * fails immediately instead of blocking on a password prompt — a route
-     * handler must never be able to hang on a prompt.
-     */
-    sudo?: boolean;
-  } = {},
+  opts: HermesCliOptions = {},
 ): Promise<HermesCliResult> {
-  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const bin = opts.sudo ? SUDO_BIN : HERMES_BIN;
   const argv = opts.sudo ? ["-n", HERMES_BIN, ...args] : args;
+
+  if (opts.silenceUpdateCheck && !opts.sudo && isSilenceableVersionCall(args)) {
+    const budgetMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const started = Date.now();
+    try {
+      const quiet = await spawnHermes(HERMES_VENV_PYTHON, ["-c", SILENT_VERSION_PY], {
+        ...opts,
+        // Half the budget, never more. The silent form does no network at all
+        // (measured 853-857 ms on a Hermes box), and whatever it does spend
+        // has to leave the fallback enough of the CALLER's deadline to answer
+        // — a fix that turns one timeout into two would be worse than the
+        // defect it removes.
+        timeoutMs: Math.max(1, Math.floor(budgetMs / 2)),
+        // The package IS the checkout — there is no pip dist to import — so
+        // the checkout goes on the path the shim's `exec <dir>/hermes` would
+        // have put there. PYTHONHOME is removed rather than set: an inherited
+        // one would send this interpreter at a different stdlib.
+        env: { PYTHONPATH: HERMES_AGENT_DIR, PYTHONHOME: undefined, ...opts.env },
+      });
+      if (quiet.code === 0 && quiet.stdout) return quiet;
+    } catch {
+      // Fall through to the supported call. Not swallowing an outcome: this
+      // path has produced nothing yet, and the call below is the answer.
+    }
+    return spawnHermes(bin, argv, {
+      ...opts,
+      timeoutMs: Math.max(1, budgetMs - (Date.now() - started)),
+    });
+  }
+
+  return spawnHermes(bin, argv, opts);
+}
+
+function spawnHermes(
+  bin: string,
+  argv: string[],
+  opts: HermesCliOptions,
+): Promise<HermesCliResult> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   // Already aborted BEFORE the call: nothing may be started. `abort` fires
   // once, so a listener registered below would never hear it and the child
   // would run to completion for a caller that is already gone — the route
@@ -81,24 +178,29 @@ export function runHermesCli(
   // install is precisely the thing to avoid. Same rejection as `onAbort`, so
   // callers have one message to recognise.
   if (opts.signal?.aborted) return Promise.reject(new Error("hermes call cancelled"));
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    HOME: HOME_DIR,
+    PATH: `${path.dirname(HERMES_BIN)}:${process.env.PATH || ""}`,
+    // Hermes prints through `rich`, which falls back to 80 columns when
+    // stdout is a pipe and hard-wraps everything it renders — mid-sentence
+    // in a refusal, mid-cell in a table. Every caller that reads this
+    // output is parsing it, so the wide console is the default rather than
+    // something each one has to remember (three call sites already passed
+    // their own COLUMNS, at two different widths). Still overridable
+    // through `opts.env`.
+    COLUMNS: WIDE_CONSOLE_COLUMNS,
+    ...opts.env,
+  };
+  // An `undefined` from `opts.env` means REMOVE, not "leave as inherited":
+  // deleted here rather than relied on inside `spawn`, so the contract is the
+  // one this file states.
+  for (const [key, value] of Object.entries(env)) if (value === undefined) delete env[key];
   return new Promise<HermesCliResult>((resolve, reject) => {
     const child = spawn(bin, argv, {
       stdio: [opts.input !== undefined ? "pipe" : "ignore", "pipe", "pipe"],
       cwd: HOME_DIR,
-      env: {
-        ...process.env,
-        HOME: HOME_DIR,
-        PATH: `${path.dirname(HERMES_BIN)}:${process.env.PATH || ""}`,
-        // Hermes prints through `rich`, which falls back to 80 columns when
-        // stdout is a pipe and hard-wraps everything it renders — mid-sentence
-        // in a refusal, mid-cell in a table. Every caller that reads this
-        // output is parsing it, so the wide console is the default rather than
-        // something each one has to remember (three call sites already passed
-        // their own COLUMNS, at two different widths). Still overridable
-        // through `opts.env`.
-        COLUMNS: WIDE_CONSOLE_COLUMNS,
-        ...opts.env,
-      },
+      env: env as NodeJS.ProcessEnv,
     });
 
     let out = "";

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -2466,10 +2466,21 @@ async function readClawboxVersion(): Promise<string> {
  * the venv the shim execs) should report an unknown version for a few
  * seconds, not fail the whole version endpoint that ClawBox's own update
  * tile also depends on.
+ *
+ * TASK-613: remove once hermes-agent#104275 lands (HERMES_DISABLE_UPDATE_CHECK
+ * / updates.check). `hermes --version` is the one hermes call that runs the
+ * agent's passive update check, and every six hours the first probe pays for a
+ * `git fetch` plus a GitHub compare inside the 10 s allowed for the whole call
+ * — after which this reads a timeout and answers null over an agent that is
+ * running perfectly. `silenceUpdateCheck` asks for the same banner without it,
+ * and falls back to the plain call if it cannot.
  */
 async function readHermesVersion(): Promise<string | null> {
   try {
-    const { code, stdout } = await runHermesCli(["--version"], { timeoutMs: 10_000 });
+    const { code, stdout } = await runHermesCli(["--version"], {
+      timeoutMs: 10_000,
+      silenceUpdateCheck: true,
+    });
     if (code !== 0) return null;
     return parseHermesVersion(stdout);
   } catch {

--- a/src/tests/unit/hermes-cli-update-check.test.ts
+++ b/src/tests/unit/hermes-cli-update-check.test.ts
@@ -1,0 +1,306 @@
+import { EventEmitter } from "events";
+import fs from "node:fs";
+import path from "node:path";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+
+import { parseHermesVersion } from "@/lib/version-utils";
+
+/**
+ * TASK-613 — ClawBox's own `hermes --version` pays for an update check nobody
+ * asked for, and on a cache miss it pays for it with the whole probe.
+ *
+ * `hermes --version` is the ONLY non-interactive hermes call that runs the
+ * agent's passive update check: in 0.20.5 `banner.check_for_updates()` has
+ * exactly two call sites — `_startup_fast.py:238`, inside
+ * `print_fast_version_info`, and `banner.py:646`, the interactive welcome
+ * banner. Every `config` / `skills` / `plugins` / `approvals` call ClawBox
+ * makes is already silent, which is why the silence is asked for at ONE call
+ * site rather than blanket-applied.
+ *
+ * What that one call costs, measured on the Hermes box (read-only):
+ *  - it appends `Update available: 7669 commits behind — run 'hermes update'`
+ *    to the banner ClawBox parses — advice that is wrong twice over on a
+ *    device pinned to a commit whose update path is not `hermes update`;
+ *  - the answer is cached for six hours, and every miss synchronously runs
+ *    `git fetch origin main --depth 1` (10 s ceiling, `banner.py:339-347`) and
+ *    an unauthenticated GitHub compare (10 s ceiling, `banner.py:196-231`) —
+ *    inside the 10 s `runHermesCli` budget `readHermesVersion` gives the WHOLE
+ *    call. The probe then rejects with "hermes timed out", `readHermesVersion`
+ *    catches it and answers null, and the About screen reports no Hermes
+ *    version on a box whose agent is running fine. A plain `git ls-remote`
+ *    from that box took 43.1 s on its first GitHub contact.
+ *
+ * The switch already exists upstream — `print_fast_version_info(*,
+ * check_updates: bool = True)` returns early at `_startup_fast.py:228-229` —
+ * but all five of its call sites hard-code True, `banner.py` reads only
+ * `HERMES_REVISION`, and there is no `updates.check` config key, so the CLI
+ * cannot be asked for it (NousResearch/hermes-agent#104275). Until it can,
+ * ClawBox asks the agent's own printer directly, through the interpreter the
+ * `hermes` shim execs.
+ *
+ * Pinned here:
+ *  - the silence goes through the ONE spawn seam, and is asked for by the
+ *    version probe;
+ *  - it FAILS OPEN — an interpreter that cannot answer leaves the plain
+ *    `hermes --version` call, and the banner parser still reads the version
+ *    off the noisy output (the false-failure guard);
+ *  - it never turns one deadline into two.
+ */
+
+vi.mock("child_process", () => ({ spawn: vi.fn() }));
+vi.mock("@/lib/harness", () => ({ HERMES_BIN: "/home/clawbox/.local/bin/hermes" }));
+
+import { spawn } from "child_process";
+import { runHermesCli } from "@/lib/hermes-cli";
+
+const mockSpawn = vi.mocked(spawn);
+
+const HERMES_BIN = "/home/clawbox/.local/bin/hermes";
+const HOME = process.env.HOME || "/home/clawbox";
+const AGENT_DIR = path.join(HOME, ".hermes", "hermes-agent");
+const VENV_PYTHON = path.join(AGENT_DIR, "venv", "bin", "python");
+
+/** The banner a silenced probe gets, verbatim from the Hermes box. */
+const SILENT_BANNER = [
+  "Hermes Agent v0.20.5 (2026.8.19) · upstream 089bb328 · local fcbd1076 (+24396 carried commits)",
+  "Install directory: /home/clawbox/.hermes/hermes-agent",
+  "Install method: git",
+  "Python: 3.11.15",
+  "OpenAI SDK: 2.24.0",
+].join("\n");
+
+/** The same banner with the nag the update check appends. */
+const NOISY_BANNER = `${SILENT_BANNER}\nUpdate available: 7669 commits behind — run 'hermes update'`;
+
+type FakeChild = EventEmitter & { stdout: EventEmitter; stderr: EventEmitter; kill: () => void };
+
+function fakeChild(act?: (c: FakeChild) => void): FakeChild {
+  const c = new EventEmitter() as FakeChild;
+  c.stdout = new EventEmitter();
+  c.stderr = new EventEmitter();
+  c.kill = vi.fn();
+  if (act) setImmediate(() => act(c));
+  return c;
+}
+
+/** Answers `stdout` and exits `code`. */
+const answers = (stdout: string, code = 0) =>
+  fakeChild((c) => {
+    if (stdout) c.stdout.emit("data", Buffer.from(stdout));
+    c.emit("close", code);
+  });
+
+/** Cannot be started at all — the interpreter is not there. */
+const unstartable = (errno: string) =>
+  fakeChild((c) => {
+    const e = new Error(`spawn ${errno}`) as NodeJS.ErrnoException;
+    e.code = errno;
+    c.emit("error", e);
+  });
+
+/** Started, and never says anything. */
+const hangs = () => fakeChild();
+
+const spawnedEnv = (call: number) =>
+  (mockSpawn.mock.calls[call][2] as { env: Record<string, string> }).env;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+describe("runHermesCli({ silenceUpdateCheck }) — the version probe stops paying for the update check", () => {
+  it("asks the agent's own printer for the banner with the check off", async () => {
+    mockSpawn.mockImplementation(() => answers(SILENT_BANNER) as never);
+
+    const result = await runHermesCli(["--version"], {
+      timeoutMs: 10_000,
+      silenceUpdateCheck: true,
+    });
+
+    // ONE spawn: the noisy `hermes --version` is not run at all.
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const [bin, argv] = mockSpawn.mock.calls[0];
+    // The interpreter the shim execs, not the shim — the shim has no way to
+    // pass the flag through.
+    expect(bin).toBe(VENV_PYTHON);
+    expect(argv).toEqual(["-c", expect.stringContaining("check_updates=False")]);
+    expect(result.stdout).not.toMatch(/Update available/);
+    expect(parseHermesVersion(result.stdout)).toBe("v0.20.5");
+  });
+
+  it("makes the checkout importable the way the shim does, and inherits no Python home", async () => {
+    // The shim is four lines: unset PYTHONPATH, unset PYTHONHOME, exec the
+    // venv interpreter on `<agent_dir>/hermes`. Running `-c` instead means
+    // pointing PYTHONPATH at the checkout (the package IS the checkout — there
+    // is no pip dist to import) while still refusing an inherited PYTHONHOME,
+    // which would send the interpreter at a different stdlib.
+    process.env.PYTHONHOME = "/somewhere/else";
+    try {
+      mockSpawn.mockImplementation(() => answers(SILENT_BANNER) as never);
+
+      await runHermesCli(["--version"], { timeoutMs: 10_000, silenceUpdateCheck: true });
+
+      expect(spawnedEnv(0).PYTHONPATH).toBe(AGENT_DIR);
+      expect(spawnedEnv(0)).not.toHaveProperty("PYTHONHOME");
+    } finally {
+      delete process.env.PYTHONHOME;
+    }
+  });
+
+  it("falls open to `hermes --version` when the interpreter is not there", async () => {
+    mockSpawn
+      .mockImplementationOnce(() => unstartable("ENOENT") as never)
+      .mockImplementationOnce(() => answers(NOISY_BANNER) as never);
+
+    const result = await runHermesCli(["--version"], {
+      timeoutMs: 10_000,
+      silenceUpdateCheck: true,
+    });
+
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(mockSpawn.mock.calls[1][0]).toBe(HERMES_BIN);
+    expect(mockSpawn.mock.calls[1][1]).toEqual(["--version"]);
+    // The false-failure guard: the silence being absent must cost the nag
+    // line and NOTHING else — the version still reads out of the banner.
+    expect(result.stdout).toContain("Update available");
+    expect(parseHermesVersion(result.stdout)).toBe("v0.20.5");
+  });
+
+  it("falls open when the printer is there but refuses", async () => {
+    // A renamed module or a changed signature: the interpreter starts, the
+    // import or the call raises, exit 1. Same outcome as no interpreter.
+    mockSpawn
+      .mockImplementationOnce(() => answers("", 1) as never)
+      .mockImplementationOnce(() => answers(NOISY_BANNER) as never);
+
+    const result = await runHermesCli(["--version"], {
+      timeoutMs: 10_000,
+      silenceUpdateCheck: true,
+    });
+
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(mockSpawn.mock.calls[1][0]).toBe(HERMES_BIN);
+    expect(parseHermesVersion(result.stdout)).toBe("v0.20.5");
+  });
+
+  it("leaves every other hermes call exactly as it was", async () => {
+    // `--version` is the only call that runs the check, so the flag must be a
+    // no-op everywhere else rather than a second way to spawn the agent.
+    mockSpawn.mockImplementation(() => answers("cli") as never);
+
+    await runHermesCli(["config", "get", "display.interface"], { silenceUpdateCheck: true });
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(mockSpawn.mock.calls[0][0]).toBe(HERMES_BIN);
+    expect(mockSpawn.mock.calls[0][1]).toEqual(["config", "get", "display.interface"]);
+  });
+
+  it("never silently drops sudo", async () => {
+    // Silencing a privileged call by running the interpreter directly would
+    // drop the privilege and answer for a different process than the caller
+    // asked for. Nothing calls `--version` under sudo today; the guard is what
+    // keeps that true.
+    mockSpawn.mockImplementation(() => answers(SILENT_BANNER) as never);
+
+    await runHermesCli(["--version"], { silenceUpdateCheck: true, sudo: true });
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(mockSpawn.mock.calls[0][0]).toBe("/usr/bin/sudo");
+    expect(mockSpawn.mock.calls[0][1]).toEqual(["-n", HERMES_BIN, "--version"]);
+  });
+});
+
+describe("the silence spends one deadline, not two", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("hands the fallback what is left of the caller's budget", async () => {
+    // Two full timeouts in series would turn a 10 s probe into a 20 s one and
+    // make the fix worse than the defect it removes: `getVersionInfo` is what
+    // the About screen polls.
+    mockSpawn.mockImplementation(() => hangs() as never);
+
+    const call = runHermesCli(["--version"], { timeoutMs: 10_000, silenceUpdateCheck: true });
+    const settled = call.then(
+      () => "resolved",
+      (e: Error) => e.message,
+    );
+
+    // Half the budget for the silent form — it does no network at all.
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(mockSpawn.mock.calls[1][0]).toBe(HERMES_BIN);
+
+    // …and the other half for the fallback, so the whole call is still bounded
+    // by the 10 s the caller asked for.
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(settled).resolves.toMatch(/timed out/);
+  });
+});
+
+/**
+ * install.sh probes the agent twice with `--version` — once to decide whether
+ * Hermes is installed at all, once to verify the install it just ran. Both
+ * throw the answer away with `head -1`, and on a fresh box BOTH are cache
+ * misses, so the step pays the fetch and the GitHub compare twice for a line
+ * nobody reads.
+ */
+describe("install.sh's own probes carry the same silence", () => {
+  const REPO = path.resolve(__dirname, "../../..");
+  const INSTALL_SH = fs.readFileSync(path.join(REPO, "install.sh"), "utf-8");
+  const NL = String.fromCharCode(10);
+
+  /** The step's code with comments dropped and continuations joined. */
+  const STEP = (() => {
+    const start = INSTALL_SH.indexOf("step_hermes_install() {");
+    if (start < 0) throw new Error("step_hermes_install not found in install.sh");
+    const end = INSTALL_SH.indexOf(`${NL}}`, start);
+    return INSTALL_SH.slice(start, end)
+      .split(NL)
+      .filter((l) => !l.trim().startsWith("#"))
+      .join(NL)
+      .replace(new RegExp("\\\\" + NL + "\\s*", "g"), " ");
+  })();
+
+  it("tries the silent printer at both probes", () => {
+    const silent = STEP.split(NL).filter((l) => l.includes("check_updates=False"));
+    expect(silent).toHaveLength(2);
+    for (const line of silent) {
+      // Same two rules the shim probes already follow.
+      expect(line, `must not run the agent as root: ${line}`).toContain('runuser -u "$CLAWBOX_USER"');
+      expect(line, `must pass HOME: ${line}`).toContain('HOME="$CLAWBOX_HOME"');
+    }
+  });
+
+  it("keeps the `--version` probe as the fallback, after the silent one", () => {
+    const lines = STEP.split(NL);
+    const shimProbes = lines
+      .map((l, i) => ({ l, i }))
+      .filter(({ l }) => l.includes("--version") && l.includes("$shim"));
+    expect(shimProbes).toHaveLength(2);
+    for (const { i } of shimProbes) {
+      const before = lines.slice(0, i).filter((l) => l.includes("check_updates=False"));
+      expect(before.length, "the silent probe must come first").toBeGreaterThan(0);
+    }
+  });
+});
+
+/**
+ * This is a workaround for a gap upstream has been asked to close. It has to
+ * be findable on the day it can be deleted.
+ */
+describe("the workaround is marked for removal", () => {
+  const REPO = path.resolve(__dirname, "../../..");
+  const MARKER = /TASK-613: remove once hermes-agent#104275 lands/;
+
+  it.each(["src/lib/hermes-cli.ts", "src/lib/updater.ts", "install.sh"])(
+    "%s carries the revert marker",
+    (file) => {
+      // `.test()` rather than `toMatch`, so a miss reports the file and not
+      // the whole of install.sh.
+      const marked = MARKER.test(fs.readFileSync(path.join(REPO, file), "utf-8"));
+      expect(marked, `${file} must say when this workaround can be deleted`).toBe(true);
+    },
+  );
+});

--- a/src/tests/unit/hermes-cli-update-check.test.ts
+++ b/src/tests/unit/hermes-cli-update-check.test.ts
@@ -44,7 +44,7 @@ import { parseHermesVersion } from "@/lib/version-utils";
  *  - it FAILS OPEN — an interpreter that cannot answer leaves the plain
  *    `hermes --version` call, and the banner parser still reads the version
  *    off the noisy output (the false-failure guard);
- *  - it never turns one deadline into two.
+ *  - it never shortens the supported call it falls back to.
  */
 
 vi.mock("child_process", () => ({ spawn: vi.fn() }));
@@ -133,8 +133,10 @@ describe("runHermesCli({ silenceUpdateCheck }) — the version probe stops payin
     // The shim is four lines: unset PYTHONPATH, unset PYTHONHOME, exec the
     // venv interpreter on `<agent_dir>/hermes`. Running `-c` instead means
     // pointing PYTHONPATH at the checkout (the package IS the checkout — there
-    // is no pip dist to import) while still refusing an inherited PYTHONHOME,
-    // which would send the interpreter at a different stdlib.
+    // is no pip dist to import), refusing an inherited PYTHONHOME, which would
+    // send the interpreter at a different stdlib, and keeping the CWD off
+    // `sys.path[0]` — `-c` puts it there and the shim never does, so a
+    // stdlib-shadowing file in $HOME would break a probe the shim runs fine.
     process.env.PYTHONHOME = "/somewhere/else";
     try {
       mockSpawn.mockImplementation(() => answers(SILENT_BANNER) as never);
@@ -142,10 +144,71 @@ describe("runHermesCli({ silenceUpdateCheck }) — the version probe stops payin
       await runHermesCli(["--version"], { timeoutMs: 10_000, silenceUpdateCheck: true });
 
       expect(spawnedEnv(0).PYTHONPATH).toBe(AGENT_DIR);
+      expect(spawnedEnv(0).PYTHONSAFEPATH).toBe("1");
       expect(spawnedEnv(0)).not.toHaveProperty("PYTHONHOME");
+      // …and the three variables every hermes child is promised are still there.
+      expect(spawnedEnv(0).HOME).toBe(HOME);
+      expect(spawnedEnv(0).COLUMNS).toBe("400");
     } finally {
       delete process.env.PYTHONHOME;
     }
+  });
+
+  it("follows the install the fallback would run, not a hard-coded one", async () => {
+    // Both halves have to read the SAME install: if the silent probe answered
+    // for `~/.hermes` while the shim ran an install `HERMES_HOME` moved, the
+    // About screen would show a version belonging to a different agent — and
+    // both paths exist, so nothing would look wrong. Same overrides the rest of
+    // the repo honours (hermesHome() in hermes-env.ts).
+    process.env.HERMES_HOME = "/opt/hermes-home";
+    try {
+      mockSpawn.mockImplementation(() => answers(SILENT_BANNER) as never);
+
+      await runHermesCli(["--version"], { silenceUpdateCheck: true });
+
+      expect(mockSpawn.mock.calls[0][0]).toBe(
+        path.join("/opt/hermes-home", "hermes-agent", "venv", "bin", "python"),
+      );
+      expect(spawnedEnv(0).PYTHONPATH).toBe(path.join("/opt/hermes-home", "hermes-agent"));
+    } finally {
+      delete process.env.HERMES_HOME;
+    }
+  });
+
+  it("falls open when the printer answers something that is not a banner", async () => {
+    // `parseHermesVersion` SHOWS an unrecognised first line rather than
+    // reporting nothing, so a sitecustomize notice (or a future upstream line)
+    // on stdout would become "the Hermes version" on the About screen and the
+    // supported call that prints the real one would never be made.
+    mockSpawn
+      .mockImplementationOnce(() => answers("Note: running under a virtualenv") as never)
+      .mockImplementationOnce(() => answers(NOISY_BANNER) as never);
+
+    const result = await runHermesCli(["--version"], { silenceUpdateCheck: true });
+
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(mockSpawn.mock.calls[1][0]).toBe(HERMES_BIN);
+    expect(parseHermesVersion(result.stdout)).toBe("v0.20.5");
+  });
+
+  it("does not ask the same question twice when the child said far too much", async () => {
+    // Every other failure means the child could not be STARTED, and the
+    // supported call is the answer. A runaway child is not that: retrying it
+    // would overflow the same buffer, so the caller hears the real reason.
+    mockSpawn.mockImplementation(
+      () =>
+        fakeChild((c) => {
+          c.stdout.emit("data", Buffer.alloc(1_000_001, 0x61));
+        }) as never,
+    );
+
+    const err = await runHermesCli(["--version"], { silenceUpdateCheck: true }).then(
+      () => new Error("expected a rejection"),
+      (e: Error) => e,
+    );
+
+    expect(err.message).toMatch(/exceeded the size limit/);
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
   });
 
   it("falls open to `hermes --version` when the interpreter is not there", async () => {
@@ -211,40 +274,79 @@ describe("runHermesCli({ silenceUpdateCheck }) — the version probe stops payin
   });
 });
 
-describe("the silence spends one deadline, not two", () => {
+describe("the silence never shortens the supported call", () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
 
-  it("hands the fallback what is left of the caller's budget", async () => {
-    // Two full timeouts in series would turn a 10 s probe into a 20 s one and
-    // make the fix worse than the defect it removes: `getVersionInfo` is what
-    // the About screen polls.
+  it("caps itself and hands the fallback the caller's WHOLE budget", () => {
+    // Splitting the caller's budget in half was the first shape of this, and
+    // it made the fix worse than the defect on the hardware it targets: a cold,
+    // loaded Orin where `hermes --version` answers in eight seconds would get
+    // five, time out, and report no version — a NEW false failure introduced by
+    // a change whose whole purpose is removing one. So the silent attempt has
+    // its own ceiling and the supported call keeps every millisecond it had.
     mockSpawn.mockImplementation(() => hangs() as never);
 
-    const call = runHermesCli(["--version"], { timeoutMs: 10_000, silenceUpdateCheck: true });
-    const settled = call.then(
+    const settled = runHermesCli(["--version"], {
+      timeoutMs: 10_000,
+      silenceUpdateCheck: true,
+    }).then(
       () => "resolved",
       (e: Error) => e.message,
     );
 
-    // Half the budget for the silent form — it does no network at all.
-    await vi.advanceTimersByTimeAsync(5_000);
-    expect(mockSpawn).toHaveBeenCalledTimes(2);
-    expect(mockSpawn.mock.calls[1][0]).toBe(HERMES_BIN);
+    return (async () => {
+      // The silent attempt's own 5 s ceiling, not a slice of the 10 s.
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(mockSpawn).toHaveBeenCalledTimes(2);
+      expect(mockSpawn.mock.calls[1][0]).toBe(HERMES_BIN);
+      expect(mockSpawn.mock.calls[1][1]).toEqual(["--version"]);
 
-    // …and the other half for the fallback, so the whole call is still bounded
-    // by the 10 s the caller asked for.
-    await vi.advanceTimersByTimeAsync(5_000);
-    await expect(settled).resolves.toMatch(/timed out/);
+      // …and the fallback then gets the full 10 s the caller asked for: at
+      // 9_999 ms into it nothing has settled.
+      await vi.advanceTimersByTimeAsync(9_999);
+      await expect(Promise.race([settled, Promise.resolve("pending")])).resolves.toBe("pending");
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(settled).resolves.toMatch(/timed out/);
+    })();
+  });
+
+  it("never gives the silent attempt more than the caller allowed", () => {
+    // A caller with a budget under the ceiling still bounds the whole call.
+    mockSpawn.mockImplementation(() => hangs() as never);
+
+    const settled = runHermesCli(["--version"], {
+      timeoutMs: 2_000,
+      silenceUpdateCheck: true,
+    }).then(
+      () => "resolved",
+      (e: Error) => e.message,
+    );
+
+    return (async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(mockSpawn).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(2_000);
+      await expect(settled).resolves.toMatch(/timed out/);
+    })();
   });
 });
 
 /**
- * install.sh probes the agent twice with `--version` — once to decide whether
- * Hermes is installed at all, once to verify the install it just ran. Both
- * throw the answer away with `head -1`, and on a fresh box BOTH are cache
- * misses, so the step pays the fetch and the GitHub compare twice for a line
- * nobody reads.
+ * install.sh probes the agent twice — once to decide whether Hermes is
+ * installed at all, once to verify the install it just ran. Both throw the
+ * answer away with `head -1`, and on a fresh box BOTH are cache misses, so the
+ * step paid the fetch and the GitHub compare twice for a line nobody reads.
+ *
+ * The invariant the silence must NOT take with it is the one the step exists
+ * for: runnability is the SHIM's to prove. Importing `hermes_cli` says the
+ * package is on disk; it does not say `~/.local/bin/hermes` works, and a box
+ * where it does not is exactly the box this step has to repair. Driven for
+ * real in install-hermes-install-guard.test.ts ("a broken shim over an
+ * importable package is still 'not installed'"); pinned as text here because
+ * the four things that make the silent probe work are invisible to a
+ * behavioural harness whose fake interpreter ignores its argv.
  */
 describe("install.sh's own probes carry the same silence", () => {
   const REPO = path.resolve(__dirname, "../../..");
@@ -252,7 +354,7 @@ describe("install.sh's own probes carry the same silence", () => {
   const NL = String.fromCharCode(10);
 
   /** The step's code with comments dropped and continuations joined. */
-  const STEP = (() => {
+  const LINES = (() => {
     const start = INSTALL_SH.indexOf("step_hermes_install() {");
     if (start < 0) throw new Error("step_hermes_install not found in install.sh");
     const end = INSTALL_SH.indexOf(`${NL}}`, start);
@@ -260,28 +362,72 @@ describe("install.sh's own probes carry the same silence", () => {
       .split(NL)
       .filter((l) => !l.trim().startsWith("#"))
       .join(NL)
-      .replace(new RegExp("\\\\" + NL + "\\s*", "g"), " ");
+      .replace(new RegExp("\\\\" + NL + "\\s*", "g"), " ")
+      .split(NL);
   })();
 
+  const silentProbes = () => LINES.filter((l) => l.includes("check_updates=False"));
+
   it("tries the silent printer at both probes", () => {
-    const silent = STEP.split(NL).filter((l) => l.includes("check_updates=False"));
-    expect(silent).toHaveLength(2);
-    for (const line of silent) {
-      // Same two rules the shim probes already follow.
+    expect(silentProbes()).toHaveLength(2);
+    for (const line of silentProbes()) {
+      // Same two rules every hermes invocation in this step already follows:
+      // never as root (a root-run probe writes root-owned __pycache__ into a
+      // clawbox-owned tree, which is what made the factory reset abort
+      // mid-wipe), and HOME explicitly (hermes resolves ~/.hermes from it, and
+      // install.sh's own HOME is /root).
       expect(line, `must not run the agent as root: ${line}`).toContain('runuser -u "$CLAWBOX_USER"');
       expect(line, `must pass HOME: ${line}`).toContain('HOME="$CLAWBOX_HOME"');
+      // The package IS the checkout — there is no pip dist — so without this
+      // the import fails on every box and the silence is dead code.
+      expect(line, `must put the checkout on the path: ${line}`).toContain(
+        'PYTHONPATH="$agent_dir"',
+      );
+      // An inherited PYTHONHOME aims the interpreter at a different stdlib;
+      // the shim unsets it for exactly this reason.
+      expect(line, `must not inherit a Python home: ${line}`).toContain("env -u PYTHONHOME");
+      // `-c` puts the CWD on sys.path[0] and the shim never does.
+      expect(line, `must keep the CWD off sys.path: ${line}`).toContain("PYTHONSAFEPATH=1");
+      // A traceback on stderr must not reach the log, and — under
+      // `set -euo pipefail` — the assignment must not inherit the probe's
+      // status: that is what kills `install.sh --step hermes_install` outright.
+      expect(line, `must not print a traceback: ${line}`).toContain("2>/dev/null");
+      expect(line, `must not let errexit kill the step: ${line}`).toContain('|| installed=""');
     }
   });
 
-  it("keeps the `--version` probe as the fallback, after the silent one", () => {
-    const lines = STEP.split(NL);
-    const shimProbes = lines
-      .map((l, i) => ({ l, i }))
-      .filter(({ l }) => l.includes("--version") && l.includes("$shim"));
-    expect(shimProbes).toHaveLength(2);
-    for (const { i } of shimProbes) {
-      const before = lines.slice(0, i).filter((l) => l.includes("check_updates=False"));
-      expect(before.length, "the silent probe must come first").toBeGreaterThan(0);
+  it("lets the SHIM decide whether Hermes runs, before either version read", () => {
+    // The whole point of the step: "require the interpreter to exist AND the
+    // agent to actually answer". `--help` runs the same shim → entry script →
+    // hermes_cli.main path `--version` does and no update check with it.
+    const gates = LINES.map((l, i) => ({ l, i })).filter(
+      ({ l }) => l.includes("$shim") && l.includes("--help"),
+    );
+    expect(gates).toHaveLength(2);
+    for (const { l, i } of gates) {
+      expect(l, `the gate must run as the clawbox user with HOME: ${l}`).toContain(
+        'runuser -u "$CLAWBOX_USER"',
+      );
+      expect(l).toContain('HOME="$CLAWBOX_HOME"');
+      // …and it gates the version reads rather than sitting beside them.
+      expect(l.trimStart(), `the gate must be a condition: ${l}`).toMatch(/^if runuser/);
+      const after = LINES.slice(i);
+      expect(after.findIndex((x) => x.includes("check_updates=False"))).toBeGreaterThan(-1);
+    }
+  });
+
+  it("pairs each silent probe with the `--version` fallback that follows it", () => {
+    // Fail OPEN: an interpreter that cannot answer must leave the supported
+    // probe behind it, and it must be the NEXT statement rather than one
+    // somewhere later in the step.
+    for (const line of silentProbes()) {
+      const next = LINES[LINES.indexOf(line) + 1];
+      expect(next, `no fallback after: ${line}`).toBeDefined();
+      expect(next, `the fallback must be guarded on an empty result: ${next}`).toContain(
+        '[ -n "$installed" ] ||',
+      );
+      expect(next).toContain('"$shim" --version');
+      expect(next).toContain('|| installed=""');
     }
   });
 });

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -663,6 +663,28 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     expect(r.out).toMatch(/Hermes installed \(Hermes 9\.9\.9\)/);
   });
 
+  it("a broken shim over an importable package is still 'not installed'", () => {
+    // TASK-613 put a `python -c` printer in front of the version probe to keep
+    // the agent's update check off a fresh install. The thing it must NOT do is
+    // become the proof that Hermes RUNS: importing `hermes_cli` says the
+    // package is on disk, not that `~/.local/bin/hermes` works. This is that
+    // box — the entry script the 4-line shim execs is gone or renamed (an
+    // interrupted `--force-commit` checkout, a partial restore), while the venv
+    // and the package are intact — and it is the exact device the step's own
+    // "require the interpreter to exist AND the agent to actually answer"
+    // comment was written for. Pinned WITH the agent already on the pin, which
+    // is what turns the mistake into a silent one: nothing later in the step
+    // would have contradicted "already installed at the pinned commit".
+    giveShim({ answers: false });
+    giveAgent({ venv: true, head: PIN });
+
+    const r = run();
+
+    expect(r.code).toBe(0);
+    expect(r.installerRan).toBe(true);
+    expect(r.out).not.toMatch(/already installed/);
+  });
+
   it("a shim with no agent directory reinstalls without inventing a husk", () => {
     giveShim();
 

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -2423,7 +2423,15 @@ describe("getVersionInfo harness reporting", () => {
 
     expect(info.edition).toBe("hermes");
     expect(info.hermes?.current).toBe("v0.20.5");
-    expect(mockRunHermesCli).toHaveBeenCalledWith(["--version"], expect.anything());
+    // TASK-613: and it asks for the banner WITHOUT the agent's passive update
+    // check. `--version` is the only hermes call that runs one, and on a
+    // six-hourly cache miss that check does a `git fetch` plus a GitHub
+    // compare inside the 10 s this probe allows for the whole call — after
+    // which the About screen reports no Hermes version at all.
+    expect(mockRunHermesCli).toHaveBeenCalledWith(
+      ["--version"],
+      expect.objectContaining({ silenceUpdateCheck: true }),
+    );
   });
 
   it("never spawns hermes on the openclaw edition, and reports no hermes field", async () => {


### PR DESCRIPTION
**TASK-613** (owner ruling 2026-09-06: post the upstream issue *and* ship a local silence until Hermes exposes the flag; the issue is filed as NousResearch/hermes-agent#104275).

## Customer-visible symptom

On a Hermes box, Settings → About reports **no Hermes version** every so often while the agent is running perfectly, and the version block ClawBox parses carries a line telling the owner to run `hermes update` — which is not this device's update path.

## Cause

`hermes --version` is the only non-interactive hermes call that runs the agent's passive update check. In 0.20.5 `banner.check_for_updates()` has exactly two production call sites: `hermes_cli/_startup_fast.py:238` (inside `print_fast_version_info`) and `hermes_cli/banner.py:646` (the interactive welcome banner). Every `config` / `skills` / `plugins` / `approvals` / `chat` call ClawBox makes is already silent — measured on the box, not assumed.

That one check:

- appends `Update available: 7669 commits behind — run 'hermes update'` to the banner `parseHermesVersion` reads, and
- caches its answer for six hours; **every miss** synchronously runs `git fetch origin main --depth 1` (10 s ceiling, `banner.py:339-347`) and an unauthenticated GitHub compare (10 s ceiling, `banner.py:196-231`) — inside the **10 s** `runHermesCli` budget `readHermesVersion()` gives the whole call. The probe then rejects with `hermes timed out`, `readHermesVersion` catches it and answers `null`, and the About row goes blank. False failure, on a six-hourly clock.

Sized on the box: a plain `git ls-remote` to GitHub took **43.1 s** on its first contact (1.4 s warm); the compare API 1.32 s then 0.39 s. The 10 s fetch ceiling is reached, so the whole probe is over budget.

## Harness first

The switch already exists upstream — `print_fast_version_info(*, check_updates: bool = True)` returns early at `_startup_fast.py:228-229` — but nothing can reach it: all five call sites hard-code `True`, `banner.py` reads only `HERMES_REVISION`, and there is no `updates.*` config key. That gap is what #104275 asks upstream to close. Until it lands, ClawBox asks the agent's **own printer** through the interpreter the `hermes` shim execs, marked `TASK-613: remove once hermes-agent#104275 lands` at every site and pinned by a test.

Rejected with evidence, not by preference: pre-setting `HERMES_REVISION` selects `_check_via_rev`, which does `git ls-remote` — network — and `rev` is part of the cache key, so a ClawBox probe that sets it and the owner's shell that does not would force a miss on each other in turn. Pre-warming the cache is not a silence. Nothing here writes `~/.hermes/.update_check`, so the owner's interactive banner is untouched — verified on the box.

## What changed

- `src/lib/hermes-cli.ts` — one seam: `runHermesCli(args, { silenceUpdateCheck })`. A no-op for any argv but `--version`, ignored under `sudo`, and **fails open**: no venv, a renamed module, a changed signature or an answer that is not a version banner all fall through to the plain `hermes --version`. The silent attempt has its own 5 s ceiling spent *on top of* the caller's budget, so the supported call keeps every millisecond it had.
- `src/lib/updater.ts` — `readHermesVersion()` asks for it. The only in-app `hermes --version`.
- `install.sh` — both `step_hermes_install` probes. Runnability stays the **shim's** to prove (`"$shim" --help`, the same shim → entry script → `hermes_cli.main` path, no update check, 0.82 s measured); the silent printer only supplies the version string behind it, with `"$shim" --version` still there as the fallback.

Swept: `runHermesCli` has 49 non-test call sites and none other passes `--version`; `scripts/register-mcp.sh` (`tools disable`, `plugins doctor`), `scripts/setup-hermes-edition.sh` (`-x` guards only), `install.sh`'s `hermes_tts_cli` (`config get/set`) and `setup-api/hermes/chat/route.ts` (`chat -q`) spawn hermes but never `--version` and run no check — cleared, not skipped. Nothing new spawns on an `openclaw` box: `readHermesVersion` stays behind `hasHermesHarness()` and the step behind `has_hermes_harness`.

## RED → GREEN

RED, on unmodified `origin/beta` `1c40645` (paths under the developer's home redacted as `<HOME>`):

```
 × … > asks the agent's own printer for the banner with the check off
   → expected '/home/clawbox/.local/bin/hermes' to be '<HOME>/.hermes/hermes-agent/venv…'
 × … > makes the checkout importable the way the shim does, and inherits no Python home
   → expected undefined to be '<HOME>/.hermes/hermes-agent'
 × … > falls open to `hermes --version` when the interpreter is not there
   → Hermes is not installed on this device
 × … > install.sh's own probes carry the same silence > tries the silent printer at both probes
   → expected [] to have a length of 2 but got +0
 × … > the workaround is marked for removal > src/lib/hermes-cli.ts carries the revert marker
   → expected false to be true
 Tests  10 failed | 2 passed (12)

 × src/tests/unit/updater.test.ts > getVersionInfo harness reporting > reports the Hermes agent version on the hermes edition
   AssertionError: expected "vi.fn()" to be called with arguments: [ Array(2) ]
   -     "silenceUpdateCheck": true,
```

The review's HIGH also has its own RED: the new behavioural case *"a broken shim over an importable package is still 'not installed'"* fails against the first commit's probe shape (`installerRan` false, output `already installed at the pinned commit`) and passes on this head.

GREEN — the full unit project on this head:

```
 Test Files  727 passed (727)
      Tests  11913 passed | 1 skipped (11914)
```

`tsc --noEmit` clean; `openclaw-config-mock-completeness`, `test-timeout-hygiene`, `state-updater-purity`, `install-hermes-install-guard` (48) and the `hermes-cli-*` suites all pass.

## Device leg (Hermes box, read-only, no mutex taken, nothing written)

`hermes --version` wall time, three runs each, on a **cache hit** — the six-hourly miss is the expensive case and is now not taken at all:

| | ms |
|---|---|
| before (beta) — `hermes --version` | 866 / 875 / 870 |
| after — the web server's silenced read | 852 / 856 / 859 |
| after — install.sh's shim gate + silenced read | 1676 / 1675 / 1684 |

install.sh pays ~0.8 s more local CPU per probe and stops paying the network entirely: on a fresh box both of its probes are cache misses, i.e. up to a 10 s fetch plus a 10 s compare each, for a line `head -1` throws away.

Byte-identical banner minus the `Update available:` line; exit 0 with `PYTHONHOME`/`PYTHONPATH` poisoned in the parent (the shim's `unset` is mirrored — without it the interpreter exits 1, which is the fail-open path); the shared `~/.hermes/.update_check` cache was unchanged by every probe run (`rev` still `None`, `ts` untouched).

Not measured end to end: the cache-miss path itself, which would have required a `git fetch` in the box's Hermes checkout — a mutation. Its cost is stated from the code's own ceilings plus the network legs timed above.

## Review

One the reviewer review pass (`clawbox-review`), findings by file path: 1 high, 4 medium, 4 low, 2 informational. All applied. The HIGH is the install.sh runnability regression described above; the mediums were the half-budget split that could have starved the fallback on exactly the slow hardware this targets, a hard-coded agent directory that ignored `HERMES_HOME`/`HERMES_AGENT_DIR` (so the two halves could read different installs), a behavioural harness left certifying only the silent probe, and text assertions that would not have caught the load-bearing tokens going missing. The lows: `PYTHONSAFEPATH` (`-c` puts the CWD on `sys.path[0]` and the shim never does), a non-banner answer being shown as the version, an output-size kill retried as if the child had failed to start, a doubled spawn-failure log, and the `env` type widening — reverted, removals are expressed locally now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Hermes installation validation by confirming the user-facing command is runnable before completing installation.
  - Prevented background update checks from delaying or timing out version detection.
  - Added reliable fallback behavior when silent version checks are unavailable.
  - Failed shim checks now correctly trigger reinstallation instead of reporting Hermes as installed.
  - Preserved timeout and output-limit handling during version and installation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->