### PR TITLE
fix: close the six follow-ups deferred on the core-upgrade PR (TASK-741)

### DIFF
--- a/install-x64.sh
+++ b/install-x64.sh
@@ -540,8 +540,24 @@ PATHEOF
       GATEWAY_WAS_ACTIVE=1
       systemctl stop "$GATEWAY_SERVICE"
     fi
-    as_user_runtime "$OPENCLAW_BIN" doctor --fix --non-interactive </dev/null \
-      || echo "  Warning: doctor could not complete before initial configuration"
+    # Say WHICH failure this was, like install.sh's twin (TASK-737/741). A bare
+    # `|| echo Warning` over a doctor that migrated NOTHING is the false-success
+    # shape this repo keeps producing, and the commonest reason it exits
+    # non-zero here is a legacy exec-approvals file whose mere presence makes
+    # the core refuse every migration before starting one. Still non-fatal: the
+    # gateway's own ExecStartPre moves a clearable one aside and re-runs the
+    # migration on the next start.
+    local _oc_doctor_out
+    if ! _oc_doctor_out="$(as_user_runtime "$OPENCLAW_BIN" doctor --fix --non-interactive </dev/null 2>&1)"; then
+      printf '%s\n' "$_oc_doctor_out"
+      if printf '%s\n' "$_oc_doctor_out" | grep -q 'Legacy exec approvals exist at'; then
+        echo "  Warning: doctor migrated NOTHING — a legacy exec-approvals file blocks it. The gateway's pre-start moves a clearable one aside and re-runs the migration on the next start."
+      else
+        echo "  Warning: doctor could not complete before initial configuration"
+      fi
+    else
+      printf '%s\n' "$_oc_doctor_out"
+    fi
     if [ "$GATEWAY_WAS_ACTIVE" -eq 1 ]; then
       systemctl start "$GATEWAY_SERVICE"
     fi

--- a/install.sh
+++ b/install.sh
@@ -3774,6 +3774,10 @@ step_openclaw_install() {
     # (measured against 2026.8.1, 2026-09-06). The gateway's own ExecStartPre
     # clears that and re-runs the migration, so this stays non-fatal — but the
     # install log has to name it rather than imply doctor merely stumbled.
+    # `local` like every other assignment in this function (PIN_FILE, PINNED,
+    # TARGET, CORE_NEEDS_INSTALL): without it the whole doctor transcript leaks
+    # into a global for the rest of the installer run.
+    local _oc_doctor_out
     if ! _oc_doctor_out="$(as_clawbox -H "$OPENCLAW_BIN" doctor --fix --non-interactive </dev/null 2>&1)"; then
       printf '%s\n' "$_oc_doctor_out"
       if printf '%s\n' "$_oc_doctor_out" | grep -q 'Legacy exec approvals exist at'; then

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -229,8 +229,11 @@ export CLAWBOX_OPENCLAW_V2
 # already add up to well over half of it — the version probe, two plugin
 # installs, the codex install and enable, the deepseek installs and the
 # auth-profile doctor below. The worst case added here is 65 + 180 + 65 = 310 s
-# (the two validate bounds carry a 5 s `-k` grace each), and only on a box
-# whose config the core actually refuses; an accepted config costs one probe.
+# — the two validate bounds carry a 5 s `-k` grace each, like every other CLI
+# bound in this file, because plain `timeout` sends SIGTERM only and a validator
+# that ignored it would hold this ExecStartPre for the unit's whole start
+# budget — and only on a box whose config the core actually refuses; an
+# accepted config costs one probe.
 # The doctor bound is SIGTERM-only, deliberately: a SIGKILL mid-import is how
 # a half-finished `exec-approvals.json.doctor-importing` claim gets left
 # behind, which blocks every later doctor exactly as the original file does.
@@ -282,13 +285,25 @@ PY
 # Echoes `accepted`, `refused<TAB><issues>` or `unknown<TAB><why>`.
 clawbox_core_config_verdict() {
   local out rc=0
-  out="$(timeout 60 "$OPENCLAW_BIN" config validate --json 2>/dev/null)" || rc=$?
-  # 0 = valid, 1 = the core's verdict. Anything else (124 the bound fired,
-  # 126/127 nothing to run, a crash) is NOT an answer about the config, and
-  # reporting one as a refusal would spend 180 s of doctor on every single
-  # start of a box whose config is perfectly fine.
+  out="$(timeout -k 5 60 "$OPENCLAW_BIN" config validate --json 2>/dev/null)" || rc=$?
+  # EXIT 0 IS THE ANSWER, on its own (TASK-741). The core exiting 0 IS "the
+  # gateway will load this", and `getOpenclawConfigRefusal` (src/lib/updater.ts)
+  # has always read it that way — it returns "accepted" without parsing
+  # anything. Requiring stdout to parse as JSON on top of it made a core that
+  # exits 0 with empty, banner-prefixed or non-JSON output answer `unknown`,
+  # which skips the stamp and puts every single gateway start of a healthy box
+  # through a `config validate` and a WARN, for ever. Latent rather than live —
+  # measured on 2026.8.1, a valid config gives 75 bytes of pure JSON — and the
+  # shell parser below is stricter than the TypeScript one, which slices
+  # between the first `{` and the last `}`.
+  #
+  # 1 = the core's verdict, and the only exit whose payload is worth reading.
+  # Anything else (124 the bound fired, 126/127 nothing to run, a crash) is NOT
+  # an answer about the config, and reporting one as a refusal would spend
+  # 180 s of doctor on every single start of a box whose config is fine.
   case "$rc" in
-    0|1) ;;
+    0) printf 'accepted\n'; return 0 ;;
+    1) ;;
     *) printf 'unknown\tthe validator did not answer (exit %s)\n' "$rc"; return 0 ;;
   esac
   CLAWBOX_VERDICT_JSON="$out" python3 <<'PY'
@@ -301,9 +316,8 @@ except Exception:
 if not isinstance(doc, dict) or "valid" not in doc:
     print("unknown\tthe validator's answer carried no verdict")
     sys.exit(0)
-if doc.get("valid") is True:
-    print("accepted")
-    sys.exit(0)
+# Only reached on exit 1, which is the core's refusal — `valid: true` here
+# would be the CLI contradicting its own exit code, and the exit code wins.
 parts = []
 for issue in doc.get("issues") or []:
     if not isinstance(issue, dict):
@@ -360,8 +374,15 @@ then
     clawbox_exec_approvals_hold_a_decision "$_ea_file" || _ea_verdict=$?
     case "$_ea_verdict" in
       0)
-        _ea_moved="$_ea_file.legacy-$(date +%Y%m%d-%H%M%S)"
-        if mv "$_ea_file" "$_ea_moved" 2>/dev/null; then
+        # `-$$` and `mv -n`, because the stamp is only second-resolution: two
+        # moves inside one second would otherwise silently overwrite the first
+        # copy. The pid makes the name unique per boot, `-n` refuses to clobber
+        # even so, and the test is whether the file is GONE rather than what mv
+        # exited with — an `mv -n` that declined is a success code over a move
+        # that did not happen, which is the false-success shape this file is
+        # full of guards against.
+        _ea_moved="$_ea_file.legacy-$(date +%Y%m%d-%H%M%S)-$$"
+        if mv -n "$_ea_file" "$_ea_moved" 2>/dev/null && [ ! -e "$_ea_file" ]; then
           echo "  Moved a legacy exec approvals file aside ($_ea_moved): it holds no approval of yours, and its presence stops openclaw doctor before it migrates anything"
         else
           echo "  WARN: could not move $_ea_file aside; openclaw doctor will refuse to migrate this config while it is there" >&2

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -228,15 +228,17 @@ export CLAWBOX_OPENCLAW_V2
 # (config/clawbox-gateway.service) and the rest of this script's own bounds
 # already add up to well over half of it — the version probe, two plugin
 # installs, the codex install and enable, the deepseek installs and the
-# auth-profile doctor below. The worst case added here is 65 + 180 + 65 = 310 s
-# — the two validate bounds carry a 5 s `-k` grace each, like every other CLI
-# bound in this file, because plain `timeout` sends SIGTERM only and a validator
-# that ignored it would hold this ExecStartPre for the unit's whole start
-# budget — and only on a box whose config the core actually refuses; an
+# auth-profile doctor below. What this block adds is 65 + 180 + 65 = 310 s ONCE
+# THE DOCTOR EXITS, and only on a box whose config the core actually refuses; an
 # accepted config costs one probe.
-# The doctor bound is SIGTERM-only, deliberately: a SIGKILL mid-import is how
-# a half-finished `exec-approvals.json.doctor-importing` claim gets left
-# behind, which blocks every later doctor exactly as the original file does.
+# The two validate bounds carry a 5 s `-k` grace each, like every other CLI
+# bound in this file, because plain `timeout` sends SIGTERM only and a validator
+# that ignored it would hold this ExecStartPre for the unit's whole start budget.
+# The doctor bound is SIGTERM-only, deliberately: a SIGKILL mid-import is how a
+# half-finished `exec-approvals.json.doctor-importing` claim gets left behind,
+# which blocks every later doctor exactly as the original file does. So 310 s is
+# not an upper bound on the doctor arm — `TimeoutStartSec=600` is its real
+# ceiling, and that is the trade taken on purpose.
 CLAWBOX_CONFIG_VALIDATED_STAMP="$CLAWBOX_ROOT/data/openclaw-config-validated"
 
 # Does this approvals file hold a decision of the OWNER's?
@@ -286,38 +288,54 @@ PY
 clawbox_core_config_verdict() {
   local out rc=0
   out="$(timeout -k 5 60 "$OPENCLAW_BIN" config validate --json 2>/dev/null)" || rc=$?
-  # EXIT 0 IS THE ANSWER, on its own (TASK-741). The core exiting 0 IS "the
-  # gateway will load this", and `getOpenclawConfigRefusal` (src/lib/updater.ts)
-  # has always read it that way — it returns "accepted" without parsing
-  # anything. Requiring stdout to parse as JSON on top of it made a core that
-  # exits 0 with empty, banner-prefixed or non-JSON output answer `unknown`,
-  # which skips the stamp and puts every single gateway start of a healthy box
-  # through a `config validate` and a WARN, for ever. Latent rather than live —
-  # measured on 2026.8.1, a valid config gives 75 bytes of pure JSON — and the
-  # shell parser below is stricter than the TypeScript one, which slices
-  # between the first `{` and the last `}`.
+  # EXIT 0 IS ACCEPTANCE unless the core's own payload contradicts it
+  # (TASK-741). Requiring stdout to parse as JSON on TOP of a zero exit made a
+  # core that exits 0 with empty, banner-prefixed or non-JSON output answer
+  # `unknown` — which skips the stamp and puts every single gateway start of a
+  # healthy box through a `config validate` and a WARN, for ever. Latent rather
+  # than live (measured on 2026.8.1, a valid config gives 75 bytes of pure
+  # JSON), and the shell parser below is stricter than the TypeScript one, which
+  # slices between the first `{` and the last `}`.
   #
-  # 1 = the core's verdict, and the only exit whose payload is worth reading.
-  # Anything else (124 the bound fired, 126/127 nothing to run, a crash) is NOT
-  # an answer about the config, and reporting one as a refusal would spend
-  # 180 s of doctor on every single start of a box whose config is fine.
+  # But NOT "exit 0 and never look": this stamp is durable, so a core exiting 0
+  # while printing `{"valid": false}` would be recorded as accepted and never
+  # asked again — a false success that outlives the boot. The payload is read on
+  # both exits and an explicit `valid: false` wins, whatever the exit code said.
+  #
+  # Anything other than 0 or 1 (124 the bound fired, 126/127 nothing to run, a
+  # crash) is NOT an answer about the config, and reporting one as a refusal
+  # would spend 180 s of doctor on every start of a box whose config is fine.
   case "$rc" in
-    0) printf 'accepted\n'; return 0 ;;
-    1) ;;
+    0|1) ;;
     *) printf 'unknown\tthe validator did not answer (exit %s)\n' "$rc"; return 0 ;;
   esac
