### PR TITLE
feat: arm and withdraw the ClawBox AI cloud voice at boot on Hermes (TASK-717, TASK-718)

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -2134,12 +2134,16 @@ def _clawai_route_is_ours(_base_url, _api_key, _stamped, _proxy_base_url):
     Ownership needs POSITIVE evidence, in the four shapes below. The Hermes half
     (`hermesCloudRouteIsOurs`, src/lib/hermes-tts.ts — TASK-726 is this half of
     it) asks the same question with the arms IT has: it writes no stamp, so it
-    has three, and it needs no delete arm at all because it HAS no destructive
-    path — `writeHermesCloudTarget` is the only writer of `tts.openai.*` and a
-    downgrade there just stops exposing the endpoint. The consequence is one
-    real divergence, and it is deliberate: our own `claw_` token at an address
-    of the owner's reads as OURS on Hermes and as THEIRS here, which is what
-    beta did and what the suite pins.
+    has three. Its looser reading — our own `claw_` token at an address of the
+    owner's counts as OURS there and as THEIRS here — used to rest on Hermes
+    having no destructive path at all. That premise is gone as of TASK-718:
+    `scripts/register-mcp.sh` §4a now withdraws the cloud voice on a box that
+    has left the entitled tier. So the DELETE on that edition is held to this
+    rule rather than to the refresh rule beside it — it requires a positive
+    ADDRESS of ours (the current proxy or one of the retired hosts) and never
+    the credential alone, exactly as the arm below does. The divergence that
+    remains is only in what may be REFRESHED, where the worst case is our own
+    fields rewritten to our own values.
 
       - our own stamp on the entry (`clawboxManaged`);
       - or a `claw_` portal token on it, which is what survives the proxy URL

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -953,6 +953,379 @@ else
   log "could not disable the built-in browser toolset (exit $BROWSER_DISABLE_RC) — continuing"
 fi
 
+# ── 4a. The ClawBox AI cloud voice: armed AND withdrawn, every boot. ────────
+# BEFORE §4b, deliberately. §4b's read-back is written to be "the last word on
+# what the boot leaves behind", and every `hermes config set` below is a full
+# CLI load -> save_config of the same file. Running after it would put four such
+# writes past the read-back that stamps `data/background-optouts.json` as
+# seeded — and the CLI has been seen to exit 0 while storing a string, which is
+# the exact drift §4b's record exists to prevent. This block has no dependency
+# on §4b, so it goes first and §4b keeps its invariant.
+# TASK-717 (the arm) and TASK-718 (the withdrawal). One block, because they are
+# the two halves of one decision and shipping either alone reproduces the defect
+# the other exists to fix: an arm with no withdrawal is the one-way migration
+# TASK-718 is about, and a withdrawal with no arm has nothing to take back on a
+# Hermes box that was never armed at boot in the first place.
+#
+# WHAT IS BROKEN WITHOUT IT. `applyClawaiToHermes` — the only thing on this
+# edition that ever points `tts.provider` at the ClawBox AI proxy — has three
+# callers and every one of them is an explicit (re-)link. So:
+#   - a box linked BEFORE the cloud-voice wiring existed never gets it. Nothing
+#     re-runs the link, and the owner has no reason to: Settings already says
+#     ClawBox AI is connected. It simply never speaks (TASK-717).
+#   - a box that WAS entitled and drops to a lower plan keeps `tts.openai.*`
+#     pointing at an endpoint the proxy now answers 403 to, and pays a refused
+#     round trip on every spoken reply (TASK-718).
+# The OpenClaw edition has had both arms since TASK-459: `gateway-pre-start.sh`
+# gates on `_clawai_speech_entitled` and has the `elif` that takes its own entry
+# back. This is that pair, for the edition that has no `gateway-pre-start.sh`.
+#
+# THE NATIVE SURFACE IS `hermes config set` / `unset`, and it is what this uses —
+# the same commands `hermes-tts.ts` issues for the Settings toggle, so the boot
+# repair and the panel cannot drift into writing the config two different ways.
+# Hermes has no entitlement mechanism of its own to lean on: `tts.provider` is a
+# plain selection with no notion of a plan, and the tier lives only in ClawBox's
+# device store because only ClawBox talks to the portal.
+#
+# WHY HERE. Same answer as §4b: this script already holds `${HERMES_CONFIG}.lock`
+# and already makes CLI calls under it, and `production-server.js` fire-and-
+# forgets it on every web-server boot on hermes|dual. A Node boot hook would be a
+# second, unlocked writer racing this one.
+#
+# THE ENTITLEMENT IS THE PORTAL'S, not a guess: `clawai_tier` in
+# `data/config.json`, which `/setup-api/ai-models/status` refreshes from
+# `device-info` on its 30-second poll — the same stamp `speechEntitledTier()`
+# reads for the panel and `CLAWBOX_SPEECH_DEVICE_TIER` reads on the OpenClaw
+# side. `"pro"` is the DEVICE tier of the MAX plan; the two names are off by one
+# on purpose (CLAWBOX_AI_MODEL_BY_TIER in src/lib/clawbox-ai-models.ts).
+#
+# NOT KNOWING IS NOT AN ANSWER, in either direction, and that is the whole
+# false-success/false-failure guard here. A device store that is absent,
+# unreadable or not an object; a `config.yaml` that will not parse; a tier that
+# is not recorded at all — every one of them holds, and the boot says why. Only
+# a tier we have actually been told, and a slot we can positively see is ours,
+# moves anything.
+#
+# OWNERSHIP, mirroring `hermesCloudRouteIsOurs` (src/lib/hermes-tts.ts) key for
+# key rather than inventing a second rule: the credential is a `claw_` portal
+# token, OR the endpoint names our proxy, OR the slot is genuinely empty (no
+# endpoint AND no key — `base_url` is optional for real OpenAI, so an unset
+# endpoint alone says nothing). On Hermes `tts.openai` is the GENERIC
+# OpenAI-compatible slot, not ClawBox's, and an owner may be running their own
+# speech server in it.
+#
+# THE SELECTION IS THE OWNER'S. The arm moves `tts.provider` only from a
+# genuinely unchosen value — unset, or Hermes' factory `edge` — or from
+# `clawbox-local` on a box that provably has no on-device engine, which is the
+# state the card is about: `install.sh` selects `clawbox-local` whatever the
+# engine answered, so an engineless box reads as a chosen local voice. A box on
+# `elevenlabs`, `piper` or anything else the owner picked is left alone.
+# And the withdrawal deliberately does NOT reset `tts.provider` either — the
+# same ruling the OpenClaw arm records: the panel's job is to show that the
+# choice is no longer available, and silently rewriting it would hide the
+# downgrade. Removing the DEFINITION is what stops the refused calls.
+#
+# IMAGES ARE NOT PART OF THIS, and that is measured rather than assumed: the
+# proxy publishes `modelTiers: {"gpt-image-1-mini": ["free","pro","max"]}`, so
+# the image backend has no tier to be downgraded from, and §"Re-arm the ClawAI
+# image backend" above already reconciles it every boot.
+# ONE binding, read by the decision below and by the writes after it, so the
+# endpoint we call ours and the endpoint we write cannot disagree — the same
+# staging override `hermes-clawai.ts` honours.
+CLAWBOX_VOICE_PROXY="${CLAWBOX_AI_PROXY_URL:-https://clawbox.com/api/ai}"
+CLAWBOX_VOICE_PLAN=$(
+  CLAWBOX_DEVICE_STORE="$PROJECT_DIR/data/config.json" \
+  CLAWBOX_HERMES_CONFIG="$HERMES_CONFIG" \
+  CLAWBOX_SPEECH_DEVICE_TIER="pro" \
+  CLAWBOX_AI_PROXY_URL="$CLAWBOX_VOICE_PROXY" \
+  CLAWBOX_KOKORO_STAMP="$HOME_DIR/.cache/clawbox/kokoro-installed" \
+  python3 - <<'PY' 2>/dev/null || echo "hold the voice plan could not be computed"
+import json, os
+
+# One verdict on stdout: `arm`, `withdraw`, or `hold <why>`. Everything this
+# block decides is decided here, so the shell below is only the writes.
+def say(verdict):
+    print(verdict)
+    raise SystemExit(0)
+
+try:
+    import yaml
+except ImportError:
+    say("hold PyYAML is unavailable")
+
+ENTITLED_TIER = os.environ["CLAWBOX_SPEECH_DEVICE_TIER"]
+# Trailing slashes are not significant in a base URL comparison, and
+# `hermesCloudRouteIsOurs` strips them the same way on the TypeScript side.
+PROXY = os.environ["CLAWBOX_AI_PROXY_URL"].strip().rstrip("/")
+# Every address ClawBox has ever written as its AI proxy: the live one (which a
+# staging box overrides through CLAWBOX_AI_PROXY_URL) plus the two retired
+# hosts. `CLAWBOX_AI_PROXY_URLS` in src/lib/clawbox-ai-models.ts is the shared
+# answer to exactly this question and the suite pins the two copies together.
+# It exists so an entry left on an address we have since moved off is still
+# recognisably ours — which is the ONLY thing that makes a credential-blind
+# delete safe.
+OUR_PROXIES = {
+    PROXY,
+    "https://clawbox.com/api/ai",
+    "https://openclawhardware.dev/api/ai",
+    "https://www.openclawhardware.dev/api/ai",
+}
+# Hermes' factory default, and the one selection besides "unset" that means
+# nobody has chosen: `edge` is Microsoft's cloud voice, which the box gets for
+# having expressed no opinion.
+FACTORY_PROVIDER = "edge"
+LOCAL_PROVIDER = "clawbox-local"
+CLOUD_PROVIDER = "openai"
+# The one speech model the proxy serves; the same constant `hermes-tts.ts` pins
+# as HERMES_CLOUD_TTS_MODEL, because a request that names anything else is
+# answered 400.
+CLOUD_MODEL = "gpt-4o-mini-tts"
+
+
+def text(value):
+    return value.strip() if isinstance(value, str) else ""
+
+
+def short(value):
+    """Owner-controlled text, bounded and flattened before it reaches a log line.
+
+    The verdict string is printed into the clawbox-setup journal, and
+    `tts.provider` is whatever is in the customer's config.yaml. One value stays
+    one line, and one value does not decide how much gets written — the same two
+    rules `logSafe` keeps on the TypeScript side.
+    """
+    return " ".join(value.split())[:40]
+
+
+def load(path, loader):
+    try:
+        with open(path) as fh:
+            return loader(fh), None
+    except FileNotFoundError:
+        return None, "absent"
+    except Exception as exc:  # noqa: BLE001 — every failure is "we cannot tell"
+        return None, type(exc).__name__
+
+
+store, why = load(os.environ["CLAWBOX_DEVICE_STORE"], json.load)
+if why == "absent":
+    say("hold this box has no ClawBox AI link on record")
+if why is not None:
+    say("hold the device store could not be read (%s)" % why)
+if not isinstance(store, dict):
+    say("hold the device store is not an object")
+
+token = text(store.get("clawai_token"))
+tier = store.get("clawai_tier")
+tier = tier.strip() if isinstance(tier, str) else ""
+
+cfg, why = load(os.environ["CLAWBOX_HERMES_CONFIG"], yaml.safe_load)
+if why == "absent":
+    # Unreachable in practice — §3 exits long before here on a config it cannot
+    # read — but "absent" is a state, not a failure, and reporting it as one
+    # would be the false-failure shape in the line an operator reads.
+    say("hold this box has no ~/.hermes/config.yaml yet")
+if why is not None:
+    say("hold ~/.hermes/config.yaml could not be read (%s)" % why)
+if cfg is None:
+    cfg = {}
+if not isinstance(cfg, dict):
+    say("hold ~/.hermes/config.yaml is not a mapping")
+
+tts = cfg.get("tts")
+tts = tts if isinstance(tts, dict) else {}
+provider = text(tts.get("provider"))
+slot = tts.get(CLOUD_PROVIDER)
+slot = slot if isinstance(slot, dict) else {}
+base_url = text(slot.get("base_url"))
+api_key = text(slot.get("api_key"))
+model = text(slot.get("model"))
+
+# `hermesCloudRouteIsOurs`, key for key: a `claw_` credential, OR our endpoint,
+# OR a genuinely empty slot.
+key_is_ours = api_key.startswith("claw_")
+slot_is_empty = base_url == "" and api_key == ""
+route_is_ours = key_is_ours or slot_is_empty or base_url.rstrip("/") == PROXY
+
+if token and tier == ENTITLED_TIER:
+    # ALREADY SPEAKING THROUGH US. The selection is not touched again; the
+    # DEFINITION still is, because the portal rotates the token on a re-link and
+    # this script is the only thing on the boot path that would notice. An
+    # unrefreshed key is a 401 on every utterance while every panel — which asks
+    # only that the two keys are non-empty — calls the voice configured.
+    if provider == CLOUD_PROVIDER and route_is_ours:
+        if base_url.rstrip("/") == PROXY and api_key == token and model == CLOUD_MODEL:
+            say("hold the cloud voice is already armed")
+        say("refresh")
+    if provider not in ("", FACTORY_PROVIDER, LOCAL_PROVIDER):
+        say("hold this box has already chosen how it speaks (%s)" % short(provider))
+    # UNCHOSEN IS ALL THREE, and the engine question is asked of all three.
+    # `clawbox-local` is here because `install.sh` `step_openclaw_tts` selects it
+    # on every install and every update WHATEVER the engine answered —
+    # deliberately, because to Hermes an absent `tts.provider` resolves to
+    # Microsoft's Edge cloud, so an engineless box is left honestly mute rather
+    # than speaking through a third party. So "a Hermes box with no TTS engine"
+    # reads as a CHOSEN local voice. But unset and `edge` belong with it, not
+    # apart from it: `step_openclaw_tts` has one arm that leaves the key UNSET
+    # (a `hermes config get` that did not answer — one OOM-killed Python start
+    # on a loaded Jetson), and this script runs on every web-server boot, so it
+    # would fire before anything could correct it. A box that can speak entirely
+    # on-device must not be moved off its own voice by a boot script.
+    #
+    # Moving a box off its own voice is effectively permanent — the next
+    # `step_openclaw_tts` sees `openai`, falls into its owner's-choice arm and
+    # preserves it — so it happens only on a POSITIVE "this box cannot speak for
+    # itself". The stamp is that positive: `localTtsEngineInstalled` is `stamped
+    # AND the unit is present`, so an ABSENT stamp settles it with a single file
+    # test and no systemd bus. A stamp that IS there is deliberately not pursued
+    # further: the unit could still be missing, but "we did not finish asking" is
+    # not evidence, and this boot cannot afford the probe the link path makes.
+    #
+    # The link path (`selectHermesCloudVoiceIfUnvoiced`) goes one step further
+    # and SELECTS the on-device engine here. This holds instead: it has a live
+    # engine probe and this boot does not, and `step_openclaw_tts` re-selects
+    # `clawbox-local` on the next update anyway.
+    if os.path.exists(os.environ["CLAWBOX_KOKORO_STAMP"]):
+        say("hold this box speaks for itself")
+    if not route_is_ours:
+        say("hold tts.openai already names its own speech route")
+    say("arm")
+
+# The other direction. Only over a tier we have actually been TOLD: an absent
+# stamp is a box nobody has told us about, not a box that has lost its plan, and
+# taking a working voice away over a store we could not read is the false
+# failure this whole block is written to avoid.
+if tier and tier != ENTITLED_TIER:
+    # ONLY what we wrote. The stamp the OpenClaw arm can rely on does not exist
+    # here — Hermes' `tts.openai` block is the harness's own schema and carries
+    # no room for one — so ownership is the positive endpoint/credential test
+    # above, and an EMPTY slot is explicitly not something to take back.
+    if slot_is_empty:
+        say("hold there is no ClawBox AI cloud voice on this box to withdraw")
+    # AN ADDRESS OF OURS, and only that — NOT the credential. The arm above is
+    # allowed the looser `hermesCloudRouteIsOurs` rule because the worst it can
+    # do is rewrite our own fields to our own values; this is the one place in
+    # the file that DESTROYS configuration, and `gateway-pre-start.sh` states
+    # the rule its own delete arm keeps: a `claw_` token "is enough to REFRESH
+    # an entry … it is not enough to DELETE one, because an owner can point our
+    # own token at our own proxy with a model of their choosing, and that entry
+    # is theirs". On Hermes there is no `clawboxManaged` stamp to lean on — the
+    # harness owns that schema — so the address IS the evidence, and the retired
+    # hosts are in the set so an entry left on an address we have moved off is
+    # still recognisably ours.
+    if base_url.rstrip("/") not in OUR_PROXIES:
+        say("hold tts.openai names an address that is not ours — not ours to withdraw")
+    say("withdraw")
+
+if not tier:
+    say("hold no plan has been recorded for this box yet")
+if not token:
+    say("hold this box's plan includes the cloud voice but it holds no credential")
+say("hold nothing to do")
+PY
+)
+CLAWBOX_VOICE_VERDICT="${CLAWBOX_VOICE_PLAN%% *}"
+
+# One bounded CLI call, with the exit status kept. Braces and `-k 5` for the
+# reason §4's `tools disable` documents at length: `timeout` SIGKILLs its own
+# process group, bash announces a signal-killed foreground child on the SCRIPT's
+# stderr where the command's own redirect cannot reach it, and that notice lands
+# in the clawbox-setup journal reading as this script having been killed.
+hermes_voice_write() {
+  # A COLLECTIVE budget, not four independent ceilings. This runs inside
+  # `${HERMES_CONFIG}.lock`, and `setup-hermes-dashboard-auth.sh` waits exactly
+  # `flock -w 120` for that lock before proceeding WITHOUT it — which is the
+  # config clobber the lock exists to stop. Four writes at the full
+  # `HERMES_CLI_TIMEOUT` each would add up to 200 s to the hold on their own.
+  # Measured cost of a `hermes config set` on an Orin is a few seconds, so the
+  # whole arm gets one `HERMES_CLI_TIMEOUT` between them and each call is
+  # bounded by what is left. Running out is reported and retried next boot,
+  # which is the safe direction: a lock held past 120 s is not.
+  local remaining=$(( CLAWBOX_VOICE_DEADLINE - $(date +%s) ))
+  if [ "$remaining" -le 0 ]; then
+    CLAWBOX_VOICE_RC=124
+    return 1
+  fi
+  if { timeout -k 5 "$remaining" "$HERMES_BIN" "$@" >/dev/null 2>&1; } 2>/dev/null; then
+    return 0
+  else
+    # INSIDE the else, which is the only place `$?` is the CONDITION's status —
+    # after `fi` it is the `if` statement's own 0, and every failure line would
+    # report "(exit 0)". The same shape, and the same reason, as §4's
+    # `tools disable` capture.
+    CLAWBOX_VOICE_RC=$?
+    return 1
+  fi
+}
+
+CLAWBOX_VOICE_DEADLINE=$(( $(date +%s) + HERMES_CLI_TIMEOUT ))
+
+case "$CLAWBOX_VOICE_VERDICT" in
+  arm|refresh)
+    # DEFINITION BEFORE SELECTION, the same order `selectHermesEngine` keeps:
+    # the endpoint, credential and model land first, so a failure leaves
+    # `tts.provider` untouched rather than selecting a provider with nowhere to
+    # send a request. Nothing is recorded behind a marker, so a boot that got
+    # part way is simply offered the whole thing again by the next one.
+    CLAWBOX_VOICE_TOKEN=$(
+      CLAWBOX_DEVICE_STORE="$PROJECT_DIR/data/config.json" python3 - <<'TOKENPY' 2>/dev/null || true
+import json, os
+try:
+    with open(os.environ["CLAWBOX_DEVICE_STORE"]) as fh:
+        value = json.load(fh).get("clawai_token")
+except Exception:
+    value = None
+print(value.strip() if isinstance(value, str) else "")
+TOKENPY
+    )
+    if [ -z "$CLAWBOX_VOICE_TOKEN" ]; then
+      log "NOTE: the ClawBox AI cloud voice was armable but the device token could not be re-read; leaving the voice alone"
+    elif ! hermes_voice_write config set tts.openai.base_url "$CLAWBOX_VOICE_PROXY"; then
+      log "could not write tts.openai.base_url (exit $CLAWBOX_VOICE_RC) — the cloud voice is NOT selected; the next start will try again"
+    # The credential is an ARGUMENT and never reaches a message: one of these
+    # three writes carries the device token, and the journal keeps what is
+    # logged.
+    elif ! hermes_voice_write config set tts.openai.api_key "$CLAWBOX_VOICE_TOKEN"; then
+      log "could not write tts.openai.api_key (exit $CLAWBOX_VOICE_RC) — the cloud voice is NOT selected; the next start will try again"
+    elif ! hermes_voice_write config set tts.openai.model gpt-4o-mini-tts; then
+      log "could not write tts.openai.model (exit $CLAWBOX_VOICE_RC) — the cloud voice is NOT selected; the next start will try again"
+    elif [ "$CLAWBOX_VOICE_VERDICT" = refresh ]; then
+      # The selection is already ours and is NOT rewritten: one writer of
+      # `tts.provider`, and this path is only here to keep the credential and
+      # the endpoint current.
+      log "refreshed the ClawBox AI speech credential"
+    elif ! hermes_voice_write config set tts.provider openai; then
+      log "wrote the ClawBox AI speech endpoint but could not select it (exit $CLAWBOX_VOICE_RC) — the next start will try again"
+    else
+      log "armed the ClawBox AI cloud voice — this box's plan includes it and nothing else had been chosen"
+    fi
+    ;;
+  withdraw)
+    # `tts.provider` is deliberately left where it is — see the block comment.
+    # Removing the DEFINITION is what stops the refused round trips; the panel
+    # then reports the cloud voice unconfigured, which is the truth.
+    #
+    # The CREDENTIAL first, and every step reported rather than collapsed into
+    # one verdict: a partial withdrawal announced as a whole one is exactly the
+    # false success this arm exists to end.
+    CLAWBOX_VOICE_WITHDRAWN=true
+    for CLAWBOX_VOICE_KEY in tts.openai.api_key tts.openai.base_url tts.openai.model; do
+      if ! hermes_voice_write config unset "$CLAWBOX_VOICE_KEY"; then
+        log "could not remove $CLAWBOX_VOICE_KEY (exit $CLAWBOX_VOICE_RC) — this box may still be calling a speech endpoint its plan no longer includes; the next start will try again"
+        CLAWBOX_VOICE_WITHDRAWN=false
+      fi
+    done
+    if [ "$CLAWBOX_VOICE_WITHDRAWN" = true ]; then
+      log "removed the ClawBox AI cloud voice: this box's plan no longer includes it"
+    fi
+    ;;
+  *)
+    # Every hold says why, on the boot log, because "nothing happened" is the
+    # one outcome an operator cannot tell apart from "this step is not running".
+    log "left the voice alone — ${CLAWBOX_VOICE_PLAN#hold }"
+    ;;
+esac
+
 # ── 4b. Hermes' own background jobs, opted out of ONCE per box. ─────────────
 # TASK-609 / owner ruling 2026-09-03: the assistant must not message the owner
 # or spend his tokens on its own initiative unless he asked it to. OpenClaw 2's
