### PR TITLE
fix: stand down over a legacy messages.tts key instead of writing both homes (TASK-739)

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -2229,20 +2229,38 @@ if _clawai_openai_route_is_ours:
     # tools.media.models (one list for every media capability; audio rows are
     # tagged capabilities: ["audio"]).
     _audio_models = _media.get("models") if _clawbox_v2 else _audio.get("models")
+    _audio_models_move_in_flight = False
     if _clawbox_v2 and _audio_models is None and _audio.get("models") is not None:
         # A legacy tools.media.audio.models list the loader migration has not
-        # moved yet. Seeding the v2 home beside it would duplicate the rows
-        # the moment the migration runs; whatever the list holds, this boot
-        # leaves the whole surface alone and the next boot sees it migrated.
+        # moved yet. Seeding the v2 home beside it would duplicate the rows the
+        # moment the migration runs, so the LIST is left exactly as it is and
+        # the next boot sees it migrated.
+        #
+        # Not the whole surface, which this comment used to claim (TASK-739
+        # review): `baseUrl` lives at the same address in both generations and
+        # is still written below. Harmless — the core refuses this config on
+        # `tools.media.audio: Unrecognized key: "models"` until doctor moves the
+        # list anyway — but the sentence has to match the code under it.
         _audio_models = _audio.get("models")
+        _audio_models_move_in_flight = True
     _audio_has_base_url = isinstance(_audio_base_url, str) and bool(_audio_base_url.strip())
     _audio_route_taken = bool(
         (_audio_has_base_url and not _same_endpoint(_audio_base_url, _clawai_proxy_base_url))
         or (_audio_models is not None and not _is_clawbox_audio_models(_audio_models))
     )
     if _audio_route_taken:
+        # A list this migration does not recognise is the owner's own route —
+        # UNLESS it is the legacy list above, which is a migration in flight and
+        # not a decision of his. Same skip either way; different sentence,
+        # because the first is a state to leave alone and the second is a state
+        # that clears itself on the next boot.
         print(
-            "  Skipped ClawBox AI speech to text: tools.media.audio already names its own transcription route"
+            "  Skipped ClawBox AI speech to text: %s"
+            % (
+                "a legacy tools.media.audio.models list is still waiting for the core's own migration"
+                if _audio_models_move_in_flight
+                else "tools.media.audio already names its own transcription route"
+            )
         )
     elif _audio_base_url != _clawai_proxy_base_url or _audio_models is None:
         _audio["baseUrl"] = _clawai_proxy_base_url
@@ -2350,10 +2368,9 @@ if _clawai_openai_route_is_ours and _clawai_speech_entitled:
     # through, so ownership stamps survive the move).
     _tts = (cfg.get("tts") if _clawbox_v2 else _messages.get("tts"))
     # STAND DOWN while the core's own migration still owes this box a move
-    # (TASK-739). A legacy `messages.tts` block with providers in it and no v2
-    # home yet is a migration in flight: `openclaw doctor --fix` moves the
-    # whole block, and seeding the v2 home beside it would leave two speech
-    # configs racing that move.
+    # (TASK-739). A `messages.tts` key with no v2 home yet is a migration in
+    # flight: `openclaw doctor --fix` moves the whole block, and seeding the v2
+    # home beside it would leave two speech configs racing that move.
     #
     # THIS USED TO BE A REBINDING, AND THAT WAS THE BUG. It set
     # `_tts = _legacy_tts` — the SAME dict object as `cfg["messages"]["tts"]` —
@@ -2365,20 +2382,30 @@ if _clawai_openai_route_is_ours and _clawai_speech_entitled:
     # down has to mean writing nothing, so the whole body is guarded rather
     # than the variable reassigned.
     #
