### PR TITLE
fix: harden the OpenClaw 2026.7→2026.8 core upgrade (TASK-737)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3766,8 +3766,23 @@ step_openclaw_install() {
     # The sessions-to-SQLite move must not race a still-running v1 gateway
     # writing the very files being migrated; gateway_setup restarts it later.
     systemctl stop clawbox-gateway.service 2>/dev/null || true
-    as_clawbox -H "$OPENCLAW_BIN" doctor --fix --non-interactive </dev/null \
-      || echo "  WARN: openclaw doctor --fix did not complete; the gateway may refuse readiness until it is run"
+    # Say WHICH failure this was. `|| echo WARN` over a doctor that migrated
+    # nothing is the false-success shape this repo keeps producing, and the
+    # commonest reason it exits non-zero here is a legacy exec-approvals file
+    # whose mere presence makes it refuse every migration before starting one
+    # (measured against 2026.8.1, 2026-09-06). The gateway's own ExecStartPre
+    # clears that and re-runs the migration, so this stays non-fatal — but the
+    # install log has to name it rather than imply doctor merely stumbled.
+    if ! _oc_doctor_out="$(as_clawbox -H "$OPENCLAW_BIN" doctor --fix --non-interactive </dev/null 2>&1)"; then
+      printf '%s\n' "$_oc_doctor_out"
+      if printf '%s\n' "$_oc_doctor_out" | grep -q 'Legacy exec approvals exist at'; then
+        echo "  WARN: openclaw doctor --fix migrated NOTHING — a legacy exec-approvals file blocks it. The gateway's pre-start moves an empty one aside and re-runs the migration on the next start."
+      else
+        echo "  WARN: openclaw doctor --fix did not complete; the gateway may refuse readiness until it is run"
+      fi
+    else
+      printf '%s\n' "$_oc_doctor_out"
+    fi
     # The stop above was for doctor's benefit. A FULL install restarts the
     # gateway later (gateway_setup), but this step is also on the standalone
     # run-step allow-list, where nothing follows — leaving it down would turn

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -230,10 +230,6 @@ export CLAWBOX_OPENCLAW_V2
 # so an overrun leaves the stamp unwritten and the next boot tries again.
 CLAWBOX_OPENCLAW_STATE_DIR="$(dirname "$OPENCLAW_CONFIG")"
 CLAWBOX_CONFIG_VALIDATED_STAMP="$CLAWBOX_ROOT/data/openclaw-config-validated"
-# Read by the plugin-entry pass further down, which reuses this run's warnings
-# rather than paying for a second `config validate`.
-CLAWBOX_CONFIG_VALIDATE_OUTPUT=""
-export CLAWBOX_CONFIG_VALIDATE_OUTPUT
 
 # Does this file hold any approval at all? Exit 0 = provably empty, 1 = holds
 # something, 2 = could not tell. Only 0 may lead to a move: an approval is an
@@ -307,17 +303,24 @@ then
   # "accepted". Time-boxed for the same reason as the version probe above — a
   # wedged CLI must cost this boot ten seconds of budget, not the unit's whole
   # TimeoutStartSec.
-  CLAWBOX_CONFIG_VALIDATE_OUTPUT="$(timeout -k 5 60 "$OPENCLAW_BIN" config validate 2>&1)" \
+  _cfg_validate_out="$(timeout -k 5 60 "$OPENCLAW_BIN" config validate 2>&1)" \
     && CLAWBOX_CONFIG_ACCEPTED=1 || CLAWBOX_CONFIG_ACCEPTED=0
   if [ "$CLAWBOX_CONFIG_ACCEPTED" = "0" ]; then
     echo "  The installed OpenClaw core ($CLAWBOX_OPENCLAW_EFFECTIVE) refuses this config; running its own migrations..."
-    printf '%s\n' "$CLAWBOX_CONFIG_VALIDATE_OUTPUT" | sed -n 's/^[[:space:]]*×[[:space:]]*/  refused: /p' >&2
-    cp -p "$OPENCLAW_CONFIG" "$OPENCLAW_CONFIG.pre-v2-migration-$(date +%Y%m%d-%H%M%S)" 2>/dev/null \
-      || echo "  WARN: could not back up $OPENCLAW_CONFIG before migrating it" >&2
+    printf '%s\n' "$_cfg_validate_out" | sed -n 's/^[[:space:]]*×[[:space:]]*/  refused: /p' >&2
+    # Named for the core, and never overwritten. A timestamped copy would
+    # leave one file per boot on a box whose repair keeps failing — and
+    # `Restart=always` means that is a lot of boots — while the copy anyone
+    # would want is the FIRST one, taken before anything touched the file.
+    _pre_migration_backup="$OPENCLAW_CONFIG.pre-$CLAWBOX_OPENCLAW_EFFECTIVE-migration"
+    if [ ! -e "$_pre_migration_backup" ]; then
+      cp -p "$OPENCLAW_CONFIG" "$_pre_migration_backup" 2>/dev/null \
+        || echo "  WARN: could not back up $OPENCLAW_CONFIG before migrating it" >&2
+    fi
     if ! timeout -k 10 180 "$OPENCLAW_BIN" doctor --fix --non-interactive </dev/null; then
       echo "  WARN: openclaw doctor --fix did not complete" >&2
     fi
-    CLAWBOX_CONFIG_VALIDATE_OUTPUT="$(timeout -k 5 60 "$OPENCLAW_BIN" config validate 2>&1)" \
+    _cfg_validate_out="$(timeout -k 5 60 "$OPENCLAW_BIN" config validate 2>&1)" \
       && CLAWBOX_CONFIG_ACCEPTED=1 || CLAWBOX_CONFIG_ACCEPTED=0
     if [ "$CLAWBOX_CONFIG_ACCEPTED" = "1" ]; then
       echo "  Config migrated to the $CLAWBOX_OPENCLAW_EFFECTIVE layout"
@@ -328,14 +331,13 @@ then
       # named HERE, in the boot log, instead of only in a gateway journal
       # nobody reads until an owner calls.
       echo "  ERROR: the core still refuses this config — the gateway will exit 78 until these keys are fixed:" >&2
-      printf '%s\n' "$CLAWBOX_CONFIG_VALIDATE_OUTPUT" | sed -n 's/^[[:space:]]*×[[:space:]]*/  refused: /p' >&2
+      printf '%s\n' "$_cfg_validate_out" | sed -n 's/^[[:space:]]*×[[:space:]]*/  refused: /p' >&2
     fi
   fi
   if [ "$CLAWBOX_CONFIG_ACCEPTED" = "1" ]; then
     mkdir -p "$(dirname "$CLAWBOX_CONFIG_VALIDATED_STAMP")" 2>/dev/null || true
     printf '%s\n' "$CLAWBOX_OPENCLAW_EFFECTIVE" > "$CLAWBOX_CONFIG_VALIDATED_STAMP" 2>/dev/null || true
   fi
-  export CLAWBOX_CONFIG_VALIDATE_OUTPUT
 fi
 
 # Resolve configured mDNS hostname (defaults to "clawbox" if unset/invalid)

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -220,6 +220,14 @@ export CLAWBOX_OPENCLAW_V2
 # box pays nothing and only a core bump — the state this exists for — pays the
 # CLI. The stamp is written only on success, so a failed repair is retried on
 # the next boot instead of being remembered as done.
+#
+# BUDGET. This is a blocking ExecStartPre under TimeoutStartSec=600
+# (config/clawbox-gateway.service), and the rest of the pre-start can itself
+# spend two minutes on a cold box. 60 + 180 + 60 is the whole of the worst
+# case here, and the doctor bound is the one the auth-profile repair below
+# already uses. Overrunning the unit's ceiling would have systemd kill a
+# migration halfway, which is worse than the refused config it is fixing —
+# so an overrun leaves the stamp unwritten and the next boot tries again.
 CLAWBOX_OPENCLAW_STATE_DIR="$(dirname "$OPENCLAW_CONFIG")"
 CLAWBOX_CONFIG_VALIDATED_STAMP="$CLAWBOX_ROOT/data/openclaw-config-validated"
 # Read by the plugin-entry pass further down, which reuses this run's warnings
@@ -299,17 +307,17 @@ then
   # "accepted". Time-boxed for the same reason as the version probe above — a
   # wedged CLI must cost this boot ten seconds of budget, not the unit's whole
   # TimeoutStartSec.
-  CLAWBOX_CONFIG_VALIDATE_OUTPUT="$(timeout -k 5 90 "$OPENCLAW_BIN" config validate 2>&1)" \
+  CLAWBOX_CONFIG_VALIDATE_OUTPUT="$(timeout -k 5 60 "$OPENCLAW_BIN" config validate 2>&1)" \
     && CLAWBOX_CONFIG_ACCEPTED=1 || CLAWBOX_CONFIG_ACCEPTED=0
   if [ "$CLAWBOX_CONFIG_ACCEPTED" = "0" ]; then
     echo "  The installed OpenClaw core ($CLAWBOX_OPENCLAW_EFFECTIVE) refuses this config; running its own migrations..."
     printf '%s\n' "$CLAWBOX_CONFIG_VALIDATE_OUTPUT" | sed -n 's/^[[:space:]]*×[[:space:]]*/  refused: /p' >&2
     cp -p "$OPENCLAW_CONFIG" "$OPENCLAW_CONFIG.pre-v2-migration-$(date +%Y%m%d-%H%M%S)" 2>/dev/null \
       || echo "  WARN: could not back up $OPENCLAW_CONFIG before migrating it" >&2
-    if ! timeout -k 10 300 "$OPENCLAW_BIN" doctor --fix --non-interactive </dev/null; then
+    if ! timeout -k 10 180 "$OPENCLAW_BIN" doctor --fix --non-interactive </dev/null; then
       echo "  WARN: openclaw doctor --fix did not complete" >&2
     fi
-    CLAWBOX_CONFIG_VALIDATE_OUTPUT="$(timeout -k 5 90 "$OPENCLAW_BIN" config validate 2>&1)" \
+    CLAWBOX_CONFIG_VALIDATE_OUTPUT="$(timeout -k 5 60 "$OPENCLAW_BIN" config validate 2>&1)" \
       && CLAWBOX_CONFIG_ACCEPTED=1 || CLAWBOX_CONFIG_ACCEPTED=0
     if [ "$CLAWBOX_CONFIG_ACCEPTED" = "1" ]; then
       echo "  Config migrated to the $CLAWBOX_OPENCLAW_EFFECTIVE layout"

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -192,60 +192,81 @@ export CLAWBOX_OPENCLAW_V2
 # ── First boot on a NEW OpenClaw core: make the config loadable again ───────
 #
 # THE INCIDENT (TASK-737). A customer box was dark for 25 hours after the
-# 2026.7.1 → 2026.8.1 core upgrade. OpenClaw 2026.8 does NOT migrate a 2026.7
+# 2026.7.1 → 2026.8.1 core upgrade. OpenClaw 2026.8 does not migrate a 2026.7
 # config on load: its startup guard runs the preflight with
 # `migrateLegacyConfig: false` and exits 78 with `Unrecognized keys`. The
 # migrations exist (`LEGACY_CONFIG_MIGRATIONS`, "applied by doctor") but only
 # `openclaw doctor --fix` performs them, and nothing on the boot path ran it
-# for THIS reason — the block further down is gated on an auth-profiles
-# sentinel, and the updater's own call happens after the gateway has already
-# failed.
+# for THIS reason — the auth-profile block below is gated on its own sentinel,
+# and the updater's call happens after the gateway has already failed.
 #
-# HARNESS FIRST, TWICE. The question "will the core load this?" is answered by
-# the core (`openclaw config validate`), and the repair is the core's own
-# (`openclaw doctor --fix`). This script does not carry a rename table: the
-# four moves the 2026.8 core makes are its business, and a table here would be
-# a second, staler copy of it.
+# HARNESS FIRST, TWICE OVER. The question "will the core load this?" is asked
+# of the core in its own machine-readable form — `openclaw config validate
+# --json` answers `{valid, path, issues[]}` — and the repair is the core's own
+# `doctor --fix`. No rename table lives here: the moves the 2026.8 core makes
+# are its business, and a table in this file would be a second, staler copy of
+# it. The human `config validate` output is NOT parsed: it goes to stderr and
+# marks each issue with a themed `×` that any `FORCE_COLOR` in the environment
+# repaints, so it is presentation, not a contract.
 #
 # AND THE THING THAT BLOCKS THE REPAIR. Measured against 2026.8.1 on
-# 2026-09-06: with an EMPTY legacy `exec-approvals.json` in the state
-# directory, `doctor --fix --yes --non-interactive` exits 1 having migrated
-# NOTHING, and its last line is `Legacy exec approvals exist at … Run
-# \`openclaw doctor --fix\`` — advice for the command that just ran. Move that
-# one empty file aside and the same command exits 0 and migrates everything.
-# So it is cleared FIRST, and only when it is provably empty.
+# 2026-09-06: with a legacy `exec-approvals.json` in the state directory,
+# `doctor --fix` exits 1 having migrated NOTHING, and its last line is `Legacy
+# exec approvals exist at … Run \`openclaw doctor --fix\`` — advice for the
+# command that just ran. The core's gate throws on the file's mere PRESENCE,
+# so its contents do not matter to it; move the file aside and the same
+# command exits 0 and migrates everything. It is therefore cleared FIRST, and
+# only when it provably holds no decision of the owner's.
 #
-# COST. Gated on the installed core's version, not run every boot: the stamp
-# below records the version whose config the core last ACCEPTED, so a steady
-# box pays nothing and only a core bump — the state this exists for — pays the
-# CLI. The stamp is written only on success, so a failed repair is retried on
-# the next boot instead of being remembered as done.
+# COST. Gated on a fingerprint of the config the core last ACCEPTED and the
+# core that accepted it, so a steady box pays nothing; a core bump or a
+# rewrite of openclaw.json costs one `config validate`. The stamp is written
+# only on an accepted config, so a failed repair is retried next boot rather
+# than remembered as done.
 #
-# BUDGET. This is a blocking ExecStartPre under TimeoutStartSec=600
-# (config/clawbox-gateway.service), and the rest of the pre-start can itself
-# spend two minutes on a cold box. 60 + 180 + 60 is the whole of the worst
-# case here, and the doctor bound is the one the auth-profile repair below
-# already uses. Overrunning the unit's ceiling would have systemd kill a
-# migration halfway, which is worse than the refused config it is fixing —
-# so an overrun leaves the stamp unwritten and the next boot tries again.
-CLAWBOX_OPENCLAW_STATE_DIR="$(dirname "$OPENCLAW_CONFIG")"
+# BUDGET. This is a blocking ExecStartPre under `TimeoutStartSec=600`
+# (config/clawbox-gateway.service) and the rest of this script's own bounds
+# already add up to well over half of it — the version probe, two plugin
+# installs, the codex install and enable, the deepseek installs and the
+# auth-profile doctor below. The worst case added here is 65 + 180 + 65 = 310 s
+# (the two validate bounds carry a 5 s `-k` grace each), and only on a box
+# whose config the core actually refuses; an accepted config costs one probe.
+# The doctor bound is SIGTERM-only, deliberately: a SIGKILL mid-import is how
+# a half-finished `exec-approvals.json.doctor-importing` claim gets left
+# behind, which blocks every later doctor exactly as the original file does.
 CLAWBOX_CONFIG_VALIDATED_STAMP="$CLAWBOX_ROOT/data/openclaw-config-validated"
 
-# Does this file hold any approval at all? Exit 0 = provably empty, 1 = holds
-# something, 2 = could not tell. Only 0 may lead to a move: an approval is an
-# owner decision and an unreadable file is not evidence of anything.
-clawbox_exec_approvals_are_empty() {
+# Does this approvals file hold a decision of the OWNER's?
+# 0 = provably none, 1 = yes, 2 = cannot tell. Only 0 may lead to a move.
+clawbox_exec_approvals_hold_a_decision() {
   python3 - "$1" <<'PY'
 import json, sys
 try:
-    doc = json.load(open(sys.argv[1]))
+    raw = open(sys.argv[1], "rb").read()
+except Exception:
+    sys.exit(2)
+# A zero-byte file is what a power cut mid-write leaves. It carries no
+# approval, and the core's gate refuses to migrate while it exists — so it is
+# the one shape that must not be left alone.
+if raw.strip() == b"":
+    sys.exit(0)
+try:
+    doc = json.loads(raw)
 except Exception:
     sys.exit(2)
 if not isinstance(doc, dict):
     sys.exit(2)
-# The three homes an approval can live in, per the core's own schema
-# (exec-approvals config: only `version` is required, the rest are maps).
-for key in ("socket", "defaults", "agents"):
+# `socket` is MACHINE state, not a decision: the core fills socket.path and a
+# fresh socket.token into every file it persists, with no owner involvement,
+# and regenerates both on its next write. Reading that as an approval is what
+# would make this repair decline to fire on the shape a real box carries.
+socket = doc.get("socket")
+if socket is not None and not isinstance(socket, dict):
+    sys.exit(2)
+if isinstance(socket, dict) and set(socket) - {"path", "token"}:
+    sys.exit(1)
+# These two are where a decision can live.
+for key in ("defaults", "agents"):
     node = doc.get(key)
     if node in (None, {}, []):
         continue
@@ -257,89 +278,153 @@ sys.exit(0)
 PY
 }
 
+# What the core says about this config, in the core's own words.
+# Echoes `accepted`, `refused<TAB><issues>` or `unknown<TAB><why>`.
+clawbox_core_config_verdict() {
+  local out rc=0
+  out="$(timeout 60 "$OPENCLAW_BIN" config validate --json 2>/dev/null)" || rc=$?
+  # 0 = valid, 1 = the core's verdict. Anything else (124 the bound fired,
+  # 126/127 nothing to run, a crash) is NOT an answer about the config, and
+  # reporting one as a refusal would spend 180 s of doctor on every single
+  # start of a box whose config is perfectly fine.
+  case "$rc" in
+    0|1) ;;
+    *) printf 'unknown\tthe validator did not answer (exit %s)\n' "$rc"; return 0 ;;
+  esac
+  CLAWBOX_VERDICT_JSON="$out" python3 <<'PY'
+import json, os, sys
+try:
+    doc = json.loads(os.environ.get("CLAWBOX_VERDICT_JSON") or "")
+except Exception:
+    print("unknown\tthe validator did not answer in JSON")
+    sys.exit(0)
+if not isinstance(doc, dict) or "valid" not in doc:
+    print("unknown\tthe validator's answer carried no verdict")
+    sys.exit(0)
+if doc.get("valid") is True:
+    print("accepted")
+    sys.exit(0)
+parts = []
+for issue in doc.get("issues") or []:
+    if not isinstance(issue, dict):
+        continue
+    text = ": ".join(str(x) for x in (issue.get("path"), issue.get("message")) if x)
+    if text:
+        parts.append(text)
+print("refused\t" + ("; ".join(parts) or "the core gave no reason"))
+PY
+}
+
+# A stamp is a record of a FILE this core accepted, so a later rewrite of that
+# file — this script's own python pass below, or a boot on a core one
+# generation back that writes the legacy names again — invalidates it and the
+# next boot asks again.
+clawbox_config_fingerprint() {
+  printf '%s %s' "$CLAWBOX_OPENCLAW_EFFECTIVE" \
+    "$(stat -c '%s %Y' "$OPENCLAW_CONFIG" 2>/dev/null || echo 'unknown')"
+}
+
 clawbox_stamp_read() {
   [ -f "$CLAWBOX_CONFIG_VALIDATED_STAMP" ] || return 0
-  head -c 64 "$CLAWBOX_CONFIG_VALIDATED_STAMP" 2>/dev/null | tr -d '[:space:]' || true
+  head -n1 "$CLAWBOX_CONFIG_VALIDATED_STAMP" 2>/dev/null || true
+}
+
+clawbox_stamp_write() {
+  mkdir -p "$(dirname "$CLAWBOX_CONFIG_VALIDATED_STAMP")" 2>/dev/null || true
+  if ! printf '%s\n' "$(clawbox_config_fingerprint)" > "$CLAWBOX_CONFIG_VALIDATED_STAMP" 2>/dev/null; then
+    # Not fatal, but not silent either: without the stamp every gateway start
+    # pays for a `config validate` it did not need, and "a steady box pays
+    # nothing" quietly stops being true with nothing in the log to say why.
+    echo "  WARN: could not record $CLAWBOX_CONFIG_VALIDATED_STAMP — this boot's config validation will be repeated on every gateway start" >&2
+  fi
 }
 
 if [ "$CLAWBOX_OPENCLAW_V2" = "1" ] \
   && [ -x "$OPENCLAW_BIN" ] \
   && [ -f "$OPENCLAW_CONFIG" ] \