@@ -1230,7 +1603,7 @@ if wrote:
     # that landed somewhere else, a config a concurrent writer replaced inside
     # this critical section — all of them leave `cfg` saying the right thing and
     # the box saying the old one, and recording that as seeded would mean the
-    # keys are never offered again. This block sits AFTER §4 for the same
+    # keys are never offered again. This block sits AFTER §4 and §4a for the same
     # reason: `hermes tools disable browser` does the CLI's own load ->
     # save_config on this file, so a read-back above it would not be the last
     # word on what the boot leaves behind.
@@ -1294,302 +1667,6 @@ except Exception as exc:  # noqa: BLE001
           " of them could not be written (%s); the next start will write them again"
           % type(exc).__name__, file=sys.stderr)
 PY
-
-# ── 4c. The ClawBox AI cloud voice: armed AND withdrawn, every boot. ────────
-# TASK-717 (the arm) and TASK-718 (the withdrawal). One block, because they are
-# the two halves of one decision and shipping either alone reproduces the defect
-# the other exists to fix: an arm with no withdrawal is the one-way migration
-# TASK-718 is about, and a withdrawal with no arm has nothing to take back on a
-# Hermes box that was never armed at boot in the first place.
-#
-# WHAT IS BROKEN WITHOUT IT. `applyClawaiToHermes` — the only thing on this
-# edition that ever points `tts.provider` at the ClawBox AI proxy — has three
-# callers and every one of them is an explicit (re-)link. So:
-#   - a box linked BEFORE the cloud-voice wiring existed never gets it. Nothing
-#     re-runs the link, and the owner has no reason to: Settings already says
-#     ClawBox AI is connected. It simply never speaks (TASK-717).
-#   - a box that WAS entitled and drops to a lower plan keeps `tts.openai.*`
-#     pointing at an endpoint the proxy now answers 403 to, and pays a refused
-#     round trip on every spoken reply (TASK-718).
-# The OpenClaw edition has had both arms since TASK-459: `gateway-pre-start.sh`
-# gates on `_clawai_speech_entitled` and has the `elif` that takes its own entry
-# back. This is that pair, for the edition that has no `gateway-pre-start.sh`.
-#
-# THE NATIVE SURFACE IS `hermes config set` / `unset`, and it is what this uses —
-# the same commands `hermes-tts.ts` issues for the Settings toggle, so the boot
-# repair and the panel cannot drift into writing the config two different ways.
-# Hermes has no entitlement mechanism of its own to lean on: `tts.provider` is a
-# plain selection with no notion of a plan, and the tier lives only in ClawBox's
-# device store because only ClawBox talks to the portal.
-#
-# WHY HERE. Same answer as §4b: this script already holds `${HERMES_CONFIG}.lock`
-# and already makes CLI calls under it, and `production-server.js` fire-and-
-# forgets it on every web-server boot on hermes|dual. A Node boot hook would be a
-# second, unlocked writer racing this one.
-#
-# THE ENTITLEMENT IS THE PORTAL'S, not a guess: `clawai_tier` in
-# `data/config.json`, which `/setup-api/ai-models/status` refreshes from
-# `device-info` on its 30-second poll — the same stamp `speechEntitledTier()`
-# reads for the panel and `CLAWBOX_SPEECH_DEVICE_TIER` reads on the OpenClaw
-# side. `"pro"` is the DEVICE tier of the MAX plan; the two names are off by one
-# on purpose (CLAWBOX_AI_MODEL_BY_TIER in src/lib/clawbox-ai-models.ts).
-#
-# NOT KNOWING IS NOT AN ANSWER, in either direction, and that is the whole
-# false-success/false-failure guard here. A device store that is absent,
-# unreadable or not an object; a `config.yaml` that will not parse; a tier that
-# is not recorded at all — every one of them holds, and the boot says why. Only
-# a tier we have actually been told, and a slot we can positively see is ours,
-# moves anything.
-#
-# OWNERSHIP, mirroring `hermesCloudRouteIsOurs` (src/lib/hermes-tts.ts) key for
-# key rather than inventing a second rule: the credential is a `claw_` portal
-# token, OR the endpoint names our proxy, OR the slot is genuinely empty (no
-# endpoint AND no key — `base_url` is optional for real OpenAI, so an unset
-# endpoint alone says nothing). On Hermes `tts.openai` is the GENERIC
-# OpenAI-compatible slot, not ClawBox's, and an owner may be running their own
-# speech server in it.
-#
-# THE SELECTION IS THE OWNER'S. The arm moves `tts.provider` only from a
-# genuinely unchosen value — unset, or Hermes' factory `edge` — or from
-# `clawbox-local` on a box that provably has no on-device engine, which is the
-# state the card is about: `install.sh` selects `clawbox-local` whatever the
-# engine answered, so an engineless box reads as a chosen local voice. A box on
-# `elevenlabs`, `piper` or anything else the owner picked is left alone.
-# And the withdrawal deliberately does NOT reset `tts.provider` either — the
-# same ruling the OpenClaw arm records: the panel's job is to show that the
-# choice is no longer available, and silently rewriting it would hide the
-# downgrade. Removing the DEFINITION is what stops the refused calls.
-#
-# IMAGES ARE NOT PART OF THIS, and that is measured rather than assumed: the
-# proxy publishes `modelTiers: {"gpt-image-1-mini": ["free","pro","max"]}`, so
-# the image backend has no tier to be downgraded from, and §"Re-arm the ClawAI
-# image backend" above already reconciles it every boot.
-# ONE binding, read by the decision below and by the writes after it, so the
-# endpoint we call ours and the endpoint we write cannot disagree — the same
-# staging override `hermes-clawai.ts` honours.
-CLAWBOX_VOICE_PROXY="${CLAWBOX_AI_PROXY_URL:-https://clawbox.com/api/ai}"
-CLAWBOX_VOICE_PLAN=$(
-  CLAWBOX_DEVICE_STORE="$PROJECT_DIR/data/config.json" \
-  CLAWBOX_HERMES_CONFIG="$HERMES_CONFIG" \
-  CLAWBOX_SPEECH_DEVICE_TIER="pro" \
-  CLAWBOX_AI_PROXY_URL="$CLAWBOX_VOICE_PROXY" \
-  CLAWBOX_KOKORO_STAMP="$HOME_DIR/.cache/clawbox/kokoro-installed" \
-  python3 - <<'PY' 2>/dev/null || echo "hold the voice plan could not be computed"
-import json, os
-
-# One verdict on stdout: `arm`, `withdraw`, or `hold <why>`. Everything this
-# block decides is decided here, so the shell below is only the writes.
-def say(verdict):
-    print(verdict)
-    raise SystemExit(0)
-
-try:
-    import yaml
-except ImportError:
-    say("hold PyYAML is unavailable")
-
-ENTITLED_TIER = os.environ["CLAWBOX_SPEECH_DEVICE_TIER"]
-# Trailing slashes are not significant in a base URL comparison, and
-# `hermesCloudRouteIsOurs` strips them the same way on the TypeScript side.
-PROXY = os.environ["CLAWBOX_AI_PROXY_URL"].strip().rstrip("/")
-# Hermes' factory default, and the one selection besides "unset" that means
-# nobody has chosen: `edge` is Microsoft's cloud voice, which the box gets for
-# having expressed no opinion.
-FACTORY_PROVIDER = "edge"
-LOCAL_PROVIDER = "clawbox-local"
-CLOUD_PROVIDER = "openai"
-# The one speech model the proxy serves; the same constant `hermes-tts.ts` pins
-# as HERMES_CLOUD_TTS_MODEL, because a request that names anything else is
-# answered 400.
-CLOUD_MODEL = "gpt-4o-mini-tts"
-
-
-def text(value):
-    return value.strip() if isinstance(value, str) else ""
-
-
-def load(path, loader):
-    try:
-        with open(path) as fh:
-            return loader(fh), None
-    except FileNotFoundError:
-        return None, "absent"
-    except Exception as exc:  # noqa: BLE001 — every failure is "we cannot tell"
-        return None, type(exc).__name__
-
-
-store, why = load(os.environ["CLAWBOX_DEVICE_STORE"], json.load)
-if why == "absent":
-    say("hold this box has no ClawBox AI link on record")
-if why is not None:
-    say("hold the device store could not be read (%s)" % why)
-if not isinstance(store, dict):
-    say("hold the device store is not an object")
-
-token = text(store.get("clawai_token"))
-tier = store.get("clawai_tier")
-tier = tier.strip() if isinstance(tier, str) else ""
-
-cfg, why = load(os.environ["CLAWBOX_HERMES_CONFIG"], yaml.safe_load)
-if why is not None:
-    say("hold ~/.hermes/config.yaml could not be read (%s)" % why)
-if cfg is None:
-    cfg = {}
-if not isinstance(cfg, dict):
-    say("hold ~/.hermes/config.yaml is not a mapping")
-
-tts = cfg.get("tts")
-tts = tts if isinstance(tts, dict) else {}
-provider = text(tts.get("provider"))
-slot = tts.get(CLOUD_PROVIDER)
-slot = slot if isinstance(slot, dict) else {}
-base_url = text(slot.get("base_url"))
-api_key = text(slot.get("api_key"))
-model = text(slot.get("model"))
-
-# `hermesCloudRouteIsOurs`, key for key: a `claw_` credential, OR our endpoint,
-# OR a genuinely empty slot.
-key_is_ours = api_key.startswith("claw_")
-slot_is_empty = base_url == "" and api_key == ""
-route_is_ours = key_is_ours or slot_is_empty or base_url.rstrip("/") == PROXY
-
-if token and tier == ENTITLED_TIER:
-    # ALREADY SPEAKING THROUGH US. The selection is not touched again; the
-    # DEFINITION still is, because the portal rotates the token on a re-link and
-    # this script is the only thing on the boot path that would notice. An
-    # unrefreshed key is a 401 on every utterance while every panel — which asks
-    # only that the two keys are non-empty — calls the voice configured.
-    if provider == CLOUD_PROVIDER and route_is_ours:
-        if base_url.rstrip("/") == PROXY and api_key == token and model == CLOUD_MODEL:
-            say("hold the cloud voice is already armed")
-        say("refresh")
-    if provider == LOCAL_PROVIDER:
-        # THE BOX THIS CARD IS ABOUT is here, not under "unset". `install.sh`
-        # `step_openclaw_tts` selects `clawbox-local` on every install and every
-        # update WHATEVER the engine answered — deliberately, because to Hermes
-        # an absent `tts.provider` resolves to Microsoft's Edge cloud, so an
-        # engineless box is left honestly mute rather than speaking through a
-        # third party. That is why "a Hermes box with no TTS engine" reads as a
-        # CHOSEN local voice rather than an unchosen slot.
-        #
-        # Moving a box off its own voice is effectively permanent — the next
-        # `step_openclaw_tts` sees `openai`, falls into its owner's-choice arm
-        # and preserves it — so it is done only on a POSITIVE "this box cannot
-        # speak for itself". The stamp is that positive: `localTtsEngineInstalled`
-        # is `stamped AND the unit is present`, so an ABSENT stamp settles it
-        # with a single file test and no systemd bus. A stamp that IS there is
-        # deliberately not pursued further here: the unit could still be missing,
-        # but "we did not finish asking" is not evidence, and this boot cannot
-        # afford the probe the link path makes.
-        if os.path.exists(os.environ["CLAWBOX_KOKORO_STAMP"]):
-            say("hold this box speaks for itself")
-    elif provider not in ("", FACTORY_PROVIDER):
-        say("hold this box has already chosen how it speaks (%s)" % provider)
-    if not route_is_ours:
-        say("hold tts.openai already names its own speech route")
-    say("arm")
-
-# The other direction. Only over a tier we have actually been TOLD: an absent
-# stamp is a box nobody has told us about, not a box that has lost its plan, and
-# taking a working voice away over a store we could not read is the false
-# failure this whole block is written to avoid.
-if tier and tier != ENTITLED_TIER:
-    # ONLY what we wrote. The stamp the OpenClaw arm can rely on does not exist
-    # here — Hermes' `tts.openai` block is the harness's own schema and carries
-    # no room for one — so ownership is the positive endpoint/credential test
-    # above, and an EMPTY slot is explicitly not something to take back.
-    if slot_is_empty:
-        say("hold there is no ClawBox AI cloud voice on this box to withdraw")
-    if not (key_is_ours or base_url.rstrip("/") == PROXY):
-        say("hold tts.openai names its own speech route — not ours to withdraw")
-    say("withdraw")
-
-say("hold nothing to do")
-PY
-)
-CLAWBOX_VOICE_VERDICT="${CLAWBOX_VOICE_PLAN%% *}"
-
-# One bounded CLI call, with the exit status kept. Braces and `-k 5` for the
-# reason §4's `tools disable` documents at length: `timeout` SIGKILLs its own
-# process group, bash announces a signal-killed foreground child on the SCRIPT's
-# stderr where the command's own redirect cannot reach it, and that notice lands
-# in the clawbox-setup journal reading as this script having been killed.
-hermes_voice_write() {
-  if { timeout -k 5 "$HERMES_CLI_TIMEOUT" "$HERMES_BIN" "$@" >/dev/null 2>&1; } 2>/dev/null; then
-    return 0
-  fi
-  # `$?` here is the CONDITION's status, which is what the caller reports — the
-  # same shape §4 uses, and the reason neither is written as `if ! …`, where
-  # `$?` in the branch would be the negation's 0.
-  CLAWBOX_VOICE_RC=$?
-  return 1
-}
-
-case "$CLAWBOX_VOICE_VERDICT" in
-  arm|refresh)
-    # DEFINITION BEFORE SELECTION, the same order `selectHermesEngine` keeps:
-    # the endpoint, credential and model land first, so a failure leaves
-    # `tts.provider` untouched rather than selecting a provider with nowhere to
-    # send a request. Nothing is recorded behind a marker, so a boot that got
-    # part way is simply offered the whole thing again by the next one.
-    CLAWBOX_VOICE_TOKEN=$(
-      CLAWBOX_DEVICE_STORE="$PROJECT_DIR/data/config.json" python3 - <<'TOKENPY' 2>/dev/null || true
-import json, os
-try:
-    with open(os.environ["CLAWBOX_DEVICE_STORE"]) as fh:
-        value = json.load(fh).get("clawai_token")
-except Exception:
-    value = None
-print(value.strip() if isinstance(value, str) else "")
-TOKENPY
-    )
-    if [ -z "$CLAWBOX_VOICE_TOKEN" ]; then
-      log "NOTE: the ClawBox AI cloud voice was armable but the device token could not be re-read; leaving the voice alone"
-    elif ! hermes_voice_write config set tts.openai.base_url "$CLAWBOX_VOICE_PROXY"; then
-      log "could not write tts.openai.base_url (exit $CLAWBOX_VOICE_RC) — the cloud voice is NOT selected; the next start will try again"
-    # The credential is an ARGUMENT and never reaches a message: one of these
-    # three writes carries the device token, and the journal keeps what is
-    # logged.
-    elif ! hermes_voice_write config set tts.openai.api_key "$CLAWBOX_VOICE_TOKEN"; then
-      log "could not write tts.openai.api_key (exit $CLAWBOX_VOICE_RC) — the cloud voice is NOT selected; the next start will try again"
-    elif ! hermes_voice_write config set tts.openai.model gpt-4o-mini-tts; then
-      log "could not write tts.openai.model (exit $CLAWBOX_VOICE_RC) — the cloud voice is NOT selected; the next start will try again"
-    elif [ "$CLAWBOX_VOICE_VERDICT" = refresh ]; then
-      # The selection is already ours and is NOT rewritten: one writer of
-      # `tts.provider`, and this path is only here to keep the credential and
-      # the endpoint current.
-      log "refreshed the ClawBox AI speech credential"
-    elif ! hermes_voice_write config set tts.provider openai; then
-      log "wrote the ClawBox AI speech endpoint but could not select it (exit $CLAWBOX_VOICE_RC) — the next start will try again"
-    else
-      log "armed the ClawBox AI cloud voice — this box's plan includes it and nothing else had been chosen"
-    fi
-    ;;
-  withdraw)
-    # `tts.provider` is deliberately left where it is — see the block comment.
-    # Removing the DEFINITION is what stops the refused round trips; the panel
-    # then reports the cloud voice unconfigured, which is the truth.
-    #
-    # The CREDENTIAL first, and every step reported rather than collapsed into
-    # one verdict: a partial withdrawal announced as a whole one is exactly the
-    # false success this arm exists to end.
-    CLAWBOX_VOICE_WITHDRAWN=true
-    for CLAWBOX_VOICE_KEY in tts.openai.api_key tts.openai.base_url tts.openai.model; do
-      if ! hermes_voice_write config unset "$CLAWBOX_VOICE_KEY"; then
-        log "could not remove $CLAWBOX_VOICE_KEY (exit $CLAWBOX_VOICE_RC) — this box may still be calling a speech endpoint its plan no longer includes; the next start will try again"
-        CLAWBOX_VOICE_WITHDRAWN=false
-      fi
-    done
-    if [ "$CLAWBOX_VOICE_WITHDRAWN" = true ]; then
-      log "removed the ClawBox AI cloud voice: this box's plan no longer includes it"
-    fi
-    ;;
-  *)
-    # Every hold says why, on the boot log, because "nothing happened" is the
-    # one outcome an operator cannot tell apart from "this step is not running".
-    log "left the voice alone — ${CLAWBOX_VOICE_PLAN#hold }"
-    ;;
-esac
 
 # ── 5. Prove the EMAIL: hook plugin actually LOADS, every boot. ─────────────
 # `hermes plugins list` would say "enabled" for a plugin that raises on import,

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -1042,6 +1042,15 @@ CLAWBOX_VOICE_PROXY="$(printf '%s' "$CLAWBOX_VOICE_PROXY" | tr -d '[:space:]')"
 while [ "${CLAWBOX_VOICE_PROXY%/}" != "$CLAWBOX_VOICE_PROXY" ]; do
   CLAWBOX_VOICE_PROXY="${CLAWBOX_VOICE_PROXY%/}"
 done