-    # The guard cannot be ANDed into the condition above: the `elif` below is
-    # the downgrade half of this migration, and a box in this state must not
-    # fall into it and start deleting from a home the block just declined to
-    # write.
-    _legacy_tts = _messages.get("tts")
-    _tts_move_in_flight = (
-        _clawbox_v2
-        and not isinstance(_tts, dict)
-        and isinstance(_legacy_tts, dict)
-        and bool(_legacy_tts.get("providers"))
-    )
+    # ON THE KEY, NOT ON ITS CONTENTS. Measured against 2026.8.1: `messages.tts`
+    # is refused for existing at all — `{}`, `{"provider": …}` and
+    # `{"providers": {}}` each give `messages: Unrecognized key: "tts"`, exit 1.
+    # A discriminator that asked whether the block had providers in it would
+    # have gone on writing the v2 home beside the three shapes that do not, and
+    # `messages.tts = {"provider": "tts-local-cli"}` — the selection written and
+    # the providers map never wired, the state install.sh already has an error
+    # message for — is a shape real boxes carry.
+    #
+    # STANDING DOWN IS NEVER PERMANENT. The block at the top of this script asks
+    # the core whether it will load this config and runs its `doctor --fix` when
+    # it will not, BEFORE this python program — so the next boot sees the key
+    # moved and writes the cloud voice then. The only box that stays stood down
+    # is one whose doctor is blocked, and that box is refusing to start anyway.
+    #
+    # Nested rather than ANDed into the condition above so the write half of
+    # this migration stays textually paired with the guard that owns it. An
+    # ANDed condition would hand an entitled box in this state to the `elif`
+    # below — the downgrade half — which is inert here today only by accident of
+    # it reading the same v2 home the guard has just proved is absent.
+    _tts_move_in_flight = _clawbox_v2 and not isinstance(_tts, dict) and "tts" in _messages
     if _tts_move_in_flight:
         print(
-            "  Skipped ClawBox AI cloud voice: a legacy messages.tts block is still waiting for the core's own migration"
+            "  Skipped ClawBox AI cloud voice: a legacy messages.tts key is still waiting for the core's own migration"
         )
     else:
         if not isinstance(_tts, dict):
@@ -2407,7 +2434,8 @@ if _clawai_openai_route_is_ours and _clawai_speech_entitled:
         )
         if _speech_route_taken:
             print(
-                "  Skipped ClawBox AI cloud voice: messages.tts.providers.openai already names its own speech route"
+                "  Skipped ClawBox AI cloud voice: %s.providers.openai already names its own speech route"
+                % ("tts" if _clawbox_v2 else "messages.tts")
             )
         else:
             _speech_before = dict(_speech)

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -2349,62 +2349,86 @@ if _clawai_openai_route_is_ours and _clawai_speech_entitled:
     # inner shape unchanged (the loader migration carries clawboxManaged
     # through, so ownership stamps survive the move).
     _tts = (cfg.get("tts") if _clawbox_v2 else _messages.get("tts"))
