### PR TITLE
fix: close the eleven CodeQL alerts left open on beta after #752

### DIFF
--- a/src/app/setup-api/files/route.ts
+++ b/src/app/setup-api/files/route.ts
@@ -109,12 +109,49 @@ export const dynamic = "force-dynamic";
 
 const BASE_DIR = filesBrowseRoot();
 
+/**
+ * The absolute path one request may name, or null.
+ *
+ * SAME RULE, ONE TERM AT A TIME. The two cases used to share a condition —
+ * `resolved !== base && !resolved.startsWith(base + path.sep)` — and that is
+ * what kept `js/path-injection` open on every fs call downstream of this
+ * helper (alerts #523-#528, and the dismissed #247/#248 before them). A
+ * containment check only vouches for the path when reaching the code after it
+ * REQUIRED the check to pass: with the two terms `&&`-ed, the fall-through is
+ * reachable through `resolved === base` without the prefix test having decided
+ * anything, so the check governs nothing an analyser — or a reader — can rely
+ * on. Split, each line is the only way past itself.
+ *
+ * The base case answers with the ROOT'S OWN string. It is the same value
+ * `resolved` holds there (they are equal, which is why that branch is taken),
+ * but it is the constant this module built rather than the request's spelling
+ * of it, so nothing of the request survives into the `""` answer.
+ *
+ * The accepted set is unchanged, deliberately and exactly: an absolute path
+ * that already lies under the root is still accepted (the Coding Agent's "Open
+ * in Files" sends one), a name beginning `..` — `~/..hidden` — is still a
+ * legitimate entry rather than a traversal, and everything that resolved
+ * outside the root is still refused. `isInside()` would have been the shorter
+ * spelling and is NOT equivalent: its `rel.startsWith("..")` refuses
+ * `~/..hidden`, and the Files app has always listed it.
+ *
+ * THE SAME SHAPE IS STILL SPELLED IN SIX OTHER PLACES, and none of them is
+ * reported: `files/[...path]/route.ts:65` and `:148` (this API's other half,
+ * whose input is a Next dynamic-route `params` value — not a source the query
+ * models), `webapps/route.ts:171`, `chat/attachments/route.ts:229`,
+ * `chat/media/route.ts:211` and `harness/media-root.ts:194` (each already
+ * fenced through a realpath). The rule above is about all of them, so anyone
+ * next in one of those files should take the two-line split with them; not
+ * doing it here keeps this change to the sinks the alerts name.
+ */
 function safePath(rel: string): string | null {
   const base = path.resolve(BASE_DIR);
   const resolved = path.resolve(base, rel);
-  // Require either an exact base match or a path inside base (with separator),
-  // otherwise sibling dirs like "/home/clawboxmalicious" would slip through.
-  if (resolved !== base && !resolved.startsWith(base + path.sep)) return null;
+  // The browse root itself.
+  if (resolved === base) return isProtectedFilePath(base) ? null : base;
+  // Anything else must be INSIDE it (with the separator, otherwise sibling
+  // dirs like "/home/clawboxmalicious" would slip through).
+  if (!resolved.startsWith(base + path.sep)) return null;
   // The browse root is $HOME, so secret stores (.ssh, .openclaw, the data/
   // tokens) sit inside the sandbox — deny them at the single resolve chokepoint
   // that every read/write/rename/download path funnels through.

--- a/src/app/setup-api/tts/route.ts
+++ b/src/app/setup-api/tts/route.ts
@@ -45,6 +45,7 @@ import { wireLocalVoice } from "@/lib/voice-local-wiring";
 import { getVoiceAutoReply, setVoiceAutoReply, ttsAutoModeFor } from "@/lib/voice-reply";
 import { hasOwnerSession } from "@/lib/owner-session";
 import { isSameOriginRequest } from "@/lib/same-origin";
+import { logSafe } from "@/lib/log-safe";
 
 /**
  * GET  /setup-api/tts            → who speaks for this box
@@ -70,9 +71,15 @@ const NO_STORE = { "Cache-Control": "no-store" };
  * of one of these words. Both spell the same four things and no request can
  * tell them apart — but the failure line below names the action, and a string
  * read off `request.json()` is what CodeQL reports as `js/log-injection`
- * (TASK-723). It does not recognise `logSafe` as a barrier (the note in
- * ai-models/configure/route.ts says so); a value that came out of a literal
- * array is not the request's string at all.
+ * (TASK-723). A value that came out of a literal array is not the request's
+ * string at all, and that IS a barrier the query accepts: measured against the
+ * query itself (TASK-742), `action` appears in no reported flow on this route.
+ * The alert that stayed open on beta after that change (#464) was never about
+ * this half — it ends at the `err` argument of the same `console.warn` — so it
+ * is not evidence against the array, and the comment at that line owns it.
+ *
+ * `logSafe` alone is not a barrier that query recognises (the note in
+ * ai-models/configure/route.ts says so, and it is right); `JSON.stringify` is.
  */
 const ACTIONS = ["select", "voice", "language", "autoReply"] as const;
 
@@ -505,7 +512,39 @@ export async function POST(req: Request) {
     if (action === "autoReply") return await handleAutoReply(enabled);
     return await handleSelect(choice as VoiceChoice);
   } catch (err) {
-    console.warn(`[setup-api/tts] ${action} failed:`, err);
+    // THE ERROR, NOT THE ACTION, is what CodeQL reported here (#464), and the
+    // note above `ACTIONS` was answering the wrong half: `action` never
+    // appeared in the flow — the array selection is a barrier that query does
+    // accept. The path it does report is
+    // `req.json()` -> `body.voice` -> `handleVoice` ->
+    // `runOpenclawConfigSet([…, voice])` -> the CLI's own failure ->
+    // `openclaw-config.ts`'s wrapper -> this `err`, so the value written to
+    // the journal is the openclaw CLI's stderr with the request's own string
+    // inside it, at whatever length and with whatever newlines it carries.
+    //
+    // `logSafe` bounds the record (one value, one line, capped) and
+    // `JSON.stringify` is what the query recognises as a barrier —
+    // `ai-models/configure/route.ts` reaches for the same pair at its own two
+    // flagged lines. The STACK goes with this, deliberately: what is worth
+    // reading here is which action failed and what the harness said, and the
+    // frames are of this route's own `await`s.
+    //
+    // A WIDER CAP THAN THE HOUSE DEFAULT, because this line is the whole
+    // record. `spawnOpenclaw` rejects with the CLI's entire stderr as the
+    // message (`openclaw-config.ts`), the panel is told a fixed sentence, and
+    // nothing else on the box writes that stderr anywhere — so 200 characters
+    // of plugin-load noise plus `...[+N chars]` would BE the failure report.
+    // Still bounded, and still one line: the rule is that one caller does not
+    // decide how much gets written, not that little is.
+    //
+    // The GET path's own line (`status()` below) still logs the raw error, and
+    // that is deliberate: it takes no `Request`, so neither half of this rule —
+    // an injected record, a caller-sized one — can reach it, and its stack is
+    // worth keeping.
+    console.warn(
+      `[setup-api/tts] ${action} failed:`,
+      JSON.stringify(logSafe(err instanceof Error ? err.message : String(err), 600)),
+    );
     // A harness that refused the write is a 409 the panel can explain, not a
     // 500: the box is reachable and said no. Anything else really is a fault.
     if (err instanceof HermesTtsWriteError) {

--- a/src/lib/code-projects.ts
+++ b/src/lib/code-projects.ts
@@ -115,11 +115,21 @@ function assertProjectName(name: unknown): string {
  * own: a local constant of the same name shadowed that function here, so the
  * one root in this module that still joined the caller's string was the one
  * every `code_file_*` write and delete resolves against.
+ *
+ * ONE TERM AT A TIME, for the reason `src/app/setup-api/files/route.ts` states
+ * over its own copy of this shape: `!resolved.startsWith(dir + path.sep) &&
+ * resolved !== dir` leaves the code below reachable through the second term
+ * without the prefix test having decided anything, so the containment check
+ * governs nothing that follows — which is why every fs call downstream of this
+ * helper stayed on the `js/path-injection` list (alert #529 and its siblings).
+ * The project root answers with `projectDir`'s own string, which is the value
+ * `resolved` holds in that branch; the accepted set does not move.
  */
 function safePath(projectId: string, filePath: string): string {
   const dir = projectDir(projectId);
   const resolved = path.resolve(dir, filePath);
-  if (!resolved.startsWith(dir + path.sep) && resolved !== dir) {
+  if (resolved === dir) return dir;
+  if (!resolved.startsWith(dir + path.sep)) {
     throw new ValidationError("Path traversal denied");
   }
   return resolved;

--- a/src/lib/harness-mcp-refresh.ts
+++ b/src/lib/harness-mcp-refresh.ts
@@ -1,4 +1,5 @@
 import { reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reload";
+import type { Harness } from "@/lib/harness";
 
 /**
  * Ask the agent to rebuild its tool list when the ACTIVE HARNESS moved under it.
@@ -36,6 +37,26 @@ import { reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reloa
  */
 
 /**
+ * One harness name, in a word this module spells itself.
+ *
+ * A `Record<Harness, …>` rather than a `switch`, so a third harness added to
+ * the union is a compile error here rather than a journal line that silently
+ * reads "an unrecognised harness" for it.
+ *
+ * The parameter stays `string` because that is what the callers have: both
+ * arguments reach this module from the body of `POST /setup-api/harness/select`.
+ * The fall-through is therefore not decoration — a caller handing this a value
+ * the device does not run must not have it echoed into the journal — even
+ * though it is unreachable through that route today, which admits the two
+ * names and nothing else.
+ */
+const HARNESS_NAMES: Record<Harness, string> = { openclaw: "openclaw", hermes: "hermes" };
+
+function harnessName(value: string): string {
+  return HARNESS_NAMES[value as Harness] ?? "an unrecognised harness";
+}
+
+/**
  * Reload the MCP servers iff this request actually changed the active harness.
  *
  * Both directions, and the reload goes to HERMES either way — it is the only
@@ -70,7 +91,16 @@ export async function refreshHarnessToolsIfSwitched(
   // another request may have moved in between.
   if (before === after) return false;
 
-  const moved = `the active harness moved from ${before} to ${after}`;
+  // The LINE is spelled from this module's own literals; the COMPARISON above
+  // keeps the raw values. Both halves matter: `before` and `after` reach here
+  // from the body of `POST /setup-api/harness/select`, so the journal line
+  // built from them is `js/log-injection` (#516-#518, in all three places it
+  // is written) — and `isHarness()` narrowing the body's field is exactly the
+  // `.test()`-shaped guard that leaves the caller's string in play, the same
+  // thing #464 says about `ACTIONS.find`. Rebuilding before the comparison
+  // would be the worse bug: two unknown-but-different values would collapse
+  // onto one word and a real move would report as a re-select.
+  const moved = `the active harness moved from ${harnessName(before)} to ${harnessName(after)}`;
   // `.catch` even though `reloadMcpServers` documents that it never throws: the
   // promise it makes is to the OWNER'S SWITCH, which is already persisted, and
   // it must not depend on a neighbouring module keeping its own.

--- a/src/lib/hermes-mcp-reload.ts
+++ b/src/lib/hermes-mcp-reload.ts
@@ -1,5 +1,6 @@
 import { getActiveHarness } from "@/lib/harness";
 import { dashboardRpc } from "@/lib/hermes-dashboard-rpc";
+import { logSafe } from "@/lib/log-safe";
 
 /**
  * Ask Hermes to rebuild its MCP tool list, for every caller that needs to.
@@ -99,13 +100,23 @@ export async function reloadMcpServers(): Promise<boolean> {
  *              became available"
  */
 export async function reportMcpReloadRefused(tag: string, what: string): Promise<void> {
+  // BOUND THE RECORD, whoever the caller is. Five families share these two
+  // lines — `hermes-image-refresh`, `email-mcp-refresh`, `provider-mcp-refresh`,
+  // `coding-agent-mcp-refresh` and `harness-mcp-refresh` — and one of them
+  // (`provider-mcp-refresh`) builds `what` by joining a provider list whose
+  // length nothing here decides, so one value stays one line and one caller
+  // does not decide how much gets written. It is not a barrier CodeQL
+  // recognises and is not offered as one — the values that reach the journal
+  // are rebuilt at their own source (see `harness-mcp-refresh.ts`); this is the
+  // record's own rule.
+  const line = `[${logSafe(tag, 60)}] ${logSafe(what)}`;
   const harness = await getActiveHarness().catch(() => null);
   if (harness !== null && harness !== "hermes") {
     console.log(
-      `[${tag}] ${what}; this edition has no dashboard to ask — the tool list re-probes `
+      `${line}; this edition has no dashboard to ask — the tool list re-probes `
         + "when the MCP server is next spawned",
     );
     return;
   }
-  console.error(`[${tag}] ${what}, but the agent would not reload its MCP servers`);
+  console.error(`${line}, but the agent would not reload its MCP servers`);
 }

--- a/src/lib/provider-mcp-refresh.ts
+++ b/src/lib/provider-mcp-refresh.ts
@@ -1,5 +1,6 @@
 import { getModelOptions } from "@/lib/hermes-model-options";
 import { reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reload";
+import { logSafe } from "@/lib/log-safe";
 
 /**
  * Ask the agent to re-advertise WHICH PROVIDERS it may switch this device to,
@@ -140,7 +141,11 @@ function describeMove(before: readonly string[], after: readonly string[]): stri
   const parts: string[] = [];
   if (gained.length > 0) parts.push(`gained ${gained.join(", ")}`);
   if (lost.length > 0) parts.push(`lost ${lost.join(", ")}`);
-  return `the providers this box can be switched to ${parts.join(" and ")}`;
+  // Bounded HERE, not at one of the three lines that write it. The list's
+  // length is the catalogue's, not this module's, and `reportMcpReloadRefused`
+  // bounding its own arm left the two success lines — the ones a healthy box
+  // actually writes — carrying the whole of it.
+  return logSafe(`the providers this box can be switched to ${parts.join(" and ")}`);
 }
 
 /**

--- a/src/tests/routes/files/safe-path-containment.test.ts
+++ b/src/tests/routes/files/safe-path-containment.test.ts
@@ -1,0 +1,256 @@
+import fs from "fs";
+import fsp from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+/**
+ * TASK-742 — the Files API's containment check, and the equivalence that had
+ * to hold while its SHAPE changed.
+ *
+ * `safePath()` refused a path outside the browse root with ONE condition
+ * spelling two rules: `resolved !== base && !resolved.startsWith(base +
+ * path.sep)`. That is correct and it is not a check the code below it can lean
+ * on: the fall-through is reachable through the FIRST term without the prefix
+ * test having decided anything, so nothing after the `if` was actually
+ * governed by containment. CodeQL says the same thing in its own words — every
+ * fs call downstream stayed on the `js/path-injection` list (#523-#528 on
+ * beta, the dismissed #247/#248 before them, and #529 for the identical
+ * spelling in `code-projects.ts`).
+ *
+ * Split into two statements, each line is the only way past itself, and the
+ * accepted set must not move by a single string — the Files app is where the
+ * customer's own documents are, and a rule that got stricter would orphan
+ * files that are on the box today with no error anyone could act on.
+ *
+ * So this file probes the ROUTE (through `{action:"resolve"}`, the one action
+ * that answers `safePath`'s verdict directly) against a spelled-out copy of
+ * beta's predicate over a few thousand strings — traversal, absolutes,
+ * separators, dots, NUL, lone surrogates, trailing newlines, both length
+ * bounds — and requires zero divergences. The copy uses the REAL
+ * `isProtectedFilePath`, so only the containment half is being compared.
+ */
+
+const TEST_ROOT = path.join(fs.realpathSync(os.tmpdir()), `clawbox-files-safepath-${process.pid}-${Date.now()}`);
+
+/**
+ * NUL, by code point. A raw one in the source makes git call this file binary
+ * — no diff, and nothing for a reviewer or a review bot to read — so every
+ * character a path may carry that a text file may not is written this way.
+ */
+const NUL = String.fromCharCode(0);
+
+type RouteHandler = (req: NextRequest) => Promise<Response>;
+let filesPost: RouteHandler;
+
+/**
+ * The REAL protection rule, resolved after `CLAWBOX_ROOT` points at this
+ * fixture — a static import would bind `file-guard` to the suite-wide root and
+ * quietly compare two different `data/` directories, which is a divergence in
+ * the harness rather than in the predicate.
+ */
+let isProtectedFilePath: (abs: string) => boolean;
+
+/** Beta's predicate, verbatim apart from the constant it resolves against. */
+function betaSafePath(rel: string): string | null {
+  const base = path.resolve(TEST_ROOT);
+  const resolved = path.resolve(base, rel);
+  if (resolved !== base && !resolved.startsWith(base + path.sep)) return null;
+  if (isProtectedFilePath(resolved)) return null;
+  return resolved;
+}
+
+/** What the route answers for one path: the absolute path, or null for a refusal. */
+async function routeSafePath(rel: string): Promise<string | null> {
+  const req = new NextRequest(new URL("http://localhost/setup-api/files"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action: "resolve", filePath: rel }),
+  });
+  const res = await filesPost(req);
+  if (res.status === 400) return null;
+  expect(res.status).toBe(200);
+  return (await res.json()).absPath as string;
+}
+
+async function expectAgreement(probes: readonly string[]): Promise<void> {
+  const divergences: Array<{ probe: string; beta: string | null; head: string | null }> = [];
+  for (const probe of probes) {
+    const head = await routeSafePath(probe);
+    const beta = betaSafePath(probe);
+    if (head !== beta) divergences.push({ probe, beta, head });
+  }
+  // The whole list, not the first one: a rule that moved has moved for a CLASS
+  // of paths, and one example does not say which.
+  expect(divergences).toEqual([]);
+}
+
+beforeAll(async () => {
+  process.env.FILES_ROOT = TEST_ROOT;
+  process.env.CLAWBOX_ROOT = TEST_ROOT;
+  await fsp.mkdir(TEST_ROOT, { recursive: true });
+  vi.resetModules();
+  ({ POST: filesPost } = await import("@/app/setup-api/files/route"));
+  ({ isProtectedFilePath } = await import("@/lib/file-guard"));
+});
+
+afterAll(async () => {
+  delete process.env.FILES_ROOT;
+  delete process.env.CLAWBOX_ROOT;
+  await fsp.rm(TEST_ROOT, { recursive: true, force: true });
+});
+
+describe("the Files API containment check judges every path beta accepted", () => {
+  it("agrees on the shapes a traversal is spelled with", async () => {
+    const base = path.resolve(TEST_ROOT);
+    await expectAgreement([
+      "..",
+      "../",
+      "../..",
+      "../../etc/passwd",
+      "./..",
+      "a/../..",
+      "a/b/../../..",
+      "a/./b",
+      "a//b",
+      "a/b/",
+      ".",
+      "./",
+      "/",
+      "//",
+      "///etc/passwd",
+      "/etc/passwd",
+      "/etc/../etc/passwd",
+      `${base}`,
+      `${base}/`,
+      `${base}/Documents`,
+      `${base}/../${path.basename(base)}x`,
+      `${base}x`,
+      `${base}x/inside`,
+      // A NAME that starts with dots is an ordinary entry, not a traversal —
+      // the case `isInside()`'s `rel.startsWith("..")` gets wrong and the
+      // reason this predicate was not rewritten in terms of it.
+      "..hidden",
+      "..hidden/child",
+      "...",
+      ".hidden",
+      "a/..hidden",
+      String.fromCharCode(92),
+      `..${String.fromCharCode(92)}..`,
+      `a${String.fromCharCode(92)}b`,
+    ]);
+  });
+
+  it("agrees on the values a string can carry that a path cannot", async () => {
+    await expectAgreement([
+      NUL,
+      `a${NUL}b`,
+      `a${NUL}/../..`,
+      "a\n",
+      "a\r\n",
+      "\n..",
+      "a\t b",
+      " ",
+      "  /  ",
+      "a ",
+      " a",
+      "\ud800",
+      "\udfff",
+      "a\ud800b",
+      "😀",
+      "😀/😀",
+      "café/naïve",
+      "Документы/файл.txt",
+      // U+202E RIGHT-TO-LEFT OVERRIDE, spelled by code point: a raw one in
+      // this file would be a bidi override in the repository's own source.
+      String.fromCharCode(0x202e) + "gnp.exe",
+      "a".repeat(255),
+      "a".repeat(4096),
+      `${"a/".repeat(400)}b`,
+    ]);
+  });
+
+  it("agrees on the box's own stores, which are inside the browse root", async () => {
+    await expectAgreement([
+      "data",
+      "data/config.json",
+      "data/.session-secret",
+      ".ssh",
+      ".ssh/id_ed25519",
+      ".openclaw",
+      ".openclaw/openclaw.json",
+      ".config",
+      ".config/gh/hosts.yml",
+      "Documents/notes.txt",
+      "Downloads",
+      "a/data/config.json",
+    ]);
+  });
+
+  it("agrees over a few thousand generated paths", async () => {
+    // A deterministic corpus — a failure has to be reproducible to be worth
+    // anything — built from the pieces that decide this predicate: separators,
+    // dot runs, the base's own prefix, and the characters that break naive
+    // string handling.
+    const pieces = [
+      "..", ".", "a", "bb", "ccc", "", "/", "//", String.fromCharCode(92),
+      " ", "\t", "\n", NUL, "\ud800", "😀", "é", "Ω",
+      ".hidden", "..hidden", "data", ".ssh", path.resolve(TEST_ROOT), "~",
+    ];
+    let seed = 0x5eed742;
+    const next = () => {
+      // xorshift32 — a generator whose whole state is in this file, so the
+      // corpus is the same on every machine and in every re-run.
+      seed ^= seed << 13; seed >>>= 0;
+      seed ^= seed >>> 17;
+      seed ^= seed << 5; seed >>>= 0;
+      return seed;
+    };
+    const probes: string[] = [];
+    for (let i = 0; i < 3000; i++) {
+      const parts = 1 + (next() % 5);
+      let probe = "";
+      for (let p = 0; p < parts; p++) {
+        probe += pieces[next() % pieces.length];
+        if (p + 1 < parts && next() % 2 === 0) probe += "/";
+      }
+      // `""` is not probeable through this door — the route answers 400
+      // `filePath required` before `safePath` is asked — and the empty path is
+      // covered by the base-directory cases above.
+      if (probe !== "") probes.push(probe);
+    }
+    await expectAgreement(probes);
+  });
+});
+
+describe("the containment check is one statement of its own", () => {
+  // A source pin, not a taste one: re-merging the two rules into a single
+  // condition restores exactly the shape that kept #523-#529 open, and every
+  // behavioural test above would still pass.
+  const read = (rel: string) => fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+
+  function bodyOf(source: string, anchor: string): string {
+    const start = source.indexOf(anchor);
+    expect(start).toBeGreaterThan(-1);
+    const end = source.indexOf(`${String.fromCharCode(10)}}`, start);
+    expect(end).toBeGreaterThan(start);
+    return source.slice(start, end);
+  }
+
+  it("holds the prefix test alone in the Files route", () => {
+    const body = bodyOf(read("src/app/setup-api/files/route.ts"), "function safePath(rel: string)");
+    expect(body).toContain("if (!resolved.startsWith(base + path.sep)) return null;");
+    expect(body).not.toMatch(/resolved !== base &&/);
+    // The base's own answer is the constant this module built, not the
+    // request's spelling of it.
+    expect(body).toContain("if (resolved === base) return isProtectedFilePath(base) ? null : base;");
+  });
+
+  it("holds the prefix test alone in the code-project store", () => {
+    const body = bodyOf(read("src/lib/code-projects.ts"), "function safePath(projectId: string");
+    expect(body).toContain("if (resolved === dir) return dir;");
+    expect(body).toContain("if (!resolved.startsWith(dir + path.sep)) {");
+    expect(body).not.toMatch(/&& resolved !== dir/);
+  });
+});

--- a/src/tests/routes/tts-error-log-bound.test.ts
+++ b/src/tests/routes/tts-error-log-bound.test.ts
@@ -109,7 +109,14 @@ describe("a failed voice write writes one bounded journal line", () => {
     const res = await POST(post({ action: "language", language: "en" }));
     expect(res.status).toBe(500);
 
-    const line = String((warnSpy.mock.calls.at(-1) as [string, unknown])[1]);
+    // ONE record, and the route's own prefix on it, before reading the detail:
+    // `at(-1)` alone would be satisfied by a sanitised second line written after
+    // an unsanitised first one, which is exactly the regression this case is
+    // for.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [prefix, detail] = warnSpy.mock.calls.at(-1) as [string, unknown];
+    expect(prefix).toBe("[setup-api/tts] language failed:");
+    const line = String(detail);
     expect(line.split(String.fromCharCode(10))).toHaveLength(1);
     expect(line).not.toContain(`${String.fromCharCode(10)}WARN`);
   });

--- a/src/tests/routes/tts-error-log-bound.test.ts
+++ b/src/tests/routes/tts-error-log-bound.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
  * TASK-742 — what `POST /setup-api/tts` writes into the journal when a write
@@ -67,6 +67,14 @@ beforeEach(() => {
   warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 });
 
+// Explicit, though `restoreMocks` in vitest.config.ts already restores every
+// spy between tests and the first case pins `toHaveBeenCalledTimes(1)`, which
+// is what would fail if history carried over. Stated here so the file does not
+// depend on a global setting it does not own.
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
 describe("a failed voice write writes one bounded journal line", () => {
   it("logs the harness's message as one capped, quoted value", async () => {
     writeStateMock.mockRejectedValue(new Error(CLI_STDERR));
@@ -101,7 +109,7 @@ describe("a failed voice write writes one bounded journal line", () => {
     const res = await POST(post({ action: "language", language: "en" }));
     expect(res.status).toBe(500);
 
-    const line = String((warnSpy.mock.calls[0] as [string, unknown])[1]);
+    const line = String((warnSpy.mock.calls.at(-1) as [string, unknown])[1]);
     expect(line.split(String.fromCharCode(10))).toHaveLength(1);
     expect(line).not.toContain(`${String.fromCharCode(10)}WARN`);
   });

--- a/src/tests/routes/tts-error-log-bound.test.ts
+++ b/src/tests/routes/tts-error-log-bound.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * TASK-742 — what `POST /setup-api/tts` writes into the journal when a write
+ * fails, and why alert #464 outlived the fix that was aimed at it.
+ *
+ * The card, and the note over `ACTIONS` in the route, both read the alert as
+ * being about the ACTION name. It is not. Run against the query itself, the
+ * reported flow is
+ *
+ *   `req.json()` -> `body.voice` -> `handleVoice` ->
+ *   `runOpenclawConfigSet([…, voice])` -> the CLI's failure ->
+ *   `openclaw-config.ts`'s wrapper -> `err` -> `console.warn(…, err)`
+ *
+ * and it ends at the SECOND argument. `ACTIONS.find` was a barrier the query
+ * accepts all along; the failure line's other half was never bounded at all,
+ * so an `openclaw` stderr — which quotes the request's own strings — reached
+ * the journal at whatever length and with whatever newlines it carried.
+ *
+ * What is pinned here is the RECORD: one failure, one line, capped, whatever
+ * the harness said. The `language` action is the shortest way to a thrown
+ * write; the rule belongs to the `catch`, which every action shares.
+ */
+
+const writeStateMock = vi.fn();
+
+vi.mock("@/lib/voice-output-store", () => ({
+  readVoiceState: async () => ({}),
+  writeVoiceState: (...a: unknown[]) => writeStateMock(...a),
+  readLocalVoice: async () => null,
+  writeLocalVoice: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/openclaw-config", () => ({
+  readConfig: async () => ({}),
+  runOpenclawConfigSet: vi.fn(async () => {}),
+  openclawIsAbsent: () => false,
+}));
+
+// `@/lib/config-store` is deliberately NOT mocked: the suite already points
+// `CLAWBOX_ROOT` at a temp directory of its own, and a factory that named only
+// the two functions this route reaches would drop `DATA_DIR` — the mock hole
+// #755 closed in three files and #756 re-opened in a fourth.
+
+function post(body: unknown) {
+  return new Request("http://box/setup-api/tts", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// A message shaped like the one the openclaw CLI hands back: the failing
+// assignment quoted, then the child's stderr, then more of it than a log line
+// should ever carry.
+const CLI_STDERR = [
+  "openclaw config set failed",
+  "  path: tts.providers.openai.voice",
+  `  stderr: ${"z".repeat(1200)}`,
+].join(String.fromCharCode(10));
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.resetModules();
+  writeStateMock.mockReset();
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+describe("a failed voice write writes one bounded journal line", () => {
+  it("logs the harness's message as one capped, quoted value", async () => {
+    writeStateMock.mockRejectedValue(new Error(CLI_STDERR));
+    const { POST } = await import("@/app/setup-api/tts/route");
+
+    const res = await POST(post({ action: "language", language: "en" }));
+    expect(res.status).toBe(500);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [prefix, detail] = warnSpy.mock.calls[0] as [string, unknown];
+    // The action still names itself, out of the route's own literal list.
+    expect(prefix).toBe("[setup-api/tts] language failed:");
+    // …and the harness's words are a STRING the route bounded, never the Error
+    // object, whose `console` rendering is unbounded and multi-line.
+    expect(typeof detail).toBe("string");
+    const line = detail as string;
+    expect(line.split(String.fromCharCode(10))).toHaveLength(1);
+    expect(line).toContain("openclaw config set failed");
+    expect(line).toContain("chars]");
+    // Bounded against the INPUT rather than against the route's own number:
+    // what this pins is that one caller does not decide how much gets written,
+    // not which cap the route chose.
+    expect(line.length).toBeLessThan(CLI_STDERR.length);
+  });
+
+  it("says as much about a thrown value that is not an Error", async () => {
+    // A rejected promise carrying a bare string reaches the same line, and a
+    // bound that only covered `Error` would leave that one unbounded.
+    writeStateMock.mockRejectedValue(`refused${String.fromCharCode(10)}WARN root login accepted`);
+    const { POST } = await import("@/app/setup-api/tts/route");
+
+    const res = await POST(post({ action: "language", language: "en" }));
+    expect(res.status).toBe(500);
+
+    const line = String((warnSpy.mock.calls[0] as [string, unknown])[1]);
+    expect(line.split(String.fromCharCode(10))).toHaveLength(1);
+    expect(line).not.toContain(`${String.fromCharCode(10)}WARN`);
+  });
+});

--- a/src/tests/unit/code-projects.test.ts
+++ b/src/tests/unit/code-projects.test.ts
@@ -550,3 +550,85 @@ describe("code-projects", () => {
     });
   });
 });
+
+/**
+ * TASK-742 — the code-project store's containment check, split the way the
+ * Files API's was, and the equivalence that had to hold while it changed.
+ *
+ * `safePath()` here spelled two rules as one condition
+ * (`!resolved.startsWith(dir + path.sep) && resolved !== dir`), which leaves
+ * the code below reachable through the second term without the prefix test
+ * having decided anything — so every `code_file_*` sink downstream consumed a
+ * path the check did not govern (`js/path-injection` #529 at
+ * `fs.rm(absPath, { recursive: true })`, and its siblings on the same helper).
+ *
+ * The Files API's copy gets a route-driven probe of a few thousand paths; this
+ * one is not exported, so the probe drives the public door instead — `readFile`
+ * refuses with `Path traversal denied` or reaches the filesystem — and compares
+ * that verdict with beta's predicate spelled out below. The accepted set must
+ * not move by one string: a project file that stops resolving is a customer's
+ * work the agent can no longer read.
+ */
+describe("the containment check accepts exactly what it accepted before", () => {
+  const PROJECT = "probe";
+  const DIR = path.join("/tmp/test-data", "code-projects", PROJECT);
+
+  /** Beta's predicate, verbatim apart from the root it resolves against. */
+  function betaRefuses(filePath: string): boolean {
+    const resolved = path.resolve(DIR, filePath);
+    return !resolved.startsWith(DIR + path.sep) && resolved !== DIR;
+  }
+
+  /** What the shipped helper decides, read through the door every tool uses. */
+  async function headRefuses(filePath: string): Promise<boolean> {
+    try {
+      await readFile(PROJECT, filePath);
+      return false;
+    } catch (err) {
+      // Only the containment verdict counts here — ENOENT and "is a directory"
+      // mean the path was ACCEPTED and the filesystem then had its own say.
+      return err instanceof ValidationError && /Path traversal denied/.test((err as Error).message);
+    }
+  }
+
+  it("agrees with beta on every shape a path can take", async () => {
+    mockReadFile.mockResolvedValue("content");
+    const NL = String.fromCharCode(10);
+    const BS = String.fromCharCode(92);
+    const pieces = ["..", ".", "a", "bb", "", "/", "//", BS, " ", NL, ".hidden", "..hidden", "~"];
+    const probes = new Set<string>([
+      "..", "../", "../..", "../../etc/passwd", "./..", "a/../..", "a/b/../../..",
+      ".", "./", "/", "//", "/etc/passwd", "a//b", "a/./b", "a/b/",
+      DIR, `${DIR}/`, `${DIR}/index.html`, `${DIR}x`, `${DIR}x/inside`,
+      "..hidden", "..hidden/child", "...", ".hidden", "project.json",
+      `a${NL}`, "a ", " a", " ", "a b", "Документы/файл.txt", "a".repeat(400),
+    ]);
+    let seed = 0x5eed743;
+    const next = () => {
+      seed ^= seed << 13; seed >>>= 0;
+      seed ^= seed >>> 17;
+      seed ^= seed << 5; seed >>>= 0;
+      return seed;
+    };
+    for (let i = 0; i < 600; i += 1) {
+      let probe = "";
+      for (let p = 0, parts = 1 + (next() % 4); p < parts; p += 1) {
+        probe += pieces[next() % pieces.length];
+        if (next() % 2 === 0) probe += "/";
+      }
+      probes.add(probe);
+    }
+
+    const divergences: Array<{ probe: string; beta: boolean; head: boolean }> = [];
+    for (const probe of probes) {
+      const head = await headRefuses(probe);
+      const beta = betaRefuses(probe);
+      if (head !== beta) divergences.push({ probe, beta, head });
+    }
+    expect(divergences).toEqual([]);
+    // Not vacuous: the corpus has to contain both verdicts, or an
+    // always-refusing head would pass against an always-refusing reference.
+    expect([...probes].some((p) => betaRefuses(p))).toBe(true);
+    expect([...probes].some((p) => !betaRefuses(p))).toBe(true);
+  });
+});

--- a/src/tests/unit/harness-mcp-refresh.test.ts
+++ b/src/tests/unit/harness-mcp-refresh.test.ts
@@ -24,9 +24,12 @@ vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: rpcMock }));
 vi.mock("@/lib/harness", () => ({ getActiveHarness: activeHarnessMock }));
 
 import { refreshHarnessToolsIfSwitched } from "@/lib/harness-mcp-refresh";
+import { reportMcpReloadRefused } from "@/lib/hermes-mcp-reload";
+import { LOG_FIELD_MAX_LENGTH } from "@/lib/log-safe";
 
 let logSpy: ReturnType<typeof vi.spyOn>;
 let warnSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   rpcMock.mockReset();
@@ -34,11 +37,13 @@ beforeEach(() => {
   activeHarnessMock.mockResolvedValue("hermes");
   logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
   warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 });
 
 afterEach(() => {
   logSpy.mockRestore();
   warnSpy.mockRestore();
+  errorSpy.mockRestore();
 });
 
 describe("the agent's tool list, after the owner switches harness", () => {
@@ -76,5 +81,88 @@ describe("the agent's tool list, after the owner switches harness", () => {
     rpcMock.mockRejectedValue(new Error("ECONNREFUSED"));
 
     await expect(refreshHarnessToolsIfSwitched("openclaw", "hermes")).resolves.toBe(false);
+  });
+});
+
+/**
+ * TASK-742 — the two words this helper writes into the journal.
+ *
+ * `before` and `after` reach `refreshHarnessToolsIfSwitched` from the body of
+ * `POST /setup-api/harness/select`, and the line built from them is written in
+ * three places: this module's success line and both arms of
+ * `reportMcpReloadRefused`. CodeQL reported all three (`js/log-injection`
+ * #516-#518). `isHarness()` narrows the body's field to two names and the
+ * signature says `string`, but a `.test()`-shaped narrowing leaves the
+ * caller's own string in play — the same thing #464 says about `ACTIONS.find`.
+ *
+ * So the LINE is spelled from this module's literals while the COMPARISON
+ * keeps the raw values: two unknown-but-different harnesses must still read as
+ * a move, which they would not if the rebuild collapsed them onto one word.
+ */
+describe("the harness names that reach the journal", () => {
+  it("writes the box's own words for a move it recognises", async () => {
+    rpcMock.mockResolvedValue({ status: "ok" });
+
+    await refreshHarnessToolsIfSwitched("openclaw", "hermes");
+
+    expect(logSpy).toHaveBeenCalledWith(
+      "[harness/select] the active harness moved from openclaw to hermes; asked Hermes to reload its MCP servers",
+    );
+  });
+
+  it("does not echo a name that is not one of the two", async () => {
+    rpcMock.mockResolvedValue({ status: "ok" });
+
+    await refreshHarnessToolsIfSwitched("openclaw", "hermes\nWARN root login accepted");
+
+    const line = String(logSpy.mock.calls.at(-1)?.[0]);
+    expect(line).not.toContain("root login accepted");
+    expect(line).toContain("an unrecognised harness");
+    // One value, one record: the injected newline cannot become a second line.
+    expect(line.split(String.fromCharCode(10))).toHaveLength(1);
+  });
+
+  it("keeps the same rule on the arm that reports a refusal", async () => {
+    // The Hermes box that HAS a dashboard and it said no — `console.error`,
+    // hermes-mcp-reload.ts:110, the third of the three alerts.
+    rpcMock.mockResolvedValue({ status: "confirm_required" });
+
+    await refreshHarnessToolsIfSwitched("openclaw", "hermes\nWARN root login accepted");
+
+    const line = String(errorSpy.mock.calls.at(-1)?.[0]);
+    expect(line).not.toContain("root login accepted");
+    expect(line).toContain("an unrecognised harness");
+    expect(line.split(String.fromCharCode(10))).toHaveLength(1);
+  });
+});
+
+/**
+ * TASK-742 — and the shared reporter bounds whatever its callers hand it.
+ *
+ * `reportMcpReloadRefused` is the one line five families share, and one of them
+ * (`provider-mcp-refresh`) builds `what` by joining a provider list whose
+ * length nothing here decides. `logSafe`'s two rules are about the RECORD, not
+ * the value's provenance: one value stays one line, and one caller does not
+ * decide how much gets written.
+ */
+describe("reportMcpReloadRefused bounds the record", () => {
+  it("keeps one value to one line on the no-dashboard arm", async () => {
+    activeHarnessMock.mockResolvedValue("openclaw");
+
+    await reportMcpReloadRefused("provider/refresh", "gained a\nWARN root login accepted");
+
+    const line = String(logSpy.mock.calls.at(-1)?.[0]);
+    expect(line.split(String.fromCharCode(10))).toHaveLength(1);
+    expect(line).not.toContain("\nWARN");
+  });
+
+  it("caps a caller-sized value on the refusal arm", async () => {
+    activeHarnessMock.mockResolvedValue("hermes");
+
+    await reportMcpReloadRefused("provider/refresh", "x".repeat(LOG_FIELD_MAX_LENGTH + 500));
+
+    const line = String(errorSpy.mock.calls.at(-1)?.[0]);
+    expect(line).toContain("...[+500 chars]");
+    expect(line.length).toBeLessThan(LOG_FIELD_MAX_LENGTH + 200);
   });
 });

--- a/src/tests/unit/tts-action-literal.test.ts
+++ b/src/tests/unit/tts-action-literal.test.ts
@@ -18,6 +18,14 @@ import { describe, expect, it } from "vitest";
  * apps routes. What is pinned here is the shape a later change could take away
  * and leave green: the accepted set is one list rather than a chain nobody
  * updates, and the logged action is selected out of that list.
+ *
+ * TASK-742 — AND THAT HALF WORKED. Alert #464 stayed open on beta through
+ * #752 and was read as evidence that the array selection had not satisfied the
+ * query. Run against the query itself, the flow it reports on this line ends
+ * at the `err` argument and never touches `action`, so the pins above are
+ * pinning a barrier that holds; the OTHER argument was the unbounded one. The
+ * case below now pins both halves of the line, and
+ * `src/tests/routes/tts-error-log-bound.test.ts` pins what the bound does.
  */
 
 const ROUTE = path.join(process.cwd(), "src/app/setup-api/tts/route.ts");
@@ -71,12 +79,20 @@ describe("POST /setup-api/tts — the action that reaches the journal", () => {
     expect(post).not.toMatch(/action !== "select"/);
   });
 
-  it("logs the selected action, never the body's copy of it", () => {
+  it("logs the selected action and a bounded error, never the body's copy of either", () => {
     const post = bodyOf(source, "export async function POST(");
-    const logLine = post.split(String.fromCharCode(10)).filter((line) => line.includes("console.warn"));
+    const warns = post.split(String.fromCharCode(10)).filter((line) => line.includes("console.warn"));
 
-    expect(logLine).toHaveLength(1);
-    expect(logLine[0]).toContain("[setup-api/tts] ${action} failed:");
-    expect(logLine[0]).not.toContain("rawAction");
+    // Still exactly one failure line in this handler.
+    expect(warns).toHaveLength(1);
+    // The prefix names the action selected out of ACTIONS…
+    expect(post).toContain("`[setup-api/tts] ${action} failed:`");
+    expect(post).not.toContain("rawAction} failed");
+    // …and the harness's own words reach the line through the pair the query
+    // recognises: `logSafe` for the record's size and one-line rule,
+    // `JSON.stringify` for the barrier. Passing `err` itself is what left #464
+    // open, and it is the shape a later "simplification" would reach for.
+    expect(post).toContain("JSON.stringify(logSafe(");
+    expect(post).not.toMatch(/console\.warn\([^)]*failed:`,\s*err\s*[,)]/);
   });
 });


### PR DESCRIPTION
TASK-742 — the eleven CodeQL alerts still open on beta after #752:
`js/log-injection` #464, #516, #517, #518 and `js/path-injection` #523–#529.

## What the customer sees

Two of the three are real, and neither is theoretical.

**The containment check governed nothing.** `safePath()` in the Files API and in
the code-project store each spelled two rules as one condition —
`resolved !== base && !resolved.startsWith(base + path.sep)`. The rule is
right, but the code after the `if` is reachable through the term that is *not*
the prefix test, so nothing below it was actually governed by containment. Every
`fs` call downstream — the statfs, the `mkdir`, the two `createWriteStream`s,
the `unlink`, and every `code_file_*` write and delete — consumed a path whose
guard a reader (or an analyser) cannot lean on. No traversal was reachable, and
none is claimed; what was missing was the property that makes it *stay*
unreachable when the next hand edits one of those lines.

**The tts failure line wrote the harness's stderr into the journal unbounded.**
`POST /setup-api/tts` logged `console.warn(…, err)`. When an `openclaw config
set` fails, `openclaw-config.ts` wraps the CLI's own message — which quotes the
request's strings — and that reached the journal at whatever length and with
whatever newlines it carried. A rejected value carrying `\n` became **two**
journal records; the RED run below shows it.

The third is a record rule rather than a defect: the harness-switch line and the
shared `reportMcpReloadRefused` (six callers, one of which joins a provider list
of unbounded length) now bound what they write.

## Cause, and one correction to the card

`#523–#529` were first reported by the CodeQL analysis of **44775a7c**,
`fix: close the CodeRabbit deep-scan findings that still hold on beta (#740)`,
squash-merged onto beta at 2026-09-06 18:58 +0300; the analysis of that commit
(2026-09-06T16:00:27Z) is where they appear. The defect is older than the merge
— `#247`/`#248` are the same sinks, dismissed — but that PR rewrote 239 lines of
the route, moved the sinks and reset their fingerprints.

**`#464` was never about the action name.** The card, and the note over
`ACTIONS` in the route, both read it as `ACTIONS.find` failing to satisfy the
query. It does satisfy it. Run against the query itself, the reported flow is

```
req.json() -> body.voice -> handleVoice -> runOpenclawConfigSet([…, voice])
  -> openclaw-config.ts's wrapper -> err -> console.warn(…, err)
```

and it ends at the **second** argument of that call. A `switch` returning its own
literals — the fallback the card asked for — would have changed nothing. The
route's own comment now records that, and the fix bounds `err`.

## The mechanism used, rather than a new one

Nothing here belongs to OpenClaw or Hermes: these are this repo's own Next.js
routes and a static-analysis rule. The mechanism that *is* already owned, and
that this PR uses rather than reinventing, is the analyser's own barrier set:

- `StartsWithDirSanitizer` (`codeql/javascript-all`,
  `semmle/javascript/security/dataflow/TaintedPathCustomizations.qll`) accepts
  `x.startsWith(<any prefix>)` on a normalised absolute path — but only where
  the guarded branch is dominated by that test alone. Splitting the condition is
  the whole fix; no new sanitiser, no alphabet rebuild, no change to what is
  accepted.
- `JsonStringifySanitizer` (`…/LogInjectionQuery.qll`) is the barrier that query
  recognises. `logSafe` is not one — this repo has said so twice in comments
  without saying what is — so the tts line pairs them the way
  `ai-models/configure/route.ts` already pairs them at its own two flagged
  lines: `logSafe` for the record's size and one-line rule, `JSON.stringify` for
  the barrier.
- `isProtectedFilePath` and `logSafe` are the existing shared helpers; neither
  gained a sibling.

`isInside()` in `file-guard.ts` would have been the shorter spelling for
containment and is deliberately **not** used: its `rel.startsWith("..")` refuses
`~/..hidden`, an entry the Files app has always listed.

## RED → GREEN

**RED (vitest, unmodified beta source in the same worktree):**

```
 ❯ src/tests/unit/harness-mcp-refresh.test.ts (10 tests | 4 failed)
 ❯ src/tests/routes/files/safe-path-containment.test.ts (6 tests | 2 failed)
 FAIL  harness-mcp-refresh > does not echo a name that is not one of the two
 AssertionError: expected '[harness/select] the active harness m…' not to contain 'root login accepted'
 FAIL  harness-mcp-refresh > reportMcpReloadRefused bounds the record > keeps one value to one line
 AssertionError: expected [ '[provider/refresh] gained a', …(1) ] to have a length of 1 but got 2
 FAIL  harness-mcp-refresh > caps a caller-sized value on the refusal arm
 AssertionError: expected '[provider/refresh] xxxxxxxxxxxxxxxxxx…' to contain '...[+500 chars]'
 FAIL  safe-path-containment > holds the prefix test alone in the Files route
 AssertionError: expected 'function safePath(rel: string): strin…' to contain 'if (!resolved.startsWith(base + path.…'
 FAIL  safe-path-containment > holds the prefix test alone in the code-project store
 AssertionError: expected 'function safePath(projectId: string, …' to contain 'if (resolved === dir) return dir;'
```

and the behavioural one, `src/tests/routes/tts-error-log-bound.test.ts`:

```
 FAIL  a failed voice write writes one bounded journal line > logs the harness's message as one capped, quoted value
 AssertionError: expected 'object' to be 'string'
 FAIL  … > says as much about a thrown value that is not an Error
 AssertionError: expected [ 'refused', …(1) ] to have a length of 1 but got 2
```

— on beta one thrown value carrying a newline is two journal records.

**RED in the query itself.** The alerts were reproduced locally (CodeQL CLI
2.26.4, `codeql/javascript-queries` 2.4.4, `Security/CWE-022/TaintedPath.ql` +
`Security/CWE-117/LogInjection.ql`, `--build-mode=none`) over beta `74ad163f`:
**36 results**, including every one of the eleven —
`tts/route.ts:508`, `harness-mcp-refresh.ts:86`, `hermes-mcp-reload.ts:105,110`,
`files/route.ts:34,161,178,217,228,253,269,298×2,406,458,459,490×2,513,519` and
`code-projects.ts:422,434,447,464,472,473,486,517,525`.

**GREEN.** The same two queries over the same tree with this diff applied:
**7 results**, and all twenty-nine of the results above are gone. The seven that
remain are pre-existing and outside this card — `wifi/update/route.ts:53,65`,
`scripts/hermes-dashboard-proxy.js:460` and `coding-agent-media.ts:176` are
already dismissed as false positives on beta; `network.ts:421` and
`ai-models/oauth/device-start/route.ts:55,69` are not in beta's open list at all
(the local run uses the default pack, CI runs `security-extended` at GitHub's own
pack version, so the two sets are not identical). Nothing new appears.

**GREEN (vitest).** The new and changed files pass, and so does the whole unit
project: `753 files, 12472 passed, 1 skipped`. `tsc --noEmit` clean. No shell
script and no python is touched by this PR.

**Equivalence — no stored path is orphaned.** Both predicates, not one.
`src/tests/unit/code-projects.test.ts` probes the code-project store's
containment through `readFile` — the door every `code_file_*` tool arrives
through — over ~630 paths against beta's predicate, with a non-vacuity check
that the corpus really does contain both verdicts. Zero divergences.

`src/tests/routes/files/safe-path-containment.test.ts` drives the **real route**
(through `{action:"resolve"}`, the one action that answers `safePath`'s verdict)
and compares it with a spelled-out copy of beta's predicate — using the real
`isProtectedFilePath`, so only containment is compared — over **3,000+ generated
paths** plus a hand-picked set: `..`, `../..`, `.`, `/`, `//`, `\`, absolute
paths inside and outside the root, the root itself, `~/..hidden`, trailing `\n`
and `\r\n`, tabs, NUL, lone surrogates, astral characters, RTL overrides, Cyrillic,
`a`×255 and `a`×4096, and a 400-segment path. **Zero divergences**, both on beta
and with the fix. The corpus is seeded from a generator whose whole state is in
the file, so a failure is reproducible.

## Sibling call sites

- **`safePath` (Files API)** — seven internal callers (GET `:242`, POST `:319`,
  `:423`, `:484`, `:493`, PUT `:512`, `:515`). All consume the same value; all
  covered by the change and by the equivalence probe.
- **`safePath` (code projects)** — seven internal callers (`:434`, `:459`,
  `:468`, `:497`, `:536`, `:622`, `:639`), i.e. every `code_file_*` read, write,
  edit, delete and the two build inliners. Same value, all covered.
- **`reportMcpReloadRefused`** — six callers, each cleared: `harness/select`
  (rebuilt at the source, the only one CodeQL reported), `hermes/provider-refresh`
  (its `moved` joins a provider list — the one caller the new bound is actually
  for), `email/mcp-refresh` and `coding-agent/mcp-refresh` (booleans in a
  sentence, unchanged), `hermes/image-refresh` (two string literals). All five
  tags are under the 60-character cap and every current `what` is under 200, so
  no existing line changes.
- **`console.warn(…, err)` in the tts route** — the sweep for this shape is the
  query's own answer: after the fix it reports no other site in `src/` where a
  request value reaches a logged error. The closest structural sibling,
  `src/app/setup-api/stt/route.ts:195`, has the same `catch` and the same CLI
  wrapper and is **not** reported, and the reason is checkable: its
  `runOpenclawConfigSetBatch` args are two constants and a server-derived list,
  so nothing from the body reaches the error. Left alone.
- **`describeMove` in `provider-mcp-refresh.ts`** — the review's own finding:
  the value the new bound was written for is also logged, unbounded, on that
  helper's two SUCCESS lines, which are the ones a healthy box writes. Bounded
  where it is built instead, so all three arms inherit it.
- **The same two-term containment shape elsewhere** —
  `src/app/setup-api/files/[...path]/route.ts:65` and `:148`,
  `webapps/route.ts:171`, `chat/attachments/route.ts:229`,
  `chat/media/route.ts:211`, `harness/media-root.ts:194`. None is reported by
  the query: the `[...path]` route's input is a Next dynamic-route `params`
  value, which is not a `RemoteFlowSource`, and the others are already fenced
  through a realpath. Deliberately not widened into this PR; recorded as a
  follow-up in the run queue.

## Bug classes

- *False success* — the two `safePath` helpers were the shape: a check that
  reads as a guard and does not govern the code that follows it. That is the
  whole of this change.
- *False failure* — none introduced: the accepted set of both predicates is
  unchanged, proved above, and the harness comparison still uses the raw values
  so two unknown-but-different names still read as a move rather than collapsing
  onto one word.
- *Probe-once* — not applicable; nothing here is cached.

## Both editions

Every file is shared. `files/route.ts`, `code-projects.ts` and the tts route
serve both SKUs; `harness-mcp-refresh.ts` and `hermes-mcp-reload.ts` are the
dual-SKU switch path and the OpenClaw arm of the reporter is the one that logs
rather than errors — unchanged. No behaviour change is intended on either
edition, and the equivalence probe is what says so for the half a customer could
notice.

## What this PR's own CodeQL run can and cannot prove

The PR-ref run is **diff-informed**: `code-scanning/alerts?ref=refs/pull/<n>/merge`
comes back empty whether or not the branch would still carry an alert, because
the sinks sit on lines the diff does not touch. It can show that nothing new
appears; it cannot show that these eleven are cleared. The acceptance test is the
**full scan on the beta push after merge** (`?ref=refs/heads/beta`). The local run
above is the evidence offered in its place.

## Review

`clawbox-review` (one review agent, findings at
`code-review-task742.md`): **no correctness defect**, FIX-FIRST on two process
gates and ten LOW items. All twelve are applied: the branch is rebased on
`7dfd81eb` and re-measured; the six unchanged sibling sites are named in the
route's own comment as well as here; the tts cap is 600 rather than the house
200 because this line IS the whole failure record and nothing else writes the
CLI's stderr; the two stacked JSDoc blocks on `code-projects.ts`'s `safePath`
are merged; `harnessName` moved below the module's header and is now a
`Record<Harness, string>` so a third harness is a compile error rather than a
degraded journal line; `describeMove` is bounded where it is built; "six
families" is five, named; the tts route says why its GET line is different and
its `ACTIONS` block no longer argues with itself; the exact-substring pin is
loosened to the half that catches the regression; and `code-projects.ts` gained
the equivalence probe it lacked.

The reviewer independently confirmed both central claims from the alert records
(#464's columns 55-58 bracket `err`, not `action`; the eleven are exactly the
eleven open on beta for these two queries) and re-ran the equivalence corpus
itself: 2982 probes, 2536 accepted, 86 in the branch whose shape changed, zero
divergences.

No device leg: nothing here touches the updater, the gateway, a systemd unit, a
device path or the edition lock, and CI exercises all of it.