+# AFTER the normalisation, not only through `${:-}`. A variable set to
+# whitespace survives `${:-}` and normalises to the empty string, and an empty
+# "our proxy" is the worst possible value here: it makes an owner's slot that
+# carries their key and NO base_url — the canonical way Hermes' generic `openai`
+# slot is used — read as ours, so the arm would overwrite their credential and
+# the withdrawal would delete it.
+if [ -z "$CLAWBOX_VOICE_PROXY" ]; then
+  CLAWBOX_VOICE_PROXY="https://clawbox.com/api/ai"
+fi
 CLAWBOX_VOICE_MODEL="gpt-4o-mini-tts"
 CLAWBOX_VOICE_PLAN=$(
   CLAWBOX_DEVICE_STORE="$PROJECT_DIR/data/config.json" \
@@ -1075,12 +1084,16 @@ PROXY = os.environ["CLAWBOX_AI_PROXY_URL"].strip().rstrip("/")
 # It exists so an entry left on an address we have since moved off is still
 # recognisably ours — which is the ONLY thing that makes a credential-blind
 # delete safe.
+# The empty string can never be a member: an unset endpoint is not an address,
+# and admitting one would make every owner slot with a key and no URL ours.
+# Defence in depth — the shell above restores the default before we get here.
 OUR_PROXIES = {
     PROXY,
     "https://clawbox.com/api/ai",
     "https://openclawhardware.dev/api/ai",
     "https://www.openclawhardware.dev/api/ai",
 }
+OUR_PROXIES.discard("")
 # Hermes' factory default, and the one selection besides "unset" that means
 # nobody has chosen: `edge` is Microsoft's cloud voice, which the box gets for
 # having expressed no opinion.

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -1029,15 +1029,26 @@ fi
 # proxy publishes `modelTiers: {"gpt-image-1-mini": ["free","pro","max"]}`, so
 # the image backend has no tier to be downgraded from, and §"Re-arm the ClawAI
 # image backend" above already reconciles it every boot.
-# ONE binding, read by the decision below and by the writes after it, so the
-# endpoint we call ours and the endpoint we write cannot disagree — the same
-# staging override `hermes-clawai.ts` honours.
+# ONE binding each for the endpoint and the model, read by the decision below
+# and by the writes after it, so what we call ours and what we write cannot
+# disagree. Two literals would drift the day one of them moved: the verdict
+# would answer `refresh` on every boot and store the stale value for good.
+# `CLAWBOX_AI_PROXY_URL` is the same staging override `hermes-clawai.ts` honours,
+# and it is normalised the same way that binding normalises it — trimmed, and
+# with every trailing slash removed — so the endpoint compared here and the
+# endpoint every TypeScript consumer derives are the same string.
 CLAWBOX_VOICE_PROXY="${CLAWBOX_AI_PROXY_URL:-https://clawbox.com/api/ai}"
+CLAWBOX_VOICE_PROXY="$(printf '%s' "$CLAWBOX_VOICE_PROXY" | tr -d '[:space:]')"
+while [ "${CLAWBOX_VOICE_PROXY%/}" != "$CLAWBOX_VOICE_PROXY" ]; do
+  CLAWBOX_VOICE_PROXY="${CLAWBOX_VOICE_PROXY%/}"
+done
+CLAWBOX_VOICE_MODEL="gpt-4o-mini-tts"
 CLAWBOX_VOICE_PLAN=$(
   CLAWBOX_DEVICE_STORE="$PROJECT_DIR/data/config.json" \
   CLAWBOX_HERMES_CONFIG="$HERMES_CONFIG" \
   CLAWBOX_SPEECH_DEVICE_TIER="pro" \
   CLAWBOX_AI_PROXY_URL="$CLAWBOX_VOICE_PROXY" \
+  CLAWBOX_VOICE_MODEL="$CLAWBOX_VOICE_MODEL" \
   CLAWBOX_KOKORO_STAMP="$HOME_DIR/.cache/clawbox/kokoro-installed" \
   python3 - <<'PY' 2>/dev/null || echo "hold the voice plan could not be computed"
 import json, os
@@ -1078,8 +1089,9 @@ LOCAL_PROVIDER = "clawbox-local"
 CLOUD_PROVIDER = "openai"
 # The one speech model the proxy serves; the same constant `hermes-tts.ts` pins
 # as HERMES_CLOUD_TTS_MODEL, because a request that names anything else is
-# answered 400.
-CLOUD_MODEL = "gpt-4o-mini-tts"
+# answered 400. Bound by the shell above so the model compared here and the
+# model written below are one value.
+CLOUD_MODEL = os.environ["CLAWBOX_VOICE_MODEL"]
 
 
 def text(value):
@@ -1287,7 +1299,7 @@ TOKENPY
     # logged.
     elif ! hermes_voice_write config set tts.openai.api_key "$CLAWBOX_VOICE_TOKEN"; then
       log "could not write tts.openai.api_key (exit $CLAWBOX_VOICE_RC) — the cloud voice is NOT selected; the next start will try again"
-    elif ! hermes_voice_write config set tts.openai.model gpt-4o-mini-tts; then
+    elif ! hermes_voice_write config set tts.openai.model "$CLAWBOX_VOICE_MODEL"; then
       log "could not write tts.openai.model (exit $CLAWBOX_VOICE_RC) — the cloud voice is NOT selected; the next start will try again"
     elif [ "$CLAWBOX_VOICE_VERDICT" = refresh ]; then
       # The selection is already ours and is NOT rewritten: one writer of

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -1295,6 +1295,302 @@ except Exception as exc:  # noqa: BLE001
           % type(exc).__name__, file=sys.stderr)
 PY
 
+# ── 4c. The ClawBox AI cloud voice: armed AND withdrawn, every boot. ────────
+# TASK-717 (the arm) and TASK-718 (the withdrawal). One block, because they are
+# the two halves of one decision and shipping either alone reproduces the defect
+# the other exists to fix: an arm with no withdrawal is the one-way migration
+# TASK-718 is about, and a withdrawal with no arm has nothing to take back on a
+# Hermes box that was never armed at boot in the first place.
+#
+# WHAT IS BROKEN WITHOUT IT. `applyClawaiToHermes` — the only thing on this
+# edition that ever points `tts.provider` at the ClawBox AI proxy — has three
+# callers and every one of them is an explicit (re-)link. So:
+#   - a box linked BEFORE the cloud-voice wiring existed never gets it. Nothing
+#     re-runs the link, and the owner has no reason to: Settings already says
+#     ClawBox AI is connected. It simply never speaks (TASK-717).
+#   - a box that WAS entitled and drops to a lower plan keeps `tts.openai.*`
+#     pointing at an endpoint the proxy now answers 403 to, and pays a refused
+#     round trip on every spoken reply (TASK-718).
+# The OpenClaw edition has had both arms since TASK-459: `gateway-pre-start.sh`
+# gates on `_clawai_speech_entitled` and has the `elif` that takes its own entry
+# back. This is that pair, for the edition that has no `gateway-pre-start.sh`.
+#
+# THE NATIVE SURFACE IS `hermes config set` / `unset`, and it is what this uses —
+# the same commands `hermes-tts.ts` issues for the Settings toggle, so the boot
+# repair and the panel cannot drift into writing the config two different ways.
+# Hermes has no entitlement mechanism of its own to lean on: `tts.provider` is a
+# plain selection with no notion of a plan, and the tier lives only in ClawBox's
+# device store because only ClawBox talks to the portal.
+#
+# WHY HERE. Same answer as §4b: this script already holds `${HERMES_CONFIG}.lock`
+# and already makes CLI calls under it, and `production-server.js` fire-and-
+# forgets it on every web-server boot on hermes|dual. A Node boot hook would be a
+# second, unlocked writer racing this one.
+#
+# THE ENTITLEMENT IS THE PORTAL'S, not a guess: `clawai_tier` in
+# `data/config.json`, which `/setup-api/ai-models/status` refreshes from
+# `device-info` on its 30-second poll — the same stamp `speechEntitledTier()`
+# reads for the panel and `CLAWBOX_SPEECH_DEVICE_TIER` reads on the OpenClaw
+# side. `"pro"` is the DEVICE tier of the MAX plan; the two names are off by one
+# on purpose (CLAWBOX_AI_MODEL_BY_TIER in src/lib/clawbox-ai-models.ts).
+#
+# NOT KNOWING IS NOT AN ANSWER, in either direction, and that is the whole
+# false-success/false-failure guard here. A device store that is absent,
+# unreadable or not an object; a `config.yaml` that will not parse; a tier that
+# is not recorded at all — every one of them holds, and the boot says why. Only
+# a tier we have actually been told, and a slot we can positively see is ours,
+# moves anything.
+#
+# OWNERSHIP, mirroring `hermesCloudRouteIsOurs` (src/lib/hermes-tts.ts) key for
+# key rather than inventing a second rule: the credential is a `claw_` portal
+# token, OR the endpoint names our proxy, OR the slot is genuinely empty (no
+# endpoint AND no key — `base_url` is optional for real OpenAI, so an unset
+# endpoint alone says nothing). On Hermes `tts.openai` is the GENERIC
+# OpenAI-compatible slot, not ClawBox's, and an owner may be running their own
+# speech server in it.
+#
+# THE SELECTION IS THE OWNER'S. The arm moves `tts.provider` only from a
+# genuinely unchosen value — unset, or Hermes' factory `edge` — or from
+# `clawbox-local` on a box that provably has no on-device engine, which is the
+# state the card is about: `install.sh` selects `clawbox-local` whatever the
+# engine answered, so an engineless box reads as a chosen local voice. A box on
+# `elevenlabs`, `piper` or anything else the owner picked is left alone.
+# And the withdrawal deliberately does NOT reset `tts.provider` either — the
+# same ruling the OpenClaw arm records: the panel's job is to show that the
+# choice is no longer available, and silently rewriting it would hide the
+# downgrade. Removing the DEFINITION is what stops the refused calls.
+#
+# IMAGES ARE NOT PART OF THIS, and that is measured rather than assumed: the
+# proxy publishes `modelTiers: {"gpt-image-1-mini": ["free","pro","max"]}`, so
+# the image backend has no tier to be downgraded from, and §"Re-arm the ClawAI
+# image backend" above already reconciles it every boot.
+# ONE binding, read by the decision below and by the writes after it, so the
+# endpoint we call ours and the endpoint we write cannot disagree — the same
+# staging override `hermes-clawai.ts` honours.
+CLAWBOX_VOICE_PROXY="${CLAWBOX_AI_PROXY_URL:-https://clawbox.com/api/ai}"
+CLAWBOX_VOICE_PLAN=$(
+  CLAWBOX_DEVICE_STORE="$PROJECT_DIR/data/config.json" \
+  CLAWBOX_HERMES_CONFIG="$HERMES_CONFIG" \
+  CLAWBOX_SPEECH_DEVICE_TIER="pro" \
+  CLAWBOX_AI_PROXY_URL="$CLAWBOX_VOICE_PROXY" \
+  CLAWBOX_KOKORO_STAMP="$HOME_DIR/.cache/clawbox/kokoro-installed" \
+  python3 - <<'PY' 2>/dev/null || echo "hold the voice plan could not be computed"
+import json, os
+
+# One verdict on stdout: `arm`, `withdraw`, or `hold <why>`. Everything this
+# block decides is decided here, so the shell below is only the writes.
+def say(verdict):
+    print(verdict)
+    raise SystemExit(0)
+
+try:
+    import yaml
+except ImportError:
+    say("hold PyYAML is unavailable")
+
+ENTITLED_TIER = os.environ["CLAWBOX_SPEECH_DEVICE_TIER"]
+# Trailing slashes are not significant in a base URL comparison, and
+# `hermesCloudRouteIsOurs` strips them the same way on the TypeScript side.
+PROXY = os.environ["CLAWBOX_AI_PROXY_URL"].strip().rstrip("/")
+# Hermes' factory default, and the one selection besides "unset" that means
+# nobody has chosen: `edge` is Microsoft's cloud voice, which the box gets for
+# having expressed no opinion.
+FACTORY_PROVIDER = "edge"
+LOCAL_PROVIDER = "clawbox-local"
+CLOUD_PROVIDER = "openai"
+# The one speech model the proxy serves; the same constant `hermes-tts.ts` pins
+# as HERMES_CLOUD_TTS_MODEL, because a request that names anything else is
+# answered 400.
+CLOUD_MODEL = "gpt-4o-mini-tts"
+
+
+def text(value):
+    return value.strip() if isinstance(value, str) else ""
+
+
+def load(path, loader):
+    try:
+        with open(path) as fh:
+            return loader(fh), None
+    except FileNotFoundError:
+        return None, "absent"
+    except Exception as exc:  # noqa: BLE001 — every failure is "we cannot tell"
+        return None, type(exc).__name__
+
+
+store, why = load(os.environ["CLAWBOX_DEVICE_STORE"], json.load)
+if why == "absent":
+    say("hold this box has no ClawBox AI link on record")
+if why is not None:
+    say("hold the device store could not be read (%s)" % why)
+if not isinstance(store, dict):
+    say("hold the device store is not an object")
+
+token = text(store.get("clawai_token"))
+tier = store.get("clawai_tier")
+tier = tier.strip() if isinstance(tier, str) else ""
+
+cfg, why = load(os.environ["CLAWBOX_HERMES_CONFIG"], yaml.safe_load)
+if why is not None:
+    say("hold ~/.hermes/config.yaml could not be read (%s)" % why)
+if cfg is None:
+    cfg = {}
+if not isinstance(cfg, dict):
+    say("hold ~/.hermes/config.yaml is not a mapping")
+
+tts = cfg.get("tts")
+tts = tts if isinstance(tts, dict) else {}
+provider = text(tts.get("provider"))
+slot = tts.get(CLOUD_PROVIDER)
+slot = slot if isinstance(slot, dict) else {}
+base_url = text(slot.get("base_url"))
+api_key = text(slot.get("api_key"))
+model = text(slot.get("model"))
+
+# `hermesCloudRouteIsOurs`, key for key: a `claw_` credential, OR our endpoint,
+# OR a genuinely empty slot.
+key_is_ours = api_key.startswith("claw_")
+slot_is_empty = base_url == "" and api_key == ""
+route_is_ours = key_is_ours or slot_is_empty or base_url.rstrip("/") == PROXY
+
+if token and tier == ENTITLED_TIER:
+    # ALREADY SPEAKING THROUGH US. The selection is not touched again; the
+    # DEFINITION still is, because the portal rotates the token on a re-link and
+    # this script is the only thing on the boot path that would notice. An
+    # unrefreshed key is a 401 on every utterance while every panel — which asks
+    # only that the two keys are non-empty — calls the voice configured.
+    if provider == CLOUD_PROVIDER and route_is_ours:
+        if base_url.rstrip("/") == PROXY and api_key == token and model == CLOUD_MODEL:
+            say("hold the cloud voice is already armed")
+        say("refresh")
+    if provider == LOCAL_PROVIDER:
+        # THE BOX THIS CARD IS ABOUT is here, not under "unset". `install.sh`
+        # `step_openclaw_tts` selects `clawbox-local` on every install and every
+        # update WHATEVER the engine answered — deliberately, because to Hermes
+        # an absent `tts.provider` resolves to Microsoft's Edge cloud, so an
+        # engineless box is left honestly mute rather than speaking through a
+        # third party. That is why "a Hermes box with no TTS engine" reads as a
+        # CHOSEN local voice rather than an unchosen slot.
+        #
+        # Moving a box off its own voice is effectively permanent — the next
+        # `step_openclaw_tts` sees `openai`, falls into its owner's-choice arm
+        # and preserves it — so it is done only on a POSITIVE "this box cannot
+        # speak for itself". The stamp is that positive: `localTtsEngineInstalled`
+        # is `stamped AND the unit is present`, so an ABSENT stamp settles it
+        # with a single file test and no systemd bus. A stamp that IS there is
+        # deliberately not pursued further here: the unit could still be missing,
+        # but "we did not finish asking" is not evidence, and this boot cannot
+        # afford the probe the link path makes.
+        if os.path.exists(os.environ["CLAWBOX_KOKORO_STAMP"]):
+            say("hold this box speaks for itself")
+    elif provider not in ("", FACTORY_PROVIDER):
+        say("hold this box has already chosen how it speaks (%s)" % provider)
+    if not route_is_ours:
+        say("hold tts.openai already names its own speech route")
+    say("arm")
+
+# The other direction. Only over a tier we have actually been TOLD: an absent
+# stamp is a box nobody has told us about, not a box that has lost its plan, and
+# taking a working voice away over a store we could not read is the false
+# failure this whole block is written to avoid.
+if tier and tier != ENTITLED_TIER:
+    # ONLY what we wrote. The stamp the OpenClaw arm can rely on does not exist
+    # here — Hermes' `tts.openai` block is the harness's own schema and carries
+    # no room for one — so ownership is the positive endpoint/credential test
+    # above, and an EMPTY slot is explicitly not something to take back.
+    if slot_is_empty:
+        say("hold there is no ClawBox AI cloud voice on this box to withdraw")
+    if not (key_is_ours or base_url.rstrip("/") == PROXY):
+        say("hold tts.openai names its own speech route — not ours to withdraw")
+    say("withdraw")
+
+say("hold nothing to do")
+PY
+)
+CLAWBOX_VOICE_VERDICT="${CLAWBOX_VOICE_PLAN%% *}"
+
+# One bounded CLI call, with the exit status kept. Braces and `-k 5` for the
+# reason §4's `tools disable` documents at length: `timeout` SIGKILLs its own
+# process group, bash announces a signal-killed foreground child on the SCRIPT's
+# stderr where the command's own redirect cannot reach it, and that notice lands
+# in the clawbox-setup journal reading as this script having been killed.
+hermes_voice_write() {
+  if { timeout -k 5 "$HERMES_CLI_TIMEOUT" "$HERMES_BIN" "$@" >/dev/null 2>&1; } 2>/dev/null; then
+    return 0
+  fi
+  # `$?` here is the CONDITION's status, which is what the caller reports — the
+  # same shape §4 uses, and the reason neither is written as `if ! …`, where
+  # `$?` in the branch would be the negation's 0.
+  CLAWBOX_VOICE_RC=$?
+  return 1
+}
+
+case "$CLAWBOX_VOICE_VERDICT" in
+  arm|refresh)
+    # DEFINITION BEFORE SELECTION, the same order `selectHermesEngine` keeps:
+    # the endpoint, credential and model land first, so a failure leaves
+    # `tts.provider` untouched rather than selecting a provider with nowhere to
+    # send a request. Nothing is recorded behind a marker, so a boot that got
+    # part way is simply offered the whole thing again by the next one.
+    CLAWBOX_VOICE_TOKEN=$(
+      CLAWBOX_DEVICE_STORE="$PROJECT_DIR/data/config.json" python3 - <<'TOKENPY' 2>/dev/null || true
+import json, os
+try:
+    with open(os.environ["CLAWBOX_DEVICE_STORE"]) as fh:
+        value = json.load(fh).get("clawai_token")
+except Exception:
+    value = None
+print(value.strip() if isinstance(value, str) else "")
+TOKENPY
+    )
+    if [ -z "$CLAWBOX_VOICE_TOKEN" ]; then
+      log "NOTE: the ClawBox AI cloud voice was armable but the device token could not be re-read; leaving the voice alone"
+    elif ! hermes_voice_write config set tts.openai.base_url "$CLAWBOX_VOICE_PROXY"; then
+      log "could not write tts.openai.base_url (exit $CLAWBOX_VOICE_RC) — the cloud voice is NOT selected; the next start will try again"
+    # The credential is an ARGUMENT and never reaches a message: one of these
+    # three writes carries the device token, and the journal keeps what is
+    # logged.
+    elif ! hermes_voice_write config set tts.openai.api_key "$CLAWBOX_VOICE_TOKEN"; then
+      log "could not write tts.openai.api_key (exit $CLAWBOX_VOICE_RC) — the cloud voice is NOT selected; the next start will try again"
+    elif ! hermes_voice_write config set tts.openai.model gpt-4o-mini-tts; then
+      log "could not write tts.openai.model (exit $CLAWBOX_VOICE_RC) — the cloud voice is NOT selected; the next start will try again"
+    elif [ "$CLAWBOX_VOICE_VERDICT" = refresh ]; then
+      # The selection is already ours and is NOT rewritten: one writer of
+      # `tts.provider`, and this path is only here to keep the credential and
+      # the endpoint current.
+      log "refreshed the ClawBox AI speech credential"
+    elif ! hermes_voice_write config set tts.provider openai; then
+      log "wrote the ClawBox AI speech endpoint but could not select it (exit $CLAWBOX_VOICE_RC) — the next start will try again"
+    else
+      log "armed the ClawBox AI cloud voice — this box's plan includes it and nothing else had been chosen"
+    fi
+    ;;
+  withdraw)
+    # `tts.provider` is deliberately left where it is — see the block comment.
+    # Removing the DEFINITION is what stops the refused round trips; the panel
+    # then reports the cloud voice unconfigured, which is the truth.
+    #
+    # The CREDENTIAL first, and every step reported rather than collapsed into
+    # one verdict: a partial withdrawal announced as a whole one is exactly the
+    # false success this arm exists to end.
+    CLAWBOX_VOICE_WITHDRAWN=true
+    for CLAWBOX_VOICE_KEY in tts.openai.api_key tts.openai.base_url tts.openai.model; do
+      if ! hermes_voice_write config unset "$CLAWBOX_VOICE_KEY"; then
+        log "could not remove $CLAWBOX_VOICE_KEY (exit $CLAWBOX_VOICE_RC) — this box may still be calling a speech endpoint its plan no longer includes; the next start will try again"
+        CLAWBOX_VOICE_WITHDRAWN=false
+      fi
+    done
+    if [ "$CLAWBOX_VOICE_WITHDRAWN" = true ]; then
+      log "removed the ClawBox AI cloud voice: this box's plan no longer includes it"
+    fi
+    ;;
+  *)
+    # Every hold says why, on the boot log, because "nothing happened" is the
+    # one outcome an operator cannot tell apart from "this step is not running".
+    log "left the voice alone — ${CLAWBOX_VOICE_PLAN#hold }"
+    ;;
+esac
+
 # ── 5. Prove the EMAIL: hook plugin actually LOADS, every boot. ─────────────
 # `hermes plugins list` would say "enabled" for a plugin that raises on import,
 # has no `register()`, or registers a mistyped hook name: its status is read

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -1648,7 +1648,9 @@ async function readPluginsDisabledFromCli(): Promise<Set<string> | null> {
  * The cloud ENDPOINT AND CREDENTIAL are refreshed for the provider that speaks
  * through them — a box already on `openai` over our own route, and a box this
  * call is about to point there. `writeHermesCloudTarget` is the only writer of
- * `tts.openai.*` on this edition, so returning early on a box already speaking
+ * `tts.openai.*` REACHED FROM A LINK (`scripts/register-mcp.sh` §4a is the
+ * other one, and it runs at boot rather than on a save — TASK-717/718), so
+ * returning early on a box already speaking
  * through the cloud left `tts.openai.api_key` holding the token the portal
  * has just rotated: every utterance 401s while `hermesSpeaksReplies`, which
  * asks only that the two keys are non-empty, calls the voice configured. The
@@ -1732,8 +1734,10 @@ async function selectHermesCloudVoiceIfUnvoiced(token: string, tier: ClawboxAiTi
       // An owner's own provider — elevenlabs, piper, one they added by hand.
       // The SELECTION is theirs and is never touched. The endpoint and
       // credential are refreshed only for the one provider that speaks through
-      // them, because this is the only writer of `tts.openai.*` on this edition
-      // and the portal rotates the token on a re-link: an unrefreshed key means
+      // them, because this is the only writer of `tts.openai.*` on the LINK
+      // path (the boot script's §4a is the other, and it only reaches a box
+      // whose plan it can confirm) and the portal rotates the token on a
+      // re-link: an unrefreshed key means
       // every utterance 401s while `hermesSpeaksReplies`, which asks only that
       // the two keys are non-empty, calls the voice configured. On a box
       // speaking through anything else those three writes would be 45 s of

--- a/src/tests/unit/register-mcp-clawai-voice.test.ts
+++ b/src/tests/unit/register-mcp-clawai-voice.test.ts
@@ -495,10 +495,17 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
     const tts = await import("@/lib/hermes-tts");
     const models = await import("@/lib/local-models");
     const script = fs.readFileSync(SCRIPT, "utf-8");
-    const block = script.slice(script.indexOf("── 4a. The ClawBox AI cloud voice"));
+    // BOUNDED at §4b. An unbounded slice runs to the end of the file, so a
+    // constant deleted from §4a but named anywhere later would still satisfy
+    // every assertion below — a pin that cannot fail is not a pin.
+    const start = script.indexOf("── 4a. The ClawBox AI cloud voice");
+    expect(start).toBeGreaterThan(-1);
+    const end = script.indexOf("── 4b. Hermes' own background jobs", start);
+    expect(end).toBeGreaterThan(start);
+    const block = script.slice(start, end);
 
     expect(block).toContain(`CLAWBOX_SPEECH_DEVICE_TIER="${tts.CLAWBOX_AI_SPEECH_TIER}"`);
-    expect(block).toContain(`CLOUD_MODEL = "${tts.HERMES_CLOUD_TTS_MODEL}"`);
+    expect(block).toContain(`CLAWBOX_VOICE_MODEL="${tts.HERMES_CLOUD_TTS_MODEL}"`);
     expect(block).toContain(`LOCAL_PROVIDER = "${tts.HERMES_LOCAL_TTS_PROVIDER}"`);
     expect(block).toContain(`CLOUD_PROVIDER = "${tts.HERMES_CLOUD_TTS_PROVIDER}"`);
     expect(block).toContain(`FACTORY_PROVIDER = "${tts.HERMES_FACTORY_TTS_PROVIDER}"`);
@@ -511,6 +518,23 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
     // And the tier constant is the DEVICE tier, not the plan name — the two are
     // off by one on purpose (CLAWBOX_AI_MODEL_BY_TIER).
     expect(tts.CLAWBOX_AI_SPEECH_TIER).toBe(ENTITLED_TIER);
+  });
+
+  it("normalises a proxy override so the endpoint compared is the endpoint written", () => {
+    // Two normalisations would drift. `CLAWBOX_AI_PROXY_URL` is trimmed and has
+    // every trailing slash removed, exactly as `hermes-clawai.ts`'s binding does
+    // it, so a staging override with a stray slash cannot make the verdict
+    // answer `refresh` on every boot against a value it just wrote.
+    writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER });
+
+    const first = run({ CLAWBOX_AI_PROXY_URL: " https://staging.example.invalid/api/ai// " });
+    expect(first.stdout).toContain("armed the ClawBox AI cloud voice");
+    expect(at("tts.openai.base_url")).toBe("https://staging.example.invalid/api/ai");
+
+    fs.writeFileSync(hermesLog, "");
+    const second = run({ CLAWBOX_AI_PROXY_URL: " https://staging.example.invalid/api/ai// " });
+    expect(second.stdout).toContain("the cloud voice is already armed");
+    expect(configCalls()).toEqual([]);
   });
 
   it("arms a dual box, and writes nothing into ~/.openclaw", () => {

--- a/src/tests/unit/register-mcp-clawai-voice.test.ts
+++ b/src/tests/unit/register-mcp-clawai-voice.test.ts
@@ -67,6 +67,12 @@ let hermesLog: string;
  * A `hermes` that behaves like the real one for the two verbs this block uses:
  * it records the argv and applies the write to config.yaml. A stub that only
  * exited 0 would let every case pass over a script that wrote nothing.
+ *
+ * The python heredoc'"'"'s exit status IS the stub'"'"'s status — no trailing `exit 0`.
+ * A write that raised (an unparseable config, a scalar where an intermediate
+ * mapping was expected) leaves the file unwritten, and a stub that reported
+ * success over it would let the script treat a write that never landed as
+ * applied, which is the one thing these cases exist to catch.
  */
 function writeHermesStub(exitCode = 0) {
   const stub = path.join(home, "fake-hermes");
@@ -94,7 +100,6 @@ else:
 with open(os.environ["CLAWBOX_TEST_CFG"], "w") as fh:
     yaml.safe_dump(cfg, fh, sort_keys=False)
 EOPY
-exit 0
 `);
   fs.chmodSync(stub, 0o755);
 }
@@ -349,6 +354,11 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
     function armedBox() {
       writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER });
       run();
+      // The withdrawal cases below assert ABSENCE. Without this, a fixture that
+      // silently stopped arming would leave every one of them passing over a
+      // box that never had a cloud voice to take away.
+      expect(at("tts.openai.api_key")).toBe(TOKEN);
+      expect(at("tts.openai.base_url")).toBe(PROXY);
       fs.writeFileSync(hermesLog, "");
     }
 
@@ -515,6 +525,12 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
     // credential-blind delete safe, and the one the route already shares.
     const { CLAWBOX_AI_PROXY_URLS } = await import("@/lib/clawbox-ai-models");
     for (const url of CLAWBOX_AI_PROXY_URLS) expect(block).toContain(`"${url}"`);
+    // And the LIVE endpoint the arm writes, against the binding the rest of the
+    // app resolves it through — the retired-host set alone would not notice the
+    // current one moving.
+    const { CLAWBOX_AI_PROXY_URL } = await import("@/lib/hermes-clawai");
+    expect(CLAWBOX_AI_PROXY_URL).toBe(PROXY);
+    expect(block).toContain(`CLAWBOX_VOICE_PROXY="\${CLAWBOX_AI_PROXY_URL:-${PROXY}}"`);
     // And the tier constant is the DEVICE tier, not the plan name — the two are
     // off by one on purpose (CLAWBOX_AI_MODEL_BY_TIER).
     expect(tts.CLAWBOX_AI_SPEECH_TIER).toBe(ENTITLED_TIER);

--- a/src/tests/unit/register-mcp-clawai-voice.test.ts
+++ b/src/tests/unit/register-mcp-clawai-voice.test.ts
@@ -1,0 +1,497 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { execFileSync, spawnSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+import { testEnv } from "@/tests/helpers/env";
+
+// Starts a real process (bash / python3): vitest's 5 s test and 10 s hook
+// defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+/**
+ * TASK-717 (arm) and TASK-718 (withdraw), on the Hermes edition.
+ *
+ * `applyClawaiToHermes` is the only thing on this edition that ever points
+ * `tts.provider` at the ClawBox AI proxy, and its three callers are all
+ * explicit (re-)links. So a box linked BEFORE the cloud-voice wiring existed
+ * never gets it — nothing re-runs the link, and Settings already says ClawBox
+ * AI is connected — and a box that WAS entitled and drops to a lower plan keeps
+ * `tts.openai.*` pointing at an endpoint the proxy now answers 403 to, paying a
+ * refused round trip on every spoken reply.
+ *
+ * The OpenClaw edition has had both arms since TASK-459 (`gateway-pre-start.sh`
+ * gates on `_clawai_speech_entitled` and has the `elif` that takes its own entry
+ * back). `register-mcp.sh` is this repo's Hermes counterpart of that pre-start —
+ * `production-server.js` fire-and-forgets it on every web-server boot on
+ * hermes|dual — and it already holds `${HERMES_CONFIG}.lock` while it
+ * read-modify-writes the same file, which is why the pair belongs here rather
+ * than in a second, unlocked writer.
+ *
+ * The whole real script is run, with stubs, exactly as
+ * register-mcp-background-optouts.test.ts runs it. The `hermes` stub RECORDS its
+ * argv and APPLIES `config set`/`config unset` to the YAML, so the cases assert
+ * both the native commands issued and the state they leave.
+ */
+
+const REPO = path.resolve(__dirname, "../../..");
+const SCRIPT = path.join(REPO, "scripts", "register-mcp.sh");
+
+const PROXY = "https://clawbox.com/api/ai";
+const TOKEN = "claw_token123";
+const CLOUD_MODEL = "gpt-4o-mini-tts";
+/** The DEVICE tier of the MAX plan — the two names are off by one on purpose. */
+const ENTITLED_TIER = "pro";
+
+function have(bin: string, args: string[]): boolean {
+  return spawnSync(bin, args, { stdio: "ignore" }).status === 0;
+}
+
+const CAN_RUN =
+  process.platform !== "win32"
+  && have("bash", ["-c", "true"])
+  && have("python3", ["-c", "import yaml"]);
+
+const d = CAN_RUN ? describe : describe.skip;
+
+let home: string;
+let root: string;
+let configPath: string;
+let storePath: string;
+let lockPath: string;
+let hermesLog: string;
+
+/**
+ * A `hermes` that behaves like the real one for the two verbs this block uses:
+ * it records the argv and applies the write to config.yaml. A stub that only
+ * exited 0 would let every case pass over a script that wrote nothing.
+ */
+function writeHermesStub(exitCode = 0) {
+  const stub = path.join(home, "fake-hermes");
+  fs.writeFileSync(stub, `#!/bin/sh
+printf '%s\\n' "$*" >> "${hermesLog}"
+if [ "$1" != "config" ]; then exit 0; fi
+if [ ${exitCode} -ne 0 ]; then exit ${exitCode}; fi
+CLAWBOX_TEST_CFG="${configPath}" CLAWBOX_TEST_OP="$2" CLAWBOX_TEST_KEY="$3" CLAWBOX_TEST_VALUE="$4" python3 - <<'EOPY'
+import os, yaml
+cfg = yaml.safe_load(open(os.environ["CLAWBOX_TEST_CFG"])) or {}
+parts = os.environ["CLAWBOX_TEST_KEY"].split(".")
+if os.environ["CLAWBOX_TEST_OP"] == "set":
+    node = cfg
+    for p in parts[:-1]:
+        node = node.setdefault(p, {})
+    node[parts[-1]] = os.environ["CLAWBOX_TEST_VALUE"]
+else:
+    node = cfg
+    for p in parts[:-1]:
+        node = node.get(p) if isinstance(node, dict) else None
+        if node is None:
+            break
+    if isinstance(node, dict):
+        node.pop(parts[-1], None)
+with open(os.environ["CLAWBOX_TEST_CFG"], "w") as fh:
+    yaml.safe_dump(cfg, fh, sort_keys=False)
+EOPY
+exit 0
+`);
+  fs.chmodSync(stub, 0o755);
+}
+
+function run(env: Record<string, string> = {}): { status: number; stdout: string; stderr: string } {
+  const r = spawnSync("bash", [SCRIPT], {
+    encoding: "utf-8",
+    env: testEnv({
+      PATH: process.env.PATH ?? "",
+      HOME: home,
+      CLAWBOX_ROOT: root,
+      HERMES_CONFIG: configPath,
+      HERMES_BIN: path.join(home, "fake-hermes"),
+      BUN_BIN: path.join(home, "fake-bun"),
+      CLAWBOX_EDITION_FILE: lockPath,
+      ...env,
+    }),
+  });
+  return { status: r.status ?? -1, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+function readConfig(): Record<string, unknown> {
+  const out = execFileSync(
+    "python3",
+    ["-c", "import json,sys,yaml; print(json.dumps(yaml.safe_load(open(sys.argv[1])) or {}))", configPath],
+    { encoding: "utf-8" },
+  );
+  return JSON.parse(out);
+}
+
+function at(dotted: string): unknown {
+  let node: unknown = readConfig();
+  for (const part of dotted.split(".")) {
+    if (!node || typeof node !== "object") return undefined;
+    node = (node as Record<string, unknown>)[part];
+  }
+  return node;
+}
+
+/** Every `hermes` invocation the script made, in order. */
+function hermesCalls(): string[] {
+  try {
+    return fs.readFileSync(hermesLog, "utf-8").trim().split("\n").filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function configCalls(): string[] {
+  return hermesCalls().filter((line) => line.startsWith("config "));
+}
+
+/** The device store `/setup-api/ai-models/status` stamps the portal tier into. */
+function writeStore(entries: Record<string, unknown>) {
+  fs.mkdirSync(path.dirname(storePath), { recursive: true });
+  fs.writeFileSync(storePath, JSON.stringify(entries));
+}
+
+function writeYaml(body: string) {
+  fs.writeFileSync(configPath, body);
+}
+
+/**
+ * The stamp `localTtsEngineInstalled` reads — `stamped AND the unit is present`,
+ * so an ABSENT stamp settles "no engine" on its own, with no systemd bus.
+ */
+function installKokoroStamp() {
+  const stamp = path.join(home, ".cache", "clawbox", "kokoro-installed");
+  fs.mkdirSync(path.dirname(stamp), { recursive: true });
+  fs.writeFileSync(stamp, "");
+}
+
+const BASE_CONFIG = "model:\n  default: deepseek-v4-pro\n";
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-voice-home-"));
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-voice-root-"));
+  configPath = path.join(home, ".hermes", "config.yaml");
+  storePath = path.join(root, "data", "config.json");
+  lockPath = path.join(home, "edition.env");
+  hermesLog = path.join(home, "hermes-calls.log");
+
+  fs.mkdirSync(path.join(root, "mcp"), { recursive: true });
+  fs.writeFileSync(path.join(root, "mcp", "clawbox-mcp.ts"), "// stand-in\n");
+  fs.writeFileSync(path.join(home, "fake-bun"), "#!/bin/sh\nexit 0\n");
+  fs.chmodSync(path.join(home, "fake-bun"), 0o755);
+  fs.mkdirSync(path.join(home, ".hermes"), { recursive: true });
+  writeYaml(BASE_CONFIG);
+  fs.writeFileSync(lockPath, "CLAWBOX_EDITION=hermes\n");
+  writeHermesStub();
+});
+
+afterEach(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
+  describe("the arm (TASK-717)", () => {
+    it("points an entitled, unvoiced box at the proxy and selects it", () => {
+      writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER });
+
+      const r = run();
+
+      expect(r.status).toBe(0);
+      expect(at("tts.openai.base_url")).toBe(PROXY);
+      expect(at("tts.openai.api_key")).toBe(TOKEN);
+      expect(at("tts.openai.model")).toBe(CLOUD_MODEL);
+      expect(at("tts.provider")).toBe("openai");
+      expect(r.stdout).toContain("armed the ClawBox AI cloud voice");
+    });
+
+    it("writes the definition BEFORE it selects the provider", () => {
+      // A selected provider with nowhere to send a request is strictly worse
+      // than an unchanged one — the ordering `selectHermesEngine` keeps.
+      writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER });
+
+      run();
+
+      const calls = configCalls();
+      expect(calls.indexOf("config set tts.provider openai")).toBe(calls.length - 1);
+      expect(calls).toContain(`config set tts.openai.base_url ${PROXY}`);
+    });
+
+    it("adopts Hermes' factory `edge` selection, which is nobody's choice", () => {
+      writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER });
+      writeYaml(`${BASE_CONFIG}tts:\n  provider: edge\n`);
+
+      run();
+
+      expect(at("tts.provider")).toBe("openai");
+    });
+
+    it("leaves a box that speaks for itself on its own voice", () => {
+      // Moving a box off its own voice is effectively permanent (the next
+      // `step_openclaw_tts` preserves `openai` as the owner's choice), so it is
+      // done only on a POSITIVE "this box cannot speak for itself".
+      writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER });
+      writeYaml(`${BASE_CONFIG}tts:\n  provider: clawbox-local\n`);
+      installKokoroStamp();
+
+      const r = run();
+
+      expect(at("tts.provider")).toBe("clawbox-local");
+      expect(at("tts.openai")).toBeUndefined();
+      expect(r.stdout).toContain("this box speaks for itself");
+    });
+
+    it("gives an engineless box on `clawbox-local` the voice its plan includes", () => {
+      // THE box this card is about. `install.sh` selects `clawbox-local` on
+      // every install and every update WHATEVER the engine answered — an
+      // absent `tts.provider` resolves to Microsoft's Edge cloud on Hermes, so
+      // an engineless box is left honestly mute rather than speaking through a
+      // third party. Which is why "no TTS engine" reads as a chosen local
+      // voice, and why the unset/`edge` cases above do not reach it.
+      writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER });
+      writeYaml(`${BASE_CONFIG}tts:\n  provider: clawbox-local\n`);
+
+      const r = run();
+
+      expect(at("tts.provider")).toBe("openai");
+      expect(at("tts.openai.api_key")).toBe(TOKEN);
+      expect(r.stdout).toContain("armed the ClawBox AI cloud voice");
+    });
+
+    it("leaves a voice the owner chose", () => {
+      writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER });
+      writeYaml(`${BASE_CONFIG}tts:\n  provider: elevenlabs\n`);
+
+      run();
+
+      expect(at("tts.provider")).toBe("elevenlabs");
+      expect(configCalls()).toEqual([]);
+    });
+
+    it("leaves an owner's own OpenAI-compatible speech server alone", () => {
+      // On Hermes `tts.openai` is the GENERIC slot, not ClawBox's.
+      writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER });
+      writeYaml(
+        `${BASE_CONFIG}tts:\n  openai:\n    base_url: https://speech.home.lan/v1\n    api_key: sk-theirs\n`,
+      );
+
+      const r = run();
+
+      expect(at("tts.openai.base_url")).toBe("https://speech.home.lan/v1");
+      expect(at("tts.openai.api_key")).toBe("sk-theirs");
+      expect(at("tts.provider")).toBeUndefined();
+      expect(r.stdout).toContain("already names its own speech route");
+    });
+
+    it("does not arm a box whose plan does not include the cloud voice", () => {
+      writeStore({ clawai_token: TOKEN, clawai_tier: "flash" });
+
+      run();
+
+      expect(at("tts.openai")).toBeUndefined();
+      expect(configCalls()).toEqual([]);
+    });
+
+    it("does not arm a box the portal has told us nothing about", () => {
+      // Not knowing is not an entitlement.
+      writeStore({ clawai_token: TOKEN });
+
+      run();
+
+      expect(at("tts.openai")).toBeUndefined();
+    });
+
+    it("costs no config write at all once the voice is armed", () => {
+      writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER });
+      run();
+      fs.writeFileSync(hermesLog, "");
+      const before = fs.readFileSync(configPath, "utf-8");
+
+      const r = run();
+
+      expect(fs.readFileSync(configPath, "utf-8")).toBe(before);
+      expect(configCalls()).toEqual([]);
+      expect(r.stdout).toContain("the cloud voice is already armed");
+    });
+
+    it("refreshes a rotated token rather than leaving a 401 in the slot", () => {
+      // The portal rotates the token on a re-link, and this script is the only
+      // thing on the boot path that would notice. An unrefreshed key is a 401
+      // on every utterance while every panel — which asks only that the two
+      // keys are non-empty — calls the voice configured.
+      writeStore({ clawai_token: "claw_OLD", clawai_tier: ENTITLED_TIER });
+      run();
+      writeStore({ clawai_token: "claw_NEW", clawai_tier: ENTITLED_TIER });
+      fs.writeFileSync(hermesLog, "");
+
+      const r = run();
+
+      expect(at("tts.openai.api_key")).toBe("claw_NEW");
+      // The SELECTION is already ours and is not rewritten: one writer of
+      // `tts.provider`, and re-selecting buys a fourth CLI spawn for nothing.
+      expect(configCalls()).not.toContain("config set tts.provider openai");
+      expect(r.stdout).toContain("refreshed the ClawBox AI speech credential");
+    });
+  });
+
+  describe("the withdrawal (TASK-718)", () => {
+    /** A box that WAS on the cloud voice, as the arm above leaves it. */
+    function armedBox() {
+      writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER });
+      run();
+      fs.writeFileSync(hermesLog, "");
+    }
+
+    it("takes the endpoint, credential and model back when the plan drops", () => {
+      armedBox();
+      writeStore({ clawai_token: TOKEN, clawai_tier: "flash" });
+
+      const r = run();
+
+      expect(at("tts.openai.base_url")).toBeUndefined();
+      expect(at("tts.openai.api_key")).toBeUndefined();
+      expect(at("tts.openai.model")).toBeUndefined();
+      expect(r.stdout).toContain("no longer includes it");
+    });
+
+    it("leaves the owner's SELECTION where it is", () => {
+      // The same ruling the OpenClaw arm records: the panel's job is to show
+      // that the choice is no longer available, and silently rewriting it would
+      // hide the downgrade.
+      armedBox();
+      writeStore({ clawai_token: TOKEN, clawai_tier: "flash" });
+
+      run();
+
+      expect(at("tts.provider")).toBe("openai");
+    });
+
+    it("never touches an owner's own speech server", () => {
+      writeStore({ clawai_token: TOKEN, clawai_tier: "flash" });
+      writeYaml(
+        `${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    base_url: https://speech.home.lan/v1\n    api_key: sk-theirs\n`,
+      );
+
+      const r = run();
+
+      expect(at("tts.openai.api_key")).toBe("sk-theirs");
+      expect(configCalls()).toEqual([]);
+      expect(r.stdout).toContain("not ours to withdraw");
+    });
+
+    it("withdraws an entry left on a proxy address we have since moved off", () => {
+      // The credential is the other half of the ownership rule: a `claw_` token
+      // is ours wherever it points.
+      writeStore({ clawai_token: TOKEN, clawai_tier: "flash" });
+      writeYaml(
+        `${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    base_url: https://openclawhardware.dev/api/ai\n    api_key: ${TOKEN}\n`,
+      );
+
+      run();
+
+      expect(at("tts.openai.api_key")).toBeUndefined();
+    });
+
+    it("does not withdraw over a tier nobody has told us", () => {
+      armedBox();
+      writeStore({ clawai_token: TOKEN });
+
+      run();
+
+      expect(at("tts.openai.api_key")).toBe(TOKEN);
+      expect(configCalls()).toEqual([]);
+    });
+
+    it("is idempotent — a second unentitled boot writes nothing", () => {
+      armedBox();
+      writeStore({ clawai_token: TOKEN, clawai_tier: "flash" });
+      run();
+      fs.writeFileSync(hermesLog, "");
+      const before = fs.readFileSync(configPath, "utf-8");
+
+      run();
+
+      expect(fs.readFileSync(configPath, "utf-8")).toBe(before);
+      expect(configCalls()).toEqual([]);
+    });
+  });
+
+  describe("not knowing is not an answer", () => {
+    it("holds, and says why, when there is no device store at all", () => {
+      const r = run();
+
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain("no ClawBox AI link on record");
+      expect(configCalls()).toEqual([]);
+    });
+
+    it("holds over a device store that is not JSON", () => {
+      fs.mkdirSync(path.dirname(storePath), { recursive: true });
+      fs.writeFileSync(storePath, "{");
+
+      const r = run();
+
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain("the device store could not be read");
+      expect(configCalls()).toEqual([]);
+    });
+
+    it("reports a refused write rather than claiming the voice was armed", () => {
+      // False success is the class this whole block is written against: a
+      // `hermes config set` that did not land must not be reported as a voice.
+      writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER });
+      writeHermesStub(3);
+
+      const r = run();
+
+      expect(r.stdout).not.toContain("armed the ClawBox AI cloud voice");
+      expect(r.stdout).toContain("could not write tts.openai.base_url");
+      expect(at("tts.provider")).toBeUndefined();
+    });
+
+    it("never prints the device token", () => {
+      writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER });
+
+      const r = run();
+
+      expect(r.stdout).not.toContain(TOKEN);
+      expect(r.stderr).not.toContain(TOKEN);
+    });
+  });
+
+  it("keeps every constant in step with the TypeScript that owns it", async () => {
+    // A shell block cannot import a TS constant, so the two copies are pinned
+    // against each other here instead. Each of these is a wire value a
+    // divergence would break silently: the tier gate, the one speech model the
+    // proxy serves, the three provider names, and the engine stamp.
+    const tts = await import("@/lib/hermes-tts");
+    const models = await import("@/lib/local-models");
+    const script = fs.readFileSync(SCRIPT, "utf-8");
+    const block = script.slice(script.indexOf("── 4c. The ClawBox AI cloud voice"));
+
+    expect(block).toContain(`CLAWBOX_SPEECH_DEVICE_TIER="${tts.CLAWBOX_AI_SPEECH_TIER}"`);
+    expect(block).toContain(`CLOUD_MODEL = "${tts.HERMES_CLOUD_TTS_MODEL}"`);
+    expect(block).toContain(`LOCAL_PROVIDER = "${tts.HERMES_LOCAL_TTS_PROVIDER}"`);
+    expect(block).toContain(`CLOUD_PROVIDER = "${tts.HERMES_CLOUD_TTS_PROVIDER}"`);
+    expect(block).toContain(`FACTORY_PROVIDER = "${tts.HERMES_FACTORY_TTS_PROVIDER}"`);
+    expect(models.KOKORO_STAMP.endsWith("/.cache/clawbox/kokoro-installed")).toBe(true);
+    expect(block).toContain("/.cache/clawbox/kokoro-installed");
+    // And the tier constant is the DEVICE tier, not the plan name — the two are
+    // off by one on purpose (CLAWBOX_AI_MODEL_BY_TIER).
+    expect(tts.CLAWBOX_AI_SPEECH_TIER).toBe(ENTITLED_TIER);
+  });
+
+  it("does nothing at all on an OpenClaw-only device", () => {
+    // That edition has both arms in gateway-pre-start.sh already.
+    fs.writeFileSync(lockPath, "CLAWBOX_EDITION=openclaw\n");
+    writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER });
+
+    const r = run();
+
+    expect(r.status).toBe(0);
+    expect(at("tts")).toBeUndefined();
+    expect(configCalls()).toEqual([]);
+  });
+});