-    if _clawbox_v2 and not isinstance(_tts, dict):
-        _legacy_tts = _messages.get("tts") if isinstance(_messages, dict) else None
-        if isinstance(_legacy_tts, dict) and _legacy_tts.get("providers"):
-            # A legacy messages.tts block the loader migration has not moved
-            # yet: writing the v2 home beside it would leave two speech
-            # configs racing the migration. Leave it; next boot reads the
-            # migrated home.
-            _tts = _legacy_tts
-    if not isinstance(_tts, dict):
-        _tts = {}
-    _tts_providers = _tts.get("providers")
-    if not isinstance(_tts_providers, dict):
-        _tts_providers = {}
-    _speech = _tts_providers.get("openai")
-    if not isinstance(_speech, dict):
-        _speech = {}
-
-    # Whose entry is this? `_clawai_route_is_ours` above holds the whole rule —
-    # a foreign credential takes the slot back whatever else says, then our own
-    # stamp or a `claw_` token claims it wherever it points, then the endpoint,
-    # then an empty slot. An entry that is not ours is the owner's own
-    # OpenAI-compatible voice — a self-hosted Kokoro, an OpenAI key of their
-    # own, a different route on our host — and every field of it is left alone.
-    # The endpoint arm keeps the one-trailing-slash rule the transcription
-    # migration uses: `.../api/ai//` is a deliberate route, not a typo to tidy.
-    _speech_base_url = _speech.get("baseUrl")
-    _speech_route_taken = not _clawai_route_is_ours(
-        _speech_base_url,
-        _speech.get("apiKey"),
-        _speech.get(CLAWBOX_SPEECH_MANAGED_KEY) is True,
-        _clawai_proxy_base_url,
+    # STAND DOWN while the core's own migration still owes this box a move
+    # (TASK-739). A legacy `messages.tts` block with providers in it and no v2
+    # home yet is a migration in flight: `openclaw doctor --fix` moves the
+    # whole block, and seeding the v2 home beside it would leave two speech
+    # configs racing that move.
+    #
+    # THIS USED TO BE A REBINDING, AND THAT WAS THE BUG. It set
+    # `_tts = _legacy_tts` — the SAME dict object as `cfg["messages"]["tts"]` —
+    # and then fell through into the body below, which mutates that dict and
+    # assigns it to `cfg["tts"]`. The written config then carried the block
+    # under BOTH homes, which is `messages: Unrecognized key: "tts"`: one of
+    # the four keys OpenClaw 2026.8 refuses outright with exit 78, and one of
+    # the four that kept a customer box dark for 25 hours (TASK-737). Standing
+    # down has to mean writing nothing, so the whole body is guarded rather
+    # than the variable reassigned.
+    #
+    # The guard cannot be ANDed into the condition above: the `elif` below is
+    # the downgrade half of this migration, and a box in this state must not
+    # fall into it and start deleting from a home the block just declined to
+    # write.
+    _legacy_tts = _messages.get("tts")
+    _tts_move_in_flight = (
+        _clawbox_v2
+        and not isinstance(_tts, dict)
+        and isinstance(_legacy_tts, dict)
+        and bool(_legacy_tts.get("providers"))
     )
-    if _speech_route_taken:
+    if _tts_move_in_flight:
         print(
-            "  Skipped ClawBox AI cloud voice: messages.tts.providers.openai already names its own speech route"
+            "  Skipped ClawBox AI cloud voice: a legacy messages.tts block is still waiting for the core's own migration"
         )
     else:
-        _speech_before = dict(_speech)
-        _speech["baseUrl"] = _clawai_proxy_base_url
-        _speech["model"] = CLAWBOX_SPEECH_MODEL_ID
-        _speech["apiKey"] = _clawai_token
-        # Adopt and normalise an unmarked entry that is ours by any of the other
-        # arms — a hand repair, one written before this stamp existed, or one
-        # still naming an address we have since retired — rather than leave a
-        # box with a half-configured voice. Writing is recoverable and
-        # deleting is not, which is why only the delete below insists on it.
-        _speech[CLAWBOX_SPEECH_MANAGED_KEY] = True
-        if _speech != _speech_before:
-            _tts_providers["openai"] = _speech
-            _tts["providers"] = _tts_providers
-            if _clawbox_v2:
-                cfg["tts"] = _tts
-            else:
-                _messages["tts"] = _tts
-                cfg["messages"] = _messages
-            changed = True
+        if not isinstance(_tts, dict):
+            _tts = {}
+        _tts_providers = _tts.get("providers")
+        if not isinstance(_tts_providers, dict):
+            _tts_providers = {}
+        _speech = _tts_providers.get("openai")
+        if not isinstance(_speech, dict):
+            _speech = {}
+
+        # Whose entry is this? `_clawai_route_is_ours` above holds the whole rule —
+        # a foreign credential takes the slot back whatever else says, then our own
+        # stamp or a `claw_` token claims it wherever it points, then the endpoint,
+        # then an empty slot. An entry that is not ours is the owner's own
+        # OpenAI-compatible voice — a self-hosted Kokoro, an OpenAI key of their
+        # own, a different route on our host — and every field of it is left alone.
+        # The endpoint arm keeps the one-trailing-slash rule the transcription
+        # migration uses: `.../api/ai//` is a deliberate route, not a typo to tidy.
+        _speech_base_url = _speech.get("baseUrl")
+        _speech_route_taken = not _clawai_route_is_ours(
+            _speech_base_url,
+            _speech.get("apiKey"),
+            _speech.get(CLAWBOX_SPEECH_MANAGED_KEY) is True,
+            _clawai_proxy_base_url,
+        )
+        if _speech_route_taken:
+            print(
+                "  Skipped ClawBox AI cloud voice: messages.tts.providers.openai already names its own speech route"
+            )
+        else:
+            _speech_before = dict(_speech)
+            _speech["baseUrl"] = _clawai_proxy_base_url
+            _speech["model"] = CLAWBOX_SPEECH_MODEL_ID
+            _speech["apiKey"] = _clawai_token
+            # Adopt and normalise an unmarked entry that is ours by any of the other
+            # arms — a hand repair, one written before this stamp existed, or one
+            # still naming an address we have since retired — rather than leave a
+            # box with a half-configured voice. Writing is recoverable and
+            # deleting is not, which is why only the delete below insists on it.
+            _speech[CLAWBOX_SPEECH_MANAGED_KEY] = True
+            if _speech != _speech_before:
+                _tts_providers["openai"] = _speech
+                _tts["providers"] = _tts_providers
+                if _clawbox_v2:
+                    cfg["tts"] = _tts
+                else:
+                    _messages["tts"] = _tts
+                    cfg["messages"] = _messages
+                changed = True
 
 elif _clawai_openai_route_is_ours:
     # The other direction, and it has to exist or this migration is one-way.

--- a/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
@@ -616,16 +616,36 @@ describe.skipIf(!hasPython3)("the same migration on OpenClaw 2's top-level tts h
     expect((cfg.messages as { tts: unknown }).tts).toEqual(legacy);
   });
 
