### PR TITLE
fix: the tier badge fills in a default, it never overwrites the owner's model

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -2875,6 +2875,13 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
         local_ai_configured_at: new Date().toISOString(),
         // Consumed by shouldPromoteLocalToPrimary above.
         local_ai_was_default: undefined,
+        // UNREACHABLE today, and it must stay that way or be given the pick
+        // clear its sibling batch below carries: `isLocalScope` with neither
+        // Ollama nor llama.cpp is refused with a 400 long before this, so
+        // `isClawAI && isLocalScope` cannot happen. If that guard ever loosens,
+        // this becomes a ClawBox AI token write with no `ai_model_explicit_picks`
+        // beside it — the previous account's model choice surviving into the
+        // next account's box (TASK-713).
         ...(isClawAI ? { [CLAWBOX_AI_TOKEN_CONFIG_KEY]: clawboxAiToken } : {}),
         ...(clawboxAiTierForStore ? { [CLAWBOX_AI_TIER_CONFIG_KEY]: clawboxAiTierForStore } : {}),
       });

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -51,6 +51,7 @@ import {
   CLAWBOX_AI_FLASH_MODEL_ID,
   CLAWBOX_AI_PRO_MODEL_ID,
   CLAWBOX_AI_MODEL_BY_TIER,
+  CLAWBOX_AI_MODEL_ID_BY_TIER,
   CLAWBOX_AI_DEFAULT_TIER,
   CLAWBOX_AI_PROXY_URLS,
   CLAWBOX_AI_IMAGE_PROVIDER,
@@ -95,6 +96,11 @@ import { DISABLED_PROVIDERS_KEY, normalizeProviderId, parseDisabledProviders } f
 import { setProviderEnabled } from "@/lib/provider-enablement";
 import { notifyProviderSetChanged } from "@/app/setup-api/ai-models/catalog/route";
 import { forgetProviderEnumerations } from "@/lib/provider-runnable";
+import {
+  EXPLICIT_MODEL_PICK_KEY,
+  decideClawboxAiModelId,
+  recordExplicitModelPick,
+} from "@/lib/explicit-model-pick";
 import {
   isClaudeSubscriptionOnly,
   offSurfaceClaudeModelMessage,
@@ -2157,7 +2163,29 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
       const modelName = localModelSlot || normalizedModel || getDefaultLlamaCppModel();
       config.defaultModel = `llamacpp/${modelName}`;
     } else if (isClawAI && resolvedClawboxTier) {
-      config.defaultModel = CLAWBOX_AI_MODEL_BY_TIER[resolvedClawboxTier];
+      // The badge fills in a DEFAULT, and a default never overwrites a choice
+      // (TASK-713). A re-pair arrives here carrying `clawaiTier` exactly like a
+      // plan-card press does — `clawai/poll` sends the session's tier — so the
+      // request cannot say which this is. What settles it is whether the owner
+      // has ever picked a ClawBox AI model, which is what the marker records.
+      //
+      // The primary is read for the MIGRATION only: boxes in the field carry
+      // the state this card is about and no marker, and the model they are
+      // running is the evidence of the choice.
+      const clawaiDecision = decideClawboxAiModelId({
+        storedPick: configStore[EXPLICIT_MODEL_PICK_KEY],
+        currentPrimary: (await readOpenClawConfig().catch(() => null))
+          ?.agents?.defaults?.model?.primary,
+        tierModelId: CLAWBOX_AI_MODEL_ID_BY_TIER[resolvedClawboxTier],
+      });
+      if (clawaiDecision.migrate) await recordExplicitModelPick(clawaiDecision.migrate);
+      if (clawaiDecision.explicit) {
+        console.log(
+          `[configure] ClawBox AI: keeping the owner's own model ${clawaiDecision.modelId}`
+          + ` over the ${resolvedClawboxTier} badge default`,
+        );
+      }
+      config.defaultModel = `${CLAWBOX_AI_PROVIDER}/${clawaiDecision.modelId}`;
     } else if (isChatgptSubscription && !normalizedModel) {
       // ChatGPT sign-in with no explicit pick. The hardcoded default is
       // gpt-5.5, so a Pro account used to land a generation behind and had

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -97,9 +97,10 @@ import { setProviderEnabled } from "@/lib/provider-enablement";
 import { notifyProviderSetChanged } from "@/app/setup-api/ai-models/catalog/route";
 import { forgetProviderEnumerations } from "@/lib/provider-runnable";
 import {
-  EXPLICIT_MODEL_PICK_KEY,
+  EXPLICIT_MODEL_PICKS_KEY,
   decideClawboxAiModelId,
-  recordExplicitModelPick,
+  explicitPicksFrom,
+  forgetExplicitModelPick,
 } from "@/lib/explicit-model-pick";
 import {
   isClaudeSubscriptionOnly,
@@ -405,23 +406,6 @@ async function readModelsMode(): Promise<string | null> {
   try {
     const mode = (await readOpenClawConfig())?.models?.mode;
     return typeof mode === "string" ? mode : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * `agents.defaults.model.primary` as openclaw.json carries it, or null.
- *
- * Null on the Hermes SKU (there is no OpenClaw config) and on an unreadable
- * one. Its only caller migrates a pre-marker explicit pick, and "we could not
- * read it" must leave that question open rather than answer it wrongly.
- */
-async function readOpenClawPrimaryModel(): Promise<string | null> {
-  if (openclawIsAbsent()) return null;
-  try {
-    const primary = (await readOpenClawConfig())?.agents?.defaults?.model?.primary;
-    return typeof primary === "string" && primary.trim() ? primary.trim() : null;
   } catch {
     return null;
   }
@@ -2131,6 +2115,11 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     // that filled a default in for them. Written to the store after the save
     // succeeds, beside the other facts about what was configured.
     let explicitPickToRecord: string | null = null;
+    // True when the ClawBox AI branch kept the owner's own model instead of the
+    // one the badge implies. Reported in the answer so the plan card can say the
+    // plan moved and the model deliberately did not, rather than returning 200
+    // over a screen where nothing appears to have happened.
+    let explicitPickKept = false;
 
     // For Ollama the front-end supplies the model name (e.g. "llama3.2:3b")
     // via the `apiKey` field — there is no real API key for a local provider.
@@ -2191,15 +2180,19 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
       // request cannot say which this is. What settles it is whether the owner
       // has ever picked a ClawBox AI model, which is what the marker records.
       //
-      // The primary is read for the MIGRATION only: boxes in the field carry
-      // the state this card is about and no marker, and the model they are
-      // running is the evidence of the choice.
+      // A pick belongs to the ACCOUNT that made it. On a token change — the same
+      // signal that unpairs ClawKeep at step 8 — it is dropped before it is
+      // read, so the previous owner's Max choice is not imposed on a Pro plan
+      // the new one is paying for.
+      const clawaiAccountChanged = Boolean(
+        previousClawaiToken && clawboxAiToken && previousClawaiToken !== clawboxAiToken,
+      );
+      if (clawaiAccountChanged) await forgetExplicitModelPick("clawai");
       const clawaiDecision = decideClawboxAiModelId({
-        storedPick: configStore[EXPLICIT_MODEL_PICK_KEY],
-        currentPrimary: await readOpenClawPrimaryModel(),
+        picks: clawaiAccountChanged ? {} : explicitPicksFrom(configStore[EXPLICIT_MODEL_PICKS_KEY]),
         tierModelId: CLAWBOX_AI_MODEL_ID_BY_TIER[resolvedClawboxTier],
       });
-      if (clawaiDecision.migrate) await recordExplicitModelPick(clawaiDecision.migrate);
+      explicitPickKept = clawaiDecision.explicit;
       if (clawaiDecision.explicit) {
         console.log(
           `[configure] ClawBox AI: keeping the owner's own model ${clawaiDecision.modelId}`
@@ -2899,7 +2892,14 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
         // The owner named a model in this save (TASK-713). In the same batch
         // as the other facts about it, so a save that landed and a pick that
         // was remembered cannot come apart.
-        ...(explicitPickToRecord ? { [EXPLICIT_MODEL_PICK_KEY]: explicitPickToRecord } : {}),
+        ...(explicitPickToRecord
+          ? {
+            [EXPLICIT_MODEL_PICKS_KEY]: {
+              ...explicitPicksFrom(configStore[EXPLICIT_MODEL_PICKS_KEY]),
+              [normalizeProviderId(ocProvider) ?? ocProvider]: explicitPickToRecord,
+            },
+          }
+          : {}),
       });
       // The cloud save has landed — see `forgetLocalWasDefault`.
       await forgetLocalWasDefault();
@@ -3291,7 +3291,14 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     const warning = [chatgptOrderWarning, unvalidatedPrimaryWarning, gatewayWarning]
       .filter(Boolean)
       .join(" ");
-    return NextResponse.json({ success: true, ...(warning ? { warning } : {}) });
+    return NextResponse.json({
+      success: true,
+      ...(warning ? { warning } : {}),
+      // The plan may have moved while the model deliberately did not (TASK-713).
+      // Reported so the plan card can say so, rather than answering 200 over a
+      // screen where nothing appears to have happened.
+      ...(explicitPickKept ? { explicitPickKept: true, model: config.defaultModel } : {}),
+    });
   } catch (err) {
     // The one refusal that is not a failure: the save was REFUSED before
     // anything was written, and the owner can act on it. Its own status and

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -2301,9 +2301,22 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
           return NextResponse.json({ success: true });
         }
         if (isClawAI) {
-          await applyClawaiToHermes(clawboxAiToken, resolvedClawboxTier ?? CLAWBOX_AI_DEFAULT_TIER);
+          const applied = await applyClawaiToHermes(
+            clawboxAiToken,
+            resolvedClawboxTier ?? CLAWBOX_AI_DEFAULT_TIER,
+          );
           await forgetLocalWasDefault();
-          return NextResponse.json({ success: true });
+          // Reported from the apply's OWN decision rather than the one taken
+          // above for the OpenClaw shape: on this SKU that helper is what reads
+          // the store and writes the model, so its answer is the one that
+          // happened. Same field as the OpenClaw branch, so the plan card does
+          // not have to know which edition it is on.
+          return NextResponse.json({
+            success: true,
+            ...(applied.explicitPickKept
+              ? { explicitPickKept: true, model: applied.model }
+              : {}),
+          });
         }
         if (authMode !== "subscription" && normalizedApiKey) {
           // Cloud API-key providers Hermes supports (anthropic, google→gemini,

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -100,7 +100,6 @@ import {
   EXPLICIT_MODEL_PICKS_KEY,
   decideClawboxAiModelId,
   explicitPicksFrom,
-  forgetExplicitModelPick,
 } from "@/lib/explicit-model-pick";
 import {
   isClaudeSubscriptionOnly,
@@ -2120,6 +2119,9 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     // plan moved and the model deliberately did not, rather than returning 200
     // over a screen where nothing appears to have happened.
     let explicitPickKept = false;
+    // The picks map minus the ClawBox AI entry, when this save links a DIFFERENT
+    // ClawBox AI account. Written in the same batch as the new token below.
+    let clawaiPicksToStore: Record<string, string> | null = null;
 
     // For Ollama the front-end supplies the model name (e.g. "llama3.2:3b")
     // via the `apiKey` field — there is no real API key for a local provider.
@@ -2181,15 +2183,22 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
       // has ever picked a ClawBox AI model, which is what the marker records.
       //
       // A pick belongs to the ACCOUNT that made it. On a token change — the same
-      // signal that unpairs ClawKeep at step 8 — it is dropped before it is
-      // read, so the previous owner's Max choice is not imposed on a Pro plan
-      // the new one is paying for.
+      // signal that unpairs ClawKeep at step 8 — it is not read, so the previous
+      // owner's Max choice is not imposed on a Pro plan the new one is paying
+      // for; and it is CLEARED in the same `setMany` that stores the new token,
+      // so the two cannot come apart. A separate delete could fail on its own
+      // and leave account A's pick beside account B's token, waiting for the
+      // next re-pair to apply it.
       const clawaiAccountChanged = Boolean(
         previousClawaiToken && clawboxAiToken && previousClawaiToken !== clawboxAiToken,
       );
-      if (clawaiAccountChanged) await forgetExplicitModelPick("clawai");
+      const storedPicks = explicitPicksFrom(configStore[EXPLICIT_MODEL_PICKS_KEY]);
+      if (clawaiAccountChanged && storedPicks.clawai) {
+        delete storedPicks.clawai;
+        clawaiPicksToStore = storedPicks;
+      }
       const clawaiDecision = decideClawboxAiModelId({
-        picks: clawaiAccountChanged ? {} : explicitPicksFrom(configStore[EXPLICIT_MODEL_PICKS_KEY]),
+        picks: clawaiAccountChanged ? {} : storedPicks,
         tierModelId: CLAWBOX_AI_MODEL_ID_BY_TIER[resolvedClawboxTier],
       });
       explicitPickKept = clawaiDecision.explicit;
@@ -2889,17 +2898,21 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
         ai_model_configured_at: new Date().toISOString(),
         ...(isClawAI ? { [CLAWBOX_AI_TOKEN_CONFIG_KEY]: clawboxAiToken } : {}),
         ...(clawboxAiTierForStore ? { [CLAWBOX_AI_TIER_CONFIG_KEY]: clawboxAiTierForStore } : {}),
-        // The owner named a model in this save (TASK-713). In the same batch
-        // as the other facts about it, so a save that landed and a pick that
-        // was remembered cannot come apart.
+        // The owner named a model in this save (TASK-713), or this save linked a
+        // different ClawBox AI account and the previous owner's pick goes with
+        // it. Either way in the SAME batch as the other facts about the save, so
+        // a token that landed and a pick that was remembered — or forgotten —
+        // cannot come apart.
         ...(explicitPickToRecord
           ? {
             [EXPLICIT_MODEL_PICKS_KEY]: {
-              ...explicitPicksFrom(configStore[EXPLICIT_MODEL_PICKS_KEY]),
+              ...(clawaiPicksToStore ?? explicitPicksFrom(configStore[EXPLICIT_MODEL_PICKS_KEY])),
               [normalizeProviderId(ocProvider) ?? ocProvider]: explicitPickToRecord,
             },
           }
-          : {}),
+          : clawaiPicksToStore
+            ? { [EXPLICIT_MODEL_PICKS_KEY]: clawaiPicksToStore }
+            : {}),
       });
       // The cloud save has landed — see `forgetLocalWasDefault`.
       await forgetLocalWasDefault();

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -410,6 +410,23 @@ async function readModelsMode(): Promise<string | null> {
   }
 }
 
+/**
+ * `agents.defaults.model.primary` as openclaw.json carries it, or null.
+ *
+ * Null on the Hermes SKU (there is no OpenClaw config) and on an unreadable
+ * one. Its only caller migrates a pre-marker explicit pick, and "we could not
+ * read it" must leave that question open rather than answer it wrongly.
+ */
+async function readOpenClawPrimaryModel(): Promise<string | null> {
+  if (openclawIsAbsent()) return null;
+  try {
+    const primary = (await readOpenClawConfig())?.agents?.defaults?.model?.primary;
+    return typeof primary === "string" && primary.trim() ? primary.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
 async function pasteAuthApiKey(provider: string, profileId: string, key: string): Promise<void> {
   // The sign-in guard is NOT here, deliberately: see `assertNoSignInAt`. By
   // the time this runs the request has already written its own
@@ -2110,6 +2127,11 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
           ?? normalizeClawboxAiTier(configStore[CLAWBOX_AI_TIER_CONFIG_KEY])
           ?? CLAWBOX_AI_DEFAULT_TIER)
       : null;
+    // Set by the branch below in which the OWNER named a model, rather than one
+    // that filled a default in for them. Written to the store after the save
+    // succeeds, beside the other facts about what was configured.
+    let explicitPickToRecord: string | null = null;
+
     // For Ollama the front-end supplies the model name (e.g. "llama3.2:3b")
     // via the `apiKey` field — there is no real API key for a local provider.
     if (isOllama) {
@@ -2174,8 +2196,7 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
       // running is the evidence of the choice.
       const clawaiDecision = decideClawboxAiModelId({
         storedPick: configStore[EXPLICIT_MODEL_PICK_KEY],
-        currentPrimary: (await readOpenClawConfig().catch(() => null))
-          ?.agents?.defaults?.model?.primary,
+        currentPrimary: await readOpenClawPrimaryModel(),
         tierModelId: CLAWBOX_AI_MODEL_ID_BY_TIER[resolvedClawboxTier],
       });
       if (clawaiDecision.migrate) await recordExplicitModelPick(clawaiDecision.migrate);
@@ -2238,6 +2259,11 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
           );
         }
         config.defaultModel = `${targetProvider}/${requestedModel}`;
+        // The owner named this model. Remembered for the same reason the chat
+        // picker's pick is (TASK-713): a default may fill a gap, never
+        // overwrite a choice — and the marker holds the LAST choice, whichever
+        // provider it was about.
+        explicitPickToRecord = config.defaultModel;
       }
     }
 
@@ -2870,6 +2896,10 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
         ai_model_configured_at: new Date().toISOString(),
         ...(isClawAI ? { [CLAWBOX_AI_TOKEN_CONFIG_KEY]: clawboxAiToken } : {}),
         ...(clawboxAiTierForStore ? { [CLAWBOX_AI_TIER_CONFIG_KEY]: clawboxAiTierForStore } : {}),
+        // The owner named a model in this save (TASK-713). In the same batch
+        // as the other facts about it, so a save that landed and a pick that
+        // was remembered cannot come apart.
+        ...(explicitPickToRecord ? { [EXPLICIT_MODEL_PICK_KEY]: explicitPickToRecord } : {}),
       });
       // The cloud save has landed — see `forgetLocalWasDefault`.
       await forgetLocalWasDefault();

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -1232,6 +1232,12 @@ export async function POST(request: Request) {
     if (targetOffSurface) return targetOffSurface;
 
     if (state.activeModel === targetModel) {
+      // The owner just chose the model the box already runs, and that IS a
+      // choice: without recording it, someone deliberately settled on the
+      // tier-default model has no way to say so, and the badge moves them off
+      // it the day their plan changes (TASK-713). The Hermes picker records the
+      // same no-op for the same reason.
+      if (!automaticSwitch) await recordExplicitModelPick(targetModel);
       // Already the primary — but a ChatGPT pick can arrive as `codex/<id>`
       // and remap onto a primary that IS `openai/<id>` already, on a box whose
       // Codex runtime entry is missing (written by an older ClawBox, or lost).

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -38,6 +38,7 @@ import {
   providerRowRunnable,
 } from "@/lib/provider-status";
 import { readProviderRunnable, type ProviderRunnable } from "@/lib/provider-runnable";
+import { recordExplicitModelPick } from "@/lib/explicit-model-pick";
 import { isClawboxAiImageModelId, isClawboxAiImageModelRef } from "@/lib/clawbox-ai-models";
 import {
   CHATGPT_AGENT_RUNTIME_ID,
@@ -920,12 +921,18 @@ export async function POST(request: Request) {
     return NextResponse.json(WRONG_STORE, { status: 409 });
   }
   try {
-    let body: { source?: ChatModelSource; model?: string; provider?: string };
+    let body: { source?: ChatModelSource; model?: string; provider?: string; automatic?: boolean };
     try {
       body = await request.json();
     } catch {
       return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
     }
+
+    // "The BOX made this switch, not the owner." Set by the chat's entitlement
+    // guard, which drops a Max model the portal refuses down to Flash so chat
+    // keeps working. It changes nothing about the write — only whether the
+    // result is remembered as the owner's own pick (TASK-713).
+    const automaticSwitch = body.automatic === true;
 
     // One read of openclaw.json for the request: the state below and every
     // credential fact the routing turns on come from the same snapshot.
@@ -1355,6 +1362,17 @@ export async function POST(request: Request) {
     //     Each announcement therefore sits at the write it describes.
     const pluginSwitchedOn = providerPluginSwitchedOnBy([targetModel], configBeforeBatch);
     if (pluginSwitchedOn) notifyProviderSetChanged(pluginSwitchedOn);
+
+    // 1b-2. The owner chose this model, so nothing that fills in a DEFAULT may
+    //       overwrite it later — that is the whole of TASK-713, and this is
+    //       where the choice is made. Recorded after the write landed, so a
+    //       refused batch records nothing.
+    //
+    //       `automatic` is the one exemption: the chat's entitlement guard
+    //       drops a refused Max model to Flash by posting HERE, and recording
+    //       that as a choice would pin the box to Flash for good — the box's
+    //       own recovery, read back as the owner's decision.
+    if (!automaticSwitch) await recordExplicitModelPick(targetModel);
 
     // 1c. The other side of the arm: a pick that is NOT the subscription's, on
     //     a reference an earlier ChatGPT pick armed, has to clear it — a

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -928,10 +928,19 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
     }
 
-    // "The BOX made this switch, not the owner." Set by the chat's entitlement
-    // guard, which drops a Max model the portal refuses down to Flash so chat
-    // keeps working. It changes nothing about the write — only whether the
-    // result is remembered as the owner's own pick (TASK-713).
+    // "The BOX resolved this model, the owner did not name it." Two callers set
+    // it, both in-process: the chat's entitlement guard, which drops a Max model
+    // the portal refuses down to Flash so chat keeps working, and
+    // `/setup-api/providers/default`, where the owner named a PROVIDER and this
+    // route's own state supplied the model. It changes nothing about the write —
+    // only whether the result is remembered as the owner's own pick (TASK-713).
+    //
+    // Caller-supplied because on the wire a resolved model and a chosen one are
+    // the same field, and this route cannot tell them apart; the Hermes twin can
+    // (`if (namedModel)`) only because there a provider-only switch arrives with
+    // no model at all. It is not a permission: the caller is the authenticated
+    // owner, it cannot change WHAT is written, and the worst it can do is lose
+    // its own bookkeeping — one later badge overwrite, undone by re-picking.
     const automaticSwitch = body.automatic === true;
 
     // One read of openclaw.json for the request: the state below and every
@@ -1232,11 +1241,16 @@ export async function POST(request: Request) {
     if (targetOffSurface) return targetOffSurface;
 
     if (state.activeModel === targetModel) {
-      // The owner just chose the model the box already runs, and that IS a
-      // choice: without recording it, someone deliberately settled on the
-      // tier-default model has no way to say so, and the badge moves them off
-      // it the day their plan changes (TASK-713). The Hermes picker records the
-      // same no-op for the same reason.
+      // Naming the model the box already runs is still a choice, and the write
+      // being a no-op does not make it less of one (TASK-713) — so it is
+      // recorded here as the Hermes picker records it.
+      //
+      // NOT reachable from the chat header, and the claim is not made: ChatPopup
+      // short-circuits a pick of the active model before the POST
+      // (`switchChatModel`, ChatPopup.tsx), so an owner deliberately settling on
+      // the model they are already on has no surface that says so. This branch
+      // exists for a caller that does arrive — an API client, a future picker
+      // that stops short-circuiting — and is honest for it.
       if (!automaticSwitch) await recordExplicitModelPick(targetModel);
       // Already the primary — but a ChatGPT pick can arrive as `codex/<id>`
       // and remap onto a primary that IS `openai/<id>` already, on a box whose

--- a/src/app/setup-api/hermes/clawai/route.ts
+++ b/src/app/setup-api/hermes/clawai/route.ts
@@ -133,6 +133,11 @@ export async function POST(request: Request) {
   // snapshot is taken before any write and is honest; and on a probe that threw,
   // which must not turn a link into a 500.
   let codingAgentReadyBefore: boolean | undefined;
+  // The SAME hazard, one field over: the apply drops the stored model pick when
+  // the ClawBox AI account changes, and it cannot see that change if this route
+  // has already written the new token into the store it would read (TASK-713).
+  // Captured here, ahead of that write, and handed over explicitly.
+  let previousClawaiToken: string | undefined;
   if (suppliedToken) {
     if (!isPlausibleClawaiToken(suppliedToken)) {
       return NextResponse.json({ error: "That doesn't look like a ClawBox AI token." }, { status: 400 });
@@ -140,6 +145,7 @@ export async function POST(request: Request) {
     codingAgentReadyBefore = await getCodingAgentStatus()
       .then((status) => status.ready)
       .catch(() => undefined);
+    previousClawaiToken = await readToken();
     await setMany({ clawai_token: suppliedToken });
     // A refusal the proxy gave the token being replaced is about that token,
     // not this one. Dropped here as well as in `applyClawaiToHermes`, because a
@@ -158,7 +164,10 @@ export async function POST(request: Request) {
   }
 
   try {
-    const result = await applyClawaiToHermes(token, tier, { codingAgentReadyBefore });
+    const result = await applyClawaiToHermes(token, tier, {
+      codingAgentReadyBefore,
+      previousClawaiToken,
+    });
     return NextResponse.json({ ok: true, ...result });
   } catch (err) {
     // Only OUR own error text is safe to echo — a raw spawn error can carry the

--- a/src/app/setup-api/hermes/clawai/route.ts
+++ b/src/app/setup-api/hermes/clawai/route.ts
@@ -1,7 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import { decideClawboxAiModelId, readExplicitModelPick } from "@/lib/explicit-model-pick";
+import { clawboxAiModelIdOf, readExplicitModelPicks } from "@/lib/explicit-model-pick";
 import { get, setMany } from "@/lib/config-store";
 import { forgetClawaiCredentialRefusal } from "@/lib/harness/credentials";
 import { hermesConfigGet } from "@/lib/hermes-config-cache";
@@ -52,10 +52,10 @@ export async function GET() {
   const blocked = await requireHermes();
   if (blocked) return blocked;
 
-  const [token, tierStored, storedPick] = await Promise.all([
+  const [token, tierStored, picks] = await Promise.all([
     readToken(),
     readStoredTier(),
-    readExplicitModelPick(),
+    readExplicitModelPicks(),
   ]);
   const tier: ClawboxAiTier = tierStored ?? "flash";
   // Memoised against config.yaml's mtime: this GET runs on every chat open and
@@ -73,14 +73,14 @@ export async function GET() {
     active,
     // The model this box RUNS for ClawBox AI, which is no longer the same
     // question as which tier the badge shows: an explicit pick outlives the
-    // badge (TASK-713), and the panel renders this string as "Model: …". The
-    // decision is read-only here — the migration it can suggest belongs to the
-    // link that writes, not to a GET the chat makes on every open.
-    model: decideClawboxAiModelId({
-      storedPick,
-      currentPrimary: active ? storedModel : null,
-      tierModelId: clawaiModelForTier(tier),
-    }).modelId,
+    // badge (TASK-713), and the panel renders this string as "Model: …".
+    // While ClawBox AI is the ACTIVE provider the harness's own `model.default`
+    // is the answer — no derivation can beat what the box is configured with.
+    // Otherwise it is what a link would write: the owner's pick if there is one,
+    // else the badge's default.
+    model: (active && storedModel.trim())
+      || clawboxAiModelIdOf(picks.clawai)
+      || clawaiModelForTier(tier),
   });
 }
 

--- a/src/app/setup-api/hermes/clawai/route.ts
+++ b/src/app/setup-api/hermes/clawai/route.ts
@@ -1,7 +1,12 @@
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import { clawboxAiModelIdOf, readExplicitModelPicks } from "@/lib/explicit-model-pick";
+import {
+  EXPLICIT_MODEL_PICKS_KEY,
+  clawboxAiModelIdOf,
+  picksWithoutProvider,
+  readExplicitModelPicks,
+} from "@/lib/explicit-model-pick";
 import { get, setMany } from "@/lib/config-store";
 import { forgetClawaiCredentialRefusal } from "@/lib/harness/credentials";
 import { hermesConfigGet } from "@/lib/hermes-config-cache";
@@ -146,7 +151,21 @@ export async function POST(request: Request) {
       .then((status) => status.ready)
       .catch(() => undefined);
     previousClawaiToken = await readToken();
-    await setMany({ clawai_token: suppliedToken });
+    // The pick goes with the account, and it goes in THIS write. The apply
+    // below clears it too, but only in its own final `setMany`, behind a step
+    // loop that is fatal on any failing `hermes config set` — so a step that
+    // fails after this line would answer 502 having stored account B's token
+    // beside account A's pick, and this route never rolls the token back. Every
+    // later link would then read `previousToken === trimmed`, see no account
+    // change, and write A's model as B's default for good (TASK-713).
+    const replacedAccount = Boolean(previousClawaiToken && previousClawaiToken !== suppliedToken);
+    const picksWithoutClawai = replacedAccount
+      ? picksWithoutProvider(await readExplicitModelPicks(), CLAWAI_PROVIDER)
+      : null;
+    await setMany({
+      clawai_token: suppliedToken,
+      ...(picksWithoutClawai ? { [EXPLICIT_MODEL_PICKS_KEY]: picksWithoutClawai } : {}),
+    });
     // A refusal the proxy gave the token being replaced is about that token,
     // not this one. Dropped here as well as in `applyClawaiToHermes`, because a
     // paste that never reaches the apply still changed the credential.

--- a/src/app/setup-api/hermes/clawai/route.ts
+++ b/src/app/setup-api/hermes/clawai/route.ts
@@ -1,6 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
+import { decideClawboxAiModelId, readExplicitModelPick } from "@/lib/explicit-model-pick";
 import { get, setMany } from "@/lib/config-store";
 import { forgetClawaiCredentialRefusal } from "@/lib/harness/credentials";
 import { hermesConfigGet } from "@/lib/hermes-config-cache";
@@ -51,17 +52,35 @@ export async function GET() {
   const blocked = await requireHermes();
   if (blocked) return blocked;
 
-  const [token, tierStored] = await Promise.all([readToken(), readStoredTier()]);
+  const [token, tierStored, storedPick] = await Promise.all([
+    readToken(),
+    readStoredTier(),
+    readExplicitModelPick(),
+  ]);
   const tier: ClawboxAiTier = tierStored ?? "flash";
   // Memoised against config.yaml's mtime: this GET runs on every chat open and
   // every Settings visit, and the CLI spawn behind it costs ~600 ms each time.
-  const active = (await hermesConfigGet("model.provider")) === CLAWAI_PROVIDER;
+  // The second key is free once the first has warmed that cache.
+  const [activeProvider, storedModel] = await Promise.all([
+    hermesConfigGet("model.provider"),
+    hermesConfigGet("model.default"),
+  ]);
+  const active = activeProvider === CLAWAI_PROVIDER;
   return NextResponse.json({
     hasToken: Boolean(token),
     tier,
     tierStored,
     active,
-    model: clawaiModelForTier(tier),
+    // The model this box RUNS for ClawBox AI, which is no longer the same
+    // question as which tier the badge shows: an explicit pick outlives the
+    // badge (TASK-713), and the panel renders this string as "Model: …". The
+    // decision is read-only here — the migration it can suggest belongs to the
+    // link that writes, not to a GET the chat makes on every open.
+    model: decideClawboxAiModelId({
+      storedPick,
+      currentPrimary: active ? storedModel : null,
+      tierModelId: clawaiModelForTier(tier),
+    }).modelId,
   });
 }
 

--- a/src/app/setup-api/hermes/models/route.ts
+++ b/src/app/setup-api/hermes/models/route.ts
@@ -227,6 +227,9 @@ export async function POST(request: Request) {
   // (pick Anthropic, keep saving deepseek). When the caller didn't name a
   // model we take that provider's own recommended default.
   let targetModel = model;
+  // Did the CALLER name it, or did we resolve one for them? Only the first is a
+  // choice worth remembering (TASK-713).
+  const namedModel = Boolean(model);
   if (!targetModel) {
     if (targetProvider === previousProvider) {
       targetModel = payload.current.model;
@@ -309,10 +312,15 @@ export async function POST(request: Request) {
       }
       // The owner chose this model here, so the ClawBox AI tier badge may not
       // fill one in over it on the next link or re-pair (TASK-713). Recorded
-      // after the write landed, and on the no-op path too: "already on the
-      // model I want" is the same choice, and a box that reached it before the
-      // marker existed would otherwise never get one.
-      await recordExplicitModelPick(targetModel);
+      // after the write landed, and on the no-op path too: "already on the model
+      // I want" is the same choice.
+      //
+      // Only when the REQUEST named a model. A provider-only switch — which is
+      // what `/setup-api/providers/default` and the MCP `ai_set_provider` tool
+      // send, both deliberately — resolves that provider's own recommended
+      // default, and recording another default as a choice is the very
+      // confusion this marker exists to end.
+      if (namedModel) await recordExplicitModelPick(targetModel);
     } catch (err) {
       if (providerChanged && previousProvider) {
         // runHermesCli RESOLVES with a non-zero `code` on a failed command and

--- a/src/app/setup-api/hermes/models/route.ts
+++ b/src/app/setup-api/hermes/models/route.ts
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { runHermesCli } from "@/lib/hermes-cli";
 import { safeHermesFailureMessage } from "@/lib/hermes-cli-message";
+import { recordExplicitModelPick } from "@/lib/explicit-model-pick";
 import { getActiveHarness } from "@/lib/harness";
 import { requireSession } from "@/lib/route-auth";
 import { reconcileClawaiModelsWithHermes } from "@/lib/hermes-clawai";
@@ -306,6 +307,12 @@ export async function POST(request: Request) {
       if (providerChanged || targetModel !== payload.current.model) {
         await setKey("model.default", targetModel);
       }
+      // The owner chose this model here, so the ClawBox AI tier badge may not
+      // fill one in over it on the next link or re-pair (TASK-713). Recorded
+      // after the write landed, and on the no-op path too: "already on the
+      // model I want" is the same choice, and a box that reached it before the
+      // marker existed would otherwise never get one.
+      await recordExplicitModelPick(targetModel);
     } catch (err) {
       if (providerChanged && previousProvider) {
         // runHermesCli RESOLVES with a non-zero `code` on a failed command and

--- a/src/app/setup-api/providers/default/route.ts
+++ b/src/app/setup-api/providers/default/route.ts
@@ -119,7 +119,16 @@ export async function POST(request: Request) {
     new Request("http://localhost/setup-api/chat/model", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ model: option.model }),
+      // `automatic`, because the owner named a PROVIDER and this route resolved
+      // the model — the row's representative id, picked above out of the
+      // picker's own state. Recording that as the owner's explicit model choice
+      // would defeat the very thing the marker protects: a ClawBox AI plan
+      // upgrade would then find a "pick" nobody made and leave the box on the
+      // old tier's model (TASK-713). It is the same rule the Hermes twin
+      // applies as `if (namedModel)` in `/setup-api/hermes/models`, expressed
+      // on the side that knows the answer — this caller — because on the wire
+      // a resolved model and a chosen one are the same field.
+      body: JSON.stringify({ model: option.model, automatic: true }),
     }),
   );
   const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -4461,7 +4461,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   // thing that can say a `openai/<id>` pick is the ChatGPT subscription rather
   // than the API key: on a box holding both credentials the two rows offer the
   // same reference, and the server cannot tell them apart from the model alone.
-  const switchChatModel = useCallback(async (target: { model: string; label: string; provider?: string | null }): Promise<boolean> => {
+  const switchChatModel = useCallback(async (target: { model: string; label: string; provider?: string | null; automatic?: boolean }): Promise<boolean> => {
     if (switchingModel || chatModelState?.activeModel === target.model) return false
     // Intercept a ClawBox AI pick the portal POSITIVELY refuses, and say so
     // here rather than letting every turn on it come back as the opaque
@@ -4497,6 +4497,9 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
         body: JSON.stringify({
           model: target.model,
           ...(target.provider ? { provider: target.provider } : {}),
+          // The box's own recovery is not the owner choosing this model, and
+          // the server must not remember it as one (TASK-713).
+          ...(target.automatic ? { automatic: true } : {}),
         }),
       })
       const data = await res.json()
@@ -4600,7 +4603,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     // that other switch finishes.
     if (switchingModel) return
     tierGuardAttemptRef.current = { model: active, allowed: clawboxLogin.allowedModels }
-    void switchChatModel({ model: CLAWBOX_AI_MODEL_BY_TIER.flash, label: 'Pro Tier' })
+    void switchChatModel({ model: CLAWBOX_AI_MODEL_BY_TIER.flash, label: 'Pro Tier', automatic: true })
       .then(switched => {
         // Posted from the SUCCESS path only. This sentence says the box was
         // moved, and until the POST comes back that is not known — announcing

--- a/src/lib/clawbox-ai-models.ts
+++ b/src/lib/clawbox-ai-models.ts
@@ -36,6 +36,20 @@ export const CLAWBOX_AI_MODEL_BY_TIER: Record<ClawboxAiTier, string> = {
 };
 
 /**
+ * The same table, BARE — no `deepseek/` prefix.
+ *
+ * Both spellings are load-bearing on their own side: openclaw.json's
+ * `agents.defaults.model.primary` takes the qualified ref, while Hermes'
+ * `model.default` and the ClawBox AI proxy take the bare id (a prefixed slug
+ * comes back "HTTP 400: Model not allowed"). One table so the two editions
+ * cannot answer the tier question differently.
+ */
+export const CLAWBOX_AI_MODEL_ID_BY_TIER: Record<ClawboxAiTier, string> = {
+  flash: CLAWBOX_AI_FLASH_MODEL_ID,
+  pro: CLAWBOX_AI_PRO_MODEL_ID,
+};
+
+/**
  * The BARE ids the ClawBox AI proxy serves as CHAT models, in the order a
  * picker should show them.
  *

--- a/src/lib/explicit-model-pick.ts
+++ b/src/lib/explicit-model-pick.ts
@@ -79,6 +79,33 @@ export const EXPLICIT_MODEL_PICKS_KEY = "ai_model_explicit_picks";
 export type ExplicitModelPicks = Record<string, string>;
 
 /**
+ * Writes are serialised through this chain.
+ *
+ * One KEY holds every provider's pick, and storing it is a read-modify-write:
+ * two model switches in flight together — a picker click while a promote is
+ * still settling — would each read the map, add their own slot and write their
+ * own snapshot, and the loser's provider would be dropped. Two separate config
+ * keys could not lose each other that way; one map can, which is the cost of
+ * keying by provider inside a single value.
+ *
+ * In-process is the whole of the problem here: the Next server is the only
+ * writer of this key, and `data/config.json` has no inter-process lock to take
+ * (its `set`/`setMany` carry the same unlocked read-modify-write for every
+ * other key on beta).
+ */
+let writeChain: Promise<void> = Promise.resolve();
+
+/** Run a read-modify-write on the picks map without another one interleaving. */
+function serialise(fn: () => Promise<void>): Promise<void> {
+  const next = writeChain.then(fn, fn);
+  // Never leaves a rejected promise as the chain head: the next writer would
+  // inherit it and the whole key would stop being written for the process
+  // lifetime. Each caller handles its own failure.
+  writeChain = next.then(() => {}, () => {});
+  return next;
+}
+
+/**
  * The ClawBox AI chat model this reference names, bare, or null.
  *
  * The id allowlist is what actually decides — `CLAWBOX_AI_CHAT_MODEL_IDS` is a
@@ -187,20 +214,22 @@ export async function recordExplicitModelPick(model: string): Promise<void> {
   const trimmed = model.trim();
   const slot = trimmed ? pickSlotFor(trimmed) : null;
   if (!slot) return;
-  try {
-    const { value } = await getKnown(EXPLICIT_MODEL_PICKS_KEY);
-    // `explicitPicksFrom` has already dropped every key that is not a provider
-    // slot, and `slot` itself came through `isProviderSlot`, so the property
-    // name written here is one of a bounded, known shape.
-    const picks = explicitPicksFrom(value);
-    picks[slot] = trimmed;
-    await setMany({ [EXPLICIT_MODEL_PICKS_KEY]: picks });
-  } catch (err) {
-    console.warn(
-      "[explicit-model-pick] could not record the owner's model pick:",
-      err instanceof Error ? err.message : err,
-    );
-  }
+  return serialise(async () => {
+    try {
+      const { value } = await getKnown(EXPLICIT_MODEL_PICKS_KEY);
+      // `explicitPicksFrom` has already dropped every key that is not a provider
+      // slot, and `slot` itself came through `isProviderSlot`, so the property
+      // name written here is one of a bounded, known shape.
+      const picks = explicitPicksFrom(value);
+      picks[slot] = trimmed;
+      await setMany({ [EXPLICIT_MODEL_PICKS_KEY]: picks });
+    } catch (err) {
+      console.warn(
+        "[explicit-model-pick] could not record the owner's model pick:",
+        err instanceof Error ? err.message : err,
+      );
+    }
+  });
 }
 
 /** The stored picks, for a caller that has not already loaded the whole store. */

--- a/src/lib/explicit-model-pick.ts
+++ b/src/lib/explicit-model-pick.ts
@@ -35,13 +35,26 @@
 // ClawBox AI the default" and the MCP `ai_set_provider` tool both resolve the
 // provider's own recommended model, which is another default.
 //
-// HARNESS-FIRST. There is nothing native to borrow. OpenClaw records
-// `modelOverrideSource: "user"` per SESSION and deletes the override when it
-// equals the agent default, so it can never answer this about the primary;
-// Hermes' `model.default` carries no provenance; the portal publishes a per-device
-// `deviceTier` (a default) and `allowedModels` (the entitlement, which
-// `portalDeniesClawboxAiModel` already honours) but no per-device model. The
-// marker is ClawBox's own, in ClawBox's own store, beside `clawai_tier`.
+// HARNESS-FIRST. There is nothing native to borrow, but the reason is narrower
+// than "the core does not touch the primary". OpenClaw's sticky model selection
+// (`modelSelectionScope`, default `"effective"`, which ClawBox never sets) DOES
+// propagate an owner's session pick into `agents.defaults.model.primary` when
+// `modelOverrideSource === "user"` — it simply records no provenance where it
+// lands, and the session-scoped source it came from is deleted once the override
+// equals the agent default. So the primary itself can never be asked "did the
+// owner choose this?". Hermes' `model.default` carries no provenance either; the
+// portal publishes a per-device `deviceTier` (a default) and `allowedModels`
+// (the entitlement, which `portalDeniesClawboxAiModel` already honours) but no
+// per-device model. The marker is ClawBox's own, in ClawBox's own store, beside
+// `clawai_tier`.
+//
+// WHAT THAT LEAVES UNCOVERED, stated rather than left silent: a pick made
+// through OPENCLAW'S OWN surfaces — its Control UI picker, the core's Telegram
+// `/model` keyboard, `openclaw models set` — reaches the primary without passing
+// any ClawBox route, so nothing records it here and a later re-pair still writes
+// the badge default over it. That is beta's behaviour, unchanged by this file;
+// closing it needs either a provenance field the core does not have or a read of
+// the core's session store at pair time, and it is out of scope for this card.
 
 import { getKnown, setMany } from "@/lib/config-store";
 import { CLAWBOX_AI_CHAT_MODEL_IDS, CLAWBOX_AI_PROVIDER } from "@/lib/clawbox-ai-models";

--- a/src/lib/explicit-model-pick.ts
+++ b/src/lib/explicit-model-pick.ts
@@ -190,29 +190,6 @@ export async function recordExplicitModelPick(model: string): Promise<void> {
   }
 }
 
-/**
- * Drop one provider's pick.
- *
- * For a ClawBox AI ACCOUNT switch: the choice belonged to the account that has
- * just been replaced, and imposing it on the next one hands the new owner a
- * model their plan may refuse. Same signal the configure route already unpairs
- * ClawKeep on.
- */
-export async function forgetExplicitModelPick(provider: string): Promise<void> {
-  try {
-    const { value } = await getKnown(EXPLICIT_MODEL_PICKS_KEY);
-    const picks = explicitPicksFrom(value);
-    if (!(provider in picks)) return;
-    delete picks[provider];
-    await setMany({ [EXPLICIT_MODEL_PICKS_KEY]: picks });
-  } catch (err) {
-    console.warn(
-      "[explicit-model-pick] could not clear the model pick:",
-      err instanceof Error ? err.message : err,
-    );
-  }
-}
-
 /** The stored picks, for a caller that has not already loaded the whole store. */
 export async function readExplicitModelPicks(): Promise<ExplicitModelPicks> {
   const { value } = await getKnown(EXPLICIT_MODEL_PICKS_KEY);

--- a/src/lib/explicit-model-pick.ts
+++ b/src/lib/explicit-model-pick.ts
@@ -1,48 +1,77 @@
 // "Did the OWNER choose this model, or did we fill one in for them?"
 //
-// WHY IT EXISTS (TASK-713). The ClawBox AI tier badge is a device DEFAULT —
-// the portal's `deviceTier`, which a Max subscriber may deliberately leave on
-// Flash for one box — and every pair, re-pair and wizard finalise wrote
-// `CLAWBOX_AI_MODEL_BY_TIER[badge]` straight over
-// `agents.defaults.model.primary`. On a Max account whose box is stamped
-// `flash`, an entitled Max primary was replaced by Flash on the next re-pair,
-// and the chat's own entitlement guard could not undo it: that one only ever
-// moves DOWN. The owner's ruling is that a default fills a gap and never
-// overwrites a choice.
+// WHY IT EXISTS (TASK-713). The ClawBox AI tier badge is a device DEFAULT — the
+// portal's `deviceTier`, which a Max subscriber may deliberately leave on Flash
+// for one box — and every pair, re-pair, wizard finalise and plan press wrote
+// `CLAWBOX_AI_MODEL_BY_TIER[badge]` straight over the primary model. On a Max
+// account whose box is stamped `flash`, an entitled Max primary was replaced by
+// Flash on the next re-pair, and the chat's own entitlement guard could not undo
+// it: that one only ever moves DOWN. The owner's ruling is that a default fills
+// a gap and never overwrites a choice.
 //
 // WHY IT CANNOT BE ANSWERED FROM THE REQUEST. A re-pair reaches the configure
-// route through `ai-models/clawai/poll`, which sends `clawaiTier:
-// session.tier` — the same field the plan cards send. The two are
-// indistinguishable on the wire, so "was a tier named?" cannot be the test.
-// What the box CAN know is the other half: whether the owner has ever picked a
-// ClawBox AI model themselves. That is what this records.
+// route through `ai-models/clawai/poll`, which sends `clawaiTier: session.tier`
+// — the same field the plan cards send. The two are indistinguishable on the
+// wire, so "was a tier named?" cannot be the test. What the box CAN know is the
+// other half: whether the owner has ever picked a ClawBox AI model themselves.
+// That is what this records.
+//
+// WHY THERE IS NO INFERENCE FROM THE RUNNING MODEL, and why nobody should add
+// one back. An earlier revision read "the primary is a ClawBox AI model and is
+// not the one the badge implies" as evidence of a choice. It is not: the badge
+// and the model move at different times. `/setup-api/ai-models/status` persists
+// a new portal tier on its 30-second poll while nothing rewrites the model until
+// the next configure, so the FIRST configure after any plan change sees exactly
+// that mismatch. It would mint a Flash "pick" on an upgrade — the customer pays
+// for Max and the box can never default to it again — and a Max "pick" on a
+// downgrade, which the plan then refuses on every turn while the chat guard
+// drops it back and the next re-pair re-breaks it. A pick is recorded where a
+// pick is MADE, or not at all.
 //
 // WHAT IS NOT A PICK. A switch the BOX made — the chat's entitlement guard
 // dropping a refused Max model to Flash — is not the owner choosing Flash, and
 // recording it would pin the box there for good. Those writes carry
-// `automatic: true` and are not recorded.
+// `automatic: true`. Nor is a model DERIVED from a provider-only switch: "make
+// ClawBox AI the default" and the MCP `ai_set_provider` tool both resolve the
+// provider's own recommended model, which is another default.
+//
+// HARNESS-FIRST. There is nothing native to borrow. OpenClaw records
+// `modelOverrideSource: "user"` per SESSION and deletes the override when it
+// equals the agent default, so it can never answer this about the primary;
+// Hermes' `model.default` carries no provenance; the portal publishes a per-device
+// `deviceTier` (a default) and `allowedModels` (the entitlement, which
+// `portalDeniesClawboxAiModel` already honours) but no per-device model. The
+// marker is ClawBox's own, in ClawBox's own store, beside `clawai_tier`.
 
-import { get as getConfigValue, setMany } from "@/lib/config-store";
+import { getKnown, setMany } from "@/lib/config-store";
 import { CLAWBOX_AI_CHAT_MODEL_IDS, CLAWBOX_AI_PROVIDER } from "@/lib/clawbox-ai-models";
 
 /**
- * Config-store key holding the last model the owner chose themselves, as the
- * picker wrote it — `deepseek/deepseek-v4-pro` on OpenClaw, the bare
- * `deepseek-v4-pro` on Hermes, whose config takes ids unprefixed.
+ * Config-store key: `{ <canonical provider>: <model as the picker wrote it> }`.
  *
- * One key for every provider, not one per provider: the question it answers is
- * "what did the owner last choose", and the readers below decide for themselves
- * whether that answer is about them.
+ * PER PROVIDER, not one slot for the box. The readers each ask a
+ * provider-specific question ("which ClawBox AI model did the owner choose"),
+ * and a single slot answered it wrong in the obvious case: pick ClawBox AI Max,
+ * try Anthropic for a day, re-pair ClawBox AI — the Anthropic pick is not a
+ * ClawBox AI answer, so the badge would overwrite a Max choice nobody revoked.
+ *
+ * The provider keys are the canonical UI ids (`clawai`, `anthropic`, …), and the
+ * values keep the spelling the surface that wrote them uses:
+ * `deepseek/deepseek-v4-pro` from the OpenClaw picker, the bare
+ * `deepseek-v4-pro` from Hermes, whose config takes ids unprefixed.
  */
-export const EXPLICIT_MODEL_PICK_KEY = "ai_model_explicit_pick";
+export const EXPLICIT_MODEL_PICKS_KEY = "ai_model_explicit_picks";
+
+/** Canonical provider id -> the model reference the owner chose for it. */
+export type ExplicitModelPicks = Record<string, string>;
 
 /**
- * The ClawBox AI chat model this reference names, bare, or null when it names
- * something else.
+ * The ClawBox AI chat model this reference names, bare, or null.
  *
- * The provider half is CHECKED rather than stripped. `openrouter/…` slugs keep
- * a vendor inside the id, so a bare "does the last segment match" test would
- * one day read an OpenRouter row as a ClawBox AI pick and pin a re-pair to it.
+ * The id allowlist is what actually decides — `CLAWBOX_AI_CHAT_MODEL_IDS` is a
+ * closed set of two. The provider half is checked only to reject a foreign
+ * vendor that happens to serve a same-named id, which is not idle: OpenRouter
+ * slugs carry their vendor INSIDE the id, and `deepseek/` is one of them.
  */
 export function clawboxAiModelIdOf(ref: unknown): string | null {
   if (typeof ref !== "string") return null;
@@ -51,79 +80,118 @@ export function clawboxAiModelIdOf(ref: unknown): string | null {
   const slash = trimmed.indexOf("/");
   const provider = slash === -1 ? null : trimmed.slice(0, slash).trim().toLowerCase();
   const id = slash === -1 ? trimmed : trimmed.slice(slash + 1).trim();
-  // `clawai` is the UI's name for the same provider openclaw.json calls
-  // `deepseek`; both spellings reach this from different surfaces.
+  // `clawai` is the UI's name for the provider openclaw.json calls `deepseek`;
+  // both spellings reach this from different surfaces.
   if (provider && provider !== CLAWBOX_AI_PROVIDER && provider !== "clawai") return null;
   return (CLAWBOX_AI_CHAT_MODEL_IDS as readonly string[]).includes(id) ? id : null;
 }
 
+/**
+ * Which provider slot a model reference belongs in.
+ *
+ * ClawBox AI's two spellings collapse onto `clawai`; everything else is keyed by
+ * the vendor prefix it carries, and a reference with no prefix at all (a local
+ * model id) is not a provider choice this file has anything to say about.
+ */
+function pickSlotFor(ref: string): string | null {
+  if (clawboxAiModelIdOf(ref)) return "clawai";
+  const slash = ref.indexOf("/");
+  if (slash <= 0) return null;
+  return ref.slice(0, slash).trim().toLowerCase() || null;
+}
+
+/** The stored map, tolerant of anything that is not one — the store is hand-editable JSON. */
+export function explicitPicksFrom(raw: unknown): ExplicitModelPicks {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const picks: ExplicitModelPicks = {};
+  for (const [provider, model] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof model === "string" && model.trim()) picks[provider] = model.trim();
+  }
+  return picks;
+}
+
 export interface ClawboxAiModelDecision {
-  /** The BARE model id a pair/re-pair/tier change must write. */
+  /** The BARE model id a pair, re-pair or tier change must write. */
   modelId: string;
   /** True when it is the owner's own choice rather than the tier default. */
   explicit: boolean;
-  /**
-   * Set when the pick was inferred from the model the box is already running
-   * and has to be written down — see the migration note on
-   * {@link decideClawboxAiModelId}. The caller records it; this function is
-   * pure so both editions can share it without either owning the store.
-   */
-  migrate: string | null;
 }
 
 /**
  * Which ClawBox AI model to write, and whether the owner chose it.
  *
- * THE MIGRATION. Boxes in the field are in exactly the state this card is
- * about and carry no marker, because none existed: a primary that is a ClawBox
- * AI model and is NOT the one the badge implies can only have got there by
- * someone choosing it — the chat picker, the Telegram `/model` keyboard, an
- * `openclaw config set`. Reading that as the explicit pick is what stops the
- * very next re-pair from being the thing that discovers the marker too late.
- * It is deliberately narrow: a primary that EQUALS the tier default is no
- * evidence of anything, and a primary belonging to another provider is not a
- * ClawBox AI choice at all.
+ * No I/O and no inference: the only thing that outranks the badge is a recorded
+ * pick for THIS provider. An unreadable store therefore lands on the badge, the
+ * same answer beta gave — a pair that writes no model at all is a box with no
+ * working chat, and bookkeeping we could not read is not worth holding a save
+ * hostage to.
  */
 export function decideClawboxAiModelId(opts: {
-  /** `EXPLICIT_MODEL_PICK_KEY` as the config store holds it. */
-  storedPick: unknown;
-  /** What the box runs today — `agents.defaults.model.primary`, or Hermes' `model.default`. */
-  currentPrimary: string | null | undefined;
+  picks: ExplicitModelPicks;
   /** The bare id the tier badge implies. */
   tierModelId: string;
 }): ClawboxAiModelDecision {
-  const picked = clawboxAiModelIdOf(opts.storedPick);
-  if (picked) return { modelId: picked, explicit: true, migrate: null };
-  // A pick that names another provider is an ANSWER — the owner's last choice
-  // simply was not about ClawBox AI — so the migration below must not run for
-  // it. Only the absence of any pick leaves the question open.
-  if (typeof opts.storedPick === "string" && opts.storedPick.trim()) {
-    return { modelId: opts.tierModelId, explicit: false, migrate: null };
-  }
-  const running = clawboxAiModelIdOf(opts.currentPrimary);
-  if (running && running !== opts.tierModelId) {
-    // Recorded as the box spells it, not as this function parsed it: the
-    // marker is the same field a picker writes, and one shape per edition is
-    // what makes it readable by a person looking at data/config.json.
-    return { modelId: running, explicit: true, migrate: String(opts.currentPrimary).trim() };
-  }
-  return { modelId: opts.tierModelId, explicit: false, migrate: null };
+  const picked = clawboxAiModelIdOf(opts.picks.clawai);
+  return picked
+    ? { modelId: picked, explicit: true }
+    : { modelId: opts.tierModelId, explicit: false };
 }
 
 /**
  * Write down that the owner chose this model.
  *
- * Called from the model pickers — the ones an owner presses — and from the
- * migration above. Never from a switch the box made for itself.
+ * Called from the surfaces an owner presses, and only when the request NAMED a
+ * model — a provider-only switch resolves that provider's own recommended
+ * default, which is not a choice.
+ *
+ * FAIL-SOFT, deliberately. This is bookkeeping: losing it costs one overwrite by
+ * the badge, while throwing costs a model change that has already landed on
+ * disk. `setMany` reads the store strictly and throws on a `data/config.json`
+ * left root-owned by a sudo script — a real state on these boxes — and every
+ * call site sits after the write it describes.
  */
 export async function recordExplicitModelPick(model: string): Promise<void> {
   const trimmed = model.trim();
-  if (!trimmed) return;
-  await setMany({ [EXPLICIT_MODEL_PICK_KEY]: trimmed });
+  const slot = trimmed ? pickSlotFor(trimmed) : null;
+  if (!slot) return;
+  try {
+    const { value } = await getKnown(EXPLICIT_MODEL_PICKS_KEY);
+    await setMany({
+      [EXPLICIT_MODEL_PICKS_KEY]: { ...explicitPicksFrom(value), [slot]: trimmed },
+    });
+  } catch (err) {
+    console.warn(
+      "[explicit-model-pick] could not record the owner's model pick:",
+      err instanceof Error ? err.message : err,
+    );
+  }
 }
 
-/** The stored pick, for a caller that has not already loaded the whole store. */
-export async function readExplicitModelPick(): Promise<string | null> {
-  const raw = await getConfigValue(EXPLICIT_MODEL_PICK_KEY).catch(() => null);
-  return typeof raw === "string" && raw.trim() ? raw.trim() : null;
+/**
+ * Drop one provider's pick.
+ *
+ * For a ClawBox AI ACCOUNT switch: the choice belonged to the account that has
+ * just been replaced, and imposing it on the next one hands the new owner a
+ * model their plan may refuse. Same signal the configure route already unpairs
+ * ClawKeep on.
+ */
+export async function forgetExplicitModelPick(provider: string): Promise<void> {
+  try {
+    const { value } = await getKnown(EXPLICIT_MODEL_PICKS_KEY);
+    const picks = explicitPicksFrom(value);
+    if (!(provider in picks)) return;
+    delete picks[provider];
+    await setMany({ [EXPLICIT_MODEL_PICKS_KEY]: picks });
+  } catch (err) {
+    console.warn(
+      "[explicit-model-pick] could not clear the model pick:",
+      err instanceof Error ? err.message : err,
+    );
+  }
+}
+
+/** The stored picks, for a caller that has not already loaded the whole store. */
+export async function readExplicitModelPicks(): Promise<ExplicitModelPicks> {
+  const { value } = await getKnown(EXPLICIT_MODEL_PICKS_KEY);
+  return explicitPicksFrom(value);
 }

--- a/src/lib/explicit-model-pick.ts
+++ b/src/lib/explicit-model-pick.ts
@@ -87,6 +87,24 @@ export function clawboxAiModelIdOf(ref: unknown): string | null {
 }
 
 /**
+ * The shape every provider id this file will key by has: a letter, then letters,
+ * digits or hyphens (`clawai`, `openrouter`, `openai-codex`, `kimi-coding`).
+ *
+ * The slot is derived from a model reference that arrives in a REQUEST BODY and
+ * is then used as a property name, so it is validated rather than trusted: an
+ * unbounded key would put whatever the caller sent into `data/config.json`, and
+ * a name like `__proto__` or `constructor` has meaning to an object before it
+ * has meaning to us. Anything outside this shape is simply not a slot, and the
+ * pick is not recorded.
+ */
+const PROVIDER_SLOT_RE = /^[a-z][a-z0-9-]{0,31}$/;
+const RESERVED_SLOTS: ReadonlySet<string> = new Set(["constructor", "prototype", "__proto__"]);
+
+function isProviderSlot(slot: string): boolean {
+  return PROVIDER_SLOT_RE.test(slot) && !RESERVED_SLOTS.has(slot);
+}
+
+/**
  * Which provider slot a model reference belongs in.
  *
  * ClawBox AI's two spellings collapse onto `clawai`; everything else is keyed by
@@ -97,7 +115,8 @@ function pickSlotFor(ref: string): string | null {
   if (clawboxAiModelIdOf(ref)) return "clawai";
   const slash = ref.indexOf("/");
   if (slash <= 0) return null;
-  return ref.slice(0, slash).trim().toLowerCase() || null;
+  const slot = ref.slice(0, slash).trim().toLowerCase();
+  return isProviderSlot(slot) ? slot : null;
 }
 
 /** The stored map, tolerant of anything that is not one — the store is hand-editable JSON. */
@@ -105,6 +124,7 @@ export function explicitPicksFrom(raw: unknown): ExplicitModelPicks {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
   const picks: ExplicitModelPicks = {};
   for (const [provider, model] of Object.entries(raw as Record<string, unknown>)) {
+    if (!isProviderSlot(provider)) continue;
     if (typeof model === "string" && model.trim()) picks[provider] = model.trim();
   }
   return picks;
@@ -156,9 +176,12 @@ export async function recordExplicitModelPick(model: string): Promise<void> {
   if (!slot) return;
   try {
     const { value } = await getKnown(EXPLICIT_MODEL_PICKS_KEY);
-    await setMany({
-      [EXPLICIT_MODEL_PICKS_KEY]: { ...explicitPicksFrom(value), [slot]: trimmed },
-    });
+    // `explicitPicksFrom` has already dropped every key that is not a provider
+    // slot, and `slot` itself came through `isProviderSlot`, so the property
+    // name written here is one of a bounded, known shape.
+    const picks = explicitPicksFrom(value);
+    picks[slot] = trimmed;
+    await setMany({ [EXPLICIT_MODEL_PICKS_KEY]: picks });
   } catch (err) {
     console.warn(
       "[explicit-model-pick] could not record the owner's model pick:",

--- a/src/lib/explicit-model-pick.ts
+++ b/src/lib/explicit-model-pick.ts
@@ -1,0 +1,129 @@
+// "Did the OWNER choose this model, or did we fill one in for them?"
+//
+// WHY IT EXISTS (TASK-713). The ClawBox AI tier badge is a device DEFAULT —
+// the portal's `deviceTier`, which a Max subscriber may deliberately leave on
+// Flash for one box — and every pair, re-pair and wizard finalise wrote
+// `CLAWBOX_AI_MODEL_BY_TIER[badge]` straight over
+// `agents.defaults.model.primary`. On a Max account whose box is stamped
+// `flash`, an entitled Max primary was replaced by Flash on the next re-pair,
+// and the chat's own entitlement guard could not undo it: that one only ever
+// moves DOWN. The owner's ruling is that a default fills a gap and never
+// overwrites a choice.
+//
+// WHY IT CANNOT BE ANSWERED FROM THE REQUEST. A re-pair reaches the configure
+// route through `ai-models/clawai/poll`, which sends `clawaiTier:
+// session.tier` — the same field the plan cards send. The two are
+// indistinguishable on the wire, so "was a tier named?" cannot be the test.
+// What the box CAN know is the other half: whether the owner has ever picked a
+// ClawBox AI model themselves. That is what this records.
+//
+// WHAT IS NOT A PICK. A switch the BOX made — the chat's entitlement guard
+// dropping a refused Max model to Flash — is not the owner choosing Flash, and
+// recording it would pin the box there for good. Those writes carry
+// `automatic: true` and are not recorded.
+
+import { get as getConfigValue, setMany } from "@/lib/config-store";
+import { CLAWBOX_AI_CHAT_MODEL_IDS, CLAWBOX_AI_PROVIDER } from "@/lib/clawbox-ai-models";
+
+/**
+ * Config-store key holding the last model the owner chose themselves, as the
+ * picker wrote it — `deepseek/deepseek-v4-pro` on OpenClaw, the bare
+ * `deepseek-v4-pro` on Hermes, whose config takes ids unprefixed.
+ *
+ * One key for every provider, not one per provider: the question it answers is
+ * "what did the owner last choose", and the readers below decide for themselves
+ * whether that answer is about them.
+ */
+export const EXPLICIT_MODEL_PICK_KEY = "ai_model_explicit_pick";
+
+/**
+ * The ClawBox AI chat model this reference names, bare, or null when it names
+ * something else.
+ *
+ * The provider half is CHECKED rather than stripped. `openrouter/…` slugs keep
+ * a vendor inside the id, so a bare "does the last segment match" test would
+ * one day read an OpenRouter row as a ClawBox AI pick and pin a re-pair to it.
+ */
+export function clawboxAiModelIdOf(ref: unknown): string | null {
+  if (typeof ref !== "string") return null;
+  const trimmed = ref.trim();
+  if (!trimmed) return null;
+  const slash = trimmed.indexOf("/");
+  const provider = slash === -1 ? null : trimmed.slice(0, slash).trim().toLowerCase();
+  const id = slash === -1 ? trimmed : trimmed.slice(slash + 1).trim();
+  // `clawai` is the UI's name for the same provider openclaw.json calls
+  // `deepseek`; both spellings reach this from different surfaces.
+  if (provider && provider !== CLAWBOX_AI_PROVIDER && provider !== "clawai") return null;
+  return (CLAWBOX_AI_CHAT_MODEL_IDS as readonly string[]).includes(id) ? id : null;
+}
+
+export interface ClawboxAiModelDecision {
+  /** The BARE model id a pair/re-pair/tier change must write. */
+  modelId: string;
+  /** True when it is the owner's own choice rather than the tier default. */
+  explicit: boolean;
+  /**
+   * Set when the pick was inferred from the model the box is already running
+   * and has to be written down — see the migration note on
+   * {@link decideClawboxAiModelId}. The caller records it; this function is
+   * pure so both editions can share it without either owning the store.
+   */
+  migrate: string | null;
+}
+
+/**
+ * Which ClawBox AI model to write, and whether the owner chose it.
+ *
+ * THE MIGRATION. Boxes in the field are in exactly the state this card is
+ * about and carry no marker, because none existed: a primary that is a ClawBox
+ * AI model and is NOT the one the badge implies can only have got there by
+ * someone choosing it — the chat picker, the Telegram `/model` keyboard, an
+ * `openclaw config set`. Reading that as the explicit pick is what stops the
+ * very next re-pair from being the thing that discovers the marker too late.
+ * It is deliberately narrow: a primary that EQUALS the tier default is no
+ * evidence of anything, and a primary belonging to another provider is not a
+ * ClawBox AI choice at all.
+ */
+export function decideClawboxAiModelId(opts: {
+  /** `EXPLICIT_MODEL_PICK_KEY` as the config store holds it. */
+  storedPick: unknown;
+  /** What the box runs today — `agents.defaults.model.primary`, or Hermes' `model.default`. */
+  currentPrimary: string | null | undefined;
+  /** The bare id the tier badge implies. */
+  tierModelId: string;
+}): ClawboxAiModelDecision {
+  const picked = clawboxAiModelIdOf(opts.storedPick);
+  if (picked) return { modelId: picked, explicit: true, migrate: null };
+  // A pick that names another provider is an ANSWER — the owner's last choice
+  // simply was not about ClawBox AI — so the migration below must not run for
+  // it. Only the absence of any pick leaves the question open.
+  if (typeof opts.storedPick === "string" && opts.storedPick.trim()) {
+    return { modelId: opts.tierModelId, explicit: false, migrate: null };
+  }
+  const running = clawboxAiModelIdOf(opts.currentPrimary);
+  if (running && running !== opts.tierModelId) {
+    // Recorded as the box spells it, not as this function parsed it: the
+    // marker is the same field a picker writes, and one shape per edition is
+    // what makes it readable by a person looking at data/config.json.
+    return { modelId: running, explicit: true, migrate: String(opts.currentPrimary).trim() };
+  }
+  return { modelId: opts.tierModelId, explicit: false, migrate: null };
+}
+
+/**
+ * Write down that the owner chose this model.
+ *
+ * Called from the model pickers — the ones an owner presses — and from the
+ * migration above. Never from a switch the box made for itself.
+ */
+export async function recordExplicitModelPick(model: string): Promise<void> {
+  const trimmed = model.trim();
+  if (!trimmed) return;
+  await setMany({ [EXPLICIT_MODEL_PICK_KEY]: trimmed });
+}
+
+/** The stored pick, for a caller that has not already loaded the whole store. */
+export async function readExplicitModelPick(): Promise<string | null> {
+  const raw = await getConfigValue(EXPLICIT_MODEL_PICK_KEY).catch(() => null);
+  return typeof raw === "string" && raw.trim() ? raw.trim() : null;
+}

--- a/src/lib/explicit-model-pick.ts
+++ b/src/lib/explicit-model-pick.ts
@@ -232,6 +232,30 @@ export async function recordExplicitModelPick(model: string): Promise<void> {
   });
 }
 
+/**
+ * The picks map without one provider's entry, or null when it had none.
+ *
+ * The shape every ClawBox AI token writer needs: a pick belongs to the ACCOUNT
+ * that made it, so a token change must drop it — and must drop it in the SAME
+ * `setMany` that stores the replacement token, or a failure between the two
+ * leaves the new account's token beside the old account's choice and every
+ * later comparison reads them as the same account. Returning null says "nothing
+ * to write", so a caller can spread it conditionally into the batch it is
+ * already making.
+ *
+ * One helper because there are three such writers. The fourth to be added
+ * should find this rather than re-derive it.
+ */
+export function picksWithoutProvider(
+  picks: ExplicitModelPicks,
+  provider: string,
+): ExplicitModelPicks | null {
+  if (!(provider in picks)) return null;
+  const next = { ...picks };
+  delete next[provider];
+  return next;
+}
+
 /** The stored picks, for a caller that has not already loaded the whole store. */
 export async function readExplicitModelPicks(): Promise<ExplicitModelPicks> {
   const { value } = await getKnown(EXPLICIT_MODEL_PICKS_KEY);

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -1,5 +1,9 @@
 import { getKnown, setMany } from "@/lib/config-store";
-import { decideClawboxAiModelId, forgetExplicitModelPick, readExplicitModelPicks } from "@/lib/explicit-model-pick";
+import {
+  EXPLICIT_MODEL_PICKS_KEY,
+  decideClawboxAiModelId,
+  readExplicitModelPicks,
+} from "@/lib/explicit-model-pick";
 import { refreshCodingAgentToolsIfReadinessChanged } from "@/lib/coding-agent-mcp-refresh";
 import { hermesAgentDrawsImages } from "@/lib/harness/hermes-features";
 import { runHermesCli, type HermesCliResult } from "@/lib/hermes-cli";
@@ -145,14 +149,25 @@ export async function applyClawaiToHermes(
   // press, so what settles it is whether the owner has ever picked a ClawBox AI
   // model here.
   //
-  // A pick belongs to the ACCOUNT that made it, so a token change drops it
-  // before it is read: the previous owner's Max choice must not be imposed on
-  // the Pro plan the new one is paying for. Read before the first write, like
-  // every other before/after fact this function samples.
+  // A pick belongs to the ACCOUNT that made it, so a token change means it is
+  // not read here — the previous owner's Max choice must not be imposed on the
+  // Pro plan the new one is paying for — and it is CLEARED in the same
+  // `setMany` that stores the new token at the bottom, so the two cannot come
+  // apart. A separate delete could fail on its own and leave account A's pick
+  // beside account B's token, waiting for the next link to apply it.
+  // Read before the first write, like every other before/after fact this
+  // function samples.
   const previousToken = await getStoredClawaiToken();
-  if (previousToken && previousToken !== trimmed) await forgetExplicitModelPick(CLAWAI_PROVIDER);
+  const accountChanged = Boolean(previousToken && previousToken !== trimmed);
+  const storedPicks = await readExplicitModelPicks();
+  let picksToStore: Record<string, string> | null = null;
+  if (accountChanged && storedPicks[CLAWAI_PROVIDER]) {
+    const next = { ...storedPicks };
+    delete next[CLAWAI_PROVIDER];
+    picksToStore = next;
+  }
   const clawaiDecision = decideClawboxAiModelId({
-    picks: previousToken && previousToken !== trimmed ? {} : await readExplicitModelPicks(),
+    picks: accountChanged ? {} : storedPicks,
     tierModelId: clawaiModelForTier(tier),
   });
   if (clawaiDecision.explicit) {
@@ -382,6 +397,9 @@ export async function applyClawaiToHermes(
     ai_model_configured: true,
     ai_model_provider: CLAWAI_PROVIDER,
     ai_model_configured_at: new Date().toISOString(),
+    // The previous account's model pick, dropped in the same write as its
+    // replacement token (TASK-713).
+    ...(picksToStore ? { [EXPLICIT_MODEL_PICKS_KEY]: picksToStore } : {}),
   });
 
   // The device's provider/model just changed — don't serve the old selection.

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -2,6 +2,7 @@ import { getKnown, setMany } from "@/lib/config-store";
 import {
   EXPLICIT_MODEL_PICKS_KEY,
   decideClawboxAiModelId,
+  picksWithoutProvider,
   readExplicitModelPicks,
 } from "@/lib/explicit-model-pick";
 import { refreshCodingAgentToolsIfReadinessChanged } from "@/lib/coding-agent-mcp-refresh";
@@ -175,12 +176,12 @@ export async function applyClawaiToHermes(
   const previousToken = options.previousClawaiToken?.trim() ?? await getStoredClawaiToken();
   const accountChanged = Boolean(previousToken && previousToken !== trimmed);
   const storedPicks = await readExplicitModelPicks();
-  let picksToStore: Record<string, string> | null = null;
-  if (accountChanged && storedPicks[CLAWAI_PROVIDER]) {
-    const next = { ...storedPicks };
-    delete next[CLAWAI_PROVIDER];
-    picksToStore = next;
-  }
+  // Null whenever there is nothing to drop — including when the CALLER has
+  // already dropped it, which `/setup-api/hermes/clawai` does in the same write
+  // that stores the token it supplies.
+  const picksToStore = accountChanged
+    ? picksWithoutProvider(storedPicks, CLAWAI_PROVIDER)
+    : null;
   const clawaiDecision = decideClawboxAiModelId({
     picks: accountChanged ? {} : storedPicks,
     tierModelId: clawaiModelForTier(tier),

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -22,9 +22,7 @@ import {
 } from "@/lib/hermes-image-plugin";
 import {
   CLAWBOX_AI_CHAT_MODEL_IDS,
-  CLAWBOX_AI_FLASH_MODEL_ID,
   CLAWBOX_AI_IMAGE_MODEL_ID,
-  CLAWBOX_AI_PRO_MODEL_ID,
   CLAWBOX_AI_MODEL_ID_BY_TIER,
   CLAWBOX_AI_VISION_MODEL_ID,
   type ClawboxAiTier,

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -23,6 +23,7 @@ import {
   CLAWBOX_AI_FLASH_MODEL_ID,
   CLAWBOX_AI_IMAGE_MODEL_ID,
   CLAWBOX_AI_PRO_MODEL_ID,
+  CLAWBOX_AI_MODEL_ID_BY_TIER,
   CLAWBOX_AI_VISION_MODEL_ID,
   type ClawboxAiTier,
 } from "@/lib/clawbox-ai-models";
@@ -59,7 +60,7 @@ export const CLAWBOX_AI_PROXY_URL = (
 /** BARE model id (no `deepseek/` vendor prefix) — the proxy returns
  *  "HTTP 400: Model not allowed" for a prefixed slug. */
 export function clawaiModelForTier(tier: ClawboxAiTier): string {
-  return tier === "pro" ? CLAWBOX_AI_PRO_MODEL_ID : CLAWBOX_AI_FLASH_MODEL_ID;
+  return CLAWBOX_AI_MODEL_ID_BY_TIER[tier];
 }
 
 export class ClawaiApplyError extends Error {}

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -1,4 +1,6 @@
 import { setMany } from "@/lib/config-store";
+import { decideClawboxAiModelId, readExplicitModelPick, recordExplicitModelPick } from "@/lib/explicit-model-pick";
+import { hermesConfigGet } from "@/lib/hermes-config-cache";
 import { refreshCodingAgentToolsIfReadinessChanged } from "@/lib/coding-agent-mcp-refresh";
 import { hermesAgentDrawsImages } from "@/lib/harness/hermes-features";
 import { runHermesCli, type HermesCliResult } from "@/lib/hermes-cli";
@@ -125,7 +127,25 @@ export async function applyClawaiToHermes(
   if (!trimmed || trimmed.startsWith("-")) {
     throw new ClawaiApplyError("Sign in to ClawBox AI first to get a device token.");
   }
-  const model = clawaiModelForTier(tier);
+  // The tier badge fills in a DEFAULT and never overwrites a choice (TASK-713).
+  // Same rule and same decision function as the OpenClaw route — a re-pair
+  // reaches both editions carrying a tier it cannot be told apart from a plan
+  // press, so what settles it is whether the owner has ever picked a ClawBox AI
+  // model here. `model.default` is read for the MIGRATION only, and through the
+  // mtime-keyed cache the rest of this function already uses; an unreadable one
+  // simply leaves the question open and the badge fills it in, as on beta.
+  const clawaiDecision = decideClawboxAiModelId({
+    storedPick: await readExplicitModelPick(),
+    currentPrimary: await hermesConfigGet("model.default").catch(() => null),
+    tierModelId: clawaiModelForTier(tier),
+  });
+  if (clawaiDecision.migrate) await recordExplicitModelPick(clawaiDecision.migrate);
+  if (clawaiDecision.explicit) {
+    console.log(
+      `[Hermes ClawAI] keeping the owner's own model ${clawaiDecision.modelId} over the ${tier} badge default`,
+    );
+  }
+  const model = clawaiDecision.modelId;
   // BEFORE the first write. The token is about to change — an account switch, a
   // re-pair, a rotated device token — and the step loop below can throw after
   // `providers.clawai.api_key` has already landed, which would leave the new

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -1,6 +1,5 @@
-import { setMany } from "@/lib/config-store";
-import { decideClawboxAiModelId, readExplicitModelPick, recordExplicitModelPick } from "@/lib/explicit-model-pick";
-import { hermesConfigGet } from "@/lib/hermes-config-cache";
+import { getKnown, setMany } from "@/lib/config-store";
+import { decideClawboxAiModelId, forgetExplicitModelPick, readExplicitModelPicks } from "@/lib/explicit-model-pick";
 import { refreshCodingAgentToolsIfReadinessChanged } from "@/lib/coding-agent-mcp-refresh";
 import { hermesAgentDrawsImages } from "@/lib/harness/hermes-features";
 import { runHermesCli, type HermesCliResult } from "@/lib/hermes-cli";
@@ -60,7 +59,10 @@ export const CLAWBOX_AI_PROXY_URL = (
 /** BARE model id (no `deepseek/` vendor prefix) — the proxy returns
  *  "HTTP 400: Model not allowed" for a prefixed slug. */
 export function clawaiModelForTier(tier: ClawboxAiTier): string {
-  return CLAWBOX_AI_MODEL_ID_BY_TIER[tier];
+  // Total, as the ternary it replaced was: every caller normalises the tier
+  // first, but this value goes straight into `config set model.default` argv and
+  // an `undefined` there would be a broken write rather than a wrong one.
+  return CLAWBOX_AI_MODEL_ID_BY_TIER[tier] ?? CLAWBOX_AI_MODEL_ID_BY_TIER.flash;
 }
 
 export class ClawaiApplyError extends Error {}
@@ -114,6 +116,18 @@ export interface ApplyClawaiOptions {
  * @param tier  device tier — decides which bare deepseek id becomes model.default
  * @param options see `ApplyClawaiOptions`
  */
+/**
+ * The ClawBox AI token this box already holds, or "".
+ *
+ * Read to spot an ACCOUNT switch — the same thing the OpenClaw configure route
+ * compares to unpair ClawKeep. An unreadable store answers "" and nothing is
+ * dropped, which is the direction that keeps a working link working.
+ */
+async function getStoredClawaiToken(): Promise<string> {
+  const { value } = await getKnown("clawai_token");
+  return typeof value === "string" ? value.trim() : "";
+}
+
 export async function applyClawaiToHermes(
   token: string,
   tier: ClawboxAiTier,
@@ -129,15 +143,18 @@ export async function applyClawaiToHermes(
   // Same rule and same decision function as the OpenClaw route — a re-pair
   // reaches both editions carrying a tier it cannot be told apart from a plan
   // press, so what settles it is whether the owner has ever picked a ClawBox AI
-  // model here. `model.default` is read for the MIGRATION only, and through the
-  // mtime-keyed cache the rest of this function already uses; an unreadable one
-  // simply leaves the question open and the badge fills it in, as on beta.
+  // model here.
+  //
+  // A pick belongs to the ACCOUNT that made it, so a token change drops it
+  // before it is read: the previous owner's Max choice must not be imposed on
+  // the Pro plan the new one is paying for. Read before the first write, like
+  // every other before/after fact this function samples.
+  const previousToken = await getStoredClawaiToken();
+  if (previousToken && previousToken !== trimmed) await forgetExplicitModelPick(CLAWAI_PROVIDER);
   const clawaiDecision = decideClawboxAiModelId({
-    storedPick: await readExplicitModelPick(),
-    currentPrimary: await hermesConfigGet("model.default").catch(() => null),
+    picks: previousToken && previousToken !== trimmed ? {} : await readExplicitModelPicks(),
     tierModelId: clawaiModelForTier(tier),
   });
-  if (clawaiDecision.migrate) await recordExplicitModelPick(clawaiDecision.migrate);
   if (clawaiDecision.explicit) {
     console.log(
       `[Hermes ClawAI] keeping the owner's own model ${clawaiDecision.modelId} over the ${tier} badge default`,

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -111,6 +111,21 @@ export interface ApplyClawaiOptions {
    * first, so they leave it unset and the snapshot below is honest.
    */
   codingAgentReadyBefore?: boolean;
+  /**
+   * The `clawai_token` this box held before the caller touched anything — for
+   * the same caller, for the same reason (TASK-713).
+   *
+   * A pick belongs to the ACCOUNT that made it, so this function drops the
+   * stored ClawBox AI pick when the token changes. It cannot learn that from
+   * the store if the caller has already written the new token there: the read
+   * would answer with the token it is being asked about, `accountChanged` would
+   * be false on every real link, and account A's Max choice would be applied to
+   * account B's Pro plan. `/setup-api/hermes/clawai` persists a PASTED token
+   * before it applies it and is the one caller that needs this; the configure
+   * route and the device-code finaliser write nothing first, so they leave it
+   * unset and the read below is honest.
+   */
+  previousClawaiToken?: string;
 }
 
 /**
@@ -136,7 +151,7 @@ export async function applyClawaiToHermes(
   token: string,
   tier: ClawboxAiTier,
   options: ApplyClawaiOptions = {},
-): Promise<{ provider: string; model: string; tier: ClawboxAiTier }> {
+): Promise<{ provider: string; model: string; tier: ClawboxAiTier; explicitPickKept: boolean }> {
   const trimmed = token.trim();
   // A token that starts with "-" would be read by hermes as a flag. runHermesCli
   // never uses a shell, but argv position is still meaningful.
@@ -157,7 +172,7 @@ export async function applyClawaiToHermes(
   // beside account B's token, waiting for the next link to apply it.
   // Read before the first write, like every other before/after fact this
   // function samples.
-  const previousToken = await getStoredClawaiToken();
+  const previousToken = options.previousClawaiToken?.trim() ?? await getStoredClawaiToken();
   const accountChanged = Boolean(previousToken && previousToken !== trimmed);
   const storedPicks = await readExplicitModelPicks();
   let picksToStore: Record<string, string> | null = null;
@@ -469,7 +484,10 @@ export async function applyClawaiToHermes(
     );
   }
 
-  return { provider: CLAWAI_PROVIDER, model, tier };
+  // `explicitPickKept` says the badge was overruled by the owner's own choice
+  // (TASK-713), so the caller can report it rather than answering 200 over a
+  // screen where the plan moved and the model deliberately did not.
+  return { provider: CLAWAI_PROVIDER, model, tier, explicitPickKept: clawaiDecision.explicit };
 }
 
 let clawaiModelsReconciled = false;

--- a/src/tests/components/chat-clawai-pro-entitlement.test.tsx
+++ b/src/tests/components/chat-clawai-pro-entitlement.test.tsx
@@ -201,7 +201,11 @@ describe("a ClawBox AI Pro model the account is entitled to", () => {
     // the POST is already there after the same settle() they assert emptiness
     // after. (The upgrade message itself goes into the transcript, which the
     // "Switching AI provider…" overlay covers for the whole of the switch.)
-    expect(modelWrites(calls)).toEqual(['{"model":"deepseek/deepseek-v4-flash"}']);
+    // `automatic: true` is the whole difference between the BOX recovering and
+    // the OWNER choosing Flash: the server records a pick for the second and
+    // must not for the first, or this recovery would pin the box to Flash for
+    // good (TASK-713).
+    expect(modelWrites(calls)).toEqual(['{"model":"deepseek/deepseek-v4-flash","automatic":true}']);
   });
 
   it("is left running when the entitlement could not be read at all", async () => {
@@ -272,7 +276,11 @@ describe("the boot guard when the switch it asks for fails", () => {
     release();
     await act(async () => { await new Promise((resolve) => setTimeout(resolve, 50)); });
 
-    expect(modelWrites(calls)).toEqual(['{"model":"deepseek/deepseek-v4-flash"}']);
+    // `automatic: true` is the whole difference between the BOX recovering and
+    // the OWNER choosing Flash: the server records a pick for the second and
+    // must not for the first, or this recovery would pin the box to Flash for
+    // good (TASK-713).
+    expect(modelWrites(calls)).toEqual(['{"model":"deepseek/deepseek-v4-flash","automatic":true}']);
     // The failure is reported once, as itself…
     expect(occurrences("Selected AI provider is not configured")).toBe(1);
     // …and nothing claims the box was moved off the model it is still on.

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -589,6 +589,100 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(mockUnpairLocal).not.toHaveBeenCalled();
   });
 
+  /**
+   * TASK-713 — the tier badge fills in a DEFAULT, and a default never
+   * overwrites a choice.
+   *
+   * A re-pair (and the wizard finalise, which reaches this route through
+   * `clawai/poll`) arrives carrying `clawaiTier`, so the badge cannot be told
+   * apart from an owner pressing a plan card. What settles it is the other
+   * side: whether the owner has ever picked a ClawBox AI model themselves. On
+   * a Max account whose box is stamped `deviceTier: "flash"` — a state the
+   * portal keeps on purpose — an entitled Max primary was replaced by Flash on
+   * every re-pair, and the chat's own guard could not undo it because it only
+   * ever moves down.
+   */
+  describe("a re-pair never overwrites an explicit model pick", () => {
+    async function pairClawai(tier: string) {
+      return configurePost(jsonRequest({
+        provider: "clawai",
+        apiKey: "claw_token",
+        authMode: "subscription",
+        clawaiTier: tier,
+      }));
+    }
+
+    function primaryWrites(): string[] {
+      return configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch))
+        .filter((command) => command.startsWith("config set agents.defaults.model.primary "));
+    }
+
+    it("keeps the owner's Max model when the device badge says Flash", async () => {
+      mockGetAll.mockResolvedValue({
+        clawai_tier: "flash",
+        ai_model_explicit_pick: "deepseek/deepseek-v4-pro",
+      });
+
+      expect((await pairClawai("flash")).status).toBe(200);
+
+      expect(primaryWrites()).toEqual(["config set agents.defaults.model.primary deepseek/deepseek-v4-pro"]);
+    });
+
+    it("writes the tier default when the owner has never picked a model", async () => {
+      mockGetAll.mockResolvedValue({ clawai_tier: "flash" });
+
+      expect((await pairClawai("flash")).status).toBe(200);
+
+      expect(primaryWrites()).toEqual(["config set agents.defaults.model.primary deepseek/deepseek-v4-flash"]);
+    });
+
+    it("keeps the pick on a DOWNGRADE, and lets the plan error be the one that speaks", async () => {
+      // The owner's Max pick with a box now on the Flash plan. Writing Flash
+      // here would be this route deciding an entitlement question it cannot
+      // see; the turn fails with the proxy's own "Model not allowed" instead,
+      // and the picker shows what the plan does allow.
+      mockGetAll.mockResolvedValue({
+        clawai_tier: "pro",
+        ai_model_explicit_pick: "deepseek/deepseek-v4-pro",
+      });
+
+      expect((await pairClawai("flash")).status).toBe(200);
+
+      expect(primaryWrites()).toEqual(["config set agents.defaults.model.primary deepseek/deepseek-v4-pro"]);
+    });
+
+    it("treats a primary that already differs from the tier default as an explicit pick", async () => {
+      // The migration. Boxes in the field carry the state this card is about
+      // and no marker, because none existed; the primary they are running IS
+      // the evidence of the choice, and a re-pair must not be the thing that
+      // discovers it too late.
+      mockGetAll.mockResolvedValue({ clawai_tier: "flash" });
+      mockReadOpenClawConfig.mockResolvedValue({
+        agents: { defaults: { model: { primary: "deepseek/deepseek-v4-pro" } } },
+      } as never);
+
+      expect((await pairClawai("flash")).status).toBe(200);
+
+      expect(primaryWrites()).toEqual(["config set agents.defaults.model.primary deepseek/deepseek-v4-pro"]);
+      expect(mockSetMany).toHaveBeenCalledWith(
+        expect.objectContaining({ ai_model_explicit_pick: "deepseek/deepseek-v4-pro" }),
+      );
+    });
+
+    it("ignores a pick that belongs to another provider", async () => {
+      // Connecting ClawBox AI IS a provider choice. An Anthropic pick says
+      // nothing about which ClawBox AI model to run.
+      mockGetAll.mockResolvedValue({
+        clawai_tier: "pro",
+        ai_model_explicit_pick: "anthropic/claude-opus-5",
+      });
+
+      expect((await pairClawai("pro")).status).toBe(200);
+
+      expect(primaryWrites()).toEqual(["config set agents.defaults.model.primary deepseek/deepseek-v4-pro"]);
+    });
+  });
+
   it("configures ollama without apiKey", async () => {
     const res = await configurePost(jsonRequest({
       provider: "ollama",

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -38,6 +38,9 @@ vi.mock("@/lib/route-auth", async () => {
 vi.mock("@/lib/config-store", () => ({
   DATA_DIR: "/home/clawbox/clawbox/data",
   getAll: vi.fn(),
+  // The owner's explicit model picks are read and cleared through the tri-state
+  // reader, so a store that cannot be read is not mistaken for an empty one.
+  getKnown: vi.fn(),
   setMany: vi.fn(),
 }));
 
@@ -175,7 +178,7 @@ vi.mock("@/lib/local-ai-token", () => ({
   markLocalAiTokenMigrated: vi.fn(),
 }));
 
-import { getAll, setMany } from "@/lib/config-store";
+import { getAll, getKnown, setMany } from "@/lib/config-store";
 import { unpairLocal } from "@/lib/clawkeep";
 import { inferConfiguredLocalModel, readConfig, readConfigStrict, restartGateway, runOpenclawConfigSet, runOpenclawConfigSetBatch, runOpenclawConfigUnset, applyModelOverrideToAllAgentSessions, parseFullyQualifiedModel,
   setPrimaryModelWithoutCatalogValidation,
@@ -278,6 +281,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     mockFs.rm.mockResolvedValue(undefined);
     mockFs.unlink.mockResolvedValue(undefined);
     mockGetAll.mockResolvedValue({});
+    vi.mocked(getKnown).mockResolvedValue({ value: undefined, known: true });
     // A provisioned box, past the wizard: that is the shape every case here
     // means, and it is the one where step 9 waits for the gateway to come back.
     readSetupGateFacts.mockReturnValue({ setupComplete: true, passwordConfigured: true });
@@ -620,20 +624,26 @@ describe("POST /setup-api/ai-models/configure", () => {
     it("keeps the owner's Max model when the device badge says Flash", async () => {
       mockGetAll.mockResolvedValue({
         clawai_tier: "flash",
-        ai_model_explicit_pick: "deepseek/deepseek-v4-pro",
+        ai_model_explicit_picks: { clawai: "deepseek/deepseek-v4-pro" },
       });
 
-      expect((await pairClawai("flash")).status).toBe(200);
+      const body = await (await pairClawai("flash")).json();
 
       expect(primaryWrites()).toEqual(["config set agents.defaults.model.primary deepseek/deepseek-v4-pro"]);
+      // ...and the answer SAYS so, so the plan card is not a 200 over a screen
+      // where nothing appears to have happened.
+      expect(body).toMatchObject({ explicitPickKept: true, model: "deepseek/deepseek-v4-pro" });
     });
 
     it("writes the tier default when the owner has never picked a model", async () => {
+      // The control for the case above: identical on beta, and it is what says
+      // the guard is about the marker rather than about ClawBox AI saves.
       mockGetAll.mockResolvedValue({ clawai_tier: "flash" });
 
-      expect((await pairClawai("flash")).status).toBe(200);
+      const body = await (await pairClawai("flash")).json();
 
       expect(primaryWrites()).toEqual(["config set agents.defaults.model.primary deepseek/deepseek-v4-flash"]);
+      expect(body.explicitPickKept).toBeUndefined();
     });
 
     it("keeps the pick on a DOWNGRADE, and lets the plan error be the one that speaks", async () => {
@@ -643,7 +653,7 @@ describe("POST /setup-api/ai-models/configure", () => {
       // and the picker shows what the plan does allow.
       mockGetAll.mockResolvedValue({
         clawai_tier: "pro",
-        ai_model_explicit_pick: "deepseek/deepseek-v4-pro",
+        ai_model_explicit_picks: { clawai: "deepseek/deepseek-v4-pro" },
       });
 
       expect((await pairClawai("flash")).status).toBe(200);
@@ -651,35 +661,68 @@ describe("POST /setup-api/ai-models/configure", () => {
       expect(primaryWrites()).toEqual(["config set agents.defaults.model.primary deepseek/deepseek-v4-pro"]);
     });
 
-    it("treats a primary that already differs from the tier default as an explicit pick", async () => {
-      // The migration. Boxes in the field carry the state this card is about
-      // and no marker, because none existed; the primary they are running IS
-      // the evidence of the choice, and a re-pair must not be the thing that
-      // discovers it too late.
-      mockGetAll.mockResolvedValue({ clawai_tier: "flash" });
-      mockReadOpenClawConfig.mockResolvedValue({
-        agents: { defaults: { model: { primary: "deepseek/deepseek-v4-pro" } } },
-      } as never);
-
-      expect((await pairClawai("flash")).status).toBe(200);
-
-      expect(primaryWrites()).toEqual(["config set agents.defaults.model.primary deepseek/deepseek-v4-pro"]);
-      expect(mockSetMany).toHaveBeenCalledWith(
-        expect.objectContaining({ ai_model_explicit_pick: "deepseek/deepseek-v4-pro" }),
-      );
-    });
-
-    it("ignores a pick that belongs to another provider", async () => {
-      // Connecting ClawBox AI IS a provider choice. An Anthropic pick says
-      // nothing about which ClawBox AI model to run.
+    it("is not moved by a pick the owner made for a DIFFERENT provider", async () => {
+      // Connecting ClawBox AI IS a provider choice, so an Anthropic pick says
+      // nothing about which ClawBox AI model to run — and must not erase the
+      // ClawBox AI slot either, which is why the picks are keyed per provider.
       mockGetAll.mockResolvedValue({
-        clawai_tier: "pro",
-        ai_model_explicit_pick: "anthropic/claude-opus-5",
+        clawai_tier: "flash",
+        ai_model_explicit_picks: {
+          anthropic: "anthropic/claude-opus-5",
+          clawai: "deepseek/deepseek-v4-pro",
+        },
       });
+
+      expect((await pairClawai("flash")).status).toBe(200);
+
+      expect(primaryWrites()).toEqual(["config set agents.defaults.model.primary deepseek/deepseek-v4-pro"]);
+    });
+
+    it("drops the pick when the box is linked to a DIFFERENT ClawBox AI account", async () => {
+      // The choice belonged to the account that has just been replaced —
+      // the same signal this route already unpairs ClawKeep on. Imposing account
+      // A's Max model on account B's Pro plan fails every turn on a box B has
+      // only just paired.
+      mockGetAll.mockResolvedValue({
+        clawai_tier: "flash",
+        clawai_token: "claw_ACCOUNT_A",
+        ai_model_explicit_picks: { clawai: "deepseek/deepseek-v4-pro" },
+      });
+      vi.mocked(getKnown).mockResolvedValue({
+        value: { clawai: "deepseek/deepseek-v4-pro" },
+        known: true,
+      });
+
+      const res = await configurePost(jsonRequest({
+        provider: "clawai",
+        apiKey: "claw_ACCOUNT_B",
+        authMode: "subscription",
+        clawaiTier: "flash",
+      }));
+
+      expect(res.status).toBe(200);
+      expect(primaryWrites()).toEqual(["config set agents.defaults.model.primary deepseek/deepseek-v4-flash"]);
+      expect(mockSetMany).toHaveBeenCalledWith({ ai_model_explicit_picks: {} });
+    });
+
+    it("does NOT read the model the box is running as a choice", async () => {
+      // The badge and the model move at different times: the status poll
+      // persists a new portal tier within 30 s while nothing rewrites the model
+      // until the next configure, so the first configure after ANY plan change
+      // sees a primary that differs from the tier default. Reading that as a
+      // pick minted one on every upgrade — the customer pays for Max and the box
+      // could never default to it again.
+      mockGetAll.mockResolvedValue({ clawai_tier: "pro" });
+      mockReadOpenClawConfig.mockResolvedValue({
+        agents: { defaults: { model: { primary: "deepseek/deepseek-v4-flash" } } },
+      } as never);
 
       expect((await pairClawai("pro")).status).toBe(200);
 
       expect(primaryWrites()).toEqual(["config set agents.defaults.model.primary deepseek/deepseek-v4-pro"]);
+      expect(mockSetMany).not.toHaveBeenCalledWith(
+        expect.objectContaining({ ai_model_explicit_picks: expect.anything() }),
+      );
     });
   });
 

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -702,7 +702,12 @@ describe("POST /setup-api/ai-models/configure", () => {
 
       expect(res.status).toBe(200);
       expect(primaryWrites()).toEqual(["config set agents.defaults.model.primary deepseek/deepseek-v4-flash"]);
-      expect(mockSetMany).toHaveBeenCalledWith({ ai_model_explicit_picks: {} });
+      // Cleared in the SAME write that stores the replacement token, so a failed
+      // clear cannot leave account A's pick beside account B's token.
+      expect(mockSetMany).toHaveBeenCalledWith(expect.objectContaining({
+        clawai_token: "claw_ACCOUNT_B",
+        ai_model_explicit_picks: {},
+      }));
     });
 
     it("does NOT read the model the box is running as a choice", async () => {

--- a/src/tests/routes/chat-model-codex-surface.test.ts
+++ b/src/tests/routes/chat-model-codex-surface.test.ts
@@ -6,6 +6,8 @@ vi.mock("util", () => ({ promisify: vi.fn() }));
 vi.mock("@/lib/config-store", () => ({
   DATA_DIR: "/home/clawbox/clawbox/data",
   getAll: vi.fn(),
+  // A successful switch records the owner's explicit model pick (TASK-713).
+  setMany: vi.fn(),
 }));
 
 vi.mock("fs", () => ({

--- a/src/tests/routes/chat-model-codex-surface.test.ts
+++ b/src/tests/routes/chat-model-codex-surface.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/lib/config-store", () => ({
   DATA_DIR: "/home/clawbox/clawbox/data",
   getAll: vi.fn(),
   // A successful switch records the owner's explicit model pick (TASK-713).
+  getKnown: vi.fn(async () => ({ value: undefined, known: true })),
   setMany: vi.fn(),
 }));
 

--- a/src/tests/routes/chat-model-harness.test.ts
+++ b/src/tests/routes/chat-model-harness.test.ts
@@ -27,6 +27,7 @@ vi.mock("@/lib/config-store", () => ({
   DATA_DIR: "/home/clawbox/clawbox/data",
   getAll: vi.fn(),
   // A successful switch records the owner's explicit model pick (TASK-713).
+  getKnown: vi.fn(async () => ({ value: undefined, known: true })),
   setMany: vi.fn(),
 }));
 vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({

--- a/src/tests/routes/chat-model-harness.test.ts
+++ b/src/tests/routes/chat-model-harness.test.ts
@@ -26,6 +26,8 @@ vi.mock("util", () => ({ promisify: vi.fn() }));
 vi.mock("@/lib/config-store", () => ({
   DATA_DIR: "/home/clawbox/clawbox/data",
   getAll: vi.fn(),
+  // A successful switch records the owner's explicit model pick (TASK-713).
+  setMany: vi.fn(),
 }));
 vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
   notifyProviderSetChanged: vi.fn(),

--- a/src/tests/routes/chat-model-subscription-surface.test.ts
+++ b/src/tests/routes/chat-model-subscription-surface.test.ts
@@ -6,6 +6,8 @@ vi.mock("util", () => ({ promisify: vi.fn() }));
 vi.mock("@/lib/config-store", () => ({
   DATA_DIR: "/home/clawbox/clawbox/data",
   getAll: vi.fn(),
+  // A successful switch records the owner's explicit model pick (TASK-713).
+  setMany: vi.fn(),
 }));
 
 vi.mock("fs", () => ({

--- a/src/tests/routes/chat-model-subscription-surface.test.ts
+++ b/src/tests/routes/chat-model-subscription-surface.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/lib/config-store", () => ({
   DATA_DIR: "/home/clawbox/clawbox/data",
   getAll: vi.fn(),
   // A successful switch records the owner's explicit model pick (TASK-713).
+  getKnown: vi.fn(async () => ({ value: undefined, known: true })),
   setMany: vi.fn(),
 }));
 

--- a/src/tests/routes/chat-model.test.ts
+++ b/src/tests/routes/chat-model.test.ts
@@ -14,6 +14,7 @@ vi.mock("@/lib/config-store", () => ({
   getAll: vi.fn(),
   // The owner's explicit model pick is written here after a successful switch
   // (TASK-713): a picker click is the one place a choice is made.
+  getKnown: vi.fn(async () => ({ value: undefined, known: true })),
   setMany: vi.fn(),
 }));
 
@@ -516,7 +517,23 @@ describe("/setup-api/chat/model", () => {
 
       expect((await post({ model: "deepseek/deepseek-v4-pro" })).status).toBe(200);
 
-      expect(setMany).toHaveBeenCalledWith({ ai_model_explicit_pick: "deepseek/deepseek-v4-pro" });
+      expect(setMany).toHaveBeenCalledWith({
+        ai_model_explicit_picks: { clawai: "deepseek/deepseek-v4-pro" },
+      });
+    });
+
+    it("records a re-pick of the model the box already runs", async () => {
+      // Someone deliberately settled on the tier-default model has no other way
+      // to say so, and without this the badge moves them off it the day their
+      // plan changes. The Hermes picker records the same no-op for the same
+      // reason.
+      boxWithClawaiAndAnthropic();
+
+      expect((await post({ model: "deepseek/deepseek-v4-flash" })).status).toBe(200);
+
+      expect(setMany).toHaveBeenCalledWith({
+        ai_model_explicit_picks: { clawai: "deepseek/deepseek-v4-flash" },
+      });
     });
 
     it("records NOTHING for a switch the box made for itself", async () => {
@@ -529,7 +546,7 @@ describe("/setup-api/chat/model", () => {
       expect((await post({ model: "deepseek/deepseek-v4-pro", automatic: true })).status).toBe(200);
 
       expect(setMany).not.toHaveBeenCalledWith(
-        expect.objectContaining({ ai_model_explicit_pick: expect.anything() }),
+        expect.objectContaining({ ai_model_explicit_picks: expect.anything() }),
       );
     });
   });

--- a/src/tests/routes/chat-model.test.ts
+++ b/src/tests/routes/chat-model.test.ts
@@ -12,6 +12,9 @@ vi.mock("util", () => ({
 vi.mock("@/lib/config-store", () => ({
   DATA_DIR: "/home/clawbox/clawbox/data",
   getAll: vi.fn(),
+  // The owner's explicit model pick is written here after a successful switch
+  // (TASK-713): a picker click is the one place a choice is made.
+  setMany: vi.fn(),
 }));
 
 const { configSetMock } = vi.hoisted(() => ({ configSetMock: vi.fn() }));

--- a/src/tests/routes/chat-model.test.ts
+++ b/src/tests/routes/chat-model.test.ts
@@ -81,6 +81,7 @@ import { GatewayNotReadyError, inferConfiguredLocalModel, readConfig, readConfig
 import { sqliteGet, sqliteSet } from "@/lib/sqlite-store";
 import { notifyProviderSetChanged } from "@/app/setup-api/ai-models/catalog/route";
 import { readProviderRunnable } from "@/lib/provider-runnable";
+import { setMany } from "@/lib/config-store";
 import { promisify } from "util";
 
 describe("/setup-api/chat/model", () => {
@@ -477,6 +478,60 @@ describe("/setup-api/chat/model", () => {
     ]);
     expect(body.activeSource).toBe("primary");
     expect(body.activeLabel).toBe("ClawBox AI");
+  });
+
+  describe("remembering that the OWNER chose this model", () => {
+    /**
+     * TASK-713. The ClawBox AI tier badge is a device default, and every pair
+     * and re-pair wrote it over `agents.defaults.model.primary`. What stops it
+     * doing that to a model the owner chose is knowing that they chose one —
+     * and this is the click where that happens.
+     */
+    function boxWithClawaiAndAnthropic() {
+      vi.mocked(getAll).mockResolvedValue({});
+      vi.mocked(readConfig).mockResolvedValue({
+        auth: {
+          profiles: {
+            "deepseek:default": { provider: "deepseek", mode: "api_key" },
+          },
+        },
+        models: { providers: { deepseek: { models: [
+          { id: "deepseek-v4-flash", name: "ClawBox AI Flash" },
+          { id: "deepseek-v4-pro", name: "ClawBox AI Pro" },
+        ] } } },
+        agents: { defaults: { model: { primary: "deepseek/deepseek-v4-flash" } } },
+      } as never);
+    }
+
+    async function post(body: Record<string, unknown>) {
+      return POST(new Request("http://localhost/test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }));
+    }
+
+    it("records the pick after the write lands", async () => {
+      boxWithClawaiAndAnthropic();
+
+      expect((await post({ model: "deepseek/deepseek-v4-pro" })).status).toBe(200);
+
+      expect(setMany).toHaveBeenCalledWith({ ai_model_explicit_pick: "deepseek/deepseek-v4-pro" });
+    });
+
+    it("records NOTHING for a switch the box made for itself", async () => {
+      // The chat's entitlement guard drops a Max model the portal refuses down
+      // to Flash so chat keeps working. Remembering the box's own recovery as
+      // the owner's decision would pin the box to Flash for good — the tier
+      // badge could never move it again, which is the opposite of the fix.
+      boxWithClawaiAndAnthropic();
+
+      expect((await post({ model: "deepseek/deepseek-v4-pro", automatic: true })).status).toBe(200);
+
+      expect(setMany).not.toHaveBeenCalledWith(
+        expect.objectContaining({ ai_model_explicit_pick: expect.anything() }),
+      );
+    });
   });
 
   it("rejects an invalid source", async () => {

--- a/src/tests/routes/hermes/clawai-coding-agent.test.ts
+++ b/src/tests/routes/hermes/clawai-coding-agent.test.ts
@@ -19,12 +19,20 @@ const optionsMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/config-store", () => ({
   get: vi.fn(async (key: string) => store[key] ?? null),
+  // The tri-state reader the explicit-pick marker uses (TASK-713), over the
+  // same fixture store.
+  getKnown: vi.fn(async (key: string) => ({ value: store[key], known: true })),
   setMany: vi.fn(async (values: Record<string, unknown>) => {
     for (const [key, value] of Object.entries(values)) store[key] = value;
   }),
 }));
 vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn(async () => "hermes") }));
-vi.mock("@/lib/hermes-config-cache", () => ({ hermesConfigGet: vi.fn(async () => "clawai") }));
+// Key-aware: the GET now answers with the harness's OWN `model.default` while
+// ClawBox AI is the active provider (TASK-713), so a blanket "clawai" would
+// stand in for the model as well as the provider.
+vi.mock("@/lib/hermes-config-cache", () => ({
+  hermesConfigGet: vi.fn(async (key: string) => (key === "model.provider" ? "clawai" : "")),
+}));
 vi.mock("@/lib/hermes-cli", () => ({
   runHermesCli: vi.fn(async () => ({ code: 0, stdout: "", stderr: "" })),
 }));
@@ -60,7 +68,7 @@ vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: rpcMock }));
 vi.mock("@/lib/hermes-dashboard-control", () => ({ bounceHermesDashboard: vi.fn(async () => "restarted") }));
 
 import { GET, POST } from "@/app/setup-api/hermes/clawai/route";
-import { EXPLICIT_MODEL_PICK_KEY } from "@/lib/explicit-model-pick";
+import { EXPLICIT_MODEL_PICKS_KEY } from "@/lib/explicit-model-pick";
 
 /** A well-formed pasted token: charset+length is all the route checks. */
 const PASTED = "claw_abcdef0123456789";
@@ -174,8 +182,10 @@ describe("GET /setup-api/hermes/clawai", () => {
   });
 
   it("names the owner's own model when there is one, whatever the badge says", async () => {
+    // ClawBox AI is not the active provider in this fixture (`model.default` is
+    // empty), so the answer is what a link WOULD write: the pick, not the badge.
     store.clawai_tier = "flash";
-    store[EXPLICIT_MODEL_PICK_KEY] = "deepseek/deepseek-v4-pro";
+    store[EXPLICIT_MODEL_PICKS_KEY] = { clawai: "deepseek/deepseek-v4-pro" };
 
     const body = await (await GET()).json();
 

--- a/src/tests/routes/hermes/clawai-coding-agent.test.ts
+++ b/src/tests/routes/hermes/clawai-coding-agent.test.ts
@@ -35,7 +35,8 @@ const hermesConfig: Record<string, string> = {};
 vi.mock("@/lib/hermes-config-cache", () => ({
   hermesConfigGet: vi.fn(async (key: string) => hermesConfig[key] ?? ""),
 }));
-const cliMock = vi.hoisted(() => vi.fn(async () => ({ code: 0, stdout: "", stderr: "" })));
+const cliMock = vi.hoisted(() =>
+  vi.fn(async (_args: string[]) => ({ code: 0, stdout: "", stderr: "" })));
 vi.mock("@/lib/hermes-cli", () => ({
   runHermesCli: cliMock,
 }));
@@ -171,6 +172,31 @@ describe("POST /setup-api/hermes/clawai", () => {
     // ...and the badge, not the replaced account's pick, decided the model.
     const modelWrite = modelDefaultWrite();
     expect(modelWrite).toBe("deepseek-v4-flash");
+  });
+
+  it("clears the previous account's pick even when the apply then FAILS", async () => {
+    // This route stores the pasted token ITSELF and never rolls it back, while
+    // the apply's own clear rides its final `setMany` — behind a step loop that
+    // is fatal on any failing `hermes config set`. So a step that fails after
+    // the token write answered 502 with account B's token stored beside account
+    // A's pick, and every later link then read `previousToken === trimmed`, saw
+    // no account change, and wrote A's model as B's default for good. The two
+    // writes are one write now (TASK-713).
+    store.clawai_token = "claw_ACCOUNT_A0000000";
+    store[EXPLICIT_MODEL_PICKS_KEY] = { clawai: "deepseek/deepseek-v4-pro" };
+    cliMock.mockImplementation(async (args: string[]) => (
+      args[1] === "set" && args[2] === "model.default"
+        ? { code: 1, stdout: "", stderr: "config store is locked by another writer" }
+        : { code: 0, stdout: "", stderr: "" }
+    ));
+
+    const response = await POST(post({ token: PASTED, tier: "flash" }));
+
+    expect(response.status).toBe(502);
+    // The token landed, as it does on beta — and the pick it replaced did not
+    // survive it.
+    expect(store.clawai_token).toBe(PASTED);
+    expect(store[EXPLICIT_MODEL_PICKS_KEY]).toEqual({});
   });
 
   it("keeps the pick when the SAME account re-applies its tier", async () => {

--- a/src/tests/routes/hermes/clawai-coding-agent.test.ts
+++ b/src/tests/routes/hermes/clawai-coding-agent.test.ts
@@ -35,8 +35,9 @@ const hermesConfig: Record<string, string> = {};
 vi.mock("@/lib/hermes-config-cache", () => ({
   hermesConfigGet: vi.fn(async (key: string) => hermesConfig[key] ?? ""),
 }));
+const cliMock = vi.hoisted(() => vi.fn(async () => ({ code: 0, stdout: "", stderr: "" })));
 vi.mock("@/lib/hermes-cli", () => ({
-  runHermesCli: vi.fn(async () => ({ code: 0, stdout: "", stderr: "" })),
+  runHermesCli: cliMock,
 }));
 // The box already draws, so the image family cannot be what asks for a reload
 // below — anything this test counts belongs to the coding-agent family.
@@ -74,6 +75,15 @@ import { EXPLICIT_MODEL_PICKS_KEY } from "@/lib/explicit-model-pick";
 
 /** A well-formed pasted token: charset+length is all the route checks. */
 const PASTED = "claw_abcdef0123456789";
+
+/** What `hermes config set model.default` was given, if it was called. */
+function modelDefaultWrite(): string | undefined {
+  for (const call of cliMock.mock.calls as unknown as Array<[string[]]>) {
+    const args = call[0];
+    if (Array.isArray(args) && args[1] === "set" && args[2] === "model.default") return args[3];
+  }
+  return undefined;
+}
 
 function post(body: unknown): Request {
   return new Request("http://localhost/setup-api/hermes/clawai", {
@@ -113,6 +123,7 @@ function unchangedCatalogue() {
 
 beforeEach(() => {
   for (const key of Object.keys(store)) delete store[key];
+  cliMock.mockClear();
   rpcMock.mockReset();
   statusMock.mockReset();
   optionsMock.mockReset();
@@ -140,6 +151,38 @@ describe("POST /setup-api/hermes/clawai", () => {
     const response = await POST(post({ tier: "pro" }));
     expect(response.status).toBe(200);
     expect(reloadCount()).toBe(0);
+  });
+
+  it("drops the previous account's model pick when a DIFFERENT token is pasted", async () => {
+    // TASK-713, through the route rather than the helper. This route persists a
+    // pasted token BEFORE it applies it, so a `previousToken` read inside the
+    // apply would answer with the token it is being asked about: the account
+    // change would be invisible, and account A's Max choice would be handed to
+    // account B's Pro plan on a box they had only just paired. The previous
+    // token is captured here, ahead of that write, and passed in — the same
+    // shape, and for the same reason, as `codingAgentReadyBefore` beside it.
+    store.clawai_token = "claw_ACCOUNT_A0000000";
+    store[EXPLICIT_MODEL_PICKS_KEY] = { clawai: "deepseek/deepseek-v4-pro" };
+
+    const response = await POST(post({ token: PASTED, tier: "flash" }));
+
+    expect(response.status).toBe(200);
+    expect(store[EXPLICIT_MODEL_PICKS_KEY]).toEqual({});
+    // ...and the badge, not the replaced account's pick, decided the model.
+    const modelWrite = modelDefaultWrite();
+    expect(modelWrite).toBe("deepseek-v4-flash");
+  });
+
+  it("keeps the pick when the SAME account re-applies its tier", async () => {
+    store.clawai_token = PASTED;
+    store[EXPLICIT_MODEL_PICKS_KEY] = { clawai: "deepseek/deepseek-v4-pro" };
+
+    const response = await POST(post({ token: PASTED, tier: "flash" }));
+
+    expect(response.status).toBe(200);
+    expect(store[EXPLICIT_MODEL_PICKS_KEY]).toEqual({ clawai: "deepseek/deepseek-v4-pro" });
+    const modelWrite = modelDefaultWrite();
+    expect(modelWrite).toBe("deepseek-v4-pro");
   });
 
   it("still asks only ONCE when the link moves the providers too", async () => {

--- a/src/tests/routes/hermes/clawai-coding-agent.test.ts
+++ b/src/tests/routes/hermes/clawai-coding-agent.test.ts
@@ -59,7 +59,8 @@ vi.mock("@/lib/coding-agent", () => ({
 vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: rpcMock }));
 vi.mock("@/lib/hermes-dashboard-control", () => ({ bounceHermesDashboard: vi.fn(async () => "restarted") }));
 
-import { POST } from "@/app/setup-api/hermes/clawai/route";
+import { GET, POST } from "@/app/setup-api/hermes/clawai/route";
+import { EXPLICIT_MODEL_PICK_KEY } from "@/lib/explicit-model-pick";
 
 /** A well-formed pasted token: charset+length is all the route checks. */
 const PASTED = "claw_abcdef0123456789";
@@ -149,5 +150,38 @@ describe("POST /setup-api/hermes/clawai", () => {
     const response = await POST(post({ token: PASTED, tier: "flash" }));
     expect(response.status).toBe(200);
     expect(reloadCount()).toBe(1);
+  });
+});
+
+/**
+ * TASK-713 — the panel renders this field as "Model: …", so it has to name the
+ * model the box RUNS, not the one the tier badge implies. Once an explicit pick
+ * outlives the badge, those are two different questions.
+ */
+describe("GET /setup-api/hermes/clawai", () => {
+  beforeEach(() => {
+    for (const key of Object.keys(store)) delete store[key];
+    store.clawai_token = "claw_token_abc";
+  });
+
+  it("names the tier's model when the owner has picked none", async () => {
+    store.clawai_tier = "flash";
+
+    const body = await (await GET()).json();
+
+    expect(body.model).toBe("deepseek-v4-flash");
+    expect(body.tier).toBe("flash");
+  });
+
+  it("names the owner's own model when there is one, whatever the badge says", async () => {
+    store.clawai_tier = "flash";
+    store[EXPLICIT_MODEL_PICK_KEY] = "deepseek/deepseek-v4-pro";
+
+    const body = await (await GET()).json();
+
+    expect(body.model).toBe("deepseek-v4-pro");
+    // The badge itself is untouched — it is the PLAN, and it is still what the
+    // plan card renders.
+    expect(body.tier).toBe("flash");
   });
 });

--- a/src/tests/routes/hermes/clawai-coding-agent.test.ts
+++ b/src/tests/routes/hermes/clawai-coding-agent.test.ts
@@ -30,8 +30,10 @@ vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn(async () => "hermes") 
 // Key-aware: the GET now answers with the harness's OWN `model.default` while
 // ClawBox AI is the active provider (TASK-713), so a blanket "clawai" would
 // stand in for the model as well as the provider.
+/** What `hermes config get <key>` answers in a given test. */
+const hermesConfig: Record<string, string> = {};
 vi.mock("@/lib/hermes-config-cache", () => ({
-  hermesConfigGet: vi.fn(async (key: string) => (key === "model.provider" ? "clawai" : "")),
+  hermesConfigGet: vi.fn(async (key: string) => hermesConfig[key] ?? ""),
 }));
 vi.mock("@/lib/hermes-cli", () => ({
   runHermesCli: vi.fn(async () => ({ code: 0, stdout: "", stderr: "" })),
@@ -169,21 +171,28 @@ describe("POST /setup-api/hermes/clawai", () => {
 describe("GET /setup-api/hermes/clawai", () => {
   beforeEach(() => {
     for (const key of Object.keys(store)) delete store[key];
+    for (const key of Object.keys(hermesConfig)) delete hermesConfig[key];
     store.clawai_token = "claw_token_abc";
   });
 
   it("names the tier's model when the owner has picked none", async () => {
+    // Some other provider is active, so this is what a LINK would write.
+    hermesConfig["model.provider"] = "anthropic";
+    hermesConfig["model.default"] = "anthropic/claude-opus-5";
     store.clawai_tier = "flash";
 
     const body = await (await GET()).json();
 
     expect(body.model).toBe("deepseek-v4-flash");
+    expect(body.active).toBe(false);
     expect(body.tier).toBe("flash");
   });
 
   it("names the owner's own model when there is one, whatever the badge says", async () => {
-    // ClawBox AI is not the active provider in this fixture (`model.default` is
-    // empty), so the answer is what a link WOULD write: the pick, not the badge.
+    // Again a link's answer, not the box's: ClawBox AI is not the active
+    // provider here, so the pick is what would be written.
+    hermesConfig["model.provider"] = "anthropic";
+    hermesConfig["model.default"] = "anthropic/claude-opus-5";
     store.clawai_tier = "flash";
     store[EXPLICIT_MODEL_PICKS_KEY] = { clawai: "deepseek/deepseek-v4-pro" };
 
@@ -193,5 +202,20 @@ describe("GET /setup-api/hermes/clawai", () => {
     // The badge itself is untouched — it is the PLAN, and it is still what the
     // plan card renders.
     expect(body.tier).toBe("flash");
+  });
+
+  it("names what the box is CONFIGURED with while ClawBox AI is the active provider", async () => {
+    // Nothing derived can beat the harness's own answer. A pick that disagrees
+    // with `model.default` — an out-of-band `hermes config set`, a link that
+    // half-landed — must not be painted as the model in use.
+    hermesConfig["model.provider"] = "clawai";
+    hermesConfig["model.default"] = "deepseek-v4-flash";
+    store.clawai_tier = "pro";
+    store[EXPLICIT_MODEL_PICKS_KEY] = { clawai: "deepseek/deepseek-v4-pro" };
+
+    const body = await (await GET()).json();
+
+    expect(body.model).toBe("deepseek-v4-flash");
+    expect(body.active).toBe(true);
   });
 });

--- a/src/tests/routes/hermes/models-explicit-pick.test.ts
+++ b/src/tests/routes/hermes/models-explicit-pick.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * TASK-713 — the Hermes picker is one of the two places an owner CHOOSES a
+ * model, so it is one of the two places a choice is written down. The other
+ * half matters as much: this route also serves callers that name a PROVIDER and
+ * no model, and it then resolves that provider's own recommended default.
+ *
+ *   `POST /setup-api/providers/default` — "Provider only, no model. That is
+ *   deliberate: the models route then writes that provider's OWN recommended
+ *   default … the one thing a caller here cannot pick safely."
+ *   the MCP tool `ai_set_provider` — "The default model resets to that
+ *   provider's own default."
+ *
+ * Recording one of those as the owner's pick would mint a choice out of a
+ * default — the exact confusion this marker exists to end — and would let the
+ * AGENT pin the box's model on the owner's behalf.
+ */
+
+const runHermesCliMock = vi.hoisted(() => vi.fn());
+const getModelOptionsMock = vi.hoisted(() => vi.fn());
+const setManyMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: runHermesCliMock }));
+vi.mock("@/lib/hermes-model-options", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/hermes-model-options")>();
+  return { ...actual, getModelOptions: getModelOptionsMock, invalidateModelOptions: vi.fn() };
+});
+vi.mock("@/lib/hermes-local-ai", () => ({ reconcileLocalAiWithHermes: vi.fn(async () => {}) }));
+vi.mock("@/lib/hermes-clawai", () => ({ reconcileClawaiModelsWithHermes: vi.fn(async () => {}) }));
+vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn(async () => "hermes") }));
+vi.mock("@/lib/route-auth", () => ({ requireSession: vi.fn(async () => null) }));
+vi.mock("@/lib/provider-verified", () => ({ readProviderVerified: vi.fn(async () => null) }));
+vi.mock("@/lib/config-store", () => ({
+  setMany: setManyMock,
+  getKnown: vi.fn(async () => ({ value: undefined, known: true })),
+}));
+
+import { EXPLICIT_MODEL_PICKS_KEY } from "@/lib/explicit-model-pick";
+
+/** A box on Anthropic, with two models to choose between. */
+const PAYLOAD = {
+  providers: [{
+    id: "anthropic",
+    name: "Anthropic",
+    authenticated: true,
+    verified: null,
+    isUserDefined: false,
+    source: "dashboard",
+    total: 2,
+    models: [
+      { id: "anthropic/claude-opus-5", description: "" },
+      { id: "anthropic/claude-fable-5", description: "" },
+    ],
+  }],
+  current: { provider: "anthropic", model: "anthropic/claude-opus-5" },
+  reasoning: "medium",
+  fetchedAt: Date.now(),
+  source: "dashboard" as const,
+  stale: false,
+};
+
+async function save(body: Record<string, unknown>): Promise<number> {
+  const { POST } = await import("@/app/setup-api/hermes/models/route");
+  const res = await POST(new Request("http://localhost/setup-api/hermes/models", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }));
+  return res.status;
+}
+
+/** The picks written to the store by this request, if any. */
+function recordedPicks(): unknown {
+  const call = setManyMock.mock.calls.find(
+    ([values]) => values && Object.prototype.hasOwnProperty.call(values, EXPLICIT_MODEL_PICKS_KEY),
+  );
+  return call?.[0]?.[EXPLICIT_MODEL_PICKS_KEY];
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  runHermesCliMock.mockReset();
+  runHermesCliMock.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+  getModelOptionsMock.mockReset();
+  getModelOptionsMock.mockResolvedValue(structuredClone(PAYLOAD));
+  setManyMock.mockReset();
+  setManyMock.mockResolvedValue(undefined);
+});
+
+describe("POST /setup-api/hermes/models and the owner's explicit pick", () => {
+  it("records the model when the request named one", async () => {
+    expect(await save({ provider: "anthropic", model: "anthropic/claude-fable-5" })).toBe(200);
+
+    expect(recordedPicks()).toEqual({ anthropic: "anthropic/claude-fable-5" });
+  });
+
+  it("records nothing when only a PROVIDER was named", async () => {
+    // The model that lands is that provider's own recommended default, which is
+    // another default — not a choice.
+    expect(await save({ provider: "anthropic" })).toBe(200);
+
+    expect(recordedPicks()).toBeUndefined();
+  });
+
+  it("records a re-pick of the model the box already runs", async () => {
+    // The write is skipped (already equal), the choice is not.
+    expect(await save({ provider: "anthropic", model: "anthropic/claude-opus-5" })).toBe(200);
+
+    expect(recordedPicks()).toEqual({ anthropic: "anthropic/claude-opus-5" });
+  });
+});

--- a/src/tests/routes/providers/default.test.ts
+++ b/src/tests/routes/providers/default.test.ts
@@ -127,7 +127,10 @@ describe("POST /setup-api/providers/default — OpenClaw", () => {
 
     const res = await call({ provider: "anthropic" });
 
-    expect(await delegateBody(chatModelPOST)).toEqual({ model: "anthropic/claude-sonnet-4-6" });
+    expect(await delegateBody(chatModelPOST)).toEqual({
+      model: "anthropic/claude-sonnet-4-6",
+      automatic: true,
+    });
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toMatchObject({ ok: true, model: "anthropic/claude-sonnet-4-6" });
     expect(hermesModelsPOST).not.toHaveBeenCalled();
@@ -153,7 +156,34 @@ describe("POST /setup-api/providers/default — OpenClaw", () => {
     const res = await call({ provider: "google" });
 
     expect(res.status).toBe(200);
-    expect(await delegateBody(chatModelPOST)).toEqual({ model: "google/gemini-2.5-pro" });
+    expect(await delegateBody(chatModelPOST)).toEqual({
+      model: "google/gemini-2.5-pro",
+      automatic: true,
+    });
+  });
+
+  it("tells chat/model the model was RESOLVED, not named by the owner", async () => {
+    // TASK-713. The owner named a PROVIDER here; the model is the row's
+    // representative id, picked out of the picker's own state. Handing it on
+    // unmarked made `chat/model` record it as the owner's explicit model pick,
+    // and a later ClawBox AI plan upgrade then found a "pick" nobody made and
+    // left the box on the old tier's model — an upgrade that works on beta,
+    // silently defeated.
+    //
+    // This asserts the seam. The other half — that `chat/model` records nothing
+    // for such a call — is pinned by "records NOTHING for a switch the box made
+    // for itself" in chat-model.test.ts, and the two together are the chain.
+    chatModelGET.mockResolvedValue(json({
+      options: [{ id: "a", provider: "clawai", model: "deepseek/deepseek-v4-flash", available: true }],
+    }));
+    chatModelPOST.mockResolvedValue(json({ ok: true }));
+
+    await call({ provider: "clawai" });
+
+    expect(await delegateBody(chatModelPOST)).toEqual({
+      model: "deepseek/deepseek-v4-flash",
+      automatic: true,
+    });
   });
 
   it("refuses a provider this box holds no credential for", async () => {

--- a/src/tests/unit/hermes-apply-error-text.test.ts
+++ b/src/tests/unit/hermes-apply-error-text.test.ts
@@ -33,7 +33,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const cliMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
-vi.mock("@/lib/config-store", () => ({ setMany: vi.fn(), get: vi.fn(async () => null) }));
+vi.mock("@/lib/config-store", () => ({
+  setMany: vi.fn(),
+  get: vi.fn(async () => null),
+  // Read before the first write, to spot an account switch and the owner's
+  // explicit model pick (TASK-713).
+  getKnown: vi.fn(async () => ({ value: undefined, known: true })),
+}));
 // The image half of the ClawBox AI apply writes to ~/.hermes and copies a plugin
 // into it; neither belongs in this file's blast radius, and both have their own.
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));

--- a/src/tests/unit/hermes-clawai-coding-agent.test.ts
+++ b/src/tests/unit/hermes-clawai-coding-agent.test.ts
@@ -32,10 +32,13 @@ const resolveVisionMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
 vi.mock("@/lib/harness/hermes-features", () => ({ hermesAgentDrawsImages: drawsMock }));
-// `get` too: the link reads the owner's explicit model pick before deciding
-// what the tier badge may write (TASK-713). Nothing stored here, so the badge
-// decides, exactly as it did before the marker existed.
-vi.mock("@/lib/config-store", () => ({ setMany: vi.fn(), get: vi.fn(async () => null) }));
+// `getKnown` too: the link reads the owner's explicit model picks before
+// deciding what the tier badge may write (TASK-713). Nothing stored here, so the
+// badge decides, exactly as it did before the marker existed.
+vi.mock("@/lib/config-store", () => ({
+  setMany: vi.fn(),
+  getKnown: vi.fn(async () => ({ value: undefined, known: true })),
+}));
 vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));
 vi.mock("@/lib/hermes-image-plugin", async (importOriginal) => ({

--- a/src/tests/unit/hermes-clawai-coding-agent.test.ts
+++ b/src/tests/unit/hermes-clawai-coding-agent.test.ts
@@ -32,7 +32,10 @@ const resolveVisionMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
 vi.mock("@/lib/harness/hermes-features", () => ({ hermesAgentDrawsImages: drawsMock }));
-vi.mock("@/lib/config-store", () => ({ setMany: vi.fn() }));
+// `get` too: the link reads the owner's explicit model pick before deciding
+// what the tier badge may write (TASK-713). Nothing stored here, so the badge
+// decides, exactly as it did before the marker existed.
+vi.mock("@/lib/config-store", () => ({ setMany: vi.fn(), get: vi.fn(async () => null) }));
 vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));
 vi.mock("@/lib/hermes-image-plugin", async (importOriginal) => ({

--- a/src/tests/unit/hermes-clawai-explicit-pick.test.ts
+++ b/src/tests/unit/hermes-clawai-explicit-pick.test.ts
@@ -57,6 +57,33 @@ beforeEach(() => {
   store({});
 });
 
+describe("recording a pick", () => {
+  it("does not lose a slot to a write that started beside it", async () => {
+    // One KEY holds every provider's pick, so two model switches in flight
+    // together would each read the map, add their own slot and write their own
+    // snapshot — and the loser's provider would be gone. Two separate config
+    // keys could not lose each other that way; one map can.
+    const stored: Record<string, unknown> = {};
+    getKnownMock.mockImplementation(async (key: string) => ({ value: stored[key], known: true }));
+    setManyMock.mockImplementation(async (values: Record<string, unknown>) => {
+      for (const [key, value] of Object.entries(values)) stored[key] = value;
+    });
+    const { recordExplicitModelPick } = await import("@/lib/explicit-model-pick");
+
+    await Promise.all([
+      recordExplicitModelPick(`deepseek/${CLAWBOX_AI_PRO_MODEL_ID}`),
+      recordExplicitModelPick("anthropic/claude-opus-5"),
+      recordExplicitModelPick("openrouter/openai/gpt-5"),
+    ]);
+
+    expect(stored[EXPLICIT_MODEL_PICKS_KEY]).toEqual({
+      clawai: `deepseek/${CLAWBOX_AI_PRO_MODEL_ID}`,
+      anthropic: "anthropic/claude-opus-5",
+      openrouter: "openrouter/openai/gpt-5",
+    });
+  });
+});
+
 describe("a Hermes re-pair and the owner's own model", () => {
   it("writes the tier default when the owner has never picked one", async () => {
     await applyClawaiToHermes("claw_token_abc", "flash");
@@ -134,7 +161,13 @@ describe("a Hermes re-pair and the owner's own model", () => {
     // The slot is derived from a model reference that arrives in a request
     // body, so it is validated rather than trusted — a name like `__proto__`
     // has meaning to an object before it has meaning to us.
-    store({ [EXPLICIT_MODEL_PICKS_KEY]: { __proto__: CLAWBOX_AI_PRO_MODEL_ID } });
+    // Built through JSON, not an object literal: `{ __proto__: x }` sets the
+    // PROTOTYPE and creates no own property, so a literal here would pass
+    // whatever the parser did. This is the shape a hand-edited
+    // `data/config.json` actually produces.
+    store({
+      [EXPLICIT_MODEL_PICKS_KEY]: JSON.parse(`{"__proto__": "${CLAWBOX_AI_PRO_MODEL_ID}"}`),
+    });
 
     await applyClawaiToHermes("claw_token_abc", "flash");
 

--- a/src/tests/unit/hermes-clawai-explicit-pick.test.ts
+++ b/src/tests/unit/hermes-clawai-explicit-pick.test.ts
@@ -111,7 +111,12 @@ describe("a Hermes re-pair and the owner's own model", () => {
     await applyClawaiToHermes("claw_token_ACCOUNT_B", "flash");
 
     expect(modelDefaultWrite()).toBe(CLAWBOX_AI_FLASH_MODEL_ID);
-    expect(setManyMock).toHaveBeenCalledWith({ [EXPLICIT_MODEL_PICKS_KEY]: {} });
+    // Cleared in the SAME write that stores the replacement token, so a failed
+    // clear cannot leave account A's pick beside account B's token.
+    expect(setManyMock).toHaveBeenCalledWith(expect.objectContaining({
+      clawai_token: "claw_token_ACCOUNT_B",
+      [EXPLICIT_MODEL_PICKS_KEY]: {},
+    }));
   });
 
   it("keeps the pick when the same account re-pairs", async () => {

--- a/src/tests/unit/hermes-clawai-explicit-pick.test.ts
+++ b/src/tests/unit/hermes-clawai-explicit-pick.test.ts
@@ -13,16 +13,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
  */
 
 const cliMock = vi.hoisted(() => vi.fn());
-const configGetMock = vi.hoisted(() => vi.fn());
-const storeGetMock = vi.hoisted(() => vi.fn());
+const getKnownMock = vi.hoisted(() => vi.fn());
 const setManyMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
-vi.mock("@/lib/hermes-config-cache", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/lib/hermes-config-cache")>()),
-  hermesConfigGet: configGetMock,
-}));
-vi.mock("@/lib/config-store", () => ({ setMany: setManyMock, get: storeGetMock }));
+vi.mock("@/lib/config-store", () => ({ setMany: setManyMock, getKnown: getKnownMock }));
 vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));
 vi.mock("@/lib/coding-agent", () => ({ getCodingAgentStatus: vi.fn(async () => ({ ready: false })) }));
@@ -38,7 +33,7 @@ vi.mock("@/lib/clawbox-ai-vision", async (importOriginal) => ({
 
 import { applyClawaiToHermes } from "@/lib/hermes-clawai";
 import { CLAWBOX_AI_FLASH_MODEL_ID, CLAWBOX_AI_PRO_MODEL_ID } from "@/lib/clawbox-ai-models";
-import { EXPLICIT_MODEL_PICK_KEY } from "@/lib/explicit-model-pick";
+import { EXPLICIT_MODEL_PICKS_KEY } from "@/lib/explicit-model-pick";
 
 /** What `model.default` was set to, or undefined when it was never written. */
 function modelDefaultWrite(): string | undefined {
@@ -48,15 +43,18 @@ function modelDefaultWrite(): string | undefined {
   return call?.[3];
 }
 
+/** The config store this box holds. */
+function store(values: Record<string, unknown>) {
+  getKnownMock.mockImplementation(async (key: string) => ({ value: values[key], known: true }));
+}
+
 beforeEach(() => {
   cliMock.mockReset();
   cliMock.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
-  configGetMock.mockReset();
-  configGetMock.mockResolvedValue("");
-  storeGetMock.mockReset();
-  storeGetMock.mockResolvedValue(null);
+  getKnownMock.mockReset();
   setManyMock.mockReset();
   setManyMock.mockResolvedValue(undefined);
+  store({});
 });
 
 describe("a Hermes re-pair and the owner's own model", () => {
@@ -67,8 +65,7 @@ describe("a Hermes re-pair and the owner's own model", () => {
   });
 
   it("keeps the owner's Max model when the badge says Flash", async () => {
-    storeGetMock.mockImplementation(async (key: string) =>
-      key === EXPLICIT_MODEL_PICK_KEY ? CLAWBOX_AI_PRO_MODEL_ID : null);
+    store({ [EXPLICIT_MODEL_PICKS_KEY]: { clawai: CLAWBOX_AI_PRO_MODEL_ID } });
 
     await applyClawaiToHermes("claw_token_abc", "flash");
 
@@ -76,47 +73,63 @@ describe("a Hermes re-pair and the owner's own model", () => {
   });
 
   it("reads a pick the OpenClaw picker wrote fully qualified", async () => {
-    // The marker is one key for both editions, and the two pickers spell the
+    // The marker is one store for both editions, and the two pickers spell the
     // same model differently — a box migrated between them must not lose the
     // choice to a slash.
-    storeGetMock.mockImplementation(async (key: string) =>
-      key === EXPLICIT_MODEL_PICK_KEY ? `deepseek/${CLAWBOX_AI_PRO_MODEL_ID}` : null);
+    store({ [EXPLICIT_MODEL_PICKS_KEY]: { clawai: `deepseek/${CLAWBOX_AI_PRO_MODEL_ID}` } });
 
     await applyClawaiToHermes("claw_token_abc", "flash");
 
     expect(modelDefaultWrite()).toBe(CLAWBOX_AI_PRO_MODEL_ID);
   });
 
-  it("treats a running model that differs from the badge as the pick, and writes it down", async () => {
-    // The migration: boxes in the field are in exactly this state and carry no
-    // marker, because none existed.
-    configGetMock.mockImplementation(async (key: string) =>
-      key === "model.default" ? CLAWBOX_AI_PRO_MODEL_ID : "");
+  it("is not moved by a pick the owner made for a DIFFERENT provider", async () => {
+    // Connecting ClawBox AI is itself a provider choice, and the Anthropic slot
+    // says nothing about which ClawBox AI model to run — but it must not erase
+    // the ClawBox AI slot either, which is why the picks are keyed per provider.
+    store({
+      [EXPLICIT_MODEL_PICKS_KEY]: {
+        anthropic: "anthropic/claude-opus-5",
+        clawai: CLAWBOX_AI_PRO_MODEL_ID,
+      },
+    });
 
     await applyClawaiToHermes("claw_token_abc", "flash");
 
     expect(modelDefaultWrite()).toBe(CLAWBOX_AI_PRO_MODEL_ID);
-    expect(setManyMock).toHaveBeenCalledWith(
-      expect.objectContaining({ [EXPLICIT_MODEL_PICK_KEY]: CLAWBOX_AI_PRO_MODEL_ID }),
-    );
   });
 
-  it("lets the badge decide when the config could not be read at all", async () => {
-    // An unreadable `model.default` is not evidence of a choice. The badge
-    // fills the gap, exactly as on beta.
-    configGetMock.mockRejectedValue(new Error("hermes config get failed"));
+  it("drops the pick when the box is linked to a DIFFERENT ClawBox AI account", async () => {
+    // The choice belonged to the account that has just been replaced. Imposing
+    // it on the next one hands the new owner a model their plan may refuse —
+    // and every turn fails on a box they have only just paired.
+    store({
+      clawai_token: "claw_token_ACCOUNT_A",
+      [EXPLICIT_MODEL_PICKS_KEY]: { clawai: CLAWBOX_AI_PRO_MODEL_ID },
+    });
 
-    await applyClawaiToHermes("claw_token_abc", "pro");
+    await applyClawaiToHermes("claw_token_ACCOUNT_B", "flash");
+
+    expect(modelDefaultWrite()).toBe(CLAWBOX_AI_FLASH_MODEL_ID);
+    expect(setManyMock).toHaveBeenCalledWith({ [EXPLICIT_MODEL_PICKS_KEY]: {} });
+  });
+
+  it("keeps the pick when the same account re-pairs", async () => {
+    store({
+      clawai_token: "claw_token_ACCOUNT_A",
+      [EXPLICIT_MODEL_PICKS_KEY]: { clawai: CLAWBOX_AI_PRO_MODEL_ID },
+    });
+
+    await applyClawaiToHermes("claw_token_ACCOUNT_A", "flash");
 
     expect(modelDefaultWrite()).toBe(CLAWBOX_AI_PRO_MODEL_ID);
-    expect(setManyMock).not.toHaveBeenCalledWith(
-      expect.objectContaining({ [EXPLICIT_MODEL_PICK_KEY]: expect.anything() }),
-    );
   });
 
-  it("ignores a pick that belongs to another provider", async () => {
-    storeGetMock.mockImplementation(async (key: string) =>
-      key === EXPLICIT_MODEL_PICK_KEY ? "anthropic/claude-opus-5" : null);
+  it("lets the badge decide when the store could not be read at all", async () => {
+    // Beta's answer, kept on purpose: a link that writes no model is a box with
+    // no working chat, and bookkeeping we could not read is not worth holding a
+    // pairing hostage to.
+    getKnownMock.mockResolvedValue({ value: undefined, known: false });
 
     await applyClawaiToHermes("claw_token_abc", "pro");
 

--- a/src/tests/unit/hermes-clawai-explicit-pick.test.ts
+++ b/src/tests/unit/hermes-clawai-explicit-pick.test.ts
@@ -125,6 +125,17 @@ describe("a Hermes re-pair and the owner's own model", () => {
     expect(modelDefaultWrite()).toBe(CLAWBOX_AI_PRO_MODEL_ID);
   });
 
+  it("refuses a stored slot that is not a provider name", async () => {
+    // The slot is derived from a model reference that arrives in a request
+    // body, so it is validated rather than trusted — a name like `__proto__`
+    // has meaning to an object before it has meaning to us.
+    store({ [EXPLICIT_MODEL_PICKS_KEY]: { __proto__: CLAWBOX_AI_PRO_MODEL_ID } });
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(modelDefaultWrite()).toBe(CLAWBOX_AI_FLASH_MODEL_ID);
+  });
+
   it("lets the badge decide when the store could not be read at all", async () => {
     // Beta's answer, kept on purpose: a link that writes no model is a box with
     // no working chat, and bookkeeping we could not read is not worth holding a

--- a/src/tests/unit/hermes-clawai-explicit-pick.test.ts
+++ b/src/tests/unit/hermes-clawai-explicit-pick.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * TASK-713, the Hermes leg — the ClawBox AI tier badge fills in a DEFAULT, and
+ * a default never overwrites a choice.
+ *
+ * `applyClawaiToHermes` runs on every link, re-link, pasted token and plan-card
+ * press, and it wrote `model.default = clawaiModelForTier(badge)` every time.
+ * The badge follows the portal's `deviceTier`, which is a device default a Max
+ * subscriber may deliberately leave on Flash for one box — so a re-pair
+ * replaced an entitled Max model with Flash, and nothing on the box could put
+ * it back except the owner noticing and picking it again.
+ */
+
+const cliMock = vi.hoisted(() => vi.fn());
+const configGetMock = vi.hoisted(() => vi.fn());
+const storeGetMock = vi.hoisted(() => vi.fn());
+const setManyMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
+vi.mock("@/lib/hermes-config-cache", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/hermes-config-cache")>()),
+  hermesConfigGet: configGetMock,
+}));
+vi.mock("@/lib/config-store", () => ({ setMany: setManyMock, get: storeGetMock }));
+vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
+vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));
+vi.mock("@/lib/coding-agent", () => ({ getCodingAgentStatus: vi.fn(async () => ({ ready: false })) }));
+vi.mock("@/lib/coding-agent-mcp-refresh", () => ({ refreshCodingAgentToolsIfReadinessChanged: vi.fn() }));
+vi.mock("@/lib/hermes-image-plugin", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/hermes-image-plugin")>()),
+  installHermesImagePlugin: vi.fn(),
+}));
+vi.mock("@/lib/clawbox-ai-vision", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/clawbox-ai-vision")>()),
+  resolveVisionModelId: vi.fn(async () => ({ id: "deepseek-v4-flash-vision-exp", verified: true, reason: "proxy-allows" })),
+}));
+
+import { applyClawaiToHermes } from "@/lib/hermes-clawai";
+import { CLAWBOX_AI_FLASH_MODEL_ID, CLAWBOX_AI_PRO_MODEL_ID } from "@/lib/clawbox-ai-models";
+import { EXPLICIT_MODEL_PICK_KEY } from "@/lib/explicit-model-pick";
+
+/** What `model.default` was set to, or undefined when it was never written. */
+function modelDefaultWrite(): string | undefined {
+  const call = cliMock.mock.calls
+    .map((c) => c[0] as string[])
+    .find((a) => a[1] === "set" && a[2] === "model.default");
+  return call?.[3];
+}
+
+beforeEach(() => {
+  cliMock.mockReset();
+  cliMock.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+  configGetMock.mockReset();
+  configGetMock.mockResolvedValue("");
+  storeGetMock.mockReset();
+  storeGetMock.mockResolvedValue(null);
+  setManyMock.mockReset();
+  setManyMock.mockResolvedValue(undefined);
+});
+
+describe("a Hermes re-pair and the owner's own model", () => {
+  it("writes the tier default when the owner has never picked one", async () => {
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(modelDefaultWrite()).toBe(CLAWBOX_AI_FLASH_MODEL_ID);
+  });
+
+  it("keeps the owner's Max model when the badge says Flash", async () => {
+    storeGetMock.mockImplementation(async (key: string) =>
+      key === EXPLICIT_MODEL_PICK_KEY ? CLAWBOX_AI_PRO_MODEL_ID : null);
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(modelDefaultWrite()).toBe(CLAWBOX_AI_PRO_MODEL_ID);
+  });
+
+  it("reads a pick the OpenClaw picker wrote fully qualified", async () => {
+    // The marker is one key for both editions, and the two pickers spell the
+    // same model differently — a box migrated between them must not lose the
+    // choice to a slash.
+    storeGetMock.mockImplementation(async (key: string) =>
+      key === EXPLICIT_MODEL_PICK_KEY ? `deepseek/${CLAWBOX_AI_PRO_MODEL_ID}` : null);
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(modelDefaultWrite()).toBe(CLAWBOX_AI_PRO_MODEL_ID);
+  });
+
+  it("treats a running model that differs from the badge as the pick, and writes it down", async () => {
+    // The migration: boxes in the field are in exactly this state and carry no
+    // marker, because none existed.
+    configGetMock.mockImplementation(async (key: string) =>
+      key === "model.default" ? CLAWBOX_AI_PRO_MODEL_ID : "");
+
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    expect(modelDefaultWrite()).toBe(CLAWBOX_AI_PRO_MODEL_ID);
+    expect(setManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ [EXPLICIT_MODEL_PICK_KEY]: CLAWBOX_AI_PRO_MODEL_ID }),
+    );
+  });
+
+  it("lets the badge decide when the config could not be read at all", async () => {
+    // An unreadable `model.default` is not evidence of a choice. The badge
+    // fills the gap, exactly as on beta.
+    configGetMock.mockRejectedValue(new Error("hermes config get failed"));
+
+    await applyClawaiToHermes("claw_token_abc", "pro");
+
+    expect(modelDefaultWrite()).toBe(CLAWBOX_AI_PRO_MODEL_ID);
+    expect(setManyMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ [EXPLICIT_MODEL_PICK_KEY]: expect.anything() }),
+    );
+  });
+
+  it("ignores a pick that belongs to another provider", async () => {
+    storeGetMock.mockImplementation(async (key: string) =>
+      key === EXPLICIT_MODEL_PICK_KEY ? "anthropic/claude-opus-5" : null);
+
+    await applyClawaiToHermes("claw_token_abc", "pro");
+
+    expect(modelDefaultWrite()).toBe(CLAWBOX_AI_PRO_MODEL_ID);
+  });
+});

--- a/src/tests/unit/hermes-clawai-images.test.ts
+++ b/src/tests/unit/hermes-clawai-images.test.ts
@@ -38,10 +38,13 @@ vi.mock("@/lib/coding-agent-mcp-refresh", () => ({
   refreshCodingAgentToolsIfReadinessChanged: vi.fn(),
 }));
 vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
-// `get` too: the link reads the owner's explicit model pick before deciding
-// what the tier badge may write (TASK-713). Nothing stored here, so the badge
-// decides, exactly as it did before the marker existed.
-vi.mock("@/lib/config-store", () => ({ setMany: vi.fn(), get: vi.fn(async () => null) }));
+// `getKnown` too: the link reads the owner's explicit model picks before
+// deciding what the tier badge may write (TASK-713). Nothing stored here, so the
+// badge decides, exactly as it did before the marker existed.
+vi.mock("@/lib/config-store", () => ({
+  setMany: vi.fn(),
+  getKnown: vi.fn(async () => ({ value: undefined, known: true })),
+}));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: envMock }));
 // The copy is mocked; `mergePluginsEnabled` is NOT, because the merge is the
 // part with a rule in it and it has its own reasons to be right.

--- a/src/tests/unit/hermes-clawai-images.test.ts
+++ b/src/tests/unit/hermes-clawai-images.test.ts
@@ -38,7 +38,10 @@ vi.mock("@/lib/coding-agent-mcp-refresh", () => ({
   refreshCodingAgentToolsIfReadinessChanged: vi.fn(),
 }));
 vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
-vi.mock("@/lib/config-store", () => ({ setMany: vi.fn() }));
+// `get` too: the link reads the owner's explicit model pick before deciding
+// what the tier badge may write (TASK-713). Nothing stored here, so the badge
+// decides, exactly as it did before the marker existed.
+vi.mock("@/lib/config-store", () => ({ setMany: vi.fn(), get: vi.fn(async () => null) }));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: envMock }));
 // The copy is mocked; `mergePluginsEnabled` is NOT, because the merge is the
 // part with a rule in it and it has its own reasons to be right.

--- a/src/tests/unit/hermes-clawai-vision.test.ts
+++ b/src/tests/unit/hermes-clawai-vision.test.ts
@@ -21,7 +21,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const cliMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
 vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
-vi.mock("@/lib/config-store", () => ({ setMany: vi.fn() }));
+// `get` too: the link reads the owner's explicit model pick before deciding
+// what the tier badge may write (TASK-713). Nothing stored here, so the badge
+// decides, exactly as it did before the marker existed.
+vi.mock("@/lib/config-store", () => ({ setMany: vi.fn(), get: vi.fn(async () => null) }));
 // The image half of the apply writes to ~/.hermes and copies a plugin into it.
 // Neither belongs in a unit test's blast radius, and both have their own file
 // (`hermes-clawai-images.test.ts`).

--- a/src/tests/unit/hermes-clawai-vision.test.ts
+++ b/src/tests/unit/hermes-clawai-vision.test.ts
@@ -21,10 +21,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const cliMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
 vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
-// `get` too: the link reads the owner's explicit model pick before deciding
-// what the tier badge may write (TASK-713). Nothing stored here, so the badge
-// decides, exactly as it did before the marker existed.
-vi.mock("@/lib/config-store", () => ({ setMany: vi.fn(), get: vi.fn(async () => null) }));
+// `getKnown` too: the link reads the owner's explicit model picks before
+// deciding what the tier badge may write (TASK-713). Nothing stored here, so the
+// badge decides, exactly as it did before the marker existed.
+vi.mock("@/lib/config-store", () => ({
+  setMany: vi.fn(),
+  getKnown: vi.fn(async () => ({ value: undefined, known: true })),
+}));
 // The image half of the apply writes to ~/.hermes and copies a plugin into it.
 // Neither belongs in a unit test's blast radius, and both have their own file
 // (`hermes-clawai-images.test.ts`).

--- a/src/tests/unit/hermes-clawai-voice.test.ts
+++ b/src/tests/unit/hermes-clawai-voice.test.ts
@@ -31,7 +31,10 @@ vi.mock("@/lib/hermes-image-refresh", () => ({ refreshHermesImageTools: vi.fn() 
 vi.mock("@/lib/coding-agent", () => ({ getCodingAgentStatus: vi.fn(async () => ({ ready: false })) }));
 vi.mock("@/lib/coding-agent-mcp-refresh", () => ({ refreshCodingAgentToolsIfReadinessChanged: vi.fn() }));
 vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
-vi.mock("@/lib/config-store", () => ({ setMany: vi.fn() }));
+// `get` too: the link reads the owner's explicit model pick before deciding
+// what the tier badge may write (TASK-713). Nothing stored here, so the badge
+// decides, exactly as it did before the marker existed.
+vi.mock("@/lib/config-store", () => ({ setMany: vi.fn(), get: vi.fn(async () => null) }));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));
 vi.mock("@/lib/hermes-image-plugin", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/hermes-image-plugin")>()),

--- a/src/tests/unit/hermes-clawai-voice.test.ts
+++ b/src/tests/unit/hermes-clawai-voice.test.ts
@@ -31,10 +31,13 @@ vi.mock("@/lib/hermes-image-refresh", () => ({ refreshHermesImageTools: vi.fn() 
 vi.mock("@/lib/coding-agent", () => ({ getCodingAgentStatus: vi.fn(async () => ({ ready: false })) }));
 vi.mock("@/lib/coding-agent-mcp-refresh", () => ({ refreshCodingAgentToolsIfReadinessChanged: vi.fn() }));
 vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
-// `get` too: the link reads the owner's explicit model pick before deciding
-// what the tier badge may write (TASK-713). Nothing stored here, so the badge
-// decides, exactly as it did before the marker existed.
-vi.mock("@/lib/config-store", () => ({ setMany: vi.fn(), get: vi.fn(async () => null) }));
+// `getKnown` too: the link reads the owner's explicit model picks before
+// deciding what the tier badge may write (TASK-713). Nothing stored here, so the
+// badge decides, exactly as it did before the marker existed.
+vi.mock("@/lib/config-store", () => ({
+  setMany: vi.fn(),
+  getKnown: vi.fn(async () => ({ value: undefined, known: true })),
+}));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));
 vi.mock("@/lib/hermes-image-plugin", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/hermes-image-plugin")>()),

--- a/src/tests/unit/hermes-plugins-enabled-readback.test.ts
+++ b/src/tests/unit/hermes-plugins-enabled-readback.test.ts
@@ -43,10 +43,13 @@ vi.mock("@/lib/coding-agent-mcp-refresh", () => ({
   refreshCodingAgentToolsIfReadinessChanged: vi.fn(),
 }));
 vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
-// `get` too: the link reads the owner's explicit model pick before deciding
-// what the tier badge may write (TASK-713). Nothing stored here, so the badge
-// decides, exactly as it did before the marker existed.
-vi.mock("@/lib/config-store", () => ({ setMany: vi.fn(), get: vi.fn(async () => null) }));
+// `getKnown` too: the link reads the owner's explicit model picks before
+// deciding what the tier badge may write (TASK-713). Nothing stored here, so the
+// badge decides, exactly as it did before the marker existed.
+vi.mock("@/lib/config-store", () => ({
+  setMany: vi.fn(),
+  getKnown: vi.fn(async () => ({ value: undefined, known: true })),
+}));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: envMock }));
 // The vision probe reaches the proxy over the network and waits seconds for it.
 // Nothing in this file is about vision; stubbing it keeps the suite hermetic.

--- a/src/tests/unit/hermes-plugins-enabled-readback.test.ts
+++ b/src/tests/unit/hermes-plugins-enabled-readback.test.ts
@@ -43,7 +43,10 @@ vi.mock("@/lib/coding-agent-mcp-refresh", () => ({
   refreshCodingAgentToolsIfReadinessChanged: vi.fn(),
 }));
 vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
-vi.mock("@/lib/config-store", () => ({ setMany: vi.fn() }));
+// `get` too: the link reads the owner's explicit model pick before deciding
+// what the tier badge may write (TASK-713). Nothing stored here, so the badge
+// decides, exactly as it did before the marker existed.
+vi.mock("@/lib/config-store", () => ({ setMany: vi.fn(), get: vi.fn(async () => null) }));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: envMock }));
 // The vision probe reaches the proxy over the network and waits seconds for it.
 // Nothing in this file is about vision; stubbing it keeps the suite hermetic.

--- a/src/tests/unit/hermes-provider-model-catalog.test.ts
+++ b/src/tests/unit/hermes-provider-model-catalog.test.ts
@@ -39,7 +39,10 @@ const cliMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
 const invalidateMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: invalidateMock }));
-vi.mock("@/lib/config-store", () => ({ setMany: vi.fn() }));
+// `get` too: the link reads the owner's explicit model pick before deciding
+// what the tier badge may write (TASK-713). Nothing stored here, so the badge
+// decides, exactly as it did before the marker existed.
+vi.mock("@/lib/config-store", () => ({ setMany: vi.fn(), get: vi.fn(async () => null) }));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));
 vi.mock("@/lib/coding-agent", () => ({ getCodingAgentStatus: vi.fn(async () => ({ ready: false })) }));
 vi.mock("@/lib/coding-agent-mcp-refresh", () => ({

--- a/src/tests/unit/hermes-provider-model-catalog.test.ts
+++ b/src/tests/unit/hermes-provider-model-catalog.test.ts
@@ -39,10 +39,13 @@ const cliMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
 const invalidateMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: invalidateMock }));
-// `get` too: the link reads the owner's explicit model pick before deciding
-// what the tier badge may write (TASK-713). Nothing stored here, so the badge
-// decides, exactly as it did before the marker existed.
-vi.mock("@/lib/config-store", () => ({ setMany: vi.fn(), get: vi.fn(async () => null) }));
+// `getKnown` too: the link reads the owner's explicit model picks before
+// deciding what the tier badge may write (TASK-713). Nothing stored here, so the
+// badge decides, exactly as it did before the marker existed.
+vi.mock("@/lib/config-store", () => ({
+  setMany: vi.fn(),
+  getKnown: vi.fn(async () => ({ value: undefined, known: true })),
+}));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));
 vi.mock("@/lib/coding-agent", () => ({ getCodingAgentStatus: vi.fn(async () => ({ ready: false })) }));
 vi.mock("@/lib/coding-agent-mcp-refresh", () => ({

--- a/src/tests/unit/hermes-voice-writes-once.test.ts
+++ b/src/tests/unit/hermes-voice-writes-once.test.ts
@@ -67,10 +67,13 @@ vi.mock("@/lib/hermes-image-refresh", () => ({ refreshHermesImageTools: vi.fn() 
 vi.mock("@/lib/coding-agent", () => ({ getCodingAgentStatus: vi.fn(async () => ({ ready: false })) }));
 vi.mock("@/lib/coding-agent-mcp-refresh", () => ({ refreshCodingAgentToolsIfReadinessChanged: vi.fn() }));
 vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
-// `get` too: the link reads the owner's explicit model pick before deciding
-// what the tier badge may write (TASK-713). Nothing stored here, so the badge
-// decides, exactly as it did before the marker existed.
-vi.mock("@/lib/config-store", () => ({ setMany: vi.fn(), get: vi.fn(async () => null) }));
+// `getKnown` too: the link reads the owner's explicit model picks before
+// deciding what the tier badge may write (TASK-713). Nothing stored here, so the
+// badge decides, exactly as it did before the marker existed.
+vi.mock("@/lib/config-store", () => ({
+  setMany: vi.fn(),
+  getKnown: vi.fn(async () => ({ value: undefined, known: true })),
+}));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));
 vi.mock("@/lib/hermes-image-plugin", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/hermes-image-plugin")>()),

--- a/src/tests/unit/hermes-voice-writes-once.test.ts
+++ b/src/tests/unit/hermes-voice-writes-once.test.ts
@@ -67,7 +67,10 @@ vi.mock("@/lib/hermes-image-refresh", () => ({ refreshHermesImageTools: vi.fn() 
 vi.mock("@/lib/coding-agent", () => ({ getCodingAgentStatus: vi.fn(async () => ({ ready: false })) }));
 vi.mock("@/lib/coding-agent-mcp-refresh", () => ({ refreshCodingAgentToolsIfReadinessChanged: vi.fn() }));
 vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
-vi.mock("@/lib/config-store", () => ({ setMany: vi.fn() }));
+// `get` too: the link reads the owner's explicit model pick before deciding
+// what the tier badge may write (TASK-713). Nothing stored here, so the badge
+// decides, exactly as it did before the marker existed.
+vi.mock("@/lib/config-store", () => ({ setMany: vi.fn(), get: vi.fn(async () => null) }));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));
 vi.mock("@/lib/hermes-image-plugin", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/hermes-image-plugin")>()),


### PR DESCRIPTION
## TASK-713 — a re-pair rewrote the primary model from the tier badge, over the owner's own pick

**Customer-visible symptom.** On a Max account whose box the portal stamps `deviceTier: "flash"` — a
state `mapPortalTier` preserves on purpose, because the badge is a DEVICE default and a Max subscriber
may deliberately run Flash on one box — an entitled Max primary was replaced by Flash on the next pair,
re-pair, wizard finalise or plan-card press. The chat's own guard could not put it back: that one only
ever moves down. The owner's ruling (2026-09-06): *"a re-pair NEVER overwrites an explicit pick. The
tier badge fills in a default only when there is no explicit pick; on re-pair the owner's explicit model
stays even on a downgrade — the turn then fails honestly with the plan error and the picker shows the
allowed list."*

**Cause.** `configure/route.ts` wrote `config.defaultModel = CLAWBOX_AI_MODEL_BY_TIER[badge]`
unconditionally, and `applyClawaiToHermes` wrote `model.default = clawaiModelForTier(badge)` the same
way. Neither asked whether the value they were replacing was a choice.

**Why the request cannot answer it.** A re-pair reaches the configure route through
`ai-models/clawai/poll`, which sends `clawaiTier: session.tier` — the same field the Settings plan cards
send. The two are indistinguishable on the wire, so "was a tier named?" cannot be the test. What the box
CAN know is the other half: whether the owner has ever picked a ClawBox AI model themselves.

**Harness-first: there is nothing native to borrow.** OpenClaw records `modelOverrideSource: "user"`,
but only per SESSION, and the core deletes the override when it equals the agent default — so it can
never answer this about the primary. Hermes' `model.default` carries no provenance. The ClawBox AI
portal publishes `deviceTier` (a per-device DEFAULT) and `allowedModels` (the entitlement, which
`portalDeniesClawboxAiModel` already honours), but no per-device model — and preferring the portal's own
`defaultModel` would reproduce this defect one level up, since that is a default too. openclaw.json
cannot carry a sidecar either: `models.providers.<p>.models[]` is `.strict()`. The marker is therefore
ClawBox's own, in ClawBox's own config store, beside `clawai_tier` and `ai_model_provider`. Worth asking
Mike whether a portal-side per-device *model* would retire it.

### The rule

`ai_model_explicit_picks` maps a canonical provider id to the model the owner chose for it — **per
provider**, because the readers ask a provider-specific question. One slot for the whole box answered it
wrong in the obvious case: pick ClawBox AI Max, try Anthropic for a day, re-pair ClawBox AI, and the
Anthropic pick is not a ClawBox AI answer, so the badge would overwrite a Max choice nobody revoked.

Written where a choice is MADE — and NOT where a model was merely resolved for
the owner. A provider-only gesture ("make ClawBox AI the default", the Providers-strip star, the
local-models menu's "use as fallback") names a provider and lets the server pick the model; recording
that as a choice would defeat the very upgrade this marker protects. Hermes expresses that as
`if (namedModel)`; OpenClaw cannot, because a resolved model and a chosen one are the same field on
the wire — so `/setup-api/providers/default` marks its own call, which is the side that knows.

Written where a choice is MADE:

* `POST /setup-api/chat/model` — the chat header picker, including a re-pick of the model the box
  already runs (someone who deliberately settled on the tier-default model has no other way to say so),
  and `POST /setup-api/providers/default`, which proxies to it;
* `POST /setup-api/hermes/models` — the Hermes picker, **only when the request named a model**. A
  provider-only switch resolves that provider's own recommended default, which is what
  `/setup-api/providers/default` and the MCP `ai_set_provider` tool both send deliberately; recording
  one of those would mint a choice out of a default and let the agent pin the box's model on the
  owner's behalf;
* `POST /setup-api/ai-models/configure` when the owner names a model for a cloud provider.

Read where a DEFAULT would otherwise be written: the ClawBox AI branch of the configure route (OpenClaw)
and `applyClawaiToHermes` (Hermes). One shared decision function so the two editions cannot answer
differently, and one shared bare-id tier table (`CLAWBOX_AI_MODEL_ID_BY_TIER`) replacing the hand-rolled
copy in `hermes-clawai.ts`.

**What is NOT a pick.** Two in-process callers say so with `automatic: true`, and record nothing: the
chat's entitlement guard, which drops a Max model the portal refuses down to Flash so chat keeps
working (recording that would pin the box to Flash for good), and `/setup-api/providers/default`,
where the owner named a provider and this server resolved the model.

**A pick belongs to an ACCOUNT.** On a ClawBox AI token change — the same signal the configure route
already unpairs ClawKeep on, now mirrored in `applyClawaiToHermes` — the ClawBox AI pick is dropped
before it is read, so account A's Max choice is not imposed on the Pro plan account B is paying for.

Every writer of that token drops the pick **in the same `setMany` that stores the token**, so a
failure between the two cannot leave the new account's token beside the old account's choice — a state
no later comparison could ever see, because from then on `previousToken === trimmed`. That includes
`/setup-api/hermes/clawai`, which persists a pasted token itself before the apply runs and never rolls
it back: a `hermes config set` failing after that write would otherwise have answered 502 with exactly
that pairing. One shared helper (`picksWithoutProvider`) expresses the rule for all three writers, so
a fourth finds it rather than re-deriving it; the one dead fourth site (`isLocalScope && isClawAI`,
unreachable behind a 400) carries a comment saying what it would need if that guard loosened.

**No inference from the running model, and the reason is in the module so nobody adds one back.** An
earlier revision of this branch read "the primary is a ClawBox AI model and is not the one the badge
implies" as evidence of a choice. It is not: the badge and the model move at different times.
`/setup-api/ai-models/status` persists a new portal tier on its 30-second poll while nothing rewrites
the model until the next configure, so the FIRST configure after any plan change sees exactly that
mismatch. It minted a Flash "pick" on an upgrade — the customer pays for Max and the box could never
default to it again — and a Max "pick" on a downgrade, which the plan then refuses on every turn while
the chat guard drops it back and the next re-pair re-breaks it. A pick is recorded where a pick is made,
or not at all. The cost is one more badge overwrite on a box that predates the marker; the next pick
sticks.

**Out of scope, stated rather than left silent.** OpenClaw's sticky model selection
(`modelSelectionScope`, default `"effective"`, which ClawBox never sets) propagates an owner's session
pick into `agents.defaults.model.primary` when `modelOverrideSource === "user"` — but records no
provenance where it lands. So a pick made through the core's OWN surfaces (its Control UI picker, the
core's Telegram `/model` keyboard, `openclaw models set`) reaches the primary without passing any
ClawBox route, nothing records it here, and a later re-pair still writes the badge default over it.
That is beta's behaviour, unchanged by this PR; closing it needs either a provenance field the core
does not have or a read of the core's session store at pair time.

**Concurrency.** One key holds every provider's pick, so its read-modify-write is serialised
in-process — two switches in flight together would otherwise each write their own snapshot and drop
the loser's provider. In-process is the whole of it: the Next server is this key's only writer, and
`data/config.json` has no inter-process lock to take.

**Fail-soft.** `recordExplicitModelPick` swallows and logs. It is bookkeeping — losing it costs one
overwrite, while throwing costs a model change that is already on disk, and `setMany` reads the store
strictly and throws on a `data/config.json` left root-owned by a sudo script.

**Also fixed, a sibling of the same change:** `GET /setup-api/hermes/clawai` advertised
`clawaiModelForTier(tier)`, which the Hermes provider panel renders as "Model: …". It now answers with
the harness's own `model.default` while ClawBox AI is the active provider, and with what a link would
write otherwise. And `POST /setup-api/ai-models/configure` reports `explicitPickKept: true` with the
model it kept, so the plan card is not a 200 over a screen where nothing appears to have happened.

**Deliberate consequence, per the ruling:** once a pick exists, the plan cards no longer move the model
either — they cannot be told apart from a re-pair at the route. After a plan upgrade the owner picks the
Max model in the picker, which is one click and shows the allowed list. The `explicitPickKept` flag is
the hook for saying so on that card; the copy and its ten locales are not in this PR.

### RED → GREEN

RED on unmodified beta — a re-pair on a box whose badge says Flash and whose owner picked Max:

```
FAIL src/tests/routes/ai-models/configure.test.ts > a re-pair never overwrites an explicit model pick
     > keeps the owner's Max model when the device badge says Flash
AssertionError: expected [ Array(1) ] to deeply equal [ Array(1) ]
  [
-   "config set agents.defaults.model.primary deepseek/deepseek-v4-pro",
+   "config set agents.defaults.model.primary deepseek/deepseek-v4-flash",
  ]
 ❯ src/tests/routes/ai-models/configure.test.ts:619:31
```

A second RED, for the blocking defect — an OpenClaw provider-only promote must not hand
`chat/model` a model that reads as the owner's choice:

```
FAIL src/tests/routes/providers/default.test.ts > tells chat/model the model was RESOLVED,
     not named by the owner
AssertionError: expected { model: 'deepseek/deepseek-v4-flash' } to deeply equal { …(2) }
-   "automatic": true,
    "model": "deepseek/deepseek-v4-flash",
```

And a third, for the token/pick atomicity — a `hermes config set` failing mid-apply after the route
has already stored the pasted token:

```
FAIL src/tests/routes/hermes/clawai-coding-agent.test.ts > clears the previous account's pick
     even when the apply then FAILS
AssertionError: expected { clawai: 'deepseek/deepseek-v4-pro' } to deeply equal {}
```

The three cases the brief named are covered on OpenClaw (`configure.test.ts`) and mirrored on Hermes
(`hermes-clawai-explicit-pick.test.ts`): a re-pair with a pick present leaves it alone, a re-pair with no
pick writes the tier default, a DOWNGRADE with a pick present leaves it alone. Plus: a pick for another
provider does not move ClawBox AI and is not erased by it, an account switch drops the pick, an
unreadable store lands on the badge, the running model is explicitly NOT read as a choice, and the
recording rules on both pickers (a named model records, a provider-only switch does not, an automatic
switch does not, a re-pick of the current model does).

GREEN:

```
npx vitest run src/tests/routes src/tests/unit
 Test Files  733 passed (733)
      Tests  11861 passed | 1 skipped (11862)

npx vitest run src/tests/components
 Test Files  186 passed (186)
      Tests  1607 passed (1607)
```

`npx tsc --noEmit` clean; `npx eslint` on the changed files reports nothing new.

### Device (read-only, both boxes, nothing mutated)

* OpenClaw box: `clawai_tier = pro`, `agents.defaults.model.primary = deepseek/deepseek-v4-pro`.
* Hermes box: `clawai_tier = pro`, `model.provider = clawlocal`, `model.default = gemma4-e2b-it-q4_0`.
* Neither box carries `ai_model_explicit_picks`, which is the card's premise: there was no marker. With
  no marker and no inference, a re-pair on either box behaves exactly as it does on beta, and the first
  pick made in either picker is what starts protecting the choice.

The change touches no updater, gateway, systemd unit, device path or edition lock, so CI exercises it
fully.

### Review

A merge-gate review BLOCKED an earlier head of this PR on one High defect, now fixed and covered:
an OpenClaw provider-only promote handed `chat/model` a server-resolved model unmarked, which was
then recorded as the owner's explicit pick — so a later paid ClawBox AI upgrade found a "pick" nobody
made and silently left the box on the old tier's model, an upgrade that works on beta. The rule this
PR already stated for Hermes now holds on OpenClaw too. It also caught that
`/setup-api/hermes/clawai` stores a pasted token BEFORE calling the apply, so the account-switch read
inside the apply saw the new token and `accountChanged` was never true on a real link — the previous
token is now captured ahead of that write and passed in explicitly, the same shape and for the same
reason as `codingAgentReadyBefore` beside it, with a route-level test rather than a helper-level one.

An earlier review pass, applied before that. It found the inference described above (Critical/High: it minted a pick
on both directions of a plan change) — removed entirely; the account switch (High) — the pick is now
dropped on a token change on both editions; the derived Hermes default recorded as a choice
(Medium-High) — now only a named model records; the fatal marker write (Medium-High) — now fail-soft;
the single-slot marker (Medium) — now per provider; the OpenClaw no-op path not recording (Medium) —
now records; the missing Hermes recording tests and two configure tests that also passed on beta
(Medium) — a new `models-explicit-pick.test.ts` covers the first, and the two beta-passing cases are
labelled as the controls they are and joined by cases that only pass with the fix; the misleading
docblock, the partial tier lookup and the silent success (Low) — reworded, made total again, and
reported as `explicitPickKept`.

Refuted, with the reason in the code: an unreadable config store lands on the badge rather than
declining to write a model. Beta answers the same, and a pair that writes no model at all is a box with
no working chat — bookkeeping we could not read is not worth holding a save hostage to.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - ClawBox AI and Hermes remember explicitly selected models across tier changes.
  - Tier-based defaults apply when no model preference exists.
  - Re-selecting the active model is supported.
  - Automatic fallbacks and provider-based defaults do not overwrite saved preferences.
  - Changing the linked AI account clears the previous account’s saved model selection.
  - Model status responses reflect the active or explicitly selected model.
  - Model preferences remain isolated between AI providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->