### PR TITLE
fix: stand the Hermes box down when the cloud voice is withdrawn (TASK-745)

### DIFF
--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -1067,12 +1067,17 @@ if [ -z "$CLAWBOX_VOICE_PROXY" ]; then
   CLAWBOX_VOICE_PROXY="https://clawbox.com/api/ai"
 fi
 CLAWBOX_VOICE_MODEL="gpt-4o-mini-tts"
+# The on-device voice `install.sh` registers and selects on every Hermes box,
+# and the only provider name the withdrawal below ever writes. One binding, so
+# the name the plan step may emit and the name the shell accepts cannot drift.
+CLAWBOX_VOICE_LOCAL="clawbox-local"
 CLAWBOX_VOICE_PLAN=$(
   CLAWBOX_DEVICE_STORE="$PROJECT_DIR/data/config.json" \
   CLAWBOX_HERMES_CONFIG="$HERMES_CONFIG" \
   CLAWBOX_SPEECH_DEVICE_TIER="pro" \
   CLAWBOX_AI_PROXY_URL="$CLAWBOX_VOICE_PROXY" \
   CLAWBOX_VOICE_MODEL="$CLAWBOX_VOICE_MODEL" \
+  CLAWBOX_VOICE_LOCAL="$CLAWBOX_VOICE_LOCAL" \
   CLAWBOX_KOKORO_STAMP="$HOME_DIR/.cache/clawbox/kokoro-installed" \
   python3 - <<'PY' || echo "hold the voice plan could not be computed"
 import json, os, sys, traceback
@@ -1145,7 +1150,7 @@ OUR_PROXIES.discard("")
 # nobody has chosen: `edge` is Microsoft's cloud voice, which the box gets for
 # having expressed no opinion.
 FACTORY_PROVIDER = "edge"
-LOCAL_PROVIDER = "clawbox-local"
+LOCAL_PROVIDER = os.environ["CLAWBOX_VOICE_LOCAL"]
 CLOUD_PROVIDER = "openai"
 # The one speech model the proxy serves; the same constant `hermes-tts.ts` pins
 # as HERMES_CLOUD_TTS_MODEL, because a request that names anything else is
@@ -1327,33 +1332,40 @@ if plan_tier and plan_tier != ENTITLED_TIER:
     if base_url.rstrip("/") not in OUR_PROXIES:
         say("hold tts.openai names an address that is not ours — not ours to withdraw")
     # WHERE THE BOX SPEAKS FROM AFTERWARDS, decided here with the rest of the
-    # verdict so the shell below is only the writes.
+    # verdict so the shell below is only the writes. Exactly two answers:
+    # `keep` writes no selection, and `clawbox-local` writes that one.
     #
-    # On Hermes `openai` is the harness's own BUILT-IN provider — it is in
-    # `BUILTIN_TTS_PROVIDERS` in `tools/tts_tool.py` — not a named entry ClawBox
-    # created, so emptying the three keys does not remove it the way deleting
-    # `messages.tts.providers.openai` does on the OpenClaw side. A selection
-    # left naming it resolves to the built-in with no `base_url`, which is
-    # api.openai.com: a 401 instead of the 403 at our own proxy, and the owner's
-    # text sent to a third party on every spoken reply. So the selection moves.
+    # On Hermes `openai` is the harness's own BUILT-IN provider
+    # (`BUILTIN_TTS_PROVIDERS`, tools/tts_tool.py:780 on the pinned 0.20.5), not
+    # a named entry ClawBox created, so removing the slot does not remove the
+    # provider the way deleting `messages.tts.providers.openai` does on the
+    # OpenClaw side. A selection left naming it resolves to the built-in with no
+    # `base_url`, which is api.openai.com: a 401 instead of the 403 at our own
+    # proxy, and the owner's text sent to a third party on every spoken reply.
     #
-    # It moves ONLY when it is OURS to move. An owner speaking through
-    # elevenlabs or a provider of their own has chosen that, and emptying our
-    # slot beside it says nothing about their choice.
-    if provider != CLOUD_PROVIDER:
+    # THE OWNER'S OWN PICK IS NEVER MOVED, and "their own" is the ARM's test
+    # read backwards rather than a second rule: the arm moves `""`, `edge` and
+    # `clawbox-local` because none of them is a choice, so none of them is a
+    # choice to preserve here either. `edge` in particular is Microsoft's cloud
+    # and the outcome `install.sh` selects `clawbox-local` to avoid — calling it
+    # "a voice of its own" and leaving it there would be this block telling the
+    # journal the opposite of what it did.
+    if provider not in ("", FACTORY_PROVIDER, LOCAL_PROVIDER, CLOUD_PROVIDER):
+        say("withdraw keep")
+    # ALREADY THERE. Nothing to write, and the difference matters to the CLI
+    # budget: this is the state the previous boot's withdrawal left behind.
+    if provider == LOCAL_PROVIDER:
         say("withdraw keep")
     # `hermes config unset tts.provider` is NOT a stand-down: `_get_provider`
-    # falls back to `DEFAULT_PROVIDER = "edge"`, Microsoft's cloud, which is
-    # exactly what `install.sh` selects `clawbox-local` on every Hermes box to
-    # avoid — "an engineless box is left honestly mute rather than speaking
-    # through a third party". So the box goes back to its own voice when it has
-    # a definition for one, and otherwise keeps a selection that fails at the
-    # harness rather than one that speaks to Microsoft.
-    providers = tts.get("providers")
-    providers = providers if isinstance(providers, dict) else {}
-    if isinstance(providers.get(LOCAL_PROVIDER), dict):
-        say("withdraw %s" % LOCAL_PROVIDER)
-    say("withdraw mute")
+    # falls back to `DEFAULT_PROVIDER = "edge"` (tts_tool.py:211, :661),
+    # Microsoft's cloud. `clawbox-local` is the answer even on a box that has no
+    # definition for it — that is not a gap but the state `install.sh` itself
+    # creates, and it is a REAL stand-down: an unresolvable command provider
+    # raises `tts.providers.clawbox-local.command is not configured`
+    # (tts_tool.py:1339) at the harness, with no fall-through, so nothing leaves
+    # the box. Honestly mute beats speaking to a third party, which is the
+    # ruling `step_openclaw_tts` already keeps.
+    say("withdraw %s" % LOCAL_PROVIDER)
 
 if not arm_tier:
     say("hold no plan has been recorded for this box yet")
@@ -1441,40 +1453,56 @@ TOKENPY
     fi
     ;;
   withdraw)
-    # The CREDENTIAL first, and every step reported rather than collapsed into
-    # one verdict: a partial withdrawal announced as a whole one is exactly the
-    # false success this arm exists to end.
+    # THE SELECTION FIRST, which is the mirror of the arm's definition-before-
+    # selection rule and the opposite of what an earlier draft did. Every
+    # intermediate state has to be safe, and the dangerous one is a slot our
+    # credential or endpoint has been taken out of while `tts.provider` still
+    # names `openai`: the harness's built-in then resolves to api.openai.com and
+    # the owner's text goes to a third party. De-selecting first means the only
+    # intermediate state is a box speaking from itself with a stale definition
+    # nothing points at — which leaks nothing and which the next boot tidies.
     #
-    # `voice` goes with the other three. It is the Voice tab's own key
-    # (`KEYS.cloudVoice` in src/lib/hermes-tts.ts) and leaving it behind kept a
-    # voice name for a provider this box may no longer call — which a later arm
-    # would then inherit from the plan that is being withdrawn.
-    CLAWBOX_VOICE_WITHDRAWN=true
-    for CLAWBOX_VOICE_KEY in tts.openai.api_key tts.openai.base_url tts.openai.model tts.openai.voice; do
-      if ! hermes_voice_write config unset "$CLAWBOX_VOICE_KEY"; then
-        log "could not remove $CLAWBOX_VOICE_KEY (exit $CLAWBOX_VOICE_RC) — this box may still be calling a speech endpoint its plan no longer includes; the next start will try again"
-        CLAWBOX_VOICE_WITHDRAWN=false
-      fi
-    done
-    # THE SELECTION, and only after the definition is actually gone: moving the
-    # box off a route that is still armed would be a downgrade it had not had
-    # yet, and a failed unset above means the endpoint is still there to speak
-    # through. The plan step decided WHERE — see its comment for why `unset` is
-    # not the stand-down it looks like.
+    # The plan step decided WHERE, and only two answers reach here.
     CLAWBOX_VOICE_TARGET="${CLAWBOX_VOICE_PLAN#* }"