-  CLAWBOX_VERDICT_JSON="$out" python3 <<'PY'
+  CLAWBOX_VERDICT_JSON="$out" CLAWBOX_VERDICT_RC="$rc" python3 <<'PY'
 import json, os, sys
+
+# Exit 0 with no readable verdict is still acceptance: the exit code IS the
+# answer, and a banner is not a contradiction. Exit 1 with no readable verdict
+# is `unknown` — a refusal we cannot state is not one worth spending 180 s of
+# doctor on, and the gateway's own exit 78 remains the authority either way.
+_accepted_on_zero = os.environ.get("CLAWBOX_VERDICT_RC") == "0"
+
+
+def _no_verdict(why):
+    print("accepted" if _accepted_on_zero else "unknown\t" + why)
+    sys.exit(0)
+
+
 try:
     doc = json.loads(os.environ.get("CLAWBOX_VERDICT_JSON") or "")
 except Exception:
-    print("unknown\tthe validator did not answer in JSON")
-    sys.exit(0)
+    _no_verdict("the validator did not answer in JSON")
 if not isinstance(doc, dict) or "valid" not in doc:
-    print("unknown\tthe validator's answer carried no verdict")
-    sys.exit(0)
-# Only reached on exit 1, which is the core's refusal — `valid: true` here
-# would be the CLI contradicting its own exit code, and the exit code wins.
+    _no_verdict("the validator's answer carried no verdict")
+if doc.get("valid") is not False:
+    # A zero exit with a positive verdict is the ordinary healthy answer. A
+    # NON-zero exit whose payload says the config is valid is the CLI
+    # contradicting itself, and neither half is worth a stamp or a doctor run:
+    # say so and ask again next boot.
+    _no_verdict("the validator's exit code and its verdict disagree")
 parts = []
 for issue in doc.get("issues") or []:
     if not isinstance(issue, dict):
@@ -353,11 +371,16 @@ clawbox_stamp_write() {
   fi
 }
 
-if [ "$CLAWBOX_OPENCLAW_V2" = "1" ] \
-  && [ -x "$OPENCLAW_BIN" ] \
-  && [ -f "$OPENCLAW_CONFIG" ] \
-  && [ "$(clawbox_stamp_read)" != "$(clawbox_config_fingerprint)" ]
-then
+# THE APPROVALS BLOCKER IS CLEARED ON EVERY BOOT, not only on a core bump
+# (TASK-741). It used to live inside the config-fingerprint gate below, and the
+# two are gated on different facts: the blocker is an AUTH/STATE problem and the
+# stamp is a record about the CONFIG. A box whose config is already stamped —
+# every box that has booted once since its core bump — therefore kept its
+# blocker for ever, silently, and every later `doctor --fix` on that box (the
+# auth-profile migration below, `install.sh`'s, the updater's, the AI-models
+# configure route's) exited 1 having migrated nothing. Two `[ -e ]` tests is
+# what a box with no blocker pays for this.
+if [ "$CLAWBOX_OPENCLAW_V2" = "1" ] && [ -x "$OPENCLAW_BIN" ]; then
   # Both names block the core's gate: doctor renames the file to the
   # `.doctor-importing` claim for the duration of an import, so a killed
   # import leaves one behind that refuses every later doctor just as the
@@ -397,6 +420,13 @@ then
     esac
   done
 
+fi
+
+if [ "$CLAWBOX_OPENCLAW_V2" = "1" ] \
+  && [ -x "$OPENCLAW_BIN" ] \
+  && [ -f "$OPENCLAW_CONFIG" ] \
+  && [ "$(clawbox_stamp_read)" != "$(clawbox_config_fingerprint)" ]
+then
   _cfg_verdict="$(clawbox_core_config_verdict)"
   _cfg_state="${_cfg_verdict%%$'\t'*}"
   _cfg_detail=""

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -2389,13 +2389,6 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     // because a refusal that has already persisted a credential is not a
     // refusal, it is a half-applied save. Nothing between here and there
     // writes anything (the OAuth handoff file is consumed only on success).
-    // Set when `doctor --fix` was BLOCKED rather than failed: the sign-in is
-    // written and its move into the credential store happens at the next
-    // gateway start. A `{success:true}` with nothing said would leave the owner
-    // wondering why the provider needs a restart before it answers. Declared
-    // here because the block that sets it runs well before the other warnings
-    // are collected.
-    let credentialMigrationWarning: string | undefined;
     const settledSlash = config.defaultModel.indexOf("/");
     const settledProvider = settledSlash > 0 ? config.defaultModel.slice(0, settledSlash) : null;
     const settledModelId = config.defaultModel.slice(settledSlash + 1);
@@ -2570,26 +2563,20 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
       // The stop inside is unconditional; POST restores the unit if no later
       // step restarts it.
       gateway.state = "stopped-for-doctor";
+      // WHAT KIND of doctor failure this was (TASK-741). It still FAILS — the
+      // migration provably did not happen, and a legacy auth-profiles.json left
+      // in place is what stops an OpenClaw 2 gateway from starting — so the
+      // rollback below is unchanged. What changes is the sentence: telling the
+      // owner to "run `openclaw doctor --fix` from the Terminal" is advice for
+      // the command that is blocked, and he can do nothing with it.
+      let doctorBlockedByApprovals = false;
       try {
-        // A doctor BLOCKED by a legacy exec-approvals file did not fail this
-        // migration — it never started one (TASK-741). Rolling the sign-in back
-        // over that answer archived a credential this route had just written
-        // correctly, and told the owner to run the very command that is blocked.
-        // The gateway's own ExecStartPre clears the blocker on the next start
-        // and re-runs this migration (scripts/gateway-pre-start.sh, TASK-737),
-        // so the credential stands and the owner is told it is deferred.
         if (await runOpenclawDoctorFix() === "blocked-by-legacy-exec-approvals") {
-          console.warn(
-            "[configure] doctor --fix is blocked by a legacy exec-approvals file, so the credential store"
-            + " migration is deferred to the gateway's next start; the sign-in was written and is kept",
-          );
-          // Honest about the one case the boot path CANNOT clear: an approvals
-          // file that provably holds a decision of the owner's is left alone by
-          // design (TASK-737), and then the migration waits for him. The boot
-          // log carries the actionable NOTE; this says where to look.
-          credentialMigrationWarning = "Saved. A legacy exec-approvals file is blocking the move of this sign-in"
-            + " into OpenClaw's credential store; the gateway clears that on its next start, and says in the"
-            + " boot log what to move aside if it cannot.";
+          doctorBlockedByApprovals = true;
+          // Into the SAME failure path, deliberately: the v1/v2 decision below
+          // is what says whether the legacy file may stay, and a second copy of
+          // that judgement here is how the two would come to disagree.
+          throw new Error("openclaw doctor --fix is blocked by a legacy exec approvals file");
         }
       } catch (doctorErr) {
         const siblings = await fs.readdir(path.dirname(AUTH_PROFILES_PATH)).catch(() => [] as string[]);
@@ -2617,7 +2604,13 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
           const stamp = new Date().toISOString().replace(/[:.]/g, "-");
           await fs.rename(AUTH_PROFILES_PATH, `${AUTH_PROFILES_PATH}.failed-${stamp}`).catch(() => {});
           return NextResponse.json(
-            { error: "Credential migration failed. The subscription sign-in was rolled back — try again, or run 'openclaw doctor --fix' from the Terminal." },
+            {
+              error: doctorBlockedByApprovals
+                ? "Credential migration is blocked by a legacy exec-approvals file, so the subscription sign-in"
+                  + " was rolled back. Restart the device and sign in again — the gateway clears that file on its"
+                  + " next start, and the boot log names it if it cannot."
+                : "Credential migration failed. The subscription sign-in was rolled back — try again, or run 'openclaw doctor --fix' from the Terminal.",
+            },
             { status: 502 },
           );
         }
@@ -3347,7 +3340,7 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
       await fs.unlink(pendingHandoffTokensPath).catch(() => {});
     }
 
