### PR TITLE
fix: stand down on the legacy image key instead of writing the v2 home beside it

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -1771,9 +1771,12 @@ _clawai_proxy_base_url = ""
 # so its own surfaces can still offer our image model (see the docblock in
 # src/lib/clawbox-ai-models.ts for the measurement and the two source paths);
 # ClawBox's own surfaces are closed separately. `name` is required or the
-# config will not validate, and the `imageGenerationModel` write is what
-# actually makes the tool appear: `imageModel` is a different key that selects
-# the vision model.
+# config will not validate, and the IMAGE-GENERATION SLOT write is what
+# actually makes the tool appear — `agents.defaults.mediaModels.image` on a v2
+# core, the legacy `agents.defaults.imageGenerationModel` on a v1 one, and on a
+# box still carrying the legacy key under v2 neither, because the block stands
+# down there (see the guard's own note). `imageModel` is a different key again
+# and selects the vision model.
 #
 # The model id is duplicated from CLAWBOX_AI_IMAGE_MODEL_ID in
 # src/lib/clawbox-ai-models.ts because a shell migration cannot import it. It
@@ -2079,6 +2082,51 @@ if isinstance(_clawai_token, str) and _clawai_token.startswith("claw_"):
                 and any(isinstance(ref, str) and ref.strip() for ref in _image_model_fallbacks)
             )
         )
+        # STAND DOWN on the image SLOT while the core's own migration still owes
+        # this box a move — the same shape #751 gave the cloud voice, on the key
+        # this file's own header names first (`agents.defaults.imageGenerationModel`
+        # -> `agents.defaults.mediaModels.image`), and link 1 of the incident
+        # TASK-737 is about.
+        #
+        # WHAT THIS BUYS, stated exactly, because the first draft of this
+        # comment claimed more and the core contradicts it. Measured against
+        # 2026.8.1 (`migrateFinalLayoutRenames`, dist/legacy-*.js): the core's
+        # migration deletes the legacy key on BOTH branches — it moves the value
+        # into `mediaModels.image` when that home is empty and merely REMOVES it
+        # when the home is taken. So writing the v2 home here does not strand a
+        # box, and it does not cause the exit 78: `agents.defaults` is
+        # `.strict()`, so the legacy key ALONE is already
+        # `agents.defaults: Unrecognized key: "imageGenerationModel"` and the
+        # gateway was refusing this config before this block ran.
+        #
+        # What the write DOES cost is the owner's own value. On the shapes
+        # `_has_image_model` reads as empty — `{}`, `{"primary": ""}`,
+        # `{"fallbacks": []}`, a JSON `null`, and a bare string, which the core
+        # resolves as a model even though the test above does not — claiming the
+        # v2 home first means the core's migration finds it taken and discards
+        # what the owner had. Standing down leaves the one shape the core can
+        # carry across, and makes one fewer write into a config it refuses.
+        #
+        # ON THE KEY, NOT ON ITS CONTENTS: `in` rather than
+        # `.get() is not None`, because a key whose value is `null` is present
+        # and is refused just the same.
+        #
+        # IT DOES NOT RESCUE THE BLOCKED BOX, and nothing here should be read as
+        # claiming it does. The only box that reaches this guard is one whose
+        # `doctor --fix` did not run the migration — the block at the top of this
+        # script runs it whenever the core refuses the config, and a non-empty
+        # legacy `exec-approvals.json` is what stops it. That box stays refused
+        # with this guard and without it; performing the move here instead is a
+        # real option and a decision for its own card.
+        #
+        # NARROWER THAN #751's GUARD, deliberately. There the whole block wrote
+        # ONE object into one of two homes, so standing down had to mean writing
+        # nothing. Here the block writes two independent things: the `models[]`
+        # ROW, which has one home on both cores and whose repair keeps a box
+        # bootable, and the SLOT, which is the half with two homes. Only the
+        # slot stands down; the row is still written and repaired, so the boot
+        # after the migration lands has nothing left to do.
+        _image_move_in_flight = _clawbox_v2 and "imageGenerationModel" in agents_defaults
         _openai_models = openai_provider.get("models")
         _our_entries = (
             [m for m in _openai_models if _is_our_image_row(m)]
@@ -2141,11 +2189,42 @@ if isinstance(_clawai_token, str) and _clawai_token.startswith("claw_"):
             # the stand-down undone, pointing at a model that is gone.
             _legacy_is_ours = _slot_is_ours(agents_defaults.get("imageGenerationModel"))
             _v2_is_ours = _clawbox_v2 and _slot_is_ours(_media_models.get("image"))
-            # Anything in either home that is NOT ours is the owner's image
-            # configuration, and it may well name our row — so the rows stay too.
+
+            def _slot_holds_a_decision(_cfg):
+                """Has the owner put something here the CORE would resolve?
+
+                WIDER than `_has_image_model` on purpose, and the asymmetry is
+                the file's own rule: claiming a slot is recoverable, deleting
+                the row a slot points at is not. So this accepts a bare string
+                too — `hasExplicitToolModelConfig` coerces one — where the
+                upsert's test does not.
+
+                NARROWER than `is not None`, which is what it replaces. That
+                test read `{}`, `{"primary": ""}`, `{"fallbacks": []}` and `[]`
+                as the owner's configuration, so a leftover empty key vetoed the
+                whole take-back and a box whose credential the proxy had
+                permanently refused kept the image path declared — the TASK-727
+                storm — for as long as that key survived.
+                """
+                if isinstance(_cfg, str):
+                    return bool(_cfg.strip())
+                if not isinstance(_cfg, dict):
+                    return False
+                _fallbacks = _cfg.get("fallbacks")
+                return bool(
+                    (isinstance(_cfg.get("primary"), str) and _cfg.get("primary").strip())
+                    or (
+                        isinstance(_fallbacks, list)
+                        and any(isinstance(_ref, str) and _ref.strip() for _ref in _fallbacks)
+                    )
+                )
+
+            # Anything in either home that is NOT ours and NAMES a model is the
+            # owner's image configuration, and it may well name our row — so the
+            # rows stay too.
             _slot_is_theirs = (
-                (not _legacy_is_ours and agents_defaults.get("imageGenerationModel") is not None)
-                or (_clawbox_v2 and not _v2_is_ours and _media_models.get("image") is not None)
+                (not _legacy_is_ours and _slot_holds_a_decision(agents_defaults.get("imageGenerationModel")))
+                or (_clawbox_v2 and not _v2_is_ours and _slot_holds_a_decision(_media_models.get("image")))
             )
             if not _slot_is_theirs:
                 _stood_down = False
@@ -2200,12 +2279,18 @@ if isinstance(_clawai_token, str) and _clawai_token.startswith("claw_"):
                     changed = True
 
             if not _has_image_model:
-                if _clawbox_v2:
+                if _image_move_in_flight:
+                    print(
+                        "  Skipped the ClawBox AI image model: a legacy"
+                        " agents.defaults.imageGenerationModel key is still waiting for the core's own migration"
+                    )
+                elif _clawbox_v2:
                     _media_models["image"] = {"primary": CLAWBOX_IMAGE_MODEL_REF}
                     agents_defaults["mediaModels"] = _media_models
+                    changed = True
                 else:
                     agents_defaults["imageGenerationModel"] = {"primary": CLAWBOX_IMAGE_MODEL_REF}
-                changed = True
+                    changed = True
 
 # Migration: ClawBox AI speech to text.
 #
@@ -2446,7 +2531,13 @@ if _clawai_openai_route_is_ours:
     # tagged capabilities: ["audio"]).
     _audio_models = _media.get("models") if _clawbox_v2 else _audio.get("models")
     _audio_models_move_in_flight = False
-    if _clawbox_v2 and _audio_models is None and _audio.get("models") is not None:
+    # ON THE KEY, like the image guard above and for the same measured reason: a
+    # `tools.media.audio.models: null` is PRESENT and is refused
+    # (`tools.media.audio: Unrecognized key: "models"` on 2026.8.1), while
+    # `.get("models") is not None` reads it as absent — and the `elif` below
+    # then seeds the v2 home beside a legacy key that is still there, which is
+    # the write this whole shape exists to avoid (TASK-743).
+    if _clawbox_v2 and _audio_models is None and "models" in _audio:
         # A legacy tools.media.audio.models list the loader migration has not
         # moved yet. Seeding the v2 home beside it would duplicate the rows the
         # moment the migration runs, so the LIST is left exactly as it is and
@@ -2482,7 +2573,15 @@ if _clawai_openai_route_is_ours:
         _audio["baseUrl"] = _clawai_proxy_base_url
         # Seed the list only where there is none. A list this migration
         # recognises is left exactly as Settings wrote it, order included.
-        if _audio_models is None:
+        #
+        # …and never where the LEGACY key is still present, whatever it holds.
+        # A `tools.media.audio.models: null` leaves `_audio_models` None, so the
+        # bare `is None` test above seeded the v2 home beside a key the core
+        # refuses — the same dual-home write the image guard in this file now
+        # stands down over (TASK-743). `baseUrl` is still written either way:
+        # it lives at the same address in both generations, which is what the
+        # comment on the in-flight flag says.
+        if _audio_models is None and not _audio_models_move_in_flight:
             _seed = [dict(_entry) for _entry in CLAWBOX_AUDIO_MODELS]
             if _clawbox_v2:
                 for _row in _seed:
@@ -2692,11 +2791,27 @@ elif _clawai_openai_route_is_ours:
     # them that their choice is no longer available and that the box is speaking
     # locally instead — which is precisely what it does once the entry is gone.
     # Silently rewriting their pick would hide the downgrade.
+    #
+    # BOTH HOMES on v2, not the one the arming half writes (TASK-743). A box
+    # that was Max under a v1 core wrote its stamped entry into `messages.tts`,
+    # and a v2 core whose loader migration has not run yet — or whose
+    # `doctor --fix` aborted before its state migrations, which is how the
+    # legacy image key survives one link earlier in this same file — still has
+    # it sitting there. Reading only `cfg["tts"]` left exactly that box holding
+    # our own dead entry for good, buying a refused round trip per spoken reply
+    # while the panel called the cloud voice configured: the case this arm
+    # exists for, and the one it could not see. Deleting from the legacy home is
+    # safe where WRITING to it would not be — a removal cannot create the
+    # dual-home shape the guard above stands down over, and it leaves the core's
+    # own migration less to move, not more.
     _messages = cfg.get("messages")
-    _tts = (cfg.get("tts") if _clawbox_v2 else (_messages.get("tts") if isinstance(_messages, dict) else None))
-    _tts_providers = _tts.get("providers") if isinstance(_tts, dict) else None
-    _speech = _tts_providers.get("openai") if isinstance(_tts_providers, dict) else None
-    if isinstance(_speech, dict):
+    _legacy_tts = _messages.get("tts") if isinstance(_messages, dict) else None
+    _tts_homes = ([cfg.get("tts"), _legacy_tts] if _clawbox_v2 else [_legacy_tts])
+    for _tts in _tts_homes:
+        _tts_providers = _tts.get("providers") if isinstance(_tts, dict) else None
+        _speech = _tts_providers.get("openai") if isinstance(_tts_providers, dict) else None
+        if not isinstance(_speech, dict):
+            continue
         _speech_base_url = _speech.get("baseUrl")
         # The STAMP is the authorisation, not the address. Requiring the
         # current proxy URL as well left a downgraded box that had been linked

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -1216,10 +1216,44 @@ function buildClawboxAiImageOps(
     );
     return ops;
   }
