### PR TITLE
fix: name the key that is actually blocking a refused config (TASK-754)

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -240,6 +240,16 @@ export CLAWBOX_OPENCLAW_V2
 # not an upper bound on the doctor arm — `TimeoutStartSec=600` is its real
 # ceiling, and that is the trade taken on purpose.
 CLAWBOX_CONFIG_VALIDATED_STAMP="$CLAWBOX_ROOT/data/openclaw-config-validated"
+# What the core still refuses AFTER its own migrations, remembered against the
+# same fingerprint the stamp uses — see `clawbox_core_residual_issues`.
+CLAWBOX_POST_MIGRATION_ISSUES="$CLAWBOX_ROOT/data/openclaw-post-migration-issues"
+# The two names the core's gate refuses on, in ONE place because three things
+# read them: the clearing loop below, the blocker test, and the sentence that
+# names the file to the owner. doctor renames the file to the
+# `.doctor-importing` claim for the duration of an import, so a killed import
+# leaves one behind that refuses every later doctor exactly as the original does.
+CLAWBOX_EXEC_APPROVALS_FILE="$OPENCLAW_STATE_DIR/exec-approvals.json"
+CLAWBOX_EXEC_APPROVALS_CLAIM="$CLAWBOX_EXEC_APPROVALS_FILE.doctor-importing"
 
 # Does this approvals file hold a decision of the OWNER's?
 # 0 = provably none, 1 = yes, 2 = cannot tell. Only 0 may lead to a move.
@@ -283,11 +293,32 @@ sys.exit(0)
 PY
 }
 
+# Which approvals file is still blocking `openclaw doctor`, if any.
+#
+# Read from the FILESYSTEM rather than remembered from the clearing loop above:
+# every file that loop could clear is gone by the time this is asked, so what is
+# left is exactly what stops doctor — whether it holds a real approval or could
+# not be read at all. Echoes the first blocking path; exit 1 when there is none.
+clawbox_exec_approvals_blocker() {
+  local f
+  for f in "$CLAWBOX_EXEC_APPROVALS_FILE" "$CLAWBOX_EXEC_APPROVALS_CLAIM"; do
+    if [ -e "$f" ]; then
+      printf '%s' "$f"
+      return 0
+    fi
+  done
+  return 1
+}
+
 # What the core says about this config, in the core's own words.
 # Echoes `accepted`, `refused<TAB><issues>` or `unknown<TAB><why>`.
+#
+# `$1` asks about ANOTHER file — the migration preview below has the core judge
+# a copy without openclaw.json being touched. With no argument the box's own
+# config is the subject, which is every other caller.
 clawbox_core_config_verdict() {
   local out rc=0
-  out="$(timeout -k 5 60 "$OPENCLAW_BIN" config validate --json 2>/dev/null)" || rc=$?
+  out="$(OPENCLAW_CONFIG_PATH="${1:-$OPENCLAW_CONFIG}" timeout -k 5 60 "$OPENCLAW_BIN" config validate --json 2>/dev/null)" || rc=$?
   # EXIT 0 IS ACCEPTANCE unless the core's own payload contradicts it
   # (TASK-741). Requiring stdout to parse as JSON on TOP of a zero exit made a
   # core that exits 0 with empty, banner-prefixed or non-JSON output answer
@@ -361,6 +392,132 @@ clawbox_stamp_read() {
   head -n1 "$CLAWBOX_CONFIG_VALIDATED_STAMP" 2>/dev/null || true
 }
 
+# WHAT THE CORE STILL REFUSES AFTER IT HAS DONE EVERYTHING IT KNOWS (TASK-754).
+#
+# THE 25-HOUR OUTAGE WAS A DIAGNOSIS PROBLEM, not a missing repair. Measured on
+# 2026.8.1, in throwaway homes, with a legacy `exec-approvals.json` holding a
+# real approval present throughout:
+#
+#   * a 2026.7 config whose migrated form VALIDATES — `openclaw gateway run`
+#     migrates it ITSELF and reaches `ready`. The core's own automatic startup
+#     config repair (`planStartupConfigRepair` / `commitStartupConfigRepair`)
+#     does it, and the approvals file does not stop it, because it is not doctor.
+#   * a 2026.7 config whose migrated form does NOT validate — exit 78, config
+#     untouched, with or without the approvals file.
+#
+# So there is nothing for this script to carry across: where that would help,
+# the core has already done it; where it would not, running the same table
+# produces the same refusal. What NOBODY on the box does is say which key is
+# actually in the way. The gateway names the PRE-migration keys —
+# `agents.defaults: Unrecognized keys: "memorySearch", "imageGenerationModel"`,
+# `messages: Unrecognized key: "tts"` — every one of which the core would have
+# handled, while the one that really blocks it (`tts.voiceId`, which arrives at
+# the top level verbatim because `voiceId` is renamed only inside provider
+# scopes) is never mentioned. The incident's manual repair had to work that out
+# by hand, and the box was dark for 25 hours.
+#
+# So this asks the core, with the core's own migrations, and reports the
+# REMAINDER. It reads openclaw.json and writes nothing but a preview under a
+# temporary name that is always removed.
+#
+# HARNESS FIRST. `applyLegacyDoctorMigrations` is read out of the INSTALLED
+# bundle and RUN — the same function `planStartupConfigRepair` and
+# `migrateLegacyConfig` call — found by its own declaration text and picked out
+# of the chunk by function name, because a bundle renames the export binding
+# (`applyLegacyDoctorMigrations as A`) and not the declaration. No rename table
+# lives in this file: a copy of the moves here would be a second, staler one.
+# A bundle that cannot be read reports nothing.
+#
+# WHAT IT IS NOT. Not doctor: `doctor --fix` runs these migrations and THEN
+# strips the keys the v2 schema does not recognise (`stripUnknownConfigKeys`,
+# with the active auth profile protected) — measured, it reported removing
+# `tts.voiceId` on the incident's own shape. Naming a key of the owner's and
+# deleting it are different decisions, and this only names it.
+#
+# COST. Only on a box the core refuses AND doctor could not repair — a box with
+# no gateway at all — and once per config: the answer is remembered against the
+# same fingerprint the acceptance stamp uses, so a `Restart=always` unit does
+# not pay 25 + 35 + 65 = 125 s a boot for ever, while the sentence is still
+# printed on every boot. Any rewrite of the file or a core bump asks again.
+#
+# `$include`: stood down, the way the core's own startup repair stands down —
+# the file on disk is not the whole config, so a preview built from it alone
+# would name keys an included file may already answer for.
+clawbox_core_residual_issues() {
+  local node_bin core_dist core_chunk preview verdict remembered
+
+  remembered="$(head -n1 "$CLAWBOX_POST_MIGRATION_ISSUES" 2>/dev/null || true)"
+  case "$remembered" in
+    "$(clawbox_config_fingerprint)$(printf '\t')"*) printf '%s' "${remembered#*$'\t'}"; return 0 ;;
+  esac
+
+  if grep -qF '"$include"' "$OPENCLAW_CONFIG" 2>/dev/null; then
+    return 1
+  fi
+  node_bin="$(command -v node 2>/dev/null || true)"
+  # Same derivation as the package.json read at the top of this file: the bin is
+  # npm's symlink into `../lib/node_modules/openclaw`.
+  core_dist="$(dirname "$OPENCLAW_BIN")/../lib/node_modules/openclaw/dist"
+  # `grep -rl` rather than a chunk name: every one of them is content-hashed and
+  # changes with each core build. Bounded, and a SIGPIPE from `head` closing the
+  # pipe is not a failure to report.
+  core_chunk=""
+  if [ -n "$node_bin" ] && [ -d "$core_dist" ]; then
+    core_chunk="$(timeout -k 5 20 grep -rlF --include='*.js' 'function applyLegacyDoctorMigrations(' "$core_dist" 2>/dev/null | head -n1 || true)"
+  fi
+  [ -n "$core_chunk" ] || return 1
+
+  preview="$OPENCLAW_CONFIG.clawbox-preview.$$"
+  rm -f "$preview"
+  # `cp -p` first, so the preview carries the config's own mode: it holds the
+  # same secrets for as long as it exists.
+  cp -p "$OPENCLAW_CONFIG" "$preview" 2>/dev/null || { rm -f "$preview"; return 1; }
+  if ! CLAWBOX_PREVIEW_CHUNK="$core_chunk" \
+    CLAWBOX_PREVIEW_IN="$OPENCLAW_CONFIG" \
+    CLAWBOX_PREVIEW_OUT="$preview" \
+    timeout -k 5 30 env -u OPENCLAW_HOME -u OPENCLAW_CONFIG_PATH -u OPENCLAW_STATE_DIR \
+    "$node_bin" --input-type=module -e '
+    import { readFileSync, writeFileSync } from "node:fs";
+    import { pathToFileURL } from "node:url";
+    try {
+      const mod = await import(pathToFileURL(process.env.CLAWBOX_PREVIEW_CHUNK).href);
+      const apply = Object.values(mod).find(
+        (value) => typeof value === "function" && value.name === "applyLegacyDoctorMigrations",
+      );
+      if (!apply) throw new Error("the chunk exports no applyLegacyDoctorMigrations");
+      const raw = JSON.parse(readFileSync(process.env.CLAWBOX_PREVIEW_IN, "utf8"));
+      const result = apply(raw, { authoredRaw: raw, resolvedRaw: raw });
+      if (!result || !result.next) throw new Error("the core migrations changed nothing");
+      writeFileSync(process.env.CLAWBOX_PREVIEW_OUT, JSON.stringify(result.next, null, 2) + "\n");
+      // Exited explicitly rather than by letting the loop drain: this imports a
+      // real bundle chunk and everything it pulls in, and the day one of those
+      // registers a timer at module scope the bound above would fire over an
+      // answer that was already written.
+      process.exit(0);
+    } catch {
+      process.exit(1);
+    }
+  ' >/dev/null 2>&1; then
+    rm -f "$preview"
+    return 1
+  fi
+
+  verdict="$(clawbox_core_config_verdict "$preview")"
+  rm -f "$preview"
+  case "$verdict" in
+    refused*"$(printf '\t')"*) ;;
+    # `accepted` means the core would load the migrated file — its own startup
+    # repair will do exactly that, so there is no remainder and claiming one
+    # would be a refusal nobody made. `unknown` is a validator that could not
+    # run, which says nothing about the config either.
+    *) return 1 ;;
+  esac
+  verdict="${verdict#*$'\t'}"
+  mkdir -p "$(dirname "$CLAWBOX_POST_MIGRATION_ISSUES")" 2>/dev/null || true
+  printf '%s\t%s\n' "$(clawbox_config_fingerprint)" "$verdict" > "$CLAWBOX_POST_MIGRATION_ISSUES" 2>/dev/null || true
+  printf '%s' "$verdict"
+}
+
 clawbox_stamp_write() {
   mkdir -p "$(dirname "$CLAWBOX_CONFIG_VALIDATED_STAMP")" 2>/dev/null || true
   if ! printf '%s\n' "$(clawbox_config_fingerprint)" > "$CLAWBOX_CONFIG_VALIDATED_STAMP" 2>/dev/null; then
@@ -381,13 +538,8 @@ clawbox_stamp_write() {
 # configure route's) exited 1 having migrated nothing. Two `[ -e ]` tests is
 # what a box with no blocker pays for this.
 if [ "$CLAWBOX_OPENCLAW_V2" = "1" ] && [ -x "$OPENCLAW_BIN" ]; then
-  # Both names block the core's gate: doctor renames the file to the
-  # `.doctor-importing` claim for the duration of an import, so a killed
-  # import leaves one behind that refuses every later doctor just as the
-  # original does.
-  for _ea_file in \
-    "$OPENCLAW_STATE_DIR/exec-approvals.json" \
-    "$OPENCLAW_STATE_DIR/exec-approvals.json.doctor-importing"
+  # Both names block the core's gate — see where they are defined above.
+  for _ea_file in "$CLAWBOX_EXEC_APPROVALS_FILE" "$CLAWBOX_EXEC_APPROVALS_CLAIM"
   do
     [ -e "$_ea_file" ] || continue
     # Captured, not read from `$?` after a bare call: under `set -e` a bare
@@ -466,6 +618,23 @@ then
         # keys are named HERE, in the boot log, instead of only in a gateway
         # journal nobody reads until an owner calls.
         echo "  ERROR: the core still refuses this config — the gateway will exit 78 until this is fixed: ${_cfg_detail:-$_cfg_state}" >&2
+        # AND WHICH OF THOSE KEYS IS ACTUALLY IN THE WAY (TASK-754). Every key
+        # the line above names is one the core's own migrations would handle;
+        # the key that blocks the gateway usually is not among them, because it
+        # only exists AFTER those migrations have run. This is the short list,
+        # and deriving it by hand is what cost the incident its 25 hours.
+        _cfg_residual="$(clawbox_core_residual_issues || true)"
+        if [ -n "$_cfg_residual" ]; then
+          echo "  ERROR: after the core's own migrations these remain, and they are what to fix: $_cfg_residual" >&2
+        fi
+        # The one manual step, where there is one. `openclaw doctor --fix` is
+        # what would strip the keys above, and it refuses to start while this
+        # file is here; nothing in ClawBox moves a file that holds approvals of
+        # the owner's.
+        _ea_blocker="$(clawbox_exec_approvals_blocker || true)"
+        if [ -n "$_ea_blocker" ]; then
+          echo "  ERROR: openclaw doctor --fix is the command that would repair this, and it refuses to start while $_ea_blocker exists. Review that file, move it aside by hand, and restart the gateway." >&2
+        fi
       fi
       ;;
     *)

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -398,6 +398,46 @@ clawbox_stamp_read() {
   head -n1 "$CLAWBOX_CONFIG_VALIDATED_STAMP" 2>/dev/null || true
 }
 
+# The node this box runs the core with, found the way the bundle is found.
+#
+# The bundle is located relative to `$OPENCLAW_BIN`, and the interpreter has to
+# be located the same way or the two disagree about which install is meant.
+# `config/clawbox-gateway.service` sets no `Environment=PATH`, so this unit
+# inherits systemd's default (`/usr/local/sbin:…:/bin`) — and an nvm or
+# tool-cache node, the layout where `node` and `openclaw` share ONE bin
+# directory, is not on it. Measured 2026-09-07: the CI runner for this repo is
+# bun-only and has no `/usr/bin/node` at all, which made this whole arm a silent
+# no-op there while it worked on the box.
+#
+# Order: the node beside the core's own bin, then the interpreter its entry
+# point names when that is a real path rather than `/usr/bin/env node`, then the
+# PATH. Echoes nothing and exits 1 when there is none — the caller says so.
+clawbox_node_bin() {
+  local sibling entry shebang interp
+  sibling="$(dirname "$OPENCLAW_BIN")/node"
+  if [ -x "$sibling" ]; then
+    printf '%s' "$sibling"
+    return 0
+  fi
+  entry="$(readlink -f "$OPENCLAW_BIN" 2>/dev/null || printf '%s' "$OPENCLAW_BIN")"
+  shebang="$(head -n1 "$entry" 2>/dev/null || true)"
+  case "$shebang" in
+    "#!"/*)
+      interp="${shebang#\#!}"
+      interp="${interp%% *}"
+      case "$interp" in
+        */node)
+          if [ -x "$interp" ]; then
+            printf '%s' "$interp"
+            return 0
+          fi
+          ;;
+      esac
+      ;;
+  esac
+  command -v node 2>/dev/null || return 1
+}
+
 # WHAT THE CORE STILL REFUSES AFTER IT HAS DONE EVERYTHING IT KNOWS (TASK-754).
 #
 # THE 25-HOUR OUTAGE WAS A DIAGNOSIS PROBLEM, not a missing repair. Measured on