--- a/src/tests/unit/register-mcp-clawai-voice.test.ts
+++ b/src/tests/unit/register-mcp-clawai-voice.test.ts
@@ -540,11 +540,10 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
   it.each([
     ["a whitespace-only override", " "],
     ["an override that is only slashes", "///"],
-  ])("never treats an unset endpoint as ours, given %s", (_label, override) => {
+  ])("never withdraws an unset endpoint as ours, given %s", (_label, override) => {
     // An empty "our proxy" is the worst value this binding can take: it makes
     // an owner's slot carrying their key and NO base_url — the canonical way
-    // Hermes' generic `openai` slot is used — read as ours, so the arm would
-    // overwrite their credential and the withdrawal would delete it.
+    // Hermes' generic `openai` slot is used — read as ours.
     writeStore({ clawai_token: TOKEN, clawai_tier: "flash" });
     writeYaml(`${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    api_key: sk-theirs\n`);
 
@@ -553,6 +552,32 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
     expect(at("tts.openai.api_key")).toBe("sk-theirs");
     expect(configCalls()).toEqual([]);
     expect(r.stdout).toContain("not ours to withdraw");
+  });
+
+  it.each([
+    ["a whitespace-only override", " "],
+    ["an override that is only slashes", "///"],
+  ])("never ARMS over an unset endpoint either, given %s", (_label, override) => {
+    // The other direction, and the one the withdraw cases above cannot reach:
+    // an ENTITLED box with the same owner slot. `route_is_ours` would be true
+    // over an empty `base_url` if the proxy binding were empty, and the arm
+    // would overwrite their credential with ours before any downgrade ever
+    // happened. The two guards are separately load-bearing — remove the default
+    // restoration and keep `OUR_PROXIES.discard("")` and only this half fails.
+    // The selection is left UNSET on purpose, so `route_is_ours` is the ONLY
+    // thing standing between their credential and ours — an already-chosen
+    // `openai` would be held by the selection test one line earlier and would
+    // not exercise this at all.
+    writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER });
+    writeYaml(`${BASE_CONFIG}tts:\n  openai:\n    api_key: sk-theirs\n`);
+
+    const r = run({ CLAWBOX_AI_PROXY_URL: override });
+
+    expect(at("tts.openai.api_key")).toBe("sk-theirs");
+    expect(at("tts.openai.base_url")).toBeUndefined();
+    expect(at("tts.provider")).toBeUndefined();
+    expect(configCalls()).toEqual([]);
+    expect(r.stdout).toContain("already names its own speech route");
   });
 
   it("arms a dual box, and writes nothing into ~/.openclaw", () => {

--- a/src/tests/unit/register-mcp-clawai-voice.test.ts
+++ b/src/tests/unit/register-mcp-clawai-voice.test.ts
@@ -537,6 +537,24 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
     expect(configCalls()).toEqual([]);
   });
 