-    if [ "$CLAWBOX_VOICE_WITHDRAWN" != true ]; then
-      :
-    elif [ "$CLAWBOX_VOICE_TARGET" = keep ]; then
-      log "removed the ClawBox AI cloud voice: this box's plan no longer includes it (it speaks through a voice of its own, which is left alone)"
-    elif [ "$CLAWBOX_VOICE_TARGET" = mute ]; then
-      # Nothing to fall back to. Said out loud rather than silently leaving a
-      # selection that cannot work: this box has no voice until its owner
-      # installs one, and the panel will report the cloud voice unconfigured.
-      log "removed the ClawBox AI cloud voice: this box's plan no longer includes it — and there is no on-device voice to fall back to, so it stays quiet until one is installed"
-    elif ! hermes_voice_write config set tts.provider "$CLAWBOX_VOICE_TARGET"; then
-      log "removed the ClawBox AI cloud voice but could not select $CLAWBOX_VOICE_TARGET (exit $CLAWBOX_VOICE_RC) — this box may still name a speech provider it can no longer reach; the next start will try again"
-    else
-      log "removed the ClawBox AI cloud voice: this box's plan no longer includes it, and it speaks from the box again"
+    CLAWBOX_VOICE_STOOD_DOWN=true
+    case "$CLAWBOX_VOICE_TARGET" in
+      keep) ;;
+      "$CLAWBOX_VOICE_LOCAL")
+        if ! hermes_voice_write config set tts.provider "$CLAWBOX_VOICE_LOCAL"; then
+          log "could not move this box off the ClawBox AI cloud voice (exit $CLAWBOX_VOICE_RC) — its definition is left in place so the box keeps speaking through our own proxy rather than through a slot with nothing behind it; the next start will try again"
+          CLAWBOX_VOICE_STOOD_DOWN=false
+        fi
+        ;;
+      *)
+        # Unreachable: the plan step emits `keep` or the local provider and
+        # nothing else. Named rather than trusted, because `${VAR#* }` yields
+        # the whole word when there is no space, and a stray verdict would
+        # otherwise be written into `tts.provider` verbatim.
+        log "left the voice alone — the voice plan named a selection this script does not write"
+        CLAWBOX_VOICE_STOOD_DOWN=false
+        ;;
+    esac
+    if [ "$CLAWBOX_VOICE_STOOD_DOWN" = true ]; then
+      # ONE call, and the whole slot. `hermes config unset` takes a non-leaf key
+      # — `_unset_nested` walks the dotted path and deletes whatever it lands on
+      # (hermes_cli/config.py) — so this is atomic where four per-key calls were
+      # not, and it takes the keys a per-key list cannot know about: the Voice
+      # tab's `voice` (`KEYS.cloudVoice`), and any `format`/`speed` an owner
+      # added beside our three.
+      #
+      # It is also the only shape that does not fail on a key that is not there:
+      # `unset_config_value` exits 1 when nothing was removed, and no box in the
+      # field carries `tts.openai.voice`, so unsetting it key-by-key reported a
+      # failed withdrawal on every real box.
+      if hermes_voice_write config unset tts.openai; then
+        if [ "$CLAWBOX_VOICE_TARGET" = keep ]; then
+          log "removed the ClawBox AI cloud voice: this box's plan no longer includes it, and its speech selection was already elsewhere"
+        else
+          log "removed the ClawBox AI cloud voice: this box's plan no longer includes it, and it speaks from the box again"
+        fi
+      else
+        log "moved this box off the ClawBox AI cloud voice but could not remove its definition (exit $CLAWBOX_VOICE_RC) — nothing points at it, so no request is made; the next start will try again"
+      fi
     fi
     ;;
   *)

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -1022,10 +1022,23 @@ fi
 # state the card is about: `install.sh` selects `clawbox-local` whatever the
 # engine answered, so an engineless box reads as a chosen local voice. A box on
 # `elevenlabs`, `piper` or anything else the owner picked is left alone.
-# And the withdrawal deliberately does NOT reset `tts.provider` either — the
-# same ruling the OpenClaw arm records: the panel's job is to show that the
-# choice is no longer available, and silently rewriting it would hide the
-# downgrade. Removing the DEFINITION is what stops the refused calls.
+# The WITHDRAWAL does reset it, and that is where this edition parts company
+# with the OpenClaw arm on purpose (TASK-745). There the delete removes a NAMED
+# provider entry ClawBox created, so the surviving selection names nothing and
+# the panel shows the choice is gone — leaving it is honest. Here `openai` is
+# the harness's own BUILT-IN provider (`BUILTIN_TTS_PROVIDERS` in
+# `tools/tts_tool.py`), so emptying the three keys removes nothing: the
+# selection still resolves, to a provider with no `base_url`, which is
+# api.openai.com. That is a 401 instead of the 403 at our own proxy, and the
+# owner's text sent to a third party on every spoken reply. So the box is handed
+# back to the voice it had — `clawbox-local` when it has a definition for one —
+# and only ever from `openai`, never from a provider the owner chose.
+#
+# `hermes config unset tts.provider` is NOT the stand-down it looks like:
+# `_get_provider` falls back to `DEFAULT_PROVIDER = "edge"`, Microsoft's cloud,
+# which is exactly what `install.sh` selects `clawbox-local` on every Hermes box
+# to avoid. A box with no local definition therefore keeps a selection that
+# fails at the harness, and the boot says so.
 #
 # IMAGES ARE NOT PART OF THIS, and that is measured rather than assumed: the
 # proxy publishes `modelTiers: {"gpt-image-1-mini": ["free","pro","max"]}`, so
@@ -1061,14 +1074,46 @@ CLAWBOX_VOICE_PLAN=$(
   CLAWBOX_AI_PROXY_URL="$CLAWBOX_VOICE_PROXY" \
   CLAWBOX_VOICE_MODEL="$CLAWBOX_VOICE_MODEL" \
   CLAWBOX_KOKORO_STAMP="$HOME_DIR/.cache/clawbox/kokoro-installed" \
-  python3 - <<'PY' 2>/dev/null || echo "hold the voice plan could not be computed"
-import json, os
+  python3 - <<'PY' || echo "hold the voice plan could not be computed"
+import json, os, sys, traceback
 
-# One verdict on stdout: `arm`, `withdraw`, or `hold <why>`. Everything this
-# block decides is decided here, so the shell below is only the writes.
+# One verdict on stdout: `arm <target>`, `withdraw <target>`, or `hold <why>`.
+# Everything this block decides is decided here, so the shell below is only the
+# writes.
 def say(verdict):
     print(verdict)
     raise SystemExit(0)
+
+
+def _plan_failed(_kind, _exc, _tb):
+    """An exception this block did not expect, NAMED on the boot log.
+
+    The `2>/dev/null` this heredoc used to carry meant a genuine bug in here
+    reached the operator as `hold the voice plan could not be computed` and
+    nothing else — it failed in the safe direction, silently, and the journal
+    could not say why. Dropping the redirect is what makes a compile-time error
+    visible: a SyntaxError reaches the journal in full and only ever quotes this
+    script's own source.
+
+    A RUNTIME failure is not allowed to do the same, and that is what this hook
+    is for. Such a traceback can be raised from inside a VALUE — a YAML error
+    quotes the offending line, and the line it would quote is
+    `tts.openai.api_key`. So the operator gets the exception type and the line
+    number in this block, which is what says where to look, and nothing that
+    was read off a file reaches the journal.
+
+    `os._exit(0)` rather than a raise: the shell reads this program's whole
+    stdout as the verdict, so a non-zero exit would add the `|| echo` fallback
+    line underneath this one.
+    """
+    _frames = traceback.extract_tb(_tb)
+    _where = " at line %d" % _frames[-1].lineno if _frames else ""
+    sys.stdout.write("hold the voice plan could not be computed (%s%s)\n" % (_kind.__name__, _where))
+    sys.stdout.flush()
+    os._exit(0)
+
+
+sys.excepthook = _plan_failed
 
 try:
     import yaml
@@ -1281,7 +1326,34 @@ if plan_tier and plan_tier != ENTITLED_TIER:
     # still recognisably ours.
     if base_url.rstrip("/") not in OUR_PROXIES:
         say("hold tts.openai names an address that is not ours — not ours to withdraw")
-    say("withdraw")
+    # WHERE THE BOX SPEAKS FROM AFTERWARDS, decided here with the rest of the
+    # verdict so the shell below is only the writes.
+    #
+    # On Hermes `openai` is the harness's own BUILT-IN provider — it is in
+    # `BUILTIN_TTS_PROVIDERS` in `tools/tts_tool.py` — not a named entry ClawBox
+    # created, so emptying the three keys does not remove it the way deleting
+    # `messages.tts.providers.openai` does on the OpenClaw side. A selection
+    # left naming it resolves to the built-in with no `base_url`, which is
+    # api.openai.com: a 401 instead of the 403 at our own proxy, and the owner's
+    # text sent to a third party on every spoken reply. So the selection moves.
+    #
+    # It moves ONLY when it is OURS to move. An owner speaking through
+    # elevenlabs or a provider of their own has chosen that, and emptying our
+    # slot beside it says nothing about their choice.
+    if provider != CLOUD_PROVIDER:
+        say("withdraw keep")
+    # `hermes config unset tts.provider` is NOT a stand-down: `_get_provider`
+    # falls back to `DEFAULT_PROVIDER = "edge"`, Microsoft's cloud, which is
+    # exactly what `install.sh` selects `clawbox-local` on every Hermes box to
+    # avoid — "an engineless box is left honestly mute rather than speaking
+    # through a third party". So the box goes back to its own voice when it has
+    # a definition for one, and otherwise keeps a selection that fails at the
+    # harness rather than one that speaks to Microsoft.
+    providers = tts.get("providers")
+    providers = providers if isinstance(providers, dict) else {}
+    if isinstance(providers.get(LOCAL_PROVIDER), dict):
+        say("withdraw %s" % LOCAL_PROVIDER)
+    say("withdraw mute")
 
 if not arm_tier:
     say("hold no plan has been recorded for this box yet")
@@ -1358,9 +1430,9 @@ TOKENPY
     elif ! hermes_voice_write config set tts.openai.model "$CLAWBOX_VOICE_MODEL"; then
       log "could not write tts.openai.model (exit $CLAWBOX_VOICE_RC) — the cloud voice is NOT selected; the next start will try again"
     elif [ "$CLAWBOX_VOICE_VERDICT" = refresh ]; then
-      # The selection is already ours and is NOT rewritten: one writer of
-      # `tts.provider`, and this path is only here to keep the credential and
-      # the endpoint current.
+      # The selection is already ours and is NOT rewritten: this path is only
+      # here to keep the credential and the endpoint current, and re-selecting
+      # would buy a fourth CLI spawn for nothing.
       log "refreshed the ClawBox AI speech credential"
     elif ! hermes_voice_write config set tts.provider openai; then
       log "wrote the ClawBox AI speech endpoint but could not select it (exit $CLAWBOX_VOICE_RC) — the next start will try again"
@@ -1369,22 +1441,40 @@ TOKENPY
     fi
     ;;
   withdraw)
