### PR TITLE
fix: make the unrunnable-provider rule reachable on a real box, and say what it cannot decide

### DIFF
--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -575,7 +575,7 @@ async function fetchSubscriptionSurfaceIds(provider: string): Promise<Set<string
     // today — no `SUBSCRIPTION_SURFACE` entry names a separate provider — and
     // closed rather than left for the day one does, like every other rule this
     // function had to be taught twice.
-    await recordProviderEnumeration(surfaceProvider, payload.models.length);
+    await recordProviderEnumeration(surfaceProvider, payload.models.length, models.length);
     return new Set(payload.models.map((m) => m.id));
   } catch (err) {
     console.warn(
@@ -999,8 +999,9 @@ interface CatalogFetchResult {
   diagnostic: string;
   /**
    * True when an empty `models` is THE BOX'S ANSWER rather than a failure to
-   * get one — the CLI ran, refused nothing, printed nothing on stderr and
-   * listed no rows at all.
+   * get one: the CLI ran, refused nothing, and either listed no rows at all
+   * (`count: 0`) or listed rows and marked every one of them
+   * `available: false`.
    *
    * The distinction is the whole false-failure guard for TASK-668: a refusal, a
    * timeout, a plugin that is gone, or rows that our own chat-model filter ate
@@ -1009,6 +1010,18 @@ interface CatalogFetchResult {
    * zero is recorded, and only it stops the row being offered.
    */
   emptyIsAnswer: boolean;
+  /** How many rows the CLI listed, before any filter of ours. */
+  listedRows: number;
+  /**
+   * Of those, how many the harness did NOT say it cannot route — every row
+   * except the ones explicitly `available: false`.
+   *
+   * Zero WITH rows listed is the harness's own statement that this box can take
+   * no route here, and the second thing that hides a provider row. `null` and
+   * absent count as available on purpose: they mean "not determined", which is
+   * what an unconfigured provider answers on a live box.
+   */
+  availableRows: number;
 }
 
 function toFetchResult(
@@ -1030,6 +1043,17 @@ function toFetchResult(
   const models = transformOpenclawEntries(provider, rows);
   const refusal = parsed.ok === false ? parsed.error?.message?.trim() : "";
   let diagnostic = refusal || stderr.trim();
+  // How many listed rows the harness did NOT say it cannot route.
+  //
+  // TRISTATE, and only `false` counts against a row — see the long note above
+  // `transformOpenclawEntries`. `null`/absent is "the harness did not
+  // determine", which is what an unconfigured provider answers, and counting
+  // that as unavailable would write off every provider on a box that has not
+  // finished being set up. Measured on the OpenClaw box (2026.8.1): with no
+  // Google credential all ten google rows come back `available: null`, while
+  // every deepseek row on the same box — that one is linked — comes back
+  // `true`. So `false` is a statement and `null` is a shrug.
+  const availableRows = rows.length - rows.filter((row) => row.available === false).length;
   if (!diagnostic && models.length === 0 && rows.length > 0) {
     // The CLI answered, listed rows, and none of them survived. Which filter
     // ate them decides what an operator does next — "sign in" is a different
@@ -1047,17 +1071,33 @@ function toFetchResult(
   // row. `diagnostic` covers the rest: a refusal or stderr fills it above, and
   // rows that were all filtered out by OUR chat rule fill it just now.
   //
-  // Deliberately NOT extended to "rows listed, every one `available: false`",
-  // which the core does report and which is the other way a box says it can
-  // route nothing here. It is also exactly what a provider with no credential
-  // looks like, and the two cannot be told apart from the payload — so that
-  // case keeps beta's behaviour and records nothing.
+  // STDERR IS NOT A FAILURE on these boxes, and requiring it to be empty made
+  // this whole rule dead code on the ones that ship. Measured on the OpenClaw
+  // box: every `openclaw models list` invocation, exit code 0, prints
+  // `[agents/model-registry] model catalog load issue: … Provider openai, model
+  // gpt-image-1-mini: no "api" specified` — a warning about an unrelated
+  // provider's catalogue, on every provider's enumeration. With `!diagnostic`
+  // in the condition, a genuine `count: 0` answer could never be recorded
+  // there. What actually says the answer is untrustworthy is the CLI REFUSING
+  // (`ok: false`, which it reports on stdout while still exiting 0) or the
+  // process failing outright — and that second one rejects long before here.
+  //
+  // The positive statement is what is required instead: `count: 0` present in a
+  // payload that parsed. A truncated or shape-shifted body has no count and is
+  // still not an answer.
+  //
+  // TWO shapes of the same answer, and the second is the one that fires while
+  // the CLI still has a catalogue to print: it listed rows and marked every one
+  // of them `available: false`. Our own transform drops those rows, so `models`
+  // is empty either way — what tells them apart from a failure is that the
+  // command ran and refused nothing.
+  const noRowsAtAll = rows.length === 0 && parsed.count === 0;
+  const noRoutableRows = rows.length > 0 && availableRows === 0;
   const emptyIsAnswer = models.length === 0
-    && rows.length === 0
     && parsed.ok !== false
-    && parsed.count === 0
-    && !diagnostic;
-  return { models, diagnostic, emptyIsAnswer };
+    && !refusal
+    && (noRowsAtAll || noRoutableRows);
+  return { models, diagnostic, emptyIsAnswer, listedRows: rows.length, availableRows };
 }
 
 function fetchOpenclawCatalog(provider: string): Promise<CatalogFetchResult> {
@@ -1148,7 +1188,8 @@ async function fetchOpenRouterCatalog(): Promise<CatalogFetchResult> {
   // Never an authoritative empty: this is openrouter.ai's catalogue, not this
   // box's answer about what it can route, and an empty `data` from a REST
   // endpoint is far more likely to be a bad hour upstream than a fact.
-  return { models: transformOpenRouterEntries(data.data ?? []), diagnostic: "", emptyIsAnswer: false };
+  const models = transformOpenRouterEntries(data.data ?? []);
+  return { models, diagnostic: "", emptyIsAnswer: false, listedRows: models.length, availableRows: models.length };
 }
 
 // Refresh the catalog for `provider` in the background. Returns
@@ -1323,7 +1364,13 @@ export function refreshInBackground(
     // The only catalogue with no upstream to ask: Mike's gateway routes the
     // two device tiers and nothing else, so these two rows ARE the device's
     // answer rather than a stand-in for one.
-    fetcher = Promise.resolve({ models: CLAWAI_STATIC_MODELS, diagnostic: "", emptyIsAnswer: false });
+    fetcher = Promise.resolve({
+      models: CLAWAI_STATIC_MODELS,
+      diagnostic: "",
+      emptyIsAnswer: false,
+      listedRows: CLAWAI_STATIC_MODELS.length,
+      availableRows: CLAWAI_STATIC_MODELS.length,
+    });
   } else {
     fetcher = fetchOpenclawCatalog(provider);
   }
@@ -1346,7 +1393,11 @@ export function refreshInBackground(
   // inside it is not itself inside a `try`.
   const surface = fetchSubscriptionSurfaceIds(provider).catch(() => null);
 
-  const publish = async (models: CatalogModel[], surfaceIds: Set<string> | null) => {
+  const publish = async (
+    models: CatalogModel[],
+    surfaceIds: Set<string> | null,
+    availableRows: number,
+  ) => {
     // The CLI answered, so the provider is enumerable — that much is true
     // whatever generation this is, and it is what the backoff tracks.
     recordSuccessfulRefresh(provider);
@@ -1379,7 +1430,7 @@ export function refreshInBackground(
     // the raw one, so the number and the catalogue the picker is offered cannot
     // disagree. Reached only past the generation guard above, so a fork from
     // before the box changed records nothing.
-    await recordProviderEnumeration(provider, payload.models.length);
+    await recordProviderEnumeration(provider, payload.models.length, availableRows);
     console.log(
       `[catalog] refreshed ${provider}: ${models.length} models`
       + (surfaceIds ? ` (${surfaceIds.size} on the subscription surface)` : ""),
@@ -1401,7 +1452,7 @@ export function refreshInBackground(
   };
 
   fetcher
-    .then(async ({ models, diagnostic, emptyIsAnswer }) => {
+    .then(async ({ models, diagnostic, emptyIsAnswer, availableRows }) => {
       if (models.length === 0) {
         // NOT a success, and every line of beta's handling stands: nothing is
         // published, the previous catalogue is kept, and `markStale` records
@@ -1422,7 +1473,7 @@ export function refreshInBackground(
         // no longer exists, and its zero would hide the provider the customer
         // just connected.
         if (emptyIsAnswer && forkSeq >= currentSeq(provider)) {
-          await recordProviderEnumeration(provider, 0);
+          await recordProviderEnumeration(provider, 0, 0);
         }
         console.warn(
           `[catalog] ${provider}: live enumeration returned no models, keeping the previous catalogue`
@@ -1431,9 +1482,9 @@ export function refreshInBackground(
         markStale();
         return;
       }
-      await publish(models, null);
+      await publish(models, null, availableRows);
       const surfaceIds = await surface;
-      if (surfaceIds) await publish(models, surfaceIds);
+      if (surfaceIds) await publish(models, surfaceIds, availableRows);
     })
     .catch((err: unknown) => {
       console.error(`[catalog] refresh failed for ${provider}:`, err instanceof Error ? err.message : err);

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -1079,7 +1079,13 @@ function toFetchResult(
   // of them `available: false`. Our own transform drops those rows, so `models`
   // is empty either way — what tells them apart from a failure is that the
   // command ran and refused nothing.
-  const noRowsAtAll = rows.length === 0 && parsed.count === 0;
+  // `Array.isArray` as well as the count, because `rows` above already turned a
+  // non-array `models` into `[]`: `{count: 0, models: {}}` would otherwise read
+  // as a clean zero and hide the provider for the record's whole lifetime. That
+  // coercion was written when an empty enumeration only meant "keep the previous
+  // catalogue"; it now decides whether a row is offered, so a malformed body has
+  // to fail the test rather than pass it.
+  const noRowsAtAll = Array.isArray(parsed.models) && rows.length === 0 && parsed.count === 0;
   const noRoutableRows = rows.length > 0 && availableRows === 0;
   const emptyIsAnswer = models.length === 0
     && parsed.ok !== false

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -575,7 +575,7 @@ async function fetchSubscriptionSurfaceIds(provider: string): Promise<Set<string
     // today — no `SUBSCRIPTION_SURFACE` entry names a separate provider — and
     // closed rather than left for the day one does, like every other rule this
     // function had to be taught twice.
-    await recordProviderEnumeration(surfaceProvider, payload.models.length, models.length);
+    await recordProviderEnumeration(surfaceProvider, payload.models.length);
     return new Set(payload.models.map((m) => m.id));
   } catch (err) {
     console.warn(
@@ -1010,18 +1010,6 @@ interface CatalogFetchResult {
    * zero is recorded, and only it stops the row being offered.
    */
   emptyIsAnswer: boolean;
-  /** How many rows the CLI listed, before any filter of ours. */
-  listedRows: number;
-  /**
-   * Of those, how many the harness did NOT say it cannot route — every row
-   * except the ones explicitly `available: false`.
-   *
-   * Zero WITH rows listed is the harness's own statement that this box can take
-   * no route here, and the second thing that hides a provider row. `null` and
-   * absent count as available on purpose: they mean "not determined", which is
-   * what an unconfigured provider answers on a live box.
-   */
-  availableRows: number;
 }
 
 function toFetchResult(
@@ -1097,7 +1085,7 @@ function toFetchResult(
     && parsed.ok !== false
     && !refusal
     && (noRowsAtAll || noRoutableRows);
-  return { models, diagnostic, emptyIsAnswer, listedRows: rows.length, availableRows };
+  return { models, diagnostic, emptyIsAnswer };
 }
 
 function fetchOpenclawCatalog(provider: string): Promise<CatalogFetchResult> {
@@ -1188,8 +1176,7 @@ async function fetchOpenRouterCatalog(): Promise<CatalogFetchResult> {
   // Never an authoritative empty: this is openrouter.ai's catalogue, not this
   // box's answer about what it can route, and an empty `data` from a REST
   // endpoint is far more likely to be a bad hour upstream than a fact.
-  const models = transformOpenRouterEntries(data.data ?? []);
-  return { models, diagnostic: "", emptyIsAnswer: false, listedRows: models.length, availableRows: models.length };
+  return { models: transformOpenRouterEntries(data.data ?? []), diagnostic: "", emptyIsAnswer: false };
 }
 
 // Refresh the catalog for `provider` in the background. Returns
@@ -1364,13 +1351,7 @@ export function refreshInBackground(
     // The only catalogue with no upstream to ask: Mike's gateway routes the
     // two device tiers and nothing else, so these two rows ARE the device's
     // answer rather than a stand-in for one.
-    fetcher = Promise.resolve({
-      models: CLAWAI_STATIC_MODELS,
-      diagnostic: "",
-      emptyIsAnswer: false,
-      listedRows: CLAWAI_STATIC_MODELS.length,
-      availableRows: CLAWAI_STATIC_MODELS.length,
-    });
+    fetcher = Promise.resolve({ models: CLAWAI_STATIC_MODELS, diagnostic: "", emptyIsAnswer: false });
   } else {
     fetcher = fetchOpenclawCatalog(provider);
   }
@@ -1393,11 +1374,7 @@ export function refreshInBackground(
   // inside it is not itself inside a `try`.
   const surface = fetchSubscriptionSurfaceIds(provider).catch(() => null);
 
-  const publish = async (
-    models: CatalogModel[],
-    surfaceIds: Set<string> | null,
-    availableRows: number,
-  ) => {
+  const publish = async (models: CatalogModel[], surfaceIds: Set<string> | null) => {
     // The CLI answered, so the provider is enumerable — that much is true
     // whatever generation this is, and it is what the backoff tracks.
     recordSuccessfulRefresh(provider);
@@ -1430,7 +1407,7 @@ export function refreshInBackground(
     // the raw one, so the number and the catalogue the picker is offered cannot
     // disagree. Reached only past the generation guard above, so a fork from
     // before the box changed records nothing.
-    await recordProviderEnumeration(provider, payload.models.length, availableRows);
+    await recordProviderEnumeration(provider, payload.models.length);
     console.log(
       `[catalog] refreshed ${provider}: ${models.length} models`
       + (surfaceIds ? ` (${surfaceIds.size} on the subscription surface)` : ""),
@@ -1452,7 +1429,7 @@ export function refreshInBackground(
   };
 
   fetcher
-    .then(async ({ models, diagnostic, emptyIsAnswer, availableRows }) => {
+    .then(async ({ models, diagnostic, emptyIsAnswer }) => {
       if (models.length === 0) {
         // NOT a success, and every line of beta's handling stands: nothing is
         // published, the previous catalogue is kept, and `markStale` records
@@ -1473,7 +1450,7 @@ export function refreshInBackground(
         // no longer exists, and its zero would hide the provider the customer
         // just connected.
         if (emptyIsAnswer && forkSeq >= currentSeq(provider)) {
-          await recordProviderEnumeration(provider, 0, 0);
+          await recordProviderEnumeration(provider, 0);
         }
         console.warn(
           `[catalog] ${provider}: live enumeration returned no models, keeping the previous catalogue`
@@ -1482,9 +1459,9 @@ export function refreshInBackground(
         markStale();
         return;
       }
-      await publish(models, null, availableRows);
+      await publish(models, null);
       const surfaceIds = await surface;
-      if (surfaceIds) await publish(models, surfaceIds, availableRows);
+      if (surfaceIds) await publish(models, surfaceIds);
     })
     .catch((err: unknown) => {
       console.error(`[catalog] refresh failed for ${provider}:`, err instanceof Error ? err.message : err);

--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -636,15 +636,6 @@ export default function AIModelsStep({
     () => providerStatus?.providers.find((row) => row.isDefault) ?? null,
     [providerStatus],
   );
-  // Providers this box can run NO model from (TASK-668). The server decides —
-  // this is the same list the Providers strip's rows were dropped from — so the
-  // two halves of the same Settings section cannot offer different providers.
-  // Absent, or a status call that has not landed, is an EMPTY set: nothing is
-  // hidden until the box has actually said so.
-  const unrunnableProviders = useMemo(
-    () => new Set(providerStatus?.unrunnable ?? []),
-    [providerStatus],
-  );
   /** A row's connection state, as a dot AND a word. */
   const rowStatus = useCallback((id: string) => {
     const row = statusById.get(id);
@@ -2074,13 +2065,13 @@ export default function AIModelsStep({
     return () => clearTimeout(timer);
   }, [configuringState?.completed, handleConfiguringDone]);
 
-  const baseProviders = (providerIdSet ? allowedProviders : PROVIDERS)
-    // The SELECTED row is never dropped. Everything else in this component that
-    // decides what to render — the "keep the selection valid" effect, the
-    // credential panel, the deep-link handler — resolves against the unfiltered
-    // list, so removing the selected row would leave its form on screen with no
-    // radio above it and no "show more" toggle to get back.
-    .filter((provider) => provider.id === selectedProvider || !unrunnableProviders.has(provider.id));
+  // EVERY provider this panel was asked to offer, including one the box can
+  // currently run no model from (TASK-668). This is the CONNECT list, and
+  // connecting is the way out of that state: saving a cloud provider writes its
+  // configured model rows and `models.mode: "merge"`, which is what makes it
+  // routable again. Hiding it here would leave a box with no door — the
+  // Providers strip above drops such a row precisely because this one does not.
+  const baseProviders = providerIdSet ? allowedProviders : PROVIDERS;
   // The list opens on the provider that is actually in play and keeps the rest
   // one tap behind the same toggle that used to reveal only the secondary
   // ones. Four rows plus that toggle is ~350px of catalogue standing on top of

--- a/src/components/AiProviderList.tsx
+++ b/src/components/AiProviderList.tsx
@@ -59,8 +59,18 @@ export default function AiProviderList() {
   // about which of the owner's providers answer, in what order, and which are
   // switched off. Connecting a new one is the panel below. A provider whose
   // sign-in needs refreshing is still theirs and stays listed.
+  // ...and not a provider this box can run NO model from (TASK-668). That is
+  // the owner's ruling: a row whose every model the gateway would refuse is not
+  // part of "what is connected", and the answer comes from the count the
+  // catalog route's own enumeration already recorded — no probe, no fork. The
+  // server names them and keeps them (`unrunnable`), so the Connect list below
+  // can still offer one with its real connection label; the hiding is here,
+  // where this list already decides what belongs in it.
+  const unrunnable = new Set(summary?.unrunnable ?? []);
   const rows = (summary?.providers ?? []).filter((row) =>
-    (row.state === "connected" || row.state === "needs-reauth") && row.section !== "localAi",
+    (row.state === "connected" || row.state === "needs-reauth")
+    && row.section !== "localAi"
+    && !unrunnable.has(row.id),
   );
 
   // A row nobody has probed yet cannot be filtered INTO this list — it is not

--- a/src/lib/provider-enablement.ts
+++ b/src/lib/provider-enablement.ts
@@ -78,22 +78,20 @@ export async function setProviderEnabled(id: string, enabled: boolean): Promise<
   const status = await readProviderStatus();
   const canonical = canonicalProviderId(status.harness, id);
   const row = canonical ? status.providers.find((candidate) => candidate.id === canonical) : undefined;
-  // A provider dropped from the rows because this box can run no model from it
-  // (TASK-668) is still perfectly well known here, and its switch still has to
-  // flip: the strip hides the row, it does not forget the provider. Answering
-  // "not known to this box" for one would be a false failure — and would leave
-  // whatever the switch was last set to stuck for good.
-  // Taken from the row (or from the unrunnable list) rather than re-stated
-  // from `canonical`, so what comes back is a string this box wrote — the
-  // caller's copy of the id never leaves this function.
-  const hiddenId = !row && canonical
-    ? status.unrunnable.find((candidate) => candidate === canonical)
-    : undefined;
-  const known = row?.id ?? hiddenId;
-  if (!known || !canonical) {
+  // No special case for a provider the box can run no model from any more: the
+  // status keeps every row and only NAMES such providers in `unrunnable`
+  // (TASK-668), so one is found here like any other and its switch is ordinary.
+  // The earlier shape had to exempt them because the rows were dropped, which
+  // also cost them their connection label in the Connect list.
+  //
+  // The id still comes off the ROW rather than from `canonical`, so what the
+  // answer carries is a string this box wrote and the caller's copy never
+  // leaves this function.
+  const known = row?.id;
+  if (!row || !known || !canonical) {
     return { ok: false, kind: "unknown_provider", error: "That AI provider is not known to this box." };
   }
-  if (!enabled && row?.isDefault) {
+  if (!enabled && row.isDefault) {
     return { ok: false, kind: "is_default", error: "Make another provider the default first." };
   }
 

--- a/src/lib/provider-runnable.ts
+++ b/src/lib/provider-runnable.ts
@@ -51,15 +51,6 @@ function recordPath(): string | null {
 interface EnumerationRecord {
   /** How many models the box listed. Zero is an ANSWER, not a failure. */
   models: number;
-  /**
-   * Of the rows the CLI listed, how many the harness did not say it cannot
-   * route — every row except the ones explicitly `available: false`.
-   *
-   * Absent on a record written before this was carried, and on a catalogue
-   * whose rows say nothing about routability. Absent is UNKNOWN and decides
-   * nothing; only an explicit zero beside a non-zero `models` hides a row.
-   */
-  available?: number;
   atMs: number;
 }
 
@@ -132,17 +123,9 @@ async function mutate(fn: (providers: Record<string, EnumerationRecord>) => void
  * gave: a refusal, a timeout, or a payload whose rows were all filtered out by
  * our own chat-model rule is NOT an answer and must not reach here.
  */
-export function recordProviderEnumeration(
-  provider: string,
-  models: number,
-  available: number,
-): Promise<void> {
+export function recordProviderEnumeration(provider: string, models: number): Promise<void> {
   return mutate((providers) => {
-    providers[provider] = {
-      models: Math.max(0, Math.trunc(models)),
-      available: Math.max(0, Math.trunc(available)),
-      atMs: Date.now(),
-    };
+    providers[provider] = { models: Math.max(0, Math.trunc(models)), atMs: Date.now() };
   });
 }
 
@@ -210,15 +193,13 @@ export async function readProviderRunnable(): Promise<Map<string, ProviderRunnab
       ? now - record.atMs
       : Number.POSITIVE_INFINITY;
     if (ageMs > RECORD_TTL_MS) continue;
-    // TWO ways the box says it can run nothing here, and the second is the one
-    // that fires while a catalogue is still full: the CLI listed rows and the
-    // harness marked every one of them `available: false`. A row it did not
-    // determine (`null`, or a catalogue that reports nothing at all) counts as
-    // available and leaves the verdict alone — see the note on the field.
-    const noneRoutable = typeof record.available === "number"
-      && Number.isFinite(record.available)
-      && record.available === 0;
-    verdicts.set(provider, record.models > 0 && !noneRoutable ? "some" : "none");
+    // ONE number decides it, and both ways the box says "nothing here" arrive
+    // as that number being zero: an enumeration that listed no rows at all, and
+    // one that listed rows the harness marked `available: false` — our own
+    // transform drops those, so the published count is zero either way. The
+    // catalog route is where the two are told apart from a FAILURE; by the time
+    // a count is recorded, zero means the box answered.
+    verdicts.set(provider, record.models > 0 ? "some" : "none");
   }
   return verdicts;
 }

--- a/src/lib/provider-runnable.ts
+++ b/src/lib/provider-runnable.ts
@@ -51,6 +51,15 @@ function recordPath(): string | null {
 interface EnumerationRecord {
   /** How many models the box listed. Zero is an ANSWER, not a failure. */
   models: number;
+  /**
+   * Of the rows the CLI listed, how many the harness did not say it cannot
+   * route — every row except the ones explicitly `available: false`.
+   *
+   * Absent on a record written before this was carried, and on a catalogue
+   * whose rows say nothing about routability. Absent is UNKNOWN and decides
+   * nothing; only an explicit zero beside a non-zero `models` hides a row.
+   */
+  available?: number;
   atMs: number;
 }
 
@@ -123,9 +132,17 @@ async function mutate(fn: (providers: Record<string, EnumerationRecord>) => void
  * gave: a refusal, a timeout, or a payload whose rows were all filtered out by
  * our own chat-model rule is NOT an answer and must not reach here.
  */
-export function recordProviderEnumeration(provider: string, models: number): Promise<void> {
+export function recordProviderEnumeration(
+  provider: string,
+  models: number,
+  available: number,
+): Promise<void> {
   return mutate((providers) => {
-    providers[provider] = { models: Math.max(0, Math.trunc(models)), atMs: Date.now() };
+    providers[provider] = {
+      models: Math.max(0, Math.trunc(models)),
+      available: Math.max(0, Math.trunc(available)),
+      atMs: Date.now(),
+    };
   });
 }
 
@@ -193,7 +210,15 @@ export async function readProviderRunnable(): Promise<Map<string, ProviderRunnab
       ? now - record.atMs
       : Number.POSITIVE_INFINITY;
     if (ageMs > RECORD_TTL_MS) continue;
-    verdicts.set(provider, record.models > 0 ? "some" : "none");
+    // TWO ways the box says it can run nothing here, and the second is the one
+    // that fires while a catalogue is still full: the CLI listed rows and the
+    // harness marked every one of them `available: false`. A row it did not
+    // determine (`null`, or a catalogue that reports nothing at all) counts as
+    // available and leaves the verdict alone — see the note on the field.
+    const noneRoutable = typeof record.available === "number"
+      && Number.isFinite(record.available)
+      && record.available === 0;
+    verdicts.set(provider, record.models > 0 && !noneRoutable ? "some" : "none");
   }
   return verdicts;
 }

--- a/src/lib/provider-status.ts
+++ b/src/lib/provider-status.ts
@@ -532,17 +532,17 @@ export async function readProviderStatus(): Promise<ProviderStatusSummary> {
     const verdicts = summary.harness === "openclaw"
       ? await readProviderRunnable().catch(() => new Map<string, ProviderRunnable>())
       : new Map<string, ProviderRunnable>();
-    const unrunnable = summary.providers
+    const candidates = summary.providers
       .filter((row) => {
         // The connection state is NOT consulted, and that is a change of mind
         // with a reason. It was, so that hiding a row could never take away the
         // way out of the state that hid it — but the way out is the "Connect AI
         // Provider" list, and that list no longer hides anything (see
-        // `AIModelsStep`). This strip answers "what is this box set up with and
+        // `AIModelsStep`). The strip answers "what is this box set up with and
         // can it run"; a provider it can run nothing from does not belong in
         // that answer whether or not a credential is sitting there.
         //
-        // The provider the box is POINTED AT is never hidden. It is the reason
+        // The provider the box is POINTED AT is never named. It is the reason
         // chat is broken, and a row nobody can see is a row nobody can change.
         if (row.isDefault) return false;
         // Nor is one whose plugin the boot script had to switch off: that row
@@ -551,7 +551,24 @@ export async function readProviderStatus(): Promise<ProviderStatusSummary> {
         return providerRowRunnable(row.id, verdicts) === "none";
       })
       .map((row) => row.id);
-    const hidden = new Set(unrunnable);
+    // ...and if that would be EVERY row but the default, it is none of them.
+    //
+    // The counts come from `openclaw models list`, and one failure can answer
+    // `count: 0` for several providers at once — a models.json the core cannot
+    // load, a config caught half-written, a gateway restart mid-refresh. Each of
+    // those is a clean zero per provider and none of them is a fact about what
+    // the box can run. Rather than guess which, the strip declines to act when
+    // the answer is "everything": a whole panel reduced to the default row is
+    // never the honest reading, and the owner's connected key would be nowhere
+    // on the screen for the six hours a record lives.
+    //
+    // The chat picker carries the same refusal in its own words
+    // (`chat/model/route.ts`, "if every cloud option would go, none does"). This
+    // is that rule on the surface that had none.
+    const hideable = summary.providers.filter((row) => !row.isDefault).length;
+    const unrunnable = candidates.length > 0 && candidates.length >= hideable
+      ? []
+      : candidates;
     // The rows no provider or channel row will draw. Split here rather than in
     // the panel so the two surfaces cannot disagree about which is which: the
     // badge below and this list are fed from one read and one rule.
@@ -565,9 +582,15 @@ export async function readProviderStatus(): Promise<ProviderStatusSummary> {
       }));
     return {
       ...summary,
+      // ADVISORY, and the rows stay. Dropping them server-side made a hidden
+      // provider render in the Connect list with no connection label at all —
+      // `statusById` had nothing for it — and took its enable/disable switch
+      // with it. The strip does its own hiding (`AiProviderList`), which is
+      // where it already filters by state, and every other consumer keeps a
+      // complete answer.
       unrunnable,
       ...(unattachedRepairs.length > 0 ? { unattachedRepairs } : {}),
-      providers: summary.providers.filter((row) => !hidden.has(row.id)).map((row) => {
+      providers: summary.providers.map((row) => {
         const repair = repairFor(repairs, row.id);
         return {
           ...row,

--- a/src/lib/provider-status.ts
+++ b/src/lib/provider-status.ts
@@ -534,15 +534,14 @@ export async function readProviderStatus(): Promise<ProviderStatusSummary> {
       : new Map<string, ProviderRunnable>();
     const unrunnable = summary.providers
       .filter((row) => {
-        // A row the owner has NOT connected is never hidden, whatever the
-        // count says — that row IS the fix. Connecting a cloud provider writes
-        // its configured model rows and `models.mode: "merge"`
-        // (`writeOpenAICompatProvider` in the configure route), which is
-        // exactly what turns a zero-row provider back into a routable one, so
-        // hiding it would leave the box with no way out of the state that hid
-        // it. What this hides is the other case: a provider the box IS set up
-        // for and still cannot run a single model from.
-        if (row.state !== "connected" && row.state !== "needs-reauth") return false;
+        // The connection state is NOT consulted, and that is a change of mind
+        // with a reason. It was, so that hiding a row could never take away the
+        // way out of the state that hid it — but the way out is the "Connect AI
+        // Provider" list, and that list no longer hides anything (see
+        // `AIModelsStep`). This strip answers "what is this box set up with and
+        // can it run"; a provider it can run nothing from does not belong in
+        // that answer whether or not a credential is sitting there.
+        //
         // The provider the box is POINTED AT is never hidden. It is the reason
         // chat is broken, and a row nobody can see is a row nobody can change.
         if (row.isDefault) return false;

--- a/src/lib/provider-status.ts
+++ b/src/lib/provider-status.ts
@@ -551,7 +551,8 @@ export async function readProviderStatus(): Promise<ProviderStatusSummary> {
         return providerRowRunnable(row.id, verdicts) === "none";
       })
       .map((row) => row.id);
-    // ...and if that would be EVERY row but the default, it is none of them.
+    // ...and if that would leave the strip showing the default row alone, it is
+    // none of them.
     //
     // The counts come from `openclaw models list`, and one failure can answer
     // `count: 0` for several providers at once — a models.json the core cannot
@@ -562,13 +563,32 @@ export async function readProviderStatus(): Promise<ProviderStatusSummary> {
     // never the honest reading, and the owner's connected key would be nowhere
     // on the screen for the six hours a record lives.
     //
+    // MEASURED AGAINST THE ROWS THE STRIP RENDERS, not against every row in this
+    // summary, and that is the whole of whether the rule works. Counting all of
+    // them made it unsatisfiable on every box: three of the five panel rows can
+    // never be candidates — `openai` stands for the `codex` catalogue too and
+    // that one is never enumerated, `clawai` is served from a two-row literal,
+    // and `openrouter`'s REST fetcher never records an authoritative empty — so
+    // "every non-default row is a candidate" could not happen while the harm it
+    // guards against (default + one connected provider, that one hidden) could.
+    //
+    // The filter mirrors `AiProviderList`'s, deliberately and with the coupling
+    // named: that component decides what the strip shows, and this decides what
+    // may be taken away from it. A change to one is a change to both. It cannot
+    // be shared as code — this module reads the config off disk and the
+    // component is a client one.
+    //
     // The chat picker carries the same refusal in its own words
     // (`chat/model/route.ts`, "if every cloud option would go, none does"). This
     // is that rule on the surface that had none.
-    const hideable = summary.providers.filter((row) => !row.isDefault).length;
-    const unrunnable = candidates.length > 0 && candidates.length >= hideable
-      ? []
-      : candidates;
+    const stripHideable = summary.providers
+      .filter((row) => (row.state === "connected" || row.state === "needs-reauth")
+        && row.section !== "localAi"
+        && !row.isDefault)
+      .map((row) => row.id);
+    const wouldEmptyTheStrip = stripHideable.length > 0
+      && stripHideable.every((id) => candidates.includes(id));
+    const unrunnable = wouldEmptyTheStrip ? [] : candidates;
     // The rows no provider or channel row will draw. Split here rather than in
     // the panel so the two surfaces cannot disagree about which is which: the
     // badge below and this list are fed from one read and one rule.

--- a/src/tests/components/ai-models-step.test.tsx
+++ b/src/tests/components/ai-models-step.test.tsx
@@ -108,10 +108,15 @@ describe("AIModelsStep variants", () => {
   });
 
   /**
-   * TASK-668. The Providers page decides server-side which providers this box
-   * can run a model from; this list must not go on offering the ones it
-   * dropped. `unrunnable` is what carries that decision — an empty array (and
-   * a status call that has not landed) hides nothing.
+   * TASK-668. This is the CONNECT list, and it offers every provider it was
+   * asked to — including one the Providers strip has dropped because the box
+   * can currently run no model from it.
+   *
+   * That is not an oversight, it is the pair: connecting is the way OUT of that
+   * state (saving a cloud provider writes its configured model rows and
+   * `models.mode: "merge"`), so the strip may drop such a row only because this
+   * list never does. An earlier revision filtered here too and left a box with
+   * no door.
    */
   describe("a provider the box can run no model from", () => {
     function stubStatus(unrunnable: string[]) {
@@ -158,19 +163,14 @@ describe("AIModelsStep variants", () => {
       return getByRole("radiogroup", { name: "AI Provider" }).textContent ?? "";
     }
 
-    it("is not offered", async () => {
+    it("is still offered, because connecting is the way out", async () => {
       const text = await providerGroupText(["google"]);
 
-      expect(text).not.toContain("Google Gemini");
+      expect(text).toContain("Google Gemini");
       expect(text).toContain("Anthropic");
     });
 
-    it("keeps the row the panel is CURRENTLY on, whatever the box says about it", async () => {
-      // Everything else here that decides what to render — the "keep the
-      // selection valid" effect, the credential panel, the deep-link handler —
-      // resolves against the unfiltered list. Dropping the selected row would
-      // leave its form on screen with no radio above it and no "show more"
-      // toggle to get back.
+    it("is offered when the panel is currently ON it, too", async () => {
       const text = await providerGroupText(["google"], "google");
 
       expect(text).toContain("Google Gemini");

--- a/src/tests/components/ai-provider-list.test.tsx
+++ b/src/tests/components/ai-provider-list.test.tsx
@@ -27,7 +27,7 @@ const ROWS = [
 let posts: { url: string; body: unknown }[] = [];
 
 /** The box's answers to every call this list makes, in one stub. */
-function stubFetch(rows = ROWS, opts: { refuse?: { status: number; error: string }; locale?: string; defaultAnswer?: { body: unknown; status?: number }; unattachedRepairs?: unknown[] } = {}) {
+function stubFetch(rows = ROWS, opts: { refuse?: { status: number; error: string }; locale?: string; defaultAnswer?: { body: unknown; status?: number }; unattachedRepairs?: unknown[]; unrunnable?: string[] } = {}) {
   posts = [];
   vi.stubGlobal("fetch", vi.fn(async (input: string | URL, init?: RequestInit) => {
     const url = input.toString();
@@ -42,6 +42,7 @@ function stubFetch(rows = ROWS, opts: { refuse?: { status: number; error: string
         harness: "openclaw",
         providers: rows,
         defaultProvider: "clawai",
+        unrunnable: opts.unrunnable ?? [],
         degraded: false,
         ...(opts.unattachedRepairs ? { unattachedRepairs: opts.unattachedRepairs } : {}),
       });
@@ -473,5 +474,36 @@ describe("AiProviderList — plugins with no row of their own", () => {
     renderList();
     expect(await screen.findByTestId("ai-provider-clawai")).toBeInTheDocument();
     expect(screen.queryByTestId("ai-provider-plugin-repairs")).not.toBeInTheDocument();
+  });
+});
+
+describe("a provider the box can run no model from", () => {
+  /**
+   * TASK-668, the owner's ruling: a row whose every model the gateway would
+   * refuse is not part of "what is connected".
+   *
+   * The hiding is HERE rather than in the payload. The server names such
+   * providers in `unrunnable` and keeps their rows, so the Connect panel below
+   * can still offer one with its real connection label and its switch —
+   * dropping the row server-side took both away, and connecting is the way out
+   * of the state that hid it.
+   */
+  it("leaves it out of the list, and leaves the rest alone", async () => {
+    stubFetch(ROWS, { unrunnable: ["openai"] });
+
+    render(<I18nProvider><AiProviderList /></I18nProvider>);
+
+    await waitFor(() => expect(screen.getByTestId("ai-provider-clawai")).toBeInTheDocument());
+    expect(screen.queryByTestId("ai-provider-openai")).not.toBeInTheDocument();
+    expect(screen.getByTestId("ai-provider-anthropic")).toBeInTheDocument();
+  });
+
+  it("shows every row when the box has named none", async () => {
+    stubFetch(ROWS, { unrunnable: [] });
+
+    render(<I18nProvider><AiProviderList /></I18nProvider>);
+
+    await waitFor(() => expect(screen.getByTestId("ai-provider-openai")).toBeInTheDocument());
+    expect(screen.getByTestId("ai-provider-anthropic")).toBeInTheDocument();
   });
 });

--- a/src/tests/routes/ai-models/catalog-empty-enumeration.test.ts
+++ b/src/tests/routes/ai-models/catalog-empty-enumeration.test.ts
@@ -59,7 +59,7 @@ function mockList(json: unknown, stderr = ""): void {
 
 const RECORD = path.join(DATA_DIR, "catalog-cache", "_enumerations.json");
 
-function readRecord(): Record<string, { models: number; available?: number }> {
+function readRecord(): Record<string, { models: number }> {
   const parsed = JSON.parse(fs.readFileSync(RECORD, "utf8")) as {
     providers?: Record<string, { models: number }>;
   };
@@ -133,10 +133,11 @@ describe("catalog — a clean empty enumeration is an answer, not a failure", ()
     expect(recorded.google).toBeUndefined();
   });
 
-  it("records how many listed rows the harness said it cannot route", async () => {
-    // The second thing that hides a provider row: the CLI lists a full
-    // catalogue and marks every row `available: false`. Tristate, so only an
-    // explicit `false` counts — see the next case.
+  it("records zero when the CLI listed rows and marked every one unroutable", async () => {
+    // The second shape of the same answer, and the one that fires while the CLI
+    // still has a catalogue to print. Our own transform drops an `available:
+    // false` row, so the published count is zero either way — what makes this an
+    // ANSWER rather than a failure is that the command ran and refused nothing.
     mockList({
       count: 2,
       models: [
@@ -145,19 +146,16 @@ describe("catalog — a clean empty enumeration is an answer, not a failure", ()
       ],
     });
     await get("anthropic", "&refresh=1");
-    await settle();
 
-    await vi.waitFor(() => {
-      expect(readRecord().anthropic?.available).toBe(0);
-    }, { timeout: 4000, interval: 25 });
+    expect(await recordedCount("anthropic")).toBe(0);
   });
 
-  it("counts a row the harness did not judge as routable, never against it", async () => {
+  it("records the rows the harness did not JUDGE, never against them", async () => {
     // Measured on the OpenClaw box: with no Google credential all ten google
     // rows come back `available: null`, while every row of the LINKED deepseek
     // provider on the same box comes back `true`. `null` is "not determined",
     // and writing a provider off for it would hide every one a box has not
-    // finished setting up.
+    // finished setting up — so these two rows are published and counted.
     mockList({
       count: 2,
       models: [
@@ -167,9 +165,7 @@ describe("catalog — a clean empty enumeration is an answer, not a failure", ()
     });
     await get("openai", "&refresh=1");
 
-    await vi.waitFor(() => {
-      expect(readRecord().openai?.available).toBe(2);
-    }, { timeout: 4000, interval: 25 });
+    expect(await recordedCount("openai")).toBe(2);
   });
 
   it("records NOTHING when the CLI refused — an error is not an empty catalogue", async () => {

--- a/src/tests/routes/ai-models/catalog-empty-enumeration.test.ts
+++ b/src/tests/routes/ai-models/catalog-empty-enumeration.test.ts
@@ -59,7 +59,7 @@ function mockList(json: unknown, stderr = ""): void {
 
 const RECORD = path.join(DATA_DIR, "catalog-cache", "_enumerations.json");
 
-function readRecord(): Record<string, { models: number }> {
+function readRecord(): Record<string, { models: number; available?: number }> {
   const parsed = JSON.parse(fs.readFileSync(RECORD, "utf8")) as {
     providers?: Record<string, { models: number }>;
   };
@@ -96,7 +96,13 @@ beforeEach(() => {
 
 describe("catalog — a clean empty enumeration is an answer, not a failure", () => {
   it("records zero when the CLI answers with no rows at all", async () => {
-    mockList({ count: 0, models: [] });
+    // With an unrelated warning on stderr, deliberately. Every `openclaw models
+    // list` on the shipped boxes prints `[agents/model-registry] model catalog
+    // load issue: … gpt-image-1-mini: no "api" specified` — on every provider's
+    // enumeration, exit code 0 — so requiring an empty stderr made this whole
+    // rule dead code there. What says the answer is untrustworthy is the CLI
+    // refusing, not the CLI grumbling.
+    mockList({ count: 0, models: [] }, "[agents/model-registry] model catalog load issue: …");
     await get("google", "&refresh=1");
 
     expect(await recordedCount("google")).toBe(0);
@@ -125,6 +131,45 @@ describe("catalog — a clean empty enumeration is an answer, not a failure", ()
 
     const recorded = fs.existsSync(RECORD) ? readRecord() : {};
     expect(recorded.google).toBeUndefined();
+  });
+
+  it("records how many listed rows the harness said it cannot route", async () => {
+    // The second thing that hides a provider row: the CLI lists a full
+    // catalogue and marks every row `available: false`. Tristate, so only an
+    // explicit `false` counts — see the next case.
+    mockList({
+      count: 2,
+      models: [
+        { key: "anthropic/claude-opus-5", name: "Claude Opus 5", contextWindow: 1_000_000, available: false, tags: [] },
+        { key: "anthropic/claude-sonnet-5", name: "Claude Sonnet 5", contextWindow: 1_000_000, available: false, tags: [] },
+      ],
+    });
+    await get("anthropic", "&refresh=1");
+    await settle();
+
+    await vi.waitFor(() => {
+      expect(readRecord().anthropic?.available).toBe(0);
+    }, { timeout: 4000, interval: 25 });
+  });
+
+  it("counts a row the harness did not judge as routable, never against it", async () => {
+    // Measured on the OpenClaw box: with no Google credential all ten google
+    // rows come back `available: null`, while every row of the LINKED deepseek
+    // provider on the same box comes back `true`. `null` is "not determined",
+    // and writing a provider off for it would hide every one a box has not
+    // finished setting up.
+    mockList({
+      count: 2,
+      models: [
+        { key: "openai/gpt-5.6-sol", name: "GPT-5.6 Sol", contextWindow: 400_000, available: null, tags: [] },
+        { key: "openai/gpt-5.4", name: "GPT-5.4", contextWindow: 400_000, tags: [] },
+      ],
+    });
+    await get("openai", "&refresh=1");
+
+    await vi.waitFor(() => {
+      expect(readRecord().openai?.available).toBe(2);
+    }, { timeout: 4000, interval: 25 });
   });
 
   it("records NOTHING when the CLI refused — an error is not an empty catalogue", async () => {

--- a/src/tests/routes/ai-models/catalog-empty-enumeration.test.ts
+++ b/src/tests/routes/ai-models/catalog-empty-enumeration.test.ts
@@ -121,6 +121,19 @@ describe("catalog — a clean empty enumeration is an answer, not a failure", ()
     expect(await recordedCount("google")).toBe(2);
   });
 
+  it("records NOTHING when `models` is not a list at all", async () => {
+    // The parser coerces a non-array `models` to `[]`, so a body like
+    // `{count: 0, models: {}}` looks exactly like a clean zero once it is past
+    // that line — and would hide the provider for the record's whole lifetime.
+    // A shape we do not recognise is not an answer.
+    mockList({ count: 0, models: {} });
+    await get("anthropic", "&refresh=1");
+    await settle();
+
+    const recorded = fs.existsSync(RECORD) ? readRecord() : {};
+    expect(recorded.anthropic).toBeUndefined();
+  });
+
   it("records NOTHING when the payload never stated a count", async () => {
     // Read positively, not inferred from absence: a truncated or shape-shifted
     // payload parses into the same emptiness as a real answer, and this verdict

--- a/src/tests/routes/providers/status-unrunnable.test.ts
+++ b/src/tests/routes/providers/status-unrunnable.test.ts
@@ -27,16 +27,12 @@ let probeStillOwed: Mock;
 let clawaiTokenRejectedByPortal: Mock;
 
 /** What the catalog route records after an enumeration answers for a provider. */
-function recordEnumerations(
-  counts: Record<string, number | { models: number; available: number }>,
-) {
+function recordEnumerations(counts: Record<string, number>) {
   const dir = path.join(dataDir, "catalog-cache");
   mkdirSync(dir, { recursive: true });
-  const providers: Record<string, { models: number; available?: number; atMs: number }> = {};
-  for (const [provider, value] of Object.entries(counts)) {
-    providers[provider] = typeof value === "number"
-      ? { models: value, atMs: Date.now() }
-      : { ...value, atMs: Date.now() };
+  const providers: Record<string, { models: number; atMs: number }> = {};
+  for (const [provider, models] of Object.entries(counts)) {
+    providers[provider] = { models, atMs: Date.now() };
   }
   writeFileSync(path.join(dir, "_enumerations.json"), JSON.stringify({ providers }), "utf8");
 }
@@ -87,47 +83,11 @@ describe("GET /setup-api/providers/status — a provider the box can run no mode
     recordEnumerations({ google: 0, anthropic: 9 });
     const body = await (await GET()).json();
 
-    expect(ids(body)).not.toContain("google");
+    // NAMED, and kept: the strip does the hiding, so the Connect list below it
+    // can still show this provider with its real connection label and its
+    // switch. Dropping the row server-side took both away.
     expect(body.unrunnable).toEqual(["google"]);
-    // Everything else is untouched.
-    expect(ids(body)).toEqual(expect.arrayContaining(["clawai", "openai", "anthropic", "openrouter"]));
-  });
-
-  it("drops the row when the box lists rows but can route NONE of them", async () => {
-    // The other way the harness says "this box can run nothing here", and the
-    // one that is true on a box with no Google credential: `openclaw models
-    // list --provider google --all --json` answers with the plugin's whole
-    // static catalogue and marks every row `available: false`. Ten rows and no
-    // route is the same fact as no rows at all — the owner's ruling covers
-    // both, and the count alone did not.
-    readConfig.mockResolvedValue({
-      auth: { profiles: { "anthropic:default": { provider: "anthropic", mode: "oauth" } } },
-      agents: { defaults: { model: { primary: "anthropic/claude-sonnet-4-6" } } },
-    });
-    recordEnumerations({ google: { models: 10, available: 0 } });
-    const body = await (await GET()).json();
-
-    expect(ids(body)).not.toContain("google");
-    expect(body.unrunnable).toEqual(["google"]);
-  });
-
-  it("keeps the row when even ONE listed row is routable", async () => {
-    boxWithGoogleKey();
-    recordEnumerations({ google: { models: 10, available: 1 } });
-    const body = await (await GET()).json();
-
-    expect(ids(body)).toContain("google");
-    expect(body.unrunnable).toEqual([]);
-  });
-
-  it("keeps the row when the enumeration said nothing about routability", async () => {
-    // An older record, or a catalogue whose rows carry no `available` field at
-    // all. Absent is not `false`.
-    boxWithGoogleKey();
-    recordEnumerations({ google: 10 });
-    const body = await (await GET()).json();
-
-    expect(ids(body)).toContain("google");
+    expect(ids(body)).toEqual(expect.arrayContaining(["clawai", "openai", "anthropic", "openrouter", "google"]));
   });
 
   it("keeps the row on a box that can run at least one of that provider's models", async () => {
@@ -137,6 +97,38 @@ describe("GET /setup-api/providers/status — a provider the box can run no mode
 
     expect(ids(body)).toContain("google");
     expect(body.unrunnable).toEqual([]);
+  });
+
+  it("names NONE of them when the answer would be every row but the default", async () => {
+    // One failure answers `count: 0` for several providers at once — a
+    // models.json the core cannot load, a config caught half-written, a gateway
+    // restart mid-refresh. Each is a clean zero per provider and none of them is
+    // a fact about what the box can run, so the strip declines to act on
+    // "everything" rather than guess which. A whole panel reduced to the default
+    // row is never the honest reading, and the owner's connected key would be
+    // nowhere on screen for the six hours a record lives.
+    readConfig.mockResolvedValue({
+      auth: { profiles: { "deepseek:default": { provider: "deepseek", mode: "api_key" } } },
+      agents: { defaults: { model: { primary: "deepseek/deepseek-v4-pro" } } },
+    });
+    // `codex` too: the OpenAI ROW stands for both catalogues and is only
+    // written off when each of them has answered none.
+    recordEnumerations({ google: 0, anthropic: 0, openai: 0, codex: 0, openrouter: 0 });
+    const body = await (await GET()).json();
+
+    expect(body.unrunnable).toEqual([]);
+    expect(ids(body)).toEqual(expect.arrayContaining(["clawai", "openai", "anthropic", "google", "openrouter"]));
+  });
+
+  it("still names them when one row would survive", async () => {
+    readConfig.mockResolvedValue({
+      auth: { profiles: { "deepseek:default": { provider: "deepseek", mode: "api_key" } } },
+      agents: { defaults: { model: { primary: "deepseek/deepseek-v4-pro" } } },
+    });
+    recordEnumerations({ google: 0, anthropic: 0 });
+    const body = await (await GET()).json();
+
+    expect(body.unrunnable.sort()).toEqual(["anthropic", "google"]);
   });
 
   it("keeps the row when no enumeration has answered yet — unknown is not empty", async () => {
@@ -150,7 +142,7 @@ describe("GET /setup-api/providers/status — a provider the box can run no mode
     expect(body.unrunnable).toEqual([]);
   });
 
-  it("hides a provider the box can run nothing from even before it is connected", async () => {
+  it("names a provider the box can run nothing from even before it is connected", async () => {
     // The strip answers "what is this box set up with and can it run". A
     // provider it can run nothing from does not belong in that answer whether
     // or not a credential is sitting there — and the way OUT of that state is
@@ -164,7 +156,6 @@ describe("GET /setup-api/providers/status — a provider the box can run no mode
     recordEnumerations({ google: 0 });
     const body = await (await GET()).json();
 
-    expect(ids(body)).not.toContain("google");
     expect(body.unrunnable).toEqual(["google"]);
   });
 

--- a/src/tests/routes/providers/status-unrunnable.test.ts
+++ b/src/tests/routes/providers/status-unrunnable.test.ts
@@ -27,12 +27,16 @@ let probeStillOwed: Mock;
 let clawaiTokenRejectedByPortal: Mock;
 
 /** What the catalog route records after an enumeration answers for a provider. */
-function recordEnumerations(counts: Record<string, number>) {
+function recordEnumerations(
+  counts: Record<string, number | { models: number; available: number }>,
+) {
   const dir = path.join(dataDir, "catalog-cache");
   mkdirSync(dir, { recursive: true });
-  const providers: Record<string, { models: number; atMs: number }> = {};
-  for (const [provider, models] of Object.entries(counts)) {
-    providers[provider] = { models, atMs: Date.now() };
+  const providers: Record<string, { models: number; available?: number; atMs: number }> = {};
+  for (const [provider, value] of Object.entries(counts)) {
+    providers[provider] = typeof value === "number"
+      ? { models: value, atMs: Date.now() }
+      : { ...value, atMs: Date.now() };
   }
   writeFileSync(path.join(dir, "_enumerations.json"), JSON.stringify({ providers }), "utf8");
 }
@@ -89,6 +93,43 @@ describe("GET /setup-api/providers/status — a provider the box can run no mode
     expect(ids(body)).toEqual(expect.arrayContaining(["clawai", "openai", "anthropic", "openrouter"]));
   });
 
+  it("drops the row when the box lists rows but can route NONE of them", async () => {
+    // The other way the harness says "this box can run nothing here", and the
+    // one that is true on a box with no Google credential: `openclaw models
+    // list --provider google --all --json` answers with the plugin's whole
+    // static catalogue and marks every row `available: false`. Ten rows and no
+    // route is the same fact as no rows at all — the owner's ruling covers
+    // both, and the count alone did not.
+    readConfig.mockResolvedValue({
+      auth: { profiles: { "anthropic:default": { provider: "anthropic", mode: "oauth" } } },
+      agents: { defaults: { model: { primary: "anthropic/claude-sonnet-4-6" } } },
+    });
+    recordEnumerations({ google: { models: 10, available: 0 } });
+    const body = await (await GET()).json();
+
+    expect(ids(body)).not.toContain("google");
+    expect(body.unrunnable).toEqual(["google"]);
+  });
+
+  it("keeps the row when even ONE listed row is routable", async () => {
+    boxWithGoogleKey();
+    recordEnumerations({ google: { models: 10, available: 1 } });
+    const body = await (await GET()).json();
+
+    expect(ids(body)).toContain("google");
+    expect(body.unrunnable).toEqual([]);
+  });
+
+  it("keeps the row when the enumeration said nothing about routability", async () => {
+    // An older record, or a catalogue whose rows carry no `available` field at
+    // all. Absent is not `false`.
+    boxWithGoogleKey();
+    recordEnumerations({ google: 10 });
+    const body = await (await GET()).json();
+
+    expect(ids(body)).toContain("google");
+  });
+
   it("keeps the row on a box that can run at least one of that provider's models", async () => {
     boxWithGoogleKey();
     recordEnumerations({ google: 10 });
@@ -109,11 +150,13 @@ describe("GET /setup-api/providers/status — a provider the box can run no mode
     expect(body.unrunnable).toEqual([]);
   });
 
-  it("never hides a provider the owner has not connected", async () => {
-    // That row IS the fix: connecting a cloud provider writes its configured
-    // model rows and `models.mode: "merge"`, which is exactly what turns a
-    // zero-row provider back into a routable one. Hiding it would leave the box
-    // with no way out of the state that hid it.
+  it("hides a provider the box can run nothing from even before it is connected", async () => {
+    // The strip answers "what is this box set up with and can it run". A
+    // provider it can run nothing from does not belong in that answer whether
+    // or not a credential is sitting there — and the way OUT of that state is
+    // the "Connect AI Provider" list, which offers every provider
+    // unconditionally (see `AIModelsStep`). This is the pair: the strip may
+    // drop the row only because that list never does.
     readConfig.mockResolvedValue({
       auth: { profiles: { "anthropic:default": { provider: "anthropic", mode: "oauth" } } },
       agents: { defaults: { model: { primary: "anthropic/claude-sonnet-4-6" } } },
@@ -121,9 +164,8 @@ describe("GET /setup-api/providers/status — a provider the box can run no mode
     recordEnumerations({ google: 0 });
     const body = await (await GET()).json();
 
-    expect(ids(body)).toContain("google");
-    expect(body.providers.find((p: Row) => p.id === "google")!.state).toBe("disconnected");
-    expect(body.unrunnable).toEqual([]);
+    expect(ids(body)).not.toContain("google");
+    expect(body.unrunnable).toEqual(["google"]);
   });
 
   it("stops trusting a count older than the catalogue's own refresh interval", async () => {

--- a/src/tests/routes/providers/status-unrunnable.test.ts
+++ b/src/tests/routes/providers/status-unrunnable.test.ts
@@ -37,11 +37,17 @@ function recordEnumerations(counts: Record<string, number>) {
   writeFileSync(path.join(dir, "_enumerations.json"), JSON.stringify({ providers }), "utf8");
 }
 
-/** A box with an Anthropic key and a Google key, pointed at Anthropic. */
+/**
+ * A box pointed at Anthropic, with a Google key and ClawBox AI linked.
+ *
+ * Three connected rows on purpose: hiding Google has to leave the strip with
+ * something other than the default, or the "would this empty the strip?"
+ * refusal takes over and these cases would be testing that instead.
+ */
 function boxWithGoogleKey() {
   readConfig.mockResolvedValue({
     auth: { profiles: { "anthropic:default": { provider: "anthropic", mode: "oauth" } } },
-    models: { providers: { google: { apiKey: "AIza-secret" } } },
+    models: { providers: { google: { apiKey: "AIza-secret" }, deepseek: { apiKey: "claw_token" } } },
     agents: { defaults: { model: { primary: "anthropic/claude-sonnet-4-6" } } },
   });
 }
@@ -99,36 +105,72 @@ describe("GET /setup-api/providers/status — a provider the box can run no mode
     expect(body.unrunnable).toEqual([]);
   });
 
-  it("names NONE of them when the answer would be every row but the default", async () => {
-    // One failure answers `count: 0` for several providers at once — a
-    // models.json the core cannot load, a config caught half-written, a gateway
-    // restart mid-refresh. Each is a clean zero per provider and none of them is
-    // a fact about what the box can run, so the strip declines to act on
-    // "everything" rather than guess which. A whole panel reduced to the default
-    // row is never the honest reading, and the owner's connected key would be
-    // nowhere on screen for the six hours a record lives.
-    readConfig.mockResolvedValue({
-      auth: { profiles: { "deepseek:default": { provider: "deepseek", mode: "api_key" } } },
-      agents: { defaults: { model: { primary: "deepseek/deepseek-v4-pro" } } },
+  /**
+   * The refusal, measured against the rows the STRIP renders.
+   *
+   * Every record below is one the catalog route can actually write. Counting
+   * every row in the summary instead made this unsatisfiable on every box —
+   * `openai` stands for the never-enumerated `codex` catalogue, `clawai` is a
+   * two-row literal and `openrouter` never records a zero — while the harm it
+   * guards against stayed perfectly reachable.
+   */
+  describe("when hiding would leave the strip with the default row alone", () => {
+    /** ClawBox AI is the default and connected; `keys` name the other connected rows. */
+    function boxWithConnected(keys: string[]) {
+      const providers: Record<string, { apiKey: string }> = { deepseek: { apiKey: "claw_token" } };
+      for (const key of keys) providers[key] = { apiKey: `${key}-secret` };
+      readConfig.mockResolvedValue({
+        auth: { profiles: { "deepseek:default": { provider: "deepseek", mode: "api_key" } } },
+        models: { providers },
+        agents: { defaults: { model: { primary: "deepseek/deepseek-v4-pro" } } },
+      });
+    }
+
+    it("names none — the box with one connected provider that answered zero", async () => {
+      // The reachable harm: ClawBox AI the default, a Google key pasted, google
+      // enumerating nothing. Hiding it leaves the panel showing ClawBox AI and
+      // nothing else, which is never the honest reading of one zero.
+      boxWithConnected(["google"]);
+      recordEnumerations({ google: 0 });
+      const body = await (await GET()).json();
+
+      expect(body.unrunnable).toEqual([]);
+      expect(ids(body)).toContain("google");
     });
-    // `codex` too: the OpenAI ROW stands for both catalogues and is only
-    // written off when each of them has answered none.
-    recordEnumerations({ google: 0, anthropic: 0, openai: 0, codex: 0, openrouter: 0 });
-    const body = await (await GET()).json();
 
-    expect(body.unrunnable).toEqual([]);
-    expect(ids(body)).toEqual(expect.arrayContaining(["clawai", "openai", "anthropic", "google", "openrouter"]));
-  });
+    it("still names the one that answered zero when another connected row survives", async () => {
+      // Anthropic is connected and enumerated fine, so hiding google leaves the
+      // strip with something to show and the rule does its job.
+      boxWithConnected(["google", "anthropic"]);
+      recordEnumerations({ google: 0, anthropic: 15 });
+      const body = await (await GET()).json();
 
-  it("still names them when one row would survive", async () => {
-    readConfig.mockResolvedValue({
-      auth: { profiles: { "deepseek:default": { provider: "deepseek", mode: "api_key" } } },
-      agents: { defaults: { model: { primary: "deepseek/deepseek-v4-pro" } } },
+      expect(body.unrunnable).toEqual(["google"]);
     });
-    recordEnumerations({ google: 0, anthropic: 0 });
-    const body = await (await GET()).json();
 
-    expect(body.unrunnable.sort()).toEqual(["anthropic", "google"]);
+    it("names none when BOTH connected providers answered zero", async () => {
+      // One catalogue-load failure answers `count: 0` for several providers at
+      // once. Each is a clean zero per provider and none is a fact about what
+      // the box can run.
+      boxWithConnected(["google", "anthropic"]);
+      recordEnumerations({ google: 0, anthropic: 0 });
+      const body = await (await GET()).json();
+
+      expect(body.unrunnable).toEqual([]);
+    });
+
+    it("names nothing at all on the box's own catalogue", async () => {
+      // The counts this box really records (measured read-only, `merge` mode).
+      // Nothing is hidden, and the rule is silent.
+      boxWithConnected(["google", "anthropic"]);
+      recordEnumerations({ google: 10, anthropic: 15, openai: 27, clawai: 2, openrouter: 417 });
+      const body = await (await GET()).json();
+
+      expect(body.unrunnable).toEqual([]);
+      expect(ids(body)).toEqual(
+        expect.arrayContaining(["clawai", "openai", "anthropic", "google", "openrouter"]),
+      );
+    });
   });
 
   it("keeps the row when no enumeration has answered yet — unknown is not empty", async () => {

--- a/src/tests/unit/provider-enablement.test.ts
+++ b/src/tests/unit/provider-enablement.test.ts
@@ -85,15 +85,13 @@ describe("setProviderEnabled", () => {
   });
 
   it("still flips the switch for a provider the strip hides", async () => {
-    // A row dropped because the box can run no model from it (TASK-668) is not
-    // an unknown provider: the strip hides the row, it does not forget the
-    // provider, and answering "not known to this box" would leave the switch
-    // stuck at whatever it was last set to.
-    hiddenProviders = ["google"];
-    // …and it still reports WHICH provider it flipped: the hidden ones are the
-    // one branch with no row to read the id off, so the answer comes from the
-    // unrunnable list rather than being re-stated from the caller's string.
-    expect(await lib.setProviderEnabled("google", false)).toEqual({ ok: true, provider: "google" });
-    expect(store.values.ai_disabled_providers).toEqual(["google"]);
+    // A provider the box can run no model from (TASK-668) is named in
+    // `unrunnable` and KEPT in the rows, so its switch is an ordinary one: the
+    // strip does the hiding, nothing forgets the provider, and nothing here has
+    // to know about the ruling at all. The answer still names the provider from
+    // the row rather than re-stating the caller's string.
+    hiddenProviders = ["gemini"];
+    expect(await lib.setProviderEnabled("gemini", false)).toEqual({ ok: true, provider: "gemini" });
+    expect(store.values.ai_disabled_providers).toEqual(["gemini"]);
   });
 });

--- a/src/tests/unit/provider-runnable.test.ts
+++ b/src/tests/unit/provider-runnable.test.ts
@@ -21,7 +21,9 @@ vi.mock("@/lib/config-store", () => ({
 
 const recordFile = () => path.join(dataDir, "catalog-cache", "_enumerations.json");
 
-function writeRecord(providers: Record<string, { models: number; atMs: number }>) {
+function writeRecord(
+  providers: Record<string, { models: number; available?: number; atMs: number }>,
+) {
   mkdirSync(path.dirname(recordFile()), { recursive: true });
   writeFileSync(recordFile(), JSON.stringify({ providers }), "utf8");
 }
@@ -43,13 +45,41 @@ afterEach(() => rmSync(dataDir, { recursive: true, force: true }));
 
 describe("the recorded model count", () => {
   it("says `some` for a provider that enumerated rows and `none` for a clean zero", async () => {
-    writeRecord({ google: { models: 0, atMs: Date.now() }, anthropic: { models: 9, atMs: Date.now() } });
+    writeRecord({
+      google: { models: 0, available: 0, atMs: Date.now() },
+      anthropic: { models: 9, available: 9, atMs: Date.now() },
+    });
     const { readProviderRunnable } = await load();
 
     const verdicts = await readProviderRunnable();
 
     expect(verdicts.get("google")).toBe("none");
     expect(verdicts.get("anthropic")).toBe("some");
+  });
+
+  it("says `none` when the box listed rows and could route none of them", async () => {
+    // The harness's own statement, and the one that fires while the catalogue
+    // is still full: ten rows listed, every one `available: false`.
+    writeRecord({ google: { models: 10, available: 0, atMs: Date.now() } });
+    const { readProviderRunnable } = await load();
+
+    expect((await readProviderRunnable()).get("google")).toBe("none");
+  });
+
+  it("says `some` when even one listed row is routable", async () => {
+    writeRecord({ google: { models: 10, available: 1, atMs: Date.now() } });
+    const { readProviderRunnable } = await load();
+
+    expect((await readProviderRunnable()).get("google")).toBe("some");
+  });
+
+  it("says `some` when the enumeration said nothing about routability", async () => {
+    // `available` absent — an older record, or a catalogue whose rows carry no
+    // such field. Absent is not zero.
+    writeRecord({ google: { models: 10, atMs: Date.now() } });
+    const { readProviderRunnable } = await load();
+
+    expect((await readProviderRunnable()).get("google")).toBe("some");
   });
 
   it("says nothing at all about a provider with no record", async () => {
@@ -107,9 +137,9 @@ describe("the recorded model count", () => {
     const { recordProviderEnumeration } = await load();
 
     await Promise.all([
-      recordProviderEnumeration("google", 0),
-      recordProviderEnumeration("anthropic", 9),
-      recordProviderEnumeration("openai", 2),
+      recordProviderEnumeration("google", 0, 0),
+      recordProviderEnumeration("anthropic", 9, 9),
+      recordProviderEnumeration("openai", 2, 2),
     ]);
 
     expect(Object.keys(readRecord()).sort()).toEqual(["anthropic", "google", "openai"]);
@@ -123,7 +153,7 @@ describe("the recorded model count", () => {
     vi.resetModules();
     const { recordProviderEnumeration, readProviderRunnable } = await load();
 
-    await expect(recordProviderEnumeration("google", 0)).resolves.toBeUndefined();
+    await expect(recordProviderEnumeration("google", 0, 0)).resolves.toBeUndefined();
     expect([...(await readProviderRunnable())]).toEqual([]);
   });
 });

--- a/src/tests/unit/provider-runnable.test.ts
+++ b/src/tests/unit/provider-runnable.test.ts
@@ -21,9 +21,7 @@ vi.mock("@/lib/config-store", () => ({
 
 const recordFile = () => path.join(dataDir, "catalog-cache", "_enumerations.json");
 
-function writeRecord(
-  providers: Record<string, { models: number; available?: number; atMs: number }>,
-) {
+function writeRecord(providers: Record<string, { models: number; atMs: number }>) {
   mkdirSync(path.dirname(recordFile()), { recursive: true });
   writeFileSync(recordFile(), JSON.stringify({ providers }), "utf8");
 }
@@ -45,41 +43,13 @@ afterEach(() => rmSync(dataDir, { recursive: true, force: true }));
 
 describe("the recorded model count", () => {
   it("says `some` for a provider that enumerated rows and `none` for a clean zero", async () => {
-    writeRecord({
-      google: { models: 0, available: 0, atMs: Date.now() },
-      anthropic: { models: 9, available: 9, atMs: Date.now() },
-    });
+    writeRecord({ google: { models: 0, atMs: Date.now() }, anthropic: { models: 9, atMs: Date.now() } });
     const { readProviderRunnable } = await load();
 
     const verdicts = await readProviderRunnable();
 
     expect(verdicts.get("google")).toBe("none");
     expect(verdicts.get("anthropic")).toBe("some");
-  });
-
-  it("says `none` when the box listed rows and could route none of them", async () => {
-    // The harness's own statement, and the one that fires while the catalogue
-    // is still full: ten rows listed, every one `available: false`.
-    writeRecord({ google: { models: 10, available: 0, atMs: Date.now() } });
-    const { readProviderRunnable } = await load();
-
-    expect((await readProviderRunnable()).get("google")).toBe("none");
-  });
-
-  it("says `some` when even one listed row is routable", async () => {
-    writeRecord({ google: { models: 10, available: 1, atMs: Date.now() } });
-    const { readProviderRunnable } = await load();
-
-    expect((await readProviderRunnable()).get("google")).toBe("some");
-  });
-
-  it("says `some` when the enumeration said nothing about routability", async () => {
-    // `available` absent — an older record, or a catalogue whose rows carry no
-    // such field. Absent is not zero.
-    writeRecord({ google: { models: 10, atMs: Date.now() } });
-    const { readProviderRunnable } = await load();
-
-    expect((await readProviderRunnable()).get("google")).toBe("some");
   });
 
   it("says nothing at all about a provider with no record", async () => {
@@ -137,9 +107,9 @@ describe("the recorded model count", () => {
     const { recordProviderEnumeration } = await load();
 
     await Promise.all([
-      recordProviderEnumeration("google", 0, 0),
-      recordProviderEnumeration("anthropic", 9, 9),
-      recordProviderEnumeration("openai", 2, 2),
+      recordProviderEnumeration("google", 0),
+      recordProviderEnumeration("anthropic", 9),
+      recordProviderEnumeration("openai", 2),
     ]);
 
     expect(Object.keys(readRecord()).sort()).toEqual(["anthropic", "google", "openai"]);
@@ -153,7 +123,7 @@ describe("the recorded model count", () => {
     vi.resetModules();
     const { recordProviderEnumeration, readProviderRunnable } = await load();
 
-    await expect(recordProviderEnumeration("google", 0, 0)).resolves.toBeUndefined();
+    await expect(recordProviderEnumeration("google", 0)).resolves.toBeUndefined();
     expect([...(await readProviderRunnable())]).toEqual([]);
   });
 });


### PR DESCRIPTION
## TASK-668 residual — what the box actually says, and what it does not

**Read this part first: the premise this residual was opened on does not hold on the
hardware, and this PR does not hide the Google row on the box it was reported from.**

The residual asked for "rows listed, every one `available: false`" to be treated like a
count of zero. Measured read-only on the OpenClaw box (2026.8.1), with no Google
credential:

```
openclaw models list --provider google   --all --json   exit 0  count=10  available: {null: 10}
openclaw models list --provider deepseek --all --json   exit 0  count=3   available: {true: 3}
```

Google's rows come back **`available: null`, not `false`**. The field works — the linked
provider on the same box answers `true` — so `null` is the tristate's third state, "did not
determine". `catalog/route.ts` already carries that measurement from an earlier pass and
says reading `null` as "no" *"would empty the list on exactly the boxes that have not
finished setting up"*. Counting a shrug as a refusal would hide Anthropic and OpenAI on
every unconfigured box, which is the opposite of the ruling's "a box that can run at least
one Google model keeps the row".

So on that box the harness does not assert that Google is unroutable. The only true
statement there is "there is no Google credential", and hiding on *that* is a different
ruling from the one written — it is the Connect list's inverse, and it needs the owner's
call rather than a fixer's. **What is in the PR body's gift is to say so plainly and hand
the decision back.**

### What this PR does fix — and it is real

**#743's rule was dead code on every shipped box.** Its `emptyIsAnswer` required an *empty
stderr*, and every `openclaw models list` invocation on the OpenClaw box, for every
provider, exit code 0, prints:

```
[agents/model-registry] model catalog load issue: Failed to load models.json:
Provider openai, model gpt-image-1-mini: no "api" specified…
```

So a genuine `count: 0` answer — the `models.mode: "replace"` state TASK-668 was opened on,
where Google really does enumerate nothing — could never be recorded there. A grumbling CLI
is not a refusing one: the gate now requires the CLI to have refused (`ok: false`, which it
reports on stdout while still exiting 0), and keeps the positive `count: 0` requirement that
stops a truncated payload counting as an answer.

**And the second shape of the same answer is now recognised**: the CLI lists rows and marks
every one of them explicitly `available: false`. Our own transform drops exactly those rows,
so the published count is zero either way; what tells it apart from a failure is that the
command ran and refused nothing. `null` and absent are counted as available, deliberately,
per the measurement above.

No new probe, no fork, no change to any freshness or backoff rule — the counts ride the
enumeration the catalog route was already going to run.

### Three corrections to #743 that came out of the review

* **`unrunnable` is advisory and the rows stay.** #743 dropped them server-side, which made
  a hidden provider render in the Connect list with **no connection label at all**
  (`statusById` had nothing for it) and took its switch with it. The strip does its own
  hiding now, which is where it already filters by state; every other consumer keeps a
  complete answer, and `setProviderEnabled` needs no special case.
* **The Connect list never hides anything.** Connecting is the way out — saving a cloud
  provider writes its configured rows and `models.mode: "merge"` — so the strip may drop a
  row only because that list does not. The two go together and #743 had both.
* **The strip never hides its way down to the default row alone.** One failure answers
  `count: 0` for several providers at once (a models.json the core cannot load, a config
  caught half-written, a gateway restart mid-refresh); each is a clean zero per provider and
  none is a fact about what the box can run. The chat picker already carried this refusal in
  its own words; the strip had none, and dropping the stderr gate is what made that matter.

  **This is measured against the rows the strip RENDERS**, and the first cut got that wrong
  in a way worth naming, because it is the same defect this PR removed one section below.
  Counting every row in the summary made the rule unsatisfiable on every box — `openai`
  stands for the `codex` catalogue too and that one is never enumerated, `clawai` is served
  from a two-row literal, `openrouter`'s REST fetcher never records a zero — so "every
  non-default row is a candidate" could not happen, while the harm it guards against could:
  ClawBox AI the default, a Google key pasted, google enumerating zero, and the panel shows
  ClawBox AI alone. Its test passed only by hand-writing `codex: 0` and `openrouter: 0`,
  records no production path can write. The rule now asks the question its comment states,
  and every record in its tests is one the catalog route can actually produce — including
  the box's own measured counts (google 10, anthropic 15, openai 27, clawai 2, openrouter
  417), on which it correctly does nothing.

### Deliberately removed as unreachable

The first cut of this branch carried a per-provider `available` count into the record and a
verdict branch for it. The review proved it could never fire: the published model count is
always ≤ the rows the harness did not mark unroutable, so `available === 0` can only ever
land beside `models === 0`, where the verdict was already `none` — and the three tests that
appeared to cover it were writing a record shape no production path can produce. The
mechanism, the record field, the signature change and those tests are all gone; what the PR
delivers is the two `emptyIsAnswer` terms above.

### RED → GREEN

RED on beta, the reachable half — a clean `count: 0` with the box's ordinary stderr noise:

```
FAIL src/tests/routes/ai-models/catalog-empty-enumeration.test.ts > records zero when the
     CLI answers with no rows at all
AssertionError: expected false to be true    // the record was never written
```

GREEN:

```
npx vitest run src/tests/routes src/tests/unit \
  src/tests/components/ai-provider-list.test.tsx src/tests/components/ai-models-step.test.tsx
 Test Files  733 passed (733)
      Tests  11868 passed | 1 skipped (11869)
```

(One parallel-load flake in `telegram/status.test.ts`, a file this PR does not touch, passing
in isolation and already logged in the queue.) `tsc --noEmit` clean, lint reports nothing new.

### Hermes

Unaffected by construction: verdicts are computed only when the harness is OpenClaw, so
`unrunnable` is always empty there, and the Connect-list change is a no-op on that edition
(`HermesProviderConfig` owns the panel).

### Known and deliberate

A hidden provider's enable/disable **switch** is unreachable from the UI while it is hidden
— the switch lives on the strip row. Connecting is reachable and clears the record at once
(`notifyProviderSetChanged` → `forgetProviderEnumeration`), so the row comes back on the
next render rather than after the six-hour TTL.

### The open question for the owner

On the measured box, "can run no Google model" reduces to "has no Google credential",
because the harness declines to judge. If the ruling means that box's Google row should go,
the signal is the credential the strip already reads — not the catalogue — and the Connect
list stays the way back. That is a product decision, and it is not made here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider setup now includes providers without currently runnable models, allowing them to be configured.
  * Providers with no available models are identified while remaining manageable in setup.
* **Bug Fixes**
  * Improved handling of empty and unavailable-model catalog results.
  * Clean zero-model responses with warnings no longer incorrectly report failures.
  * Provider availability indicators now align with the visible provider list.
  * Providers marked unrunnable can still be enabled or disabled when available in setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->