### PR TITLE
fix: rebuild the agent's coding tool list when a save connects ClawBox AI (TASK-577)

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -31,6 +31,8 @@ import {
 } from "@/lib/openclaw-config";
 import { enableProviderPluginOps } from "@/lib/provider-plugin-ops";
 import { getActiveHarness } from "@/lib/harness";
+import { getCodingAgentStatus } from "@/lib/coding-agent";
+import { refreshCodingAgentToolsIfReadinessChanged } from "@/lib/coding-agent-mcp-refresh";
 import { applyLocalAiToHermes, HermesLocalApplyError } from "@/lib/hermes-local-ai";
 import { applyClawaiToHermes, ClawaiApplyError } from "@/lib/hermes-clawai";
 import { isClawboxAiVisionId, resolveVisionModelId } from "@/lib/clawbox-ai-vision";
@@ -2932,6 +2934,32 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     // computed earlier so the value stored alongside the token always
     // matches the tier that drove `agents.defaults.model.primary` above.
     const clawboxAiTierForStore = resolvedClawboxTier;
+    // The coding agent's three tools — `coding_agent_run`, `_status`, `_stop` —
+    // are registered CONDITIONALLY by the ClawBox MCP server, from a probe it
+    // makes ONCE while it boots; it is then a long-lived stdio child of the
+    // agent. `getCodingAgentStatus().ready` is `enabled` AND the coding harness
+    // installed AND ClawBox AI connected, and "connected" IS the `clawai_token`
+    // the batches below write. So this route can flip readiness, and until now
+    // it was the one writer of that key that never said so: the panel went
+    // "ready" and the running agent still had none of the three tools.
+    //
+    // `/setup-api/hermes/clawai` closes the same gap by sampling the verdict
+    // ahead of its own write, and `coding-agent-mcp-refresh`'s docblock states
+    // the invariant as "every Hermes connect entry point funnels through
+    // `applyClawaiToHermes`". THIS path is the counter-example, and it is
+    // reachable: `openclawIsAbsent()` is `readEdition() === "hermes"`, so an
+    // `edition=dual` box running the Hermes harness comes down here rather than
+    // through the Hermes branch above (TASK-577).
+    //
+    // BEFORE the write, for the reason that route spells out: read it a line
+    // later and the answer is always true, the before/after guard sees no
+    // change, and nothing is refreshed. Only for a save that can write the key
+    // — `undefined` everywhere else, so no other save pays for two status
+    // reads — and `undefined` again on a probe that threw, which must not turn
+    // a save into a 500 or buy a reload nobody asked for.
+    const codingAgentReadyBefore = isClawAI
+      ? await getCodingAgentStatus().then((status) => status.ready).catch(() => undefined)
+      : undefined;
     if (isLocalScope) {
       await setMany({
         local_ai_configured: true,
@@ -3001,6 +3029,22 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
       });
       // The cloud save has landed — see `forgetLocalWasDefault`.
       await forgetLocalWasDefault();
+    }
+
+    // The credential is on disk, so ask the agent to rebuild its tool list if
+    // — and only if — this save is what made the coding agent usable, or
+    // stopped it being. The guard lives in the helper: a reload respawns every
+    // MCP child and invalidates the model's prompt cache, so a re-save of a
+    // token the box already held must not buy one. Best effort by design; the
+    // owner's save has already landed and an edition with no dashboard to ask
+    // re-probes at the next respawn on its own.
+    if (codingAgentReadyBefore !== undefined) {
+      const readyAfter = await getCodingAgentStatus()
+        .then((status) => status.ready)
+        .catch(() => undefined);
+      if (readyAfter !== undefined) {
+        await refreshCodingAgentToolsIfReadinessChanged(codingAgentReadyBefore, readyAfter);
+      }
     }
 
     // Connecting a provider is the owner saying "use this one": a provider the

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -31,7 +31,6 @@ import {
 } from "@/lib/openclaw-config";
 import { enableProviderPluginOps } from "@/lib/provider-plugin-ops";
 import { getActiveHarness } from "@/lib/harness";
-import { getCodingAgentStatus } from "@/lib/coding-agent";
 import { refreshCodingAgentToolsIfReadinessChanged } from "@/lib/coding-agent-mcp-refresh";
 import { applyLocalAiToHermes, HermesLocalApplyError } from "@/lib/hermes-local-ai";
 import { applyClawaiToHermes, ClawaiApplyError } from "@/lib/hermes-clawai";
@@ -698,6 +697,31 @@ async function storedClawboxAiToken(): Promise<string> {
       : "";
   } catch {
     return "";
+  }
+}
+
+/**
+ * `getCodingAgentStatus().ready`, or `undefined` when the probe could not answer.
+ *
+ * IMPORTED LAZILY, the same move `hermes-clawai.ts` makes for the reason it
+ * states: `coding-agent` owns the runs store and captures `DATA_DIR`,
+ * `CODE_PROJECTS_DIR` and `RUNS_PATH` at module evaluation, and it drags
+ * `child_process`, the app proxy, the git helpers and the browser-session
+ * machinery in behind it. A static import here would put all of that in the
+ * graph of every route that statically imports THIS one — `clawai/poll` and
+ * `llamacpp/install` — and on the Hermes SKU it would be paid on a path that
+ * returns long before this code can run.
+ *
+ * `undefined` on a throw, never `false`: "we could not find out" must not read
+ * as "the coding agent is not ready", which would buy a reload on a save that
+ * changed nothing.
+ */
+async function codingAgentReady(): Promise<boolean | undefined> {
+  try {
+    const { getCodingAgentStatus } = await import("@/lib/coding-agent");
+    return (await getCodingAgentStatus()).ready;
+  } catch {
+    return undefined;
   }
 }
 
@@ -2957,9 +2981,7 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     // — `undefined` everywhere else, so no other save pays for two status
     // reads — and `undefined` again on a probe that threw, which must not turn
     // a save into a 500 or buy a reload nobody asked for.