-    # `tts.provider` is deliberately left where it is — see the block comment.
-    # Removing the DEFINITION is what stops the refused round trips; the panel
-    # then reports the cloud voice unconfigured, which is the truth.
-    #
     # The CREDENTIAL first, and every step reported rather than collapsed into
     # one verdict: a partial withdrawal announced as a whole one is exactly the
     # false success this arm exists to end.
+    #
+    # `voice` goes with the other three. It is the Voice tab's own key
+    # (`KEYS.cloudVoice` in src/lib/hermes-tts.ts) and leaving it behind kept a
+    # voice name for a provider this box may no longer call — which a later arm
+    # would then inherit from the plan that is being withdrawn.
     CLAWBOX_VOICE_WITHDRAWN=true
-    for CLAWBOX_VOICE_KEY in tts.openai.api_key tts.openai.base_url tts.openai.model; do
+    for CLAWBOX_VOICE_KEY in tts.openai.api_key tts.openai.base_url tts.openai.model tts.openai.voice; do
       if ! hermes_voice_write config unset "$CLAWBOX_VOICE_KEY"; then
         log "could not remove $CLAWBOX_VOICE_KEY (exit $CLAWBOX_VOICE_RC) — this box may still be calling a speech endpoint its plan no longer includes; the next start will try again"
         CLAWBOX_VOICE_WITHDRAWN=false
       fi
     done
-    if [ "$CLAWBOX_VOICE_WITHDRAWN" = true ]; then
-      log "removed the ClawBox AI cloud voice: this box's plan no longer includes it"
+    # THE SELECTION, and only after the definition is actually gone: moving the
+    # box off a route that is still armed would be a downgrade it had not had
+    # yet, and a failed unset above means the endpoint is still there to speak
+    # through. The plan step decided WHERE — see its comment for why `unset` is
+    # not the stand-down it looks like.
+    CLAWBOX_VOICE_TARGET="${CLAWBOX_VOICE_PLAN#* }"
+    if [ "$CLAWBOX_VOICE_WITHDRAWN" != true ]; then
+      :
+    elif [ "$CLAWBOX_VOICE_TARGET" = keep ]; then
+      log "removed the ClawBox AI cloud voice: this box's plan no longer includes it (it speaks through a voice of its own, which is left alone)"
+    elif [ "$CLAWBOX_VOICE_TARGET" = mute ]; then
+      # Nothing to fall back to. Said out loud rather than silently leaving a
+      # selection that cannot work: this box has no voice until its owner
+      # installs one, and the panel will report the cloud voice unconfigured.
+      log "removed the ClawBox AI cloud voice: this box's plan no longer includes it — and there is no on-device voice to fall back to, so it stays quiet until one is installed"
+    elif ! hermes_voice_write config set tts.provider "$CLAWBOX_VOICE_TARGET"; then
+      log "removed the ClawBox AI cloud voice but could not select $CLAWBOX_VOICE_TARGET (exit $CLAWBOX_VOICE_RC) — this box may still name a speech provider it can no longer reach; the next start will try again"
+    else
+      log "removed the ClawBox AI cloud voice: this box's plan no longer includes it, and it speaks from the box again"
     fi
     ;;
   *)

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -975,7 +975,9 @@ fi
 #     ClawBox AI is connected. It simply never speaks (TASK-717).
 #   - a box that WAS entitled and drops to a lower plan keeps `tts.openai.*`
 #     pointing at an endpoint the proxy now answers 403 to, and pays a refused
-#     round trip on every spoken reply (TASK-718).
+#     round trip on every spoken reply (TASK-718). The withdrawal removes that
+#     slot WHOLESALE — one `hermes config unset tts.openai` — and moves the
+#     selection off it first; see the paragraph on TASK-745 below.
 # The OpenClaw edition has had both arms since TASK-459: `gateway-pre-start.sh`
 # gates on `_clawai_speech_entitled` and has the `elif` that takes its own entry
 # back. This is that pair, for the edition that has no `gateway-pre-start.sh`.
@@ -1022,23 +1024,31 @@ fi
 # state the card is about: `install.sh` selects `clawbox-local` whatever the
 # engine answered, so an engineless box reads as a chosen local voice. A box on
 # `elevenlabs`, `piper` or anything else the owner picked is left alone.
-# The WITHDRAWAL does reset it, and that is where this edition parts company
-# with the OpenClaw arm on purpose (TASK-745). There the delete removes a NAMED
+# The WITHDRAWAL resets it, and that is where this edition parts company with
+# the OpenClaw arm on purpose (TASK-745). There the delete removes a NAMED
 # provider entry ClawBox created, so the surviving selection names nothing and
-# the panel shows the choice is gone — leaving it is honest. Here `openai` is
-# the harness's own BUILT-IN provider (`BUILTIN_TTS_PROVIDERS` in
-# `tools/tts_tool.py`), so emptying the three keys removes nothing: the
-# selection still resolves, to a provider with no `base_url`, which is
-# api.openai.com. That is a 401 instead of the 403 at our own proxy, and the
-# owner's text sent to a third party on every spoken reply. So the box is handed
-# back to the voice it had — `clawbox-local` when it has a definition for one —
-# and only ever from `openai`, never from a provider the owner chose.
+# the panel showing the choice is gone is the truth — leaving it is honest.
+# Here `openai` is the harness's own BUILT-IN provider (`BUILTIN_TTS_PROVIDERS`,
+# tools/tts_tool.py:780), so removing the slot removes nothing: the selection
+# still resolves, to a provider with no `base_url`, which is api.openai.com.
+# That is a 401 instead of the 403 at our own proxy, and the owner's text sent
+# to a third party on every spoken reply.
 #
-# `hermes config unset tts.provider` is NOT the stand-down it looks like:
-# `_get_provider` falls back to `DEFAULT_PROVIDER = "edge"`, Microsoft's cloud,
-# which is exactly what `install.sh` selects `clawbox-local` on every Hermes box
-# to avoid. A box with no local definition therefore keeps a selection that
-# fails at the harness, and the boot says so.
+# RESTORING, NOT OVERRIDING. `tts.provider: openai` on a box whose `tts.openai`
+# this block has just removed is ClawBox's own residue, not a choice the owner
+# made — the arm wrote it, and it points at a slot the arm has taken away. The
+# selection therefore moves ONLY from `openai`, and only to `clawbox-local`, and
+# only when `tts.providers.clawbox-local` is a definition the harness can
+# actually resolve. An owner's own pick, the factory `edge`, an unset key and a
+# box already on its own voice are all left exactly where they are.
+#
+# WHERE THERE IS NOWHERE SAFE TO GO, nothing is withdrawn. Unsetting the
+# selection is not a stand-down — `_get_provider` falls back to
+# `DEFAULT_PROVIDER = "edge"` (:211, :661), Microsoft's cloud — and neither is
+# naming a provider the harness cannot resolve, which lands in the same Edge
+# default (:3276-3282). Keeping the cloud voice is the only outcome that leaves
+# the box refused at OUR proxy, so that is what a box with no on-device voice
+# gets, with the reason on the boot log.
 #
 # IMAGES ARE NOT PART OF THIS, and that is measured rather than assumed: the
 # proxy publishes `modelTiers: {"gpt-image-1-mini": ["free","pro","max"]}`, so