-    const warning = [chatgptOrderWarning, credentialMigrationWarning, unvalidatedPrimaryWarning, gatewayWarning]
+    const warning = [chatgptOrderWarning, unvalidatedPrimaryWarning, gatewayWarning]
       .filter(Boolean)
       .join(" ");
     return NextResponse.json({

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -2583,8 +2583,13 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
             "[configure] doctor --fix is blocked by a legacy exec-approvals file, so the credential store"
             + " migration is deferred to the gateway's next start; the sign-in was written and is kept",
           );
-          credentialMigrationWarning = "Saved. Moving the sign-in into OpenClaw's credential store is waiting on"
-            + " a legacy approvals file; the gateway clears it and finishes the move on its next start.";
+          // Honest about the one case the boot path CANNOT clear: an approvals
+          // file that provably holds a decision of the owner's is left alone by
+          // design (TASK-737), and then the migration waits for him. The boot
+          // log carries the actionable NOTE; this says where to look.
+          credentialMigrationWarning = "Saved. A legacy exec-approvals file is blocking the move of this sign-in"
+            + " into OpenClaw's credential store; the gateway clears that on its next start, and says in the"
+            + " boot log what to move aside if it cannot.";
         }
       } catch (doctorErr) {
         const siblings = await fs.readdir(path.dirname(AUTH_PROFILES_PATH)).catch(() => [] as string[]);

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -2605,10 +2605,17 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
           await fs.rename(AUTH_PROFILES_PATH, `${AUTH_PROFILES_PATH}.failed-${stamp}`).catch(() => {});
           return NextResponse.json(
             {
+              // Both outcomes named, in the order the owner meets them. The
+              // boot path moves a clearable blocker aside on the next start —
+              // but a file that provably holds approvals of HIS is left alone
+              // by design (TASK-737), and for that box a restart changes
+              // nothing. Leading with "restart and retry" alone would send
+              // exactly those owners round a loop.
               error: doctorBlockedByApprovals
                 ? "Credential migration is blocked by a legacy exec-approvals file, so the subscription sign-in"
-                  + " was rolled back. Restart the device and sign in again — the gateway clears that file on its"
-                  + " next start, and the boot log names it if it cannot."
+                  + " was rolled back. Restart the device and sign in again: the gateway moves that file aside on"
+                  + " its next start unless it holds approvals of yours. If the sign-in is refused again, the"
+                  + " gateway boot log names the file to move aside by hand."
                 : "Credential migration failed. The subscription sign-in was rolled back — try again, or run 'openclaw doctor --fix' from the Terminal.",
             },
             { status: 502 },

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -2389,6 +2389,13 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     // because a refusal that has already persisted a credential is not a
     // refusal, it is a half-applied save. Nothing between here and there
     // writes anything (the OAuth handoff file is consumed only on success).
+    // Set when `doctor --fix` was BLOCKED rather than failed: the sign-in is
+    // written and its move into the credential store happens at the next
+    // gateway start. A `{success:true}` with nothing said would leave the owner
+    // wondering why the provider needs a restart before it answers. Declared
+    // here because the block that sets it runs well before the other warnings
+    // are collected.
+    let credentialMigrationWarning: string | undefined;
     const settledSlash = config.defaultModel.indexOf("/");
     const settledProvider = settledSlash > 0 ? config.defaultModel.slice(0, settledSlash) : null;
     const settledModelId = config.defaultModel.slice(settledSlash + 1);
@@ -2564,7 +2571,21 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
       // step restarts it.
       gateway.state = "stopped-for-doctor";
       try {
-        await runOpenclawDoctorFix();
+        // A doctor BLOCKED by a legacy exec-approvals file did not fail this
+        // migration — it never started one (TASK-741). Rolling the sign-in back
+        // over that answer archived a credential this route had just written
+        // correctly, and told the owner to run the very command that is blocked.
+        // The gateway's own ExecStartPre clears the blocker on the next start
+        // and re-runs this migration (scripts/gateway-pre-start.sh, TASK-737),
+        // so the credential stands and the owner is told it is deferred.
+        if (await runOpenclawDoctorFix() === "blocked-by-legacy-exec-approvals") {
+          console.warn(
+            "[configure] doctor --fix is blocked by a legacy exec-approvals file, so the credential store"
+            + " migration is deferred to the gateway's next start; the sign-in was written and is kept",
+          );
+          credentialMigrationWarning = "Saved. Moving the sign-in into OpenClaw's credential store is waiting on"
+            + " a legacy approvals file; the gateway clears it and finishes the move on its next start.";
+        }
       } catch (doctorErr) {
         const siblings = await fs.readdir(path.dirname(AUTH_PROFILES_PATH)).catch(() => [] as string[]);
         const migratedStore = siblings.some((name) => name.startsWith("auth-profiles.json.migrated-"));
@@ -3321,7 +3342,7 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
       await fs.unlink(pendingHandoffTokensPath).catch(() => {});
     }
 
-    const warning = [chatgptOrderWarning, unvalidatedPrimaryWarning, gatewayWarning]
+    const warning = [chatgptOrderWarning, credentialMigrationWarning, unvalidatedPrimaryWarning, gatewayWarning]
       .filter(Boolean)
       .join(" ");
     return NextResponse.json({

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -2617,9 +2617,39 @@ export function gatewayIsAbsent(): boolean {
  * install.sh: gateway stopped first (doctor migrates the store the gateway
  * holds open), safe migrations only, and the caller's restart starts it
  * again. On OpenClaw 1 there is nothing to migrate and doctor answers fast.
+ *
+ * ONE FAILURE IS NOT A FAILED MIGRATION, and it is reported rather than thrown
+ * (TASK-741). With a legacy `exec-approvals.json` in the state directory the
+ * core's security gate throws on the file's mere PRESENCE, so `doctor --fix`
+ * exits 1 having migrated NOTHING and its last line asks the operator to run
+ * the command that has just run — measured against 2026.8.1 on 2026-09-06, the
+ * sentence arrives on STDERR:
+ *
+ *     Legacy exec approvals exist at <state>/exec-approvals.json. Run
+ *     `openclaw doctor --fix` … before using exec approvals.
+ *
+ * Presenting that to the caller as a credential-migration failure is what made
+ * `configure/route.ts` roll back a subscription sign-in it had in fact written.
+ * The blocker is cleared by the gateway's own ExecStartPre on the next start
+ * (`scripts/gateway-pre-start.sh`, TASK-737), which then re-runs this exact
+ * migration — so the credential is not lost, it is deferred, and the caller can
+ * say so instead of undoing it.
+ *
+ * Returned rather than thrown as a typed error on purpose: 59 suites replace
+ * this module with a hand-written factory, and a new class to narrow on with
+ * `instanceof` is `undefined` in every one of them that omits it (see
+ * `openclaw-config-mock-completeness.test.ts`). A value a caller compares is
+ * inert under those mocks — an omitted `runOpenclawDoctorFix` answers
+ * `undefined`, which is not this outcome, which is the behaviour they have now.
+ * EVERY OTHER failure still throws, untouched.
  */
-export async function runOpenclawDoctorFix(): Promise<void> {
-  if (gatewayIsAbsent()) return;
+export type OpenclawDoctorFixOutcome = "completed" | "blocked-by-legacy-exec-approvals";
+
+/** The core's own words for the blocker, matched rather than re-derived. */
+const LEGACY_EXEC_APPROVALS_RE = /Legacy exec approvals exist at/i;
+
+export async function runOpenclawDoctorFix(): Promise<OpenclawDoctorFixOutcome> {
+  if (gatewayIsAbsent()) return "completed";
   try {
     await exec("/usr/bin/sudo", ["-n", "/usr/bin/systemctl", "stop", "clawbox-gateway.service"], {
       timeout: 30000,
@@ -2627,7 +2657,18 @@ export async function runOpenclawDoctorFix(): Promise<void> {
   } catch {
     /* older sudoers or already stopped — doctor itself reports real trouble */
   }
-  await spawnOpenclaw(["doctor", "--fix", "--non-interactive"], { timeoutMs: 180_000 });
+  try {
+    await spawnOpenclaw(["doctor", "--fix", "--non-interactive"], { timeoutMs: 180_000 });
+  } catch (err) {
+    // `spawnOpenclaw` rejects with `stderr.trim()` when there is any, which is
+    // where the core prints this. A timeout or a spawn error carries neither
+    // the sentence nor a verdict and is rethrown.
+    if (err instanceof Error && LEGACY_EXEC_APPROVALS_RE.test(err.message)) {
+      return "blocked-by-legacy-exec-approvals";
+    }
+    throw err;
+  }
+  return "completed";
 }
 
 /**

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -2621,19 +2621,28 @@ export function gatewayIsAbsent(): boolean {
  * ONE FAILURE IS NOT A FAILED MIGRATION, and it is reported rather than thrown
  * (TASK-741). With a legacy `exec-approvals.json` in the state directory the
  * core's security gate throws on the file's mere PRESENCE, so `doctor --fix`
- * exits 1 having migrated NOTHING and its last line asks the operator to run
- * the command that has just run — measured against 2026.8.1 on 2026-09-06, the
- * sentence arrives on STDERR:
+ * exits 1 having migrated NOTHING — measured against 2026.8.1 on 2026-09-06,
+ * with the sentence on STDERR and in full:
  *
  *     Legacy exec approvals exist at <state>/exec-approvals.json. Run
- *     `openclaw doctor --fix` … before using exec approvals.
+ *     `openclaw doctor --fix` with OPENCLAW_STATE_DIR set to <state> before
+ *     using exec approvals.
  *
- * Presenting that to the caller as a credential-migration failure is what made
- * `configure/route.ts` roll back a subscription sign-in it had in fact written.
- * The blocker is cleared by the gateway's own ExecStartPre on the next start
- * (`scripts/gateway-pre-start.sh`, TASK-737), which then re-runs this exact
- * migration — so the credential is not lost, it is deferred, and the caller can
- * say so instead of undoing it.
+ * — i.e. advice for the command that has just run, with the state directory the
+ * caller had already set. THE MIGRATION STILL FAILED, and the caller's answer
+ * to that does not change: a legacy `auth-profiles.json` left in place is what
+ * stops an OpenClaw 2 gateway from starting. What changes is that the caller
+ * can now say WHICH failure it was, and name a file the owner can act on,
+ * instead of repeating the core's unusable advice.
+ *
+ * HARNESS FIRST, and the answer is uncomfortable: the core DOES have the
+ * importer. `--fix` arms its state migrations, and `migrateLegacyExecApprovals`
+ * imports a non-empty legacy file into SQLite, verifies it and removes the
+ * JSON. The exit 1 above is a different check — the runtime gate
+ * `assertNoPendingLegacyExecApprovals` — firing before that migration gets to
+ * run. So ClawBox is routing around an ordering defect in the core's own
+ * doctor, not filling a missing capability; that is worth reporting upstream
+ * and worth deleting from here when it lands.
  *
  * Returned rather than thrown as a typed error on purpose: 59 suites replace
  * this module with a hand-written factory, and a new class to narrow on with
@@ -2645,7 +2654,15 @@ export function gatewayIsAbsent(): boolean {
  */
 export type OpenclawDoctorFixOutcome = "completed" | "blocked-by-legacy-exec-approvals";
 
-/** The core's own words for the blocker, matched rather than re-derived. */
+/**
+ * The core's own words for the blocker, matched rather than re-derived.
+ *
+ * Three matchers now read this one English sentence — `install.sh`,
+ * `install-x64.sh` and `scripts/gateway-pre-start.sh` grep it case-sensitively,
+ * this one is case-insensitive. All three fail SAFE: a reworded upstream
+ * sentence simply reverts each to its old, stricter behaviour. A fourth site
+ * would be the point at which this deserves one shared constant.
+ */
 const LEGACY_EXEC_APPROVALS_RE = /Legacy exec approvals exist at/i;
 
 export async function runOpenclawDoctorFix(): Promise<OpenclawDoctorFixOutcome> {

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1345,6 +1345,16 @@ async function askCoreToValidateConfig(): Promise<CoreConfigVerdict | null> {
     const { stdout } = await execFile(OPENCLAW_BIN, ["config", "validate", "--json"], {
       timeout: 60_000,
       maxBuffer: 2 * 1024 * 1024,
+      // SIGKILL at the deadline, the counterpart of the `-k 5` the boot
+      // script's validate bounds carry (TASK-741): node's `execFile` sends
+      // `killSignal` ONCE and never escalates, so the default SIGTERM leaves a
+      // validator that ignores it running with nothing to stop it, holding this
+      // recovery open past its bound. Safe here and only here — `config
+      // validate` writes nothing. The doctor bound above keeps SIGTERM for the
+      // opposite reason: a SIGKILL mid-import is what leaves an
+      // `exec-approvals.json.doctor-importing` claim behind, which then blocks
+      // every later doctor exactly as the original file does.
+      killSignal: "SIGKILL",
       env: openclawChildEnv(),
     });
     text = stdout ?? "";
@@ -2420,10 +2430,13 @@ async function recordPluginCapabilityConsent(pluginId: string): Promise<void> {
  * malformed config must not be what stops a box from coming back.
  */
 async function readOpenclawConfigForRepair(): Promise<Record<string, unknown> | null> {
-  // `OPENCLAW_CONFIG` first, and only here: this caller READS a file and the
-  // other two spawn children that resolve their own path from
-  // `OPENCLAW_CONFIG_PATH`. Sharing one config-path rule would change which
-  // file two of the three address.
+  // `OPENCLAW_CONFIG` first, and the helper deliberately does not settle it:
+  // this caller READS a file, `runCurrentGatewayPreStart` passes `process.env`
+  // through to a script that prefers the same name, and `openclawChildEnv`
+  // alone ignores it because the core CLI reads `OPENCLAW_CONFIG_PATH` instead.
+  // Nothing on a box sets `OPENCLAW_CONFIG` — it is a test-only name — but
+  // folding three different rules into one shared one is how they would come to
+  // address different files.
   const configPath = process.env.OPENCLAW_CONFIG
     || path.join(openclawTreePaths().openclawHome, "openclaw.json");
   try {

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1362,6 +1362,18 @@ async function askCoreToValidateConfig(): Promise<CoreConfigVerdict | null> {
     // The core prints the verdict as JSON on stdout and exits 1 when it
     // refuses. Any other non-zero exit carries no verdict at all.
     accepted = false;
+    // A KILLED child answered nothing, whatever is in its buffer. It did not
+    // reach the exit code that carries the core's verdict, so anything parsed
+    // out of what it had written is this file guessing — and the guess is not
+    // free: `coreReportedMissingPlugins` reads `warnings[]` from the payload
+    // whatever the exit was, and would switch plugin entries off on it. The
+    // same rule this function already states for a validator it could not run,
+    // now applied to one it could not let finish (and the `killSignal` above
+    // makes that kill harder, so the two belong together).
+    if ((err as { killed?: boolean; signal?: unknown } | null)?.killed
+      || (err as { signal?: unknown } | null)?.signal) {
+      return { accepted, payload: null };
+    }
     text = commandOutput(err);
   }
   let parsed: unknown;

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1203,6 +1203,35 @@ function waitForGateway(timeoutMs: number): Promise<boolean> {
 }
 
 /**
+ * Where this device's OpenClaw tree is, in one place.
+ *
+ * The two-line derivation below appeared three times — in `openclawChildEnv`,
+ * in `runCurrentGatewayPreStart` and in `readOpenclawConfigForRepair` — and
+ * three copies of a rule is two chances for them to disagree about which
+ * config a repair is reasoning over.
+ *
+ * PURE, and it returns the paths only. It deliberately does NOT build an
+ * environment: the three callers set genuinely different ones and one shared
+ * env would be wrong for all of them. `runCurrentGatewayPreStart` spawns a bash
+ * script that reads ClawBox's own names and must pin those; `openclawChildEnv`
+ * feeds the core CLI, which reads only `OPENCLAW_CONFIG_PATH` /
+ * `OPENCLAW_STATE_DIR`; `readOpenclawConfigForRepair` spawns nothing at all and
+ * only wants a path to read.
+ *
+ * `OPENCLAW_HOME` is read here as a FALLBACK and must never be exported to a
+ * child: ClawBox uses that name for the `.openclaw` directory itself, while the
+ * OpenClaw CLI reads it as the ACCOUNT home and builds its tree at
+ * `$OPENCLAW_HOME/.openclaw`. Each caller that spawns something deletes it.
+ */
+function openclawTreePaths(): { home: string; openclawHome: string } {
+  const home = process.env.CLAWBOX_HOME_DIR || process.env.HOME || "/home/clawbox";
+  const openclawHome = process.env.CLAWBOX_OPENCLAW_HOME
+    || process.env.OPENCLAW_HOME
+    || path.join(home, ".openclaw");
+  return { home, openclawHome };
+}
+
+/**
  * The environment that pins an `openclaw` child to THIS device's real config.
  *
  * Same rule as `runCurrentGatewayPreStart`: the CLI reads `OPENCLAW_HOME` as
@@ -1214,10 +1243,7 @@ function waitForGateway(timeoutMs: number): Promise<boolean> {
  * is dead.
  */
 function openclawChildEnv(): NodeJS.ProcessEnv {
-  const home = process.env.CLAWBOX_HOME_DIR || process.env.HOME || "/home/clawbox";
-  const openclawHome = process.env.CLAWBOX_OPENCLAW_HOME
-    || process.env.OPENCLAW_HOME
-    || path.join(home, ".openclaw");
+  const { home, openclawHome } = openclawTreePaths();
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     HOME: home,
@@ -1534,10 +1560,7 @@ function pluginPayloadsRepairedByPreStart(preStartOutput: string): Set<string> {
 /** Run the newly checked-out pre-start repair while the gateway is stopped. */
 async function runCurrentGatewayPreStart(): Promise<string> {
   if (!existsSync(CURRENT_GATEWAY_PRE_START)) return "";
-  const home = process.env.CLAWBOX_HOME_DIR || process.env.HOME || "/home/clawbox";
-  const openclawHome = process.env.CLAWBOX_OPENCLAW_HOME
-    || process.env.OPENCLAW_HOME
-    || path.join(home, ".openclaw");
+  const { home, openclawHome } = openclawTreePaths();
   // Never `OPENCLAW_HOME` in a child's environment. ClawBox reads that name as
   // the .openclaw directory; the OpenClaw CLI reads it as the ACCOUNT home and
   // puts its tree at `$OPENCLAW_HOME/.openclaw`. Exported here it made every
@@ -2397,11 +2420,12 @@ async function recordPluginCapabilityConsent(pluginId: string): Promise<void> {
  * malformed config must not be what stops a box from coming back.
  */
 async function readOpenclawConfigForRepair(): Promise<Record<string, unknown> | null> {
-  const home = process.env.CLAWBOX_HOME_DIR || process.env.HOME || "/home/clawbox";
-  const openclawHome = process.env.CLAWBOX_OPENCLAW_HOME
-    || process.env.OPENCLAW_HOME
-    || path.join(home, ".openclaw");
-  const configPath = process.env.OPENCLAW_CONFIG || path.join(openclawHome, "openclaw.json");
+  // `OPENCLAW_CONFIG` first, and only here: this caller READS a file and the
+  // other two spawn children that resolve their own path from
+  // `OPENCLAW_CONFIG_PATH`. Sharing one config-path rule would change which
+  // file two of the three address.
+  const configPath = process.env.OPENCLAW_CONFIG
+    || path.join(openclawTreePaths().openclawHome, "openclaw.json");
   try {
     return JSON.parse(await readFile(configPath, "utf-8")) as Record<string, unknown>;
   } catch {

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -2638,8 +2638,11 @@ describe("POST /setup-api/ai-models/configure", () => {
       expect(body.error).toMatch(/legacy exec-approvals file/i);
       // The advice that could not work is gone from this arm.
       expect(body.error).not.toMatch(/run 'openclaw doctor --fix' from the Terminal/i);
-      // …and honest about the one case the boot path cannot clear on its own.
-      expect(body.error).toMatch(/if it cannot/i);
+      // …and honest about the one case the boot path cannot clear on its own,
+      // which is the difference between an owner who restarts once and one who
+      // restarts for ever.
+      expect(body.error).toMatch(/unless it holds approvals of yours/i);
+      expect(body.error).toMatch(/move aside by hand/i);
       // Fail closed, exactly as before: the legacy file does not stay behind.
       expect(mockFs.rename).toHaveBeenCalledWith(
         expect.stringMatching(/auth-profiles\.json$/),

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -2635,7 +2635,9 @@ describe("POST /setup-api/ai-models/configure", () => {
       expect(body.success).toBe(true);
       // Said, not swallowed: a clean `{success:true}` would leave the owner
       // wondering why the provider needs a restart before it answers.
-      expect(body.warning).toMatch(/legacy approvals file/i);
+      expect(body.warning).toMatch(/legacy exec-approvals file is blocking/i);
+      // And honest about the one case the boot path cannot clear on its own.
+      expect(body.warning).toMatch(/if it cannot/i);
       // And the credential it wrote is still where it wrote it.
       expect(mockFs.rename).not.toHaveBeenCalledWith(
         expect.stringMatching(/auth-profiles\.json$/),

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -2612,6 +2612,37 @@ describe("POST /setup-api/ai-models/configure", () => {
       );
     });
 
+    it("keeps a sign-in whose migration was BLOCKED, and says it is deferred", async () => {
+      // TASK-741. A legacy exec-approvals file makes the core's own gate throw
+      // on the file's PRESENCE, so `doctor --fix` exits 1 having migrated
+      // nothing and asks for the command that just ran. That is not a failed
+      // credential migration — it is one that never started — and rolling the
+      // sign-in back over it archived a profile this route had just written
+      // correctly. The gateway's own ExecStartPre clears the blocker and
+      // re-runs the same migration on the next start (TASK-737).
+      vi.mocked(runOpenclawDoctorFix).mockResolvedValueOnce("blocked-by-legacy-exec-approvals");
+
+      const res = await configurePost(jsonRequest({
+        provider: "anthropic",
+        apiKey: ANTHROPIC_OAUTH_ACCESS,
+        authMode: "subscription",
+        refreshToken: "refresh-token",
+        expiresIn: 3600,
+      }));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      // Said, not swallowed: a clean `{success:true}` would leave the owner
+      // wondering why the provider needs a restart before it answers.
+      expect(body.warning).toMatch(/legacy approvals file/i);
+      // And the credential it wrote is still where it wrote it.
+      expect(mockFs.rename).not.toHaveBeenCalledWith(
+        expect.stringMatching(/auth-profiles\.json$/),
+        expect.stringMatching(/auth-profiles\.json\.failed-/),
+      );
+    });
+
     it("keeps the legacy best-effort doctor behavior on an explicit OpenClaw 1 binary", async () => {
       vi.mocked(runOpenclawDoctorFix).mockRejectedValueOnce(new Error("v1 doctor unavailable"));
       vi.mocked(spawnOpenclawCli).mockResolvedValueOnce("OpenClaw 2026.7.9 (test)\n");

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -2612,15 +2612,18 @@ describe("POST /setup-api/ai-models/configure", () => {
       );
     });
 
-    it("keeps a sign-in whose migration was BLOCKED, and says it is deferred", async () => {
+    it("names the exec-approvals blocker instead of advising the command it blocks", async () => {
       // TASK-741. A legacy exec-approvals file makes the core's own gate throw
       // on the file's PRESENCE, so `doctor --fix` exits 1 having migrated
-      // nothing and asks for the command that just ran. That is not a failed
-      // credential migration — it is one that never started — and rolling the
-      // sign-in back over it archived a profile this route had just written
-      // correctly. The gateway's own ExecStartPre clears the blocker and
-      // re-runs the same migration on the next start (TASK-737).
+      // nothing and its last line asks for the command that just ran. The
+      // migration still FAILED — the legacy auth-profiles.json this route wrote
+      // is what stops an OpenClaw 2 gateway from starting — so the rollback is
+      // unchanged and deliberately so. What changes is that the owner is told
+      // the cause and an action he can take, rather than being sent to a
+      // Terminal command that is blocked for exactly this reason.
       vi.mocked(runOpenclawDoctorFix).mockResolvedValueOnce("blocked-by-legacy-exec-approvals");
+      vi.mocked(spawnOpenclawCli).mockResolvedValueOnce("OpenClaw 2026.8.1 (test)\n");
+      mockFs.readdir.mockResolvedValueOnce([]);
 
       const res = await configurePost(jsonRequest({
         provider: "anthropic",
@@ -2631,18 +2634,39 @@ describe("POST /setup-api/ai-models/configure", () => {
       }));
       const body = await res.json();
 
-      expect(res.status).toBe(200);
-      expect(body.success).toBe(true);
-      // Said, not swallowed: a clean `{success:true}` would leave the owner
-      // wondering why the provider needs a restart before it answers.
-      expect(body.warning).toMatch(/legacy exec-approvals file is blocking/i);
-      // And honest about the one case the boot path cannot clear on its own.
-      expect(body.warning).toMatch(/if it cannot/i);
-      // And the credential it wrote is still where it wrote it.
-      expect(mockFs.rename).not.toHaveBeenCalledWith(
+      expect(res.status).toBe(502);
+      expect(body.error).toMatch(/legacy exec-approvals file/i);
+      // The advice that could not work is gone from this arm.
+      expect(body.error).not.toMatch(/run 'openclaw doctor --fix' from the Terminal/i);
+      // …and honest about the one case the boot path cannot clear on its own.
+      expect(body.error).toMatch(/if it cannot/i);
+      // Fail closed, exactly as before: the legacy file does not stay behind.
+      expect(mockFs.rename).toHaveBeenCalledWith(
         expect.stringMatching(/auth-profiles\.json$/),
         expect.stringMatching(/auth-profiles\.json\.failed-/),
       );
+    });
+
+    it("still sends every OTHER doctor failure to the generic advice", async () => {
+      // The half that must not move: a doctor that failed for any other reason
+      // is a state the owner can act on with the command, and this arm is what
+      // keeps the new sentence from swallowing it.
+      vi.mocked(runOpenclawDoctorFix).mockRejectedValueOnce(new Error("doctor exploded"));
+      vi.mocked(spawnOpenclawCli).mockResolvedValueOnce("OpenClaw 2026.8.1 (test)\n");
+      mockFs.readdir.mockResolvedValueOnce([]);
+
+      const res = await configurePost(jsonRequest({
+        provider: "anthropic",
+        apiKey: ANTHROPIC_OAUTH_ACCESS,
+        authMode: "subscription",
+        refreshToken: "refresh-token",
+        expiresIn: 3600,
+      }));
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expect(body.error).toMatch(/run 'openclaw doctor --fix' from the Terminal/i);
+      expect(body.error).not.toMatch(/exec-approvals/i);
     });
 
     it("keeps the legacy best-effort doctor behavior on an explicit OpenClaw 1 binary", async () => {

--- a/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
+++ b/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
@@ -488,6 +488,58 @@ d("gateway pre-start: the config-repair block's own edges", () => {
     expect(src).not.toContain('timeout -k 5 180 "$OPENCLAW_BIN" doctor');
   });
 
+  it("clears the approvals blocker on a box whose config is already stamped", () => {
+    // The blocker is an AUTH/STATE fact and the stamp is a record about the
+    // CONFIG, and the two were gated on one another: the whole clearing loop
+    // sat inside the config-fingerprint guard, so a box that had booted once
+    // since its core bump kept its blocker for ever, silently — and every later
+    // `doctor --fix` on that box (the auth-profile migration in this same
+    // script, install.sh's, the updater's, the AI-models configure route's)
+    // exited 1 having migrated nothing.
+    writeFileSync(stampPath, `${currentFingerprint()}\n`);
+    writeFileSync(
+      path.join(stateDir, "exec-approvals.json"),
+      JSON.stringify({ version: 1, socket: {}, defaults: {}, agents: {} }),
+    );
+
+    const r = run();
+
+    expect(r.status).toBe(0);
+    expect(existsSync(path.join(stateDir, "exec-approvals.json"))).toBe(false);
+    expect(approvalsFiles().some((n) => n.startsWith("exec-approvals.json.legacy-"))).toBe(true);
+    // …and the config half is still gated on the stamp, so a steady box pays
+    // for the two `[ -e ]` tests above and nothing else.
+    expect(calls()).toEqual([]);
+  });
+
+  it("refuses a config the core calls invalid, whatever it exited with", () => {
+    // The other half of "exit 0 is the answer". The stamp is DURABLE, so a core
+    // exiting 0 while printing `{"valid": false}` would be recorded as accepted
+    // and never asked again — a false success that outlives the boot and leaves
+    // the gateway exiting 78 with nothing in the log.
+    writeFileSync(
+      path.join(binDir, "openclaw"),
+      "#!/usr/bin/env bash\n"
+      + "printf '%s\\n' \"$*\" >> \"$OC_CALLS\"\n"
+      + "if [ \"$1\" = \"config\" ]; then\n"
+      + "  if [ -f \"$OC_STATE/migrated\" ]; then echo '{\"valid\":true,\"warnings\":[]}'; exit 0; fi\n"
+      + "  echo '{\"valid\":false,\"issues\":[{\"path\":\"a\",\"message\":\"bad\"}]}'; exit 0\n"
+      + "fi\n"
+      + "if [ \"$1\" = \"doctor\" ]; then touch \"$OC_STATE/migrated\"; exit 0; fi\n"
+      + "exit 0\n",
+    );
+    chmodSync(path.join(binDir, "openclaw"), 0o755);
+
+    const r = run();
+
+    expect(r.status).toBe(0);
+    // The core's own reason reached the boot log, and its own repair ran.
+    expect(r.stderr).toContain("refused: a: bad");
+    expect(calls().some((c) => c.startsWith("doctor --fix"))).toBe(true);
+    // …and the config it then ACCEPTED is the one that gets stamped.
+    expect(readFileSync(stampPath, "utf-8").trim()).toBe(currentFingerprint());
+  });
+
   it("never overwrites an earlier moved-aside approvals file", () => {
     // The stamp is second-resolution and `mv` was unguarded, so two boots
     // inside one second would silently overwrite the first copy. `date` is

--- a/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
+++ b/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
@@ -439,3 +439,81 @@ d("gateway pre-start: the auth-profile repair meets the same blocker", () => {
     expect(r.stderr).toContain("auth-profile migration failed");
   });
 });
+
+/**
+ * TASK-741 — the three follow-ups from #746's review that live in this block.
+ *
+ * All three are LATENT on the pinned core rather than live, and each is the
+ * kind of latency this repo has been bitten by: a verdict that reads an exit
+ * code and then second-guesses it, a bound whose comment promises a grace the
+ * code does not have, and a destination two writes can share.
+ */
+d("gateway pre-start: the config-repair block's own edges", () => {
+  it("takes exit 0 as the core's acceptance, whatever it printed", () => {
+    // ALIGNED WITH `getOpenclawConfigRefusal` (src/lib/updater.ts), which has
+    // treated exit 0 as acceptance without parsing since TASK-737. Requiring
+    // stdout to parse as JSON on top of the exit code answered `unknown` for a
+    // core that exits 0 with a banner, an empty line or a progress frame — and
+    // `unknown` skips the stamp, so EVERY gateway start of a healthy box would
+    // pay for a `config validate` and print a WARN, for ever.
+    writeFileSync(
+      path.join(binDir, "openclaw"),
+      "#!/usr/bin/env bash\n"
+      + "printf '%s\\n' \"$*\" >> \"$OC_CALLS\"\n"
+      + "if [ \"$1\" = \"config\" ]; then echo 'OpenClaw 2026.8.1 — All your chats, one OpenClaw.'; exit 0; fi\n"
+      + "exit 0\n",
+    );
+    chmodSync(path.join(binDir, "openclaw"), 0o755);
+
+    const r = run();
+
+    expect(r.status).toBe(0);
+    expect(r.stderr).not.toContain("could not ask the installed core");
+    // Accepted means stamped, which is what stops the next boot re-asking.
+    expect(readFileSync(stampPath, "utf-8").trim()).toBe(currentFingerprint());
+    // …and no doctor: there is nothing to repair.
+    expect(calls().some((c) => c.startsWith("doctor"))).toBe(false);
+  });
+
+  it("gives the validator bound a SIGKILL grace, like every other CLI bound here", () => {
+    // The BUDGET comment above the block claims `65 + 180 + 65` on the strength
+    // of a 5 s `-k` grace the two validate bounds did not have. Plain `timeout`
+    // sends SIGTERM only: a validator that ignored it would hold this blocking
+    // ExecStartPre for the unit's entire start budget. The doctor bound stays
+    // SIGTERM-only on purpose — a SIGKILL mid-import is what leaves the
+    // `.doctor-importing` claim file this same block has to clear.
+    const src = block();
+    expect(src).toContain('timeout -k 5 60 "$OPENCLAW_BIN" config validate --json');
+    expect(src).toContain('timeout 180 "$OPENCLAW_BIN" doctor --fix --non-interactive');
+    expect(src).not.toContain('timeout -k 5 180 "$OPENCLAW_BIN" doctor');
+  });
+
+  it("never overwrites an earlier moved-aside approvals file", () => {
+    // The stamp is second-resolution and `mv` was unguarded, so two boots
+    // inside one second would silently overwrite the first copy. `date` is
+    // stubbed to one fixed answer here so the collision is the case under
+    // test rather than a race the clock usually wins.
+    writeFileSync(
+      path.join(binDir, "date"),
+      "#!/usr/bin/env bash\nprintf '%s\\n' 20260906-181500\n",
+    );
+    chmodSync(path.join(binDir, "date"), 0o755);
+    const approvals = { version: 1, socket: {}, defaults: {}, agents: {} };
+
+    writeFileSync(path.join(stateDir, "exec-approvals.json"), JSON.stringify(approvals));
+    expect(run().status).toBe(0);
+
+    // A second boot in the same second, over a config the core refuses again.
+    rmSync(path.join(stateDir, "migrated"), { force: true });
+    writeFileSync(configPath, JSON.stringify({ agents: { defaults: { memorySearch: {}, x: 1 } } }, null, 2));
+    writeFileSync(path.join(stateDir, "exec-approvals.json"), JSON.stringify(approvals));
+    expect(run().status).toBe(0);
+
+    // BOTH copies are still there. Neither holds a decision of the owner's, so
+    // nothing of his could have been lost — but a move-aside that overwrites is
+    // a write reported as a move, and this file is the only record that the
+    // repair ever fired.
+    expect(approvalsFiles().filter((n) => n.includes(".legacy-"))).toHaveLength(2);
+    expect(existsSync(path.join(stateDir, "exec-approvals.json"))).toBe(false);
+  });
+});

--- a/src/tests/unit/install-plugin-capability-consent.test.ts
+++ b/src/tests/unit/install-plugin-capability-consent.test.ts
@@ -122,3 +122,25 @@ describe("install.sh plugin refresh", () => {
     expect(offenders).toEqual([]);
   });
 });
+
+/**
+ * TASK-741 — the doctor transcript in the same function is not a global.
+ *
+ * `step_openclaw_install` captures the whole `openclaw doctor --fix` output to
+ * decide WHICH failure it was (TASK-737 made that branch honest). Every other
+ * assignment in the function is `local`; that one was not, so a transcript that
+ * can run to hundreds of lines outlived the function for the rest of an
+ * installer run whose later steps read whatever happens to be set.
+ *
+ * A source assertion, like the rest of this file: what has to be true of the
+ * line is its declaration, and running the step reaches npm and the registry.
+ */
+describe("step_openclaw_install keeps its doctor transcript to itself", () => {
+  it("declares _oc_doctor_out local", () => {
+    const start = INSTALL_SH.indexOf("step_openclaw_install() {");
+    expect(start, "step_openclaw_install was not found").toBeGreaterThan(-1);
+    const fn = INSTALL_SH.slice(start, INSTALL_SH.indexOf("\n}\n", start));
+    expect(fn).toContain("_oc_doctor_out");
+    expect(fn).toMatch(/^\s*local _oc_doctor_out\s*$/m);
+  });
+});

--- a/src/tests/unit/openclaw-doctor-fix-blocked.test.ts
+++ b/src/tests/unit/openclaw-doctor-fix-blocked.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import * as childProcess from "child_process";
+import { EventEmitter } from "events";
+import type { ChildProcess } from "child_process";
+
+/**
+ * TASK-741, item 6 — a doctor that was BLOCKED did not fail a migration.
+ *
+ * With a legacy `exec-approvals.json` in the state directory the core's
+ * security gate throws on the file's mere PRESENCE, so `openclaw doctor --fix`
+ * exits 1 having migrated NOTHING and its last line asks the operator to run
+ * the command that has just run. Measured against 2026.8.1 on 2026-09-06 (in a
+ * throwaway `OPENCLAW_STATE_DIR` under /tmp, on the OpenClaw box):
+ *
+ *   RC=1, and on STDERR:
+ *   Legacy exec approvals exist at <state>/exec-approvals.json. Run
+ *   `openclaw doctor --fix` … before using exec approvals.
+ *
+ * `runOpenclawDoctorFix` threw that at its caller like any other failure, and
+ * `configure/route.ts` answered by ARCHIVING the auth-profiles file it had just
+ * written and returning 502 — a subscription sign-in rolled back over a
+ * migration that had not been attempted. The blocker is cleared by the
+ * gateway's own ExecStartPre on the next start (TASK-737), which re-runs this
+ * same migration, so the credential is deferred rather than lost.
+ *
+ * The two halves that must both hold: this one answer is reported, and every
+ * other failure still throws.
+ */
+
+vi.mock("child_process", () => ({
+  execFile: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+vi.mock("fs", () => ({
+  default: {
+    // `readEdition()` stats the edition file before reading it; a mock without
+    // `statSync` throws a TypeError into its own catch and the edition guard
+    // this whole path depends on is never exercised.
+    statSync: vi.fn(() => { throw new Error("no edition file"); }),
+    readFileSync: vi.fn(() => { throw new Error("no edition file"); }),
+    existsSync: vi.fn(() => true),
+    readdirSync: vi.fn(() => { throw new Error("no nvm dir"); }),
+  },
+}));
+
+vi.mock("fs/promises", () => ({
+  default: { readFile: vi.fn(), writeFile: vi.fn(), rename: vi.fn(), mkdir: vi.fn() },
+}));
+
+const mockSpawn = vi.mocked(childProcess.spawn);
+const mockExecFile = vi.mocked(childProcess.execFile);
+
+let openclawConfig: typeof import("@/lib/openclaw-config");
+
+/** A child that writes `stderr` and exits 1, like the blocked doctor. */
+function failingChild(stderrText: string): ChildProcess {
+  const child = new EventEmitter() as ChildProcess;
+  const stderr = new EventEmitter();
+  child.stdout = new EventEmitter() as unknown as ChildProcess["stdout"];
+  child.stderr = stderr as unknown as ChildProcess["stderr"];
+  child.kill = vi.fn(() => true) as unknown as ChildProcess["kill"];
+  queueMicrotask(() => {
+    stderr.emit("data", Buffer.from(stderrText));
+    child.emit("close", 1);
+  });
+  return child;
+}
+
+let ambientEdition: string | undefined;
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  ambientEdition = process.env.CLAWBOX_EDITION;
+  process.env.CLAWBOX_EDITION = "openclaw";
+  // The `systemctl stop` before doctor: promisified `execFile`, callback style.
+  mockExecFile.mockImplementation(((
+    _cmd: string,
+    _args: string[],
+    _opts: unknown,
+    cb?: (e: Error | null, r: { stdout: string; stderr: string }) => void,
+  ) => {
+    cb?.(null, { stdout: "", stderr: "" });
+    return undefined as unknown as ChildProcess;
+  }) as unknown as typeof childProcess.execFile);
+  openclawConfig = await import("@/lib/openclaw-config");
+});
+
+afterEach(() => {
+  if (ambientEdition === undefined) delete process.env.CLAWBOX_EDITION;
+  else process.env.CLAWBOX_EDITION = ambientEdition;
+});
+
+describe("runOpenclawDoctorFix and the legacy exec-approvals blocker", () => {
+  it("reports the blocker instead of throwing it as a migration failure", async () => {
+    mockSpawn.mockImplementation(() => failingChild(
+      "Legacy exec approvals exist at /home/clawbox/.openclaw/exec-approvals.json."
+      + " Run `openclaw doctor --fix` before using exec approvals.\n",
+    ));
+
+    await expect(openclawConfig.runOpenclawDoctorFix()).resolves.toBe("blocked-by-legacy-exec-approvals");
+  });
+
+  it("still throws every other doctor failure", async () => {
+    // The invariant the change must not remove: a doctor that genuinely could
+    // not migrate leaves a credential store OpenClaw 2 refuses to hydrate, and
+    // the caller's rollback is the right answer to that.
+    mockSpawn.mockImplementation(() => failingChild("doctor exploded\n"));
+
+    await expect(openclawConfig.runOpenclawDoctorFix()).rejects.toThrow("doctor exploded");
+  });
+
+  it("answers completed on the ordinary path", async () => {
+    mockSpawn.mockImplementation(() => {
+      const child = new EventEmitter() as ChildProcess;
+      child.stdout = new EventEmitter() as unknown as ChildProcess["stdout"];
+      child.stderr = new EventEmitter() as unknown as ChildProcess["stderr"];
+      child.kill = vi.fn(() => true) as unknown as ChildProcess["kill"];
+      queueMicrotask(() => child.emit("close", 0));
+      return child;
+    });
+
+    await expect(openclawConfig.runOpenclawDoctorFix()).resolves.toBe("completed");
+  });
+
+  it("spawns nothing on the Hermes edition", async () => {
+    process.env.CLAWBOX_EDITION = "hermes";
+    vi.resetModules();
+    const hermes = await import("@/lib/openclaw-config");
+
+    await expect(hermes.runOpenclawDoctorFix()).resolves.toBe("completed");
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/unit/updater-openclaw-tree-paths.test.ts
+++ b/src/tests/unit/updater-openclaw-tree-paths.test.ts
@@ -31,15 +31,22 @@ const UPDATER = readFileSync(path.join(REPO, "src", "lib", "updater.ts"), "utf-8
 
 describe("the OpenClaw tree is derived in one place", () => {
   it("has exactly one derivation of openclawHome", () => {
-    const copies = UPDATER.match(/process\.env\.CLAWBOX_OPENCLAW_HOME\s*\n?\s*\|\|\s*process\.env\.OPENCLAW_HOME/g) ?? [];
-    expect(copies).toHaveLength(1);
     expect(UPDATER).toContain("function openclawTreePaths()");
+    // Counted on each PART of the rule, not on the pairing: a fourth site
+    // written as `process.env.OPENCLAW_HOME || path.join(home, ".openclaw")`
+    // slips past a regex that only knows the two-name form, which is exactly
+    // the hand-written copy this guard exists to catch.
+    expect(UPDATER.match(/process\.env\.CLAWBOX_OPENCLAW_HOME/g) ?? []).toHaveLength(1);
+    expect(UPDATER.match(/path\.join\(home, "\.openclaw"\)/g) ?? []).toHaveLength(1);
+    // And the fallback itself is read in exactly one place. (Comments name the
+    // variable too, so this counts the READ rather than the word.)
+    expect(UPDATER.match(/process\.env\.OPENCLAW_HOME/g) ?? []).toHaveLength(1);
   });
 
   it("still deletes OPENCLAW_HOME from every child environment it builds", () => {
-    // The helper hands back paths, not an environment, precisely so each caller
-    // keeps the one it actually sets — and both callers that spawn something
-    // owe this line.
+    // A PIN, not a regression test — both lines predate this change. The helper
+    // hands back paths rather than an environment precisely so each caller keeps
+    // the one it actually sets, and both callers that spawn something owe this.
     expect(UPDATER.match(/delete env\.OPENCLAW_HOME;/g) ?? []).toHaveLength(2);
   });
 });

--- a/src/tests/unit/updater-openclaw-tree-paths.test.ts
+++ b/src/tests/unit/updater-openclaw-tree-paths.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * TASK-741 — where this device's OpenClaw tree is, derived once.
+ *
+ * The same two-line rule — `CLAWBOX_OPENCLAW_HOME`, then `OPENCLAW_HOME`, then
+ * `$HOME/.openclaw` — appeared three times in `src/lib/updater.ts`: in the
+ * environment for an `openclaw` child, in the environment for the gateway
+ * pre-start, and in the config read the plugin repairs reason over. Three
+ * copies of one rule is two chances for a repair to decide about a different
+ * config from the one the CLI it just ran was writing.
+ *
+ * A SOURCE assertion, deliberately. The three callers are private, the rule is
+ * environment-derived, and what has to stay true is that there is one copy of
+ * it — which is a property of the file, not of any one call. This fails the day
+ * a fourth site is written by hand.
+ *
+ * `OPENCLAW_HOME` is read as a FALLBACK and must never be EXPORTED to a child:
+ * ClawBox uses that name for the `.openclaw` directory itself, while the
+ * OpenClaw CLI reads it as the ACCOUNT home and builds its tree at
+ * `$OPENCLAW_HOME/.openclaw` — the 2026-09-04 defect where every `openclaw` the
+ * pre-start ran wrote a second config under `~/.openclaw/.openclaw/` and
+ * reported success. Both spawning callers still delete it, and that is pinned
+ * here too.
+ */
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const UPDATER = readFileSync(path.join(REPO, "src", "lib", "updater.ts"), "utf-8");
+
+describe("the OpenClaw tree is derived in one place", () => {
+  it("has exactly one derivation of openclawHome", () => {
+    const copies = UPDATER.match(/process\.env\.CLAWBOX_OPENCLAW_HOME\s*\n?\s*\|\|\s*process\.env\.OPENCLAW_HOME/g) ?? [];
+    expect(copies).toHaveLength(1);
+    expect(UPDATER).toContain("function openclawTreePaths()");
+  });
+
+  it("still deletes OPENCLAW_HOME from every child environment it builds", () => {
+    // The helper hands back paths, not an environment, precisely so each caller
+    // keeps the one it actually sets — and both callers that spawn something
+    // owe this line.
+    expect(UPDATER.match(/delete env\.OPENCLAW_HOME;/g) ?? []).toHaveLength(2);
+  });
+});

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -2949,6 +2949,39 @@ describe("updater", () => {
       expect(disableRan("byteplus")).toBe(true);
     });
 
+    it("acts on nothing a KILLED validator had buffered", async () => {
+      // TASK-741. The bound above now sends SIGKILL, and a killed child never
+      // reached the exit code that carries the core's verdict — so whatever it
+      // had already written to stdout is not an answer, however well-formed.
+      // This reader takes `warnings[]` from the payload whatever the exit was,
+      // and would switch the owner's plugin entries off on a buffer.
+      setupBox([notInstalledWarning("byteplus")]);
+      const buffered = Object.assign(new Error("Command failed: openclaw config validate --json"), {
+        killed: true,
+        signal: "SIGKILL",
+        stdout: JSON.stringify({ valid: true, warnings: [notInstalledWarning("byteplus")] }),
+        stderr: "",
+      });
+      setupExecFileMock({
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
+        "/usr/bin/journalctl -u clawbox-gateway.service": { stdout: refusedJournal, stderr: "" },
+        [VALIDATE]: buffered,
+        [CONFIG_SET]: { stdout: "", stderr: "" },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+      });
+
+      const state = await runContinuation();
+
+      expect(disableRan("byteplus")).toBe(false);
+      expect(mockRecordPluginRepair).not.toHaveBeenCalled();
+      // …and the box is still reported dead, honestly, on the journal's own
+      // words rather than on a verdict nobody gave.
+      expect(state.phase).toBe("failed");
+      expect(state.error).not.toContain("refuses this device's configuration");
+    });
+
     it("leaves a plugin the core does not call not-installed to its owner", async () => {
       // A genuinely installed plugin whose reviewed surface is stale is a
       // consent question, and consenting for a plugin ClawBox did not install

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -2977,8 +2977,12 @@ describe("updater", () => {
       expect(disableRan("byteplus")).toBe(false);
       expect(mockRecordPluginRepair).not.toHaveBeenCalled();
       // …and the box is still reported dead, honestly, on the journal's own
-      // words rather than on a verdict nobody gave.
+      // words rather than on a verdict nobody gave. Asserted POSITIVELY: an
+      // absence alone would go on passing if the diagnosis degraded to a bare
+      // "not listening" with the journal's reason dropped too.
       expect(state.phase).toBe("failed");
+      expect(state.error).toContain("OpenClaw gateway is not listening on port 18789");
+      expect(state.error).toContain('Plugin "xiaomi" requires capability consent');
       expect(state.error).not.toContain("refuses this device's configuration");
     });
 

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -2648,6 +2648,48 @@ describe("updater", () => {
       expect(state.error).toContain("gateway crashed for an unrelated reason");
     });
 
+    it("bounds the validator with a signal that actually stops it", async () => {
+      // TASK-741, the TypeScript half of the same fix as the boot script's
+      // `timeout -k 5 60`. Node's `execFile` sends `killSignal` ONCE at the
+      // deadline and never escalates, so the default SIGTERM leaves a validator
+      // that ignores it running with nothing to stop it — and this call is on
+      // the recovery path of an update that has already failed, where the
+      // 60 s bound is the only thing between the owner and a hung step.
+      //
+      // Safe for THIS call and not for its neighbour: `config validate` writes
+      // nothing, while a SIGKILL mid-`doctor --fix` is what leaves an
+      // `exec-approvals.json.doctor-importing` claim behind and blocks every
+      // later doctor. Both halves are asserted, because the second is the one a
+      // future tidy-up would "fix" by making them consistent.
+      setupExecFileMock({
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
+        "/usr/bin/journalctl -u clawbox-gateway.service": {
+          stdout: "gateway crashed for an unrelated reason\n",
+          stderr: "",
+        },
+        [DOCTOR]: new Error("Command failed: openclaw doctor --fix"),
+        [VALIDATE]: { stdout: JSON.stringify({ valid: true, warnings: [] }), stderr: "" },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+      });
+
+      await runContinuation();
+
+      const optionsFor = (needle: string) => mockExecFile.mock.calls
+        .filter(([cmd, args]) => `${cmd} ${(args as string[]).join(" ")}`.includes(needle))
+        .map(([, , options]) => options as { timeout?: number; killSignal?: string });
+
+      const validate = optionsFor(VALIDATE);
+      expect(validate.length).toBeGreaterThan(0);
+      expect(validate.every((o) => o.killSignal === "SIGKILL")).toBe(true);
+      expect(validate.every((o) => o.timeout === 60_000)).toBe(true);
+
+      const doctor = optionsFor(DOCTOR);
+      expect(doctor.length).toBeGreaterThan(0);
+      expect(doctor.every((o) => o.killSignal === undefined)).toBe(true);
+    });
+
     it("still blames the journal when the core ACCEPTS the config", async () => {
       // The load-bearing half: doctor exiting non-zero is not by itself proof
       // of anything — it is what a doctor that lost a lock to a LIVE gateway


### PR DESCRIPTION
Finding **TASK-741** — the six items answered in-thread on **#746** (the OpenClaw 2026.7→2026.8 core-upgrade hardening) and deferred rather than amended into it, because that PR already carried a MERGE-OK verdict against its final head.

## Customer-visible symptom

Five of the six are **latent**: they are the edges of the repair #746 shipped, each of which turns into an outage or a permanent WARN on a box whose state differs slightly from the one that was measured. **Item 6 is live**, and it is the one worth reading:

> An owner signs in to a ChatGPT or Anthropic subscription. The route writes the credential, runs `openclaw doctor --fix` to move it into OpenClaw 2's store — and on a box with a legacy `exec-approvals.json`, doctor exits 1 having migrated **nothing**, because the core's security gate throws on that file's mere presence. The route reads that as a failed credential migration, **archives the sign-in it had just written correctly**, and answers *"Credential migration failed … try again, or run `openclaw doctor --fix` from the Terminal"* — advice for the command that is blocked. Trying again reproduces it exactly.

## The six, and what each one now does

| # | Where | Was | Is |
|---|---|---|---|
| 1 | `install.sh` `step_openclaw_install` | `_oc_doctor_out` the only non-`local` assignment in the function, leaking the whole doctor transcript as a global for the rest of the run | `local`, like `PIN_FILE`, `PINNED`, `TARGET` and `CORE_NEEDS_INSTALL` beside it |
| 2 | `gateway-pre-start.sh` `clawbox_core_config_verdict` | accepted rc 0 **and then** required stdout to parse as JSON, so a core exiting 0 with a banner, an empty line or a progress frame answered `unknown` — which skips the stamp and puts **every** gateway start of a healthy box through a `config validate` and a WARN, for ever | exit 0 is the core's own acceptance, full stop |
| 3 | `src/lib/updater.ts` | the `home`/`openclawHome` derivation written out three times | one pure `openclawTreePaths()` returning the two paths; each caller keeps the environment it actually sets |
| 4 | `gateway-pre-start.sh` BUDGET | the comment claimed a 5 s `-k` grace the two validate bounds did not have | `-k 5` on the validate bound, so the arithmetic is true and a validator that ignores SIGTERM cannot hold a blocking ExecStartPre for the unit's whole start budget |
| 5 | `gateway-pre-start.sh` move-aside | `mv "$f" "$f.legacy-$(date +…%H%M%S)"` — second-resolution, unguarded | `-$$` in the name, `mv -n`, and the move judged by the source file being **gone** rather than by `mv`'s exit code |
| 6 | `openclaw-config.ts` / `configure/route.ts` | a blocked doctor thrown like any other failure, so the owner was told to run the command that is blocked | the blocker is **classified**, the rollback is unchanged, and the message names the file that is blocking instead of the advice that cannot work |
| 6b | `gateway-pre-start.sh` | the approvals blocker was cleared only inside the config-fingerprint gate | cleared on **every** boot — see below |

### Why item 2's fix is an alignment, not a new rule

`getOpenclawConfigRefusal` (`src/lib/updater.ts`) has treated exit 0 as acceptance **without reading the payload** since #746. The shell verdict was the stricter of the two, and its parser is stricter again than the TypeScript one, which slices between the first `{` and the last `}`. The asymmetry is closed from the shell end, which is the direction that removes a permanent cost rather than adding one.

### Item 6 fails closed, and the review is why

The first cut of this PR did what the card's wording invites — *stop rolling back a sign-in that was written* — and the `clawbox-review` pass showed that to be wrong, with a reproduction:

> The pre-start clears the blocker only when the approvals file provably holds **no** decision of the owner's **and** the config fingerprint has changed. Neither is guaranteed. Any box whose owner has ever approved an exec command hits the branch that deliberately refuses to move the file; and with a fresh stamp and a perfectly clearable approvals file, the shipped block **runs to completion, spawns no `openclaw` at all, prints nothing, and leaves the blocker in place** — because the whole clearing loop sat inside a gate about the *config*.

Keeping the credential on that promise would have left the box with a legacy `auth-profiles.json`, which this repo's own comments say stops an OpenClaw 2 gateway from starting — and answered `{success:true}` over it, invisibly in the first-run wizard. Before the change that box got a 502 with the credential archived: sign-in lost, box alive. So:

- **The rollback stays.** The migration provably did not happen; that is a failure and it fails closed. The blocked case is routed into the *same* v1/v2 decision the generic failure uses — a second copy of that judgement is how the two would come to disagree — and only the sentence differs.
- **The blocker is cleared on every boot instead (6b).** The clearing loop moves out from under the config-fingerprint gate: the blocker is auth state and the stamp is a record about the config, and gating one on the other is what made a box that had booted once since its bump keep its blocker for ever, silently, breaking *every* later `doctor --fix` on it — this script's own auth-profile migration, `install.sh`'s, the updater's, and this route's. A box with no blocker pays two `[ -e ]` tests for it.

So the customer story is now: one honest error naming the file, one restart in which the pre-start clears it, one retry that works.

### Why item 6 is a returned value and not a typed error

`runOpenclawDoctorFix` now answers `"completed" | "blocked-by-legacy-exec-approvals"`, and **every other failure still throws, untouched**. A new error class to narrow on with `instanceof` would be `undefined` in every one of the **59 hand-written factories** that replace this module in tests and omit it — the exact TypeError `openclaw-config-mock-completeness.test.ts` exists to prevent. A value a caller compares is inert under those mocks: an omitted `runOpenclawDoctorFix` answers `undefined`, which is not this outcome, which is the behaviour they have today.

## Harness first — and the answer is uncomfortable

Item 6 recognises **the core's own sentence** rather than re-deriving its gate by testing for the file — the same alignment #746 made in the boot script and `install.sh`, now made in the third place that asks doctor to migrate. Item 2 makes ClawBox trust the CLI's own exit code instead of second-guessing it with a parser.

But the review read the pinned **2026.8.1** bundle and found that **the core already has the importer**: `--fix` arms its state migrations, and `migrateLegacyExecApprovals` imports a non-empty legacy `exec-approvals.json` into SQLite, verifies it, records a receipt and removes the JSON — including the "holds a decision" case ClawBox refuses to touch. The measured exit 1 is a *different* check, the runtime gate `assertNoPendingLegacyExecApprovals`, firing from another doctor contribution **before** that migration runs.

So ClawBox is routing around an **ordering defect in the core's own doctor**, not filling a missing capability. That is written into the code comment, it is a finding rather than a licence, and it is the second upstream issue this incident has produced (the first two are drafted and unposted per the owner's call). When it lands upstream, this workaround is deletable.

A related honesty fix from the same read: every quotation of the core's sentence in this repo elided `with OPENCLAW_STATE_DIR set to <dir>` — **the actionable half**. Quoting it with that cut out is exactly what made it read as advice for the command that just ran. The full sentence is now in the comment.

## RED → GREEN

Every one of the six has a test, and each was proved RED against unmodified `origin/beta` (`01958e5d`) by putting beta's own file back under the new suites:

```
$ npx vitest run src/tests/unit/openclaw-doctor-fix-blocked.test.ts          # item 6, beta's openclaw-config.ts
 × reports the blocker instead of throwing it as a migration failure
     promise rejected "Error: Legacy exec approvals exist at /ho…" instead of resolving
 × answers completed on the ordinary path            expected undefined to be 'completed'
 × spawns nothing on the Hermes edition              expected undefined to be 'completed'
 Tests  3 failed | 1 passed (4)      # "still throws every other doctor failure" passes on beta — the invariant

$ npx vitest run src/tests/unit/gateway-pre-start-v2-config-repair.test.ts   # items 2, 4, 5, beta's script
 × takes exit 0 as the core's acceptance, whatever it printed
     expected '  WARN: could not ask the installed c…' not to contain 'could not ask the installed core'
 × gives the validator bound a SIGKILL grace, like every other CLI bound here
 × never overwrites an earlier moved-aside approvals file        expected [ Array(1) ] to have a length of 2
 Tests  3 failed | 15 skipped (18)

$ npx vitest run src/tests/unit/install-plugin-capability-consent.test.ts    # item 1, beta's install.sh
 × declares _oc_doctor_out local

$ npx vitest run src/tests/unit/updater-openclaw-tree-paths.test.ts          # item 3, beta's updater.ts
 × has exactly one derivation of openclawHome        expected [ …(3) ] to have a length of 1 but got 3
```

and two more from the review round, also RED on beta's own script:

```
 × clears the approvals blocker on a box whose config is already stamped
     the loop is inside the fingerprint gate, so nothing is moved
 × never overwrites an earlier moved-aside approvals file        expected [ Array(1) ] to have a length of 2
```

The route half of item 6 (`configure.test.ts`, *"names the exec-approvals blocker instead of advising the command it blocks"*) asserts the sentence the owner is shown and that the rollback still happens.

**Two cases are controls and pass on beta by design** — they pin what must NOT move: *"still throws every other doctor failure"* and *"refuses a config the core calls invalid, whatever it exited with"*, plus *"still sends every OTHER doctor failure to the generic advice"*.

GREEN on this branch:

```
$ npx vitest run --project unit          # on the rebased head
 Test Files  750 passed (750)      Tests  12384 passed | 1 skipped (12385)
$ npx tsc --noEmit           # clean outside the pre-existing e2e-install/playwright errors
$ bash -n install.sh && bash -n install-x64.sh && bash -n scripts/gateway-pre-start.sh   # ok
$ npx eslint <touched>       # the same pre-existing warnings as beta, 0 errors
```

## Device leg — the real 2026.8.1 core, on the OpenClaw box

Item 6 turns on **which stream** the core's sentence arrives on, so it was measured rather than assumed. Throwaway `OPENCLAW_STATE_DIR` under `/tmp`, `doctor --fix --non-interactive` over a legacy `exec-approvals.json`:

```
RC=1
stdout: only the compile-cache banner frame        (grep for the sentence: 0)
stderr: Legacy exec approvals exist at /tmp/…/exec-approvals.json. Run `openclaw doctor --fix`
        with OPENCLAW_STATE_DIR set to /tmp/… before using exec approvals.   (grep: 1)
```

`spawnOpenclaw` rejects with `stderr.trim()` when there is any, so the sentence reaches the matcher with **no `captureStdout` change needed** — which is why this PR does not make one.

The box's own state was not touched: every run wrote only under `/tmp`. Its `openclaw.json` md5 does differ across the window and that is **not this work** — another agent held the device mutex for an in-app update of beta throughout, which is also why its gateway is restarting in those readings.

## Both editions

OpenClaw-only, each by its own gate:

- `runOpenclawDoctorFix` returns `"completed"` on `gatewayIsAbsent()` **before spawning anything** — pinned by a case that asserts `spawn` was never called on the Hermes edition.
- `configure/route.ts` reaches the doctor only inside its OpenClaw-2 auth-profiles branch; `configure-hermes.test.ts` is in the 737 files above.
- `scripts/gateway-pre-start.sh` `exit 0`s when `$OPENCLAW_BIN` is not executable and is wired only as the `ExecStartPre` of `config/clawbox-gateway.service`; Hermes runs its own units.
- `install.sh` item 1 is inside `step_openclaw_install`, which a Hermes install does not run.

## Siblings swept

- **`runOpenclawDoctorFix`** — the exported one has exactly one caller, `configure/route.ts:2512`; **fixed there**. `src/lib/updater.ts` has a **private function of the same name** which is a different function with a different contract (it swallows deliberately, #746) and is **not touched**.
- **`clawbox_core_config_verdict`** — both call sites are inside the block it lives in and both take the changed answer; the JSON reader below it now only ever runs on exit 1, and its `accepted` branch is removed rather than left unreachable.
- **`openclawTreePaths`** — all three former copies converted, and a guard test fails the day a fourth is written by hand. `readOpenclawConfigForRepair` keeps its own `OPENCLAW_CONFIG` rule, which the other two must not share: they spawn children that resolve their own path from `OPENCLAW_CONFIG_PATH`. Both spawning callers still `delete env.OPENCLAW_HOME`, also pinned.
- **Other `doctor --fix` sites** — `install.sh:3780` (already recognises the same sentence, #746), `gateway-pre-start.sh`'s auth-profile block (same, #746), `install.sh:6133`/`:6189` (deliberately non-fatal, #731): **cleared**, all three already tell this failure apart.
- **Other `config validate` callers** — only the one in this block and `getOpenclawConfigRefusal`; `install-x64.sh` has neither. **Cleared.**
- **Other exec-approvals move-aside sites** — there is exactly one, the loop this PR changes. **Cleared.**
- **`_oc_doctor_out`** — one function; `install.sh:6196`'s sibling capture is already `local`. **Cleared.**
- **`install-x64.sh:543`** — the sibling of item 1 and of #746's honesty fix, and it was still `|| echo "Warning: doctor could not complete"` with no capture and no classification. **Fixed here** rather than left unremarked while its `install.sh` twin is polished: same capture, same recognition of the blocker, same non-fatal outcome.
- **The validate/doctor bounds in `src/lib/updater.ts`** — the sibling of item 4 in the other language. Node's `execFile({ timeout })` sends `killSignal` once and never escalates, so the default SIGTERM is the same gap `-k 5` just closed in shell: `config validate` now escalates to SIGKILL, and the doctor bound deliberately does **not**, for the same reason the shell's does not.

## Review round

One `clawbox-review` pass (findings by file path): **1 high, 2 medium, 8 low/nit**. Every one applied or answered:

- **HIGH** — the non-rollback, above. Reworked to fail closed, with the boot-path gate fixed so the promise it *does* make is one the box keeps.
- **MEDIUM** — exit 0 was made authoritative *and* the payload was never read, so a core exiting 0 while printing `{"valid": false}` would be stamped as accepted and never re-asked. The stamp is durable, so that is a false success that outlives the boot. An explicit `valid: false` now wins over the exit code, and every other exit-0 shape (banner, empty, non-JSON) is still acceptance — which was the point of the fix.
- **MEDIUM** — the harness-first finding, above.
- **LOW** — the BUDGET comment still claimed 310 s as an upper bound while saying two lines later that the doctor arm is SIGTERM-only; it now says `TimeoutStartSec=600` is that arm's real ceiling. The updater's own bounds (sibling of item 4). `install-x64.sh` (sibling of item 1). The `OPENCLAW_CONFIG` comment, which asserted an agreement between the three callers that does not hold. The tree-paths guard, which only matched the two-name form and so would have missed a fourth copy written the other way. The route test, which was green on beta for three of its four assertions — replaced by a pair that pins both arms.
- **NIT, answered not changed** — three matchers now read the core's one English sentence, graded differently (two case-sensitive greps, one case-insensitive regex). All three fail SAFE: a reworded upstream sentence reverts each to its old, stricter behaviour. Written into the comment; a fourth site is where a shared constant earns itself.

## Bug classes

- *False failure* — item 6's message: an error whose stated cause was wrong and whose advice could not work. Item 5's read-back is the same shape one level down: `mv -n` that declines still exits 0 on some coreutils generations, so the file's absence is the verdict rather than the code.
- *False success* — item 2 is its mirror: a verdict invented from a parser rather than taken from the exit code, which made a healthy box pay for a validate on every start and say so in a WARN nobody could act on.
- *Probe-once* — this is where 6b and the M1 fix both land. A stamp is a probe result written to disk, and two things were gated on it that are not about the config at all: the approvals blocker (moved out), and, after the first cut of item 2, any refusal the core reported with a zero exit (an explicit `valid: false` now wins).

## Coordination

Rebased onto `origin/beta` `7f81a03e`, i.e. **after #750 and #751 both landed** — this is the last of the three B19 PRs.

That rebase had exactly one conflict, in `src/lib/updater.ts`, and it is worth naming because the wrong resolution is silent: **#750 lifted the inline `config validate` `execFile` into a new `askCoreToValidateConfig()` helper, which carries no `killSignal`, while this PR adds `killSignal: "SIGKILL"` to that very call** — item 4's TypeScript half. Taking either side whole loses one of the two, and nothing covered it. Resolved by keeping #750's helper and adding the option to it, plus the test that fails without it:

```
$ npx vitest run src/tests/unit/updater.test.ts -t "bounds the validator"   # against beta's updater.ts
 × bounds the validator with a signal that actually stops it
     AssertionError: expected false to be true
```

It asserts **both** halves, because the second is the one a later tidy-up would "fix" by making them consistent: `config validate` carries `killSignal: "SIGKILL"` and its 60 s bound, and `doctor --fix` carries **no** `killSignal` — a SIGKILL mid-import is what leaves the `.doctor-importing` claim behind that blocks every later doctor.

`scripts/gateway-pre-start.sh` auto-merged (this PR owns the config-repair block at the top; #751 owned the cloud-voice block and #750 changed one comment near line 4000), and `openclawTreePaths()` survives with exactly one derivation left in the file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OpenClaw 2 migration handling for legacy approval blockers.
  - Added clearer warnings, recovery guidance, and successful migration feedback.
  - Improved gateway configuration validation and timeout handling.
  - Prevented previously moved approval files from being overwritten across restarts.
  - Ensured approval blockers are cleared during startup when detected.

- **Setup & Sign-In**
  - Subscription sign-in failures now explain when a restart and retry are required.
  - Other migration failures continue to provide guidance for manual repair.
  - Improved installer reliability by keeping diagnostic output scoped correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