@@ -480,13 +520,12 @@ clawbox_core_residual_issues() {
   if grep -qF '"$include"' "$OPENCLAW_CONFIG" 2>/dev/null; then
     return 1
   fi
-  node_bin="$(command -v node 2>/dev/null || true)"
+  node_bin="$(clawbox_node_bin || true)"
   if [ -z "$node_bin" ]; then
-    # Said, not swallowed: this unit inherits systemd's default PATH, and the
-    # sibling node guard further down this file prints the same NOTE for the
-    # same reason. A diagnosis that disappears silently is one nobody knows to
-    # ask for.
-    echo "  NOTE: no node on PATH, so what the core still refuses AFTER its own migrations could not be worked out here" >&2
+    # Said, not swallowed, and FAIL CLOSED: nothing is written and the caller's
+    # honest refusal line still stands. A diagnosis that disappears silently is
+    # one nobody knows to ask for.
+    echo "  NOTE: no node beside $OPENCLAW_BIN and none on PATH, so what the core still refuses AFTER its own migrations could not be worked out here" >&2
     return 1
   fi
   # Same derivation as the package.json read at the top of this file: the bin is

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -473,6 +473,10 @@ clawbox_core_residual_issues() {
       ;;
   esac
 
+  # A cheap pre-filter only — the AUTHORITATIVE test is in the node child
+  # below, which tests the DECODED key the way the core's own
+  # `containsConfigIncludeDirective` does. JSON may spell the same key
+  # `"\u0024include"`, which no grep over the raw bytes can see.
   if grep -qF '"$include"' "$OPENCLAW_CONFIG" 2>/dev/null; then
     return 1
   fi
@@ -527,6 +531,17 @@ clawbox_core_residual_issues() {
       );
       if (!apply) throw new Error("the chunk exports no applyLegacyDoctorMigrations");
       const raw = JSON.parse(readFileSync(process.env.CLAWBOX_PREVIEW_IN, "utf8"));
+      // The same test `containsConfigIncludeDirective` makes in the core, on
+      // the DECODED document: a `$include` may be written `"\u0024include"` in
+      // JSON, which the shell pre-filter cannot see, and a preview built from
+      // one file alone would name keys an included file may already answer for.
+      const hasInclude = (value) => {
+        if (Array.isArray(value)) return value.some(hasInclude);
+        if (!value || typeof value !== "object") return false;
+        if (Object.hasOwn(value, "$include")) return true;
+        return Object.values(value).some(hasInclude);
+      };
+      if (hasInclude(raw)) throw new Error("the config carries a $include directive");
       const result = apply(raw, { authoredRaw: raw, resolvedRaw: raw });
       if (!result || !result.next) throw new Error("the core migrations changed nothing");
       writeFileSync(process.env.CLAWBOX_PREVIEW_OUT, JSON.stringify(result.next, null, 2) + "\n");

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -543,6 +543,12 @@ clawbox_core_residual_issues() {
       };
       if (hasInclude(raw)) throw new Error("the config carries a $include directive");
       const result = apply(raw, { authoredRaw: raw, resolvedRaw: raw });
+      // `{next: null, changes: []}` is the core saying it changed NOTHING, and
+      // it says it in no other case. A preview built from the file anyway would
+      // be byte-identical to the one the core has just refused, so its verdict
+      // can only repeat the issues the caller printed one line earlier — a
+      // second, longer copy of the sentence this whole arm exists to shorten,
+      // bought with another 65 s of a blocking ExecStartPre.
       if (!result || !result.next) throw new Error("the core migrations changed nothing");
       writeFileSync(process.env.CLAWBOX_PREVIEW_OUT, JSON.stringify(result.next, null, 2) + "\n");
       // Exited explicitly rather than by letting the loop drain: this imports a

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -229,16 +229,22 @@ export CLAWBOX_OPENCLAW_V2
 # already add up to well over half of it — the version probe, two plugin
 # installs, the codex install and enable, the deepseek installs and the
 # auth-profile doctor below. What this block adds is 65 + 180 + 65 = 310 s ONCE
-# THE DOCTOR EXITS, and only on a box whose config the core actually refuses; an
-# accepted config costs one probe.
+# THE DOCTOR EXITS, plus TASK-754's 25 + 35 + 65 = 125 s post-migration check —
+# 435 s in all — and only on a box whose config the core actually refuses; an
+# accepted config costs one probe. That check is answered ONCE per config, both
+# ways, so a `Restart=always` unit on a box in either state pays it on one boot
+# rather than on every five seconds.
 # The two validate bounds carry a 5 s `-k` grace each, like every other CLI
 # bound in this file, because plain `timeout` sends SIGTERM only and a validator
 # that ignored it would hold this ExecStartPre for the unit's whole start budget.
 # The doctor bound is SIGTERM-only, deliberately: a SIGKILL mid-import is how a
 # half-finished `exec-approvals.json.doctor-importing` claim gets left behind,
-# which blocks every later doctor exactly as the original file does. So 310 s is
+# which blocks every later doctor exactly as the original file does. So 435 s is
 # not an upper bound on the doctor arm — `TimeoutStartSec=600` is its real
-# ceiling, and that is the trade taken on purpose.
+# ceiling, and that is the trade taken on purpose. A killed ExecStartPre is a
+# unit START failure, which `RestartPreventExitStatus=78` does not cover, which
+# is why the 125 s is bounded on each of its three legs and remembered after the
+# first boot that spends it.
 CLAWBOX_CONFIG_VALIDATED_STAMP="$CLAWBOX_ROOT/data/openclaw-config-validated"
 # What the core still refuses AFTER its own migrations, remembered against the
 # same fingerprint the stamp uses — see `clawbox_core_residual_issues`.
@@ -417,8 +423,15 @@ clawbox_stamp_read() {
 # by hand, and the box was dark for 25 hours.
 #
 # So this asks the core, with the core's own migrations, and reports the
-# REMAINDER. It reads openclaw.json and writes nothing but a preview under a
-# temporary name that is always removed.
+# REMAINDER. It reads openclaw.json and writes nothing beside it: the preview it
+# builds lives in a private directory under TMPDIR, removed on every path here
+# and by the OS if this process is killed.
+#
+# It also answers the OTHER question that decides what to say. When the core
+# ACCEPTS what its own migrations make of the file, the gateway is not going to
+# exit 78 at all — its startup repair applies them — so the caller must not
+# print the refusal sentence or ask the owner to move his approvals file aside.
+# That is a distinct answer (exit 2), not an absence of one.
 #
 # HARNESS FIRST. `applyLegacyDoctorMigrations` is read out of the INSTALLED
 # bundle and RUN — the same function `planStartupConfigRepair` and
@@ -434,27 +447,44 @@ clawbox_stamp_read() {
 # `tts.voiceId` on the incident's own shape. Naming a key of the owner's and
 # deleting it are different decisions, and this only names it.
 #
-# COST. Only on a box the core refuses AND doctor could not repair — a box with
-# no gateway at all — and once per config: the answer is remembered against the
-# same fingerprint the acceptance stamp uses, so a `Restart=always` unit does
-# not pay 25 + 35 + 65 = 125 s a boot for ever, while the sentence is still
-# printed on every boot. Any rewrite of the file or a core bump asks again.
+# COST. Only on a box the core refuses and doctor did not repair — which
+# includes a box the core is about to repair by itself at gateway start, since
+# nothing knows that until this asks — and once per config: BOTH answers are
+# remembered against the same fingerprint the acceptance stamp uses, so a
+# `Restart=always` unit does not pay 25 + 35 + 65 = 125 s a boot for ever, while
+# the sentence is still printed on every boot. Any rewrite of the file or a core
+# bump asks again.
 #
 # `$include`: stood down, the way the core's own startup repair stands down —
 # the file on disk is not the whole config, so a preview built from it alone
 # would name keys an included file may already answer for.
 clawbox_core_residual_issues() {
-  local node_bin core_dist core_chunk preview verdict remembered
+  local node_bin core_dist core_chunk preview_dir preview verdict remembered fingerprint
 
+  fingerprint="$(clawbox_config_fingerprint)"
   remembered="$(head -n1 "$CLAWBOX_POST_MIGRATION_ISSUES" 2>/dev/null || true)"
   case "$remembered" in
-    "$(clawbox_config_fingerprint)$(printf '\t')"*) printf '%s' "${remembered#*$'\t'}"; return 0 ;;
+    "$fingerprint$(printf '\t')"*)
+      remembered="${remembered#*$'\t'}"
+      case "$remembered" in
+        accepted) return 2 ;;
+        refused"$(printf '\t')"*) printf '%s' "${remembered#*$'\t'}"; return 0 ;;
+      esac
+      ;;
   esac
 
   if grep -qF '"$include"' "$OPENCLAW_CONFIG" 2>/dev/null; then
     return 1
   fi
   node_bin="$(command -v node 2>/dev/null || true)"
+  if [ -z "$node_bin" ]; then
+    # Said, not swallowed: this unit inherits systemd's default PATH, and the
+    # sibling node guard further down this file prints the same NOTE for the
+    # same reason. A diagnosis that disappears silently is one nobody knows to
+    # ask for.
+    echo "  NOTE: no node on PATH, so what the core still refuses AFTER its own migrations could not be worked out here" >&2
+    return 1
+  fi
   # Same derivation as the package.json read at the top of this file: the bin is
   # npm's symlink into `../lib/node_modules/openclaw`.
   core_dist="$(dirname "$OPENCLAW_BIN")/../lib/node_modules/openclaw/dist"
@@ -462,16 +492,27 @@ clawbox_core_residual_issues() {
   # changes with each core build. Bounded, and a SIGPIPE from `head` closing the
   # pipe is not a failure to report.
   core_chunk=""
-  if [ -n "$node_bin" ] && [ -d "$core_dist" ]; then
+  if [ -d "$core_dist" ]; then
     core_chunk="$(timeout -k 5 20 grep -rlF --include='*.js' 'function applyLegacyDoctorMigrations(' "$core_dist" 2>/dev/null | head -n1 || true)"
   fi
-  [ -n "$core_chunk" ] || return 1
+  if [ -z "$core_chunk" ]; then
+    echo "  NOTE: the installed core's own migration table could not be read from $core_dist, so what it still refuses AFTER those migrations could not be worked out here" >&2
+    return 1
+  fi
 
-  preview="$OPENCLAW_CONFIG.clawbox-preview.$$"
-  rm -f "$preview"
-  # `cp -p` first, so the preview carries the config's own mode: it holds the
-  # same secrets for as long as it exists.
-  cp -p "$OPENCLAW_CONFIG" "$preview" 2>/dev/null || { rm -f "$preview"; return 1; }
+  # OUTSIDE THE STATE DIRECTORY, deliberately. The preview is never renamed into
+  # place — it exists only to be read — so it does not need to share a
+  # filesystem with openclaw.json, and putting it beside openclaw.json means a
+  # SIGTERM in the ~100 s this function can take (TimeoutStartSec firing, a
+  # `systemctl stop`, a reboot) leaves a full copy of the config in the state
+  # directory that only a boot with the same pid would ever clear. A private
+  # 0700 directory under TMPDIR is removed on every path here and by the OS if
+  # this process is killed before any of them.
+  preview_dir="$(mktemp -d "${TMPDIR:-/tmp}/clawbox-config-preview-XXXXXX" 2>/dev/null)" || return 1
+  preview="$preview_dir/openclaw.json"
+  # `cp -p`, so the preview carries the config's own mode: it holds the same
+  # secrets for as long as it exists.
+  cp -p "$OPENCLAW_CONFIG" "$preview" 2>/dev/null || { rm -rf "$preview_dir"; return 1; }
   if ! CLAWBOX_PREVIEW_CHUNK="$core_chunk" \
     CLAWBOX_PREVIEW_IN="$OPENCLAW_CONFIG" \
     CLAWBOX_PREVIEW_OUT="$preview" \
@@ -498,24 +539,52 @@ clawbox_core_residual_issues() {
       process.exit(1);
     }
   ' >/dev/null 2>&1; then
-    rm -f "$preview"
+    rm -rf "$preview_dir"
     return 1
   fi
 
   verdict="$(clawbox_core_config_verdict "$preview")"
-  rm -f "$preview"
+  rm -rf "$preview_dir"
   case "$verdict" in
-    refused*"$(printf '\t')"*) ;;
-    # `accepted` means the core would load the migrated file — its own startup
-    # repair will do exactly that, so there is no remainder and claiming one
-    # would be a refusal nobody made. `unknown` is a validator that could not
-    # run, which says nothing about the config either.
+    # THE CORE WOULD LOAD THE MIGRATED FILE, so its own automatic startup repair
+    # will produce it when the gateway starts — measured. There is no remainder,
+    # and the caller must not say the gateway will exit 78 over a box that is
+    # about to come up. Answered apart from "could not tell", because those two
+    # lead to opposite sentences.
+    accepted*) clawbox_remember_residual "$fingerprint" "accepted"; return 2 ;;
+    refused"$(printf '\t')"*) ;;
+    # A validator that could not run says nothing about the config, and is not
+    # remembered: it is a fact about this boot, not about this file.
     *) return 1 ;;
   esac
