### PR TITLE
fix: gate the cloud voice on the portal PLAN tier, not the device badge (TASK-744)

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -2690,7 +2690,7 @@ def _clawai_tier_stamps():
         _tier = _store.get(_key)
         _tier = _tier.strip().lower() if isinstance(_tier, str) else ""
         # `normalizeClawboxAiTier` admits exactly `flash` and `pro` and answers
-        # null to everything else, and `normalizeClawaiPlanTier` is that plus
+        # null to everything else, and `normalizeClawboxAiPlanTier` is that plus
         # the unpaid word. A value outside the vocabulary is a store somebody
         # edited or a build we have not seen: not evidence of anything, and
         # least of all of a downgrade.

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -1900,7 +1900,7 @@ def _clawai_credential_refused():
     """Has the proxy refused this box's ClawBox AI credential?
 
     Unreadable, absent, malformed and non-numeric all collapse to False on
-    purpose, exactly as `_clawai_device_tier()` collapses them to None: every
+    purpose, exactly as `_clawai_stamped_tier()` collapses them to None: every
     one of them means "nobody has told us this credential is dead", and a box
     we have not been told about is left armed. Failing the other way would take
     the picture button off every box whose Next app has never written a
@@ -2169,9 +2169,10 @@ if isinstance(_clawai_token, str) and _clawai_token.startswith("claw_"):
             #
             # SCOPE, stated plainly rather than implied: this arm covers the
             # IMAGE path only. Neither of those two migrations reads the
-            # refusal — the cloud voice gates on `clawai_tier`, which a box with
-            # a dead credential can never refresh because only a portal-ANSWERED
-            # poll writes it — so a refused Max box still buys one refused round
+            # refusal — the cloud voice gates on the tier stamps
+            # (`clawai_plan_tier`, then `clawai_tier`), which a box with a dead
+            # credential can never refresh because only a portal-ANSWERED poll
+            # writes them — so a refused Max box still buys one refused round
             # trip per spoken reply and per voice note. Lower volume than the
             # image storm by orders of magnitude, and its own change.
             def _slot_is_ours(_cfg):
@@ -2625,13 +2626,14 @@ if _clawai_openai_route_is_ours:
 # than leaving it alone: the panel would call the cloud voice configured, Auto
 # would move the primary onto it, and every spoken reply would pay a failed
 # round trip before falling back to the voice the box already had. So the
-# stamp the status route persists from a live portal answer is the gate.
-# `clawai_tier` is a DEVICE tier, and "pro" is the device tier of the MAX
-# plan — the two names are off by one on purpose (see CLAWBOX_AI_MODEL_BY_TIER
-# in src/lib/clawbox-ai-models.ts). Anything else, including a missing stamp,
-# means we have not been told this box is entitled, and an unentitled box is
-# left exactly as it was. A customer who upgrades gets the cloud voice at the
-# next gateway start, once the status route has refreshed the stamp.
+# stamp the status route persists from a live portal answer is the gate —
+# `clawai_plan_tier`, the PLAN, with `clawai_tier` behind it for a box the poll
+# has not answered for yet (see `_clawai_entitlement_tier` below). "pro" is the
+# tier of the MAX plan; the two names are off by one on purpose (see
+# CLAWBOX_AI_MODEL_BY_TIER in src/lib/clawbox-ai-models.ts). Anything else means
+# we have not been told this box is entitled, and an unentitled box is left
+# exactly as it was. A customer who upgrades gets the cloud voice at the next
+# gateway start, once the status route has refreshed the stamp.
 #
 # The customer-facing "your plan speaks locally, Max speaks in the cloud" line
 # is TASK-486 and deliberately not written here.
@@ -2651,12 +2653,12 @@ CLAWBOX_SPEECH_MANAGED_KEY = "clawboxManaged"
 # via globals() because the unit tests run this block extracted from the file.
 _clawbox_v2 = bool(globals().get("CLAWBOX_OPENCLAW_V2", False))
 
-def _clawai_device_tier():
-    """The portal-confirmed plan stamp, or None when the store cannot be read.
+def _clawai_stamped_tier(_key):
+    """One tier stamp out of the device store, or None when it cannot be read.
 
     Unreadable, absent and malformed all collapse to None on purpose: every one
-    of them means "nobody has told us this box is on Max", and the gate below
-    treats not-knowing exactly like not-entitled.
+    of them means "nobody has told us", which is what the gate below has to be
+    able to tell apart from "we were told, and the answer is no".
     """
     _store_path = os.environ.get("CLAWBOX_DEVICE_STORE") or ""
     if not _store_path:
@@ -2668,11 +2670,31 @@ def _clawai_device_tier():
         return None
     if not isinstance(_store, dict):
         return None
-    _tier = _store.get("clawai_tier")
-    return _tier.strip() if isinstance(_tier, str) else None
+    _tier = _store.get(_key)
+    _tier = _tier.strip().lower() if isinstance(_tier, str) else ""
+    # Only the two tiers this enum has. `normalizeClawboxAiTier` admits exactly
+    # these and answers null to everything else, and a stamp we do not
+    # recognise is not evidence of anything — least of all of a downgrade.
+    return _tier if _tier in ("flash", CLAWBOX_SPEECH_DEVICE_TIER) else None
 
 
-_clawai_speech_entitled = _clawai_device_tier() == CLAWBOX_SPEECH_DEVICE_TIER
+# THE ENTITLEMENT IS THE PLAN, and the device stamp only when the plan is
+# unknown — `clawaiEntitlementTier` in src/lib/clawai-plan-tier.ts, transcribed
+# because a shell cannot import it and the suite pins the two together.
+#
+# `clawai_tier` is `mapPortalTier`'s answer, and that function prefers the
+# portal's `deviceTier` STAMP deliberately: it answers "what should this box
+# DEFAULT to", and a Max subscriber is allowed to run Flash here.
+# `clawai_plan_tier` is `mapPortalPlanTier`'s — "what does this ACCOUNT pay
+# for" — and `clawbox-ai-portal-tier.ts` states the rule in as many words:
+# "Read the first for a default to write; read this one before refusing
+# anything." This block both refuses AND deletes, so it reads the second, and
+# falls back to the first only where the status poll has not answered yet —
+# which is every box in the field until it has run once (TASK-744).
+_clawai_entitlement_tier = (
+    _clawai_stamped_tier("clawai_plan_tier") or _clawai_stamped_tier("clawai_tier")
+)
+_clawai_speech_entitled = _clawai_entitlement_tier == CLAWBOX_SPEECH_DEVICE_TIER
 
 if _clawai_openai_route_is_ours and _clawai_speech_entitled:
     _messages = cfg.get("messages")
@@ -2773,7 +2795,16 @@ if _clawai_openai_route_is_ours and _clawai_speech_entitled:
                     cfg["messages"] = _messages
                 changed = True
 
-elif _clawai_openai_route_is_ours:
+elif _clawai_openai_route_is_ours and _clawai_entitlement_tier:
+    # ONLY OVER A TIER WE HAVE ACTUALLY BEEN TOLD. This condition used to be
+    # `_clawai_openai_route_is_ours` alone, so every reading that was not a
+    # positive "pro" reached the delete: a device store that was absent, or
+    # unreadable, or carried no stamp yet, took a working cloud voice away —
+    # not knowing read as a downgrade, which is the false failure this file
+    # warns about everywhere else. The Hermes arm in `register-mcp.sh` has
+    # required a tier it was TOLD since it was written; this is that same
+    # requirement, on the edition that shipped first (TASK-744).
+    #
     # The other direction, and it has to exist or this migration is one-way.
     # A box that was Max and is not any more keeps an entry pointing at an
     # endpoint that now answers 403, so every spoken reply buys a refused round

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -1900,7 +1900,7 @@ def _clawai_credential_refused():
     """Has the proxy refused this box's ClawBox AI credential?
 
     Unreadable, absent, malformed and non-numeric all collapse to False on
-    purpose, exactly as `_clawai_stamped_tier()` collapses them to None: every
+    purpose, exactly as `_clawai_tier_stamps()` collapses them to None: every
     one of them means "nobody has told us this credential is dead", and a box
     we have not been told about is left armed. Failing the other way would take
     the picture button off every box whose Next app has never written a
@@ -2628,7 +2628,8 @@ if _clawai_openai_route_is_ours:
 # round trip before falling back to the voice the box already had. So the
 # stamp the status route persists from a live portal answer is the gate —
 # `clawai_plan_tier`, the PLAN, with `clawai_tier` behind it for a box the poll
-# has not answered for yet (see `_clawai_entitlement_tier` below). "pro" is the
+# has not answered for yet, and the PLAN alone for the delete below (see
+# `_clawai_speech_entitled` and `_clawai_speech_withdrawable`). "pro" is the
 # tier of the MAX plan; the two names are off by one on purpose (see
 # CLAWBOX_AI_MODEL_BY_TIER in src/lib/clawbox-ai-models.ts). Anything else means
 # we have not been told this box is entitled, and an unentitled box is left
@@ -2653,48 +2654,82 @@ CLAWBOX_SPEECH_MANAGED_KEY = "clawboxManaged"
 # via globals() because the unit tests run this block extracted from the file.
 _clawbox_v2 = bool(globals().get("CLAWBOX_OPENCLAW_V2", False))
 
-def _clawai_stamped_tier(_key):
-    """One tier stamp out of the device store, or None when it cannot be read.
+# "The portal answered and this account has no paid plan" — the third value
+# `clawai_plan_tier` can hold, and it has to exist. `mapPortalTier` and
+# `mapPortalPlanTier` both answer null for an unpaid account, so without a
+# positive word for it a CANCELLED subscription would be indistinguishable from
+# a box nobody has ever asked about, and the withdrawal below could never fire
+# on the commoner of the two downgrade paths. `CLAWAI_PLAN_UNPAID` in
+# src/lib/clawai-plan-tier.ts is the same word; the suite pins the two.
+CLAWBOX_PLAN_UNPAID = "free"
+
+
+def _clawai_tier_stamps():
+    """(plan, device) out of the device store, normalised, or (None, None).
+
+    ONE read for the pair, because they are one fact about one account: the
+    status route writes them in the same store write, and a boot that read them
+    across two `open()`s could see a new badge beside an old plan.
 
     Unreadable, absent and malformed all collapse to None on purpose: every one
-    of them means "nobody has told us", which is what the gate below has to be
-    able to tell apart from "we were told, and the answer is no".
+    of them means "nobody has told us", which is what the two gates below have
+    to be able to tell apart from "we were told, and the answer is no".
     """
     _store_path = os.environ.get("CLAWBOX_DEVICE_STORE") or ""
     if not _store_path:
-        return None
+        return None, None
     try:
         with open(_store_path) as _fh:
             _store = json.load(_fh)
     except Exception:
-        return None
+        return None, None
     if not isinstance(_store, dict):