@@ -1101,11 +1111,13 @@ def _plan_failed(_kind, _exc, _tb):
     script's own source.
 
     A RUNTIME failure is not allowed to do the same, and that is what this hook
-    is for. Such a traceback can be raised from inside a VALUE — a YAML error
-    quotes the offending line, and the line it would quote is
-    `tts.openai.api_key`. So the operator gets the exception type and the line
-    number in this block, which is what says where to look, and nothing that
-    was read off a file reaches the journal.
+    is for: a bug in the POLICY CODE below, where the values in scope are the
+    device store and this box's speech configuration. `load()` already catches
+    the parse errors and reports only the exception type, so nothing routine
+    reaches here — but an exception raised anywhere after it carries whatever
+    the raiser put in its message, and `str(exc)` is one `%s` away from a
+    credential. The operator gets the type and the line number in this block,
+    which is what says where to look; nothing read off a file is printed.
 
     `os._exit(0)` rather than a raise: the shell reads this program's whole
     stdout as the verdict, so a non-zero exit would add the `|| echo` fallback
@@ -1343,29 +1355,55 @@ if plan_tier and plan_tier != ENTITLED_TIER:
     # `base_url`, which is api.openai.com: a 401 instead of the 403 at our own
     # proxy, and the owner's text sent to a third party on every spoken reply.
     #
-    # THE OWNER'S OWN PICK IS NEVER MOVED, and "their own" is the ARM's test
-    # read backwards rather than a second rule: the arm moves `""`, `edge` and
-    # `clawbox-local` because none of them is a choice, so none of them is a
-    # choice to preserve here either. `edge` in particular is Microsoft's cloud
-    # and the outcome `install.sh` selects `clawbox-local` to avoid — calling it
-    # "a voice of its own" and leaving it there would be this block telling the
-    # journal the opposite of what it did.
-    if provider not in ("", FACTORY_PROVIDER, LOCAL_PROVIDER, CLOUD_PROVIDER):
+    # ONLY A SELECTION THAT IS OURS MOVES, and `openai` is the only one that is:
+    # it is what this block's own arm writes. Everything else — an owner's
+    # `elevenlabs`, the factory `edge`, an unset key, `clawbox-local` — is left
+    # exactly where it is, because nothing about removing OUR slot changes where
+    # any of them sends a request. The slot still goes.
+    if provider != CLOUD_PROVIDER:
         say("withdraw keep")
-    # ALREADY THERE. Nothing to write, and the difference matters to the CLI
-    # budget: this is the state the previous boot's withdrawal left behind.
-    if provider == LOCAL_PROVIDER:
-        say("withdraw keep")
-    # `hermes config unset tts.provider` is NOT a stand-down: `_get_provider`
-    # falls back to `DEFAULT_PROVIDER = "edge"` (tts_tool.py:211, :661),
-    # Microsoft's cloud. `clawbox-local` is the answer even on a box that has no
-    # definition for it — that is not a gap but the state `install.sh` itself
-    # creates, and it is a REAL stand-down: an unresolvable command provider
-    # raises `tts.providers.clawbox-local.command is not configured`
-    # (tts_tool.py:1339) at the harness, with no fall-through, so nothing leaves
-    # the box. Honestly mute beats speaking to a third party, which is the
-    # ruling `step_openclaw_tts` already keeps.
-    say("withdraw %s" % LOCAL_PROVIDER)
+    # AND ONLY TO A DEFINITION THE HARNESS CAN ACTUALLY RESOLVE.
+    #
+    # This gate is here because the obvious shortcut is wrong, and it was
+    # measured wrong rather than argued: selecting `clawbox-local` on a box that
+    # has no definition for it does NOT fail locally.
+    # `_resolve_command_provider_config` (tts_tool.py:857) answers None for a
+    # name that is unknown or not a command type, `_dispatch_to_plugin_provider`
+    # answers None too, and the dispatch then walks its `elif` chain and lands
+    # in `else: # Default: Edge TTS` — the module says so at :3276-3282,
+    # "unknown names hit the Edge TTS default at the bottom". So that shortcut
+    # hands the owner's every spoken reply to MICROSOFT while the journal claims
+    # the box speaks for itself.
+    #
+    # `_is_command_provider_config` (tts_tool.py:846) is what "resolvable"
+    # means, transcribed: a non-empty `command`, and `type` either absent or
+    # `command`.
+    providers = tts.get("providers")
+    providers = providers if isinstance(providers, dict) else {}
+    local = providers.get(LOCAL_PROVIDER)
+    local = local if isinstance(local, dict) else {}
+    local_command = local.get("command")
+    local_type = local.get("type")
+    if (
+        isinstance(local_command, str)
+        and local_command.strip()
+        and local_type in (None, "command")
+    ):
+        say("withdraw %s" % LOCAL_PROVIDER)
+    # NOWHERE SAFE TO STAND DOWN TO, so nothing is withdrawn at all.
+    #
+    # Every alternative sends the owner's words to somebody: leaving `openai`
+    # over a removed slot is api.openai.com (this card), unsetting the selection
+    # or naming an unresolvable provider is Microsoft's Edge (above). Keeping
+    # the cloud voice is the only outcome that sends them to US, where the proxy
+    # answers 403 and the plan is the reason. It costs one refused round trip
+    # per spoken reply — the cost TASK-718 set out to remove — and it is the
+    # lesser of the four on a box that cannot speak for itself.
+    #
+    # Self-healing: `install.sh` `step_openclaw_tts` re-registers
+    # `tts.providers.clawbox-local` on every install and every update, so the
+    # next update makes this box withdrawable and the next boot withdraws it.
+    say("hold this box has no on-device voice to stand down to — its cloud voice stays, refused at our own proxy, rather than falling through to Microsoft's")
 
 if not arm_tier:
     say("hold no plan has been recorded for this box yet")
@@ -1494,12 +1532,23 @@ TOKENPY
       # `unset_config_value` exits 1 when nothing was removed, and no box in the
       # field carries `tts.openai.voice`, so unsetting it key-by-key reported a
       # failed withdrawal on every real box.
+      #
+      # THE LOSS IS ONE-WAY, and worth stating: the arm writes back only
+      # `base_url`, `api_key` and `model`, so a downgrade followed by an upgrade
+      # does not restore a cloud voice the owner had picked in the Voice tab.
+      # That is the card's own instruction — a voice name for a provider this
+      # box may no longer call is residue, and it would otherwise be inherited
+      # by the next arm from the plan being withdrawn — and it is bounded by the
+      # same ownership gate as everything else here: only a slot naming an
+      # address of OURS is ever touched.
       if hermes_voice_write config unset tts.openai; then
         if [ "$CLAWBOX_VOICE_TARGET" = keep ]; then
           log "removed the ClawBox AI cloud voice: this box's plan no longer includes it, and its speech selection was already elsewhere"
         else
           log "removed the ClawBox AI cloud voice: this box's plan no longer includes it, and it speaks from the box again"
         fi
+      elif [ "$CLAWBOX_VOICE_TARGET" = keep ]; then
+        log "could not remove the ClawBox AI cloud voice definition (exit $CLAWBOX_VOICE_RC) — this box's speech selection is elsewhere, so nothing points at it and no request is made; the next start will try again"
       else
         log "moved this box off the ClawBox AI cloud voice but could not remove its definition (exit $CLAWBOX_VOICE_RC) — nothing points at it, so no request is made; the next start will try again"
       fi

--- a/src/lib/hermes-config-yaml.ts
+++ b/src/lib/hermes-config-yaml.ts
@@ -201,8 +201,12 @@ async function applyViaCli(patch: HermesConfigPatch): Promise<void> {
     }
   }
   for (const key of patch.unset ?? []) {
-    // `unset` on an absent key is a no-op, so a partial registration cleans up
-    // as happily as a complete one.
+    // The exit code is DISCARDED, and that is what makes a partial registration
+    // clean up as happily as a complete one — not the CLI being forgiving.
+    // Measured on the pinned 0.20.5: `unset_config_value` prints "Config key
+    // not set" and EXITS 1 when the key was not there (`_unset_nested` returns
+    // false), so a loop that started checking `r.code` would break every
+    // partial cleanup. TASK-745 disproved the older reading of this line.
     await runHermesCli(["config", "unset", key], { timeoutMs: 15_000 });
   }
 }