+  it.each([
+    ["a whitespace-only override", " "],
+    ["an override that is only slashes", "///"],
+  ])("never treats an unset endpoint as ours, given %s", (_label, override) => {
+    // An empty "our proxy" is the worst value this binding can take: it makes
+    // an owner's slot carrying their key and NO base_url — the canonical way
+    // Hermes' generic `openai` slot is used — read as ours, so the arm would
+    // overwrite their credential and the withdrawal would delete it.
+    writeStore({ clawai_token: TOKEN, clawai_tier: "flash" });
+    writeYaml(`${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    api_key: sk-theirs\n`);
+
+    const r = run({ CLAWBOX_AI_PROXY_URL: override });
+
+    expect(at("tts.openai.api_key")).toBe("sk-theirs");
+    expect(configCalls()).toEqual([]);
+    expect(r.stdout).toContain("not ours to withdraw");
+  });
+
   it("arms a dual box, and writes nothing into ~/.openclaw", () => {
     // Edition-gated, not harness-gated, and consistent with §4b: the web server
     // is not restarted when the owner switches harness, so a block that asked

--- a/src/tests/unit/register-mcp-clawai-voice.test.ts
+++ b/src/tests/unit/register-mcp-clawai-voice.test.ts
@@ -228,18 +228,26 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
       expect(at("tts.provider")).toBe("openai");
     });
 