+  // STAND DOWN while a legacy `agents.defaults.imageGenerationModel` is still
+  // on the box (TASK-743) — the same guard `scripts/gateway-pre-start.sh` now
+  // carries, and this is the half an owner reaches by pressing Save rather than
+  // by rebooting.
+  //
+  // WHAT IT BUYS, measured against 2026.8.1 rather than assumed: the core's own
+  // `migrateFinalLayoutRenames` moves the legacy value into `mediaModels.image`
+  // when that home is EMPTY and merely deletes it when the home is taken. So
+  // claiming the home first does not strand the box — `agents.defaults` is
+  // `.strict()`, so the legacy key alone is already `Unrecognized key` and
+  // gateway exit 78 before this route runs — it throws away what the OWNER had.
+  // The shapes this covers are the ones `hasToolModelConfig` reads as empty
+  // (`{}`, `{"primary": ""}`, `{"fallbacks": []}`, `null`, and a bare string,
+  // which the core resolves as a model even though that test does not).
+  //
+  // ON THE KEY, NOT ITS CONTENTS: `Object.hasOwn`, because a key whose value is
+  // `null` is present and is refused just the same. `!= null` on `defaults`
+  // rather than `!== undefined`, because `"defaults": null` would otherwise
+  // reach `Object.hasOwn(null, …)`, which throws — and the caller's catch would
+  // then discard the provider key and the model row this function is still
+  // allowed to write.
+  //
+  // Not permanent, and not a rescue either: the next gateway start runs the
+  // core's `doctor --fix` over a config it refuses and the save after that
+  // writes the slot as usual — EXCEPT on a box whose doctor is itself blocked,
+  // which stays refused with this guard and without it.
+  if (defaults != null && Object.hasOwn(defaults, "imageGenerationModel")) {
+    console.log(
+      "[AI Config] Left the image-generation model alone: a legacy agents.defaults.imageGenerationModel key is still waiting for the core's own migration",
+    );
+    return ops;
+  }
   ops.push([
-    // OpenClaw 2's home for the image-generation model. gateway-pre-start.sh
-    // writes the same key under the same version gate; the two must stay in
-    // step.
+    // OpenClaw 2's home for the image-generation model, and this route writes it
+    // on every core: unlike the boot script, which has a `_clawbox_v2` arm, this
+    // function has no version gate and never had one. Fine while the pin is
+    // 2026.8.x, wrong the day a v1 box saves — its own card, named here so the
+    // next reader does not read the sibling's gate as parity.
     "agents.defaults.mediaModels.image",
     JSON.stringify({ primary: CLAWBOX_AI_IMAGE_MODEL }),
     "--json",

--- a/src/lib/harness/capabilities.ts
+++ b/src/lib/harness/capabilities.ts
@@ -240,9 +240,10 @@ export function capabilitiesFor(id: HarnessId, facts: HarnessFacts): HarnessCapa
     // NOT gated on `hasClawaiImageRoute`, unlike Hermes, and the asymmetry is
     // real rather than an oversight. Here the picture comes from the AGENT'S
     // image provider, which is only ours by default: `ai-models/configure`
-    // leaves `agents.defaults.imageGenerationModel` alone when it already names
-    // one, so a customer who pointed it at their own provider draws pictures
-    // that never touch the ClawBox AI proxy. Probing our route and answering
+    // leaves the image-generation slot alone when it already names a model AND
+    // whenever the legacy `agents.defaults.imageGenerationModel` key is still
+    // on the box at all (TASK-743), so a customer who pointed it at their own
+    // provider draws pictures that never touch the ClawBox AI proxy. Probing our route and answering
     // false would hide a button that works — the "wrong false" this table
     // spends most of its comments avoiding.
     canGenerateImages: facts.hasClawaiToken,

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1370,8 +1370,20 @@ async function askCoreToValidateConfig(): Promise<CoreConfigVerdict | null> {
     // same rule this function already states for a validator it could not run,
     // now applied to one it could not let finish (and the `killSignal` above
     // makes that kill harder, so the two belong together).
-    if ((err as { killed?: boolean; signal?: unknown } | null)?.killed
-      || (err as { signal?: unknown } | null)?.signal) {
+    //
+    // A MAXBUFFER OVERFLOW IS THE SAME EVENT WITH NEITHER FLAG SET. Node kills
+    // the child when its stdout passes `maxBuffer`, and the error it rejects
+    // with carries `code: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER"` while `killed`
+    // and `signal` are both `undefined` (measured) — so the two-flag test above
+    // let a TRUNCATED buffer through to the parser. Low, because 2 MB against
+    // this payload's tens of bytes means it takes a core gone haywire to reach,
+    // and truncated JSON usually fails to parse anyway; but "usually" is the
+    // whole of the risk — `{"valid":true,"warnings":[…` cut mid-array can still
+    // slice cleanly between the first `{` and the last `}` this reader looks
+    // for, and `coreReportedMissingPlugins` would then switch the owner's
+    // plugin entries off on half a verdict.
+    const failure = err as { killed?: boolean; signal?: unknown; code?: unknown } | null;
+    if (failure?.killed || failure?.signal || failure?.code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER") {
       return { accepted, payload: null };
     }
     text = commandOutput(err);

--- a/src/tests/routes/ai-models/configure-images.test.ts
+++ b/src/tests/routes/ai-models/configure-images.test.ts
@@ -649,8 +649,18 @@ describe("POST /setup-api/ai-models/configure — ClawBox AI image provider", ()
   });
 
   describe("does not steal an image model the owner already chose", () => {
-    async function connectWithImageModel(imageGenerationModel: unknown) {
-      mockReadConfig.mockResolvedValue({ agents: { defaults: { imageGenerationModel } } } as never);
+    /**
+     * `undefined` means the KEY IS ABSENT, not present holding undefined.
+     * openclaw.json is JSON, so a key can be missing or `null` and never
+     * `undefined` — and since TASK-743 the difference decides the answer: a
+     * legacy key that is THERE, whatever it holds, is a migration the core
+     * still owes this box.
+     */
+    async function connectWithImageModel(imageGenerationModel?: unknown) {
+      const defaults = arguments.length === 0
+        ? {}
+        : { imageGenerationModel };
+      mockReadConfig.mockResolvedValue({ agents: { defaults } } as never);
       await connectClawai();
     }
 
@@ -692,8 +702,68 @@ describe("POST /setup-api/ai-models/configure — ClawBox AI image provider", ()
       expect(callFor("agents.defaults.mediaModels.image")).toBeUndefined();
     });
 
+    /**
+     * The V2 home, seeded directly — which no case in this file did before
+     * TASK-743, and every case that seeded the LEGACY key now stops at the new
+     * key-presence stand-down BEFORE `hasToolModelConfig` is consulted. Without
+     * this case, deleting the `hasToolModelConfig(existingImageModel)` early
+     * return would leave the whole suite green and the next Save on a v2 box
+     * would replace a customer's own `mediaModels.image` with ours.
+     */
+    it("leaves an owner's own mediaModels.image alone", async () => {
+      mockReadConfig.mockResolvedValue({
+        agents: { defaults: { mediaModels: { image: { primary: "replicate/flux-pro" } } } },
+      } as never);
+      await connectClawai();
+
+      expect(callFor("agents.defaults.mediaModels.image")).toBeUndefined();
+      // The provider block is still ours to write; only the slot is not.
+      expect(callFor("models.providers.openai.apiKey")?.[1]).toBe(CLAWAI_TOKEN);
+    });
+
+    it("leaves an owner's fallbacks-only mediaModels.image alone", async () => {
+      // `hasToolModelConfig` accepts a non-empty fallback, and the write would
+      // replace the whole object and take the owner's fallbacks with it.
+      mockReadConfig.mockResolvedValue({
+        agents: { defaults: { mediaModels: { image: { fallbacks: ["replicate/flux-pro"] } } } },
+      } as never);
+      await connectClawai();
+
+      expect(callFor("agents.defaults.mediaModels.image")).toBeUndefined();
+    });
+
+    it("claims the slot when the legacy key is absent altogether", async () => {
+      await connectWithImageModel();
+
+      expect(JSON.parse(callFor("agents.defaults.mediaModels.image")?.[1] ?? "null")).toEqual({
+        primary: CLAWBOX_AI_IMAGE_MODEL,
+      });
+    });
+
+    /**
+     * TASK-743 — the same stand-down `scripts/gateway-pre-start.sh` gained, in
+     * the OTHER writer of this slot.
+     *
+     * These shapes resolve no model, so this route used to claim the slot and
+     * write `agents.defaults.mediaModels.image` — beside a legacy
+     * `agents.defaults.imageGenerationModel` that is still on the box. Both
+     * homes present is what OpenClaw 2026.8 refuses outright
+     * (`agents.defaults: Unrecognized key: "imageGenerationModel"`, gateway
+     * exit 78), and it also strands the box for good: the core's own loader
+     * migration moves the legacy key only into a home that is EMPTY, so a
+     * `mediaModels.image` written here is what stops it ever being moved.
+     *
+     * Nothing is lost by waiting. The next gateway start runs the core's
+     * `doctor --fix` over a config it will not load, and the save after that
+     * claims the slot as this route always did — except on a box whose doctor
+     * is itself blocked, which stays refused either way.
+     *
+     * "Resolve no model" is `hasToolModelConfig`'s rule, not the core's: the
+     * core coerces a bare string, so the last case below is an owner's
+     * configured model that this route reads as empty. Separate defect, its own
+     * card; the guard covers it either way.
+     */
     it.each<[string, unknown]>([
-      ["absent", undefined],
       ["null", null],
       ["an empty object", {}],
       ["a blank primary", { primary: "   " }],
@@ -702,12 +772,16 @@ describe("POST /setup-api/ai-models/configure — ClawBox AI image provider", ()
       ["fallbacks that is not a list", { fallbacks: "replicate/flux-pro" }],
       ["a non-string primary", { primary: 42 }],
       ["a plain string", "openai/gpt-image-1-mini"],
-    ])("claims the slot when it holds %s — OpenClaw resolves no model from it", async (_label, existing) => {
+    ])("stands down while a legacy key holding %s is still on the box", async (_label, existing) => {
       await connectWithImageModel(existing);
 
-      expect(JSON.parse(callFor("agents.defaults.mediaModels.image")?.[1] ?? "null")).toEqual({
-        primary: CLAWBOX_AI_IMAGE_MODEL,
-      });
+      expect(callFor("agents.defaults.mediaModels.image")).toBeUndefined();
+      // The provider block is still ours to write — only the slot waits.
+      expect(callFor("models.providers.openai.apiKey")?.[1]).toBe(CLAWAI_TOKEN);
+      expect(callFor("models.providers.openai.models")).toBeDefined();
+      // …and nothing writes the legacy key back: this route is not the
+      // migrator either.
+      expect(callFor("agents.defaults.imageGenerationModel")).toBeUndefined();
     });
   });
 

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -50,6 +50,13 @@ vi.mock("@/lib/config-store", () => ({
   DATA_DIR: "/home/clawbox/clawbox/data",
   getAll: vi.fn(),
   setMany: vi.fn(),
+  // `get`/`set` are how `@/lib/clawai-credential-refusal` reads and clears the
+  // persisted ClawBox AI credential refusal. Both of its calls sit inside a
+  // catch that answers a DEFAULT, so omitting them here would not fail this
+  // file — it would quietly make every case take the "no refusal on record"
+  // branch. Guarded by openclaw-config-mock-completeness.test.ts.
+  get: vi.fn(async () => undefined),
+  set: vi.fn(async () => {}),
 }));
 
 vi.mock("@/lib/clawkeep", () => ({ unpairLocal: vi.fn() }));
@@ -459,7 +466,22 @@ describe("POST /setup-api/ai-models/configure and the Claude subscription surfac
     }));
 
     expect(res.status).toBe(200);
-    expect(mockSurfaceRead).not.toHaveBeenCalled();
+    // Still every read this route makes, with ONE file named — not a filter
+    // over the interesting ones, which would stop catching a regression that
+    // made this save read some other cache.
+    //
+    // The assertion was a bare `not.toHaveBeenCalled()` and held only because
+    // this file's `@/lib/config-store` factory omitted `get`. The mechanism,
+    // measured rather than guessed (TASK-743): `configureModel` calls
+    // `setProviderEnabled(ocProvider, true)` inside a try/catch that logs and
+    // carries on, and that reaches `readProviderStatus` ->
+    // `readProviderRunnable` -> `_enumerations.json`. With `get` missing the
+    // very first hop threw, the catch swallowed it, and the whole re-enable
+    // step — not just the read — silently did not happen in any case in this
+    // file. On a box it always does.
+    expect(mockSurfaceRead.mock.calls.map(([file]) => String(file))).toEqual([
+      "/home/clawbox/clawbox/data/catalog-cache/_enumerations.json",
+    ]);
   });
 });
 

