### PR TITLE
fix: scope the built-in wallpapers to the device edition

### DIFF
--- a/docs-site/editions/hermes.mdx
+++ b/docs-site/editions/hermes.mdx
@@ -46,6 +46,7 @@ not exist on the box. Everything that depended on it is gone with it:
 | Apps previously installed from the App Store | Hidden from the desktop. ClawBox webapps you or the agent built stay visible. |
 | **ClawKeep** cloud backups | Not available. ClawKeep archives the OpenClaw agent through the `openclaw` CLI, which this edition does not ship — the app opens and says so. |
 | The CLI update path (`clawbox-cli.ts update`) | **Refused.** It is an OpenClaw-edition tool. Update from **Settings → System Update** instead, which runs the edition-correct installer steps. |
+| The **ClawBox wallpaper** in Settings → Appearance | Not offered. This edition ships the Hermes artwork and Deep Space; the standard product's wallpaper is another product's branding and is not one of the choices. Wallpapers you upload yourself are unaffected. |
 
 <Warning>
 Do not try to start `clawbox-gateway.service` on a Hermes device. The unit is
@@ -57,9 +58,11 @@ the box in a state that support cannot reason about. Update through
 ## The desktop
 
 Everything else on the desktop is unchanged — Chat, Terminal, Files, Browser,
-Coding, Remote Desktop, System Update, Settings and any webapps. The ClawKeep
-icon is present but the feature is not available on this edition (see the table
-above). Two icons are specific to this edition:
+Coding, Remote Desktop, System Update, Settings and any webapps — with one
+edition difference inside Settings: **Appearance** offers the Hermes wallpaper
+and Deep Space, not the standard product's ClawBox artwork (see the table
+above). The ClawKeep icon is present but the feature is not available on this
+edition. Two icons are specific to this edition:
 
 - **Skills** — the [Hermes Skills](/editions/hermes-skills) store.
 - **Hermes** — the Hermes dashboard. It opens through an authenticated proxy on

--- a/docs-site/editions/overview.mdx
+++ b/docs-site/editions/overview.mdx
@@ -11,11 +11,13 @@ afterwards.
 
 ## The three editions
 
-| | Agent | Capability store | Desktop |
-|---|---|---|---|
-| **OpenClaw** — the standard product | OpenClaw gateway | App Store | OpenClaw Control UI |
-| **Hermes** | Hermes Agent by Nous Research | Hermes Skills | Hermes dashboard |
-| **Dual** — premium | Both, switchable at runtime | Both | Both |
+| | Agent | Capability store | Desktop | Built-in wallpapers |
+|---|---|---|---|---|
+| **OpenClaw** — the standard product | OpenClaw gateway | App Store | OpenClaw Control UI | ClawBox + Deep Space |
+| **Hermes** | Hermes Agent by Nous Research | Hermes Skills | Hermes dashboard | Hermes + Deep Space |
+| **Dual** — premium | Both, switchable at runtime | Both | Both | The active agent's, + Deep Space |
+
+Wallpapers you upload yourself are on every edition.
 
 <Columns cols={2}>
   <Card title="Hermes Edition" href="/editions/hermes" icon="feather">

--- a/e2e/helpers/clawbox.ts
+++ b/e2e/helpers/clawbox.ts
@@ -647,7 +647,7 @@ export async function installClawboxMocks(page: Page, options: MockOptions = {})
     // the App Store and the OpenClaw Control UI off the shelf — the two apps
     // store-flow and installed-app-settings drive.
     if (path === "/setup-api/harness/active") {
-      await fulfillJson(route, { active: "openclaw", edition: "openclaw", editionKnown: true });
+      await fulfillJson(route, { active: "openclaw", edition: "openclaw", activeKnown: true });
       return;
     }
 

--- a/e2e/helpers/clawbox.ts
+++ b/e2e/helpers/clawbox.ts
@@ -647,7 +647,7 @@ export async function installClawboxMocks(page: Page, options: MockOptions = {})
     // the App Store and the OpenClaw Control UI off the shelf — the two apps
     // store-flow and installed-app-settings drive.
     if (path === "/setup-api/harness/active") {
-      await fulfillJson(route, { active: "openclaw", edition: "openclaw" });
+      await fulfillJson(route, { active: "openclaw", edition: "openclaw", editionKnown: true });
       return;
     }
 

--- a/src/app/app/[id]/page.tsx
+++ b/src/app/app/[id]/page.tsx
@@ -6,12 +6,13 @@ import dynamic from "next/dynamic";
 import Image from "next/image";
 import Link from "next/link";
 import { fetchHarness } from "@/lib/client-harness";
+import { customWallpaperId, wallpaperIdAfterDelete } from "@/lib/custom-wallpapers";
 import {
-  customWallpaperId,
-  customWallpaperIndex,
-  isCustomWallpaperInRange,
-  wallpaperIdAfterDelete,
-} from "@/lib/custom-wallpapers";
+  brandingHarness,
+  brandWallpaperId,
+  builtinWallpapers,
+  renderedWallpaperId as resolveRenderedWallpaperId,
+} from "@/lib/builtin-wallpapers";
 import { apps } from "@/lib/desktop-apps";
 import { I18nProvider, useT } from "@/lib/i18n";
 import { handoffSettingsSection, STANDALONE_SETTINGS_SECTION_PARAM } from "@/lib/ui-events";
@@ -51,17 +52,15 @@ const APP_TITLES: Record<string, string> = {
 type WpFit = "fill" | "fit" | "center";
 
 /**
- * The wallpapers the desktop offers, and the localStorage key it keeps the
- * uploaded ones under. Both are mirrored from src/app/page.tsx, whose copies
- * are locals inside that page component and cannot be imported — keep the two
- * lists in step. The storage key MUST be the same string: the desktop and this
- * page are one origin, so a wallpaper added on either is the same list.
+ * The localStorage key the uploaded wallpapers live under. It MUST be the same
+ * string the desktop uses: the desktop and this page are one origin, so a
+ * wallpaper added on either is the same list.
+ *
+ * The BUILT-IN list used to be mirrored here too, with a comment asking for the
+ * two copies to be kept in step by hand. It is `builtinWallpapers()` on both
+ * surfaces now — the list is edition-scoped, and a rule applied in two places
+ * is a rule that will be applied in one.
  */
-const WALLPAPERS: { id: string; name: string; image?: string }[] = [
-  { id: "clawbox", name: "ClawBox", image: "/clawbox-wallpaper.jpeg" },
-  { id: "hermes", name: "Hermes", image: "/hermes-wallpaper.jpeg" },
-  { id: "deep-space", name: "Deep Space" },
-];
 const CUSTOM_WPS_KEY = "clawbox-custom-wallpapers";
 
 /** The wallpapers this browser was given by hand. Read where the state is
@@ -121,19 +120,15 @@ function usePreferenceSaver(loadedRef: { current: boolean }) {
  * `ui_mascot_hidden`) and the same uploaded-wallpaper list, so a change made
  * from a phone is the change the desktop would have made.
  */
-function useAppearance(enabled: boolean, activeHarness: string | null) {
-  // What a box with no custom wallpaper selected shows: the harness's own art,
-  // the same default the desktop opens a first boot on. An unresolved harness
-  // reads as ClawBox, which is also this page's initial `wallpaperId` — the
-  // probe is a same-origin call that answers long before a card can be opened
-  // and a picture deleted on it.
-  const harnessDefaultWallpaperId = activeHarness === "hermes" ? "hermes" : "clawbox";
-  // Painted vs persisted, exactly as on the desktop: this route answers
-  // `d?.active || "unknown"` on a probe that failed, and "unknown" reads as
-  // OpenClaw above. Null means the delete writes no fallback at all.
-  const persistableDefaultWallpaperId =
-    activeHarness === "hermes" || activeHarness === "openclaw" ? harnessDefaultWallpaperId : null;
-  const [wallpaperId, setWallpaperId] = useState("clawbox");
+function useAppearance(enabled: boolean, wallpaperHarness: string | null) {
+  // The built-ins this EDITION offers, and — painted vs persisted, exactly as
+  // on the desktop — what a box with nothing showable selected falls back to.
+  // `wallpaperHarness` is null until the device has named an edition, and then
+  // there is no brand to fall back to and none to write.
+  const wallpapers = builtinWallpapers(wallpaperHarness);
+  const persistableFallbackWallpaperId = brandWallpaperId(wallpaperHarness);
+  // Null until something has chosen one — see the desktop's copy of this.
+  const [wallpaperId, setWallpaperId] = useState<string | null>(null);
   const [wpFit, setWpFit] = useState<WpFit>("fill");
   const [wpBgColor, setWpBgColor] = useState("#000000");
   const [wpOpacity, setWpOpacity] = useState(50);
@@ -193,15 +188,22 @@ function useAppearance(enabled: boolean, activeHarness: string | null) {
     return () => { alive = false; };
   }, [enabled]);
 
-  const renderedWallpaperId =
-    customWallpaperIndex(wallpaperId) !== null
-      && !isCustomWallpaperInRange(wallpaperId, customWallpapers.length)
-      ? harnessDefaultWallpaperId
-      : wallpaperId;
+  // This browser's list is read synchronously into the state above, so it is
+  // never "not read yet" here — the desktop's third argument is what carries
+  // that case.
+  const renderedWallpaperId = resolveRenderedWallpaperId(
+    wallpaperId ?? "",
+    wallpaperHarness,
+    customWallpapers.length,
+  );
 
   const save = usePreferenceSaver(loaded);
   useEffect(() => {
-    save({ wp_id: wallpaperId, wp_fit: wpFit, wp_bg_color: wpBgColor, wp_opacity: wpOpacity });
+    // `wp_id` is left out while nothing has chosen one — the desktop's rule and
+    // for the same reason: this page must not pick a wallpaper box-wide for a
+    // box whose edition it could not read.
+    const appearance = { wp_fit: wpFit, wp_bg_color: wpBgColor, wp_opacity: wpOpacity };
+    save(wallpaperId === null ? appearance : { ...appearance, wp_id: wallpaperId });
   }, [wallpaperId, wpFit, wpBgColor, wpOpacity, save]);
   useEffect(() => { save({ ui_mascot_hidden: mascotHidden ? 1 : 0 }); }, [mascotHidden, save]);
   // Declared AFTER both save effects, deliberately. `loaded.current = true`
@@ -245,7 +247,7 @@ function useAppearance(enabled: boolean, activeHarness: string | null) {
       wpBgColor,
       wpOpacity,
       mascotHidden,
-      wallpapers: WALLPAPERS,
+      wallpapers,
       customWallpapers,
       onWallpaperChange: setWallpaperId,
       onWpFitChange: setWpFit,
@@ -268,7 +270,10 @@ function useAppearance(enabled: boolean, activeHarness: string | null) {
         // captured before the store above advances the ref to the shortened
         // one — not the list the saved id was originally chosen against, which
         // may have been another browser's entirely.
-        setWallpaperId(wallpaperIdAfterDelete(wallpaperId, idx, before, persistableDefaultWallpaperId));
+        //
+        // Nothing chosen yet is nothing to renumber (the desktop's rule).
+        if (wallpaperId === null) return;
+        setWallpaperId(wallpaperIdAfterDelete(wallpaperId, idx, before, persistableFallbackWallpaperId));
       },
     },
   };
@@ -312,14 +317,22 @@ export default function StandaloneAppPage() {
   // null while unresolved — a harness-only app must not paint before we know
   // which harness this device actually runs.
   const [harness, setHarness] = useState<string | null>(null);
-  const appearance = useAppearance(id === "settings", harness);
+  // Which harness's BRANDING this device wears — null while that is unknown,
+  // which is not the same question as the app gate's `harness` above. See the
+  // desktop's copy of this pair.
+  const [wallpaperHarness, setWallpaperHarness] = useState<string | null>(null);
+  const appearance = useAppearance(id === "settings", wallpaperHarness);
 
   useEffect(() => {
     let alive = true;
     // "unknown" rather than a guess: this route is reachable directly (a
     // bookmark, "Open in new tab"), so falling back to "openclaw" rendered the
     // whole OpenClaw App Store on a Hermes box whenever the probe failed.
-    void fetchHarness().then((d) => { if (alive) setHarness(d?.active || "unknown"); });
+    void fetchHarness().then((d) => {
+      if (!alive) return;
+      setHarness(d?.active || "unknown");
+      setWallpaperHarness(brandingHarness(d));
+    });
     return () => { alive = false; };
   }, []);
 

--- a/src/app/app/[id]/page.tsx
+++ b/src/app/app/[id]/page.tsx
@@ -93,9 +93,11 @@ function usePreferenceSaver(loadedRef: { current: boolean }) {
       map.clear();
     };
   }, []);