-  it("still writes the v2 home when the legacy block holds no providers", () => {
-    // The stand-down is about a legacy block with something IN it. An empty or
-    // provider-less `messages.tts` is not a migration in flight, and treating
-    // it as one would leave a Max box with no cloud voice for ever.
-    const { cfg, changed } = migrate({ messages: { tts: {} } }, { v2: true });
+  it("stands down on the KEY, whatever the legacy block holds", () => {
+    // The core refuses `messages.tts` for EXISTING, not for its contents:
+    // measured against 2026.8.1, `{}`, `{"provider": …}` and `{"providers": {}}`
+    // each give `messages: Unrecognized key: "tts"` with exit 1. A
+    // contents-based discriminator went on writing the v2 home beside the three
+    // shapes that carry no providers map — and `{"provider": "tts-local-cli"}`,
+    // the selection written and the map never wired, is a state install.sh
+    // already has an error message for.
+    //
+    // Not a Max box left without a voice, either: the block at the top of this
+    // script runs the core's own `doctor --fix` over a config the core refuses
+    // BEFORE this program, so the next boot sees the key moved and writes the
+    // cloud voice then.
+    for (const legacy of [{}, { provider: "tts-local-cli" }, { providers: {} }]) {
+      const { cfg, changed } = migrate({ messages: { tts: legacy } }, { v2: true });
+
+      expect(changed).toBe(false);
+      expect(cfg).not.toHaveProperty("tts");
+      expect((cfg.messages as { tts: unknown }).tts).toEqual(legacy);
+    }
+  });
+
+  it("writes the v2 home when there is no legacy key at all", () => {
+    // The other side of the same guard: standing down on a key that is not
+    // there would leave every entitled box without a cloud voice.
+    const { cfg, changed } = migrate({ messages: { provider: "telegram" } }, { v2: true });
 
     expect(changed).toBe(true);
     const tts = cfg.tts as { providers?: Record<string, SpeechEntry> } | undefined;
     expect(tts?.providers?.openai).toEqual({ baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN, ...MANAGED });
-    expect((cfg.messages as { tts: unknown }).tts).toEqual({});
   });
 });
 