--- a/src/tests/routes/ai-models/configure-vision.test.ts
+++ b/src/tests/routes/ai-models/configure-vision.test.ts
@@ -57,6 +57,13 @@ vi.mock("@/lib/config-store", () => ({
   DATA_DIR: "/home/clawbox/clawbox/data",
   getAll: vi.fn(),
   setMany: vi.fn(),
+  // `get`/`set` are how `@/lib/clawai-credential-refusal` reads and clears the
+  // persisted ClawBox AI credential refusal. Both of its calls sit inside a
+  // catch that answers a DEFAULT, so omitting them here would not fail this
+  // file — it would quietly make every case take the "no refusal on record"
+  // branch. Guarded by openclaw-config-mock-completeness.test.ts.
+  get: vi.fn(async () => undefined),
+  set: vi.fn(async () => {}),
 }));
 
 vi.mock("@/lib/clawkeep", () => ({

--- a/src/tests/routes/providers/status-unrunnable.test.ts
+++ b/src/tests/routes/providers/status-unrunnable.test.ts
@@ -11,7 +11,7 @@ let dataDir = "";
 vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn() }));
 vi.mock("@/lib/harness/credentials", () => ({ hasClawaiToken: vi.fn() }));
 vi.mock("@/lib/openclaw-config", () => ({ readConfig: vi.fn() }));
-vi.mock("@/lib/config-store", () => ({ get: vi.fn(), get DATA_DIR() { return dataDir; } }));
+vi.mock("@/lib/config-store", () => ({ get: vi.fn(), set: vi.fn(async () => {}), get DATA_DIR() { return dataDir; } }));
 vi.mock("@/lib/hermes-model-options", () => ({
   getModelOptions: vi.fn(),
   probeStillOwed: vi.fn(),

--- a/src/tests/routes/providers/status.test.ts
+++ b/src/tests/routes/providers/status.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn() }));
 vi.mock("@/lib/harness/credentials", () => ({ hasClawaiToken: vi.fn() }));
 vi.mock("@/lib/openclaw-config", () => ({ readConfig: vi.fn() }));
-vi.mock("@/lib/config-store", () => ({ get: vi.fn() }));
+vi.mock("@/lib/config-store", () => ({ get: vi.fn(), set: vi.fn(async () => {}) }));
 vi.mock("@/lib/hermes-model-options", () => ({
   getModelOptions: vi.fn(),
   probeStillOwed: vi.fn(),

--- a/src/tests/unit/gateway-pre-start-clawai-audio.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-audio.test.ts
@@ -351,4 +351,27 @@ describe.skipIf(!hasPython3)("the same migration on OpenClaw 2 homes", () => {
     expect(media?.models).toEqual(foreign);
     expect(media?.audio).toBeUndefined();
   });
+
+  /**
+   * TASK-743 — the in-flight guard here read the KEY's contents, and a JSON
+   * `null` slipped past it.
+   *
+   * `tools.media.audio.models: null` is PRESENT and is refused by the core
+   * (`tools.media.audio: Unrecognized key: "models"`, measured on 2026.8.1),
+   * but `_audio.get("models") is not None` reads it as absent — so the block
+   * seeded `tools.media.models` beside the surviving legacy key, which is the
+   * dual-home write the image guard in the same file stands down over. The
+   * test on the sibling image key is what found this one.
+   */
+  it("does not seed the shared list beside a legacy audio.models key holding null", () => {
+    const { cfg } = migrate({ tools: { media: { audio: { models: null } } } }, true, true);
+
+    const media = (cfg.tools as { media?: { models?: unknown; audio?: AudioConfig } }).media;
+    expect(media?.models).toBeUndefined();
+    // The legacy key is left exactly as it was — this block is not the migrator.
+    expect((media?.audio as { models?: unknown } | undefined)?.models).toBeNull();
+    // `baseUrl` lives at the same address in both generations and is still
+    // written, which is what the in-flight comment says.
+    expect((media?.audio as { baseUrl?: unknown } | undefined)?.baseUrl).toBe(PROXY);
+  });
 });

--- a/src/tests/unit/gateway-pre-start-clawai-images.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-images.test.ts
@@ -772,6 +772,117 @@ describe.skipIf(!hasPython3)("the image-generation home on OpenClaw 2", () => {
     );
     expect(mediaImage(cfg)).toEqual({ primary: "openai/their-pick" });
   });
