### PR TITLE
fix: install a pinned native Codex CLI instead of the npm global

### DIFF
--- a/config/clawbox-root-step.sh
+++ b/config/clawbox-root-step.sh
@@ -70,7 +70,7 @@ esac
 ALLOWED_STEPS="
 bootstrap_updater apt_update nvidia_jetpack performance_mode jtop_install
 ollama_install llamacpp_install llamacpp_model embed_model chromium_install ai_tools_install
-coding_harness vnc_install vnc_refresh openclaw_setup openclaw_install
+coding_harness codex_cli vnc_install vnc_refresh openclaw_setup openclaw_install
 openclaw_patch openclaw_config openclaw_models openclaw_tts edition_lock
 edition_foreign_teardown hermes_install hermes_edition network_setup
 set_hostname set_timezone setup_config system_config git_pull build rebuild rebuild_reboot

--- a/config/codex-target.txt
+++ b/config/codex-target.txt
@@ -1,0 +1,15 @@
+# The OpenAI Codex CLI this fleet runs, and the digest that proves what we ran
+# to install it. ONE line, two fields: <version> <sha256 of the installer>.
+#
+#   version — the openai/codex release, installed by the vendor's own installer
+#             as `--release <version>` (its `rust-v<version>` tag).
+#   sha256  — sha256 of that release's own `install.sh` asset, which
+#             install.sh verifies before executing anything.
+#
+# The two are ONE fact and are bumped together: a version without its digest
+# cannot be installed, which is the point. Read by install.sh and
+# install-x64.sh, in the same spirit as config/openclaw-target.txt.
+#
+# 0.153.4 published 2026-09-04; its install.sh asset is byte-identical to the
+# https://chatgpt.com/codex/install.sh that OpenAI's README documents.
+0.153.4 ba92dd27e5c06f0d3bbc58bfa4b9cfb6599cd2742fbb1f92a2765e6c07dedb5a

--- a/docs-site/technical/filesystem.mdx
+++ b/docs-site/technical/filesystem.mdx
@@ -59,7 +59,8 @@ Rows marked **OpenClaw/dual** or **Hermes/dual** exist only on those editions. C
 | `~/.openclaw` (AI config, credentials, chats) | ✅ kept | ❌ wiped |
 | `~/.hermes` (Hermes config, chats, agent install) | ✅ kept | ❌ wiped, except `hermes-agent` (the agent install) and the whole of `bin/` (which holds `tirith`, the pre-exec shell scanner) — neither can be re-downloaded in AP mode. `bin/` is kept entire rather than filtered down to `tirith`, so anything else upstream puts there survives too |
 | `~/.clawkeep` (backup pairing) | ✅ kept | ❌ wiped |
-| `~/.codex` (Codex CLI auth) | ✅ kept | ❌ wiped |
+| `~/.codex` (Codex CLI auth and state) | ✅ kept | ❌ wiped |
+| `~/.local/share/codex` (the Codex CLI binary itself) | ✅ kept, replaced when the pinned version moves | ✅ kept (a 117 MB download the box cannot make in AP mode) |
 | `~/Documents`, `~/Downloads`, `~/Desktop` | ✅ kept | ❌ contents wiped, directories kept |
 | User crontab | ✅ kept | ❌ cleared |
 | Portal device identity (`data/cloudflared/device-id`) | ✅ kept | ⚠️ the file is deleted, but the id is re-derived identically from `/etc/machine-id` — the box reappears in the portal as the same device |