-  && [ "$(clawbox_stamp_read)" != "$CLAWBOX_OPENCLAW_EFFECTIVE" ]
+  && [ "$(clawbox_stamp_read)" != "$(clawbox_config_fingerprint)" ]
 then
-  # An empty legacy approvals file makes every doctor run below exit 1 before
-  # it migrates anything, so it goes first — and only when it is provably
-  # empty. A file with approvals in it is the owner's, and the core imports it
-  # itself; saying so is the whole of what this script may do about it.
-  CLAWBOX_LEGACY_EXEC_APPROVALS="$CLAWBOX_OPENCLAW_STATE_DIR/exec-approvals.json"
-  if [ -f "$CLAWBOX_LEGACY_EXEC_APPROVALS" ]; then
+  # Both names block the core's gate: doctor renames the file to the
+  # `.doctor-importing` claim for the duration of an import, so a killed
+  # import leaves one behind that refuses every later doctor just as the
+  # original does.
+  for _ea_file in \
+    "$OPENCLAW_STATE_DIR/exec-approvals.json" \
+    "$OPENCLAW_STATE_DIR/exec-approvals.json.doctor-importing"
+  do
+    [ -e "$_ea_file" ] || continue
     # Captured, not read from `$?` after a bare call: under `set -e` a bare
-    # call that answers "holds approvals" (exit 1) would abort the whole
+    # call answering "holds a decision" (exit 1) would abort the whole
     # pre-start, which is the opposite of leaving the owner's file alone.
     _ea_verdict=0
-    clawbox_exec_approvals_are_empty "$CLAWBOX_LEGACY_EXEC_APPROVALS" || _ea_verdict=$?
+    clawbox_exec_approvals_hold_a_decision "$_ea_file" || _ea_verdict=$?
     case "$_ea_verdict" in
       0)
-        _ea_moved="$CLAWBOX_LEGACY_EXEC_APPROVALS.legacy-$(date +%Y%m%d-%H%M%S)"
-        if mv "$CLAWBOX_LEGACY_EXEC_APPROVALS" "$_ea_moved" 2>/dev/null; then
-          echo "  Moved an empty legacy exec-approvals.json aside ($_ea_moved): it holds no approvals, and its presence stops openclaw doctor before it migrates anything"
+        _ea_moved="$_ea_file.legacy-$(date +%Y%m%d-%H%M%S)"
+        if mv "$_ea_file" "$_ea_moved" 2>/dev/null; then
+          echo "  Moved a legacy exec approvals file aside ($_ea_moved): it holds no approval of yours, and its presence stops openclaw doctor before it migrates anything"
         else
-          echo "  WARN: could not move the empty legacy exec-approvals.json aside; openclaw doctor will refuse to migrate this config" >&2
+          echo "  WARN: could not move $_ea_file aside; openclaw doctor will refuse to migrate this config while it is there" >&2
         fi
         ;;
       1)
-        echo "  NOTE: $CLAWBOX_LEGACY_EXEC_APPROVALS holds approvals — left in place for the core to import; doctor refuses config migrations until it has" >&2
+        echo "  NOTE: $_ea_file holds exec approvals, and openclaw doctor refuses every config migration while it exists. Nothing here will move it: review it, move it aside by hand, and restart the gateway." >&2
         ;;
       *)
-        echo "  WARN: could not read $CLAWBOX_LEGACY_EXEC_APPROVALS — leaving it alone" >&2
+        echo "  WARN: could not read $_ea_file — leaving it alone; openclaw doctor will refuse to migrate this config while it is there" >&2
         ;;
     esac
-  fi
+  done
 
-  # Ask the core, then let the core repair itself, then ask again.
-  #
-  # `|| true` on the assignment and not on the test: the exit code is the
-  # answer here, and losing it under `set -e` would turn "refused" into
-  # "accepted". Time-boxed for the same reason as the version probe above — a
-  # wedged CLI must cost this boot ten seconds of budget, not the unit's whole
-  # TimeoutStartSec.
-  _cfg_validate_out="$(timeout -k 5 60 "$OPENCLAW_BIN" config validate 2>&1)" \
-    && CLAWBOX_CONFIG_ACCEPTED=1 || CLAWBOX_CONFIG_ACCEPTED=0
-  if [ "$CLAWBOX_CONFIG_ACCEPTED" = "0" ]; then
-    echo "  The installed OpenClaw core ($CLAWBOX_OPENCLAW_EFFECTIVE) refuses this config; running its own migrations..."
-    printf '%s\n' "$_cfg_validate_out" | sed -n 's/^[[:space:]]*×[[:space:]]*/  refused: /p' >&2
-    # Named for the core, and never overwritten. A timestamped copy would
-    # leave one file per boot on a box whose repair keeps failing — and
-    # `Restart=always` means that is a lot of boots — while the copy anyone
-    # would want is the FIRST one, taken before anything touched the file.
-    _pre_migration_backup="$OPENCLAW_CONFIG.pre-$CLAWBOX_OPENCLAW_EFFECTIVE-migration"
-    if [ ! -e "$_pre_migration_backup" ]; then
-      cp -p "$OPENCLAW_CONFIG" "$_pre_migration_backup" 2>/dev/null \
-        || echo "  WARN: could not back up $OPENCLAW_CONFIG before migrating it" >&2
-    fi
-    if ! timeout -k 10 180 "$OPENCLAW_BIN" doctor --fix --non-interactive </dev/null; then
-      echo "  WARN: openclaw doctor --fix did not complete" >&2
-    fi
-    _cfg_validate_out="$(timeout -k 5 60 "$OPENCLAW_BIN" config validate 2>&1)" \
-      && CLAWBOX_CONFIG_ACCEPTED=1 || CLAWBOX_CONFIG_ACCEPTED=0
-    if [ "$CLAWBOX_CONFIG_ACCEPTED" = "1" ]; then
-      echo "  Config migrated to the $CLAWBOX_OPENCLAW_EFFECTIVE layout"
-    else
-      # Not fatal: everything below still runs on a config the core will
-      # refuse, exactly as it did before this block existed, and the gateway's
-      # own exit 78 stays the authority. What changes is that the keys are
-      # named HERE, in the boot log, instead of only in a gateway journal
-      # nobody reads until an owner calls.
-      echo "  ERROR: the core still refuses this config — the gateway will exit 78 until these keys are fixed:" >&2
-      printf '%s\n' "$_cfg_validate_out" | sed -n 's/^[[:space:]]*×[[:space:]]*/  refused: /p' >&2
-    fi
-  fi
-  if [ "$CLAWBOX_CONFIG_ACCEPTED" = "1" ]; then
-    mkdir -p "$(dirname "$CLAWBOX_CONFIG_VALIDATED_STAMP")" 2>/dev/null || true
-    printf '%s\n' "$CLAWBOX_OPENCLAW_EFFECTIVE" > "$CLAWBOX_CONFIG_VALIDATED_STAMP" 2>/dev/null || true
-  fi
+  _cfg_verdict="$(clawbox_core_config_verdict)"
+  _cfg_state="${_cfg_verdict%%$'\t'*}"
+  _cfg_detail=""
+  case "$_cfg_verdict" in *"$(printf '\t')"*) _cfg_detail="${_cfg_verdict#*$'\t'}" ;; esac
+
+  case "$_cfg_state" in
+    accepted)
+      clawbox_stamp_write
+      ;;
+    refused)
+      echo "  The installed OpenClaw core ($CLAWBOX_OPENCLAW_EFFECTIVE) refuses this config; running its own migrations..."
+      echo "  refused: $_cfg_detail" >&2
+      # Named for the core, and never overwritten. A timestamped copy would
+      # leave one file per boot on a box whose repair keeps failing — and
+      # `Restart=always` means that is a lot of boots — while the copy anyone
+      # would want is the FIRST one, taken before anything touched the file.
+      _pre_migration_backup="$OPENCLAW_CONFIG.pre-$CLAWBOX_OPENCLAW_EFFECTIVE-migration"
+      if [ ! -e "$_pre_migration_backup" ]; then
+        cp -p "$OPENCLAW_CONFIG" "$_pre_migration_backup" 2>/dev/null \
+          || echo "  WARN: could not back up $OPENCLAW_CONFIG before migrating it" >&2
+      fi
+      # SIGTERM only, no `-k`: see BUDGET above.
+      if ! timeout 180 "$OPENCLAW_BIN" doctor --fix --non-interactive </dev/null; then
+        echo "  WARN: openclaw doctor --fix did not complete" >&2
+      fi
+      _cfg_verdict="$(clawbox_core_config_verdict)"
+      _cfg_state="${_cfg_verdict%%$'\t'*}"
+      _cfg_detail=""
+      case "$_cfg_verdict" in *"$(printf '\t')"*) _cfg_detail="${_cfg_verdict#*$'\t'}" ;; esac
+      if [ "$_cfg_state" = "accepted" ]; then
+        echo "  Config migrated to the $CLAWBOX_OPENCLAW_EFFECTIVE layout"
+        clawbox_stamp_write
+      else
+        # Not fatal: everything below still runs on a config the core will
+        # refuse, exactly as it did before this block existed, and the
+        # gateway's own exit 78 stays the authority. What changes is that the
+        # keys are named HERE, in the boot log, instead of only in a gateway
+        # journal nobody reads until an owner calls.
+        echo "  ERROR: the core still refuses this config — the gateway will exit 78 until this is fixed: ${_cfg_detail:-$_cfg_state}" >&2
+      fi
+      ;;
+    *)
+      # A validator that could not be run says nothing about the config.
+      # Claiming a refusal here would put every boot of a healthy box through
+      # a 180 s doctor run, permanently.
+      echo "  WARN: could not ask the installed core whether it will load this config (${_cfg_detail:-no reason given}) — leaving it exactly as it is" >&2
+      ;;
+  esac
 fi