-    it("leaves a box that speaks for itself on its own voice", () => {
-      // Moving a box off its own voice is effectively permanent (the next
-      // `step_openclaw_tts` preserves `openai` as the owner's choice), so it is
-      // done only on a POSITIVE "this box cannot speak for itself".
+    it.each([
+      ["an unset selection", ""],
+      ["Hermes' factory `edge`", "edge"],
+      ["`clawbox-local`", "clawbox-local"],
+    ])("leaves a box with a working engine alone, whatever %s says", (_label, provider) => {
+      // The engine question is asked in EVERY unchosen state, not only over
+      // `clawbox-local`. `step_openclaw_tts` has one arm that leaves the key
+      // UNSET — a `hermes config get` that did not answer, i.e. one OOM-killed
+      // Python start on a loaded Jetson — and this script runs on every
+      // web-server boot, so it would fire before anything could correct it. A
+      // box that can speak entirely on-device must not be moved off its own
+      // voice by a boot script, and the move is effectively permanent.
       writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER });
-      writeYaml(`${BASE_CONFIG}tts:\n  provider: clawbox-local\n`);
+      writeYaml(provider ? `${BASE_CONFIG}tts:\n  provider: ${provider}\n` : BASE_CONFIG);
       installKokoroStamp();
 
       const r = run();
 
-      expect(at("tts.provider")).toBe("clawbox-local");
       expect(at("tts.openai")).toBeUndefined();
+      expect(at("tts.provider")).toBe(provider || undefined);
       expect(r.stdout).toContain("this box speaks for itself");
     });
 