-  verdict="${verdict#*$'\t'}"
-  mkdir -p "$(dirname "$CLAWBOX_POST_MIGRATION_ISSUES")" 2>/dev/null || true
-  printf '%s\t%s\n' "$(clawbox_config_fingerprint)" "$verdict" > "$CLAWBOX_POST_MIGRATION_ISSUES" 2>/dev/null || true
+  # Collapsed to one line before it is remembered: the record is read back with
+  # `head -n1`, so an issue message carrying a newline would be replayed as its
+  # first fragment on every later boot.
+  verdict="$(printf '%s' "${verdict#*$'\t'}" | tr '\n\t' '  ')"
+  clawbox_remember_residual "$fingerprint" "refused$(printf '\t')$verdict"
   printf '%s' "$verdict"
+}
+
+# The answer above, kept against the fingerprint that produced it.
+#
+# Both outcomes are remembered, not only the refusal: a box whose config the
+# core would migrate on its own must not pay 125 s of grep, node and validate on
+# every restart of a `Restart=always` unit to be told the same thing.
+#
+# NOT remembered when the core could not be identified — `clawbox_config_fingerprint`
+# then carries an empty version, and two boots that both failed the version probe
+# across a core bump would share a key. And the answer depends on the PLUGIN set
+# as well as the file (`config validate` validates with plugins), which this key
+# does not cover: the codex and deepseek installs further down this script can
+# make a key valid that was named here on an earlier boot. A stale sentence is
+# the cost; it is corrected by the next write of openclaw.json, which this same
+# script performs on any boot that changes anything.
+clawbox_remember_residual() {
+  case "$1" in ""|" "*) return 0 ;; esac
+  mkdir -p "$(dirname "$CLAWBOX_POST_MIGRATION_ISSUES")" 2>/dev/null || true
+  if ! printf '%s\t%s\n' "$1" "$2" > "$CLAWBOX_POST_MIGRATION_ISSUES" 2>/dev/null; then
+    echo "  WARN: could not record $CLAWBOX_POST_MIGRATION_ISSUES — this boot's post-migration check will be repeated on every gateway start" >&2
+  fi
 }
 
 clawbox_stamp_write() {
@@ -617,23 +686,53 @@ then
         # gateway's own exit 78 stays the authority. What changes is that the
         # keys are named HERE, in the boot log, instead of only in a gateway
         # journal nobody reads until an owner calls.
-        echo "  ERROR: the core still refuses this config — the gateway will exit 78 until this is fixed: ${_cfg_detail:-$_cfg_state}" >&2
-        # AND WHICH OF THOSE KEYS IS ACTUALLY IN THE WAY (TASK-754). Every key
-        # the line above names is one the core's own migrations would handle;
-        # the key that blocks the gateway usually is not among them, because it
-        # only exists AFTER those migrations have run. This is the short list,
-        # and deriving it by hand is what cost the incident its 25 hours.
-        _cfg_residual="$(clawbox_core_residual_issues || true)"
-        if [ -n "$_cfg_residual" ]; then
-          echo "  ERROR: after the core's own migrations these remain, and they are what to fix: $_cfg_residual" >&2
+        # WHICH OF THOSE KEYS IS ACTUALLY IN THE WAY (TASK-754), asked BEFORE
+        # anything is said. Every key the core named above is one its own
+        # migrations would handle; the key that blocks the gateway usually is
+        # not among them, because it only exists AFTER those migrations have
+        # run. And the same question answers whether the gateway is going to
+        # come up at all — the core's own startup repair applies those
+        # migrations when it starts — so it is asked first and the sentence
+        # follows the answer, rather than the other way round.
+        #
+        # Only over a REFUSAL. An `unknown` verdict is a validator that could
+        # not run, and telling the owner to move a file of his over a config
+        # nothing has a verdict on is the class this block's own `*)` arm below
+        # exists to prevent.
+        _cfg_residual=""
+        _cfg_residual_rc=0
+        if [ "$_cfg_state" = "refused" ]; then
+          _cfg_residual="$(clawbox_core_residual_issues)" || _cfg_residual_rc=$?
         fi
-        # The one manual step, where there is one. `openclaw doctor --fix` is
-        # what would strip the keys above, and it refuses to start while this
-        # file is here; nothing in ClawBox moves a file that holds approvals of
-        # the owner's.
-        _ea_blocker="$(clawbox_exec_approvals_blocker || true)"
-        if [ -n "$_ea_blocker" ]; then
-          echo "  ERROR: openclaw doctor --fix is the command that would repair this, and it refuses to start while $_ea_blocker exists. Review that file, move it aside by hand, and restart the gateway." >&2
+        if [ "$_cfg_residual_rc" = "2" ]; then
+          # MEASURED: the core accepts what its own migrations make of this
+          # file, and `openclaw gateway run` applies them itself and reaches
+          # ready — with a legacy exec-approvals file present throughout,
+          # because that gate is doctor's and the startup repair is not doctor.
+          # Saying "the gateway will exit 78" here, or asking the owner to move
+          # a file holding his own approvals, would be wrong on the one box that
+          # was never broken.
+          echo "  The core refuses this config as it stands and accepts what its own migrations make of it; it applies them itself when the gateway starts, so nothing here needs doing by hand."
+        else
+          # Not fatal, and unchanged: everything below still runs on a config
+          # the core will refuse, and the gateway's own exit 78 stays the
+          # authority.
+          echo "  ERROR: the core still refuses this config — the gateway will exit 78 until this is fixed: ${_cfg_detail:-$_cfg_state}" >&2
+          if [ -n "$_cfg_residual" ]; then
+            # The short list, and deriving it by hand is what cost the incident
+            # its 25 hours.
+            echo "  ERROR: after the core's own migrations these remain, and they are what to fix: $_cfg_residual" >&2
+          fi
+          # The one manual step, where there is one. `openclaw doctor --fix` is
+          # what would strip the keys above, and it refuses to start while this
+          # file is here; nothing in ClawBox moves a file that holds approvals
+          # of the owner's.
+          if [ "$_cfg_state" = "refused" ]; then
+            _ea_blocker="$(clawbox_exec_approvals_blocker || true)"
+            if [ -n "$_ea_blocker" ]; then
+              echo "  ERROR: openclaw doctor --fix is the command that would repair this, and it refuses to start while $_ea_blocker exists. Review that file, move it aside by hand, and restart the gateway." >&2
+            fi
+          fi
         fi
       fi
       ;;

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -17,6 +17,7 @@ import { ANTHROPIC_PLUGIN_ENABLED_KEY } from "@/lib/provider-plugin-ops";
 import { isSafeDiscordToken } from "@/lib/discord-api";
 import { envPort, waitForPortOpen } from "@/lib/port-probe";
 import { getLocalAiToken } from "@/lib/local-ai-token";
+import { LEGACY_EXEC_APPROVALS_RE } from "@/lib/openclaw-doctor-blocker";
 
 const exec = promisify(execFile);
 
@@ -2653,17 +2654,6 @@ export function gatewayIsAbsent(): boolean {
  * EVERY OTHER failure still throws, untouched.
  */
 export type OpenclawDoctorFixOutcome = "completed" | "blocked-by-legacy-exec-approvals";
-
-/**
- * The core's own words for the blocker, matched rather than re-derived.
- *
- * Three matchers now read this one English sentence — `install.sh`,
- * `install-x64.sh` and `scripts/gateway-pre-start.sh` grep it case-sensitively,
- * this one is case-insensitive. All three fail SAFE: a reworded upstream
- * sentence simply reverts each to its old, stricter behaviour. A fourth site
- * would be the point at which this deserves one shared constant.
- */
-const LEGACY_EXEC_APPROVALS_RE = /Legacy exec approvals exist at/i;
 
 export async function runOpenclawDoctorFix(): Promise<OpenclawDoctorFixOutcome> {
   if (gatewayIsAbsent()) return "completed";

--- a/src/lib/openclaw-doctor-blocker.ts
+++ b/src/lib/openclaw-doctor-blocker.ts
@@ -1,0 +1,66 @@
+import path from "path";
+import { existsSync } from "fs";
+
+/**
+ * The one thing that stops `openclaw doctor` before it migrates anything.
+ *
+ * With a legacy `exec-approvals.json` in the state directory the core's
+ * security gate (`assertNoPendingLegacyExecApprovals`) throws on the file's
+ * mere PRESENCE, so `doctor --fix` exits 1 having migrated NOTHING — measured
+ * against 2026.8.1 on 2026-09-06, with the sentence on stderr and in full:
+ *
+ *     Legacy exec approvals exist at <state>/exec-approvals.json. Run
+ *     `openclaw doctor --fix` with OPENCLAW_STATE_DIR set to <state> before
+ *     using exec approvals.
+ *
+ * — advice for the command that has just run, with the state directory the
+ * caller had already set. ClawBox never moves a file that holds approvals of
+ * the owner's, so on that box the useful half of the sentence is the PATH and
+ * the actionable half is the owner's own.
+ *
+ * WHY THIS IS A MODULE. `scripts/gateway-pre-start.sh`, `install.sh` and
+ * `install-x64.sh` grep this sentence case-sensitively and `openclaw-config.ts`
+ * matched it case-insensitively with a copy of its own; the comment beside that
+ * copy said a fourth reader was where a shared constant earned itself, and
+ * `updater.ts` is the fourth. A module of its own rather than another export on
+ * `@/lib/openclaw-config`: fifty-nine suites replace that module with a
+ * hand-written factory, and an export none of them lists is `undefined` at
+ * runtime — a matcher that answers `undefined.test(…)` throws where a missing
+ * function merely returns nothing. Nothing mocks this file.
+ *
+ * All the readers fail SAFE: a reworded upstream sentence reverts each of them
+ * to its old, stricter behaviour rather than to a wrong classification.
+ */
+export const LEGACY_EXEC_APPROVALS_RE = /Legacy exec approvals exist at/i;
+
+/**
+ * Both names the core's gate refuses on, in the order it finds them.
+ *
+ * doctor renames the file to the `.doctor-importing` claim for the duration of
+ * an import, so a killed import leaves one behind that blocks every later
+ * doctor exactly as the original does.
+ */
+export const LEGACY_EXEC_APPROVALS_NAMES = [
+  "exec-approvals.json",
+  "exec-approvals.json.doctor-importing",
+] as const;
+
+/** Doctor's own sentence with the path it names captured. */
+const LEGACY_EXEC_APPROVALS_PATH_RE = /Legacy exec approvals exist at\s+(\S+?)[.,;]?(?:\s|$)/i;
+
+/**
+ * WHICH file is blocking, in the order of what can be trusted.
+ *
+ * The core's own sentence first — it names the file the gate actually tripped
+ * over, which is the only source that cannot be wrong about a box with a
+ * non-standard state directory. Then the filesystem, because a doctor killed
+ * before it printed anything still leaves the blocker where it is. The
+ * canonical path last, so the owner is always given something to look at
+ * rather than a sentence about a file with no name.
+ */
+export function legacyExecApprovalsBlocker(said: string, openclawHome: string): string {
+  const named = LEGACY_EXEC_APPROVALS_PATH_RE.exec(said)?.[1];
+  if (named) return named;
+  const candidates = LEGACY_EXEC_APPROVALS_NAMES.map((name) => path.join(openclawHome, name));
+  return candidates.find((candidate) => existsSync(candidate)) ?? candidates[0];
+}

--- a/src/lib/openclaw-doctor-blocker.ts
+++ b/src/lib/openclaw-doctor-blocker.ts
@@ -45,8 +45,17 @@ export const LEGACY_EXEC_APPROVALS_NAMES = [
   "exec-approvals.json.doctor-importing",
 ] as const;
 
-/** Doctor's own sentence with the path it names captured. */
-const LEGACY_EXEC_APPROVALS_PATH_RE = /Legacy exec approvals exist at\s+(\S+?)[.,;]?(?:\s|$)/i;
+/**
+ * Doctor's own sentence with the path it names captured.
+ *
+ * Anchored on the FILE NAME rather than on "run of non-whitespace", because a
+ * state directory may contain a space (`OPENCLAW_STATE_DIR` is whatever the
+ * operator set) and `(\S+?)` would then hand the owner `/srv/ClawBox` as the
+ * file to move aside. Non-greedy up to the known suffix, so the sentence's own
+ * trailing full stop and everything after it stay out.
+ */
+const LEGACY_EXEC_APPROVALS_PATH_RE =
+  /Legacy exec approvals exist at\s+(\S.*?exec-approvals\.json(?:\.doctor-importing)?)(?=[.,;]?(?:\s|$))/i;
 
 /**
  * WHICH file is blocking, in the order of what can be trusted.

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -13,6 +13,10 @@ import {
   openclawIsAbsent,
   gatewayIsAbsent,
 } from "./openclaw-config";
+import {
+  LEGACY_EXEC_APPROVALS_RE,
+  legacyExecApprovalsBlocker,
+} from "./openclaw-doctor-blocker";
 import { hasHermesHarness, readEdition, type EditionName } from "./edition-source";
 import { runHermesCli } from "./hermes-cli";
 import { waitForPortOpen } from "./port-probe";
@@ -1286,6 +1290,23 @@ async function runOpenclawDoctorFix(): Promise<void> {
       env: openclawChildEnv(),
     });
   } catch (err) {
+    // WHICH failure this was, and what the owner can do about it (TASK-754).
+    // A doctor blocked by a legacy exec-approvals file migrated NOTHING, and
+    // its own closing sentence is advice for the command that is blocked —
+    // exactly what #754 removed from the subscription sign-in route. This
+    // warning IS the Settings → System Update surface, and on the one box the
+    // core-upgrade chain still leaves dark (an approvals file holding a real
+    // decision, which `gateway-pre-start.sh` will not move) the one manual step
+    // is the owner's: move that file aside himself.
+    const said = commandOutput(err);
+    if (LEGACY_EXEC_APPROVALS_RE.test(said)) {
+      const blocker = legacyExecApprovalsBlocker(said, openclawTreePaths().openclawHome);
+      warnUpdate("openclaw-doctor-fix-failed", `\`openclaw doctor --fix\` migrated nothing. `
+        + `Legacy exec approvals exist at ${blocker}, and the core refuses every config and session `
+        + `migration while that file is there. ClawBox never moves one that holds approvals of yours: `
+        + `review it, move it aside by hand, and restart the gateway.`);
+      return;
+    }
     warnUpdate("openclaw-doctor-fix-failed", `\`openclaw doctor --fix\` did not complete. `
       + `Config and session migrations it performs may still be pending: ${describeDoctorFailure(err)}`);
   }

--- a/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
+++ b/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
@@ -55,6 +55,7 @@ let binDir: string;
 let stateDir: string;
 let configPath: string;
 let stampPath: string;
+let coreDistDir: string;
 
 /**
  * An `openclaw` that behaves like 2026.8.1 on a 2026.7 config.
@@ -121,6 +122,7 @@ function run(version = "2026.8.1", extraEnv: Record<string, string> = {}) {
       OPENCLAW_CONFIG: configPath,
       OC_CALLS: path.join(dir, "calls.log"),
       OC_STATE: stateDir,
+      OC_CORE_PY: path.join(binDir, "core.py"),
       ...extraEnv,
     }),
     timeout: 30_000,
@@ -567,5 +569,306 @@ d("gateway pre-start: the config-repair block's own edges", () => {
     // repair ever fired.
     expect(approvalsFiles().filter((n) => n.includes(".legacy-"))).toHaveLength(2);
     expect(existsSync(path.join(stateDir, "exec-approvals.json"))).toBe(false);
+  });
+});
+
+/**
+ * TASK-754 — the 25-hour outage was a DIAGNOSIS problem, not a missing repair.
+ *
+ * Measured against the pinned 2026.8.1 core, in throwaway homes, with a legacy
+ * `exec-approvals.json` holding a real approval present throughout:
+ *
+ *   * a 2026.7 config whose migrated form VALIDATES — `openclaw gateway run`
+ *     migrates it ITSELF and reaches `ready`. The core's own automatic startup
+ *     config repair does it, and the approvals file does not stop it, because
+ *     it is not doctor.
+ *   * a 2026.7 config whose migrated form does NOT validate — exit 78, config
+ *     untouched, with or without the approvals file.
+ *
+ * So there is nothing for ClawBox to carry across: where that would help the
+ * core has already done it, and where it would not, running the same table
+ * produces the same refusal. What nothing on the box does is say WHICH key is
+ * in the way. The gateway names the pre-migration keys — every one of which the
+ * core would have handled — while the key that really blocks it exists only
+ * after those migrations have run. `tts.voiceId` is the incident's own: the
+ * `messages.tts → tts` move is verbatim, `voiceId` is renamed only inside
+ * provider scopes, and `doctor --fix` gets past it in a LATER step that DELETES
+ * it (`stripUnknownConfigKeys`) — a step this block does not perform, because
+ * naming a key of the owner's and deleting it are different decisions.
+ */
+d("gateway pre-start: naming what the core still refuses after its own migrations", () => {
+  /** The shape #746 refuses to move: a decision of the owner's. */
+  const realApproval = JSON.stringify({
+    version: 1,
+    socket: { path: "/run/user/1000/openclaw/exec-approvals.sock", token: "6f2c" },
+    defaults: { deny: ["rm -rf /"] },
+    agents: {},
+  });
+
+  /** The incident's own 2026.7 layout: four legacy keys, one of them fatal. */
+  function incidentConfig(): Record<string, unknown> {
+    return {
+      agents: {
+        defaults: {
+          memorySearch: { enabled: true },
+          imageGenerationModel: { primary: "openai/gpt-image-1" },
+        },
+      },
+      messages: { tts: { enabled: true, voiceId: "nova" } },
+    };
+  }
+
+  /**
+   * The 2026.7 → 2026.8 rename table and the v2 schema, as a stand-in core.
+   *
+   * `issues` is what `config validate --json` reports about a FILE — so a
+   * preview built by anything other than doctor is judged on its content the
+   * way the real core judges it — and `migrate` is what `doctor --fix` does,
+   * which includes the strip step the block under test deliberately does not.
+   * Both halves model behaviour measured on 2026.8.1.
+   */
+  function stubCorePython() {
+    writeFileSync(
+      path.join(binDir, "core.py"),
+      `import json, sys
+
+MODE, CFG = sys.argv[1], sys.argv[2]
+doc = json.load(open(CFG))
+defaults = (doc.get("agents") or {}).get("defaults") or {}
+legacy = [k for k in ("memorySearch", "imageGenerationModel") if k in defaults]
+
+if MODE == "issues":
+    out = []
+    if legacy:
+        keys = ", ".join('QQ%sQQ' % k for k in legacy)
+        out.append('{"path":"agents.defaults","message":"Unrecognized keys: %s"}' % keys)
+    if "tts" in (doc.get("messages") or {}):
+        out.append('{"path":"messages","message":"Unrecognized key: QQttsQQ"}')
+    # The key the whole card is about: the move is verbatim and voiceId is
+    # renamed only inside provider scopes, so it reaches a .strict() schema.
+    if "voiceId" in (doc.get("tts") or {}):
+        out.append('{"path":"tts","message":"Unrecognized key: QQvoiceIdQQ"}')
+    sys.stdout.write(",".join(out).replace("QQ", chr(92) + chr(34)))
+    sys.exit(0)
+
+if "imageGenerationModel" in defaults:
+    defaults.setdefault("mediaModels", {}).setdefault("image", defaults.pop("imageGenerationModel"))
+if "memorySearch" in defaults:
+    doc.setdefault("memory", {}).setdefault("search", defaults.pop("memorySearch"))
+if "tts" in (doc.get("messages") or {}):
+    moved = doc["messages"].pop("tts")
+    if moved.pop("enabled", None):
+        moved["auto"] = "always"
+    doc.setdefault("tts", moved)
+# doctor's LATER step, stripUnknownConfigKeys, which the block does not perform.
+(doc.get("tts") or {}).pop("voiceId", None)
+json.dump(doc, open(CFG, "w"), indent=2)
+`,
+    );
+  }
+
+  /**
+   * The core's own migration, where the block looks for it.
+   *
+   * Found by its DECLARATION text and picked out by function NAME, because a
+   * bundle renames the export binding (`applyLegacyDoctorMigrations as A`) and
+   * not the declaration — both indirections are reproduced here, so a discovery
+   * that only worked on a matching export name fails. It performs the moves and
+   * NOT the strip, exactly as the real one does.
+   */
+  function stubCoreMigrationChunk() {
+    mkdirSync(coreDistDir, { recursive: true });
+    writeFileSync(
+      path.join(coreDistDir, "legacy-pGW3ZP3t.js"),
+      `function applyLegacyDoctorMigrations(raw, context, options) {
+  if (!raw || typeof raw !== "object") return { next: null, changes: [] };
+  const next = structuredClone(raw);
+  const changes = [];
+  const defaults = next.agents && next.agents.defaults;
+  if (defaults && Object.hasOwn(defaults, "imageGenerationModel")) {
+    const mediaModels = defaults.mediaModels || {};
+    if (mediaModels.image === undefined) mediaModels.image = defaults.imageGenerationModel;
+    defaults.mediaModels = mediaModels;
+    delete defaults.imageGenerationModel;
+    changes.push("Moved agents.defaults.imageGenerationModel -> agents.defaults.mediaModels.image.");
+  }
+  if (defaults && Object.hasOwn(defaults, "memorySearch")) {
+    next.memory = next.memory || {};
+    if (next.memory.search === undefined) next.memory.search = defaults.memorySearch;
+    delete defaults.memorySearch;
+    changes.push("Moved agents.defaults.memorySearch -> memory.search.");
+  }
+  if (next.messages && Object.hasOwn(next.messages, "tts")) {
+    if (next.tts === undefined) {
+      const moved = next.messages.tts;
+      if (moved && moved.enabled) { delete moved.enabled; moved.auto = "always"; }
+      next.tts = moved;
+    }
+    delete next.messages.tts;
+    changes.push("Moved messages.tts -> tts.");
+  }
+  if (changes.length === 0) return { next: null, changes: [] };
+  return { next, changes };
+}
+export { applyLegacyDoctorMigrations as A };
+`,
+    );
+  }
+
+  /** An `openclaw` that judges the FILE it is pointed at, like the real one. */
+  function stubContentAwareOpenclaw() {
+    const p = path.join(binDir, "openclaw");
+    writeFileSync(
+      p,
+      `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$OC_CALLS"
+CFG="\${OPENCLAW_CONFIG_PATH:-\${OPENCLAW_CONFIG}}"
+if [ "$1" = "config" ] && [ "$2" = "validate" ]; then
+  ISSUES="\$(python3 "$OC_CORE_PY" issues "\$CFG")" || ISSUES='{"path":"config","message":"unreadable"}'
+  if [ -z "\$ISSUES" ]; then
+    printf '{"valid":true,"path":"%s","warnings":[]}\\n' "\$CFG"
+    exit 0
+  fi
+  printf '{"valid":false,"issues":[%s]}\\n' "\$ISSUES"
+  exit 1
+fi
+if [ "$1" = "doctor" ]; then
+  for f in "$OC_STATE/exec-approvals.json" "$OC_STATE/exec-approvals.json.doctor-importing"; do
+    if [ -e "\$f" ]; then
+      echo "Legacy exec approvals exist at \$f. Run \\\`openclaw doctor --fix\\\` before using exec approvals."
+      exit 1
+    fi
+  done
+  python3 "$OC_CORE_PY" migrate "\$CFG"
+  touch "$OC_STATE/migrated"
+  exit 0
+fi
+exit 0
+`,
+    );
+    chmodSync(p, 0o755);
+  }
+
+  function withRealApproval() {
+    writeFileSync(path.join(stateDir, "exec-approvals.json"), realApproval);
+  }
+
+  function previewFiles(): string[] {
+    return spawnSync("bash", ["-c", `ls ${JSON.stringify(stateDir)}`], { encoding: "utf-8" })
+      .stdout.split("\n").filter((n) => n.includes("clawbox-preview"));
+  }
+
+  beforeEach(() => {
+    coreDistDir = path.join(dir, "lib", "node_modules", "openclaw", "dist");
+    writeFileSync(configPath, JSON.stringify(incidentConfig(), null, 2));
+    stubCorePython();
+    stubCoreMigrationChunk();
+    stubContentAwareOpenclaw();
+  });
+
+  it("names the key that is actually in the way, not the ones the core would have handled", () => {
+    withRealApproval();
+    const before = readFileSync(configPath, "utf-8");
+
+    const r = run();
+
+    expect(r.status).toBe(0);
+    // The keys the gateway itself reports — all four of which the core migrates.
+    expect(r.stderr).toContain('agents.defaults: Unrecognized keys: "memorySearch", "imageGenerationModel"');
+    // …and the one that is left once it has, which is the one to fix. This
+    // sentence is what the incident's manual repair had to derive by hand.
+    expect(r.stderr).toContain("after the core's own migrations these remain");
+    expect(r.stderr).toContain('tts: Unrecognized key: "voiceId"');
+    expect(r.stderr).not.toContain("these remain, and they are what to fix: agents.defaults");
+    // NOTHING was written: not the config, not a preview, not a stamp.
+    expect(readFileSync(configPath, "utf-8")).toBe(before);
+    expect(previewFiles()).toEqual([]);
+    expect(existsSync(stampPath)).toBe(false);
+    // …and the owner's approval is byte-identical, under its own name.
+    expect(readFileSync(path.join(stateDir, "exec-approvals.json"), "utf-8")).toBe(realApproval);
+    expect(approvalsFiles()).toEqual(["exec-approvals.json"]);
+  });
+
+  it("names the file that blocks the repair as the one manual step", () => {
+    withRealApproval();
+
+    const r = run();
+
+    expect(r.stderr).toContain("refuses to start while");
+    expect(r.stderr).toContain(path.join(stateDir, "exec-approvals.json"));
+    expect(r.stderr).toContain("move it aside by hand");
+  });
+
+  it("claims no remainder when the core's own migrations would make the config valid", () => {
+    // The measured case that makes the carry-it-across idea unnecessary: this
+    // is the box `openclaw gateway run` repairs by itself. Inventing a
+    // remainder here would be a refusal nobody made.
+    const carryable = incidentConfig() as { messages: { tts: Record<string, unknown> } };
+    delete carryable.messages.tts.voiceId;
+    writeFileSync(configPath, JSON.stringify(carryable, null, 2));
+    writeFileSync(
+      path.join(stateDir, "exec-approvals.json"),
+      JSON.stringify({ version: 1, socket: {}, defaults: { deny: ["rm -rf /"] }, agents: {} }),
+    );
+
+    const r = run();
+
+    expect(r.stderr).toContain("the core still refuses this config");
+    expect(r.stderr).not.toContain("after the core's own migrations these remain");
+    expect(previewFiles()).toEqual([]);
+  });
+
+  it("asks the core once per config, and still says it on every boot", () => {
+    // 125 s on a box with no gateway is worth paying once; on a `Restart=always`
+    // unit it is not worth paying every five seconds. The ANSWER is remembered
+    // against the same fingerprint the acceptance stamp uses — the sentence is
+    // not, so the owner reads it whenever he looks.
+    withRealApproval();
+
+    const first = run();
+    const afterFirst = calls().length;
+    const second = run();
+
+    expect(first.stderr).toContain('tts: Unrecognized key: "voiceId"');
+    expect(second.stderr).toContain('tts: Unrecognized key: "voiceId"');
+    // The preview's own `config validate` is not spent a second time.
+    expect(calls().length - afterFirst).toBeLessThan(afterFirst);
+    // …and it asks again the moment the file changes, so this is not a verdict
+    // remembered for ever.
+    const fixed = incidentConfig() as { messages: { tts: Record<string, unknown> } };
+    delete fixed.messages.tts.voiceId;
+    writeFileSync(configPath, JSON.stringify(fixed, null, 2));
+    expect(run().stderr).not.toContain("after the core's own migrations these remain");
+  });
+
+  it("says nothing about a remainder when the core's own table cannot be read", () => {
+    // "Read the table from the installed bundle" is the whole of the harness
+    // claim here. A bundle that is not there is not a licence to guess the
+    // moves from a copy in this file, and a diagnosis nobody can stand behind
+    // is worse than none.
+    rmSync(coreDistDir, { recursive: true, force: true });
+    withRealApproval();
+
+    const r = run();
+
+    expect(r.stderr).toContain("the core still refuses this config");
+    expect(r.stderr).not.toContain("after the core's own migrations these remain");
+    expect(previewFiles()).toEqual([]);
+  });
+
+  it("stands down on a config that carries a $include", () => {
+    // The core's own startup repair refuses an include for the same reason: the
+    // file on disk is not the whole config, so a preview built from it alone
+    // would name keys an included file may already answer for.
+    writeFileSync(
+      configPath,
+      JSON.stringify({ ...incidentConfig(), $include: "./extra.json" }, null, 2),
+    );
+    withRealApproval();
+
+    const r = run();
+
+    expect(r.stderr).not.toContain("after the core's own migrations these remain");
+    expect(previewFiles()).toEqual([]);
   });
 });

--- a/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
+++ b/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
@@ -884,6 +884,24 @@ exit 0
     expect(previewFiles()).toEqual([]);
   });
 
+  it("stands down on a $include spelled the way JSON also allows", () => {
+    // `"\u0024include"` decodes to `$include`, so the core's own
+    // `containsConfigIncludeDirective` sees it and no grep over the raw bytes
+    // can. The authoritative test is therefore made on the decoded document.
+    writeFileSync(
+      configPath,
+      `{"\\u0024include":"./extra.json",${JSON.stringify(incidentConfig()).slice(1)}`,
+    );
+    withRealApproval();
+
+    const r = run();
+
+    // The arm WAS reached — the core refuses this config — and stood down.
+    expect(r.stderr).toContain("the core still refuses this config");
+    expect(r.stderr).not.toContain("after the core's own migrations these remain");
+    expect(previewFiles()).toEqual([]);
+  });
+
   it("stands down on a config that carries a $include", () => {
     // The core's own startup repair refuses an include for the same reason: the
     // file on disk is not the whole config, so a preview built from it alone
@@ -896,6 +914,7 @@ exit 0
 
     const r = run();
 
+    expect(r.stderr).toContain("the core still refuses this config");
     expect(r.stderr).not.toContain("after the core's own migrations these remain");
     expect(previewFiles()).toEqual([]);
   });

--- a/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
+++ b/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -56,6 +56,7 @@ let stateDir: string;
 let configPath: string;
 let stampPath: string;
 let coreDistDir: string;
+let tmpDir: string;
 
 /**
  * An `openclaw` that behaves like 2026.8.1 on a 2026.7 config.
@@ -152,6 +153,10 @@ beforeEach(() => {
   root = path.join(dir, "clawbox");
   binDir = path.join(dir, "bin");
   stateDir = path.join(dir, "openclaw");
+  // The block builds its migration preview under TMPDIR; per test, so one case
+  // cannot see another's leftovers or the machine's.
+  tmpDir = path.join(dir, "tmp");
+  mkdirSync(tmpDir, { recursive: true });
   mkdirSync(path.join(root, "data"), { recursive: true });
   mkdirSync(binDir, { recursive: true });
   mkdirSync(stateDir, { recursive: true });
@@ -761,12 +766,28 @@ exit 0
       .stdout.split("\n").filter((n) => n.includes("clawbox-preview"));
   }
 
+  /**
+   * The node the block runs the core's own migration with.
+   *
+   * Placed BESIDE the openclaw bin, which is the nvm and npm-global layout —
+   * `node` and `openclaw` in one bin directory — and the layout the block looks
+   * at first, for the same reason it looks for the bundle there: this unit sets
+   * no `Environment=PATH`, so an nvm node is not on the one systemd hands it.
+   * Measured 2026-09-07: this repo's CI runner is bun-only and has no
+   * `/usr/bin/node`, so a PATH-only lookup made the whole arm a silent no-op
+   * there while it worked on the box.
+   */
+  function installNodeBesideTheCore() {
+    symlinkSync(process.execPath, path.join(binDir, "node"));
+  }
+
   beforeEach(() => {
     coreDistDir = path.join(dir, "lib", "node_modules", "openclaw", "dist");
     writeFileSync(configPath, JSON.stringify(incidentConfig(), null, 2));
     stubCorePython();
     stubCoreMigrationChunk();
     stubContentAwareOpenclaw();
+    installNodeBesideTheCore();
   });
 
   it("names the key that is actually in the way, not the ones the core would have handled", () => {
@@ -881,6 +902,55 @@ exit 0
 
     expect(r.stderr).toContain("the core still refuses this config");
     expect(r.stderr).not.toContain("after the core's own migrations these remain");
+    expect(previewFiles()).toEqual([]);
+  });
+
+  it("finds the interpreter beside the core when it is not on PATH at all", () => {
+    // The failure this replaced: the bundle was located relative to
+    // `$OPENCLAW_BIN` and the interpreter was looked up on PATH only, so on any
+    // box (or CI runner) whose node is not on the unit's PATH the whole arm
+    // returned 1 and said one NOTE. PATH here carries no node at all.
+    withRealApproval();
+
+    const r = run("2026.8.1", { PATH: "/usr/bin:/bin" });
+
+    expect(r.stderr).toContain('tts: Unrecognized key: "voiceId"');
+    expect(r.stderr).not.toContain("could not be worked out here");
+  });
+
+  /**
+   * A PATH carrying every tool this block uses and NO node.
+   *
+   * Built rather than assumed: this dev PC has `/usr/bin/node` and the CI
+   * runner does not, so a case that just names `/usr/bin:/bin` would be
+   * measuring the machine instead of the code.
+   */
+  function pathWithoutNode(): string {
+    const toolsDir = path.join(dir, "tools-without-node");
+    mkdirSync(toolsDir, { recursive: true });
+    for (const tool of [
+      "bash", "sh", "head", "grep", "dirname", "cp", "rm", "mv", "mktemp",
+      "timeout", "date", "stat", "sed", "tr", "cut", "ls", "python3", "readlink",
+    ]) {
+      const found = spawnSync("bash", ["-c", `command -v ${tool} || true`], { encoding: "utf-8" })
+        .stdout.trim();
+      if (found) symlinkSync(found, path.join(toolsDir, tool));
+    }
+    return `${binDir}:${toolsDir}`;
+  }
+
+  it("fails closed, and says so, when there is no node anywhere", () => {
+    rmSync(path.join(binDir, "node"), { force: true });
+    withRealApproval();
+    const before = readFileSync(configPath, "utf-8");
+
+    const r = run("2026.8.1", { PATH: pathWithoutNode() });
+
+    // Nothing invented, nothing written, and the honest refusal still printed.
+    expect(r.stderr).toContain("could not be worked out here");
+    expect(r.stderr).toContain("the core still refuses this config");
+    expect(r.stderr).not.toContain("after the core's own migrations these remain");
+    expect(readFileSync(configPath, "utf-8")).toBe(before);
     expect(previewFiles()).toEqual([]);
   });
 

--- a/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
+++ b/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
@@ -124,6 +124,10 @@ function run(version = "2026.8.1", extraEnv: Record<string, string> = {}) {
       OC_CALLS: path.join(dir, "calls.log"),
       OC_STATE: stateDir,
       OC_CORE_PY: path.join(binDir, "core.py"),
+      // The block builds its migration preview under TMPDIR, so the "nothing is
+      // left behind" checks have to look where it actually writes. Per test, so
+      // one case cannot see another's leftovers or the machine's.
+      TMPDIR: tmpDir,
       ...extraEnv,
     }),
     timeout: 30_000,