+
+  /**
+   * TASK-743 — the dual-home shape, on the key this file's own header names
+   * first, and link 1 of the incident TASK-737 is about.
+   *
+   * `_has_image_model` reads the legacy key as a FALLBACK when the v2 home is
+   * absent, so a box whose `agents.defaults.imageGenerationModel` names a model
+   * was never at risk. The shapes it reads as an EMPTY slot are: `{}`,
+   * `{"primary": ""}`, `{"fallbacks": []}`, a JSON `null`, a scalar — and for
+   * every one of them this block wrote `mediaModels.image` and left the legacy
+   * key sitting beside it. Measured against 2026.8.1, both homes present is
+   * `agents.defaults: Unrecognized key: "imageGenerationModel"`, exit 1 — the
+   * gateway exit 78 that kept a customer box dark for 25 hours.
+   *
+   * The guard is #751's, on the KEY rather than its contents, for the reason
+   * that comment gives about `messages.tts`: a discriminator that asked what
+   * the key HELD would go on writing the second home beside every shape that
+   * holds nothing.
+   *
+   * "Holds nothing" here means `_has_image_model`'s rule, NOT the core's. The
+   * core coerces a bare string (`hasExplicitToolModelConfig` ->
+   * `resolveAgentModelPrimaryValue`, measured on 2026.8.1), so the scalar case
+   * below is a configured model this block reads as an empty slot — which is a
+   * separate defect, out of this card and recorded in the run queue. It is
+   * listed here because the guard covers it either way, not because the core
+   * agrees that it is empty.
+   */
+  describe("a legacy image key the core has not migrated yet", () => {
+    const EMPTY_LEGACY_SHAPES: Array<[string, unknown]> = [
+      ["an empty object", {}],
+      ["an empty primary", { primary: "" }],
+      ["a whitespace primary", { primary: "   " }],
+      ["an empty fallbacks list", { fallbacks: [] }],
+      ["a null", null],
+      ["a scalar", "openai/gpt-image-1"],
+      ["a list", []],
+    ];
+
+    for (const [name, legacy] of EMPTY_LEGACY_SHAPES) {
+      it(`stands down rather than writing the v2 home beside ${name}`, () => {
+        const { cfg, log } = migrate(
+          pairedBox({ agents: { defaults: { imageGenerationModel: legacy } } }),
+          true,
+        );
+
+        // The v2 home is NOT created…
+        expect(mediaImage(cfg)).toBeUndefined();
+        // …and the legacy key is left exactly as it was, for the core's own
+        // migration to move. This block never removes it: taking it away here
+        // would be this file deciding a migration the core owns.
+        expect(imageGenerationModel(cfg)).toEqual(legacy);
+        expect(log).toContain("Skipped the ClawBox AI image model");
+      });
+    }
+
+    it("still writes the provider and the model row, so the next boot has nothing left to do", () => {
+      // Narrower than #751's stand-down on purpose: the `models[]` row has ONE
+      // home on both cores and its repair is what keeps a box bootable, so only
+      // the slot stands down.
+      const { cfg, changed } = migrate(
+        pairedBox({ agents: { defaults: { imageGenerationModel: { primary: "" } } } }),
+        true,
+      );
+
+      expect(changed).toBe(true);
+      expect(openaiProvider(cfg).apiKey).toBe("claw_token123");
+      expect(imageEntry(cfg)).toEqual({
+        id: CLAWBOX_AI_IMAGE_MODEL_ID,
+        name: CLAWBOX_AI_IMAGE_MODEL_LABEL,
+        baseUrl: "https://clawbox.com/api/ai",
+      });
+    });
+
+    it("claims the v2 home the moment the core's migration has moved the key", () => {
+      // Standing down is never permanent — the same promise the cloud voice's
+      // guard makes. Once `doctor --fix` has moved the key, the next boot is an
+      // ordinary one.
+      const { cfg, changed, log } = migrate(pairedBox(), true);
+
+      expect(changed).toBe(true);
+      expect(mediaImage(cfg)).toEqual({ primary: CLAWBOX_AI_IMAGE_MODEL });
+      expect(imageGenerationModel(cfg)).toBeUndefined();
+      expect(log).not.toContain("Skipped the ClawBox AI image model");
+    });
+
+    it("does not stand down on a v1 core, whose only home this key is", () => {
+      // The guard is `_clawbox_v2` AND the key. On a 2026.7 box the legacy key
+      // IS the home, and standing down there would leave the image path
+      // undeclared for good.
+      const { cfg, log } = migrate(
+        pairedBox({ agents: { defaults: { imageGenerationModel: { primary: "" } } } }),
+      );
+
+      expect(imageGenerationModel(cfg)).toEqual({ primary: CLAWBOX_AI_IMAGE_MODEL });
+      expect(log).not.toContain("Skipped the ClawBox AI image model");
+    });
+
+    it("reports no change when the slot is all there was to write", () => {
+      // A box that already has our row and our provider, standing down on the
+      // slot, must not report a write it did not make — `changed` is what makes
+      // the boot script rewrite openclaw.json.
+      const armed = migrate(pairedBox(), true).cfg;
+      const agents = (armed.agents ?? {}) as { defaults: Record<string, unknown> };
+      delete (agents.defaults.mediaModels as Record<string, unknown>).image;
+      agents.defaults.imageGenerationModel = { primary: "" };
+
+      const { changed } = migrate(armed, true);
+
+      expect(changed).toBe(false);
+    });
+  });
 });
 
 /**
@@ -952,6 +1063,57 @@ describe.skipIf(!hasPython3)("standing down when the credential has been refused
     expect(mediaImage(cfg)).toBeUndefined();
     expect(imageEntry(cfg)).toBeUndefined();
     expect(both).toBeTruthy();
+  });
+
+  /**
+   * TASK-743 — an EMPTY leftover legacy key used to veto the whole take-back.
+   *
+   * `_slot_is_theirs` asked `agents_defaults.get("imageGenerationModel") is not
+   * None`, so `{}`, `{"primary": ""}`, `{"fallbacks": []}` and `[]` — the very
+   * shapes the guard above treats as holding no decision — read as the owner's
+   * image configuration and stopped #755's arm from removing anything. A box
+   * whose credential the proxy had permanently refused therefore kept the image
+   * path declared for as long as that key survived, which is the TASK-727 shape
+   * (6,554 refused calls in twelve hours).
+   *
+   * Both arms now ask ONE question, and it is deliberately WIDER for the delete
+   * than the upsert's: a bare string counts, because the core coerces one and
+   * this is the only place in the file that destroys configuration.
+   */
+  it.each<[string, unknown]>([
+    ["an empty object", {}],
+    ["an empty primary", { primary: "" }],
+    ["an empty fallbacks list", { fallbacks: [] }],
+    ["a list", []],
+  ])("takes the image path back over a leftover legacy key holding %s", (_label, leftover) => {
+    const withLeftover = JSON.parse(JSON.stringify(armedBox(true))) as Config;
+    ((withLeftover.agents as { defaults: Record<string, unknown> }).defaults)
+      .imageGenerationModel = leftover;
+
+    const { cfg, changed } = migrate(withLeftover, true, REFUSED);
+
+    expect(changed).toBe(true);
+    expect(mediaImage(cfg)).toBeUndefined();
+    expect(imageEntry(cfg)).toBeUndefined();
+    // The leftover itself is not ours to remove — only the core migrates it.
+    expect(imageGenerationModel(cfg)).toEqual(leftover);
+  });
+
+  it("still leaves a legacy key that NAMES a model, including a bare string", () => {
+    // The other side of the same predicate. A string is a configured model to
+    // the core (`hasExplicitToolModelConfig` coerces it), so it may well name
+    // our row — and a delete cannot be undone.
+    for (const theirs of [{ primary: "replicate/flux-pro" }, "replicate/flux-pro"]) {
+      const withTheirs = JSON.parse(JSON.stringify(armedBox(true))) as Config;
+      ((withTheirs.agents as { defaults: Record<string, unknown> }).defaults)
+        .imageGenerationModel = theirs;
+
+      const { cfg, changed } = migrate(withTheirs, true, REFUSED);
+
+      expect(changed).toBe(false);
+      expect(imageEntry(cfg)).toBeDefined();
+      expect(imageGenerationModel(cfg)).toEqual(theirs);
+    }
   });
 
   it("removes the models list it created rather than leaving an empty one", () => {

--- a/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
@@ -647,6 +647,83 @@ describe.skipIf(!hasPython3)("the same migration on OpenClaw 2's top-level tts h
     const tts = cfg.tts as { providers?: Record<string, SpeechEntry> } | undefined;
     expect(tts?.providers?.openai).toEqual({ baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN, ...MANAGED });
   });
+
+  /**
+   * TASK-743 — the DOWNGRADE half only ever looked in the v2 home, and the box
+   * it was written for is exactly the one whose entry is not there.
+   *
+   * A box that was Max under a 2026.7 core wrote its stamped entry into
+   * `messages.tts.providers.openai`. Upgrade the core and drop the plan to Pro
+   * before the loader migration has moved that block — which is the ordinary
+   * order, and is guaranteed on a box whose `doctor --fix` aborts before its
+   * state migrations, the same thing that strands the legacy image key one
+   * migration earlier in this file — and this arm read `cfg["tts"]`, found
+   * nothing, and left our own dead entry in place: every spoken reply buying a
+   * 403 round trip while the Voice panel calls the cloud voice configured.
+   *
+   * Deleting from the legacy home is safe where WRITING to it is not: a
+   * removal cannot create the dual-home shape the arming half stands down
+   * over, and it leaves the core's own migration less to move rather than more.
+   */
+  describe("taking the cloud voice back from wherever the entry actually is", () => {
+    const OURS = { baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN, ...MANAGED };
+
+    it("takes back a stamped entry stranded in the legacy home", () => {
+      const seeded = { messages: { tts: { providers: { openai: { ...OURS } } } } };
+
+      const { cfg, changed } = migrate(seeded, { v2: true, deviceTier: PRO_DEVICE_TIER });
+
+      expect(changed).toBe(true);
+      const messages = cfg.messages as { tts: { providers: Record<string, SpeechEntry> } };
+      expect(messages.tts.providers.openai).toBeUndefined();
+      // The rest of the legacy block is untouched — this arm removes one entry,
+      // it does not migrate or tidy the home it found it in.
+      expect(messages.tts.providers).toEqual({});
+    });
+
+    it("takes back an entry in EITHER home when a box carries both", () => {
+      const seeded = {
+        tts: { providers: { openai: { ...OURS } } },
+        messages: { tts: { providers: { openai: { ...OURS } } } },
+      };
+
+      const { cfg, changed } = migrate(seeded, { v2: true, deviceTier: PRO_DEVICE_TIER });
+
+      expect(changed).toBe(true);
+      expect((cfg.tts as { providers: Record<string, SpeechEntry> }).providers.openai).toBeUndefined();
+      const messages = cfg.messages as { tts: { providers: Record<string, SpeechEntry> } };
+      expect(messages.tts.providers.openai).toBeUndefined();
+    });
+
+    it("leaves an owner's own entry in the legacy home alone", () => {
+      // The extra home widens WHERE this arm looks, never WHAT it may delete:
+      // the stamp is still the only thing that opens the door, and this is the
+      // one place in the file that destroys configuration.
+      const theirs = { baseUrl: "https://their.own/voice", model: "x" };
+      const seeded = { messages: { tts: { providers: { openai: { ...theirs } } } } };
+
+      const { cfg, changed } = migrate(seeded, { v2: true, deviceTier: PRO_DEVICE_TIER });
+
+      expect(changed).toBe(false);
+      const messages = cfg.messages as { tts: { providers: Record<string, SpeechEntry> } };
+      expect(messages.tts.providers.openai).toEqual(theirs);
+    });
+
+    it("still reads only the legacy home on a v1 core", () => {
+      // `cfg["tts"]` is not a home a 2026.7 core has, and reading it there
+      // would be this arm inventing one.
+      const seeded = {
+        tts: { providers: { openai: { ...OURS } } },
+        messages: { tts: { providers: { openai: { ...OURS } } } },
+      };
+
+      const { cfg } = migrate(seeded, { deviceTier: PRO_DEVICE_TIER });
+
+      expect((cfg.tts as { providers: Record<string, SpeechEntry> }).providers.openai).toEqual(OURS);
+      const messages = cfg.messages as { tts: { providers: Record<string, SpeechEntry> } };
+      expect(messages.tts.providers.openai).toBeUndefined();
+    });
+  });
 });
 
 /**

--- a/src/tests/unit/hermes-clawai-voice.test.ts
+++ b/src/tests/unit/hermes-clawai-voice.test.ts
@@ -37,6 +37,13 @@ vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }
 vi.mock("@/lib/config-store", () => ({
   setMany: vi.fn(),
   getKnown: vi.fn(async () => ({ value: undefined, known: true })),
+  // `get`/`set` are how `@/lib/clawai-credential-refusal` reads and clears the
+  // persisted ClawBox AI credential refusal. Both of its calls sit inside a
+  // catch that answers a DEFAULT, so omitting them here would not fail this
+  // file — it would quietly make every case take the "no refusal on record"
+  // branch. Guarded by openclaw-config-mock-completeness.test.ts.
+  get: vi.fn(async () => undefined),
+  set: vi.fn(async () => {}),
 }));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));
 vi.mock("@/lib/hermes-image-plugin", async (importOriginal) => ({

--- a/src/tests/unit/hermes-voice-writes-once.test.ts
+++ b/src/tests/unit/hermes-voice-writes-once.test.ts
@@ -73,6 +73,13 @@ vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }
 vi.mock("@/lib/config-store", () => ({
   setMany: vi.fn(),
   getKnown: vi.fn(async () => ({ value: undefined, known: true })),
+  // `get`/`set` are how `@/lib/clawai-credential-refusal` reads and clears the
+  // persisted ClawBox AI credential refusal. Both of its calls sit inside a
+  // catch that answers a DEFAULT, so omitting them here would not fail this
+  // file — it would quietly make every case take the "no refusal on record"
+  // branch. Guarded by openclaw-config-mock-completeness.test.ts.
+  get: vi.fn(async () => undefined),
+  set: vi.fn(async () => {}),
 }));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));
 vi.mock("@/lib/hermes-image-plugin", async (importOriginal) => ({

--- a/src/tests/unit/openclaw-config-mock-completeness.test.ts
+++ b/src/tests/unit/openclaw-config-mock-completeness.test.ts
@@ -199,6 +199,77 @@ const SILENT_STORE_READER = "@/lib/clawai-credential-refusal";
 /** What that reader takes off the store, and therefore what a factory must name. */
 const STORE_EXPORTS = ["get", "set"] as const;
 