-        return None
-    _tier = _store.get(_key)
-    _tier = _tier.strip().lower() if isinstance(_tier, str) else ""
-    # Only the two tiers this enum has. `normalizeClawboxAiTier` admits exactly
-    # these and answers null to everything else, and a stamp we do not
-    # recognise is not evidence of anything — least of all of a downgrade.
-    return _tier if _tier in ("flash", CLAWBOX_SPEECH_DEVICE_TIER) else None
+        return None, None
+
+    def _one(_key, _allowed):
+        _tier = _store.get(_key)
+        _tier = _tier.strip().lower() if isinstance(_tier, str) else ""
+        # `normalizeClawboxAiTier` admits exactly `flash` and `pro` and answers
+        # null to everything else, and `normalizeClawaiPlanTier` is that plus
+        # the unpaid word. A value outside the vocabulary is a store somebody
+        # edited or a build we have not seen: not evidence of anything, and
+        # least of all of a downgrade.
+        return _tier if _tier in _allowed else None
+
+    return (
+        _one("clawai_plan_tier", ("flash", CLAWBOX_SPEECH_DEVICE_TIER, CLAWBOX_PLAN_UNPAID)),
+        _one("clawai_tier", ("flash", CLAWBOX_SPEECH_DEVICE_TIER)),
+    )
 
 
-# THE ENTITLEMENT IS THE PLAN, and the device stamp only when the plan is
-# unknown — `clawaiEntitlementTier` in src/lib/clawai-plan-tier.ts, transcribed
-# because a shell cannot import it and the suite pins the two together.
-#
-# `clawai_tier` is `mapPortalTier`'s answer, and that function prefers the
-# portal's `deviceTier` STAMP deliberately: it answers "what should this box
-# DEFAULT to", and a Max subscriber is allowed to run Flash here.
-# `clawai_plan_tier` is `mapPortalPlanTier`'s — "what does this ACCOUNT pay
-# for" — and `clawbox-ai-portal-tier.ts` states the rule in as many words:
-# "Read the first for a default to write; read this one before refusing
-# anything." This block both refuses AND deletes, so it reads the second, and
-# falls back to the first only where the status poll has not answered yet —
-# which is every box in the field until it has run once (TASK-744).
-_clawai_entitlement_tier = (
-    _clawai_stamped_tier("clawai_plan_tier") or _clawai_stamped_tier("clawai_tier")
+# THE ENTITLEMENT IS THE PLAN. `clawai_tier` is `mapPortalTier`'s answer, and
+# that function prefers the portal's `deviceTier` STAMP deliberately: it answers
+# "what should this box DEFAULT to", and a Max subscriber is allowed to run
+# Flash here. `clawai_plan_tier` is `mapPortalPlanTier`'s — "what does this
+# ACCOUNT pay for" — and `clawbox-ai-portal-tier.ts` states the rule in as many
+# words: "Read the first for a default to write; read this one before refusing
+# anything" (TASK-744).
+_clawai_plan_tier, _clawai_device_tier = _clawai_tier_stamps()
+
+# ARM: the plan when we have been told one, the badge only when we have not —
+# `clawaiEntitlementTier` in src/lib/clawai-plan-tier.ts, transcribed because a
+# shell cannot import it and the suite pins the two together. The fallback
+# belongs on THIS side alone: arming is recoverable (our own fields, our own
+# values, taken back by the next boot once the plan is on record), and every box
+# in the field has no plan recorded until its first successful status poll.
+_clawai_speech_entitled = (
+    _clawai_plan_tier or _clawai_device_tier
+) == CLAWBOX_SPEECH_DEVICE_TIER
+
+# WITHDRAW: the PLAN alone, and never the badge — `clawaiSpeechWithdrawable`.
+# This is the one irreversible act in this file, and the badge is a DEFAULT a
+# Max subscriber is allowed to have set to Flash: deleting on it is TASK-744
+# with the customer's configuration gone. A box whose plan is not on record
+# keeps what it has. The cost of holding is a refused round trip per spoken
+# reply until the next poll; the cost of deleting is a Max subscriber's voice.
+_clawai_speech_withdrawable = bool(
+    _clawai_plan_tier and _clawai_plan_tier != CLAWBOX_SPEECH_DEVICE_TIER
 )
-_clawai_speech_entitled = _clawai_entitlement_tier == CLAWBOX_SPEECH_DEVICE_TIER
 
 if _clawai_openai_route_is_ours and _clawai_speech_entitled:
     _messages = cfg.get("messages")
@@ -2795,15 +2830,18 @@ if _clawai_openai_route_is_ours and _clawai_speech_entitled:
                     cfg["messages"] = _messages
                 changed = True
 
-elif _clawai_openai_route_is_ours and _clawai_entitlement_tier:
-    # ONLY OVER A TIER WE HAVE ACTUALLY BEEN TOLD. This condition used to be
+elif _clawai_openai_route_is_ours and _clawai_speech_withdrawable:
+    # ONLY OVER A PLAN WE HAVE ACTUALLY BEEN TOLD. This condition used to be
     # `_clawai_openai_route_is_ours` alone, so every reading that was not a
     # positive "pro" reached the delete: a device store that was absent, or
-    # unreadable, or carried no stamp yet, took a working cloud voice away —
-    # not knowing read as a downgrade, which is the false failure this file
-    # warns about everywhere else. The Hermes arm in `register-mcp.sh` has
-    # required a tier it was TOLD since it was written; this is that same
-    # requirement, on the edition that shipped first (TASK-744).
+    # unreadable, or carrying only the DEFAULT badge, took a working cloud voice
+    # away — not knowing read as a downgrade, and a Max subscriber running Flash
+    # on this box read as one too (TASK-744). Both are the false failure this
+    # file warns about everywhere else.
+    #
+    # A CANCELLED subscription still withdraws, and that is what the third plan
+    # value is for: the portal answering "no paid plan" is recorded as `free`,
+    # which is a plan we were told and is below the entitlement.
     #
     # The other direction, and it has to exist or this migration is one-way.
     # A box that was Max and is not any more keeps an entry pointing at an

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -1149,7 +1149,7 @@ def stamped_tier(key, allowed):
     """One tier stamp out of the device store, normalised, or "" for unknown.
 
     `normalizeClawboxAiTier` admits exactly `flash` and `pro` and answers null
-    to everything else, and `normalizeClawaiPlanTier` is that plus the unpaid
+    to everything else, and `normalizeClawboxAiPlanTier` is that plus the unpaid
     word. A value outside the vocabulary is a store somebody edited or a build
     we have not seen: not evidence of anything, least of all of a downgrade, so
     it collapses to the same "" as an absent one.

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -993,12 +993,13 @@ fi
 # second, unlocked writer racing this one.
 #
 # THE ENTITLEMENT IS THE PORTAL'S, not a guess: `clawai_plan_tier` in
-# `data/config.json`, with `clawai_tier` behind it, both refreshed from
-# `device-info` by `/setup-api/ai-models/status` on its 30-second poll — the
-# same pair `speechEntitledTier()` reads for the panel and
-# `_clawai_entitlement_tier` reads on the OpenClaw side. `"pro"` is the tier of
-# the MAX plan; the two names are off by one on purpose
-# (CLAWBOX_AI_MODEL_BY_TIER in src/lib/clawbox-ai-models.ts).
+# `data/config.json`, with `clawai_tier` behind it for the ARM and NOT behind it
+# for the withdrawal, both written by whoever writes the credential and
+# refreshed from `device-info` by `/setup-api/ai-models/status` on its
+# 30-second poll — the same pair `speechEntitledTier()` reads for the panel and
+# `_clawai_speech_entitled` / `_clawai_speech_withdrawable` read on the OpenClaw
+# side. `"pro"` is the tier of the MAX plan; the two names are off by one on
+# purpose (CLAWBOX_AI_MODEL_BY_TIER in src/lib/clawbox-ai-models.ts).
 #
 # NOT KNOWING IS NOT AN ANSWER, in either direction, and that is the whole
 # false-success/false-failure guard here. A device store that is absent,
@@ -1144,32 +1145,41 @@ if not isinstance(store, dict):
 token = text(store.get("clawai_token"))
 
 
-def stamped_tier(key):
+def stamped_tier(key, allowed):
     """One tier stamp out of the device store, normalised, or "" for unknown.
 
     `normalizeClawboxAiTier` admits exactly `flash` and `pro` and answers null
-    to everything else; a stamp we do not recognise is not evidence of anything,
-    least of all of a downgrade, so it collapses to the same "" as an absent one.
+    to everything else, and `normalizeClawaiPlanTier` is that plus the unpaid
+    word. A value outside the vocabulary is a store somebody edited or a build
+    we have not seen: not evidence of anything, least of all of a downgrade, so
+    it collapses to the same "" as an absent one.
     """
     value = store.get(key)
     value = value.strip().lower() if isinstance(value, str) else ""
-    return value if value in ("flash", ENTITLED_TIER) else ""
+    return value if value in allowed else ""
 
 
-# THE ENTITLEMENT IS THE PLAN, and the device stamp only when the plan is
-# unknown — `clawaiEntitlementTier` in src/lib/clawai-plan-tier.ts, transcribed
-# because a shell cannot import it and the suite pins the two together.
+# THE ENTITLEMENT IS THE PLAN. `clawai_tier` is `mapPortalTier`'s answer and
+# prefers the portal's `deviceTier` STAMP deliberately: it answers "what should
+# this box DEFAULT to", and a Max subscriber is allowed to run Flash here.
+# `clawai_plan_tier` is `mapPortalPlanTier`'s — "what does this ACCOUNT pay
+# for" — and `clawbox-ai-portal-tier.ts` states the rule outright: "Read the
+# first for a default to write; read this one before refusing anything"
+# (TASK-744).
 #
-# `clawai_tier` is `mapPortalTier`'s answer and prefers the portal's
-# `deviceTier` STAMP deliberately: it answers "what should this box DEFAULT to",
-# and a Max subscriber is allowed to run Flash here. `clawai_plan_tier` is
-# `mapPortalPlanTier`'s — "what does this ACCOUNT pay for" — and
-# `clawbox-ai-portal-tier.ts` states the rule outright: "Read the first for a
-# default to write; read this one before refusing anything." This block both
-# refuses and WITHDRAWS, so it reads the plan, and falls back to the device
-# stamp only where the status poll has not answered yet — which is every box in
-# the field until it has run once (TASK-744).
-tier = stamped_tier("clawai_plan_tier") or stamped_tier("clawai_tier")
+# `free` is the third plan value and it has to exist: `mapPortalTier` and
+# `mapPortalPlanTier` both answer null for an unpaid account, so without a
+# positive word for it a CANCELLED subscription would be indistinguishable from
+# a box nobody has ever asked about. `CLAWAI_PLAN_UNPAID` is the same word.
+PLAN_UNPAID = "free"
+plan_tier = stamped_tier("clawai_plan_tier", ("flash", ENTITLED_TIER, PLAN_UNPAID))
+device_tier = stamped_tier("clawai_tier", ("flash", ENTITLED_TIER))
+
+# ARM: the plan when we have been told one, the badge only when we have not —
+# `clawaiEntitlementTier`. The fallback belongs on THIS side alone, because
+# arming is recoverable (our own fields, our own values) and every box in the
+# field has no plan recorded until its first successful status poll.
+arm_tier = plan_tier or device_tier
 
 cfg, why = load(os.environ["CLAWBOX_HERMES_CONFIG"], yaml.safe_load)
 if why == "absent":
@@ -1199,7 +1209,7 @@ key_is_ours = api_key.startswith("claw_")
 slot_is_empty = base_url == "" and api_key == ""
 route_is_ours = key_is_ours or slot_is_empty or base_url.rstrip("/") == PROXY
 
-if token and tier == ENTITLED_TIER:
+if token and arm_tier == ENTITLED_TIER:
     # ALREADY SPEAKING THROUGH US. The selection is not touched again; the
     # DEFINITION still is, because the portal rotates the token on a re-link and
     # this script is the only thing on the boot path that would notice. An
@@ -1243,11 +1253,15 @@ if token and tier == ENTITLED_TIER:
         say("hold tts.openai already names its own speech route")
     say("arm")
 
-# The other direction. Only over a tier we have actually been TOLD: an absent
-# stamp is a box nobody has told us about, not a box that has lost its plan, and
-# taking a working voice away over a store we could not read is the false
-# failure this whole block is written to avoid.
-if tier and tier != ENTITLED_TIER:
+# The other direction — `clawaiSpeechWithdrawable`, and it reads the PLAN
+# ALONE. Only over a plan we have actually been TOLD: an absent stamp is a box
+# nobody has told us about, not a box that has lost its plan, and taking a
+# working voice away over a store we could not read is the false failure this
+# whole block is written to avoid. And never over the BADGE, which is a default
+# a Max subscriber is allowed to have set to Flash — withdrawing on it is
+# TASK-744 with the customer's configuration gone. `free` is a plan we were
+# told, so a cancelled subscription still withdraws.
+if plan_tier and plan_tier != ENTITLED_TIER:
     # ONLY what we wrote. The stamp the OpenClaw arm can rely on does not exist
     # here — Hermes' `tts.openai` block is the harness's own schema and carries
     # no room for one — so ownership is the positive endpoint/credential test
@@ -1269,8 +1283,10 @@ if tier and tier != ENTITLED_TIER:
         say("hold tts.openai names an address that is not ours — not ours to withdraw")
     say("withdraw")
 
-if not tier:
+if not arm_tier:
     say("hold no plan has been recorded for this box yet")
+if not plan_tier:
+    say("hold only this box's badge says it is not entitled, and a badge is not a plan")
 if not token:
     say("hold this box's plan includes the cloud voice but it holds no credential")
 say("hold nothing to do")

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -992,12 +992,13 @@ fi
 # forgets it on every web-server boot on hermes|dual. A Node boot hook would be a
 # second, unlocked writer racing this one.
 #
-# THE ENTITLEMENT IS THE PORTAL'S, not a guess: `clawai_tier` in
-# `data/config.json`, which `/setup-api/ai-models/status` refreshes from
-# `device-info` on its 30-second poll — the same stamp `speechEntitledTier()`
-# reads for the panel and `CLAWBOX_SPEECH_DEVICE_TIER` reads on the OpenClaw
-# side. `"pro"` is the DEVICE tier of the MAX plan; the two names are off by one
-# on purpose (CLAWBOX_AI_MODEL_BY_TIER in src/lib/clawbox-ai-models.ts).
+# THE ENTITLEMENT IS THE PORTAL'S, not a guess: `clawai_plan_tier` in
+# `data/config.json`, with `clawai_tier` behind it, both refreshed from
+# `device-info` by `/setup-api/ai-models/status` on its 30-second poll — the
+# same pair `speechEntitledTier()` reads for the panel and
+# `_clawai_entitlement_tier` reads on the OpenClaw side. `"pro"` is the tier of
+# the MAX plan; the two names are off by one on purpose
+# (CLAWBOX_AI_MODEL_BY_TIER in src/lib/clawbox-ai-models.ts).
 #
 # NOT KNOWING IS NOT AN ANSWER, in either direction, and that is the whole
 # false-success/false-failure guard here. A device store that is absent,
@@ -1141,8 +1142,34 @@ if not isinstance(store, dict):
     say("hold the device store is not an object")
 
 token = text(store.get("clawai_token"))
-tier = store.get("clawai_tier")
-tier = tier.strip() if isinstance(tier, str) else ""
+
+
+def stamped_tier(key):
+    """One tier stamp out of the device store, normalised, or "" for unknown.
+
+    `normalizeClawboxAiTier` admits exactly `flash` and `pro` and answers null
+    to everything else; a stamp we do not recognise is not evidence of anything,
+    least of all of a downgrade, so it collapses to the same "" as an absent one.
+    """
+    value = store.get(key)
+    value = value.strip().lower() if isinstance(value, str) else ""
+    return value if value in ("flash", ENTITLED_TIER) else ""
+
+
+# THE ENTITLEMENT IS THE PLAN, and the device stamp only when the plan is
+# unknown — `clawaiEntitlementTier` in src/lib/clawai-plan-tier.ts, transcribed
+# because a shell cannot import it and the suite pins the two together.
+#
+# `clawai_tier` is `mapPortalTier`'s answer and prefers the portal's
+# `deviceTier` STAMP deliberately: it answers "what should this box DEFAULT to",
+# and a Max subscriber is allowed to run Flash here. `clawai_plan_tier` is
+# `mapPortalPlanTier`'s — "what does this ACCOUNT pay for" — and
+# `clawbox-ai-portal-tier.ts` states the rule outright: "Read the first for a
+# default to write; read this one before refusing anything." This block both
+# refuses and WITHDRAWS, so it reads the plan, and falls back to the device
+# stamp only where the status poll has not answered yet — which is every box in
+# the field until it has run once (TASK-744).
+tier = stamped_tier("clawai_plan_tier") or stamped_tier("clawai_tier")
 
 cfg, why = load(os.environ["CLAWBOX_HERMES_CONFIG"], yaml.safe_load)
 if why == "absent":

--- a/src/app/setup-api/ai-models/clawai/poll/route.ts
+++ b/src/app/setup-api/ai-models/clawai/poll/route.ts
@@ -96,9 +96,12 @@ async function runConfigureInBackground(session: ClawAiConnectSession, accessTok
       // record — so no withdrawal would be reachable at all until a BROWSER
       // happened to poll `/setup-api/ai-models/status` (TASK-744).
       //
-      // Costs nothing the wizard was not already paying: `fetchPortalTier`
-      // caches for 120 s and de-duplicates in flight, and the wizard polls the
-      // status route every 30 s while this runs.
+      // ONE cold round trip, bounded at `PORTAL_FETCH_TIMEOUT_MS` (4 s) — the
+      // cache is keyed by token and the box has never held this one — against a
+      // finaliser the UI gives three minutes. It cannot fail the pairing:
+      // `fetchPortalTier` reports every failure as `unreachable` rather than
+      // throwing. The wizard's next status poll then lands on the entry this
+      // call warmed.
       const lookup = await fetchPortalTier(accessToken).catch(() => null);
       try {
         await applyClawaiToHermes(accessToken, uiTierToDeviceTier(uiTier), {

--- a/src/app/setup-api/ai-models/clawai/poll/route.ts
+++ b/src/app/setup-api/ai-models/clawai/poll/route.ts
@@ -3,6 +3,7 @@ import { POST as configureAiModelsPost } from "@/app/setup-api/ai-models/configu
 import { getActiveHarness } from "@/lib/harness";
 import { ClawaiApplyError, applyClawaiToHermes } from "@/lib/hermes-clawai";
 import { normalizeClawaiUiTier, uiTierToDeviceTier } from "@/lib/clawbox-ai-tiers";
+import { fetchPortalTier } from "@/lib/clawbox-ai-portal-tier";
 import {
   type ClawAiConnectSession,
   clearClawAiSession,
@@ -87,8 +88,24 @@ async function runConfigureInBackground(session: ClawAiConnectSession, accessTok
     // device, so the OpenClaw path below is untouched.
     if ((await getActiveHarness()) === "hermes") {
       const uiTier = normalizeClawaiUiTier(session.tier) ?? "flash";
+      // THE PLAN, asked here as well, because this is the primary link path on
+      // this edition and nothing else on it holds a portal answer. The OpenClaw
+      // branch below reaches `/setup-api/ai-models/configure`, which records
+      // the plan itself; without this the two editions' own device-code flows
+      // would disagree, and a Hermes box would finish the link with no plan on
+      // record — so no withdrawal would be reachable at all until a BROWSER
+      // happened to poll `/setup-api/ai-models/status` (TASK-744).
+      //
+      // Costs nothing the wizard was not already paying: `fetchPortalTier`
+      // caches for 120 s and de-duplicates in flight, and the wizard polls the
+      // status route every 30 s while this runs.
+      const lookup = await fetchPortalTier(accessToken).catch(() => null);
       try {
-        await applyClawaiToHermes(accessToken, uiTierToDeviceTier(uiTier));
+        await applyClawaiToHermes(accessToken, uiTierToDeviceTier(uiTier), {
+          // Absent unless the portal ANSWERED — an unreachable lookup or a
+          // probe that threw retires the plan rather than recording a guess.
+          portalPlan: lookup?.source === "portal" ? { verdict: lookup.planVerdict } : undefined,
+        });
       } catch (err) {
         // Only our own message is safe to store/show — a raw spawn failure can
         // carry the hermes binary path.

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -2434,8 +2434,9 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
           const applied = await applyClawaiToHermes(
             clawboxAiToken,
             resolvedClawboxTier ?? CLAWBOX_AI_DEFAULT_TIER,
-            // The apply owns the store write on this SKU, so the plan travels
-            // with the badge from there rather than being written twice.
+            // The apply writes the store on this SKU, so the plan travels with
+            // the badge from there. (The two batches below also carry it on any
+            // save that reaches them — the same value, harmlessly.)
             { portalPlan },
           );
           await forgetLocalWasDefault();

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -34,6 +34,14 @@ import { getActiveHarness } from "@/lib/harness";
 import { refreshCodingAgentToolsIfReadinessChanged } from "@/lib/coding-agent-mcp-refresh";
 import { applyLocalAiToHermes, HermesLocalApplyError } from "@/lib/hermes-local-ai";
 import { applyClawaiToHermes, ClawaiApplyError } from "@/lib/hermes-clawai";
+// The PLAN this account pays for, recorded in the same store write as the
+// badge: both boot scripts decide the cloud-voice entitlement from the pair and
+// one of them DELETES on it, so neither may outlive the credential (TASK-744).
+import {
+  CLAWAI_PLAN_TIER_KEY,
+  clawaiPlanTierForStore,
+  type ClawaiPortalPlan,
+} from "@/lib/clawai-plan-tier";
 import { isClawboxAiVisionId, resolveVisionModelId } from "@/lib/clawbox-ai-vision";
 import { applyCloudProviderKeyToHermes, HermesCloudApplyError } from "@/lib/hermes-cloud-provider";
 import {
@@ -2187,9 +2195,28 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     // keeps "Max subscriber who deliberately runs Flash on this device"
     // working rather than being force-promoted here.
     let portalConfirmedTier: ClawboxAiTier | null = null;
+    // The PLAN this same lookup answered, or ABSENT for "it did not answer" —
+    // a third state the badge does not need and the plan does, because a
+    // RECORDED plan is what both boot scripts read as having been told, and one
+    // of them deletes a working cloud voice over it (TASK-744).
+    //
+    // WHY HERE AS WELL AS IN `/setup-api/ai-models/status`: that route is the
+    // 30-second poll, and every caller of it is a BROWSER — the wizard step,
+    // the Settings panel, the login hook. Nothing on the box asks it on its
+    // own. A customer who pairs and closes the tab would never have a plan on
+    // record, both scripts would fall back to the device badge for good, and
+    // that IS the state this card is about. This route holds a portal answer
+    // for the credential it is writing, at the moment it writes it.
+    let portalPlan: ClawaiPortalPlan | undefined;
     if (isClawAI && clawboxAiToken) {
       try {
         const lookup = await fetchPortalTier(clawboxAiToken);
+        // On ANY portal answer, including the Free one that leaves `tier` null:
+        // "this account pays for nothing" is an answer, and it is the one that
+        // has to retire a previous account's Max plan rather than leave it
+        // standing over the token this save is writing — and the one that lets
+        // a CANCELLED subscription's cloud voice be withdrawn at all.
+        if (lookup.source === "portal") portalPlan = { tier: lookup.planTier };
         if (lookup.source === "portal" && lookup.tier) {
           portalConfirmedTier = lookup.tier;
           if (requestedClawboxAiTier && requestedClawboxAiTier !== lookup.tier) {
@@ -2403,6 +2430,9 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
           const applied = await applyClawaiToHermes(
             clawboxAiToken,
             resolvedClawboxTier ?? CLAWBOX_AI_DEFAULT_TIER,
+            // The apply owns the store write on this SKU, so the plan travels
+            // with the badge from there rather than being written twice.
+            { portalPlan },
           );
           await forgetLocalWasDefault();
           // Reported from the apply's OWN decision rather than the one taken
@@ -3033,6 +3063,13 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
         // next account's box (TASK-713).
         ...(isClawAI ? { [CLAWBOX_AI_TOKEN_CONFIG_KEY]: clawboxAiToken } : {}),
         ...(clawboxAiTierForStore ? { [CLAWBOX_AI_TIER_CONFIG_KEY]: clawboxAiTierForStore } : {}),
+        // The PLAN beside the badge, in the SAME batch so the pair the boot
+        // scripts read cannot come apart, and `undefined` — the store's DELETE
+        // — when the portal did not answer: this save has just rewritten the
+        // badge for whatever account the box now holds, and the previous
+        // account's plan may not be left standing beside it. Only on a ClawBox
+        // AI save; any other save leaves both keys exactly as they are.
+        ...(isClawAI ? { [CLAWAI_PLAN_TIER_KEY]: clawaiPlanTierForStore(portalPlan) } : {}),
       });
       // Everything above configures OpenClaw. On a Hermes device that left the
       // model running and unreachable: Settings said "configured" while the
@@ -3067,6 +3104,13 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
         ai_model_configured_at: new Date().toISOString(),
         ...(isClawAI ? { [CLAWBOX_AI_TOKEN_CONFIG_KEY]: clawboxAiToken } : {}),
         ...(clawboxAiTierForStore ? { [CLAWBOX_AI_TIER_CONFIG_KEY]: clawboxAiTierForStore } : {}),
+        // The PLAN beside the badge, in the SAME batch so the pair the boot
+        // scripts read cannot come apart, and `undefined` — the store's DELETE
+        // — when the portal did not answer: this save has just rewritten the
+        // badge for whatever account the box now holds, and the previous
+        // account's plan may not be left standing beside it. Only on a ClawBox
+        // AI save; any other save leaves both keys exactly as they are.
+        ...(isClawAI ? { [CLAWAI_PLAN_TIER_KEY]: clawaiPlanTierForStore(portalPlan) } : {}),
         // The owner named a model in this save (TASK-713), or this save linked a
         // different ClawBox AI account and the previous owner's pick goes with
         // it. Either way in the SAME batch as the other facts about the save, so

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -2216,7 +2216,11 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
         // has to retire a previous account's Max plan rather than leave it
         // standing over the token this save is writing — and the one that lets
         // a CANCELLED subscription's cloud voice be withdrawn at all.
-        if (lookup.source === "portal") portalPlan = { tier: lookup.planTier };
+        // `planVerdict`, not `planTier`: that one answers `null` to a
+        // genuinely unpaid account, to an absent `tier` and to a plan word this
+        // build has never seen alike, and only the first of the three is a
+        // downgrade something may later be deleted over.
+        if (lookup.source === "portal") portalPlan = { verdict: lookup.planVerdict };
         if (lookup.source === "portal" && lookup.tier) {
           portalConfirmedTier = lookup.tier;
           if (requestedClawboxAiTier && requestedClawboxAiTier !== lookup.tier) {

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -3027,6 +3027,26 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     // computed earlier so the value stored alongside the token always
     // matches the tier that drove `agents.defaults.model.primary` above.
     const clawboxAiTierForStore = resolvedClawboxTier;
+    // The PLAN entry for the batches below, and whether there is one at all.
+    //
+    // A writer with NO portal answer retires the plan only when the ACCOUNT
+    // changed. A save on the same token — the owner switching model, nudging
+    // the plan pill, re-saving anything on this page — is not a change, and a
+    // portal that happened to be unreachable during it is no reason to throw
+    // away a plan that is still that account's. Deleting there puts the box
+    // back on its device badge, which is the default TASK-744 exists to stop
+    // deciding things: the Voice panel would tell a Max subscriber his plan has
+    // no cloud voice while the box speaks through one, and `register-mcp.sh`
+    // would stop arming it, until the next successful poll. `applyClawaiToHermes`
+    // keeps the same rule for the batch it owns.
+    // NOT `previousClawaiToken && …`: a box with no token on record is one we
+    // cannot vouch for either, so a plan sitting there belongs to nobody this
+    // save knows about and goes with the rest. Deleting a key that is not there
+    // is a no-op; leaving one that outlived its account is not.
+    const clawaiPlanIsForAnotherAccount = isClawAI && previousClawaiToken !== clawboxAiToken;
+    const clawaiPlanForStore = isClawAI && (portalPlan || clawaiPlanIsForAnotherAccount)
+      ? { [CLAWAI_PLAN_TIER_KEY]: clawaiPlanTierForStore(portalPlan) }
+      : {};
     // The coding agent's three tools — `coding_agent_run`, `_status`, `_stop` —
     // are registered CONDITIONALLY by the ClawBox MCP server, from a probe it
     // makes ONCE while it boots; it is then a long-lived stdio child of the
@@ -3069,12 +3089,10 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
         ...(isClawAI ? { [CLAWBOX_AI_TOKEN_CONFIG_KEY]: clawboxAiToken } : {}),
         ...(clawboxAiTierForStore ? { [CLAWBOX_AI_TIER_CONFIG_KEY]: clawboxAiTierForStore } : {}),
         // The PLAN beside the badge, in the SAME batch so the pair the boot
-        // scripts read cannot come apart, and `undefined` — the store's DELETE
-        // — when the portal did not answer: this save has just rewritten the
-        // badge for whatever account the box now holds, and the previous
-        // account's plan may not be left standing beside it. Only on a ClawBox
-        // AI save; any other save leaves both keys exactly as they are.
-        ...(isClawAI ? { [CLAWAI_PLAN_TIER_KEY]: clawaiPlanTierForStore(portalPlan) } : {}),
+        // scripts read cannot come apart — see `clawaiPlanForStore` above for
+        // when it is written, when it is retired, and when the key is left
+        // exactly as it is.
+        ...clawaiPlanForStore,
       });
       // Everything above configures OpenClaw. On a Hermes device that left the
       // model running and unreachable: Settings said "configured" while the
@@ -3110,12 +3128,10 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
         ...(isClawAI ? { [CLAWBOX_AI_TOKEN_CONFIG_KEY]: clawboxAiToken } : {}),
         ...(clawboxAiTierForStore ? { [CLAWBOX_AI_TIER_CONFIG_KEY]: clawboxAiTierForStore } : {}),
         // The PLAN beside the badge, in the SAME batch so the pair the boot
-        // scripts read cannot come apart, and `undefined` — the store's DELETE
-        // — when the portal did not answer: this save has just rewritten the
-        // badge for whatever account the box now holds, and the previous
-        // account's plan may not be left standing beside it. Only on a ClawBox
-        // AI save; any other save leaves both keys exactly as they are.
-        ...(isClawAI ? { [CLAWAI_PLAN_TIER_KEY]: clawaiPlanTierForStore(portalPlan) } : {}),
+        // scripts read cannot come apart — see `clawaiPlanForStore` above for
+        // when it is written, when it is retired, and when the key is left
+        // exactly as it is.
+        ...clawaiPlanForStore,
         // The owner named a model in this save (TASK-713), or this save linked a
         // different ClawBox AI account and the previous owner's pick goes with
         // it. Either way in the SAME batch as the other facts about the save, so

--- a/src/app/setup-api/ai-models/status/route.ts
+++ b/src/app/setup-api/ai-models/status/route.ts
@@ -24,7 +24,7 @@ import {
 // The portal's PLAN, written where the same two boot scripts can read it. The
 // tier stamp beside it is a device DEFAULT and may not be refused on — see
 // `clawai-plan-tier.ts` and TASK-744.
-import { persistClawaiPlanTier } from "@/lib/clawai-plan-tier";
+import { clawaiPlanGeneration, persistClawaiPlanTier } from "@/lib/clawai-plan-tier";
 
 export const dynamic = "force-dynamic";
 
@@ -229,6 +229,10 @@ async function buildStatusResponse(state: ResolvedAiState): Promise<NextResponse
       // NEW credential can both land inside that window — see
       // `clearPersistedClawaiCredentialRefusal`.
       const askedAt = Date.now();
+      // The credential counter as it stands NOW, for the plan write below. Same
+      // window and same hazard as `askedAt` above: the portal takes up to four
+      // seconds and the box can be re-linked inside that time.
+      const askedAtGeneration = clawaiPlanGeneration();
       const lookup = await fetchPortalTier(state.clawaiToken);
       if (lookup.source === "portal") {
         clawaiAccountTier = lookup.tier;
@@ -252,11 +256,13 @@ async function buildStatusResponse(state: ResolvedAiState): Promise<NextResponse
         // scripts decide an ENTITLEMENT — whether this box may keep a cloud
         // voice at all, and one of them DELETES the definition when it may not
         // — and the badge above is a device DEFAULT that a Max subscriber is
-        // allowed to have set to Flash. Written only here, in the
-        // portal-ANSWERED branch: the wizard's plan picker is a guess the
-        // account has not been consulted about (TASK-481), and an `unreachable`
-        // verdict is the not-knowing the key exists to keep distinguishable.
-        await persistClawaiPlanTier(lookup.planTier);
+        // allowed to have set to Flash. Only the portal-ANSWERED branch writes
+        // it: the wizard's plan picker is a guess the account has not been
+        // consulted about (TASK-481), and an `unreachable` verdict is the
+        // not-knowing the key exists to keep distinguishable. `null` here is
+        // "answered: no paid plan" and is stored as such, which is what lets a
+        // CANCELLED subscription still withdraw the voice.
+        await persistClawaiPlanTier(lookup.planTier, askedAtGeneration);
         // The portal ANSWERED about the credential this box holds, so any
         // refusal recorded against it is over. Same poll, same store, same
         // "write only on change" discipline as the tier stamp above — the

--- a/src/app/setup-api/ai-models/status/route.ts
+++ b/src/app/setup-api/ai-models/status/route.ts
@@ -249,7 +249,14 @@ async function buildStatusResponse(state: ResolvedAiState): Promise<NextResponse
         // fallback reflects the last *confirmed* tier, not a stale
         // configure-time value (which flapped a Free badge to Pro and
         // re-fired the celebration). Write only on change to avoid churn.
-        if (lookup.tier !== localTier) {
+        //
+        // GUARDED THE SAME WAY as the plan below, and by the same snapshot. The
+        // two stamps are read together by both boot scripts and one of them
+        // deletes on the pair, so they have to describe the same ACCOUNT: an
+        // unguarded badge write would land the RETIRED account's badge beside a
+        // plan write that was correctly skipped, and the arm would then fall
+        // back to a badge belonging to a token this box no longer holds.
+        if (askedAtGeneration === clawaiPlanGeneration() && lookup.tier !== localTier) {
           await setConfigValue(CLAWBOX_AI_TIER_CONFIG_KEY, lookup.tier).catch(() => {});
         }
         // The PLAN, beside the badge and never instead of it. The two boot
@@ -259,10 +266,11 @@ async function buildStatusResponse(state: ResolvedAiState): Promise<NextResponse
         // allowed to have set to Flash. Only the portal-ANSWERED branch writes
         // it: the wizard's plan picker is a guess the account has not been
         // consulted about (TASK-481), and an `unreachable` verdict is the
-        // not-knowing the key exists to keep distinguishable. `null` here is
-        // "answered: no paid plan" and is stored as such, which is what lets a
-        // CANCELLED subscription still withdraw the voice.
-        await persistClawaiPlanTier(lookup.planTier, askedAtGeneration);
+        // not-knowing the key exists to keep distinguishable. `planVerdict`
+        // rather than `planTier`, because that one answers `null` to a
+        // genuinely unpaid account, to an ABSENT `tier` and to a plan word this
+        // build has never seen alike — and only the first is a downgrade.
+        await persistClawaiPlanTier({ verdict: lookup.planVerdict }, askedAtGeneration);
         // The portal ANSWERED about the credential this box holds, so any
         // refusal recorded against it is over. Same poll, same store, same
         // "write only on change" discipline as the tier stamp above — the

--- a/src/app/setup-api/ai-models/status/route.ts
+++ b/src/app/setup-api/ai-models/status/route.ts
@@ -21,6 +21,10 @@ import {
   clearPersistedClawaiCredentialRefusal,
   persistClawaiCredentialRefusal,
 } from "@/lib/clawai-credential-refusal";
+// The portal's PLAN, written where the same two boot scripts can read it. The
+// tier stamp beside it is a device DEFAULT and may not be refused on — see
+// `clawai-plan-tier.ts` and TASK-744.
+import { persistClawaiPlanTier } from "@/lib/clawai-plan-tier";
 
 export const dynamic = "force-dynamic";
 
@@ -244,6 +248,15 @@ async function buildStatusResponse(state: ResolvedAiState): Promise<NextResponse
         if (lookup.tier !== localTier) {
           await setConfigValue(CLAWBOX_AI_TIER_CONFIG_KEY, lookup.tier).catch(() => {});
         }
+        // The PLAN, beside the badge and never instead of it. The two boot
+        // scripts decide an ENTITLEMENT — whether this box may keep a cloud
+        // voice at all, and one of them DELETES the definition when it may not
+        // — and the badge above is a device DEFAULT that a Max subscriber is
+        // allowed to have set to Flash. Written only here, in the
+        // portal-ANSWERED branch: the wizard's plan picker is a guess the
+        // account has not been consulted about (TASK-481), and an `unreachable`
+        // verdict is the not-knowing the key exists to keep distinguishable.
+        await persistClawaiPlanTier(lookup.planTier);
         // The portal ANSWERED about the credential this box holds, so any
         // refusal recorded against it is over. Same poll, same store, same
         // "write only on change" discipline as the tier stamp above — the

--- a/src/app/setup-api/hermes/clawai/route.ts
+++ b/src/app/setup-api/hermes/clawai/route.ts
@@ -175,8 +175,9 @@ export async function POST(request: Request) {
       // account B's token beside account A's plan — and both boot scripts read
       // that plan as this box's entitlement, so a Free box would go on arming
       // and keeping a cloud voice its credential is answered 403 for
-      // (TASK-744). Only on an account CHANGE, so a re-paste of the same token
-      // does not throw away a plan that is still true.
+      // (TASK-744). Only on an account CHANGE — and the apply's own batch keeps
+      // the same rule, so a re-paste of the same token or a tier-pill change
+      // leaves a plan that is still true exactly where it is.
       ...(replacedAccount ? { [CLAWAI_PLAN_TIER_KEY]: undefined } : {}),
     });
     // A refusal the proxy gave the token being replaced is about that token,

--- a/src/app/setup-api/hermes/clawai/route.ts
+++ b/src/app/setup-api/hermes/clawai/route.ts
@@ -9,6 +9,9 @@ import {
 } from "@/lib/explicit-model-pick";
 import { get, setMany } from "@/lib/config-store";
 import { forgetClawaiCredentialRefusal } from "@/lib/harness/credentials";
+// The recorded PLAN. This route writes the credential in a batch of its own, so
+// it owes the plan the same treatment the model picks get — see TASK-744.
+import { CLAWAI_PLAN_TIER_KEY } from "@/lib/clawai-plan-tier";
 import { hermesConfigGet } from "@/lib/hermes-config-cache";
 import { getActiveHarness } from "@/lib/harness";
 import { getCodingAgentStatus } from "@/lib/coding-agent";
@@ -165,6 +168,16 @@ export async function POST(request: Request) {
     await setMany({
       clawai_token: suppliedToken,
       ...(picksWithoutClawai ? { [EXPLICIT_MODEL_PICKS_KEY]: picksWithoutClawai } : {}),
+      // The recorded PLAN goes in THIS batch too, for the reason the picks do:
+      // `applyClawaiToHermes` retires it in its own final `setMany`, and that
+      // one sits behind a step loop that is fatal on any failing
+      // `hermes config set`. A step that failed after this line would leave
+      // account B's token beside account A's plan — and both boot scripts read
+      // that plan as this box's entitlement, so a Free box would go on arming
+      // and keeping a cloud voice its credential is answered 403 for
+      // (TASK-744). Only on an account CHANGE, so a re-paste of the same token
+      // does not throw away a plan that is still true.
+      ...(replacedAccount ? { [CLAWAI_PLAN_TIER_KEY]: undefined } : {}),
     });
     // A refusal the proxy gave the token being replaced is about that token,
     // not this one. Dropped here as well as in `applyClawaiToHermes`, because a

--- a/src/lib/clawai-plan-tier.ts
+++ b/src/lib/clawai-plan-tier.ts
@@ -31,11 +31,11 @@ import { normalizeClawboxAiTier, type ClawboxAiTier } from "@/lib/clawbox-ai-mod
  * `deviceTier: "flash"` — a state `mapPortalTier` preserves deliberately — had
  * his cloud voice DELETED at every boot.
  *
- * Values are the same two-value enum `clawai_tier` uses (`"flash"` for the Pro
- * plan, `"pro"` for the Max plan — the names are off by one on purpose, see
- * `CLAWBOX_AI_MODEL_BY_TIER`). Anything else, `null` included, means the portal
- * has told us nothing we can act on, and every reader falls back to the device
- * stamp there rather than treating it as a downgrade.
+ * ALWAYS WRITTEN BESIDE `clawai_tier`, in the same store write, and deleted in
+ * that same write when the writer had no portal answer. The badge and the plan
+ * therefore always describe the same account: a plan that outlived the
+ * credential it was read for would be a fact about a retired account deciding
+ * whether this box keeps its voice.
  */
 export const CLAWAI_PLAN_TIER_KEY = "clawai_plan_tier";
 
@@ -49,34 +49,89 @@ export const CLAWAI_PLAN_TIER_KEY = "clawai_plan_tier";
 const CLAWAI_DEVICE_TIER_KEY = "clawai_tier";
 
 /**
- * The tier an ENTITLEMENT may be decided from: the plan when the portal has
- * told us one, and the device stamp only when it has not.
+ * "The portal answered, and this account has no paid plan."
  *
- * ONE rule, four implementations — this one, `speechEntitledTier()`, and a
- * transcription of it in each boot script — because neither shell can import
- * TypeScript. The suites pin the four together; nothing else stops them
- * drifting into disagreeing about which boxes have a cloud voice.
+ * A THIRD value, and it has to exist. `mapPortalTier` and `mapPortalPlanTier`
+ * both answer `null` for an unpaid account, and an absent key already means
+ * "the portal has never answered for this box" — so without a positive word
+ * for it, a CANCELLED subscription is indistinguishable from a box nobody has
+ * ever asked about, and the withdrawal below can never fire on the commoner of
+ * the two downgrade paths. `clawai_tier` cannot carry it (the badge's enum is
+ * the two paid tiers and `null`), which is the other reason this is a separate
+ * key rather than a widened one.
+ */
+export const CLAWAI_PLAN_UNPAID = "free";
+
+/** What the portal can tell us a plan IS: the two paid tiers, or unpaid. */
+export type ClawaiPlanTier = ClawboxAiTier | typeof CLAWAI_PLAN_UNPAID;
+
+/**
+ * The recorded plan, or `null` for a value no writer of ours produces.
  *
- * `null` is "nobody has told us", and it is NOT "not entitled": a caller that
- * refuses on it turns a portal outage or a box the status poll has never run on
- * into a downgrade. Callers that DESTROY configuration must require a non-null
- * answer; callers that merely decline to arm may treat it as declining.
+ * `normalizeClawboxAiTier`'s vocabulary plus {@link CLAWAI_PLAN_UNPAID}, and
+ * nothing else: an unrecognised string is a store somebody edited or a build we
+ * have not seen, and reading it as a plan would let a value we cannot interpret
+ * decide an entitlement.
+ */
+export function normalizeClawaiPlanTier(value: unknown): ClawaiPlanTier | null {
+  const paid = normalizeClawboxAiTier(value);
+  if (paid) return paid;
+  return typeof value === "string" && value.trim().toLowerCase() === CLAWAI_PLAN_UNPAID
+    ? CLAWAI_PLAN_UNPAID
+    : null;
+}
+
+/**
+ * ARM side: the tier a box may be GIVEN the cloud voice on — the plan when the
+ * portal has told us one, the device stamp only when it has not.
+ *
+ * The fallback belongs on this side alone. Arming is recoverable — the worst it
+ * does is write our own fields to our own values, and the next boot takes it
+ * back once the plan is on record — so a box whose plan nobody has asked about
+ * yet is better served by the badge than by silence. Every box in the field is
+ * in that state until its first successful status poll.
+ *
+ * ONE rule, three implementations — this one and a transcription in each boot
+ * script, because neither shell can import TypeScript. The suite pins the three
+ * together; nothing else stops them drifting into disagreeing about which boxes
+ * have a cloud voice.
  */
 export function clawaiEntitlementTier(
   planTier: unknown,
   deviceTier: unknown,
-): ClawboxAiTier | null {
-  return normalizeClawboxAiTier(planTier) ?? normalizeClawboxAiTier(deviceTier);
+): ClawaiPlanTier | null {
+  return normalizeClawaiPlanTier(planTier) ?? normalizeClawboxAiTier(deviceTier);
 }
 
 /**
- * The same rule, over the two stamps as they sit in `data/config.json`.
+ * WITHDRAW side: may this box's cloud voice be TAKEN AWAY?
+ *
+ * THE PLAN ALONE, and never the device stamp. This is the one irreversible act
+ * in either boot script, and the stamp is a DEFAULT a Max subscriber is allowed
+ * to have set to Flash — refusing on it is TASK-744 itself, and deleting on it
+ * is TASK-744 with the customer's configuration gone. So a box whose plan is
+ * not on record keeps what it has: not knowing is not a downgrade, and the cost
+ * of holding is a refused round trip per spoken reply until the next poll,
+ * against the cost of deleting, which is a Max subscriber's voice.
+ *
+ * @param planTier the recorded plan, as it sits in the store.
+ * @param entitledTier the tier the proxy serves speech to (`"pro"`, the tier of
+ *   the MAX plan — the names are off by one on purpose). Passed in rather than
+ *   imported so this module does not pull `hermes-tts.ts`'s graph behind it.
+ */
+export function clawaiSpeechWithdrawable(planTier: unknown, entitledTier: string): boolean {
+  const plan = normalizeClawaiPlanTier(planTier);
+  return plan !== null && plan !== entitledTier;
+}
+
+/**
+ * The same ARM rule, over the two stamps as they sit in `data/config.json`.
  *
  * The one TypeScript reader, so no surface derives the pair for itself. Reads
  * both keys, because "the plan is unknown" is a fact about the store rather
  * than about either value on its own.
  */
-export async function readClawaiEntitlementTier(): Promise<ClawboxAiTier | null> {
+export async function readClawaiEntitlementTier(): Promise<ClawaiPlanTier | null> {
   const [planTier, deviceTier] = await Promise.all([
     get(CLAWAI_PLAN_TIER_KEY),
     get(CLAWAI_DEVICE_TIER_KEY),
@@ -85,60 +140,102 @@ export async function readClawaiEntitlementTier(): Promise<ClawboxAiTier | null>
 }
 
 /**
- * Record the portal's plan answer.
+ * A portal answer about this box's plan, or the absence of one.
  *
- * Only a portal-ANSWERED lookup may call this — never the wizard's plan picker,
- * which is a guess the account has not been consulted about (TASK-481), and
- * never an `unreachable` verdict, which is the not-knowing this key exists to
- * keep distinguishable.
+ * `tier` is `mapPortalPlanTier`'s value: a paid tier, or `null` for an account
+ * with no paid plan. The OBJECT's presence is what says the portal answered at
+ * all — an `unreachable` lookup, a probe that threw, and a caller that never
+ * asked all pass nothing, and are all "we do not know".
+ */
+export interface ClawaiPortalPlan {
+  tier: ClawboxAiTier | null;
+}
+
+/**
+ * The value to write for {@link CLAWAI_PLAN_TIER_KEY} in the same store write
+ * that records `clawai_tier`.
+ *
+ * `undefined` is a DELETE in `set`/`setMany`, and that is the answer for a
+ * writer with no portal answer: it has just rewritten the badge for whatever
+ * account this box now holds, and leaving the previous account's plan beside it
+ * is how a retired Max plan comes to keep a Pro box's cloud voice armed.
+ */
+export function clawaiPlanTierForStore(
+  portalPlan: ClawaiPortalPlan | undefined,
+): ClawaiPlanTier | undefined {
+  if (!portalPlan) return undefined;
+  return portalPlan.tier ?? CLAWAI_PLAN_UNPAID;
+}
+
+/**
+ * How many times the box's ClawBox AI credential has been REPLACED.
+ *
+ * A plain counter, never anything derived from a token — the same shape, and
+ * the same reason, as `provenGeneration` in `clawbox-ai-portal-tier.ts`. It
+ * lives in this thin module rather than in `@/lib/harness/credentials` because
+ * the status route is one of its readers and importing that module into a badge
+ * route drags the whole Hermes adapter graph in behind it.
+ */
+let credentialGeneration = 0;
+
+/** Read the counter, to be handed back to {@link persistClawaiPlanTier}. */
+export function clawaiPlanGeneration(): number {
+  return credentialGeneration;
+}
+
+/**
+ * The credential was rewritten — anything learned about the old one is about an
+ * account this box has moved on from.
+ *
+ * Called from `forgetClawaiCredentialRefusal`, the funnel every credential
+ * writer already goes through. Nothing is CLEARED here: the writers record or
+ * delete the plan in the same store write as the badge, so there is never a
+ * moment where one describes a different account than the other. This only
+ * stops an answer that was already in flight from landing afterwards.
+ */
+export function noteClawaiCredentialReplaced(): void {
+  credentialGeneration += 1;
+}
+
+/** Test seam: forget the generation. */
+export function _resetClawaiPlanGeneration(): void {
+  credentialGeneration = 0;
+}
+
+/**
+ * Record what the portal said this account's plan is.
+ *
+ * ONLY a portal-ANSWERED lookup may call this. `planTier` is
+ * `mapPortalPlanTier`'s value, so `null` here means "the portal answered and
+ * this account has no paid plan" and is stored as {@link CLAWAI_PLAN_UNPAID} —
+ * NOT as an absent key, which means the opposite. The wizard's plan picker is a
+ * guess the account has not been consulted about (TASK-481) and an
+ * `unreachable` verdict is the not-knowing this key exists to keep
+ * distinguishable; neither may reach this function.
+ *
+ * `askedAtGeneration` is the credential counter as it stood when the lookup was
+ * SENT. Up to four seconds pass before the portal answers, and the box can be
+ * re-linked inside that window — writing then would be a plan for a token the
+ * box no longer holds, which is how a retired Pro plan comes to withdraw a Max
+ * subscriber's voice at the next boot. The same guard, for the same race, that
+ * `clearPersistedClawaiCredentialRefusal`'s `notRecordedSince` is.
  *
  * Read before write, so the overwhelmingly common path (the plan has not
  * changed) never opens the store for writing, and best-effort for the same
  * reason the refusal stamp is: a badge poll must not fail because a hint could
  * not be saved. What it costs when it fails is honest and bounded — the boot
- * scripts go on reading the device stamp, which is what they did before this
- * key existed.
+ * scripts go on reading the badge for the ARM and withdraw nothing at all.
  */
-export async function persistClawaiPlanTier(planTier: ClawboxAiTier | null): Promise<void> {
+export async function persistClawaiPlanTier(
+  planTier: ClawboxAiTier | null,
+  askedAtGeneration?: number,
+): Promise<void> {
+  if (askedAtGeneration !== undefined && askedAtGeneration !== credentialGeneration) return;
   try {
-    const stored = normalizeClawboxAiTier(await get(CLAWAI_PLAN_TIER_KEY));
-    if (stored === planTier) return;
-    // `undefined` DELETES the key, which is the honest record of "the portal
-    // answered and this account has no paid plan": there is no third enum value
-    // for it, and writing `null` would be read back as a plan we cannot act on
-    // anyway. Both leave the boot scripts on the device stamp.
-    await set(CLAWAI_PLAN_TIER_KEY, planTier ?? undefined);
+    const next = planTier ?? CLAWAI_PLAN_UNPAID;
+    if (normalizeClawaiPlanTier(await get(CLAWAI_PLAN_TIER_KEY)) === next) return;
+    await set(CLAWAI_PLAN_TIER_KEY, next);
   } catch {
     // See the docblock. The next poll writes it again.
-  }
-}
-
-/**
- * Forget the recorded plan — the credential changed, so the plan on record
- * belongs to an account this box no longer holds a token for.
- *
- * Called from `forgetClawaiCredentialRefusal`, the one funnel every credential
- * writer already goes through, rather than beside each of them: a writer that
- * retired the refusal and left the plan would let the PREVIOUS account's Max
- * plan keep the cloud voice armed on a box that has just been re-linked to a
- * lower one, which is a refused round trip per spoken reply and the panel
- * calling the voice configured while it happens. That funnel fires on every
- * credential WRITE rather than only on a change, and clearing too eagerly is
- * the safe direction here: it puts both boot scripts back on the device stamp
- * until the next status poll answers — which is exactly, and only, where they
- * were before this key existed. Clearing too seldom would be a fact about a
- * retired account overriding a fresh one.
- *
- * Costs nothing when it lands on a box whose plan has not been recorded — the
- * read below is what decides.
- */
-export async function clearClawaiPlanTier(): Promise<void> {
-  try {
-    if ((await get(CLAWAI_PLAN_TIER_KEY)) === undefined) return;
-    await set(CLAWAI_PLAN_TIER_KEY, undefined);
-  } catch {
-    // Bounded the same way: an uncleared plan costs one status poll, after
-    // which the portal's answer for the credential the box now holds replaces
-    // it.
   }
 }

--- a/src/lib/clawai-plan-tier.ts
+++ b/src/lib/clawai-plan-tier.ts
@@ -1,5 +1,10 @@
 import { get, set } from "@/lib/config-store";
-import { normalizeClawboxAiTier, type ClawboxAiTier } from "@/lib/clawbox-ai-models";
+import {
+  CLAWBOX_AI_PLAN_UNPAID,
+  normalizeClawboxAiPlanTier,
+  normalizeClawboxAiTier,
+  type ClawboxAiPlanTier,
+} from "@/lib/clawbox-ai-models";
 
 /**
  * The subscription PLAN the portal reports for this box's credential, written
@@ -49,37 +54,14 @@ export const CLAWAI_PLAN_TIER_KEY = "clawai_plan_tier";
 const CLAWAI_DEVICE_TIER_KEY = "clawai_tier";
 
 /**
- * "The portal answered, and this account has no paid plan."
- *
- * A THIRD value, and it has to exist. `mapPortalTier` and `mapPortalPlanTier`
- * both answer `null` for an unpaid account, and an absent key already means
- * "the portal has never answered for this box" — so without a positive word
- * for it, a CANCELLED subscription is indistinguishable from a box nobody has
- * ever asked about, and the withdrawal below can never fire on the commoner of
- * the two downgrade paths. `clawai_tier` cannot carry it (the badge's enum is
- * the two paid tiers and `null`), which is the other reason this is a separate
- * key rather than a widened one.
+ * The unpaid word and the plan vocabulary, re-exported from their one home so
+ * the boot scripts' parity test and every caller here name the same values.
+ * `mapPortalPlanVerdict` is the only thing allowed to DECIDE that a portal
+ * answer means unpaid — see its docblock for why `mapPortalPlanTier`'s `null`
+ * may not be read as one.
  */
-export const CLAWAI_PLAN_UNPAID = "free";
-
-/** What the portal can tell us a plan IS: the two paid tiers, or unpaid. */
-export type ClawaiPlanTier = ClawboxAiTier | typeof CLAWAI_PLAN_UNPAID;
-
-/**
- * The recorded plan, or `null` for a value no writer of ours produces.
- *
- * `normalizeClawboxAiTier`'s vocabulary plus {@link CLAWAI_PLAN_UNPAID}, and
- * nothing else: an unrecognised string is a store somebody edited or a build we
- * have not seen, and reading it as a plan would let a value we cannot interpret
- * decide an entitlement.
- */
-export function normalizeClawaiPlanTier(value: unknown): ClawaiPlanTier | null {
-  const paid = normalizeClawboxAiTier(value);
-  if (paid) return paid;
-  return typeof value === "string" && value.trim().toLowerCase() === CLAWAI_PLAN_UNPAID
-    ? CLAWAI_PLAN_UNPAID
-    : null;
-}
+export { CLAWBOX_AI_PLAN_UNPAID as CLAWAI_PLAN_UNPAID } from "@/lib/clawbox-ai-models";
+export type { ClawboxAiPlanTier as ClawaiPlanTier } from "@/lib/clawbox-ai-models";
 
 /**
  * ARM side: the tier a box may be GIVEN the cloud voice on — the plan when the
@@ -99,8 +81,8 @@ export function normalizeClawaiPlanTier(value: unknown): ClawaiPlanTier | null {
 export function clawaiEntitlementTier(
   planTier: unknown,
   deviceTier: unknown,
-): ClawaiPlanTier | null {
-  return normalizeClawaiPlanTier(planTier) ?? normalizeClawboxAiTier(deviceTier);
+): ClawboxAiPlanTier | null {
+  return normalizeClawboxAiPlanTier(planTier) ?? normalizeClawboxAiTier(deviceTier);
 }
 
 /**
@@ -120,7 +102,7 @@ export function clawaiEntitlementTier(
  *   imported so this module does not pull `hermes-tts.ts`'s graph behind it.
  */
 export function clawaiSpeechWithdrawable(planTier: unknown, entitledTier: string): boolean {
-  const plan = normalizeClawaiPlanTier(planTier);
+  const plan = normalizeClawboxAiPlanTier(planTier);
   return plan !== null && plan !== entitledTier;
 }
 
@@ -131,7 +113,7 @@ export function clawaiSpeechWithdrawable(planTier: unknown, entitledTier: string
  * both keys, because "the plan is unknown" is a fact about the store rather
  * than about either value on its own.
  */
-export async function readClawaiEntitlementTier(): Promise<ClawaiPlanTier | null> {
+export async function readClawaiEntitlementTier(): Promise<ClawboxAiPlanTier | null> {
   const [planTier, deviceTier] = await Promise.all([
     get(CLAWAI_PLAN_TIER_KEY),
     get(CLAWAI_DEVICE_TIER_KEY),
@@ -142,13 +124,17 @@ export async function readClawaiEntitlementTier(): Promise<ClawaiPlanTier | null
 /**
  * A portal answer about this box's plan, or the absence of one.
  *
- * `tier` is `mapPortalPlanTier`'s value: a paid tier, or `null` for an account
- * with no paid plan. The OBJECT's presence is what says the portal answered at
- * all — an `unreachable` lookup, a probe that threw, and a caller that never
- * asked all pass nothing, and are all "we do not know".
+ * `verdict` is `mapPortalPlanVerdict`'s value — a paid tier, the unpaid word,
+ * or `null` for an answer this build cannot interpret. NOT `mapPortalPlanTier`,
+ * whose `null` also covers an absent field and an unknown plan name; recording
+ * either of those as unpaid hands the boot scripts a licence to delete.
+ *
+ * The OBJECT's presence says the portal answered at all — an `unreachable`
+ * lookup, a probe that threw, and a caller that never asked all pass nothing,
+ * and are all "we do not know".
  */
 export interface ClawaiPortalPlan {
-  tier: ClawboxAiTier | null;
+  verdict: ClawboxAiPlanTier | null;
 }
 
 /**
@@ -162,9 +148,13 @@ export interface ClawaiPortalPlan {
  */
 export function clawaiPlanTierForStore(
   portalPlan: ClawaiPortalPlan | undefined,
-): ClawaiPlanTier | undefined {
-  if (!portalPlan) return undefined;
-  return portalPlan.tier ?? CLAWAI_PLAN_UNPAID;
+): ClawboxAiPlanTier | undefined {
+  // An answer we could not interpret is a DELETE too, not an unpaid plan: the
+  // boot scripts read a recorded plan as one they were told, and one of them
+  // destroys configuration on it. Falling back to the badge for the ARM is the
+  // right cost of not understanding the portal; deleting a Max subscriber's
+  // voice is not.
+  return portalPlan?.verdict ?? undefined;
 }
 
 /**
@@ -192,6 +182,13 @@ export function clawaiPlanGeneration(): number {
  * delete the plan in the same store write as the badge, so there is never a
  * moment where one describes a different account than the other. This only
  * stops an answer that was already in flight from landing afterwards.
+ *
+ * DELIBERATELY OVER-APPROXIMATE. Two of that funnel's three callers reach it on
+ * any credential WRITE, a re-paste of the identical token included, so the
+ * counter moves more often than the credential really changes. That is the safe
+ * direction and the reason it is not narrowed: bumping too often defers one
+ * poll's plan write by 30 seconds, and bumping too seldom records a retired
+ * account's plan and lets the next boot decide this box's entitlement from it.
  */
 export function noteClawaiCredentialReplaced(): void {
   credentialGeneration += 1;
@@ -205,12 +202,12 @@ export function _resetClawaiPlanGeneration(): void {
 /**
  * Record what the portal said this account's plan is.
  *
- * ONLY a portal-ANSWERED lookup may call this. `planTier` is
- * `mapPortalPlanTier`'s value, so `null` here means "the portal answered and
- * this account has no paid plan" and is stored as {@link CLAWAI_PLAN_UNPAID} —
- * NOT as an absent key, which means the opposite. The wizard's plan picker is a
+ * ONLY a portal-ANSWERED lookup may call this, and it passes
+ * `mapPortalPlanVerdict`'s three-valued reading: a paid tier, the unpaid word,
+ * or `null` for an answer this build cannot interpret — which is stored as an
+ * absent key, exactly like never having asked. The wizard's plan picker is a
  * guess the account has not been consulted about (TASK-481) and an
- * `unreachable` verdict is the not-knowing this key exists to keep
+ * `unreachable` lookup is the not-knowing this key exists to keep
  * distinguishable; neither may reach this function.
  *
  * `askedAtGeneration` is the credential counter as it stood when the lookup was
@@ -227,13 +224,13 @@ export function _resetClawaiPlanGeneration(): void {
  * scripts go on reading the badge for the ARM and withdraw nothing at all.
  */
 export async function persistClawaiPlanTier(
-  planTier: ClawboxAiTier | null,
+  portalPlan: ClawaiPortalPlan,
   askedAtGeneration?: number,
 ): Promise<void> {
   if (askedAtGeneration !== undefined && askedAtGeneration !== credentialGeneration) return;
   try {
-    const next = planTier ?? CLAWAI_PLAN_UNPAID;
-    if (normalizeClawaiPlanTier(await get(CLAWAI_PLAN_TIER_KEY)) === next) return;
+    const next = clawaiPlanTierForStore(portalPlan);
+    if (normalizeClawboxAiPlanTier(await get(CLAWAI_PLAN_TIER_KEY)) === (next ?? null)) return;
     await set(CLAWAI_PLAN_TIER_KEY, next);
   } catch {
     // See the docblock. The next poll writes it again.

--- a/src/lib/clawai-plan-tier.ts
+++ b/src/lib/clawai-plan-tier.ts
@@ -1,0 +1,144 @@
+import { get, set } from "@/lib/config-store";
+import { normalizeClawboxAiTier, type ClawboxAiTier } from "@/lib/clawbox-ai-models";
+
+/**
+ * The subscription PLAN the portal reports for this box's credential, written
+ * down where the ROOT boot scripts can read it. SERVER ONLY.
+ *
+ * Split out for the same reason `clawai-credential-refusal.ts` was: three of
+ * the four readers of "may this box have the cloud voice" are not in the Next
+ * process — `scripts/gateway-pre-start.sh`, which decides whether to declare
+ * the OpenClaw speech provider at all, `scripts/register-mcp.sh`, which does
+ * the same on Hermes, and the next Next process after a restart. The portal is
+ * the only thing that knows the answer and only this app can ask it, so the
+ * answer has to be left somewhere both boot scripts can find it.
+ */
+
+/**
+ * The store key.
+ *
+ * A sibling of `clawai_tier` and NOT a replacement for it. The two answer
+ * different questions and `clawbox-ai-portal-tier.ts` spells out which is
+ * which: `mapPortalTier` prefers the portal's `deviceTier` stamp on purpose,
+ * because it answers "what should this BOX default to" and a Max subscriber is
+ * allowed to run Flash here; `mapPortalPlanTier` answers "what does this
+ * ACCOUNT pay for", which is "the only question an entitlement may be derived
+ * from. Read the first for a default to write; read this one before refusing
+ * anything."
+ *
+ * TASK-744 is what reading the wrong one costs: the speech gate on both
+ * editions read the device stamp, so a Max subscriber whose box is stamped
+ * `deviceTier: "flash"` — a state `mapPortalTier` preserves deliberately — had
+ * his cloud voice DELETED at every boot.
+ *
+ * Values are the same two-value enum `clawai_tier` uses (`"flash"` for the Pro
+ * plan, `"pro"` for the Max plan — the names are off by one on purpose, see
+ * `CLAWBOX_AI_MODEL_BY_TIER`). Anything else, `null` included, means the portal
+ * has told us nothing we can act on, and every reader falls back to the device
+ * stamp there rather than treating it as a downgrade.
+ */
+export const CLAWAI_PLAN_TIER_KEY = "clawai_plan_tier";
+
+/**
+ * The device badge's key, spelled here so this module can read the pair.
+ *
+ * Deliberately not exported: the two routes that WRITE it already keep their
+ * own constant, and a shared name would invite a caller to read the badge
+ * alone — which is the thing this module exists to stop.
+ */
+const CLAWAI_DEVICE_TIER_KEY = "clawai_tier";
+
+/**
+ * The tier an ENTITLEMENT may be decided from: the plan when the portal has
+ * told us one, and the device stamp only when it has not.
+ *
+ * ONE rule, four implementations — this one, `speechEntitledTier()`, and a
+ * transcription of it in each boot script — because neither shell can import
+ * TypeScript. The suites pin the four together; nothing else stops them
+ * drifting into disagreeing about which boxes have a cloud voice.
+ *
+ * `null` is "nobody has told us", and it is NOT "not entitled": a caller that
+ * refuses on it turns a portal outage or a box the status poll has never run on
+ * into a downgrade. Callers that DESTROY configuration must require a non-null
+ * answer; callers that merely decline to arm may treat it as declining.
+ */
+export function clawaiEntitlementTier(
+  planTier: unknown,
+  deviceTier: unknown,
+): ClawboxAiTier | null {
+  return normalizeClawboxAiTier(planTier) ?? normalizeClawboxAiTier(deviceTier);
+}
+
+/**
+ * The same rule, over the two stamps as they sit in `data/config.json`.
+ *
+ * The one TypeScript reader, so no surface derives the pair for itself. Reads
+ * both keys, because "the plan is unknown" is a fact about the store rather
+ * than about either value on its own.
+ */
+export async function readClawaiEntitlementTier(): Promise<ClawboxAiTier | null> {
+  const [planTier, deviceTier] = await Promise.all([
+    get(CLAWAI_PLAN_TIER_KEY),
+    get(CLAWAI_DEVICE_TIER_KEY),
+  ]);
+  return clawaiEntitlementTier(planTier, deviceTier);
+}
+
+/**
+ * Record the portal's plan answer.
+ *
+ * Only a portal-ANSWERED lookup may call this — never the wizard's plan picker,
+ * which is a guess the account has not been consulted about (TASK-481), and
+ * never an `unreachable` verdict, which is the not-knowing this key exists to
+ * keep distinguishable.
+ *
+ * Read before write, so the overwhelmingly common path (the plan has not
+ * changed) never opens the store for writing, and best-effort for the same
+ * reason the refusal stamp is: a badge poll must not fail because a hint could
+ * not be saved. What it costs when it fails is honest and bounded — the boot
+ * scripts go on reading the device stamp, which is what they did before this
+ * key existed.
+ */
+export async function persistClawaiPlanTier(planTier: ClawboxAiTier | null): Promise<void> {
+  try {
+    const stored = normalizeClawboxAiTier(await get(CLAWAI_PLAN_TIER_KEY));
+    if (stored === planTier) return;
+    // `undefined` DELETES the key, which is the honest record of "the portal
+    // answered and this account has no paid plan": there is no third enum value
+    // for it, and writing `null` would be read back as a plan we cannot act on
+    // anyway. Both leave the boot scripts on the device stamp.
+    await set(CLAWAI_PLAN_TIER_KEY, planTier ?? undefined);
+  } catch {
+    // See the docblock. The next poll writes it again.
+  }
+}
+
+/**
+ * Forget the recorded plan — the credential changed, so the plan on record
+ * belongs to an account this box no longer holds a token for.
+ *
+ * Called from `forgetClawaiCredentialRefusal`, the one funnel every credential
+ * writer already goes through, rather than beside each of them: a writer that
+ * retired the refusal and left the plan would let the PREVIOUS account's Max
+ * plan keep the cloud voice armed on a box that has just been re-linked to a
+ * lower one, which is a refused round trip per spoken reply and the panel
+ * calling the voice configured while it happens. That funnel fires on every
+ * credential WRITE rather than only on a change, and clearing too eagerly is
+ * the safe direction here: it puts both boot scripts back on the device stamp
+ * until the next status poll answers — which is exactly, and only, where they
+ * were before this key existed. Clearing too seldom would be a fact about a
+ * retired account overriding a fresh one.
+ *
+ * Costs nothing when it lands on a box whose plan has not been recorded — the
+ * read below is what decides.
+ */
+export async function clearClawaiPlanTier(): Promise<void> {
+  try {
+    if ((await get(CLAWAI_PLAN_TIER_KEY)) === undefined) return;
+    await set(CLAWAI_PLAN_TIER_KEY, undefined);
+  } catch {
+    // Bounded the same way: an uncleared plan costs one status poll, after
+    // which the portal's answer for the credential the box now holds replaces
+    // it.
+  }
+}

--- a/src/lib/clawai-plan-tier.ts
+++ b/src/lib/clawai-plan-tier.ts
@@ -1,6 +1,5 @@
 import { get, set } from "@/lib/config-store";
 import {
-  CLAWBOX_AI_PLAN_UNPAID,
   normalizeClawboxAiPlanTier,
   normalizeClawboxAiTier,
   type ClawboxAiPlanTier,
@@ -36,11 +35,18 @@ import {
  * `deviceTier: "flash"` — a state `mapPortalTier` preserves deliberately — had
  * his cloud voice DELETED at every boot.
  *
- * ALWAYS WRITTEN BESIDE `clawai_tier`, in the same store write, and deleted in
- * that same write when the writer had no portal answer. The badge and the plan
- * therefore always describe the same account: a plan that outlived the
- * credential it was read for would be a fact about a retired account deciding
- * whether this box keeps its voice.
+ * ALWAYS WRITTEN BESIDE `clawai_tier`, in the same guarded pass, and deleted
+ * beside it when a writer that CHANGED the credential had no portal answer. The
+ * badge and the plan therefore always describe the same account: a plan that
+ * outlived the credential it was read for would be a fact about a retired
+ * account deciding whether this box keeps its voice.
+ *
+ * The credential writers put both in one `setMany`. The status poll writes them
+ * with two `set` calls under one generation snapshot, so they cannot describe
+ * different ACCOUNTS — but they are not atomic, and a boot landing between them
+ * can read a new badge beside an older plan. That costs at most one spurious
+ * verdict, which the next boot corrects; making it atomic would mean the poll
+ * writing the badge through this module too.
  */
 export const CLAWAI_PLAN_TIER_KEY = "clawai_plan_tier";
 
@@ -187,8 +193,10 @@ export function clawaiPlanGeneration(): number {
  * any credential WRITE, a re-paste of the identical token included, so the
  * counter moves more often than the credential really changes. That is the safe
  * direction and the reason it is not narrowed: bumping too often defers one
- * poll's plan write by 30 seconds, and bumping too seldom records a retired
- * account's plan and lets the next boot decide this box's entitlement from it.
+ * poll's stamp writes — the badge as well as the plan, since commit 3 gave them
+ * the same snapshot — by 30 seconds, and in that window the writer that bumped
+ * has itself written both. Bumping too seldom records a retired account's plan
+ * and lets the next boot decide this box's entitlement from it.
  */
 export function noteClawaiCredentialReplaced(): void {
   credentialGeneration += 1;
@@ -228,6 +236,12 @@ export async function persistClawaiPlanTier(
   askedAtGeneration?: number,
 ): Promise<void> {
   if (askedAtGeneration !== undefined && askedAtGeneration !== credentialGeneration) return;
+  // "WE CANNOT TELL" MAY NOT OVERWRITE "WE WERE TOLD", about the same account.
+  // The credential has not changed here — this is a poll, not a link — so a
+  // plan already on record is still that account's, and one unreadable response
+  // is no reason to forget it. The credential WRITERS delete on the same value,
+  // and must: there the account may have changed under it.
+  if (portalPlan.verdict === null) return;
   try {
     const next = clawaiPlanTierForStore(portalPlan);
     if (normalizeClawboxAiPlanTier(await get(CLAWAI_PLAN_TIER_KEY)) === (next ?? null)) return;

--- a/src/lib/clawbox-ai-models.ts
+++ b/src/lib/clawbox-ai-models.ts
@@ -102,6 +102,40 @@ export function normalizeClawboxAiTier(value: unknown): ClawboxAiTier | null {
 }
 
 /**
+ * "The portal answered, and this account has no paid plan."
+ *
+ * The third thing a PLAN can be, beside the two paid tiers. It exists because
+ * `mapPortalTier` and `mapPortalPlanTier` both answer `null` for an unpaid
+ * account, and an absent stamp already means "the portal has never answered
+ * for this box" — so without a positive word a CANCELLED subscription is
+ * indistinguishable from a box nobody has asked about, and nothing can ever be
+ * withdrawn from it (TASK-744).
+ *
+ * It is a value that AUTHORISES A DELETE, which is why it is written only for a
+ * plan word this build positively recognises as unpaid. See
+ * `mapPortalPlanVerdict`.
+ */
+export const CLAWBOX_AI_PLAN_UNPAID = "free";
+
+/** What a PLAN can be: the two paid tiers, or positively unpaid. */
+export type ClawboxAiPlanTier = ClawboxAiTier | typeof CLAWBOX_AI_PLAN_UNPAID;
+
+/**
+ * The plan vocabulary, and `null` for anything outside it.
+ *
+ * {@link normalizeClawboxAiTier}'s two values plus {@link CLAWBOX_AI_PLAN_UNPAID}.
+ * A string outside the set is a store somebody edited or a build we have not
+ * seen: not evidence of anything, and least of all of a downgrade.
+ */
+export function normalizeClawboxAiPlanTier(value: unknown): ClawboxAiPlanTier | null {
+  const paid = normalizeClawboxAiTier(value);
+  if (paid) return paid;
+  return typeof value === "string" && value.trim().toLowerCase() === CLAWBOX_AI_PLAN_UNPAID
+    ? CLAWBOX_AI_PLAN_UNPAID
+    : null;
+}
+
+/**
  * True if `model` is a fully-qualified ClawBox AI Pro slug
  * (`clawai/deepseek-v4-pro` or `deepseek/deepseek-v4-pro`).
  *

--- a/src/lib/clawbox-ai-portal-tier.ts
+++ b/src/lib/clawbox-ai-portal-tier.ts
@@ -1,6 +1,8 @@
 import {
+  CLAWBOX_AI_PLAN_UNPAID,
   normalizeAllowedModelIds,
   normalizeClawboxAiTier,
+  type ClawboxAiPlanTier,
   type ClawboxAiTier,
 } from "@/lib/clawbox-ai-models";
 
@@ -82,6 +84,16 @@ export type PortalLookup =
        * for (TASK-691).
        */
       planTier: ClawboxAiTier | null;
+      /**
+       * The same plan as a THREE-valued answer — see {@link mapPortalPlanVerdict}.
+       *
+       * `planTier` above answers `null` to a genuinely unpaid account, to an
+       * absent `tier` and to a plan word this build does not know alike, and
+       * only the first of those is a downgrade. Anything that records a plan —
+       * and therefore anything that later DELETES on one — must read this
+       * field; `planTier` is for callers to whom only the paid tiers matter.
+       */
+      planVerdict: ClawboxAiPlanTier | null;
       /** Entitled model ids, or null when the portal published none. */
       allowedModels: string[] | null;
     }
@@ -105,6 +117,7 @@ export type PortalLookup =
 interface PortalCacheEntry {
   tier: ClawboxAiTier | null;
   planTier: ClawboxAiTier | null;
+  planVerdict: ClawboxAiPlanTier | null;
   allowedModels: string[] | null;
   expiresAt: number;
 }
@@ -145,6 +158,7 @@ function rememberTier(
   token: string,
   tier: ClawboxAiTier | null,
   planTier: ClawboxAiTier | null,
+  planVerdict: ClawboxAiPlanTier | null,
   allowedModels: string[] | null,
   now: number,
 ) {
@@ -159,6 +173,7 @@ function rememberTier(
   portalTierCache.set(token, {
     tier,
     planTier,
+    planVerdict,
     allowedModels,
     expiresAt: now + PORTAL_TIER_CACHE_TTL_MS,
   });
@@ -216,6 +231,40 @@ export function mapPortalPlanTier(body: DeviceInfoResponse): ClawboxAiTier | nul
 }
 
 /**
+ * Plan words this build positively recognises as "no active paid plan".
+ *
+ * EVERY WORD IN HERE AUTHORISES A DELETE, so it is deliberately short and may
+ * only grow with a word that can mean nothing else. Getting it too narrow costs
+ * a refused round trip per spoken reply until the portal says something we
+ * recognise; getting it too wide costs a paying customer his configuration.
+ */
+const UNPAID_PLAN_WORDS = new Set(["free", "none", "unpaid", "canceled", "cancelled", "expired"]);
+
+/**
+ * The PLAN as a three-valued answer: a paid tier, positively unpaid, or `null`
+ * for "we cannot tell".
+ *
+ * {@link mapPortalPlanTier}'s `null` is three different facts and only one of
+ * them is a downgrade — that account genuinely pays for nothing. The other two
+ * are an ABSENT `tier` (the field is optional in our own type, and
+ * `allowedModelsForCompat` exists because older portal builds answer with less
+ * than the current ones do) and a plan word this build has never heard of (a
+ * new SKU, a rename, a localised string). Anything that DESTROYS configuration
+ * on the strength of "not paid" has to be able to tell the three apart, or a
+ * response shape we did not anticipate deletes a Max subscriber's cloud voice
+ * (TASK-744).
+ *
+ * Read this one before recording a plan; read {@link mapPortalPlanTier} where
+ * only the paid tiers matter.
+ */
+export function mapPortalPlanVerdict(body: DeviceInfoResponse): ClawboxAiPlanTier | null {
+  const paid = mapPortalPlanTier(body);
+  if (paid) return paid;
+  const plan = (body.tier ?? "").trim().toLowerCase();
+  return UNPAID_PLAN_WORDS.has(plan) ? CLAWBOX_AI_PLAN_UNPAID : null;
+}
+
+/**
  * Resolves a `claw_*` token's current tier against the portal, with
  * a short in-memory cache and concurrent-request de-duplication.
  *
@@ -246,6 +295,7 @@ export async function fetchPortalTier(token: string): Promise<PortalLookup> {
       source: "portal",
       tier: cached.tier,
       planTier: cached.planTier,
+      planVerdict: cached.planVerdict,
       allowedModels: cached.allowedModels,
     };
   }
@@ -284,8 +334,11 @@ export async function fetchPortalTier(token: string): Promise<PortalLookup> {
         const body = await res.json() as DeviceInfoResponse;
         const tier = mapPortalTier(body);
         const planTier = mapPortalPlanTier(body);
+        // The three-valued reading, for the callers that RECORD the plan — and
+        // therefore for the boot scripts that later delete on it.
+        const planVerdict = mapPortalPlanVerdict(body);
         const allowedModels = mapPortalAllowedModels(body);
-        rememberTier(token, tier, planTier, allowedModels, now);
+        rememberTier(token, tier, planTier, planVerdict, allowedModels, now);
         // Every negative verdict, not just this token's. A device holds ONE
         // ClawBox AI credential at a time, so a 200 for the one it holds now
         // says the rejection recorded against the one it held a minute ago is
@@ -294,7 +347,7 @@ export async function fetchPortalTier(token: string): Promise<PortalLookup> {
         // sign-in" for the rest of that entry's window after a re-link.
         portalUnreachableCache.clear();
         provenGeneration += 1;
-        return { source: "portal", tier, planTier, allowedModels };
+        return { source: "portal", tier, planTier, planVerdict, allowedModels };
       }
       // 401/403 is ambiguous AS A TIER: it can mean genuinely Free OR token
       // revoked / migrated / corrupted on a still-paid account. We

--- a/src/lib/clawbox-ai-portal-tier.ts
+++ b/src/lib/clawbox-ai-portal-tier.ts
@@ -233,12 +233,21 @@ export function mapPortalPlanTier(body: DeviceInfoResponse): ClawboxAiTier | nul
 /**
  * Plan words this build positively recognises as "no active paid plan".
  *
- * EVERY WORD IN HERE AUTHORISES A DELETE, so it is deliberately short and may
- * only grow with a word that can mean nothing else. Getting it too narrow costs
- * a refused round trip per spoken reply until the portal says something we
- * recognise; getting it too wide costs a paying customer his configuration.
+ * EVERY WORD IN HERE AUTHORISES A DELETE — the one irreversible act in both boot
+ * scripts — so it holds exactly what this repository has evidence for and
+ * nothing that merely sounds right. `"free"` is what every `device-info` fixture
+ * in the tree spells and what `mapPortalTier` above has always read as unpaid.
+ *
+ * A word may be added only after the portal's own handler has been read, and a
+ * near-miss is the reason: `"canceled"` is the obvious rendering of Stripe's
+ * `cancel_at_period_end`, which leaves the subscription ACTIVE and the customer
+ * served to the end of the period — admitting it would delete a Max
+ * subscriber's cloud voice with 25 paid days left. `"expired"` has the same
+ * shape over a dunning state. The error the other way costs one refused round
+ * trip per spoken reply until the portal says something we recognise, and it is
+ * paid only by an account that is genuinely unpaid.
  */
-const UNPAID_PLAN_WORDS = new Set(["free", "none", "unpaid", "canceled", "cancelled", "expired"]);
+const UNPAID_PLAN_WORDS = new Set(["free"]);
 
 /**
  * The PLAN as a three-valued answer: a paid tier, positively unpaid, or `null`

--- a/src/lib/harness/credentials.ts
+++ b/src/lib/harness/credentials.ts
@@ -9,6 +9,9 @@ import {
   clearPersistedClawaiCredentialRefusal,
   persistClawaiCredentialRefusal,
 } from "@/lib/clawai-credential-refusal";
+// The other mark about a credential this box holds — the PLAN the portal
+// reported for it. Retired by the same funnel below, for the same reason.
+import { clearClawaiPlanTier } from "@/lib/clawai-plan-tier";
 
 export {
   CLAWAI_CREDENTIAL_REFUSED_KEY,
@@ -199,6 +202,14 @@ export async function forgetClawaiCredentialRefusal(): Promise<void> {
   // would leave a freshly re-linked box standing its image path down at the
   // very restart the re-link triggers.
   await clearPersistedClawaiCredentialRefusal();
+  // And so does the recorded PLAN, which is a fact about the ACCOUNT behind the
+  // credential that has just been replaced. Left standing, the previous
+  // account's Max plan would keep the cloud voice armed on a box re-linked to a
+  // lower one — a refused round trip per spoken reply, with the panel calling
+  // the voice configured while it happens. Clearing it puts both boot scripts
+  // back on the device stamp until the next status poll answers for the
+  // credential this box now holds.
+  await clearClawaiPlanTier();
 }
 
 /** Test seam: forget every remembered refusal. */

--- a/src/lib/harness/credentials.ts
+++ b/src/lib/harness/credentials.ts
@@ -10,8 +10,11 @@ import {
   persistClawaiCredentialRefusal,
 } from "@/lib/clawai-credential-refusal";
 // The other mark about a credential this box holds — the PLAN the portal
-// reported for it. Retired by the same funnel below, for the same reason.
-import { clearClawaiPlanTier } from "@/lib/clawai-plan-tier";
+// reported for it. Nothing is CLEARED here: its writers record or delete it in
+// the same store write as `clawai_tier`, so the two always describe the same
+// account. What the funnel below owes it is that an answer already IN FLIGHT
+// for the retired credential cannot land afterwards.
+import { noteClawaiCredentialReplaced } from "@/lib/clawai-plan-tier";
 
 export {
   CLAWAI_CREDENTIAL_REFUSED_KEY,
@@ -202,14 +205,16 @@ export async function forgetClawaiCredentialRefusal(): Promise<void> {
   // would leave a freshly re-linked box standing its image path down at the
   // very restart the re-link triggers.
   await clearPersistedClawaiCredentialRefusal();
-  // And so does the recorded PLAN, which is a fact about the ACCOUNT behind the
-  // credential that has just been replaced. Left standing, the previous
-  // account's Max plan would keep the cloud voice armed on a box re-linked to a
-  // lower one — a refused round trip per spoken reply, with the panel calling
-  // the voice configured while it happens. Clearing it puts both boot scripts
-  // back on the device stamp until the next status poll answers for the
-  // credential this box now holds.
-  await clearClawaiPlanTier();
+  // The recorded PLAN is a fact about the ACCOUNT behind the credential that
+  // has just been replaced, and a portal lookup for the OLD token can still be
+  // in flight — up to four seconds, the same window `notRecordedSince` above
+  // exists for. Landing after this point it would write a retired account's
+  // plan, and the next boot would decide this box's entitlement from it: a
+  // retired Pro plan withdrawing a Max subscriber's voice, which is TASK-744
+  // again. Bumping the counter is all this owes; the plan itself is rewritten
+  // or deleted by whoever writes the credential, in the same store write as the
+  // badge, so it never outlives the account it describes.
+  noteClawaiCredentialReplaced();
 }
 
 /** Test seam: forget every remembered refusal. */

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -34,6 +34,16 @@ import {
 import { isClawboxAiVisionId, resolveVisionModelId } from "@/lib/clawbox-ai-vision";
 import { forgetProviderVerified } from "@/lib/provider-verified";
 import { forgetClawaiCredentialRefusal } from "@/lib/harness/credentials";
+// The PLAN this box's account pays for, and the badge behind it — the one rule
+// the panel and both boot scripts read for "may this box have the cloud voice"
+// (TASK-744). Written into the store by this module, read back below.
+import {
+  CLAWAI_PLAN_TIER_KEY,
+  clawaiEntitlementTier,
+  clawaiPlanTierForStore,
+  type ClawaiPlanTier,
+  type ClawaiPortalPlan,
+} from "@/lib/clawai-plan-tier";
 
 // Applying ClawBox AI to a HERMES device, in one place.
 //
@@ -127,6 +137,20 @@ export interface ApplyClawaiOptions {
    * unset and the read below is honest.
    */
   previousClawaiToken?: string;
+  /**
+   * What the PORTAL said about this account's plan, when the caller asked it.
+   *
+   * The plan is written into the store below in the SAME write as `clawai_tier`
+   * and is DELETED there when this is absent — see `clawaiPlanTierForStore`.
+   * The two boot scripts decide an entitlement from the pair and one of them
+   * deletes the cloud voice on it, so a plan that outlived the credential it
+   * was read for would be a retired account deciding this box's voice
+   * (TASK-744). Only `/setup-api/ai-models/configure` has an answer to pass:
+   * the device-code finaliser and `/setup-api/hermes/clawai` carry the wizard's
+   * plan PICKER, which is a guess the account has not been consulted about
+   * (TASK-481) and must never be recorded as a plan.
+   */
+  portalPlan?: ClawaiPortalPlan;
 }
 
 /**
@@ -410,6 +434,11 @@ export async function applyClawaiToHermes(
   await setMany({
     clawai_token: trimmed,
     clawai_tier: tier,
+    // The PLAN, in the same write as the badge and the token it belongs to, and
+    // `undefined` — a DELETE — when this caller had no portal answer. That
+    // pairing is the whole invariant: the entitlement the boot scripts read can
+    // never describe an account this box has moved on from.
+    [CLAWAI_PLAN_TIER_KEY]: clawaiPlanTierForStore(options.portalPlan),
     ai_model_configured: true,
     ai_model_provider: CLAWAI_PROVIDER,
     ai_model_configured_at: new Date().toISOString(),
@@ -436,7 +465,15 @@ export async function applyClawaiToHermes(
   // Hermes' factory `edge` cloud is still selected, or where the on-device
   // provider is selected with no engine behind it, which is the state the
   // measured box was left in.
-  await selectHermesCloudVoiceIfUnvoiced(trimmed, tier);
+  // The entitlement, resolved HERE from the two facts this call already holds
+  // rather than read back out of the store it has just written: the plan the
+  // portal answered (when this caller asked it) with the badge behind it, which
+  // is `clawaiEntitlementTier` exactly. A function that re-read its own write
+  // would also be one a fixture could satisfy without the write ever landing.
+  await selectHermesCloudVoiceIfUnvoiced(
+    trimmed,
+    clawaiEntitlementTier(clawaiPlanTierForStore(options.portalPlan), tier),
+  );
 
   // Everything above wrote to DISK. The agent that will serve the next turn is
   // a process that has been running since long before any of it, and two of the
@@ -1663,7 +1700,10 @@ async function readPluginsDisabledFromCli(): Promise<Set<string> | null> {
  * Never throws: a link that worked must not report failure because the voice
  * could not be pointed. The Voice panel remains the place to set it by hand.
  */
-async function selectHermesCloudVoiceIfUnvoiced(token: string, tier: ClawboxAiTier): Promise<void> {
+async function selectHermesCloudVoiceIfUnvoiced(
+  token: string,
+  entitlementTier: ClawaiPlanTier | null,
+): Promise<void> {
   try {
     const [
       {
@@ -1681,28 +1721,6 @@ async function selectHermesCloudVoiceIfUnvoiced(token: string, tier: ClawboxAiTi
       import("@/lib/hermes-tts"),
       import("@/lib/local-models"),
     ]);
-    // The tier just linked, not a re-read: `setMany` wrote `clawai_tier` a
-    // moment ago, but the argument is the same fact without a second round trip
-    // and without a window where the store has not settled. It is the DEVICE
-    // tier, and the PLAN stamp `speechEntitledTier()` and both boot scripts
-    // prefer (`clawai_plan_tier`, TASK-744) is deliberately not read here:
-    // `forgetClawaiCredentialRefusal` retires it a few lines up as part of
-    // writing this very credential, so there is nothing on record to prefer.
-    // The device tier is the only answer this call has, and it is the one it
-    // has always used.
-    //
-    // What that costs is bounded and one-directional: a Max subscriber whose
-    // box is stamped Flash is not handed the cloud voice by the LINK. He is
-    // handed it by `register-mcp.sh` at the next web-server boot, once the
-    // status poll has recorded the plan — and the Voice tab offers it in the
-    // meantime, because the panel reads the pair. Nothing here can take a voice
-    // away; this function only ever selects one on a box that had none.
-    if (tier !== CLAWBOX_AI_SPEECH_TIER) {
-      console.log(
-        `[hermes-clawai] this plan does not include the cloud voice — leaving tts.provider alone`,
-      );
-      return;
-    }
     const voice = await readHermesVoice();
     // A READ THAT FAILED IS NOT AN ANSWER, asked of every key this decides on
     // rather than only of `tts.provider`. `hermes config get` exits the same
@@ -1763,6 +1781,26 @@ async function selectHermesCloudVoiceIfUnvoiced(token: string, tier: ClawboxAiTi
           "[hermes-clawai] tts.openai already names its own speech route — leaving it alone",
         );
       }
+      return;
+    }
+    // THE ENTITLEMENT, and only now. Everything above either refreshed a
+    // credential this box is ALREADY speaking through or left an owner's own
+    // choice alone, and neither depends on the plan; what follows SELECTS the
+    // cloud voice on a box that has chosen nothing, which is the one decision
+    // the entitlement governs. The gate used to sit at the top of this
+    // function, above the read — so a box on our own cloud route whose token
+    // the portal had just rotated was never refreshed, and every utterance
+    // 401'd, which is the hole this function's own docblock describes.
+    //
+    // The PLAN with the badge behind it — `clawaiEntitlementTier`, the same
+    // rule the Voice panel and both boot scripts read, resolved by the caller.
+    // Reading the badge alone is TASK-744: a Max subscriber whose box is
+    // stamped `deviceTier: flash` was refused the voice `register-mcp.sh` arms
+    // for him at the next boot.
+    if (entitlementTier !== CLAWBOX_AI_SPEECH_TIER) {
+      console.log(
+        "[hermes-clawai] this plan does not include the cloud voice — leaving tts.provider alone",
+      );
       return;
     }
     // What this box HAS, asked in every unchosen state rather than only over a

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -443,7 +443,12 @@ export async function applyClawaiToHermes(
     // the Voice panel would tell a Max subscriber his plan has no cloud voice
     // while the box was speaking through one, and the boot script would stop
     // arming it until a browser next polled the status route.
-    ...(options.portalPlan || accountChanged
+    // `previousToken !== trimmed` rather than `accountChanged`, which is the
+    // PICKS' question and carries a `previousToken &&` guard so a first link is
+    // not treated as a switch. For the plan the safe direction is the other
+    // one: a box with no token on record is one we cannot vouch for, so a plan
+    // sitting there goes with the rest.
+    ...(options.portalPlan || previousToken !== trimmed
       ? { [CLAWAI_PLAN_TIER_KEY]: clawaiPlanTierForStore(options.portalPlan) }
       : {}),
     ai_model_configured: true,

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -434,11 +434,18 @@ export async function applyClawaiToHermes(
   await setMany({
     clawai_token: trimmed,
     clawai_tier: tier,
-    // The PLAN, in the same write as the badge and the token it belongs to, and
-    // `undefined` — a DELETE — when this caller had no portal answer. That
-    // pairing is the whole invariant: the entitlement the boot scripts read can
-    // never describe an account this box has moved on from.
-    [CLAWAI_PLAN_TIER_KEY]: clawaiPlanTierForStore(options.portalPlan),
+    // The PLAN, in the same write as the badge and the token it belongs to.
+    // Written when this caller HAS a portal answer, retired when the ACCOUNT
+    // changed and the caller has none, and left exactly as it is otherwise —
+    // the same account re-applying, which is what the Settings tier pill and a
+    // re-pasted token are. Deleting there would put the box back on its badge,
+    // which is the default this whole change exists to stop deciding things:
+    // the Voice panel would tell a Max subscriber his plan has no cloud voice
+    // while the box was speaking through one, and the boot script would stop
+    // arming it until a browser next polled the status route.
+    ...(options.portalPlan || accountChanged
+      ? { [CLAWAI_PLAN_TIER_KEY]: clawaiPlanTierForStore(options.portalPlan) }
+      : {}),
     ai_model_configured: true,
     ai_model_provider: CLAWAI_PROVIDER,
     ai_model_configured_at: new Date().toISOString(),

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -1792,6 +1792,14 @@ async function selectHermesCloudVoiceIfUnvoiced(
     // the portal had just rotated was never refreshed, and every utterance
     // 401'd, which is the hole this function's own docblock describes.
     //
+    // WHAT THE ORDER COSTS, stated rather than implied: an UNENTITLED box
+    // already on our own route now pays three `hermes config set` spawns to
+    // write a fresh credential into a slot the next boot will take away. That
+    // is the trade — a 401 is a worse answer than the 403 the plan has earned,
+    // and the box is calling that endpoint on every spoken reply until the boot
+    // script gets to it. An owner's own speech server is untouched either way:
+    // `hermesCloudRouteIsOurs` gates the write above.
+    //
     // The PLAN with the badge behind it — `clawaiEntitlementTier`, the same
     // rule the Voice panel and both boot scripts read, resolved by the caller.
     // Reading the badge alone is TASK-744: a Max subscriber whose box is

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -1683,9 +1683,20 @@ async function selectHermesCloudVoiceIfUnvoiced(token: string, tier: ClawboxAiTi
     ]);
     // The tier just linked, not a re-read: `setMany` wrote `clawai_tier` a
     // moment ago, but the argument is the same fact without a second round trip
-    // and without a window where the store has not settled. It is already the
-    // DEVICE tier — the same value `speechEntitledTier()` reads back — so it is
-    // compared with the constant directly.
+    // and without a window where the store has not settled. It is the DEVICE
+    // tier, and the PLAN stamp `speechEntitledTier()` and both boot scripts
+    // prefer (`clawai_plan_tier`, TASK-744) is deliberately not read here:
+    // `forgetClawaiCredentialRefusal` retires it a few lines up as part of
+    // writing this very credential, so there is nothing on record to prefer.
+    // The device tier is the only answer this call has, and it is the one it
+    // has always used.
+    //
+    // What that costs is bounded and one-directional: a Max subscriber whose
+    // box is stamped Flash is not handed the cloud voice by the LINK. He is
+    // handed it by `register-mcp.sh` at the next web-server boot, once the
+    // status poll has recorded the plan — and the Voice tab offers it in the
+    // meantime, because the panel reads the pair. Nothing here can take a voice
+    // away; this function only ever selects one on a box that had none.
     if (tier !== CLAWBOX_AI_SPEECH_TIER) {
       console.log(
         `[hermes-clawai] this plan does not include the cloud voice — leaving tts.provider alone`,

--- a/src/lib/hermes-tts.ts
+++ b/src/lib/hermes-tts.ts
@@ -660,15 +660,23 @@ export const CLAWBOX_AI_SPEECH_TIER = "pro";
 /**
  * Does this box's plan include the cloud voice?
  *
- * Read from the tier the portal hand-off stamped (`clawai_tier`), the same
- * fact the gateway pre-start reads. Fails CLOSED: a tier that cannot be read
- * is not evidence of an entitlement, and claiming one would put the panel back
- * to calling a 403 a configured voice.
+ * The PLAN the portal reported (`clawai_plan_tier`), with the device stamp
+ * (`clawai_tier`) behind it for a box the status poll has not answered for yet
+ * — `clawaiEntitlementTier`, the same rule both boot scripts transcribe, so the
+ * panel and the two boots cannot disagree about who has a cloud voice. Reading
+ * the stamp alone told a Max subscriber whose box is stamped `deviceTier:
+ * "flash"` that his plan did not include the voice his boot script had just
+ * armed (TASK-744).
+ *
+ * Fails CLOSED: a pair that cannot be read is not evidence of an entitlement,
+ * and claiming one would put the panel back to calling a 403 a configured
+ * voice. That is the right direction HERE and not in the boot scripts' delete
+ * arms, which must be told before they destroy anything.
  */
 export async function speechEntitledTier(): Promise<boolean> {
   try {
-    const { get } = await import("@/lib/config-store");
-    return (await get("clawai_tier")) === CLAWBOX_AI_SPEECH_TIER;
+    const { readClawaiEntitlementTier } = await import("@/lib/clawai-plan-tier");
+    return (await readClawaiEntitlementTier()) === CLAWBOX_AI_SPEECH_TIER;
   } catch {
     return false;
   }

--- a/src/tests/routes/ai-models/clawai-poll-hermes-plan.test.ts
+++ b/src/tests/routes/ai-models/clawai-poll-hermes-plan.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * TASK-744, on the device-code finaliser's HERMES branch.
+ *
+ * `/setup-api/ai-models/clawai/poll` is the primary link path on both editions.
+ * On OpenClaw it hands over to `/setup-api/ai-models/configure`, which asks the
+ * portal and records the plan; on Hermes it calls `applyClawaiToHermes`
+ * directly, and that helper only records what its caller passes. Without a
+ * lookup here the two editions' own device-code flows disagreed, and a Hermes
+ * box finished the link with NO plan on record — so no withdrawal was reachable
+ * on it at all until a BROWSER happened to poll the status route.
+ *
+ * Its own file rather than a describe inside `clawai-connect.test.ts`: this one
+ * has to mock `@/lib/harness` and `@/lib/hermes-clawai`, and that file's other
+ * cases deliberately take the OpenClaw branch.
+ */
+
+vi.mock("@/lib/clawai-connect", () => ({
+  createClawAiUserCode: vi.fn(() => "ABCD-1234"),
+  createClawAiDeviceId: vi.fn(() => "device-id-xyz"),
+  CLAWAI_USER_CODE_LENGTH: 8,
+  writeClawAiSession: vi.fn(),
+  readClawAiSession: vi.fn(),
+  clearClawAiSession: vi.fn(),
+  isClawAiSessionExpired: vi.fn(() => false),
+}));
+vi.mock("@/app/setup-api/ai-models/configure/route", () => ({
+  POST: vi.fn(async () => new Response(JSON.stringify({ success: true }), { status: 200 })),
+}));
+vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn(async () => "hermes") }));
+vi.mock("@/lib/hermes-clawai", () => ({
+  applyClawaiToHermes: vi.fn(async () => ({})),
+  ClawaiApplyError: class ClawaiApplyError extends Error {},
+}));
+vi.mock("@/lib/clawbox-ai-portal-tier", () => ({ fetchPortalTier: vi.fn() }));
+
+import { readClawAiSession, writeClawAiSession } from "@/lib/clawai-connect";
+import { applyClawaiToHermes } from "@/lib/hermes-clawai";
+import { fetchPortalTier } from "@/lib/clawbox-ai-portal-tier";
+
+const mockReadSession = vi.mocked(readClawAiSession);
+const mockWriteSession = vi.mocked(writeClawAiSession);
+const mockApply = vi.mocked(applyClawaiToHermes);
+const mockFetchPortalTier = vi.mocked(fetchPortalTier);
+
+const TOKEN = "claw_device_code_token";
+
+/** The plan this finaliser passed to the apply, or `undefined` for none. */
+function planPassed(): unknown {
+  const options = mockApply.mock.calls.at(-1)?.[2];
+  return options?.portalPlan;
+}
+
+/** Drive the poll to the point where it finalises a claimed session. */
+async function finalise() {
+  mockReadSession.mockResolvedValue({
+    device_id: "device-id-xyz",
+    user_code: "ABCD-1234",
+    status: "pending",
+    createdAt: Date.now(),
+    tier: "flash",
+  } as never);
+  vi.stubGlobal("fetch", vi.fn(async () => new Response(
+    JSON.stringify({ status: "complete", access_token: TOKEN }),
+    { status: 200 },
+  )));
+  const { POST } = await import("@/app/setup-api/ai-models/clawai/poll/route");
+  await POST();
+  // The finalise runs in the background; let its microtasks drain.
+  for (let i = 0; i < 20; i += 1) await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("the device-code finaliser records the PLAN on Hermes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockWriteSession.mockResolvedValue(undefined as never);
+    mockApply.mockResolvedValue({} as never);
+  });
+
+  it("passes the portal's plan verdict through to the apply", async () => {
+    // The card's own customer, arriving through the device-code flow: the
+    // account is Max and the portal stamps the box `flash`. The badge that
+    // reaches the store is the picker's; the PLAN has to be the portal's.
+    mockFetchPortalTier.mockResolvedValue({
+      source: "portal",
+      tier: "flash",
+      planTier: "pro",
+      planVerdict: "pro",
+      allowedModels: null,
+    } as never);
+
+    await finalise();
+
+    expect(mockApply).toHaveBeenCalled();
+    expect(planPassed()).toEqual({ verdict: "pro" });
+  });
+
+  it("passes an UNPAID verdict through, so a downgrade can be acted on", async () => {
+    mockFetchPortalTier.mockResolvedValue({
+      source: "portal",
+      tier: null,
+      planTier: null,
+      planVerdict: "free",
+      allowedModels: null,
+    } as never);
+
+    await finalise();
+
+    expect(planPassed()).toEqual({ verdict: "free" });
+  });
+
+  it("passes NOTHING when the portal did not answer", async () => {
+    // An unreachable portal may not put a plan on record — and may not leave a
+    // previous account's standing either, which is why the apply DELETES the
+    // key when it is handed nothing.
+    mockFetchPortalTier.mockResolvedValue({ source: "unreachable", rejected: false } as never);
+
+    await finalise();
+
+    expect(mockApply).toHaveBeenCalled();
+    expect(planPassed()).toBeUndefined();
+  });
+
+  it("still links the box when the plan lookup throws", async () => {
+    // A plan probe may never break a pairing: the credential is what the
+    // customer is waiting for, and the plan is a hint the next poll re-asks.
+    mockFetchPortalTier.mockRejectedValue(new Error("portal down"));
+
+    await finalise();
+
+    expect(mockApply).toHaveBeenCalled();
+    expect(planPassed()).toBeUndefined();
+  });
+});

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -2376,6 +2376,28 @@ describe("POST /setup-api/ai-models/configure", () => {
         expect(plansWritten()).toEqual(["free"]);
       });
 
+      it.each([
+        ["a plan name this build has never seen", { tier: "enterprise" }],
+        ["a response with no tier field at all", { deviceTier: "pro" }],
+      ])("records NO plan for %s", async (_label, body) => {
+        // `mapPortalPlanTier` answers null to a genuinely unpaid account, to an
+        // absent `tier` and to an unknown plan word alike, and only the first
+        // is a downgrade. Recording the other two as unpaid hands both boot
+        // scripts a licence to DELETE a Max subscriber's cloud voice over a
+        // response shape this build simply predates — the same bug class this
+        // card exists to close, pointing the other way.
+        vi.stubGlobal("fetch", deviceInfo(body));
+
+        const res = await configurePost(jsonRequest({
+          provider: "clawai",
+          apiKey: "claw_an_answer_we_cannot_read",
+          clawaiTier: "pro",
+        }));
+
+        expect(res.status).toBe(200);
+        expect(plansWritten()).toEqual([undefined]);
+      });
+
       it("retires the previous account's plan when the portal did not answer", async () => {
         // The false-failure guard AND the staleness rule in one: an outage may
         // not put a plan on record, and this save has just rewritten the badge

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -2417,6 +2417,43 @@ describe("POST /setup-api/ai-models/configure", () => {
         expect(plansWritten()).toEqual([undefined]);
       });
 
+      it("keeps a plan that is still true when the portal is unreachable on a SAME-token save", async () => {
+        // A save on the same token — a model switch, a nudge of the plan pill —
+        // is not an account change, and a portal that happened to be down
+        // during it is no reason to throw away a plan that is still that
+        // account's. Deleting there puts the box back on its device badge,
+        // which is the default this card exists to stop deciding things.
+        mockGetAll.mockResolvedValue({ clawai_token: "claw_same_account" });
+        vi.stubGlobal("fetch", vi.fn(async () => {
+          throw new Error("portal unreachable");
+        }));
+
+        const res = await configurePost(jsonRequest({
+          provider: "clawai",
+          apiKey: "claw_same_account",
+          clawaiTier: "pro",
+        }));
+
+        expect(res.status).toBe(200);
+        expect(plansWritten()).toEqual([]);
+      });
+
+      it("still retires it when a DIFFERENT account is saved and the portal is unreachable", async () => {
+        mockGetAll.mockResolvedValue({ clawai_token: "claw_previous_account" });
+        vi.stubGlobal("fetch", vi.fn(async () => {
+          throw new Error("portal unreachable");
+        }));
+
+        const res = await configurePost(jsonRequest({
+          provider: "clawai",
+          apiKey: "claw_a_different_account",
+          clawaiTier: "pro",
+        }));
+
+        expect(res.status).toBe(200);
+        expect(plansWritten()).toEqual([undefined]);
+      });
+
       it("leaves both keys alone on a save that is not about ClawBox AI", async () => {
         const res = await configurePost(jsonRequest({
           provider: "anthropic",

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -2326,6 +2326,86 @@ describe("POST /setup-api/ai-models/configure", () => {
       expect(primaryModelWritten()).toBe("deepseek/deepseek-v4-flash");
     });
 
+    // TASK-744. Both boot scripts decide an ENTITLEMENT from the store and one
+    // of them DELETES the cloud voice over it, so they read the PLAN
+    // (`clawai_plan_tier`) with the device badge only behind it — and never
+    // behind it for the delete. This route is the second place on the box that
+    // ever holds a portal answer, and the only one a headless pairing reaches:
+    // `/setup-api/ai-models/status` is polled by BROWSERS alone, so a customer
+    // who pairs and closes the tab would otherwise never have a plan on record.
+    describe("recording the PLAN beside the badge", () => {
+      /** Every `clawai_plan_tier` this save wrote, in order. */
+      const plansWritten = () =>
+        mockSetMany.mock.calls
+          .map(([entries]) => entries as Record<string, unknown>)
+          .filter((entries) => "clawai_plan_tier" in entries)
+          .map((entries) => entries.clawai_plan_tier);
+
+      it("records the plan of a Max account whose box is stamped flash", async () => {
+        // The exact shape of the card: the badge stays `flash`, because running
+        // Flash on this box is a choice the portal preserves on purpose, and
+        // the plan says `pro`, because that is what the account pays for and
+        // the only thing an entitlement may be read from.
+        vi.stubGlobal("fetch", deviceInfo({ tier: "max", deviceTier: "flash" }));
+
+        const res = await configurePost(jsonRequest({
+          provider: "clawai",
+          apiKey: "claw_max_running_flash",
+          clawaiTier: "pro",
+        }));
+
+        expect(res.status).toBe(200);
+        expect(mockSetMany).toHaveBeenCalledWith(
+          expect.objectContaining({ clawai_tier: "flash", clawai_plan_tier: "pro" }),
+        );
+      });
+
+      it("records an UNPAID answer as such, so a cancellation can be acted on", async () => {
+        // Not `undefined`: an absent key means "the portal has never answered
+        // for this box", and collapsing the two is what leaves a cancelled
+        // subscription's cloud voice armed and 403-ing for good.
+        vi.stubGlobal("fetch", deviceInfo({ tier: "free" }));
+
+        const res = await configurePost(jsonRequest({
+          provider: "clawai",
+          apiKey: "claw_free_account",
+          clawaiTier: "flash",
+        }));
+
+        expect(res.status).toBe(200);
+        expect(plansWritten()).toEqual(["free"]);
+      });
+
+      it("retires the previous account's plan when the portal did not answer", async () => {
+        // The false-failure guard AND the staleness rule in one: an outage may
+        // not put a plan on record, and this save has just rewritten the badge
+        // for whatever account the box now holds — so the old plan may not be
+        // left standing beside it either. `undefined` is the store's delete.
+        vi.stubGlobal("fetch", vi.fn(async () => {
+          throw new Error("portal unreachable");
+        }));
+
+        const res = await configurePost(jsonRequest({
+          provider: "clawai",
+          apiKey: "claw_offline",
+          clawaiTier: "pro",
+        }));
+
+        expect(res.status).toBe(200);
+        expect(plansWritten()).toEqual([undefined]);
+      });
+
+      it("leaves both keys alone on a save that is not about ClawBox AI", async () => {
+        const res = await configurePost(jsonRequest({
+          provider: "anthropic",
+          apiKey: "sk-ant-not-a-clawbox-key",
+        }));
+
+        expect(res.status).toBe(200);
+        expect(plansWritten()).toEqual([]);
+      });
+    });
+
     it("keeps the picker's choice when the portal is unreachable", async () => {
       // A portal outage during setup must never quietly downgrade a paying
       // box. `fetchPortalTier` reports network failures as `unreachable`.

--- a/src/tests/routes/ai-models/status.test.ts
+++ b/src/tests/routes/ai-models/status.test.ts
@@ -235,6 +235,13 @@ describe("/setup-api/ai-models/status", () => {
     // the cloud voice when it is not met, so the PLAN has to be written down
     // beside the badge; this poll is the only thing on the box that ever gets a
     // portal answer to write.
+    /**
+     * Every config-store key this poll actually wrote — a DELETE included.
+     * `expect.anything()` does not match `undefined`, so the "did not write"
+     * assertions below cannot be expressed with it.
+     */
+    const keysWritten = () => mockSetConfigValue.mock.calls.map(([key]) => key);
+
     it("records the PLAN beside the device badge", async () => {
       mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
       // KEY-KEYED, not one answer for every key: a mock that answers the same
@@ -289,7 +296,23 @@ describe("/setup-api/ai-models/status", () => {
 
       await GET();
 
-      expect(mockSetConfigValue).not.toHaveBeenCalledWith("clawai_plan_tier", expect.anything());
+      expect(keysWritten()).not.toContain("clawai_plan_tier");
+    });
+
+    it("keeps a plan it was correctly told when one answer cannot be read", async () => {
+      // "We cannot tell" may not overwrite "we were told", about the same
+      // account: this is a poll, not a link, so a plan already on record still
+      // belongs to the credential this box holds. Deleting it would put the
+      // Voice panel back to telling a Max subscriber his plan has no cloud
+      // voice, and stop the boot script arming it, over one unreadable answer.
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      const stamps: Record<string, unknown> = { clawai_tier: "flash", clawai_plan_tier: "pro" };
+      mockGetConfigValue.mockImplementation(async (key: string) => stamps[key] ?? null);
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({ tier: "enterprise" }), { status: 200 }));
+
+      await GET();
+
+      expect(keysWritten()).not.toContain("clawai_plan_tier");
     });
 
     it("does not write a plan for a credential the box no longer holds", async () => {
@@ -309,7 +332,13 @@ describe("/setup-api/ai-models/status", () => {
 
       await GET();
 
-      expect(mockSetConfigValue).not.toHaveBeenCalledWith("clawai_plan_tier", expect.anything());
+      expect(keysWritten()).not.toContain("clawai_plan_tier");
+      // AND THE BADGE BESIDE IT, which is the half a guard on the plan alone
+      // would miss: the two are read together by both boot scripts and one of
+      // them deletes on the pair, so writing the RETIRED account's badge while
+      // correctly skipping its plan leaves the ARM falling back to a badge
+      // belonging to a token this box no longer holds.
+      expect(keysWritten()).not.toContain("clawai_tier");
     });
 
     it("records no plan at all when the portal did not answer", async () => {
@@ -322,12 +351,7 @@ describe("/setup-api/ai-models/status", () => {
 
       await GET();
 
-      expect(mockSetConfigValue).not.toHaveBeenCalledWith("clawai_plan_tier", expect.anything());
-      // AND the badge beside it. The two are read together by both boot scripts
-      // and one of them deletes on the pair, so writing the RETIRED account's
-      // badge while correctly skipping its plan would leave the arm falling
-      // back to a badge belonging to a token this box no longer holds.
-      expect(mockSetConfigValue).not.toHaveBeenCalledWith("clawai_tier", expect.anything());
+      expect(keysWritten()).not.toContain("clawai_plan_tier");
     });
 
     it("queries the portal even when local picker is unset so Free → Paid upgrades are visible without re-login", async () => {

--- a/src/tests/routes/ai-models/status.test.ts
+++ b/src/tests/routes/ai-models/status.test.ts
@@ -261,8 +261,10 @@ describe("/setup-api/ai-models/status", () => {
       // word the two are indistinguishable and neither boot script can ever
       // withdraw a cancelled subscription's cloud voice.
       mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
-      mockGetConfigValue.mockImplementation(async (key: string) =>
-        key === "clawai_plan_tier" ? "pro" : "pro");
+      // Key-keyed, like its sibling above: both arms answering the same value
+      // would let this pass over a writer that read the wrong key.
+      const stamps: Record<string, unknown> = { clawai_tier: "pro", clawai_plan_tier: "pro" };
+      mockGetConfigValue.mockImplementation(async (key: string) => stamps[key] ?? null);
       fetchSpy.mockResolvedValue(new Response(
         JSON.stringify({ tier: "free", deviceTier: null }),
         { status: 200 },
@@ -271,6 +273,23 @@ describe("/setup-api/ai-models/status", () => {
       await GET();
 
       expect(mockSetConfigValue).toHaveBeenCalledWith("clawai_plan_tier", "free");
+    });
+
+    it.each([
+      ["a plan name this build has never seen", { tier: "enterprise" }],
+      ["a response with no tier field at all", { deviceTier: "pro" }],
+    ])("records NO plan for %s", async (_label, body) => {
+      // The other half of the unpaid word. `mapPortalPlanTier` cannot tell a
+      // cancelled account from a response this build cannot read, and only the
+      // first may reach the store: both boot scripts treat a recorded plan as
+      // one they were told, and one of them deletes the cloud voice over it.
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue(null);
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify(body), { status: 200 }));
+
+      await GET();
+
+      expect(mockSetConfigValue).not.toHaveBeenCalledWith("clawai_plan_tier", expect.anything());
     });
 
     it("does not write a plan for a credential the box no longer holds", async () => {
@@ -304,6 +323,11 @@ describe("/setup-api/ai-models/status", () => {
       await GET();
 
       expect(mockSetConfigValue).not.toHaveBeenCalledWith("clawai_plan_tier", expect.anything());
+      // AND the badge beside it. The two are read together by both boot scripts
+      // and one of them deletes on the pair, so writing the RETIRED account's
+      // badge while correctly skipping its plan would leave the arm falling
+      // back to a badge belonging to a token this box no longer holds.
+      expect(mockSetConfigValue).not.toHaveBeenCalledWith("clawai_tier", expect.anything());
     });
 
     it("queries the portal even when local picker is unset so Free → Paid upgrades are visible without re-login", async () => {

--- a/src/tests/routes/ai-models/status.test.ts
+++ b/src/tests/routes/ai-models/status.test.ts
@@ -228,6 +228,54 @@ describe("/setup-api/ai-models/status", () => {
       expect(mockSetConfigValue).not.toHaveBeenCalled();
     });
 
+    // TASK-744. The badge above is `mapPortalTier`, which prefers the portal's
+    // `deviceTier` stamp on purpose — it answers "what should this box default
+    // to", and a Max subscriber is allowed to run Flash here. Two boot scripts
+    // decide an ENTITLEMENT from a stamp in this store and one of them DELETES
+    // the cloud voice when it is not met, so the PLAN has to be written down
+    // beside the badge; this poll is the only thing on the box that ever gets a
+    // portal answer to write.
+    it("records the PLAN beside the device badge", async () => {
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue(null);
+      fetchSpy.mockResolvedValue(new Response(
+        // The exact shape TASK-744 is about: Max plan, box stamped Flash.
+        JSON.stringify({ tier: "max", deviceTier: "flash" }),
+        { status: 200 },
+      ));
+
+      await GET();
+
+      expect(mockSetConfigValue).toHaveBeenCalledWith("clawai_tier", "flash");
+      expect(mockSetConfigValue).toHaveBeenCalledWith("clawai_plan_tier", "pro");
+    });
+
+    it("clears the recorded plan when the portal answers that the account is unpaid", async () => {
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue("pro");
+      fetchSpy.mockResolvedValue(new Response(
+        JSON.stringify({ tier: "free", deviceTier: null }),
+        { status: 200 },
+      ));
+
+      await GET();
+
+      expect(mockSetConfigValue).toHaveBeenCalledWith("clawai_plan_tier", undefined);
+    });
+
+    it("records no plan at all when the portal did not answer", async () => {
+      // The false-failure guard, at the writer. An unreachable portal must not
+      // put a plan on record, because the boot scripts read a recorded plan as
+      // having been TOLD — and one of them deletes a working voice over it.
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue(null);
+      fetchSpy.mockResolvedValue(new Response("nope", { status: 503 }));
+
+      await GET();
+
+      expect(mockSetConfigValue).not.toHaveBeenCalledWith("clawai_plan_tier", expect.anything());
+    });
+
     it("queries the portal even when local picker is unset so Free → Paid upgrades are visible without re-login", async () => {
       // Free users who paired without picking a paid pill ALSO need the
       // portal lookup so a later upgrade is detected without forcing

--- a/src/tests/routes/ai-models/status.test.ts
+++ b/src/tests/routes/ai-models/status.test.ts
@@ -237,7 +237,11 @@ describe("/setup-api/ai-models/status", () => {
     // portal answer to write.
     it("records the PLAN beside the device badge", async () => {
       mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
-      mockGetConfigValue.mockResolvedValue(null);
+      // KEY-KEYED, not one answer for every key: a mock that answers the same
+      // value everywhere would let this pass over a writer that read
+      // `clawai_tier` where it meant `clawai_plan_tier`.
+      const stamps: Record<string, unknown> = {};
+      mockGetConfigValue.mockImplementation(async (key: string) => stamps[key] ?? null);
       fetchSpy.mockResolvedValue(new Response(
         // The exact shape TASK-744 is about: Max plan, box stamped Flash.
         JSON.stringify({ tier: "max", deviceTier: "flash" }),
@@ -250,9 +254,15 @@ describe("/setup-api/ai-models/status", () => {
       expect(mockSetConfigValue).toHaveBeenCalledWith("clawai_plan_tier", "pro");
     });
 
-    it("clears the recorded plan when the portal answers that the account is unpaid", async () => {
+    it("records an UNPAID plan as such, not as an absent one", async () => {
+      // The cancelled subscription. `mapPortalTier` and `mapPortalPlanTier`
+      // both answer null for a Free account, and an absent key already means
+      // "the portal has never answered for this box" — so without a positive
+      // word the two are indistinguishable and neither boot script can ever
+      // withdraw a cancelled subscription's cloud voice.
       mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
-      mockGetConfigValue.mockResolvedValue("pro");
+      mockGetConfigValue.mockImplementation(async (key: string) =>
+        key === "clawai_plan_tier" ? "pro" : "pro");
       fetchSpy.mockResolvedValue(new Response(
         JSON.stringify({ tier: "free", deviceTier: null }),
         { status: 200 },
@@ -260,7 +270,27 @@ describe("/setup-api/ai-models/status", () => {
 
       await GET();
 
-      expect(mockSetConfigValue).toHaveBeenCalledWith("clawai_plan_tier", undefined);
+      expect(mockSetConfigValue).toHaveBeenCalledWith("clawai_plan_tier", "free");
+    });
+
+    it("does not write a plan for a credential the box no longer holds", async () => {
+      // The re-link race, on the plan. The poll asks about the token the box
+      // held when the request started; four seconds later it has been
+      // re-linked. Writing then puts a RETIRED account's plan on record, and
+      // the next boot decides this box's entitlement from it — a retired Pro
+      // plan withdrawing a Max subscriber's voice, which is TASK-744 again.
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue(null);
+      const { noteClawaiCredentialReplaced } = await import("@/lib/clawai-plan-tier");
+      fetchSpy.mockImplementation(async () => {
+        // The re-link lands while this lookup is still on the wire.
+        noteClawaiCredentialReplaced();
+        return new Response(JSON.stringify({ tier: "pro", deviceTier: "flash" }), { status: 200 });
+      });
+
+      await GET();
+
+      expect(mockSetConfigValue).not.toHaveBeenCalledWith("clawai_plan_tier", expect.anything());
     });
 
     it("records no plan at all when the portal did not answer", async () => {

--- a/src/tests/routes/hermes/clawai-coding-agent.test.ts
+++ b/src/tests/routes/hermes/clawai-coding-agent.test.ts
@@ -224,22 +224,48 @@ describe("POST /setup-api/hermes/clawai", () => {
   });
 
   it("keeps a plan that is still true when the SAME account re-applies", async () => {
-    // The mirror: a re-paste of the identical token is not an account change,
-    // and throwing the plan away there would put the box back on its device
-    // badge — which is the default this card exists to stop deciding things.
+    // The mirror, and it has to be proven on the path that SUCCEEDS: a re-paste
+    // of the identical token, or a nudge of the tier pill, is not an account
+    // change. Throwing the plan away there would put the box back on its device
+    // badge — the default this card exists to stop deciding things — so the
+    // Voice panel would tell a Max subscriber his plan has no cloud voice while
+    // the box was speaking through one, and the boot script would stop arming
+    // it until a browser next polled the status route.
     store.clawai_token = PASTED;
     store.clawai_tier = "flash";
     store.clawai_plan_tier = "pro";
-    cliMock.mockImplementation(async (args: string[]) => (
-      args[1] === "set" && args[2] === "model.default"
-        ? { code: 1, stdout: "", stderr: "config store is locked by another writer" }
-        : { code: 0, stdout: "", stderr: "" }
-    ));
 
     const response = await POST(post({ token: PASTED, tier: "flash" }));
 
-    expect(response.status).toBe(502);
+    expect(response.status).toBe(200);
     expect(store.clawai_plan_tier).toBe("pro");
+  });
+
+  it("keeps it on a tier change with no token at all", async () => {
+    // The Settings plan pill: no credential in the body, so nothing about the
+    // account has changed and the plan on record is still that account's.
+    store.clawai_token = PASTED;
+    store.clawai_tier = "flash";
+    store.clawai_plan_tier = "pro";
+
+    const response = await POST(post({ tier: "pro" }));
+
+    expect(response.status).toBe(200);
+    expect(store.clawai_plan_tier).toBe("pro");
+  });
+
+  it("retires it on a DIFFERENT account even when the apply succeeds", async () => {
+    // And the other direction on the same path: the plan belongs to the account
+    // behind the credential, so a token that replaces it takes the plan with it
+    // rather than leaving a retired Max plan to decide a Free box's voice.
+    store.clawai_token = "claw_ACCOUNT_A0000000";
+    store.clawai_tier = "flash";
+    store.clawai_plan_tier = "pro";
+
+    const response = await POST(post({ token: PASTED, tier: "flash" }));
+
+    expect(response.status).toBe(200);
+    expect(store.clawai_plan_tier).toBeUndefined();
   });
 
   it("keeps the pick when the SAME account re-applies its tier", async () => {

--- a/src/tests/routes/hermes/clawai-coding-agent.test.ts
+++ b/src/tests/routes/hermes/clawai-coding-agent.test.ts
@@ -199,6 +199,49 @@ describe("POST /setup-api/hermes/clawai", () => {
     expect(store[EXPLICIT_MODEL_PICKS_KEY]).toEqual({});
   });
 
+  it("retires the previous account's PLAN even when the apply then FAILS", async () => {
+    // TASK-744, the same shape as the pick above and for the same reason: the
+    // plan is retired inside `applyClawaiToHermes`'s final `setMany`, behind a
+    // step loop that is fatal on any failing `hermes config set`. A step that
+    // failed after the token write left account B's token beside account A's
+    // plan — and both boot scripts read that plan as this box's entitlement, so
+    // a Free box would go on arming and keeping a cloud voice its credential is
+    // answered 403 for.
+    store.clawai_token = "claw_ACCOUNT_A0000000";
+    store.clawai_tier = "flash";
+    store.clawai_plan_tier = "pro";
+    cliMock.mockImplementation(async (args: string[]) => (
+      args[1] === "set" && args[2] === "model.default"
+        ? { code: 1, stdout: "", stderr: "config store is locked by another writer" }
+        : { code: 0, stdout: "", stderr: "" }
+    ));
+
+    const response = await POST(post({ token: PASTED, tier: "flash" }));
+
+    expect(response.status).toBe(502);
+    expect(store.clawai_token).toBe(PASTED);
+    expect(store.clawai_plan_tier).toBeUndefined();
+  });
+
+  it("keeps a plan that is still true when the SAME account re-applies", async () => {
+    // The mirror: a re-paste of the identical token is not an account change,
+    // and throwing the plan away there would put the box back on its device
+    // badge — which is the default this card exists to stop deciding things.
+    store.clawai_token = PASTED;
+    store.clawai_tier = "flash";
+    store.clawai_plan_tier = "pro";
+    cliMock.mockImplementation(async (args: string[]) => (
+      args[1] === "set" && args[2] === "model.default"
+        ? { code: 1, stdout: "", stderr: "config store is locked by another writer" }
+        : { code: 0, stdout: "", stderr: "" }
+    ));
+
+    const response = await POST(post({ token: PASTED, tier: "flash" }));
+
+    expect(response.status).toBe(502);
+    expect(store.clawai_plan_tier).toBe("pro");
+  });
+
   it("keeps the pick when the SAME account re-applies its tier", async () => {
     store.clawai_token = PASTED;
     store[EXPLICIT_MODEL_PICKS_KEY] = { clawai: "deepseek/deepseek-v4-pro" };

--- a/src/tests/routes/tts-hermes-parity.test.ts
+++ b/src/tests/routes/tts-hermes-parity.test.ts
@@ -422,6 +422,34 @@ describe("a Hermes box whose plan has no cloud voice", () => {
     expect(cloud.detail).toMatch(/Max/i);
   });
 
+  // TASK-744. `clawai_tier` is the DEVICE default and a Max subscriber is
+  // allowed to have it set to Flash; `clawai_plan_tier` is what the account
+  // pays for, and it is the only one an entitlement may be read from. The panel
+  // has to answer this the same way both boot scripts do, or a box whose cloud
+  // voice `register-mcp.sh` has just armed is told its plan does not include it.
+  it("offers the cloud voice to a Max plan whose device is stamped flash", async () => {
+    storeValues = { clawai_tier: "flash", clawai_plan_tier: "pro" };
+    hermesConfig["tts.openai.base_url"] = "https://clawbox.test/api/ai";
+    hermesConfig["tts.openai.api_key"] = "claw_a_linked_hermes_box";
+    const { GET } = await route();
+    const body = await (await GET()).json();
+
+    const cloud = body.engines.find((e: { id: string }) => e.id === "cloud");
+    expect(cloud.configured).toBe(true);
+  });
+
+  it("still withholds it when the PLAN itself is below the entitlement", async () => {
+    storeValues = { clawai_tier: "pro", clawai_plan_tier: "flash" };
+    hermesConfig["tts.openai.base_url"] = "https://clawbox.test/api/ai";
+    hermesConfig["tts.openai.api_key"] = "claw_a_linked_hermes_box";
+    const { GET } = await route();
+    const body = await (await GET()).json();
+
+    const cloud = body.engines.find((e: { id: string }) => e.id === "cloud");
+    expect(cloud.configured).toBe(false);
+    expect(cloud.detail).toMatch(/Max/i);
+  });
+
   it("does not offer the cloud voice it would only be refused for", async () => {
     // The proxy serves speech to `pro` and answers 403 below it —
     // gateway-pre-start.sh gates the OpenClaw side on the same tier, and its

--- a/src/tests/routes/tts-hermes-parity.test.ts
+++ b/src/tests/routes/tts-hermes-parity.test.ts
@@ -79,7 +79,7 @@ vi.mock("@/lib/voice-output-store", () => ({
   writeLocalVoice: (...a: unknown[]) => writeLocalVoiceMock(...a),
 }));
 
-/** `pref:ui_language` and `clawai_tier`; the box is on the plan that has a voice. */
+/** `pref:ui_language` and the two tier stamps; the box is on the plan that has a voice. */
 let storeValues: Record<string, unknown> = {};
 // Partial: the route now reaches the store through the owner gate (auth.ts
 // reads DATA_DIR at import) and the spoken-replies switch; only the reads

--- a/src/tests/unit/clawai-plan-verdict.test.ts
+++ b/src/tests/unit/clawai-plan-verdict.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { mapPortalPlanTier, mapPortalPlanVerdict } from "@/lib/clawbox-ai-portal-tier";
+import { CLAWBOX_AI_PLAN_UNPAID } from "@/lib/clawbox-ai-models";
+
+/**
+ * TASK-744. The one function on the box that may decide a ClawBox AI account
+ * pays for nothing.
+ *
+ * `mapPortalPlanTier` answers `null` to three different facts — a genuinely
+ * unpaid account, a `tier` field the response omits (optional in this repo's
+ * own `DeviceInfoResponse`), and a plan word this build has never seen — and
+ * only the first is a downgrade. Both boot scripts read a RECORDED plan as one
+ * the box was told, and one of them deletes the customer's cloud voice over it,
+ * so the writer that fills that key has to be able to tell the three apart.
+ *
+ * Every word this function accepts as unpaid authorises that delete, which is
+ * why the accepted set is pinned here by name rather than by property: adding
+ * one is a decision, and it should have to be made in this file too.
+ */
+describe("mapPortalPlanVerdict — the only door to 'this account pays for nothing'", () => {
+  it("maps the two paid plans exactly as the tier reader does", () => {
+    expect(mapPortalPlanVerdict({ tier: "max" })).toBe("pro");
+    expect(mapPortalPlanVerdict({ tier: "pro" })).toBe("flash");
+    // The plan reading ignores the device stamp entirely — that is the whole
+    // point of it. A Max subscriber may run Flash on this box.
+    expect(mapPortalPlanVerdict({ tier: "max", deviceTier: "flash" })).toBe("pro");
+    expect(mapPortalPlanTier({ tier: "max", deviceTier: "flash" })).toBe("pro");
+  });
+
+  it("accepts exactly one word as unpaid, and it is the one the portal sends", () => {
+    // Every device-info fixture in this repository spells it `free`, and
+    // `mapPortalTier` has always read it as no paid plan.
+    expect(mapPortalPlanVerdict({ tier: "free" })).toBe(CLAWBOX_AI_PLAN_UNPAID);
+    expect(mapPortalPlanVerdict({ tier: " Free " })).toBe(CLAWBOX_AI_PLAN_UNPAID);
+  });
+
+  it.each([
+    // Stripe's `cancel_at_period_end` leaves the subscription ACTIVE and the
+    // customer served to the end of the period. Reading the obvious rendering
+    // of it as unpaid would delete a Max subscriber's cloud voice with weeks
+    // left on his plan.
+    "canceled",
+    "cancelled",
+    // A dunning or grace state — still paid, still served.
+    "past_due",
+    "expired",
+    "unpaid",
+    // A trial is access, not the absence of it.
+    "trialing",
+    // A plan tier this build simply predates.
+    "enterprise",
+    "team",
+    // And the shapes that are not a word at all.
+    "",
+    "   ",
+  ])("refuses to call %o unpaid", (tier) => {
+    expect(mapPortalPlanVerdict({ tier })).toBeNull();
+  });
+
+  it("refuses a response that carries no tier field at all", () => {
+    // `tier` is optional in our own type, and `allowedModelsForCompat` exists
+    // because older portal builds answer with less than current ones do. An
+    // absent field is not a statement about the plan.
+    expect(mapPortalPlanVerdict({})).toBeNull();
+    expect(mapPortalPlanVerdict({ deviceTier: "pro" })).toBeNull();
+  });
+
+  it("is never more permissive than the tier reader about what is PAID", () => {
+    // The two must not drift into disagreeing about which accounts pay: every
+    // word one calls paid, the other calls paid.
+    for (const tier of ["max", "pro", "free", "enterprise", "canceled", ""]) {
+      const paid = mapPortalPlanTier({ tier });
+      if (paid) expect(mapPortalPlanVerdict({ tier })).toBe(paid);
+    }
+  });
+});

--- a/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
@@ -219,7 +219,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
     it("removes the entry it wrote when the plan drops to Pro", () => {
       const { cfg, changed, log } = migrate(
         { messages: { tts: { providers: { openai: ours } } } },
-        { deviceTier: PRO_DEVICE_TIER },
+        { deviceTier: PRO_DEVICE_TIER, planTier: PRO_DEVICE_TIER },
       );
 
       expect(changed).toBe(true);
@@ -237,7 +237,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
             },
           },
         },
-        { deviceTier: PRO_DEVICE_TIER },
+        { deviceTier: PRO_DEVICE_TIER, planTier: PRO_DEVICE_TIER },
       );
 
       const tts = (cfg.messages as { tts: { provider: string; providers: Record<string, unknown> } }).tts;
@@ -256,7 +256,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
       const unstamped = { baseUrl: PROXY, model: "some-other-tts", apiKey: "claw_theirs" };
       const { cfg, changed } = migrate(
         { messages: { tts: { providers: { openai: unstamped } } } },
-        { deviceTier: PRO_DEVICE_TIER },
+        { deviceTier: PRO_DEVICE_TIER, planTier: PRO_DEVICE_TIER },
       );
 
       expect(changed).toBe(false);
@@ -267,7 +267,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
       const own = { baseUrl: "https://api.openai.com/v1", model: "tts-1-hd", apiKey: "sk-owner" };
       const { cfg, changed } = migrate(
         { messages: { tts: { providers: { openai: own } } } },
-        { deviceTier: PRO_DEVICE_TIER },
+        { deviceTier: PRO_DEVICE_TIER, planTier: PRO_DEVICE_TIER },
       );
 
       // Their voice is theirs whatever their ClawBox AI plan says.
@@ -276,7 +276,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
     });
 
     it("does nothing on an unentitled box that never had one", () => {
-      const { cfg, changed } = migrate({}, { deviceTier: PRO_DEVICE_TIER });
+      const { cfg, changed } = migrate({}, { deviceTier: PRO_DEVICE_TIER, planTier: PRO_DEVICE_TIER });
       expect(changed).toBe(false);
       expect(speech(cfg)).toBeUndefined();
     });
@@ -284,7 +284,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
     it("stays out of a box whose openai slot belongs to its owner", () => {
       const { cfg, changed } = migrate(
         { messages: { tts: { providers: { openai: ours } } } },
-        { deviceTier: PRO_DEVICE_TIER, routeIsOurs: false },
+        { deviceTier: PRO_DEVICE_TIER, planTier: PRO_DEVICE_TIER, routeIsOurs: false },
       );
 
       expect(changed).toBe(false);
@@ -298,7 +298,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
     // cloud voice configured, move Auto onto it, and buy a failed round trip
     // before every spoken reply.
     it("leaves a Pro box alone", () => {
-      const { cfg, changed } = migrate({}, { deviceTier: PRO_DEVICE_TIER });
+      const { cfg, changed } = migrate({}, { deviceTier: PRO_DEVICE_TIER, planTier: PRO_DEVICE_TIER });
       expect(changed).toBe(false);
       expect(speech(cfg)).toBeUndefined();
     });
@@ -376,6 +376,29 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
       expect(speech(cfg)).toBeUndefined();
     });
 
+    it("takes the voice back from a CANCELLED subscription", () => {
+      // H1 of the review, and the commoner of the two downgrade paths. The
+      // portal answers "no paid plan" and BOTH `mapPortalTier` and
+      // `mapPortalPlanTier` map that to null, so without a positive word for it
+      // a cancellation is indistinguishable from a box nobody has asked about
+      // and the entry stays, 403-ing, for good. `free` is that word.
+      const { cfg, changed, log } = migrate(
+        { messages: { tts: { providers: { openai: ours } } } },
+        { deviceTier: null, planTier: "free" },
+      );
+
+      expect(changed).toBe(true);
+      expect(speech(cfg)).toBeUndefined();
+      expect(log).toContain("no longer includes it");
+    });
+
+    it("does not arm a cancelled subscription either", () => {
+      const { cfg, changed } = migrate({}, { deviceTier: MAX_DEVICE_TIER, planTier: "free" });
+
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toBeUndefined();
+    });
+
     it("falls back to the device stamp when no plan has been recorded", () => {
       // Every box in the field is in this state until the status poll has
       // written the plan once, so the old rule has to keep answering there.
@@ -445,6 +468,21 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
         expect(speech(cfg)).toEqual(ours);
       });
 
+      // H2 of the review: the badge may fill in for a missing plan when ARMING
+      // and never when DESTROYING. `mapPortalTier` prefers `deviceTier` on
+      // purpose, so a Max subscriber running Flash on this box carries exactly
+      // this pair — and until his first status poll there is no plan to correct
+      // it with. Deleting on the badge is TASK-744 with his configuration gone.
+      it("does not withdraw on the device badge alone, however low it reads", () => {
+        const { cfg, changed } = migrate(
+          { messages: { tts: { providers: { openai: ours } } } },
+          { deviceTier: PRO_DEVICE_TIER },
+        );
+
+        expect(changed).toBe(false);
+        expect(speech(cfg)).toEqual(ours);
+      });
+
       it("does not withdraw over a device stamp that is not a tier we recognise", () => {
         // `normalizeClawboxAiTier` admits `flash` and `pro` and nothing else, so
         // every writer of these stamps produces one of the two. A third string
@@ -500,7 +538,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
       // while it did.
       const { cfg, changed, log } = migrate(
         { messages: { tts: { providers: { openai: { baseUrl: RETIRED, model: SPEECH_MODEL, apiKey: TOKEN, ...MANAGED } } } } },
-        { deviceTier: PRO_DEVICE_TIER },
+        { deviceTier: PRO_DEVICE_TIER, planTier: PRO_DEVICE_TIER },
       );
 
       expect(changed).toBe(true);
@@ -518,7 +556,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
       const preStamp = { baseUrl: RETIRED, model: SPEECH_MODEL, apiKey: TOKEN };
       const { cfg, changed } = migrate(
         { messages: { tts: { providers: { openai: preStamp } } } },
-        { deviceTier: PRO_DEVICE_TIER },
+        { deviceTier: PRO_DEVICE_TIER, planTier: PRO_DEVICE_TIER },
       );
 
       expect(changed).toBe(false);
@@ -531,7 +569,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
       const own = { baseUrl: RETIRED, model: "tts-1", apiKey: "sk-owner" };
       const { cfg, changed } = migrate(
         { messages: { tts: { providers: { openai: own } } } },
-        { deviceTier: PRO_DEVICE_TIER },
+        { deviceTier: PRO_DEVICE_TIER, planTier: PRO_DEVICE_TIER },
       );
 
       expect(changed).toBe(false);
@@ -593,7 +631,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
       const own = { baseUrl: "https://kokoro.local/v1", model: "kokoro", apiKey: "sk-owner", clawboxManaged: true };
       const { cfg, changed } = migrate(
         { messages: { tts: { providers: { openai: own } } } },
-        { deviceTier: PRO_DEVICE_TIER },
+        { deviceTier: PRO_DEVICE_TIER, planTier: PRO_DEVICE_TIER },
       );
 
       expect(changed).toBe(false);
@@ -621,7 +659,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
       const own = { baseUrl: "https://kokoro.local/v1", model: "kokoro", clawboxManaged: true };
       const { cfg, changed } = migrate(
         { messages: { tts: { providers: { openai: own } } } },
-        { deviceTier: PRO_DEVICE_TIER },
+        { deviceTier: PRO_DEVICE_TIER, planTier: PRO_DEVICE_TIER },
       );
 
       expect(changed).toBe(false);
@@ -723,7 +761,7 @@ describe.skipIf(!hasPython3)("the same migration on OpenClaw 2's top-level tts h
     const seeded = {
       tts: { providers: { openai: { baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN, ...MANAGED } } },
     };
-    const { cfg, changed } = migrate(seeded, { v2: true, deviceTier: PRO_DEVICE_TIER });
+    const { cfg, changed } = migrate(seeded, { v2: true, deviceTier: PRO_DEVICE_TIER, planTier: PRO_DEVICE_TIER });
     expect(changed).toBe(true);
     const tts = cfg.tts as { providers?: Record<string, SpeechEntry> };
     expect(tts.providers?.openai).toBeUndefined();
@@ -731,7 +769,7 @@ describe.skipIf(!hasPython3)("the same migration on OpenClaw 2's top-level tts h
 
   it("leaves an owner's own entry in the v2 home alone on a downgrade", () => {
     const seeded = { tts: { providers: { openai: { baseUrl: "https://their.own/voice", model: "x" } } } };
-    const { cfg, changed } = migrate(seeded, { v2: true, deviceTier: PRO_DEVICE_TIER });
+    const { cfg, changed } = migrate(seeded, { v2: true, deviceTier: PRO_DEVICE_TIER, planTier: PRO_DEVICE_TIER });
     expect(changed).toBe(false);
     const tts = cfg.tts as { providers?: Record<string, SpeechEntry> };
     expect(tts.providers?.openai).toEqual({ baseUrl: "https://their.own/voice", model: "x" });
@@ -899,33 +937,62 @@ describe("both editions gate cloud speech on the same tier", () => {
   // cannot import it. These pin the key name and the preference order in all
   // three, so a rename or a reordering fails here rather than on a customer's
   // box six weeks later.
-  it("both boot scripts read the plan key the TypeScript module names", async () => {
-    const { CLAWAI_PLAN_TIER_KEY } = await import("@/lib/clawai-plan-tier");
+  it("both boot scripts read the plan key and the unpaid word the module names", async () => {
+    const { CLAWAI_PLAN_TIER_KEY, CLAWAI_PLAN_UNPAID } = await import("@/lib/clawai-plan-tier");
     const pre = readFileSync(SCRIPT, "utf-8");
     const hermes = readFileSync(path.resolve(process.cwd(), "scripts/register-mcp.sh"), "utf-8");
 
-    expect(pre).toContain(`_clawai_stamped_tier("${CLAWAI_PLAN_TIER_KEY}")`);
-    expect(hermes).toContain(`stamped_tier("${CLAWAI_PLAN_TIER_KEY}")`);
-    // The PLAN first and the device stamp behind it, in both — the whole of the
-    // card, and the half a key-name check alone would not catch.
-    expect(pre).toContain(
-      `_clawai_stamped_tier("${CLAWAI_PLAN_TIER_KEY}") or _clawai_stamped_tier("clawai_tier")`,
-    );
-    expect(hermes).toContain(
-      `stamped_tier("${CLAWAI_PLAN_TIER_KEY}") or stamped_tier("clawai_tier")`,
-    );
+    expect(pre).toContain(`_one("${CLAWAI_PLAN_TIER_KEY}"`);
+    expect(hermes).toContain(`stamped_tier("${CLAWAI_PLAN_TIER_KEY}"`);
+    // The third plan value, without which a CANCELLED subscription cannot be
+    // told apart from a box nobody has ever asked about.
+    expect(pre).toContain(`CLAWBOX_PLAN_UNPAID = "${CLAWAI_PLAN_UNPAID}"`);
+    expect(hermes).toContain(`PLAN_UNPAID = "${CLAWAI_PLAN_UNPAID}"`);
   });
 
-  it("the TypeScript rule prefers the plan and falls back to the stamp", async () => {
+  it("both boot scripts arm on the pair and withdraw on the plan alone", async () => {
+    // The whole of the card, and the half a key-name check would not catch: the
+    // badge may fill in for a missing plan when ARMING, and never when the
+    // question is whether to destroy an owner's configuration.
+    const pre = readFileSync(SCRIPT, "utf-8");
+    const hermes = readFileSync(path.resolve(process.cwd(), "scripts/register-mcp.sh"), "utf-8");
+
+    expect(pre).toContain("_clawai_plan_tier or _clawai_device_tier");
+    expect(pre).toContain(
+      "_clawai_plan_tier and _clawai_plan_tier != CLAWBOX_SPEECH_DEVICE_TIER",
+    );
+    expect(hermes).toContain("arm_tier = plan_tier or device_tier");
+    expect(hermes).toContain("if plan_tier and plan_tier != ENTITLED_TIER:");
+  });
+
+  it("the TypeScript arm rule prefers the plan and falls back to the badge", async () => {
     const { clawaiEntitlementTier } = await import("@/lib/clawai-plan-tier");
 
     expect(clawaiEntitlementTier("pro", "flash")).toBe("pro");
     expect(clawaiEntitlementTier("flash", "pro")).toBe("flash");
+    expect(clawaiEntitlementTier("free", "pro")).toBe("free");
     // Unknown is not an answer, in either slot: it falls through rather than
     // deciding, and two unknowns decide nothing at all.
     expect(clawaiEntitlementTier(null, "pro")).toBe("pro");
     expect(clawaiEntitlementTier("enterprise", "pro")).toBe("pro");
     expect(clawaiEntitlementTier(undefined, undefined)).toBeNull();
-    expect(clawaiEntitlementTier("enterprise", "free")).toBeNull();
+    expect(clawaiEntitlementTier("enterprise", "enterprise")).toBeNull();
+  });
+
+  it("the TypeScript withdrawal rule reads the plan and NEVER the badge", async () => {
+    const { clawaiSpeechWithdrawable } = await import("@/lib/clawai-plan-tier");
+    const { CLAWBOX_AI_SPEECH_TIER } = await import("@/lib/hermes-tts");
+
+    // A plan below the entitlement, cancellation included, withdraws.
+    expect(clawaiSpeechWithdrawable("flash", CLAWBOX_AI_SPEECH_TIER)).toBe(true);
+    expect(clawaiSpeechWithdrawable("free", CLAWBOX_AI_SPEECH_TIER)).toBe(true);
+    // The entitled plan, and every shape of not-knowing, do not.
+    expect(clawaiSpeechWithdrawable("pro", CLAWBOX_AI_SPEECH_TIER)).toBe(false);
+    expect(clawaiSpeechWithdrawable(null, CLAWBOX_AI_SPEECH_TIER)).toBe(false);
+    expect(clawaiSpeechWithdrawable(undefined, CLAWBOX_AI_SPEECH_TIER)).toBe(false);
+    expect(clawaiSpeechWithdrawable("enterprise", CLAWBOX_AI_SPEECH_TIER)).toBe(false);
+    // And it takes ONE argument's worth of evidence: there is no device stamp
+    // in this signature to fall back to, which is the point.
+    expect(clawaiSpeechWithdrawable.length).toBe(2);
   });
 });

--- a/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
@@ -72,6 +72,11 @@ interface Options {
   routeIsOurs?: boolean;
   /** `clawai_tier` in the device store, or `null` for a store without one. */
   deviceTier?: string | null;
+  /**
+   * `clawai_plan_tier` in the device store — the portal's PLAN, or `null` for a
+   * box whose plan the portal has never answered for.
+   */
+  planTier?: string | null;
   /** `false` writes no device store at all — a box the Next app has never run on. */
   storeExists?: boolean;
   /** A device store that is not an object, or not JSON. */
@@ -89,12 +94,25 @@ interface Options {
  * provider entry. `CLAWBOX_DEVICE_STORE` is the env var the shell exports.
  */
 function migrate(cfg: Config, opts: Options = {}): { cfg: Config; changed: boolean; log: string } {
-  const { routeIsOurs = true, deviceTier = MAX_DEVICE_TIER, storeExists = true, storeBody, v2 = false } = opts;
+  const {
+    routeIsOurs = true,
+    deviceTier = MAX_DEVICE_TIER,
+    planTier = null,
+    storeExists = true,
+    storeBody,
+    v2 = false,
+  } = opts;
   const file = path.join(dir, "config.json");
   writeFileSync(file, JSON.stringify(cfg));
   const store = path.join(dir, "device-store.json");
   if (storeExists) {
-    writeFileSync(store, storeBody ?? JSON.stringify(deviceTier === null ? {} : { clawai_tier: deviceTier }));
+    writeFileSync(
+      store,
+      storeBody ?? JSON.stringify({
+        ...(deviceTier === null ? {} : { clawai_tier: deviceTier }),
+        ...(planTier === null ? {} : { clawai_plan_tier: planTier }),
+      }),
+    );
   }
   const program = [
     "import json, os, sys",
@@ -310,6 +328,140 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
     });
   });
 
+  // TASK-744. `clawai_tier` is `mapPortalTier`'s answer, and that function
+  // prefers the portal's `deviceTier` STAMP on purpose — it answers "what
+  // should this box default to", and a Max subscriber is allowed to run Flash
+  // here. `clawbox-ai-portal-tier.ts` says the rule outright: "Read the first
+  // for a default to write; read this one [`mapPortalPlanTier`] before refusing
+  // anything." This block both refuses and DELETES on the device default, so a
+  // Max subscriber whose box is stamped `deviceTier: flash` had his cloud voice
+  // removed at every gateway start.
+  describe("the entitlement is the PLAN, and the device stamp only when the plan is unknown", () => {
+    const ours = { baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN, ...MANAGED };
+
+    it("keeps the cloud voice of a Max subscriber whose device is stamped flash", () => {
+      const { cfg, changed } = migrate(
+        { messages: { tts: { providers: { openai: ours } } } },
+        { deviceTier: PRO_DEVICE_TIER, planTier: MAX_DEVICE_TIER },
+      );
+
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toEqual(ours);
+    });
+
+    it("arms one for that box in the first place", () => {
+      const { cfg, changed } = migrate({}, { deviceTier: PRO_DEVICE_TIER, planTier: MAX_DEVICE_TIER });
+
+      expect(changed).toBe(true);
+      expect(speech(cfg)).toEqual(ours);
+    });
+
+    it("still takes the voice back when the PLAN itself has dropped", () => {
+      // The mirror case, and the one the withdrawal exists for: the plan is Pro,
+      // which the proxy answers 403 to, whatever this box's stamp says.
+      const { cfg, changed, log } = migrate(
+        { messages: { tts: { providers: { openai: ours } } } },
+        { deviceTier: MAX_DEVICE_TIER, planTier: PRO_DEVICE_TIER },
+      );
+
+      expect(changed).toBe(true);
+      expect(speech(cfg)).toBeUndefined();
+      expect(log).toContain("no longer includes it");
+    });
+
+    it("does not arm a Pro plan whose device stamp says otherwise", () => {
+      const { cfg, changed } = migrate({}, { deviceTier: MAX_DEVICE_TIER, planTier: PRO_DEVICE_TIER });
+
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toBeUndefined();
+    });
+
+    it("falls back to the device stamp when no plan has been recorded", () => {
+      // Every box in the field is in this state until the status poll has
+      // written the plan once, so the old rule has to keep answering there.
+      const { cfg, changed } = migrate({}, { deviceTier: MAX_DEVICE_TIER, planTier: null });
+
+      expect(changed).toBe(true);
+      expect(speech(cfg)).toEqual(ours);
+    });
+
+    it("ignores a plan stamp that is not a tier we recognise", () => {
+      // NOT KNOWING IS NOT AN ANSWER. A junk value is not evidence that the
+      // plan has dropped, so it falls through to the stamp rather than
+      // withdrawing a working voice over it.
+      const { cfg, changed } = migrate(
+        { messages: { tts: { providers: { openai: ours } } } },
+        { deviceTier: MAX_DEVICE_TIER, planTier: "enterprise" },
+      );
+
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toEqual(ours);
+    });
+
+    it("does not withdraw over a plan stamp alone when neither is recognisable", () => {
+      const { cfg, changed } = migrate(
+        { messages: { tts: { providers: { openai: ours } } } },
+        { deviceTier: null, planTier: "enterprise" },
+      );
+
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toEqual(ours);
+    });
+
+    // NOT KNOWING IS NOT AN ANSWER, in the destructive direction too. On beta
+    // this edition's `elif` carried no tier test at all, so every reading that
+    // was not a positive "pro" — an absent store, an unreadable one, a store
+    // with no stamp yet — deleted a working cloud voice. The Hermes arm has
+    // required a tier it was actually TOLD since it was written; this is that
+    // rule, on the edition that shipped first.
+    describe("and a reading we could not make is never one of them", () => {
+      it("does not withdraw a working voice over a store with no tier in it", () => {
+        const { cfg, changed } = migrate(
+          { messages: { tts: { providers: { openai: ours } } } },
+          { deviceTier: null },
+        );
+
+        expect(changed).toBe(false);
+        expect(speech(cfg)).toEqual(ours);
+      });
+
+      it("does not withdraw a working voice over a device store it cannot read", () => {
+        const { cfg, changed } = migrate(
+          { messages: { tts: { providers: { openai: ours } } } },
+          { storeBody: "not json at all" },
+        );
+
+        expect(changed).toBe(false);
+        expect(speech(cfg)).toEqual(ours);
+      });
+
+      it("does not withdraw a working voice over a box with no device store", () => {
+        const { cfg, changed } = migrate(
+          { messages: { tts: { providers: { openai: ours } } } },
+          { storeExists: false },
+        );
+
+        expect(changed).toBe(false);
+        expect(speech(cfg)).toEqual(ours);
+      });
+
+      it("does not withdraw over a device stamp that is not a tier we recognise", () => {
+        // `normalizeClawboxAiTier` admits `flash` and `pro` and nothing else, so
+        // every writer of these stamps produces one of the two. A third string
+        // is a store somebody edited or a build we have not seen, and reading it
+        // as "below the entitlement" would delete a working voice over a value
+        // we cannot interpret.
+        const { cfg, changed } = migrate(
+          { messages: { tts: { providers: { openai: ours } } } },
+          { deviceTier: "free" },
+        );
+
+        expect(changed).toBe(false);
+        expect(speech(cfg)).toEqual(ours);
+      });
+    });
+  });
+
   describe("a box we linked under a previous proxy address (TASK-726)", () => {
     // CLAWBOX_AI_PROXY_URL is env-overridable and moves between releases, so
     // an entry WE wrote can name an endpoint that has since been retired. The
@@ -348,7 +500,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
       // while it did.
       const { cfg, changed, log } = migrate(
         { messages: { tts: { providers: { openai: { baseUrl: RETIRED, model: SPEECH_MODEL, apiKey: TOKEN, ...MANAGED } } } } },
-        { deviceTier: "free" },
+        { deviceTier: PRO_DEVICE_TIER },
       );
 
       expect(changed).toBe(true);
@@ -366,7 +518,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
       const preStamp = { baseUrl: RETIRED, model: SPEECH_MODEL, apiKey: TOKEN };
       const { cfg, changed } = migrate(
         { messages: { tts: { providers: { openai: preStamp } } } },
-        { deviceTier: "free" },
+        { deviceTier: PRO_DEVICE_TIER },
       );
 
       expect(changed).toBe(false);
@@ -379,7 +531,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
       const own = { baseUrl: RETIRED, model: "tts-1", apiKey: "sk-owner" };
       const { cfg, changed } = migrate(
         { messages: { tts: { providers: { openai: own } } } },
-        { deviceTier: "free" },
+        { deviceTier: PRO_DEVICE_TIER },
       );
 
       expect(changed).toBe(false);
@@ -441,7 +593,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
       const own = { baseUrl: "https://kokoro.local/v1", model: "kokoro", apiKey: "sk-owner", clawboxManaged: true };
       const { cfg, changed } = migrate(
         { messages: { tts: { providers: { openai: own } } } },
-        { deviceTier: "free" },
+        { deviceTier: PRO_DEVICE_TIER },
       );
 
       expect(changed).toBe(false);
@@ -469,7 +621,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
       const own = { baseUrl: "https://kokoro.local/v1", model: "kokoro", clawboxManaged: true };
       const { cfg, changed } = migrate(
         { messages: { tts: { providers: { openai: own } } } },
-        { deviceTier: "free" },
+        { deviceTier: PRO_DEVICE_TIER },
       );
 
       expect(changed).toBe(false);
@@ -740,5 +892,40 @@ describe("both editions gate cloud speech on the same tier", () => {
     const m = src.match(/^CLAWBOX_SPEECH_DEVICE_TIER\s*=\s*"([^"]+)"/m);
     expect(m, "gateway-pre-start.sh no longer names CLAWBOX_SPEECH_DEVICE_TIER").not.toBeNull();
     expect(m?.[1]).toBe(CLAWBOX_AI_SPEECH_TIER);
+  });
+
+  // TASK-744. The rule is "the PLAN, and the device stamp only when the plan is
+  // unknown", written once in TypeScript and transcribed into two shells that
+  // cannot import it. These pin the key name and the preference order in all
+  // three, so a rename or a reordering fails here rather than on a customer's
+  // box six weeks later.
+  it("both boot scripts read the plan key the TypeScript module names", async () => {
+    const { CLAWAI_PLAN_TIER_KEY } = await import("@/lib/clawai-plan-tier");
+    const pre = readFileSync(SCRIPT, "utf-8");
+    const hermes = readFileSync(path.resolve(process.cwd(), "scripts/register-mcp.sh"), "utf-8");
+
+    expect(pre).toContain(`_clawai_stamped_tier("${CLAWAI_PLAN_TIER_KEY}")`);
+    expect(hermes).toContain(`stamped_tier("${CLAWAI_PLAN_TIER_KEY}")`);
+    // The PLAN first and the device stamp behind it, in both — the whole of the
+    // card, and the half a key-name check alone would not catch.
+    expect(pre).toContain(
+      `_clawai_stamped_tier("${CLAWAI_PLAN_TIER_KEY}") or _clawai_stamped_tier("clawai_tier")`,
+    );
+    expect(hermes).toContain(
+      `stamped_tier("${CLAWAI_PLAN_TIER_KEY}") or stamped_tier("clawai_tier")`,
+    );
+  });
+
+  it("the TypeScript rule prefers the plan and falls back to the stamp", async () => {
+    const { clawaiEntitlementTier } = await import("@/lib/clawai-plan-tier");
+
+    expect(clawaiEntitlementTier("pro", "flash")).toBe("pro");
+    expect(clawaiEntitlementTier("flash", "pro")).toBe("flash");
+    // Unknown is not an answer, in either slot: it falls through rather than
+    // deciding, and two unknowns decide nothing at all.
+    expect(clawaiEntitlementTier(null, "pro")).toBe("pro");
+    expect(clawaiEntitlementTier("enterprise", "pro")).toBe("pro");
+    expect(clawaiEntitlementTier(undefined, undefined)).toBeNull();
+    expect(clawaiEntitlementTier("enterprise", "free")).toBeNull();
   });
 });

--- a/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
@@ -856,12 +856,18 @@ describe.skipIf(!hasPython3)("the same migration on OpenClaw 2's top-level tts h
    * over, and it leaves the core's own migration less to move rather than more.
    */
   describe("taking the cloud voice back from wherever the entry actually is", () => {
+    // The withdrawal reads the PLAN and never the device badge (TASK-744): the
+    // badge is `mapPortalTier`'s answer and prefers the portal's `deviceTier`
+    // stamp on purpose, so a Max subscriber running Flash carries a low badge
+    // and must not lose his voice over it. "A box that was Max and is not any
+    // more" — which is what every case here is about — is therefore a box whose
+    // PLAN is below the entitlement, and that is what these fixtures record.
     const OURS = { baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN, ...MANAGED };
 
     it("takes back a stamped entry stranded in the legacy home", () => {
       const seeded = { messages: { tts: { providers: { openai: { ...OURS } } } } };
 
-      const { cfg, changed } = migrate(seeded, { v2: true, deviceTier: PRO_DEVICE_TIER });
+      const { cfg, changed } = migrate(seeded, { v2: true, deviceTier: PRO_DEVICE_TIER, planTier: PRO_DEVICE_TIER });
 
       expect(changed).toBe(true);
       const messages = cfg.messages as { tts: { providers: Record<string, SpeechEntry> } };
@@ -877,7 +883,7 @@ describe.skipIf(!hasPython3)("the same migration on OpenClaw 2's top-level tts h
         messages: { tts: { providers: { openai: { ...OURS } } } },
       };
 
-      const { cfg, changed } = migrate(seeded, { v2: true, deviceTier: PRO_DEVICE_TIER });
+      const { cfg, changed } = migrate(seeded, { v2: true, deviceTier: PRO_DEVICE_TIER, planTier: PRO_DEVICE_TIER });
 
       expect(changed).toBe(true);
       expect((cfg.tts as { providers: Record<string, SpeechEntry> }).providers.openai).toBeUndefined();
@@ -892,7 +898,7 @@ describe.skipIf(!hasPython3)("the same migration on OpenClaw 2's top-level tts h
       const theirs = { baseUrl: "https://their.own/voice", model: "x" };
       const seeded = { messages: { tts: { providers: { openai: { ...theirs } } } } };
 
-      const { cfg, changed } = migrate(seeded, { v2: true, deviceTier: PRO_DEVICE_TIER });
+      const { cfg, changed } = migrate(seeded, { v2: true, deviceTier: PRO_DEVICE_TIER, planTier: PRO_DEVICE_TIER });
 
       expect(changed).toBe(false);
       const messages = cfg.messages as { tts: { providers: Record<string, SpeechEntry> } };
@@ -907,7 +913,7 @@ describe.skipIf(!hasPython3)("the same migration on OpenClaw 2's top-level tts h
         messages: { tts: { providers: { openai: { ...OURS } } } },
       };
 
-      const { cfg } = migrate(seeded, { deviceTier: PRO_DEVICE_TIER });
+      const { cfg } = migrate(seeded, { deviceTier: PRO_DEVICE_TIER, planTier: PRO_DEVICE_TIER });
 
       expect((cfg.tts as { providers: Record<string, SpeechEntry> }).providers.openai).toEqual(OURS);
       const messages = cfg.messages as { tts: { providers: Record<string, SpeechEntry> } };

--- a/src/tests/unit/harness-credentials.test.ts
+++ b/src/tests/unit/harness-credentials.test.ts
@@ -324,6 +324,21 @@ describe("a credential the ClawBox AI proxy has refused", () => {
     expect(configStoreSet).not.toHaveBeenCalled();
   });
 
+  it("retires the recorded PLAN with it, because that is a fact about the same credential", async () => {
+    // TASK-744. Two boot scripts prefer `clawai_plan_tier` over the device
+    // badge, and one of them deletes the cloud voice when the plan does not
+    // cover it. Left standing across a re-link, the PREVIOUS account's Max plan
+    // would keep the voice armed on a box now holding a lower plan's token —
+    // a refused round trip per spoken reply, with the panel calling the voice
+    // configured while it happens.
+    const mod = await memo();
+    configStoreGet.mockResolvedValue("pro");
+
+    await mod.forgetClawaiCredentialRefusal();
+
+    expect(configStoreSet).toHaveBeenCalledWith("clawai_plan_tier", undefined);
+  });
+
   it("still forgets in memory when the store cannot be written", async () => {
     // A root-owned data/config.json is a state this repo has seen. Losing the
     // hint must not cost the caller its own answer.

--- a/src/tests/unit/harness-credentials.test.ts
+++ b/src/tests/unit/harness-credentials.test.ts
@@ -324,19 +324,25 @@ describe("a credential the ClawBox AI proxy has refused", () => {
     expect(configStoreSet).not.toHaveBeenCalled();
   });
 
-  it("retires the recorded PLAN with it, because that is a fact about the same credential", async () => {
+  it("retires an in-flight PLAN answer for the credential it replaced", async () => {
     // TASK-744. Two boot scripts prefer `clawai_plan_tier` over the device
-    // badge, and one of them deletes the cloud voice when the plan does not
-    // cover it. Left standing across a re-link, the PREVIOUS account's Max plan
-    // would keep the voice armed on a box now holding a lower plan's token —
-    // a refused round trip per spoken reply, with the panel calling the voice
-    // configured while it happens.
+    // badge and one of them DELETES the cloud voice over it, and a portal
+    // lookup for the OLD token can still be in flight — the same four-second
+    // window `notRecordedSince` above exists for. Landing afterwards it would
+    // write a retired account's plan, and the next boot would decide this box's
+    // entitlement from it.
+    //
+    // The plan itself is NOT cleared here: its writers record or delete it in
+    // the same store write as the badge, so it never outlives the account it
+    // describes. What this funnel owes it is the counter.
     const mod = await memo();
-    configStoreGet.mockResolvedValue("pro");
+    const { clawaiPlanGeneration } = await import("@/lib/clawai-plan-tier");
+    const before = clawaiPlanGeneration();
 
     await mod.forgetClawaiCredentialRefusal();
 
-    expect(configStoreSet).toHaveBeenCalledWith("clawai_plan_tier", undefined);
+    expect(clawaiPlanGeneration()).not.toBe(before);
+    expect(configStoreSet).not.toHaveBeenCalledWith("clawai_plan_tier", expect.anything());
   });
 
   it("still forgets in memory when the store cannot be written", async () => {

--- a/src/tests/unit/hermes-clawai-voice.test.ts
+++ b/src/tests/unit/hermes-clawai-voice.test.ts
@@ -465,8 +465,26 @@ describe("pointing a linked Hermes box at a voice it can actually use", () => {
     expect(selectProviderMock).toHaveBeenCalledWith("cloud");
   });
 
-  it("writes nothing at all to the voice config on an unentitled box", async () => {
+  it("keeps the credential current on an unentitled box already speaking through us, and selects nothing", async () => {
+    // TASK-744 moved the entitlement gate BELOW the refresh. A box on our own
+    // cloud route is already calling that endpoint on every spoken reply, and
+    // the portal rotates the token on a re-link: leaving the old one there
+    // makes every utterance 401 rather than the 403 its plan has earned, and
+    // this is the only writer of `tts.openai.*` on the LINK path. What the plan
+    // governs is the SELECTION, which is never made here — taking the voice
+    // away is `register-mcp.sh` §4a's job, on a plan it can confirm.
     readVoiceMock.mockResolvedValue(voice("openai"));
+
+    await applyClawaiToHermes(TOKEN, "flash");
+
+    expect(writeCloudMock).toHaveBeenCalledWith(TOKEN);
+    expect(selectProviderMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps its hands off an unentitled box that is NOT on our route", async () => {
+    // The other half, and the one that must not move: an owner's own speech
+    // server is not ours to refresh whatever their plan says.
+    readVoiceMock.mockResolvedValue(voice("elevenlabs"));
 
     await applyClawaiToHermes(TOKEN, "flash");
 

--- a/src/tests/unit/register-mcp-clawai-voice.test.ts
+++ b/src/tests/unit/register-mcp-clawai-voice.test.ts
@@ -449,6 +449,95 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
     });
   });
 
+  // TASK-744. `clawai_tier` is `mapPortalTier`'s answer, and that function
+  // prefers the portal's `deviceTier` STAMP on purpose — it answers "what
+  // should this box default to", and a Max subscriber is allowed to run Flash
+  // here. `clawbox-ai-portal-tier.ts` states the rule: "Read the first for a
+  // default to write; read this one [`mapPortalPlanTier`] before refusing
+  // anything." This block both refuses and WITHDRAWS on the device default, so
+  // a Max subscriber whose box is stamped `deviceTier: flash` had the cloud
+  // voice taken away at every web-server boot.
+  describe("the entitlement is the PLAN, and the device stamp only when the plan is unknown (TASK-744)", () => {
+    /** Leave the box on the cloud voice, as the arm does. */
+    function armedYaml() {
+      writeYaml(
+        `${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    base_url: ${PROXY}\n    api_key: ${TOKEN}\n    model: ${CLOUD_MODEL}\n`,
+      );
+    }
+
+    it("keeps the cloud voice of a Max subscriber whose device is stamped flash", () => {
+      armedYaml();
+      writeStore({ clawai_token: TOKEN, clawai_tier: "flash", clawai_plan_tier: ENTITLED_TIER });
+
+      const r = run();
+
+      expect(at("tts.openai.api_key")).toBe(TOKEN);
+      expect(at("tts.openai.base_url")).toBe(PROXY);
+      expect(configCalls()).toEqual([]);
+      expect(r.stdout).toContain("the cloud voice is already armed");
+    });
+
+    it("arms one for that box in the first place", () => {
+      writeStore({ clawai_token: TOKEN, clawai_tier: "flash", clawai_plan_tier: ENTITLED_TIER });
+
+      const r = run();
+
+      expect(at("tts.openai.base_url")).toBe(PROXY);
+      expect(at("tts.openai.api_key")).toBe(TOKEN);
+      expect(at("tts.provider")).toBe("openai");
+      expect(r.stdout).toContain("armed the ClawBox AI cloud voice");
+    });
+
+    it("still withdraws when the PLAN itself has dropped", () => {
+      // The mirror case: the plan is Pro, which the proxy answers 403 to,
+      // whatever this box's device stamp says.
+      armedYaml();
+      writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER, clawai_plan_tier: "flash" });
+
+      const r = run();
+
+      expect(at("tts.openai.api_key")).toBeUndefined();
+      expect(at("tts.openai.base_url")).toBeUndefined();
+      expect(r.stdout).toContain("no longer includes it");
+    });
+
+    it("falls back to the device stamp when no plan has been recorded", () => {
+      // Every box in the field is in this state until the status poll has
+      // written the plan once, so the old rule has to keep answering there.
+      writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER });
+
+      const r = run();
+
+      expect(at("tts.openai.base_url")).toBe(PROXY);
+      expect(r.stdout).toContain("armed the ClawBox AI cloud voice");
+    });
+
+    it("ignores a plan stamp that is not a tier we recognise", () => {
+      // NOT KNOWING IS NOT AN ANSWER. A junk value is not evidence that the
+      // plan has dropped, so it falls through to the stamp rather than
+      // withdrawing a working voice over it.
+      armedYaml();
+      writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER, clawai_plan_tier: "enterprise" });
+
+      const r = run();
+
+      expect(at("tts.openai.api_key")).toBe(TOKEN);
+      expect(configCalls()).toEqual([]);
+      expect(r.stdout).toContain("the cloud voice is already armed");
+    });
+
+    it("does not withdraw over a plan stamp alone when neither is recognisable", () => {
+      armedYaml();
+      writeStore({ clawai_token: TOKEN, clawai_plan_tier: "enterprise" });
+
+      const r = run();
+
+      expect(at("tts.openai.api_key")).toBe(TOKEN);
+      expect(configCalls()).toEqual([]);
+      expect(r.stdout).toContain("no plan has been recorded for this box yet");
+    });
+  });
+
   describe("not knowing is not an answer", () => {
     it("holds, and says why, when there is no device store at all", () => {
       const r = run();

--- a/src/tests/unit/register-mcp-clawai-voice.test.ts
+++ b/src/tests/unit/register-mcp-clawai-voice.test.ts
@@ -299,7 +299,7 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
     });
 
     it("does not arm a box whose plan does not include the cloud voice", () => {
-      writeStore({ clawai_token: TOKEN, clawai_tier: "flash" });
+      writeStore({ clawai_token: TOKEN, clawai_tier: "flash", clawai_plan_tier: "flash" });
 
       run();
 
@@ -364,7 +364,7 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
 
     it("takes the endpoint, credential and model back when the plan drops", () => {
       armedBox();
-      writeStore({ clawai_token: TOKEN, clawai_tier: "flash" });
+      writeStore({ clawai_token: TOKEN, clawai_tier: "flash", clawai_plan_tier: "flash" });
 
       const r = run();
 
@@ -379,7 +379,7 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
       // that the choice is no longer available, and silently rewriting it would
       // hide the downgrade.
       armedBox();
-      writeStore({ clawai_token: TOKEN, clawai_tier: "flash" });
+      writeStore({ clawai_token: TOKEN, clawai_tier: "flash", clawai_plan_tier: "flash" });
 
       run();
 
@@ -395,7 +395,7 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
       // DELETE one.
       ["OUR key at THEIR address", TOKEN],
     ])("never touches an owner's own speech server, even with %s in it", (_label, key) => {
-      writeStore({ clawai_token: TOKEN, clawai_tier: "flash" });
+      writeStore({ clawai_token: TOKEN, clawai_tier: "flash", clawai_plan_tier: "flash" });
       writeYaml(
         `${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    base_url: https://speech.home.lan/v1\n    api_key: ${key}\n    model: my-own-voice\n`,
       );
@@ -414,7 +414,7 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
       // under a previous address is still recognisably ours. No `claw_` token
       // here on purpose: the ADDRESS has to be what authorises the delete, or
       // this case would pass for the reason the one above forbids.
-      writeStore({ clawai_token: TOKEN, clawai_tier: "flash" });
+      writeStore({ clawai_token: TOKEN, clawai_tier: "flash", clawai_plan_tier: "flash" });
       writeYaml(
         `${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    base_url: https://openclawhardware.dev/api/ai\n    api_key: sk-someone-elses\n`,
       );
@@ -437,7 +437,7 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
 
     it("is idempotent — a second unentitled boot writes nothing", () => {
       armedBox();
-      writeStore({ clawai_token: TOKEN, clawai_tier: "flash" });
+      writeStore({ clawai_token: TOKEN, clawai_tier: "flash", clawai_plan_tier: "flash" });
       run();
       fs.writeFileSync(hermesLog, "");
       const before = fs.readFileSync(configPath, "utf-8");
@@ -499,6 +499,35 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
       expect(at("tts.openai.api_key")).toBeUndefined();
       expect(at("tts.openai.base_url")).toBeUndefined();
       expect(r.stdout).toContain("no longer includes it");
+    });
+
+    it("withdraws from a CANCELLED subscription", () => {
+      // The commoner of the two downgrade paths, and the one no null tier can
+      // express: `mapPortalTier` and `mapPortalPlanTier` both answer null for
+      // an unpaid account, so `free` is the word that tells a cancellation
+      // apart from a box nobody has ever asked about.
+      armedYaml();
+      writeStore({ clawai_token: TOKEN, clawai_plan_tier: "free" });
+
+      const r = run();
+
+      expect(at("tts.openai.api_key")).toBeUndefined();
+      expect(r.stdout).toContain("no longer includes it");
+    });
+
+    it("does not withdraw on the device badge alone, however low it reads", () => {
+      // The badge may fill in for a missing plan when ARMING and never when
+      // destroying: `mapPortalTier` prefers `deviceTier` on purpose, so a Max
+      // subscriber running Flash carries exactly this pair until his first
+      // status poll, and withdrawing on it is the card's own defect.
+      armedYaml();
+      writeStore({ clawai_token: TOKEN, clawai_tier: "flash" });
+
+      const r = run();
+
+      expect(at("tts.openai.api_key")).toBe(TOKEN);
+      expect(configCalls()).toEqual([]);
+      expect(r.stdout).toContain("a badge is not a plan");
     });
 
     it("falls back to the device stamp when no plan has been recorded", () => {
@@ -649,7 +678,7 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
     // An empty "our proxy" is the worst value this binding can take: it makes
     // an owner's slot carrying their key and NO base_url — the canonical way
     // Hermes' generic `openai` slot is used — read as ours.
-    writeStore({ clawai_token: TOKEN, clawai_tier: "flash" });
+    writeStore({ clawai_token: TOKEN, clawai_tier: "flash", clawai_plan_tier: "flash" });
     writeYaml(`${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    api_key: sk-theirs\n`);
 
     const r = run({ CLAWBOX_AI_PROXY_URL: override });


### PR DESCRIPTION
**TASK-744** — found by the reviewer of #757 (MEDIUM-1), on both editions.

## What the customer saw

A ClawBox AI **Max** subscriber whose box is stamped `deviceTier: flash` had his
cloud voice **taken away at every boot**. On OpenClaw `gateway-pre-start.sh`
deleted the `tts.providers.openai` entry it had written itself; on Hermes
`register-mcp.sh` unset `tts.openai.{api_key,base_url,model}`. Settings then
reported the cloud voice unconfigured — honestly, about a plan that pays for it.

## Cause

Both gates read `clawai_tier`. That stamp is `mapPortalTier`'s answer, and that
function prefers the portal's `deviceTier` stamp **on purpose**: it says what a
box should DEFAULT to, and a Max subscriber is allowed to run Flash on one.
`src/lib/clawbox-ai-portal-tier.ts` states the rule outright:

> `mapPortalTier` prefers `deviceTier` on purpose, because it answers "what
> should this BOX default to" and a Max subscriber is allowed to run Flash
> here… Read the first for a default to write; read this one
> [`mapPortalPlanTier`] before refusing anything.

The speech gate both refuses **and deletes**, and it read the first.

## The native mechanism, named

The plan is the **portal's** own answer — `GET /api/clawbox-ai/device-info`,
whose `tier` field `mapPortalPlanTier` already maps. Neither harness has a
notion of a ClawBox AI plan: on Hermes `tts.provider` is a plain selection with
no tier behind it, and OpenClaw's speech providers carry no entitlement either.
So there is nothing in the harness to lean on, and the portal is asked exactly
where it is already asked — `fetchPortalTier`, in the status poll and in the
configure route — rather than by a new probe from a boot script that has no
network guarantee.

**One new persisted key, and the body owes the reason:** `clawai_plan_tier` in
`data/config.json`, a sibling of `clawai_tier` in the same store the boot
scripts already open through `CLAWBOX_DEVICE_STORE`. The boot scripts cannot ask
the portal and cannot import TypeScript, so the answer has to be left where they
can read it — the same shape and the same argument as
`clawai_credential_refused_at` (TASK-727).

It holds three values — `pro` (Max), `flash` (Pro), `free` — and the third one
earns its place: `mapPortalTier` and `mapPortalPlanTier` **both** answer `null`
for an unpaid account, and an absent key already means "the portal has never
answered for this box". Without a word for "answered: no paid plan", a
**cancelled subscription** is indistinguishable from a box nobody has asked
about, and the withdrawal can never fire on the commoner of the two downgrade
paths.

That word is written only for a plan the build positively recognises as unpaid.
`mapPortalPlanTier`'s `null` covers three different facts — a genuinely unpaid
account, a `tier` field the response omits (optional in our own type), and a
plan word this build has never seen — and only the first is a downgrade, so
`mapPortalPlanVerdict` is the three-valued reading and the other two are
recorded as an absent key, exactly like never having asked.
`UNPAID_PLAN_WORDS` is `{"free"}`, the only word this repository evidences:
every word in it authorises the one irreversible act in both boot scripts, and
`"canceled"` is the obvious rendering of Stripe's `cancel_at_period_end`, which
leaves a subscription ACTIVE and the customer served to the end of the period.

## The rule — two arms, deliberately not one

| | reads | why |
|---|---|---|
| **ARM** `clawaiEntitlementTier` | the plan, with the badge behind it | recoverable — our own fields, our own values, taken back by the next boot once the plan is on record. Every box in the field has no plan until its first successful poll, so the fallback is what keeps them working. |
| **WITHDRAW** `clawaiSpeechWithdrawable` | the plan **alone** | the one irreversible act in either script. The badge is a DEFAULT a Max subscriber is allowed to have set to Flash: deleting on it is this very card, with the customer's configuration gone. Not knowing is not a downgrade. |

Written once in `src/lib/clawai-plan-tier.ts` and transcribed into the two boot
scripts (neither shell can import it). The suite pins the key name, the unpaid
word, **both** arms in both shells, and the TypeScript behaviour — so a rename
or a re-merge of the two arms fails in CI rather than on a customer's box.

## Where the plan is written

In the **same store write as `clawai_tier`**, by every writer of the credential,
and DELETED in that same write when the writer had no portal answer. The badge
and the plan therefore always describe the same account.

- `/setup-api/ai-models/status` — the portal-ANSWERED branch of the 30 s poll.
- `/setup-api/ai-models/configure` — both `setMany` batches, and through
  `applyClawaiToHermes`'s new `portalPlan` option on the Hermes SKU. This one is
  load-bearing: the status route is polled by **browsers** only, so a customer
  who pairs and closes the tab would otherwise never have a plan on record and
  both scripts would fall back to the badge for good.
- `/setup-api/ai-models/clawai/poll` — the device-code finaliser's Hermes
  branch asks the portal itself. On OpenClaw it hands over to the configure
  route, so without this the two editions' own primary link paths disagreed and
  a Hermes box finished the link with no plan at all.
- `/setup-api/hermes/clawai` carries the wizard's plan PICKER, which is a guess
  the account has not been consulted about (TASK-481), so it records none — and
  retires the plan **in its own batch** on an account change, because the
  apply's batch sits behind a step loop that is fatal on a failing
  `hermes config set` and a 502 there would leave account B's token beside
  account A's plan.

A writer with no portal answer retires the plan only when the ACCOUNT changed.
A re-pasted token or a nudge of the Settings tier pill is not a change, and
throwing the plan away there would put the box back on its badge — the panel
then telling a Max subscriber his plan has no cloud voice while the box speaks
through one.

Nothing clears the plan on its own. `forgetClawaiCredentialRefusal` bumps a
counter that `persistClawaiPlanTier` checks, so a portal answer already in
flight for the credential that was just replaced cannot land afterwards — the
same race, and the same shape, as `clearPersistedClawaiCredentialRefusal`'s
`notRecordedSince`.

## Every reader, updated or explicitly cleared

| site | now |
|---|---|
| `scripts/gateway-pre-start.sh` | `_clawai_speech_entitled` (pair) and `_clawai_speech_withdrawable` (plan alone) |
| `scripts/register-mcp.sh` §4a | `arm_tier = plan or badge`; `if plan_tier and plan_tier != ENTITLED_TIER` |
| `src/lib/hermes-tts.ts` `speechEntitledTier()` | the pair, through `readClawaiEntitlementTier()` |
| `src/lib/hermes-clawai.ts` `selectHermesCloudVoiceIfUnvoiced` | the entitlement is computed by the caller from the plan it just recorded and the badge behind it, and its gate moved **below** the credential refresh (see next section) |

Deliberately unchanged, and checked: `scripts/claude-ds` reads `clawai_tier` to
pick a MODEL DEFAULT, which is precisely what `mapPortalTier` is for;
`/setup-api/hermes/clawai` and `TierUpgradeCelebration` read it as the BADGE,
same reason. The image entitlement is untouched — the proxy publishes
`modelTiers: {"gpt-image-1-mini": ["free","pro","max"]}`, so there is no tier to
be downgraded from there.

## Three false failures fixed with it

1. **The OpenClaw withdraw arm carried no tier test at all** (`elif
   _clawai_openai_route_is_ours:`), so an absent, unreadable or unstamped device
   store deleted a working cloud voice.
2. **The device badge alone could destroy configuration.** It cannot now, on
   either edition.
3. **An unrecognised tier string read as a downgrade.**
   `normalizeClawboxAiTier` admits exactly `flash` and `pro`; anything outside
   the vocabulary is now not-knowing, in both scripts.

And one false success: `selectHermesCloudVoiceIfUnvoiced` refreshed the cloud
credential only *after* its tier gate, so a box already speaking through our own
proxy whose token the portal had just rotated was left 401ing on every utterance
while the panel called the voice configured. The refresh now runs first — it is
about a route we already own, which no plan changes — and the gate governs only
the SELECTION. An owner's own speech server is still never touched in either
direction.

## RED → GREEN

**RED, on unmodified `origin/beta`** (a scratch worktree at beta with only the
two boot-script suites and the new module copied in — the scripts untouched):

```
 Test Files  2 failed (2)
      Tests  18 failed | 82 passed (100)
```

The 18 include the destructive arms' own regression cases —
`does not withdraw on the device badge alone, however low it reads` (both
editions) and Hermes `withdraws from a CANCELLED subscription` — plus every
arm/withdraw case the card names and the shell/TypeScript parity pins.

**GREEN on this head:** the whole suite — **942 files, 14,181 tests**, `tsc
--noEmit` clean, `bash -n` clean on both scripts, all 30 embedded python
heredocs `py_compile` clean, eslint clean on every changed source file (the
remaining warnings are pre-existing unused symbols this branch does not touch).
Three component/install suites flaked once each under parallel load on the dev
machine and pass in isolation; none is in this diff.

## Proved on hardware, read-only

The OpenClaw box's mutex was held by an in-app update throughout and was not
taken or waited on, because nothing was mutated: the decision blocks were
extracted from the shipped scripts and run against each box's REAL
configuration, and the real config files were never opened for writing.

**Hermes box** — `clawai_tier: pro`, no plan recorded, `tts.provider: openai`,
`tts.openai` = base_url/api_key/model on our proxy, Kokoro stamp present:

```
real stamps today (badge=pro, no plan)     hold the cloud voice is already armed
Max plan, badge flash  (the card)          hold the cloud voice is already armed
plan dropped to Pro                        withdraw
subscription CANCELLED (plan=free)         withdraw
badge flash ALONE, no plan                 hold only this box's badge says it is
                                                not entitled, and a badge is not a plan
nothing recorded at all                    hold no plan has been recorded for this box yet
```

Line 1 is the convergence invariant #757 established: a steady-state boot still
costs **zero** `hermes` spawns. On unmodified beta, the same box with the same
files answers `withdraw` for line 2.

**OpenClaw box** — `clawai_tier: pro`, no plan recorded, a real
`tts.providers.openai` with `clawboxManaged: true` on our proxy:

```
real stamps today (badge=pro, no plan)     entry present=True
Max plan, badge flash  (the card)          entry present=True    (beta: DELETED)
plan dropped to Pro                        Removed …             entry present=False
subscription CANCELLED (plan=free)         Removed …             entry present=False
badge flash ALONE, no plan                 entry present=True    (beta: DELETED)
nothing recorded at all                    entry present=True    (beta: DELETED)
```

**Harness read, on the Hermes box:** `hermes config` verbs are
`{show,edit,get,set,unset,path,env-path,check,migrate}`; `tools/tts_tool.py`
carries `DEFAULT_PROVIDER = "edge"` and `_get_provider` returns it for an absent
selection, and `openai` is in `BUILTIN_TTS_PROVIDERS`. Recorded here because it
settles the follow-up (TASK-745): unsetting `tts.provider` would hand the box to
Microsoft's Edge cloud, which ClawBox never selects.

## Scope

The withdrawal now requires a recorded plan, so a box whose owner never opens
the panel AND whose link happened while the portal was unreachable keeps a
403-ing entry until either happens. That is the deliberate trade: the cost of
holding is a refused round trip per spoken reply, and the cost of deleting on
the badge is a Max subscriber's voice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloud voice eligibility now reflects the recorded subscription plan, with safe fallback to the device tier when plan information is unavailable.
  * Explicit unpaid plans are recognized and can withdraw cloud voice access.
  * Plan status is captured during ClawBox AI setup and status checks.

* **Bug Fixes**
  * Missing, invalid, or unreachable plan data no longer removes configured cloud voice.
  * Stale account responses can no longer overwrite current entitlement information.
  * Replacing credentials correctly resets associated plan details.
  * Existing cloud voice configurations retain their provider while credentials are refreshed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->