### PR TITLE
fix: rebuild the transcript key and stop request text reaching two log lines

### DIFF
--- a/src/app/setup-api/providers/enabled/route.ts
+++ b/src/app/setup-api/providers/enabled/route.ts
@@ -57,9 +57,26 @@ export async function POST(request: Request) {
       { status: result.kind === "is_default" ? 409 : 404 },
     );
   }
-  // The id is one the rule just matched to a row, but it is still the body's
-  // spelling of it: one line per flip, whatever the body carried.
-  console.error(`[providers] ${logSafe(provider)} switched ${fields.enabled ? "on" : "off"} by the owner`);
+  // The id the box FLIPPED, reported back by the rule from its own row —
+  // `deepseek` in the body is `clawai` here, and that is the id an operator
+  // greps the journal for. Nothing off the REQUEST reaches the line any more,
+  // which is what clears js/log-injection (TASK-723): CodeQL does not read
+  // `logSafe` as a barrier, and the note in ai-models/configure/route.ts says
+  // so.
+  //
+  // `logSafe` STAYS, and it is now guarding a different thing. A row id is
+  // ours in the sense that the box wrote it, not in the sense that it has a
+  // shape: `provider-status.ts` pushes the prefix of
+  // `agents.defaults.model.primary` as a row of its own, and
+  // `normalizeProviderId` only trims and lowercases it — so an agent holding
+  // the MCP bearer, which may run `openclaw config set` but may not POST here,
+  // can put an embedded newline or a megabyte into that id and have the
+  // owner's next flip write it. Both of `log-safe.ts`'s rules are about the
+  // record's SHAPE rather than who chose it: one value stays one line, and one
+  // caller does not decide how much gets written. Sanitising a value that is
+  // not a taint source cannot resurrect the alert — a barrier CodeQL fails to
+  // recognise is one that never creates a finding either.
+  console.error(`[providers] ${logSafe(result.provider)} switched ${fields.enabled ? "on" : "off"} by the owner`);
 
   // DELIBERATELY no catalogue signal here, and the reason is worth writing
   // down because it looks like one is missing. This flip writes exactly one

--- a/src/app/setup-api/tts/route.ts
+++ b/src/app/setup-api/tts/route.ts
@@ -63,6 +63,19 @@ import { isSameOriginRequest } from "@/lib/same-origin";
 
 const NO_STORE = { "Cache-Control": "no-store" };
 
+/**
+ * The four things POST does, as a list rather than a chain of `!==`.
+ *
+ * The value the handler uses is SELECTED OUT OF THIS ARRAY, not the body's copy
+ * of one of these words. Both spell the same four things and no request can
+ * tell them apart — but the failure line below names the action, and a string
+ * read off `request.json()` is what CodeQL reports as `js/log-injection`
+ * (TASK-723). It does not recognise `logSafe` as a barrier (the note in
+ * ai-models/configure/route.ts says so); a value that came out of a literal
+ * array is not the request's string at all.
+ */
+const ACTIONS = ["select", "voice", "language", "autoReply"] as const;
+
 function refuse(error: string, code: string, status: number) {
   return NextResponse.json({ error, code }, { status, headers: NO_STORE });
 }
@@ -455,9 +468,10 @@ export async function POST(req: Request) {
   } catch {
     return refuse("Invalid request body", "bad_request", 400);
   }
-  const { action, choice, engine, voice, language, enabled } = (body ?? {}) as Record<string, unknown>;
+  const { action: rawAction, choice, engine, voice, language, enabled } = (body ?? {}) as Record<string, unknown>;
 
