### PR TITLE
feat: route EMAIL: directives on the gateway's own Control UI chat

### DIFF
--- a/src/app/setup-api/gateway/route.ts
+++ b/src/app/setup-api/gateway/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getGatewayToken } from "@/lib/gateway-proxy";
+import { controlUiEmailDirectiveScript } from "@/lib/control-ui-email-directives";
+import * as configStore from "@/lib/config-store";
 import { getGatewayServiceHealth, type GatewayServiceHealth } from "@/lib/gateway-health";
 import { envPort } from "@/lib/port-probe";
 import { readEditionSource } from "@/lib/edition-source";
@@ -71,7 +73,16 @@ export async function GET(request: NextRequest) {
         });
       })();
     </script>`;
-    html = html.replace(/<head\b[^>]*>/i, '$&' + autoConnect);
+    // The SECOND route that serves the Control UI's HTML. `serveGatewayHTML`
+    // injects the same handling for TASK-700, and a directive shown as a bare
+    // id here would be the same defect through a different door — the failure
+    // this repo keeps producing is the sibling call site, not the fix.
+    //
+    // From `<head>` the observer is what does the work: `document.body` is null
+    // this early, `scan(null)` returns, and `document.documentElement` already
+    // exists, so every node the SPA adds afterwards is still seen.
+    const emailDirectives = controlUiEmailDirectiveScript(await uiLocale());
+    html = html.replace(/<head\b[^>]*>/i, '$&' + autoConnect + emailDirectives);
     return new NextResponse(html, {
       status: 200,
       headers: {
@@ -83,6 +94,16 @@ export async function GET(request: NextRequest) {
     });
   } catch {
     return gatewayOfflineResponse(await getGatewayServiceHealth());
+  }
+}
+
+/** The language the owner picked; see the twin in `gateway-proxy.ts`. */
+async function uiLocale(): Promise<string | undefined> {
+  try {
+    const value = await configStore.get("pref:ui_language");
+    return typeof value === "string" && value ? value : undefined;
+  } catch {
+    return undefined;
   }
 }
 

--- a/src/app/setup-api/gateway/route.ts
+++ b/src/app/setup-api/gateway/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getGatewayToken } from "@/lib/gateway-proxy";
-import { controlUiEmailDirectiveScript } from "@/lib/control-ui-email-directives";
-import * as configStore from "@/lib/config-store";
+import { controlUiEmailDirectiveScript, controlUiLocale } from "@/lib/control-ui-email-directives";
 import { getGatewayServiceHealth, type GatewayServiceHealth } from "@/lib/gateway-health";
 import { envPort } from "@/lib/port-probe";
 import { readEditionSource } from "@/lib/edition-source";
@@ -81,8 +80,11 @@ export async function GET(request: NextRequest) {
     // From `<head>` the observer is what does the work: `document.body` is null
     // this early, `scan(null)` returns, and `document.documentElement` already
     // exists, so every node the SPA adds afterwards is still seen.
-    const emailDirectives = controlUiEmailDirectiveScript(await uiLocale());
-    html = html.replace(/<head\b[^>]*>/i, '$&' + autoConnect + emailDirectives);
+    const emailDirectives = controlUiEmailDirectiveScript(await controlUiLocale());
+    // A replacer FUNCTION: the injected script carries a translated label, and
+    // `$&` / `` $` `` / `$'` / `$1` are substitutions inside a replacement
+    // string. Same reason as `serveGatewayHTML`.
+    html = html.replace(/<head\b[^>]*>/i, (match) => match + autoConnect + emailDirectives);
     return new NextResponse(html, {
       status: 200,
       headers: {
@@ -94,16 +96,6 @@ export async function GET(request: NextRequest) {
     });
   } catch {
     return gatewayOfflineResponse(await getGatewayServiceHealth());
-  }
-}
-
-/** The language the owner picked; see the twin in `gateway-proxy.ts`. */
-async function uiLocale(): Promise<string | undefined> {
-  try {
-    const value = await configStore.get("pref:ui_language");
-    return typeof value === "string" && value ? value : undefined;
-  } catch {
-    return undefined;
   }
 }
 

--- a/src/components/ChatApp.tsx
+++ b/src/components/ChatApp.tsx
@@ -21,8 +21,7 @@ import { prettifyAssistantText, isSentinel, isInterSessionEnvelope } from '@/lib
 // rendered `EMAIL:<uid>` as text because only one of the two chats had learned
 // to lift the directive out, and sharing the pieces is what stops them drifting
 // apart again.
-import { splitEmailRefs, streamingEmailRefsText, dropUnfinishedDirective, parseEmailUid } from '@/lib/chat-email-refs'
-import { CONTROL_UI_EMAIL_PARAM } from '@/lib/control-ui-email-directives'
+import { splitEmailRefs, streamingEmailRefsText, dropUnfinishedDirective, parseEmailUid, CONTROL_UI_EMAIL_PARAM } from '@/lib/chat-email-refs'
 import { EmailCard, EmailFullView } from '@/lib/chat-email'
 // Same reason, one convention over: a generated picture and a spoken reply are
 // named by a `MEDIA:` line inside the reply text rather than delivered as

--- a/src/components/ChatApp.tsx
+++ b/src/components/ChatApp.tsx
@@ -21,8 +21,7 @@ import { prettifyAssistantText, isSentinel, isInterSessionEnvelope } from '@/lib
 // rendered `EMAIL:<uid>` as text because only one of the two chats had learned
 // to lift the directive out, and sharing the pieces is what stops them drifting
 // apart again.
-import { splitEmailRefs, streamingEmailRefsText, dropUnfinishedDirective } from '@/lib/chat-email-refs'
-import { parseEmailUid } from '@/lib/chat-email-refs'
+import { splitEmailRefs, streamingEmailRefsText, dropUnfinishedDirective, parseEmailUid } from '@/lib/chat-email-refs'
 import { CONTROL_UI_EMAIL_PARAM } from '@/lib/control-ui-email-directives'
 import { EmailCard, EmailFullView } from '@/lib/chat-email'
 // Same reason, one convention over: a generated picture and a spoken reply are
@@ -158,8 +157,14 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
   // render would make it unclosable while the query string is still there.
   useEffect(() => {
     if (typeof window === 'undefined') return
-    const named = new URLSearchParams(window.location.search).get(CONTROL_UI_EMAIL_PARAM)
+    const url = new URL(window.location.href)
+    const named = url.searchParams.get(CONTROL_UI_EMAIL_PARAM)
     if (named === null) return
+    // Taken OUT of the address once it has been read. Left in, a reload, a Back,
+    // or any remount reopens the panel the owner just closed — and the id sits
+    // in history and in anything he bookmarks or pastes.
+    url.searchParams.delete(CONTROL_UI_EMAIL_PARAM)
+    window.history.replaceState({}, '', `${url.pathname}${url.search}${url.hash}`)
     const uid = parseEmailUid(named)
     if (uid !== null) setOpenEmailUid(uid)
   }, [])

--- a/src/components/ChatApp.tsx
+++ b/src/components/ChatApp.tsx
@@ -22,6 +22,8 @@ import { prettifyAssistantText, isSentinel, isInterSessionEnvelope } from '@/lib
 // to lift the directive out, and sharing the pieces is what stops them drifting
 // apart again.
 import { splitEmailRefs, streamingEmailRefsText, dropUnfinishedDirective } from '@/lib/chat-email-refs'
+import { parseEmailUid } from '@/lib/chat-email-refs'
+import { CONTROL_UI_EMAIL_PARAM } from '@/lib/control-ui-email-directives'
 import { EmailCard, EmailFullView } from '@/lib/chat-email'
 // Same reason, one convention over: a generated picture and a spoken reply are
 // named by a `MEDIA:` line inside the reply text rather than delivered as
@@ -142,6 +144,25 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
   }, [])
 
   useEffect(() => { scrollToBottom() }, [messages, streaming, scrollToBottom])