-
 # Resolve configured mDNS hostname (defaults to "clawbox" if unset/invalid)
 CONFIGURED_HOSTNAME="clawbox"
 if [ -f "$HOSTNAME_ENV" ]; then
@@ -2489,11 +2574,23 @@ if [ "$CLAWBOX_OPENCLAW_V2" = "1" ]; then
   LEGACY_AUTH_PROFILE="$(find "$(dirname "$OPENCLAW_CONFIG")/agents" -mindepth 3 -maxdepth 3 -name auth-profiles.json -type f -print -quit 2>/dev/null || true)"
   if [ -n "$LEGACY_AUTH_PROFILE" ]; then
     echo "  Migrating legacy auth profiles into OpenClaw 2 SQLite state..."
-    if ! timeout 180 "$OPENCLAW_BIN" doctor --fix --non-interactive </dev/null; then
+    # Doctor exits non-zero over a legacy exec-approvals file having done
+    # nothing at all — measured against 2026.8.1, 2026-09-06, and the reason
+    # the block at the top of this script clears one first. That is not a
+    # failed auth-profile migration, and failing this ExecStartPre over it is
+    # STRICTLY WORSE than letting the gateway start and refuse: exit 78 is
+    # covered by RestartPreventExitStatus (config/clawbox-gateway.service), a
+    # failed pre-start is not, so it burns StartLimitBurst=20 and leaves the
+    # box with no gateway and no way back without a console.
+    _authdoc_rc=0
+    _authdoc_out="$(timeout 180 "$OPENCLAW_BIN" doctor --fix --non-interactive </dev/null 2>&1)" || _authdoc_rc=$?
+    printf '%s\n' "$_authdoc_out"
+    if printf '%s\n' "$_authdoc_out" | grep -q 'Legacy exec approvals exist at'; then
+      echo "  WARN: openclaw doctor is blocked by a legacy exec approvals file, so the auth profiles were NOT migrated; starting the gateway anyway rather than failing this boot" >&2
+    elif [ "$_authdoc_rc" -ne 0 ]; then
       echo "  ERROR: OpenClaw 2 auth-profile migration failed" >&2
       exit 1
-    fi
-    if find "$(dirname "$OPENCLAW_CONFIG")/agents" -mindepth 3 -maxdepth 3 -name auth-profiles.json -type f -print -quit 2>/dev/null | grep -q .; then
+    elif find "$(dirname "$OPENCLAW_CONFIG")/agents" -mindepth 3 -maxdepth 3 -name auth-profiles.json -type f -print -quit 2>/dev/null | grep -q .; then
       echo "  ERROR: OpenClaw doctor left a legacy auth-profiles.json in place" >&2
       exit 1
     fi

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -189,6 +189,147 @@ if [ -z "${CLAWBOX_OPENCLAW_V2:-}" ]; then
 fi
 export CLAWBOX_OPENCLAW_V2
 