-  if (action !== "select" && action !== "voice" && action !== "language" && action !== "autoReply") {
+  const action = ACTIONS.find((name) => name === rawAction);
+  if (!action) {
     return refuse("Unknown action.", "bad_request", 400);
   }
   // OWNER ONLY for the switch, and from OUR page: whether the box answers a

--- a/src/lib/harness/transcript-key.ts
+++ b/src/lib/harness/transcript-key.ts
@@ -15,12 +15,72 @@
 export const DESKTOP_TRANSCRIPT_KEY = "desktop";
 
 /**
- * A key must be a bare filename, because it becomes one.
+ * The characters a transcript key may be spelled with, and how many of them.
  *
- * This is the guard that stops `../../openclaw.json` being a transcript name
- * the moment a key arrives from a request. Exported so its test can hold it
- * to that.
+ * Exactly the rule `transcriptKeyIsSafe` used to state as a regex — one
+ * alphanumeric, then up to sixty-three more of those plus `_` and `-` — held
+ * here as an alphabet so the key can be REBUILT from it rather than tested and
+ * passed through.
+ */
+const KEY_ALPHABET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+const KEY_TAIL_ALPHABET = `${KEY_ALPHABET}_-`;
+const MAX_KEY_CHARS = 64;
+
+/**
+ * The key a transcript path may be joined from, or null for anything else.
+ *
+ * A key must be a bare filename, because it becomes one: this is what stops
+ * `../../openclaw.json` being a transcript name the moment a key arrives from
+ * a request.
+ *
+ * Rather than testing the key and then joining the ORIGINAL string, the value
+ * the store joins is assembled here one character at a time out of the
+ * alphabet — whatever the caller sent, the filename is made of these
+ * characters and no more than this many of them. The rule is exactly the regex
+ * it replaces; it is written this way for the reason `safeAppId`,
+ * `safeProjectId` and `safeSkillName` state in their own modules — a `.test()`
+ * guard leaves the caller's string in play, and a static analyser rightly
+ * keeps flagging every path built from it (`js/path-injection`, TASK-723).
+ *
+ * ITS OWN COPY, and this module has the strongest reason of the four to keep
+ * one: nothing here imports anything, deliberately, so `ChatPopup` and the
+ * other client components can share `DESKTOP_TRANSCRIPT_KEY` and this rule
+ * without pulling the store in. `webapp-icon.ts` — where `safeAppId` lives —
+ * imports `fs/promises`, `crypto` and the image client, so collapsing the two
+ * would drag `fs` into the browser bundle. (`code-projects.ts` says the same
+ * thing about its own copy, for its own reason.)
+ *
+ * Takes `unknown`, and refuses a non-string rather than coercing it: every
+ * route door checks the type first, and each is one `as string` away from not
+ * doing so — `/re/.test(7)` answers true and would have opened `7.jsonl`.
+ *
+ * The length bound is `key.length`, which counts UTF-16 code units, while the
+ * loop below walks CODE POINTS. The two can only differ outside the BMP, and
+ * every character this alphabet admits is ASCII — so an astral character is
+ * refused by the loop before the difference could matter, and the bound stays
+ * exactly the `{0,63}` the regex counted.
+ */
+export function safeTranscriptKey(key: unknown): string | null {
+  if (typeof key !== "string" || key.length < 1 || key.length > MAX_KEY_CHARS) return null;
+  let safe = "";
+  for (const ch of key) {
+    // The first character carries the narrower alphabet: a key may not start
+    // with `_` or `-`.
+    const alphabet = safe.length === 0 ? KEY_ALPHABET : KEY_TAIL_ALPHABET;
+    const at = alphabet.indexOf(ch);
+    if (at < 0) return null;
+    safe += alphabet[at];
+  }
+  return safe;
+}
+
+/**
+ * Whether a key may become a filename — the door the routes hold requests to.
+ *
+ * Asks the rebuild whether it produced anything rather than repeating the
+ * rule, so the value a route admits and the value the store joins cannot
+ * drift apart.
  */
 export function transcriptKeyIsSafe(key: string): boolean {
-  return /^[a-z0-9][a-z0-9_-]{0,63}$/i.test(key);
+  return safeTranscriptKey(key) !== null;
 }

--- a/src/lib/harness/transcript-store.ts
+++ b/src/lib/harness/transcript-store.ts
@@ -1,7 +1,7 @@
 import fsp from "fs/promises";
 import path from "path";
 import { DATA_DIR } from "@/lib/config-store";
-import { DESKTOP_TRANSCRIPT_KEY, transcriptKeyIsSafe } from "./transcript-key";
+import { DESKTOP_TRANSCRIPT_KEY, safeTranscriptKey, transcriptKeyIsSafe } from "./transcript-key";
 
 /**
  * A durable transcript for a harness whose transport does not keep one.
@@ -164,13 +164,21 @@ export interface TranscriptRecord {
  * `transcript-key.ts` so the client can share them without importing `fs`;
  * they are re-exported here for the callers that always found them here.
  */
-export { DESKTOP_TRANSCRIPT_KEY, transcriptKeyIsSafe };
+export { DESKTOP_TRANSCRIPT_KEY, safeTranscriptKey, transcriptKeyIsSafe };
 
+/**
+ * The file one key names — joined from the REBUILT key, never the argument.
+ *
+ * See `safeTranscriptKey`: the routes test a key before it gets here, and a
+ * test leaves the caller's string in play. This is the last door, so it takes
+ * the rebuild's answer and joins that.
+ */
 function transcriptPath(key: string): string {
-  if (!transcriptKeyIsSafe(key)) {
+  const safe = safeTranscriptKey(key);
+  if (safe === null) {
     throw new Error("Invalid transcript key");
   }
-  return path.join(TRANSCRIPT_DIR, `${key}.jsonl`);
+  return path.join(TRANSCRIPT_DIR, `${safe}.jsonl`);
 }
 
 /** Clamp one tool chip to what a line is allowed to carry. */

--- a/src/lib/provider-enablement.ts
+++ b/src/lib/provider-enablement.ts
@@ -27,7 +27,15 @@ import {
 } from "@/lib/provider-status";
 
 export type SetProviderEnabledResult =
-  | { ok: true }
+  /**
+   * `provider` is the id the box actually flipped, taken from ITS OWN rows
+   * rather than from the caller's spelling — `deepseek` comes back as
+   * `clawai`. A caller that wants to name the switch in a log line, or repaint
+   * a row, would otherwise have to re-derive the canonical id, and the one
+   * that did not was writing request text into the journal (TASK-723,
+   * `js/log-injection`).
+   */
+  | { ok: true; provider: string }
   | { ok: false; kind: "is_default" | "unknown_provider"; error: string };
 
 /**
@@ -75,8 +83,14 @@ export async function setProviderEnabled(id: string, enabled: boolean): Promise<
   // flip: the strip hides the row, it does not forget the provider. Answering
   // "not known to this box" for one would be a false failure — and would leave
   // whatever the switch was last set to stuck for good.
-  const hidden = !row && !!canonical && status.unrunnable.includes(canonical);
-  if ((!row && !hidden) || !canonical) {
+  // Taken from the row (or from the unrunnable list) rather than re-stated
+  // from `canonical`, so what comes back is a string this box wrote — the
+  // caller's copy of the id never leaves this function.
+  const hiddenId = !row && canonical
+    ? status.unrunnable.find((candidate) => candidate === canonical)
+    : undefined;
+  const known = row?.id ?? hiddenId;
+  if (!known || !canonical) {
     return { ok: false, kind: "unknown_provider", error: "That AI provider is not known to this box." };
   }
   if (!enabled && row?.isDefault) {
@@ -90,5 +104,5 @@ export async function setProviderEnabled(id: string, enabled: boolean): Promise<
     // Sorted so the stored list is stable across flips and diffs cleanly.
     await setConfigValue(DISABLED_PROVIDERS_KEY, [...disabled].sort());
   });
-  return { ok: true };
+  return { ok: true, provider: known };
 }

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -49,7 +49,7 @@ vi.mock("@/lib/clawkeep", () => ({
 // providers/enabled route tests; here only the call matters.
 vi.mock("@/lib/provider-enablement", () => ({
   getDisabledProviders: async () => new Set<string>(),
-  setProviderEnabled: vi.fn(async () => ({ ok: true })),
+  setProviderEnabled: vi.fn(async (id: string) => ({ ok: true, provider: id })),
 }));
 
 // The configure route fires a catalog refresh out-of-band and deliberately does

--- a/src/tests/routes/providers/enabled.test.ts
+++ b/src/tests/routes/providers/enabled.test.ts
@@ -158,17 +158,78 @@ describe("what it refuses before writing", () => {
 });
 
 describe("the log line", () => {
-  it("records the body's spelling of the id as ONE line, control characters replaced", async () => {
-    // The rule matched the id to a row; the line still carries what the body
-    // sent. A newline in it would have written a second, forged record.
-    setProviderEnabled.mockResolvedValueOnce({ ok: true });
+  // TASK-723. The line used to be built from the BODY's spelling of the id,
+  // run through `logSafe` — which CodeQL does not recognise as a barrier (the
+  // note in ai-models/configure/route.ts says so), and which is only ever
+  // damage control over text a request chose. The rule has already matched the
+  // id to one of the box's own rows by this point, so the honest thing to name
+  // is that row: an id from our enumeration, not from `request.json()`.
+  it("names the id the box flipped, not the caller's spelling of it", async () => {
+    // The real rule, no mock: `deepseek` is ClawBox AI's wire id in
+    // openclaw.json and `clawai` is the row — and the key the switch is stored
+    // under. An operator grepping the journal for the switch that moved wants
+    // the id the box actually flipped.
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
-    const res = await asOwner({ provider: "openrouter\n[providers] forged line", enabled: false });
+
+    const res = await asOwner({ provider: "deepseek", enabled: false });
+
     expect(res.status).toBe(200);
+    expect(store.get("ai_disabled_providers")).toEqual(["clawai"]);
     const lines = error.mock.calls.map((call) => call.join(" ")).filter((line) => line.includes("switched off"));
+    expect(lines).toEqual(["[providers] clawai switched off by the owner"]);
+  });
+
+  it("cannot be made to carry a second, forged record", async () => {
+    // A newline in the body used to reach the journal as U+FFFD — one line, so
+    // not a forged RECORD, but still a sentence a request wrote into an
+    // operator's log. Nothing off the body reaches the line now.
+    //
+    // The REAL rule, deliberately not a mock: `normalizeProviderId` collapses
+    // this onto `openrouter` through its `startsWith` arm and the fixture has
+    // that row, so the whole chain answers — a mocked `{ok:true, provider}`
+    // would only pin that the route interpolates the field it is handed.
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await asOwner({ provider: "openrouter\n[providers] forged line", enabled: false });
+
+    expect(res.status).toBe(200);
+    expect(store.get("ai_disabled_providers")).toEqual(["openrouter"]);
+    const lines = error.mock.calls.map((call) => call.join(" ")).filter((line) => line.includes("switched off"));
+    expect(lines).toEqual(["[providers] openrouter switched off by the owner"]);
+  });
+
+  it("keeps one line even when the ROW's own id carries a newline", async () => {
+    // The id is the box's, not the request's — and that is a statement about
+    // WHO wrote it, not about its shape. `readOpenclawStatus` pushes the prefix
+    // of `agents.defaults.model.primary` as a row of its own (provider-status
+    // `rows.push({ id: defaultProvider … })`) and `normalizeProviderId` only
+    // trims and lowercases, so an agent that may run `openclaw config set` —
+    // and may NOT post here — chooses that id. `logSafe` is what keeps the
+    // record one bounded line whatever it says.
+    //
+    // Switched ON, not off: the `is_default` refusal covers only the off
+    // direction, so this is the reachable path where such a row's id actually
+    // reaches the journal.
+    const forged = "boot\n[providers] anthropic switched on by the owner";
+    readConfig.mockResolvedValue({
+      auth: { profiles: { "anthropic:default": { provider: "anthropic", mode: "oauth" } } },
+      models: { providers: { openrouter: { apiKey: "sk-or-secret" } } },
+      agents: { defaults: { model: { primary: `${forged}/x` } } },
+    });
+    store.set("ai_disabled_providers", [forged]);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await asOwner({ provider: forged, enabled: true });
+
+    expect(res.status).toBe(200);
+    const lines = error.mock.calls.map((call) => call.join(" ")).filter((line) => line.includes("switched on"));
     expect(lines).toHaveLength(1);
+    // ONE record: the newline is replaced rather than passed through, so the
+    // owner's flip cannot write the agent's sentence as a second journal line.
     expect(lines[0]).not.toContain("\n");
-    expect(lines[0]).toContain("[providers] openrouter�[providers] forged line switched off by the owner");
+    expect(lines[0]).toBe(
+      "[providers] boot�[providers] anthropic switched on by the owner switched on by the owner",
+    );
   });
 });
 

--- a/src/tests/unit/provider-enablement.test.ts
+++ b/src/tests/unit/provider-enablement.test.ts
@@ -61,14 +61,14 @@ describe("setProviderEnabled", () => {
       lib.setProviderEnabled("openrouter", false),
       lib.setProviderEnabled("gemini", false),
     ]);
-    expect(a).toEqual({ ok: true });
-    expect(b).toEqual({ ok: true });
+    expect(a).toEqual({ ok: true, provider: "openrouter" });
+    expect(b).toEqual({ ok: true, provider: "gemini" });
     expect(store.values.ai_disabled_providers).toEqual(["gemini", "openrouter"]);
   });
 
   it("switches a provider back on", async () => {
     store.values.ai_disabled_providers = ["gemini", "openrouter"];
-    expect(await lib.setProviderEnabled("gemini", true)).toEqual({ ok: true });
+    expect(await lib.setProviderEnabled("gemini", true)).toEqual({ ok: true, provider: "gemini" });
     expect(store.values.ai_disabled_providers).toEqual(["openrouter"]);
     expect(await lib.isProviderEnabled("gemini")).toBe(true);
     expect(await lib.isProviderEnabled("openrouter")).toBe(false);
@@ -90,7 +90,10 @@ describe("setProviderEnabled", () => {
     // provider, and answering "not known to this box" would leave the switch
     // stuck at whatever it was last set to.
     hiddenProviders = ["google"];
-    expect(await lib.setProviderEnabled("google", false)).toEqual({ ok: true });
+    // …and it still reports WHICH provider it flipped: the hidden ones are the
+    // one branch with no row to read the id off, so the answer comes from the
+    // unrunnable list rather than being re-stated from the caller's string.
+    expect(await lib.setProviderEnabled("google", false)).toEqual({ ok: true, provider: "google" });
     expect(store.values.ai_disabled_providers).toEqual(["google"]);
   });
 });

--- a/src/tests/unit/transcript-key-rebuild.test.ts
+++ b/src/tests/unit/transcript-key-rebuild.test.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { saveEnv } from "@/tests/helpers/env";
 
 /**
  * TASK-723 — the session key that becomes a transcript FILENAME.
@@ -31,12 +32,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  */
 
 let root: string;
+let restoreEnv: () => void;
 let store: typeof import("@/lib/harness/transcript-store");
 
 const STORE_SOURCE = path.join(process.cwd(), "src/lib/harness/transcript-store.ts");
 
 describe("the transcript key that becomes a filename", () => {
   beforeEach(async () => {
+    // RESTORED, not deleted: vitest reuses a worker across files, so an
+    // `afterEach` that deletes a variable the worker already had takes it away
+    // from every file after this one. `saveEnv` is the repo's own undo.
+    restoreEnv = saveEnv("CLAWBOX_ROOT");
     root = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-transcript-key-"));
     process.env.CLAWBOX_ROOT = root;
     vi.resetModules();
@@ -44,7 +50,7 @@ describe("the transcript key that becomes a filename", () => {
   });
 
   afterEach(() => {
-    delete process.env.CLAWBOX_ROOT;
+    restoreEnv();
     fs.rmSync(root, { recursive: true, force: true });
   });
 

--- a/src/tests/unit/transcript-key-rebuild.test.ts
+++ b/src/tests/unit/transcript-key-rebuild.test.ts
@@ -1,0 +1,148 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * TASK-723 — the session key that becomes a transcript FILENAME.
+ *
+ * `transcriptPath` joined the CALLER'S string after a `.test()` guard, which is
+ * the shape the rest of this tree stopped using: `webapp-icon.ts` (safeAppId),
+ * `code-projects.ts` (safeProjectId) and `openclaw-skill-info.ts`
+ * (safeSkillName) each REBUILD the id one character at a time out of a constant
+ * alphabet before joining, and each says why — a `.test()` leaves the caller's
+ * value in play, so every path built from it is still built from request data.
+ * CodeQL reported that here as `js/path-injection` (high) twelve times over,
+ * once per path this module joins.
+ *
+ * WHAT THIS FILE CAN AND CANNOT PROVE, said the way #637 said it. For a STRING
+ * the rebuild is semantically identical to the regex it replaces — `$` in
+ * JavaScript matches only at the end of input, so not even a trailing newline
+ * tells the two apart, and no request can. That half is CodeQL's to report, on
+ * the PR ref.
+ *
+ * What these cases pin is everything a later change could take away and leave
+ * green: that the two rules cannot DRIFT (the door the routes call and the
+ * rebuild the store joins are one rule, not two), that the store is a real last
+ * door rather than a comment about one (a key that is not a string at all is
+ * refused instead of coerced into a filename), and — structurally, anchored and
+ * bounded to the one function — that what reaches `path.join` is the rebuilt id
+ * and not the argument.
+ */
+
+let root: string;
+let store: typeof import("@/lib/harness/transcript-store");
+
+const STORE_SOURCE = path.join(process.cwd(), "src/lib/harness/transcript-store.ts");
+
+describe("the transcript key that becomes a filename", () => {
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-transcript-key-"));
+    process.env.CLAWBOX_ROOT = root;
+    vi.resetModules();
+    store = await import("@/lib/harness/transcript-store");
+  });
+
+  afterEach(() => {
+    delete process.env.CLAWBOX_ROOT;
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  const dir = () => path.join(root, "data", "chat-transcripts");
+  const filenames = () => (fs.existsSync(dir()) ? fs.readdirSync(dir()).sort() : []);
+
+  it("rebuilds a key the routes accept into exactly itself", async () => {
+    const { safeTranscriptKey } = await import("@/lib/harness/transcript-key");
+
+    for (const key of ["desktop", "a", "A9", "tab_2", "tab-2", "Session-9_x", "a".repeat(64)]) {
+      expect(safeTranscriptKey(key)).toBe(key);
+    }
+  });
+
+  it("refuses everything the door refuses, and returns null rather than a partial id", async () => {
+    const { safeTranscriptKey } = await import("@/lib/harness/transcript-key");
+
+    for (
+      const key of [
+        "",
+        "..",
+        "../../openclaw",
+        "desktop/../x",
+        "desktop.jsonl",
+        "_leading",
+        "-leading",
+        "has space",
+        `desktop${String.fromCharCode(10)}`,
+        "a".repeat(65),
+      ]
+    ) {
+      expect(safeTranscriptKey(key)).toBeNull();
+    }
+  });
+
+  it("keeps the door and the rebuild ONE rule, so neither can drift from the other", async () => {
+    // The routes ask `transcriptKeyIsSafe`; the store joins what
+    // `safeTranscriptKey` returns. Two separately written rules is how a key a
+    // route admits becomes a filename the store spells differently — so the
+    // predicate has to be the rebuild, asked whether it produced anything.
+    const { safeTranscriptKey, transcriptKeyIsSafe } = await import("@/lib/harness/transcript-key");
+
+    const alphabet = "abzABZ059_-";
+    const candidates: string[] = ["", "a", "a".repeat(64), "a".repeat(65)];
+    for (const first of alphabet) {
+      for (const second of alphabet) {
+        candidates.push(first, `${first}${second}`, `${first}${second}${first}`);
+      }
+    }
+    for (const odd of [".", "/", "\\", " ", "é", "…", String.fromCharCode(0), String.fromCharCode(10)]) {
+      candidates.push(odd, `a${odd}`, `${odd}a`, `a${odd}b`);
+    }
+
+    for (const key of candidates) {
+      expect([key, transcriptKeyIsSafe(key)]).toEqual([key, safeTranscriptKey(key) !== null]);
+    }
+  });
+
+  it("refuses a key that is not a string at all instead of coercing one into a filename", async () => {
+    // Every route door checks `typeof … === "string"` first, and each is one
+    // `as string` away from not doing so. `/re/.test(7)` coerces and answers
+    // true, so the store's own guard used to admit a number and open
+    // `7.jsonl`; the rebuild starts by refusing anything that is not a string.
+    expect(await store.appendTranscript({ role: "user", text: "hi", timestamp: 1 }, 7 as never)).toBe(false);
+    expect(await store.appendTranscript({ role: "user", text: "hi", timestamp: 1 }, null as never)).toBe(false);
+    expect(filenames()).toEqual([]);
+
+    expect(await store.readTranscript(50, 7 as never)).toEqual([]);
+  });
+
+  it("still writes, reads and clears the conversation a valid key names", async () => {
+    // The rebuild is a barrier, not a new refusal: the ordinary path is
+    // unchanged, which is the half a taint fix most easily breaks.
+    await store.appendTranscript({ role: "user", text: "remember 41", timestamp: 10 }, "tab-2");
+    expect(filenames()).toEqual(["tab-2.jsonl"]);
+    expect(await store.readTranscript(50, "tab-2")).toEqual([
+      { role: "user", text: "remember 41", timestamp: 10 },
+    ]);
+
+    await store.clearTranscript("tab-2");
+    expect(filenames()).toEqual([]);
+  });
+
+  it("joins the rebuilt id, not the argument", async () => {
+    // A source pin, ANCHORED and BOUNDED to `transcriptPath`'s own body: sliced
+    // to end of file it would happily read some other function's `path.join`
+    // and stay green over a `transcriptPath` that had lost the rebuild.
+    const source = fs.readFileSync(STORE_SOURCE, "utf8");
+    const start = source.indexOf("function transcriptPath(");
+    expect(start).toBeGreaterThan(-1);
+    const end = source.indexOf(`${String.fromCharCode(10)}}`, start);
+    expect(end).toBeGreaterThan(start);
+    const body = source.slice(start, end);
+
+    // What reaches `path.join` is the value the rebuild returned…
+    expect(body).toMatch(/safeTranscriptKey\(/);
+    expect(body).toMatch(/path\.join\(TRANSCRIPT_DIR,\s*`\$\{safe\}\.jsonl`\)/);
+    // …and the argument itself never does.
+    expect(body).not.toMatch(/path\.join\(TRANSCRIPT_DIR,\s*`\$\{key\}/);
+  });
+});

--- a/src/tests/unit/tts-action-literal.test.ts
+++ b/src/tests/unit/tts-action-literal.test.ts
@@ -1,0 +1,82 @@
+import fs from "fs";
+import path from "path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * TASK-723 — the action name `POST /setup-api/tts` writes into the journal.
+ *
+ * The route's failure line said `[setup-api/tts] ${action} failed:` with
+ * `action` destructured straight off `request.json()`. Four literals is all it
+ * can ever be — the handler refuses anything else before reaching this — but
+ * the value in the line was still the BODY's copy of one of them, and CodeQL
+ * reported it as `js/log-injection`. Neither the `!==` chain that narrowed it
+ * nor `logSafe` is a barrier that query recognises; a value taken OUT OF a
+ * literal array is not the request's string at all.
+ *
+ * Semantically identical, therefore, and no request can tell the two apart —
+ * that half is CodeQL's to report on the PR ref, the way #637 said it for the
+ * apps routes. What is pinned here is the shape a later change could take away
+ * and leave green: the accepted set is one list rather than a chain nobody
+ * updates, and the logged action is selected out of that list.
+ */
+
+const ROUTE = path.join(process.cwd(), "src/app/setup-api/tts/route.ts");
+
+/** One function's own body, anchored at its opening line and bounded at its close. */
+function bodyOf(source: string, anchor: string): string {
+  const start = source.indexOf(anchor);
+  expect(start).toBeGreaterThan(-1);
+  const end = source.indexOf(`${String.fromCharCode(10)}}`, start);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe("POST /setup-api/tts — the action that reaches the journal", () => {
+  const source = fs.readFileSync(ROUTE, "utf8");
+
+  it("keeps the four actions as one list", () => {
+    // A fifth action added to the switch below but not to this list is refused
+    // at the door, which is the failure an operator can see. The reverse — a
+    // name added here and handled nowhere — falls through to `handleSelect`,
+    // so the list is the door and the door is the list.
+    //
+    // The CONTENTS, not the formatting: a fifth entry would push the literal
+    // past the print width and wrap it, and a pin that went red for that would
+    // say nothing about why.
+    const start = source.indexOf("const ACTIONS = [");
+    expect(start).toBeGreaterThan(-1);
+    const end = source.indexOf("]", start);
+    expect(end).toBeGreaterThan(start);
+    const names = source
+      .slice(start + "const ACTIONS = [".length, end)
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+
+    expect(names).toEqual(['"select"', '"voice"', '"language"', '"autoReply"']);
+    // `as const` is what gives the `.find` below its literal union — without it
+    // `action` widens to `string` and the four handlers lose their narrowing.
+    expect(source.slice(end, end + 12)).toContain("as const");
+  });
+
+  it("selects the action out of that list rather than off the body", () => {
+    const post = bodyOf(source, "export async function POST(");
+
+    // The body's own field is read under a name of its own…
+    expect(post).toMatch(/action: rawAction/);
+    // …and what the rest of the handler uses comes back out of the literals.
+    expect(post).toMatch(/const action = ACTIONS\.find\(\(name\) => name === rawAction\);/);
+    // The old chain of comparisons against the destructured field is gone, so
+    // nothing narrows the request's string into use again.
+    expect(post).not.toMatch(/action !== "select"/);
+  });
+
+  it("logs the selected action, never the body's copy of it", () => {
+    const post = bodyOf(source, "export async function POST(");
+    const logLine = post.split(String.fromCharCode(10)).filter((line) => line.includes("console.warn"));
+
+    expect(logLine).toHaveLength(1);
+    expect(logLine[0]).toContain("[setup-api/tts] ${action} failed:");
+    expect(logLine[0]).not.toContain("rawAction");
+  });
+});


### PR DESCRIPTION
**TASK-723** — clear the open CodeQL alerts beta has been carrying: `js/path-injection` (high) ×12 in `src/lib/harness/transcript-store.ts` and `js/log-injection` (medium) in `setup-api/providers/enabled/route.ts` and `setup-api/tts/route.ts`.

The card cited six path-injection alerts at `2c7cacf3`; on today's beta the same defect reports **twelve** (`:246, :249, :276, :280, :289, :302, :317, :333, :334, :335 ×2, :341`) — one per path the module joins. All twelve come from one function.

## Customer-visible symptom

Nothing a customer sees today, and the PR says so rather than inventing one. What beta carries is a **security dashboard that is not clean**, so a genuinely new path-injection or log-injection alert lands in a list of fourteen already-open ones and is not noticed. Two smaller real effects are fixed along the way:

- the transcript store took a **non-string** session key and coerced it into a filename — `/^…$/.test(7)` answers `true`, so `appendTranscript(record, 7)` opened `data/chat-transcripts/7.jsonl`. Every route door checks `typeof … === "string"` first, and each is one `as string` away from not doing so; the store is the last door and was not acting like one;
- `POST /setup-api/providers/enabled` wrote the **body's spelling** of the provider id into the journal. An operator grepping for the switch that moved on a box where the owner sent `deepseek` found nothing, because what the box flipped is `clawai` — and a newline in that field reached the line as U+FFFD, i.e. a sentence a request chose, in an operator's log.

## Cause

`transcriptPath` **tested** the key with a regex and then joined the caller's string:

```ts
function transcriptPath(key: string): string {
  if (!transcriptKeyIsSafe(key)) throw new Error("Invalid transcript key");
  return path.join(TRANSCRIPT_DIR, `${key}.jsonl`);   // ← the caller's string
}
```

The rest of this tree stopped doing that in #637: `safeAppId` (`webapp-icon.ts`), `safeProjectId` (`code-projects.ts`) and `safeSkillName` (`openclaw-skill-info.ts`) each **rebuild** the id one character at a time out of a constant alphabet before joining, and each says why in a comment — a `.test()` guard leaves the caller's value in play, so every path built from it is still built from request data, and a static analyser rightly keeps flagging it.

Both log lines named a value read off `request.json()`. `logSafe` was applied to one of them and is **not a barrier CodeQL recognises** — `ai-models/configure/route.ts:1597` already records that, and its `applyCloudProviderTransport` returns a boolean rather than a string for exactly this reason.

## The native mechanism (harness first)

There is no OpenClaw or Hermes mechanism in play here — these are ClawBox's own paths and ClawBox's own journal — and the mechanism that *is* native is **this repository's own**, established by #637 and named in `CLAUDE.md`:

> Every id that reaches a path on these routes is REBUILT from the alphabet rather than tested and passed through (`safeAppId` …, `safeProjectId` …, `safeSkillName` …) — a `.test()` guard leaves the caller's string in play, and CodeQL rightly flags every path built from it (`js/path-injection`).

`safeTranscriptKey` is that same helper for the fourth id, in `transcript-key.ts` (client-safe, no `fs`) beside the rule it replaces. Nothing new was invented.

## The fix

**`src/lib/harness/transcript-key.ts`** — `safeTranscriptKey(key: unknown): string | null` rebuilds the key from `KEY_ALPHABET` (first character) and `KEY_TAIL_ALPHABET` (the rest), bounded at 64. `transcriptKeyIsSafe` — the door all four routes hold requests to — is now `safeTranscriptKey(key) !== null`, so **the value a route admits and the value the store joins are one rule** and cannot drift apart.

**`src/lib/harness/transcript-store.ts`** — `transcriptPath` joins the rebuild's answer.

**`src/lib/provider-enablement.ts`** — `SetProviderEnabledResult`'s ok branch carries `provider`: the id taken from the box's own row (or, for a provider the strip hides, the matching entry of `status.unrunnable`), never re-stated from the caller's string.

**`src/app/setup-api/providers/enabled/route.ts`** — logs `result.provider`; `logSafe` stays on the providers journal line (see M1 below) because there is no longer anything off the request in the line.

**`src/app/setup-api/tts/route.ts`** — `const ACTIONS = ["select","voice","language","autoReply"] as const;` and `const action = ACTIONS.find((name) => name === rawAction)`, replacing the chain of `!==`. The TypeScript narrowing is identical; the value in the log line now comes out of a literal array.

### Equivalence, checked rather than asserted

For a **string** the rebuild is semantically identical to `/^[a-z0-9][a-z0-9_-]{0,63}$/i`, so no request can tell them apart and an existing on-disk transcript cannot be orphaned. Verified exhaustively rather than argued: every code point `U+0000`–`U+2FFF` plus astral samples and lone surrogates, as a 1-, 2- and 3-character key, and every length around the 64 bound — **49,179 probes, 0 divergences**, and `safeTranscriptKey(k) === k` for every accepted `k`. (JavaScript's `$` matches only at end of input, so not even a trailing newline separates them.)

## Both editions

All five files are **shared by both SKUs and unchanged in behaviour on either**. The transcript store is the Hermes chat's replay log and the OpenClaw desktop chat's alike (`hermes/chat`, `chat/history`, `chat/images` all pass through `transcriptKeyIsSafe`, whose answer is byte-identical); `providers/enabled` and the tts route are edition-shared routes whose only change is which string reaches `console`. There is no edition branch in the diff and no edition-specific test to write: the proof that the other edition is unaffected is that no observable behaviour changed on either.

## Sibling call sites — swept

| Call site | Verdict |
| --- | --- |
| `src/lib/harness/hermes-adapter.ts:560` (`transcriptKeyIsSafe`) | cleared — the rule is byte-identical for a string, and the adapter mints keys it then validates |
| `src/app/setup-api/chat/history/route.ts:68` | cleared — same, `typeof` checked upstream |
| `src/app/setup-api/chat/images/route.ts:86` | cleared — same |
| `src/app/setup-api/hermes/chat/route.ts:981` | cleared — same |
| `appendTranscript` / `readTranscript` / `clearTranscript` / `sweepTranscripts` | all go through `transcriptPath`; `sweepTranscripts` reads `readdir` and never joins a key |
| `src/app/setup-api/ai-models/configure/route.ts:2855` (`setProviderEnabled`) | cleared — ignores the return value; its test mock updated to answer the new shape |
| `src/lib/log-safe.ts` | unchanged; every other `logSafe` caller is untouched |
| `src/lib/openclaw-session-store.ts` `sessionStorePath(agentId, …)` | cleared, not fixed — `agentId` is a `[A-Za-z0-9_-]+` regex CAPTURE from the session key, so no separator can reach the join, and CodeQL does not report it |
| `src/lib/chat-spoken-history.ts` `resolveTranscript` | cleared — already contains its own realpath containment check and rebuilds from the trusted root |

## RED → GREEN

RED, on unmodified `origin/beta`:

```
 ❯ |unit| src/tests/unit/transcript-key-rebuild.test.ts (6 tests | 5 failed)
     × rebuilds a key the routes accept into exactly itself
     × refuses everything the door refuses, and returns null rather than a partial id
     × keeps the door and the rebuild ONE rule, so neither can drift from the other
         TypeError: safeTranscriptKey is not a function
     × refuses a key that is not a string at all instead of coercing one into a filename
         AssertionError: expected true to be false      <- appendTranscript(rec, 7) wrote 7.jsonl
     × joins the rebuilt id, not the argument
         Received: "function transcriptPath(key: string): string {
                      if (!transcriptKeyIsSafe(key)) { throw new Error(\"Invalid transcript key\"); }
                      return path.join(TRANSCRIPT_DIR, `${key}.jsonl`);"

 ❯ |unit| src/tests/unit/tts-action-literal.test.ts (3 tests | 2 failed)
     × keeps the four actions as one list
     × selects the action out of that list rather than off the body

 ❯ |unit| src/tests/routes/providers/enabled.test.ts (16 tests | 2 failed)
     × names the id the box flipped, not the caller's spelling of it
         - "[providers] clawai switched off by the owner"
         + "[providers] deepseek switched off by the owner"
     × cannot be made to carry a second, forged record
         - "[providers] openrouter switched off by the owner"
         + "[providers] openrouter\uFFFD[providers] forged line switched off by the owner"

 Test Files  3 failed (3)
      Tests  9 failed | 16 passed (25)
```

GREEN on this branch — the new tests plus every neighbouring suite:

```
 Test Files  20 passed (20)
      Tests  357 passed (357)

(the two new suites, plus harness-transcript-store, instrumentation-transcript-sweep,
 provider-enablement, routes/providers/*, chat-history, chat-images, tts, tts-edition,
 tts-hermes-parity, tts-speak, hermes-chat-streaming, ai-models/configure, and the three
 required hygiene suites: openclaw-config-mock-completeness, test-timeout-hygiene,
 state-updater-purity)
```

Full suite: **13,631 passed / 922 files**, two unrelated timeouts (`chat-email-refs-surfaces.test.tsx`, `telegram/status.test.ts`) that pass on their own — the TASK-702 flake class, neither file touched here. `tsc --noEmit` clean. `bun run lint` reports nothing on any file in this diff. No shell script is touched, so there is no `bash -n` leg.

## What proves it — and what it does NOT

The repository tests pin the contracts. The CodeQL half needs stating precisely, because the obvious query does not say what it looks like it says.

**Measured on this head (`95a16901`, merge ref `a043c95b`):**

```
$ gh api "repos/id-robots/clawbox/code-scanning/analyses?ref=refs/pull/752/merge"
2026-09-06T15:40:19Z ref=refs/pull/752/merge cat=/language:javascript-typescript results=0 rules=103

$ gh api ".../check-runs" --jq '… select(.name=="CodeQL") …'
CodeQL | success | No new alerts in code changed by this pull request
```

**What that does prove:** the security-extended suite (103 rules) ran on the merge commit and reports nothing in the code this PR changed — so the rewritten `transcriptPath`, the rewritten `providers/enabled` log line and the rewritten tts handler introduce no alert of their own.

**What it does NOT prove:** that the fourteen alerts this card names are cleared. The PR run is **diff-informed** — it reports alerts in changed code — and eleven of the twelve `js/path-injection` alerts are reported at the `fsp.*` SINKS (`:246 … :341`), which are lines this PR does not touch. A query for open alerts on `refs/pull/752/merge` therefore returns an empty set whether the fix worked or not, and quoting that emptiness as the proof would be a false success of exactly the kind this repo keeps producing. There is no CodeQL CLI on the machine this was written on to settle it locally.

**The definitive check is the full scan that runs on push to `beta`** (`codeql.yml` triggers on `push: [main, beta]`), after this merges:

```
gh api "repos/id-robots/clawbox/code-scanning/alerts?ref=refs/heads/beta&state=open&per_page=100" \
  --jq '[.[] | select(.rule.id=="js/path-injection" and (.most_recent_instance.location.path|test("transcript-store")))] | length'   # expect 0
gh api "repos/id-robots/clawbox/code-scanning/alerts?ref=refs/heads/beta&state=open&per_page=100" \
  --jq '[.[] | select(.rule.id=="js/log-injection" and (.most_recent_instance.location.path|test("providers/enabled|tts/route")))] | length'   # expect 0
```

Beta carries **21** alerts of these two rules today; 14 of them are this card's.

**The evidence that it will clear, short of that scan:** the transcript half is the identical mechanism as #637, and no open `js/path-injection` remains on beta for any path built through `safeAppId` or `safeProjectId` — the precedent worked, twice, and the taint's only entry point here is the single `path.join` this PR rewrites. The log-injection half removes the request-derived value from the sink expression outright, which is what the rule tracks. The one construct with **no precedent in this repo** is `ACTIONS.find` as a narrowing barrier (`Array.prototype.find` returns an element of an untainted literal array; the tainted value appears only in the predicate's boolean) — if the beta scan shows `tts/route.ts` still flagged, the fallback is a `switch (rawAction)` whose arms `return` their own literal, and that is a one-line follow-up.

## Deliberately NOT taken (recorded in the queue's Found section)

Beta carries seven more alerts of the same two rules that this card does not name, and widening into them would have put this PR into three subsystems and into files two concurrent fixers hold:

- `js/log-injection` at `src/lib/harness-mcp-refresh.ts:86` and `src/lib/hermes-mcp-reload.ts:105,110` — the harness-select route body reaching `reportMcpReloadRefused(tag, what)`, which has **six** callers. The fix is to rebuild the harness name from the closed set at the source, but `hermes-mcp-reload.ts` is in TASK-577's blast radius, which is the next card in this batch.
- `js/path-injection` at `src/lib/app-proxy.ts:207` (and `:254`), `src/lib/clawbox-manifest.ts:101`, `src/app/setup-api/webapps/route.ts:152` — one chain: `projectFolderFor` guards with `APP_ID_RE.test(id)` and then joins. `safeAppId` is one import away and would likely clear all four, but that is the app-proxy subsystem, not this one.

So `js/path-injection` and `js/log-injection` will **not be empty on beta** after this merges; what should be empty is the set of fourteen alerts this card names, and the query above is how to tell.

## Review pass (`clawbox-review`) — 1 MEDIUM, 4 LOW, all applied

**M1 — I had removed `logSafe` and broken a guarantee that was not the one I was fixing.** The reviewer was right and I confirmed it in the code: `provider-status.ts` pushes the prefix of `agents.defaults.model.primary` as a row of its own (`rows.push({ id: defaultProvider … })`, and the Hermes reader does the same with `payload.current.provider`), while `normalizeProviderId`'s fall-through only trims and lowercases. So the id is the BOX's in the sense of who wrote it, not in the sense that it has a shape — and an agent holding the MCP bearer may run `openclaw config set` even though it may not POST here. `logSafe` is restored, with the comment rewritten to say it now guards the ROW's shape rather than the request's, so the next reader does not delete it again for the same reason I did. Sanitising a value that is not a taint source cannot resurrect the alert: a barrier CodeQL fails to recognise never creates a finding either.

The reachable path is the ON direction — the `is_default` refusal only covers OFF — so the new case `keeps one line even when the ROW's own id carries a newline` switches such a row back on and pins one bounded record. **Mutation-checked:** reverting `logSafe(result.provider)` to `result.provider` reddens exactly that case with `expected '[providers] boot\n[providers] anthrop…' not to contain '\n'`.

**L3 — a test stubbed into passing.** `cannot be made to carry a second, forged record` mocked `setProviderEnabled`, so it could only pin that the route interpolates the field it is handed. The mock was also unnecessary: `normalizeProviderId` collapses that body onto `openrouter` through its `startsWith` arm and the fixture has that row, so the real rule answers. Mock deleted; the case now proves the whole chain and asserts the stored list too.

**L4 — a source pin that matched formatting rather than a rule.** The `ACTIONS` assertion required one line with exact spacing, so a legitimate fifth action would have gone red for Prettier's wrapping. It now extracts the array and asserts its contents (plus that `as const` survives, since without it `action` widens to `string` and the four handlers lose their narrowing).

**L5 — two missing clauses in `transcript-key.ts`.** Why this is a fourth private copy rather than a call into `safeAppId` (this module is deliberately import-free so client components can share the rule; `webapp-icon.ts` imports `fs/promises`, `crypto` and the image client), and why the `key.length` bound and the `for…of` loop agree (they can differ only outside the BMP, and every character the alphabet admits is ASCII).

**L2 — rebase.** Done: this head is on `01958e5d`, and `git diff --stat origin/beta...HEAD` lists only the ten files above with `--diff-filter=DR` empty.

The reviewer independently fuzzed the regex equivalence — all 65,536 single BMP code units, two-character combinations against all 65,536, lone surrogates and astral pairs including the 64-code-unit / 63-code-point boundary, `ſ`/`K` against the `/i` flag without `/u`, and ~420,000 random strings — and reported **0 mismatches**, agreeing with the 49,179-probe check above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider enablement audit logs now consistently record the correct provider ID and remain safely formatted.
  * Text-to-speech actions are validated against the supported action set, improving handling of invalid requests.
  * Transcript filenames now use validated, canonical keys, preventing unsafe characters, traversal patterns, and malformed inputs from affecting transcript storage.
* **Security**
  * Strengthened input handling for provider, text-to-speech, and transcript operations to reduce risks from forged or unexpected values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