+
+  // `?email=<uid>` opens that message on arrival.
+  //
+  // The other end of a card on the gateway's own Control UI chat (TASK-700).
+  // That page is a third `webchat` surface ClawBox serves but does not build,
+  // so its card can only be a link — and this is where the link lands, in the
+  // panel a card in this chat opens, through the same fetch. The id is read by
+  // the directive's own rule rather than a second one, so a link that names
+  // nothing usable opens nothing rather than asking the mailbox about it.
+  //
+  // Once, on mount: the owner may close the panel, and reopening it on every
+  // render would make it unclosable while the query string is still there.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const named = new URLSearchParams(window.location.search).get(CONTROL_UI_EMAIL_PARAM)
+    if (named === null) return
+    const uid = parseEmailUid(named)
+    if (uid !== null) setOpenEmailUid(uid)
+  }, [])
 
   const wsRequest = useCallback((method: string, params: unknown): Promise<unknown> => {
     return new Promise((resolve, reject) => {

--- a/src/lib/chat-email-refs.ts
+++ b/src/lib/chat-email-refs.ts
@@ -35,7 +35,7 @@
  * `\u2028` or `\u2029` held back from its end — `.` cannot cross those three,
  * so the engine tried every split of the spaces between the two quantifiers.
  * One character class cannot backtrack against itself. Dropping the `\s*`
- * changes nothing else: `parseUid` trims the payload before reading it.
+ * changes nothing else: `parseEmailUid` trims the payload before reading it.
  *
  * This is the shared grammar — the same change is in the OpenClaw plugin's
  * `email-directives.mjs` and the Hermes plugin's `email_directives.py`, and
@@ -89,7 +89,7 @@ export function splitEmailRefs(raw: string): SplitEmailRefs {
       kept.push(line);
       continue;
     }
-    const uid = parseUid(match[1]);
+    const uid = parseEmailUid(match[1]);
     // A directive that names nothing usable is kept as text rather than
     // silently swallowed: dropping the line would hide the fact that the agent
     // meant to point at something.
@@ -125,8 +125,16 @@ export function splitEmailRefs(raw: string): SplitEmailRefs {
   return { text, uids };
 }
 
-/** A UID, or null when the payload is not one. */
-function parseUid(payload: string): number | null {
+/**
+ * A UID, or null when the payload is not one.
+ *
+ * Exported because a directive is no longer the only way one arrives: a card on
+ * the gateway's own Control UI chat is a LINK back into this chat
+ * (`control-ui-email-directives.ts`, TASK-700), and the id it carries has to be
+ * read by the same rule the directive is read by rather than by a second one
+ * written next to `useSearchParams`.
+ */
+export function parseEmailUid(payload: string): number | null {
   const value = unwrapQuoted(payload.trim());
   // Digits only: `+7`, `7.0`, `0x1f` and `7 or so` are all model output that
   // happens to start like a number, and `Number()` would take most of them.

--- a/src/lib/chat-email-refs.ts
+++ b/src/lib/chat-email-refs.ts
@@ -126,6 +126,24 @@ export function splitEmailRefs(raw: string): SplitEmailRefs {
 }
 
 /**
+ * The query parameter `/app/clawbox` reads to open one message on arrival, and
+ * the link that carries it.
+ *
+ * HERE rather than beside the script that draws the card
+ * (`control-ui-email-directives.ts`, TASK-700), because that module is
+ * SERVER-ONLY — it reads the owner's language out of the config store, which is
+ * `node:fs` — and this constant is needed by the full-screen chat, which is a
+ * client component. Importing the server module from there put `fs` in the
+ * browser bundle and the Turbopack build refused it outright.
+ */
+export const CONTROL_UI_EMAIL_PARAM = "email";
+
+/** Where a Control UI card sends the owner: the chat that already draws it. */
+export function controlUiEmailHref(uid: number): string {
+  return `/app/clawbox?${CONTROL_UI_EMAIL_PARAM}=${uid}`;
+}
+
+/**
  * A UID, or null when the payload is not one.
  *
  * Exported because a directive is no longer the only way one arrives: a card on

--- a/src/lib/control-ui-email-directives.ts
+++ b/src/lib/control-ui-email-directives.ts
@@ -1,0 +1,295 @@
+// ── `EMAIL:` directives on the gateway's own Control UI chat ────────────────
+//
+// THE THIRD WEBCHAT SURFACE. `EMAIL:4471` is how the agent points a ClawBox
+// chat at a message the owner can open; `chat-email-refs.ts` lifts the line out
+// and draws a card. The OpenClaw gateway's Control UI at `/chat` is a `webchat`
+// surface too — a ClawBox-served, default-pinned app on that edition
+// (`desktop-apps.ts`) — and it renders the line as a bare internal id.
+//
+// WHY THE HARNESS CANNOT ANSWER THIS, read off the pinned 2026.8.1 core on the
+// box. The outbound seam ClawBox already rides, `reply_payload_sending`, is
+// handed ONE payload for ONE channel: its context carries `channelId`,
+// `accountId`, `conversationId` and `sessionKey` and nothing client-shaped, and
+// all three webchat clients — ClawBox's dashboard chat, ClawBox's mascot popup
+// and the Control UI — arrive as `webchat`. ClawBox's own connect frame does
+// say `version: "clawbox-chat"`, but the gateway keeps that on the live
+// connection record and the presence row, where no hook can read it. So a strip
+// in the hook would take the card away from the two surfaces that make one, and
+// there is no per-client outbound hook in the `transform` / `message_sending` /
+// `after_turn` family that would let one message be three. `presentation`
+// (`docs/plugins/message-presentation.md`) is the core's own rich-card contract,
+// but its renderers are channel plugins — the provider table has no webchat row
+// — so a presentation block reaches this surface as fallback text.
+//
+// WHAT IS LEFT IS OURS. ClawBox serves that page: `src/app/[...gateway]/route.ts`
+// hands it to `serveGatewayHTML`, which already injects the ClawBox bar and the
+// gateway-connect script into the HTML. Same origin, so the card can link
+// straight at the chat that already renders the message, and the owner's
+// session rides along.
+//
+// ONE GRAMMAR, NOW IN FOUR PLACES. The rule is the same rule:
+// `src/lib/chat-email-refs.ts` (the chat window), the OpenClaw plugin's
+// `email-directives.mjs`, the Hermes plugin's `email_directives.py`, and this
+// one. They cannot share a file — this copy is evaluated by the browser inside
+// the gateway's own page, with no bundler and no imports. What holds them
+// together is the case table: `src/tests/fixtures/email-directive-cases.ts` runs
+// through all four, three of them in `email-directive-parity.test.ts` and this
+// one in `control-ui-email-directives.test.ts`, which evaluates the string that
+// actually ships.
+
+import { desktopTranslations } from "./desktop-translations";
+import type { Locale } from "./i18n";
+
+/** The query parameter `/app/clawbox` reads to open one message on arrival. */
+export const CONTROL_UI_EMAIL_PARAM = "email";
+
+/** Where a Control UI card sends the owner: the chat that already draws it. */
+export function controlUiEmailHref(uid: number): string {
+  return `/app/clawbox?${CONTROL_UI_EMAIL_PARAM}=${uid}`;
+}
+
+/** The card's label, in the language the owner picked, falling back to English. */
+export function controlUiCardLabel(locale: string | undefined): string {
+  const table = desktopTranslations[locale as Locale] ?? desktopTranslations.en;
+  return table["chat.email.openFull"] ?? desktopTranslations.en["chat.email.openFull"];
+}
+
+/**
+ * The `EMAIL:<uid>` grammar as the browser gets it — the fourth copy of the
+ * rule in `chat-email-refs.ts`, held to it case for case by
+ * `src/tests/unit/control-ui-email-directives.test.ts`.
+ *
+ * ES5-shaped on purpose: this is evaluated inside a page ClawBox does not
+ * build, so it uses nothing a bundler would have to provide and nothing the
+ * gateway's own scripts could collide with (everything is inside one IIFE at
+ * the call site).
+ *
+ * `[\s\S]` and not `\s*(.*)`, for the reason the other three copies give: the
+ * two quantifiers overlap on the space character and `$` without `m` matches
+ * only at the end of the input, which made the pattern quadratic on a line
+ * starting `email:` with a long run of spaces and a `\r`, ` ` or ` `
+ * held back from its end.
+ */
+export const CONTROL_UI_DIRECTIVE_PARSER_JS = `
+var EMAIL_LINE_RE = /^email:([\\s\\S]*)$/i;
+var FENCE_RE = /^(?:\`\`\`|~~~)/;
+var MAX_UID = 4294967295;
+var MAX_REFS = 25;
+
+function unwrapQuoted(value) {
+  var quotes = ["\`", '"', "'"];
+  for (var i = 0; i < quotes.length; i++) {
+    var quote = quotes[i];
+    if (value.length >= 2 && value.charAt(0) === quote && value.charAt(value.length - 1) === quote) {
+      return value.slice(1, -1).trim();
+    }
+  }
+  return value;
+}
+
+function parseUid(payload) {
+  var value = unwrapQuoted(payload.trim());
+  if (!/^[0-9]{1,10}$/.test(value)) return null;
+  var uid = Number(value);
+  if (!isFinite(uid) || Math.floor(uid) !== uid || uid < 1 || uid > MAX_UID) return null;
+  return uid;
+}
+
+function splitEmailRefs(raw) {
+  if (typeof raw !== "string") return { text: "", uids: [] };
+  if (!/email:/i.test(raw)) return { text: raw, uids: [] };
+
+  var uids = [];
+  var seen = {};
+  var kept = [];
+  var inFence = false;
+  var lines = raw.split("\\n");
+
+  for (var i = 0; i < lines.length; i++) {
+    var line = lines[i];
+    var trimmed = line.trim();
+    if (FENCE_RE.test(trimmed)) {
+      inFence = !inFence;
+      kept.push(line);
+      continue;
+    }
+    var match = inFence ? null : EMAIL_LINE_RE.exec(trimmed);
+    if (!match) {
+      kept.push(line);
+      continue;
+    }
+    var uid = parseUid(match[1]);
+    if (uid === null) {
+      kept.push(line);
+      continue;
+    }
+    if (seen["u" + uid]) continue;
+    if (uids.length >= MAX_REFS) {
+      kept.push(line);
+      continue;
+    }
+    seen["u" + uid] = true;
+    uids.push(uid);
+  }
+
+  if (kept.length === lines.length) return { text: raw, uids: uids };
+  return { text: kept.join("\\n").replace(/\\n{3,}/g, "\\n\\n").trim(), uids: uids };
+}
+`;
+
+/**
+ * The card, styled to read as the chat window's own: the same amber on the same
+ * dark ground, because it is the same affordance on a page ClawBox does not
+ * otherwise dress. Inline, since none of ClawBox's stylesheets are loaded here.
+ */
+const CARD_STYLE = [
+  "display:inline-flex",
+  "align-items:center",
+  "gap:6px",
+  "margin:4px 0",
+  "padding:6px 10px",
+  "border:1px solid rgba(249,115,22,0.25)",
+  "border-radius:8px",
+  "background:rgba(249,115,22,0.06)",
+  "color:#fdba74",
+  "font:inherit",
+  "font-size:13px",
+  "text-decoration:none",
+  "cursor:pointer",
+].join(";");
+
+/**
+ * The program injected into the Control UI page.
+ *
+ * A TEXT-NODE rewrite and not a selector: the only thing it assumes about a page
+ * ClawBox does not build is that a reply's prose ends up in text nodes, which is
+ * true of any HTML and survives a gateway upgrade. A class name or a container
+ * id would be the probe-once fix that silently stops working after an update —
+ * and silently is the whole complaint here.
+ *
+ * IDEMPOTENT BY CONSTRUCTION. A rewritten node no longer carries the directive,
+ * so the observer's own re-entry finds nothing and the pass terminates. That is
+ * also why the card is never counted or de-duplicated by hand: the same turn
+ * seen twice cannot produce two cards, because the second look has nothing left
+ * to match.
+ *
+ * WHAT IT WILL NOT TOUCH: text inside `pre`, `code`, `script`, `style`,
+ * `textarea`, `input` or an editable element — an explanation of the syntax, and
+ * anything the owner is still typing, stay exactly as they are. The parser's own
+ * fenced-code rule covers the same ground when a whole reply arrives in one text
+ * node; the tag check covers it when the page has already rendered the fence.
+ *
+ * The chrome tags (`label`, `button`, `th`, `dt`, `summary`, `legend`, `select`)
+ * are there for a different reason, and it is the accepted cost of a rule that
+ * reads a whole page rather than a transcript it owns: a line that is exactly
+ * `Email: 12345` is a directive by this grammar wherever it appears, so a form
+ * label or a table header that happened to be shaped that way would become a
+ * card. Chrome is where such a line would plausibly live; prose is where a
+ * directive does. A reply's own paragraph is touched by neither list.
+ */
+export function controlUiEmailDirectiveScript(locale?: string): string {
+  const label = jsonForScript(controlUiCardLabel(locale));
+  const href = jsonForScript(`/app/clawbox?${CONTROL_UI_EMAIL_PARAM}=`);
+  return `<script>${controlUiEmailDirectiveScriptBody(label, href)}</script>`;
+}
+
+/** The same program without its element, for a test that has to evaluate it. */
+export function controlUiEmailDirectiveScriptBody(
+  label = jsonForScript(controlUiCardLabel(undefined)),
+  href = jsonForScript(`/app/clawbox?${CONTROL_UI_EMAIL_PARAM}=`),
+): string {
+  return `(function(){
+${CONTROL_UI_DIRECTIVE_PARSER_JS}
+var LABEL = ${label};
+var HREF = ${href};
+var SKIP_TAGS = {
+  PRE: 1, CODE: 1, SCRIPT: 1, STYLE: 1, TITLE: 1,
+  TEXTAREA: 1, INPUT: 1, OPTION: 1, SELECT: 1,
+  LABEL: 1, BUTTON: 1, SUMMARY: 1, LEGEND: 1, TH: 1, DT: 1,
+};
+var CARD_CLASS = "clawbox-email-card";
+
+function skipped(node) {
+  for (var el = node.parentNode; el && el.nodeType === 1; el = el.parentNode) {
+    if (SKIP_TAGS[el.nodeName]) return true;
+    if (el.id === "clawbox-bar") return true;
+    if (el.isContentEditable) return true;
+    if (el.getAttribute && el.getAttribute("class") === CARD_CLASS) return true;
+  }
+  return false;
+}
+
+function card(uid) {
+  var a = document.createElement("a");
+  a.className = CARD_CLASS;
+  a.setAttribute("data-clawbox-email-uid", String(uid));
+  a.setAttribute("href", HREF + uid);
+  a.setAttribute("target", "_blank");
+  a.setAttribute("rel", "noopener noreferrer");
+  a.setAttribute("style", ${JSON.stringify(CARD_STYLE)});
+  a.textContent = LABEL;
+  return a;
+}
+
+function rewrite(node) {
+  if (!node || node.nodeType !== 3) return;
+  var raw = node.nodeValue;
+  if (!raw || !/email:/i.test(raw)) return;
+  if (skipped(node)) return;
+  var split = splitEmailRefs(raw);
+  if (!split.uids.length) return;
+  var parent = node.parentNode;
+  if (!parent) return;
+  var frag = document.createDocumentFragment();
+  if (split.text) frag.appendChild(document.createTextNode(split.text));
+  for (var i = 0; i < split.uids.length; i++) frag.appendChild(card(split.uids[i]));
+  parent.replaceChild(frag, node);
+}
+
+function scan(root) {
+  if (!root) return;
+  if (root.nodeType === 3) { rewrite(root); return; }
+  if (root.nodeType !== 1 && root.nodeType !== 9 && root.nodeType !== 11) return;
+  // Collected before anything is replaced: a walker whose current node is taken
+  // out of the document stops there, and the rest of the reply keeps its ids.
+  var walker = document.createTreeWalker(root, 4, null);
+  var pending = [];
+  var next;
+  while ((next = walker.nextNode())) pending.push(next);
+  for (var i = 0; i < pending.length; i++) rewrite(pending[i]);
+}
+
+try {
+  var observer = new MutationObserver(function (records) {
+    for (var i = 0; i < records.length; i++) {
+      var record = records[i];
+      if (record.type === "characterData") { rewrite(record.target); continue; }
+      for (var j = 0; j < record.addedNodes.length; j++) scan(record.addedNodes[j]);
+    }
+  });
+  observer.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+    characterData: true,
+  });
+  scan(document.body);
+} catch (e) {
+  // The page is the gateway's, not ClawBox's. A directive shown as text is a
+  // blemish; a script that throws on this page could cost the owner the chat.
+}
+})();`;
+}
+
+/**
+ * A JSON literal safe to sit inside a `<script>` element.
+ *
+ * The same escaping `serveGatewayHTML` applies to the gateway token, and for the
+ * same reason: `</script>` inside a string literal ends the ELEMENT, not the
+ * string, and the rest of the program lands in the document as text.
+ */
+function jsonForScript(value: string): string {
+  return JSON.stringify(value)
+    .replace(/&/g, "\\u0026")
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e");
+}

--- a/src/lib/control-ui-email-directives.ts
+++ b/src/lib/control-ui-email-directives.ts
@@ -8,23 +8,23 @@
 //
 // WHY THE HARNESS CANNOT ANSWER THIS, read off the pinned 2026.8.1 core on the
 // box. The outbound seam ClawBox already rides, `reply_payload_sending`, is
-// handed ONE payload for ONE channel: its context carries `channelId`,
-// `accountId`, `conversationId` and `sessionKey` and nothing client-shaped, and
+// handed ONE payload for ONE delivery: its context carries `sessionKey`,
+// `runId`, `messageId`, `senderId` and trace ids and nothing client-shaped, and
 // all three webchat clients — ClawBox's dashboard chat, ClawBox's mascot popup
-// and the Control UI — arrive as `webchat`. ClawBox's own connect frame does
-// say `version: "clawbox-chat"`, but the gateway keeps that on the live
-// connection record and the presence row, where no hook can read it. So a strip
-// in the hook would take the card away from the two surfaces that make one, and
-// there is no per-client outbound hook in the `transform` / `message_sending` /
-// `after_turn` family that would let one message be three. `presentation`
-// (`docs/plugins/message-presentation.md`) is the core's own rich-card contract,
-// but its renderers are channel plugins — the provider table has no webchat row
-// — so a presentation block reaches this surface as fallback text.
+// and the Control UI — arrive as `webchat`. So a strip in the hook would take
+// the card away from the two surfaces that make one, and no hook in the
+// catalog is per-client. ClawBox's own connect frame does say
+// `version: "clawbox-chat"`, but the gateway keeps that on the live connection
+// record and the presence row, where no hook can read it. `presentation`
+// (`docs/plugins/message-presentation.md`) is the core's own rich-card
+// contract and would have been the answer if webchat had a renderer: its
+// provider table lists Discord, Feishu, Matrix, Mattermost, Teams, Slack,
+// Telegram and "plain channels — text fallback", and no webchat row.
 //
 // WHAT IS LEFT IS OURS. ClawBox serves that page: `src/app/[...gateway]/route.ts`
-// hands it to `serveGatewayHTML`, which already injects the ClawBox bar and the
-// gateway-connect script into the HTML. Same origin, so the card can link
-// straight at the chat that already renders the message, and the owner's
+// hands a navigation to `serveGatewayHTML`, which already injects the ClawBox
+// bar and the gateway-connect script into the HTML. Same origin, so the card
+// links straight into the chat that already renders the message and the owner's
 // session rides along.
 //
 // ONE GRAMMAR, NOW IN FOUR PLACES. The rule is the same rule:
@@ -32,20 +32,29 @@
 // `email-directives.mjs`, the Hermes plugin's `email_directives.py`, and this
 // one. They cannot share a file — this copy is evaluated by the browser inside
 // the gateway's own page, with no bundler and no imports. What holds them
-// together is the case table: `src/tests/fixtures/email-directive-cases.ts` runs
-// through all four, three of them in `email-directive-parity.test.ts` and this
-// one in `control-ui-email-directives.test.ts`, which evaluates the string that
-// actually ships.
+// together is `src/tests/unit/email-directive-parity.test.ts`, which runs the
+// shared case table AND both generated sweeps through all four.
+//
+// THE OTHER EDITION. The Control UI app is OpenClaw-only
+// (`desktop-app-editions.ts`). Its Hermes twin is the Hermes dashboard, served
+// through `scripts/hermes-dashboard-proxy.js` — which pipes the upstream
+// response straight through and injects no HTML, so this module cannot reach it
+// without giving that authentication proxy body buffering and content-encoding
+// handling. Everything below is edition-neutral and ready for it.
 
 import { desktopTranslations } from "./desktop-translations";
+import * as configStore from "./config-store";
 import type { Locale } from "./i18n";
 
 /** The query parameter `/app/clawbox` reads to open one message on arrival. */
 export const CONTROL_UI_EMAIL_PARAM = "email";
 
+/** The one place the deep link's shape is written. */
+const CONTROL_UI_EMAIL_HREF_PREFIX = `/app/clawbox?${CONTROL_UI_EMAIL_PARAM}=`;
+
 /** Where a Control UI card sends the owner: the chat that already draws it. */
 export function controlUiEmailHref(uid: number): string {
-  return `/app/clawbox?${CONTROL_UI_EMAIL_PARAM}=${uid}`;
+  return `${CONTROL_UI_EMAIL_HREF_PREFIX}${uid}`;
 }
 
 /** The card's label, in the language the owner picked, falling back to English. */
@@ -55,19 +64,37 @@ export function controlUiCardLabel(locale: string | undefined): string {
 }
 
 /**
+ * The language the owner picked, or undefined when nothing has been picked or
+ * the store cannot be read.
+ *
+ * ONE copy, imported by both routes that serve this page. The injected script
+ * carries a label, and this page is the one place ClawBox draws UI it does not
+ * own — `i18n.tsx` and its provider are not loaded there. Read on the server
+ * rather than fetched by the script, which would cost a request per page load
+ * to say three words.
+ */
+export async function controlUiLocale(): Promise<string | undefined> {
+  try {
+    const value = await configStore.get("pref:ui_language");
+    return typeof value === "string" && value ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * The `EMAIL:<uid>` grammar as the browser gets it — the fourth copy of the
- * rule in `chat-email-refs.ts`, held to it case for case by
- * `src/tests/unit/control-ui-email-directives.test.ts`.
+ * rule in `chat-email-refs.ts`, held to it case for case (and over both
+ * generated sweeps) by `src/tests/unit/email-directive-parity.test.ts`.
  *
  * ES5-shaped on purpose: this is evaluated inside a page ClawBox does not
- * build, so it uses nothing a bundler would have to provide and nothing the
- * gateway's own scripts could collide with (everything is inside one IIFE at
- * the call site).
+ * build, so it uses nothing a bundler would have to provide, and everything is
+ * inside one IIFE at the call site so it can collide with nothing.
  *
  * `[\s\S]` and not `\s*(.*)`, for the reason the other three copies give: the
  * two quantifiers overlap on the space character and `$` without `m` matches
  * only at the end of the input, which made the pattern quadratic on a line
- * starting `email:` with a long run of spaces and a `\r`, ` ` or ` `
+ * starting `email:` with a long run of spaces and a `\r`, ` ` or ` `
  * held back from its end.
  */
 export const CONTROL_UI_DIRECTIVE_PARSER_JS = `
@@ -95,12 +122,19 @@ function parseUid(payload) {
   return uid;
 }
 
-function splitEmailRefs(raw) {
+/**
+ * The shared rule. \`budget\` lets the CALLER carry the "already seen" set and
+ * the remaining card count across the several text nodes one reply is rendered
+ * into; omitted, it behaves exactly like the other three copies, which is what
+ * the parity suite runs.
+ */
+function splitEmailRefs(raw, budget) {
   if (typeof raw !== "string") return { text: "", uids: [] };
   if (!/email:/i.test(raw)) return { text: raw, uids: [] };
 
   var uids = [];
-  var seen = {};
+  var seen = budget && budget.seen ? budget.seen : {};
+  var taken = budget && typeof budget.taken === "number" ? budget.taken : 0;
   var kept = [];
   var inFence = false;
   var lines = raw.split("\\n");
@@ -124,7 +158,7 @@ function splitEmailRefs(raw) {
       continue;
     }
     if (seen["u" + uid]) continue;
-    if (uids.length >= MAX_REFS) {
+    if (taken + uids.length >= MAX_REFS) {
       kept.push(line);
       continue;
     }
@@ -132,31 +166,71 @@ function splitEmailRefs(raw) {
     uids.push(uid);
   }
 
+  if (budget) budget.taken = taken + uids.length;
   if (kept.length === lines.length) return { text: raw, uids: uids };
   return { text: kept.join("\\n").replace(/\\n{3,}/g, "\\n\\n").trim(), uids: uids };
 }
 `;
 
 /**
- * The card, styled to read as the chat window's own: the same amber on the same
- * dark ground, because it is the same affordance on a page ClawBox does not
- * otherwise dress. Inline, since none of ClawBox's stylesheets are loaded here.
+ * The card, dressed to read as the chat window's own — the same affordance on a
+ * page ClawBox does not otherwise style.
+ *
+ * A stylesheet and a class rather than an inline `style`, because the Control UI
+ * ships light themes as well as dark (`data-theme-mode="light"`, and the
+ * system preference): amber-on-dark is unreadable on a `#faf9f7` ground, and an
+ * inline style cannot carry a media query.
  */
-const CARD_STYLE = [
-  "display:inline-flex",
-  "align-items:center",
-  "gap:6px",
-  "margin:4px 0",
-  "padding:6px 10px",
-  "border:1px solid rgba(249,115,22,0.25)",
-  "border-radius:8px",
-  "background:rgba(249,115,22,0.06)",
-  "color:#fdba74",
-  "font:inherit",
-  "font-size:13px",
-  "text-decoration:none",
-  "cursor:pointer",
-].join(";");
+const CARD_CSS = `
+.clawbox-email-card {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 4px 0;
+  padding: 6px 10px;
+  border: 1px solid rgba(249, 115, 22, 0.35);
+  border-radius: 8px;
+  background: rgba(249, 115, 22, 0.08);
+  color: #fdba74;
+  font: inherit;
+  font-size: 13px;
+  text-decoration: none;
+  cursor: pointer;
+}
+@media (prefers-color-scheme: light) {
+  .clawbox-email-card { color: #9a3412; background: rgba(249, 115, 22, 0.12); }
+}
+:root[data-theme-mode="light"] .clawbox-email-card,
+[data-theme-mode="light"] .clawbox-email-card {
+  color: #9a3412;
+  background: rgba(249, 115, 22, 0.12);
+}
+:root[data-theme-mode="dark"] .clawbox-email-card,
+[data-theme-mode="dark"] .clawbox-email-card {
+  color: #fdba74;
+  background: rgba(249, 115, 22, 0.08);
+}
+`;
+
+/** How often the sweep looks for text that has stopped changing. */
+export const CONTROL_UI_SWEEP_MS = 250;
+
+/**
+ * How long a piece of text must hold still before a directive in it becomes a
+ * card.
+ *
+ * THE REASON THIS IS NOT IMMEDIATE. A reply streams, and the text node holding
+ * it is rewritten token by token: `EMAIL:4`, `EMAIL:44`, `EMAIL:447`,
+ * `EMAIL:4471`. Every one of those is a usable uid by this grammar, so a
+ * rewrite on sight draws a card for message 4, then 44, then 447 — and if the
+ * turn is interrupted between two digits the last one STAYS, pointing at
+ * somebody else's mail, with no `EMAIL:` text left on screen to show that it is
+ * wrong. ClawBox's own chats have `dropUnfinishedDirective` for exactly this
+ * and can use it because they know the turn is streaming; this page carries no
+ * such signal, so quiet is the signal. Half a second is far below noticing and
+ * far above a token gap.
+ */
+export const CONTROL_UI_SETTLE_MS = 500;
 
 /**
  * The program injected into the Control UI page.
@@ -167,56 +241,97 @@ const CARD_STYLE = [
  * id would be the probe-once fix that silently stops working after an update —
  * and silently is the whole complaint here.
  *
- * IDEMPOTENT BY CONSTRUCTION. A rewritten node no longer carries the directive,
- * so the observer's own re-entry finds nothing and the pass terminates. That is
- * also why the card is never counted or de-duplicated by hand: the same turn
- * seen twice cannot produce two cards, because the second look has nothing left
- * to match.
+ * NOTHING IS DRAWN TWICE. Three separate rules, because the observer sees its
+ * own work: the text a rewrite puts back is remembered and never looked at
+ * again (so the lines a reply had past the 25-card cap stay text instead of
+ * being converted by the next pass); the card elements carry no `email:` text
+ * to match; and the "already seen" set and the remaining card count are carried
+ * ACROSS the text nodes that share a parent, so a reply the page rendered one
+ * directive per line is deduped and capped as one reply rather than as N.
  *
  * WHAT IT WILL NOT TOUCH: text inside `pre`, `code`, `script`, `style`,
- * `textarea`, `input` or an editable element — an explanation of the syntax, and
- * anything the owner is still typing, stay exactly as they are. The parser's own
- * fenced-code rule covers the same ground when a whole reply arrives in one text
- * node; the tag check covers it when the page has already rendered the fence.
+ * `textarea`, `input`, a link, or an editable element — an explanation of the
+ * syntax, and anything the owner is still typing, stay exactly as they are. The
+ * parser's own fenced-code rule covers the same ground when a whole reply
+ * arrives in one text node; the tag check covers it when the page has already
+ * rendered the fence.
  *
- * The chrome tags (`label`, `button`, `th`, `dt`, `summary`, `legend`, `select`)
- * are there for a different reason, and it is the accepted cost of a rule that
- * reads a whole page rather than a transcript it owns: a line that is exactly
- * `Email: 12345` is a directive by this grammar wherever it appears, so a form
- * label or a table header that happened to be shaped that way would become a
- * card. Chrome is where such a line would plausibly live; prose is where a
- * directive does. A reply's own paragraph is touched by neither list.
+ * The chrome tags (`label`, `button`, `th`, `td`, `dt`, `dd`, `summary`,
+ * `legend`, `select`, `kbd`, `samp`, `var`) are there for a different reason,
+ * and it is the accepted cost of a rule that reads a whole page rather than a
+ * transcript it owns: a line that is exactly `Email: 12345` is a directive by
+ * this grammar wherever it appears, so a form label, a table cell or a
+ * definition row that happened to be shaped that way would become a card.
+ * Chrome is where such a line would plausibly live; prose is where a directive
+ * does. A reply's own paragraph is touched by neither list.
  */
 export function controlUiEmailDirectiveScript(locale?: string): string {
-  const label = jsonForScript(controlUiCardLabel(locale));
-  const href = jsonForScript(`/app/clawbox?${CONTROL_UI_EMAIL_PARAM}=`);
-  return `<script>${controlUiEmailDirectiveScriptBody(label, href)}</script>`;
+  return `<script>${controlUiEmailDirectiveScriptBody({ locale })}</script>`;
+}
+
+export interface ControlUiScriptOptions {
+  /** The owner's language, for the card's label. */
+  readonly locale?: string;
+  /** Quiet required before a directive becomes a card. Tests shorten it. */
+  readonly settleMs?: number;
+  /** How often the sweep runs. Tests shorten it. */
+  readonly sweepMs?: number;
 }
 
 /** The same program without its element, for a test that has to evaluate it. */
 export function controlUiEmailDirectiveScriptBody(
-  label = jsonForScript(controlUiCardLabel(undefined)),
-  href = jsonForScript(`/app/clawbox?${CONTROL_UI_EMAIL_PARAM}=`),
+  options: ControlUiScriptOptions = {},
 ): string {
+  const label = jsonForScript(controlUiCardLabel(options.locale));
+  const href = jsonForScript(CONTROL_UI_EMAIL_HREF_PREFIX);
+  const css = jsonForScript(CARD_CSS);
+  const settleMs = Math.max(0, Math.trunc(options.settleMs ?? CONTROL_UI_SETTLE_MS));
+  const sweepMs = Math.max(1, Math.trunc(options.sweepMs ?? CONTROL_UI_SWEEP_MS));
   return `(function(){
+// ONE per document. Two routes serve this page and a future third might; two
+// copies of this program would each keep their own "already ours" set, draw the
+// same reply twice and defeat the card cap between them.
+if (document.__clawboxEmailCards) return;
+document.__clawboxEmailCards = true;
 ${CONTROL_UI_DIRECTIVE_PARSER_JS}
 var LABEL = ${label};
 var HREF = ${href};
-var SKIP_TAGS = {
-  PRE: 1, CODE: 1, SCRIPT: 1, STYLE: 1, TITLE: 1,
-  TEXTAREA: 1, INPUT: 1, OPTION: 1, SELECT: 1,
-  LABEL: 1, BUTTON: 1, SUMMARY: 1, LEGEND: 1, TH: 1, DT: 1,
-};
+var CSS = ${css};
+var SETTLE_MS = ${settleMs};
+var SWEEP_MS = ${sweepMs};
 var CARD_CLASS = "clawbox-email-card";
+var SKIP_TAGS = {
+  PRE: 1, CODE: 1, SCRIPT: 1, STYLE: 1, TITLE: 1, NOSCRIPT: 1,
+  TEXTAREA: 1, INPUT: 1, OPTION: 1, SELECT: 1, A: 1,
+  LABEL: 1, BUTTON: 1, SUMMARY: 1, LEGEND: 1,
+  TH: 1, TD: 1, DT: 1, DD: 1, KBD: 1, SAMP: 1, VAR: 1
+};
+
+// The text nodes this script itself put back. The observer sees its own work,
+// and without this the lines a reply had past the card cap — which the parser
+// deliberately leaves as TEXT — would be converted by the very next pass, one
+// batch of 25 at a time, until none were left.
+var ours = typeof WeakSet === "function" ? new WeakSet() : null;
+// Candidate text node -> the last time it was seen changing.
+var pending = typeof Map === "function" ? new Map() : null;
+var timer = null;
 
 function skipped(node) {
   for (var el = node.parentNode; el && el.nodeType === 1; el = el.parentNode) {
     if (SKIP_TAGS[el.nodeName]) return true;
     if (el.id === "clawbox-bar") return true;
     if (el.isContentEditable) return true;
-    if (el.getAttribute && el.getAttribute("class") === CARD_CLASS) return true;
   }
   return false;
+}
+
+function styleOnce() {
+  if (document.getElementById("clawbox-email-card-style")) return;
+  var style = document.createElement("style");
+  style.id = "clawbox-email-card-style";
+  style.textContent = CSS;
+  var head = document.head || document.documentElement;
+  if (head) head.appendChild(style);
 }
 
 function card(uid) {
@@ -224,46 +339,107 @@ function card(uid) {
   a.className = CARD_CLASS;
   a.setAttribute("data-clawbox-email-uid", String(uid));
   a.setAttribute("href", HREF + uid);
-  a.setAttribute("target", "_blank");
+  // A NAMED target, so a reply naming five messages does not leave five tabs
+  // behind; and the uid in the accessible name, because otherwise a screen
+  // reader hears the same three words once per card.
+  a.setAttribute("target", "clawbox-chat");
   a.setAttribute("rel", "noopener noreferrer");
-  a.setAttribute("style", ${JSON.stringify(CARD_STYLE)});
+  a.setAttribute("aria-label", LABEL + " #" + uid);
+  a.setAttribute("title", LABEL + " #" + uid);
   a.textContent = LABEL;
   return a;
 }
 
-function rewrite(node) {
+function note(node) {
   if (!node || node.nodeType !== 3) return;
+  if (!pending) return;
+  if (ours && ours.has(node)) return;
   var raw = node.nodeValue;
-  if (!raw || !/email:/i.test(raw)) return;
+  if (!raw || !/email:/i.test(raw)) { pending["delete"](node); return; }
   if (skipped(node)) return;
-  var split = splitEmailRefs(raw);
+  pending.set(node, Date.now());
+  start();
+}
+
+function convert(node, budget) {
+  var raw = node.nodeValue;
+  if (!raw) return;
+  var split = splitEmailRefs(raw, budget);
   if (!split.uids.length) return;
   var parent = node.parentNode;
   if (!parent) return;
+  styleOnce();
   var frag = document.createDocumentFragment();
-  if (split.text) frag.appendChild(document.createTextNode(split.text));
+  if (split.text) {
+    // The parser trims, because in the other three copies its input is a WHOLE
+    // reply. Here it is one text node, which in any rendered markdown is a
+    // fragment sitting beside inline elements — so the space after a </b> is
+    // load-bearing and is put back.
+    var lead = /^\\s*/.exec(raw)[0];
+    var tail = /\\s*$/.exec(raw)[0];
+    var kept = document.createTextNode(lead + split.text + tail);
+    if (ours) ours.add(kept);
+    frag.appendChild(kept);
+  }
   for (var i = 0; i < split.uids.length; i++) frag.appendChild(card(split.uids[i]));
   parent.replaceChild(frag, node);
 }
 
+function flush() {
+  if (!pending) return;
+  var now = Date.now();
+  var due = [];
+  pending.forEach(function (seenAt, node) {
+    if (!node.parentNode) { due.push([node, true]); return; }
+    if (now - seenAt >= SETTLE_MS) due.push([node, false]);
+  });
+  // The "already seen" set and the card count are shared by the text nodes that
+  // share a parent: that is as close to "one reply" as a page ClawBox does not
+  // build will say, and it is the scope the chat window's own dedupe and cap
+  // have. Nodes in different parents get their own budget, so a second reply
+  // cannot be capped by the first.
+  var budgets = typeof Map === "function" ? new Map() : null;
+  for (var i = 0; i < due.length; i++) {
+    var node = due[i][0];
+    var gone = due[i][1];
+    pending["delete"](node);
+    if (gone) continue;
+    var parent = node.parentNode;
+    var budget = budgets ? budgets.get(parent) : null;
+    if (!budget) {
+      budget = { seen: {}, taken: 0 };
+      if (budgets) budgets.set(parent, budget);
+    }
+    convert(node, budget);
+  }
+  if (!pending.size) stop();
+}
+
+function start() {
+  if (timer !== null) return;
+  timer = setInterval(flush, SWEEP_MS);
+}
+
+function stop() {
+  if (timer === null) return;
+  clearInterval(timer);
+  timer = null;
+}
+
 function scan(root) {
   if (!root) return;
-  if (root.nodeType === 3) { rewrite(root); return; }
+  if (root.nodeType === 3) { note(root); return; }
   if (root.nodeType !== 1 && root.nodeType !== 9 && root.nodeType !== 11) return;
-  // Collected before anything is replaced: a walker whose current node is taken
-  // out of the document stops there, and the rest of the reply keeps its ids.
   var walker = document.createTreeWalker(root, 4, null);
-  var pending = [];
   var next;
-  while ((next = walker.nextNode())) pending.push(next);
-  for (var i = 0; i < pending.length; i++) rewrite(pending[i]);
+  while ((next = walker.nextNode())) note(next);
 }
 
 try {
   var observer = new MutationObserver(function (records) {
     for (var i = 0; i < records.length; i++) {
       var record = records[i];
-      if (record.type === "characterData") { rewrite(record.target); continue; }
+      if (record.type === "characterData") { note(record.target); continue; }
       for (var j = 0; j < record.addedNodes.length; j++) scan(record.addedNodes[j]);
     }
   });

--- a/src/lib/control-ui-email-directives.ts
+++ b/src/lib/control-ui-email-directives.ts
@@ -44,18 +44,17 @@
 
 import { desktopTranslations } from "./desktop-translations";
 import * as configStore from "./config-store";
+import { CONTROL_UI_EMAIL_PARAM, controlUiEmailHref } from "./chat-email-refs";
 import type { Locale } from "./i18n";
 
-/** The query parameter `/app/clawbox` reads to open one message on arrival. */
-export const CONTROL_UI_EMAIL_PARAM = "email";
+// SERVER-ONLY. `configStore` is `node:fs`, so nothing a client component can
+// reach may import this file — the link's own shape lives in
+// `chat-email-refs.ts`, which the chat imports, and is re-exported here so the
+// script and the chat cannot describe the same link differently.
+export { CONTROL_UI_EMAIL_PARAM, controlUiEmailHref };
 
 /** The one place the deep link's shape is written. */
-const CONTROL_UI_EMAIL_HREF_PREFIX = `/app/clawbox?${CONTROL_UI_EMAIL_PARAM}=`;
-
-/** Where a Control UI card sends the owner: the chat that already draws it. */
-export function controlUiEmailHref(uid: number): string {
-  return `${CONTROL_UI_EMAIL_HREF_PREFIX}${uid}`;
-}
+const CONTROL_UI_EMAIL_HREF_PREFIX = controlUiEmailHref(0).slice(0, -1);
 
 /** The card's label, in the language the owner picked, falling back to English. */
 export function controlUiCardLabel(locale: string | undefined): string {

--- a/src/lib/control-ui-email-directives.ts
+++ b/src/lib/control-ui-email-directives.ts
@@ -384,6 +384,20 @@ function convert(node, budget) {
   parent.replaceChild(frag, node);
 }
 
+/** What this reply has already been given: the cards standing under it now. */
+function budgetFor(parent) {
+  var budget = { seen: {}, taken: 0 };
+  if (!parent || typeof parent.querySelectorAll !== "function") return budget;
+  var drawn = parent.querySelectorAll("a." + CARD_CLASS + "[data-clawbox-email-uid]");
+  for (var i = 0; i < drawn.length; i++) {
+    var uid = drawn[i].getAttribute("data-clawbox-email-uid");
+    if (!uid || budget.seen["u" + uid]) continue;
+    budget.seen["u" + uid] = true;
+    budget.taken += 1;
+  }
+  return budget;
+}
+
 function flush() {
   if (!pending) return;
   var now = Date.now();
@@ -397,6 +411,15 @@ function flush() {
   // build will say, and it is the scope the chat window's own dedupe and cap
   // have. Nodes in different parents get their own budget, so a second reply
   // cannot be capped by the first.
+  //
+  // AND IT IS READ BACK OFF THE DOM, not carried in a variable. One reply's
+  // text nodes do not have to settle in the same sweep — a directive that
+  // arrived a second after its neighbour lands in the next one — so a
+  // per-sweep budget would give it a fresh count and a fresh "already seen"
+  // set, and the same message would get a second card. The cards already on
+  // screen under that parent ARE the count, which also means a card the page
+  // removed takes its place in the budget with it, instead of capping a
+  // conversation for good the way a stored one would.
   var budgets = typeof Map === "function" ? new Map() : null;
   for (var i = 0; i < due.length; i++) {
     var node = due[i][0];
@@ -406,7 +429,7 @@ function flush() {
     var parent = node.parentNode;
     var budget = budgets ? budgets.get(parent) : null;
     if (!budget) {
-      budget = { seen: {}, taken: 0 };
+      budget = budgetFor(parent);
       if (budgets) budgets.set(parent, budget);
     }
     convert(node, budget);

--- a/src/lib/gateway-proxy.ts
+++ b/src/lib/gateway-proxy.ts
@@ -11,8 +11,7 @@ import {
   normalizeOrigin,
   resolveOriginsPath,
 } from "./control-ui-origins";
-import { controlUiEmailDirectiveScript } from "./control-ui-email-directives";
-import * as configStore from "./config-store";
+import { controlUiEmailDirectiveScript, controlUiLocale } from "./control-ui-email-directives";
 
 const GATEWAY_PORT = envPort(process.env.GATEWAY_PORT, 18789);
 const OPENCLAW_CONFIG_PATH = `${
@@ -220,26 +219,10 @@ export async function getOrGenerateGatewayToken(): Promise<string | null> {
 }
 
 /**
- * The language the owner picked, or undefined when nothing has been picked or
- * the store cannot be read.
- *
- * The card injected below carries a label, and this page is the one place
- * ClawBox draws UI it does not own — `i18n.tsx` and its provider are not loaded
- * here. Read on the server rather than fetched by the injected script: the
- * script would need a second request on every page load to say three words.
- */
-async function uiLocale(): Promise<string | undefined> {
-  try {
-    const value = await configStore.get("pref:ui_language");
-    return typeof value === "string" && value ? value : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * Fetches the gateway SPA HTML and injects the ClawBox bar + auth token.
- * Used by both the root route and the catch-all gateway route.
+ * Fetches the gateway SPA HTML and injects the ClawBox bar, the auth token and
+ * the `EMAIL:` directive handling. Its one caller is the catch-all gateway
+ * route (`src/app/[...gateway]/route.ts`), which reaches it only for a
+ * NAVIGATION — a script `fetch()` for the same path is proxied as bytes.
  */
 export async function serveGatewayHTML(
   request: NextRequest
@@ -315,9 +298,14 @@ export async function serveGatewayHTML(
     // in with the bar — on the page ClawBox already serves and already injects
     // into. Not gated on the owner session: the shell is served without one and
     // an id on screen is not a credential.
+    const emailDirectives = controlUiEmailDirectiveScript(await controlUiLocale());
+    // A replacer FUNCTION, not a string: `$&`, `` $` ``, `$'` and `$1` are
+    // substitutions inside a replacement string, and the injected script now
+    // carries a translated label — one `$'` from a translator would otherwise
+    // duplicate the rest of the document into the page.
     html = html.replace(
       /<body\b[^>]*>/i,
-      `$&${CLAWBOX_BAR}${wsScript}${controlUiEmailDirectiveScript(await uiLocale())}`,
+      (match) => `${match}${CLAWBOX_BAR}${wsScript}${emailDirectives}`,
     );
     return new NextResponse(html, {
       status: 200,

--- a/src/lib/gateway-proxy.ts
+++ b/src/lib/gateway-proxy.ts
@@ -11,6 +11,8 @@ import {
   normalizeOrigin,
   resolveOriginsPath,
 } from "./control-ui-origins";
+import { controlUiEmailDirectiveScript } from "./control-ui-email-directives";
+import * as configStore from "./config-store";
 
 const GATEWAY_PORT = envPort(process.env.GATEWAY_PORT, 18789);
 const OPENCLAW_CONFIG_PATH = `${
@@ -218,6 +220,24 @@ export async function getOrGenerateGatewayToken(): Promise<string | null> {
 }
 
 /**
+ * The language the owner picked, or undefined when nothing has been picked or
+ * the store cannot be read.
+ *
+ * The card injected below carries a label, and this page is the one place
+ * ClawBox draws UI it does not own — `i18n.tsx` and its provider are not loaded
+ * here. Read on the server rather than fetched by the injected script: the
+ * script would need a second request on every page load to say three words.
+ */
+async function uiLocale(): Promise<string | undefined> {
+  try {
+    const value = await configStore.get("pref:ui_language");
+    return typeof value === "string" && value ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Fetches the gateway SPA HTML and injects the ClawBox bar + auth token.
  * Used by both the root route and the catch-all gateway route.
  */
@@ -289,7 +309,16 @@ export async function serveGatewayHTML(
   }catch(e){}
 })();
 </script>`;
-    html = html.replace(/<body\b[^>]*>/i, `$&${CLAWBOX_BAR}${wsScript}`);
+    // TASK-700: the gateway's own Control UI chat is a third `webchat` surface
+    // and showed `EMAIL:<uid>` as a bare internal id. No outbound hook can
+    // separate it from ClawBox's own two chats, so the directive handling rides
+    // in with the bar — on the page ClawBox already serves and already injects
+    // into. Not gated on the owner session: the shell is served without one and
+    // an id on screen is not a credential.
+    html = html.replace(
+      /<body\b[^>]*>/i,
+      `$&${CLAWBOX_BAR}${wsScript}${controlUiEmailDirectiveScript(await uiLocale())}`,
+    );
     return new NextResponse(html, {
       status: 200,
       headers: {

--- a/src/tests/components/chat-email-refs-surfaces.test.tsx
+++ b/src/tests/components/chat-email-refs-surfaces.test.tsx
@@ -386,3 +386,39 @@ describe("the mascot chat, which had the same hole one step further in", () => {
     expect(screen.queryAllByTestId("chat-email-card")).toHaveLength(0);
   });
 });
+
+// ── The other end of a Control UI card ───────────────────────────────────────
+//
+// The gateway's own Control UI chat is a third `webchat` surface and rendered
+// the directive as a bare id (TASK-700). Nothing in the harness can tell the
+// three webchat clients apart, so the card is drawn by a script ClawBox injects
+// into the page it already serves — and that card can only be a LINK. This is
+// where the link lands: the same chat, showing the same message, through the
+// same panel a card here opens. One behaviour, not a third.
+describe("opening one message by link", () => {
+  const path = window.location.pathname;
+
+  afterEach(() => {
+    window.history.replaceState({}, "", path);
+  });
+
+  it("opens the message the link names, without asking for it twice", async () => {
+    window.history.replaceState({}, "", "/app/clawbox?email=4471");
+
+    render(<ChatApp />);
+
+    await screen.findByTestId("email-full-view");
+    await screen.findByText("Wednesday plan");
+    expect(mailboxReads()).toBe(1);
+  });
+
+  it("opens nothing at all when the link names no usable id", async () => {
+    window.history.replaceState({}, "", "/app/clawbox?email=0");
+
+    render(<ChatApp />);
+    await waitFor(() => expect(document.body.textContent).toContain(SUMMARY));
+
+    expect(screen.queryByTestId("email-full-view")).toBeNull();
+    expect(mailboxReads()).toBe(0);
+  });
+});

--- a/src/tests/components/chat-email-refs-surfaces.test.tsx
+++ b/src/tests/components/chat-email-refs-surfaces.test.tsx
@@ -410,6 +410,16 @@ describe("opening one message by link", () => {
     await screen.findByTestId("email-full-view");
     await screen.findByText("Wednesday plan");
     expect(mailboxReads()).toBe(1);
+    // The stub answers every unmatched URL with the same message, so the panel
+    // rendering proves nothing about WHICH message was asked for.
+    const asked = vi
+      .mocked(globalThis.fetch)
+      .mock.calls.map((call) => String(call[0]))
+      .filter((url) => url.includes("/setup-api/email/messages"));
+    expect(asked[0]).toContain("uid=4471");
+    // And the id is taken back out of the address, so a reload does not reopen
+    // the panel the owner has just closed.
+    expect(window.location.search).not.toContain("email=");
   });
 
   it("opens nothing at all when the link names no usable id", async () => {

--- a/src/tests/components/control-ui-email-card.test.tsx
+++ b/src/tests/components/control-ui-email-card.test.tsx
@@ -4,20 +4,32 @@
 // The repro on the card: OpenClaw edition → the pinned OpenClaw icon → "read my
 // last two emails" → the reply ends with bare `EMAIL:<id>` lines. Nothing in the
 // harness can fix that without taking the card away from ClawBox's own two
-// chats (one payload, one channel, three clients — see
+// chats (one payload, one delivery, three clients — see
 // `src/lib/control-ui-email-directives.ts`), so ClawBox does it in the page it
 // already serves and already injects into.
 //
 // The script is run here EXACTLY as it ships — the same string
 // `serveGatewayHTML` puts in the element — against a DOM shaped like a rendered
 // transcript. Asserting on a TypeScript twin of it would pin nothing.
+//
+// It installs ONCE per document and every later `installScript()` is the no-op
+// the page would get from a second injection, which is also what the "seen
+// again" case below asserts. jsdom hands the whole file one document, so a
+// script that installed per call would leave one live observer per test and
+// they would draw over each other's work — the same way two copies on a real
+// page would. The label's ten locales are pinned in the unit suite, where
+// asserting them does not need a second install.
 
 import { describe, expect, it, beforeEach } from "vitest";
 
 import { controlUiEmailDirectiveScriptBody } from "@/lib/control-ui-email-directives";
 
+/** The production settle is half a second; these tests use the same clock, shorter. */
+const SETTLE_MS = 20;
+const SWEEP_MS = 5;
+
 /**
- * Evaluate the shipped program with its three dependencies passed in by name.
+ * Evaluate the shipped program with its two dependencies passed in by name.
  *
  * `new Function` over a module constant, not over anything a request can reach:
  * the point is to run the string the browser runs. Naming `document` and
@@ -28,7 +40,7 @@ function installScript(): void {
   const run = new Function(
     "document",
     "MutationObserver",
-    controlUiEmailDirectiveScriptBody(),
+    controlUiEmailDirectiveScriptBody({ settleMs: SETTLE_MS, sweepMs: SWEEP_MS }),
   ) as (doc: Document, observer: typeof MutationObserver) => void;
   run(document, MutationObserver);
 }
@@ -37,21 +49,33 @@ function cards(): HTMLAnchorElement[] {
   return Array.from(document.querySelectorAll<HTMLAnchorElement>("a.clawbox-email-card"));
 }
 
-/** One microtask turn, which is when a MutationObserver callback runs. */
+function uids(): string[] {
+  return cards().map((a) => a.getAttribute("data-clawbox-email-uid") ?? "");
+}
+
+/**
+ * Long enough for the text to have held still and for one sweep to have run.
+ *
+ * The whole point of the settle is that nothing is converted while the text is
+ * still arriving, so every assertion here has to wait for quiet — a
+ * `queueMicrotask` would see the DOM exactly as it was.
+ */
 function settle(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
+  return new Promise((resolve) => setTimeout(resolve, SETTLE_MS + SWEEP_MS * 4));
 }
 
 describe("the Control UI chat and an EMAIL: directive", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
+    document.getElementById("clawbox-email-card-style")?.remove();
   });
 
-  it("turns a directive already on the page into a card and leaves the prose", () => {
+  it("turns a directive already on the page into a card and leaves the prose", async () => {
     document.body.innerHTML =
       '<div class="msg"><p>Jane sent the plan, and Accounts sent an invoice.\nEMAIL:4471\nEMAIL:4468</p></div>';
 
     installScript();
+    await settle();
 
     expect(document.body.textContent).not.toContain("EMAIL:4471");
     expect(document.body.textContent).not.toContain("4468");
@@ -61,6 +85,9 @@ describe("the Control UI chat and an EMAIL: directive", () => {
       "/app/clawbox?email=4468",
     ]);
     expect(cards()[0].textContent).toBe("Open full message");
+    // One tab for all of them, and a name a screen reader can tell apart.
+    expect(cards()[0].getAttribute("target")).toBe("clawbox-chat");
+    expect(cards()[0].getAttribute("aria-label")).toBe("Open full message #4471");
   });
 
   it("turns a directive that arrives later into a card", async () => {
@@ -75,26 +102,91 @@ describe("the Control UI chat and an EMAIL: directive", () => {
     expect(cards()).toHaveLength(1);
   });
 
+  it("never draws a card for a uid that was still being typed", async () => {
+    // The one that matters. A reply STREAMS, so the node holding it reads
+    // `EMAIL:4`, `EMAIL:44`, `EMAIL:447`, `EMAIL:4471` in turn — every one a
+    // usable id by this grammar. Converting on sight draws a card for message
+    // 4, then 44, then 447; and a turn interrupted between two digits leaves
+    // the wrong one on screen with no `EMAIL:` text left to show it is wrong.
+    installScript();
+    const bubble = document.createElement("p");
+    bubble.textContent = "Here it is.";
+    document.body.appendChild(bubble);
+    const node = bubble.firstChild as Text;
+
+    for (const text of ["Here it is.\nEMAIL:4", "Here it is.\nEMAIL:44", "Here it is.\nEMAIL:447"]) {
+      node.data = text;
+      await new Promise((resolve) => setTimeout(resolve, SWEEP_MS));
+      expect(cards()).toHaveLength(0);
+    }
+    node.data = "Here it is.\nEMAIL:4471";
+    await settle();
+
+    expect(uids()).toEqual(["4471"]);
+  });
+
+  it("caps the cards under one reply where the chat window caps them", async () => {
+    // The chat window shows 25 and leaves the rest as text. Without a marker on
+    // the text a rewrite puts BACK, the observer sees its own work and converts
+    // the remainder 25 at a time until none is left.
+    const lines = Array.from({ length: 30 }, (_, i) => `EMAIL:${i + 1}`).join("\n");
+    document.body.innerHTML = `<p>Thirty.\n${lines}</p>`;
+
+    installScript();
+    await settle();
+    await settle();
+
+    expect(cards()).toHaveLength(25);
+    expect(document.body.textContent).toContain("EMAIL:26");
+    expect(document.body.textContent).toContain("EMAIL:30");
+  });
+
+  it("counts one reply once even when the page renders a line per node", async () => {
+    // The page puts each directive on its own line — that IS the bug report —
+    // so a dedupe scoped to one text node sees each of them alone and the same
+    // message gets two identical cards.
+    document.body.innerHTML =
+      "<p>Two of them.<br>EMAIL:7<br>EMAIL:7<br>EMAIL:8</p>";
+
+    installScript();
+    await settle();
+
+    expect(uids()).toEqual(["7", "8"]);
+  });
+
+  it("does not weld two words together when the directive follows inline markup", async () => {
+    // The parser trims because in the other three copies its input is a whole
+    // reply; here it is one fragment sitting beside a <b>.
+    document.body.innerHTML = "<p><b>Jane</b> sent the plan.\nEMAIL:4471</p>";
+
+    installScript();
+    await settle();
+
+    expect(document.querySelector("p")?.textContent).toContain("Jane sent the plan.");
+    expect(cards()).toHaveLength(1);
+  });
+
   it("does not draw the same message twice when the turn is seen again", async () => {
-    // The false-success guard. Both ClawBox chats and this page can be open on
-    // the same turn, and a streaming UI re-renders the same bubble many times:
-    // the card must be the reply's, not the pass's.
+    // Both ClawBox chats and this page can be open on the same turn, and a
+    // streaming UI re-renders one bubble many times: the card must be the
+    // reply's, not the pass's.
     document.body.innerHTML = "<p>Done.\nEMAIL:4471</p>";
 
     installScript();
-    // A second pass over the same DOM, and a third the observer runs itself.
     installScript();
     document.body.appendChild(document.createElement("span"));
+    await settle();
     await settle();
 
     expect(cards()).toHaveLength(1);
   });
 
-  it("leaves a reply that EXPLAINS the syntax alone", () => {
+  it("leaves a reply that EXPLAINS the syntax alone", async () => {
     document.body.innerHTML =
       "<p>End the reply with</p><pre><code>EMAIL:4471</code></pre>";
 
     installScript();
+    await settle();
 
     expect(document.body.textContent).toContain("EMAIL:4471");
     expect(cards()).toHaveLength(0);
@@ -110,26 +202,34 @@ describe("the Control UI chat and an EMAIL: directive", () => {
     expect(cards()).toHaveLength(0);
   });
 
-  it("leaves the page's own chrome alone", () => {
+  it("leaves the page's own chrome alone", async () => {
     // The accepted cost of reading a whole page rather than a transcript: a
     // line that is exactly `Email: 12345` is a directive by this grammar
     // wherever it appears. Chrome is where such a line plausibly lives.
-    document.body.innerHTML =
-      "<table><tr><th>Email: 12345</th></tr></table><label>Email: 99</label>";
+    document.body.innerHTML = [
+      "<table><tr><th>Email: 12345</th><td>Email: 12346</td></tr></table>",
+      "<label>Email: 99</label>",
+      "<dl><dt>Email: 98</dt><dd>Email: 97</dd></dl>",
+      '<a href="/x">Email: 96</a>',
+    ].join("");
 
     installScript();
+    await settle();
 
-    expect(document.body.textContent).toContain("Email: 12345");
-    expect(document.body.textContent).toContain("Email: 99");
+    for (const id of ["12345", "12346", "99", "98", "97", "96"]) {
+      expect(document.body.textContent).toContain(`Email: ${id}`);
+    }
     expect(cards()).toHaveLength(0);
   });
 
-  it("keeps a directive that names no usable id as text", () => {
+  it("keeps a directive that names no usable id as text", async () => {
     document.body.innerHTML = "<p>Done.\nEMAIL:abc</p>";
 
     installScript();
+    await settle();
 
     expect(document.body.textContent).toContain("EMAIL:abc");
     expect(cards()).toHaveLength(0);
   });
+
 });

--- a/src/tests/components/control-ui-email-card.test.tsx
+++ b/src/tests/components/control-ui-email-card.test.tsx
@@ -20,13 +20,25 @@
 // page would. The label's ten locales are pinned in the unit suite, where
 // asserting them does not need a second install.
 
-import { describe, expect, it, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { controlUiEmailDirectiveScriptBody } from "@/lib/control-ui-email-directives";
 
-/** The production settle is half a second; these tests use the same clock, shorter. */
-const SETTLE_MS = 20;
-const SWEEP_MS = 5;
+/**
+ * The production settle is half a second; these tests use the same clock,
+ * shorter, and ADVANCED BY HAND.
+ *
+ * The streaming case mutates the node every `SWEEP_MS` and asserts that nothing
+ * has been converted yet, so the margin between the two is what the test is
+ * actually made of — and on a real clock a scheduler stall longer than
+ * `SETTLE_MS` between the mutation and the assertion would let the sweep
+ * convert `EMAIL:44` and fail for the machine's reason rather than the code's.
+ * Fake timers take the machine out of it: `Date.now()`, which is what the
+ * script measures quiet with, moves exactly as far as each `advanceTimersBy`
+ * says and no further.
+ */
+const SETTLE_MS = 150;
+const SWEEP_MS = 10;
 
 /**
  * Evaluate the shipped program with its two dependencies passed in by name.
@@ -60,14 +72,21 @@ function uids(): string[] {
  * still arriving, so every assertion here has to wait for quiet — a
  * `queueMicrotask` would see the DOM exactly as it was.
  */
-function settle(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, SETTLE_MS + SWEEP_MS * 4));
+async function settle(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(SETTLE_MS + SWEEP_MS * 4);
 }
 
 describe("the Control UI chat and an EMAIL: directive", () => {
   beforeEach(() => {
+    // The clock the settle is measured against, driven by hand: the sweep and
+    // the assertions must not race a loaded runner's scheduler.
+    vi.useFakeTimers();
     document.body.innerHTML = "";
     document.getElementById("clawbox-email-card-style")?.remove();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("turns a directive already on the page into a card and leaves the prose", async () => {
@@ -116,7 +135,7 @@ describe("the Control UI chat and an EMAIL: directive", () => {
 
     for (const text of ["Here it is.\nEMAIL:4", "Here it is.\nEMAIL:44", "Here it is.\nEMAIL:447"]) {
       node.data = text;
-      await new Promise((resolve) => setTimeout(resolve, SWEEP_MS));
+      await vi.advanceTimersByTimeAsync(SWEEP_MS);
       expect(cards()).toHaveLength(0);
     }
     node.data = "Here it is.\nEMAIL:4471";
@@ -152,6 +171,23 @@ describe("the Control UI chat and an EMAIL: directive", () => {
     await settle();
 
     expect(uids()).toEqual(["7", "8"]);
+  });
+
+  it("counts one reply once even when its lines settle in different sweeps", async () => {
+    // One reply's text nodes do not have to hold still together: a directive
+    // that arrives a second after its neighbour settles in a later sweep. A
+    // budget carried only for the length of one sweep would give it a fresh
+    // count and a fresh "already seen" set, and the same message would get a
+    // second card.
+    document.body.innerHTML = "<p>Two of them.<br>EMAIL:7</p>";
+    installScript();
+    await settle();
+    expect(uids()).toEqual(["7"]);
+
+    document.querySelector("p")?.appendChild(document.createTextNode("EMAIL:7"));
+    await settle();
+
+    expect(uids()).toEqual(["7"]);
   });
 
   it("does not weld two words together when the directive follows inline markup", async () => {

--- a/src/tests/components/control-ui-email-card.test.tsx
+++ b/src/tests/components/control-ui-email-card.test.tsx
@@ -1,0 +1,135 @@
+// What the owner sees on the gateway's own Control UI chat after a reply that
+// names his mail.
+//
+// The repro on the card: OpenClaw edition → the pinned OpenClaw icon → "read my
+// last two emails" → the reply ends with bare `EMAIL:<id>` lines. Nothing in the
+// harness can fix that without taking the card away from ClawBox's own two
+// chats (one payload, one channel, three clients — see
+// `src/lib/control-ui-email-directives.ts`), so ClawBox does it in the page it
+// already serves and already injects into.
+//
+// The script is run here EXACTLY as it ships — the same string
+// `serveGatewayHTML` puts in the element — against a DOM shaped like a rendered
+// transcript. Asserting on a TypeScript twin of it would pin nothing.
+
+import { describe, expect, it, beforeEach } from "vitest";
+
+import { controlUiEmailDirectiveScriptBody } from "@/lib/control-ui-email-directives";
+
+/**
+ * Evaluate the shipped program with its three dependencies passed in by name.
+ *
+ * `new Function` over a module constant, not over anything a request can reach:
+ * the point is to run the string the browser runs. Naming `document` and
+ * `MutationObserver` as parameters also states, and enforces, the whole of what
+ * the script is allowed to touch.
+ */
+function installScript(): void {
+  const run = new Function(
+    "document",
+    "MutationObserver",
+    controlUiEmailDirectiveScriptBody(),
+  ) as (doc: Document, observer: typeof MutationObserver) => void;
+  run(document, MutationObserver);
+}
+
+function cards(): HTMLAnchorElement[] {
+  return Array.from(document.querySelectorAll<HTMLAnchorElement>("a.clawbox-email-card"));
+}
+
+/** One microtask turn, which is when a MutationObserver callback runs. */
+function settle(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("the Control UI chat and an EMAIL: directive", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("turns a directive already on the page into a card and leaves the prose", () => {
+    document.body.innerHTML =
+      '<div class="msg"><p>Jane sent the plan, and Accounts sent an invoice.\nEMAIL:4471\nEMAIL:4468</p></div>';
+
+    installScript();
+
+    expect(document.body.textContent).not.toContain("EMAIL:4471");
+    expect(document.body.textContent).not.toContain("4468");
+    expect(document.body.textContent).toContain("Jane sent the plan, and Accounts sent an invoice.");
+    expect(cards().map((a) => a.getAttribute("href"))).toEqual([
+      "/app/clawbox?email=4471",
+      "/app/clawbox?email=4468",
+    ]);
+    expect(cards()[0].textContent).toBe("Open full message");
+  });
+
+  it("turns a directive that arrives later into a card", async () => {
+    installScript();
+
+    const bubble = document.createElement("p");
+    bubble.textContent = "Here it is.\nEMAIL:4471";
+    document.body.appendChild(bubble);
+    await settle();
+
+    expect(document.body.textContent).not.toContain("EMAIL:");
+    expect(cards()).toHaveLength(1);
+  });
+
+  it("does not draw the same message twice when the turn is seen again", async () => {
+    // The false-success guard. Both ClawBox chats and this page can be open on
+    // the same turn, and a streaming UI re-renders the same bubble many times:
+    // the card must be the reply's, not the pass's.
+    document.body.innerHTML = "<p>Done.\nEMAIL:4471</p>";
+
+    installScript();
+    // A second pass over the same DOM, and a third the observer runs itself.
+    installScript();
+    document.body.appendChild(document.createElement("span"));
+    await settle();
+
+    expect(cards()).toHaveLength(1);
+  });
+
+  it("leaves a reply that EXPLAINS the syntax alone", () => {
+    document.body.innerHTML =
+      "<p>End the reply with</p><pre><code>EMAIL:4471</code></pre>";
+
+    installScript();
+
+    expect(document.body.textContent).toContain("EMAIL:4471");
+    expect(cards()).toHaveLength(0);
+  });
+
+  it("leaves what the owner is still typing alone", async () => {
+    document.body.innerHTML = '<textarea>EMAIL:4471</textarea>';
+
+    installScript();
+    await settle();
+
+    expect(document.querySelector("textarea")?.textContent).toBe("EMAIL:4471");
+    expect(cards()).toHaveLength(0);
+  });
+
+  it("leaves the page's own chrome alone", () => {
+    // The accepted cost of reading a whole page rather than a transcript: a
+    // line that is exactly `Email: 12345` is a directive by this grammar
+    // wherever it appears. Chrome is where such a line plausibly lives.
+    document.body.innerHTML =
+      "<table><tr><th>Email: 12345</th></tr></table><label>Email: 99</label>";
+
+    installScript();
+
+    expect(document.body.textContent).toContain("Email: 12345");
+    expect(document.body.textContent).toContain("Email: 99");
+    expect(cards()).toHaveLength(0);
+  });
+
+  it("keeps a directive that names no usable id as text", () => {
+    document.body.innerHTML = "<p>Done.\nEMAIL:abc</p>";
+
+    installScript();
+
+    expect(document.body.textContent).toContain("EMAIL:abc");
+    expect(cards()).toHaveLength(0);
+  });
+});

--- a/src/tests/routes/gateway/gateway.test.ts
+++ b/src/tests/routes/gateway/gateway.test.ts
@@ -109,6 +109,20 @@ describe("/setup-api/gateway", () => {
     expect(html).toContain("clawbox.local");
   });
 
+  it("carries the EMAIL: directive handling the other door already has", async () => {
+    // The sibling call site of TASK-700. `serveGatewayHTML` is not the only
+    // route that hands this page to a browser, and a bare `EMAIL:<uid>` here
+    // would be the same defect one door along.
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve("<html><head></head><body>Gateway</body></html>"),
+    });
+    const res = await GET(new NextRequest(new URL("http://clawbox.local/setup-api/gateway")));
+    const html = await res.text();
+    expect(html).toContain("clawbox-email-card");
+    expect(html).toContain("/app/clawbox?email=");
+  });
+
   it("returns offline HTML when gateway is down", async () => {
     mockFetch.mockRejectedValue(new Error("Connection refused"));
     const req = new NextRequest(new URL("http://clawbox.local/setup-api/gateway"));

--- a/src/tests/unit/control-ui-email-directives.test.ts
+++ b/src/tests/unit/control-ui-email-directives.test.ts
@@ -1,0 +1,84 @@
+// The gateway's own Control UI chat is a THIRD `webchat` surface, and it showed
+// `EMAIL:<uid>` as a bare internal id.
+//
+// ClawBox's two chats lift the directive out and draw an "open full message"
+// card. The OpenClaw Control UI at `/chat` — a ClawBox-served, default-pinned
+// app on that edition — is `webchat` too, and nothing the gateway hands an
+// outbound hook separates the three: the hook sees one payload going to one
+// channel, so a strip there would take the card away from the two surfaces that
+// make one. That is why the harness cannot answer this and ClawBox's own
+// injection into the page it already serves has to (TASK-700).
+//
+// This file pins the half that has to agree with everything else: the grammar
+// the injected script carries is the SAME grammar, case for case, as the three
+// implementations `email-directive-parity.test.ts` already holds together.
+
+import { describe, expect, it } from "vitest";
+import vm from "node:vm";
+
+import { splitEmailRefs, parseEmailUid } from "@/lib/chat-email-refs";
+import {
+  CONTROL_UI_DIRECTIVE_PARSER_JS,
+  controlUiEmailHref,
+  controlUiEmailDirectiveScript,
+} from "@/lib/control-ui-email-directives";
+import { EMAIL_DIRECTIVE_CASES } from "@/tests/fixtures/email-directive-cases";
+
+interface BrowserSplit {
+  (raw: string): { text: string; uids: number[] };
+}
+
+/**
+ * The parser the browser gets, evaluated exactly as the browser evaluates it.
+ *
+ * Asserting on a TypeScript copy of the rule would prove nothing about the
+ * string that actually ships inside the `<script>`; this runs THAT string.
+ */
+function browserSplit(): BrowserSplit {
+  return vm.runInNewContext(
+    `${CONTROL_UI_DIRECTIVE_PARSER_JS}\nsplitEmailRefs;`,
+  ) as BrowserSplit;
+}
+
+describe("the Control UI's copy of the EMAIL: grammar", () => {
+  it("answers every shared case the way the chat window does", () => {
+    const split = browserSplit();
+    for (const testCase of EMAIL_DIRECTIVE_CASES) {
+      expect(split(testCase.input).text, testCase.name).toBe(testCase.stripped);
+      expect(split(testCase.input).uids, testCase.name).toEqual(
+        splitEmailRefs(testCase.input).uids,
+      );
+    }
+  });
+
+  it("caps the cards under one reply where the chat window caps them", () => {
+    // 30 directives, cap 25: the last five go back to being text on BOTH sides.
+    const raw = Array.from({ length: 30 }, (_, i) => `EMAIL:${i + 1}`).join("\n");
+    const split = browserSplit();
+    expect(split(raw).uids).toEqual(splitEmailRefs(raw).uids);
+    expect(split(raw).text).toBe(splitEmailRefs(raw).text);
+  });
+});
+
+describe("the link a Control UI card opens", () => {
+  it("points at the chat that already renders the message", () => {
+    expect(controlUiEmailHref(4471)).toBe("/app/clawbox?email=4471");
+  });
+
+  it("reads back through the same uid rule the directive uses", () => {
+    expect(parseEmailUid("4471")).toBe(4471);
+    expect(parseEmailUid("0")).toBeNull();
+    expect(parseEmailUid("4294967296")).toBeNull();
+    expect(parseEmailUid("4x")).toBeNull();
+  });
+});
+
+describe("the script that is injected into the page ClawBox already serves", () => {
+  it("carries the parser and no closing tag that could end the element early", () => {
+    const script = controlUiEmailDirectiveScript();
+    expect(script).toContain(CONTROL_UI_DIRECTIVE_PARSER_JS);
+    // `</script>` anywhere inside would close the injected element at that
+    // point and spill the rest of the program into the document as text.
+    expect(script.slice("<script>".length, -"</script>".length)).not.toMatch(/<\/script/i);
+  });
+});

--- a/src/tests/unit/control-ui-email-directives.test.ts
+++ b/src/tests/unit/control-ui-email-directives.test.ts
@@ -4,65 +4,39 @@
 // ClawBox's two chats lift the directive out and draw an "open full message"
 // card. The OpenClaw Control UI at `/chat` — a ClawBox-served, default-pinned
 // app on that edition — is `webchat` too, and nothing the gateway hands an
-// outbound hook separates the three: the hook sees one payload going to one
-// channel, so a strip there would take the card away from the two surfaces that
+// outbound hook separates it from the two: the hook sees one payload for one
+// delivery, so a strip there would take the card away from the surfaces that
 // make one. That is why the harness cannot answer this and ClawBox's own
 // injection into the page it already serves has to (TASK-700).
 //
-// This file pins the half that has to agree with everything else: the grammar
-// the injected script carries is the SAME grammar, case for case, as the three
-// implementations `email-directive-parity.test.ts` already holds together.
+// The grammar's own parity — the shared case table AND both generated sweeps —
+// lives with the other three copies in `email-directive-parity.test.ts`. This
+// file pins what is only true of the fourth: the shape of the thing that ships.
 
 import { describe, expect, it } from "vitest";
-import vm from "node:vm";
 
-import { splitEmailRefs, parseEmailUid } from "@/lib/chat-email-refs";
+import { parseEmailUid } from "@/lib/chat-email-refs";
 import {
-  CONTROL_UI_DIRECTIVE_PARSER_JS,
-  controlUiEmailHref,
+  CONTROL_UI_EMAIL_PARAM,
+  CONTROL_UI_SETTLE_MS,
+  CONTROL_UI_SWEEP_MS,
+  controlUiCardLabel,
   controlUiEmailDirectiveScript,
+  controlUiEmailDirectiveScriptBody,
+  controlUiEmailHref,
 } from "@/lib/control-ui-email-directives";
-import { EMAIL_DIRECTIVE_CASES } from "@/tests/fixtures/email-directive-cases";
-
-interface BrowserSplit {
-  (raw: string): { text: string; uids: number[] };
-}
-
-/**
- * The parser the browser gets, evaluated exactly as the browser evaluates it.
- *
- * Asserting on a TypeScript copy of the rule would prove nothing about the
- * string that actually ships inside the `<script>`; this runs THAT string.
- */
-function browserSplit(): BrowserSplit {
-  return vm.runInNewContext(
-    `${CONTROL_UI_DIRECTIVE_PARSER_JS}\nsplitEmailRefs;`,
-  ) as BrowserSplit;
-}
-
-describe("the Control UI's copy of the EMAIL: grammar", () => {
-  it("answers every shared case the way the chat window does", () => {
-    const split = browserSplit();
-    for (const testCase of EMAIL_DIRECTIVE_CASES) {
-      expect(split(testCase.input).text, testCase.name).toBe(testCase.stripped);
-      expect(split(testCase.input).uids, testCase.name).toEqual(
-        splitEmailRefs(testCase.input).uids,
-      );
-    }
-  });
-
-  it("caps the cards under one reply where the chat window caps them", () => {
-    // 30 directives, cap 25: the last five go back to being text on BOTH sides.
-    const raw = Array.from({ length: 30 }, (_, i) => `EMAIL:${i + 1}`).join("\n");
-    const split = browserSplit();
-    expect(split(raw).uids).toEqual(splitEmailRefs(raw).uids);
-    expect(split(raw).text).toBe(splitEmailRefs(raw).text);
-  });
-});
 
 describe("the link a Control UI card opens", () => {
   it("points at the chat that already renders the message", () => {
     expect(controlUiEmailHref(4471)).toBe("/app/clawbox?email=4471");
+  });
+
+  it("is the same link the shipped script builds", () => {
+    // One shape, one place. The helper is what `ChatApp` is tested against and
+    // what the script's prefix is derived from, so they cannot drift.
+    const prefix = controlUiEmailHref(1).slice(0, -1);
+    expect(controlUiEmailDirectiveScriptBody()).toContain(JSON.stringify(prefix));
+    expect(prefix.endsWith(`${CONTROL_UI_EMAIL_PARAM}=`)).toBe(true);
   });
 
   it("reads back through the same uid rule the directive uses", () => {
@@ -74,11 +48,27 @@ describe("the link a Control UI card opens", () => {
 });
 
 describe("the script that is injected into the page ClawBox already serves", () => {
-  it("carries the parser and no closing tag that could end the element early", () => {
+  it("carries no closing tag that could end the element early", () => {
     const script = controlUiEmailDirectiveScript();
-    expect(script).toContain(CONTROL_UI_DIRECTIVE_PARSER_JS);
     // `</script>` anywhere inside would close the injected element at that
     // point and spill the rest of the program into the document as text.
     expect(script.slice("<script>".length, -"</script>".length)).not.toMatch(/<\/script/i);
+  });
+
+  it("waits for the text to hold still before it draws anything", () => {
+    // The production numbers, asserted where a reviewer can see them: a reply
+    // streams, and every prefix of `EMAIL:4471` is a usable id, so converting
+    // on sight draws cards for messages 4, 44 and 447 on the way.
+    expect(CONTROL_UI_SETTLE_MS).toBeGreaterThanOrEqual(250);
+    expect(CONTROL_UI_SWEEP_MS).toBeLessThanOrEqual(CONTROL_UI_SETTLE_MS);
+    expect(controlUiEmailDirectiveScriptBody()).toContain(`var SETTLE_MS = ${CONTROL_UI_SETTLE_MS};`);
+    expect(controlUiEmailDirectiveScriptBody()).toContain(`var SWEEP_MS = ${CONTROL_UI_SWEEP_MS};`);
+  });
+
+  it("says it in the owner's language, escaped for a script element", () => {
+    expect(controlUiCardLabel("bg")).toBe("Отвори цялото писмо");
+    expect(controlUiCardLabel("xx")).toBe("Open full message");
+    expect(controlUiCardLabel(undefined)).toBe("Open full message");
+    expect(controlUiEmailDirectiveScript("bg")).toContain(JSON.stringify("Отвори цялото писмо"));
   });
 });

--- a/src/tests/unit/email-directive-parity.test.ts
+++ b/src/tests/unit/email-directive-parity.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 import { execFileSync, spawnSync } from "node:child_process";
 import path from "node:path";
+import vm from "node:vm";
 
 import { splitEmailRefs } from "@/lib/chat-email-refs";
+import { CONTROL_UI_DIRECTIVE_PARSER_JS } from "@/lib/control-ui-email-directives";
 import { stripEmailDirectives } from "../../../scripts/openclaw-plugins/clawbox-email-directives/email-directives.mjs";
 import { EMAIL_DIRECTIVE_CASES } from "@/tests/fixtures/email-directive-cases";
 
@@ -11,11 +13,13 @@ import { EMAIL_DIRECTIVE_CASES } from "@/tests/fixtures/email-directive-cases";
 // src/tests/unit/test-timeout-hygiene.test.ts.
 vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
-// THE PIN. `EMAIL:<uid>` is understood in three places by three languages:
+// THE PIN. `EMAIL:<uid>` is understood in four places:
 //
 //   src/lib/chat-email-refs.ts                    the chat window's cards (TS)
 //   scripts/hermes-plugins/…/email_directives.py    the Hermes plugin (Py)
 //   scripts/openclaw-plugins/…/email-directives.mjs   the OpenClaw plugin (JS)
+//   src/lib/control-ui-email-directives.ts        the Control UI page (browser JS,
+//                                                 shipped as a string — TASK-700)
 //
 // They cannot share a file — each is loaded by a different runtime, two of them
 // inside a harness's own process — so the risk is drift: a rule tightened in
@@ -32,6 +36,21 @@ const REPO = path.resolve(__dirname, "../../..");
 const PY_PLUGIN_DIR = path.join(REPO, "scripts/hermes-plugins/clawbox_email_directives");
 
 const hasPython3 = spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
+
+/**
+ * The FOURTH copy, evaluated exactly as the browser evaluates it.
+ *
+ * Not a TypeScript twin: `CONTROL_UI_DIRECTIVE_PARSER_JS` is the string that
+ * ships inside the `<script>` element, so running anything else here would pin
+ * nothing. It takes an optional per-caller budget the other three do not have
+ * (the Control UI renders one reply into several text nodes); called without
+ * one it must behave exactly like them, which is what everything below asserts.
+ */
+const browserSplit = vm.runInNewContext(
+  `${CONTROL_UI_DIRECTIVE_PARSER_JS}\nsplitEmailRefs;`,
+) as (raw: string) => { text: string; uids: number[] };
+
+const browserStrip = (raw: string): string => browserSplit(raw).text;
 
 /**
  * Every case through the Python module in ONE interpreter start: a spawn per
@@ -51,7 +70,7 @@ function pythonAnswers(inputs: string[]): string[] {
   return JSON.parse(out);
 }
 
-describe("EMAIL: directive grammar — one rule, three implementations", () => {
+describe("EMAIL: directive grammar — one rule, four implementations", () => {
   // ASSERTED, NOT SKIPPED ON. `describe.skip`/`it.skip` on a missing `python3`
   // turned the only thing standing between the three grammars into a green
   // no-op: the guard would leave the build with nothing saying so. That is the
@@ -68,6 +87,10 @@ describe("EMAIL: directive grammar — one rule, three implementations", () => {
 
   it.each(EMAIL_DIRECTIVE_CASES)("JavaScript (the OpenClaw plugin): $name", ({ input, stripped }) => {
     expect(stripEmailDirectives(input)).toBe(stripped);
+  });
+
+  it.each(EMAIL_DIRECTIVE_CASES)("browser JS (the Control UI page): $name", ({ input, stripped }) => {
+    expect(browserStrip(input)).toBe(stripped);
   });
 
   it("Python (the Hermes plugin) answers the whole table identically", () => {
@@ -93,7 +116,7 @@ describe("EMAIL: directive grammar — one rule, three implementations", () => {
     0x200b, 0x200c, 0x200d, 0x2060, 0x180e,
   ];
 
-  it("the three agree on every whitespace-boundary character", () => {
+  it("all four agree on every whitespace-boundary character", () => {
     const inputs: string[] = [];
     for (const cp of BOUNDARY_CODE_POINTS) {
       const c = String.fromCodePoint(cp);
@@ -115,12 +138,13 @@ describe("EMAIL: directive grammar — one rule, three implementations", () => {
     }
     const ts = inputs.map((raw) => splitEmailRefs(raw).text);
     const js = inputs.map((raw) => stripEmailDirectives(raw));
+    const ui = inputs.map((raw) => browserStrip(raw));
     const py = pythonAnswers(inputs);
     // Reported as a list of disagreements rather than a first-mismatch throw, so
     // a drift shows every character it affects in one run.
     const disagreements = inputs
-      .map((raw, i) => ({ raw, ts: ts[i], js: js[i], py: py[i] }))
-      .filter((row) => row.ts !== row.js || row.ts !== row.py)
+      .map((raw, i) => ({ raw, ts: ts[i], js: js[i], ui: ui[i], py: py[i] }))
+      .filter((row) => row.ts !== row.js || row.ts !== row.py || row.ts !== row.ui)
       .map((row) => JSON.stringify(row));
     expect(disagreements).toEqual([]);
   });
@@ -193,7 +217,7 @@ describe("EMAIL: directive grammar — one rule, three implementations", () => {
     );
   }
 
-  it("the three agree on every code point any of them folds onto the keyword", () => {
+  it("all four agree on every code point any of them folds onto the keyword", () => {
     const js = jsCaseFoldCandidates();
     const py = pythonCaseFoldCandidates();
 
@@ -221,10 +245,11 @@ describe("EMAIL: directive grammar — one rule, three implementations", () => {
 
     const tsOut = inputs.map((raw) => splitEmailRefs(raw).text);
     const jsOut = inputs.map((raw) => stripEmailDirectives(raw));
+    const uiOut = inputs.map((raw) => browserStrip(raw));
     const pyOut = pythonAnswers(inputs);
     const disagreements = inputs
-      .map((raw, i) => ({ raw, ts: tsOut[i], js: jsOut[i], py: pyOut[i] }))
-      .filter((row) => row.ts !== row.js || row.ts !== row.py)
+      .map((raw, i) => ({ raw, ts: tsOut[i], js: jsOut[i], ui: uiOut[i], py: pyOut[i] }))
+      .filter((row) => row.ts !== row.js || row.ts !== row.py || row.ts !== row.ui)
       .map((row) => JSON.stringify(row));
     expect(disagreements).toEqual([]);
   }, 60_000);
@@ -277,6 +302,9 @@ describe("EMAIL: directive grammar — one rule, three implementations", () => {
     const PARSERS: [string, (raw: string) => string][] = [
       ["TypeScript (the chat's own parser)", (raw) => splitEmailRefs(raw).text],
       ["JavaScript (the OpenClaw plugin)", (raw) => stripEmailDirectives(raw)],
+      // The browser copy runs on the OWNER'S machine over text a stranger's
+      // email can shape, so it is the one that must not be quadratic.
+      ["browser JS (the Control UI page)", browserStrip],
     ];
 
     /**

--- a/src/tests/unit/gateway-proxy.test.ts
+++ b/src/tests/unit/gateway-proxy.test.ts
@@ -211,6 +211,43 @@ describe("gateway-proxy", () => {
       expect(html).toContain("Gateway Content");
     });
 
+    it("injects the EMAIL: directive handling this page had never heard of", async () => {
+      // TASK-700. This page is the gateway's own Control UI chat — a third
+      // `webchat` surface — and it showed `EMAIL:<uid>` as a bare internal id.
+      // No outbound hook can separate it from ClawBox's own two chats (one
+      // payload, one channel, three clients), so the only ClawBox-owned code on
+      // this surface is the script it already injects here.
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve("<html><body>Gateway Content</body></html>"),
+      }));
+
+      const html = await (
+        await gatewayProxy.serveGatewayHTML(createRequest("http://clawbox.local/chat"))
+      ).text();
+
+      expect(html).toContain("clawbox-email-card");
+      expect(html).toContain("/app/clawbox?email=");
+    });
+
+    it("injects it for a caller with no owner session too", async () => {
+      // The shell is served without a session (first boot, the login redirect)
+      // and simply carries no token. The directive handling is not a credential
+      // and must not be gated on one, or the page that IS served would keep
+      // showing the id.
+      ownerSession.mockResolvedValue(false);
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve("<html><body></body></html>"),
+      }));
+
+      const html = await (
+        await gatewayProxy.serveGatewayHTML(createRequest("http://clawbox.local/chat"))
+      ).text();
+
+      expect(html).toContain("clawbox-email-card");
+    });
+
     it("injects auth token when available", async () => {
       mockFs.readFile.mockResolvedValue(JSON.stringify({
         gateway: { auth: { token: "my-secret-token" } },


### PR DESCRIPTION
TASK-700 (owner ruling, 2026-09-06: *"ROUTE directives there too — the same directive handling the #713 plugin path uses, so emails render/queue exactly as in the ClawBox chat; no third behaviour."*)

## The symptom

`EMAIL:4471` is how the agent points a chat at a message the owner can open: `chat-email-refs.ts` lifts the line out and the bubble shows an **Open full message** card. The OpenClaw gateway's own Control UI chat at `/chat` — a ClawBox-served, **default-pinned** app on that edition (`src/lib/desktop-apps.ts`) — is a `webchat` surface too, and it has never heard of the directive. The repro on the card: OpenClaw edition → the pinned OpenClaw icon → "read my last two emails" → the reply ends with bare `EMAIL:<id>` lines above the summary.

Two chats make a card; a third shows an internal id. That is the "third behaviour" the ruling names.

## Harness first — and why the harness cannot answer this one

Read off the **pinned 2026.8.1 core on the OpenClaw box**, read-only.

The whole hook catalog (`docs/plugins/hooks.md`, "Hook catalog") is: `after_compaction, after_tool_call, agent_end, agent_turn_prepare, before_agent_finalize, before_agent_reply, before_agent_run, before_compaction, before_dispatch, before_install, before_message_write, before_model_resolve, before_prompt_build, before_reset, before_tool_call, channel_pairing_requested, cron_changed, cron_reconciled, gateway_start, gateway_stop, heartbeat_prompt_contribution, inbound_claim, llm_input, llm_output, message_received, message_sending, message_sent, model_call_ended, model_call_started, reply_dispatch, reply_payload_sending, resolve_exec_env, session_end, session_start, skill_changed, skill_proposal_changed, skill_proposal_evaluate, subagent_delivery_target, subagent_ended, subagent_progress, subagent_spawned, tool_result_persist`. There is no `after_turn` and no `transform_*` family on this edition — the outbound seams are `message_sending` (rewrite `content`), `reply_payload_sending` (rewrite the normalized `ReplyPayload`, `presentation` included) and `reply_dispatch`.

None of them can help, and the reason is structural rather than a missing field:

- **A hook is handed one payload for one delivery, not one per client.** The doc's own list of what a message hook context carries is `ctx.sessionKey`, `ctx.runId`, `ctx.messageId`, `ctx.senderId`, `ctx.trace`, `ctx.traceId`, `ctx.spanId`, `ctx.parentSpanId`, `ctx.callDepth` — nothing client-shaped. All three webchat clients (ClawBox's dashboard chat, ClawBox's mascot popup, the Control UI) arrive as `webchat`, so a strip in the plugin takes the card away from the two surfaces that make one. `scripts/openclaw-plugins/clawbox-email-directives/index.mjs` already says exactly this in its `KEEP_CHANNELS` comment, and names TASK-700.
- **ClawBox's own connect frame does say `version: "clawbox-chat"`**, and the gateway keeps it on the live connection record and the presence row, where no hook can read it.
- **`presentation` is the core's own rich-card contract** (`docs/plugins/message-presentation.md`) and would have been the right answer if webchat had a renderer. It does not: presentation is rendered by a channel plugin's `renderPresentation`, and the provider-mapping table lists Discord, Feishu, Matrix, Mattermost, Teams, Slack, Telegram and "plain channels — text fallback". A presentation block reaches this surface as flattened text.

So the seam is not in the harness. **It is in ClawBox**, and it already exists: `src/app/[...gateway]/route.ts` hands a navigation to `serveGatewayHTML`, which injects the ClawBox bar and the gateway-connect script into that page's HTML. Same origin, so the card can link straight into the chat that already renders the message and the owner's session rides along.

## The fix

- **`src/lib/control-ui-email-directives.ts`** (new) — the `EMAIL:` grammar as browser JS, plus a small program injected into the page. It rewrites **text nodes**, not selectors: the only thing it assumes about a page ClawBox does not build is that a reply's prose ends up in text nodes, which is true of any HTML and survives a gateway upgrade. A class name or a container id would have been the probe-once fix that silently stops working after an update — and silently is the whole complaint here.
- **`src/lib/gateway-proxy.ts`** — injected beside the bar. Deliberately **not** gated on the owner session: the shell is served without one (first boot, the login redirect) and an id on screen is not a credential.
- **`src/app/setup-api/gateway/route.ts`** — the sibling call site. It is the *second* route that hands this page to a browser, and a bare id there would be the same defect one door along. Injected from `<head>`, where `document.body` is null and the observer on `document.documentElement` does the work.
- **`src/components/ChatApp.tsx`** — `/app/clawbox?email=<uid>` opens that message on arrival, through the same `EmailFullView` panel and the same `GET /setup-api/email/messages?uid=…&view=full` a card in this chat opens. That is where a Control UI card lands: **one behaviour, not a third.** Read once, on mount, so the owner can close the panel; the id is read by the directive's own rule (`parseEmailUid`, exported from `chat-email-refs.ts` rather than written a second time next to a query-string read), so a link naming nothing usable opens nothing and asks the mailbox for nothing.

### Nothing is drawn on a guess, and nothing is drawn twice

**It waits for the text to hold still.** A reply *streams*, and the node holding it reads `EMAIL:4`, `EMAIL:44`, `EMAIL:447`, `EMAIL:4471` in turn — every one of those a usable id by this grammar. Rewriting on sight draws a card for message 4, then 44, then 447 on the way; and a turn interrupted between two digits leaves the wrong one on screen **with no `EMAIL:` text left to show that it is wrong**, so the owner opens somebody else's mail believing it is the one the agent named. ClawBox's own chats have `dropUnfinishedDirective` for exactly this and can use it because they know the turn is streaming. This page carries no such signal, so quiet is the signal: a text node becomes a card only after it has not changed for 500 ms. That also removes the flicker.

**Three separate rules keep it from drawing twice** — the false-success guard the ruling asks for:

- the text a rewrite puts *back* is remembered and never looked at again, so the lines a reply had past the 25-card cap stay text instead of being converted 25 at a time by the next pass;
- the "already seen" set and the remaining card count are carried **across the text nodes that share a parent**, so a reply the page rendered one directive per line is deduped and capped as one reply rather than as N — which is the shape the bug report describes;
- the script installs **once per document**, so two injections on one page cannot each keep their own book.

Nothing is sent or queued by any of this: the directive is a *reference* to a message already in the mailbox, opened `EXAMINE` + `BODY.PEEK`, and the card is a link.

**The grammar is now in four places, and the fourth joined the suite that holds the other three together.** `src/tests/unit/email-directive-parity.test.ts` evaluates the shipped string with `node:vm` and puts it through everything the other three answer: the shared case table, the **generated** whitespace-boundary sweep, the **generated** case-fold sweep, and the linearity block — the browser copy is the one that runs on the owner's own machine over text a stranger's email can shape, so it is the one that must not be quadratic. A copy is what the codebase already does here and for the same reason: each is loaded by a runtime that cannot import the others.

**The server half is server-only, and the link is not.** `control-ui-email-directives.ts` reads the owner's language out of the config store, which is `node:fs`, so nothing a client component can reach may import it. The deep link's own shape — the query parameter and `controlUiEmailHref` — therefore lives in `chat-email-refs.ts`, which the chat already imports, and is re-exported from the server module so the script and the chat cannot describe the same link differently. The first head got this wrong and the Turbopack build said so outright (`Module not found: Can't resolve 'fs'`); the split is verified by a local `next build`, and by putting the bad import back and watching the same error return.

**Localized.** The card says what the chat's card says, in the language the owner picked: the label comes from `desktopTranslations["chat.email.openFull"]`, resolved on the server from `pref:ui_language` rather than fetched by the injected script, which would have cost a request per page load to say three words.

## Accepted costs, stated

- **A line that is exactly `Email: 12345` is a directive by this grammar wherever it appears.** Reading a whole page rather than a transcript we own is what makes that possible, so the pass skips the tags where such a line plausibly lives — `label`, `button`, `th`, `dt`, `summary`, `legend`, `select`, on top of `pre`/`code`/`script`/`style`/`textarea`/`input` and anything editable. A reply's own paragraph is touched by neither list. Pinned by a test.
- **A directive is on screen as text for the half second before it settles.** That is strictly better than before — the line used to stay forever — and it is the price of never drawing a card for an id that was still being typed.
- **The cap and the dedupe are scoped to a parent element, not to a reply**, because a page ClawBox does not build will not say where a reply begins. Two replies whose directives land in one element share a budget; the worst that does is leave a line as text, which is what it already was.

## The other edition

The Control UI app is OpenClaw-only (`OPENCLAW_ONLY_APP_IDS` in `src/lib/desktop-app-editions.ts`). Its Hermes twin is the **Hermes dashboard** (`src/lib/desktop-apps.ts`, served through ClawBox's own auth proxy `scripts/hermes-dashboard-proxy.js`), and `mcp/README.md` already records that it has never heard of the directive either. It is **not** fixed here: that proxy `pipe()`s the upstream response straight through and injects no HTML, so reaching it means adding HTML buffering and content-encoding handling to an authentication proxy — a separate change on a file this PR otherwise only reads. The shared module is edition-neutral and ready for it.

Note the asymmetry that makes the Hermes case smaller: on that edition the outbound hook *can* tell surfaces apart. `transform_llm_output` is handed `platform`, and `scripts/hermes-plugins/clawbox_email_directives/__init__.py` keeps the directive only for `KEEP_PLATFORMS`; every other surface already gets it stripped.

## Review

One the reviewer review pass (findings recorded off-repo) returned **1 HIGH, 6 MEDIUM, 10 LOW**, and every one is answered on this head. The three that changed the design:

- **HIGH — a streaming reply drew cards for truncated uids, and an interrupted turn kept one.** The whole "wait for quiet" rule above is that finding; the reviewer reproduced it against the shipped string driven through lit's own commit path (`EMAIL:4` / `44` / `447` / `4471` → four cards).
- **The 25-card cap was not enforced**, because the observer saw its own work: the over-cap lines went back as a fresh text node and the next pass converted 25 more, until none was left. The text a rewrite puts back is now remembered.
- **Dedupe and the cap were per text node**, so the moment the page rendered one directive per line — which is the bug report — the same message got two identical cards and there was no cap at all. Both are now carried across the nodes that share a parent.

Also taken: `td`/`dd`/`a`/`kbd`/`samp`/`var` added to the skip list (a data cell reading `Email: 12345` became a card while the header above it did not); the parser's `trim()` no longer welds two words together when the directive follows inline markup (`<b>Jane</b> sent the plan.` came out `Janesent the plan.`); the card is a class with a **light-theme palette** rather than amber-on-dark inline (the Control UI ships seven themes and the label computed to ≈1.6:1 on a light ground); both `.replace()` calls take a replacer **function**, since the injected script now carries a translated label and `$'` in a replacement string duplicates the document; the deep link's uid is taken back out of the address once read; one shared `controlUiLocale()` instead of the same helper in two files; a named window target and a per-uid accessible name; and the browser copy joined the parity suite's two **generated** sweeps and its linearity block, not just the hand-written table.

The reviewer's "checked and could not fault" list is worth keeping: the pinned core really is `2026.8.1` and its provider table really has no webchat row; the Control UI's own base class is `createRenderRoot(){return this}`, so the transcript is in light DOM and a document-level walker can see it; the fourth parser copy agreed with the OpenClaw plugin over **656,020 generated inputs, 0 disagreements**, and is linear on the pathological shape; and the `?email=` link cannot do more than open one of the owner's own messages, read-only.

## RED → GREEN

RED, on unmodified `origin/beta` (`1c406458`):

```
 FAIL  |unit| src/tests/unit/control-ui-email-directives.test.ts
Error: Cannot find package '@/lib/control-ui-email-directives' imported from
       src/tests/unit/control-ui-email-directives.test.ts

 FAIL  |unit| src/tests/unit/gateway-proxy.test.ts > serveGatewayHTML
        > injects the EMAIL: directive handling this page had never heard of
 FAIL  |unit| src/tests/unit/gateway-proxy.test.ts > serveGatewayHTML
        > injects it for a caller with no owner session too
   - clawbox-email-card
   + <html><body><div id="clawbox-bar" …></div><script> … </script></body></html>

 FAIL  |components| src/tests/components/control-ui-email-card.test.tsx
Error: Failed to resolve import "@/lib/control-ui-email-directives"

 FAIL  |components| src/tests/components/chat-email-refs-surfaces.test.tsx
        > opening one message by link > opens the message the link names, without asking for it twice
Error: Test timed out in 5000ms.

 Test Files  4 failed
```

GREEN, on this head (rebased onto `bb206f1a`):

```
 Test Files  727 passed (727)        # --project unit
      Tests  11939 passed | 1 skipped (11940)

 Test Files  187 passed (187)        # --project components
      Tests  1620 passed (1620)
```

`npx tsc --noEmit` clean; eslint clean on every changed file (only the four pre-existing `no-img-element` warnings in `ChatApp.tsx`). The beta guard suites (`openclaw-config-mock-completeness`, `test-timeout-hygiene`, `state-updater-purity`) pass, and are inside that unit run.

**A dev-PC flake, declared rather than hidden.** The `components` project is not reliably green under full parallel load on this machine *on beta itself*: an unmodified `origin/beta` checkout failed five ChatPopup-family tests in one such run (`chat-popup-dismiss-and-geometry`, `chat-spoken-reply` ×3, `desktop-wallpaper-delete`), and this branch failed one from the same family in another. Every one of them passes when its file is run alone, on both trees. That is TASK-702's recorded class; CI is the proof for this project.

## Device proof (read-only, OpenClaw box, beta `8599f074`)

Nothing was mutated; no mail was read, sent or queued; nothing was posted to any channel.

- The hook catalog, the message-hook context field list, and the `presentation` provider-mapping table above were all read off the installed 2026.8.1 package.
- `/chat` fetched **as a navigation** with the owner's session is the page `serveGatewayHTML` serves: `id="clawbox-bar"` present, the gateway-connect script present, **`clawbox-email-card` absent** — the before state, on the real page, at the real injection point. (Fetched with `Accept: */*` and no `Sec-Fetch-Mode` it is proxied bytes instead, per that route's navigation test — worth knowing when checking this by hand.)

Not provable off a box, and stated as a gap: that a *live reply* carrying a directive is redrawn as a card on that page needs this branch deployed and a real turn. That is the owner test below.

## What to try (owner)

Prerequisites: OpenClaw edition, a mail account connected in Settings → Email with reading enabled.

1. Open the pinned **OpenClaw** icon on the desktop (the Control UI chat).
2. Ask: **"read my last two emails"**.
3. **Expect:** while the answer types, the `EMAIL:` lines are briefly there; about half a second after it stops, each becomes an amber **Open full message** row and no id is left on screen.
4. Click one. **Expect:** a new tab on the ClawBox chat with that message open in the full-message panel — subject, From/To/Date, the body — the same panel a card in the ClawBox chat opens.
5. Ask it to **explain the syntax** ("show me an example of an EMAIL directive in a code block"). **Expect:** the fenced example still reads `EMAIL:4471` as text, with no card.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gateway chat pages now recognize `EMAIL:<uid>` directives and display localized, clickable email cards.
  * Cards open the corresponding message in the ClawBox email viewer, including through direct links.
  * Support includes streamed content, duplicate prevention, theme-aware styling, and protection for code or editable areas.
  * Invalid email references are safely ignored.

* **Bug Fixes**
  * Email query parameters are removed from the browser URL after opening a message.

* **Tests**
  * Added coverage for email cards, deep links, localization, streaming content, invalid IDs, and gateway rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->