--- a/src/lib/hermes-local-ai.ts
+++ b/src/lib/hermes-local-ai.ts
@@ -500,8 +500,9 @@ async function removeLocalAi(): Promise<{ wasDefault: boolean; model: string | n
 
   // PROVED, not inferred. `patchHermesConfig`'s merge path reads every key back
   // (patchText), but its CLI fallback does not: `applyViaCli`'s unset loop
-  // discards the exit code, because `hermes config unset` on a key that was
-  // never there is the no-op the loop relies on. So a config.yaml the line
+  // discards the exit code, which is what the cleanup relies on — NOT the CLI
+  // being forgiving. Measured on 0.20.5 for TASK-745: `hermes config unset` on
+  // a key that was never there prints "Config key not set" and exits 1. So a config.yaml the line
   // editor refuses (a flow mapping, a duplicate key) sends the patch to a CLI
   // that a `step_hermes_install` rebuild has left exiting 127 before argparse,
   // and this function returned as if the provider were gone.

--- a/src/tests/unit/register-mcp-clawai-voice.test.ts
+++ b/src/tests/unit/register-mcp-clawai-voice.test.ts
@@ -81,7 +81,7 @@ printf '%s\\n' "$*" >> "${hermesLog}"
 if [ "$1" != "config" ]; then exit 0; fi
 if [ ${exitCode} -ne 0 ]; then exit ${exitCode}; fi
 CLAWBOX_TEST_CFG="${configPath}" CLAWBOX_TEST_OP="$2" CLAWBOX_TEST_KEY="$3" CLAWBOX_TEST_VALUE="$4" python3 - <<'EOPY'
-import os, yaml
+import os, sys, yaml
 cfg = yaml.safe_load(open(os.environ["CLAWBOX_TEST_CFG"])) or {}
 parts = os.environ["CLAWBOX_TEST_KEY"].split(".")
 if os.environ["CLAWBOX_TEST_OP"] == "set":
@@ -90,13 +90,30 @@ if os.environ["CLAWBOX_TEST_OP"] == "set":
         node = node.setdefault(p, {})
     node[parts[-1]] = os.environ["CLAWBOX_TEST_VALUE"]
 else:
+    # _unset_nested + unset_config_value, as the pinned 0.20.5 really
+    # behaves: it walks the dotted path, deletes whatever it lands on (a
+    # non-leaf key included), prunes the container it emptied, and EXITS 1
+    # when nothing was removed. A stub that treated an absent key as a
+    # silent no-op is what let a per-key unset loop look correct here while
+    # failing on every real box.
+    parents = []
     node = cfg
+    ok = True
     for p in parts[:-1]:
-        node = node.get(p) if isinstance(node, dict) else None
-        if node is None:
+        parents.append((node, p))
+        if isinstance(node, dict) and p in node:
+            node = node[p]
+        else:
+            ok = False
             break
-    if isinstance(node, dict):
-        node.pop(parts[-1], None)
+    if ok and isinstance(node, dict) and parts[-1] in node:
+        del node[parts[-1]]
+        for parent, key in reversed(parents):
+            if isinstance(parent.get(key), dict) and not parent[key]:
+                del parent[key]
+    else:
+        sys.stderr.write("Config key not set: %s\\n" % os.environ["CLAWBOX_TEST_KEY"])
+        raise SystemExit(1)
 with open(os.environ["CLAWBOX_TEST_CFG"], "w") as fh:
     yaml.safe_dump(cfg, fh, sort_keys=False)
 EOPY
@@ -352,6 +369,14 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
   describe("the withdrawal (TASK-718)", () => {
     /** A box that WAS on the cloud voice, as the arm above leaves it. */
     function armedBox() {
+      // WITH the on-device provider definition `install.sh` `step_openclaw_tts`
+      // registers on every install and every update. Leaving it out made this
+      // fixture the one state no real box is in, and every assertion built on
+      // it certified whatever the code did in that state (TASK-745 review).
+      writeYaml(
+        `${BASE_CONFIG}tts:\n  providers:\n    clawbox-local:\n      type: command\n`
+        + `      command: /usr/bin/true\n`,
+      );
       writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER });
       run();
       // The withdrawal cases below assert ABSENCE. Without this, a fixture that
@@ -419,7 +444,8 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
       // this case would pass for the reason the one above forbids.
       writeStore({ clawai_token: TOKEN, clawai_tier: "flash", clawai_plan_tier: "flash" });
       writeYaml(
-        `${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    base_url: https://openclawhardware.dev/api/ai\n    api_key: sk-someone-elses\n`,
+        `${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    base_url: https://openclawhardware.dev/api/ai\n    api_key: sk-someone-elses\n`
+        + `  providers:\n    clawbox-local:\n      type: command\n      command: /usr/bin/true\n`,
       );
 
       const r = run();
@@ -463,8 +489,12 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
   describe("the entitlement is the PLAN, and the device stamp only when the plan is unknown (TASK-744)", () => {
     /** Leave the box on the cloud voice, as the arm does. */
     function armedYaml() {
+      // WITH the on-device provider `install.sh` registers on every Hermes box.
+      // A withdrawal needs somewhere to stand the box down TO (TASK-745), and a
+      // fixture without it is the one state no real box is in.
       writeYaml(
-        `${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    base_url: ${PROXY}\n    api_key: ${TOKEN}\n    model: ${CLOUD_MODEL}\n`,
+        `${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    base_url: ${PROXY}\n    api_key: ${TOKEN}\n    model: ${CLOUD_MODEL}\n`
+        + `  providers:\n    clawbox-local:\n      type: command\n      command: /usr/bin/true\n`,
       );
     }
 
@@ -607,6 +637,27 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
       expect(r.stdout).toContain("no longer includes it");
     });
 
+    it("removes the slot in ONE call, which is what a per-key loop cannot do", () => {
+      // The measurement that drove this shape: `hermes config unset` EXITS 1
+      // when the key was not there (`unset_config_value` → `_unset_nested`
+      // returns False → "Config key not set" → exit 1), and no box in the field
+      // carries `tts.openai.voice`. A per-key loop over the four keys therefore
+      // reports a failed withdrawal on every real box. The stub above models
+      // that contract, so this case fails on the per-key shape and passes on
+      // the wholesale one.
+      armedWithLocalEngine();
+      downgraded();
+
+      const r = run();
+
+      expect(configCalls().filter((c) => c.startsWith("config unset"))).toEqual([
+        "config unset tts.openai",
+      ]);
+      expect(at("tts.openai")).toBeUndefined();
+      expect(r.stdout).toContain("no longer includes it");
+      expect(r.stdout).not.toContain("could not remove");
+    });
+
     it("drops the cloud voice name with the rest of the definition", () => {
       // `tts.openai.voice` is written by the Voice tab (`KEYS.cloudVoice`) and
       // was left behind: a voice name for a provider this box may no longer
@@ -634,14 +685,16 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
       expect(at("tts.provider")).toBe("elevenlabs");
     });
 
-    it("stands a box with no engine DEFINITION down locally, never onto Microsoft", () => {
-      // `hermes config unset tts.provider` is not a stand-down: `_get_provider`
-      // falls back to `DEFAULT_PROVIDER = "edge"`, Microsoft's cloud. Selecting
-      // `clawbox-local` with no definition behind it IS one — an unresolvable
-      // command provider raises `tts.providers.clawbox-local.command is not
-      // configured` at the harness, with no fall-through, so nothing leaves the
-      // box. It is also the state install.sh itself creates on a board that
-      // declines Kokoro.
+    it("withdraws NOTHING from a box with nowhere safe to stand down to", () => {
+      // Measured on the box, and it is why this case exists: selecting
+      // `clawbox-local` with no resolvable definition is NOT a local failure.
+      // `_resolve_command_provider_config` answers None for an unknown name,
+      // and the dispatch falls through its elif chain into
+      // `else: # Default: Edge TTS` — Microsoft's cloud. Unsetting the
+      // selection lands in the same place, and leaving `openai` over a removed
+      // slot is api.openai.com. Every way out sends the owner's words to
+      // somebody, so the cloud voice stays and the box goes on being refused at
+      // OUR proxy, which is the only party that already has them.
       writeYaml(
         `${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    base_url: ${PROXY}\n`
         + `    api_key: ${TOKEN}\n    model: ${CLOUD_MODEL}\n`,
@@ -650,11 +703,48 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
 
       const r = run();
 
-      expect(at("tts.openai")).toBeUndefined();
+      expect(at("tts.openai.api_key")).toBe(TOKEN);
+      expect(at("tts.openai.base_url")).toBe(PROXY);
+      expect(at("tts.provider")).toBe("openai");
+      expect(configCalls()).toEqual([]);
+      expect(r.stdout).toContain("no on-device voice to stand down to");
+    });
+
+    it.each([
+      ["a providers map that is not a mapping", "  providers: nonsense\n"],
+      ["a clawbox-local entry that is not a mapping", "  providers:\n    clawbox-local: nonsense\n"],
+      ["a definition with no command", "  providers:\n    clawbox-local:\n      type: command\n"],
+      ["a command that is only whitespace", "  providers:\n    clawbox-local:\n      command: '   '\n"],
+    ])("treats %s as nowhere to stand down to", (_label, providers) => {
+      // `_is_command_provider_config` is what "resolvable" means, and each of
+      // these resolves to None exactly as an absent definition does.
+      writeYaml(
+        `${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    base_url: ${PROXY}\n`
+        + `    api_key: ${TOKEN}\n    model: ${CLOUD_MODEL}\n${providers}`,
+      );
+      downgraded();
+
+      const r = run();
+
+      expect(at("tts.openai.api_key")).toBe(TOKEN);
+      expect(configCalls()).toEqual([]);
+      expect(r.stdout).toContain("no on-device voice to stand down to");
+    });
+
+    it("accepts a definition whose type is omitted, as the harness does", () => {
+      // `_is_command_provider_config` accepts `command` without `type`, and
+      // that is the shape install.sh's own write order can leave behind.
+      writeYaml(
+        `${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    base_url: ${PROXY}\n`
+        + `    api_key: ${TOKEN}\n    model: ${CLOUD_MODEL}\n`
+        + `  providers:\n    clawbox-local:\n      command: /usr/bin/true\n`,
+      );
+      downgraded();
+
+      run();
+
       expect(at("tts.provider")).toBe("clawbox-local");
-      expect(configCalls()).not.toContain("config unset tts.provider");
-      expect(configCalls()).not.toContain("config set tts.provider edge");
-      expect(r.stdout).toContain("speaks from the box again");
+      expect(at("tts.openai")).toBeUndefined();
     });
 
     it("moves the selection BEFORE it removes the definition", () => {
@@ -750,7 +840,7 @@ if [ -n "\${CLAWBOX_KOKORO_STAMP:-}" ]; then
   echo "ZeroDivisionError: division by zero" >&2
   exit 1
 fi
-exec ${real} "$@"
+exec "${real}" "$@"
 `);
       fs.chmodSync(stub, 0o755);
       return dir;

--- a/src/tests/unit/register-mcp-clawai-voice.test.ts
+++ b/src/tests/unit/register-mcp-clawai-voice.test.ts
@@ -104,8 +104,8 @@ EOPY
   fs.chmodSync(stub, 0o755);
 }
 
-function run(env: Record<string, string> = {}): { status: number; stdout: string; stderr: string } {
-  const r = spawnSync("bash", [SCRIPT], {
+function run(env: Record<string, string> = {}, script: string = SCRIPT): { status: number; stdout: string; stderr: string } {
+  const r = spawnSync("bash", [script], {
     encoding: "utf-8",
     env: testEnv({
       PATH: process.env.PATH ?? "",
@@ -374,16 +374,19 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
       expect(r.stdout).toContain("no longer includes it");
     });
 
-    it("leaves the owner's SELECTION where it is", () => {
-      // The same ruling the OpenClaw arm records: the panel's job is to show
-      // that the choice is no longer available, and silently rewriting it would
-      // hide the downgrade.
+    it("moves the SELECTION off our own route, which is the point of TASK-745", () => {
+      // This used to assert the opposite, on the OpenClaw arm's ruling that the
+      // panel's job is to show the choice is gone. That ruling holds where the
+      // delete removes a NAMED entry and the selection is left pointing at
+      // nothing. On Hermes `openai` is the harness's own built-in, so a
+      // selection left naming it resolves to api.openai.com — the box would
+      // speak to a third party to show its owner that it cannot.
       armedBox();
       writeStore({ clawai_token: TOKEN, clawai_tier: "flash", clawai_plan_tier: "flash" });
 
       run();
 
-      expect(at("tts.provider")).toBe("openai");
+      expect(at("tts.provider")).toBe("clawbox-local");
     });
 
     it.each([
@@ -631,11 +634,14 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
       expect(at("tts.provider")).toBe("elevenlabs");
     });
 
-    it("does not hand a box with no local engine to Microsoft's cloud", () => {
-      // `hermes config unset tts.provider` is NOT a stand-down: `_get_provider`
-      // in tools/tts_tool.py falls back to `DEFAULT_PROVIDER = "edge"`, which
-      // is Microsoft's cloud — install.sh selects `clawbox-local` on every
-      // Hermes box precisely so an engineless board is honestly mute instead.
+    it("stands a box with no engine DEFINITION down locally, never onto Microsoft", () => {
+      // `hermes config unset tts.provider` is not a stand-down: `_get_provider`
+      // falls back to `DEFAULT_PROVIDER = "edge"`, Microsoft's cloud. Selecting
+      // `clawbox-local` with no definition behind it IS one — an unresolvable
+      // command provider raises `tts.providers.clawbox-local.command is not
+      // configured` at the harness, with no fall-through, so nothing leaves the
+      // box. It is also the state install.sh itself creates on a board that
+      // declines Kokoro.
       writeYaml(
         `${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    base_url: ${PROXY}\n`
         + `    api_key: ${TOKEN}\n    model: ${CLOUD_MODEL}\n`,
@@ -644,10 +650,47 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
 
       const r = run();
 
-      expect(at("tts.openai.api_key")).toBeUndefined();
+      expect(at("tts.openai")).toBeUndefined();
+      expect(at("tts.provider")).toBe("clawbox-local");
       expect(configCalls()).not.toContain("config unset tts.provider");
       expect(configCalls()).not.toContain("config set tts.provider edge");
-      expect(r.stdout).toContain("no on-device voice to fall back to");
+      expect(r.stdout).toContain("speaks from the box again");
+    });
+
+    it("moves the selection BEFORE it removes the definition", () => {
+      // Every intermediate state has to be safe, and the dangerous one is a
+      // slot our endpoint has been taken out of while `tts.provider` still
+      // names `openai`: the built-in then resolves to api.openai.com and the
+      // owner's text goes to a third party. De-selecting first means the only
+      // intermediate state is a box speaking from itself with a stale
+      // definition nothing points at.
+      armedWithLocalEngine();
+      downgraded();
+
+      run();
+
+      const calls = configCalls();
+      const selected = calls.findIndex((c) => c.startsWith("config set tts.provider"));
+      const removed = calls.findIndex((c) => c === "config unset tts.openai");
+      expect(selected).toBeGreaterThanOrEqual(0);
+      expect(removed).toBeGreaterThan(selected);
+    });
+
+    it("leaves the definition in place when it cannot move the selection", () => {
+      // The failure that matters: if the box cannot be moved off `openai`, its
+      // route must stay complete, so a spoken reply is refused at OUR proxy
+      // rather than sent to OpenAI with no credential.
+      armedWithLocalEngine();
+      downgraded();
+      writeHermesStub(9);
+
+      const r = run();
+
+      expect(at("tts.openai.api_key")).toBe(TOKEN);
+      expect(at("tts.openai.base_url")).toBe(PROXY);
+      expect(configCalls()).not.toContain("config unset tts.openai");
+      expect(r.stdout).toContain("could not move this box off the ClawBox AI cloud voice");
+      expect(r.stdout).toContain("(exit 9)");
     });
   });
 
@@ -656,6 +699,37 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
   // computed` and nothing else: it failed in the safe direction, silently, and
   // the boot log could not say why.
   describe("a plan step that crashes says so on the boot log", () => {
+    /**
+     * The shipped script with one line inserted into the plan heredoc, so a
+     * REAL exception is raised inside the real program with the real hook
+     * installed. Nothing else about the file changes.
+     */
+    function scriptThatRaises(): string {
+      const src = fs.readFileSync(SCRIPT, "utf-8");
+      const anchor = "sys.excepthook = _plan_failed\n";
+      expect(src).toContain(anchor);
+      const patched = src.replace(anchor, `${anchor}\nraise RuntimeError("boom")\n`);
+      const out = path.join(home, "register-mcp-raises.sh");
+      fs.writeFileSync(out, patched);
+      return out;
+    }
+
+    it("names the exception and the line, and keeps the traceback out of the journal", () => {
+      // A runtime failure is not allowed to print a traceback: it can be raised
+      // from inside a VALUE — a YAML error quotes the offending line, and the
+      // line it would quote is `tts.openai.api_key`. The operator gets the type
+      // and the line in this block, which is what says where to look.
+      writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER });
+
+      const r = run({}, scriptThatRaises());
+
+      expect(r.status).toBe(0);
+      expect(configCalls()).toEqual([]);
+      expect(r.stdout).toMatch(/the voice plan could not be computed \(RuntimeError at line \d+\)/);
+      expect(r.stderr).not.toContain("Traceback");
+      expect(r.stderr).not.toContain("boom");
+    });
+
     /**
      * A `python3` that fails ONLY for the plan step.
      *
@@ -682,14 +756,17 @@ exec ${real} "$@"
       return dir;
     }
 
-    it("lets the traceback reach the journal instead of /dev/null", () => {
+    it("lets a python that fails to START reach the journal instead of /dev/null", () => {
       writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER });
       const dir = shadowPython();
 
       const r = run({ PATH: `${dir}:${process.env.PATH ?? ""}` });
 
-      // The script still stands down — a plan it could not compute writes
-      // nothing — and now it says what happened.
+      // The half the excepthook cannot cover: an interpreter that dies before
+      // the program runs (a SyntaxError in the heredoc, a broken python) has no
+      // hook installed, and its stderr only ever quotes this script's own
+      // source. `2>/dev/null` swallowed exactly that. The script still stands
+      // down — a plan it could not compute writes nothing — and now it says so.
       expect(r.status).toBe(0);
       expect(configCalls()).toEqual([]);
       expect(r.stdout).toContain("the voice plan could not be computed");
@@ -764,7 +841,11 @@ exec ${real} "$@"
 
     expect(block).toContain(`CLAWBOX_SPEECH_DEVICE_TIER="${tts.CLAWBOX_AI_SPEECH_TIER}"`);
     expect(block).toContain(`CLAWBOX_VOICE_MODEL="${tts.HERMES_CLOUD_TTS_MODEL}"`);
-    expect(block).toContain(`LOCAL_PROVIDER = "${tts.HERMES_LOCAL_TTS_PROVIDER}"`);
+    // The local name is now a SHELL binding, because the withdrawal writes it
+    // and the plan step names it — one value, passed in, so the two cannot
+    // drift into disagreeing about which provider the box falls back to.
+    expect(block).toContain(`CLAWBOX_VOICE_LOCAL="${tts.HERMES_LOCAL_TTS_PROVIDER}"`);
+    expect(block).toContain('LOCAL_PROVIDER = os.environ["CLAWBOX_VOICE_LOCAL"]');
     expect(block).toContain(`CLOUD_PROVIDER = "${tts.HERMES_CLOUD_TTS_PROVIDER}"`);
     expect(block).toContain(`FACTORY_PROVIDER = "${tts.HERMES_FACTORY_TTS_PROVIDER}"`);
     expect(models.KOKORO_STAMP.endsWith("/.cache/clawbox/kokoro-installed")).toBe(true);

--- a/src/tests/unit/register-mcp-clawai-voice.test.ts
+++ b/src/tests/unit/register-mcp-clawai-voice.test.ts
@@ -567,6 +567,136 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
     });
   });
 
+  // TASK-745. On Hermes `tts.openai` is the HARNESS's built-in generic OpenAI
+  // slot, not a named entry ClawBox created — `BUILTIN_TTS_PROVIDERS` in
+  // `tools/tts_tool.py` lists it — so emptying its three keys does not remove
+  // the provider the way deleting `messages.tts.providers.openai` does on
+  // OpenClaw. With `tts.provider` still naming it, Hermes' own speech path
+  // resolves to that built-in and goes to api.openai.com, which is a 401 and a
+  // round trip carrying the owner's text to a third party — where before the
+  // withdrawal it was a 403 at our own proxy. The withdrawal has to hand the
+  // box back to something real.
+  describe("standing the box down, not just emptying the slot (TASK-745)", () => {
+    /** A box on the cloud voice, as the arm leaves it, with a local engine defined. */
+    function armedWithLocalEngine(extra = "") {
+      writeYaml(
+        `${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    base_url: ${PROXY}\n`
+        + `    api_key: ${TOKEN}\n    model: ${CLOUD_MODEL}\n${extra}`
+        + `  providers:\n    clawbox-local:\n      type: command\n      command: /usr/bin/true\n`,
+      );
+    }
+
+    /** The plan is below the entitlement on beta AND after TASK-744. */
+    function downgraded() {
+      writeStore({ clawai_token: TOKEN, clawai_tier: "flash", clawai_plan_tier: "flash" });
+    }
+
+    it("selects the box's own voice instead of leaving a name over an emptied slot", () => {
+      armedWithLocalEngine();
+      downgraded();
+
+      const r = run();
+
+      expect(at("tts.openai.api_key")).toBeUndefined();
+      // The point of the card: `openai` here is the harness's own built-in, so
+      // the selection has to move or every spoken reply goes to api.openai.com.
+      expect(at("tts.provider")).toBe("clawbox-local");
+      expect(r.stdout).toContain("no longer includes it");
+    });
+
+    it("drops the cloud voice name with the rest of the definition", () => {
+      // `tts.openai.voice` is written by the Voice tab (`KEYS.cloudVoice`) and
+      // was left behind: a voice name for a provider this box may no longer
+      // call, which the next arm would then inherit from the previous plan.
+      armedWithLocalEngine("    voice: shimmer\n");
+      downgraded();
+
+      run();
+
+      expect(at("tts.openai.voice")).toBeUndefined();
+    });
+
+    it("leaves an owner's own SELECTION alone while still emptying our slot", () => {
+      // The box speaks through something the owner chose; our slot is armed
+      // beside it. Emptying the slot is ours to do and the selection is not.
+      writeYaml(
+        `${BASE_CONFIG}tts:\n  provider: elevenlabs\n  openai:\n    base_url: ${PROXY}\n`
+        + `    api_key: ${TOKEN}\n    model: ${CLOUD_MODEL}\n`,
+      );
+      downgraded();
+
+      run();
+
+      expect(at("tts.openai.api_key")).toBeUndefined();
+      expect(at("tts.provider")).toBe("elevenlabs");
+    });
+
+    it("does not hand a box with no local engine to Microsoft's cloud", () => {
+      // `hermes config unset tts.provider` is NOT a stand-down: `_get_provider`
+      // in tools/tts_tool.py falls back to `DEFAULT_PROVIDER = "edge"`, which
+      // is Microsoft's cloud — install.sh selects `clawbox-local` on every
+      // Hermes box precisely so an engineless board is honestly mute instead.
+      writeYaml(
+        `${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    base_url: ${PROXY}\n`
+        + `    api_key: ${TOKEN}\n    model: ${CLOUD_MODEL}\n`,
+      );
+      downgraded();
+
+      const r = run();
+
+      expect(at("tts.openai.api_key")).toBeUndefined();
+      expect(configCalls()).not.toContain("config unset tts.provider");
+      expect(configCalls()).not.toContain("config set tts.provider edge");
+      expect(r.stdout).toContain("no on-device voice to fall back to");
+    });
+  });
+
+  // TASK-745. `python3 - <<'PY' 2>/dev/null` meant a genuine bug inside the
+  // plan step reached the operator as `hold the voice plan could not be
+  // computed` and nothing else: it failed in the safe direction, silently, and
+  // the boot log could not say why.
+  describe("a plan step that crashes says so on the boot log", () => {
+    /**
+     * A `python3` that fails ONLY for the plan step.
+     *
+     * `CLAWBOX_KOKORO_STAMP` is set for that one invocation and for no other,
+     * so every other `python3` in the script — the token re-read, §4b's
+     * seeding — still runs the real interpreter.
+     */
+    function shadowPython(): string {
+      // The REAL interpreter, resolved before the stub shadows it — an `exec
+      // python3` inside the stub would find the stub again and fork bomb.
+      const real = execFileSync("sh", ["-c", "command -v python3"], { encoding: "utf-8" }).trim();
+      const dir = path.join(home, "shadow-bin");
+      fs.mkdirSync(dir, { recursive: true });
+      const stub = path.join(dir, "python3");
+      fs.writeFileSync(stub, `#!/bin/sh
+if [ -n "\${CLAWBOX_KOKORO_STAMP:-}" ]; then
+  echo "Traceback (most recent call last):" >&2
+  echo "ZeroDivisionError: division by zero" >&2
+  exit 1
+fi
+exec ${real} "$@"
+`);
+      fs.chmodSync(stub, 0o755);
+      return dir;
+    }
+
+    it("lets the traceback reach the journal instead of /dev/null", () => {
+      writeStore({ clawai_token: TOKEN, clawai_tier: ENTITLED_TIER });
+      const dir = shadowPython();
+
+      const r = run({ PATH: `${dir}:${process.env.PATH ?? ""}` });
+
+      // The script still stands down — a plan it could not compute writes
+      // nothing — and now it says what happened.
+      expect(r.status).toBe(0);
+      expect(configCalls()).toEqual([]);
+      expect(r.stdout).toContain("the voice plan could not be computed");
+      expect(`${r.stdout}${r.stderr}`).toContain("ZeroDivisionError");
+    });
+  });
+
   describe("not knowing is not an answer", () => {
     it("holds, and says why, when there is no device store at all", () => {
       const r = run();


### PR DESCRIPTION
**TASK-745** — found by the reviewer of #757 (MEDIUM-2, LOW-3, LOW-5), and since **reproduced on
the real Hermes box under the device mutex** (device lane 2026-09-07 run "e", finding 1).

Built on **#762 (TASK-744)**, now merged — this branch is rebased on it, so the withdrawal fix sits
on the plan-tier gate as it shipped. The one rebase conflict was two `describe` blocks inserted at
the same line in the shared test file; both kept.

## What the customer got

On a Hermes box whose plan drops, the boot seed withdrew the cloud voice — and left
`tts.provider: openai` naming a slot it had just deleted. Measured on hardware:

```
store.set("clawai_tier","flash"); sudo systemctl restart clawbox-setup
journal: [register-mcp] removed the ClawBox AI cloud voice: this box's plan no longer includes it
yaml.safe_load(~/.hermes/config.yaml)["tts"]
  → {'provider': 'openai', 'providers': {'clawbox-local': …}}      # no `openai` key at all
```

On this edition `openai` is the **harness's own built-in** provider
(`BUILTIN_TTS_PROVIDERS`, `tools/tts_tool.py:780`), not a named entry ClawBox created. So the
selection still resolves — to a provider with no `base_url`, which is **api.openai.com**. Where the
box used to get a 403 at our own proxy it now gets a 401 at OpenAI, and the owner's text goes to a
third party on every spoken reply. TASK-718's refused round trip was relocated, not removed.

The OpenClaw analogue is genuinely different and is left alone: there the delete removes a NAMED
provider entry, so the surviving selection names nothing and the panel showing "no cloud voice" is
the truth.

## Why this is not "silently rewriting the owner's choice"

#757's ruling — the panel's job is to show the choice is gone, and rewriting it would hide the
downgrade — protects a provider **the owner chose**. `tts.provider: openai` on a box whose
`tts.openai` ClawBox has just emptied is not that: it is ClawBox's own residue, written by
ClawBox's arm, pointing at a slot ClawBox removed. Restoring the selection the box had before the
arm moved it is the opposite of overriding the owner.

That is exactly what the arm's own ownership test already says, read backwards. The arm moves
`tts.provider` only from `""`, Hermes' factory `edge`, or `clawbox-local` — the three values that
mean *nobody has chosen*. The withdrawal now uses the same three, so anything else (`elevenlabs`,
`piper`, a hand-picked `openai`) is the owner's and is never touched.

**This is queued as an owner decision**; the PR implements the reading above and nothing here
depends on it beyond the one corner named under "The open question".

## What it does

The plan step's verdict carries where the box speaks from afterwards — two answers only:

| verdict | when | writes |
|---|---|---|
| `withdraw clawbox-local` | the selection is `openai` AND the box has a resolvable on-device definition | `config set tts.provider clawbox-local`, then the slot removal |
| `withdraw keep` | the selection is anything else | the slot removal only |
| `hold …` | the selection is `openai` and there is nowhere safe to go | nothing at all |

The selection moves **only from `openai`** — what our own arm wrote. An owner's `elevenlabs`, the
factory `edge`, an unset key and a box already on its own voice are all left where they are, because
removing our slot says nothing about where any of them sends a request.

**The selection moves FIRST**, which is the mirror of the arm's definition-before-selection rule
and the opposite of this PR's own first draft. Every intermediate state has to be safe, and the
dangerous one is a slot our endpoint has been taken out of while `tts.provider` still says
`openai` — the built-in then resolves to api.openai.com. De-selecting first means the only
intermediate state is a box speaking from itself with a stale definition nothing points at, and a
failed move leaves the route complete so a reply is refused at our own proxy instead.

**One atomic call removes the slot.** `hermes config unset tts.openai` — `_unset_nested`
(`hermes_cli/config.py`) walks a dotted path and deletes whatever it lands on, then prunes the
empty container. That takes `tts.openai.voice` (the Voice tab's `KEYS.cloudVoice`, LOW-3 of the
#757 review) and any `format`/`speed` an owner added beside our three, which a fixed per-key list
cannot know about.

## Two things measured on the box that changed the design

Read-only, from the installed Hermes 0.20.5:

1. **`hermes config unset` exits 1 when the key was absent.** `unset_config_value` prints
   `Config key not set` and `sys.exit(1)` on a false return from `_unset_nested`. No box in the
   field carries `tts.openai.voice` — the real box's `tts.openai` keys are
   `['api_key','base_url','model']` — so this PR's first draft, which added `voice` to the per-key
   loop, would have reported a **failed withdrawal on every real box**. This contradicts a comment
   in this repo at `src/lib/hermes-local-ai.ts:501-504` recording unset-on-an-absent-key as a
   proved no-op; that comment is wrong for the pinned build and is noted for its owner.
2. **`unset` accepts a non-leaf key**, which is what makes the atomic slot removal possible.

## Where there is nowhere safe to stand down to

A box whose `tts.providers.clawbox-local` the harness cannot resolve gets **no withdrawal at all**,
and says so on the boot log.

This branch first claimed the opposite — that selecting `clawbox-local` undefined fails locally, so
nothing leaves the box. **That claim was false**, and it was disproved by executing the shipped
resolver on the box rather than by reading it: `_resolve_command_provider_config`
(`tts_tool.py:857`) answers `None` for a name that is unknown or not a command type,
`_dispatch_to_plugin_provider` answers `None`, and the dispatch then walks its `elif` chain into
`else: # Default: Edge TTS`. The module states it at `:3276-3282` — *"unknown names hit the Edge
TTS default at the bottom"*. The raise the branch cited (`:1339`) is unreachable from that path.
So the shortcut handed the owner's speech to **Microsoft** while the journal said the box spoke for
itself.

Every way out of that state sends the owner's words to somebody:

| option | where the words go |
|---|---|
| leave `tts.provider: openai` over a removed slot | api.openai.com — this card's own defect |
| `hermes config unset tts.provider` | Edge, i.e. Microsoft (`DEFAULT_PROVIDER`, `:211`/`:661`) |
| select `clawbox-local` with no definition | Edge, by the fall-through above |
| **keep the cloud voice** | **our own proxy**, which answers 403 |

So the withdrawal holds. It costs the refused round trip TASK-718 set out to remove, on the one box
shape that cannot speak for itself, and it is the only outcome that adds no new recipient. It also
self-heals: `install.sh` `step_openclaw_tts` re-registers the definition on every install and every
update, after which the next boot withdraws normally. The real box carries it —
`{'command': '…/clawbox-tts.sh --text-file={input_path} -- {output_path}', 'output_format': 'wav',
'type': 'command'}` — so this is a corner, not the common path.

"Resolvable" is `_is_command_provider_config`'s own rule (`tts_tool.py:846`), transcribed: a
non-empty `command`, and `type` absent or `command`.

## RED → GREEN

**RED on unmodified `origin/beta`** (scratch worktree at beta, only this suite copied in):

```
 Test Files  1 failed (1)
      Tests  4 failed | 33 passed (37)
```

— the selection left over an emptied slot, the residual `tts.openai.voice`, the stand-down, and
the swallowed plan-step failure.

**GREEN on this head:** whole suite **948 files / 14,297 tests**; `tsc --noEmit` clean; `bash -n`
clean; all 30 embedded python heredocs `py_compile` clean. Two guards are mutation-proven: deleting
`sys.excepthook = _plan_failed` fails the excepthook case, and the `hermes` stub now models the
CLI's real `unset` contract so the atomicity change fails on the per-key shape.

## Proved on hardware, read-only

The plan step extracted from the shipped script and run against the real Hermes box's own
`~/.hermes/config.yaml` and device store, no mutex taken and nothing written:

```
real config (provider=openai, its own definition)  withdraw clawbox-local
openai, NO definition                              hold … no on-device voice to stand down to
openai, definition with no command                 hold … no on-device voice to stand down to
owner picked elevenlabs                            withdraw keep
factory edge                                       withdraw keep
already on its own voice                           withdraw keep
```

The box's own definition, read at the same time, is
`{'command': '…/clawbox-tts.sh --text-file={input_path} -- {output_path}', 'output_format': 'wav',
'type': 'command'}`.

## Also fixed: the plan step no longer hides why it failed

`python3 - <<'PY' 2>/dev/null` meant a genuine bug in the block reached the operator as
`hold the voice plan could not be computed` and nothing else (LOW-5 of the #757 review). The
redirect is gone, so a SyntaxError reaches the journal in full and only ever quotes this script's
own source. A RUNTIME failure is still not allowed to: `sys.excepthook` reports the exception type
and the line number, because a YAML error quotes the offending line and the line it would quote is
`tts.openai.api_key`.

## Notes for whoever tests this on a box

Three facts from the device lane, each of which would otherwise produce a false reading:

- the seed logs to **`clawbox-setup`**, not `hermes-gateway` (`[register-mcp]` lines over 7 days:
  `clawbox-setup` 47, `hermes-gateway` 0), and the sanctioned restart is
  `sudo systemctl restart clawbox-setup`.
- `hermes config set`/`unset` strips ~2 KB of the harness's own trailing comment template from
  `config.yaml` and it returns on the next seed boot — an upstream defect, cosmetic. **Compare the
  parsed `tts` subtree, never the bytes.**
- `clawai_tier` cannot be held at a test value while a browser has the AI Models panel open, since
  `/setup-api/ai-models/status` rewrites it within seconds. The flip and the restart must be one
  script.

## Scope

Hermes only, and proved so: `scripts/register-mcp.sh` `exit 0`s on any edition but `hermes|dual`
(`:132`), and this change is entirely inside that script — `gateway-pre-start.sh` is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ClawBox AI voice withdrawal by switching to a valid local voice provider before removing cloud voice settings.
  - Preserves the cloud voice route when a safe local provider cannot be selected.
  - Prevents incomplete voice configuration cleanup when no valid local fallback is available.
  - Improved diagnostics for unexpected voice-plan processing failures, including sanitized error location details.
  - Partial configuration cleanup now continues reliably when settings are already absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->