@@ -761,9 +765,26 @@ exit 0
     writeFileSync(path.join(stateDir, "exec-approvals.json"), realApproval);
   }
 
+  /**
+   * Everything the block's migration preview could have left behind.
+   *
+   * BOTH places, because the preview moved: it used to sit beside openclaw.json
+   * in the state directory and now lives in its own directory under TMPDIR. A
+   * helper that looked only at the old place, under the old name, made every
+   * "nothing is left behind" assertion unfailable — verified by mutation: with
+   * the three `rm -rf "$preview_dir"` lines removed from the block, the
+   * migrated config (secrets and all) is left as `openclaw.json` inside a
+   * `clawbox-config-preview-` directory, and the old helper still answered
+   * with an empty list.
+   */
   function previewFiles(): string[] {
-    return spawnSync("bash", ["-c", `ls ${JSON.stringify(stateDir)}`], { encoding: "utf-8" })
-      .stdout.split("\n").filter((n) => n.includes("clawbox-preview"));
+    const listing = (at: string) =>
+      spawnSync("bash", ["-c", `ls -A ${JSON.stringify(at)} 2>/dev/null || true`], { encoding: "utf-8" })
+        .stdout.split("\n").filter(Boolean);
+    return [
+      ...listing(stateDir).filter((n) => n.includes("preview")),
+      ...listing(tmpDir).filter((n) => n.includes("preview")),
+    ];
   }
 
   /**

--- a/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
+++ b/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
@@ -724,6 +724,9 @@ export { applyLegacyDoctorMigrations as A };
 printf '%s\\n' "$*" >> "$OC_CALLS"
 CFG="\${OPENCLAW_CONFIG_PATH:-\${OPENCLAW_CONFIG}}"
 if [ "$1" = "config" ] && [ "$2" = "validate" ]; then
+  if [ -n "\${OC_VALIDATE_RC:-}" ] && [ "\${OC_VALIDATE_RC}" != "0" ] && [ "\${OC_VALIDATE_RC}" != "1" ]; then
+    exit "\$OC_VALIDATE_RC"
+  fi
   ISSUES="\$(python3 "$OC_CORE_PY" issues "\$CFG")" || ISSUES='{"path":"config","message":"unreadable"}'
   if [ -z "\$ISSUES" ]; then
     printf '{"valid":true,"path":"%s","warnings":[]}\\n' "\$CFG"
@@ -799,22 +802,43 @@ exit 0
     expect(r.stderr).toContain("move it aside by hand");
   });
 
-  it("claims no remainder when the core's own migrations would make the config valid", () => {
-    // The measured case that makes the carry-it-across idea unnecessary: this
-    // is the box `openclaw gateway run` repairs by itself. Inventing a
-    // remainder here would be a refusal nobody made.
+  it("says the core will repair this one itself, instead of predicting exit 78 over it", () => {
+    // THE BOX THAT WAS NEVER BROKEN. Measured on 2026.8.1 with a real approval
+    // present throughout: `openclaw gateway run` migrates this config ITSELF
+    // and reaches `ready`, because the approvals gate is doctor's and the
+    // startup repair is not doctor. Telling that owner his gateway will exit 78
+    // and asking him to move a file holding his own deny rules aside would be
+    // wrong on the first box that reads this block — and the answer is already
+    // in hand two frames down, so throwing it away is the defect.
     const carryable = incidentConfig() as { messages: { tts: Record<string, unknown> } };
     delete carryable.messages.tts.voiceId;
     writeFileSync(configPath, JSON.stringify(carryable, null, 2));
-    writeFileSync(
-      path.join(stateDir, "exec-approvals.json"),
-      JSON.stringify({ version: 1, socket: {}, defaults: { deny: ["rm -rf /"] }, agents: {} }),
-    );
+    withRealApproval();
 
     const r = run();
 
-    expect(r.stderr).toContain("the core still refuses this config");
+    expect(r.stdout).toContain("it applies them itself when the gateway starts");
+    expect(r.stderr).not.toContain("the core still refuses this config");
     expect(r.stderr).not.toContain("after the core's own migrations these remain");
+    // …and this PR's own manual step is not asked for over a box that is about
+    // to come up. (The approvals clearing loop's own NOTE above is beta's and
+    // is about the file, not about the gateway's fate.)
+    expect(r.stderr).not.toContain("refuses to start while");
+    expect(previewFiles()).toEqual([]);
+  });
+
+  it("says nothing about a remainder, and asks for nothing, when the validator could not run", () => {
+    // The rule this block's own `*)` arm states one screen down: a validator
+    // that could not be run says nothing about the config. A 124 there must not
+    // become a sentence about the owner's exec approvals.
+    withRealApproval();
+
+    const r = run("2026.8.1", { OC_VALIDATE_RC: "124" });
+
+    expect(r.status).toBe(0);
+    expect(r.stderr).toContain("could not ask the installed core");
+    expect(r.stderr).not.toContain("after the core's own migrations these remain");
+    expect(r.stderr).not.toContain("refuses to start while");
     expect(previewFiles()).toEqual([]);
   });
 
@@ -831,8 +855,12 @@ exit 0
 
     expect(first.stderr).toContain('tts: Unrecognized key: "voiceId"');
     expect(second.stderr).toContain('tts: Unrecognized key: "voiceId"');
-    // The preview's own `config validate` is not spent a second time.
-    expect(calls().length - afterFirst).toBeLessThan(afterFirst);
+    // Boot one spends three `config validate` (the verdict, the preview, the
+    // re-ask after doctor) and one doctor; boot two spends the same MINUS the
+    // preview's, because that answer is remembered. Asserted exactly, because
+    // an inequality would also hold for a boot that skipped the arm entirely.
+    expect(calls().filter((c) => c === "config validate --json")).toHaveLength(5);
+    expect(calls().length - afterFirst).toBe(afterFirst - 1);
     // …and it asks again the moment the file changes, so this is not a verdict
     // remembered for ever.
     const fixed = incidentConfig() as { messages: { tts: Record<string, unknown> } };

--- a/src/tests/unit/openclaw-doctor-blocker.test.ts
+++ b/src/tests/unit/openclaw-doctor-blocker.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  LEGACY_EXEC_APPROVALS_NAMES,
+  LEGACY_EXEC_APPROVALS_RE,
+  legacyExecApprovalsBlocker,
+} from "@/lib/openclaw-doctor-blocker";
+
+/**
+ * TASK-754. The file the owner is asked to move aside by hand is named in
+ * Settings → System Update, so getting it WRONG is worse than saying nothing:
+ * an owner who moves a file that was not blocking anything has lost his
+ * approvals and gained no gateway.
+ */
+describe("which exec-approvals file is blocking openclaw doctor", () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(path.join(tmpdir(), "clawbox-doctor-blocker-"));
+    mkdirSync(home, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("takes the path from the core's own sentence, whatever this box's layout is", () => {
+    // The one source that cannot be wrong: the gate tripped over THAT file.
+    const said = "Legacy exec approvals exist at /srv/openclaw-state/exec-approvals.json."
+      + " Run `openclaw doctor --fix` with OPENCLAW_STATE_DIR set to /srv/openclaw-state"
+      + " before using exec approvals.";
+
+    expect(legacyExecApprovalsBlocker(said, home)).toBe("/srv/openclaw-state/exec-approvals.json");
+  });
+
+  it("falls back to the claim file a killed import left behind", () => {
+    // A doctor killed before it printed anything says nothing, and the claim is
+    // the name the blocker carries mid-import — refused exactly as the original.
+    const claim = path.join(home, "exec-approvals.json.doctor-importing");
+    writeFileSync(claim, "{}");
+
+    expect(legacyExecApprovalsBlocker("", home)).toBe(claim);
+  });
+
+  it("names the canonical path rather than nothing when neither can be read", () => {
+    // The owner is always given a file to look at: a sentence about a file with
+    // no name is not a manual step.
+    expect(legacyExecApprovalsBlocker("", home)).toBe(path.join(home, "exec-approvals.json"));
+  });
+
+  it("prefers the plain name over the claim when both are on disk", () => {
+    writeFileSync(path.join(home, "exec-approvals.json"), "{}");
+    writeFileSync(path.join(home, "exec-approvals.json.doctor-importing"), "{}");
+
+    expect(legacyExecApprovalsBlocker("", home)).toBe(path.join(home, "exec-approvals.json"));
+  });
+
+  it("matches the core's sentence in either case, and nothing else", () => {
+    // Fail-safe by construction: a reworded upstream sentence reverts every
+    // reader to its old, stricter behaviour rather than to a wrong verdict.
+    expect(LEGACY_EXEC_APPROVALS_RE.test("legacy EXEC approvals exist at /x")).toBe(true);
+    expect(LEGACY_EXEC_APPROVALS_RE.test("Legacy exec approval records exist at /x")).toBe(false);
+    expect(LEGACY_EXEC_APPROVALS_NAMES).toEqual([
+      "exec-approvals.json",
+      "exec-approvals.json.doctor-importing",
+    ]);
+  });
+
+  it("keeps the shell's two names and this module's in step", () => {
+    // `scripts/gateway-pre-start.sh` clears the same two names on every boot,
+    // and the sentence this module builds tells the owner about the one it left
+    // behind. Two lists for one fact is how they come to disagree.
+    const script = readFileSync(path.resolve(process.cwd(), "scripts/gateway-pre-start.sh"), "utf-8");
+    expect(script).toContain('CLAWBOX_EXEC_APPROVALS_FILE="$OPENCLAW_STATE_DIR/exec-approvals.json"');
+    expect(script).toContain('CLAWBOX_EXEC_APPROVALS_CLAIM="$CLAWBOX_EXEC_APPROVALS_FILE.doctor-importing"');
+  });
+});