--- a/install-x64.sh
+++ b/install-x64.sh
@@ -1012,16 +1012,17 @@ step_chromium_install() {
 
 # ── The OpenAI Codex CLI (TASK-439) ──────────────────────────────────────────
 #
-# The device installer's twin, kept deliberately small. Same pin file — one
-# `<version> <sha256>` line in config/codex-target.txt, so this host and the
-# fleet cannot end up on two different builds — same vendor installer, same
-# refusal to run a script whose digest is not the pinned one, and the same
-# order: install the native binary, prove it, and only then take the npm copy
-# away. The vendor installer resolves x86_64-unknown-linux-musl here on its own.
+# The device installer's twin, kept deliberately small and parallel to it. Same
+# pin file — one `<version> <sha256>` line in config/codex-target.txt, so this
+# host and the fleet cannot end up on two different builds — same vendor
+# installer, the same refusal to run a script whose digest is not the pinned
+# one, and the same order: install the native binary, prove it, and only then
+# take the npm copy away. The installer resolves x86_64-unknown-linux-musl here
+# on its own.
 CODEX_NATIVE_BIN="$CLAWBOX_HOME/.local/bin/codex"
 # NOT the installer's default package root ($CODEX_HOME, ~/.codex): that
-# directory is the CLI's auth and state, and on a device a factory reset removes
-# it whole. Kept identical to install.sh so the two hosts have one layout.
+# directory is the CLI's auth and state. Kept identical to install.sh, where a
+# factory reset removes ~/.codex whole, so the two hosts have one layout.
 CODEX_PACKAGE_HOME="$CLAWBOX_HOME/.local/share/codex"
 
 codex_pin_field() {
@@ -1034,8 +1035,36 @@ codex_pin_field() {
   ' "$file"
 }
 
+# By path, never through `command -v`: ~/.npm-global/bin comes first on this
+# PATH too, so while the npm copy survives it is what answers for `codex`.
+codex_native_is_current() {
+  local want="$1" reported
+  [ -x "$CODEX_NATIVE_BIN" ] || return 1
+  reported="$(as_user_login "'$CODEX_NATIVE_BIN' --version" 2>/dev/null | tr -d '\r' | tail -n1)"
+  case " $reported " in *" $want "*) return 0 ;; esac
+  return 1
+}
+
+npm_codex_present() {
+  # -L as well as -e: a half-finished npm uninstall leaves a dangling symlink.
+  [ -e "$NPM_PREFIX/bin/codex" ] || [ -L "$NPM_PREFIX/bin/codex" ]
+}
+
+remove_npm_codex() {
+  npm_codex_present || return 0
+  local rc=0
+  as_user_login "npm uninstall -g @openai/codex --prefix '$NPM_PREFIX'" >/dev/null 2>&1 || rc=$?
+  # npm exits non-zero for a package it never had and zero for one it failed to
+  # unlink, so the re-probe is the verdict and that code only a diagnostic.
+  if npm_codex_present; then
+    echo "  WARN: npm uninstall exited $rc and $NPM_PREFIX/bin/codex is still there; it shadows the native Codex on PATH" >&2
+    return 1
+  fi
+  echo "  Removed the npm-installed Codex"
+}
+
 ensure_codex_cli() {
-  local version sha url installer actual reported
+  local version sha url installer actual
 
   version="$(codex_pin_field 1 2>/dev/null || true)"
   sha="$(codex_pin_field 2 2>/dev/null || true)"
@@ -1045,17 +1074,10 @@ ensure_codex_cli() {
     return 1
   fi
 
-  # By path, not through `command -v`: ~/.npm-global/bin comes first on this
-  # PATH too, so while the npm copy survives it is what answers for `codex`.
-  if [ -x "$CODEX_NATIVE_BIN" ]; then
-    reported="$(as_user_login "'$CODEX_NATIVE_BIN' --version" 2>/dev/null | tr -d '\r' | tail -n1)"
-    case " $reported " in
-      *" $version "*)
-        echo "  OpenAI Codex $version already installed"
-        remove_npm_codex
-        return $?
-        ;;
-    esac
+  if codex_native_is_current "$version"; then
+    echo "  OpenAI Codex $version already installed"
+    remove_npm_codex
+    return $?
   fi
 
   url="https://github.com/openai/codex/releases/download/rust-v$version/install.sh"
@@ -1090,30 +1112,13 @@ ensure_codex_cli() {
   fi
   rm -f "$installer"
 
-  # The installer's exit code is not the outcome.
-  reported="$(as_user_login "'$CODEX_NATIVE_BIN' --version" 2>/dev/null | tr -d '\r' | tail -n1)"
-  case " $reported " in
-    *" $version "*) ;;
-    *)
-      echo "  WARN: the Codex installer exited 0 but $CODEX_NATIVE_BIN does not report $version" >&2
-      return 1
-      ;;
-  esac
-  echo "  OpenAI Codex $version installed at $CODEX_NATIVE_BIN"
-  remove_npm_codex
-}
-
-remove_npm_codex() {
-  # -L as well as -e, because a half-finished npm uninstall leaves a dangling
-  # symlink behind.
-  { [ -e "$NPM_PREFIX/bin/codex" ] || [ -L "$NPM_PREFIX/bin/codex" ]; } || return 0
-  local rc=0
-  as_user_login "npm uninstall -g @openai/codex --prefix '$NPM_PREFIX'" >/dev/null 2>&1 || rc=$?
-  if [ -e "$NPM_PREFIX/bin/codex" ] || [ -L "$NPM_PREFIX/bin/codex" ]; then
-    echo "  WARN: npm uninstall exited $rc and $NPM_PREFIX/bin/codex is still there; it shadows the native Codex on PATH" >&2
+  # The installer's exit code is not the outcome. Ask the binary.
+  if ! codex_native_is_current "$version"; then
+    echo "  WARN: the Codex installer exited 0 but $CODEX_NATIVE_BIN does not report $version" >&2
     return 1
   fi
-  echo "  Removed the npm-installed Codex"
+  echo "  OpenAI Codex $version installed at $CODEX_NATIVE_BIN"
+  remove_npm_codex
 }
 
 step_ai_tools_install() {

--- a/install-x64.sh
+++ b/install-x64.sh
@@ -1040,7 +1040,10 @@ codex_pin_field() {
 codex_native_is_current() {
   local want="$1" reported
   [ -x "$CODEX_NATIVE_BIN" ] || return 1
-  reported="$(as_user_login "'$CODEX_NATIVE_BIN' --version" 2>/dev/null | tr -d '\r' | tail -n1)"
+  # `|| true`: under `set -euo pipefail` a binary that will not exec would fail
+  # the pipeline, fail the assignment and end the whole run, over the very case
+  # this line exists to detect.
+  reported="$(as_user_login "'$CODEX_NATIVE_BIN' --version" 2>/dev/null | tr -d '\r' | tail -n1 || true)"
   case " $reported " in *" $want "*) return 0 ;; esac
   return 1
 }
@@ -1090,7 +1093,9 @@ ensure_codex_cli() {
     return 1
   fi
 
-  actual="$(sha256sum "$installer" 2>/dev/null | cut -d' ' -f1)"
+  # `|| true` for the same reason: an unusable sha256sum must reach the
+  # refusal below (which already words an empty digest), not end the run.
+  actual="$(sha256sum "$installer" 2>/dev/null | cut -d' ' -f1 || true)"
   if [ "$actual" != "$sha" ]; then
     echo "  WARN: the Codex installer for rust-v$version does not match its pinned sha256 — not running it" >&2
     rm -f "$installer"

--- a/install-x64.sh
+++ b/install-x64.sh
@@ -1010,6 +1010,112 @@ step_chromium_install() {
   ensure_playwright_chromium
 }
 
+# ── The OpenAI Codex CLI (TASK-439) ──────────────────────────────────────────
+#
+# The device installer's twin, kept deliberately small. Same pin file — one
+# `<version> <sha256>` line in config/codex-target.txt, so this host and the
+# fleet cannot end up on two different builds — same vendor installer, same
+# refusal to run a script whose digest is not the pinned one, and the same
+# order: install the native binary, prove it, and only then take the npm copy
+# away. The vendor installer resolves x86_64-unknown-linux-musl here on its own.
+CODEX_NATIVE_BIN="$CLAWBOX_HOME/.local/bin/codex"
+# NOT the installer's default package root ($CODEX_HOME, ~/.codex): that
+# directory is the CLI's auth and state, and on a device a factory reset removes
+# it whole. Kept identical to install.sh so the two hosts have one layout.
+CODEX_PACKAGE_HOME="$CLAWBOX_HOME/.local/share/codex"
+
+codex_pin_field() {
+  local file="${CODEX_PIN_FILE:-$PROJECT_DIR/config/codex-target.txt}"
+  [ -f "$file" ] || return 1
+  awk -v n="$1" '
+    /^[[:space:]]*#/ { next }
+    NF >= 2 { print $n; found = 1; exit }
+    END { if (!found) exit 1 }
+  ' "$file"
+}
+
+ensure_codex_cli() {
+  local version sha url installer actual reported
+
+  version="$(codex_pin_field 1 2>/dev/null || true)"
+  sha="$(codex_pin_field 2 2>/dev/null || true)"
+  if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' \
+    || ! printf '%s' "$sha" | grep -Eq '^[0-9a-f]{64}$'; then
+    echo "  WARN: config/codex-target.txt carries no '<version> <sha256>' pin; not installing Codex" >&2
+    return 1
+  fi
+
+  # By path, not through `command -v`: ~/.npm-global/bin comes first on this
+  # PATH too, so while the npm copy survives it is what answers for `codex`.
+  if [ -x "$CODEX_NATIVE_BIN" ]; then
+    reported="$(as_user_login "'$CODEX_NATIVE_BIN' --version" 2>/dev/null | tr -d '\r' | tail -n1)"
+    case " $reported " in
+      *" $version "*)
+        echo "  OpenAI Codex $version already installed"
+        remove_npm_codex
+        return $?
+        ;;
+    esac
+  fi
+
+  url="https://github.com/openai/codex/releases/download/rust-v$version/install.sh"
+  installer="$(mktemp)"
+  if ! curl -fsSL --proto '=https' --proto-redir '=https' \
+      --connect-timeout 15 --max-time 300 "$url" -o "$installer" 2>/dev/null \
+    || [ ! -s "$installer" ]; then
+    echo "  WARN: could not download OpenAI's Codex installer from $url" >&2
+    rm -f "$installer"
+    return 1
+  fi
+
+  actual="$(sha256sum "$installer" 2>/dev/null | cut -d' ' -f1)"
+  if [ "$actual" != "$sha" ]; then
+    echo "  WARN: the Codex installer for rust-v$version does not match its pinned sha256 — not running it" >&2
+    rm -f "$installer"
+    return 1
+  fi
+
+  # After the download, before the run: mktemp makes the file root:root 0600 and
+  # it is executed as the unprivileged user.
+  if ! chown "$CLAWBOX_USER" "$installer"; then
+    echo "  WARN: could not hand the Codex installer to $CLAWBOX_USER; not running it" >&2
+    rm -f "$installer"
+    return 1
+  fi
+
+  if ! as_user_login "CODEX_RELEASE='$version' CODEX_NON_INTERACTIVE=true CODEX_INSTALL_DIR='$CLAWBOX_HOME/.local/bin' CODEX_HOME='$CODEX_PACKAGE_HOME' sh '$installer'" </dev/null; then
+    echo "  WARN: OpenAI's Codex installer ran but failed" >&2
+    rm -f "$installer"
+    return 1
+  fi
+  rm -f "$installer"
+
+  # The installer's exit code is not the outcome.
+  reported="$(as_user_login "'$CODEX_NATIVE_BIN' --version" 2>/dev/null | tr -d '\r' | tail -n1)"
+  case " $reported " in
+    *" $version "*) ;;
+    *)
+      echo "  WARN: the Codex installer exited 0 but $CODEX_NATIVE_BIN does not report $version" >&2
+      return 1
+      ;;
+  esac
+  echo "  OpenAI Codex $version installed at $CODEX_NATIVE_BIN"
+  remove_npm_codex
+}
+
+remove_npm_codex() {
+  # -L as well as -e, because a half-finished npm uninstall leaves a dangling
+  # symlink behind.
+  { [ -e "$NPM_PREFIX/bin/codex" ] || [ -L "$NPM_PREFIX/bin/codex" ]; } || return 0
+  local rc=0
+  as_user_login "npm uninstall -g @openai/codex --prefix '$NPM_PREFIX'" >/dev/null 2>&1 || rc=$?
+  if [ -e "$NPM_PREFIX/bin/codex" ] || [ -L "$NPM_PREFIX/bin/codex" ]; then
+    echo "  WARN: npm uninstall exited $rc and $NPM_PREFIX/bin/codex is still there; it shadows the native Codex on PATH" >&2
+    return 1
+  fi
+  echo "  Removed the npm-installed Codex"
+}
+
 step_ai_tools_install() {
   # Claude Code
   if sudo -u "$CLAWBOX_USER" bash -c 'command -v claude' &>/dev/null; then
@@ -1019,13 +1125,8 @@ step_ai_tools_install() {
     echo "  Claude Code installed"
   fi
 
-  # OpenAI Codex CLI
-  if as_user_login "command -v codex" &>/dev/null; then
-    echo "  OpenAI Codex already installed"
-  else
-    as_user_login "npm i -g @openai/codex --prefix $NPM_PREFIX" 2>/dev/null || echo "  Warning: Codex install failed"
-    echo "  OpenAI Codex installed"
-  fi
+  # OpenAI Codex CLI — the pinned native binary, never an npm global (TASK-439).
+  ensure_codex_cli || echo "  Warning: Codex install failed"
 
   # Google Gemini CLI
   if as_user_login "command -v gemini" &>/dev/null; then

--- a/install-x64.sh
+++ b/install-x64.sh
@@ -1084,7 +1084,7 @@ ensure_codex_cli() {
   fi
 
   url="https://github.com/openai/codex/releases/download/rust-v$version/install.sh"
-  installer="$(mktemp)"
+  installer="$(mktemp || true)"
   if ! curl -fsSL --proto '=https' --proto-redir '=https' \
       --connect-timeout 15 --max-time 300 "$url" -o "$installer" 2>/dev/null \
     || [ ! -s "$installer" ]; then
@@ -1110,7 +1110,12 @@ ensure_codex_cli() {
     return 1
   fi
 
-  if ! as_user_login "CODEX_RELEASE='$version' CODEX_NON_INTERACTIVE=true CODEX_INSTALL_DIR='$CLAWBOX_HOME/.local/bin' CODEX_HOME='$CODEX_PACKAGE_HOME' sh '$installer'" </dev/null; then
+  # CODEX_NON_INTERACTIVE=true is what declines the installer's own offer to
+  # remove the npm copy (its prompt opens /dev/tty, so </dev/null alone would
+  # not) — the removal is ours, after the verification. `timeout` bounds the
+  # ~117 MB package fetch, which the vendor leaves unbounded on its GitHub
+  # fallback path.
+  if ! as_user_login "CODEX_RELEASE='$version' CODEX_NON_INTERACTIVE=true CODEX_INSTALL_DIR='$CLAWBOX_HOME/.local/bin' CODEX_HOME='$CODEX_PACKAGE_HOME' timeout -k 30 1800 sh '$installer'" </dev/null; then
     echo "  WARN: OpenAI's Codex installer ran but failed" >&2
     rm -f "$installer"
     return 1

--- a/install-x64.sh
+++ b/install-x64.sh
@@ -1128,7 +1128,21 @@ ensure_codex_cli() {
     return 1
   fi
   echo "  OpenAI Codex $version installed at $CODEX_NATIVE_BIN"
-  remove_npm_codex
+
+  local rc=0
+  remove_npm_codex || rc=1
+  # The same verdict the device installer ends on: PATH order, not the presence
+  # of a file. `as_user_login` puts ~/.bun/bin ahead of ~/.local/bin, so a codex
+  # installed by bun still shadows the pinned one and this would otherwise
+  # report success — and the two installers would answer differently about the
+  # same box.
+  local resolved
+  resolved="$(as_user_login "command -v codex" 2>/dev/null | tr -d '\r' | tail -n1 || true)"
+  if [ "$resolved" != "$CODEX_NATIVE_BIN" ]; then
+    echo "  WARN: \`codex\` still resolves to ${resolved:-nothing}, not $CODEX_NATIVE_BIN" >&2
+    rc=1
+  fi
+  return "$rc"
 }
 
 step_ai_tools_install() {

--- a/install.sh
+++ b/install.sh
@@ -7328,9 +7328,7 @@ ensure_claude_code() {
   fi
 
   local installer rc=1
-  # `|| true` for the errexit reason above; an empty path then falls into the
-  # download-failed branch, which reports rather than ends the run.
-  installer="$(mktemp || true)"
+  installer="$(mktemp)"
   # --max-time bounds a STALLED vendor: this runs inside step_post_update, and
   # every recovery step after it waits behind this download. --proto-redir keeps
   # a redirect from stepping down to plain HTTP on the way to something we then
@@ -7643,7 +7641,10 @@ ensure_codex_cli() {
   fi
 
   url="https://github.com/openai/codex/releases/download/rust-v$version/install.sh"
-  installer="$(mktemp)"
+  # `|| true` for the errexit reason above: `--step codex_cli` calls this
+  # plainly, so a full or read-only /tmp would end install.sh at this line with
+  # nothing said. Empty, it falls into the download-failed branch, which reports.
+  installer="$(mktemp || true)"
   # --max-time bounds THIS fetch — the ~30 KB installer script, nothing more.
   # The vendor's own 117 MB package download is bounded separately below.
   # --proto-redir stops a redirect stepping down to plain HTTP on the way to

--- a/install.sh
+++ b/install.sh
@@ -748,6 +748,25 @@ OPENCLAW_VERSION="2026.8.1"
 #
 # Current pin: upstream tag v2026.8.19 == "Hermes Agent v0.20.5".
 HERMES_PIN_COMMIT="${HERMES_PIN_COMMIT:-fcbd1076a93841fa88855acce810e342a5b78101}"
+
+# The OpenAI Codex CLI (TASK-439). The pinned version and the digest that
+# authorises it live in config/codex-target.txt; these two are only WHERE the
+# result lands.
+#
+# The binary the vendor's installer links into ~/.local/bin, and the only path
+# this file ever treats as "the native Codex". `command -v codex` is not that
+# test: ~/.bashrc and as_clawbox_login both put ~/.npm-global/bin AHEAD of
+# ~/.local/bin, so while the npm copy survives it answers for `codex`.
+CODEX_NATIVE_BIN="$CLAWBOX_HOME/.local/bin/codex"
+# Where the installer unpacks its standalone package — deliberately NOT its
+# default, which is $CODEX_HOME (~/.codex). A factory reset removes ~/.codex
+# whole (HOME_REMOVE_PATHS in src/app/setup-api/setup/reset/route.ts), and that
+# is right for the credentials and state it holds; it would be wrong for a
+# 117 MB binary, because the reset leaves the box in AP mode with no internet
+# and ~/.local/bin/codex would dangle until an update ran. Only the installer
+# is told this — nothing exports CODEX_HOME at runtime, so the CLI still reads
+# its auth and config from ~/.codex, which is what the auth-sync timer writes.
+CODEX_PACKAGE_HOME="$CLAWBOX_HOME/.local/share/codex"
 GATEWAY_DIST="$NPM_PREFIX/lib/node_modules/openclaw/dist"
 DNSMASQ_DIR="/etc/NetworkManager/dnsmasq-shared.d"
 AVAHI_CONF="/etc/avahi/avahi-daemon.conf"
@@ -934,7 +953,10 @@ as_clawbox_login() {
 ensure_clawbox_bashrc_path() {
   # Make ~/.npm-global/bin and ~/.local/bin available in the clawbox user's
   # interactive shells (e.g. the in-UI terminal) so CLIs like openclaw, claude,
-  # codex, gemini, hf, and clawkeep resolve without a full path.
+  # codex, gemini, hf, and clawkeep resolve without a full path. Codex is a
+  # user-local binary since TASK-439; the stanza's own wording is left as it
+  # is, because it is TEXT ALREADY WRITTEN into every shipped box's ~/.bashrc
+  # and rewording it here would only make the two disagree.
   local BASHRC="$CLAWBOX_HOME/.bashrc"
   if ! grep -q 'npm-global/bin' "$BASHRC" 2>/dev/null; then
     cat >> "$BASHRC" <<'PATHEOF'
@@ -6070,6 +6092,12 @@ step_post_update() {
   # already-shipped box has `claude` on it today. Idempotent — a present
   # `claude` short-circuits after one `command -v`, and the wrapper is a copy.
   step_coding_harness || echo "  Warning: coding_harness step failed (non-fatal)"
+  # The Codex CLI. Without this call the pinned native binary would be
+  # fresh-install-only — step_post_update does not run step_ai_tools_install —
+  # and every box in the field would keep the unpinned, unverified npm copy for
+  # good. Idempotent: a box already on the pin does one `codex --version` and
+  # stops.
+  step_codex_cli || echo "  Warning: codex_cli step failed (non-fatal)"
   # On-device TTS: installs/refreshes Kokoro and the voice scripts, and seeds
   # the tts-local-cli provider. Without this call the whole of TASK-383 would
   # be fresh-install-only, and every already-shipped box would keep answering
@@ -7496,6 +7524,198 @@ step_coding_harness() {
   fi
 }
 
+# ── The OpenAI Codex CLI (TASK-439) ──────────────────────────────────────────
+#
+# One field of config/codex-target.txt: 1 = the pinned version, 2 = the sha256
+# of that release's own installer. Comment lines are skipped, and a file that
+# carries no `<version> <sha256>` line answers nothing — which every caller
+# treats as "install nothing", never as a default.
+codex_pin_field() {
+  local file="${CODEX_PIN_FILE:-$PROJECT_DIR/config/codex-target.txt}"
+  [ -f "$file" ] || return 1
+  awk -v n="$1" '
+    /^[[:space:]]*#/ { next }
+    NF >= 2 { print $n; found = 1; exit }
+    END { if (!found) exit 1 }
+  ' "$file"
+}
+
+# Is the pinned native Codex the binary at $CODEX_NATIVE_BIN?
+#
+# Asked of the FILE, never through `command -v`: while the npm copy survives it
+# comes first on the login shell's PATH, so a PATH probe answers "not the
+# native one" on a box where the native one is installed and current — and this
+# step would then re-download OpenAI's package on every single update until the
+# npm removal finally succeeded.
+codex_native_is_current() {
+  local want="$1" reported
+  [ -x "$CODEX_NATIVE_BIN" ] || return 1
+  reported="$(as_clawbox_login "'$CODEX_NATIVE_BIN' --version" 2>/dev/null | tr -d '\r' | tail -n1)"
+  # A whole token, so 0.153.40 is not read as 0.153.4, and tolerant of whatever
+  # else the vendor puts on that line.
+  case " $reported " in *" $want "*) return 0 ;; esac
+  return 1
+}
+
+npm_codex_present() {
+  # -e alone is false for a DANGLING symlink, which is what a half-finished npm
+  # uninstall leaves behind. Such a link shadows nothing (it is not executable),
+  # but it is still something left over, and reporting it beats calling the
+  # removal a success over it.
+  [ -e "$NPM_PREFIX/bin/codex" ] || [ -L "$NPM_PREFIX/bin/codex" ]
+}
+
+# Take the npm-installed Codex away, so exactly one codex is on PATH.
+#
+# Called ONLY over a native install that has been verified — never before one,
+# and never over an installer that merely exited 0. A box left with no codex at
+# all is worse than a box still running the old one.
+remove_npm_codex() {
+  npm_codex_present || return 0
+  local rc=0
+  as_clawbox_login "npm uninstall -g @openai/codex --prefix '$NPM_PREFIX'" >/dev/null 2>&1 || rc=$?
+  # That exit code is a DIAGNOSTIC, not the verdict: npm exits non-zero for a
+  # package it never had, and zero for one it failed to unlink. The re-probe is
+  # the verdict.
+  if npm_codex_present; then
+    echo "  WARN: npm uninstall exited $rc and $NPM_PREFIX/bin/codex is still there;" >&2
+    echo "  it comes before ~/.local/bin on PATH, so it still shadows the native Codex." >&2
+    return 1
+  fi
+  echo "  Removed the npm-installed Codex"
+}
+
+# What the box is left running when an install did not happen. Said out loud,
+# because "could not install Codex" and "this box now has no Codex" are
+# different facts and only one of them needs anybody's attention.
+codex_left_as_is() {
+  if [ -x "$CODEX_NATIVE_BIN" ]; then
+    echo "  Keeping the Codex already at $CODEX_NATIVE_BIN" >&2
+  elif npm_codex_present; then
+    echo "  Keeping the npm-installed Codex at $NPM_PREFIX/bin/codex" >&2
+  else
+    echo "  This box has no Codex CLI" >&2
+  fi
+}
+
+# Install the pinned Codex CLI with OpenAI's own installer, and leave exactly
+# one codex on PATH.
+#
+# The vendor's documented installer is `curl -fsSL https://chatgpt.com/codex/
+# install.sh | sh`, which always serves `latest` and cannot be checksummed. The
+# SAME script is attached to every release as an immutable asset, so that is
+# what is fetched, verified against config/codex-target.txt and then run with
+# `--release` pinned. The installer itself resolves the release from
+# releases.openai.com (GitHub Releases is its own fallback), checks the package
+# archive against OpenAI's published codex-package_SHA256SUMS, unpacks it and
+# links ~/.local/bin/codex at it — none of which is reimplemented here.
+#
+# Returns 0 only when `codex` on the owner's PATH IS the pinned native binary.
+ensure_codex_cli() {
+  local version sha url installer actual resolved rc
+
+  version="$(codex_pin_field 1 2>/dev/null || true)"
+  sha="$(codex_pin_field 2 2>/dev/null || true)"
+  if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' \
+    || ! printf '%s' "$sha" | grep -Eq '^[0-9a-f]{64}$'; then
+    echo "  WARN: config/codex-target.txt carries no '<version> <sha256>' pin; not installing Codex" >&2
+    codex_left_as_is
+    return 1
+  fi
+
+  if codex_native_is_current "$version"; then
+    echo "  OpenAI Codex $version already installed"
+    # Still converge on ONE codex: an earlier run may have installed the binary
+    # and failed to take the npm copy away, and until it goes the owner's
+    # `codex` is still the old one.
+    remove_npm_codex || return 1
+    return 0
+  fi
+
+  url="https://github.com/openai/codex/releases/download/rust-v$version/install.sh"
+  installer="$(mktemp)"
+  # --max-time bounds a stalled vendor: this runs inside step_post_update and
+  # every later recovery step waits behind it. --proto-redir stops a redirect
+  # stepping down to plain HTTP on the way to something we then execute.
+  if ! curl -fsSL --proto '=https' --proto-redir '=https' \
+      --connect-timeout 15 --max-time 300 "$url" -o "$installer" 2>/dev/null \
+    || [ ! -s "$installer" ]; then
+    echo "  WARN: could not download OpenAI's Codex installer from $url" >&2
+    codex_left_as_is
+    rm -f "$installer"
+    return 1
+  fi
+
+  actual="$(sha256sum "$installer" 2>/dev/null | cut -d' ' -f1)"
+  if [ "$actual" != "$sha" ]; then
+    echo "  WARN: the Codex installer for rust-v$version does not match its pinned sha256 — not running it" >&2
+    echo "  expected $sha, got ${actual:-<none>}" >&2
+    codex_left_as_is
+    rm -f "$installer"
+    return 1
+  fi
+
+  # AFTER the download and before the run — both halves paid for on hardware by
+  # the sibling coding CLI (TASK-378). mktemp makes the file root:root 0600 and
+  # it is executed AS the clawbox user, so without this every run answers
+  # "Permission denied"; moved before the curl, fs.protected_regular=2 stops
+  # even root writing a file it does not own in sticky world-writable /tmp and
+  # curl exits 23, "Failure writing output to destination".
+  if ! chown "$CLAWBOX_USER" "$installer"; then
+    echo "  WARN: could not hand the Codex installer to $CLAWBOX_USER; not running it" >&2
+    codex_left_as_is
+    rm -f "$installer"
+    return 1
+  fi
+
+  # </dev/null as well as CODEX_NON_INTERACTIVE=true: an installer that found a
+  # tty here would be asking an unattended update a question nobody can answer.
+  # It DOES notice the npm copy and offer to remove it; under non-interactive
+  # that offer is declined, which is why the removal below is ours to do — and
+  # ours is the honest order, since the vendor's would take the working Codex
+  # away before knowing whether the new one runs.
+  if ! as_clawbox_login "CODEX_RELEASE='$version' CODEX_NON_INTERACTIVE=true CODEX_INSTALL_DIR='$CLAWBOX_HOME/.local/bin' CODEX_HOME='$CODEX_PACKAGE_HOME' sh '$installer'" </dev/null; then
+    echo "  WARN: OpenAI's Codex installer ran but failed" >&2
+    codex_left_as_is
+    rm -f "$installer"
+    return 1
+  fi
+  rm -f "$installer"
+
+  # Its exit code is not the outcome. Ask the binary.
+  if ! codex_native_is_current "$version"; then
+    echo "  WARN: the Codex installer exited 0 but $CODEX_NATIVE_BIN does not report $version" >&2
+    codex_left_as_is
+    return 1
+  fi
+  echo "  OpenAI Codex $version installed at $CODEX_NATIVE_BIN"
+
+  rc=0
+  remove_npm_codex || rc=1
+
+  # The acceptance this card is about: what the owner gets when they type
+  # `codex` in the box's own terminal, which is PATH order and not the presence
+  # of a file.
+  resolved="$(as_clawbox_login "command -v codex" 2>/dev/null | tr -d '\r' | tail -n1)"
+  if [ "$resolved" != "$CODEX_NATIVE_BIN" ]; then
+    echo "  WARN: \`codex\` still resolves to ${resolved:-nothing}, not $CODEX_NATIVE_BIN" >&2
+    rc=1
+  fi
+  return "$rc"
+}
+
+# Dispatchable on its own and called from step_post_update — the same shape
+# step_coding_harness has, and for the same reason: an in-app update has to
+# deliver this without also reinstalling the Gemini CLI on every box that
+# updates, and every box in the field today carries the npm Codex it replaces.
+step_codex_cli() {
+  if is_test_mode; then
+    echo "  CLAWBOX_TEST_MODE=1, skipping the Codex CLI install"
+    return 0
+  fi
+  ensure_codex_cli
+}
+
 step_ai_tools_install() {
   if is_test_mode; then
     echo "  CLAWBOX_TEST_MODE=1, skipping Claude/Codex/Gemini CLI install"
@@ -7509,14 +7729,10 @@ step_ai_tools_install() {
 
   ensure_claude_code || true
 
-  # OpenAI Codex CLI (optional)
-  if as_clawbox_login "command -v codex" &>/dev/null; then
-    echo "  OpenAI Codex already installed"
-  elif as_clawbox_login "npm i -g @openai/codex --prefix $NPM_PREFIX"; then
-    echo "  OpenAI Codex installed"
-  else
-    echo "  WARN: OpenAI Codex CLI install failed; skipping (optional, continuing)"
-  fi
+  # OpenAI Codex CLI (optional): the pinned native binary, never an npm global.
+  # Swallowed here for the same reason as Claude Code above — this step must not
+  # abort over an optional tool — and reported honestly inside the function.
+  ensure_codex_cli || true
 
   # Google Gemini CLI (optional)
   if as_clawbox_login "command -v gemini" &>/dev/null; then
@@ -8197,7 +8413,7 @@ step_validate_services() {
 DISPATCH_STEPS=(
   bootstrap_updater apt_update nvidia_jetpack performance_mode jtop_install ollama_install llamacpp_install llamacpp_model
   embed_model
-  chromium_install ai_tools_install coding_harness vnc_install vnc_refresh
+  chromium_install ai_tools_install coding_harness codex_cli vnc_install vnc_refresh
   openclaw_setup openclaw_install openclaw_patch openclaw_config openclaw_models openclaw_tts
   # Edition steps must be dispatchable or no in-app update can ever re-bake the
   # lock, install Hermes, or repair a Hermes appliance — which is how a Hermes

--- a/install.sh
+++ b/install.sh
@@ -953,15 +953,12 @@ as_clawbox_login() {
 ensure_clawbox_bashrc_path() {
   # Make ~/.npm-global/bin and ~/.local/bin available in the clawbox user's
   # interactive shells (e.g. the in-UI terminal) so CLIs like openclaw, claude,
-  # codex, gemini, hf, and clawkeep resolve without a full path. Codex is a
-  # user-local binary since TASK-439; the stanza's own wording is left as it
-  # is, because it is TEXT ALREADY WRITTEN into every shipped box's ~/.bashrc
-  # and rewording it here would only make the two disagree.
+  # codex, gemini, hf, and clawkeep resolve without a full path.
   local BASHRC="$CLAWBOX_HOME/.bashrc"
   if ! grep -q 'npm-global/bin' "$BASHRC" 2>/dev/null; then
     cat >> "$BASHRC" <<'PATHEOF'
 
-# npm global binaries (openclaw, codex, gemini) and user-local binaries (claude, hf, clawkeep)
+# npm global binaries (openclaw, gemini) and user-local binaries (claude, codex, hf, clawkeep)
 export PATH="$HOME/.npm-global/bin:$HOME/.local/bin:$PATH"
 PATHEOF
     chown "$CLAWBOX_USER:$CLAWBOX_USER" "$BASHRC"
@@ -7331,7 +7328,9 @@ ensure_claude_code() {
   fi
 
   local installer rc=1
-  installer="$(mktemp)"
+  # `|| true` for the errexit reason above; an empty path then falls into the
+  # download-failed branch, which reports rather than ends the run.
+  installer="$(mktemp || true)"
   # --max-time bounds a STALLED vendor: this runs inside step_post_update, and
   # every recovery step after it waits behind this download. --proto-redir keeps
   # a redirect from stepping down to plain HTTP on the way to something we then
@@ -7593,11 +7592,17 @@ remove_npm_codex() {
 # What the box is left running when an install did not happen. Said out loud,
 # because "could not install Codex" and "this box now has no Codex" are
 # different facts and only one of them needs anybody's attention.
+#
+# The login shell is asked, rather than the two files being tested in some
+# order: on the commonest failure BOTH are present — every shipped box has the
+# npm copy, and a previous partial run may have left a native binary — and PATH
+# order decides which one the owner gets. Naming the other one would state the
+# opposite of what this line is for.
 codex_left_as_is() {
-  if [ -x "$CODEX_NATIVE_BIN" ]; then
-    echo "  Keeping the Codex already at $CODEX_NATIVE_BIN" >&2
-  elif npm_codex_present; then
-    echo "  Keeping the npm-installed Codex at $NPM_PREFIX/bin/codex" >&2
+  local resolved
+  resolved="$(as_clawbox_login "command -v codex" 2>/dev/null | tr -d '\r' | tail -n1 || true)"
+  if [ -n "$resolved" ]; then
+    echo "  Keeping the Codex this box resolves today: $resolved" >&2
   else
     echo "  This box has no Codex CLI" >&2
   fi
@@ -7639,9 +7644,10 @@ ensure_codex_cli() {
 
   url="https://github.com/openai/codex/releases/download/rust-v$version/install.sh"
   installer="$(mktemp)"
-  # --max-time bounds a stalled vendor: this runs inside step_post_update and
-  # every later recovery step waits behind it. --proto-redir stops a redirect
-  # stepping down to plain HTTP on the way to something we then execute.
+  # --max-time bounds THIS fetch — the ~30 KB installer script, nothing more.
+  # The vendor's own 117 MB package download is bounded separately below.
+  # --proto-redir stops a redirect stepping down to plain HTTP on the way to
+  # something we then execute.
   if ! curl -fsSL --proto '=https' --proto-redir '=https' \
       --connect-timeout 15 --max-time 300 "$url" -o "$installer" 2>/dev/null \
     || [ ! -s "$installer" ]; then
@@ -7675,13 +7681,29 @@ ensure_codex_cli() {
     return 1
   fi
 
-  # </dev/null as well as CODEX_NON_INTERACTIVE=true: an installer that found a
-  # tty here would be asking an unattended update a question nobody can answer.
-  # It DOES notice the npm copy and offer to remove it; under non-interactive
-  # that offer is declined, which is why the removal below is ours to do — and
-  # ours is the honest order, since the vendor's would take the working Codex
-  # away before knowing whether the new one runs.
-  if ! as_clawbox_login "CODEX_RELEASE='$version' CODEX_NON_INTERACTIVE=true CODEX_INSTALL_DIR='$CLAWBOX_HOME/.local/bin' CODEX_HOME='$CODEX_PACKAGE_HOME' sh '$installer'" </dev/null; then
+  # CODEX_NON_INTERACTIVE=true is load-bearing, and </dev/null is not a
+  # substitute for it: the installer's prompt opens /dev/tty directly, so only
+  # the variable stops an unattended update being asked a question nobody can
+  # answer. It DOES notice the npm copy and offer to remove it; that offer is
+  # what non-interactive declines, which is why the removal below is ours to do
+  # — and ours is the honest order, since the vendor's would take the working
+  # Codex away before knowing whether the new one runs.
+  #
+  # Two side effects of the vendor's, recorded rather than fought:
+  #   * having seen the npm copy it also appends its own marked block
+  #     (`# >>> Codex installer >>>`) to the clawbox user's ~/.bashrc, putting
+  #     ~/.local/bin first. Marker-guarded, so it cannot duplicate, and it does
+  #     not disturb ensure_clawbox_bashrc_path (whose guard greps the export
+  #     line, not the comment). It makes the native binary win sooner, which is
+  #     the direction this step is going in anyway.
+  #   * it downloads a ~117 MB package, and on its GitHub fallback path applies
+  #     no timeout of its own. `timeout` is therefore ours: without it a stalled
+  #     fetch parks step_post_update — and every recovery step queued behind it
+  #     — until systemd's TimeoutStartSec=7200 fires two hours later. -k because
+  #     a plain SIGTERM is not a ceiling; a killed install leaves the vendor's
+  #     staging directory rather than a half-linked codex, and the verification
+  #     below is what decides either way.
+  if ! as_clawbox_login "CODEX_RELEASE='$version' CODEX_NON_INTERACTIVE=true CODEX_INSTALL_DIR='$CLAWBOX_HOME/.local/bin' CODEX_HOME='$CODEX_PACKAGE_HOME' timeout -k 30 1800 sh '$installer'" </dev/null; then
     echo "  WARN: OpenAI's Codex installer ran but failed" >&2
     codex_left_as_is
     rm -f "$installer"
@@ -7737,7 +7759,7 @@ step_ai_tools_install() {
   ensure_claude_code || true
 
   # OpenAI Codex CLI (optional): the pinned native binary, never an npm global.
-  # Swallowed here for the same reason as Claude Code above — this step must not
+  # Swallowed here for the same reason as the CLI above — this step must not
   # abort over an optional tool — and reported honestly inside the function.
   ensure_codex_cli || true
 

--- a/install.sh
+++ b/install.sh
@@ -7550,7 +7550,12 @@ codex_pin_field() {
 codex_native_is_current() {
   local want="$1" reported
   [ -x "$CODEX_NATIVE_BIN" ] || return 1
-  reported="$(as_clawbox_login "'$CODEX_NATIVE_BIN' --version" 2>/dev/null | tr -d '\r' | tail -n1)"
+  # `|| true` because `set -euo pipefail` is in force and this may be reached
+  # from a PLAIN call (`--step codex_cli` runs "step_${name}" unguarded): a
+  # binary that will not exec makes the pipeline fail, the assignment fail, and
+  # errexit end the run silently — over the very case this line is here to
+  # detect and report.
+  reported="$(as_clawbox_login "'$CODEX_NATIVE_BIN' --version" 2>/dev/null | tr -d '\r' | tail -n1 || true)"
   # A whole token, so 0.153.40 is not read as 0.153.4, and tolerant of whatever
   # else the vendor puts on that line.
   case " $reported " in *" $want "*) return 0 ;; esac
@@ -7646,7 +7651,9 @@ ensure_codex_cli() {
     return 1
   fi
 
-  actual="$(sha256sum "$installer" 2>/dev/null | cut -d' ' -f1)"
+  # `|| true` for the same reason: an unusable sha256sum must reach the
+  # refusal below (which already words an empty digest), not end the run.
+  actual="$(sha256sum "$installer" 2>/dev/null | cut -d' ' -f1 || true)"
   if [ "$actual" != "$sha" ]; then
     echo "  WARN: the Codex installer for rust-v$version does not match its pinned sha256 — not running it" >&2
     echo "  expected $sha, got ${actual:-<none>}" >&2
@@ -7696,7 +7703,7 @@ ensure_codex_cli() {
   # The acceptance this card is about: what the owner gets when they type
   # `codex` in the box's own terminal, which is PATH order and not the presence
   # of a file.
-  resolved="$(as_clawbox_login "command -v codex" 2>/dev/null | tr -d '\r' | tail -n1)"
+  resolved="$(as_clawbox_login "command -v codex" 2>/dev/null | tr -d '\r' | tail -n1 || true)"
   if [ "$resolved" != "$CODEX_NATIVE_BIN" ]; then
     echo "  WARN: \`codex\` still resolves to ${resolved:-nothing}, not $CODEX_NATIVE_BIN" >&2
     rc=1

--- a/src/tests/unit/install-codex-cli.test.ts
+++ b/src/tests/unit/install-codex-cli.test.ts
@@ -189,6 +189,16 @@ describe("the x64 desktop installer follows the same rules", () => {
   // running different builds, and it is asserted above.
   const ensure = () => extractShellFunctionFrom(INSTALL_X64, "ensure_codex_cli");
 
+  it("ends on the same verdict the device installer does: what `codex` resolves to", () => {
+    // Both files must answer the same question about the same box. `as_user_login`
+    // puts ~/.bun/bin ahead of ~/.local/bin here too, so removing the npm copy
+    // is not the same fact as the pinned binary being the one that runs.
+    const fn = shellCode(ensure());
+    expect(fn).toContain('as_user_login "command -v codex"');
+    expect(fn).toMatch(/still resolves to/);
+    expect(fn.lastIndexOf("command -v codex")).toBeGreaterThan(fn.lastIndexOf("remove_npm_codex"));
+  });
+
   it("verifies the installer's digest before running it, and probes with a login shell", () => {
     const fn = ensure();
     expect(fn.indexOf("sha256sum")).toBeGreaterThan(-1);
@@ -296,6 +306,8 @@ function runEnsure(opts: {
   pin?: string;
   /** Can the box compute a digest at all? */
   sha256sumWorks?: boolean;
+  /** Can it make a temp file at all? (a full or read-only /tmp) */
+  mktempWorks?: boolean;
   /** Call it the way `--step codex_cli` does: plainly, under `set -e`. */
   plainCall?: boolean;
 }): Run {
@@ -307,6 +319,7 @@ function runEnsure(opts: {
     bunCodex = false,
     npmDangling = false,
     sha256sumWorks = true,
+    mktempWorks = true,
     plainCall = false,
   } = opts;
   const pinned = readPin();
@@ -360,6 +373,7 @@ function runEnsure(opts: {
     '  cat "$PAYLOAD" > "$out"',
     "}",
     ...(sha256sumWorks ? [] : ["sha256sum() { return 127; }"]),
+    ...(mktempWorks ? [] : ["mktemp() { return 1; }"]),
     "chown() {",
     '  printf "chown %s\\n" "$*" >> "$CALLS"',
     "}",
@@ -445,6 +459,16 @@ d("a download that did not happen never deletes the working Codex", () => {
 });
 
 d("errexit must not swallow the refusal it is meant to print", () => {
+  it("says why it will not run an installer it could not write, called the way --step does", () => {
+    // Same shape as the digest one: a full or read-only /tmp fails `mktemp`,
+    // and unguarded that assignment ends install.sh at that line in silence.
+    const r = runEnsure({ payload: "#!/bin/sh\ntrue\n", mktempWorks: false, plainCall: true });
+    expect(r.status).not.toBe(0);
+    expect(r.output).toMatch(/could not download OpenAI's Codex installer/);
+    expect(r.output).toMatch(/Keeping the Codex this box resolves today/);
+    expect(r.npmExists).toBe(true);
+  });
+
   it("says why it will not run an installer it could not hash, called the way --step does", () => {
     // `--step codex_cli` runs "step_${name}" PLAINLY under `set -euo pipefail`,
     // so an unguarded `x="$(a | b)"` whose pipeline fails ends the whole run at

--- a/src/tests/unit/install-codex-cli.test.ts
+++ b/src/tests/unit/install-codex-cli.test.ts
@@ -175,6 +175,31 @@ describe("Codex is installed the way OpenAI supports", () => {
   });
 });
 
+describe("the x64 desktop installer follows the same rules", () => {
+  // install-x64.sh is a standalone twin of install.sh by design, so its copy is
+  // the one most likely to drift back to `curl | sh`. Only the rules that make
+  // the install SAFE are pinned here; the pin file is what stops the two hosts
+  // running different builds, and it is asserted above.
+  const ensure = () => extractShellFunctionFrom(INSTALL_X64, "ensure_codex_cli");
+
+  it("verifies the installer's digest before running it, and probes with a login shell", () => {
+    const fn = ensure();
+    expect(fn.indexOf("sha256sum")).toBeGreaterThan(-1);
+    expect(fn.indexOf("sha256sum")).toBeLessThan(fn.indexOf("sh '$installer'"));
+    expect(fn).toContain('chown "$CLAWBOX_USER" "$installer"');
+    expect(fn.indexOf("curl")).toBeLessThan(fn.indexOf('chown "$CLAWBOX_USER"'));
+    expect(shellCode(fn)).not.toContain("sudo -u");
+  });
+
+  it("takes the npm copy away only after the native binary reports the pin", () => {
+    const fn = ensure();
+    const verified = fn.lastIndexOf("codex_native_is_current");
+    const removed = fn.lastIndexOf("remove_npm_codex");
+    expect(verified).toBeGreaterThan(-1);
+    expect(verified).toBeLessThan(removed);
+  });
+});
+
 describe("delivery to devices already in the field", () => {
   it("post_update installs it, so an in-app update is enough", () => {
     // Fresh-install-only delivery is this installer's default failure mode:

--- a/src/tests/unit/install-codex-cli.test.ts
+++ b/src/tests/unit/install-codex-cli.test.ts
@@ -168,10 +168,17 @@ describe("Codex is installed the way OpenAI supports", () => {
     // reset would delete the BINARY along with the credentials and leave
     // ~/.local/bin/codex dangling on a box that has just rebooted into AP mode
     // with no internet to re-download 117 MB.
-    const fn = ensure();
-    expect(INSTALL_SH).toContain('CODEX_PACKAGE_HOME="$CLAWBOX_HOME/.local/share/codex"');
-    expect(fn).toContain("CODEX_HOME=");
-    expect(fn).not.toContain('CODEX_HOME="$CLAWBOX_HOME/.codex"');
+    //
+    // Asserted on the INVOCATION and with a pattern that covers every way the
+    // wrong path could be spelled. An earlier version of this test spelled the
+    // forbidden value in double quotes, which the shell here never uses — so
+    // pointing CODEX_HOME straight back at ~/.codex passed it, on both files.
+    for (const [name, source] of [["install.sh", INSTALL_SH], ["install-x64.sh", INSTALL_X64]] as const) {
+      const fn = extractShellFunctionFrom(source, "ensure_codex_cli");
+      expect(source, name).toContain('CODEX_PACKAGE_HOME="$CLAWBOX_HOME/.local/share/codex"');
+      expect(fn, name).toMatch(/CODEX_HOME='\$CODEX_PACKAGE_HOME'/);
+      expect(fn, name).not.toMatch(/CODEX_HOME=['"]?\$\{?CLAWBOX_HOME\}?\/\.codex/);
+    }
   });
 });
 
@@ -191,12 +198,20 @@ describe("the x64 desktop installer follows the same rules", () => {
     expect(shellCode(fn)).not.toContain("sudo -u");
   });
 
-  it("takes the npm copy away only after the native binary reports the pin", () => {
-    const fn = ensure();
-    const verified = fn.lastIndexOf("codex_native_is_current");
-    const removed = fn.lastIndexOf("remove_npm_codex");
-    expect(verified).toBeGreaterThan(-1);
-    expect(verified).toBeLessThan(removed);
+  it("takes the npm copy away in exactly two places, both of them after a check", () => {
+    // install.sh's own version of this rule is proved by running the function
+    // (the download-failed and digest-mismatch cases below assert that no
+    // `npm uninstall` happened at all). Nothing runs the x64 twin, so the rule
+    // is structural here — and it counts the call sites rather than comparing
+    // the last of each, because comparing catches a MOVED removal and misses
+    // an ADDED one on the not-yet-installed path, which is the same defect.
+    const fn = shellCode(ensure());
+    const removals = [...fn.matchAll(/^\s*remove_npm_codex\b/gm)].map((m) => m.index ?? -1);
+    expect(removals).toHaveLength(2);
+    // The first is the already-installed path, before anything is downloaded.
+    expect(removals[0]).toBeLessThan(fn.indexOf('url="https://github.com'));
+    // The second is after the installed binary has reported the pinned version.
+    expect(removals[1]).toBeGreaterThan(fn.lastIndexOf("codex_native_is_current"));
   });
 });
 
@@ -273,6 +288,10 @@ function runEnsure(opts: {
   preinstalledVersion?: string;
   /** Is the npm copy there before the run? */
   npmPresent?: boolean;
+  /** A THIRD codex, ahead of both on the login shell's PATH (~/.bun/bin). */
+  bunCodex?: boolean;
+  /** Leave the npm entry as a DANGLING symlink instead of a real file. */
+  npmDangling?: boolean;
   /** Pin file contents; defaults to the repo's real pin. */
   pin?: string;
   /** Can the box compute a digest at all? */
@@ -285,6 +304,8 @@ function runEnsure(opts: {
     installerWorks = true,
     npmUninstallWorks = true,
     npmPresent = true,
+    bunCodex = false,
+    npmDangling = false,
     sha256sumWorks = true,
     plainCall = false,
   } = opts;
@@ -292,6 +313,7 @@ function runEnsure(opts: {
   const home = path.join(tmp, "home");
   const npmPrefix = path.join(home, ".npm-global");
   const nativeBin = path.join(home, ".local", "bin", "codex");
+  const bunBin = path.join(home, ".bun", "bin", "codex");
   const calls = path.join(tmp, "calls");
   const payloadFile = path.join(tmp, "payload");
   const projectDir = path.join(tmp, "project");
@@ -305,7 +327,12 @@ function runEnsure(opts: {
     path.join(projectDir, "config", "codex-target.txt"),
     opts.pin ?? `${pinned.version} ${pinned.sha256}\n`,
   );
-  if (npmPresent) fs.writeFileSync(path.join(npmPrefix, "bin", "codex"), "#!/usr/bin/env node\n", { mode: 0o755 });
+  if (npmDangling) fs.symlinkSync(path.join(npmPrefix, "lib", "gone", "codex.js"), path.join(npmPrefix, "bin", "codex"));
+  else if (npmPresent) fs.writeFileSync(path.join(npmPrefix, "bin", "codex"), "#!/usr/bin/env node\n", { mode: 0o755 });
+  if (bunCodex) {
+    fs.mkdirSync(path.dirname(bunBin), { recursive: true });
+    fs.writeFileSync(bunBin, "#!/usr/bin/env node\n", { mode: 0o755 });
+  }
   if (opts.preinstalledVersion) fs.writeFileSync(nativeBin, "native\n", { mode: 0o755 });
 
   const installedVersion = opts.installedVersion ?? opts.preinstalledVersion ?? pinned.version;
@@ -323,6 +350,7 @@ function runEnsure(opts: {
     `INSTALLED_VERSION=${JSON.stringify(installedVersion)}`,
     `INSTALLER_WORKS=${installerWorks ? 1 : 0}`,
     `NPM_UNINSTALL_WORKS=${npmUninstallWorks ? 1 : 0}`,
+    `BUN_BIN=${JSON.stringify(bunBin)}`,
     // The stub curl: writes $PAYLOAD to the -o path, or fails when it is empty.
     "curl() {",
     '  printf "curl %s\\n" "$*" >> "$CALLS"',
@@ -350,7 +378,9 @@ function runEnsure(opts: {
     '      [ -x "$CODEX_NATIVE_BIN" ] || return 127',
     '      printf "codex-cli %s\\n" "$INSTALLED_VERSION"; return 0 ;;',
     '    *"command -v codex"*)',
-    // The login shell's real PATH order: the npm copy wins while it exists.
+    // The login shell's real PATH order, spelled out in install.sh's own
+    // as_clawbox_login: ~/.bun/bin, then ~/.npm-global/bin, then ~/.local/bin.
+    '      if [ -x "$BUN_BIN" ]; then printf "%s\\n" "$BUN_BIN"; return 0; fi',
     '      if [ -x "$NPM_PREFIX/bin/codex" ]; then printf "%s\\n" "$NPM_PREFIX/bin/codex"; return 0; fi',
     '      if [ -x "$CODEX_NATIVE_BIN" ]; then printf "%s\\n" "$CODEX_NATIVE_BIN"; return 0; fi',
     "      return 1 ;;",
@@ -376,7 +406,8 @@ function runEnsure(opts: {
     output,
     calls: fs.readFileSync(calls, "utf-8").split("\n").filter(Boolean),
     nativeExists: fs.existsSync(nativeBin),
-    npmExists: fs.existsSync(path.join(npmPrefix, "bin", "codex")),
+    // lstat, not stat: a dangling symlink is something still there.
+    npmExists: fs.lstatSync(path.join(npmPrefix, "bin", "codex"), { throwIfNoEntry: false }) !== undefined,
   };
 }
 
@@ -386,7 +417,8 @@ d("a download that did not happen never deletes the working Codex", () => {
     expect(r.status).not.toBe(0);
     expect(r.npmExists).toBe(true);
     expect(r.calls.join("\n")).not.toContain("npm uninstall");
-    expect(r.output).toMatch(/Keeping the npm-installed Codex/);
+    // Names the codex the OWNER gets, which is PATH order and not a guess.
+    expect(r.output).toMatch(/Keeping the Codex this box resolves today: .*\.npm-global\/bin\/codex/);
   });
 
   it("refuses an installer whose digest is not the pinned one, and runs nothing", () => {
@@ -421,7 +453,7 @@ d("errexit must not swallow the refusal it is meant to print", () => {
     const r = runEnsure({ payload: "#!/bin/sh\ntrue\n", sha256sumWorks: false, plainCall: true });
     expect(r.status).not.toBe(0);
     expect(r.output).toMatch(/does not match its pinned sha256/);
-    expect(r.output).toMatch(/Keeping the npm-installed Codex/);
+    expect(r.output).toMatch(/Keeping the Codex this box resolves today: .*\.npm-global\/bin\/codex/);
     expect(r.calls.filter((c) => c.includes("sh '"))).toHaveLength(0);
     expect(r.npmExists).toBe(true);
   });
@@ -465,6 +497,43 @@ d("a verified native install leaves exactly one codex on PATH", () => {
     expect(r.calls.filter((c) => c.startsWith("curl "))).toHaveLength(0);
     expect(r.npmExists).toBe(false);
     expect(r.status).toBe(0);
+  });
+});
+
+d("what the owner actually types is the verdict", () => {
+  it("refuses to call it done while a third codex still wins PATH", () => {
+    // ~/.bun/bin comes BEFORE both ~/.npm-global/bin and ~/.local/bin on
+    // as_clawbox_login's PATH, and the vendor installer has a bun branch — so
+    // this box exists. Removing the npm copy is not the same fact as `codex`
+    // resolving to the pinned binary, and only the second one is the card.
+    const body = "#!/bin/sh\ntrue\n";
+    const sha = createHash("sha256").update(body).digest("hex");
+    const r = runEnsure({ payload: body, pin: `${readPin().version} ${sha}\n`, bunCodex: true });
+    expect(r.nativeExists).toBe(true);
+    expect(r.npmExists).toBe(false);
+    expect(r.status).not.toBe(0);
+    expect(r.output).toMatch(/still resolves to .*\.bun\/bin\/codex/);
+  });
+
+  it("does not read 0.153.40 as the 0.153.4 it pinned", () => {
+    // A whole-token match, so a future release whose number extends the pin is
+    // installed rather than mistaken for it.
+    const pin = readPin();
+    const r = runEnsure({ preinstalledVersion: pin.version, installedVersion: `${pin.version}0`, payload: "" });
+    // Not current => it tries to install, and there is nothing to download.
+    expect(r.calls.filter((c) => c.startsWith("curl "))).toHaveLength(1);
+    expect(r.status).not.toBe(0);
+    expect(r.npmExists).toBe(true);
+  });
+
+  it("counts a dangling npm symlink as still there", () => {
+    // What a half-finished `npm uninstall` leaves. It shadows nothing, but
+    // calling the removal a success over it hides a box that needs a look.
+    const pin = readPin();
+    const r = runEnsure({ preinstalledVersion: pin.version, payload: "", npmDangling: true, npmUninstallWorks: false });
+    expect(r.calls.join("\n")).toContain("npm uninstall");
+    expect(r.status).not.toBe(0);
+    expect(r.output).toMatch(/still there/);
   });
 });
 

--- a/src/tests/unit/install-codex-cli.test.ts
+++ b/src/tests/unit/install-codex-cli.test.ts
@@ -275,12 +275,18 @@ function runEnsure(opts: {
   npmPresent?: boolean;
   /** Pin file contents; defaults to the repo's real pin. */
   pin?: string;
+  /** Can the box compute a digest at all? */
+  sha256sumWorks?: boolean;
+  /** Call it the way `--step codex_cli` does: plainly, under `set -e`. */
+  plainCall?: boolean;
 }): Run {
   const {
     payload = "",
     installerWorks = true,
     npmUninstallWorks = true,
     npmPresent = true,
+    sha256sumWorks = true,
+    plainCall = false,
   } = opts;
   const pinned = readPin();
   const home = path.join(tmp, "home");
@@ -325,6 +331,7 @@ function runEnsure(opts: {
     '  [ -s "$PAYLOAD" ] || return 22',
     '  cat "$PAYLOAD" > "$out"',
     "}",
+    ...(sha256sumWorks ? [] : ["sha256sum() { return 127; }"]),
     "chown() {",
     '  printf "chown %s\\n" "$*" >> "$CALLS"',
     "}",
@@ -356,7 +363,7 @@ function runEnsure(opts: {
     extractShellFunction("remove_npm_codex"),
     extractShellFunction("codex_left_as_is"),
     extractShellFunction("ensure_codex_cli"),
-    'ensure_codex_cli || echo "rc=$?"',
+    plainCall ? "ensure_codex_cli" : 'ensure_codex_cli || echo "rc=$?"',
   ].join("\n");
 
   const r = spawnSync("bash", ["-c", script], {
@@ -402,6 +409,21 @@ d("a download that did not happen never deletes the working Codex", () => {
     expect(r.status).not.toBe(0);
     expect(r.npmExists).toBe(true);
     expect(r.output).toMatch(/does not report/i);
+  });
+});
+
+d("errexit must not swallow the refusal it is meant to print", () => {
+  it("says why it will not run an installer it could not hash, called the way --step does", () => {
+    // `--step codex_cli` runs "step_${name}" PLAINLY under `set -euo pipefail`,
+    // so an unguarded `x="$(a | b)"` whose pipeline fails ends the whole run at
+    // that line. That would kill install.sh over exactly the case these lines
+    // exist to report, and with nothing said.
+    const r = runEnsure({ payload: "#!/bin/sh\ntrue\n", sha256sumWorks: false, plainCall: true });
+    expect(r.status).not.toBe(0);
+    expect(r.output).toMatch(/does not match its pinned sha256/);
+    expect(r.output).toMatch(/Keeping the npm-installed Codex/);
+    expect(r.calls.filter((c) => c.includes("sh '"))).toHaveLength(0);
+    expect(r.npmExists).toBe(true);
   });
 });
 

--- a/src/tests/unit/install-codex-cli.test.ts
+++ b/src/tests/unit/install-codex-cli.test.ts
@@ -1,0 +1,431 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { testEnv } from "@/tests/helpers/env";
+
+// Starts a real bash: vitest's 5 s test and 10 s hook defaults are not enough
+// on a loaded CI runner. See src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+/**
+ * How the OpenAI Codex CLI reaches a device (TASK-439).
+ *
+ * Every box in the field carries Codex as an npm global — `npm i -g
+ * @openai/codex` into ~/.npm-global. The owner's ruling on TASK-378 was the
+ * NATIVE installer for both coding CLIs, and the sibling coding CLI (TASK-378)
+ * already ships that way; this file pins the Codex half so it cannot drift back
+ * to npm, and pins the four things that half has to get right:
+ *
+ *   1. the vendor's own installer, at a PINNED release whose script is
+ *      checksum-verified before anything executes it;
+ *   2. exactly ONE codex on PATH — ~/.bashrc puts ~/.npm-global/bin BEFORE
+ *      ~/.local/bin, so the native binary is shadowed until the npm one is gone;
+ *   3. the npm copy removed only over a native install that actually verified,
+ *      never over one that merely exited 0;
+ *   4. delivered from step_post_update, not fresh-install-only — the failure
+ *      mode that left the whole fleet without the sibling CLI for months.
+ */
+
+const REPO = path.resolve(__dirname, "../../..");
+const INSTALL_SH_PATH = path.join(REPO, "install.sh");
+const INSTALL_SH = fs.readFileSync(INSTALL_SH_PATH, "utf-8");
+const INSTALL_X64 = fs.readFileSync(path.join(REPO, "install-x64.sh"), "utf-8");
+const PIN_PATH = path.join(REPO, "config", "codex-target.txt");
+
+const CAN_RUN =
+  process.platform !== "win32"
+  && spawnSync("bash", ["-c", "true"], { stdio: "ignore" }).status === 0;
+const d = CAN_RUN ? describe : describe.skip;
+
+function extractShellFunctionFrom(source: string, name: string): string {
+  const start = source.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found`);
+  const end = source.indexOf("\n}", start);
+  if (end < 0) throw new Error(`${name} has no closing brace`);
+  return `${source.slice(start, end)}\n}`;
+}
+
+function extractShellFunction(name: string): string {
+  return extractShellFunctionFrom(INSTALL_SH, name);
+}
+
+/** A shell function's code with its comments stripped, so a comment mentioning
+ *  `npm i -g` cannot satisfy — or break — an assertion about what it RUNS. */
+function shellCode(fn: string): string {
+  return fn
+    .split("\n")
+    .filter((l) => !l.trim().startsWith("#"))
+    .join("\n");
+}
+
+function bashArray(source: string, name: string): string[] {
+  const start = source.indexOf(`${name}=(`);
+  if (start < 0) throw new Error(`${name} not found`);
+  const end = source.indexOf("\n)", start);
+  return source
+    .slice(start + `${name}=(`.length, end)
+    .split("\n")
+    .flatMap((l) => l.replace(/#.*$/, "").trim().split(/\s+/))
+    .filter(Boolean);
+}
+
+/** The pin as config/codex-target.txt spells it: `<version> <sha256>`. */
+function readPin(): { version: string; sha256: string } {
+  const line = fs
+    .readFileSync(PIN_PATH, "utf-8")
+    .split("\n")
+    .map((l) => l.trim())
+    .find((l) => l && !l.startsWith("#"));
+  if (!line) throw new Error("config/codex-target.txt carries no pin line");
+  const [version, sha256] = line.split(/\s+/);
+  return { version, sha256 };
+}
+
+describe("the Codex CLI is pinned, in one place both installers read", () => {
+  it("config/codex-target.txt carries a version and the installer's sha256", () => {
+    // One file, the way config/openclaw-target.txt pins the core: install.sh
+    // and install-x64.sh both install Codex, and a version that can drift
+    // between two shell files is a fleet running two builds.
+    const { version, sha256 } = readPin();
+    expect(version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("both installers read the pin file rather than carrying their own copy", () => {
+    expect(INSTALL_SH).toContain("config/codex-target.txt");
+    expect(INSTALL_X64).toContain("config/codex-target.txt");
+  });
+
+  it("neither installer installs Codex from npm any more", () => {
+    // The whole card: `npm i -g @openai/codex` is what put an unpinned,
+    // unverified Codex on every box.
+    expect(shellCode(INSTALL_SH)).not.toContain("npm i -g @openai/codex");
+    expect(shellCode(INSTALL_X64)).not.toContain("npm i -g @openai/codex");
+  });
+});
+
+describe("Codex is installed the way OpenAI supports", () => {
+  // Extracted per test, not once at collection: a missing function then fails
+  // each assertion it breaks instead of taking the whole file down with it.
+  const ensure = () => extractShellFunction("ensure_codex_cli");
+
+  it("uses the vendor's own installer, from an immutable release asset", () => {
+    // https://chatgpt.com/codex/install.sh is what OpenAI documents, and it is
+    // byte-identical to the install.sh asset attached to each release tag. The
+    // documented URL always serves `latest` and is not checksummable; the
+    // release asset is immutable, so that is what the pin can name.
+    const fn = ensure();
+    expect(fn).toContain("https://github.com/openai/codex/releases/download/rust-v");
+    expect(fn).toContain("install.sh");
+  });
+
+  it("verifies the installer's sha256 BEFORE running it", () => {
+    const fn = ensure();
+    const digest = fn.indexOf("sha256sum");
+    const run = fn.indexOf("sh '$installer'");
+    expect(digest).toBeGreaterThan(-1);
+    expect(run).toBeGreaterThan(-1);
+    expect(digest).toBeLessThan(run);
+  });
+
+  it("pins the release the installer resolves, so it cannot drift to latest", () => {
+    // The installer's own knob (`--release` / CODEX_RELEASE, from its --help).
+    const fn = ensure();
+    expect(fn).toMatch(/CODEX_RELEASE=|--release/);
+    expect(fn).toContain("CODEX_NON_INTERACTIVE=true");
+  });
+
+  it("hands the downloaded installer to the user that will execute it, after the download", () => {
+    // The two hardware failures the sibling CLI (TASK-378) already paid for, in
+    // order: mktemp makes the file root:root 0600 and it is executed AS the
+    // clawbox user, so without the chown every run answers "Permission denied";
+    // and with the chown moved before the curl, fs.protected_regular=2 stops
+    // even root writing a file it does not own in sticky /tmp and curl exits 23.
+    const fn = ensure();
+    const chown = 'chown "$CLAWBOX_USER" "$installer"';
+    expect(fn).toContain(chown);
+    expect(fn.indexOf("curl")).toBeLessThan(fn.indexOf(chown));
+    expect(fn.indexOf(chown)).toBeLessThan(fn.indexOf("sh '$installer'"));
+  });
+
+  it("probes with a login shell, never `sudo -u clawbox bash -c`", () => {
+    // Non-login and non-interactive reads neither ~/.profile nor ~/.bashrc, so
+    // it answers "missing" on a box where the tool works — the false negative
+    // that made the sibling CLI's fast path dead for months.
+    const fn = ensure();
+    expect(shellCode(fn)).not.toContain("sudo -u");
+    expect(fn).toContain("as_clawbox_login");
+  });
+
+  it("keeps the standalone package out of ~/.codex, which a factory reset wipes", () => {
+    // The vendor installer unpacks under $CODEX_HOME/packages/standalone, and
+    // ~/.codex is on the reset REMOVE-list (HOME_REMOVE_PATHS in
+    // src/app/setup-api/setup/reset/route.ts). Left at the default, a factory
+    // reset would delete the BINARY along with the credentials and leave
+    // ~/.local/bin/codex dangling on a box that has just rebooted into AP mode
+    // with no internet to re-download 117 MB.
+    const fn = ensure();
+    expect(INSTALL_SH).toContain('CODEX_PACKAGE_HOME="$CLAWBOX_HOME/.local/share/codex"');
+    expect(fn).toContain("CODEX_HOME=");
+    expect(fn).not.toContain('CODEX_HOME="$CLAWBOX_HOME/.codex"');
+  });
+});
+
+describe("delivery to devices already in the field", () => {
+  it("post_update installs it, so an in-app update is enough", () => {
+    // Fresh-install-only delivery is this installer's default failure mode:
+    // step_post_update never called step_ai_tools_install, which is why no
+    // shipped box had the sibling CLI on it.
+    expect(extractShellFunction("step_post_update")).toContain("step_codex_cli");
+  });
+
+  it("post_update cannot be aborted by it", () => {
+    const line = extractShellFunction("step_post_update")
+      .split("\n")
+      .find((l) => l.includes("step_codex_cli"));
+    expect(line).toMatch(/\|\|\s*echo/);
+  });
+
+  it("a fresh install ships it too", () => {
+    expect(shellCode(extractShellFunction("step_ai_tools_install"))).toContain("ensure_codex_cli");
+  });
+
+  it("is dispatchable on its own, so a box can repair Codex without a reinstall", () => {
+    expect(bashArray(INSTALL_SH, "DISPATCH_STEPS")).toContain("codex_cli");
+  });
+
+  it("exactly one function installs it, so the paths cannot drift", () => {
+    const callers = INSTALL_SH.split("\n").filter(
+      (l) => l.includes("ensure_codex_cli") && !l.trim().startsWith("#") && !l.includes("() {"),
+    );
+    expect(callers).toHaveLength(2); // step_ai_tools_install + step_codex_cli
+  });
+});
+
+// ── Behaviour, against the shipped functions ────────────────────────────────
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-codex-cli-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+type Run = {
+  status: number;
+  output: string;
+  calls: string[];
+  nativeExists: boolean;
+  npmExists: boolean;
+};
+
+/**
+ * Drive the shipped `ensure_codex_cli` against a box modelled in $tmp.
+ *
+ * The stubs are the three seams the function actually crosses: `curl` (the
+ * download), `chown` (the root->clawbox hand-off) and `as_clawbox_login`
+ * (everything that runs as the owner). `as_clawbox_login` models the box's real
+ * PATH order — ~/.npm-global/bin ahead of ~/.local/bin — so a test can tell a
+ * shadowed native binary from a resolved one.
+ */
+function runEnsure(opts: {
+  /** What the stub curl writes; "" means the download fails. */
+  payload?: string;
+  /** Version the installed native binary reports. Defaults to the pin. */
+  installedVersion?: string;
+  /** Does the vendor installer succeed at producing the binary? */
+  installerWorks?: boolean;
+  /** Does `npm uninstall` actually remove the npm copy? */
+  npmUninstallWorks?: boolean;
+  /** Is the native binary already there before the run? */
+  preinstalledVersion?: string;
+  /** Is the npm copy there before the run? */
+  npmPresent?: boolean;
+  /** Pin file contents; defaults to the repo's real pin. */
+  pin?: string;
+}): Run {
+  const {
+    payload = "",
+    installerWorks = true,
+    npmUninstallWorks = true,
+    npmPresent = true,
+  } = opts;
+  const pinned = readPin();
+  const home = path.join(tmp, "home");
+  const npmPrefix = path.join(home, ".npm-global");
+  const nativeBin = path.join(home, ".local", "bin", "codex");
+  const calls = path.join(tmp, "calls");
+  const payloadFile = path.join(tmp, "payload");
+  const projectDir = path.join(tmp, "project");
+
+  fs.mkdirSync(path.dirname(nativeBin), { recursive: true });
+  fs.mkdirSync(path.join(npmPrefix, "bin"), { recursive: true });
+  fs.mkdirSync(path.join(projectDir, "config"), { recursive: true });
+  fs.writeFileSync(calls, "");
+  fs.writeFileSync(payloadFile, payload);
+  fs.writeFileSync(
+    path.join(projectDir, "config", "codex-target.txt"),
+    opts.pin ?? `${pinned.version} ${pinned.sha256}\n`,
+  );
+  if (npmPresent) fs.writeFileSync(path.join(npmPrefix, "bin", "codex"), "#!/usr/bin/env node\n", { mode: 0o755 });
+  if (opts.preinstalledVersion) fs.writeFileSync(nativeBin, "native\n", { mode: 0o755 });
+
+  const installedVersion = opts.installedVersion ?? opts.preinstalledVersion ?? pinned.version;
+
+  const script = [
+    "set -euo pipefail",
+    `CLAWBOX_HOME=${JSON.stringify(home)}`,
+    'CLAWBOX_USER="$(id -un)"',
+    `NPM_PREFIX=${JSON.stringify(npmPrefix)}`,
+    `PROJECT_DIR=${JSON.stringify(projectDir)}`,
+    `CODEX_NATIVE_BIN=${JSON.stringify(nativeBin)}`,
+    'CODEX_PACKAGE_HOME="$CLAWBOX_HOME/.local/share/codex"',
+    `CALLS=${JSON.stringify(calls)}`,
+    `PAYLOAD=${JSON.stringify(payloadFile)}`,
+    `INSTALLED_VERSION=${JSON.stringify(installedVersion)}`,
+    `INSTALLER_WORKS=${installerWorks ? 1 : 0}`,
+    `NPM_UNINSTALL_WORKS=${npmUninstallWorks ? 1 : 0}`,
+    // The stub curl: writes $PAYLOAD to the -o path, or fails when it is empty.
+    "curl() {",
+    '  printf "curl %s\\n" "$*" >> "$CALLS"',
+    '  local out=""; local prev=""',
+    '  for a in "$@"; do [ "$prev" = "-o" ] && out="$a"; prev="$a"; done',
+    '  [ -s "$PAYLOAD" ] || return 22',
+    '  cat "$PAYLOAD" > "$out"',
+    "}",
+    "chown() {",
+    '  printf "chown %s\\n" "$*" >> "$CALLS"',
+    "}",
+    // The box, as the owner sees it.
+    "as_clawbox_login() {",
+    '  printf "login %s\\n" "$*" >> "$CALLS"',
+    '  case "$*" in',
+    '    *"sh \'"*)',
+    '      [ "$INSTALLER_WORKS" = 1 ] || return 1',
+    '      printf "#!/bin/sh\\n" > "$CODEX_NATIVE_BIN"; chmod 0755 "$CODEX_NATIVE_BIN"',
+    "      return 0 ;;",
+    '    *"npm uninstall"*)',
+    '      [ "$NPM_UNINSTALL_WORKS" = 1 ] || return 1',
+    '      rm -f "$NPM_PREFIX/bin/codex"; return 0 ;;',
+    '    *"--version"*)',
+    '      [ -x "$CODEX_NATIVE_BIN" ] || return 127',
+    '      printf "codex-cli %s\\n" "$INSTALLED_VERSION"; return 0 ;;',
+    '    *"command -v codex"*)',
+    // The login shell's real PATH order: the npm copy wins while it exists.
+    '      if [ -x "$NPM_PREFIX/bin/codex" ]; then printf "%s\\n" "$NPM_PREFIX/bin/codex"; return 0; fi',
+    '      if [ -x "$CODEX_NATIVE_BIN" ]; then printf "%s\\n" "$CODEX_NATIVE_BIN"; return 0; fi',
+    "      return 1 ;;",
+    "  esac",
+    "  return 0",
+    "}",
+    extractShellFunction("codex_pin_field"),
+    extractShellFunction("npm_codex_present"),
+    extractShellFunction("codex_native_is_current"),
+    extractShellFunction("remove_npm_codex"),
+    extractShellFunction("codex_left_as_is"),
+    extractShellFunction("ensure_codex_cli"),
+    'ensure_codex_cli || echo "rc=$?"',
+  ].join("\n");
+
+  const r = spawnSync("bash", ["-c", script], {
+    encoding: "utf-8",
+    env: testEnv({ PATH: process.env.PATH ?? "" }),
+  });
+  const output = `${r.stdout ?? ""}${r.stderr ?? ""}`;
+  return {
+    status: /rc=(\d+)/.exec(output) ? Number(/rc=(\d+)/.exec(output)![1]) : (r.status ?? -1),
+    output,
+    calls: fs.readFileSync(calls, "utf-8").split("\n").filter(Boolean),
+    nativeExists: fs.existsSync(nativeBin),
+    npmExists: fs.existsSync(path.join(npmPrefix, "bin", "codex")),
+  };
+}
+
+d("a download that did not happen never deletes the working Codex", () => {
+  it("keeps the npm copy when the installer cannot be downloaded", () => {
+    const r = runEnsure({ payload: "" });
+    expect(r.status).not.toBe(0);
+    expect(r.npmExists).toBe(true);
+    expect(r.calls.join("\n")).not.toContain("npm uninstall");
+    expect(r.output).toMatch(/Keeping the npm-installed Codex/);
+  });
+
+  it("refuses an installer whose digest is not the pinned one, and runs nothing", () => {
+    const r = runEnsure({ payload: "#!/bin/sh\necho not the pinned installer\n" });
+    expect(r.status).not.toBe(0);
+    expect(r.output).toMatch(/pinned sha256|does not match/i);
+    // Nothing was executed: the only login calls are probes.
+    expect(r.calls.filter((c) => c.includes("sh '"))).toHaveLength(0);
+    expect(r.npmExists).toBe(true);
+  });
+
+  it("keeps the npm copy when the installer exits 0 without producing the pinned version", () => {
+    const body = "#!/bin/sh\ntrue\n";
+    const sha = createHash("sha256").update(body).digest("hex");
+    const r = runEnsure({
+      payload: body,
+      pin: `${readPin().version} ${sha}\n`,
+      installedVersion: "0.0.1",
+    });
+    expect(r.status).not.toBe(0);
+    expect(r.npmExists).toBe(true);
+    expect(r.output).toMatch(/does not report/i);
+  });
+});
+
+d("a verified native install leaves exactly one codex on PATH", () => {
+  it("installs the pinned release, then removes the npm copy", () => {
+    const body = "#!/bin/sh\ntrue\n";
+    const sha = createHash("sha256").update(body).digest("hex");
+    const pin = readPin();
+    const r = runEnsure({ payload: body, pin: `${pin.version} ${sha}\n` });
+    expect(r.status).toBe(0);
+    expect(r.nativeExists).toBe(true);
+    expect(r.npmExists).toBe(false);
+    const login = r.calls.filter((c) => c.startsWith("login ")).join("\n");
+    expect(login).toContain(`CODEX_RELEASE='${pin.version}'`);
+    expect(login).toContain("npm uninstall -g @openai/codex");
+    // The removal comes after the install, never before: a box that loses the
+    // download must not be left with no codex at all.
+    expect(login.indexOf("sh '")).toBeLessThan(login.indexOf("npm uninstall"));
+  });
+
+  it("says so when the npm copy survives, because it still shadows the native binary", () => {
+    const body = "#!/bin/sh\ntrue\n";
+    const sha = createHash("sha256").update(body).digest("hex");
+    const r = runEnsure({
+      payload: body,
+      pin: `${readPin().version} ${sha}\n`,
+      npmUninstallWorks: false,
+    });
+    expect(r.status).not.toBe(0);
+    expect(r.output).toMatch(/shadow/i);
+  });
+
+  it("re-tries the removal on a later run without downloading anything again", () => {
+    // The convergence case: a previous run installed the binary and failed to
+    // remove the npm copy. Nothing needs downloading — but the box still has
+    // two codexes, and the step has to finish the job.
+    const pin = readPin();
+    const r = runEnsure({ preinstalledVersion: pin.version, payload: "" });
+    expect(r.calls.filter((c) => c.startsWith("curl "))).toHaveLength(0);
+    expect(r.npmExists).toBe(false);
+    expect(r.status).toBe(0);
+  });
+});
+
+d("the pin itself is what is trusted", () => {
+  it("installs nothing when config/codex-target.txt is not a usable pin", () => {
+    const r = runEnsure({ pin: "# no pin here\n", payload: "whatever" });
+    expect(r.status).not.toBe(0);
+    expect(r.calls.filter((c) => c.startsWith("curl "))).toHaveLength(0);
+    expect(r.npmExists).toBe(true);
+  });
+});


### PR DESCRIPTION
**Finding:** TASK-439 — replace the npm-installed OpenAI Codex CLI with a pinned native binary.

## The symptom a customer has today

Every box carries Codex as an npm global — `npm i -g @openai/codex` into `~/.npm-global/bin/codex`, `install.sh` `step_ai_tools_install`. Three things follow from that:

- **Unpinned.** Two boxes flashed a week apart run different builds of the CLI. The OpenClaw box checked read-only for this PR is on `codex-cli 0.147.0`; the card recorded 0.149.0 on another box in August.
- **Unverified.** Nothing checks what was downloaded — the CWE-494 shape that was declined on TASK-378's PR for the sibling coding CLI because that CLI's vendor installer URL is mutable and carries no digest. A GitHub release asset is neither.
- **Fresh-install-only.** `step_post_update` does not run `step_ai_tools_install`, so a box already in the field never gets a newer one.

The owner's ruling on TASK-378 (2026-08-22) was the **native installer for both coding CLIs, not npm**. The sibling coding CLI (TASK-378) already ships that way; the Codex half was deliberately left out of that PR and is this one.

## The native mechanism, named

OpenAI documents `curl -fsSL https://chatgpt.com/codex/install.sh | sh` in the `openai/codex` README. That URL always serves `latest` and cannot be checksummed, so this PR fetches the **same script** from the immutable per-release asset instead:

```
https://github.com/openai/codex/releases/download/rust-v0.153.4/install.sh
sha256 ba92dd27e5c06f0d3bbc58bfa4b9cfb6599cd2742fbb1f92a2765e6c07dedb5a
```

Verified on the dev PC: that asset is **byte-identical** to the documented `https://chatgpt.com/codex/install.sh` (both hash to the digest above). The version and the digest are one fact, so they live on one line of the new `config/codex-target.txt`, in the same spirit as `config/openclaw-target.txt` — and both installers read that file, so the fleet and the x64 desktop host cannot end up on two builds.

`install.sh` downloads that script, refuses to execute anything whose digest is not the pinned one, and then runs the vendor's installer with its own documented knobs (`--help`: `--release` / `CODEX_RELEASE`, `CODEX_NON_INTERACTIVE`, plus `CODEX_INSTALL_DIR` and `CODEX_HOME`). Everything below that is the vendor's and is **not** reimplemented here: resolving the release from `releases.openai.com` with GitHub Releases as its own fallback, checking the package archive against OpenAI's published `codex-package_SHA256SUMS`, the install lock, the staged unpack, the `current` symlink and the link at `~/.local/bin/codex`.

### One deliberate deviation from the card

The card says "fetch the tarball, verify it, and place the binary in `~/.local/bin`". This PR runs the vendor's installer over that tarball instead, for two reasons. The harness-first rule: unpacking, the install lock, the staged replace, the `current` symlink and the version bookkeeping are the vendor's and are not worth reimplementing. And the bare `codex-<target>.tar.gz` the card names is the binary alone, while the installer takes `codex-package-<target>.tar.gz` — the same binary plus the `rg` and `bwrap` resources Codex looks for beside itself. The card's real requirement, a pinned version whose download is checksum-verified, is met either way, and this way the digest chain is rooted in a script we pinned rather than in one we wrote.

## What this PR is careful about

- **Exactly one codex on PATH.** `~/.bashrc` and `as_clawbox_login` both put `~/.npm-global/bin` *before* `~/.local/bin`, so the native binary is shadowed until the npm one is gone. The npm copy is removed — and the verdict is the re-probe, not npm's exit code, which is non-zero for a package it never had.
- **Order, and the offline path.** Install the native binary, ask *the binary* whether it reports the pinned version, and only then take the npm copy away. A box that cannot download keeps the Codex it has and says which one it kept; nothing here reports success it did not verify. The vendor installer notices the npm copy and offers to remove it — under `CODEX_NON_INTERACTIVE` that offer is declined, which is why the removal is ours, in our order.
- **The last word is PATH order**, not the presence of a file: the step ends by asking a login shell what `codex` resolves to and warns if it is not the native binary.
- **The package root is not `~/.codex`.** The installer's default package root is `$CODEX_HOME`, i.e. `~/.codex` — which a factory reset removes whole (`HOME_REMOVE_PATHS`), and which `config/clawbox-codex-auth-sync.service` holds read-write. A 117 MB binary under either of those is wrong, so the installer is pointed at `~/.local/share/codex` and nothing exports `CODEX_HOME` at runtime, so the CLI still reads its auth and state from `~/.codex` and the auth-sync timer is untouched. Documented in the reset table.
- **Probes are login shells** (`as_clawbox_login`), never `sudo -u clawbox bash -c` — the false negative TASK-378 paid for — and the root-written temp file is `chown`ed **after** the download, because these devices run `fs.protected_regular=2` and a chown first makes root's own `curl` exit 23. Both are pinned by tests.
- **Delivery.** `step_codex_cli` is dispatchable (`--step codex_cli`) and is called from `step_post_update`, so boxes already in the field get this on their next update; the fresh-install path reaches the same function through `step_ai_tools_install`.
- **Both editions.** The coding CLIs exist on OpenClaw and Hermes alike; this is an installer step with no edition gate, and it touches no harness config. `install-x64.sh`'s sibling block gets the same treatment off the same pin file (it also had a false success: it printed "OpenAI Codex installed" on the line after `|| echo "Warning: Codex install failed"`).
- **A second defect found while writing it.** Both installers run under `set -euo pipefail`, and `--step <name>` calls the step function *plainly*, so an unguarded `x="$(a | b)"` whose pipeline fails ends the run at that line. The digest computation and the `--version` probes are exactly where a broken box fails, and each had a `WARN` under it that could never have been printed. Guarded, with the regression test calling the function the way the dispatcher does.

## RED → GREEN

RED — `src/tests/unit/install-codex-cli.test.ts` on unmodified `origin/beta` (`ccd26686`), the same file this PR ships, in a throwaway worktree with nothing else added:

```
 ❯ |unit| src/tests/unit/install-codex-cli.test.ts (29 tests | 29 failed) 53ms
     × config/codex-target.txt carries a version and the installer's sha256 4ms
     × both installers read the pin file rather than carrying their own copy 14ms
     × neither installer installs Codex from npm any more 10ms
     × uses the vendor's own installer, from an immutable release asset 1ms
     × verifies the installer's sha256 BEFORE running it 1ms
     × pins the release the installer resolves, so it cannot drift to latest 1ms
     × hands the downloaded installer to the user that will execute it, after the download 1ms
     × probes with a login shell, never `sudo -u clawbox bash -c` 1ms
     × keeps the standalone package out of ~/.codex, which a factory reset wipes 1ms
     × ends on the same verdict the device installer does: what `codex` resolves to 1ms
     × verifies the installer's digest before running it, and probes with a login shell 0ms
     × takes the npm copy away in exactly two places, both of them after a check 0ms
     × post_update installs it, so an in-app update is enough 4ms
     × post_update cannot be aborted by it 1ms
     × a fresh install ships it too 1ms
     × is dispatchable on its own, so a box can repair Codex without a reinstall 1ms
     × exactly one function installs it, so the paths cannot drift 2ms
     × keeps the npm copy when the installer cannot be downloaded 1ms
     × refuses an installer whose digest is not the pinned one, and runs nothing 0ms
     × keeps the npm copy when the installer exits 0 without producing the pinned version 1ms
     × says why it will not run an installer it could not write, called the way --step does 0ms
     × says why it will not run an installer it could not hash, called the way --step does 0ms
     × installs the pinned release, then removes the npm copy 3ms
     × says so when the npm copy survives, because it still shadows the native binary 0ms
     × re-tries the removal on a later run without downloading anything again 0ms
     × refuses to call it done while a third codex still wins PATH 0ms
     × does not read 0.153.40 as the 0.153.4 it pinned 0ms
     × counts a dangling npm symlink as still there 0ms
     × installs nothing when config/codex-target.txt is not a usable pin 0ms

 Tests  29 failed (29)
```

GREEN — 29/29 pass on this branch, and with them the suites around the installer:
`install-codex-cli`, `install-coding-harness`, `install-coding-harness-repair`, `root-steps`, `install-post-update-units`, `install-step-counter`, `install-x64`, `sudoers-coverage`, `observability-install`, `install-update-branch-pin`, `openclaw-config-mock-completeness`, `test-timeout-hygiene`, `state-updater-purity` — **13 files, 218 tests, 0 failures**. The whole unit project: **760 files, 12,640 passed, 1 skipped**. `tsc --noEmit` clean, `eslint` clean on the new test, `bash -n` clean on both installers.

The behavioural half of the test drives the shipped shell functions against a modelled box whose PATH order is the box's real one (`~/.bun/bin`, then `~/.npm-global/bin`, then `~/.local/bin`), and every assertion here was checked by mutation: dropping the post-install version check, disabling the digest check, moving the npm removal ahead of the install, removing the `errexit` guard, pointing `CODEX_HOME` back at `~/.codex` (in either installer), deleting the `command -v codex` acceptance check, relaxing the whole-token version match, dropping the dangling-symlink arm, and adding or moving a removal in the x64 twin — each of them fails the suite.

## The review pass

The line-by-line round found two more, both applied in `b84733be` and both answered in-thread: `install-x64.sh` stopped after the npm removal instead of ending on the PATH verdict its twin ends on (so the two installers could answer differently about the same box), and the `errexit` guard written for `ensure_codex_cli`'s `mktemp` had landed on `ensure_claude_code` by a first-occurrence replace — leaving the function this PR owns unguarded and quietly touching one it does not. That sibling is byte-identical to beta at this head; its own latent copy of the same shape is recorded as a residual rather than fixed here.

One review agent, findings at `code-review-task439.md`: **2 MEDIUM, 5 LOW, 1 INFO**, all applied. The two MEDIUMs were dead assertions the reviewer proved dead by mutation — the `~/.codex` guard spelled the forbidden value in a quoting style this shell never writes (so pointing the package back at the factory-reset-wiped directory passed CI on *both* installers), and the whole `command -v codex` acceptance block could be deleted with the suite still green, because the fixture could not model a third codex ahead of both on PATH. The LOWs: `codex_left_as_is` named the wrong survivor whenever both copies were present (which is every box in the field) and now asks the login shell instead; `codex_cli` was dispatchable but missing from the root dispatcher's allow-list; the vendor's 117 MB download had no timeout on its GitHub fallback path, so a stall parked `step_post_update` until systemd's two-hour ceiling; the `~/.bashrc` stanza's own comment still called codex an npm global; and the vendor installer's own `~/.bashrc` PATH edit is now recorded beside the call. The reviewer separately confirmed the harness-first choice, that `CODEX_NON_INTERACTIVE=true` is load-bearing (`</dev/null` alone would not do — the vendor's prompt opens `/dev/tty` directly), that reset survival holds, and that no sibling call site was missed.

## Sibling call sites

`npm i -g @openai/codex` had exactly two occurrences (`install.sh`, `install-x64.sh`); both are gone. Nothing else in the tree resolves a Codex **binary**: `command -v codex` appeared only in those two files, no service unit puts `~/.npm-global/bin` on a PATH that would matter (`clawbox-gateway.service` sets none, so systemd's default PATH has neither directory), and the TypeScript PATH builders that spawn tools — `runnerPath()` in `src/lib/coding-agent.ts` and `buildSpawnEnv()` in `src/lib/clawkeep.ts` — already carry `~/.local/bin`. Every other `codex` in `src/` and `scripts/` is the OpenClaw `@openclaw/codex` **plugin** and its auth mirror, which touch `~/.codex/auth.json` and never the CLI binary; that mirror's unit is unaffected by design (see above).

## Device leg (read-only, nothing installed, nothing changed)

The device mutex was held by another lane, so this was strictly read-only and mutated nothing. On the OpenClaw box: `uname -m` = `aarch64`; `~/.npm-global/bin/codex` present as an npm symlink reporting `codex-cli 0.147.0`; `~/.local/bin/codex` absent; `~/.codex` holds `auth.json`, `models_cache.json` and the CLI's sqlite state. `HEAD` (no body) from the box for the three pinned URLs — the installer asset, `codex-package-aarch64-unknown-linux-musl.tar.gz` and `codex-package_SHA256SUMS` — all answer 200, and the installer's primary source `releases.openai.com/codex/releases/0.153.4/…` answers 200 as well. The new binary was **not** run and nothing was uninstalled: the installer change is exercised by CI's `e2e-install` and by the next box update.

**What the owner will see after the next update:** `codex --version` typed into the ClawBox web terminal answers `codex-cli 0.153.4` from `~/.local/bin/codex`, `~/.npm-global/bin/codex` is gone, and `~/.codex` (the ChatGPT session the auth-sync timer maintains) is untouched.