--- a/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
@@ -584,6 +584,49 @@ describe.skipIf(!hasPython3)("the same migration on OpenClaw 2's top-level tts h
     const tts = cfg.tts as { providers?: Record<string, SpeechEntry> };
     expect(tts.providers?.openai).toEqual({ baseUrl: "https://their.own/voice", model: "x" });
   });
+
+  /**
+   * TASK-739. The stand-down over a legacy `messages.tts` block says in its own
+   * comment that writing the v2 home beside it "would leave two speech configs
+   * racing the migration" — and then did exactly that: `_tts = _legacy_tts`
+   * binds the SAME dict object as `cfg["messages"]["tts"]`, and the body below
+   * it went on to mutate that dict and alias it at `cfg["tts"]`.
+   *
+   * The written config then carries the block under BOTH homes, which is the
+   * `messages: Unrecognized key: "tts"` OpenClaw 2026.8 refuses with exit 78 —
+   * one of the four keys that kept a customer box dark for 25 hours
+   * (TASK-737). Latent on the healthy path now that the pre-start migrates
+   * before this block runs, and one owner action that re-enters this block
+   * puts the legacy key straight back.
+   */
+  it("stands down over a legacy messages.tts block instead of writing it under BOTH homes", () => {
+    const local = { command: "/home/clawbox/clawbox/scripts/openclaw/clawbox-tts.sh", outputFormat: "wav" };
+    const legacy = { provider: "tts-local-cli", providers: { "tts-local-cli": local } };
+
+    const { cfg, changed } = migrate({ messages: { tts: legacy } }, { v2: true });
+
+    // Nothing written: the core's own migration has not moved this block yet,
+    // and the next boot reads the migrated home.
+    expect(changed).toBe(false);
+    // The key 2026.8 refuses. Present at all is the defect — aliased to the
+    // same object as `messages.tts` is how it got there.
+    expect(cfg).not.toHaveProperty("tts");
+    // …and the owner's legacy block is left exactly as it was. This block is
+    // not the migrator; standing down must not edit what it stood down over.
+    expect((cfg.messages as { tts: unknown }).tts).toEqual(legacy);
+  });
+
+  it("still writes the v2 home when the legacy block holds no providers", () => {
+    // The stand-down is about a legacy block with something IN it. An empty or
+    // provider-less `messages.tts` is not a migration in flight, and treating
+    // it as one would leave a Max box with no cloud voice for ever.
+    const { cfg, changed } = migrate({ messages: { tts: {} } }, { v2: true });
+
+    expect(changed).toBe(true);
+    const tts = cfg.tts as { providers?: Record<string, SpeechEntry> } | undefined;
+    expect(tts?.providers?.openai).toEqual({ baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN, ...MANAGED });
+    expect((cfg.messages as { tts: unknown }).tts).toEqual({});
+  });
 });
 
 /**


### PR DESCRIPTION
Finding **TASK-739**, found while fixing TASK-737 (#746) and left out of it deliberately: it needs its own review because the correct fix re-indents a sixty-line block.

## Customer-visible symptom

`scripts/gateway-pre-start.sh` writes the ClawBox AI cloud-voice entry into a config that then carries the speech block under **both** `messages.tts` and the top-level `tts`. That is `messages: Unrecognized key: "tts"` — one of the four keys OpenClaw **2026.8 refuses outright with exit 78**, and one of the four that kept a customer box dark for 25 hours. A box in that state has no gateway: no chat, no Telegram, no agent turn.

Latent today rather than live, because #746 made the same script migrate the config through the core's own `doctor --fix` *before* this block runs. What this closes is the hole that puts the key straight back.

## Cause

In the OpenClaw-2 stand-down, `_tts = _legacy_tts` binds **the same dict object** as `cfg["messages"]["tts"]` — and then falls through into the body below, which mutates that dict and assigns it to `cfg["tts"]`. The comment three lines above says writing the v2 home beside the legacy one "would leave two speech configs racing the migration"; the code then did exactly that.

Standing down has to mean writing nothing, so the whole body is guarded rather than the variable reassigned. The guard **cannot** simply be ANDed into the outer condition: the `elif` after it is the downgrade half of the same migration, and an entitled box in this state would be handed to it.

## Harness first

Nothing is re-implemented here and no rename table is added. The block **stands down and defers to the core's own migration** — `openclaw doctor --fix`, which this same script already drives from the core's own `openclaw config validate --json` verdict (the #746 block at the top of the file). That is also why standing down is never permanent: on any boot where the core refuses the config, that block runs *before* this python program, moves the key, and the next boot writes the cloud voice.

## RED → GREEN

RED on unmodified `origin/beta` (`01958e5d`), the shipped block sliced verbatim and run over a v2 fixture:

```
$ npx vitest run src/tests/unit/gateway-pre-start-clawai-speech.test.ts -t "stands down"
 × stands down over a legacy messages.tts block instead of writing it under BOTH homes
     AssertionError: expected true to be false      (changed)
 × stands down on the KEY, whatever the legacy block holds
     AssertionError: expected true to be false      (changed)
 Tests  2 failed | 40 skipped (42)
```

and what beta actually writes, over `{"messages":{"tts":{"provider":"tts-local-cli","providers":{"tts-local-cli":{…}}}}}`:

```json
{"messages": {"tts": {"provider": "tts-local-cli",
                      "providers": {"tts-local-cli": {…}, "openai": {"baseUrl": "…", "model": "gpt-4o-mini-tts",
                                                                     "apiKey": "claw_…", "clawboxManaged": true}}}},
 "tts":      {"provider": "tts-local-cli",
              "providers": {"tts-local-cli": {…}, "openai": {…}}}}
```

GREEN on this branch — the same input comes back byte-identical, with `changed: false` and one line in the boot log:

```
  Skipped ClawBox AI cloud voice: a legacy messages.tts key is still waiting for the core's own migration

$ npx vitest run src/tests/unit/gateway-pre-start-*.test.ts
 Test Files  22 passed (22)      Tests  502 passed (502)
$ npx vitest run --project unit
 Test Files  735 passed (735)    Tests  12053 passed | 1 skipped (12054)
$ npx tsc --noEmit               # clean outside the pre-existing e2e-install/playwright errors
$ bash -n scripts/gateway-pre-start.sh    # ok
```

## Device leg — the real 2026.8.1 core, on the OpenClaw box

The block's own output was produced from the shipped script and handed to the pinned core in throwaway `OPENCLAW_HOME`s under `/tmp`:

| config | `openclaw config validate --json` |
|---|---|
| beta's output over `messages.tts = {"provider": "tts-local-cli"}` | exit 1, `messages: Unrecognized key: "tts"` — beta **adds** the second home to a config the core already refuses |
| this branch's output over the same input (byte-identical to the input) | exit 1, the same one pre-existing key, and nothing added — the core's own migration's job, which the block at the top of this script runs first |
| this branch's output with no legacy key | **`{"valid": true, …}`, exit 0** — the v2 home written, the config loads |

The box's own `openclaw.json` md5 was identical before and after every run. (Its gateway was restarting during the window: another agent held the device mutex for an in-app update of `6e6481d7` throughout. Nothing here touched the box's state — every run was a `/tmp` config path and state dir.)

## Review round

One `clawbox-review` pass  (findings by file path): **2 medium, 4 low, 2 info**. Applied:

- **The guard was contents-based and the core's refusal is key-based.** Measured against 2026.8.1: `messages.tts` is refused for *existing* — `{}`, `{"provider": …}` and `{"providers": {}}` each give `messages: Unrecognized key: "tts"`, exit 1. Testing `bool(_legacy_tts.get("providers"))` therefore went on writing the v2 home beside the three shapes that carry no providers map, and `messages.tts = {"provider": "tts-local-cli"}` — the selection written and the map never wired — is a state `install.sh` already has an error message for. The guard is now `"tts" in _messages`, and the second test flipped to pin it (RED on beta, above).
- **The comment justifying the nested `if/else` was wrong.** In the guarded state the `elif` is inert *today* — it reads the v2 home the guard has just proved is absent — so it cannot "start deleting". The structure is still right and the reason now says why: the write half stays textually paired with the guard that owns it, rather than relying on the downgrade half staying inert by accident.
- **The skip line named the wrong key on a v2 box** (`messages.tts.providers.openai` on a box whose home is `tts.providers.openai`). It now names the home the box actually uses.

## Siblings swept — every other `_clawbox_v2` home switch in this file

- **The transcription migration** (`tools.media.audio.models` → `tools.media.models`) has the identical rebind-and-fall-through shape and is **CLEAR of this defect**: its seed write is gated on `_audio_models is None`, so after the rebind the v2 home is never written. Two honesty fixes taken here, no behaviour change: its comment claimed the boot "leaves the whole surface alone" when it still writes `baseUrl`, and its skip line called a migration in flight "already names its own transcription route" — a false-failure sentence over a state that clears itself.
- **`gateway.controlUi.allowInsecureAuth` / `dangerouslyDisableDeviceAuth`** — **CLEAR**: it *deletes* the retired keys under v2, so there is no dual-home window.
- **The image migration** (`agents.defaults.imageGenerationModel` → `agents.defaults.mediaModels.image`) is **AFFECTED by the same shape** and is **NOT fixed here**: it always writes the v2 home and never removes the legacy key, so an "empty" legacy value (`{}`, `{"primary": ""}`, `{"fallbacks": []}`) leaves both. Measured: exit 1, `agents.defaults: Unrecognized key: "imageGenerationModel"` — the first of the incident's four refused keys. Recorded with the reproduction in the run queue rather than widened into this PR, which owns the cloud-voice block.
- **A pre-existing residual surfaced by the same run, also recorded not fixed:** the downgrade half only ever reads the v2 home, so a lapsed-plan v2 box whose stamped entry is stranded in `messages.tts` never has it taken back.

## Not a repair

A config that *already* carries both homes does not trip the guard (`_tts` is a dict), so this block writes into `tts` and leaves the legacy key. Deliberate: recovering that box is the `config validate --json` + `doctor --fix` block at the top of this same script, which is the harness's own answer and needs no code here.

## Both editions

OpenClaw only, proved rather than assumed: the script `exit 0`s when `$OPENCLAW_BIN` is not executable, and it is wired only as the `ExecStartPre` of `config/clawbox-gateway.service`. Hermes runs its own units and has its own speech-ownership rule (`hermesCloudRouteIsOurs`, `src/lib/hermes-tts.ts`); on a dual box this script runs but writes only `openclaw.json`. The Hermes suites are in the 735 files above.

## Bug classes

- *False success* — the stand-down prints its skip and leaves `changed` untouched; it never reports a write that did not happen.
- *False failure* — the two skip lines that described the wrong state (the v2 home name, and a migration in flight called an owner's own route) are the reason both were corrected.
- *Probe-once* — none introduced; the tier stamp is read once per boot, exactly as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OpenClaw 2 migration handling for speech-to-text and cloud voice settings.
  - Legacy audio model configurations are now preserved while migration determines whether they require updates.
  - Cloud voice migration now pauses when legacy text-to-speech settings are present, preventing conflicting configuration changes.
  - Existing legacy settings remain unchanged, while new installations continue receiving the appropriate current voice configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->