--- a/src/tests/unit/openclaw-doctor-blocker.test.ts
+++ b/src/tests/unit/openclaw-doctor-blocker.test.ts
@@ -36,6 +36,24 @@ describe("which exec-approvals file is blocking openclaw doctor", () => {
     expect(legacyExecApprovalsBlocker(said, home)).toBe("/srv/openclaw-state/exec-approvals.json");
   });
 
+  it("keeps a state directory that contains a space whole", () => {
+    // `OPENCLAW_STATE_DIR` is whatever the operator set, and a path cut at the
+    // first space names a directory rather than a file — so the owner is told
+    // to move aside something that is not the blocker.
+    const said = "Legacy exec approvals exist at /srv/ClawBox State/exec-approvals.json."
+      + " Run `openclaw doctor --fix` with OPENCLAW_STATE_DIR set to /srv/ClawBox State"
+      + " before using exec approvals.";
+
+    expect(legacyExecApprovalsBlocker(said, home)).toBe("/srv/ClawBox State/exec-approvals.json");
+  });
+
+  it("names the claim file when that is the one the core tripped over", () => {
+    const said = "Legacy exec approvals exist at /x/exec-approvals.json.doctor-importing."
+      + " Run `openclaw doctor --fix` before using exec approvals.";
+
+    expect(legacyExecApprovalsBlocker(said, home)).toBe("/x/exec-approvals.json.doctor-importing");
+  });
+
   it("falls back to the claim file a killed import left behind", () => {
     // A doctor killed before it printed anything says nothing, and the claim is
     // the name the blocker carries mid-import — refused exactly as the original.

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -2603,6 +2603,42 @@ describe("updater", () => {
       expect(doctorWarning?.message).not.toContain("Command failed:");
     });
 
+    it("names the approvals file and the step the owner can take, not the advice for the command it blocks", async () => {
+      // TASK-754. The warning IS the Settings → System Update surface, and on
+      // this box it repeated the core's own closing sentence — "Run `openclaw
+      // doctor --fix` … before using exec approvals" — which is advice for the
+      // command that is blocked. #754 removed exactly that sentence from the
+      // subscription sign-in route; this is the same defect on the update path,
+      // and the one manual step the boot repair leaves for the owner.
+      setupExecFileMock({
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
+        "/usr/bin/journalctl -u clawbox-gateway.service": { stdout: refusedJournal, stderr: "" },
+        [DOCTOR]: Object.assign(new Error("Command failed: openclaw doctor --fix"), {
+          stdout: "",
+          stderr: "Legacy exec approvals exist at /home/clawbox/.openclaw/exec-approvals.json."
+            + " Run `openclaw doctor --fix` with OPENCLAW_STATE_DIR set to /home/clawbox/.openclaw"
+            + " before using exec approvals.\n",
+        }),
+        [VALIDATE]: validateRefusal,
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+      });
+
+      const state = await runContinuation();
+
+      const doctorWarning = state.warnings?.find((w) => w.code === "openclaw-doctor-fix-failed");
+      // The file the owner has to move, taken from the core's own sentence so a
+      // box with a non-standard state directory is named correctly.
+      expect(doctorWarning?.message).toContain("/home/clawbox/.openclaw/exec-approvals.json");
+      // …and what to do with it, which is his to do: nothing here may move a
+      // file that holds approvals of his.
+      expect(doctorWarning?.message).toContain("move it aside by hand");
+      // NOT the core's advice for the command that is blocked.
+      expect(doctorWarning?.message).not.toContain("before using exec approvals");
+      expect(doctorWarning?.message).not.toContain("OPENCLAW_STATE_DIR");
+    });
+
     it("keys the mock on argv that cannot collide with the binary's own path", () => {
       // NOT decoration. `setupExecFileMock` matches on
       // `key.includes(k) || k.includes(cmd)`, and `cmd` is whatever


### PR DESCRIPTION
Finding **TASK-754** — "core-upgrade link 1 is still open: carry the legacy values across ourselves when doctor is blocked by a real approvals file".

**The card's mechanism is REFUTED, and the outage it descends from is a diagnosis defect.** Read the measurement below before the diff.

## What the card asked for, and why it is not what to build

> when the pre-start's config verdict is `refused` for the legacy layout AND doctor is blocked by a real approvals file, apply the core's own rename table … to carry the owner's values into the v2 homes, stamp it

Measured against the pinned **openclaw 2026.8.1 (ea80657)** — on the OpenClaw box and, for the repeats, in throwaway `HOME` / `OPENCLAW_CONFIG_PATH` / `OPENCLAW_STATE_DIR` trees under `/tmp` — **with a legacy `exec-approvals.json` holding a real approval (`defaults.deny`) present throughout**:

| 2026.7-layout config | `openclaw gateway run` | `doctor --fix` |
|---|---|---|
| migrated form **validates** | **migrates the file itself and reaches `ready`** | exits 1 at the approvals gate, config byte-identical |
| migrated form does **not** validate (`messages.tts.voiceId`) | **exit 78**, config byte-identical | exits 1, config byte-identical |

Two things follow, and they kill the deliverable:

1. **The approvals file is not what keeps a box in the 2026.7 layout.** The core's own automatic startup config repair (`planStartupConfigRepair` / `commitStartupConfigRepair`) runs on `gateway run`, is not doctor, and so is not subject to doctor's gate — it migrated the config and reached `ready` with a real approval present throughout. What decides is whether the **migrated form validates**, not whether doctor could finish.
2. **Applying the same table ourselves changes nothing.** Where it would help, the core has already done it. Where it would not, we produce the same file the core refuses.

So a "carry it across" arm is a no-op in both worlds — and in the world where it appears to work it is re-implementing what the harness already does, which is the wrong-fix class these rules warn about. It is not in this PR.

## What is real: the 25 hours were spent not knowing which key was wrong

On the incident's own shape the gateway says:

```
agents.defaults: Unrecognized keys: "memorySearch", "imageGenerationModel"
messages: Unrecognized key: "tts"
```

**Every one of those four keys is one the core migrates.** The key that actually blocks the gateway is `tts.voiceId`, and it does not exist until after those migrations have run: the `messages.tts → tts` move is verbatim and `voiceId` is renamed only inside provider scopes, so it lands in a `.strict()` schema. `doctor --fix` gets past it in a **later** step that DELETES it (`stripUnknownConfigKeys`, with the active auth profile protected) — measured, it reported removing exactly `tts.voiceId`. The incident report's own manual repair had to derive that by hand ("removed the voiceId").

Nothing on the box says it. This PR makes the boot log say it.

## The change

`scripts/gateway-pre-start.sh` — in the arm that already reports a config the core still refuses after doctor:

- `clawbox_core_residual_issues` runs the **core's own** `applyLegacyDoctorMigrations` — read out of the installed bundle and executed, found by its declaration text and picked out of the chunk by `Function.name`, because a bundle renames the export binding (`applyLegacyDoctorMigrations as A`) and not the declaration — on a **preview copy**, asks the core about that preview with `config validate --json`, and reports the remainder. **openclaw.json is never written**; the preview is removed on every path.
- The approvals file, when one is blocking doctor, is named as the one manual step.
- **Both** answers are distinct and both are remembered against the same fingerprint the acceptance stamp uses, so a `Restart=always` unit pays the 125 s once in either state, while the sentence is printed on **every** boot. When the core ACCEPTS what its own migrations make of the file, the block says so and asks for nothing — predicting exit 78 there, or asking the owner to move a file holding his own deny rules aside, would be wrong on the one box that was never broken.
- Neither new sentence fires over an `unknown` verdict: a validator that could not run says nothing about the config.
- The preview lives in a private directory under `TMPDIR`, removed on every path, so a SIGTERM inside its window cannot leave a copy of the config in the state directory.
- A missing `node` and an unreadable bundle each get their own NOTE rather than disappearing silently.
- Stands down on a `$include`, the way the core's own startup repair does — the file on disk is not the whole config.
- No rename table lives in this file, and a bundle that cannot be read reports nothing.

`src/lib/updater.ts` — the **Settings → System Update** half. A doctor blocked by that file migrated nothing, and the warning repeated the core's own closing sentence, `Run \`openclaw doctor --fix\` with OPENCLAW_STATE_DIR set to … before using exec approvals` — advice for the command that is blocked. It now names the file and the owner's one step. This is the same defect #754 removed from the subscription sign-in route, on the path it did not reach.

`src/lib/openclaw-doctor-blocker.ts` — the matcher `openclaw-config.ts` carried privately, whose own comment said "a fourth site would be the point at which this deserves one shared constant". `updater.ts` is the fourth. A module of its own rather than another export on `@/lib/openclaw-config`, because fifty-nine suites replace that module with a hand-written factory and a matcher that answers `undefined.test(…)` throws where a missing function merely returns nothing.

## Harness first

- `openclaw doctor --fix` — the core's own migrations; **not** re-implemented, and this PR does not route around its gate.
- `applyLegacyDoctorMigrations` — the core's own table, **run**, never copied.
- `openclaw config validate --json` — the core's own verdict, on the preview, through the reader that already existed (given an optional path).
- The core's own **automatic startup config repair** — named, measured, and the reason the carry arm is absent.
- `openclaw update --channel` performs the same migration and is an update of the core, not a repair; there is no `openclaw config migrate`; doctor's `--only`/`--skip` are `--lint` options.

## RED → GREEN

**RED**, new tests against unmodified `origin/beta`:

```
$ npx vitest run src/tests/unit/gateway-pre-start-v2-config-repair.test.ts   # beta's script
 × names the key that is actually in the way, not the ones the core would have handled
     AssertionError: expected '  NOTE: …' to contain 'after the core's own migrations these remain'
 × names the file that blocks the repair as the one manual step
     AssertionError: expected '  NOTE: …' to contain 'refuses to start while'
 × asks the core once per config, and still says it on every boot
 Tests  3 failed | 23 passed (26)

$ npx vitest run src/tests/unit/updater.test.ts -t "names the approvals file"   # beta's updater.ts
 × names the approvals file and the step the owner can take, not the advice for the command it blocks
   AssertionError: expected '`openclaw doctor --fix` did not compl…' to contain 'move it aside by hand'
   Received: "`openclaw doctor --fix` did not complete. Config and session migrations it performs
              may still be pending: Legacy exec approvals exist at …/exec-approvals.json. Run
              `openclaw doctor --fix` with OPENCLAW_STATE_DIR set to … before using exec approvals."
```

Three of the new cases **pass on beta by design** and are controls — they pin what must NOT happen: no remainder claimed when the core's own migrations would make the config valid, nothing claimed when the bundle cannot be read, and the `$include` stand-down.

**GREEN** on this head:

```
$ npx vitest run --project unit
 Test Files  760 passed (760)      Tests  12646 passed | 1 skipped (12647)
$ npx tsc --noEmit                 # clean outside the pre-existing e2e-install/playwright errors
$ bash -n scripts/gateway-pre-start.sh          # ok
$ python3 -m py_compile <all 14 embedded python heredocs>   # 0 failures
$ npx eslint <touched>             # 0 errors, the same pre-existing warnings as beta
```

`openclaw-config-mock-completeness`, `test-timeout-hygiene` and `state-updater-purity` pass, with the nine neighbouring suites: 11 files / 311 tests.

## Device leg — the shipped block, sliced out verbatim, on the box's real 2026.8.1 core

Two boots per fixture, throwaway trees under `/tmp`, a real approval present throughout.

**A — the incident's shape.** The core cannot repair it (`GW_EXIT=78`, `ready` never reached, config byte-identical), and the block now says which key:

```
  ERROR: the core still refuses this config — the gateway will exit 78 until this is fixed:
         agents.defaults: Unrecognized keys: "memorySearch", "imageGenerationModel"; messages: Unrecognized key: "tts"
  ERROR: after the core's own migrations these remain, and they are what to fix: tts: Unrecognized key: "voiceId"
  ERROR: openclaw doctor --fix is the command that would repair this, and it refuses to start while
         …/exec-approvals.json exists. Review that file, move it aside by hand, and restart the gateway.
```

openclaw.json byte-identical, the approval byte-identical and still under its own name, **zero** previews left behind, and the only thing written is the issues cache.

**B — a shape the core repairs by itself.** `GW_EXIT=124` (it ran until the bound killed it), `gateway reached ready: 1`, the config migrated **by the core** with the approvals file present the whole time — the measurement that refutes the card. On a fresh tree with the same fixture the block says, on both boots:

```
  The core refuses this config as it stands and accepts what its own migrations make of it;
  it applies them itself when the gateway starts, so nothing here needs doing by hand.
```

and prints neither the exit-78 sentence nor any manual step. openclaw.json byte-identical.

**Control:** the box's own `openclaw.json` md5 and `~/.config/systemd/user` listing were identical before and after every run.

## Bug classes

- *False failure* — both halves. The boot log named four keys that are not the problem and never the one that is; the updater warning gave advice for a command that cannot run. Neither invents a refusal either: a validator that could not answer is not reported as one, and no remainder is claimed when the core would accept the migrated file.
- *False success* — the reason nothing is written. A preview the core refuses is discarded; a rewrite that swapped one refused config for another would buy the box nothing and lose the file the owner can still be helped from.
- *Probe-once* — the remembered answer is keyed on the same fingerprint the acceptance stamp uses, so a rewrite of the file or a core bump asks again; it is refused when the core cannot be identified; and the blocker is re-read from the filesystem on every boot rather than remembered.

## Review

One `clawbox-review` pass on the first cut of this branch (a "carry the values across" arm) and one on this one, findings by file path. The first is why the carry arm does not exist: it made the box that had been repaired stop running `doctor --fix` for good, and its success fixture was a shape the real core refuses. The second found the HIGH that shaped the final sentence — the block predicted exit 78 and asked for a manual step on the box the core repairs by itself, with the answer already in hand — plus the `unknown` verdict leaking into both new sentences, the preview's kill window, the half-cached answer, the silent give-ups and the budget arithmetic. All applied and re-measured on the box.

## Siblings swept

- **`clawbox_core_config_verdict`** — three call sites, all in this block; the two existing ones take the new optional argument unchanged. **Cleared.**
- **The exec-approvals path pair** — the clearing loop and the new blocker reader now share one definition instead of two literal lists; `src/lib/openclaw-doctor-blocker.ts` carries the same two names for the TypeScript side, pinned against the script by a test. **Fixed.**
- **`LEGACY_EXEC_APPROVALS_RE`** — the two TypeScript readers (`openclaw-config.ts`, `updater.ts`) now share the module; `install.sh`, `install-x64.sh` and `gateway-pre-start.sh` keep their own case-sensitive greps, documented, all failing safe. **Fixed / cleared.**
- **`runOpenclawDoctorFix`** — the exported one (`openclaw-config.ts`, one caller in the configure route) already classifies this blocker and is untouched; the **private** one of the same name in `updater.ts` is a different function with a different contract and is the one changed. **Both handled.**
- **`install.sh:3784` / `install-x64.sh:554`** — both already classify the blocker and both say the pre-start moves a *clearable* one aside and re-runs the migration, which remains exactly true. **Cleared** (an earlier draft of this PR widened those sentences to promise a repair; the measurement above is why they are back as they were).
- **`gateway-pre-start.sh`'s auth-profile doctor** — recognises the same blocker and is deliberately non-fatal (#746); unaffected. **Cleared.**
- **`describeDeadGateway` / `getOpenclawConfigRefusal`** — report the same pre-migration keys in `state.error`; extending the remainder to them means the bundle read in TypeScript and is **not** in this PR (recorded).

## Both editions

**OpenClaw only.** The block is gated on `CLAWBOX_OPENCLAW_V2=1` **and** `-x $OPENCLAW_BIN`, and a Hermes box has neither an `openclaw` binary nor a `clawbox-gateway` unit to run `gateway-pre-start.sh` at all. In `updater.ts` the private `runOpenclawDoctorFix` returns on `openclawIsAbsent()` before spawning anything. `openclaw-doctor-blocker.ts` is a matcher and two file names, with no edition behaviour of its own.

## Upstream

Two items for whoever posts them, both measured here and neither ours to fix:

- `doctor --fix` aborts on `assertNoPendingLegacyExecApprovals` **before** `migrateLegacyExecApprovals`, the importer that would clear it — already recorded on #754.
- `applyLegacyDoctorMigrations` moves `messages.tts` verbatim, so `voiceId` reaches a `.strict()` top-level `tts` and only the later strip step removes it. A rename at that level would make the core's own startup repair able to fix this class of box by itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration-repair diagnostics for legacy settings remaining after migration.
  * Diagnostics now identify residual configuration keys and distinguish automatically repairable issues from those requiring manual action.
  * Error messages identify approval files blocking recovery and provide clearer guidance for resolving legacy execution-approval files.
  * Added cached diagnostic results to avoid repeating identical migration checks.

* **Tests**
  * Added coverage for migration diagnostics, approval-file detection, caching, and configuration preservation.
  * Added validation for consistent approval-file names and diagnostic messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->