### PR TITLE
fix: stop offering a provider the box can run no model from

### DIFF
--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -14,7 +14,7 @@ import {
   isNonChatModelId,
   subscriptionSurfaceProvider,
 } from "@/lib/provider-models";
-import { recordProviderEnumeration } from "@/lib/provider-runnable";
+import { forgetProviderEnumeration, recordProviderEnumeration } from "@/lib/provider-runnable";
 
 export const dynamic = "force-dynamic";
 
@@ -569,6 +569,13 @@ async function fetchSubscriptionSurfaceIds(provider: string): Promise<Set<string
     publishedSeq.set(surfaceProvider, currentSeq(surfaceProvider));
     recordSuccessfulRefresh(surfaceProvider);
     await writeDiskCache(surfaceProvider, payload);
+    // The same count `publish` records. This is the file's second full publish
+    // path, and a catalogue published here while the record still said zero
+    // would keep a provider hidden that had just answered with rows. Dead
+    // today — no `SUBSCRIPTION_SURFACE` entry names a separate provider — and
+    // closed rather than left for the day one does, like every other rule this
+    // function had to be taught twice.
+    await recordProviderEnumeration(surfaceProvider, payload.models.length);
     return new Set(payload.models.map((m) => m.id));
   } catch (err) {
     console.warn(
@@ -1033,10 +1040,24 @@ function toFetchResult(
       ? `all ${rows.length} listed rows report available: false (no route this box can take yet)`
       : `${rows.length} rows listed, none of them chat models this picker can offer`;
   }
-  // A clean zero: the command ran, said nothing was wrong, and listed nothing.
-  // `diagnostic` is empty in exactly that case — a refusal or stderr fills it
-  // above, and rows that were all filtered out fill it just now.
-  return { models, diagnostic, emptyIsAnswer: models.length === 0 && !diagnostic };
+  // A clean zero: the command ran, said nothing was wrong, and STATED that it
+  // has nothing — `count: 0` beside an empty `models`. Read positively rather
+  // than inferred from absence, because a truncated or shape-shifted payload
+  // parses into the same emptiness as a real answer and this verdict hides a
+  // row. `diagnostic` covers the rest: a refusal or stderr fills it above, and
+  // rows that were all filtered out by OUR chat rule fill it just now.
+  //
+  // Deliberately NOT extended to "rows listed, every one `available: false`",
+  // which the core does report and which is the other way a box says it can
+  // route nothing here. It is also exactly what a provider with no credential
+  // looks like, and the two cannot be told apart from the payload — so that
+  // case keeps beta's behaviour and records nothing.
+  const emptyIsAnswer = models.length === 0
+    && rows.length === 0
+    && parsed.ok !== false
+    && parsed.count === 0
+    && !diagnostic;
+  return { models, diagnostic, emptyIsAnswer };
 }
 
 function fetchOpenclawCatalog(provider: string): Promise<CatalogFetchResult> {
@@ -1355,9 +1376,9 @@ export function refreshInBackground(
     await writeDiskCache(provider, payload);
     // What the box can run, for the surfaces that only need the COUNT (the
     // Providers rows, the picker). Written from the published list rather than
-    // the raw one so it cannot disagree with what the picker is offered, and
-    // written on every publish so a provider that comes back from zero stops
-    // being hidden without anything else having to notice.
+    // the raw one, so the number and the catalogue the picker is offered cannot
+    // disagree. Reached only past the generation guard above, so a fork from
+    // before the box changed records nothing.
     await recordProviderEnumeration(provider, payload.models.length);
     console.log(
       `[catalog] refreshed ${provider}: ${models.length} models`
@@ -1382,40 +1403,32 @@ export function refreshInBackground(
   fetcher
     .then(async ({ models, diagnostic, emptyIsAnswer }) => {
       if (models.length === 0) {
-        // Still NOT a catalogue. Nothing is published and nothing is written to
-        // `<provider>.json` on either branch below — "[catalog] refreshed
-        // codex: 0 models" used to be followed by a disk write of the curated
-        // list, which then read back as a device answer.
+        // NOT a success, and every line of beta's handling stands: nothing is
+        // published, the previous catalogue is kept, and `markStale` records
+        // the backoff that rations the retries. "[catalog] refreshed codex: 0
+        // models" used to be followed by a disk write of the curated list,
+        // which then read back as a device answer.
         //
-        // What splits the two branches is whether the box ANSWERED. A refusal,
-        // a plugin that is gone, or rows our own chat filter ate are failures:
-        // they keep beta's behaviour exactly — the previous catalogue stays and
-        // the backoff rations the retries.
-        if (!emptyIsAnswer) {
-          console.warn(
-            `[catalog] ${provider}: live enumeration returned no models, keeping the previous catalogue`
-            + (diagnostic ? ` — ${diagnostic.slice(-300)}` : " (the CLI gave no reason)"),
-          );
-          markStale();
-          return;
+        // What is NEW is only that a clean zero is written down as a COUNT
+        // (TASK-668). Under `models.mode: "replace"` the core skips the
+        // authenticated catalogue and `openclaw models list --provider google`
+        // genuinely lists nothing, and the surfaces need to know that to stop
+        // offering a connected provider whose every row the gateway refuses.
+        // It changes no freshness or backoff rule: this branch behaves exactly
+        // as it does on beta, and the record is an extra fact beside it.
+        //
+        // Generation-guarded like `publish` is, and for the same reason: a fork
+        // that started before a credential landed is answering about a box that
+        // no longer exists, and its zero would hide the provider the customer
+        // just connected.
+        if (emptyIsAnswer && forkSeq >= currentSeq(provider)) {
+          await recordProviderEnumeration(provider, 0);
         }
-        // A clean zero IS the answer: under `models.mode: "replace"` the core
-        // skips the authenticated catalogue and `openclaw models list
-        // --provider google` genuinely lists nothing (TASK-668). Recording it
-        // is what lets the Providers page and the picker stop offering a
-        // provider whose every row the gateway would refuse.
-        //
-        // Counted as an ANSWERED generation, and as a successful refresh, on
-        // purpose: this is the half the previous attempt at this card got
-        // wrong. Leaving the generation unanswered made the `.finally` below
-        // start a replacement immediately, and `markStale()` made the row
-        // permanently stale — together, a three-minute two-core enumeration
-        // per backoff window, for ever, over a provider that had already told
-        // us the truth.
-        recordSuccessfulRefresh(provider);
-        publishedSeq.set(provider, forkSeq);
-        await recordProviderEnumeration(provider, 0);
-        console.log(`[catalog] ${provider}: the box lists no models for it — recorded, nothing re-enumerated`);
+        console.warn(
+          `[catalog] ${provider}: live enumeration returned no models, keeping the previous catalogue`
+          + (diagnostic ? ` — ${diagnostic.slice(-300)}` : " (the CLI gave no reason)"),
+        );
+        markStale();
         return;
       }
       await publish(models, null);
@@ -1482,6 +1495,12 @@ export function refreshInBackground(
 export function notifyProviderSetChanged(ocProvider: string | null | undefined): void {
   if (!ocProvider) return;
   const catalogProvider = ocProvider === "deepseek" ? "clawai" : ocProvider;
+  // The recorded model COUNT is about the box as it was, and the box has just
+  // changed (TASK-668). Forgetting it is what makes a hidden row come back on
+  // the next render — a plan change, a model install, a key paste — without
+  // waiting for an enumeration that, for a hidden provider, nothing would ask
+  // for. It costs one small file write and starts nothing.
+  void forgetProviderEnumeration(catalogProvider);
   if (!isCatalogProvider(catalogProvider)) return;
   if (NO_CLI_ENUMERATION_PROVIDERS.has(catalogProvider)) return;
   refreshInBackground(catalogProvider, { providerChanged: true });

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -14,6 +14,7 @@ import {
   isNonChatModelId,
   subscriptionSurfaceProvider,
 } from "@/lib/provider-models";
+import { recordProviderEnumeration } from "@/lib/provider-runnable";
 
 export const dynamic = "force-dynamic";
 
@@ -989,6 +990,18 @@ interface CatalogFetchResult {
    * the command, else its stderr. Empty when it simply had nothing to list.
    */
   diagnostic: string;
+  /**
+   * True when an empty `models` is THE BOX'S ANSWER rather than a failure to
+   * get one — the CLI ran, refused nothing, printed nothing on stderr and
+   * listed no rows at all.
+   *
+   * The distinction is the whole false-failure guard for TASK-668: a refusal, a
+   * timeout, a plugin that is gone, or rows that our own chat-model filter ate
+   * all produce an empty list too, and recording any of them as "this box can
+   * run no <provider> model" would hide a provider that works. Only the clean
+   * zero is recorded, and only it stops the row being offered.
+   */
+  emptyIsAnswer: boolean;
 }
 
 function toFetchResult(
@@ -1020,7 +1033,10 @@ function toFetchResult(
       ? `all ${rows.length} listed rows report available: false (no route this box can take yet)`
       : `${rows.length} rows listed, none of them chat models this picker can offer`;
   }
-  return { models, diagnostic };
+  // A clean zero: the command ran, said nothing was wrong, and listed nothing.
+  // `diagnostic` is empty in exactly that case — a refusal or stderr fills it
+  // above, and rows that were all filtered out fill it just now.
+  return { models, diagnostic, emptyIsAnswer: models.length === 0 && !diagnostic };
 }
 
 function fetchOpenclawCatalog(provider: string): Promise<CatalogFetchResult> {
@@ -1108,7 +1124,10 @@ async function fetchOpenRouterCatalog(): Promise<CatalogFetchResult> {
     throw new Error(`openrouter ${res.status}`);
   }
   const data = (await res.json()) as OpenRouterListResponse;
-  return { models: transformOpenRouterEntries(data.data ?? []), diagnostic: "" };
+  // Never an authoritative empty: this is openrouter.ai's catalogue, not this
+  // box's answer about what it can route, and an empty `data` from a REST
+  // endpoint is far more likely to be a bad hour upstream than a fact.
+  return { models: transformOpenRouterEntries(data.data ?? []), diagnostic: "", emptyIsAnswer: false };
 }
 
 // Refresh the catalog for `provider` in the background. Returns
@@ -1283,7 +1302,7 @@ export function refreshInBackground(
     // The only catalogue with no upstream to ask: Mike's gateway routes the
     // two device tiers and nothing else, so these two rows ARE the device's
     // answer rather than a stand-in for one.
-    fetcher = Promise.resolve({ models: CLAWAI_STATIC_MODELS, diagnostic: "" });
+    fetcher = Promise.resolve({ models: CLAWAI_STATIC_MODELS, diagnostic: "", emptyIsAnswer: false });
   } else {
     fetcher = fetchOpenclawCatalog(provider);
   }
@@ -1334,6 +1353,12 @@ export function refreshInBackground(
     memCache.set(provider, payload);
     publishedSeq.set(provider, forkSeq);
     await writeDiskCache(provider, payload);
+    // What the box can run, for the surfaces that only need the COUNT (the
+    // Providers rows, the picker). Written from the published list rather than
+    // the raw one so it cannot disagree with what the picker is offered, and
+    // written on every publish so a provider that comes back from zero stops
+    // being hidden without anything else having to notice.
+    await recordProviderEnumeration(provider, payload.models.length);
     console.log(
       `[catalog] refreshed ${provider}: ${models.length} models`
       + (surfaceIds ? ` (${surfaceIds.size} on the subscription surface)` : ""),
@@ -1355,19 +1380,42 @@ export function refreshInBackground(
   };
 
   fetcher
-    .then(async ({ models, diagnostic }) => {
+    .then(async ({ models, diagnostic, emptyIsAnswer }) => {
       if (models.length === 0) {
-        // NOT a success. "[catalog] refreshed codex: 0 models" used to be
-        // followed by a disk write of the curated list, which then read back
-        // as a device answer — a false success in the exact shape this
-        // codebase keeps producing. An empty enumeration says the plugin is
-        // disabled, the provider id is gone, or the CLI failed silently; none
-        // of those are facts about what the box can run.
-        console.warn(
-          `[catalog] ${provider}: live enumeration returned no models, keeping the previous catalogue`
-          + (diagnostic ? ` — ${diagnostic.slice(-300)}` : " (the CLI gave no reason)"),
-        );
-        markStale();
+        // Still NOT a catalogue. Nothing is published and nothing is written to
+        // `<provider>.json` on either branch below — "[catalog] refreshed
+        // codex: 0 models" used to be followed by a disk write of the curated
+        // list, which then read back as a device answer.
+        //
+        // What splits the two branches is whether the box ANSWERED. A refusal,
+        // a plugin that is gone, or rows our own chat filter ate are failures:
+        // they keep beta's behaviour exactly — the previous catalogue stays and
+        // the backoff rations the retries.
+        if (!emptyIsAnswer) {
+          console.warn(
+            `[catalog] ${provider}: live enumeration returned no models, keeping the previous catalogue`
+            + (diagnostic ? ` — ${diagnostic.slice(-300)}` : " (the CLI gave no reason)"),
+          );
+          markStale();
+          return;
+        }
+        // A clean zero IS the answer: under `models.mode: "replace"` the core
+        // skips the authenticated catalogue and `openclaw models list
+        // --provider google` genuinely lists nothing (TASK-668). Recording it
+        // is what lets the Providers page and the picker stop offering a
+        // provider whose every row the gateway would refuse.
+        //
+        // Counted as an ANSWERED generation, and as a successful refresh, on
+        // purpose: this is the half the previous attempt at this card got
+        // wrong. Leaving the generation unanswered made the `.finally` below
+        // start a replacement immediately, and `markStale()` made the row
+        // permanently stale — together, a three-minute two-core enumeration
+        // per backoff window, for ever, over a provider that had already told
+        // us the truth.
+        recordSuccessfulRefresh(provider);
+        publishedSeq.set(provider, forkSeq);
+        await recordProviderEnumeration(provider, 0);
+        console.log(`[catalog] ${provider}: the box lists no models for it — recorded, nothing re-enumerated`);
         return;
       }
       await publish(models, null);

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -94,6 +94,7 @@ import {
 import { DISABLED_PROVIDERS_KEY, normalizeProviderId, parseDisabledProviders } from "@/lib/provider-status";
 import { setProviderEnabled } from "@/lib/provider-enablement";
 import { notifyProviderSetChanged } from "@/app/setup-api/ai-models/catalog/route";
+import { forgetProviderEnumerations } from "@/lib/provider-runnable";
 import {
   isClaudeSubscriptionOnly,
   offSurfaceClaudeModelMessage,
@@ -386,6 +387,23 @@ async function writeAuthProfiles(authProfiles: AuthProfilesFile) {
  * v2 — and updates the openclaw.json metadata itself. The key rides stdin,
  * never argv.
  */
+/**
+ * `models.mode` as openclaw.json carries it, or null when there is none to read.
+ *
+ * Null on the Hermes SKU (no OpenClaw config at all) and on an unreadable one,
+ * which is why the caller compares two reads rather than testing a value: two
+ * nulls are "nothing changed", the honest answer in both cases.
+ */
+async function readModelsMode(): Promise<string | null> {
+  if (openclawIsAbsent()) return null;
+  try {
+    const mode = (await readOpenClawConfig())?.models?.mode;
+    return typeof mode === "string" ? mode : null;
+  } catch {
+    return null;
+  }
+}
+
 async function pasteAuthApiKey(provider: string, profileId: string, key: string): Promise<void> {
   // The sign-in guard is NOT here, deliberately: see `assertNoSignInAt`. By
   // the time this runs the request has already written its own
@@ -1940,6 +1958,15 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     // key; the auth mode is what tells the two apart from here on.
     const isChatgptSubscription = authMode === "subscription" && ocProvider === CHATGPT_PROVIDER;
 
+    // `models.mode` as it was BEFORE this save. Six branches below write it —
+    // the ClawBox AI pass, the two local-model passes, the cloud-transport
+    // paths — and under `replace` the core skips the authenticated catalogue
+    // for EVERY provider, so a flip changes what the gateway will route far
+    // beyond the provider being saved. Captured once here and compared once at
+    // step 8d rather than threaded through each branch, so a branch added
+    // later cannot forget it (TASK-668).
+    const modelsModeBefore = await readModelsMode();
+
     // BEFORE anything is written, and before this request has put anything of
     // its own in the store — a refusal is not a failure and must not leave a
     // trail, and by the time the save reaches the paste it has unpaired
@@ -3081,6 +3108,17 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     //     backoff it recorded describe a box that no longer exists. A client's
     //     `?refresh=1` cannot count it; only a write can.
     notifyProviderSetChanged(ocProvider);
+
+    // 8d. Did this save flip `models.mode`? Then every recorded model COUNT was
+    //     taken under a rule that no longer holds — under `replace` the core
+    //     serves the configured rows alone, which is how google goes from ten
+    //     models to none — so none of them may keep a Providers row hidden.
+    //     Forgetting them shows every row again at once, at the cost of one
+    //     small file write and no enumeration at all; each provider records the
+    //     new truth on the next refresh that happens for its own reasons.
+    //     Compared against the config as it is NOW, so a write that did not
+    //     land counts for nothing.
+    if ((await readModelsMode()) !== modelsModeBefore) await forgetProviderEnumerations();
 
     // Codex 2026.6.x reads its ChatGPT session from the Codex CLI's own
     // ~/.codex/auth.json, which gateway-pre-start.sh synthesizes from this

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -844,28 +844,53 @@ const WRONG_STORE = {
  * cannot disagree about who is offered. Nothing recorded is `unknown`, and an
  * unknown provider keeps its option exactly as on beta.
  *
- * OFFERED, not accepted: this runs on the READ path only. A POST naming such a
- * model is still judged by the catalogue guards it always was, so a verdict
- * that is somehow wrong costs a row in a dropdown and never a refusal over a
- * model the gateway would have routed.
+ * OFFERED, not accepted, and only on the picker's own read: a POST naming such
+ * a model is judged by the catalogue guards it always was, so a verdict that is
+ * somehow wrong costs a row in a dropdown and never a refusal over a model the
+ * gateway would have routed. `/setup-api/providers/default` resolves its target
+ * through this same handler, which is why the filter is applied to the RESPONSE
+ * in `GET` rather than inside `loadChatModelState` — that route reads the
+ * unfiltered state and a hidden row stays promotable.
  *
- * The active model is exempt: it is what the header pill names, and an option
- * list that omits it leaves the chat showing a model that is in no list.
+ * Two exemptions, both matching the Providers page's:
+ *  * the provider the box is pointed at — a broken default must stay visible;
+ *  * the model the chat is running — the header pill names it, and an option
+ *    list without it shows a model that is in no list.
+ *
+ * And one refusal to act: if every cloud option would go, none does. A picker
+ * holding only "Local AI" and no way into provider setup is worse than one
+ * offering a row the gateway may refuse.
  */
-async function withoutUnrunnableProviders(
+function withoutUnrunnableProviders(
   state: Awaited<ReturnType<typeof loadChatModelState>>,
-): Promise<Awaited<ReturnType<typeof loadChatModelState>>> {
-  const verdicts = await readProviderRunnable().catch(
-    () => new Map<string, ProviderRunnable>(),
-  );
+  verdicts: Map<string, ProviderRunnable>,
+): Awaited<ReturnType<typeof loadChatModelState>> {
   if (verdicts.size === 0) return state;
+  const defaultProvider = normalizeProviderId(state.primary.provider);
   const options = state.options.filter((option) => {
     if (option.model && option.model === state.activeModel) return true;
     const canonical = normalizeProviderId(option.provider);
     if (!canonical) return true;
+    if (canonical === defaultProvider) return true;
     return providerRowRunnable(canonical, verdicts) !== "none";
   });
-  return options.length === state.options.length ? state : { ...state, options };
+  if (options.length === state.options.length) return state;
+  if (!options.some((option) => !option.isLocal && option.model)) return state;
+  return { ...state, options };
+}
+
+/**
+ * The picker state BEFORE the unrunnable filter above.
+ *
+ * For `/setup-api/providers/default`, which resolves "make this one the
+ * default" through the same state the header reads. Hiding a row is about what
+ * is OFFERED; promoting a provider the owner names is an explicit instruction,
+ * and answering it "provider_unconfigured" over a provider that is connected
+ * would be a false failure of exactly the kind this repo keeps producing. The
+ * write it goes on to make is judged by the catalogue guards either way.
+ */
+export function readChatModelStateUnfiltered(): ReturnType<typeof loadChatModelState> {
+  return loadChatModelState();
 }
 
 export async function GET() {
@@ -873,7 +898,10 @@ export async function GET() {
     return NextResponse.json(WRONG_STORE, { status: 409, headers: { "Cache-Control": "no-store" } });
   }
   try {
-    const state = await withoutUnrunnableProviders(await loadChatModelState());
+    const verdicts = await readProviderRunnable().catch(
+      () => new Map<string, ProviderRunnable>(),
+    );
+    const state = withoutUnrunnableProviders(await loadChatModelState(), verdicts);
     return NextResponse.json(state, {
       headers: { "Cache-Control": "no-store" },
     });

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -31,7 +31,13 @@ import {
   isValidModelId,
   parseModelSlug,
 } from "@/lib/provider-models";
-import { DISABLED_PROVIDERS_KEY, normalizeProviderId, parseDisabledProviders } from "@/lib/provider-status";
+import {
+  DISABLED_PROVIDERS_KEY,
+  normalizeProviderId,
+  parseDisabledProviders,
+  providerRowRunnable,
+} from "@/lib/provider-status";
+import { readProviderRunnable, type ProviderRunnable } from "@/lib/provider-runnable";
 import { isClawboxAiImageModelId, isClawboxAiImageModelRef } from "@/lib/clawbox-ai-models";
 import {
   CHATGPT_AGENT_RUNTIME_ID,
@@ -830,12 +836,44 @@ const WRONG_STORE = {
   code: "wrong_store",
 } as const;
 
+/**
+ * Drop the options for a provider this box can run NO model from (TASK-668).
+ *
+ * The same verdict the Providers page hides its row on, read from the same
+ * recorded enumeration — one file read, no probe, no fork — so the two surfaces
+ * cannot disagree about who is offered. Nothing recorded is `unknown`, and an
+ * unknown provider keeps its option exactly as on beta.
+ *
+ * OFFERED, not accepted: this runs on the READ path only. A POST naming such a
+ * model is still judged by the catalogue guards it always was, so a verdict
+ * that is somehow wrong costs a row in a dropdown and never a refusal over a
+ * model the gateway would have routed.
+ *
+ * The active model is exempt: it is what the header pill names, and an option
+ * list that omits it leaves the chat showing a model that is in no list.
+ */
+async function withoutUnrunnableProviders(
+  state: Awaited<ReturnType<typeof loadChatModelState>>,
+): Promise<Awaited<ReturnType<typeof loadChatModelState>>> {
+  const verdicts = await readProviderRunnable().catch(
+    () => new Map<string, ProviderRunnable>(),
+  );
+  if (verdicts.size === 0) return state;
+  const options = state.options.filter((option) => {
+    if (option.model && option.model === state.activeModel) return true;
+    const canonical = normalizeProviderId(option.provider);
+    if (!canonical) return true;
+    return providerRowRunnable(canonical, verdicts) !== "none";
+  });
+  return options.length === state.options.length ? state : { ...state, options };
+}
+
 export async function GET() {
   if (!(await chatModelLivesHere())) {
     return NextResponse.json(WRONG_STORE, { status: 409, headers: { "Cache-Control": "no-store" } });
   }
   try {
-    const state = await loadChatModelState();
+    const state = await withoutUnrunnableProviders(await loadChatModelState());
     return NextResponse.json(state, {
       headers: { "Cache-Control": "no-store" },
     });

--- a/src/app/setup-api/providers/default/route.ts
+++ b/src/app/setup-api/providers/default/route.ts
@@ -7,6 +7,7 @@ import { isProviderEnabled } from "@/lib/provider-enablement";
 import { POST as setHermesPairing } from "@/app/setup-api/hermes/models/route";
 import {
   GET as readChatModelState,
+  readChatModelStateUnfiltered,
   POST as setChatModel,
 } from "@/app/setup-api/chat/model/route";
 
@@ -92,9 +93,19 @@ export async function POST(request: Request) {
   const state = (await stateRes.json().catch(() => ({}))) as {
     options?: { provider?: string; model?: string | null; available?: boolean }[];
   };
-  const option = (state.options ?? []).find(
-    (candidate) => candidate.provider === provider && candidate.available && candidate.model,
-  );
+  const matches = (
+    candidate: { provider?: string | null; model?: string | null; available?: boolean },
+  ): boolean => candidate.provider === provider && !!candidate.available && !!candidate.model;
+  let option: { model?: string | null } | undefined = (state.options ?? []).find(matches);
+  if (!option?.model) {
+    // The picker drops a provider this box can run no model from (TASK-668).
+    // That is about what is OFFERED — the owner naming one here is an explicit
+    // instruction, and "provider_unconfigured" over a provider that holds a
+    // working credential would be a false failure. The write below is judged by
+    // the same catalogue guards either way.
+    const unfiltered = await readChatModelStateUnfiltered();
+    option = unfiltered.options.find(matches);
+  }
   if (!option?.model) {
     // Not "unknown provider" — the provider is known, it just has no credential
     // on this box yet, and the fix is to connect it rather than to retry.

--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -636,6 +636,15 @@ export default function AIModelsStep({
     () => providerStatus?.providers.find((row) => row.isDefault) ?? null,
     [providerStatus],
   );
+  // Providers this box can run NO model from (TASK-668). The server decides —
+  // this is the same list the Providers strip's rows were dropped from — so the
+  // two halves of the same Settings section cannot offer different providers.
+  // Absent, or a status call that has not landed, is an EMPTY set: nothing is
+  // hidden until the box has actually said so.
+  const unrunnableProviders = useMemo(
+    () => new Set(providerStatus?.unrunnable ?? []),
+    [providerStatus],
+  );
   /** A row's connection state, as a dot AND a word. */
   const rowStatus = useCallback((id: string) => {
     const row = statusById.get(id);
@@ -2065,7 +2074,8 @@ export default function AIModelsStep({
     return () => clearTimeout(timer);
   }, [configuringState?.completed, handleConfiguringDone]);
 
-  const baseProviders = providerIdSet ? allowedProviders : PROVIDERS;
+  const baseProviders = (providerIdSet ? allowedProviders : PROVIDERS)
+    .filter((provider) => !unrunnableProviders.has(provider.id));
   // The list opens on the provider that is actually in play and keeps the rest
   // one tap behind the same toggle that used to reveal only the secondary
   // ones. Four rows plus that toggle is ~350px of catalogue standing on top of

--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -2075,7 +2075,12 @@ export default function AIModelsStep({
   }, [configuringState?.completed, handleConfiguringDone]);
 
   const baseProviders = (providerIdSet ? allowedProviders : PROVIDERS)
-    .filter((provider) => !unrunnableProviders.has(provider.id));
+    // The SELECTED row is never dropped. Everything else in this component that
+    // decides what to render — the "keep the selection valid" effect, the
+    // credential panel, the deep-link handler — resolves against the unfiltered
+    // list, so removing the selected row would leave its form on screen with no
+    // radio above it and no "show more" toggle to get back.
+    .filter((provider) => provider.id === selectedProvider || !unrunnableProviders.has(provider.id));
   // The list opens on the provider that is actually in play and keeps the rest
   // one tap behind the same toggle that used to reveal only the secondary
   // ones. Four rows plus that toggle is ~350px of catalogue standing on top of

--- a/src/lib/provider-enablement.ts
+++ b/src/lib/provider-enablement.ts
@@ -70,10 +70,16 @@ export async function setProviderEnabled(id: string, enabled: boolean): Promise<
   const status = await readProviderStatus();
   const canonical = canonicalProviderId(status.harness, id);
   const row = canonical ? status.providers.find((candidate) => candidate.id === canonical) : undefined;
-  if (!row || !canonical) {
+  // A provider dropped from the rows because this box can run no model from it
+  // (TASK-668) is still perfectly well known here, and its switch still has to
+  // flip: the strip hides the row, it does not forget the provider. Answering
+  // "not known to this box" for one would be a false failure — and would leave
+  // whatever the switch was last set to stuck for good.
+  const hidden = !row && !!canonical && status.unrunnable.includes(canonical);
+  if ((!row && !hidden) || !canonical) {
     return { ok: false, kind: "unknown_provider", error: "That AI provider is not known to this box." };
   }
-  if (!enabled && row.isDefault) {
+  if (!enabled && row?.isDefault) {
     return { ok: false, kind: "is_default", error: "Make another provider the default first." };
   }
 

--- a/src/lib/provider-runnable.ts
+++ b/src/lib/provider-runnable.ts
@@ -1,0 +1,158 @@
+// "Can this box run any model from provider X?" — answered from what the box
+// has already been told, and from nothing else.
+//
+// WHY IT EXISTS (TASK-668). `models.mode: "replace"` — which a local-model save
+// at primary scope writes — makes the core skip the authenticated catalogue for
+// EVERY provider. Measured on a box, `openclaw models list --provider <p> --all
+// --json | jq .count` before and after the flip: anthropic 15 -> 9, openai
+// 30 -> 2, google 10 -> **0**. A provider at zero is not "not connected yet":
+// there is no model to pick, so a Providers row for it offers a key entry whose
+// only outcome is a picker the gateway refuses. The owner's ruling is to hide
+// such a row, and to keep it exactly as today for a box that can run at least
+// one of that provider's models.
+//
+// WHAT THIS MODULE MAY NOT DO. It never probes and never forks. `openclaw
+// models list` costs about three minutes on a Jetson, and the whole reason the
+// obvious version of this fix was refused is that it bought a permanent `stale`
+// flag plus one fork per backoff window. The count read here is recorded by the
+// enumeration the catalog route ALREADY runs (boot warmup, a picker open, the
+// six-hour interval); this module only reads the file that route writes.
+//
+// THE ONE RULE. Only a definite count decides anything. No record, an
+// unreadable record, a record for another provider — all of that is UNKNOWN,
+// and unknown keeps the row. Hiding a provider on an answer nobody gave is the
+// false failure this codebase keeps producing, and it would delete a working
+// provider from the only screen that can fix it.
+
+import { promises as fsp } from "fs";
+import path from "path";
+import { DATA_DIR } from "@/lib/config-store";
+
+/**
+ * Beside the catalogues it is derived from, and named so it can never collide
+ * with a `<provider>.json`: no provider id may start with an underscore
+ * (`CATALOG_PROVIDERS` is the closed set the route validates against).
+ *
+ * Counts and provider ids only — the directory is public-servable
+ * (`DATA_DIR_PUBLIC_SUBTREES`), and nothing here is a credential.
+ */
+const RECORD_PATH = path.join(DATA_DIR, "catalog-cache", "_enumerations.json");
+
+/** What the last enumeration for a provider answered. */
+interface EnumerationRecord {
+  /** How many models the box listed. Zero is an ANSWER, not a failure. */
+  models: number;
+  atMs: number;
+}
+
+interface RecordFile {
+  providers?: Record<string, EnumerationRecord>;
+}
+
+/**
+ * How many models this box can run for a provider, as far as it knows.
+ *
+ *  * `some`    — an enumeration answered with rows.
+ *  * `none`    — an enumeration answered with nothing. The row is hidden.
+ *  * `unknown` — nobody has asked, or the answer could not be read. The row
+ *                stays, unchanged from beta.
+ */
+export type ProviderRunnable = "some" | "none" | "unknown";
+
+/**
+ * Writes are serialised through this chain.
+ *
+ * Two refreshes can finish within the same tick (the main enumeration and the
+ * subscription-surface one), and a read-modify-write pair interleaved with
+ * another would drop the loser's provider. One Next process owns this file —
+ * the catalog route is its only writer — so an in-process chain is the whole
+ * of the problem; there is no second writer to lock against.
+ */
+let writeChain: Promise<void> = Promise.resolve();
+
+async function readRecordFile(): Promise<Record<string, EnumerationRecord>> {
+  try {
+    const parsed = JSON.parse(await fsp.readFile(RECORD_PATH, "utf8")) as RecordFile;
+    const providers = parsed?.providers;
+    if (!providers || typeof providers !== "object") return {};
+    return providers;
+  } catch {
+    // Absent, unreadable, half-written, hand-edited to nonsense: all of them
+    // are "we do not know", and the caller's default is to show every row.
+    return {};
+  }
+}
+
+async function mutate(fn: (providers: Record<string, EnumerationRecord>) => void): Promise<void> {
+  const next = writeChain.then(async () => {
+    const providers = await readRecordFile();
+    fn(providers);
+    const tmp = `${RECORD_PATH}.${process.pid}.tmp`;
+    await fsp.mkdir(path.dirname(RECORD_PATH), { recursive: true });
+    await fsp.writeFile(tmp, JSON.stringify({ providers }), "utf8");
+    await fsp.rename(tmp, RECORD_PATH);
+  }).catch((err: unknown) => {
+    // A record we could not write costs a row that stays visible, which is the
+    // safe direction. It must never take the refresh that produced it down.
+    console.warn(
+      "[provider-runnable] could not record the enumeration:",
+      err instanceof Error ? err.message : err,
+    );
+  });
+  writeChain = next;
+  return next;
+}
+
+/**
+ * Record what an enumeration answered for `provider`.
+ *
+ * Called by the catalog route only, and only for an answer the CLI actually
+ * gave: a refusal, a timeout, or a payload whose rows were all filtered out by
+ * our own chat-model rule is NOT an answer and must not reach here.
+ */
+export function recordProviderEnumeration(provider: string, models: number): Promise<void> {
+  return mutate((providers) => {
+    providers[provider] = { models: Math.max(0, Math.trunc(models)), atMs: Date.now() };
+  });
+}
+
+/**
+ * Forget every recorded count.
+ *
+ * `models.mode` decides what a catalogue MEANS — under `replace` the core
+ * skips the authenticated rows for every provider at once — so a flip
+ * invalidates every count taken under the old mode. Forgetting is the whole
+ * response: every row comes straight back (`unknown` shows), nothing is
+ * re-enumerated, and the next refresh that happens for its own reasons records
+ * the new truth. Marking the catalogues behind-generation instead is what the
+ * owner refused: it buys a fork per provider, three minutes each.
+ */
+export function forgetProviderEnumerations(): Promise<void> {
+  return mutate((providers) => {
+    for (const key of Object.keys(providers)) delete providers[key];
+  });
+}
+
+/**
+ * The verdict for every provider the box has an answer for.
+ *
+ * One file read per call, deliberately not memoised: the callers are a
+ * 30-second status poll and a picker load, and a cached verdict would keep a
+ * hidden row hidden after the enumeration that brings it back.
+ */
+export async function readProviderRunnable(): Promise<Map<string, ProviderRunnable>> {
+  const providers = await readRecordFile();
+  const verdicts = new Map<string, ProviderRunnable>();
+  for (const [provider, record] of Object.entries(providers)) {
+    if (typeof record?.models !== "number" || !Number.isFinite(record.models)) continue;
+    verdicts.set(provider, record.models > 0 ? "some" : "none");
+  }
+  return verdicts;
+}
+
+/**
+ * The verdict for one provider — `unknown` unless the box has a count for it.
+ */
+export async function providerRunnable(provider: string): Promise<ProviderRunnable> {
+  return (await readProviderRunnable()).get(provider) ?? "unknown";
+}

--- a/src/lib/provider-runnable.ts
+++ b/src/lib/provider-runnable.ts
@@ -35,8 +35,16 @@ import { DATA_DIR } from "@/lib/config-store";
  *
  * Counts and provider ids only — the directory is public-servable
  * (`DATA_DIR_PUBLIC_SUBTREES`), and nothing here is a credential.
+ *
+ * Resolved per call, and null rather than thrown when there is no data
+ * directory to resolve it against. A module-level `path.join` on an undefined
+ * root throws AT IMPORT, which would take down every route that transitively
+ * imports the Providers strip — the opposite of what a file whose absence is
+ * supposed to mean "we do not know" may do.
  */
-const RECORD_PATH = path.join(DATA_DIR, "catalog-cache", "_enumerations.json");
+function recordPath(): string | null {
+  return DATA_DIR ? path.join(DATA_DIR, "catalog-cache", "_enumerations.json") : null;
+}
 
 /** What the last enumeration for a provider answered. */
 interface EnumerationRecord {
@@ -71,8 +79,10 @@ export type ProviderRunnable = "some" | "none" | "unknown";
 let writeChain: Promise<void> = Promise.resolve();
 
 async function readRecordFile(): Promise<Record<string, EnumerationRecord>> {
+  const file = recordPath();
+  if (!file) return {};
   try {
-    const parsed = JSON.parse(await fsp.readFile(RECORD_PATH, "utf8")) as RecordFile;
+    const parsed = JSON.parse(await fsp.readFile(file, "utf8")) as RecordFile;
     const providers = parsed?.providers;
     if (!providers || typeof providers !== "object") return {};
     return providers;
@@ -85,12 +95,14 @@ async function readRecordFile(): Promise<Record<string, EnumerationRecord>> {
 
 async function mutate(fn: (providers: Record<string, EnumerationRecord>) => void): Promise<void> {
   const next = writeChain.then(async () => {
+    const file = recordPath();
+    if (!file) return;
     const providers = await readRecordFile();
     fn(providers);
-    const tmp = `${RECORD_PATH}.${process.pid}.tmp`;
-    await fsp.mkdir(path.dirname(RECORD_PATH), { recursive: true });
+    const tmp = `${file}.${process.pid}.tmp`;
+    await fsp.mkdir(path.dirname(file), { recursive: true });
     await fsp.writeFile(tmp, JSON.stringify({ providers }), "utf8");
-    await fsp.rename(tmp, RECORD_PATH);
+    await fsp.rename(tmp, file);
   }).catch((err: unknown) => {
     // A record we could not write costs a row that stays visible, which is the
     // safe direction. It must never take the refresh that produced it down.

--- a/src/lib/provider-runnable.ts
+++ b/src/lib/provider-runnable.ts
@@ -197,10 +197,3 @@ export async function readProviderRunnable(): Promise<Map<string, ProviderRunnab
   }
   return verdicts;
 }
-
-/**
- * The verdict for one provider — `unknown` unless the box has a count for it.
- */
-export async function providerRunnable(provider: string): Promise<ProviderRunnable> {
-  return (await readProviderRunnable()).get(provider) ?? "unknown";
-}

--- a/src/lib/provider-runnable.ts
+++ b/src/lib/provider-runnable.ts
@@ -14,9 +14,10 @@
 // WHAT THIS MODULE MAY NOT DO. It never probes and never forks. `openclaw
 // models list` costs about three minutes on a Jetson, and the whole reason the
 // obvious version of this fix was refused is that it bought a permanent `stale`
-// flag plus one fork per backoff window. The count read here is recorded by the
-// enumeration the catalog route ALREADY runs (boot warmup, a picker open, the
-// six-hour interval); this module only reads the file that route writes.
+// flag plus one fork per backoff window. The count read here is recorded by an
+// enumeration the catalog route was ALREADY going to run — its boot warmup, or
+// a picker open — and that route's freshness and backoff rules are untouched by
+// it. This module only reads the file that route writes.
 //
 // THE ONE RULE. Only a definite count decides anything. No record, an
 // unreadable record, a record for another provider — all of that is UNKNOWN,
@@ -129,6 +130,20 @@ export function recordProviderEnumeration(provider: string, models: number): Pro
 }
 
 /**
+ * Forget one provider's count, because the BOX changed under it.
+ *
+ * Called from `notifyProviderSetChanged` — a key pasted, a plugin switched on,
+ * a plan changed — where the number stops describing anything before the next
+ * enumeration can say what replaced it. Nothing is started here: the row simply
+ * goes back to `unknown` and is shown.
+ */
+export function forgetProviderEnumeration(provider: string): Promise<void> {
+  return mutate((providers) => {
+    delete providers[provider];
+  });
+}
+
+/**
  * Forget every recorded count.
  *
  * `models.mode` decides what a catalogue MEANS — under `replace` the core
@@ -146,7 +161,20 @@ export function forgetProviderEnumerations(): Promise<void> {
 }
 
 /**
- * The verdict for every provider the box has an answer for.
+ * How long a recorded count is still a fact about this box.
+ *
+ * The catalog route's own freshness interval, and the same argument: past it,
+ * the enumeration behind the number is old enough that the route would re-ask
+ * before serving it. It matters most in one direction — a row hidden by a
+ * count nothing has refreshed since comes BACK rather than staying gone, and
+ * the picker open that follows is what re-enumerates it. Every other path that
+ * brings a row back is an event (`notifyProviderSetChanged`, a `models.mode`
+ * flip); this is the one that needs no event at all.
+ */
+const RECORD_TTL_MS = 6 * 60 * 60_000;
+
+/**
+ * The verdict for every provider the box has a CURRENT answer for.
  *
  * One file read per call, deliberately not memoised: the callers are a
  * 30-second status poll and a picker load, and a cached verdict would keep a
@@ -155,8 +183,16 @@ export function forgetProviderEnumerations(): Promise<void> {
 export async function readProviderRunnable(): Promise<Map<string, ProviderRunnable>> {
   const providers = await readRecordFile();
   const verdicts = new Map<string, ProviderRunnable>();
+  const now = Date.now();
   for (const [provider, record] of Object.entries(providers)) {
     if (typeof record?.models !== "number" || !Number.isFinite(record.models)) continue;
+    // A clock that jumped backwards makes `now - atMs` negative, which is not
+    // "expired" — an unusable stamp is treated as expired instead, the side
+    // that shows the row.
+    const ageMs = typeof record.atMs === "number" && Number.isFinite(record.atMs)
+      ? now - record.atMs
+      : Number.POSITIVE_INFINITY;
+    if (ageMs > RECORD_TTL_MS) continue;
     verdicts.set(provider, record.models > 0 ? "some" : "none");
   }
   return verdicts;

--- a/src/lib/provider-status.ts
+++ b/src/lib/provider-status.ts
@@ -27,6 +27,7 @@ import {
 } from "@/lib/hermes-providers";
 import { getModelOptions, probeStillOwed } from "@/lib/hermes-model-options";
 import { readPluginRepairs, repairFor, type PluginRepairStage } from "@/lib/plugin-repair";
+import { readProviderRunnable, type ProviderRunnable } from "@/lib/provider-runnable";
 
 /**
  * What the strip paints, and the only five things it may say.
@@ -102,6 +103,17 @@ export interface ProviderStatusSummary {
   providers: ProviderStatusRow[];
   /** The default provider's id, or null when the box has none yet. */
   defaultProvider: string | null;
+  /**
+   * Provider ids dropped from `providers` because this box can run NO model
+   * from them — the owner's ruling on TASK-668, and the only reason a curated
+   * row ever goes missing.
+   *
+   * Carried rather than left implicit because "absent" and "the summary could
+   * not be built" look the same to a client, and a second surface that renders
+   * its own hard-coded provider list (the Connect panel) has to be able to tell
+   * them apart: an empty array means every row it knows about may be shown.
+   */
+  unrunnable: string[];
   /**
    * True when the answer came from a fallback rather than from the live box —
    * a Hermes dashboard that did not respond, or an unreadable config. The strip
@@ -192,7 +204,7 @@ function sectionFor(id: string): "ai" | "localAi" {
 
 /** A row before the owner's switch is stamped on it; see `readProviderStatus`. */
 type UnstampedRow = Omit<ProviderStatusRow, "enabled">;
-interface UnstampedSummary extends Omit<ProviderStatusSummary, "providers"> {
+interface UnstampedSummary extends Omit<ProviderStatusSummary, "providers" | "unrunnable"> {
   providers: UnstampedRow[];
 }
 
@@ -412,6 +424,28 @@ async function readOpenclawStatus(): Promise<UnstampedSummary> {
 }
 
 /**
+ * "Can this box run any model from the provider this ROW stands for?"
+ *
+ * The verdicts are keyed by CATALOGUE provider, and a row can stand for more
+ * than one: `codex` — the ChatGPT-subscription catalogue — folds onto the
+ * `openai` row. So the row is only written off when every catalogue behind it
+ * says the same thing, and one that can still run something keeps it. Nothing
+ * recorded at all is `unknown`, which shows the row.
+ */
+function rowRunnable(
+  rowId: string,
+  verdicts: Map<string, ProviderRunnable>,
+): ProviderRunnable {
+  let sawNone = false;
+  for (const [catalogueProvider, verdict] of verdicts) {
+    if (normalizeProviderId(catalogueProvider) !== rowId) continue;
+    if (verdict === "some") return "some";
+    if (verdict === "none") sawNone = true;
+  }
+  return sawNone ? "none" : "unknown";
+}
+
+/**
  * The aggregate, for whichever harness this box runs.
  *
  * Never throws: a box that cannot answer reports `degraded` with no rows,
@@ -433,9 +467,30 @@ export async function readProviderStatus(): Promise<ProviderStatusSummary> {
     // readers from having to know about it at all. On Hermes the file never
     // exists and this is an empty map, so the badge is absent by construction.
     const repairs = await readPluginRepairs();
+    // TASK-668, the owner's ruling: a provider this box can run NO model from
+    // is not offered at all. The verdict is read from what the enumeration the
+    // catalog route already performs recorded — no probe, no fork — and a
+    // provider with no recorded answer keeps its row exactly as on beta.
+    //
+    // OpenClaw only. Hermes' rows carry a `total` from the dashboard, but a
+    // zero there is documented (see `providerHasModels` in
+    // hermes-model-options.ts) as "credentialed and its /v1/models could not be
+    // enumerated" as often as "serves nothing" — the two are indistinguishable
+    // under `include_unconfigured=true`, so hiding on it would delete a working
+    // provider. Hermes keeps every panel row until that answer exists.
+    const verdicts = summary.harness === "openclaw"
+      ? await readProviderRunnable().catch(() => new Map<string, ProviderRunnable>())
+      : new Map<string, ProviderRunnable>();
+    const unrunnable = summary.providers
+      // The provider the box is POINTED AT is never hidden. It is the reason
+      // chat is broken, and a row nobody can see is a row nobody can change.
+      .filter((row) => !row.isDefault && rowRunnable(row.id, verdicts) === "none")
+      .map((row) => row.id);
+    const hidden = new Set(unrunnable);
     return {
       ...summary,
-      providers: summary.providers.map((row) => {
+      unrunnable,
+      providers: summary.providers.filter((row) => !hidden.has(row.id)).map((row) => {
         const repair = repairFor(repairs, row.id);
         return {
           ...row,
@@ -454,6 +509,6 @@ export async function readProviderStatus(): Promise<ProviderStatusSummary> {
       }),
     };
   } catch {
-    return { harness, providers: [], defaultProvider: null, degraded: true };
+    return { harness, providers: [], defaultProvider: null, unrunnable: [], degraded: true };
   }
 }

--- a/src/lib/provider-status.ts
+++ b/src/lib/provider-status.ts
@@ -432,7 +432,7 @@ async function readOpenclawStatus(): Promise<UnstampedSummary> {
  * says the same thing, and one that can still run something keeps it. Nothing
  * recorded at all is `unknown`, which shows the row.
  */
-function rowRunnable(
+export function providerRowRunnable(
   rowId: string,
   verdicts: Map<string, ProviderRunnable>,
 ): ProviderRunnable {
@@ -484,7 +484,7 @@ export async function readProviderStatus(): Promise<ProviderStatusSummary> {
     const unrunnable = summary.providers
       // The provider the box is POINTED AT is never hidden. It is the reason
       // chat is broken, and a row nobody can see is a row nobody can change.
-      .filter((row) => !row.isDefault && rowRunnable(row.id, verdicts) === "none")
+      .filter((row) => !row.isDefault && providerRowRunnable(row.id, verdicts) === "none")
       .map((row) => row.id);
     const hidden = new Set(unrunnable);
     return {

--- a/src/lib/provider-status.ts
+++ b/src/lib/provider-status.ts
@@ -424,23 +424,44 @@ async function readOpenclawStatus(): Promise<UnstampedSummary> {
 }
 
 /**
+ * The catalogues that answer for one ROW.
+ *
+ * A row can stand for more than one: `codex` — the ChatGPT-subscription
+ * catalogue — normalises onto the `openai` row, and a box signed in to ChatGPT
+ * with no API key runs on the one while the other has nothing.
+ */
+const CATALOGUES_BY_ROW: ReadonlyMap<string, readonly string[]> = new Map(
+  Object.entries({
+    clawai: ["clawai"],
+    openai: ["openai", "codex"],
+    anthropic: ["anthropic"],
+    google: ["google"],
+    openrouter: ["openrouter"],
+  }),
+);
+
+/**
  * "Can this box run any model from the provider this ROW stands for?"
  *
- * The verdicts are keyed by CATALOGUE provider, and a row can stand for more
- * than one: `codex` — the ChatGPT-subscription catalogue — folds onto the
- * `openai` row. So the row is only written off when every catalogue behind it
- * says the same thing, and one that can still run something keeps it. Nothing
- * recorded at all is `unknown`, which shows the row.
+ * `none` demands UNANIMITY, and every catalogue behind the row must actually
+ * have answered: one `some` keeps the row, and so does one that nobody has
+ * asked about. That is what stops a ChatGPT-subscription box losing its OpenAI
+ * row because the API-key catalogue is empty — and, since `codex` has no
+ * enumeration on this core at all (`hasNoEnumerationOnThisCore` in the catalog
+ * route), it means the OpenAI row is never hidden today. Deliberate: the
+ * alternative is hiding the row a subscription box actually runs on.
  */
 export function providerRowRunnable(
   rowId: string,
   verdicts: Map<string, ProviderRunnable>,
 ): ProviderRunnable {
+  const catalogues = CATALOGUES_BY_ROW.get(rowId) ?? [rowId];
   let sawNone = false;
-  for (const [catalogueProvider, verdict] of verdicts) {
-    if (normalizeProviderId(catalogueProvider) !== rowId) continue;
+  for (const catalogue of catalogues) {
+    const verdict = verdicts.get(catalogue);
     if (verdict === "some") return "some";
     if (verdict === "none") sawNone = true;
+    else return "unknown";
   }
   return sawNone ? "none" : "unknown";
 }
@@ -482,9 +503,24 @@ export async function readProviderStatus(): Promise<ProviderStatusSummary> {
       ? await readProviderRunnable().catch(() => new Map<string, ProviderRunnable>())
       : new Map<string, ProviderRunnable>();
     const unrunnable = summary.providers
-      // The provider the box is POINTED AT is never hidden. It is the reason
-      // chat is broken, and a row nobody can see is a row nobody can change.
-      .filter((row) => !row.isDefault && providerRowRunnable(row.id, verdicts) === "none")
+      .filter((row) => {
+        // A row the owner has NOT connected is never hidden, whatever the
+        // count says — that row IS the fix. Connecting a cloud provider writes
+        // its configured model rows and `models.mode: "merge"`
+        // (`writeOpenAICompatProvider` in the configure route), which is
+        // exactly what turns a zero-row provider back into a routable one, so
+        // hiding it would leave the box with no way out of the state that hid
+        // it. What this hides is the other case: a provider the box IS set up
+        // for and still cannot run a single model from.
+        if (row.state !== "connected" && row.state !== "needs-reauth") return false;
+        // The provider the box is POINTED AT is never hidden. It is the reason
+        // chat is broken, and a row nobody can see is a row nobody can change.
+        if (row.isDefault) return false;
+        // Nor is one whose plugin the boot script had to switch off: that row
+        // carries the Retry, the single affordance that repairs it (TASK-606).
+        if (repairFor(repairs, row.id)) return false;
+        return providerRowRunnable(row.id, verdicts) === "none";
+      })
       .map((row) => row.id);
     const hidden = new Set(unrunnable);
     return {

--- a/src/tests/components/ai-models-step.test.tsx
+++ b/src/tests/components/ai-models-step.test.tsx
@@ -138,12 +138,16 @@ describe("AIModelsStep variants", () => {
       }));
     }
 
-    async function providerGroupText(unrunnable: string[]): Promise<string> {
+    async function providerGroupText(
+      unrunnable: string[],
+      selected?: string,
+    ): Promise<string> {
       stubStatus(unrunnable);
       const { getByRole, findByText } = render(
         <AIModelsStep
           embedded
           providerIds={["clawai", "anthropic", "google"]}
+          {...(selected ? { defaultProviderId: selected } : {})}
           testId="providers-test"
         />,
       );
@@ -159,6 +163,17 @@ describe("AIModelsStep variants", () => {
 
       expect(text).not.toContain("Google Gemini");
       expect(text).toContain("Anthropic");
+    });
+
+    it("keeps the row the panel is CURRENTLY on, whatever the box says about it", async () => {
+      // Everything else here that decides what to render — the "keep the
+      // selection valid" effect, the credential panel, the deep-link handler —
+      // resolves against the unfiltered list. Dropping the selected row would
+      // leave its form on screen with no radio above it and no "show more"
+      // toggle to get back.
+      const text = await providerGroupText(["google"], "google");
+
+      expect(text).toContain("Google Gemini");
     });
 
     it("is offered exactly as before when the box has said nothing about it", async () => {

--- a/src/tests/components/ai-models-step.test.tsx
+++ b/src/tests/components/ai-models-step.test.tsx
@@ -107,6 +107,68 @@ describe("AIModelsStep variants", () => {
     }));
   });
 
+  /**
+   * TASK-668. The Providers page decides server-side which providers this box
+   * can run a model from; this list must not go on offering the ones it
+   * dropped. `unrunnable` is what carries that decision — an empty array (and
+   * a status call that has not landed) hides nothing.
+   */
+  describe("a provider the box can run no model from", () => {
+    function stubStatus(unrunnable: string[]) {
+      vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input instanceof Request ? input.url : input.toString();
+        if (url.includes("/setup-api/providers/status")) {
+          return {
+            ok: true,
+            json: async () => ({
+              harness: "openclaw",
+              defaultProvider: "clawai",
+              unrunnable,
+              degraded: false,
+              providers: [
+                { id: "clawai", label: "ClawBox AI", state: "connected", isDefault: true, section: "ai", enabled: true },
+              ],
+            }),
+          };
+        }
+        if (url.includes("/setup-api/ai-models/oauth/providers")) {
+          return { ok: true, json: async () => ({ providers: [] }) };
+        }
+        return { ok: true, json: async () => ({}) };
+      }));
+    }
+
+    async function providerGroupText(unrunnable: string[]): Promise<string> {
+      stubStatus(unrunnable);
+      const { getByRole, findByText } = render(
+        <AIModelsStep
+          embedded
+          providerIds={["clawai", "anthropic", "google"]}
+          testId="providers-test"
+        />,
+      );
+      // The list opens collapsed onto the selected row; the whole point here is
+      // what the EXPANDED list offers.
+      const showMore = await findByText("Show more providers...").catch(() => null);
+      if (showMore) fireEvent.click(showMore);
+      return getByRole("radiogroup", { name: "AI Provider" }).textContent ?? "";
+    }
+
+    it("is not offered", async () => {
+      const text = await providerGroupText(["google"]);
+
+      expect(text).not.toContain("Google Gemini");
+      expect(text).toContain("Anthropic");
+    });
+
+    it("is offered exactly as before when the box has said nothing about it", async () => {
+      const text = await providerGroupText([]);
+
+      expect(text).toContain("Google Gemini");
+      expect(text).toContain("Anthropic");
+    });
+  });
+
   it("renders only Gemma in Local AI mode and defaults to llama.cpp", async () => {
     const { getByRole, getByText, queryByText } = render(
       <AIModelsStep

--- a/src/tests/components/ai-providers-section.test.tsx
+++ b/src/tests/components/ai-providers-section.test.tsx
@@ -63,6 +63,7 @@ vi.mock("@/hooks/useHermesModelOptions", () => ({
 const summary = (overrides: Partial<ProviderStatusSummary> = {}): ProviderStatusSummary => ({
   harness: "hermes",
   defaultProvider: "clawai",
+  unrunnable: [],
   degraded: false,
   providers: [
     { id: "clawai", label: "ClawBox AI", state: "connected", isDefault: true, section: "ai", enabled: true },

--- a/src/tests/components/openclaw-provider-panel.test.tsx
+++ b/src/tests/components/openclaw-provider-panel.test.tsx
@@ -76,6 +76,7 @@ vi.mock("@/hooks/useLlamaCppModels", () => ({
 const summary: ProviderStatusSummary = {
   harness: "openclaw",
   defaultProvider: "clawai",
+  unrunnable: [],
   degraded: false,
   providers: [
     { id: "clawai", label: "ClawBox AI", state: "connected", isDefault: true, section: "ai", enabled: true },

--- a/src/tests/routes/ai-models/catalog-empty-enumeration.test.ts
+++ b/src/tests/routes/ai-models/catalog-empty-enumeration.test.ts
@@ -115,6 +115,18 @@ describe("catalog — a clean empty enumeration is an answer, not a failure", ()
     expect(await recordedCount("google")).toBe(2);
   });
 
+  it("records NOTHING when the payload never stated a count", async () => {
+    // Read positively, not inferred from absence: a truncated or shape-shifted
+    // payload parses into the same emptiness as a real answer, and this verdict
+    // hides a row.
+    mockList({ models: [] });
+    await get("google", "&refresh=1");
+    await settle();
+
+    const recorded = fs.existsSync(RECORD) ? readRecord() : {};
+    expect(recorded.google).toBeUndefined();
+  });
+
   it("records NOTHING when the CLI refused — an error is not an empty catalogue", async () => {
     // The false-failure guard. `ok: false` and a message on stderr mean the
     // question was not answered; recording zero there would hide a provider

--- a/src/tests/routes/ai-models/catalog-empty-enumeration.test.ts
+++ b/src/tests/routes/ai-models/catalog-empty-enumeration.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+import * as childProcess from "child_process";
+import fs from "fs";
+import path from "path";
+import { NextRequest } from "next/server";
+
+// TASK-668 — "the box can run no model from this provider" is a FACT the
+// harness already tells us, and beta throws it away.
+//
+// `openclaw models list --provider google --all --json` answers `{count: 0}`
+// on a box whose `models.mode` is `replace` (measured: anthropic 15->9,
+// openai 30->2, google 10->0). Beta logs that, records a failed refresh and
+// keeps the previous catalogue — so the picker and the Providers page keep
+// offering rows the gateway will refuse, and the backoff re-forks a
+// three-minute enumeration for ever.
+//
+// A CLEAN zero is an answer: it is recorded, so the surfaces can drop the row
+// (the owner's ruling), and the generation counts as answered so nothing
+// re-forks. A zero that came with a refusal, with stderr, or after every listed
+// row was filtered out is NOT an answer and is recorded as nothing at all.
+
+vi.mock("child_process", () => ({ spawn: vi.fn() }));
+
+vi.mock("@/lib/openclaw-config", () => ({
+  findOpenclawBin: () => "openclaw",
+  openclawIsAbsent: () => false,
+}));
+
+const DATA_DIR = "/tmp/clawbox-catalog-empty-enumeration-test";
+vi.mock("@/lib/config-store", () => ({ DATA_DIR: "/tmp/clawbox-catalog-empty-enumeration-test" }));
+
+import { GET } from "@/app/setup-api/ai-models/catalog/route";
+
+const mockSpawn = vi.mocked(childProcess.spawn);
+
+function fakeChild(json: unknown, stderr = "") {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: () => void;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = () => {};
+  queueMicrotask(() => {
+    if (stderr) child.stderr.emit("data", Buffer.from(stderr, "utf8"));
+    child.stdout.emit("data", Buffer.from(JSON.stringify(json), "utf8"));
+    child.emit("close", 0);
+  });
+  return child;
+}
+
+function mockList(json: unknown, stderr = ""): void {
+  mockSpawn.mockImplementation(
+    () => fakeChild(json, stderr) as unknown as ReturnType<typeof childProcess.spawn>,
+  );
+}
+
+const RECORD = path.join(DATA_DIR, "catalog-cache", "_enumerations.json");
+
+function readRecord(): Record<string, { models: number }> {
+  const parsed = JSON.parse(fs.readFileSync(RECORD, "utf8")) as {
+    providers?: Record<string, { models: number }>;
+  };
+  return parsed.providers ?? {};
+}
+
+async function get(provider: string, params = ""): Promise<Record<string, unknown>> {
+  const url = `http://clawbox.local/setup-api/ai-models/catalog?provider=${provider}${params}`;
+  return (await (await GET(new NextRequest(url))).json()) as Record<string, unknown>;
+}
+
+/** Wait for the detached refresh to have written the record for `provider`. */
+async function recordedCount(provider: string): Promise<number | undefined> {
+  let count: number | undefined;
+  await vi.waitFor(() => {
+    expect(fs.existsSync(RECORD)).toBe(true);
+    count = readRecord()[provider]?.models;
+    expect(count).toBeTypeOf("number");
+  }, { timeout: 4000, interval: 25 });
+  return count;
+}
+
+function settle(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 300));
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn(async () => {
+    throw new Error("no network in this suite");
+  }));
+  vi.clearAllMocks();
+  fs.rmSync(path.join(DATA_DIR, "catalog-cache"), { recursive: true, force: true });
+});
+
+describe("catalog — a clean empty enumeration is an answer, not a failure", () => {
+  it("records zero when the CLI answers with no rows at all", async () => {
+    mockList({ count: 0, models: [] });
+    await get("google", "&refresh=1");
+
+    expect(await recordedCount("google")).toBe(0);
+  });
+
+  it("records the count when the enumeration answers with rows", async () => {
+    mockList({
+      count: 2,
+      models: [
+        { key: "google/gemini-2.5-pro", name: "Gemini 2.5 Pro", contextWindow: 1_000_000, available: true, tags: [] },
+        { key: "google/gemini-2.5-flash", name: "Gemini 2.5 Flash", contextWindow: 1_000_000, available: true, tags: ["default"] },
+      ],
+    });
+    await get("google", "&refresh=1");
+
+    expect(await recordedCount("google")).toBe(2);
+  });
+
+  it("records NOTHING when the CLI refused — an error is not an empty catalogue", async () => {
+    // The false-failure guard. `ok: false` and a message on stderr mean the
+    // question was not answered; recording zero there would hide a provider
+    // the box can run perfectly well.
+    mockList({ ok: false, error: { message: "provider plugin is not installed" }, models: [] }, "boom");
+    await get("google", "&refresh=1");
+    await settle();
+
+    const recorded = fs.existsSync(RECORD) ? readRecord() : {};
+    expect(recorded.google).toBeUndefined();
+  });
+
+  it("records NOTHING when rows were listed but every one was filtered out", async () => {
+    // "17 rows, none of them chat models this picker can offer" is a fact
+    // about OUR filter, not about what the box can run.
+    mockList({
+      count: 1,
+      models: [
+        { key: "google/imagen-4", name: "Imagen 4", contextWindow: 0, available: true, tags: [] },
+      ],
+    });
+    await get("google", "&refresh=1");
+    await settle();
+
+    const recorded = fs.existsSync(RECORD) ? readRecord() : {};
+    expect(recorded.google).toBeUndefined();
+  });
+});

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -68,6 +68,14 @@ vi.mock("@/lib/provider-enablement", () => ({
 // console silencing and no global unhandled-rejection swallow, either of which
 // would hide this class of bug rather than remove it. Nothing in this file
 // asserts on the refresh; it is out-of-band work by design.
+// TASK-668: the recorded per-provider model counts. Only the forget is
+// reachable from this route, and only on a `models.mode` flip.
+vi.mock("@/lib/provider-runnable", () => ({
+  forgetProviderEnumerations: vi.fn(async () => {}),
+  recordProviderEnumeration: vi.fn(async () => {}),
+  readProviderRunnable: vi.fn(async () => new Map()),
+}));
+
 vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
   refreshInBackground: vi.fn(),
   notifyProviderSetChanged: vi.fn(),
@@ -181,6 +189,7 @@ import { getDefaultLlamaCppModel, getLlamaCppContextWindow, getLlamaCppMaxTokens
 import { getLocalAiProxyBaseUrl } from "@/lib/local-ai-runtime";
 import { getLocalAiToken } from "@/lib/local-ai-token";
 import { notifyProviderSetChanged } from "@/app/setup-api/ai-models/catalog/route";
+import { forgetProviderEnumerations } from "@/lib/provider-runnable";
 
 const mockSpawn = vi.mocked(childProcess.spawn);
 const mockGetAll = vi.mocked(getAll);
@@ -728,6 +737,49 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(commands).toContain("config set agents.defaults.model.primary llamacpp/gemma4-e2b-it-q4_0");
     expect(commands).not.toContain('config set agents.defaults.model.fallbacks ["llamacpp/gemma4-e2b-it-q4_0"] --json');
     expect(commands).toContain("config set models.mode merge");
+  });
+
+  /**
+   * `models.mode` decides what EVERY provider's catalogue means: under
+   * `replace` the core skips the authenticated rows for all of them at once
+   * (measured on a box — anthropic 15->9, openai 30->2, google 10->0). So a
+   * flip invalidates every model count recorded under the old mode, and none
+   * of them may go on hiding a Providers row. Forgetting is the whole
+   * response: no enumeration, no fork, every row back at once (TASK-668).
+   */
+  describe("a models.mode flip forgets the recorded model counts", () => {
+    /** openclaw.json's `models.mode`, kept in step with what the route writes. */
+    function trackModelsMode(initial: string) {
+      let mode = initial;
+      mockReadOpenClawConfig.mockImplementation(async () => ({ models: { mode } }));
+      vi.mocked(runOpenclawConfigSetBatch).mockImplementation(async (batch) => {
+        for (const op of batch) if (op[0] === "models.mode" && typeof op[1] === "string") mode = op[1];
+      });
+    }
+
+    it("forgets them when a local-model save flips merge -> replace", async () => {
+      trackModelsMode("merge");
+
+      const res = await configurePost(jsonRequest({ provider: "llamacpp" }));
+
+      expect(res.status).toBe(200);
+      const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
+      expect(commands).toContain("config set models.mode replace");
+      expect(vi.mocked(forgetProviderEnumerations)).toHaveBeenCalledTimes(1);
+    });
+
+    it("leaves them alone when the mode is written but does not change", async () => {
+      // The false-failure direction to avoid is the other one — forgetting is
+      // cheap — but a save that changed nothing should still change nothing.
+      trackModelsMode("merge");
+
+      const res = await configurePost(jsonRequest({ provider: "llamacpp", scope: "local" }));
+
+      expect(res.status).toBe(200);
+      const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
+      expect(commands).toContain("config set models.mode merge");
+      expect(vi.mocked(forgetProviderEnumerations)).not.toHaveBeenCalled();
+    });
   });
 
   it("keeps local AI as fallback-only when a primary AI provider is already configured", async () => {

--- a/src/tests/routes/chat-model.test.ts
+++ b/src/tests/routes/chat-model.test.ts
@@ -66,10 +66,18 @@ vi.mock("@/lib/sqlite-store", () => ({
   sqliteSet: vi.fn(),
 }));
 
+// TASK-668. The recorded per-provider model counts the catalog route writes
+// after each enumeration. Empty by default — nothing recorded is UNKNOWN, and
+// unknown changes nothing about the list this route serves.
+vi.mock("@/lib/provider-runnable", () => ({
+  readProviderRunnable: vi.fn(async () => new Map<string, string>()),
+}));
+
 import { getAll } from "@/lib/config-store";
 import { GatewayNotReadyError, inferConfiguredLocalModel, readConfig, readConfigStrict, restartGateway, runOpenclawConfigSet, runOpenclawConfigUnset, applyModelOverrideToAllAgentSessions, parseFullyQualifiedModel, setProviderPlugins, runOpenclawConfigSetBatch } from "@/lib/openclaw-config";
 import { sqliteGet, sqliteSet } from "@/lib/sqlite-store";
 import { notifyProviderSetChanged } from "@/app/setup-api/ai-models/catalog/route";
+import { readProviderRunnable } from "@/lib/provider-runnable";
 import { promisify } from "util";
 
 describe("/setup-api/chat/model", () => {
@@ -225,6 +233,64 @@ describe("/setup-api/chat/model", () => {
       "anthropic/claude-opus-5",
       "llamacpp/gemma4-e2b-it-q4_0",
     ]);
+  });
+
+  describe("a provider the box can run no model from", () => {
+    /** The three-profile box of the test above: ClawBox AI, OpenAI, Anthropic. */
+    function threeProviderBox(primary: string) {
+      vi.mocked(readConfig).mockResolvedValue({
+        auth: {
+          profiles: {
+            "deepseek:default": { provider: "deepseek", mode: "api_key" },
+            "openai:default": { provider: "openai", mode: "token" },
+            "anthropic:default": { provider: "anthropic", mode: "token" },
+          },
+        },
+        models: { mode: "replace", providers: {} },
+        agents: { defaults: { model: { primary } } },
+      } as never);
+    }
+
+    it("is not offered, even though its credential is right there", async () => {
+      // Under `models.mode: "replace"` the core answers `openclaw models list
+      // --provider anthropic` with nothing, so every Anthropic row in this
+      // dropdown is a button whose only outcome is a refusal from the gateway.
+      threeProviderBox("deepseek/deepseek-v4-flash");
+      vi.mocked(readProviderRunnable).mockResolvedValue(
+        new Map([["anthropic", "none"], ["openai", "some"]]) as never,
+      );
+
+      const body = await (await GET()).json();
+
+      const labels = body.options.map((option: { label: string }) => option.label);
+      expect(labels).not.toContain("Anthropic Claude");
+      expect(labels).toEqual(expect.arrayContaining(["ClawBox AI", "OpenAI GPT"]));
+    });
+
+    it("keeps the row when the model in question is the one the box is running", async () => {
+      // The header pill names it. A dropdown that omits the active model shows
+      // the customer a model that is in no list.
+      threeProviderBox("anthropic/claude-opus-5");
+      vi.mocked(readProviderRunnable).mockResolvedValue(
+        new Map([["anthropic", "none"]]) as never,
+      );
+
+      const body = await (await GET()).json();
+
+      expect(body.options.map((option: { model: string | null }) => option.model))
+        .toContain("anthropic/claude-opus-5");
+    });
+
+    it("keeps every row when nothing has been recorded", async () => {
+      // The false-failure guard: an empty record is "nobody has asked", and
+      // beta's list is what it must produce.
+      threeProviderBox("deepseek/deepseek-v4-flash");
+
+      const body = await (await GET()).json();
+
+      expect(body.options.map((option: { label: string }) => option.label))
+        .toEqual(expect.arrayContaining(["ClawBox AI", "OpenAI GPT", "Anthropic Claude"]));
+    });
   });
 
   it("switches the active chat model to Local AI and restarts the gateway", async () => {

--- a/src/tests/routes/providers/default.test.ts
+++ b/src/tests/routes/providers/default.test.ts
@@ -15,7 +15,13 @@ vi.mock("@/lib/harness", () => ({
   HERMES_BIN: "/usr/bin/hermes-test",
 }));
 vi.mock("@/app/setup-api/hermes/models/route", () => ({ POST: vi.fn() }));
-vi.mock("@/app/setup-api/chat/model/route", () => ({ GET: vi.fn(), POST: vi.fn() }));
+vi.mock("@/app/setup-api/chat/model/route", () => ({
+  GET: vi.fn(),
+  POST: vi.fn(),
+  // Consulted only when the filtered list has no row for the named provider
+  // (TASK-668); an empty list here keeps every existing case unchanged.
+  readChatModelStateUnfiltered: vi.fn(async () => ({ options: [] })),
+}));
 vi.mock("@/lib/provider-enablement", () => ({ isProviderEnabled: vi.fn() }));
 
 let POST: (request: Request) => Promise<Response>;

--- a/src/tests/routes/providers/default.test.ts
+++ b/src/tests/routes/providers/default.test.ts
@@ -20,7 +20,7 @@ vi.mock("@/app/setup-api/chat/model/route", () => ({
   POST: vi.fn(),
   // Consulted only when the filtered list has no row for the named provider
   // (TASK-668); an empty list here keeps every existing case unchanged.
-  readChatModelStateUnfiltered: vi.fn(async () => ({ options: [] })),
+  readChatModelStateUnfiltered: vi.fn(),
 }));
 vi.mock("@/lib/provider-enablement", () => ({ isProviderEnabled: vi.fn() }));
 
@@ -28,6 +28,7 @@ let POST: (request: Request) => Promise<Response>;
 let getActiveHarness: Mock;
 let hermesModelsPOST: Mock;
 let chatModelGET: Mock;
+let chatModelStateUnfiltered: Mock;
 let chatModelPOST: Mock;
 let isProviderEnabled: Mock;
 
@@ -51,7 +52,14 @@ beforeEach(async () => {
   vi.clearAllMocks();
   ({ getActiveHarness } = (await import("@/lib/harness")) as unknown as { getActiveHarness: Mock });
   ({ POST: hermesModelsPOST } = (await import("@/app/setup-api/hermes/models/route")) as unknown as { POST: Mock });
-  ({ GET: chatModelGET, POST: chatModelPOST } = (await import("@/app/setup-api/chat/model/route")) as unknown as { GET: Mock; POST: Mock });
+  ({
+    GET: chatModelGET,
+    POST: chatModelPOST,
+    readChatModelStateUnfiltered: chatModelStateUnfiltered,
+  } = (await import("@/app/setup-api/chat/model/route")) as unknown as {
+    GET: Mock; POST: Mock; readChatModelStateUnfiltered: Mock;
+  });
+  chatModelStateUnfiltered.mockResolvedValue({ options: [] });
   ({ isProviderEnabled } = (await import("@/lib/provider-enablement")) as unknown as { isProviderEnabled: Mock });
   isProviderEnabled.mockResolvedValue(true);
   ({ POST } = await import("@/app/setup-api/providers/default/route"));
@@ -123,6 +131,29 @@ describe("POST /setup-api/providers/default — OpenClaw", () => {
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toMatchObject({ ok: true, model: "anthropic/claude-sonnet-4-6" });
     expect(hermesModelsPOST).not.toHaveBeenCalled();
+  });
+
+  it("still promotes a provider the picker hides because it can run no model", async () => {
+    // TASK-668 drops such a provider from the picker's OPTIONS, which is about
+    // what is offered. Naming it here is an explicit instruction, and answering
+    // "provider_unconfigured" over a provider that holds a working credential
+    // would be a false failure — so the promote resolves against the unfiltered
+    // state and the write is judged by the catalogue guards as it always was.
+    chatModelGET.mockResolvedValue(json({
+      options: [{ id: "a", provider: "clawai", model: "deepseek/deepseek-v4-flash", available: true }],
+    }));
+    chatModelStateUnfiltered.mockResolvedValue({
+      options: [
+        { id: "a", provider: "clawai", model: "deepseek/deepseek-v4-flash", available: true },
+        { id: "b", provider: "google", model: "google/gemini-2.5-pro", available: true },
+      ],
+    });
+    chatModelPOST.mockResolvedValue(json({ ok: true }));
+
+    const res = await call({ provider: "google" });
+
+    expect(res.status).toBe(200);
+    expect(await delegateBody(chatModelPOST)).toEqual({ model: "google/gemini-2.5-pro" });
   });
 
   it("refuses a provider this box holds no credential for", async () => {

--- a/src/tests/routes/providers/status-unrunnable.test.ts
+++ b/src/tests/routes/providers/status-unrunnable.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// A real DATA_DIR: the runnable verdict is read off disk, from the file the
+// catalog route writes when an enumeration answers. Everything else the strip
+// touches stays mocked exactly as in status.test.ts.
+let dataDir = "";
+
+vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn() }));
+vi.mock("@/lib/harness/credentials", () => ({ hasClawaiToken: vi.fn() }));
+vi.mock("@/lib/openclaw-config", () => ({ readConfig: vi.fn() }));
+vi.mock("@/lib/config-store", () => ({ get: vi.fn(), get DATA_DIR() { return dataDir; } }));
+vi.mock("@/lib/hermes-model-options", () => ({
+  getModelOptions: vi.fn(),
+  probeStillOwed: vi.fn(),
+}));
+vi.mock("@/lib/clawbox-ai-portal-tier", () => ({ clawaiTokenRejectedByPortal: vi.fn() }));
+
+let GET: () => Promise<Response>;
+let getActiveHarness: Mock;
+let hasClawaiToken: Mock;
+let readConfig: Mock;
+let getConfigValue: Mock;
+let probeStillOwed: Mock;
+let clawaiTokenRejectedByPortal: Mock;
+
+/** What the catalog route records after an enumeration answers for a provider. */
+function recordEnumerations(counts: Record<string, number>) {
+  const dir = path.join(dataDir, "catalog-cache");
+  mkdirSync(dir, { recursive: true });
+  const providers: Record<string, { models: number; atMs: number }> = {};
+  for (const [provider, models] of Object.entries(counts)) {
+    providers[provider] = { models, atMs: Date.now() };
+  }
+  writeFileSync(path.join(dir, "_enumerations.json"), JSON.stringify({ providers }), "utf8");
+}
+
+/** A box with an Anthropic key and a Google key, pointed at Anthropic. */
+function boxWithGoogleKey() {
+  readConfig.mockResolvedValue({
+    auth: { profiles: { "anthropic:default": { provider: "anthropic", mode: "oauth" } } },
+    models: { providers: { google: { apiKey: "AIza-secret" } } },
+    agents: { defaults: { model: { primary: "anthropic/claude-sonnet-4-6" } } },
+  });
+}
+
+beforeEach(async () => {
+  dataDir = mkdtempSync(path.join(tmpdir(), "clawbox-runnable-"));
+  vi.resetModules();
+  vi.clearAllMocks();
+  ({ getActiveHarness } = (await import("@/lib/harness")) as unknown as { getActiveHarness: Mock });
+  ({ hasClawaiToken } = (await import("@/lib/harness/credentials")) as unknown as { hasClawaiToken: Mock });
+  ({ readConfig } = (await import("@/lib/openclaw-config")) as unknown as { readConfig: Mock });
+  ({ get: getConfigValue } = (await import("@/lib/config-store")) as unknown as { get: Mock });
+  ({ probeStillOwed } = (await import("@/lib/hermes-model-options")) as unknown as { probeStillOwed: Mock });
+  ({ clawaiTokenRejectedByPortal } = (await import("@/lib/clawbox-ai-portal-tier")) as unknown as {
+    clawaiTokenRejectedByPortal: Mock;
+  });
+  getConfigValue.mockResolvedValue(null);
+  hasClawaiToken.mockResolvedValue(false);
+  clawaiTokenRejectedByPortal.mockReturnValue(false);
+  probeStillOwed.mockResolvedValue(false);
+  getActiveHarness.mockResolvedValue("openclaw");
+  ({ GET } = await import("@/app/setup-api/providers/status/route"));
+});
+
+afterEach(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+interface Row { id: string; state: string; isDefault: boolean }
+const ids = (body: { providers: Row[] }) => body.providers.map((p) => p.id);
+
+describe("GET /setup-api/providers/status — a provider the box can run no model from", () => {
+  it("drops the row when the box's own enumeration came back with nothing", async () => {
+    // TASK-668. Under `models.mode: "replace"` the core answers `openclaw
+    // models list --provider google` with zero rows: connecting a key there
+    // buys a picker entry the gateway will refuse. The owner's ruling is that
+    // such a row is not offered at all.
+    boxWithGoogleKey();
+    recordEnumerations({ google: 0, anthropic: 9 });
+    const body = await (await GET()).json();
+
+    expect(ids(body)).not.toContain("google");
+    expect(body.unrunnable).toEqual(["google"]);
+    // Everything else is untouched.
+    expect(ids(body)).toEqual(expect.arrayContaining(["clawai", "openai", "anthropic", "openrouter"]));
+  });
+
+  it("keeps the row on a box that can run at least one of that provider's models", async () => {
+    boxWithGoogleKey();
+    recordEnumerations({ google: 10 });
+    const body = await (await GET()).json();
+
+    expect(ids(body)).toContain("google");
+    expect(body.unrunnable).toEqual([]);
+  });
+
+  it("keeps the row when no enumeration has answered yet — unknown is not empty", async () => {
+    // The false-failure guard. A box that has never enumerated google, or
+    // whose record cannot be read, knows nothing about it; hiding the row on
+    // an absent answer would delete a working provider from the UI.
+    boxWithGoogleKey();
+    const body = await (await GET()).json();
+
+    expect(ids(body)).toContain("google");
+    expect(body.unrunnable).toEqual([]);
+  });
+
+  it("keeps the row when the record is corrupt", async () => {
+    boxWithGoogleKey();
+    const dir = path.join(dataDir, "catalog-cache");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, "_enumerations.json"), "{not json", "utf8");
+    const body = await (await GET()).json();
+
+    expect(ids(body)).toContain("google");
+  });
+
+  it("never hides the provider the box is actually pointed at", async () => {
+    // A default that can run nothing is the one row that MUST stay visible:
+    // it is why chat is broken, and hiding it leaves no way to see or change
+    // it.
+    readConfig.mockResolvedValue({
+      auth: { profiles: { "google:default": { provider: "google", mode: "api_key" } } },
+      agents: { defaults: { model: { primary: "google/gemini-2.5-pro" } } },
+    });
+    recordEnumerations({ google: 0 });
+    const body = await (await GET()).json();
+
+    expect(ids(body)).toContain("google");
+    expect(body.providers.find((p: Row) => p.id === "google")!.isDefault).toBe(true);
+    expect(body.unrunnable).toEqual([]);
+  });
+});

--- a/src/tests/routes/providers/status-unrunnable.test.ts
+++ b/src/tests/routes/providers/status-unrunnable.test.ts
@@ -109,6 +109,42 @@ describe("GET /setup-api/providers/status — a provider the box can run no mode
     expect(body.unrunnable).toEqual([]);
   });
 
+  it("never hides a provider the owner has not connected", async () => {
+    // That row IS the fix: connecting a cloud provider writes its configured
+    // model rows and `models.mode: "merge"`, which is exactly what turns a
+    // zero-row provider back into a routable one. Hiding it would leave the box
+    // with no way out of the state that hid it.
+    readConfig.mockResolvedValue({
+      auth: { profiles: { "anthropic:default": { provider: "anthropic", mode: "oauth" } } },
+      agents: { defaults: { model: { primary: "anthropic/claude-sonnet-4-6" } } },
+    });
+    recordEnumerations({ google: 0 });
+    const body = await (await GET()).json();
+
+    expect(ids(body)).toContain("google");
+    expect(body.providers.find((p: Row) => p.id === "google")!.state).toBe("disconnected");
+    expect(body.unrunnable).toEqual([]);
+  });
+
+  it("stops trusting a count older than the catalogue's own refresh interval", async () => {
+    // Nothing re-enumerates a hidden provider — no row, no picker, no configure
+    // POST for it — so a verdict that has aged past the interval the catalogue
+    // itself would re-ask on has to expire back to `unknown` rather than hide
+    // the row for the life of the box.
+    boxWithGoogleKey();
+    const dir = path.join(dataDir, "catalog-cache");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      path.join(dir, "_enumerations.json"),
+      JSON.stringify({ providers: { google: { models: 0, atMs: Date.now() - 7 * 60 * 60_000 } } }),
+      "utf8",
+    );
+    const body = await (await GET()).json();
+
+    expect(ids(body)).toContain("google");
+    expect(body.unrunnable).toEqual([]);
+  });
+
   it("keeps the row when the record is corrupt", async () => {
     boxWithGoogleKey();
     const dir = path.join(dataDir, "catalog-cache");

--- a/src/tests/routes/providers/status.test.ts
+++ b/src/tests/routes/providers/status.test.ts
@@ -449,7 +449,9 @@ describe("the response carries statuses, never credentials", () => {
     const body = await (await GET()).json();
 
     expect(Object.keys(body).sort()).toEqual(
-      ["defaultProvider", "degraded", "harness", "providers"],
+      // `unrunnable` is a list of provider IDS — a status, like every other
+      // field here, and pinned by the same contract (TASK-668).
+      ["defaultProvider", "degraded", "harness", "providers", "unrunnable"],
     );
     for (const row of body.providers) {
       expect(Object.keys(row).sort()).toEqual(["enabled", "id", "isDefault", "label", "section", "state"]);
@@ -469,7 +471,9 @@ describe("the response carries statuses, never credentials", () => {
     const body = await (await GET()).json();
 
     expect(Object.keys(body).sort()).toEqual(
-      ["defaultProvider", "degraded", "harness", "providers"],
+      // `unrunnable` is a list of provider IDS — a status, like every other
+      // field here, and pinned by the same contract (TASK-668).
+      ["defaultProvider", "degraded", "harness", "providers", "unrunnable"],
     );
     expect(body.providers.some((row: Row) => row.state === "checking")).toBe(true);
     for (const row of body.providers) {

--- a/src/tests/unit/provider-enablement.test.ts
+++ b/src/tests/unit/provider-enablement.test.ts
@@ -28,6 +28,9 @@ vi.mock("@/lib/provider-status", async (importOriginal) => {
     ...actual,
     readProviderStatus: async () => ({
       harness: "openclaw",
+      // Nothing hidden here: a provider dropped for running no model is still
+      // switchable, and that case has its own assertion below.
+      unrunnable: hiddenProviders,
       providers: [
         { id: "anthropic", isDefault: true },
         { id: "openrouter", isDefault: false },
@@ -37,6 +40,9 @@ vi.mock("@/lib/provider-status", async (importOriginal) => {
   };
 });
 
+/** Ids `readProviderStatus` dropped from its rows for this test. */
+let hiddenProviders: string[] = [];
+
 type Lib = typeof import("@/lib/provider-enablement");
 let lib: Lib;
 
@@ -44,6 +50,7 @@ beforeEach(async () => {
   vi.resetModules();
   store.values = {};
   store.writeDelayMs = 0;
+  hiddenProviders = [];
   lib = await import("@/lib/provider-enablement");
 });
 
@@ -75,5 +82,15 @@ describe("setProviderEnabled", () => {
 
   it("refuses a provider the status does not know", async () => {
     expect(await lib.setProviderEnabled("nonesuch", false)).toMatchObject({ ok: false, kind: "unknown_provider" });
+  });
+
+  it("still flips the switch for a provider the strip hides", async () => {
+    // A row dropped because the box can run no model from it (TASK-668) is not
+    // an unknown provider: the strip hides the row, it does not forget the
+    // provider, and answering "not known to this box" would leave the switch
+    // stuck at whatever it was last set to.
+    hiddenProviders = ["google"];
+    expect(await lib.setProviderEnabled("google", false)).toEqual({ ok: true });
+    expect(store.values.ai_disabled_providers).toEqual(["google"]);
   });
 });

--- a/src/tests/unit/provider-runnable.test.ts
+++ b/src/tests/unit/provider-runnable.test.ts
@@ -53,23 +53,23 @@ describe("the recorded model count", () => {
   });
 
   it("says nothing at all about a provider with no record", async () => {
-    const { providerRunnable } = await load();
+    const { readProviderRunnable } = await load();
 
-    expect(await providerRunnable("google")).toBe("unknown");
+    expect((await readProviderRunnable()).get("google")).toBeUndefined();
   });
 
   it("expires a count older than the catalogue's refresh interval", async () => {
     writeRecord({ google: { models: 0, atMs: Date.now() - 7 * 60 * 60_000 } });
-    const { providerRunnable } = await load();
+    const { readProviderRunnable } = await load();
 
-    expect(await providerRunnable("google")).toBe("unknown");
+    expect((await readProviderRunnable()).get("google")).toBeUndefined();
   });
 
   it("treats an unusable timestamp as expired, not as fresh", async () => {
     writeRecord({ google: { models: 0, atMs: Number.NaN } });
-    const { providerRunnable } = await load();
+    const { readProviderRunnable } = await load();
 
-    expect(await providerRunnable("google")).toBe("unknown");
+    expect((await readProviderRunnable()).get("google")).toBeUndefined();
   });
 
   it("reads a corrupt record as nothing known, rather than throwing", async () => {
@@ -121,9 +121,9 @@ describe("the recorded model count", () => {
     // answer to "where is the store" is the same as to a missing file.
     dataDir = "";
     vi.resetModules();
-    const { recordProviderEnumeration, providerRunnable } = await load();
+    const { recordProviderEnumeration, readProviderRunnable } = await load();
 
     await expect(recordProviderEnumeration("google", 0)).resolves.toBeUndefined();
-    expect(await providerRunnable("google")).toBe("unknown");
+    expect([...(await readProviderRunnable())]).toEqual([]);
   });
 });

--- a/src/tests/unit/provider-runnable.test.ts
+++ b/src/tests/unit/provider-runnable.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// TASK-668 — "can this box run any model from provider X?", answered from the
+// count the catalog route's own enumeration recorded, and from nothing else.
+//
+// Every case here is about the ONE rule this file exists to keep: only a
+// definite, CURRENT count decides anything. No record, an unreadable record, a
+// stamp too old to be a fact — all of them are UNKNOWN, and unknown shows the
+// row. Hiding a provider on an answer nobody gave would delete a working
+// provider from the only screen that can fix it.
+
+let dataDir = "";
+vi.mock("@/lib/config-store", () => ({
+  get DATA_DIR() { return dataDir; },
+  setMany: vi.fn(),
+  get: vi.fn(),
+}));
+
+const recordFile = () => path.join(dataDir, "catalog-cache", "_enumerations.json");
+
+function writeRecord(providers: Record<string, { models: number; atMs: number }>) {
+  mkdirSync(path.dirname(recordFile()), { recursive: true });
+  writeFileSync(recordFile(), JSON.stringify({ providers }), "utf8");
+}
+
+function readRecord(): Record<string, { models: number }> {
+  return JSON.parse(readFileSync(recordFile(), "utf8")).providers;
+}
+
+async function load() {
+  return import("@/lib/provider-runnable");
+}
+
+beforeEach(() => {
+  dataDir = mkdtempSync(path.join(tmpdir(), "clawbox-runnable-unit-"));
+  vi.resetModules();
+});
+
+afterEach(() => rmSync(dataDir, { recursive: true, force: true }));
+
+describe("the recorded model count", () => {
+  it("says `some` for a provider that enumerated rows and `none` for a clean zero", async () => {
+    writeRecord({ google: { models: 0, atMs: Date.now() }, anthropic: { models: 9, atMs: Date.now() } });
+    const { readProviderRunnable } = await load();
+
+    const verdicts = await readProviderRunnable();
+
+    expect(verdicts.get("google")).toBe("none");
+    expect(verdicts.get("anthropic")).toBe("some");
+  });
+
+  it("says nothing at all about a provider with no record", async () => {
+    const { providerRunnable } = await load();
+
+    expect(await providerRunnable("google")).toBe("unknown");
+  });
+
+  it("expires a count older than the catalogue's refresh interval", async () => {
+    writeRecord({ google: { models: 0, atMs: Date.now() - 7 * 60 * 60_000 } });
+    const { providerRunnable } = await load();
+
+    expect(await providerRunnable("google")).toBe("unknown");
+  });
+
+  it("treats an unusable timestamp as expired, not as fresh", async () => {
+    writeRecord({ google: { models: 0, atMs: Number.NaN } });
+    const { providerRunnable } = await load();
+
+    expect(await providerRunnable("google")).toBe("unknown");
+  });
+
+  it("reads a corrupt record as nothing known, rather than throwing", async () => {
+    mkdirSync(path.dirname(recordFile()), { recursive: true });
+    writeFileSync(recordFile(), "{not json", "utf8");
+    const { readProviderRunnable } = await load();
+
+    expect([...(await readProviderRunnable())]).toEqual([]);
+  });
+
+  it("keeps the other providers when one is forgotten", async () => {
+    // What a provider-set change does: the box moved under that ONE count.
+    writeRecord({ google: { models: 0, atMs: Date.now() }, openai: { models: 2, atMs: Date.now() } });
+    const { forgetProviderEnumeration, readProviderRunnable } = await load();
+
+    await forgetProviderEnumeration("google");
+
+    expect(readRecord().google).toBeUndefined();
+    expect((await readProviderRunnable()).get("openai")).toBe("some");
+  });
+
+  it("forgets every count when the mode that gave them meaning changed", async () => {
+    writeRecord({ google: { models: 0, atMs: Date.now() }, openai: { models: 2, atMs: Date.now() } });
+    const { forgetProviderEnumerations, readProviderRunnable } = await load();
+
+    await forgetProviderEnumerations();
+
+    expect([...(await readProviderRunnable())]).toEqual([]);
+  });
+
+  it("does not lose a write to a write that started beside it", async () => {
+    // Two enumerations can finish in the same tick — the main one and the
+    // subscription-surface one — and a read-modify-write pair interleaved with
+    // another would drop the loser's provider.
+    const { recordProviderEnumeration } = await load();
+
+    await Promise.all([
+      recordProviderEnumeration("google", 0),
+      recordProviderEnumeration("anthropic", 9),
+      recordProviderEnumeration("openai", 2),
+    ]);
+
+    expect(Object.keys(readRecord()).sort()).toEqual(["anthropic", "google", "openai"]);
+  });
+
+  it("keeps working when there is no data directory to write to", async () => {
+    // The module is imported by the Providers strip, which is imported by
+    // routes: a throw at import time would take them down, and the honest
+    // answer to "where is the store" is the same as to a missing file.
+    dataDir = "";
+    vi.resetModules();
+    const { recordProviderEnumeration, providerRunnable } = await load();
+
+    await expect(recordProviderEnumeration("google", 0)).resolves.toBeUndefined();
+    expect(await providerRunnable("google")).toBe("unknown");
+  });
+});


### PR DESCRIPTION
## TASK-668 — a Providers row for a provider the box can run no model from

**Customer-visible symptom.** A box that has saved a local model at primary scope carries
`models.mode: "replace"`, and under that flag the pinned core skips the authenticated catalogue for
**every** provider. Measured on a box, `openclaw models list --provider <p> --all --json | jq .count`
before and after the flip: anthropic 15 → 9, openai 30 → **2**, google 10 → **0**. Settings still shows
the Google row as *Connected*, the chat picker still offers Gemini, and every pick reaches a gateway
that will not route it. The owner's ruling (2026-09-06) is that such a row is not offered at all, while
a box that can run at least one of that provider's models keeps the row exactly as today.

**Cause.** Nothing on the box wrote down what an enumeration answered. `openclaw models list` returning
zero rows was logged, recorded as a failed refresh and thrown away, so the surfaces had no way to tell
"this provider has no models here" from "nobody has asked yet".

**The harness mechanism this uses.** `openclaw models list --provider <p> --all --json` is the
catalogue, and `/setup-api/ai-models/catalog` already runs it (boot warmup, a picker open) and caches
the result. This adds no probe and no fork: it writes the COUNT that enumeration already produced to
`data/catalog-cache/_enumerations.json` and reads it back. The core's own `replace` semantics
(`appendAuthenticatedCatalogRows`, `dist/list.row-sources-*.js:409`) are what make the zero real.
The earlier attempt at this card — marking every catalogue behind-generation on a `models.mode` flip —
was refused for buying a permanent `stale` flag plus a ~3-minute two-core Jetson fork per backoff
window; **this PR changes no freshness or backoff rule at all**. The empty-enumeration branch behaves
exactly as it does on beta; the recorded count is an extra fact beside it.

### What is hidden, and what is never hidden

Hidden: a provider whose row is `connected` or `needs-reauth` and whose own enumeration answered zero.

Never hidden, each for its own reason:
* **A provider the owner has not connected.** That row *is* the fix — connecting a cloud provider goes
  through `writeOpenAICompatProvider`, which writes its configured model rows **and**
  `models.mode: "merge"`, which is exactly what turns a zero-row provider back into a routable one.
  Hiding it would leave the box with no way out of the state that hid it.
* **The provider the box is pointed at.** It is why chat is broken; a row nobody can see is a row
  nobody can change.
* **A row carrying `needsRepair`** — it holds the Retry, the one affordance that fixes it.
* **Anything unknown**: no record, an unreadable record, a count older than the catalogue's own
  refresh interval, or a row whose other catalogue (`codex` for the OpenAI row) has not answered.

### The row comes back without a restart
* `notifyProviderSetChanged(<p>)` — a key pasted, a plugin switched on, a plan changed — forgets that
  provider's count, so the row returns on the next render and the enumeration that follows records the
  new truth. No fork is started by the forgetting.
* A `models.mode` flip forgets every count: they were all taken under a rule that no longer holds.
* A count ages out after the catalogue's own six-hour refresh interval.

### Surfaces swept, so they agree
`/setup-api/providers/status` (the strip and `AiProviderList`), the "Connect AI Provider" list
(`AIModelsStep`, which now reads the server's `unrunnable` list rather than deciding for itself), and
the chat picker (`/setup-api/chat/model` GET). `POST /setup-api/providers/default` resolves against the
UNFILTERED state, so naming a hidden provider explicitly is not answered `provider_unconfigured`, and
`setProviderEnabled` still flips the switch for a hidden provider rather than calling it unknown.
The MCP `ai_list_models` tool is Hermes-only and unaffected.

**Hermes.** No equivalent, deliberately. Hermes' rows carry a `total`, but a zero there is documented in
this repo (`providerHasModels`, `hermes-model-options.ts`) as "credentialed and its `/v1/models` could
not be enumerated" as often as "serves nothing", and `include_unconfigured=true` makes it
indistinguishable from "not set up". The Hermes strip therefore keeps every panel row until that
answer exists.

### RED → GREEN

RED on unmodified beta (`/setup-api/providers/status`, a box whose google enumeration answered zero):

```
FAIL src/tests/routes/providers/status-unrunnable.test.ts > drops the row when the box's own
     enumeration came back with nothing
AssertionError: expected [ 'clawai', 'openai', …(3) ] to not include 'google'
 ❯ src/tests/routes/providers/status-unrunnable.test.ts:86:27
```

and, for the fact the row is decided from:

```
FAIL src/tests/routes/ai-models/catalog-empty-enumeration.test.ts > records zero when the CLI answers
     with no rows at all
AssertionError: expected false to be true   // the enumeration record was never written
 ❯ src/tests/routes/ai-models/catalog-empty-enumeration.test.ts:78:35
```

GREEN — the new suites plus every neighbouring one:

```
npx vitest run src/tests/routes src/tests/unit src/tests/components/ai-models-step.test.tsx \
  src/tests/components/ai-provider-list.test.tsx src/tests/components/ai-providers-section.test.tsx \
  src/tests/components/openclaw-provider-panel.test.tsx src/tests/components/provider-rows-narrow.test.tsx
 Test Files  730 passed (730)
      Tests  11763 passed | 1 skipped (11764)
```

`npx tsc --noEmit` clean; `npm run lint` reports nothing new for the changed files.

### Review

One the reviewer review pass, applied: the hide is now gated on a connected row (it hid the connect
affordance); the empty branch keeps beta's backoff and publishes nothing (it had removed the only brake
and would have forked per catalog GET); a provider-set change and a TTL bring a hidden row back; the
record is generation-guarded like `publish`, so a fork from before a credential landed cannot hide the
provider that was just connected; `providerRowRunnable` now demands unanimity, so a ChatGPT-subscription
box cannot lose its OpenAI row to an empty API-key catalogue; the second publish path records too;
`AIModelsStep` never drops the selected row; `providers/default` and `setProviderEnabled` no longer
answer a false failure over a hidden provider.

Two findings deliberately not taken, with reasons in the code: a payload whose every row reports
`available: false` is **not** recorded — it is also exactly what a provider with no credential looks
like, and the two cannot be told apart from the payload; and the clean-zero test cannot wait for the
child's exit code, because the CLI's wrapper holds the pipe for about three more minutes after the JSON
arrives, so it requires an explicit `count: 0` with `ok !== false` and no stderr instead.

### Device

Read-only on the OpenClaw box: `models.mode` is `merge` today and the configured rows are deepseek 3,
llamacpp 1, openai 1, openrouter 4 — no google rows, which is why the flip takes google to zero. The
count itself comes from the measurement recorded on the card. Nothing was mutated and no enumeration was
forked. The change touches no updater, gateway, systemd unit, device path or edition lock, so CI
exercises it fully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider lists now hide connected providers with no runnable models while preserving active and default providers.
  * Explicitly selected providers remain usable even when hidden from selection lists.
  * Provider status reports unavailable providers.
  * Model catalog refreshes track valid model counts and preserve prior results for uncertain responses.
  * Availability data refreshes after relevant configuration changes.

* **Bug Fixes**
  * Improved handling of empty, refused, malformed, and filtered catalog responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->