@@ -368,30 +376,43 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
       expect(at("tts.provider")).toBe("openai");
     });
 
-    it("never touches an owner's own speech server", () => {
+    it.each([
+      ["their key", "sk-theirs"],
+      // THE case, and the one the OpenClaw arm's ruling names outright: an owner
+      // can point OUR OWN token at an endpoint of their choosing, and that entry
+      // is theirs. A `claw_` credential is enough to REFRESH an entry — the worst
+      // that does is rewrite our fields to our values — and it is never enough to
+      // DELETE one.
+      ["OUR key at THEIR address", TOKEN],
+    ])("never touches an owner's own speech server, even with %s in it", (_label, key) => {
       writeStore({ clawai_token: TOKEN, clawai_tier: "flash" });
       writeYaml(
-        `${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    base_url: https://speech.home.lan/v1\n    api_key: sk-theirs\n`,
+        `${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    base_url: https://speech.home.lan/v1\n    api_key: ${key}\n    model: my-own-voice\n`,
       );
 
       const r = run();
 
-      expect(at("tts.openai.api_key")).toBe("sk-theirs");
+      expect(at("tts.openai.api_key")).toBe(key);
+      expect(at("tts.openai.base_url")).toBe("https://speech.home.lan/v1");
+      expect(at("tts.openai.model")).toBe("my-own-voice");
       expect(configCalls()).toEqual([]);
       expect(r.stdout).toContain("not ours to withdraw");
     });
 
     it("withdraws an entry left on a proxy address we have since moved off", () => {
-      // The credential is the other half of the ownership rule: a `claw_` token
-      // is ours wherever it points.
+      // The retired hosts are in the ownership set precisely so a box linked
+      // under a previous address is still recognisably ours. No `claw_` token
+      // here on purpose: the ADDRESS has to be what authorises the delete, or
+      // this case would pass for the reason the one above forbids.
       writeStore({ clawai_token: TOKEN, clawai_tier: "flash" });
       writeYaml(
-        `${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    base_url: https://openclawhardware.dev/api/ai\n    api_key: ${TOKEN}\n`,
+        `${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    base_url: https://openclawhardware.dev/api/ai\n    api_key: sk-someone-elses\n`,
       );
 
-      run();
+      const r = run();
 
       expect(at("tts.openai.api_key")).toBeUndefined();
+      expect(r.stdout).toContain("no longer includes it");
     });
 
     it("does not withdraw over a tier nobody has told us", () => {
@@ -447,7 +468,12 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
       const r = run();
 
       expect(r.stdout).not.toContain("armed the ClawBox AI cloud voice");
-      expect(r.stdout).toContain("could not write tts.openai.base_url");
+      // THE NUMBER, not just the sentence. `$?` captured after `fi` is the `if`
+      // statement's own 0, so every failure line would read "(exit 0)" — which
+      // both misreports the cause and reads as a contradiction. §4's twenty-line
+      // comment on `tools disable` explains why 3, 124, 125 and 127 are four
+      // different facts to whoever is reading the journal.
+      expect(r.stdout).toContain("could not write tts.openai.base_url (exit 3)");
       expect(at("tts.provider")).toBeUndefined();
     });
 
@@ -469,7 +495,7 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
     const tts = await import("@/lib/hermes-tts");
     const models = await import("@/lib/local-models");
     const script = fs.readFileSync(SCRIPT, "utf-8");
-    const block = script.slice(script.indexOf("── 4c. The ClawBox AI cloud voice"));
+    const block = script.slice(script.indexOf("── 4a. The ClawBox AI cloud voice"));
 
     expect(block).toContain(`CLAWBOX_SPEECH_DEVICE_TIER="${tts.CLAWBOX_AI_SPEECH_TIER}"`);
     expect(block).toContain(`CLOUD_MODEL = "${tts.HERMES_CLOUD_TTS_MODEL}"`);
@@ -478,9 +504,32 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
     expect(block).toContain(`FACTORY_PROVIDER = "${tts.HERMES_FACTORY_TTS_PROVIDER}"`);
     expect(models.KOKORO_STAMP.endsWith("/.cache/clawbox/kokoro-installed")).toBe(true);
     expect(block).toContain("/.cache/clawbox/kokoro-installed");
+    // Every address ClawBox has ever written as its proxy — the set that makes a
+    // credential-blind delete safe, and the one the route already shares.
+    const { CLAWBOX_AI_PROXY_URLS } = await import("@/lib/clawbox-ai-models");
+    for (const url of CLAWBOX_AI_PROXY_URLS) expect(block).toContain(`"${url}"`);
     // And the tier constant is the DEVICE tier, not the plan name — the two are
     // off by one on purpose (CLAWBOX_AI_MODEL_BY_TIER).
     expect(tts.CLAWBOX_AI_SPEECH_TIER).toBe(ENTITLED_TIER);
+  });
+
+  it("arms a dual box, and writes nothing into ~/.openclaw", () => {
+    // Edition-gated, not harness-gated, and consistent with §4b: the web server
+    // is not restarted when the owner switches harness, so a block that asked
+    // which harness was active at boot would leave a switched-over box unvoiced.
+    // Dual is the one SKU where both editions' arms coexist — the OpenClaw half
+    // lives in gateway-pre-start.sh and this must not reach it.
+    fs.writeFileSync(lockPath, "CLAWBOX_EDITION=dual\n");
+    const openclawConfig = path.join(home, ".openclaw", "openclaw.json");
+    fs.mkdirSync(path.dirname(openclawConfig), { recursive: true });
+    fs.writeFileSync(openclawConfig, JSON.stringify({ agents: { defaults: {} } }));
+    writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER });
+
+    const r = run();
+
+    expect(r.status).toBe(0);
+    expect(at("tts.provider")).toBe("openai");
+    expect(JSON.parse(fs.readFileSync(openclawConfig, "utf-8"))).toEqual({ agents: { defaults: {} } });
   });
 
   it("does nothing at all on an OpenClaw-only device", () => {


### PR DESCRIPTION
## TASK-717 + TASK-718 — the ClawBox AI cloud voice, armed and withdrawn at boot on Hermes

**One PR, not two, and the split would have been artificial.** These are the two halves of one `if`/`elif` in one new section. An arm with no withdrawal is precisely the one-way migration TASK-718 exists to end, and a withdrawal with no arm has nothing to take back on a Hermes box that was never armed at boot in the first place. Landing either alone would ship the defect the other fixes.

**What the customer sees today.**
- **TASK-717** — a Hermes box linked to ClawBox AI before the cloud-voice wiring existed never speaks. Nothing re-runs the link, and the owner has no reason to: Settings already says ClawBox AI is connected.
- **TASK-718** — a box that WAS on the entitled plan and drops keeps `tts.openai.*` pointing at an endpoint the proxy now answers 403 to, and buys a refused round trip on every spoken reply and every `text_to_speech` call.

**Cause.** `applyClawaiToHermes` is the only thing on this edition that ever points `tts.provider` at the ClawBox AI proxy, and all three of its callers are an explicit (re-)link. The OpenClaw edition has had both arms since TASK-459 — `gateway-pre-start.sh` gates on `_clawai_speech_entitled` and has the `elif` that takes its own stamped entry back. Hermes has no `gateway-pre-start.sh` and had neither.

### The native mechanism, named

**`hermes config set` / `hermes config unset`** — the harness's own configuration surface, and the same commands `src/lib/hermes-tts.ts` issues for the Settings toggle, so the boot repair and the panel cannot drift into writing the config two different ways. Confirmed present on the pinned build read-only from a box: `hermes config {show,edit,get,set,unset,path,env-path,check,migrate}`.

What the harness does **not** have is any notion of an entitlement: `tts.provider` is a plain selection with no plan attached, and the tier lives only in ClawBox's device store because only ClawBox talks to the portal. That is the gap this fills, and it fills it with the harness's own writer rather than a second one — `patchHermesConfig` (the comment-preserving Node writer the Settings toggles use) cannot take `${HERMES_CONFIG}.lock`, so a boot hook in the web server would have been a second, unlocked writer racing this script.

**Where it lives** is the same answer §4b already gives for the background-job seed: `scripts/register-mcp.sh` is this repo's Hermes counterpart of the OpenClaw pre-start (`production-server.js` names it as such and fire-and-forgets it on every web-server boot on `hermes|dual`), and it already holds the config lock while it read-modify-writes the same file.

### The decision, in one place

A python step emits exactly one verdict — `arm`, `refresh`, `withdraw`, or `hold <why>` — and the shell below it only writes.

- **Arm** (entitled, `tts.provider` unchosen, the slot ours or empty): endpoint, credential and model, then the selection. Definition before selection, so a failure leaves `tts.provider` untouched rather than selecting a provider with nowhere to send a request.
- **Refresh** (already speaking through us): the definition only, never the selection — the portal rotates the token on a re-link and this script is the only thing on the boot path that would notice.
- **Withdraw** (a tier we have been told, and it is not the entitled one): the endpoint, credential and model, and deliberately **not** `tts.provider`. That is the ruling the OpenClaw arm already records: the panel's job is to show the owner that their choice is no longer available, and silently rewriting it would hide the downgrade. Removing the DEFINITION is what stops the refused calls.
- **Hold**, with a reason on the boot log for every one of them, because "nothing happened" is the one outcome an operator cannot tell apart from "this step is not running".

**Not knowing is never an answer, in either direction.** An absent, unreadable or non-object device store; a `config.yaml` that will not parse; a tier that is not recorded at all — every one holds. Only a tier we have actually been told, and a slot we can positively see is ours, moves anything.

**The owner's voice is the owner's.** The arm moves `tts.provider` only from unset, Hermes' factory `edge`, or `clawbox-local` on a box that provably has **no on-device engine** — `localTtsEngineInstalled` is `stamped AND the unit is present`, so an absent `~/.cache/clawbox/kokoro-installed` settles it with one file test and no systemd bus. That third case is the box TASK-717 is about: `install.sh` `step_openclaw_tts` selects `clawbox-local` whatever the engine answered (deliberately — an absent `tts.provider` resolves to Microsoft's Edge cloud on Hermes, so an engineless box is left honestly mute rather than speaking through a third party), so "no TTS engine" reads as a chosen local voice. The engine question is asked in **all three** unchosen states, not only over `clawbox-local`: `step_openclaw_tts` has one arm that leaves the key unset, and moving a box off its own voice is effectively permanent.

**The withdrawal requires an ADDRESS of ours, never the credential.** `hermesCloudRouteIsOurs`'s looser reading — our own `claw_` token at an address of the owner's counts as ours — is fine for a refresh, whose worst case is our own fields rewritten to our own values. It is not enough to DELETE, for exactly the reason `gateway-pre-start.sh`'s own delete arm gives: an owner can point our token at an endpoint of their choosing, and that entry is theirs. So the withdrawal matches `base_url` against the shared `CLAWBOX_AI_PROXY_URLS` set (current host plus the two retired ones, so a box linked under a previous address is still recognisably ours) and against nothing else.

### RED → GREEN

RED, against unmodified `origin/beta` with only the new test file added — **15 of 27 cases fail**, including every arm and every withdrawal:

```
 × points an entitled, unvoiced box at the proxy and selects it
 × writes the definition BEFORE it selects the provider
 × adopts Hermes' factory `edge` selection, which is nobody's choice
 × gives an engineless box on `clawbox-local` the voice its plan includes
 × leaves an owner's own OpenAI-compatible speech server alone
 × costs no config write at all once the voice is armed
 × refreshes a rotated token rather than leaving a 401 in the slot
 × takes the endpoint, credential and model back when the plan drops
 × leaves the owner's SELECTION where it is
 × never touches an owner's own speech server, even with their key in it
 × withdraws an entry left on a proxy address we have since moved off
 × does not withdraw over a tier nobody has told us
 × holds, and says why, when there is no device store at all
 × holds over a device store that is not JSON
 × reports a refused write rather than claiming the voice was armed
```

GREEN on this head: that file 27/27, the neighbouring script and voice suites **9 files / 197 tests**, full `npm run test:unit` **12378 passed | 1 skipped**, `tsc --noEmit` clean, `bash -n` clean on both touched scripts.

### Device leg — read-only, on the Hermes box

The block's plan step was extracted from the shipped script and run against that box's **real** `~/.hermes/config.yaml` and `data/config.json`, read-only, with nothing written and no mutex taken (the device lock was held by other work at the time, so nothing beyond reads was done):

```
== dry run of the section 4a plan against this box's REAL files (read-only) ==
hold the cloud voice is already armed
```

That is the convergence proof a mocked CLI cannot give: the box is entitled (`clawai_tier` = the entitled device tier), holds a credential, and already carries `tts.openai.{base_url,model,api_key}` written by the link path through `hermes config set` — and the block recognises its own writes byte for byte and spends **zero** CLI calls. Also confirmed there: `hermes config unset` exists on the pinned build, the Kokoro stamp and unit are both present, and the slot's key is the device token (compared as a boolean; no credential was printed).

### Cost

| Boot | `hermes` spawns |
|---|---|
| steady state (armed, or held for any reason) | **0** |
| arm | 4 |
| refresh (rotated token) | 3 |
| withdraw | 3 |

The four writes share **one** collective `HERMES_CLI_TIMEOUT` budget rather than one each, and each call is bounded by what is left. That matters because this runs inside `${HERMES_CONFIG}.lock` and `setup-hermes-dashboard-auth.sh` waits exactly `flock -w 120` before proceeding **without** it — four independent 45 s ceilings would have added up to 200 s to the hold on their own. Running out of budget is reported and retried on the next boot, which is the safe direction; a lock held past 120 s is not.

### Sibling call sites swept

| Writer of `tts.*` on Hermes | Status |
|---|---|
| `writeHermesCloudTarget` / `selectHermesProvider` (`hermes-tts.ts`) — the Voice panel and the link path | unchanged; the two now share the same key names and constants, pinned by a test |
| `applyClawaiToHermes` → `selectHermesCloudVoiceIfUnvoiced` | unchanged; it has a live engine probe this boot cannot afford and still owns the richer decision |
| `install.sh` `step_openclaw_tts` | unchanged, and it does not fight this: it selects `clawbox-local` from unset/`edge`/`clawbox-local` and preserves anything else as the owner's choice, so an armed box reads as chosen and is left alone |
| `scripts/register-mcp.sh` §4a | **new** |

**Three comments elsewhere asserted a premise this PR removes**, and one of them was load-bearing rather than decorative: `gateway-pre-start.sh` justified the looser Hermes ownership rule with "it needs no delete arm at all because it HAS no destructive path". That is now false, so the ruling is rewritten in the same PR to say that the Hermes DELETE is held to the stricter address rule while the refresh keeps the looser one. The two "only writer of `tts.openai.*`" claims in `hermes-clawai.ts` are corrected to "the only writer on the LINK path".

### Editions

- The block is **edition-gated, not harness-gated** — §1 makes the whole script a no-op on `edition=openclaw`, and on `dual` it runs whichever harness is currently active. That is the same choice §4b documents: the web server is not restarted when the owner switches harness, so a block that asked which harness was active at boot would leave a switched-over box unvoiced. Both are pinned by tests, including one that arms a `dual` box and asserts `~/.openclaw` is untouched.
- The OpenClaw edition already has both arms in `gateway-pre-start.sh` and is not changed here — its only edit is the corrected ruling comment quoted above. `gateway-pre-start-clawai-speech.test.ts` is unchanged and green.
- **Images are deliberately not part of this**, and that is measured rather than assumed: the proxy publishes `modelTiers: {"gpt-image-1-mini": ["free","pro","max"]}`, so the image backend has no tier to be downgraded from, and the "Re-arm the ClawAI image backend" block already reconciles it every boot.

### Bug classes

- *Probe-once*: the whole of TASK-717 — an entitlement applied once, at link time, and never revisited. The block re-decides at every boot from facts on disk and records nothing behind a marker, so a boot that got part way is simply offered the whole thing again.
- *False success*: a `hermes config set` that did not land must never be reported as a voice. Each write is checked, the sequence stops at the first failure, the selection is never made over a definition that did not land, and every failure line carries the CLI's real exit status — captured inside the `else`, because `$?` after `fi` is the `if` statement's own 0 and would print "(exit 0)" on every failure.
- *False failure*: an unreadable store, an unparseable config or an unrecorded tier all hold rather than withdraw, and a withdrawal needs a positive address of ours.

### Explicit owner picks (#747)

Untouched, and nothing here can reach them: `ai_model_explicit_picks` records model choices, and this block writes only `tts.*`. The voice has no equivalent marker because it needs none — the owner's pick IS `tts.provider`, and it is only ever moved from a value that means nobody has chosen.

### Deliberately not in this PR

- **The withdrawal does not reset `tts.provider`.** A downgraded box left on `openai` with the definition gone speaks nothing and the panel says so honestly, which is the OpenClaw ruling; giving it back a voice would mean choosing one for the owner.
- **The worst-case lock hold.** It was ~100 s before this change (two bounded CLI calls) and is now ~150 s with the arm's collective budget, against the 120 s the cooperating writer waits. The arm boot is a one-off transition and the measured per-call cost is a few seconds, but the arithmetic is stated rather than hidden; raising that waiter's `-w` belongs with whoever owns it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - ClawBox AI cloud voice is configured automatically when an eligible device starts.
  - Voice settings, including the service endpoint, credentials, and model, refresh when configuration changes.
  - Cloud voice access is withdrawn when a device is no longer on an eligible plan.

- **Bug Fixes**
  - Improved safeguards apply voice configuration only when device ownership and eligibility are positively confirmed.
  - Added reliable handling for repeated, incomplete, or unsuccessful configuration updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->