+/** Index of the next character that is neither whitespace nor a comment. */
+function skipTrivia(text: string, from: number): number {
+  let i = from;
+  for (;;) {
+    while (i < text.length && /\s/.test(text[i])) i += 1;
+    if (text[i] === "/" && text[i + 1] === "/") {
+      const nl = text.indexOf(String.fromCharCode(10), i);
+      if (nl < 0) return text.length;
+      i = nl + 1;
+      continue;
+    }
+    if (text[i] === "/" && text[i + 1] === "*") {
+      const close = text.indexOf("*/", i + 2);
+      if (close < 0) return text.length;
+      i = close + 2;
+      continue;
+    }
+    return i;
+  }
+}
+
+/**
+ * Where the object the factory RETURNS begins, or -1.
+ *
+ * Only two shapes count, and picking them apart matters: the direct
+ * arrow-expression body `() => ({ … })`, and a block body's own top-level
+ * `return { … }`. Taking the first `({` after the arrow instead would read a
+ * LOCAL object — `() => { const d = ({ get, set }); return { set }; }` reports
+ * both exports and misses that the mock omits one, which is the gate passing
+ * over exactly the hole it exists for.
+ */
+function returnedObjectStart(factory: string, from: number): number {
+  const head = skipTrivia(factory, from);
+  if (factory[head] === "(") {
+    const inner = skipTrivia(factory, head + 1);
+    return factory[inner] === "{" ? inner : -1;
+  }
+  if (factory[head] !== "{") return -1;
+
+  // A block body: find `return` at the body's own depth, not inside a nested
+  // function or object.
+  let depth = 0;
+  for (let i = head; i < factory.length; i += 1) {
+    const ch = factory[i];
+    if (ch === "/" && (factory[i + 1] === "/" || factory[i + 1] === "*")) {
+      i = skipTrivia(factory, i) - 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      i += 1;
+      while (i < factory.length && factory[i] !== quote) {
+        if (factory[i] === "\\") i += 1;
+        i += 1;
+      }
+      continue;
+    }
+    if (ch === "{" || ch === "[" || ch === "(") { depth += 1; continue; }
+    if (ch === "}" || ch === "]" || ch === ")") { depth -= 1; if (depth === 0) return -1; continue; }
+    if (depth !== 1 || ch !== "r" || !/^return\b/.test(factory.slice(i))) continue;
+    const after = skipTrivia(factory, i + "return".length);
+    if (factory[after] === "{") return after;
+    if (factory[after] === "(") {
+      const inner = skipTrivia(factory, after + 1);
+      return factory[inner] === "{" ? inner : -1;
+    }
+    return -1;
+  }
+  return -1;
+}
+
 /**
  * The names a mock factory actually EXPORTS — the members of the object it
  * returns, at that object's own level and nowhere else.
@@ -223,18 +294,10 @@ const STORE_EXPORTS = ["get", "set"] as const;
  * read is a shape nobody has checked.
  */
 function factoryExports(factory: string): Set<string> | null {
-  // `() => ({ … })` is the form every factory in this repo uses; `return {`
-  // covers a block-bodied one. Anything else is unparseable here by design.
   const arrow = factory.indexOf("=>");
   if (arrow < 0) return null;
-  const parenObject = factory.indexOf("({", arrow);
-  const returned = factory.indexOf("return", arrow);
-  const start = parenObject >= 0
-    ? parenObject + 1
-    : returned >= 0
-      ? factory.indexOf("{", returned)
-      : -1;
-  if (start < 0 || factory[start] !== "{") return null;
+  const start = returnedObjectStart(factory, arrow + 2);
+  if (start < 0) return null;
 
   const names = new Set<string>();
   let depth = 0;
@@ -388,6 +451,14 @@ describe(`every ${STORE_MODULE} mock in front of a ${SILENT_STORE_READER} caller
     // A block body, and a factory shape this cannot read at all.
     expect([...exportsOf("() => { return { get: vi.fn(), set: vi.fn() }; }")!].sort()).toEqual(["get", "set"]);
     expect(factoryExports('vi.mock("x", someHelper)')).toBeNull();
+
+    // A LOCAL object before the return is not what the factory exports. Reading
+    // the first `({` after the arrow would answer `get, set` here and miss that
+    // the mock omits `get` — the gate passing over the hole it exists for.
+    expect([...exportsOf("() => { const d = ({ get: vi.fn(), set: vi.fn() }); return { set: d.set }; }")!])
+      .toEqual(["set"]);
+    // …and a parenthesised return object is still read.
+    expect([...exportsOf("() => { return ({ get: vi.fn(), set: vi.fn() }); }")!].sort()).toEqual(["get", "set"]);
 
     // And the omission the gate exists for.
     expect([...exportsOf("() => ({ getAll: vi.fn(), setMany: vi.fn() })")!].sort()).toEqual(["getAll", "setMany"]);

--- a/src/tests/unit/openclaw-config-mock-completeness.test.ts
+++ b/src/tests/unit/openclaw-config-mock-completeness.test.ts
@@ -258,7 +258,13 @@ function returnedObjectStart(factory: string, from: number): number {
     }
     if (ch === "{" || ch === "[" || ch === "(") { depth += 1; continue; }
     if (ch === "}" || ch === "]" || ch === ")") { depth -= 1; if (depth === 0) return -1; continue; }
-    if (depth !== 1 || ch !== "r" || !/^return\b/.test(factory.slice(i))) continue;
+    if (ch !== "r" || !/^return\b/.test(factory.slice(i))) continue;
+    // A CONDITIONAL return makes the factory unreadable, not merely different.
+    // `() => { if (partial) return { set }; return { get, set }; }` has a path
+    // that omits an export, and answering from the unconditional one would
+    // clear it — the gate passing over the hole it exists for, for the third
+    // time in this review. Reported instead, so a human reads the factory.
+    if (depth !== 1) return -1;
     const after = skipTrivia(factory, i + "return".length);
     if (factory[after] === "{") return after;
     if (factory[after] === "(") {
@@ -459,6 +465,12 @@ describe(`every ${STORE_MODULE} mock in front of a ${SILENT_STORE_READER} caller
       .toEqual(["set"]);
     // …and a parenthesised return object is still read.
     expect([...exportsOf("() => { return ({ get: vi.fn(), set: vi.fn() }); }")!].sort()).toEqual(["get", "set"]);
+
+    // A BRANCH-DEPENDENT factory is unreadable, not "whatever the last return
+    // says": one path here omits `get`, and answering from the unconditional
+    // return would clear it.
+    expect(exportsOf("() => { if (p) { return { set: vi.fn() }; } return { get: vi.fn(), set: vi.fn() }; }"))
+      .toBeNull();
 
     // And the omission the gate exists for.
     expect([...exportsOf("() => ({ getAll: vi.fn(), setMany: vi.fn() })")!].sort()).toEqual(["getAll", "setMany"]);

--- a/src/tests/unit/openclaw-config-mock-completeness.test.ts
+++ b/src/tests/unit/openclaw-config-mock-completeness.test.ts
@@ -223,57 +223,27 @@ function skipTrivia(text: string, from: number): number {
 /**
  * Where the object the factory RETURNS begins, or -1.
  *
- * Only two shapes count, and picking them apart matters: the direct
- * arrow-expression body `() => ({ … })`, and a block body's own top-level
- * `return { … }`. Taking the first `({` after the arrow instead would read a
- * LOCAL object — `() => { const d = ({ get, set }); return { set }; }` reports
- * both exports and misses that the mock omits one, which is the gate passing
- * over exactly the hole it exists for.
+ * ONE shape is read: the direct arrow-expression body, `() => ({ … })`, which
+ * is what every mock factory in this repo is written as. Everything else — a
+ * block body, an identifier, a helper passed by name — answers -1, and the
+ * caller REPORTS such a factory rather than skipping it.
+ *
+ * A block-bodied branch was written first and then deleted, and the reason is
+ * worth keeping: reading `return { … }` out of a `{ … }` body is not a lookup,
+ * it is control flow. A local object before the return, a `return` inside an
+ * `if` block, an UNBRACED `if (p) return { … };`, an identifier called
+ * `myreturn` — each one is a way for the scan to answer from a path that is not
+ * the factory's only path, and each was a separate defect in review. A gate
+ * that needs a control-flow analysis to be right has bugs of its own, and every
+ * one of them fails in the direction that clears a factory nobody checked.
+ * Refusing to read the shape is the honest answer, and it costs nothing while
+ * no factory uses it.
  */
 function returnedObjectStart(factory: string, from: number): number {
   const head = skipTrivia(factory, from);
-  if (factory[head] === "(") {
-    const inner = skipTrivia(factory, head + 1);
-    return factory[inner] === "{" ? inner : -1;
-  }
-  if (factory[head] !== "{") return -1;
-
-  // A block body: find `return` at the body's own depth, not inside a nested
-  // function or object.
-  let depth = 0;
-  for (let i = head; i < factory.length; i += 1) {
-    const ch = factory[i];
-    if (ch === "/" && (factory[i + 1] === "/" || factory[i + 1] === "*")) {
-      i = skipTrivia(factory, i) - 1;
-      continue;
-    }
-    if (ch === '"' || ch === "'" || ch === "`") {
-      const quote = ch;
-      i += 1;
-      while (i < factory.length && factory[i] !== quote) {
-        if (factory[i] === "\\") i += 1;
-        i += 1;
-      }
-      continue;
-    }
-    if (ch === "{" || ch === "[" || ch === "(") { depth += 1; continue; }
-    if (ch === "}" || ch === "]" || ch === ")") { depth -= 1; if (depth === 0) return -1; continue; }
-    if (ch !== "r" || !/^return\b/.test(factory.slice(i))) continue;
-    // A CONDITIONAL return makes the factory unreadable, not merely different.
-    // `() => { if (partial) return { set }; return { get, set }; }` has a path
-    // that omits an export, and answering from the unconditional one would
-    // clear it — the gate passing over the hole it exists for, for the third
-    // time in this review. Reported instead, so a human reads the factory.
-    if (depth !== 1) return -1;
-    const after = skipTrivia(factory, i + "return".length);
-    if (factory[after] === "{") return after;
-    if (factory[after] === "(") {
-      const inner = skipTrivia(factory, after + 1);
-      return factory[inner] === "{" ? inner : -1;
-    }
-    return -1;
-  }
-  return -1;
+  if (factory[head] !== "(") return -1;
+  const inner = skipTrivia(factory, head + 1);
+  return factory[inner] === "{" ? inner : -1;
 }
 
 /**
@@ -454,23 +424,21 @@ describe(`every ${STORE_MODULE} mock in front of a ${SILENT_STORE_READER} caller
     expect([...exportsOf("() => ({ getAll: vi.fn(), getKnown: vi.fn(), setMany: vi.fn() })")!].sort())
       .toEqual(["getAll", "getKnown", "setMany"]);
 
-    // A block body, and a factory shape this cannot read at all.
-    expect([...exportsOf("() => { return { get: vi.fn(), set: vi.fn() }; }")!].sort()).toEqual(["get", "set"]);
+    // Anything that is not the direct arrow-expression body is UNREADABLE, and
+    // unreadable is reported rather than skipped. Every one of these was a way
+    // for an earlier, cleverer version to answer from a path that is not the
+    // factory's only path.
     expect(factoryExports('vi.mock("x", someHelper)')).toBeNull();
-
-    // A LOCAL object before the return is not what the factory exports. Reading
-    // the first `({` after the arrow would answer `get, set` here and miss that
-    // the mock omits `get` — the gate passing over the hole it exists for.
-    expect([...exportsOf("() => { const d = ({ get: vi.fn(), set: vi.fn() }); return { set: d.set }; }")!])
-      .toEqual(["set"]);
-    // …and a parenthesised return object is still read.
-    expect([...exportsOf("() => { return ({ get: vi.fn(), set: vi.fn() }); }")!].sort()).toEqual(["get", "set"]);
-
-    // A BRANCH-DEPENDENT factory is unreadable, not "whatever the last return
-    // says": one path here omits `get`, and answering from the unconditional
-    // return would clear it.
+    expect(exportsOf("() => { return { get: vi.fn(), set: vi.fn() }; }")).toBeNull();
+    // …a local object before the return,
+    expect(exportsOf("() => { const d = ({ get: vi.fn(), set: vi.fn() }); return { set: d.set }; }")).toBeNull();
+    // …a braced conditional return, and an UNBRACED one,
     expect(exportsOf("() => { if (p) { return { set: vi.fn() }; } return { get: vi.fn(), set: vi.fn() }; }"))
       .toBeNull();
+    expect(exportsOf("() => { if (p) return { get: vi.fn(), set: vi.fn() }; return { set: vi.fn() }; }"))
+      .toBeNull();
+    // …and an identifier that merely ENDS in the keyword.
+    expect(exportsOf("() => { const myreturn = 1; return { get: vi.fn(), set: vi.fn() }; }")).toBeNull();
 
     // And the omission the gate exists for.
     expect([...exportsOf("() => ({ getAll: vi.fn(), setMany: vi.fn() })")!].sort()).toEqual(["getAll", "setMany"]);

--- a/src/tests/unit/openclaw-config-mock-completeness.test.ts
+++ b/src/tests/unit/openclaw-config-mock-completeness.test.ts
@@ -200,17 +200,109 @@ const SILENT_STORE_READER = "@/lib/clawai-credential-refusal";
 const STORE_EXPORTS = ["get", "set"] as const;
 
 /**
- * Does this factory name that export, in any of the forms a factory writes one?
+ * The names a mock factory actually EXPORTS — the members of the object it
+ * returns, at that object's own level and nowhere else.
  *
- * `get: vi.fn()`, `get,` (shorthand), `get)` (last entry) — and `get()` /
- * `async get()`, the object-METHOD form. The last one is why the opening paren
- * is in the class: without it a perfectly complete factory written with methods
- * would be reported as missing, and a gate whose failure mode is a false
- * positive is one nobody trusts. `\b` anchors the start, so `getAll:` and
- * `getKnown:` — both live in this repo's factories — never match `get`.
+ * A regex over the factory text cannot answer this, and both of its failure
+ * modes were real (found in review): `({ get: vi.fn(), set })` ends its last
+ * member at a `}` rather than a `,` or `)`, so a name-followed-by-punctuation
+ * test reports a COMPLETE factory as missing one; and `({ set() { get(); } })`
+ * contains the text `get(`, so the same test reports an export the factory does
+ * not have. A gate that fails correct code is worse than no gate, and one that
+ * passes the hole it exists to catch is pointless.
+ *
+ * So this walks instead: strings and template literals are skipped whole,
+ * bracket depth is counted, and a name is taken only where a member may begin —
+ * straight after the object's `{` or after a `,` at that same depth. `async`,
+ * and the `get`/`set` accessor keywords, are read as modifiers when another
+ * identifier follows them, so `async get() {}` is the member `get` and
+ * `get value() {}` is the member `value`.
+ *
+ * Returns null when the factory's returned object cannot be found, and the
+ * caller REPORTS such a factory rather than skipping it: a shape this cannot
+ * read is a shape nobody has checked.
  */
-function storeExportNamed(name: string): RegExp {
-  return new RegExp(`\\b${name}\\s*[:,)(]`);
+function factoryExports(factory: string): Set<string> | null {
+  // `() => ({ … })` is the form every factory in this repo uses; `return {`
+  // covers a block-bodied one. Anything else is unparseable here by design.
+  const arrow = factory.indexOf("=>");
+  if (arrow < 0) return null;
+  const parenObject = factory.indexOf("({", arrow);
+  const returned = factory.indexOf("return", arrow);
+  const start = parenObject >= 0
+    ? parenObject + 1
+    : returned >= 0
+      ? factory.indexOf("{", returned)
+      : -1;
+  if (start < 0 || factory[start] !== "{") return null;
+
+  const names = new Set<string>();
+  let depth = 0;
+  let expectKey = false;
+  for (let i = start; i < factory.length; i += 1) {
+    const ch = factory[i];
+    // COMMENTS FIRST, and this is not a nicety: every factory in this repo
+    // explains itself between its members, and a comment carrying an
+    // apostrophe ("the owner's picks") or a bare word after a comma was read
+    // as a string opener and as the next member's name. Both were measured —
+    // seven complete factories reported as missing an export, one as
+    // unparseable — before this branch existed.
+    if (ch === "/" && factory[i + 1] === "/") {
+      const nl = factory.indexOf(String.fromCharCode(10), i);
+      i = nl < 0 ? factory.length : nl;
+      continue;
+    }
+    if (ch === "/" && factory[i + 1] === "*") {
+      const close = factory.indexOf("*/", i + 2);
+      i = close < 0 ? factory.length : close + 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      // Skip the literal whole, escapes included. A `{` or a member name inside
+      // a string is text, not structure.
+      const quote = ch;
+      i += 1;
+      while (i < factory.length && factory[i] !== quote) {
+        if (factory[i] === "\\") i += 1;
+        i += 1;
+      }
+      continue;
+    }
+    if (ch === "{" || ch === "[" || ch === "(") {
+      depth += 1;
+      if (ch === "{" && depth === 1) expectKey = true;
+      continue;
+    }
+    if (ch === "}" || ch === "]" || ch === ")") {
+      depth -= 1;
+      if (depth === 0) return names;
+      continue;
+    }
+    if (depth === 1 && ch === ",") {
+      expectKey = true;
+      continue;
+    }
+    if (!expectKey || depth !== 1) continue;
+    if (/\s/.test(ch)) continue;
+    const identifier = /^[A-Za-z_$][A-Za-z0-9_$]*/.exec(factory.slice(i));
+    if (!identifier) {
+      // A computed key, a spread, a string key — none of them names one of the
+      // exports this gate asks about.
+      expectKey = false;
+      continue;
+    }
+    const after = factory.slice(i + identifier[0].length).match(/^\s*([A-Za-z_$])?/);
+    // `async get()`, `get value()`: a bare identifier followed by another one
+    // is a modifier, so keep looking for the member on this same entry.
+    if (after?.[1]) {
+      i += identifier[0].length - 1;
+      continue;
+    }
+    names.add(identifier[0]);
+    i += identifier[0].length - 1;
+    expectKey = false;
+  }
+  return null;
 }
 
 describe(`every ${STORE_MODULE} mock in front of a ${SILENT_STORE_READER} caller carries its store functions`, () => {
@@ -233,7 +325,14 @@ describe(`every ${STORE_MODULE} mock in front of a ${SILENT_STORE_READER} caller
     const factory = mockCall(read.get(file)!, STORE_MODULE);
     if (!factory) continue;
     if (factory.includes("importActual") || factory.includes("importOriginal")) continue;
-    const missing = STORE_EXPORTS.filter((name) => !storeExportNamed(name).test(factory));
+    const exported = factoryExports(factory);
+    // A factory this cannot read is REPORTED, not skipped: an unreadable shape
+    // is one nobody has checked, and the sibling gate above learned the hard
+    // way that a mock the scanner cannot see is the one failure a gate must
+    // not have.
+    const missing = exported === null
+      ? ["unparseable factory"]
+      : STORE_EXPORTS.filter((name) => !exported.has(name));
     if (missing.length > 0) offenders.push(`${path.relative(SRC, file)} (${missing.join(", ")})`);
   }
 
@@ -258,23 +357,55 @@ describe(`every ${STORE_MODULE} mock in front of a ${SILENT_STORE_READER} caller
     ).toBeGreaterThan(3);
   });
 
-  it("reports a factory that omits them, in either quote form", () => {
-    // The predicate itself, over the two shapes: the sibling above learned the
-    // hard way that a mock the scanner cannot SEE is skipped rather than
-    // reported.
-    const omits = `vi.mock('${STORE_MODULE}', () => ({ getAll: vi.fn(), setMany: vi.fn() }));`;
-    const carries = `vi.mock("${STORE_MODULE}", () => ({ get: vi.fn(), set: vi.fn() }));`;
-    // The object-METHOD form of the same complete factory: a gate that reported
-    // this as missing would fail a PR over correct code.
-    const methods = `vi.mock("${STORE_MODULE}", () => ({ async get() {}, async set() {} }));`;
-    const seen = mockCall(omits, STORE_MODULE);
-    expect(seen).not.toBeNull();
-    expect(STORE_EXPORTS.filter((n) => !storeExportNamed(n).test(seen!))).toEqual(["get", "set"]);
-    expect(STORE_EXPORTS.filter((n) => !storeExportNamed(n).test(mockCall(carries, STORE_MODULE)!))).toEqual([]);
-    expect(STORE_EXPORTS.filter((n) => !storeExportNamed(n).test(mockCall(methods, STORE_MODULE)!))).toEqual([]);
-    // …and the two neighbours that share the prefix are still not it.
-    const prefixes = `vi.mock("${STORE_MODULE}", () => ({ getAll: vi.fn(), getKnown: vi.fn(), setMany: vi.fn() }));`;
-    expect(STORE_EXPORTS.filter((n) => !storeExportNamed(n).test(mockCall(prefixes, STORE_MODULE)!)))
-      .toEqual(["get", "set"]);
+  it("reads the members a factory exports, in every shape one is written", () => {
+    // The predicate itself. Both of the shapes below were false answers from
+    // the regex this replaced, and both came out of review rather than out of
+    // this file — which is why they are pinned here.
+    const exportsOf = (body: string) => factoryExports(mockCall(`vi.mock("${STORE_MODULE}", ${body});`, STORE_MODULE)!);
+
+    // The plain form, and either quote around the module id.
+    expect([...exportsOf("() => ({ get: vi.fn(), set: vi.fn() })")!].sort()).toEqual(["get", "set"]);
+    expect(factoryExports(mockCall(`vi.mock('${STORE_MODULE}', () => ({ get: vi.fn() }));`, STORE_MODULE)!)!.has("get"))
+      .toBe(true);
+
+    // TRAILING SHORTHAND: the last member ends at a `}`, not at a `,` or a `)`.
+    expect([...exportsOf("() => ({ get: vi.fn(), set })")!].sort()).toEqual(["get", "set"]);
+
+    // A NESTED CALL is not an export. `get(` appears in the text and the
+    // factory does not export it.
+    expect([...exportsOf("() => ({ set() { get(); } })")!]).toEqual(["set"]);
+
+    // The object-METHOD form, with and without `async`.
+    expect([...exportsOf("() => ({ async get() {}, set() {} })")!].sort()).toEqual(["get", "set"]);
+
+    // An ACCESSOR names the property after the keyword, not the keyword.
+    expect([...exportsOf("() => ({ get DATA_DIR() { return d; } })")!]).toEqual(["DATA_DIR"]);
+
+    // The two neighbours that share the prefix are still not it.
+    expect([...exportsOf("() => ({ getAll: vi.fn(), getKnown: vi.fn(), setMany: vi.fn() })")!].sort())
+      .toEqual(["getAll", "getKnown", "setMany"]);
+
+    // A block body, and a factory shape this cannot read at all.
+    expect([...exportsOf("() => { return { get: vi.fn(), set: vi.fn() }; }")!].sort()).toEqual(["get", "set"]);
+    expect(factoryExports('vi.mock("x", someHelper)')).toBeNull();
+
+    // And the omission the gate exists for.
+    expect([...exportsOf("() => ({ getAll: vi.fn(), setMany: vi.fn() })")!].sort()).toEqual(["getAll", "setMany"]);
+
+    // COMMENTS between members, which every factory in this repo has: an
+    // apostrophe in one used to open a "string" that swallowed the rest, and a
+    // word after a comma used to be read as the next member's name. Seven
+    // complete factories were reported as missing an export before the walker
+    // consumed comments.
+    const commented = [
+      "() => ({",
+      "  getAll: vi.fn(),",
+      "  // the owner's picks are read through the tri-state reader",
+      "  get: vi.fn(),",
+      "  /* block form too */",
+      "  set: vi.fn(),",
+      "})",
+    ].join(String.fromCharCode(10));
+    expect([...exportsOf(commented)!].sort()).toEqual(["get", "getAll", "set"]);
   });
 });

--- a/src/tests/unit/openclaw-config-mock-completeness.test.ts
+++ b/src/tests/unit/openclaw-config-mock-completeness.test.ts
@@ -199,6 +199,20 @@ const SILENT_STORE_READER = "@/lib/clawai-credential-refusal";
 /** What that reader takes off the store, and therefore what a factory must name. */
 const STORE_EXPORTS = ["get", "set"] as const;
 
+/**
+ * Does this factory name that export, in any of the forms a factory writes one?
+ *
+ * `get: vi.fn()`, `get,` (shorthand), `get)` (last entry) — and `get()` /
+ * `async get()`, the object-METHOD form. The last one is why the opening paren
+ * is in the class: without it a perfectly complete factory written with methods
+ * would be reported as missing, and a gate whose failure mode is a false
+ * positive is one nobody trusts. `\b` anchors the start, so `getAll:` and
+ * `getKnown:` — both live in this repo's factories — never match `get`.
+ */
+function storeExportNamed(name: string): RegExp {
+  return new RegExp(`\\b${name}\\s*[:,)(]`);
+}
+
 describe(`every ${STORE_MODULE} mock in front of a ${SILENT_STORE_READER} caller carries its store functions`, () => {
   const readerFile = resolveAlias(SILENT_STORE_READER);
 
@@ -219,7 +233,7 @@ describe(`every ${STORE_MODULE} mock in front of a ${SILENT_STORE_READER} caller
     const factory = mockCall(read.get(file)!, STORE_MODULE);
     if (!factory) continue;
     if (factory.includes("importActual") || factory.includes("importOriginal")) continue;
-    const missing = STORE_EXPORTS.filter((name) => !new RegExp(`\\b${name}\\s*[:,)]`).test(factory));
+    const missing = STORE_EXPORTS.filter((name) => !storeExportNamed(name).test(factory));
     if (missing.length > 0) offenders.push(`${path.relative(SRC, file)} (${missing.join(", ")})`);
   }
 
@@ -250,10 +264,17 @@ describe(`every ${STORE_MODULE} mock in front of a ${SILENT_STORE_READER} caller
     // reported.
     const omits = `vi.mock('${STORE_MODULE}', () => ({ getAll: vi.fn(), setMany: vi.fn() }));`;
     const carries = `vi.mock("${STORE_MODULE}", () => ({ get: vi.fn(), set: vi.fn() }));`;
+    // The object-METHOD form of the same complete factory: a gate that reported
+    // this as missing would fail a PR over correct code.
+    const methods = `vi.mock("${STORE_MODULE}", () => ({ async get() {}, async set() {} }));`;
     const seen = mockCall(omits, STORE_MODULE);
     expect(seen).not.toBeNull();
-    expect(STORE_EXPORTS.filter((n) => !new RegExp(`\\b${n}\\s*[:,)]`).test(seen!))).toEqual(["get", "set"]);
-    expect(STORE_EXPORTS.filter((n) => !new RegExp(`\\b${n}\\s*[:,)]`).test(mockCall(carries, STORE_MODULE)!)))
-      .toEqual([]);
+    expect(STORE_EXPORTS.filter((n) => !storeExportNamed(n).test(seen!))).toEqual(["get", "set"]);
+    expect(STORE_EXPORTS.filter((n) => !storeExportNamed(n).test(mockCall(carries, STORE_MODULE)!))).toEqual([]);
+    expect(STORE_EXPORTS.filter((n) => !storeExportNamed(n).test(mockCall(methods, STORE_MODULE)!))).toEqual([]);
+    // …and the two neighbours that share the prefix are still not it.
+    const prefixes = `vi.mock("${STORE_MODULE}", () => ({ getAll: vi.fn(), getKnown: vi.fn(), setMany: vi.fn() }));`;
+    expect(STORE_EXPORTS.filter((n) => !storeExportNamed(n).test(mockCall(prefixes, STORE_MODULE)!)))
+      .toEqual(["get", "set"]);
   });
 });

--- a/src/tests/unit/openclaw-config-mock-completeness.test.ts
+++ b/src/tests/unit/openclaw-config-mock-completeness.test.ts
@@ -170,3 +170,90 @@ describe(`every ${MOCKED_MODULE} mock that can reach an ${NARROWED_EXPORT} narro
     ).toBeGreaterThan(20);
   });
 });
+
+/**
+ * The same hole, one module over: `@/lib/config-store`.
+ *
+ * `@/lib/clawai-credential-refusal` reads and writes the persisted ClawBox AI
+ * credential refusal through that store, and BOTH of its calls sit inside a
+ * `try` whose `catch` answers a default — deliberately, because "the store
+ * could not be read" is not "the credential was refused". That makes a missing
+ * export worse here than in the module above: `get` being `undefined` does not
+ * crash a test, it makes `clawaiCredentialRefusalOnRecord()` answer `false`
+ * for every case in the file, so the image-ops gate is never exercised and
+ * nothing says so. A green suite over an untested gate.
+ *
+ * #755 fixed exactly that by hand in three files. #756 opened it again in a
+ * fourth on the same day, and fixed it by hand too. That is the point at which
+ * a rule earns a gate.
+ *
+ * THE SCOPE IS THE HAZARD, not the import graph. Nearly every route in this
+ * repo reaches this reader transitively — the whole-graph rule the sibling
+ * above uses reports fifty files here, which is a list nobody acts on. What
+ * makes a file able to hit the wrong answer is that its own subject calls the
+ * reader, so the scope is one hop: a test that imports a module which imports
+ * `@/lib/clawai-credential-refusal` itself.
+ */
+const STORE_MODULE = "@/lib/config-store";
+const SILENT_STORE_READER = "@/lib/clawai-credential-refusal";
+/** What that reader takes off the store, and therefore what a factory must name. */
+const STORE_EXPORTS = ["get", "set"] as const;
+
+describe(`every ${STORE_MODULE} mock in front of a ${SILENT_STORE_READER} caller carries its store functions`, () => {
+  const readerFile = resolveAlias(SILENT_STORE_READER);
+
+  // The modules that call the reader directly. Their own suites, and the
+  // suites of anything that imports them, are what can silently take the
+  // default answer.
+  const callers = new Set(
+    files.filter((f) => f !== readerFile && aliasImports(read.get(f)!).includes(SILENT_STORE_READER)),
+  );
+  const exposed = new Set<string>(callers);
+  for (const caller of callers) {
+    for (const importer of importers.get(caller) ?? []) exposed.add(importer);
+  }
+
+  const offenders: string[] = [];
+  for (const file of exposed) {
+    if (!/\.test\.tsx?$/.test(file)) continue;
+    const factory = mockCall(read.get(file)!, STORE_MODULE);
+    if (!factory) continue;
+    if (factory.includes("importActual") || factory.includes("importOriginal")) continue;
+    const missing = STORE_EXPORTS.filter((name) => !new RegExp(`\\b${name}\\s*[:,)]`).test(factory));
+    if (missing.length > 0) offenders.push(`${path.relative(SRC, file)} (${missing.join(", ")})`);
+  }
+
+  it("has no factory missing them", () => {
+    expect(
+      offenders.sort(),
+      `These suites mock ${STORE_MODULE} with a factory that omits ${STORE_EXPORTS.join("/")}, and they exercise a module that reads the persisted ClawBox AI credential refusal through it. ` +
+        `Those reads are wrapped in a catch that answers a DEFAULT, so the omission does not fail the suite — it silently makes every case take the "no refusal on record" branch. ` +
+        `Add \`get\`/\`set\` to the factory (see src/tests/routes/ai-models/configure-images.test.ts), or make it a partial mock over importActual.`,
+    ).toEqual([]);
+  });
+
+  it("is actually watching something", () => {
+    // Without this, a rename of the reader would empty every set above and the
+    // gate would pass by finding nothing — the one failure a gate must not
+    // have. Both ends are pinned: the reader resolves, and it has callers whose
+    // suites mock the store.
+    expect(readerFile).not.toBeNull();
+    expect(callers.size).toBeGreaterThan(1);
+    expect(
+      [...exposed].filter((f) => /\.test\.tsx?$/.test(f) && mockCall(read.get(f)!, STORE_MODULE) !== null).length,
+    ).toBeGreaterThan(3);
+  });
+
+  it("reports a factory that omits them, in either quote form", () => {
+    // The predicate itself, over the two shapes: the sibling above learned the
+    // hard way that a mock the scanner cannot SEE is skipped rather than
+    // reported.
+    const omits = `vi.mock('${STORE_MODULE}', () => ({ getAll: vi.fn(), setMany: vi.fn() }));`;
+    const carries = `vi.mock("${STORE_MODULE}", () => ({ get: vi.fn(), set: vi.fn() }));`;
+    const seen = mockCall(omits, STORE_MODULE);
+    expect(seen).not.toBeNull();
+    expect(STORE_EXPORTS.filter((n) => !new RegExp(`\\b${n}\\s*[:,)]`).test(seen!))).toEqual(["get", "set"]);
+    expect(STORE_EXPORTS.filter((n) => !new RegExp(`\\b${n}\\s*[:,)]`).test(mockCall(carries, STORE_MODULE)!)))
+      .toEqual([]);
+  });
+});