-    const codingAgentReadyBefore = isClawAI
-      ? await getCodingAgentStatus().then((status) => status.ready).catch(() => undefined)
-      : undefined;
+    const codingAgentReadyBefore = isClawAI ? await codingAgentReady() : undefined;
     if (isLocalScope) {
       await setMany({
         local_ai_configured: true,
@@ -3032,16 +3054,17 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     }
 
     // The credential is on disk, so ask the agent to rebuild its tool list if
-    // — and only if — this save is what made the coding agent usable, or
-    // stopped it being. The guard lives in the helper: a reload respawns every
+    // — and only if — this save is what made the coding agent usable. Only that
+    // direction is live here: `getConfiguredClawboxAiToken` falls back to the
+    // stored token and an empty one is refused with a 400 long before this, so
+    // a ClawBox AI save can never CLEAR `clawaiConnected`. The guard is the
+    // helper's either way: a reload respawns every
     // MCP child and invalidates the model's prompt cache, so a re-save of a
     // token the box already held must not buy one. Best effort by design; the
     // owner's save has already landed and an edition with no dashboard to ask
     // re-probes at the next respawn on its own.
     if (codingAgentReadyBefore !== undefined) {
-      const readyAfter = await getCodingAgentStatus()
-        .then((status) => status.ready)
-        .catch(() => undefined);
+      const readyAfter = await codingAgentReady();
       if (readyAfter !== undefined) {
         await refreshCodingAgentToolsIfReadinessChanged(codingAgentReadyBefore, readyAfter);
       }

--- a/src/lib/coding-agent-mcp-refresh.ts
+++ b/src/lib/coding-agent-mcp-refresh.ts
@@ -66,14 +66,26 @@ export interface CodingAgentRefreshOptions {
  * next restart — which is exactly the behaviour of every box before this
  * existed.
  *
- * BOTH WRITE PATHS, not just the switch. `ready` is `enabled` AND the harness
+ * EVERY WRITE PATH, not just the switch. `ready` is `enabled` AND the harness
  * installed AND ClawBox AI connected, and the owner can move the third one on
- * its own: `applyClawaiToHermes` is what writes `clawai_token`, and every Hermes
- * connect entry point funnels through it. A box whose switch is already on goes
- * ready:false → ready:true the moment the AI is connected — which is exactly the
- * order the readiness text sends the owner in ("ClawBox AI is not connected.
- * Open Settings → AI Models and sign in to ClawBox AI first."). So this helper
- * hangs off the connect path too; see `hermes-clawai.ts`.
+ * its own: a box whose switch is already on goes ready:false → ready:true the
+ * moment the AI is connected — which is exactly the order the readiness text
+ * sends the owner in ("ClawBox AI is not connected. Open Settings → AI Models
+ * and sign in to ClawBox AI first."). So this helper hangs off the connect path
+ * too.
+ *
+ * THE RULE IS PER WRITER, not per funnel, and the difference has cost a
+ * defect. This docblock used to say "`applyClawaiToHermes` is what writes
+ * `clawai_token`, and every Hermes connect entry point funnels through it" —
+ * and it was false. `POST /setup-api/ai-models/configure` writes that key with
+ * its own `setMany` on every SKU where the openclaw binary exists, which on
+ * `edition=dual` with `active_harness=hermes` is a box whose agent IS Hermes;
+ * an audit that trusted the funnel claim is how that site survived #514 and
+ * #528 (TASK-577). So: **every writer of `clawai_token` snapshots
+ * `getCodingAgentStatus().ready` BEFORE its write and calls this helper after
+ * it.** Today that is `applyClawaiToHermes` (`hermes-clawai.ts`) and the
+ * configure route's two `setMany` batches; anything that becomes a third
+ * carries the same obligation.
  *
  * @param before what `getCodingAgentStatus().ready` said BEFORE the write
  * @param after  what it says after — the same field the panel is shown, so the

--- a/src/tests/routes/ai-models/configure-dual-coding-tools.test.ts
+++ b/src/tests/routes/ai-models/configure-dual-coding-tools.test.ts
@@ -1,0 +1,395 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import * as childProcess from "child_process";
+import fsp from "fs/promises";
+import type { ChildProcess } from "child_process";
+import { EventEmitter } from "events";
+
+/**
+ * TASK-577, SITE 1 — the dual SKU.
+ *
+ * `getCodingAgentStatus().ready` is `enabled` AND the coding harness installed
+ * AND ClawBox AI connected, and "connected" IS the `clawai_token` key in the
+ * device store. The ClawBox MCP server registers `coding_agent_run` /
+ * `_status` / `_stop` only when that is true, and it asks ONCE while it boots —
+ * it is then a long-lived stdio child of the agent. So a save that flips
+ * readiness without asking the agent to rebuild its tool list leaves Settings
+ * saying "ready" over an agent that has none of the three tools.
+ *
+ * Every OTHER writer of `clawai_token` already closes that: the Hermes route
+ * snapshots the verdict before its write and `applyClawaiToHermes` refreshes,
+ * and `coding-agent-mcp-refresh`'s own docblock states the invariant —
+ * "`applyClawaiToHermes` is what writes `clawai_token`, and every Hermes connect
+ * entry point funnels through it". THIS route is the counter-example, and it is
+ * reachable on the dual SKU: `openclawIsAbsent()` is `readEdition() === hermes`,
+ * so on `edition=dual` with `active_harness=hermes` the route takes the OpenClaw
+ * path, writes the token with its own `setMany`, and nothing tells the running
+ * Hermes agent.
+ *
+ * Mocks are configure-images.test.ts's set (the route's collaborators), plus the
+ * harness, the coding-agent status and the reload transport — so what is
+ * asserted is the reload actually being ASKED FOR, not that a helper was called.
+ */
+
+vi.mock("child_process", () => ({
+  execFile: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+// PARTIAL mock — only the setup-gate read is replaceable, and it is pinned
+// rather than left to the filesystem. Without it `readSetupGateFacts()` runs
+// for real, reads `${CLAWBOX_ROOT}/data/config.json` under the hermetic floor
+// vitest.config.ts sets, gets ENOENT and answers `setupComplete: false` — so
+// every case in this file silently exercised the FIRST-RUN WIZARD branch
+// (`awaitReady: false`), which is not the box these Settings-side cases
+// describe. Deterministic, but named by accident; the first assertion on
+// restartGateway's argument added here would have pinned the wrong one.
+vi.mock("@/lib/route-auth", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/route-auth")>("@/lib/route-auth");
+  return { ...actual, readSetupGateFacts: () => ({ setupComplete: true, passwordConfigured: true }) };
+});
+
+vi.mock("fs/promises", () => ({
+  default: {
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    rename: vi.fn(),
+    chown: vi.fn(),
+    mkdir: vi.fn(),
+    rm: vi.fn(),
+    unlink: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/config-store", () => ({
+  DATA_DIR: "/home/clawbox/clawbox/data",
+  getAll: vi.fn(),
+  setMany: vi.fn(),
+}));
+
+vi.mock("@/lib/clawkeep", () => ({
+  unpairLocal: vi.fn(),
+}));
+
+// With the harness pinned to Hermes below, the real one of these reaches for the
+// Hermes dashboard and the whole request waits on a socket that is not there.
+// Neither is under test: the switch is bookkeeping the route does after the
+// credential write.
+vi.mock("@/lib/provider-enablement", () => ({
+  getDisabledProviders: async () => new Set<string>(),
+  setProviderEnabled: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("@/lib/provider-runnable", () => ({
+  forgetProviderEnumerations: vi.fn(async () => {}),
+  recordProviderEnumeration: vi.fn(async () => {}),
+  readProviderRunnable: vi.fn(async () => new Map()),
+}));
+
+// Out-of-band catalog refresh the route deliberately does not await; stubbing
+// it stops its late console write from racing worker teardown. See the long
+// note in configure.test.ts.
+vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
+  refreshInBackground: vi.fn(),
+  notifyProviderSetChanged: vi.fn(),
+}));
+
+const { parseFullyQualifiedModelImpl, LLAMACPP_PROXY_BASE_URL } = vi.hoisted(() => ({
+  parseFullyQualifiedModelImpl(fq: string) {
+    const idx = fq.indexOf("/");
+    if (idx <= 0 || idx === fq.length - 1) return null;
+    return { provider: fq.slice(0, idx), modelId: fq.slice(idx + 1) };
+  },
+  LLAMACPP_PROXY_BASE_URL: "http://127.0.0.1/setup-api/local-ai/llamacpp/v1",
+}));
+
+vi.mock("@/lib/openclaw-config", () => ({
+  // A REAL class, not `vi.fn()` and not an omitted export: the configure route
+  // narrows on `instanceof GatewayNotReadyError` to tell "the gateway has not
+  // finished coming back" from "the restart was refused", and `instanceof
+  // undefined` throws a TypeError the first time a test makes it reject.
+  GatewayNotReadyError: class GatewayNotReadyError extends Error {
+    constructor(message = "gateway did not come back") {
+      super(message);
+      this.name = "GatewayNotReadyError";
+    }
+  },
+  DEFAULT_COMPACTION_RESERVE_TOKENS_FLOOR: 24000,
+  compactionReserveFloorForContext: (contextWindow: number) =>
+    Number.isFinite(contextWindow) && contextWindow > 0
+      ? Math.min(24000, Math.max(4096, Math.round(contextWindow / 4)))
+      : 24000,
+  restartGateway: vi.fn(),
+  findOpenclawBin: vi.fn().mockReturnValue("/usr/local/bin/openclaw"),
+  readConfig: vi.fn(),
+  // The configure route reads the config STRICTLY before it removes an
+  // openai-compat override, so the mock has to carry both readers.
+  readConfigStrict: vi.fn().mockResolvedValue({}),
+  inferConfiguredLocalModel: vi.fn(),
+  runOpenclawConfigSet: vi.fn(),
+  spawnOpenclawCli: vi.fn().mockResolvedValue(""),
+  runOpenclawDoctorFix: vi.fn().mockResolvedValue(undefined),
+  runOpenclawConfigSetBatch: vi.fn(),
+  runOpenclawConfigUnset: vi.fn(),
+  applyModelOverrideToAllAgentSessions: vi.fn().mockResolvedValue(undefined),
+  parseFullyQualifiedModel: vi.fn(parseFullyQualifiedModelImpl),
+  setProviderPlugins: vi.fn().mockResolvedValue(undefined),
+  openclawIsAbsent: vi.fn().mockReturnValue(false),
+  OpenclawUnavailableError: class OpenclawUnavailableError extends Error {},
+}));
+
+vi.mock("@/lib/llamacpp", () => ({
+  getDefaultLlamaCppModel: vi.fn().mockReturnValue("gemma4-e2b-it-q4_0"),
+  getLlamaCppContextWindow: vi.fn().mockReturnValue(131072),
+  getLlamaCppMaxTokens: vi.fn().mockReturnValue(131072),
+  getLlamaCppProxyBaseUrl: vi.fn().mockReturnValue(LLAMACPP_PROXY_BASE_URL),
+}));
+
+vi.mock("@/lib/local-ai-runtime", () => ({
+  getLocalAiProxyBaseUrl: vi.fn((provider: string) =>
+    provider === "llamacpp"
+      ? LLAMACPP_PROXY_BASE_URL
+      : `http://127.0.0.1/setup-api/local-ai/${provider}`,
+  ),
+}));
+
+vi.mock("@/lib/local-ai-token", () => ({
+  getLocalAiToken: vi.fn().mockReturnValue("a".repeat(64)),
+  verifyLocalAiBearer: vi.fn().mockReturnValue(true),
+  markLocalAiTokenMigrated: vi.fn(),
+}));
+
+// PARTIAL — a whole-module factory here HANGS the route: `@/lib/harness` has
+// nine other exports and the ones this graph reaches are then `undefined`.
+vi.mock("@/lib/harness", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/harness")>()),
+  getActiveHarness: vi.fn(),
+}));
+
+vi.mock("@/lib/coding-agent", () => ({ getCodingAgentStatus: vi.fn() }));
+
+// The transport the refresh ends at. Mocked HERE rather than mocking
+// `refreshCodingAgentToolsIfReadinessChanged` itself, so the real guard runs and
+// the assertion is about the agent being asked, not about a call being made.
+vi.mock("@/lib/hermes-mcp-reload", () => ({
+  reloadMcpServers: vi.fn(),
+  reportMcpReloadRefused: vi.fn(),
+}));
+
+import { getAll, setMany } from "@/lib/config-store";
+import { unpairLocal } from "@/lib/clawkeep";
+import {
+  inferConfiguredLocalModel,
+  readConfig,
+  readConfigStrict,
+  restartGateway,
+  runOpenclawConfigSet,
+  runOpenclawConfigSetBatch,
+  applyModelOverrideToAllAgentSessions,
+  parseFullyQualifiedModel,
+} from "@/lib/openclaw-config";
+import { getActiveHarness } from "@/lib/harness";
+import { getCodingAgentStatus } from "@/lib/coding-agent";
+import { reloadMcpServers } from "@/lib/hermes-mcp-reload";
+
+
+const mockSpawn = vi.mocked(childProcess.spawn);
+const mockGetAll = vi.mocked(getAll);
+const mockSetMany = vi.mocked(setMany);
+const mockReadConfig = vi.mocked(readConfig);
+const mockReadConfigStrict = vi.mocked(readConfigStrict);
+const mockRunOpenclawConfigSet = vi.mocked(runOpenclawConfigSet);
+const mockRunOpenclawConfigSetBatch = vi.mocked(runOpenclawConfigSetBatch);
+const mockFs = vi.mocked(fsp);
+let mockGetActiveHarness: ReturnType<typeof vi.mocked<typeof getActiveHarness>>;
+let mockGetCodingAgentStatus: ReturnType<typeof vi.mocked<typeof getCodingAgentStatus>>;
+let mockReloadMcpServers: ReturnType<typeof vi.mocked<typeof reloadMcpServers>>;
+
+/**
+ * The same three-part rule `getCodingAgentStatus` applies, with the two halves
+ * this route cannot move (the switch, the installed harness) pinned on: what is
+ * left is exactly "is ClawBox AI connected", which IS `clawai_token` in the
+ * store. Bound to the live `store` below rather than to a fixed answer, so a
+ * fixture cannot pass for the route doing the right thing.
+ */
+let store: Record<string, unknown> = {};
+async function readyFromStore(): Promise<Awaited<ReturnType<typeof getCodingAgentStatus>>> {
+  const token = store.clawai_token;
+  return { ready: typeof token === "string" && token.trim() !== "" } as Awaited<
+    ReturnType<typeof getCodingAgentStatus>
+  >;
+}
+
+function createSuccessfulChildProcess(): ChildProcess {
+  const emitter = new EventEmitter() as ChildProcess;
+  emitter.stdin = { end: vi.fn() } as unknown as ChildProcess["stdin"];
+  emitter.stdout = new EventEmitter() as unknown as ChildProcess["stdout"];
+  emitter.stderr = new EventEmitter() as unknown as ChildProcess["stderr"];
+  emitter.kill = vi.fn();
+  queueMicrotask(() => emitter.emit("close", 0));
+  return emitter;
+}
+
+
+const CLAWAI_TOKEN = "claw_token123";
+
+describe("POST /setup-api/ai-models/configure — the coding agent's tool list on the dual SKU", () => {
+  let configurePost: (req: Request) => Promise<Response>;
+
+  function jsonRequest(body: unknown): Request {
+    return new Request("http://localhost/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ version: 1, profiles: {} }));
+    mockFs.writeFile.mockResolvedValue();
+    mockFs.rename.mockResolvedValue();
+    mockFs.chown.mockResolvedValue();
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.rm.mockResolvedValue(undefined);
+    mockFs.unlink.mockResolvedValue(undefined);
+    mockReadConfig.mockResolvedValue({});
+    mockReadConfigStrict.mockResolvedValue({});
+    vi.mocked(inferConfiguredLocalModel).mockReturnValue(null);
+    vi.mocked(restartGateway).mockResolvedValue();
+    mockSpawn.mockImplementation(() => createSuccessfulChildProcess());
+    mockRunOpenclawConfigSet.mockResolvedValue(undefined);
+    mockRunOpenclawConfigSetBatch.mockResolvedValue(undefined);
+    vi.mocked(unpairLocal).mockResolvedValue(undefined);
+    vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0, sessionsSkipped: 0 });
+    vi.mocked(parseFullyQualifiedModel).mockImplementation(parseFullyQualifiedModelImpl);
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network disabled in tests")));
+
+    // A real store, because the fact under test is one the route WRITES: a
+    // fixture that answered a fixed `ready` would pass whatever the route did.
+    store = {};
+    mockGetAll.mockImplementation(async () => ({ ...store }));
+    mockSetMany.mockImplementation(async (entries: Record<string, unknown>) => {
+      for (const [key, value] of Object.entries(entries)) {
+        if (value === undefined) delete store[key];
+        else store[key] = value;
+      }
+    });
+    // Resolved from the SAME post-reset module registry the route imports, the
+    // way configure-hermes.test.ts does: a handle captured at file scope is a
+    // different `vi.fn()` after `vi.resetModules()`, so an implementation set on
+    // it never reaches the route — and `getActiveHarness` then answers
+    // `undefined` where the route awaits a harness.
+    const harnessMod = await import("@/lib/harness");
+    mockGetActiveHarness = vi.mocked(harnessMod.getActiveHarness);
+    // The dual SKU: the openclaw binary EXISTS (so `openclawIsAbsent()` is
+    // false and the route takes the OpenClaw path), and Hermes is the agent
+    // actually answering.
+    mockGetActiveHarness.mockResolvedValue("hermes");
+
+    const codingMod = await import("@/lib/coding-agent");
+    mockGetCodingAgentStatus = vi.mocked(codingMod.getCodingAgentStatus);
+    mockGetCodingAgentStatus.mockImplementation(readyFromStore);
+
+    const reloadMod = await import("@/lib/hermes-mcp-reload");
+    mockReloadMcpServers = vi.mocked(reloadMod.reloadMcpServers);
+    mockReloadMcpServers.mockResolvedValue(true);
+
+    const ocMod = await import("@/lib/openclaw-config");
+    vi.mocked(ocMod.openclawIsAbsent).mockReturnValue(false);
+
+    const mod = await import("@/app/setup-api/ai-models/configure/route");
+    configurePost = mod.POST;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("asks the agent to rebuild its tool list when this save connects ClawBox AI", async () => {
+    const res = await configurePost(jsonRequest({ provider: "clawai", apiKey: CLAWAI_TOKEN }));
+
+    expect(res.status).toBe(200);
+    expect(store.clawai_token).toBe(CLAWAI_TOKEN);
+    expect(mockReloadMcpServers).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not charge a reload for a save that changed nothing about readiness", async () => {
+    // The guard half. A reload respawns every MCP child and invalidates the
+    // model's prompt cache, so the next turn re-pays for a cached system
+    // prompt — a re-save of a token this box already holds must not buy that.
+    store.clawai_token = CLAWAI_TOKEN;
+
+    const res = await configurePost(jsonRequest({ provider: "clawai", apiKey: CLAWAI_TOKEN }));
+
+    expect(res.status).toBe(200);
+    expect(mockReloadMcpServers).not.toHaveBeenCalled();
+  });
+
+  it("does not reload on a save that writes no ClawBox AI credential", async () => {
+    const res = await configurePost(jsonRequest({ provider: "anthropic", apiKey: "sk-ant-test" }));
+
+    expect(res.status).toBe(200);
+    expect(mockReloadMcpServers).not.toHaveBeenCalled();
+  });
+
+  it("samples the verdict BEFORE the write, not after it", async () => {
+    // The ordering trap the Hermes route documents: read `ready` one line later
+    // and the answer is always true, the before/after guard sees no change, and
+    // the box ends up with a panel that says ready over an agent that has none
+    // of the three tools.
+    const readyWhenAsked: boolean[] = [];
+    mockGetCodingAgentStatus.mockImplementation(async () => {
+      const ready = typeof store.clawai_token === "string" && (store.clawai_token as string).trim() !== "";
+      readyWhenAsked.push(ready);
+      return { ready } as Awaited<ReturnType<typeof getCodingAgentStatus>>;
+    });
+
+    await configurePost(jsonRequest({ provider: "clawai", apiKey: CLAWAI_TOKEN }));
+
+    expect(readyWhenAsked).toEqual([false, true]);
+  });
+
+  it("still answers 200 when the agent refuses the reload", async () => {
+    // The credential IS written by the time the refresh runs. A best-effort
+    // rebuild that could not be done must not turn the owner's save into an
+    // error — the switch is enforced route-side either way and the tool list
+    // catches up at the next respawn.
+    mockReloadMcpServers.mockResolvedValue(false);
+
+    const res = await configurePost(jsonRequest({ provider: "clawai", apiKey: CLAWAI_TOKEN }));
+
+    expect(res.status).toBe(200);
+    expect(store.clawai_token).toBe(CLAWAI_TOKEN);
+  });
+
+  it("still answers 200 when the readiness probe itself throws", async () => {
+    mockGetCodingAgentStatus.mockRejectedValue(new Error("cannot read the store"));
+
+    const res = await configurePost(jsonRequest({ provider: "clawai", apiKey: CLAWAI_TOKEN }));
+
+    expect(res.status).toBe(200);
+    expect(mockReloadMcpServers).not.toHaveBeenCalled();
+  });
+
+  /*
+   * The OTHER fix this card names — swapping `openclawIsAbsent()` for
+   * `(await getActiveHarness()) === "hermes"` at the Hermes early return — is
+   * NOT taken, and this case is why. That early return's local-model arm is
+   * `isLocalScope && (isLlamaCpp || isOllama)`; a PRIMARY-scope local save on a
+   * dual box does not match it, matches neither of the other two arms, and
+   * would fall through to the branch's closing 400. Today that save takes the
+   * OpenClaw path and is registered with Hermes on the way out — the block at
+   * the end of it that says in as many words "This branch runs on the `dual`
+   * SKU, where OpenClaw exists but Hermes is the harness actually answering".
+   * Pinned so the predicate swap cannot be made without this failing first.
+   */
+  it("keeps configuring a primary-scope local model on dual, rather than refusing it", async () => {
+    const res = await configurePost(jsonRequest({ provider: "llamacpp" }));
+
+    expect(res.status).toBe(200);
+    expect(store.ai_model_configured).toBe(true);
+  });
+});

--- a/src/tests/routes/ai-models/configure-dual-coding-tools.test.ts
+++ b/src/tests/routes/ai-models/configure-dual-coding-tools.test.ts
@@ -328,11 +328,17 @@ describe("POST /setup-api/ai-models/configure — the coding agent's tool list o
     expect(mockReloadMcpServers).not.toHaveBeenCalled();
   });
 
-  it("does not reload on a save that writes no ClawBox AI credential", async () => {
+  it("does not reload — or even ASK — on a save that writes no ClawBox AI credential", async () => {
     const res = await configurePost(jsonRequest({ provider: "anthropic", apiKey: "sk-ant-test" }));
 
     expect(res.status).toBe(200);
     expect(mockReloadMcpServers).not.toHaveBeenCalled();
+    // The cost guard, pinned. Asserting only "no reload" would hold even if the
+    // route probed on EVERY provider save — with no `clawai_token` the verdict
+    // is false before and after either way — and each probe is a config read
+    // plus PATH scans for `claude`, the wrapper and `setpriv`, plus a readdir of
+    // the owner's project folder, on a Jetson.
+    expect(mockGetCodingAgentStatus).not.toHaveBeenCalled();
   });
 
   it("samples the verdict BEFORE the write, not after it", async () => {
@@ -377,17 +383,29 @@ describe("POST /setup-api/ai-models/configure — the coding agent's tool list o
   /*
    * The OTHER fix this card names — swapping `openclawIsAbsent()` for
    * `(await getActiveHarness()) === "hermes"` at the Hermes early return — is
-   * NOT taken, and this case is why. That early return's local-model arm is
-   * `isLocalScope && (isLlamaCpp || isOllama)`; a PRIMARY-scope local save on a
-   * dual box does not match it, matches neither of the other two arms, and
-   * would fall through to the branch's closing 400. Today that save takes the
-   * OpenClaw path and is registered with Hermes on the way out — the block at
-   * the end of it that says in as many words "This branch runs on the `dual`
-   * SKU, where OpenClaw exists but Hermes is the harness actually answering".
-   * Pinned so the predicate swap cannot be made without this failing first.
+   * NOT taken, and this case is why.
+   *
+   * That early return's local-model arm is `isLocalScope && (isLlamaCpp ||
+   * isOllama)`, and a PRIMARY-scope local save does not match it. It does not
+   * fall through to the branch's closing 400 either, which is worse: for a
+   * local provider the `apiKey` slot carries the MODEL ID (both
+   * `/setup-api/llamacpp/install` and `useOllamaModels` post it that way), so
+   * `normalizedApiKey` is non-empty and the save would match the branch's THIRD
+   * arm — handed to `applyCloudProviderKeyToHermes` with a model id as the API
+   * key. Today it takes the OpenClaw path and is registered with Hermes on the
+   * way out, by the block whose comment says in as many words "This branch runs
+   * on the `dual` SKU, where OpenClaw exists but Hermes is the harness actually
+   * answering". `@/lib/hermes-cloud-provider` is deliberately NOT mocked here,
+   * so an attempted swap fails loudly rather than quietly.
    */
-  it("keeps configuring a primary-scope local model on dual, rather than refusing it", async () => {
-    const res = await configurePost(jsonRequest({ provider: "llamacpp" }));
+  it("keeps configuring a primary-scope local model on dual, rather than diverting it", async () => {
+    // The shape `configureLlamaCpp` actually sends: for a local provider the
+    // `apiKey` slot carries the model id.
+    const res = await configurePost(jsonRequest({
+      provider: "llamacpp",
+      apiKey: "gemma4-e2b-it-q4_0",
+      authMode: "local",
+    }));
 
     expect(res.status).toBe(200);
     expect(store.ai_model_configured).toBe(true);

--- a/src/tests/routes/ai-models/configure-dual-coding-tools.test.ts
+++ b/src/tests/routes/ai-models/configure-dual-coding-tools.test.ts
@@ -57,6 +57,12 @@ vi.mock("fs/promises", () => ({
     mkdir: vi.fn(),
     rm: vi.fn(),
     unlink: vi.fn(),
+    // Present, and RESOLVING by default, so a ClawBox AI save exercises the
+    // ordinary box — the one whose deepseek provider plugin is already
+    // installed. Omit it and every such case throws at `fs.access`, falls into
+    // the missing-plugin branch and spends the save installing a plugin, which
+    // is not the path these cases are about.
+    access: vi.fn(),
   },
 }));
 
@@ -254,6 +260,7 @@ describe("POST /setup-api/ai-models/configure — the coding agent's tool list o
     mockFs.mkdir.mockResolvedValue(undefined);
     mockFs.rm.mockResolvedValue(undefined);
     mockFs.unlink.mockResolvedValue(undefined);
+    mockFs.access.mockResolvedValue(undefined);
     mockReadConfig.mockResolvedValue({});
     mockReadConfigStrict.mockResolvedValue({});
     vi.mocked(inferConfiguredLocalModel).mockReturnValue(null);

--- a/src/tests/routes/ai-models/configure-dual-coding-tools.test.ts
+++ b/src/tests/routes/ai-models/configure-dual-coding-tools.test.ts
@@ -397,7 +397,14 @@ describe("POST /setup-api/ai-models/configure — the coding agent's tool list o
     // helper existed.
     mockGetCodingAgentStatus
       .mockImplementationOnce(readyFromStore)
-      .mockRejectedValueOnce(new Error("cannot read the store"));
+      .mockImplementationOnce(async () => {
+        // Asserted INSIDE the second probe, so the ordering is pinned and not
+        // just the count: a regression that took both readings before the write
+        // would still be called twice, still answer 200 and still buy no
+        // reload — and would be exactly the bug this whole change is about.
+        expect(store.clawai_token).toBe(CLAWAI_TOKEN);
+        throw new Error("cannot read the store");
+      });
 
     const res = await configurePost(jsonRequest({ provider: "clawai", apiKey: CLAWAI_TOKEN }));
 

--- a/src/tests/routes/ai-models/configure-dual-coding-tools.test.ts
+++ b/src/tests/routes/ai-models/configure-dual-coding-tools.test.ts
@@ -70,6 +70,15 @@ vi.mock("@/lib/config-store", () => ({
   DATA_DIR: "/home/clawbox/clawbox/data",
   getAll: vi.fn(),
   setMany: vi.fn(),
+  // `get`/`set` are how the route reads and clears the persisted ClawBox AI
+  // credential refusal (@/lib/clawai-credential-refusal, TASK-727). Omit them
+  // and `clawaiCredentialRefusalOnRecord()` throws into its own catch and
+  // answers `false` for every case in this file — so the image-ops gate would
+  // never be exercised here, and nothing would say so. Backed by the same
+  // `store` the other two use, so a clear the route performs is visible to a
+  // read taken after it.
+  get: vi.fn(),
+  set: vi.fn(),
 }));
 
 vi.mock("@/lib/clawkeep", () => ({
@@ -181,7 +190,7 @@ vi.mock("@/lib/hermes-mcp-reload", () => ({
   reportMcpReloadRefused: vi.fn(),
 }));
 
-import { getAll, setMany } from "@/lib/config-store";
+import { getAll, setMany, get as configGet, set as configSet } from "@/lib/config-store";
 import { unpairLocal } from "@/lib/clawkeep";
 import {
   inferConfiguredLocalModel,
@@ -283,6 +292,12 @@ describe("POST /setup-api/ai-models/configure — the coding agent's tool list o
         else store[key] = value;
       }
     });
+    // The same store, so the refusal gate reads what this request wrote.
+    vi.mocked(configGet).mockImplementation(async (key: string) => store[key]);
+    vi.mocked(configSet).mockImplementation(async (key: string, value: unknown) => {
+      if (value === undefined) delete store[key];
+      else store[key] = value;
+    });
     // Resolved from the SAME post-reset module registry the route imports, the
     // way configure-hermes.test.ts does: a handle captured at file scope is a
     // different `vi.fn()` after `vi.resetModules()`, so an implementation set on
@@ -321,6 +336,11 @@ describe("POST /setup-api/ai-models/configure — the coding agent's tool list o
     expect(res.status).toBe(200);
     expect(store.clawai_token).toBe(CLAWAI_TOKEN);
     expect(mockReloadMcpServers).toHaveBeenCalledTimes(1);
+    // And the refusal gate really ASKED the store, rather than throwing into
+    // its own catch over a `get` the factory did not provide. Without this the
+    // mock could be trimmed back to `getAll`/`setMany` and every case here
+    // would go on passing over an image-ops gate that never ran (TASK-727).
+    expect(vi.mocked(configGet)).toHaveBeenCalledWith("clawai_credential_refused_at");
   });
 
   it("does not charge a reload for a save that changed nothing about readiness", async () => {

--- a/src/tests/routes/ai-models/configure-dual-coding-tools.test.ts
+++ b/src/tests/routes/ai-models/configure-dual-coding-tools.test.ts
@@ -379,11 +379,30 @@ describe("POST /setup-api/ai-models/configure — the coding agent's tool list o
   });
 
   it("still answers 200 when the readiness probe itself throws", async () => {
+    // The BEFORE probe. The route never gets a verdict to compare against, so
+    // it must not buy a reload on a guess — and must not turn the save into a
+    // 500 either.
     mockGetCodingAgentStatus.mockRejectedValue(new Error("cannot read the store"));
 
     const res = await configurePost(jsonRequest({ provider: "clawai", apiKey: CLAWAI_TOKEN }));
 
     expect(res.status).toBe(200);
+    expect(mockReloadMcpServers).not.toHaveBeenCalled();
+  });
+
+  it("still answers 200 when the probe throws AFTER the credential is written", async () => {
+    // The other half, and the one that matters more: by then the token IS on
+    // disk. The save has landed and must be reported as landed; the tool list
+    // catches up at the next respawn, which is what every box did before this
+    // helper existed.
+    mockGetCodingAgentStatus
+      .mockImplementationOnce(readyFromStore)
+      .mockRejectedValueOnce(new Error("cannot read the store"));
+
+    const res = await configurePost(jsonRequest({ provider: "clawai", apiKey: CLAWAI_TOKEN }));
+
+    expect(res.status).toBe(200);
+    expect(store.clawai_token).toBe(CLAWAI_TOKEN);
     expect(mockReloadMcpServers).not.toHaveBeenCalled();
   });
 

--- a/src/tests/routes/ai-models/configure-dual-coding-tools.test.ts
+++ b/src/tests/routes/ai-models/configure-dual-coding-tools.test.ts
@@ -404,6 +404,10 @@ describe("POST /setup-api/ai-models/configure — the coding agent's tool list o
     expect(res.status).toBe(200);
     expect(store.clawai_token).toBe(CLAWAI_TOKEN);
     expect(mockReloadMcpServers).not.toHaveBeenCalled();
+    // And the post-write probe was actually REACHED. Without this the case
+    // would pass over a route that skipped the second read entirely — 200, the
+    // token stored and no reload are all true of that route too.
+    expect(mockGetCodingAgentStatus).toHaveBeenCalledTimes(2);
   });
 
   /*


### PR DESCRIPTION
## TASK-577, SITE 1 — the Hermes agent keeps a stale `coding_agent_*` tool list on the dual SKU

**Symptom the customer sees.** On a `dual` box running the Hermes harness, the owner pastes their ClawBox AI portal token in Settings → AI Models. The save answers 200 and the Coding panel says the coding agent is ready. The agent does not have `coding_agent_run`, `coding_agent_status` or `coding_agent_stop`, and will not have them until something unrelated respawns its MCP children.

**Cause.** `getCodingAgentStatus().ready` is `enabled` AND the coding harness installed AND ClawBox AI connected — and "connected" IS the `clawai_token` key in the device store. The ClawBox MCP server registers those three tools only when that is true, and it asks ONCE while it boots; it is then a long-lived stdio child of the agent. `POST /setup-api/ai-models/configure` writes `clawai_token` with its own `setMany` and told nobody. It is reachable on the dual SKU because `openclawIsAbsent()` is `readEdition() === "hermes"`, so an `edition=dual` box whose active harness is Hermes takes the OpenClaw path.

### The native mechanism, named

The agent's own **`reload.mcp`**, over Hermes' dashboard JSON-RPC socket — `{confirm: true}` with no `session_id` runs `shutdown_mcp_servers()` + `discover_mcp_tools()` globally. Nothing new is built here: `src/lib/hermes-mcp-reload.ts` already owns that call and `src/lib/coding-agent-mcp-refresh.ts` already owns the rule for when it is worth paying for (a reload respawns every MCP child and invalidates the model's prompt cache). This PR adds the missing CALL SITE, which is the fourth of the same family — #486 did it for `email_list`/`email_read`, #503 for the image tools, #514/#528 for the coding-agent switch.

### The change

Snapshot `getCodingAgentStatus().ready` immediately before the two `setMany` batches, and call `refreshCodingAgentToolsIfReadinessChanged(before, after)` immediately after them.

- **Before the write, not after.** `/setup-api/hermes/clawai` spells out why in its own comment: read it a line later and the answer is always true, the before/after guard sees no change, and nothing is refreshed. There is a regression test that pins the ordering by recording what the verdict was each time it was asked (`[false, true]`).
- **Only for a ClawBox AI save.** Of the five facts behind `ready`, this route can move exactly one, and only under `isClawAI`. No other save pays for two status reads — pinned, because asserting "no reload" alone would hold even if the route probed on every save.
- **Never fatal.** The credential is on disk by the time this runs. A refused reload, a box with no dashboard and a probe that throws all leave the save at 200; the switch is enforced route-side either way and the tool list catches up at the next respawn.

### Why the card's OTHER fix was not taken

The card offers two: swap `if (openclawIsAbsent())` for `(await getActiveHarness()) === "hermes"` at the Hermes early return, or "snapshot and refresh around the two setMany writes the way /setup-api/hermes/clawai now does". This PR takes the second, because the first regresses three flows on the SKU it is meant to help:

- **A primary-scope local save.** The early return's local arm is `isLocalScope && (isLlamaCpp || isOllama)`, which a primary-scope save does not match. It would not reach the branch's closing 400 either, which is worse: for a local provider the `apiKey` slot carries the MODEL ID (`/setup-api/llamacpp/install` and `useOllamaModels` both post it that way), so the save would match the branch's THIRD arm and be handed to `applyCloudProviderKeyToHermes` with a model id as the API key. Today it takes the OpenClaw path and is registered with Hermes on the way out, by the block whose own comment reads "This branch runs on the `dual` SKU, where OpenClaw exists but Hermes is the harness actually answering". There is a test pinning that, and `@/lib/hermes-cloud-provider` is deliberately not mocked in that file so an attempted swap fails loudly.
- Every cloud API-key save on dual+hermes would be diverted into the Hermes cloud apply, and OpenClaw would stop getting the credential.
- Every subscription save would 400.

### SITE 2 is REFUTED on current beta

The card's second site — `install.sh --step coding_harness` moving readiness with no refresh — was closed on 2026-08-28, about two hours after the card's own re-verification comment was written, by `05530c58` ("fix: make the documented coding-harness repair report, and reach the agent"). `step_coding_harness` now snapshots `was_ready` before installing, and on the false→true transition calls `refresh_agent_coding_tools`, which `try-restart`s **both** `clawbox-gateway.service` and `clawbox-hermes-dashboard.service` — dual-aware, acting only on units that are already running, and failing unless every running unit was asked. Independently re-verified against today's beta. Nothing is changed for it here; the refutation is written on the card.

### RED → GREEN

RED, against unmodified `origin/beta` with only the new test file added:

```
 ❯ src/tests/routes/ai-models/configure-dual-coding-tools.test.ts (7 tests | 2 failed)
 FAIL … > asks the agent to rebuild its tool list when this save connects ClawBox AI
 AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
 FAIL … > samples the verdict BEFORE the write, not after it
 AssertionError: expected [] to deeply equal [ false, true ]
```

The empty array in the second is the whole defect: on beta the route never asks at all.

GREEN on this head: that file 7/7, `src/tests/routes/ai-models/` + `coding-agent-mcp-refresh` **22 files / 383 tests**, full `npm run test:unit` **749 files / 12358 tests passed | 1 skipped**, `tsc --noEmit` clean, eslint clean apart from two pre-existing warnings. `openclaw-config-mock-completeness`, `test-timeout-hygiene` and `state-updater-purity` pass.

### Sibling call sites swept

Every fact behind `ready` is `enabled` AND `wrapperInstalled` AND `claudeInstalled` AND `clawaiConnected` AND `capabilityDropAvailable`. This route can move only `clawaiConnected`.

| Writer of `clawai_token` / the switch | Refresh |
|---|---|
| `applyClawaiToHermes` (`hermes-clawai.ts`) — the Hermes link path | already had it |
| `/setup-api/hermes/clawai` | already had it (snapshots ahead of its own write) |
| `/setup-api/ai-models/configure` — the two `setMany` batches | **this PR** |
| `/setup-api/coding-agent/enable`, `/setup-api/coding-agent/reset` — the switch | already had it |
| `install.sh --step coding_harness` — the harness install | already had it (`refresh_agent_coding_tools`) |

The `isLocalScope` batch's `isClawAI` spread is documented-unreachable and really is (`isLocalScope && !isOllama && !isLlamaCpp` 400s long before it), so the snapshot placed ahead of both batches covers everything either can write.

**The stale invariant that caused this in the first place is corrected.** `coding-agent-mcp-refresh.ts`'s docblock asserted "`applyClawaiToHermes` is what writes `clawai_token`, and every Hermes connect entry point funnels through it". That was false, and it is how this site survived #514 and #528 — an audit of "who writes this key" was told there was exactly one funnel and that the funnel already refreshed. The rule is now stated per WRITER, names both of today's, and says that anything which becomes a third carries the same obligation.

### Editions

- The code change is in a route that serves **every** edition, and the behaviour it adds is edition-agnostic by construction: the transport (`reportMcpReloadRefused`) words itself per edition and an OpenClaw box has no dashboard to ask, so it logs "this edition has no dashboard to ask — the tool list re-probes when the MCP server is next spawned" and moves on. That is the established behaviour of all four callers in this family.
- The Hermes branch of this route is untouched (it returns long before the new code) — `configure-hermes.test.ts` is unchanged and green.
- The customer-visible effect lands on `edition=dual` with `active_harness=hermes`, which is the SKU the card names.

### Bug classes

- *Probe-once*: the whole defect — a capability probed once at MCP-server boot and treated as fact for the child's lifetime. Closed by asking the agent to re-probe on the transition.
- *False success*: the panel said "ready" over an agent that had none of the three tools. Now the two cannot disagree — the refresh compares the same `ready` field the panel is shown.
- *False failure*: guarded. A probe that throws yields `undefined` and buys no reload (a reload nobody can justify is charged to the owner's next turn), and no failure in this path can turn the save into an error.

### Deliberately not in this PR

On `edition=dual, active_harness=hermes` this route still never calls `applyClawaiToHermes`, so Hermes' own provider catalogue, image backend and cloud voice never learn the token — `ai_set_provider("clawai")` keeps answering "That provider is not set up on this device" for a box that just linked. The coding-agent half this card is about is genuinely unaffected by that (`scripts/claude-ds` reads `clawai_token` from `data/config.json` directly), and the route already carries the analogous case through for LOCAL models. It wants its own card rather than widening this one; it is recorded in the run notes.

### Device leg

Unrun, and not applicable: no script, unit, device path or edition lock is touched — the change is one route and CI exercises it. Neither test box is a `dual` box, which is the SKU this defect needs, so a device leg could not have proved it either; the card says the same.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Coding-agent readiness is checked when saving ClawBox AI configuration.
  * Coding-agent tools refresh automatically when readiness changes.

* **Bug Fixes**
  * Configuration saves succeed even if readiness checks or tool refreshes fail.
  * Unchanged readiness avoids unnecessary tool reloads.
  * Unrelated provider saves no longer trigger readiness checks.
  * Local model configuration continues to work on dual installations.

* **Documentation**
  * Updated guidance for maintaining coding-agent readiness after credential changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->