-  return useCallback((body: Record<string, unknown>) => {
+  return useCallback((body: Record<string, unknown>, slotKey?: string) => {
     if (!loadedRef.current) return;
-    const slot = Object.keys(body).join(",");
+    // An explicit slot where the body's SHAPE changes over the life of the page
+    // — see the desktop's copy.
+    const slot = slotKey ?? Object.keys(body).join(",");
     const pending = timers.current.get(slot);
     if (pending) clearTimeout(pending);
     timers.current.set(slot, setTimeout(() => {
@@ -192,7 +194,7 @@ function useAppearance(enabled: boolean, wallpaperHarness: string | null) {
   // never "not read yet" here — the desktop's third argument is what carries
   // that case.
   const renderedWallpaperId = resolveRenderedWallpaperId(
-    wallpaperId ?? "",
+    wallpaperId,
     wallpaperHarness,
     customWallpapers.length,
   );
@@ -201,9 +203,9 @@ function useAppearance(enabled: boolean, wallpaperHarness: string | null) {
   useEffect(() => {
     // `wp_id` is left out while nothing has chosen one — the desktop's rule and
     // for the same reason: this page must not pick a wallpaper box-wide for a
-    // box whose edition it could not read.
+    // box whose edition it could not read. One slot for both shapes.
     const appearance = { wp_fit: wpFit, wp_bg_color: wpBgColor, wp_opacity: wpOpacity };
-    save(wallpaperId === null ? appearance : { ...appearance, wp_id: wallpaperId });
+    save(wallpaperId === null ? appearance : { ...appearance, wp_id: wallpaperId }, "appearance");
   }, [wallpaperId, wpFit, wpBgColor, wpOpacity, save]);
   useEffect(() => { save({ ui_mascot_hidden: mascotHidden ? 1 : 0 }); }, [mascotHidden, save]);
   // Declared AFTER both save effects, deliberately. `loaded.current = true`

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,7 +46,13 @@ import type { InstalledMeta } from "@/lib/store-categories";
 import { SKILL_CHANGE_EVENT, announceSkillChange, installedAppRemovedDetail } from "@/lib/skill-change-message";
 import { apps, type AppDef } from "@/lib/desktop-apps";
 import { hiddenAppIdsForHarness, isInstalledAppVisible } from "@/lib/desktop-app-editions";
-import { customWallpaperId, customWallpaperIndex, isCustomWallpaperInRange, wallpaperIdAfterDelete } from "@/lib/custom-wallpapers";
+import { customWallpaperId, customWallpaperIndex, wallpaperIdAfterDelete } from "@/lib/custom-wallpapers";
+import {
+  brandingHarness,
+  brandWallpaperId,
+  builtinWallpapers,
+  renderedWallpaperId as resolveRenderedWallpaperId,
+} from "@/lib/builtin-wallpapers";
 import { TOAST_EVENT } from "@/components/ToastHost";
 import {
   layoutIcons,
@@ -369,6 +375,13 @@ function ChromeDesktopInner() {
   // overwrite it.
   const wallpaperChosen = useRef(false);
   const [activeHarness, setActiveHarness] = useState<string | null>(null);
+  // The harness whose BRANDING this device wears, null until the device has
+  // actually named an edition. A separate value from `activeHarness` because
+  // the two questions fail closed in different directions: "which agent runs
+  // here" may take the route's word and hide both harnesses' apps on a doubt,
+  // which is safe either way, while a BRAND shown on a doubt is the other
+  // product's artwork on the customer's screen half the time.
+  const [wallpaperHarness, setWallpaperHarness] = useState<string | null>(null);
   useEffect(() => {
     let alive = true;
     const load = async (attempt: number): Promise<void> => {
@@ -377,13 +390,18 @@ function ChromeDesktopInner() {
         if (!alive) return;
         if (d?.active) {
           setActiveHarness(d.active);
-          // A Hermes device that has never picked a wallpaper opens on the
-          // Hermes art. Guarded on wallpaperChosen because the preferences
-          // request and this one race, and a saved choice must survive
-          // whichever order they land in.
-          if (d.active === "hermes" && !wallpaperChosen.current) {
+          const branding = brandingHarness(d);
+          setWallpaperHarness(branding);
+          // A device that has never picked a wallpaper opens on its OWN
+          // edition's art — and on a device that has named no edition it opens
+          // on neither, since `brandWallpaperId` answers null there and no
+          // wallpaper is chosen at all. Guarded on wallpaperChosen because the
+          // preferences request and this one race, and a saved choice must
+          // survive whichever order they land in.
+          const brand = brandWallpaperId(branding);
+          if (brand && !wallpaperChosen.current) {
             wallpaperChosen.current = true;
-            setWallpaperId("hermes");
+            setWallpaperId(brand);
           }
           return;
         }
@@ -461,15 +479,15 @@ function ChromeDesktopInner() {
   }, []);
 
   // ─── Wallpapers ───
-  const wallpapers = [
-    { id: "clawbox", name: "ClawBox", gradient: "", stars: false, nebula: false, image: "/clawbox-wallpaper.jpeg" },
-    { id: "hermes", name: "Hermes", gradient: "", stars: false, nebula: false, image: "/hermes-wallpaper.jpeg" },
-    { id: "deep-space", name: "Deep Space", gradient: "bg-gradient-to-br from-[#0a0f1a] via-[#111827] to-[#1a1f2e]", stars: true, nebula: false, image: "" },
-  ] as const;
-  // Both wallpapers stay available on every device — this only decides which
-  // one a device that has never chosen starts on. A Hermes box opens on the
-  // Hermes art; OpenClaw is untouched.
-  const [wallpaperId, setWallpaperId] = useState("clawbox");
+  // Edition-scoped: this box's own brand plus the neutral one, and only the
+  // neutral one while the edition is unknown (src/lib/builtin-wallpapers.ts).
+  // The other product's art is not offered, not painted and not fetched.
+  const wallpapers = builtinWallpapers(wallpaperHarness);
+  // Null until something has CHOSEN one — the box's saved `wp_id`, this
+  // device's own edition once the probe answers, or the owner. What is painted
+  // meanwhile is `renderedWallpaperId` below, and nothing is written: seeding a
+  // brand here would persist it box-wide on a box whose edition never resolved.
+  const [wallpaperId, setWallpaperId] = useState<string | null>(null);
   type WpFit = "fill" | "fit" | "center";
   const [wpFit, setWpFit] = useState<WpFit>("fill");
   const [wpBgColor, setWpBgColor] = useState("#000000");
@@ -593,17 +611,11 @@ function ChromeDesktopInner() {
   // the state while leaving the mirror behind. A mirror kept in step by convention is an invisible LOST
   // write, and the purity rule cannot see one: it reports side effects INSIDE
   // an updater, never a missing ref advance outside one.
-  // What a box with no custom wallpaper selected shows — the harness's own
-  // art, the same default the mount path above picks for a first boot.
-  const harnessDefaultWallpaperId = activeHarness === "hermes" ? "hermes" : "clawbox";
-  // The same answer, but only once the probe has actually given one. The line
-  // above has to name a wallpaper to PAINT while `activeHarness` is still null,
-  // and guessing there is free — the paint corrects itself when the probe
-  // lands. Guessing in a value that gets PERSISTED box-wide is not free: an
-  // unresolved harness reads as OpenClaw, so it would write the ClawBox art
-  // over a Hermes box's selection for good. Null means "do not write one".
-  const persistableDefaultWallpaperId =
-    activeHarness === "hermes" || activeHarness === "openclaw" ? harnessDefaultWallpaperId : null;
+  // What a box with nothing showable selected PAINTS — this edition's own art,
+  // or the neutral one while the edition is unknown — against what it may
+  // WRITE, which is null until the device has named an edition. Both rules live
+  // in one module now; see the note on `persistableDefaultWallpaperId` there.
+  const persistableFallbackWallpaperId = brandWallpaperId(wallpaperHarness);
   // The fallback below has to be able to tell "no custom wallpapers" from "not
   // read yet": an empty initial state puts every `custom-<n>` out of range, so
   // without this a perfectly good selection flashes the default on every load.
@@ -661,11 +673,11 @@ function ChromeDesktopInner() {
   // So the fallback lives here, in the render, and nowhere else. `wallpaperId`
   // — the value the debounced write sends — only ever changes on an explicit
   // choice: picking a tile, uploading, or deleting the picture in use.
-  const renderedWallpaperId =
-    customWallpapersLoaded && customWallpaperIndex(wallpaperId) !== null
-      && !isCustomWallpaperInRange(wallpaperId, customWallpapers.length)
-      ? harnessDefaultWallpaperId
-      : wallpaperId;
+  const renderedWallpaperId = resolveRenderedWallpaperId(
+    wallpaperId ?? "",
+    wallpaperHarness,
+    customWallpapersLoaded ? customWallpapers.length : null,
+  );
   const currentWallpaper = wallpapers.find(w => w.id === renderedWallpaperId) || wallpapers[0];
   const wallpaperInputRef = useRef<HTMLInputElement>(null);
   const handleWallpaperUpload = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -823,7 +835,12 @@ function ChromeDesktopInner() {
   // and installed_meta are not among them.
   const savePreferences = usePreferenceWriter(prefsLoaded);
   useEffect(() => {
-    savePreferences({ wp_id: wallpaperId, wp_fit: wpFit, wp_bg_color: wpBgColor, wp_opacity: wpOpacity });
+    // `wp_id` is left OUT while nothing has chosen one. The rest of the card is
+    // still the owner's to change: a box whose edition never resolved must be
+    // able to set its fit and opacity, and must not have a wallpaper picked for
+    // it box-wide by the browser that happened to open first.
+    const appearance = { wp_fit: wpFit, wp_bg_color: wpBgColor, wp_opacity: wpOpacity };
+    savePreferences(wallpaperId === null ? appearance : { ...appearance, wp_id: wallpaperId });
   }, [wallpaperId, wpFit, wpBgColor, wpOpacity, savePreferences]);
   useEffect(() => { savePreferences({ desktop_apps: desktopApps }); }, [desktopApps, savePreferences]);
   useEffect(() => { savePreferences({ hidden_installed: hiddenInstalledApps }); }, [hiddenInstalledApps, savePreferences]);
@@ -2007,7 +2024,7 @@ function ChromeDesktopInner() {
               wpBgColor,
               wpOpacity,
               mascotHidden,
-              wallpapers: wallpapers.map(w => ({ id: w.id, name: w.name, image: w.image || undefined })),
+              wallpapers,
               customWallpapers,
               onWallpaperChange: setWallpaperId,
               onWpFitChange: setWpFit,
@@ -2035,7 +2052,13 @@ function ChromeDesktopInner() {
                 // advances the ref to the shortened one — and it is what tells
                 // the rule whether the saved id was an index into this
                 // browser's list at all.
-                setWallpaperId(wallpaperIdAfterDelete(wallpaperId, idx, before, persistableDefaultWallpaperId));
+                //
+                // Nothing chosen yet is nothing to renumber: the fallback on
+                // screen is a built-in, so no `custom-<n>` can be pointing into
+                // this list, and writing one now would persist a selection the
+                // owner never made.
+                if (wallpaperId === null) return;
+                setWallpaperId(wallpaperIdAfterDelete(wallpaperId, idx, before, persistableFallbackWallpaperId));
               },
             }} />
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -155,11 +155,15 @@ function usePreferenceWriter(loadedRef: { current: boolean }) {
       map.clear();
     };
   }, []);
-  return useCallback((body: Record<string, unknown>) => {
+  return useCallback((body: Record<string, unknown>, slotKey?: string) => {
     // Nothing is written before the saved preferences have been read: until
     // then the state is the defaults, and writing them would erase the device's.
     if (!loadedRef.current) return;
-    const slot = Object.keys(body).join(",");
+    // The key set names the slot, so a body whose SHAPE changes over the life
+    // of the page would debounce against itself: the appearance write drops
+    // `wp_id` until something has chosen one, and without an explicit slot the
+    // pending short write and the long one that replaced it would both fire.
+    const slot = slotKey ?? Object.keys(body).join(",");
     const pending = timers.current.get(slot);
     if (pending) clearTimeout(pending);
     timers.current.set(slot, setTimeout(() => {
@@ -384,6 +388,12 @@ function ChromeDesktopInner() {
   const [wallpaperHarness, setWallpaperHarness] = useState<string | null>(null);
   useEffect(() => {
     let alive = true;
+    // Backing off and giving up, shared by the two ways this can fail to
+    // answer: no reply at all, and a reply that could not name the harness.
+    const retry = (attempt: number) => {
+      if (!alive || attempt >= 2) return; // stay unresolved = stay closed
+      setTimeout(() => { if (alive) load(attempt + 1); }, 500 * (attempt + 1));
+    };
     const load = async (attempt: number): Promise<void> => {
       try {
         const d = await fetchHarness({ force: attempt > 0 });
@@ -403,12 +413,19 @@ function ChromeDesktopInner() {
             wallpaperChosen.current = true;
             setWallpaperId(brand);
           }
+          // A device that could not name its harness has not given a settled
+          // answer, only the honest one for now — and `force` re-reads the
+          // route rather than the cache, so asking again is not asking the same
+          // stale reply. install.sh truncates and rewrites the edition lock on
+          // EVERY update and the desktop reloads right after it, so a mount
+          // inside that window would otherwise wear no branding, and write no
+          // `wp_id`, for the life of the tab: the probe-once class.
+          if (!branding) retry(attempt);
           return;
         }
         throw new Error("no harness");
       } catch {
-        if (!alive || attempt >= 2) return; // stay unresolved = stay closed
-        setTimeout(() => { if (alive) load(attempt + 1); }, 500 * (attempt + 1));
+        retry(attempt);
       }
     };
     load(0);
@@ -674,7 +691,7 @@ function ChromeDesktopInner() {
   // — the value the debounced write sends — only ever changes on an explicit
   // choice: picking a tile, uploading, or deleting the picture in use.
   const renderedWallpaperId = resolveRenderedWallpaperId(
-    wallpaperId ?? "",
+    wallpaperId,
     wallpaperHarness,
     customWallpapersLoaded ? customWallpapers.length : null,
   );
@@ -838,9 +855,13 @@ function ChromeDesktopInner() {
     // `wp_id` is left OUT while nothing has chosen one. The rest of the card is
     // still the owner's to change: a box whose edition never resolved must be
     // able to set its fit and opacity, and must not have a wallpaper picked for
-    // it box-wide by the browser that happened to open first.
+    // it box-wide by the browser that happened to open first. One slot for both
+    // shapes, so the transition does not cost a second POST.
     const appearance = { wp_fit: wpFit, wp_bg_color: wpBgColor, wp_opacity: wpOpacity };
-    savePreferences(wallpaperId === null ? appearance : { ...appearance, wp_id: wallpaperId });
+    savePreferences(
+      wallpaperId === null ? appearance : { ...appearance, wp_id: wallpaperId },
+      "appearance",
+    );
   }, [wallpaperId, wpFit, wpBgColor, wpOpacity, savePreferences]);
   useEffect(() => { savePreferences({ desktop_apps: desktopApps }); }, [desktopApps, savePreferences]);
   useEffect(() => { savePreferences({ hidden_installed: hiddenInstalledApps }); }, [hiddenInstalledApps, savePreferences]);

--- a/src/app/setup-api/harness/active/route.ts
+++ b/src/app/setup-api/harness/active/route.ts
@@ -1,7 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import { getActiveHarness, getEdition } from "@/lib/harness";
+import { getActiveHarness, getEdition, getEditionSource } from "@/lib/harness";
 
 // Just the active harness — a config read, no health probes. The desktop chat
 // polls this on mount to decide how to route; the full /harness/status (with
@@ -11,6 +11,19 @@ import { getActiveHarness, getEdition } from "@/lib/harness";
 // edition-aware UI skip /harness/status, whose per-harness liveness probes cost
 // ~500 ms of retry sleep on this hardware — long enough that the AI panel used
 // to paint the OpenClaw provider list before learning it was a Hermes device.
+//
+// `editionKnown` says whether anything on this device actually NAMED an
+// edition. Both fields above collapse "nobody said" into `readEditionSource()`'s
+// own "openclaw" default — the safe way to be wrong for "which SKU is this",
+// since openclaw is the non-premium one, and the wrong way round for anything
+// that BRANDS the box: an unreadable lock (a truncated write, a permission
+// change, a partial reflash) would then dress a Hermes device as a ClawBox. A
+// caller that must not guess reads this flag and shows neither brand until it
+// is true; see src/lib/builtin-wallpapers.ts.
 export async function GET() {
-  return NextResponse.json({ active: await getActiveHarness(), edition: getEdition() });
+  return NextResponse.json({
+    active: await getActiveHarness(),
+    edition: getEdition(),
+    editionKnown: !getEditionSource().defaulted,
+  });
 }

--- a/src/app/setup-api/harness/active/route.ts
+++ b/src/app/setup-api/harness/active/route.ts
@@ -1,7 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import { getActiveHarness, getEdition, getEditionSource } from "@/lib/harness";
+import { getActiveHarnessSource, getEdition } from "@/lib/harness";
 
 // Just the active harness — a config read, no health probes. The desktop chat
 // polls this on mount to decide how to route; the full /harness/status (with
@@ -12,18 +12,16 @@ import { getActiveHarness, getEdition, getEditionSource } from "@/lib/harness";
 // ~500 ms of retry sleep on this hardware — long enough that the AI panel used
 // to paint the OpenClaw provider list before learning it was a Hermes device.
 //
-// `editionKnown` says whether anything on this device actually NAMED an
-// edition. Both fields above collapse "nobody said" into `readEditionSource()`'s
-// own "openclaw" default — the safe way to be wrong for "which SKU is this",
-// since openclaw is the non-premium one, and the wrong way round for anything
-// that BRANDS the box: an unreadable lock (a truncated write, a permission
-// change, a partial reflash) would then dress a Hermes device as a ClawBox. A
-// caller that must not guess reads this flag and shows neither brand until it
-// is true; see src/lib/builtin-wallpapers.ts.
+// `activeKnown` says whether `active` is a FACT or this device's own default.
+// Both fields above collapse "nobody could answer" into "openclaw" — the safe
+// way to be wrong for "which SKU is this", since openclaw is the non-premium
+// one, and the wrong way round for anything that BRANDS the box: an unreadable
+// edition lock, or an unreadable config store on the one SKU whose harness is a
+// runtime choice, would then dress a Hermes device as a ClawBox. A caller that
+// must not guess reads this flag and shows neither brand until it is true; see
+// src/lib/builtin-wallpapers.ts. `getActiveHarnessSource` owns the distinction,
+// so no surface re-derives it.
 export async function GET() {
-  return NextResponse.json({
-    active: await getActiveHarness(),
-    edition: getEdition(),
-    editionKnown: !getEditionSource().defaulted,
-  });
+  const { active, defaulted } = await getActiveHarnessSource();
+  return NextResponse.json({ active, edition: getEdition(), activeKnown: !defaulted });
 }

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -53,7 +53,8 @@ export interface UISettings {
   wpBgColor: string;
   wpOpacity: number;
   mascotHidden: boolean;
-  wallpapers: { id: string; name: string; image?: string }[];
+  /** Readonly: the shared built-in list is frozen per edition and never mutated here. */
+  wallpapers: readonly { id: string; name: string; image?: string }[];
   customWallpapers: string[];
   onWallpaperChange: (id: string) => void;
   onWpFitChange: (fit: "fill" | "fit" | "center") => void;
@@ -3267,6 +3268,8 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                     <button
                       key={wp.id}
                       type="button"
+                      data-testid="wallpaper-tile"
+                      data-wallpaper-id={wp.id}
                       aria-pressed={selected}
                       aria-label={wp.name}
                       onClick={() => ui.onWallpaperChange(wp.id)}

--- a/src/lib/builtin-wallpapers.ts
+++ b/src/lib/builtin-wallpapers.ts
@@ -20,18 +20,20 @@
  *
  * `harness` here is the device's OWN answer — `/setup-api/harness/active`,
  * which resolves through the root-owned edition lock (src/lib/edition-source.ts)
- * — and `null` means NOBODY HAS SAID YET, which covers three real states: the
- * probe is still in flight, the probe failed, and the lock exists but no edition
- * could be read out of it. All three are the same question to this module, and
- * the answer is the same: show the neutral wallpaper only.
+ * and, on the one SKU that leaves the harness open, the config store — and
+ * `null` means NOBODY HAS SAID YET. That covers four real states: the probe is
+ * still in flight, the probe failed, the lock exists but no edition could be
+ * read out of it, and a licensed `dual` box whose config store could not be
+ * read. All four are the same question to this module, and the answer is the
+ * same: show the neutral wallpaper only.
  *
  * That is the fail-closed direction, and it is chosen rather than inherited.
- * `readEditionSource()` collapses "nobody said" into its own "openclaw" default
- * — the right default for "which SKU is this", where guessing the non-premium
- * answer is the safe way to be wrong, and the WRONG one here, where the guess is
- * a competitor's picture across the customer's screen. So the route reports
- * whether anything actually named an edition (`editionKnown`) and this module
- * refuses to brand a box on a guess.
+ * Both of those reads collapse "nobody could answer" into "openclaw" — the
+ * right default for "which SKU is this", where guessing the non-premium answer
+ * is the safe way to be wrong, and the WRONG one here, where the guess is a
+ * competitor's picture across the customer's screen. So the route reports
+ * whether `active` is a fact (`activeKnown`, from `getActiveHarnessSource`) and
+ * this module refuses to brand a box on a guess.
  *
  * PAINTING vs PERSISTING is the rule PR #728 established for the same values
  * and it holds here: a guess is fine to paint, because the paint corrects itself
@@ -47,14 +49,19 @@ import { customWallpaperIndex } from "@/lib/custom-wallpapers";
 /** The neutral wallpaper. On every edition, and the only one on an unknown box. */
 export const DEEP_SPACE_WALLPAPER_ID = "deep-space";
 
+/**
+ * Deeply readonly: the three entries below are module-level singletons handed to
+ * every surface at once, so a field write would corrupt the painted background,
+ * both Appearance grids and the Appearance subtitle together.
+ */
 export interface BuiltinWallpaper {
-  id: string;
-  name: string;
+  readonly id: string;
+  readonly name: string;
   /** The image file, or "" when the tile is painted from `gradient`/`stars`. */
-  image: string;
-  gradient: string;
-  stars: boolean;
-  nebula: boolean;
+  readonly image: string;
+  readonly gradient: string;
+  readonly stars: boolean;
+  readonly nebula: boolean;
 }
 
 const CLAWBOX_WALLPAPER: BuiltinWallpaper = {
@@ -93,22 +100,20 @@ const HERMES_WALLPAPERS: readonly BuiltinWallpaper[] = [HERMES_WALLPAPER, DEEP_S
  * known — from the answer `fetchHarness()` gives.
  *
  * `active` rather than `edition` because the ruling says the dual SKU shows the
- * ACTIVE edition's brand, and `getActiveHarness()` is already that value on
- * every SKU: a single-harness edition is locked to itself, and only an unlocked
+ * ACTIVE edition's brand, and that value is already the active edition on every
+ * SKU: a single-harness edition is locked to itself, and only an unlocked
  * `dual` resolves a runtime choice.
  *
- * Anything but `editionKnown === true` discards `active` entirely — an absent
- * field included, since a server that predates it did not say. On a box whose
- * lock cannot be read that field is not an independent answer either:
- * `getActiveHarness()` traces back through `lockedHarness()` to the very same
- * file, so it can only echo "openclaw", on a Hermes box as readily as on an
- * OpenClaw one. Taking it would put ClawBox branding on a Hermes device, which
- * is the one outcome the ruling names.
+ * Anything but `activeKnown === true` discards `active` entirely — an absent
+ * field included, since a server that predates it did not say. Where `active`
+ * is a fallback it is a fallback to "openclaw" whatever the box really is, so
+ * taking it would put ClawBox branding on a Hermes device, which is the one
+ * outcome the ruling names.
  */
 export function brandingHarness(
-  info: { active?: string | null; editionKnown?: boolean } | null | undefined,
+  info: { active?: string | null; activeKnown?: boolean } | null | undefined,
 ): string | null {
-  if (info?.editionKnown !== true) return null;
+  if (info?.activeKnown !== true) return null;
   return info.active === "hermes" || info.active === "openclaw" ? info.active : null;
 }
 
@@ -162,14 +167,15 @@ export function defaultWallpaperId(harness: string | null): string {
  *    It resolves to this edition's own art, and the stored value stays put —
  *    the owner's next explicit pick is what replaces it.
  *
- * An empty `savedId` — nothing chosen yet — takes the same path as an unknown
- * one and lands on the default.
+ * A null `savedId` — nothing chosen yet — takes the same path as an unknown one
+ * and lands on the default.
  */
 export function renderedWallpaperId(
-  savedId: string,
+  savedId: string | null,
   harness: string | null,
   customWallpaperCount: number | null,
 ): string {
+  if (savedId === null) return defaultWallpaperId(harness);
   const customIndex = customWallpaperIndex(savedId);
   if (customIndex !== null) {
     if (customWallpaperCount === null) return savedId;

--- a/src/lib/builtin-wallpapers.ts
+++ b/src/lib/builtin-wallpapers.ts
@@ -1,0 +1,181 @@
+/**
+ * The wallpapers a ClawBox ships with, and which of them THIS edition offers.
+ *
+ * The owner's ruling (2026-09-06): "Remove the Hermes wallpaper from the
+ * OpenClaw version. And vice versa — the ClawBox wallpaper from the Hermes
+ * version." So the built-in list is edition-scoped — the OpenClaw edition
+ * offers its own brand plus the neutral Deep Space, the Hermes edition offers
+ * the Hermes art plus Deep Space, the premium `dual` SKU follows whichever
+ * harness is active, and the pictures the owner uploaded are on every edition.
+ * A customer never sees the other product's artwork on a box they bought.
+ *
+ * ONE list, because there are five readers of it — the desktop's painted
+ * background, the desktop's Appearance grid, `/app/settings`'s Appearance grid,
+ * the Appearance row's subtitle (which prints the selected wallpaper's NAME),
+ * and the upload path that appends to it. The desktop and the standalone route
+ * each held their own copy with a comment asking for them to be kept in step by
+ * hand; a rule that has to be applied twice is a rule that will be applied once.
+ *
+ * WHAT THE EDITION IS, AND WHAT IT IS NOT
+ *
+ * `harness` here is the device's OWN answer — `/setup-api/harness/active`,
+ * which resolves through the root-owned edition lock (src/lib/edition-source.ts)
+ * — and `null` means NOBODY HAS SAID YET, which covers three real states: the
+ * probe is still in flight, the probe failed, and the lock exists but no edition
+ * could be read out of it. All three are the same question to this module, and
+ * the answer is the same: show the neutral wallpaper only.
+ *
+ * That is the fail-closed direction, and it is chosen rather than inherited.
+ * `readEditionSource()` collapses "nobody said" into its own "openclaw" default
+ * — the right default for "which SKU is this", where guessing the non-premium
+ * answer is the safe way to be wrong, and the WRONG one here, where the guess is
+ * a competitor's picture across the customer's screen. So the route reports
+ * whether anything actually named an edition (`editionKnown`) and this module
+ * refuses to brand a box on a guess.
+ *
+ * PAINTING vs PERSISTING is the rule PR #728 established for the same values
+ * and it holds here: a guess is fine to paint, because the paint corrects itself
+ * the moment the device answers, and is never fine to write to `wp_id` — that
+ * key is box-wide SQLite, so a browser writing its guess there decides for every
+ * other browser and for the box's own screen, permanently. That is the whole
+ * difference between `defaultWallpaperId` (always names one) and
+ * `brandWallpaperId` (null on a doubt, and so the only one safe to write).
+ */
+
+import { customWallpaperIndex } from "@/lib/custom-wallpapers";
+
+/** The neutral wallpaper. On every edition, and the only one on an unknown box. */
+export const DEEP_SPACE_WALLPAPER_ID = "deep-space";
+
+export interface BuiltinWallpaper {
+  id: string;
+  name: string;
+  /** The image file, or "" when the tile is painted from `gradient`/`stars`. */
+  image: string;
+  gradient: string;
+  stars: boolean;
+  nebula: boolean;
+}
+
+const CLAWBOX_WALLPAPER: BuiltinWallpaper = {
+  id: "clawbox",
+  name: "ClawBox",
+  image: "/clawbox-wallpaper.jpeg",
+  gradient: "",
+  stars: false,
+  nebula: false,
+};
+
+const HERMES_WALLPAPER: BuiltinWallpaper = {
+  id: "hermes",
+  name: "Hermes",
+  image: "/hermes-wallpaper.jpeg",
+  gradient: "",
+  stars: false,
+  nebula: false,
+};
+
+const DEEP_SPACE_WALLPAPER: BuiltinWallpaper = {
+  id: DEEP_SPACE_WALLPAPER_ID,
+  name: "Deep Space",
+  image: "",
+  gradient: "bg-gradient-to-br from-[#0a0f1a] via-[#111827] to-[#1a1f2e]",
+  stars: true,
+  nebula: false,
+};
+
+const NEUTRAL_ONLY: readonly BuiltinWallpaper[] = [DEEP_SPACE_WALLPAPER];
+const OPENCLAW_WALLPAPERS: readonly BuiltinWallpaper[] = [CLAWBOX_WALLPAPER, DEEP_SPACE_WALLPAPER];
+const HERMES_WALLPAPERS: readonly BuiltinWallpaper[] = [HERMES_WALLPAPER, DEEP_SPACE_WALLPAPER];
+
+/**
+ * The harness whose branding this device shows, or null while that is not
+ * known — from the answer `fetchHarness()` gives.
+ *
+ * `active` rather than `edition` because the ruling says the dual SKU shows the
+ * ACTIVE edition's brand, and `getActiveHarness()` is already that value on
+ * every SKU: a single-harness edition is locked to itself, and only an unlocked
+ * `dual` resolves a runtime choice.
+ *
+ * Anything but `editionKnown === true` discards `active` entirely — an absent
+ * field included, since a server that predates it did not say. On a box whose
+ * lock cannot be read that field is not an independent answer either:
+ * `getActiveHarness()` traces back through `lockedHarness()` to the very same
+ * file, so it can only echo "openclaw", on a Hermes box as readily as on an
+ * OpenClaw one. Taking it would put ClawBox branding on a Hermes device, which
+ * is the one outcome the ruling names.
+ */
+export function brandingHarness(
+  info: { active?: string | null; editionKnown?: boolean } | null | undefined,
+): string | null {
+  if (info?.editionKnown !== true) return null;
+  return info.active === "hermes" || info.active === "openclaw" ? info.active : null;
+}
+
+/**
+ * This edition's own brand wallpaper, or null while the edition is unknown.
+ *
+ * The null is what makes this the ONLY one of the three answers here that may
+ * be WRITTEN. `wp_id` is box-wide SQLite, so a fallback a browser derived from
+ * a probe that had not answered is a permanent decision made on a guess — the
+ * rule #728 established for the same value. {@link defaultWallpaperId} always
+ * names something, which is right for a paint and wrong for a write.
+ */
+export function brandWallpaperId(harness: string | null): string | null {
+  if (harness === "hermes") return HERMES_WALLPAPER.id;
+  if (harness === "openclaw") return CLAWBOX_WALLPAPER.id;
+  return null;
+}
+
+/** The built-in wallpapers this edition offers, in the order they are shown. */
+export function builtinWallpapers(harness: string | null): readonly BuiltinWallpaper[] {
+  if (harness === "hermes") return HERMES_WALLPAPERS;
+  if (harness === "openclaw") return OPENCLAW_WALLPAPERS;
+  return NEUTRAL_ONLY;
+}
+
+/**
+ * What to PAINT when the saved selection cannot be shown on this device — this
+ * edition's own brand, or the neutral wallpaper while the edition is unknown.
+ *
+ * Never written anywhere; see {@link brandWallpaperId}.
+ */
+export function defaultWallpaperId(harness: string | null): string {
+  return brandWallpaperId(harness) ?? DEEP_SPACE_WALLPAPER_ID;
+}
+
+/**
+ * What is actually on screen for a saved `wp_id`, which is not always what the
+ * box holds.
+ *
+ * Two ways a selection can be unshowable here, and both heal in the RENDER and
+ * nowhere else:
+ *
+ *  - a `custom-<n>` this browser cannot answer. The pictures live in one
+ *    browser's `localStorage` while `wp_id` is box-wide, so an id past the end
+ *    of THIS list is almost always another browser's, still resolving perfectly
+ *    there (#728). `customWallpaperCount` is null while this browser's list has
+ *    not been read yet — every `custom-<n>` would be out of range against an
+ *    empty initial state, and a good selection would flash the default on load.
+ *  - a built-in this edition does not ship: the other product's brand, from a
+ *    box re-imaged onto the other edition or a choice made before the ruling.
+ *    It resolves to this edition's own art, and the stored value stays put —
+ *    the owner's next explicit pick is what replaces it.
+ *
+ * An empty `savedId` — nothing chosen yet — takes the same path as an unknown
+ * one and lands on the default.
+ */
+export function renderedWallpaperId(
+  savedId: string,
+  harness: string | null,
+  customWallpaperCount: number | null,
+): string {
+  const customIndex = customWallpaperIndex(savedId);
+  if (customIndex !== null) {
+    if (customWallpaperCount === null) return savedId;
+    return customIndex < customWallpaperCount ? savedId : defaultWallpaperId(harness);
+  }
+  return builtinWallpapers(harness).some((wp) => wp.id === savedId)
+    ? savedId
+    : defaultWallpaperId(harness);
+}

--- a/src/lib/client-harness.ts
+++ b/src/lib/client-harness.ts
@@ -22,17 +22,35 @@
  * Concurrent callers share one in-flight request instead of firing five.
  */
 
-export type HarnessInfo = { active: string; edition: string };
+export type HarnessInfo = {
+  active: string;
+  edition: string;
+  /**
+   * Whether anything on the device actually NAMED an edition, or `edition`
+   * above is `readEditionSource()`'s own "openclaw" default (no lock file, no
+   * `CLAWBOX_EDITION`, or a lock that could not be parsed).
+   *
+   * Cached with `edition` and for the same reason: both come from a root-owned
+   * file that only an edition switch rewrites. A caller that must not guess —
+   * anything that BRANDS the box — reads this before believing `active` either,
+   * since on an unreadable lock that field traces back through
+   * `lockedHarness()` to the very same file and can only echo "openclaw".
+   *
+   * False for a server that predates the field, which is the honest reading: it
+   * did not say.
+   */
+  editionKnown: boolean;
+};
 
 const ACTIVE_TTL_MS = 5_000;
 
-let editionCache: string | null = null;
+let editionCache: { value: string; known: boolean } | null = null;
 let activeCache: { value: string; at: number } | null = null;
 let inFlight: Promise<HarnessInfo | null> | null = null;
 
 /** The edition if it is already known, else null. Never triggers a fetch. */
 export function cachedEdition(): string | null {
-  return editionCache;
+  return editionCache?.value ?? null;
 }
 
 /** The active harness if a fresh value is cached, else null. Never fetches. */
@@ -65,7 +83,7 @@ export function fetchHarness(options?: {
 }): Promise<HarnessInfo | null> {
   const active = options?.force ? null : cachedActiveHarness();
   if (active !== null && editionCache !== null) {
-    return Promise.resolve({ active, edition: editionCache });
+    return Promise.resolve({ active, edition: editionCache.value, editionKnown: editionCache.known });
   }
   if (inFlight && !options?.force) return inFlight;
 
@@ -75,13 +93,16 @@ export function fetchHarness(options?: {
   })
     .then((r) => (r.ok ? r.json() : null))
     .then((d: unknown) => {
-      const data = (d ?? {}) as { active?: unknown; edition?: unknown };
-      if (typeof data.edition === "string") editionCache = data.edition;
+      const data = (d ?? {}) as { active?: unknown; edition?: unknown; editionKnown?: unknown };
+      if (typeof data.edition === "string") {
+        editionCache = { value: data.edition, known: data.editionKnown === true };
+      }
       if (typeof data.active === "string") activeCache = { value: data.active, at: Date.now() };
       if (typeof data.active !== "string" && typeof data.edition !== "string") return null;
       return {
         active: typeof data.active === "string" ? data.active : "",
         edition: typeof data.edition === "string" ? data.edition : "",
+        editionKnown: data.editionKnown === true,
       };
     })
     .catch(() => null)

--- a/src/lib/client-harness.ts
+++ b/src/lib/client-harness.ts
@@ -26,31 +26,28 @@ export type HarnessInfo = {
   active: string;
   edition: string;
   /**
-   * Whether anything on the device actually NAMED an edition, or `edition`
-   * above is `readEditionSource()`'s own "openclaw" default (no lock file, no
-   * `CLAWBOX_EDITION`, or a lock that could not be parsed).
+   * Whether `active` is the device's own answer, or the default it falls back
+   * to when nothing could answer — an unreadable edition lock, or an unreadable
+   * config store on the one SKU whose harness is a runtime choice. The server
+   * owns the distinction (`getActiveHarnessSource`); this only carries it.
    *
-   * Cached with `edition` and for the same reason: both come from a root-owned
-   * file that only an edition switch rewrites. A caller that must not guess —
-   * anything that BRANDS the box — reads this before believing `active` either,
-   * since on an unreadable lock that field traces back through
-   * `lockedHarness()` to the very same file and can only echo "openclaw".
-   *
-   * False for a server that predates the field, which is the honest reading: it
-   * did not say.
+   * A caller that must not guess — anything that BRANDS the box — reads this
+   * before believing `active`. False for a server that predates the field,
+   * which is the honest reading: it did not say.
    */
-  editionKnown: boolean;
+  activeKnown: boolean;
 };
 
 const ACTIVE_TTL_MS = 5_000;
 
-let editionCache: { value: string; known: boolean } | null = null;
+let editionCache: string | null = null;
+let activeKnownCache: boolean | null = null;
 let activeCache: { value: string; at: number } | null = null;
 let inFlight: Promise<HarnessInfo | null> | null = null;
 
 /** The edition if it is already known, else null. Never triggers a fetch. */
 export function cachedEdition(): string | null {
-  return editionCache?.value ?? null;
+  return editionCache;
 }
 
 /** The active harness if a fresh value is cached, else null. Never fetches. */
@@ -62,12 +59,14 @@ export function cachedActiveHarness(): string | null {
 /** Drop the cached active harness — call after switching harnesses. */
 export function invalidateActiveHarness(): void {
   activeCache = null;
+  activeKnownCache = null;
 }
 
 /** Test seam: forget everything, including the immutable edition. */
 export function resetHarnessCache(): void {
   editionCache = null;
   activeCache = null;
+  activeKnownCache = null;
   inFlight = null;
 }
 
@@ -82,8 +81,8 @@ export function fetchHarness(options?: {
   force?: boolean;
 }): Promise<HarnessInfo | null> {
   const active = options?.force ? null : cachedActiveHarness();
-  if (active !== null && editionCache !== null) {
-    return Promise.resolve({ active, edition: editionCache.value, editionKnown: editionCache.known });
+  if (active !== null && editionCache !== null && activeKnownCache !== null) {
+    return Promise.resolve({ active, edition: editionCache, activeKnown: activeKnownCache });
   }
   if (inFlight && !options?.force) return inFlight;
 
@@ -93,16 +92,20 @@ export function fetchHarness(options?: {
   })
     .then((r) => (r.ok ? r.json() : null))
     .then((d: unknown) => {
-      const data = (d ?? {}) as { active?: unknown; edition?: unknown; editionKnown?: unknown };
-      if (typeof data.edition === "string") {
-        editionCache = { value: data.edition, known: data.editionKnown === true };
+      const data = (d ?? {}) as { active?: unknown; edition?: unknown; activeKnown?: unknown };
+      if (typeof data.edition === "string") editionCache = data.edition;
+      if (typeof data.active === "string") {
+        activeCache = { value: data.active, at: Date.now() };
+        // Cached beside `active`, not beside `edition`: it certifies THAT
+        // value, and a cached answer that dropped it would turn a fact into a
+        // doubt on the second mount.
+        activeKnownCache = data.activeKnown === true;
       }
-      if (typeof data.active === "string") activeCache = { value: data.active, at: Date.now() };
       if (typeof data.active !== "string" && typeof data.edition !== "string") return null;
       return {
         active: typeof data.active === "string" ? data.active : "",
         edition: typeof data.edition === "string" ? data.edition : "",
-        editionKnown: data.editionKnown === true,
+        activeKnown: data.activeKnown === true,
       };
     })
     .catch(() => null)

--- a/src/lib/custom-wallpapers.ts
+++ b/src/lib/custom-wallpapers.ts
@@ -53,13 +53,16 @@ export function isCustomWallpaperInRange(wallpaperId: string, count: number): bo
  *
  * `null` there means the edition is NOT KNOWN YET, and then this returns the id
  * unchanged rather than guessing. The guess would be persisted box-wide and is
- * wrong half the time: `activeHarness` unresolved reads as OpenClaw everywhere
- * it is turned into a wallpaper, so a Hermes box whose probe was slow or failed
- * would write the ClawBox art over the owner's selection, permanently, on a
- * delete that had nothing to do with the edition. The desktop already refuses
- * that write on the MOUNT path; this is the same refusal on the delete path.
- * What the owner sees meanwhile is the render fallback, which costs nothing and
- * corrects itself the moment the probe lands.
+ * wrong half the time: every read that resolves the edition falls back to
+ * OpenClaw when nothing on the device could answer, so a Hermes box whose probe
+ * was slow or failed would write the ClawBox art over the owner's selection,
+ * permanently, on a delete that had nothing to do with the edition. Callers get
+ * the null from `brandWallpaperId` (src/lib/builtin-wallpapers.ts), which is the
+ * one place that decides whether this device may be branded at all. The desktop
+ * already refuses that write on the MOUNT path; this is the same refusal on the
+ * delete path. What the owner sees meanwhile is the render fallback — the
+ * NEUTRAL wallpaper while the edition is unknown, never the other edition's
+ * brand — which costs nothing and corrects itself the moment the probe lands.
  *
  * `before` is the list as it stood BEFORE the removal, and it is what decides
  * whether the rule applies at all: renumbering only makes sense for a selection

--- a/src/lib/harness.ts
+++ b/src/lib/harness.ts
@@ -9,7 +9,7 @@
 
 import fs from "fs";
 import path from "path";
-import { get, swap } from "@/lib/config-store";
+import { getKnown, swap } from "@/lib/config-store";
 import { envPort } from "@/lib/port-probe";
 import { verifyDualLicense } from "@/lib/edition-license";
 import { readEdition, readEditionSource, type EditionSource } from "@/lib/edition-source";
@@ -119,18 +119,47 @@ export function isHarness(value: unknown): value is Harness {
   return value === "openclaw" || value === "hermes";
 }
 
-export async function getActiveHarness(): Promise<Harness> {
+/** {@link getActiveHarness}, plus whether the device actually RESOLVED it. */
+export interface ActiveHarnessSource {
+  active: Harness;
+  /**
+   * True when `active` is this module's `DEFAULT_HARNESS` because nothing on
+   * the device could answer — NOT because the device answered "openclaw".
+   *
+   * The two ways that happens are the two reads behind the value. An edition
+   * nobody named makes `lockedHarness()` itself a guess: it reads
+   * `getEdition()`, which is `readEditionSource()`'s own "openclaw" default
+   * there, so on a Hermes box with an unreadable lock this function can only
+   * say "openclaw". And on the one SKU the edition deliberately leaves open —
+   * an unlocked, licensed `dual` — the answer comes from `data/config.json`,
+   * which a `sudo` script can leave root-owned; the forgiving reader answers
+   * `undefined` to that exactly as it does to a box that has never switched.
+   *
+   * An ABSENT key is not a doubt: a `dual` box nobody has switched genuinely
+   * runs the default harness, which is why this asks `getKnown` rather than
+   * treating "no value" as "could not look". A stored value that is not a
+   * harness is the same case — `setActiveHarness` only ever writes a real one.
+   *
+   * Callers that BRAND the device read this; callers that merely route to a
+   * harness take `active` and are right either way.
+   */
+  defaulted: boolean;
+}
+
+export async function getActiveHarnessSource(): Promise<ActiveHarnessSource> {
+  if (readEditionSource().defaulted) return { active: DEFAULT_HARNESS, defaulted: true };
   // A locked (single-harness / unlicensed-dual) device ignores the stored value
   // entirely — the edition is the source of truth, so editing config.json can't
   // change which agent runs.
   const locked = lockedHarness();
-  if (locked) return locked;
-  try {
-    const value = await get(HARNESS_CONFIG_KEY);
-    return isHarness(value) ? value : DEFAULT_HARNESS;
-  } catch {
-    return DEFAULT_HARNESS;
-  }
+  if (locked) return { active: locked, defaulted: false };
+  const { value, known } = await getKnown(HARNESS_CONFIG_KEY);
+  if (!known) return { active: DEFAULT_HARNESS, defaulted: true };
+  return { active: isHarness(value) ? value : DEFAULT_HARNESS, defaulted: false };
+}
+
+export async function getActiveHarness(): Promise<Harness> {
+  return (await getActiveHarnessSource()).active;
 }
 
 /**

--- a/src/tests/components/desktop-wallpaper-delete.test.tsx
+++ b/src/tests/components/desktop-wallpaper-delete.test.tsx
@@ -44,8 +44,8 @@ const WP = [
 let savedWallpaperId = "custom-2";
 /** Which harness the box reports — the fallback wallpaper follows it. */
 let activeHarness = "openclaw";
-/** Whether anything on the device actually NAMED an edition (the lock, or the env). */
-let editionKnown = true;
+/** Whether the device could actually RESOLVE its harness, or `active` is its own default. */
+let activeKnown = true;
 /** Milliseconds the harness probe takes to answer, so a case can run inside the window where it has not. */
 let harnessDelayMs = 0;
 /** Every preference body the desktop POSTed, in order. */
@@ -71,7 +71,7 @@ function installFetch() {
     if (url.includes("/setup-api/setup/status")) return answer({ setup_complete: true });
     if (url.includes("/setup-api/harness/active")) {
       if (harnessDelayMs > 0) await new Promise((resolve) => setTimeout(resolve, harnessDelayMs));
-      return answer({ active: activeHarness, edition: activeHarness, editionKnown });
+      return answer({ active: activeHarness, edition: activeHarness, activeKnown });
     }
     if (url.includes("/setup-api/preferences?all=1")) {
       return answer({ wp_id: savedWallpaperId, wp_opacity: 100 });
@@ -123,14 +123,23 @@ async function mountDesktop(expected: string) {
   await waitFor(() => expect(wallpaperUrls().some((u) => u.includes(expected))).toBe(true));
 }
 
+/**
+ * Testing-library's implicit `findBy` budget is 1 s, which is not a load-safe
+ * one HERE: every case mounts the whole desktop shell, so under the components
+ * project's four workers the Settings window can take longer than that to paint
+ * and the failure lands as "Unable to find role=button" on a case that is not
+ * broken. The file's own `testTimeout` above is what actually bounds a hang.
+ */
+const PAINTS_SOON = { timeout: 8_000 };
+
 async function openAppearanceSettings() {
   fireEvent.contextMenu(screen.getByTestId("desktop-surface"));
-  const menu = await screen.findByTestId("desktop-context-menu");
+  const menu = await screen.findByTestId("desktop-context-menu", {}, PAINTS_SOON);
   const settings = Array.from(menu.querySelectorAll("button"))
     .find((b) => /settings/i.test(b.textContent || ""));
   expect(settings).toBeTruthy();
   fireEvent.click(settings!);
-  fireEvent.click(await screen.findByRole("button", { name: /appearance/i }));
+  fireEvent.click(await screen.findByRole("button", { name: /appearance/i }, PAINTS_SOON));
 }
 
 beforeEach(() => {
@@ -138,7 +147,7 @@ beforeEach(() => {
   window.localStorage.setItem("clawbox-custom-wallpapers", JSON.stringify(WP));
   savedWallpaperId = "custom-2";
   activeHarness = "openclaw";
-  editionKnown = true;
+  activeKnown = true;
   harnessDelayMs = 0;
   saved.length = 0;
   resetHarnessCache();
@@ -179,7 +188,7 @@ describe("deleting a custom wallpaper", () => {
     await mountDesktop(WP[2]);
 
     await openAppearanceSettings();
-    fireEvent.click(await screen.findByRole("button", { name: /Remove custom 1/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /Remove custom 1/i }, PAINTS_SOON));
 
     // It is now Custom 2 of two, but it is the same picture.
     await waitFor(() => {
@@ -200,7 +209,7 @@ describe("deleting a custom wallpaper", () => {
     await mountDesktop(WP[2]);
 
     await openAppearanceSettings();
-    fireEvent.click(await screen.findByRole("button", { name: /Remove custom 3/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /Remove custom 3/i }, PAINTS_SOON));
 
     await waitFor(() => expect(wallpaperUrls().some((u) => u.includes("hermes-wallpaper"))).toBe(true));
     expect(wallpaperUrls().some((u) => u.includes("clawbox-wallpaper"))).toBe(false);
@@ -236,7 +245,7 @@ describe("deleting a custom wallpaper", () => {
     await mountDesktop("clawbox-wallpaper");
 
     await openAppearanceSettings();
-    fireEvent.click(await screen.findByRole("button", { name: /Remove custom 1/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /Remove custom 1/i }, PAINTS_SOON));
 
     // This browser's own list did shrink — the delete is not being refused.
     await waitFor(() => {
@@ -341,7 +350,7 @@ describe("deleting a custom wallpaper", () => {
     await waitFor(() => expect(wallpaperUrls().some((u) => u.includes(WP[2]))).toBe(true));
 
     await openAppearanceSettings();
-    fireEvent.click(await screen.findByRole("button", { name: /Remove custom 3/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /Remove custom 3/i }, PAINTS_SOON));
 
     // The delete itself is not blocked — a local operation must not wait on a
     // remote probe. Only the box-wide guess is withheld.
@@ -364,7 +373,7 @@ describe("deleting a custom wallpaper", () => {
     await mountDesktop("clawbox-wallpaper");
 
     await openAppearanceSettings();
-    const tile = await screen.findByRole("button", { name: /^ClawBox$/i });
+    const tile = await screen.findByRole("button", { name: /^ClawBox$/i }, PAINTS_SOON);
     expect(tile.getAttribute("aria-pressed")).toBe("true");
   });
 });
@@ -407,7 +416,7 @@ describe("the built-in wallpapers this edition offers", () => {
     // write, a permission change, a partial reflash), so `readEditionSource`
     // falls back to its own "openclaw" — which the route now reports as a
     // GUESS. Taking the guess would put ClawBox branding on a Hermes box.
-    editionKnown = false;
+    activeKnown = false;
     savedWallpaperId = "clawbox";
     render(<ChromeDesktop />);
     await waitFor(() => expect(screen.getByTestId("desktop-root")).toBeTruthy());
@@ -419,19 +428,5 @@ describe("the built-in wallpapers this edition offers", () => {
     // fallback this browser derived is never written back (TASK-719/#728).
     await new Promise((resolve) => setTimeout(resolve, 900));
     expect(saved.some((body) => "wp_id" in body && body.wp_id !== "clawbox")).toBe(false);
-  });
-
-  it("heals a stored OTHER-edition brand to this one for the paint, and persists nothing", async () => {
-    // A box re-imaged onto the other edition, or a `wp_id` chosen before this
-    // ruling: the id names an art this edition does not ship. It resolves to
-    // the local brand on screen and the stored value is left alone.
-    savedWallpaperId = "hermes";
-    await mountDesktop("clawbox-wallpaper");
-    await openAppearanceSettings();
-
-    expect(brandWallpaperAssets().some((url) => url.includes("hermes-wallpaper"))).toBe(false);
-    expect(builtinWallpaperTiles()).toEqual(["clawbox", "deep-space"]);
-    await new Promise((resolve) => setTimeout(resolve, 900));
-    expect(saved.some((body) => "wp_id" in body && body.wp_id !== "hermes")).toBe(false);
   });
 });

--- a/src/tests/components/desktop-wallpaper-delete.test.tsx
+++ b/src/tests/components/desktop-wallpaper-delete.test.tsx
@@ -44,6 +44,8 @@ const WP = [
 let savedWallpaperId = "custom-2";
 /** Which harness the box reports — the fallback wallpaper follows it. */
 let activeHarness = "openclaw";
+/** Whether anything on the device actually NAMED an edition (the lock, or the env). */
+let editionKnown = true;
 /** Milliseconds the harness probe takes to answer, so a case can run inside the window where it has not. */
 let harnessDelayMs = 0;
 /** Every preference body the desktop POSTed, in order. */
@@ -69,7 +71,7 @@ function installFetch() {
     if (url.includes("/setup-api/setup/status")) return answer({ setup_complete: true });
     if (url.includes("/setup-api/harness/active")) {
       if (harnessDelayMs > 0) await new Promise((resolve) => setTimeout(resolve, harnessDelayMs));
-      return answer({ active: activeHarness, edition: activeHarness });
+      return answer({ active: activeHarness, edition: activeHarness, editionKnown });
     }
     if (url.includes("/setup-api/preferences?all=1")) {
       return answer({ wp_id: savedWallpaperId, wp_opacity: 100 });
@@ -92,6 +94,29 @@ function wallpaperUrls(): string[] {
     .map((el) => el.style.backgroundImage);
 }
 
+/** The built-in wallpaper tiles the Appearance card offers, in order. */
+function builtinWallpaperTiles(): string[] {
+  return Array.from(document.querySelectorAll<HTMLElement>("[data-testid='wallpaper-tile']"))
+    .map((el) => el.dataset.wallpaperId ?? "");
+}
+
+/**
+ * Every reference to a BRAND wallpaper image anywhere on screen — the painted
+ * background and the Appearance tiles both. The removed brand's picture must
+ * not be fetched on the other edition either, and a tile is an `<img src>`
+ * rather than a background-image, so the two are asked together.
+ */
+function deepSpacePainted(): boolean {
+  return document.querySelector(".bg-stars") !== null;
+}
+
+function brandWallpaperAssets(): string[] {
+  const painted = wallpaperUrls();
+  const tiles = Array.from(document.querySelectorAll<HTMLImageElement>("img"))
+    .map((el) => el.getAttribute("src") ?? "");
+  return [...painted, ...tiles].filter((url) => url.includes("-wallpaper.jpeg"));
+}
+
 async function mountDesktop(expected: string) {
   render(<ChromeDesktop />);
   await waitFor(() => expect(screen.getByTestId("desktop-root")).toBeTruthy());
@@ -108,47 +133,48 @@ async function openAppearanceSettings() {
   fireEvent.click(await screen.findByRole("button", { name: /appearance/i }));
 }
 
+beforeEach(() => {
+  window.localStorage.clear();
+  window.localStorage.setItem("clawbox-custom-wallpapers", JSON.stringify(WP));
+  savedWallpaperId = "custom-2";
+  activeHarness = "openclaw";
+  editionKnown = true;
+  harnessDelayMs = 0;
+  saved.length = 0;
+  resetHarnessCache();
+  // jsdom does not implement it at all, so `vi.spyOn` cannot be used and
+  // `restoreMocks` has nothing to restore — put it back by hand below.
+  Element.prototype.scrollIntoView = vi.fn();
+  // The shared `matchMedia` from `src/tests/setup.ts` is a `vi.fn()`, and
+  // `mockReset: true` (vitest.config.ts) empties every mock's implementation
+  // after each test — so from the SECOND case in any file it answers
+  // `undefined` and the mascot's reduced-motion effect throws on `.matches`.
+  // A plain function has no implementation to reset.
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener() {},
+      removeListener() {},
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent: () => false,
+    }),
+  });
+  installFetch();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetHarnessCache();
+  delete (Element.prototype as { scrollIntoView?: unknown }).scrollIntoView;
+  window.localStorage.clear();
+});
+
 describe("deleting a custom wallpaper", () => {
-  beforeEach(() => {
-    window.localStorage.clear();
-    window.localStorage.setItem("clawbox-custom-wallpapers", JSON.stringify(WP));
-    savedWallpaperId = "custom-2";
-    activeHarness = "openclaw";
-    harnessDelayMs = 0;
-    saved.length = 0;
-    resetHarnessCache();
-    // jsdom does not implement it at all, so `vi.spyOn` cannot be used and
-    // `restoreMocks` has nothing to restore — put it back by hand below.
-    Element.prototype.scrollIntoView = vi.fn();
-    // The shared `matchMedia` from `src/tests/setup.ts` is a `vi.fn()`, and
-    // `mockReset: true` (vitest.config.ts) empties every mock's implementation
-    // after each test — so from the SECOND case in any file it answers
-    // `undefined` and the mascot's reduced-motion effect throws on `.matches`.
-    // A plain function has no implementation to reset.
-    Object.defineProperty(window, "matchMedia", {
-      writable: true,
-      configurable: true,
-      value: (query: string) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener() {},
-        removeListener() {},
-        addEventListener() {},
-        removeEventListener() {},
-        dispatchEvent: () => false,
-      }),
-    });
-    installFetch();
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-    resetHarnessCache();
-    delete (Element.prototype as { scrollIntoView?: unknown }).scrollIntoView;
-    window.localStorage.clear();
-  });
-
   it("keeps the picture the owner is actually looking at", async () => {
     await mountDesktop(WP[2]);
 
@@ -267,13 +293,18 @@ describe("deleting a custom wallpaper", () => {
     expect(saved.some((body) => "wp_id" in body && body.wp_id !== "custom-2")).toBe(false);
   });
 
-  it("writes nothing while the harness probe has not answered, and lands on the Hermes art", async () => {
+  it("shows no branding at all while the harness probe has not answered, and lands on the Hermes art", async () => {
     // The preferences call and the harness probe race, and until the probe
     // answers the desktop cannot know which edition's art the fallback is. The
     // repair this replaced ran in that window and PERSISTED "clawbox" — on a
     // Hermes box, box-wide and for good, since the later Hermes answer found a
     // selection already made. Nothing is written now, so the paint simply
     // catches up when the probe lands.
+    //
+    // And the paint inside that window is the NEUTRAL one. It used to be the
+    // ClawBox art — a guess, shown as a fact, on a device that had not yet said
+    // which product it is; on the Hermes box that is a competitor's picture
+    // flickering across the customer's screen on every load.
     activeHarness = "hermes";
     harnessDelayMs = 900;
     window.localStorage.removeItem("clawbox-custom-wallpapers");
@@ -282,7 +313,8 @@ describe("deleting a custom wallpaper", () => {
     render(<ChromeDesktop />);
     await waitFor(() => expect(screen.getByTestId("desktop-root")).toBeTruthy());
     // Inside the window: the preferences have landed, the probe has not.
-    await waitFor(() => expect(wallpaperUrls().some((u) => u.includes("clawbox-wallpaper"))).toBe(true));
+    await waitFor(() => expect(deepSpacePainted()).toBe(true));
+    expect(brandWallpaperAssets()).toEqual([]);
     expect(saved.some((body) => "wp_id" in body && body.wp_id !== "custom-2")).toBe(false);
 
     // And once it does answer, the paint follows the edition.
@@ -334,5 +366,72 @@ describe("deleting a custom wallpaper", () => {
     await openAppearanceSettings();
     const tile = await screen.findByRole("button", { name: /^ClawBox$/i });
     expect(tile.getAttribute("aria-pressed")).toBe("true");
+  });
+});
+
+/**
+ * The built-in list is EDITION-SCOPED (owner ruling 2026-09-06): the OpenClaw
+ * edition offers ClawBox + Deep Space, the Hermes edition offers Hermes + Deep
+ * Space, and the uploads are on both. The other edition's branding is not
+ * something a customer can select, so it is not something the box ships.
+ *
+ * The edition is the device's own answer, and while nobody has given one the
+ * neutral Deep Space is the whole list: painting a brand there is a coin flip,
+ * and the wrong side of it is another product's artwork on the customer's
+ * screen.
+ */
+describe("the built-in wallpapers this edition offers", () => {
+  it("offers ClawBox and Deep Space on an OpenClaw box, and never the Hermes art", async () => {
+    savedWallpaperId = "clawbox";
+    await mountDesktop("clawbox-wallpaper");
+    await openAppearanceSettings();
+
+    // Not merely unselectable — not fetched. The tile is an <img src>, so a
+    // tile for the other edition would still pull the other product's picture.
+    expect(brandWallpaperAssets().some((url) => url.includes("hermes-wallpaper"))).toBe(false);
+    expect(builtinWallpaperTiles()).toEqual(["clawbox", "deep-space"]);
+  });
+
+  it("offers Hermes and Deep Space on a Hermes box, and never the ClawBox art", async () => {
+    activeHarness = "hermes";
+    savedWallpaperId = "hermes";
+    await mountDesktop("hermes-wallpaper");
+    await openAppearanceSettings();
+
+    expect(brandWallpaperAssets().some((url) => url.includes("clawbox-wallpaper"))).toBe(false);
+    expect(builtinWallpaperTiles()).toEqual(["hermes", "deep-space"]);
+  });
+
+  it("offers only Deep Space while no edition could be read, and writes nothing", async () => {
+    // The lock exists and says nothing this device could parse (a truncated
+    // write, a permission change, a partial reflash), so `readEditionSource`
+    // falls back to its own "openclaw" — which the route now reports as a
+    // GUESS. Taking the guess would put ClawBox branding on a Hermes box.
+    editionKnown = false;
+    savedWallpaperId = "clawbox";
+    render(<ChromeDesktop />);
+    await waitFor(() => expect(screen.getByTestId("desktop-root")).toBeTruthy());
+    await openAppearanceSettings();
+
+    expect(brandWallpaperAssets()).toEqual([]);
+    expect(builtinWallpaperTiles()).toEqual(["deep-space"]);
+    // The neutral paint is a paint. The box keeps the value it holds — a
+    // fallback this browser derived is never written back (TASK-719/#728).
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    expect(saved.some((body) => "wp_id" in body && body.wp_id !== "clawbox")).toBe(false);
+  });
+
+  it("heals a stored OTHER-edition brand to this one for the paint, and persists nothing", async () => {
+    // A box re-imaged onto the other edition, or a `wp_id` chosen before this
+    // ruling: the id names an art this edition does not ship. It resolves to
+    // the local brand on screen and the stored value is left alone.
+    savedWallpaperId = "hermes";
+    await mountDesktop("clawbox-wallpaper");
+    await openAppearanceSettings();
+
+    expect(brandWallpaperAssets().some((url) => url.includes("hermes-wallpaper"))).toBe(false);
+    expect(builtinWallpaperTiles()).toEqual(["clawbox", "deep-space"]);
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    expect(saved.some((body) => "wp_id" in body && body.wp_id !== "hermes")).toBe(false);
   });
 });

--- a/src/tests/components/standalone-app-appearance.test.tsx
+++ b/src/tests/components/standalone-app-appearance.test.tsx
@@ -27,10 +27,10 @@ vi.mock("next/image", () => ({ default: () => null }));
 // Hoisted so a case can decide what the probe answers — including answering
 // without an `active`, which is what a failed probe looks like to this route.
 const harnessMock = vi.hoisted(() =>
-  vi.fn(async (): Promise<{ active?: string; edition?: string; editionKnown?: boolean }> => ({
+  vi.fn(async (): Promise<{ active?: string; edition?: string; activeKnown?: boolean }> => ({
     active: "openclaw",
     edition: "openclaw",
-    editionKnown: true,
+    activeKnown: true,
   })),
 );
 vi.mock("@/lib/client-harness", () => ({ fetchHarness: harnessMock }));
@@ -89,7 +89,7 @@ let posts: Record<string, unknown>[];
 beforeEach(() => {
   posts = [];
   localStorage.clear();
-  harnessMock.mockResolvedValue({ active: "openclaw", edition: "openclaw", editionKnown: true });
+  harnessMock.mockResolvedValue({ active: "openclaw", edition: "openclaw", activeKnown: true });
   vi.stubGlobal(
     "fetch",
     vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -350,7 +350,7 @@ describe("/app/settings — Appearance", () => {
     // The built-in list is edition-scoped (owner ruling 2026-09-06). This route
     // is the phone's Settings, so it must scope it the same way the desktop
     // does — one source of truth, not a second copy that drifts.
-    harnessMock.mockResolvedValue({ active: "hermes", edition: "hermes", editionKnown: true });
+    harnessMock.mockResolvedValue({ active: "hermes", edition: "hermes", activeKnown: true });
     render(<StandaloneAppPage />);
     // `wp_fit` proves the box's answer landed, as elsewhere in this file.
     await waitFor(() => expect(screen.getByTestId("ui-fit").textContent).toBe("center"));
@@ -358,10 +358,11 @@ describe("/app/settings — Appearance", () => {
   });
 
   it("offers only the neutral wallpaper while no edition could be read", async () => {
-    // An unreadable lock reads as OpenClaw in `readEditionSource`, and the
-    // route reports that as a guess. Neither brand may be offered on a guess:
-    // one of the two answers is another product's artwork.
-    harnessMock.mockResolvedValue({ active: "openclaw", edition: "openclaw", editionKnown: false });
+    // An unreadable edition lock — or, on the dual SKU, an unreadable config
+    // store — resolves to OpenClaw, and the route reports that as a guess.
+    // Neither brand may be offered on a guess: one of the two answers is
+    // another product's artwork.
+    harnessMock.mockResolvedValue({ active: "openclaw", edition: "openclaw", activeKnown: false });
     render(<StandaloneAppPage />);
     await waitFor(() => expect(screen.getByTestId("ui-fit").textContent).toBe("center"));
     expect(screen.getByTestId("ui-wallpapers").textContent).toBe("deep-space");

--- a/src/tests/components/standalone-app-appearance.test.tsx
+++ b/src/tests/components/standalone-app-appearance.test.tsx
@@ -26,7 +26,13 @@ vi.mock("next/link", () => ({
 vi.mock("next/image", () => ({ default: () => null }));
 // Hoisted so a case can decide what the probe answers — including answering
 // without an `active`, which is what a failed probe looks like to this route.
-const harnessMock = vi.hoisted(() => vi.fn(async (): Promise<{ active?: string }> => ({ active: "openclaw" })));
+const harnessMock = vi.hoisted(() =>
+  vi.fn(async (): Promise<{ active?: string; edition?: string; editionKnown?: boolean }> => ({
+    active: "openclaw",
+    edition: "openclaw",
+    editionKnown: true,
+  })),
+);
 vi.mock("@/lib/client-harness", () => ({ fetchHarness: harnessMock }));
 
 interface StubUi {
@@ -57,6 +63,7 @@ vi.mock("@/components/SettingsApp", () => ({
         <span data-testid="ui-wallpapers">{ui.wallpapers.map((w) => w.id).join(",")}</span>
         <span data-testid="ui-custom">{ui.customWallpapers.length}</span>
         <button data-testid="pick-deep-space" onClick={() => ui.onWallpaperChange("deep-space")}>wp</button>
+        <button data-testid="pick-clawbox" onClick={() => ui.onWallpaperChange("clawbox")}>brand</button>
         <button data-testid="pick-center" onClick={() => ui.onWpFitChange("center")}>fit</button>
         <button data-testid="pick-opacity" onClick={() => ui.onWpOpacityChange(80)}>opacity</button>
         <button data-testid="show-mascot" onClick={() => ui.onMascotToggle(false)}>mascot</button>
@@ -70,7 +77,7 @@ vi.mock("@/components/SettingsApp", () => ({
 }));
 
 const SAVED = {
-  wp_id: "hermes",
+  wp_id: "deep-space",
   wp_fit: "center",
   wp_bg_color: "#000000",
   wp_opacity: 50,
@@ -82,7 +89,7 @@ let posts: Record<string, unknown>[];
 beforeEach(() => {
   posts = [];
   localStorage.clear();
-  harnessMock.mockResolvedValue({ active: "openclaw" });
+  harnessMock.mockResolvedValue({ active: "openclaw", edition: "openclaw", editionKnown: true });
   vi.stubGlobal(
     "fetch",
     vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -108,29 +115,31 @@ const SAVED_SOON = { timeout: 4000 };
 describe("/app/settings — Appearance", () => {
   it("shows the appearance this box actually has, and the wallpapers it can choose between", async () => {
     render(<StandaloneAppPage />);
-    await waitFor(() => expect(screen.getByTestId("ui-wallpaper").textContent).toBe("hermes"));
+    await waitFor(() => expect(screen.getByTestId("ui-wallpaper").textContent).toBe("deep-space"));
     expect(screen.getByTestId("ui-fit").textContent).toBe("center");
     expect(screen.getByTestId("ui-opacity").textContent).toBe("50");
     expect(screen.getByTestId("ui-bg").textContent).toBe("#000000");
     expect(screen.getByTestId("ui-mascot").textContent).toBe("hidden");
     // The card used to be handed an empty list, so it drew nothing but the
-    // Upload tile — three wallpapers exist and every one is pickable here.
-    expect(screen.getByTestId("ui-wallpapers").textContent).toBe("clawbox,hermes,deep-space");
+    // Upload tile. It is now handed the wallpapers THIS EDITION ships — its own
+    // brand and the neutral one — rather than both products' branding
+    // (owner ruling 2026-09-06).
+    expect(screen.getByTestId("ui-wallpapers").textContent).toBe("clawbox,deep-space");
   });
 
   it("saves a wallpaper, a fit and an opacity to the preferences the desktop reads", async () => {
     render(<StandaloneAppPage />);
-    await waitFor(() => expect(screen.getByTestId("ui-wallpaper").textContent).toBe("hermes"));
+    await waitFor(() => expect(screen.getByTestId("ui-wallpaper").textContent).toBe("deep-space"));
     posts.length = 0;
 
-    fireEvent.click(screen.getByTestId("pick-deep-space"));
-    expect(screen.getByTestId("ui-wallpaper").textContent).toBe("deep-space");
-    await waitFor(() => expect(posts.at(-1)).toMatchObject({ wp_id: "deep-space" }), SAVED_SOON);
+    fireEvent.click(screen.getByTestId("pick-clawbox"));
+    expect(screen.getByTestId("ui-wallpaper").textContent).toBe("clawbox");
+    await waitFor(() => expect(posts.at(-1)).toMatchObject({ wp_id: "clawbox" }), SAVED_SOON);
 
     fireEvent.click(screen.getByTestId("pick-center"));
     fireEvent.click(screen.getByTestId("pick-opacity"));
     await waitFor(
-      () => expect(posts.at(-1)).toMatchObject({ wp_id: "deep-space", wp_fit: "center", wp_opacity: 80 }),
+      () => expect(posts.at(-1)).toMatchObject({ wp_id: "clawbox", wp_fit: "center", wp_opacity: 80 }),
       SAVED_SOON,
     );
   });
@@ -163,13 +172,13 @@ describe("/app/settings — Appearance", () => {
           posts.push(JSON.parse(String(init.body)) as Record<string, unknown>);
           return { ok: true, json: async () => ({ ok: true }) };
         }
-        if (url.includes("keys=wp_id")) return { ok: true, json: async () => ({ wp_id: "hermes" }) };
+        if (url.includes("keys=wp_id")) return { ok: true, json: async () => ({ wp_id: "deep-space" }) };
         return { ok: true, json: async () => ({}) };
       }),
     );
 
     render(<StandaloneAppPage />);
-    await waitFor(() => expect(screen.getByTestId("ui-wallpaper").textContent).toBe("hermes"));
+    await waitFor(() => expect(screen.getByTestId("ui-wallpaper").textContent).toBe("deep-space"));
     // Well past the 500 ms debounce: anything the hydration commit queued has
     // had its chance to land.
     await new Promise((resolve) => setTimeout(resolve, 900));
@@ -315,11 +324,13 @@ describe("/app/settings — Appearance", () => {
     // The delete is not blocked — a local operation must not wait on a probe.
     fireEvent.click(screen.getByTestId("delete-custom-0"));
     expect(screen.getByTestId("ui-custom").textContent).toBe("0");
-    // Painted locally…
-    expect(screen.getByTestId("ui-wallpaper").textContent).toBe("clawbox");
+    // Painted locally, and painted NEUTRAL: with no edition there is no brand
+    // to fall back to, and picking one would put the other product's artwork on
+    // the customer's screen.
+    expect(screen.getByTestId("ui-wallpaper").textContent).toBe("deep-space");
     // …and not written. Well past the 500 ms debounce.
     await new Promise((resolve) => setTimeout(resolve, 900));
-    expect(posts.some((body) => body.wp_id === "clawbox")).toBe(false);
+    expect(posts.some((body) => "wp_id" in body)).toBe(false);
   });
 
   it("offers the wallpapers this browser already uploaded, and asks the file input for a new one", async () => {
@@ -333,5 +344,50 @@ describe("/app/settings — Appearance", () => {
     input.addEventListener("click", clicked);
     fireEvent.click(screen.getByTestId("ask-upload"));
     expect(clicked).toHaveBeenCalled();
+  });
+
+  it("offers the HERMES branding and no ClawBox one on a Hermes box", async () => {
+    // The built-in list is edition-scoped (owner ruling 2026-09-06). This route
+    // is the phone's Settings, so it must scope it the same way the desktop
+    // does — one source of truth, not a second copy that drifts.
+    harnessMock.mockResolvedValue({ active: "hermes", edition: "hermes", editionKnown: true });
+    render(<StandaloneAppPage />);
+    // `wp_fit` proves the box's answer landed, as elsewhere in this file.
+    await waitFor(() => expect(screen.getByTestId("ui-fit").textContent).toBe("center"));
+    expect(screen.getByTestId("ui-wallpapers").textContent).toBe("hermes,deep-space");
+  });
+
+  it("offers only the neutral wallpaper while no edition could be read", async () => {
+    // An unreadable lock reads as OpenClaw in `readEditionSource`, and the
+    // route reports that as a guess. Neither brand may be offered on a guess:
+    // one of the two answers is another product's artwork.
+    harnessMock.mockResolvedValue({ active: "openclaw", edition: "openclaw", editionKnown: false });
+    render(<StandaloneAppPage />);
+    await waitFor(() => expect(screen.getByTestId("ui-fit").textContent).toBe("center"));
+    expect(screen.getByTestId("ui-wallpapers").textContent).toBe("deep-space");
+  });
+
+  it("heals a stored other-edition brand for the card, and leaves the box's value alone", async () => {
+    // A `wp_id` naming the art this edition no longer ships — a box re-imaged
+    // onto the other edition, or a choice made before the ruling. The card
+    // shows this edition's own brand; the stored value is not rewritten, for
+    // the same reason an unanswerable `custom-<n>` is not (#728).
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (init?.method === "POST") {
+          posts.push(JSON.parse(String(init.body)) as Record<string, unknown>);
+          return { ok: true, json: async () => ({ ok: true }) };
+        }
+        if (url.includes("keys=wp_id")) return { ok: true, json: async () => ({ ...SAVED, wp_id: "hermes" }) };
+        return { ok: true, json: async () => ({}) };
+      }),
+    );
+
+    render(<StandaloneAppPage />);
+    await waitFor(() => expect(screen.getByTestId("ui-wallpaper").textContent).toBe("clawbox"));
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    expect(posts.some((body) => "wp_id" in body)).toBe(false);
   });
 });

--- a/src/tests/routes/harness-active.test.ts
+++ b/src/tests/routes/harness-active.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * `/setup-api/harness/active` is where the browser learns which product this
+ * box is, and since the wallpaper list became edition-scoped (owner ruling
+ * 2026-09-06) it is also where the browser learns whether that answer is worth
+ * believing.
+ *
+ * `edition` and `active` both resolve through `readEditionSource()`, which
+ * collapses "nobody said" into its own "openclaw" default — the safe way to be
+ * wrong for "which SKU is this", since openclaw is the non-premium one, and the
+ * wrong way round for anything that BRANDS the box: a Hermes device whose lock
+ * is unreadable would be dressed as a ClawBox. `editionKnown` is what lets a
+ * caller tell the two apart, so the route reports the doubt instead of hiding
+ * it behind a default.
+ */
+
+let lockPath: string;
+let previousEditionFile: string | undefined;
+let previousEdition: string | undefined;
+
+async function get(): Promise<{ active: string; edition: string; editionKnown: boolean }> {
+  vi.resetModules();
+  const mod = await import("@/app/setup-api/harness/active/route");
+  return (await mod.GET()).json();
+}
+
+beforeEach(() => {
+  previousEditionFile = process.env.CLAWBOX_EDITION_FILE;
+  previousEdition = process.env.CLAWBOX_EDITION;
+  // A fresh path per case: edition-source caches by mtime, and two writes
+  // inside the same millisecond would otherwise be one cached answer.
+  lockPath = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-edition-")),
+    "edition.env",
+  );
+  process.env.CLAWBOX_EDITION_FILE = lockPath;
+  delete process.env.CLAWBOX_EDITION;
+});
+
+afterEach(() => {
+  if (previousEditionFile === undefined) delete process.env.CLAWBOX_EDITION_FILE;
+  else process.env.CLAWBOX_EDITION_FILE = previousEditionFile;
+  if (previousEdition === undefined) delete process.env.CLAWBOX_EDITION;
+  else process.env.CLAWBOX_EDITION = previousEdition;
+  fs.rmSync(path.dirname(lockPath), { recursive: true, force: true });
+});
+
+describe("GET /setup-api/harness/active — is the edition a fact or a default?", () => {
+  it("says the edition is known when the root-owned lock names one", async () => {
+    fs.writeFileSync(lockPath, "CLAWBOX_EDITION=hermes\n");
+    expect(await get()).toMatchObject({ active: "hermes", edition: "hermes", editionKnown: true });
+  });
+
+  it("says the edition is known when only the environment names one", async () => {
+    // Dev machines, CI and pre-3.x installs never had the lock file, and the
+    // documented env fallback is still an answer somebody gave.
+    process.env.CLAWBOX_EDITION = "openclaw";
+    expect(await get()).toMatchObject({ edition: "openclaw", editionKnown: true });
+  });
+
+  it("says the edition is NOT known when the lock carries none", async () => {
+    // A truncated write, a permission change, a partial reflash. `edition` and
+    // `active` still answer "openclaw" — every other caller of this route
+    // depends on that default — and `editionKnown` is what says it was a guess.
+    fs.writeFileSync(lockPath, "# ClawBox edition lock\n# (truncated)\n");
+    expect(await get()).toEqual({ active: "openclaw", edition: "openclaw", editionKnown: false });
+  });
+
+  it("says the edition is NOT known when nothing on the device names one", async () => {
+    expect(await get()).toMatchObject({ editionKnown: false });
+  });
+
+  it("says the edition is not known for a lock naming something unrecognised", async () => {
+    // "openclaw" here is this module's default, not the file's word.
+    fs.writeFileSync(lockPath, "CLAWBOX_EDITION=enterprise\n");
+    expect(await get()).toMatchObject({ edition: "openclaw", editionKnown: false });
+  });
+});

--- a/src/tests/routes/harness-active.test.ts
+++ b/src/tests/routes/harness-active.test.ts
@@ -9,23 +9,37 @@ import path from "node:path";
  * 2026-09-06) it is also where the browser learns whether that answer is worth
  * believing.
  *
- * `edition` and `active` both resolve through `readEditionSource()`, which
- * collapses "nobody said" into its own "openclaw" default — the safe way to be
- * wrong for "which SKU is this", since openclaw is the non-premium one, and the
- * wrong way round for anything that BRANDS the box: a Hermes device whose lock
- * is unreadable would be dressed as a ClawBox. `editionKnown` is what lets a
- * caller tell the two apart, so the route reports the doubt instead of hiding
- * it behind a default.
+ * `active` is resolved from the root-owned edition lock and, on the one SKU the
+ * lock deliberately leaves open, from `data/config.json`. Both of those reads
+ * fall back to "openclaw" when nothing could answer — the safe way to be wrong
+ * for "which SKU is this", since openclaw is the non-premium one, and the wrong
+ * way round for anything that BRANDS the box: a Hermes device whose lock is
+ * unreadable, or a licensed `dual` running Hermes whose config store a `sudo`
+ * script left root-owned, would be dressed as a ClawBox. `activeKnown` is what
+ * lets a caller tell a fact from a fallback, so the route reports the doubt
+ * instead of hiding it behind a default.
  */
+
+interface Answer {
+  active: string;
+  edition: string;
+  activeKnown: boolean;
+}
 
 let lockPath: string;
 let previousEditionFile: string | undefined;
 let previousEdition: string | undefined;
 
-async function get(): Promise<{ active: string; edition: string; editionKnown: boolean }> {
+/** The route, freshly imported — `edition-source` captures its path at load. */
+async function get(): Promise<Answer> {
   vi.resetModules();
   const mod = await import("@/app/setup-api/harness/active/route");
   return (await mod.GET()).json();
+}
+
+/** The premium SKU actually unlocked: the licence is not env-overridable. */
+function licenseDual(): void {
+  vi.doMock("@/lib/edition-license", () => ({ verifyDualLicense: () => true }));
 }
 
 beforeEach(() => {
@@ -42,6 +56,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.doUnmock("@/lib/edition-license");
+  vi.doUnmock("@/lib/config-store");
   if (previousEditionFile === undefined) delete process.env.CLAWBOX_EDITION_FILE;
   else process.env.CLAWBOX_EDITION_FILE = previousEditionFile;
   if (previousEdition === undefined) delete process.env.CLAWBOX_EDITION;
@@ -49,34 +65,80 @@ afterEach(() => {
   fs.rmSync(path.dirname(lockPath), { recursive: true, force: true });
 });
 
-describe("GET /setup-api/harness/active — is the edition a fact or a default?", () => {
-  it("says the edition is known when the root-owned lock names one", async () => {
+describe("GET /setup-api/harness/active — is `active` a fact or a default?", () => {
+  it("resolves a single-harness edition from the root-owned lock", async () => {
     fs.writeFileSync(lockPath, "CLAWBOX_EDITION=hermes\n");
-    expect(await get()).toMatchObject({ active: "hermes", edition: "hermes", editionKnown: true });
+    expect(await get()).toEqual({ active: "hermes", edition: "hermes", activeKnown: true });
   });
 
-  it("says the edition is known when only the environment names one", async () => {
-    // Dev machines, CI and pre-3.x installs never had the lock file, and the
-    // documented env fallback is still an answer somebody gave.
+  it("takes the environment's word when there is no lock file", async () => {
+    // Dev machines, CI and pre-3.x installs never had one, and the documented
+    // env fallback is still an answer somebody gave.
     process.env.CLAWBOX_EDITION = "openclaw";
-    expect(await get()).toMatchObject({ edition: "openclaw", editionKnown: true });
+    expect(await get()).toMatchObject({ edition: "openclaw", activeKnown: true });
   });
 
-  it("says the edition is NOT known when the lock carries none", async () => {
+  it("says the harness is NOT resolved when the lock carries no edition", async () => {
     // A truncated write, a permission change, a partial reflash. `edition` and
     // `active` still answer "openclaw" — every other caller of this route
-    // depends on that default — and `editionKnown` is what says it was a guess.
+    // depends on that default — and `activeKnown` is what says it was a guess.
     fs.writeFileSync(lockPath, "# ClawBox edition lock\n# (truncated)\n");
-    expect(await get()).toEqual({ active: "openclaw", edition: "openclaw", editionKnown: false });
+    expect(await get()).toEqual({ active: "openclaw", edition: "openclaw", activeKnown: false });
   });
 
-  it("says the edition is NOT known when nothing on the device names one", async () => {
-    expect(await get()).toMatchObject({ editionKnown: false });
+  it("says the harness is NOT resolved when nothing on the device names an edition", async () => {
+    expect(await get()).toMatchObject({ activeKnown: false });
   });
 
-  it("says the edition is not known for a lock naming something unrecognised", async () => {
-    // "openclaw" here is this module's default, not the file's word.
+  it("says the harness is not resolved for a lock naming something unrecognised", async () => {
+    // "openclaw" here is edition-source's default, not the file's word.
     fs.writeFileSync(lockPath, "CLAWBOX_EDITION=enterprise\n");
-    expect(await get()).toMatchObject({ edition: "openclaw", editionKnown: false });
+    expect(await get()).toMatchObject({ edition: "openclaw", activeKnown: false });
+  });
+});
+
+describe("GET /setup-api/harness/active — the dual SKU, whose harness is a runtime choice", () => {
+  beforeEach(() => {
+    fs.writeFileSync(lockPath, "CLAWBOX_EDITION=dual\n");
+  });
+
+  it("pins an UNLICENSED dual to the default harness, and that is a fact", async () => {
+    // No licence, so the switcher never unlocks and the stored value is ignored
+    // outright — the box really is on the default, not guessed onto it.
+    expect(await get()).toEqual({ active: "openclaw", edition: "dual", activeKnown: true });
+  });
+
+  it("resolves a licensed dual from the config store", async () => {
+    licenseDual();
+    vi.doMock("@/lib/config-store", async (orig) => ({
+      ...(await orig<typeof import("@/lib/config-store")>()),
+      getKnown: async () => ({ value: "hermes", known: true }),
+    }));
+    expect(await get()).toEqual({ active: "hermes", edition: "dual", activeKnown: true });
+  });
+
+  it("treats a licensed dual nobody has switched as a fact, not a doubt", async () => {
+    // An ABSENT key is a real answer: that box runs the default harness. Calling
+    // it unknown would strip the branding from every healthy dual box.
+    licenseDual();
+    vi.doMock("@/lib/config-store", async (orig) => ({
+      ...(await orig<typeof import("@/lib/config-store")>()),
+      getKnown: async () => ({ value: undefined, known: true }),
+    }));
+    expect(await get()).toEqual({ active: "openclaw", edition: "dual", activeKnown: true });
+  });
+
+  it("says the harness is NOT resolved when the config store cannot be read", async () => {
+    // The gap this pair of tests exists for. `data/config.json` left root-owned
+    // by a `sudo` script: the forgiving reader answers "openclaw" for a box
+    // that is running Hermes, and taking that as a fact paints the ClawBox art
+    // on it — and, on a box that had never chosen, writes `wp_id: "clawbox"`
+    // box-wide. The edition is perfectly readable here; only the harness is not.
+    licenseDual();
+    vi.doMock("@/lib/config-store", async (orig) => ({
+      ...(await orig<typeof import("@/lib/config-store")>()),
+      getKnown: async () => ({ value: undefined, known: false }),
+    }));
+    expect(await get()).toEqual({ active: "openclaw", edition: "dual", activeKnown: false });
   });
 });

--- a/src/tests/unit/builtin-wallpapers.test.ts
+++ b/src/tests/unit/builtin-wallpapers.test.ts
@@ -37,7 +37,9 @@ describe("which built-ins an edition offers", () => {
 
   it("does not carry the other edition's image file at all", () => {
     // The tile is an <img src>, so an entry that is merely unselectable would
-    // still fetch the picture. This is the asset half of the ruling.
+    // still fetch the picture. This is about what the PAGE requests — both
+    // files ship on both editions and stay fetchable by URL, which the ruling
+    // does not ask about.
     expect(builtinWallpapers("openclaw").map((wp) => wp.image)).not.toContain("/hermes-wallpaper.jpeg");
     expect(builtinWallpapers("hermes").map((wp) => wp.image)).not.toContain("/clawbox-wallpaper.jpeg");
     expect(builtinWallpapers(null).every((wp) => wp.image === "")).toBe(true);
@@ -53,17 +55,16 @@ describe("which built-ins an edition offers", () => {
 
 describe("which harness's branding the device wears", () => {
   it("follows the ACTIVE harness, so the dual SKU shows the one that is running", () => {
-    expect(brandingHarness({ active: "hermes", editionKnown: true })).toBe("hermes");
-    expect(brandingHarness({ active: "openclaw", editionKnown: true })).toBe("openclaw");
+    expect(brandingHarness({ active: "hermes", activeKnown: true })).toBe("hermes");
+    expect(brandingHarness({ active: "openclaw", activeKnown: true })).toBe("openclaw");
   });
 
-  it("discards `active` entirely when no edition could be read", () => {
-    // On an unreadable lock `active` is not an independent answer:
-    // getActiveHarness() -> lockedHarness() -> readEdition() is the same file,
-    // so it can only echo "openclaw", on a Hermes box as readily as on an
-    // OpenClaw one. Taking it would brand a Hermes device as a ClawBox.
-    expect(brandingHarness({ active: "openclaw", editionKnown: false })).toBeNull();
-    expect(brandingHarness({ active: "hermes", editionKnown: false })).toBeNull();
+  it("discards `active` entirely when the device could not resolve it", () => {
+    // Where `active` is a fallback it is a fallback to "openclaw" whatever the
+    // box really is — an unreadable edition lock, or an unreadable config store
+    // on a licensed `dual`. Taking it would brand a Hermes device as a ClawBox.
+    expect(brandingHarness({ active: "openclaw", activeKnown: false })).toBeNull();
+    expect(brandingHarness({ active: "hermes", activeKnown: false })).toBeNull();
   });
 
   it("says nothing for a probe that has not answered, or a server that predates the field", () => {

--- a/src/tests/unit/builtin-wallpapers.test.ts
+++ b/src/tests/unit/builtin-wallpapers.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  brandingHarness,
+  brandWallpaperId,
+  builtinWallpapers,
+  defaultWallpaperId,
+  renderedWallpaperId,
+} from "@/lib/builtin-wallpapers";
+
+/**
+ * The built-in wallpaper list is EDITION-SCOPED (owner ruling 2026-09-06), and
+ * the rule lives here rather than in the two pages that draw it — the desktop
+ * and `/app/settings` each held a copy of the list with a comment asking for
+ * them to be kept in step by hand.
+ *
+ * The three questions this module answers are deliberately separate, because
+ * they have different answers on a box that has not said which edition it is:
+ * what may be OFFERED, what may be PAINTED, and what may be WRITTEN.
+ */
+
+const ids = (harness: string | null) => builtinWallpapers(harness).map((wp) => wp.id);
+
+describe("which built-ins an edition offers", () => {
+  it("gives an OpenClaw box its own brand and the neutral one", () => {
+    expect(ids("openclaw")).toEqual(["clawbox", "deep-space"]);
+  });
+
+  it("gives a Hermes box its own brand and the neutral one", () => {
+    expect(ids("hermes")).toEqual(["hermes", "deep-space"]);
+  });
+
+  it("gives an unknown edition the neutral one alone", () => {
+    // Not "both", and not a guess at one: a brand shown on a doubt is the other
+    // product's artwork on the customer's screen half the time.
+    expect(ids(null)).toEqual(["deep-space"]);
+  });
+
+  it("does not carry the other edition's image file at all", () => {
+    // The tile is an <img src>, so an entry that is merely unselectable would
+    // still fetch the picture. This is the asset half of the ruling.
+    expect(builtinWallpapers("openclaw").map((wp) => wp.image)).not.toContain("/hermes-wallpaper.jpeg");
+    expect(builtinWallpapers("hermes").map((wp) => wp.image)).not.toContain("/clawbox-wallpaper.jpeg");
+    expect(builtinWallpapers(null).every((wp) => wp.image === "")).toBe(true);
+  });
+
+  it("treats an unrecognised harness name as unknown", () => {
+    // `/app/settings` stores `d?.active || "unknown"` for a failed probe, and a
+    // future harness id must not fall through to one of today's brands.
+    expect(ids("unknown")).toEqual(["deep-space"]);
+    expect(ids("")).toEqual(["deep-space"]);
+  });
+});
+
+describe("which harness's branding the device wears", () => {
+  it("follows the ACTIVE harness, so the dual SKU shows the one that is running", () => {
+    expect(brandingHarness({ active: "hermes", editionKnown: true })).toBe("hermes");
+    expect(brandingHarness({ active: "openclaw", editionKnown: true })).toBe("openclaw");
+  });
+
+  it("discards `active` entirely when no edition could be read", () => {
+    // On an unreadable lock `active` is not an independent answer:
+    // getActiveHarness() -> lockedHarness() -> readEdition() is the same file,
+    // so it can only echo "openclaw", on a Hermes box as readily as on an
+    // OpenClaw one. Taking it would brand a Hermes device as a ClawBox.
+    expect(brandingHarness({ active: "openclaw", editionKnown: false })).toBeNull();
+    expect(brandingHarness({ active: "hermes", editionKnown: false })).toBeNull();
+  });
+
+  it("says nothing for a probe that has not answered, or a server that predates the field", () => {
+    expect(brandingHarness(null)).toBeNull();
+    expect(brandingHarness(undefined)).toBeNull();
+    expect(brandingHarness({ active: "openclaw" })).toBeNull();
+  });
+});
+
+describe("painting a fallback vs persisting one", () => {
+  it("paints — and offers to write — this edition's own brand once it is known", () => {
+    expect(defaultWallpaperId("openclaw")).toBe("clawbox");
+    expect(defaultWallpaperId("hermes")).toBe("hermes");
+    expect(brandWallpaperId("openclaw")).toBe("clawbox");
+    expect(brandWallpaperId("hermes")).toBe("hermes");
+  });
+
+  it("paints the neutral wallpaper while it is not, and offers nothing to write", () => {
+    // The paint corrects itself the moment the device answers. `wp_id` is
+    // box-wide SQLite and does not (#728), so the write is refused instead —
+    // which is the whole reason these are two functions and not one.
+    expect(defaultWallpaperId(null)).toBe("deep-space");
+    expect(brandWallpaperId(null)).toBeNull();
+  });
+});
+
+describe("what a saved wp_id actually paints", () => {
+  it("keeps a built-in this edition ships", () => {
+    expect(renderedWallpaperId("clawbox", "openclaw", 0)).toBe("clawbox");
+    expect(renderedWallpaperId("deep-space", "hermes", 0)).toBe("deep-space");
+  });
+
+  it("heals the OTHER edition's brand to this one", () => {
+    // A box re-imaged onto the other edition, or a choice made before the
+    // ruling. For the PAINT only — the caller writes nothing back.
+    expect(renderedWallpaperId("hermes", "openclaw", 0)).toBe("clawbox");
+    expect(renderedWallpaperId("clawbox", "hermes", 0)).toBe("hermes");
+  });
+
+  it("shows neither brand while the edition is unknown", () => {
+    expect(renderedWallpaperId("clawbox", null, 0)).toBe("deep-space");
+    expect(renderedWallpaperId("hermes", null, 0)).toBe("deep-space");
+  });
+
+  it("keeps an uploaded picture on every edition, known or not", () => {
+    expect(renderedWallpaperId("custom-1", "hermes", 3)).toBe("custom-1");
+    expect(renderedWallpaperId("custom-0", null, 1)).toBe("custom-0");
+  });
+
+  it("falls back for an upload this browser cannot answer", () => {
+    expect(renderedWallpaperId("custom-5", "hermes", 3)).toBe("hermes");
+    expect(renderedWallpaperId("custom-5", null, 3)).toBe("deep-space");
+  });
+
+  it("does not flash the default before this browser's list has been read", () => {
+    // Every `custom-<n>` is out of range against an empty initial state, so a
+    // perfectly good selection would blink the brand on every load.
+    expect(renderedWallpaperId("custom-2", "openclaw", null)).toBe("custom-2");
+  });
+
+  it("lands on the default for nothing chosen at all", () => {
+    expect(renderedWallpaperId("", "openclaw", 0)).toBe("clawbox");
+    expect(renderedWallpaperId("", null, 0)).toBe("deep-space");
+  });
+});

--- a/src/tests/unit/client-harness.test.ts
+++ b/src/tests/unit/client-harness.test.ts
@@ -20,7 +20,10 @@ describe("client harness cache", () => {
     calls = 0;
     vi.stubGlobal("fetch", vi.fn(async () => {
       calls++;
-      return { ok: true, json: async () => ({ active: "hermes", edition: "hermes" }) } as Response;
+      return {
+        ok: true,
+        json: async () => ({ active: "hermes", edition: "hermes", editionKnown: true }),
+      } as Response;
     }));
   });
 
@@ -31,8 +34,29 @@ describe("client harness cache", () => {
   });
 
   it("serves repeat callers from cache instead of re-fetching", async () => {
-    expect(await fetchHarness()).toEqual({ active: "hermes", edition: "hermes" });
-    expect(await fetchHarness()).toEqual({ active: "hermes", edition: "hermes" });
+    const answer = { active: "hermes", edition: "hermes", editionKnown: true };
+    expect(await fetchHarness()).toEqual(answer);
+    // From the cache, and carrying the same `editionKnown`: a caller that must
+    // not brand the box on a guess reads it, and a cached answer that dropped
+    // it would silently turn a fact back into a doubt on the second mount.
+    expect(await fetchHarness()).toEqual(answer);
+    expect(calls).toBe(1);
+  });
+
+  it("reports the edition as NOT known when the device did not say", async () => {
+    // A server that predates the field. Absent is not "true": the field exists
+    // because an unreadable lock answers "openclaw" like a real OpenClaw box,
+    // and reading silence as a fact is the failure it was added to stop.
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      calls++;
+      return { ok: true, json: async () => ({ active: "openclaw", edition: "openclaw" }) } as Response;
+    }));
+    expect(await fetchHarness()).toEqual({
+      active: "openclaw",
+      edition: "openclaw",
+      editionKnown: false,
+    });
+    expect(await fetchHarness()).toMatchObject({ editionKnown: false });
     expect(calls).toBe(1);
   });
 

--- a/src/tests/unit/client-harness.test.ts
+++ b/src/tests/unit/client-harness.test.ts
@@ -22,7 +22,7 @@ describe("client harness cache", () => {
       calls++;
       return {
         ok: true,
-        json: async () => ({ active: "hermes", edition: "hermes", editionKnown: true }),
+        json: async () => ({ active: "hermes", edition: "hermes", activeKnown: true }),
       } as Response;
     }));
   });
@@ -34,16 +34,16 @@ describe("client harness cache", () => {
   });
 
   it("serves repeat callers from cache instead of re-fetching", async () => {
-    const answer = { active: "hermes", edition: "hermes", editionKnown: true };
+    const answer = { active: "hermes", edition: "hermes", activeKnown: true };
     expect(await fetchHarness()).toEqual(answer);
-    // From the cache, and carrying the same `editionKnown`: a caller that must
+    // From the cache, and carrying the same `activeKnown`: a caller that must
     // not brand the box on a guess reads it, and a cached answer that dropped
     // it would silently turn a fact back into a doubt on the second mount.
     expect(await fetchHarness()).toEqual(answer);
     expect(calls).toBe(1);
   });
 
-  it("reports the edition as NOT known when the device did not say", async () => {
+  it("reports the harness as NOT resolved when the device did not say", async () => {
     // A server that predates the field. Absent is not "true": the field exists
     // because an unreadable lock answers "openclaw" like a real OpenClaw box,
     // and reading silence as a fact is the failure it was added to stop.
@@ -54,9 +54,9 @@ describe("client harness cache", () => {
     expect(await fetchHarness()).toEqual({
       active: "openclaw",
       edition: "openclaw",
-      editionKnown: false,
+      activeKnown: false,
     });
-    expect(await fetchHarness()).toMatchObject({ editionKnown: false });
+    expect(await fetchHarness()).toMatchObject({ activeKnown: false });
     expect(calls).toBe(1);
   });
 

--- a/src/tests/unit/harness-edition.test.ts
+++ b/src/tests/unit/harness-edition.test.ts
@@ -5,6 +5,10 @@ const mockGet = vi.fn();
 const mockSwap = vi.fn();
 vi.mock("@/lib/config-store", () => ({
   get: (...a: unknown[]) => mockGet(...a),
+  // `getActiveHarnessSource` reads the store tri-state, so that "we could not
+  // read it" is not served as "the default harness" to anything that BRANDS
+  // the box. These cases are about the LOCK, so the store always answers.
+  getKnown: async (...a: unknown[]) => ({ value: await mockGet(...a), known: true }),
   swap: (...a: unknown[]) => mockSwap(...a),
 }));
 

--- a/src/tests/unit/setup-skin.test.ts
+++ b/src/tests/unit/setup-skin.test.ts
@@ -7,6 +7,9 @@ const mockGet = vi.fn();
 const mockSet = vi.fn();
 vi.mock("@/lib/config-store", () => ({
   get: (...a: unknown[]) => mockGet(...a),
+  // See harness-edition.test.ts: the harness read is tri-state now, and these
+  // cases are about the lock and the licence, so the store always answers.
+  getKnown: async (...a: unknown[]) => ({ value: await mockGet(...a), known: true }),
   set: (...a: unknown[]) => mockSet(...a),
 }));
 


### PR DESCRIPTION
**OWNER RULING 2026-09-06 16:05** — "Remove the Hermes wallpaper from the OpenClaw version. And vice versa — the ClawBox wallpaper from the Hermes version."

## The symptom

Settings → Appearance offered **both products' branding on every box**. The owner's screenshot is an OpenClaw box with a Hermes tile in the picker; the mirror image is true on the Hermes box. Both `.jpeg` files were also *fetched* on both editions, because a tile is an `<img src>`.

Measured read-only on the two boxes, both on beta `1c406458`, both pinned to `beta`:

```
OpenClaw box   CLAWBOX_EDITION=openclaw   wp_id=clawbox
  shipped client bundle references hermes-wallpaper.jpeg   ← the screenshot
Hermes box     CLAWBOX_EDITION=hermes     wp_id=hermes
  shipped client bundle references clawbox-wallpaper.jpeg
```

## The cause

The built-in list was a literal, spelled out twice — `src/app/page.tsx` (the desktop) and `src/app/app/[id]/page.tsx` (`/app/settings`, the phone's Settings), the second carrying a comment asking for the two to be kept in step by hand. Neither consulted the edition at all: the edition only ever decided which of the three a box that had *never chosen* opened on.

## Harness-first

Neither OpenClaw nor Hermes has a wallpaper or desktop-asset store — #728 established that, and it has not changed; there is no native list being re-implemented here. **The native mechanism this change does use is the sanctioned edition reader**: `readEditionSource()` (`src/lib/edition-source.ts`), the root-owned `/etc/clawbox/edition.env`, through `getEditionSource()` and `getActiveHarness()`. Nothing new derives the edition, and nothing reads file presence or `ctx.install`'s default.

What was missing was a way for the *browser* to see the reader's own honesty flag. `edition` and `active` both collapse "nobody could answer" into `"openclaw"` — the safe way to be wrong for "which SKU is this", where openclaw is the non-premium answer, and the wrong way round for anything that **brands** the box. So `/setup-api/harness/active` now also answers `activeKnown`, from a new `getActiveHarnessSource()` beside the existing `getEditionSource()` — the same shape, one function along.

It has to certify `active`, not the edition, and that distinction is the review pass's top finding. There are **two** reads behind that value and both default silently:

- an unreadable **edition lock** (a truncated write, a permission change, a partial reflash) makes `lockedHarness()` itself a guess, since it reads `getEdition()`, which is `readEditionSource()`'s own `"openclaw"` there;
- on the one SKU the lock deliberately leaves open — a licensed `dual` — the answer comes from `data/config.json`, which a `sudo` script can leave root-owned. The forgiving reader answers `undefined` to that, so a `dual` box *running Hermes* resolved to `"openclaw"`, and the first head of this PR would have taken it as a fact: ClawBox art on a Hermes box, no way to select the Hermes wallpaper at all, and on a box that had never chosen, `wp_id: "clawbox"` written box-wide. Exactly the outcome the ruling names, one read along.

`getActiveHarnessSource()` closes both through the config store's **own** tri-state reader, `getKnown()` (`src/lib/config-store.ts`) — not a new one. That distinction matters in the other direction too: an **absent** key is a real answer (a `dual` box nobody has switched genuinely runs the default harness), so only an unreadable store is a doubt. Calling absence a doubt would have stripped the branding from every healthy dual box — the false-failure class.

## The fix

`src/lib/builtin-wallpapers.ts` is the one source of truth for "the built-ins for this edition", and every consumer reads it: the desktop's painted background, the desktop's Appearance grid, `/app/settings`'s Appearance grid, the Appearance row's subtitle (which prints the selected wallpaper's *name*) and the upload path.

- `openclaw` → `[clawbox, deep-space]`, `hermes` → `[hermes, deep-space]`, unknown → `[deep-space]`. Uploads are on every edition, unchanged.
- The **dual SKU** follows `active`, which is already "the active edition" on every SKU: a single-harness edition is locked to itself and only an unlocked `dual` resolves a runtime choice.
- The other edition's image is not merely unselectable — it is **not in the list**, so nothing renders an `<img>` for it and the file is never requested.

**Painting vs persisting** is #728's rule and it holds throughout:

- `defaultWallpaperId(harness)` always names one — this edition's brand, or Deep Space while unknown. It is what gets **painted** and what `SettingsApp` is handed, so the grid highlights the tile that is actually on screen and the subtitle names it.
- `brandWallpaperId(harness)` is null on a doubt, and is therefore the only one that may be **written**. It is what `wallpaperIdAfterDelete` gets as its `fallbackId`, which already treats null as "return the id unchanged".

A stored `wp_id` naming the other edition's brand heals to this edition's for the paint and the box keeps its value; the owner's next explicit pick replaces it.

**The probe's in-flight state can no longer flicker the wrong brand in.** `wallpaperId` was `useState("clawbox")` on both surfaces — the ClawBox art was on screen before the device had said anything, which on a Hermes box is a competitor's picture on every load (the desktop's own comment admitted it: the Hermes box was corrected "for one round-trip, and forever if the fetch failed"). It is `null` until something chooses one — the box's saved `wp_id`, this device's own edition once the probe answers, or the owner — and the debounced write omits `wp_id` while it is null, so a box whose edition never resolves has no wallpaper picked for it box-wide by whichever browser opened first. The rest of the Appearance card (fit, background colour, opacity) still saves throughout: a box that cannot read its lock must still be settable.

## Sibling call sites

- **`src/app/app/[id]/page.tsx`** — `/app/settings`, the phone's Settings and the second copy of every rule here. Fixed: the shared list, the shared render fallback, the same `wp_id`-null write rule, the same delete guard. Its `WALLPAPERS` literal is gone.
- **`SettingsApp.tsx`** — the grid and the Appearance subtitle both read `ui.wallpapers`, so both follow. The prop is `readonly` now (the shared list is frozen per edition); the desktop stopped re-mapping it, so both surfaces hand the panel the identical object.
- **`src/lib/harness.ts`** — `getActiveHarness()` now delegates to `getActiveHarnessSource()`, so there is one reader of that key rather than two. Three suites mocked `@/lib/config-store` with a factory listing `get` and not `getKnown`; each gained the one line, answering `known: true`, which is exactly what they asserted before.
- **`src/lib/client-harness.ts`** — the cache carries `activeKnown` beside `active` (not beside `edition`: it certifies *that* value, and a cached answer that dropped it would turn a fact into a doubt on the second mount). A server that omits the field reads as **not known**, never as `true`: absent is silence, and reading silence as a fact is the failure the field exists to stop.
- **Every other `fetchHarness()` consumer** (`SettingsApp`, `AIModelsStep`, `SetupWizard`, `TelegramConfiguringOverlay`, `BrowserApp`, `use-harness-adapter`) reads `active`/`edition` and is untouched — additive field, and their own fail-closed rules are their own.
- **`e2e/helpers/clawbox.ts`** — the mocked device answers `activeKnown: true`, so the e2e desktop is a real OpenClaw box rather than an unknown one.
- **`docs-site/editions/hermes.mdx` and `overview.mdx`** — the Hermes page said "Everything else on the desktop is unchanged — … Settings …", which is now false. It carries the wallpaper row in its own table and the overview gains a Built-in wallpapers column. A customer-visible edition difference belongs on the page that enumerates them, or it becomes a support ticket for a wallpaper that was removed on purpose.
- **Asset sweep**: `/clawbox-wallpaper.jpeg` and `/hermes-wallpaper.jpeg` were referenced in exactly those two page files and are now named once, in the shared module. Nothing preloads either.
- `isCustomWallpaperInRange` is now internal to `custom-wallpapers.ts` (its own `wallpaperIdAfterDelete` guard); the range question moved into `renderedWallpaperId`, which also carries the "not read yet" case the desktop needed.

## Probe-once, closed

`install.sh` truncates and rewrites `/etc/clawbox/edition.env` on **every** update, and the in-app updater reloads the desktop right after. A mount inside that window used to latch "no edition" for the life of the tab — Deep Space painted, only Deep Space offered, and no `wp_id` ever written, until someone reloaded. The desktop's existing bounded retry now covers that case as well as a failed fetch (`fetchHarness({ force })` re-reads the route rather than the cache), and gives up after the same two attempts.

## RED → GREEN

### RED, on unmodified `origin/beta` (`1c406458`)

```
 FAIL  standalone-app-appearance.test.tsx > shows the appearance this box actually has, and the wallpapers it can choose between
AssertionError: expected 'clawbox,hermes,deep-space' to be 'clawbox,deep-space'
Expected: "clawbox,deep-space"
Received: "clawbox,hermes,deep-space"

 FAIL  standalone-app-appearance.test.tsx > offers the HERMES branding and no ClawBox one on a Hermes box
AssertionError: expected 'clawbox,hermes,deep-space' to be 'hermes,deep-space'

 FAIL  standalone-app-appearance.test.tsx > offers only the neutral wallpaper while no edition could be read
AssertionError: expected 'clawbox,hermes,deep-space' to be 'deep-space'

 FAIL  standalone-app-appearance.test.tsx > writes no edition fallback when the probe never said which edition this is
AssertionError: expected 'clawbox' to be 'deep-space'

 FAIL  desktop-wallpaper-delete.test.tsx > offers ClawBox and Deep Space on an OpenClaw box, and never the Hermes art
AssertionError: expected true to be false     // an <img src=/hermes-wallpaper.jpeg> in the picker

 FAIL  desktop-wallpaper-delete.test.tsx > offers Hermes and Deep Space on a Hermes box, and never the ClawBox art
AssertionError: expected true to be false     // an <img src=/clawbox-wallpaper.jpeg> in the picker

 FAIL  desktop-wallpaper-delete.test.tsx > offers only Deep Space while no edition could be read, and writes nothing
AssertionError: expected [ …(3) ] to deeply equal []

 FAIL  desktop-wallpaper-delete.test.tsx > heals a stored OTHER-edition brand to this one for the paint, and persists nothing
 FAIL  desktop-wallpaper-delete.test.tsx > shows no branding at all while the harness probe has not answered, and lands on the Hermes art

 Test Files  2 failed (2)
      Tests  9 failed | 18 passed (27)
```

### GREEN on this head

```
$ npx vitest run builtin-wallpapers harness-active custom-wallpapers desktop-wallpaper-delete \
    standalone-app-appearance settings-appearance-a11y settings-app \
    standalone-app-settings-section standalone-app-i18n standalone-app-installed \
    standalone-back-link client-harness openclaw-config-mock-completeness \
    test-timeout-hygiene state-updater-purity
 Test Files  15 passed (15)
      Tests  129 passed (129)

$ npx vitest run --project unit         → 728 files, 11 922 passed, 1 skipped
$ npx vitest run --project components   → 186 files, 1 613 passed
$ npx tsc --noEmit                      → exit 0
```

Both whole projects green (the review-pass head, before the rebase). Earlier runs on this branch surfaced the machine's known parallel-load flakes on files this PR does not touch — `run-tunnel.test.ts`, `chat-spoken-reply.test.tsx`, `chat-header-seed-race.test.tsx`, `telegram/status*.test.ts` — each passing on its own and each already logged in the run queue.

One real slowdown was found and fixed rather than absorbed: the four new cases took `desktop-wallpaper-delete.test.tsx` (which mounts the whole shell per case) from ~26 s to ~43 s, and an existing case in it started losing testing-library's implicit 1 s `findBy` budget. The duplicate desktop copy of the heal case is gone — `/app/settings` and the unit suite pin the same rule for a fraction of the cost — and the two `findBy` steps carry an explicit, load-safe budget. The file is back to 16-25 s and passed three consecutive runs.

New coverage: `src/tests/unit/builtin-wallpapers.test.ts` (the list per edition, branding vs unknown, paint vs persist, what a saved `wp_id` paints) and `src/tests/routes/harness-active.test.ts`, which drives the real `readEditionSource()` through a temporary `CLAWBOX_EDITION_FILE` — a lock naming an edition, a lock naming none, a lock naming something unrecognised, and no lock at all — rather than mocking `@/lib/harness`.

## Device proof (read-only, both boxes, nothing mutated, no mutex taken)

Before-state on beta `1c406458`:

```
OpenClaw box   /etc/clawbox/edition.env → CLAWBOX_EDITION=openclaw   (root:root 0644)
               GET /setup-api/harness/active → {"active":"openclaw","edition":"openclaw"}
               .next/static references hermes-wallpaper.jpeg
Hermes box     /etc/clawbox/edition.env → CLAWBOX_EDITION=hermes
               GET /setup-api/harness/active → {"active":"hermes","edition":"hermes"}
               .next/static references clawbox-wallpaper.jpeg
```

Note the missing `editionKnown` in both answers — that is the field this PR adds. Both boxes hold a `wp_id` that is already their own edition's brand (`clawbox` / `hermes`), so after this lands each box paints exactly what it paints today and the only visible change is the other brand's tile leaving the picker.

## What the owner will see

- **OpenClaw box** → Appearance offers **ClawBox, Deep Space** + his uploads. The Hermes tile is gone and `hermes-wallpaper.jpeg` is never requested.
- **Hermes box** → Appearance offers **Hermes, Deep Space** + his uploads; `clawbox-wallpaper.jpeg` is never requested.
- **Either box, first paint** → Deep Space for the one same-origin round-trip the harness probe takes, then this edition's own art. It never flashes the other product's picture, which is what it did before on the Hermes box. Worth stating plainly: beta's first *painted* frame was not the brand either — it was a `background-image` div with a 900 KB JPEG still loading — so the practical change is a dark starfield where there used to be nothing, and the ruling asks for exactly that ("show only the neutral Deep Space… never the wrong brand").
- **A box whose edition lock cannot be read** → Deep Space and the uploads, nothing branded, and no `wp_id` written until he picks one.

## Residuals — recorded, not fixed here

(All four are in the run queue's Found list with their fix directions.)

- **The branding is resolved in the browser when this repo already resolves the same value on the server at first byte.** `src/app/setup/layout.tsx:33-39` says it outright — "the customer never sees the wrong skin, not even for a frame. A client-side `fetchHarness()` could not offer that" — and the desktop is a client component that does exactly what that comment rules out. Deliberately out of scope here (it touches the root render path while several fixers are in flight), but it would remove both the first-frame neutral paint and the probe retry above.
- **`install.sh:5892` is `step_edition_lock || echo "Warning: … (non-fatal)"`** — false-success class, pre-existing, and now carrying one more consequence: a box whose lock write failed loses its tool set, its setup skin *and* its wallpaper branding, with only a journal line. The systemd `EnvironmentFile` plus the legacy `Environment=CLAWBOX_EDITION=` drop-in usually cover it, which is why "unknown edition" is a dev/CI/first-boot state and not a fleet one — but the branding rule is only as good as that write.
- **The two branding surfaces now fail in opposite directions on the same unknown-edition box**: `src/lib/setup-skin.ts:31-45` deliberately tints the wizard ClawBox coral there ("a wrong tint is cosmetic"), while the desktop shows no brand. Both defensible — a coral tint is not the other product's photograph — but somebody should decide it on purpose.
- **Both brand JPEGs still ship and stay fetchable by URL on both editions.** Only the picker, the paint and the `<img>` requests are scoped. That matches the ruling as written; dropping a file per edition would mean an install-time or build-time split.
- The built-in wallpaper NAMES ("ClawBox", "Hermes", "Deep Space") are not translated. Pre-existing, unchanged by this PR, and the same one-pass argument #728 made about the desktop's toasts: translating the tile names alone would leave the card half-localised.
- A box that had genuinely chosen the other edition's brand keeps that `wp_id` in SQLite forever, painting the local brand over it. Deliberate — it is the #728 rule — and it costs nothing; the owner's next pick clears it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added edition-specific built-in wallpapers for ClawBox, Hermes, and Deep Space.
  - Wallpaper choices now adapt to the detected edition, with a neutral fallback when the edition is unknown.
  - Custom wallpaper handling now preserves unselected states and safely falls back when files are unavailable.
  - Added wallpaper details to the editions comparison documentation.

- **Bug Fixes**
  - Improved wallpaper rendering, deletion, and preference saving when edition detection is delayed or unavailable.
  - Clarified Hermes wallpaper behavior in the documentation.

- **Tests**
  - Expanded coverage for edition-specific wallpapers, fallback behavior, detection states, and custom wallpaper handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->