--- a/src/tests/unit/provider-status-openclaw-no-probe.test.ts
+++ b/src/tests/unit/provider-status-openclaw-no-probe.test.ts
@@ -52,7 +52,7 @@ vi.mock("@/lib/hermes-config-cache", () => ({
 vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn(), HERMES_BIN: "/usr/bin/hermes" }));
 vi.mock("@/lib/harness/credentials", () => ({ hasClawaiToken: vi.fn() }));
 vi.mock("@/lib/openclaw-config", () => ({ readConfig: vi.fn() }));
-vi.mock("@/lib/config-store", () => ({ get: vi.fn() }));
+vi.mock("@/lib/config-store", () => ({ get: vi.fn(), set: vi.fn(async () => {}) }));
 
 /** Every `systemctl` argv the module forked, so the claim can name the unit. */
 function systemctlCalls(): string[][] {

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -2986,6 +2986,44 @@ describe("updater", () => {
       expect(state.error).not.toContain("refuses this device's configuration");
     });
 
+    it("acts on nothing a validator that OVERFLOWED its buffer had written", async () => {
+      // The sibling of the case above, and the one the two-flag test missed.
+      // Node kills a child whose stdout passes `maxBuffer` and rejects with
+      // `code: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER"` — with `killed` and
+      // `signal` both `undefined` (measured), so the guard above did not fire
+      // and the TRUNCATED buffer went to the parser. The cut is not always
+      // unparseable: a payload sliced between its first `{` and its last `}`
+      // can still be valid JSON carrying half a verdict, and this reader takes
+      // `warnings[]` off it whatever the exit was.
+      setupBox([notInstalledWarning("byteplus")]);
+      const overflowed = Object.assign(new Error("stdout maxBuffer length exceeded"), {
+        code: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER",
+        killed: undefined,
+        signal: undefined,
+        stdout: JSON.stringify({ valid: true, warnings: [notInstalledWarning("byteplus")] }),
+        stderr: "",
+      });
+      setupExecFileMock({
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
+        "/usr/bin/journalctl -u clawbox-gateway.service": { stdout: refusedJournal, stderr: "" },
+        [VALIDATE]: overflowed,
+        [CONFIG_SET]: { stdout: "", stderr: "" },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+      });
+
+      const state = await runContinuation();
+
+      expect(disableRan("byteplus")).toBe(false);
+      expect(mockRecordPluginRepair).not.toHaveBeenCalled();
+      // Positively, like its sibling: the box is still reported dead on the
+      // journal's own words rather than on a verdict nobody finished giving.
+      expect(state.phase).toBe("failed");
+      expect(state.error).toContain("OpenClaw gateway is not listening on port 18789");
+      expect(state.error).not.toContain("refuses this device's configuration");
+    });
+
     it("leaves a plugin the core does not call not-installed to its owner", async () => {
       // A genuinely installed plugin whose reviewed surface is stale is a
       // consent question, and consenting for a plugin ClawBox did not install


### PR DESCRIPTION
TASK-743 — the image migration in `scripts/gateway-pre-start.sh` writes the
image model under the v2 home while the legacy home is still on the box. Plus
the cloud-voice downgrade half reading only one home, and the two small items
the #754 and #755/#756 reviewers asked to be folded in.

Read the "what this PR does NOT do" paragraph before the rest: the card files
this as link 1 of the customer incident, and it is not — measured against the
core, the block's write never caused that outage and the blocked box is not
rescued here.

## What the customer sees

**The owner's own image model, thrown away by us.** On a v2 core the two homes
for the image-generation pick are `agents.defaults.imageGenerationModel`
(legacy) and `agents.defaults.mediaModels.image`. This block read the legacy key
as a fallback but treated the shapes that resolve no model by ITS rule — `{}`,
`{"primary": ""}`, `{"fallbacks": []}`, a JSON `null`, and a bare string, which
the core resolves as a model even though this block does not — as an empty slot,
and claimed the v2 home.

That matters because of what the core's own migration does with a home that is
already taken. `migrateFinalLayoutRenames` (read out of the pinned bundle):

```js
if (!Object.hasOwn(defaults, legacyKey)) continue;
if (mediaModels[canonicalKey] === void 0) mediaModels[canonicalKey] = defaults[legacyKey];
else changes.push(`Removed agents.defaults.${legacyKey} (…already set).`);
delete defaults[legacyKey];            // both branches
```

So writing the v2 home first does not strand the box — the legacy key is deleted
either way — it makes the core DISCARD the owner's value instead of carrying it
across. Standing down leaves the one shape the core can migrate, and makes one
fewer write into a config it is refusing anyway.

**Measured on the pinned core** (`openclaw 2026.8.1 (ea80657)`, on the OpenClaw
box, `openclaw config validate --json` in a throwaway
`HOME`/`OPENCLAW_CONFIG_PATH`/`OPENCLAW_STATE_DIR` under `/tmp`, `OPENCLAW_HOME`
unset, scratch removed afterwards — the real config was never opened):

| config | verdict |
|---|---|
| `imageGenerationModel: {"primary": ""}` **and** `mediaModels.image` — what beta writes | `rc=1`, `agents.defaults: Unrecognized key: "imageGenerationModel"` |
| `imageGenerationModel: {"primary": ""}` alone — what this fix leaves | `rc=1`, the same issue |
| `mediaModels.image` alone — after the core's migration | `rc=0`, `{"valid":true,…,"warnings":[]}` |

**What this PR does NOT do, said plainly.** The second row is the point twice
over. `agents.defaults` is `.strict()`, so the legacy key ALONE is already exit
78 — this block's write never caused the outage it was filed under. And the only
box that reaches the new guard is one whose `doctor --fix` did not run the
migration (the block at the top of this script runs it whenever the core refuses
the config; a non-empty legacy `exec-approvals.json` is what stops it). **That
box stays dark with this change and without it, so link 1 of TASK-737 is not
closed here.** Performing the move in this file instead — which it already does
for `agents.defaults.tools` and `systemPromptSuffix` 1,300 lines above — is a
real option and wants its own card; it is a bigger decision than a stand-down,
and #751 deliberately did not take it for the sibling key.

**A Pro box paying for a refused round trip on every spoken reply.** The
cloud-voice DOWNGRADE arm read only `cfg["tts"]` under v2. A box that was Max
under a 2026.7 core wrote its stamped entry into `messages.tts`, and a v2 core
that has not run its migration still has it there — so the arm found nothing,
left our own dead entry in place, and the Voice panel went on calling the cloud
voice configured while every utterance bought a 403.

## The fix

Both halves are #751's shape, and the second is #751's own arm reaching one home
further.

- **A stand-down keyed on the legacy key's PRESENCE**, not its contents, around
  the image SLOT write. `in`, not `.get() is not None`, because a key whose
  value is `null` is present and is refused too. Standing down is never
  permanent: the next boot after `doctor --fix` sees the key moved and writes
  the slot as always.
- **One predicate for "this slot holds a decision", used by #755's take-back
  arm.** That arm asked `is not None`, so a leftover EMPTY legacy key —
  exactly the shapes the guard above treats as holding nothing — vetoed the
  whole stand-down, and a box whose credential the proxy had permanently refused
  kept the image path declared (the TASK-727 storm, 6,554 refused calls in
  twelve hours). The new predicate is deliberately WIDER for the delete than for
  the upsert: it counts a bare string, because the core coerces one and this is
  the only place in the file that destroys configuration.
- **The sibling in-flight guard one screen up had the same `null` hole the new
  comment says `in` was chosen for.** `tools.media.audio.models: null` is
  present and refused, and `.get("models") is not None` read it as absent — so
  the audio block seeded `tools.media.models` beside the surviving legacy key.
  Fixed with `"models" in _audio` plus a seed guard, with its own case.
- **Narrower than #751's guard, deliberately.** There the whole block wrote ONE
  object into one of two homes, so standing down had to mean writing nothing.
  Here the block writes two independent things: the `models[]` ROW, which has
  one home on both cores and whose repair (a missing `name`) is what keeps a box
  bootable, and the SLOT, which is the half with two homes. Only the slot stands
  down, so the boot after the migration lands has nothing left to do.
- **The downgrade arm reads both homes on v2** and deletes our stamped entry
  from whichever one holds it. Deleting from the legacy home is safe where
  WRITING to it is not: a removal cannot create the dual-home shape the guard
  above stands down over, and it leaves the core's own migration less to move.
  The stamp is still the only thing that opens that door — it is the one place
  in the file that destroys configuration — so the extra home widens WHERE the
  arm looks, never WHAT it may delete.
- **#755's refusal/take-back arm is untouched.** It is in the same block and was
  read first; it removes each home on its own already (`_legacy_is_ours` /
  `_v2_is_ours`), which is the same rule pointing the other way, and the new
  guard sits on the upsert arm only.

## The sibling: the other writer of the same slot

`grep` for the slot found a second writer with the identical hole, and it is the
half an owner reaches by pressing **Save** rather than by rebooting:
`buildClawboxAiImageOps` in `src/app/setup-api/ai-models/configure/route.ts`
honours the legacy key as "already configured" only when it NAMES a model, then
pushes `agents.defaults.mediaModels.image`. Same guard applied there, same
reason, with the `it.each` of empty shapes in `configure-images.test.ts` split
into "the key is absent → claim the slot" and "the key is there → stand down".
That file's helper also stopped spelling *absent* as `{ imageGenerationModel:
undefined }`: openclaw.json is JSON, so the distinction that decides this is
missing versus `null`, and a property explicitly set to `undefined` is neither.

## Sibling call sites, each cleared

- **Every `_clawbox_v2` switch in the boot script**, which is where a
  dual-home write can hide: `gateway.controlUi.allowInsecureAuth` /
  `dangerouslyDisableDeviceAuth` DELETE the retired keys under v2 (the opposite
  shape); the codex switches decide model refs and profiles, not homes;
  `tools.media.audio.models` already has its own `_audio_models_move_in_flight`
  stand-down; `messages.tts` is #751. The image slot was the last one without a
  guard.
- **Readers of the image slot** — `harness/capabilities.ts:174,243`,
  `harness/clawai-images.ts:23`, `harness/transport.ts:81`,
  `openclaw-config.ts:1173-1179` — read it or describe it, and none writes it;
  `openclaw-config.ts` already types both homes.
- **`askCoreToValidateConfig`'s killed-child guard** (extra (a) below): the
  other three readers of that flag in `updater.ts` are cleared with a reason —
  `isRetryableRemoteFailure:182` and `describeRemoteFailure:275` decide whether a
  git failure is worth retrying, and a buffer that overflowed is not a timeout
  and must not be retried into another overflow; `describeDoctorFailure:1305`
  and `startRootStep:2888` only choose the WORDING of a failure that is a
  failure either way. `apps/install/route.ts:225` is the same: `killed` picks a
  message, never a verdict. This one is the only site where the flag gates a
  PARSE, and the parse decides whether the owner's plugin entries are switched
  off.
- **`@/lib/config-store` mocks** (extra (b)): the new gate found seven suites
  with the hole, all fixed in this PR.

## Extras folded in, each with its own test

**(a) `src/lib/updater.ts` — the killed-validator guard did not fire on a
maxBuffer overflow.** Node kills a child whose stdout passes `maxBuffer` and
rejects with `code: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER"` while `killed` and
`signal` are both `undefined`, so the two-flag test let a TRUNCATED buffer reach
the parser — and `coreReportedMissingPlugins` takes `warnings[]` off the payload
whatever the exit was. LOW (2 MB against a payload of tens of bytes), and the
cut is not always unparseable: a slice between the first `{` and the last `}` can
still be valid JSON carrying half a verdict.

**(b) `openclaw-config-mock-completeness.test.ts` now guards
`@/lib/config-store` too.** `@/lib/clawai-credential-refusal` reads and writes
the persisted ClawBox AI credential refusal, and both of its calls sit inside a
catch that answers a DEFAULT — so a factory missing `get` does not fail a suite,
it silently makes every case take the "no refusal on record" branch. #755 fixed
that by hand in three files; #756 opened it again in a fourth the same day.

**The scope is the hazard, not the import graph.** Nearly every route reaches
that reader transitively, and the whole-graph rule the sibling gate uses reports
FIFTY files — a list nobody acts on. What makes a suite able to take the wrong
answer is that its own subject calls the reader, so the gate is one hop: a test
that imports a module which imports `@/lib/clawai-credential-refusal` itself.
That found **seven** offenders, all fixed here.

One of those seven turned out to be a test passing because of the hole:
`configure-subscription-surface.test.ts`'s case for a save that cannot touch the
subscription surface at all asserted `not.toHaveBeenCalled()` over the WHOLE of
`fs/promises.readFile`, and it held only because the missing export threw inside
the save so the request never reached `forgetProviderEnumerations()` — which
reads `catalog-cache/_enumerations.json` whenever `models.mode` moved, and on a
box always has. The pin is narrowed to the per-provider surface cache, which is
what that file is about.

## RED → GREEN

**RED**, against beta with the new tests in place — 12 failures across all four
areas:

```
 ❯ src/tests/unit/gateway-pre-start-clawai-images.test.ts (80 tests | 8 failed)
 ❯ src/tests/unit/gateway-pre-start-clawai-speech.test.ts (46 tests | 2 failed)
 ❯ src/tests/unit/openclaw-config-mock-completeness.test.ts (6 tests | 1 failed)
 ❯ src/tests/unit/updater.test.ts (93 tests | 1 failed)

 FAIL  … a legacy image key the core has not migrated yet > stands down rather than
       writing the v2 home beside an empty primary
 AssertionError: expected { primary: 'openai/gpt-image-1-mini' } to be undefined

 FAIL  … taking the cloud voice back from wherever the entry actually is >
       takes back a stamped entry stranded in the legacy home
 AssertionError: expected false to be true

 FAIL  … acts on nothing a validator that OVERFLOWED its buffer had written
 AssertionError: expected true to be false      (byteplus was switched off)

 FAIL  … every @/lib/config-store mock … carries its store functions
 AssertionError: expected [ …(7) ] to deeply equal []
```

The first of those is the defect in one line: on beta the script writes
`mediaModels.image` while `imageGenerationModel` is still in the file.

**GREEN.** All four suites pass, and so does the whole unit project. `tsc
--noEmit` clean, ESLint clean on the changed files, `bash -n` clean on
`scripts/gateway-pre-start.sh`, and all 23 python heredocs in that script
compile (`compile()` per heredoc — the blocks are not files, so `py_compile`
needs the extraction).

## Both editions

`scripts/gateway-pre-start.sh` is OpenClaw's, and **the Hermes edition never
enters it** — proved from the shipped code rather than asserted:

- It runs as `ExecStartPre` of `clawbox-gateway.service`
  (`config/clawbox-gateway.service:61`, and `install-x64.sh:1088` writes the same
  line). On the `hermes` edition `step_edition_gateway_state` stops, disables,
  REMOVES and masks that unit; it is dropped from `EXPECTED_ACTIVE_SERVICES` and
  listed in `FOREIGN_EDITION_UNITS`, so `step_validate_services` fails if it ever
  comes back — pinned by `install-foreign-edition-teardown.test.ts`.
- The one other invoker is `runCurrentGatewayPreStart()` in `updater.ts`, reached
  only from `ensureGatewayHealthy()`, whose two callers are the `gateway_verify`
  step (`applies: () => !gatewayIsAbsent()`, i.e. not on `hermes`) and the
  OpenClaw-only update flow, which `startOpenclawUpdate()` refuses outright when
  `openclawIsAbsent()`. `updater.test.ts` already pins that an update on a Hermes
  box does not run `gateway_verify`.

`dual` DOES run it, correctly — that SKU runs both harnesses and this is
OpenClaw's own config. The `updater.ts` and route changes are edition-agnostic
and shared.

## Review

`clawbox-review` (one review agent, findings at `code-review-task743.md`):
FIX-FIRST, 2 HIGH / 4 MEDIUM / 3 LOW / 2 INFO — and the two HIGHs were about
this PR's own record rather than its code. The reviewer read
`migrateFinalLayoutRenames` out of the pinned bundle and ran `doctor --fix`
against an isolated home, and both of the claims the first draft rested on were
wrong: the legacy key is deleted on BOTH branches (no stranding), and
`agents.defaults` being `.strict()` means the legacy key alone is already the
exit 78 (this block never caused it). Every comment that carried those claims —
in the script, in the route, and in both test files — is rewritten to what was
measured, and the "does not rescue the blocked box" paragraph above exists
because of that finding.

Applied in full: the shared take-back predicate (MEDIUM-3), the `null` hole in
the sibling audio guard (MEDIUM-2), the route's untested owner-pick guard, which
every legacy-seeded case now short-circuits past (MEDIUM-1, two new cases
seeding `mediaModels.image` directly), the missing version-gate note on the
route (MEDIUM-4), `Object.hasOwn(null, …)` throwing and taking the provider row
with it (LOW-1 — a real bug this PR introduced), the corrected cause behind the
narrowed `readFile` assertion (LOW-2 — re-measured: `setProviderEnabled` inside
a try/catch reaches `readProviderStatus` -> `_enumerations.json`, and with `get`
missing the whole re-enable step was silently skipped), and the three stale
comments (LOW-3). Both INFOs are recorded in the run queue as their own cards.

## Bug classes

- *False success* — the image block reported (and persisted) a slot write that
  left the box unable to load its config at all. That is the change.
- *False failure* — the downgrade arm reporting "nothing of ours here" over an
  entry that was ours, one home over.
- *Probe-once* — none introduced; every read here is per boot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI model migrations to preserve existing image, audio, and voice configurations across OpenClaw versions.
  * Prevented duplicate or premature configuration entries, including configurations with empty or null legacy values.
  * Improved cleanup of refused or outdated provider and voice configurations while preserving customer settings.
  * Prevented truncated configuration validation output from being processed as valid.

* **Tests**
  * Added regression coverage for migration, cleanup, downgrade, and validation edge cases.
  * Improved test coverage for configuration reads and writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->