+# ── First boot on a NEW OpenClaw core: make the config loadable again ───────
+#
+# THE INCIDENT (TASK-737). A customer box was dark for 25 hours after the
+# 2026.7.1 → 2026.8.1 core upgrade. OpenClaw 2026.8 does NOT migrate a 2026.7
+# config on load: its startup guard runs the preflight with
+# `migrateLegacyConfig: false` and exits 78 with `Unrecognized keys`. The
+# migrations exist (`LEGACY_CONFIG_MIGRATIONS`, "applied by doctor") but only
+# `openclaw doctor --fix` performs them, and nothing on the boot path ran it
+# for THIS reason — the block further down is gated on an auth-profiles
+# sentinel, and the updater's own call happens after the gateway has already
+# failed.
+#
+# HARNESS FIRST, TWICE. The question "will the core load this?" is answered by
+# the core (`openclaw config validate`), and the repair is the core's own
+# (`openclaw doctor --fix`). This script does not carry a rename table: the
+# four moves the 2026.8 core makes are its business, and a table here would be
+# a second, staler copy of it.
+#
+# AND THE THING THAT BLOCKS THE REPAIR. Measured against 2026.8.1 on
+# 2026-09-06: with an EMPTY legacy `exec-approvals.json` in the state
+# directory, `doctor --fix --yes --non-interactive` exits 1 having migrated
+# NOTHING, and its last line is `Legacy exec approvals exist at … Run
+# \`openclaw doctor --fix\`` — advice for the command that just ran. Move that
+# one empty file aside and the same command exits 0 and migrates everything.
+# So it is cleared FIRST, and only when it is provably empty.
+#
+# COST. Gated on the installed core's version, not run every boot: the stamp
+# below records the version whose config the core last ACCEPTED, so a steady
+# box pays nothing and only a core bump — the state this exists for — pays the
+# CLI. The stamp is written only on success, so a failed repair is retried on
+# the next boot instead of being remembered as done.
+CLAWBOX_OPENCLAW_STATE_DIR="$(dirname "$OPENCLAW_CONFIG")"
+CLAWBOX_CONFIG_VALIDATED_STAMP="$CLAWBOX_ROOT/data/openclaw-config-validated"
+# Read by the plugin-entry pass further down, which reuses this run's warnings
+# rather than paying for a second `config validate`.
+CLAWBOX_CONFIG_VALIDATE_OUTPUT=""
+export CLAWBOX_CONFIG_VALIDATE_OUTPUT
+
+# Does this file hold any approval at all? Exit 0 = provably empty, 1 = holds
+# something, 2 = could not tell. Only 0 may lead to a move: an approval is an
+# owner decision and an unreadable file is not evidence of anything.
+clawbox_exec_approvals_are_empty() {
+  python3 - "$1" <<'PY'
+import json, sys
+try:
+    doc = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(2)
+if not isinstance(doc, dict):
+    sys.exit(2)
+# The three homes an approval can live in, per the core's own schema
+# (exec-approvals config: only `version` is required, the rest are maps).
+for key in ("socket", "defaults", "agents"):
+    node = doc.get(key)
+    if node in (None, {}, []):
+        continue
+    sys.exit(1)
+# Anything the core added that this predicate does not understand is content.
+if set(doc) - {"version", "socket", "defaults", "agents"}:
+    sys.exit(1)
+sys.exit(0)
+PY
+}
+
+clawbox_stamp_read() {
+  [ -f "$CLAWBOX_CONFIG_VALIDATED_STAMP" ] || return 0
+  head -c 64 "$CLAWBOX_CONFIG_VALIDATED_STAMP" 2>/dev/null | tr -d '[:space:]' || true
+}
+
+if [ "$CLAWBOX_OPENCLAW_V2" = "1" ] \
+  && [ -x "$OPENCLAW_BIN" ] \
+  && [ -f "$OPENCLAW_CONFIG" ] \
+  && [ "$(clawbox_stamp_read)" != "$CLAWBOX_OPENCLAW_EFFECTIVE" ]
+then
+  # An empty legacy approvals file makes every doctor run below exit 1 before
+  # it migrates anything, so it goes first — and only when it is provably
+  # empty. A file with approvals in it is the owner's, and the core imports it
+  # itself; saying so is the whole of what this script may do about it.
+  CLAWBOX_LEGACY_EXEC_APPROVALS="$CLAWBOX_OPENCLAW_STATE_DIR/exec-approvals.json"
+  if [ -f "$CLAWBOX_LEGACY_EXEC_APPROVALS" ]; then
+    # Captured, not read from `$?` after a bare call: under `set -e` a bare
+    # call that answers "holds approvals" (exit 1) would abort the whole
+    # pre-start, which is the opposite of leaving the owner's file alone.
+    _ea_verdict=0
+    clawbox_exec_approvals_are_empty "$CLAWBOX_LEGACY_EXEC_APPROVALS" || _ea_verdict=$?
+    case "$_ea_verdict" in
+      0)
+        _ea_moved="$CLAWBOX_LEGACY_EXEC_APPROVALS.legacy-$(date +%Y%m%d-%H%M%S)"
+        if mv "$CLAWBOX_LEGACY_EXEC_APPROVALS" "$_ea_moved" 2>/dev/null; then
+          echo "  Moved an empty legacy exec-approvals.json aside ($_ea_moved): it holds no approvals, and its presence stops openclaw doctor before it migrates anything"
+        else
+          echo "  WARN: could not move the empty legacy exec-approvals.json aside; openclaw doctor will refuse to migrate this config" >&2
+        fi
+        ;;
+      1)
+        echo "  NOTE: $CLAWBOX_LEGACY_EXEC_APPROVALS holds approvals — left in place for the core to import; doctor refuses config migrations until it has" >&2
+        ;;
+      *)
+        echo "  WARN: could not read $CLAWBOX_LEGACY_EXEC_APPROVALS — leaving it alone" >&2
+        ;;
+    esac
+  fi
+
+  # Ask the core, then let the core repair itself, then ask again.
+  #
+  # `|| true` on the assignment and not on the test: the exit code is the
+  # answer here, and losing it under `set -e` would turn "refused" into
+  # "accepted". Time-boxed for the same reason as the version probe above — a
+  # wedged CLI must cost this boot ten seconds of budget, not the unit's whole
+  # TimeoutStartSec.
+  CLAWBOX_CONFIG_VALIDATE_OUTPUT="$(timeout -k 5 90 "$OPENCLAW_BIN" config validate 2>&1)" \
+    && CLAWBOX_CONFIG_ACCEPTED=1 || CLAWBOX_CONFIG_ACCEPTED=0
+  if [ "$CLAWBOX_CONFIG_ACCEPTED" = "0" ]; then
+    echo "  The installed OpenClaw core ($CLAWBOX_OPENCLAW_EFFECTIVE) refuses this config; running its own migrations..."
+    printf '%s\n' "$CLAWBOX_CONFIG_VALIDATE_OUTPUT" | sed -n 's/^[[:space:]]*×[[:space:]]*/  refused: /p' >&2
+    cp -p "$OPENCLAW_CONFIG" "$OPENCLAW_CONFIG.pre-v2-migration-$(date +%Y%m%d-%H%M%S)" 2>/dev/null \
+      || echo "  WARN: could not back up $OPENCLAW_CONFIG before migrating it" >&2
+    if ! timeout -k 10 300 "$OPENCLAW_BIN" doctor --fix --non-interactive </dev/null; then
+      echo "  WARN: openclaw doctor --fix did not complete" >&2
+    fi
+    CLAWBOX_CONFIG_VALIDATE_OUTPUT="$(timeout -k 5 90 "$OPENCLAW_BIN" config validate 2>&1)" \
+      && CLAWBOX_CONFIG_ACCEPTED=1 || CLAWBOX_CONFIG_ACCEPTED=0
+    if [ "$CLAWBOX_CONFIG_ACCEPTED" = "1" ]; then
+      echo "  Config migrated to the $CLAWBOX_OPENCLAW_EFFECTIVE layout"
+    else
+      # Not fatal: everything below still runs on a config the core will
+      # refuse, exactly as it did before this block existed, and the gateway's
+      # own exit 78 stays the authority. What changes is that the keys are
+      # named HERE, in the boot log, instead of only in a gateway journal
+      # nobody reads until an owner calls.
+      echo "  ERROR: the core still refuses this config — the gateway will exit 78 until these keys are fixed:" >&2
+      printf '%s\n' "$CLAWBOX_CONFIG_VALIDATE_OUTPUT" | sed -n 's/^[[:space:]]*×[[:space:]]*/  refused: /p' >&2
+    fi
+  fi
+  if [ "$CLAWBOX_CONFIG_ACCEPTED" = "1" ]; then
+    mkdir -p "$(dirname "$CLAWBOX_CONFIG_VALIDATED_STAMP")" 2>/dev/null || true
+    printf '%s\n' "$CLAWBOX_OPENCLAW_EFFECTIVE" > "$CLAWBOX_CONFIG_VALIDATED_STAMP" 2>/dev/null || true
+  fi
+  export CLAWBOX_CONFIG_VALIDATE_OUTPUT
+fi
+
 # Resolve configured mDNS hostname (defaults to "clawbox" if unset/invalid)
 CONFIGURED_HOSTNAME="clawbox"
 if [ -f "$HOSTNAME_ENV" ]; then

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1276,10 +1276,15 @@ async function getOpenclawConfigRefusal(): Promise<string | null> {
       .filter((line) => line.startsWith("\u00d7"))
       .map((line) => line.replace(/^\u00d7\s*/, ""));
     if (offending.length === 0) {
-      // Non-zero for a reason the validator did not phrase as a key: keep the
-      // first line rather than claiming to know more than it said.
-      const first = text.split(/\r?\n/).map((l) => l.trim()).find(Boolean);
-      return first ?? null;
+      // Non-zero WITHOUT the validator's own verdict in the output is not a
+      // refusal — it is a validator that could not be run. A broken node
+      // engine after a half-finished core install exits non-zero here too,
+      // and reporting its stack as "OpenClaw refuses this configuration"
+      // would be a false failure over a config that is fine. Say nothing and
+      // let the journal answer.
+      return /config is invalid|Invalid config/i.test(text)
+        ? (text.split(/\r?\n/).map((l) => l.trim()).find(Boolean) ?? null)
+        : null;
     }
     return offending.join("; ");
   }

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1150,6 +1150,7 @@ const GATEWAY_WAIT_INTERVAL_MS = Number(process.env.GATEWAY_WAIT_INTERVAL_MS || 
 // tunable: a pre-start still running at this point is killed by systemd
 // itself, so the wait below never outlives the thing it waits for.
 const GATEWAY_PRE_START_TIMEOUT_MS = 600_000;
+const DOCTOR_FIX_TIMEOUT_MS = 90_000;
 const ROOT_STEP_SETTLE_TIMEOUT_MS = Number(process.env.ROOT_STEP_SETTLE_TIMEOUT_MS || "7200000");
 const LEGACY_GATEWAY_BLOCKER_RE =
   /installs\.json|conflicting plugin install metadata|carl_pir|belongs to agent piper/i;
@@ -1195,17 +1196,51 @@ function waitForGateway(timeoutMs: number): Promise<boolean> {
 }
 
 /**
- * Run the core's own repair, and REMEMBER whether it worked.
+ * The environment that pins an `openclaw` child to THIS device's real config.
+ *
+ * Same rule as `runCurrentGatewayPreStart`: the CLI reads `OPENCLAW_HOME` as
+ * the ACCOUNT home and builds its tree at `$OPENCLAW_HOME/.openclaw`, while
+ * ClawBox uses that name for the `.openclaw` directory itself — so an
+ * inherited one makes the core answer about a second, empty config. That does
+ * not matter for a command whose answer is thrown away; it matters a great
+ * deal for one whose answer is printed to the owner as the reason his gateway
+ * is dead.
+ */
+function openclawChildEnv(): NodeJS.ProcessEnv {
+  const home = process.env.CLAWBOX_HOME_DIR || process.env.HOME || "/home/clawbox";
+  const openclawHome = process.env.CLAWBOX_OPENCLAW_HOME
+    || process.env.OPENCLAW_HOME
+    || path.join(home, ".openclaw");
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: home,
+    OPENCLAW_STATE_DIR: openclawHome,
+    OPENCLAW_CONFIG_PATH: path.join(openclawHome, "openclaw.json"),
+  };
+  delete env.OPENCLAW_HOME;
+  return env;
+}
+
+/** Everything a failed child said, whichever stream it said it on. */
+function commandOutput(err: unknown): string {
+  const detail = err as { stdout?: unknown; stderr?: unknown; message?: unknown };
+  return [detail.stdout, detail.stderr, detail.message]
+    .map((part) => (typeof part === "string" ? part : ""))
+    .join("\n");
+}
+
+/**
+ * Run the core's own repair, and RECORD whether it worked.
  *
  * Still non-fatal, and that is load-bearing: doctor exiting non-zero because
  * the gateway holds its state directory is the gateway proving it is alive
  * (install.sh:step_gateway_legacy_state_recovery, measured 2026-09-06), so the
  * restart + positive port probe that follows remains the verdict, not the exit
  * code — which is why neither caller branches on this, and it returns nothing.
- * What changed is that the exit code is no longer DISCARDED: a doctor
- * that could not finish is the single most useful fact about an update that
- * then finds no gateway, and swallowing it silently is what left a customer
- * box dark for 25 hours with "Applying system fixups — completed" on screen
+ * What changed is that the exit code is no longer DISCARDED: a doctor that
+ * could not finish is the single most useful fact about an update that then
+ * finds no gateway, and swallowing it silently is what left a customer box
+ * dark for 25 hours with "Applying system fixups — completed" on screen
  * (TASK-737).
  */
 async function runOpenclawDoctorFix(): Promise<void> {
@@ -1213,80 +1248,96 @@ async function runOpenclawDoctorFix(): Promise<void> {
   if (openclawIsAbsent()) return;
   try {
     await execFile(OPENCLAW_BIN, ["doctor", "--fix", "--yes", "--non-interactive"], {
-      timeout: 90_000,
+      timeout: DOCTOR_FIX_TIMEOUT_MS,
       maxBuffer: 2 * 1024 * 1024,
+      env: openclawChildEnv(),
     });
   } catch (err) {
-    warnUpdate(
-      "openclaw-doctor-fix-failed",
-      "`openclaw doctor --fix` did not complete. Config and session migrations it "
-      + `performs may still be pending: ${firstLineOf(err)}`,
-    );
+    warnUpdate("openclaw-doctor-fix-failed", `\`openclaw doctor --fix\` did not complete. `
+      + `Config and session migrations it performs may still be pending: ${describeDoctorFailure(err)}`);
   }
 }
 
-/** The first meaningful line of a failure, for a one-line warning or error. */
-function firstLineOf(err: unknown): string {
-  const text = err instanceof Error ? (err.message ?? "") : String(err);
-  const line = text.split(/\r?\n/).map((l) => l.trim()).find(Boolean);
-  return line ?? "no output";
+/**
+ * Why doctor did not finish, in words worth reading.
+ *
+ * NOT `err.message`: node sets it to `Command failed: <the whole argv>`, so a
+ * warning built from its first line would name the command back at the owner
+ * and nothing else. Doctor states its own blocker — `Legacy exec approvals
+ * exist at …` is the one this card is about — and it states it in the output,
+ * so that is what is quoted. A killed child is called killed, because a 90 s
+ * timeout and a refusal are not the same problem.
+ */
+function describeDoctorFailure(err: unknown): string {
+  if ((err as { killed?: boolean } | null)?.killed) {
+    return `it was still running after ${Math.round(DOCTOR_FIX_TIMEOUT_MS / 1000)}s and was stopped`;
+  }
+  const said = commandOutput(err)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    // Its own summary frame is drawn with box-drawing characters and says
+    // nothing; the sentence that names the blocker is plain text.
+    .filter((line) => !/^[\u2500-\u257f\u25c6\u2502]/.test(line) && !line.startsWith("Command failed:"));
+  return said.at(-1) ?? "it gave no reason";
 }
 
 /**
  * Ask the CORE whether it will accept this device's configuration.
  *
- * HARNESS FIRST. `openclaw config validate` is the core's own answer to
- * "would the gateway start?", and until TASK-737 nothing in ClawBox ever
- * asked it — not the updater, not install.sh, not the boot script. That gap
- * is the whole of the incident: OpenClaw 2026.8 REFUSES a 2026.7-layout
- * config instead of migrating it on load (`Unrecognized keys`, gateway exit
- * 78), so a box whose migration did not run has a gateway that provably
- * cannot start, and ClawBox reported "not listening on port 18789" — true,
- * unactionable, and indistinguishable from a dozen other causes.
+ * HARNESS FIRST. `openclaw config validate --json` is the core's own answer to
+ * "would the gateway start?" — `{valid, path, issues[]}` — and until TASK-737
+ * nothing in ClawBox ever asked it: not the updater, not install.sh, not the
+ * boot script. That gap is the whole of the incident: OpenClaw 2026.8 REFUSES
+ * a 2026.7-layout config instead of migrating it on load (`Unrecognized
+ * keys`, gateway exit 78), so a box whose migration did not run has a gateway
+ * that provably cannot start — and ClawBox reported "not listening on port
+ * 18789", which is true, unactionable, and indistinguishable from a dozen
+ * other causes.
  *
- * Returns the validator's own words when it refuses, and null when it
- * accepts, when there is no core to ask (Hermes), or when the validator
- * itself could not be run. Null is deliberately the "say nothing" answer:
- * this is a DIAGNOSIS of an update that has already failed, so a validator we
- * could not reach must never invent a cause of its own.
+ * `--json`, not the human output: that goes to stderr and marks each issue
+ * with a themed `×` glyph any `FORCE_COLOR` in the environment repaints, so
+ * scraping it would be reading presentation as a contract.
+ *
+ * Returns the core's own reasons when it refuses, and null when it accepts,
+ * when there is no core to ask (Hermes), or when the validator could not be
+ * run at all. Null is deliberately the "say nothing" answer: this is a
+ * DIAGNOSIS of an update that has already failed, so a validator we could not
+ * reach must never invent a cause of its own — a half-installed core whose
+ * node engine is wrong exits non-zero here too, and calling that a bad config
+ * would be a false failure over a config that is fine.
  */
 async function getOpenclawConfigRefusal(): Promise<string | null> {
   if (openclawIsAbsent()) return null;
+  let payload: string;
   try {
-    await execFile(OPENCLAW_BIN, ["config", "validate"], {
+    await execFile(OPENCLAW_BIN, ["config", "validate", "--json"], {
       timeout: 60_000,
       maxBuffer: 2 * 1024 * 1024,
+      env: openclawChildEnv(),
     });
     return null;
   } catch (err) {
-    // The validator prints the offending keys on stdout and exits non-zero.
-    // execFile's rejection carries both streams; the keys are what matters.
-    const detail = err as { stdout?: unknown; stderr?: unknown; message?: unknown };
-    const text = [detail.stdout, detail.stderr, detail.message]
-      .map((part) => (typeof part === "string" ? part : ""))
-      .join("\n");
-    const offending = text
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      // The core marks each rejected key with a leading `×`. Nothing else in
-      // its output is a reason, and the trailing "Run `openclaw doctor --fix`"
-      // advice is the line ClawBox must NOT hand back as the cause: doctor is
-      // exactly what just ran and failed.
-      .filter((line) => line.startsWith("\u00d7"))
-      .map((line) => line.replace(/^\u00d7\s*/, ""));
-    if (offending.length === 0) {
-      // Non-zero WITHOUT the validator's own verdict in the output is not a
-      // refusal — it is a validator that could not be run. A broken node
-      // engine after a half-finished core install exits non-zero here too,
-      // and reporting its stack as "OpenClaw refuses this configuration"
-      // would be a false failure over a config that is fine. Say nothing and
-      // let the journal answer.
-      return /config is invalid|Invalid config/i.test(text)
-        ? (text.split(/\r?\n/).map((l) => l.trim()).find(Boolean) ?? null)
-        : null;
-    }
-    return offending.join("; ");
+    // The core prints the verdict as JSON on stdout and exits 1 when it
+    // refuses. Any other non-zero exit carries no verdict at all.
+    payload = commandOutput(err);
   }
+  let verdict: unknown;
+  try {
+    verdict = JSON.parse(payload.slice(payload.indexOf("{"), payload.lastIndexOf("}") + 1));
+  } catch {
+    return null;
+  }
+  if (typeof verdict !== "object" || verdict === null) return null;
+  const { valid, issues } = verdict as { valid?: unknown; issues?: unknown };
+  if (valid !== false) return null;
+  const reasons = (Array.isArray(issues) ? issues : [])
+    .map((issue) => {
+      const { path: at, message } = (issue ?? {}) as { path?: unknown; message?: unknown };
+      return [at, message].filter((part) => typeof part === "string" && part).join(": ");
+    })
+    .filter(Boolean);
+  return reasons.length > 0 ? reasons.join("; ") : "the core gave no reason";
 }
 
 async function setGatewayMaintenanceMask(masked: boolean): Promise<void> {

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1201,28 +1201,27 @@ function waitForGateway(timeoutMs: number): Promise<boolean> {
  * the gateway holds its state directory is the gateway proving it is alive
  * (install.sh:step_gateway_legacy_state_recovery, measured 2026-09-06), so the
  * restart + positive port probe that follows remains the verdict, not the exit
- * code. What changed is that the exit code is no longer DISCARDED: a doctor
+ * code — which is why neither caller branches on this, and it returns nothing.
+ * What changed is that the exit code is no longer DISCARDED: a doctor
  * that could not finish is the single most useful fact about an update that
  * then finds no gateway, and swallowing it silently is what left a customer
  * box dark for 25 hours with "Applying system fixups — completed" on screen
  * (TASK-737).
  */
-async function runOpenclawDoctorFix(): Promise<boolean> {
+async function runOpenclawDoctorFix(): Promise<void> {
   // No openclaw binary on the Hermes edition — nothing to doctor.
-  if (openclawIsAbsent()) return true;
+  if (openclawIsAbsent()) return;
   try {
     await execFile(OPENCLAW_BIN, ["doctor", "--fix", "--yes", "--non-interactive"], {
       timeout: 90_000,
       maxBuffer: 2 * 1024 * 1024,
     });
-    return true;
   } catch (err) {
     warnUpdate(
       "openclaw-doctor-fix-failed",
       "`openclaw doctor --fix` did not complete. Config and session migrations it "
       + `performs may still be pending: ${firstLineOf(err)}`,
     );
-    return false;
   }
 }
 

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1194,17 +1194,94 @@ function waitForGateway(timeoutMs: number): Promise<boolean> {
   });
 }
 
-async function runOpenclawDoctorFix(): Promise<void> {
+/**
+ * Run the core's own repair, and REMEMBER whether it worked.
+ *
+ * Still non-fatal, and that is load-bearing: doctor exiting non-zero because
+ * the gateway holds its state directory is the gateway proving it is alive
+ * (install.sh:step_gateway_legacy_state_recovery, measured 2026-09-06), so the
+ * restart + positive port probe that follows remains the verdict, not the exit
+ * code. What changed is that the exit code is no longer DISCARDED: a doctor
+ * that could not finish is the single most useful fact about an update that
+ * then finds no gateway, and swallowing it silently is what left a customer
+ * box dark for 25 hours with "Applying system fixups — completed" on screen
+ * (TASK-737).
+ */
+async function runOpenclawDoctorFix(): Promise<boolean> {
   // No openclaw binary on the Hermes edition — nothing to doctor.
-  if (openclawIsAbsent()) return;
+  if (openclawIsAbsent()) return true;
   try {
     await execFile(OPENCLAW_BIN, ["doctor", "--fix", "--yes", "--non-interactive"], {
       timeout: 90_000,
       maxBuffer: 2 * 1024 * 1024,
     });
-  } catch {
-    // Doctor can still repair some state before exiting non-zero. Continue
-    // into a restart + positive gateway probe rather than trusting exit code.
+    return true;
+  } catch (err) {
+    warnUpdate(
+      "openclaw-doctor-fix-failed",
+      "`openclaw doctor --fix` did not complete. Config and session migrations it "
+      + `performs may still be pending: ${firstLineOf(err)}`,
+    );
+    return false;
+  }
+}
+
+/** The first meaningful line of a failure, for a one-line warning or error. */
+function firstLineOf(err: unknown): string {
+  const text = err instanceof Error ? (err.message ?? "") : String(err);
+  const line = text.split(/\r?\n/).map((l) => l.trim()).find(Boolean);
+  return line ?? "no output";
+}
+
+/**
+ * Ask the CORE whether it will accept this device's configuration.
+ *
+ * HARNESS FIRST. `openclaw config validate` is the core's own answer to
+ * "would the gateway start?", and until TASK-737 nothing in ClawBox ever
+ * asked it — not the updater, not install.sh, not the boot script. That gap
+ * is the whole of the incident: OpenClaw 2026.8 REFUSES a 2026.7-layout
+ * config instead of migrating it on load (`Unrecognized keys`, gateway exit
+ * 78), so a box whose migration did not run has a gateway that provably
+ * cannot start, and ClawBox reported "not listening on port 18789" — true,
+ * unactionable, and indistinguishable from a dozen other causes.
+ *
+ * Returns the validator's own words when it refuses, and null when it
+ * accepts, when there is no core to ask (Hermes), or when the validator
+ * itself could not be run. Null is deliberately the "say nothing" answer:
+ * this is a DIAGNOSIS of an update that has already failed, so a validator we
+ * could not reach must never invent a cause of its own.
+ */
+async function getOpenclawConfigRefusal(): Promise<string | null> {
+  if (openclawIsAbsent()) return null;
+  try {
+    await execFile(OPENCLAW_BIN, ["config", "validate"], {
+      timeout: 60_000,
+      maxBuffer: 2 * 1024 * 1024,
+    });
+    return null;
+  } catch (err) {
+    // The validator prints the offending keys on stdout and exits non-zero.
+    // execFile's rejection carries both streams; the keys are what matters.
+    const detail = err as { stdout?: unknown; stderr?: unknown; message?: unknown };
+    const text = [detail.stdout, detail.stderr, detail.message]
+      .map((part) => (typeof part === "string" ? part : ""))
+      .join("\n");
+    const offending = text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      // The core marks each rejected key with a leading `×`. Nothing else in
+      // its output is a reason, and the trailing "Run `openclaw doctor --fix`"
+      // advice is the line ClawBox must NOT hand back as the cause: doctor is
+      // exactly what just ran and failed.
+      .filter((line) => line.startsWith("\u00d7"))
+      .map((line) => line.replace(/^\u00d7\s*/, ""));
+    if (offending.length === 0) {
+      // Non-zero for a reason the validator did not phrase as a key: keep the
+      // first line rather than claiming to know more than it said.
+      const first = text.split(/\r?\n/).map((l) => l.trim()).find(Boolean);
+      return first ?? null;
+    }
+    return offending.join("; ");
   }
 }
 
@@ -2083,12 +2160,7 @@ async function ensureGatewayHealthy(options: { restartFirst?: boolean } = {}): P
 
   const beforeRecoveryLog = await readGatewayJournalTail();
   if (!LEGACY_GATEWAY_BLOCKER_RE.test(beforeRecoveryLog)) {
-    const lastLog = getGatewayFailureDetail(beforeRecoveryLog);
-    throw new Error(
-      lastLog
-        ? `OpenClaw gateway is not listening on port ${GATEWAY_PORT}: ${lastLog}`
-        : `OpenClaw gateway is not listening on port ${GATEWAY_PORT}`,
-    );
+    throw new Error(await describeDeadGateway(beforeRecoveryLog));
   }
 
   await withGatewayQuiesced(async () => {
@@ -2099,12 +2171,36 @@ async function ensureGatewayHealthy(options: { restartFirst?: boolean } = {}): P
   if (await waitForGateway(GATEWAY_RECOVERY_WAIT_MS)) return;
 
   const afterRecoveryLog = await readGatewayJournalTail();
-  const lastLog = getGatewayFailureDetail(afterRecoveryLog);
   throw new Error(
-    lastLog
-      ? `OpenClaw gateway still offline after legacy state recovery: ${lastLog}`
-      : "OpenClaw gateway still offline after legacy state recovery",
+    await describeDeadGateway(afterRecoveryLog, "OpenClaw gateway still offline after legacy state recovery"),
   );
+}
+
+/**
+ * Say WHY the gateway is not there, in the order of what the owner can act on.
+ *
+ * A configuration the core refuses outranks anything in the journal, because
+ * it is a cause rather than a symptom and it is the one the journal states
+ * worst. On a 2026.7 → 2026.8 core upgrade whose migration did not run, the
+ * gateway's own last line is `Run "openclaw doctor --fix" to repair the
+ * config, then retry.` — advice for a command ClawBox has just run and that
+ * has just failed — and `getGatewayFailureDetail` hands exactly that line back
+ * as the cause (measured against 2026.8.1 on 2026-09-06). The keys the core
+ * actually named are three lines further up and were never reported at all.
+ *
+ * Asked only here, on a path where the update has already failed: a healthy
+ * update never pays for the extra CLI call.
+ */
+async function describeDeadGateway(
+  journal: string,
+  prefix = `OpenClaw gateway is not listening on port ${GATEWAY_PORT}`,
+): Promise<string> {
+  const refusal = await getOpenclawConfigRefusal();
+  if (refusal) {
+    return `${prefix}: OpenClaw refuses this device's configuration — ${refusal}`;
+  }
+  const lastLog = getGatewayFailureDetail(journal);
+  return lastLog ? `${prefix}: ${lastLog}` : prefix;
 }
 
 const UPDATE_STEPS: UpdateStepDef[] = [

--- a/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
+++ b/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
@@ -197,12 +197,28 @@ d("gateway pre-start: making a bumped core's config loadable", () => {
     expect(seen.filter((c) => c === "config validate")).toHaveLength(2);
     expect(seen.indexOf("doctor --fix --non-interactive")).toBeGreaterThan(0);
     expect(readFileSync(stampPath, "utf-8").trim()).toBe("2026.8.1");
-    // A backup of the pre-migration file is kept next to it.
+    // A backup of the pre-migration file is kept next to it, named for the
+    // core and taken once — not one per boot on a box that keeps failing.
+    expect(existsSync(path.join(stateDir, "openclaw.json.pre-2026.8.1-migration"))).toBe(true);
+  });
+
+  it("keeps the FIRST pre-migration backup when the repair fails and the next boot retries", () => {
+    writeFileSync(path.join(stateDir, "openclaw.json.pre-2026.8.1-migration"), '{"first":true}');
+    writeFileSync(configPath, JSON.stringify({ agents: { defaults: { memorySearch: { second: true } } } }));
+    writeFileSync(
+      path.join(stateDir, "exec-approvals.json"),
+      JSON.stringify({ version: 1, defaults: { "rm -rf": "deny" } }),
+    );
+
+    run();
+
+    expect(readFileSync(path.join(stateDir, "openclaw.json.pre-2026.8.1-migration"), "utf-8"))
+      .toBe('{"first":true}');
     expect(
       spawnSync("bash", ["-c", `ls ${JSON.stringify(stateDir)}`], { encoding: "utf-8" })
         .stdout.split("\n")
-        .some((n) => n.startsWith("openclaw.json.pre-v2-migration-")),
-    ).toBe(true);
+        .filter((n) => n.includes("pre-") && n.includes("-migration")),
+    ).toHaveLength(1);
   });
 
   it("costs a steady box nothing: the stamp already names the installed core", () => {

--- a/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
+++ b/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { testEnv } from "@/tests/helpers/env";
+import { sliceScript } from "@/tests/helpers/gateway-pre-start";
+
+// Starts a real process (bash / python3): vitest's 5 s test and 10 s hook
+// defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+// TASK-737. A customer box was dark for 25 hours after the 2026.7.1 → 2026.8.1
+// core upgrade: OpenClaw 2026.8 does not migrate a 2026.7 config on load, it
+// REFUSES it (`Unrecognized keys`, gateway exit 78), and the migrations it
+// names are performed only by `openclaw doctor --fix`. Nothing on the boot path
+// ran doctor for that reason.
+//
+// And the repair had a blocker of its own, measured against 2026.8.1 on
+// 2026-09-06: with an EMPTY legacy `exec-approvals.json` in the state
+// directory, `doctor --fix --yes --non-interactive` exits 1 having migrated
+// NOTHING and asks the operator to run the command that just ran. Move that one
+// empty file aside and the same command exits 0 and migrates everything. The
+// stub below models exactly that, so these cases fail if either half regresses.
+//
+// The three failure shapes pinned:
+//   false success — a boot that "started the gateway" on a config the core will
+//                   not load. The config has to be provably ACCEPTED by the
+//                   core afterwards, not merely doctored at.
+//   false failure — an approvals file with content is the owner's data; it is
+//                   never moved, and its presence is reported rather than
+//                   silently repaired.
+//   probe-once    — the stamp records the core version whose config was
+//                   accepted, and is written ONLY on success, so a failed
+//                   repair is retried on the next boot rather than remembered
+//                   as done.
+
+const hasPython3 = spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
+const hasBash = spawnSync("bash", ["--version"], { stdio: "ignore" }).status === 0;
+const d = hasPython3 && hasBash ? describe : describe.skip;
+
+/** The shipped block, run verbatim — a drift in the script fails here. */
+function block(): string {
+  return sliceScript(
+    "# ── First boot on a NEW OpenClaw core: make the config loadable again ",
+    "# Resolve configured mDNS hostname",
+  );
+}
+
+let dir: string;
+let root: string;
+let binDir: string;
+let stateDir: string;
+let configPath: string;
+let stampPath: string;
+
+/**
+ * An `openclaw` that behaves like 2026.8.1 on a 2026.7 config.
+ *
+ * `config validate` refuses until the migration has run; `doctor --fix`
+ * performs it — unless a legacy exec-approvals.json is still present, in which
+ * case it exits 1 having done nothing, which is the measured behaviour this
+ * whole block exists to get past.
+ */
+function stubOpenclaw() {
+  const p = path.join(binDir, "openclaw");
+  writeFileSync(
+    p,
+    `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$OC_CALLS"
+if [ "$1" = "config" ] && [ "$2" = "validate" ]; then
+  if [ -f "$OC_STATE/migrated" ]; then
+    echo "Config valid: $OPENCLAW_CONFIG"
+    exit 0
+  fi
+  echo "OpenClaw config is invalid: $OPENCLAW_CONFIG"
+  echo "  × openclaw.json:4 — agents.defaults: Unrecognized keys: \\"memorySearch\\", \\"imageGenerationModel\\""
+  echo "  × openclaw.json:11 — messages: Unrecognized key: \\"tts\\""
+  exit 1
+fi
+if [ "$1" = "doctor" ]; then
+  if [ -f "$OC_STATE/exec-approvals.json" ]; then
+    echo "Legacy exec approvals exist at $OC_STATE/exec-approvals.json. Run \\\`openclaw doctor --fix\\\` before using exec approvals."
+    exit 1
+  fi
+  touch "$OC_STATE/migrated"
+  exit 0
+fi
+exit 0
+`,
+  );
+  chmodSync(p, 0o755);
+}
+
+function run(version = "2026.8.1") {
+  const program = [
+    "set -euo pipefail",
+    `CLAWBOX_ROOT=${JSON.stringify(root)}`,
+    `OPENCLAW_CONFIG=${JSON.stringify(configPath)}`,
+    `OPENCLAW_BIN=${JSON.stringify(path.join(binDir, "openclaw"))}`,
+    "CLAWBOX_OPENCLAW_V2=1",
+    `CLAWBOX_OPENCLAW_EFFECTIVE=${JSON.stringify(version)}`,
+    block(),
+  ].join("\n");
+  const r = spawnSync("bash", ["-c", program], {
+    encoding: "utf-8",
+    env: testEnv({
+      PATH: `${binDir}:/usr/bin:/bin`,
+      OPENCLAW_CONFIG: configPath,
+      OC_CALLS: path.join(dir, "calls.log"),
+      OC_STATE: stateDir,
+    }),
+    timeout: 30_000,
+  });
+  return { status: r.status ?? -1, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+function calls(): string[] {
+  const p = path.join(dir, "calls.log");
+  return existsSync(p) ? readFileSync(p, "utf-8").split("\n").filter(Boolean) : [];
+}
+
+function approvalsFiles(): string[] {
+  return spawnSync("bash", ["-c", `ls ${JSON.stringify(stateDir)}`], { encoding: "utf-8" })
+    .stdout.split("\n")
+    .filter((n) => n.startsWith("exec-approvals"));
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "clawbox-v2-config-repair-"));
+  root = path.join(dir, "clawbox");
+  binDir = path.join(dir, "bin");
+  stateDir = path.join(dir, "openclaw");
+  mkdirSync(path.join(root, "data"), { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+  mkdirSync(stateDir, { recursive: true });
+  configPath = path.join(stateDir, "openclaw.json");
+  stampPath = path.join(root, "data", "openclaw-config-validated");
+  writeFileSync(configPath, JSON.stringify({ agents: { defaults: { memorySearch: {} } } }, null, 2));
+  stubOpenclaw();
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+d("gateway pre-start: making a bumped core's config loadable", () => {
+  it("moves an EMPTY legacy exec-approvals.json aside so the core's own migration can run", () => {
+    writeFileSync(
+      path.join(stateDir, "exec-approvals.json"),
+      JSON.stringify({ version: 1, socket: {}, defaults: {}, agents: {} }),
+    );
+
+    const r = run();
+
+    expect(r.status).toBe(0);
+    // The empty file is gone from its blocking name and kept under another.
+    expect(existsSync(path.join(stateDir, "exec-approvals.json"))).toBe(false);
+    expect(approvalsFiles().some((n) => n.startsWith("exec-approvals.json.legacy-"))).toBe(true);
+    // …and with it out of the way the core migrated and now ACCEPTS the config.
+    expect(calls().some((c) => c.startsWith("doctor --fix"))).toBe(true);
+    expect(existsSync(path.join(stateDir, "migrated"))).toBe(true);
+    expect(readFileSync(stampPath, "utf-8").trim()).toBe("2026.8.1");
+  });
+
+  it("never moves an approvals file that holds approvals, and says why", () => {
+    writeFileSync(
+      path.join(stateDir, "exec-approvals.json"),
+      JSON.stringify({ version: 1, socket: {}, defaults: { "rm -rf": "deny" }, agents: {} }),
+    );
+
+    const r = run();
+
+    expect(existsSync(path.join(stateDir, "exec-approvals.json"))).toBe(true);
+    expect(approvalsFiles()).toEqual(["exec-approvals.json"]);
+    expect(r.stderr).toContain("holds approvals");
+    // The repair still fails — that is the honest outcome — and it is REPORTED
+    // with the keys the core named, not swallowed.
+    expect(r.stderr).toContain("the core still refuses this config");
+    expect(r.stderr).toContain('agents.defaults: Unrecognized keys: "memorySearch", "imageGenerationModel"');
+    // A failed repair is NOT remembered as done.
+    expect(existsSync(stampPath)).toBe(false);
+  });
+
+  it("runs the core's own migration when the core refuses the config, and re-asks the core", () => {
+    const r = run();
+
+    expect(r.status).toBe(0);
+    const seen = calls();
+    expect(seen[0]).toBe("config validate");
+    expect(seen.some((c) => c.startsWith("doctor --fix"))).toBe(true);
+    // Asked AGAIN afterwards: doctor exiting 0 is not evidence that the core
+    // will load the file, and taking it as such is the false success that left
+    // a box dark for a day.
+    expect(seen.filter((c) => c === "config validate")).toHaveLength(2);
+    expect(seen.indexOf("doctor --fix --non-interactive")).toBeGreaterThan(0);
+    expect(readFileSync(stampPath, "utf-8").trim()).toBe("2026.8.1");
+    // A backup of the pre-migration file is kept next to it.
+    expect(
+      spawnSync("bash", ["-c", `ls ${JSON.stringify(stateDir)}`], { encoding: "utf-8" })
+        .stdout.split("\n")
+        .some((n) => n.startsWith("openclaw.json.pre-v2-migration-")),
+    ).toBe(true);
+  });
+
+  it("costs a steady box nothing: the stamp already names the installed core", () => {
+    mkdirSync(path.dirname(stampPath), { recursive: true });
+    writeFileSync(stampPath, "2026.8.1\n");
+
+    const r = run();
+
+    expect(r.status).toBe(0);
+    expect(calls()).toEqual([]);
+  });
+
+  it("re-asks after a core bump even though the previous core was accepted", () => {
+    mkdirSync(path.dirname(stampPath), { recursive: true });
+    writeFileSync(stampPath, "2026.7.1\n");
+
+    run("2026.8.1");
+
+    expect(calls()[0]).toBe("config validate");
+    expect(readFileSync(stampPath, "utf-8").trim()).toBe("2026.8.1");
+  });
+});

--- a/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
+++ b/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -71,20 +71,29 @@ function stubOpenclaw() {
     `#!/usr/bin/env bash
 printf '%s\\n' "$*" >> "$OC_CALLS"
 if [ "$1" = "config" ] && [ "$2" = "validate" ]; then
+  if [ -n "\${OC_VALIDATE_RC:-}" ] && [ "\${OC_VALIDATE_RC}" != "0" ] && [ "\${OC_VALIDATE_RC}" != "1" ]; then
+    exit "\$OC_VALIDATE_RC"
+  fi
   if [ -f "$OC_STATE/migrated" ]; then
-    echo "Config valid: $OPENCLAW_CONFIG"
+    echo '{"valid":true,"path":"'"$OPENCLAW_CONFIG"'","warnings":[]}'
     exit 0
   fi
-  echo "OpenClaw config is invalid: $OPENCLAW_CONFIG"
-  echo "  × openclaw.json:4 — agents.defaults: Unrecognized keys: \\"memorySearch\\", \\"imageGenerationModel\\""
-  echo "  × openclaw.json:11 — messages: Unrecognized key: \\"tts\\""
+  cat <<'JSON'
+{"error":{"type":"cli_error","message":"OpenClaw config is invalid"},
+ "valid":false,
+ "issues":[{"path":"agents.defaults","message":"Unrecognized keys: \\"memorySearch\\", \\"imageGenerationModel\\""},
+           {"path":"messages","message":"Unrecognized key: \\"tts\\""}]}
+JSON
   exit 1
 fi
 if [ "$1" = "doctor" ]; then
-  if [ -f "$OC_STATE/exec-approvals.json" ]; then
-    echo "Legacy exec approvals exist at $OC_STATE/exec-approvals.json. Run \\\`openclaw doctor --fix\\\` before using exec approvals."
-    exit 1
-  fi
+  # The core's gate throws on the PRESENCE of either name, contents irrelevant.
+  for f in "$OC_STATE/exec-approvals.json" "$OC_STATE/exec-approvals.json.doctor-importing"; do
+    if [ -e "\$f" ]; then
+      echo "Legacy exec approvals exist at \$f. Run \\\`openclaw doctor --fix\\\` before using exec approvals."
+      exit 1
+    fi
+  done
   touch "$OC_STATE/migrated"
   exit 0
 fi
@@ -94,11 +103,12 @@ exit 0
   chmodSync(p, 0o755);
 }
 
-function run(version = "2026.8.1") {
+function run(version = "2026.8.1", extraEnv: Record<string, string> = {}) {
   const program = [
     "set -euo pipefail",
     `CLAWBOX_ROOT=${JSON.stringify(root)}`,
     `OPENCLAW_CONFIG=${JSON.stringify(configPath)}`,
+    `OPENCLAW_STATE_DIR=${JSON.stringify(stateDir)}`,
     `OPENCLAW_BIN=${JSON.stringify(path.join(binDir, "openclaw"))}`,
     "CLAWBOX_OPENCLAW_V2=1",
     `CLAWBOX_OPENCLAW_EFFECTIVE=${JSON.stringify(version)}`,
@@ -111,10 +121,17 @@ function run(version = "2026.8.1") {
       OPENCLAW_CONFIG: configPath,
       OC_CALLS: path.join(dir, "calls.log"),
       OC_STATE: stateDir,
+      ...extraEnv,
     }),
     timeout: 30_000,
   });
   return { status: r.status ?? -1, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+/** What the block will record once the core has accepted the config on disk. */
+function currentFingerprint(version = "2026.8.1"): string {
+  const st = statSync(configPath);
+  return `${version} ${st.size} ${Math.floor(st.mtimeMs / 1000)}`;
 }
 
 function calls(): string[] {
@@ -162,7 +179,7 @@ d("gateway pre-start: making a bumped core's config loadable", () => {
     // …and with it out of the way the core migrated and now ACCEPTS the config.
     expect(calls().some((c) => c.startsWith("doctor --fix"))).toBe(true);
     expect(existsSync(path.join(stateDir, "migrated"))).toBe(true);
-    expect(readFileSync(stampPath, "utf-8").trim()).toBe("2026.8.1");
+    expect(readFileSync(stampPath, "utf-8").trim()).toMatch(/^2026\.8\.1 \d+ \d+$/);
   });
 
   it("never moves an approvals file that holds approvals, and says why", () => {
@@ -175,7 +192,10 @@ d("gateway pre-start: making a bumped core's config loadable", () => {
 
     expect(existsSync(path.join(stateDir, "exec-approvals.json"))).toBe(true);
     expect(approvalsFiles()).toEqual(["exec-approvals.json"]);
-    expect(r.stderr).toContain("holds approvals");
+    expect(r.stderr).toContain("holds exec approvals");
+    // …and tells the owner what to actually do, rather than promising a
+    // repair by a core whose only importer is the command that is blocked.
+    expect(r.stderr).toContain("move it aside by hand");
     // The repair still fails — that is the honest outcome — and it is REPORTED
     // with the keys the core named, not swallowed.
     expect(r.stderr).toContain("the core still refuses this config");
@@ -189,14 +209,14 @@ d("gateway pre-start: making a bumped core's config loadable", () => {
 
     expect(r.status).toBe(0);
     const seen = calls();
-    expect(seen[0]).toBe("config validate");
+    expect(seen[0]).toBe("config validate --json");
     expect(seen.some((c) => c.startsWith("doctor --fix"))).toBe(true);
     // Asked AGAIN afterwards: doctor exiting 0 is not evidence that the core
     // will load the file, and taking it as such is the false success that left
     // a box dark for a day.
-    expect(seen.filter((c) => c === "config validate")).toHaveLength(2);
+    expect(seen.filter((c) => c === "config validate --json")).toHaveLength(2);
     expect(seen.indexOf("doctor --fix --non-interactive")).toBeGreaterThan(0);
-    expect(readFileSync(stampPath, "utf-8").trim()).toBe("2026.8.1");
+    expect(readFileSync(stampPath, "utf-8").trim()).toMatch(/^2026\.8\.1 \d+ \d+$/);
     // A backup of the pre-migration file is kept next to it, named for the
     // core and taken once — not one per boot on a box that keeps failing.
     expect(existsSync(path.join(stateDir, "openclaw.json.pre-2026.8.1-migration"))).toBe(true);
@@ -221,9 +241,90 @@ d("gateway pre-start: making a bumped core's config loadable", () => {
     ).toHaveLength(1);
   });
 
+  it("moves aside the shape a real box actually carries: a core-generated socket block", () => {
+    // THE case this whole block exists for, and the one a fixture with
+    // `socket: {}` silently missed. The core fills socket.path and a fresh
+    // socket.token into every exec-approvals.json it persists, with no owner
+    // involvement, and regenerates both on its next write — so a file whose
+    // only content is that block holds no decision of anyone's, and reading it
+    // as an approval would make this repair decline to fire on every real box.
+    writeFileSync(
+      path.join(stateDir, "exec-approvals.json"),
+      JSON.stringify({
+        version: 1,
+        socket: { path: "/run/user/1000/openclaw/exec-approvals.sock", token: "6f2c…" },
+        defaults: {},
+        agents: {},
+      }),
+    );
+
+    const r = run();
+
+    expect(r.status).toBe(0);
+    expect(existsSync(path.join(stateDir, "exec-approvals.json"))).toBe(false);
+    expect(existsSync(path.join(stateDir, "migrated"))).toBe(true);
+    expect(readFileSync(stampPath, "utf-8").trim()).toMatch(/^2026\.8\.1 \d+ \d+$/);
+  });
+
+  it("moves aside a zero-byte approvals file — the shape a power cut leaves", () => {
+    // It parses as nothing, so it cannot be read for approvals; but the core's
+    // gate throws on its PRESENCE, so leaving it alone blocks every future
+    // doctor for good.
+    writeFileSync(path.join(stateDir, "exec-approvals.json"), "");
+
+    const r = run();
+
+    expect(r.status).toBe(0);
+    expect(existsSync(path.join(stateDir, "exec-approvals.json"))).toBe(false);
+    expect(existsSync(path.join(stateDir, "migrated"))).toBe(true);
+  });
+
+  it("clears the .doctor-importing claim a killed import leaves behind", () => {
+    // doctor renames the file to this for the duration of an import, and its
+    // gate refuses on either name — so a doctor killed mid-import leaves a
+    // blocker that no amount of re-running doctor can clear by itself.
+    writeFileSync(
+      path.join(stateDir, "exec-approvals.json.doctor-importing"),
+      JSON.stringify({ version: 1, socket: {}, defaults: {}, agents: {} }),
+    );
+
+    const r = run();
+
+    expect(r.status).toBe(0);
+    expect(existsSync(path.join(stateDir, "exec-approvals.json.doctor-importing"))).toBe(false);
+    expect(existsSync(path.join(stateDir, "migrated"))).toBe(true);
+  });
+
+  it("does not read a validator that could not run as a refusal", () => {
+    // 124 (the bound fired), 127 (nothing to run) and a crash say nothing
+    // about the config. Reading one as "the core refuses this" would put every
+    // single gateway start of a HEALTHY box through a 180 s doctor run, for
+    // good, because the stamp is never written either.
+    const r = run("2026.8.1", { OC_VALIDATE_RC: "124" });
+
+    expect(r.status).toBe(0);
+    expect(r.stderr).toContain("could not ask the installed core");
+    expect(r.stderr).not.toContain("refuses this config");
+    expect(calls().some((c) => c.startsWith("doctor"))).toBe(false);
+    expect(existsSync(stampPath)).toBe(false);
+  });
+
+  it("says so when the stamp cannot be recorded, instead of silently re-validating forever", () => {
+    // A root-owned or read-only data dir would otherwise add a CLI round trip
+    // to every gateway start with nothing in the log to explain it.
+    rmSync(path.join(root, "data"), { recursive: true, force: true });
+    writeFileSync(path.join(root, "data"), "not a directory");
+
+    const r = run();
+
+    expect(r.status).toBe(0);
+    expect(r.stderr).toContain("will be repeated on every gateway start");
+  });
+
   it("costs a steady box nothing: the stamp already names the installed core", () => {
+    // The stamp records the core AND a fingerprint of the file it accepted.
     mkdirSync(path.dirname(stampPath), { recursive: true });
-    writeFileSync(stampPath, "2026.8.1\n");
+    writeFileSync(stampPath, `${currentFingerprint()}\n`);
 
     const r = run();
 
@@ -240,8 +341,8 @@ d("gateway pre-start: making a bumped core's config loadable", () => {
 
     run("2026.8.1");
 
-    expect(calls()[0]).toBe("config validate");
-    expect(readFileSync(stampPath, "utf-8").trim()).toBe("2026.8.1");
+    expect(calls()[0]).toBe("config validate --json");
+    expect(readFileSync(stampPath, "utf-8").trim()).toMatch(/^2026\.8\.1 \d+ \d+$/);
   });
 
   it("creates the stamp directory when the data dir is not there yet", () => {
@@ -250,16 +351,91 @@ d("gateway pre-start: making a bumped core's config loadable", () => {
     const r = run();
 
     expect(r.status).toBe(0);
-    expect(readFileSync(stampPath, "utf-8").trim()).toBe("2026.8.1");
+    expect(readFileSync(stampPath, "utf-8").trim()).toMatch(/^2026\.8\.1 \d+ \d+$/);
   });
 
   it("re-asks after a core bump even though the previous core was accepted", () => {
     mkdirSync(path.dirname(stampPath), { recursive: true });
-    writeFileSync(stampPath, "2026.7.1\n");
+    writeFileSync(stampPath, `${currentFingerprint("2026.7.1")}\n`);
 
     run("2026.8.1");
 
-    expect(calls()[0]).toBe("config validate");
-    expect(readFileSync(stampPath, "utf-8").trim()).toBe("2026.8.1");
+    expect(calls()[0]).toBe("config validate --json");
+    expect(readFileSync(stampPath, "utf-8").trim()).toMatch(/^2026\.8\.1 \d+ \d+$/);
+  });
+});
+
+/**
+ * The sibling the same discovery makes dangerous.
+ *
+ * The auth-profile repair 2 100 lines below runs the SAME `doctor --fix`, and
+ * treated every non-zero exit as a failed migration with `exit 1` — which
+ * fails a blocking ExecStartPre. That is strictly worse than the exit-78 state
+ * this card is about: exit 78 is covered by `RestartPreventExitStatus`
+ * (config/clawbox-gateway.service:78) so the unit stops trying, while a failed
+ * pre-start burns `StartLimitBurst=20` and leaves the box with no gateway.
+ */
+d("gateway pre-start: the auth-profile repair meets the same blocker", () => {
+  function authBlock(): string {
+    return sliceScript(
+      "# OpenClaw 2 refuses to start while any legacy auth-profiles.json remains",
+      "# Patch the installed openclaw deepseek plugin JSON",
+    );
+  }
+
+  function runAuth() {
+    const program = [
+      "set -euo pipefail",
+      `OPENCLAW_CONFIG=${JSON.stringify(configPath)}`,
+      `OPENCLAW_BIN=${JSON.stringify(path.join(binDir, "openclaw"))}`,
+      "CLAWBOX_OPENCLAW_V2=1",
+      authBlock(),
+    ].join("\n");
+    const r = spawnSync("bash", ["-c", program], {
+      encoding: "utf-8",
+      env: testEnv({
+        PATH: `${binDir}:/usr/bin:/bin`,
+        OPENCLAW_CONFIG: configPath,
+        OC_CALLS: path.join(dir, "calls.log"),
+        OC_STATE: stateDir,
+      }),
+      timeout: 30_000,
+    });
+    return { status: r.status ?? -1, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+  }
+
+  beforeEach(() => {
+    // The sentinel this block is gated on.
+    mkdirSync(path.join(stateDir, "agents", "main", "agent"), { recursive: true });
+    writeFileSync(path.join(stateDir, "agents", "main", "agent", "auth-profiles.json"), "{}");
+  });
+
+  it("does not fail the boot when doctor is blocked by a legacy exec approvals file", () => {
+    writeFileSync(
+      path.join(stateDir, "exec-approvals.json"),
+      JSON.stringify({ version: 1, socket: {}, defaults: {}, agents: {} }),
+    );
+
+    const r = runAuth();
+
+    expect(r.status).toBe(0);
+    expect(r.stderr).toContain("blocked by a legacy exec approvals file");
+    expect(r.stderr).not.toContain("auth-profile migration failed");
+  });
+
+  it("still fails the boot when doctor fails for any other reason", () => {
+    // The invariant the change must not remove: a genuinely failed auth-profile
+    // migration leaves a store OpenClaw 2 refuses to start on, and that is
+    // worth stopping for.
+    writeFileSync(
+      path.join(binDir, "openclaw"),
+      "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$OC_CALLS\"\necho 'doctor exploded' >&2\nexit 1\n",
+    );
+    chmodSync(path.join(binDir, "openclaw"), 0o755);
+
+    const r = runAuth();
+
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("auth-profile migration failed");
   });
 });

--- a/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
+++ b/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
@@ -215,6 +215,28 @@ d("gateway pre-start: making a bumped core's config loadable", () => {
     expect(calls()).toEqual([]);
   });
 
+  it("treats an unreadable stamp as no stamp rather than as agreement", () => {
+    // A stamp is a RECORD, and anything that is not this core's version is
+    // not a record of this core. Reading garbage as "already validated" would
+    // leave a box that cannot boot never asking why.
+    mkdirSync(path.dirname(stampPath), { recursive: true });
+    writeFileSync(stampPath, "\u0000\u0000not-a-version\n");
+
+    run("2026.8.1");
+
+    expect(calls()[0]).toBe("config validate");
+    expect(readFileSync(stampPath, "utf-8").trim()).toBe("2026.8.1");
+  });
+
+  it("creates the stamp directory when the data dir is not there yet", () => {
+    rmSync(path.join(root, "data"), { recursive: true, force: true });
+
+    const r = run();
+
+    expect(r.status).toBe(0);
+    expect(readFileSync(stampPath, "utf-8").trim()).toBe("2026.8.1");
+  });
+
   it("re-asks after a core bump even though the previous core was accepted", () => {
     mkdirSync(path.dirname(stampPath), { recursive: true });
     writeFileSync(stampPath, "2026.7.1\n");

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -2465,15 +2465,29 @@ describe("updater", () => {
    *                   not listening".
    */
   describe("a core the config no longer suits", () => {
-    /** What `openclaw config validate` says about a 2026.7-layout config. */
-    const validateRefusal = Object.assign(new Error("Command failed: openclaw config validate"), {
-      stdout: [
-        "OpenClaw config is invalid: /home/clawbox/.openclaw/openclaw.json",
-        '  \u00d7 openclaw.json:4 \u2014 agents.defaults: Unrecognized keys: "memorySearch", "imageGenerationModel"',
-        '  \u00d7 openclaw.json:11 \u2014 messages: Unrecognized key: "tts"',
-        "",
-        "Run `openclaw doctor --fix` to repair, or fix the keys above manually.",
-      ].join("\n"),
+    // The mock matches on `key.includes(k) || k.includes(cmd)`, and `cmd` is
+    // whatever `findOpenclawBin()` resolved — the bare string `openclaw` on a
+    // machine with no core installed, which is every CI runner. Keyed on the
+    // argv SUFFIX so `openclaw config validate --json` cannot fall through to
+    // the `openclaw doctor --fix` entry via `k.includes("openclaw")`, which is
+    // what made these cases pass only on a developer PC that happened to have
+    // the core installed.
+    const DOCTOR = " doctor --fix";
+    const VALIDATE = " config validate";
+
+    /** `openclaw config validate --json` on a 2026.7-layout config. */
+    const validateRefusal = Object.assign(new Error("Command failed: openclaw config validate --json"), {
+      // The core's own shape, measured on 2026.8.1: the verdict is JSON on
+      // stdout and the exit code is 1.
+      stdout: JSON.stringify({
+        error: { type: "cli_error", message: "OpenClaw config is invalid" },
+        valid: false,
+        path: "/home/clawbox/.openclaw/openclaw.json",
+        issues: [
+          { path: "agents.defaults", message: 'Unrecognized keys: "memorySearch", "imageGenerationModel"' },
+          { path: "messages", message: 'Unrecognized key: "tts"' },
+        ],
+      }),
       stderr: "",
     });
 
@@ -2504,8 +2518,12 @@ describe("updater", () => {
       setupExecFileMock({
         "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
         "/usr/bin/journalctl -u clawbox-gateway.service": { stdout: refusedJournal, stderr: "" },
-        "openclaw doctor --fix": new Error("Command failed: openclaw doctor --fix"),
-        "openclaw config validate": validateRefusal,
+        [DOCTOR]: Object.assign(new Error("Command failed: openclaw doctor --fix"), {
+          stdout: "Legacy exec approvals exist at /home/clawbox/.openclaw/exec-approvals.json."
+            + " Run `openclaw doctor --fix` before using exec approvals.\n",
+          stderr: "",
+        }),
+        [VALIDATE]: validateRefusal,
         ping: { stdout: "", stderr: "" },
         systemctl: { stdout: "", stderr: "" },
         openclaw: { stdout: "1.0.0", stderr: "" },
@@ -2524,8 +2542,12 @@ describe("updater", () => {
       setupExecFileMock({
         "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
         "/usr/bin/journalctl -u clawbox-gateway.service": { stdout: refusedJournal, stderr: "" },
-        "openclaw doctor --fix": new Error("Command failed: openclaw doctor --fix"),
-        "openclaw config validate": validateRefusal,
+        [DOCTOR]: Object.assign(new Error("Command failed: openclaw doctor --fix"), {
+          stdout: "Legacy exec approvals exist at /home/clawbox/.openclaw/exec-approvals.json."
+            + " Run `openclaw doctor --fix` before using exec approvals.\n",
+          stderr: "",
+        }),
+        [VALIDATE]: validateRefusal,
         ping: { stdout: "", stderr: "" },
         systemctl: { stdout: "", stderr: "" },
         openclaw: { stdout: "1.0.0", stderr: "" },
@@ -2534,6 +2556,31 @@ describe("updater", () => {
       const state = await runContinuation();
 
       expect(state.warnings?.map((w) => w.code)).toContain("openclaw-doctor-fix-failed");
+      // The warning exists to name the reason, so it must carry doctor's own
+      // sentence and not node's `Command failed: <argv>`, which names the
+      // command back at the owner and nothing else.
+      const doctorWarning = state.warnings?.find((w) => w.code === "openclaw-doctor-fix-failed");
+      expect(doctorWarning?.message).toContain("Legacy exec approvals exist at");
+      expect(doctorWarning?.message).not.toContain("Command failed:");
+    });
+
+    it("keys the mock on argv that cannot collide with the binary's own path", () => {
+      // NOT decoration. `setupExecFileMock` matches on
+      // `key.includes(k) || k.includes(cmd)`, and `cmd` is whatever
+      // `findOpenclawBin()` resolved: an absolute path on a machine with the
+      // core installed, and the BARE string `openclaw` on one without — which
+      // is every CI runner, and not the PC these cases were written on. A key
+      // containing "openclaw" would then swallow the bare `cmd` and route
+      // `config validate` to the doctor's fixture, so the case above would
+      // pass here and fail in CI over a diagnosis that was never exercised.
+      // Keys that never mention the binary cannot do that under either shape.
+      expect(DOCTOR).not.toContain("openclaw");
+      expect(VALIDATE).not.toContain("openclaw");
+      expect("/usr/bin/openclaw config validate --json").toContain(VALIDATE);
+      expect("openclaw config validate --json").toContain(VALIDATE);
+      expect("/usr/bin/openclaw doctor --fix --yes --non-interactive").toContain(DOCTOR);
+      expect("openclaw doctor --fix --yes --non-interactive").toContain(DOCTOR);
+      expect("openclaw config validate --json").not.toContain(DOCTOR);
     });
 
     it("says nothing when the validator itself could not run", async () => {
@@ -2546,8 +2593,8 @@ describe("updater", () => {
           stdout: "gateway crashed for an unrelated reason\n",
           stderr: "",
         },
-        "openclaw doctor --fix": new Error("Command failed: openclaw doctor --fix"),
-        "openclaw config validate": Object.assign(new Error("Command failed"), {
+        [DOCTOR]: new Error("Command failed: openclaw doctor --fix"),
+        [VALIDATE]: Object.assign(new Error("Command failed"), {
           stdout: "",
           stderr: "node: bad option: --experimental-strip-types\n",
         }),
@@ -2573,8 +2620,8 @@ describe("updater", () => {
           stdout: "gateway crashed for an unrelated reason\n",
           stderr: "",
         },
-        "openclaw doctor --fix": new Error("Command failed: openclaw doctor --fix"),
-        "openclaw config validate": { stdout: "Config valid\n", stderr: "" },
+        [DOCTOR]: new Error("Command failed: openclaw doctor --fix"),
+        [VALIDATE]: { stdout: JSON.stringify({ valid: true, warnings: [] }), stderr: "" },
         ping: { stdout: "", stderr: "" },
         systemctl: { stdout: "", stderr: "" },
         openclaw: { stdout: "1.0.0", stderr: "" },

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -2443,6 +2443,124 @@ describe("updater", () => {
       );
     });
   });
+
+  /**
+   * TASK-737 — a customer box was dark for 25 hours after the OpenClaw
+   * 2026.7.1 → 2026.8.1 core upgrade.
+   *
+   * 2026.8 does not migrate a 2026.7 config on load, it REFUSES it and exits
+   * 78. Measured against 2026.8.1 on 2026-09-06, the gateway's LAST journal
+   * line in that state is `Run "openclaw doctor --fix" to repair the config,
+   * then retry.` — advice for the command the updater has just run and that
+   * has just failed — and `getGatewayFailureDetail` hands exactly that line
+   * back as the cause. The keys the core actually named are three lines
+   * further up and were never reported at all.
+   *
+   * Two shapes pinned here:
+   *   false success — a doctor that could not finish was swallowed whole, so
+   *                   the single most useful fact about the update never
+   *                   reached the owner.
+   *   false lead    — the reported cause was advice that could not work,
+   *                   which is how a config refusal reads as "the gateway is
+   *                   not listening".
+   */
+  describe("a core the config no longer suits", () => {
+    /** What `openclaw config validate` says about a 2026.7-layout config. */
+    const validateRefusal = Object.assign(new Error("Command failed: openclaw config validate"), {
+      stdout: [
+        "OpenClaw config is invalid: /home/clawbox/.openclaw/openclaw.json",
+        '  \u00d7 openclaw.json:4 \u2014 agents.defaults: Unrecognized keys: "memorySearch", "imageGenerationModel"',
+        '  \u00d7 openclaw.json:11 \u2014 messages: Unrecognized key: "tts"',
+        "",
+        "Run `openclaw doctor --fix` to repair, or fix the keys above manually.",
+      ].join("\n"),
+      stderr: "",
+    });
+
+    /** The gateway's own journal in that state — advice line last, on purpose. */
+    const refusedJournal = [
+      "Gateway failed to start: Invalid config at /home/clawbox/.openclaw/openclaw.json:",
+      'openclaw.json:4 \u2014 agents.defaults: Unrecognized keys: "memorySearch", "imageGenerationModel"',
+      'Run "openclaw doctor --fix" to repair, then retry.',
+      'Run "openclaw doctor --fix" to repair the config, then retry.',
+      "",
+    ].join("\n");
+
+    async function runContinuation() {
+      vi.resetModules();
+      mockGet.mockResolvedValue(true);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockRebuiltBox();
+      mockGatewayUp.mockResolvedValue(false);
+      updater = await import("@/lib/updater");
+      updater.resetUpdateState();
+      expect(await updater.checkContinuation()).toBe(true);
+      await vi.waitFor(() => expect(updater.getUpdateState().phase).toBe("failed"));
+      return updater.getUpdateState();
+    }
+
+    it("names the keys the core refused instead of repeating its own advice", async () => {
+      setupExecFileMock({
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
+        "/usr/bin/journalctl -u clawbox-gateway.service": { stdout: refusedJournal, stderr: "" },
+        "openclaw doctor --fix": new Error("Command failed: openclaw doctor --fix"),
+        "openclaw config validate": validateRefusal,
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+      });
+
+      const state = await runContinuation();
+
+      expect(state.error).toContain('agents.defaults: Unrecognized keys: "memorySearch", "imageGenerationModel"');
+      expect(state.error).toContain('messages: Unrecognized key: "tts"');
+      // The line that is true and useless. Handing it back as the cause tells
+      // the owner to run the command that has just failed.
+      expect(state.error).not.toContain("to repair the config, then retry");
+    });
+
+    it("records that doctor could not finish rather than swallowing it", async () => {
+      setupExecFileMock({
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
+        "/usr/bin/journalctl -u clawbox-gateway.service": { stdout: refusedJournal, stderr: "" },
+        "openclaw doctor --fix": new Error("Command failed: openclaw doctor --fix"),
+        "openclaw config validate": validateRefusal,
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+      });
+
+      const state = await runContinuation();
+
+      expect(state.warnings?.map((w) => w.code)).toContain("openclaw-doctor-fix-failed");
+    });
+
+    it("still blames the journal when the core ACCEPTS the config", async () => {
+      // The load-bearing half: doctor exiting non-zero is not by itself proof
+      // of anything — it is what a doctor that lost a lock to a LIVE gateway
+      // does — so a config the core accepts must leave the existing diagnosis
+      // exactly as it was.
+      setupExecFileMock({
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
+        "/usr/bin/journalctl -u clawbox-gateway.service": {
+          stdout: "gateway crashed for an unrelated reason\n",
+          stderr: "",
+        },
+        "openclaw doctor --fix": new Error("Command failed: openclaw doctor --fix"),
+        "openclaw config validate": { stdout: "Config valid\n", stderr: "" },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+      });
+
+      const state = await runContinuation();
+
+      expect(state.error).toContain("OpenClaw gateway is not listening on port 18789");
+      expect(state.error).toContain("gateway crashed for an unrelated reason");
+      expect(state.error).not.toContain("refuses this device's configuration");
+    });
+  });
 });
 
 /**

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -2536,6 +2536,32 @@ describe("updater", () => {
       expect(state.warnings?.map((w) => w.code)).toContain("openclaw-doctor-fix-failed");
     });
 
+    it("says nothing when the validator itself could not run", async () => {
+      // A half-finished core install leaves a binary that exits non-zero on
+      // everything. Reporting its stack as "OpenClaw refuses this device's
+      // configuration" would be a false failure over a config that is fine.
+      setupExecFileMock({
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
+        "/usr/bin/journalctl -u clawbox-gateway.service": {
+          stdout: "gateway crashed for an unrelated reason\n",
+          stderr: "",
+        },
+        "openclaw doctor --fix": new Error("Command failed: openclaw doctor --fix"),
+        "openclaw config validate": Object.assign(new Error("Command failed"), {
+          stdout: "",
+          stderr: "node: bad option: --experimental-strip-types\n",
+        }),
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+      });
+
+      const state = await runContinuation();
+
+      expect(state.error).not.toContain("refuses this device's configuration");
+      expect(state.error).toContain("gateway crashed for an unrelated reason");
+    });
+
     it("still blames the journal when the core ACCEPTS the config", async () => {
       // The load-bearing half: doctor exiting non-zero is not by itself proof
       // of anything — it is what a doctor that lost a lock to a LIVE gateway


### PR DESCRIPTION
Finding **TASK-737** (critical, parent TASK-604), from the owner's incident artifact on a customer box.

## Customer-visible symptom

A customer Jetson was dark for **25 hours** after the OpenClaw **2026.7.1 → 2026.8.1** core update. The in-app update showed "Applying system fixups — completed"; the gateway was dead the whole time. Chat, Telegram and every agent turn were gone. Recovering it needed someone to know that one empty JSON file has to be moved aside by hand.

## Cause

Three things compounding, all measured against **OpenClaw 2026.8.1 (ea80657)** on the OpenClaw dev box, each in a throwaway `OPENCLAW_HOME` under `/tmp` (the box's own `openclaw.json` md5 and `~/.config/systemd/user` were identical before and after every run; both units stayed active).

1. **2026.8 refuses a 2026.7 config instead of migrating it on load.** Its startup guard runs the config preflight with `migrateLegacyConfig: false` and exits **78**. The migrations exist (`LEGACY_CONFIG_MIGRATIONS`, documented "applied by doctor") but only `openclaw doctor --fix` performs them, and nothing on the boot path ran doctor for that reason — the block in `gateway-pre-start.sh` is gated on an *auth-profiles* sentinel, and the updater's own call happens only after the gateway has already failed.
2. **An empty legacy `exec-approvals.json` stops that repair before it starts.** With one present, `doctor --fix --yes --non-interactive` exits **1** having migrated **nothing**, and its last line asks the operator to run the command that has just run.
3. **The updater then reported the wrong cause.** The gateway's last journal line on a refused config is `Run "openclaw doctor --fix" to repair the config, then retry.`, and `getGatewayFailureDetail` falls back to exactly that line — so `state.error` was advice for a command ClawBox had just run and that had just failed. The keys the core actually named are three lines further up and were never reported at all.

## Harness first

Named natively, not re-implemented:

- **`openclaw config validate --json`** — the core's own answer to "will the gateway load this?", as `{valid, path, issues[]}`. **It had no caller anywhere in ClawBox** before this PR: not in `src`, not in `scripts`, not in `install.sh`. The update path never asked the core whether the config it had just rewritten would load. That absence is the finding; this PR adds the first two callers. The human output is deliberately *not* parsed — it goes to stderr and marks each issue with a themed `×` that any `FORCE_COLOR` repaints, so it is presentation, not a contract.
- **`openclaw doctor --fix`** — the core's own legacy migrations. No rename table is added here: the four moves are the core's business and a table in the boot script would be a second, staler copy of it.
- The existing auth-profiles repair in the same file is the house pattern this follows (sentinel first, then the core's own command, then verify).

## Reproduction (device, read-only for the box's own state)

| Step | Reproduced | Evidence |
|---|---|---|
| exit 78 on the 2026.7 layout | **yes** | `openclaw gateway run` → `GW_EXIT=78`, `Invalid config … agents.defaults: Unrecognized keys: "memorySearch", "imageGenerationModel"` / `tools.media.audio: Unrecognized key: "models"` / `messages: Unrecognized key: "tts"` — the report's three lines exactly. `openclaw config validate` exits **1** with the same `×` lines (78 is the *gateway's* exit code, not the validator's). |
| doctor exit 1 on `ExecApprovalsMigrationRequiredError` | **yes** | `doctor --fix --yes --non-interactive` → `EXIT=1`, `Legacy exec approvals exist at …/exec-approvals.json. Run \`openclaw doctor --fix\` before using exec approvals.`, config byte-identical afterwards. Move the empty file aside → same command `EXIT=0`, every key migrated, session store imported. **The empty file alone is the whole blocker.** |
| doctor exit 1 on the `voiceId` candidate | **no — reproduced as something else** | With the matching `@openclaw/voice-call@2026.8.1` installed, doctor exits **0** and renames `voiceId` → `speakerVoiceId` cleanly. With `@openclaw/voice-call@2026.7.1` (the customer box's state: 27 plugins built for 2026.7) doctor exits **0** but prints `quarantined 1 invalid plugin config (voice-call)` and the entry's whole `config` object is **discarded**. So it is silent data loss on version skew, not a refusal to write. |
| readiness refusal for the 11 not-bundled entries | **yes** | `OpenClaw plugin verification failed; refusing to report the gateway ready.` + eleven `Plugin "<id>" requires capability consent` lines, `GW_EXIT=1`. `openclaw config validate` reports each as `! plugins.entries.<id>: plugin not installed`. |
| session-store refusal | **yes (as the same doctor bail-out)** | The JSON `agents/main/sessions/sessions.json` is imported into SQLite by the same `doctor --fix` that the approvals file blocks; with the blocker cleared the directory is emptied. |

## RED → GREEN

RED on unmodified `origin/beta` (`1c406458`):

```
$ npx vitest run src/tests/unit/updater.test.ts -t "a core the config no longer suits"
 × names the keys the core refused instead of repeating its own advice
 × records that doctor could not finish rather than swallowing it
AssertionError: expected 'OpenClaw gateway is not listening on …' to contain 'agents.defaults: Unrecognized keys: "…'
Expected: "agents.defaults: Unrecognized keys: "memorySearch", "imageGenerationModel""
Received: "OpenClaw gateway is not listening on port 18789: Run "openclaw doctor --fix" to repair the config, then retry."
AssertionError: expected [] to include 'openclaw-doctor-fix-failed'
 Tests  2 failed | 2 passed | 78 skipped (82)

$ npx vitest run src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
Error: gateway-pre-start.sh no longer contains # ── First boot on a NEW OpenClaw core: make the config loadable again
 Tests  5 failed (5)
```

The two control cases pass on beta, which is the point of having them: a doctor failure over a config the core *accepts* must keep the existing diagnosis exactly as it was.

GREEN on this branch:

```
$ npx vitest run <20 touched + neighbouring suites, incl. openclaw-config-mock-completeness,
                  test-timeout-hygiene, state-updater-purity, gateway-pre-start-*, updater-*>
 Test Files  20 passed (20)
      Tests  359 passed (359)
$ npx vitest run --project unit          # the whole unit project, on top of the rebase onto #741
 Test Files  728 passed (728)
      Tests  11925 passed | 1 skipped (11926)
$ npx tsc --noEmit           # clean outside the pre-existing e2e-install/ playwright errors
$ bash -n scripts/gateway-pre-start.sh   # ok
$ npx eslint <touched>       # the same 2 pre-existing warnings as beta, 0 errors
```

## Device leg — the shipped block, on the box, against the real 2026.8.1 core

The block was sliced out of the branch **verbatim** and run on 2026.7-layout scratch homes, once per approvals shape:

| Fixture | Outcome |
|---|---|
| `socket:{path,token}` + empty `defaults`/`agents` — **the shape a real box carries** | moved aside → doctor ran → `valid=True` → sessions imported → stamp `2026.8.1 2778 1788703022` |
| zero-byte file (a power cut mid-write) | moved aside → `valid=True` → sessions imported |
| `defaults:{deny:["rm -rf /"]}` — a real owner decision | **left in place**, actionable NOTE, honest `ERROR: the core still refuses this config … Unrecognized keys …`, **no stamp** so the next boot retries |
| second run on the already-stamped box | completely silent, **no CLI call at all** |

The first run of the earlier cut also took the gateway from `exit 78` to a live process (`[admission] closed: restart drain`, `[shutdown] completed cleanly in 271ms`; the non-zero code was my own `timeout 90` killing a healthy gateway).

**Control:** the OpenClaw box's own current config validates cleanly today (`Config valid`, 6 warnings), so the new block is a no-op there after one probe.

Nothing on the box was mutated: its `openclaw.json` md5 and `~/.config/systemd/user` were identical before and after every run, both units stayed active, and the scratch trees were removed afterwards.

## Review

One the reviewer review pass (`clawbox-review`, findings by file path): **3 high, 9 medium, 5 low**. All applied, each re-verified against the installed core and re-proved on the box. The three high ones were mine to own:

- **The empty-approvals predicate called the core's own auto-generated `socket.path`/`socket.token` block an owner approval.** The core writes that into every `exec-approvals.json` it persists and regenerates it on the next write, so on the shape a real box actually carries the repair declined to fire — the change was a **no-op on the incident's own file**, and the test only passed because its fixture wrote `socket: {}`. Now judged on `defaults`/`agents` content, with the real shape as a case (it fails against the old predicate).
- **The new updater cases keyed the exec mock on argv containing `openclaw`.** `findOpenclawBin()` falls back to the bare string on a machine with no core — every CI runner — and the matcher would then have routed `config validate` to the *doctor's* fixture. Keyed on the argv suffix now, with a guard test that pins the property.
- **`gateway-pre-start.sh`'s auth-profile repair runs the same `doctor --fix`** and treated a doctor blocked by exec approvals as a failed migration, `exit 1` from a blocking ExecStartPre. Worse than the state being fixed: exit 78 is covered by `RestartPreventExitStatus`, a failed pre-start is not, so it burns `StartLimitBurst=20` and leaves the box with no gateway. Now recognised and non-fatal, with the genuine-failure path kept and tested (RED on beta: `expected 1 to be +0`).

Also from the review: the `×` scraping replaced by `--json` (above); a zero-byte approvals file and the `exec-approvals.json.doctor-importing` claim file both cleared; a validator that *could not run* no longer read as a refusal (it would have put every start of a healthy box through a 180 s doctor run, permanently); the stamp made a fingerprint of the accepted file so a v1 rollback or a later rewrite re-validates, and loud when it cannot be written; the doctor bound made SIGTERM-only so this boot cannot create the claim file it now clears; `openclaw` children pinned to the device's real state dir; and the doctor warning made to carry doctor's own sentence rather than node's `Command failed: <argv>`.

## Both editions

Inert on Hermes: the block is gated on `CLAWBOX_OPENCLAW_V2=1` **and** `-x $OPENCLAW_BIN`, and a Hermes box has neither an `openclaw` binary nor a `clawbox-gateway` unit to run `gateway-pre-start.sh` at all. In the updater, `runOpenclawDoctorFix` and `getOpenclawConfigRefusal` both return early on `openclawIsAbsent()`, and the `gateway_verify` step is already filtered out by `applies: () => !gatewayIsAbsent()`.

## Siblings swept

- `src/lib/updater.ts:runOpenclawDoctorFix` — the only two callers are both inside `ensureGatewayHealthy`; **fixed**. The swallow itself is kept and that is load-bearing: a doctor exiting non-zero because a live gateway holds its state directory is the gateway proving it is alive (`install.sh:step_gateway_legacy_state_recovery`, measured 2026-09-06), so the restart + positive port probe remains the verdict. What changed is that the exit code is no longer *discarded*.
- `install.sh:3725` (`openclaw_install`, the core-bump path) and `install-x64.sh:543` — both swallow with `|| echo WARN`, and both `systemctl start clawbox-gateway.service` afterwards, whose `ExecStartPre` is `gateway-pre-start.sh`; **cleared** — the new block heals them on the next start.
- `install.sh:6133` / `:6189` (`step_gateway_legacy_state_recovery`, `|| true`) — **left as-is on purpose**: #731 made a doctor refusal there deliberately non-fatal for exactly the live-gateway reason above, and the pre-start now repairs the config before that step is ever reached.
- `src/app/setup-api/ai-models/configure/route.ts:2476` — a different, exported function that already throws and rolls back; **cleared**.
- `scripts/force-update.sh` — no `doctor` and no `config validate`; **cleared**.
- Every `configSchema` hit in the repo is a plugin-manifest declaration, not a device-side gate; **cleared**.

## Coordination

`ensureGatewayHealthy`, `UPDATE_STEPS` and the terminal-phase writer (`state.phase = failed ? "failed" : "completed"`) are untouched, so **#741's** interruption/completion markers are built on rather than rewritten — its `updater.ts` edits are the config-store import, ~2715-2745, ~2830-2860 and the `setMany` payload, none of which this diff goes near; its `updater.test.ts` edits are around `dismissSettledUpdate`, and the new cases are appended at the end of the outer describe.

"Verifying gateway health" failing already leaves the update `failed` with the cause in `state.error` on beta (`failFast: true`, write-once `failed` flag, `verify_build_identity` cannot overwrite it) — verified rather than re-fixed.

## Not in this PR

Recorded with full reproduction in the queue file's "Found" section: the 11 not-bundled plugin entries still are not disabled (needs `plugin-repair.ts`'s `stage` enum and `ROW_PLUGIN_IDS` widened first); `gateway-pre-start.sh` aliasing the legacy `messages.tts` dict into the v2 home (latent now that the migration runs first, and a correct fix re-indents a 60-line block); and **the report's item 4 is refuted** — no ClawBox writer can have put `agents.defaults.memorySearch` back, because every one of them goes through `openclaw config set` and 2026.8.1 refuses that path outright (`Config validation failed: agents.defaults: Unrecognized key: "memorySearch"`, exit 1, file unchanged — measured, both the object and scalar forms).

The two upstream OpenClaw issues are drafted and **not posted**, per the owner's call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenClaw upgrade handling and configuration validation before gateway startup.
  * Added clearer warnings for legacy approval blockers, migration issues, timeouts, and repair failures.
  * Preserved gateway recovery and restart behavior while providing more actionable diagnostic details.
  * Added safeguards and backups during configuration and authentication-profile migrations.

* **Tests**
  * Expanded coverage for configuration repair, migration retries, validation states, and updater diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->