### PR TITLE
fix: a bare string in a model slot is a model, not an empty slot (TASK-755)

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -2048,13 +2048,29 @@ if isinstance(_vision_models, list) and isinstance(_vision_token, str) and _visi
     _vision_fallbacks = (
         _vision_model_cfg.get("fallbacks") if isinstance(_vision_model_cfg, dict) else None
     )
-    _has_vision_model = isinstance(_vision_model_cfg, dict) and bool(
-        (isinstance(_vision_model_cfg.get("primary"), str) and _vision_model_cfg.get("primary").strip())
+    # A BARE STRING IS A MODEL HERE TOO (TASK-755) — the sibling of the image
+    # slot below, read by the same core helper: `hasExplicitToolModelConfig`
+    # coerces the value (`resolvePrimaryStringValue` answers a string with
+    # itself) before the primary/fallbacks test. Measured on 2026.8.1:
+    # `{"agents":{"defaults":{"imageModel":"openai/gpt-4o"}}}` is `valid:true`.
+    # Reading it as empty replaces the model the owner chose for LOOKING at the
+    # pictures he sends.
+    _has_vision_model = bool(
+        (isinstance(_vision_model_cfg, str) and _vision_model_cfg.strip())
         or (
-            isinstance(_vision_fallbacks, list)
-            and any(isinstance(ref, str) and ref.strip() for ref in _vision_fallbacks)
+            isinstance(_vision_model_cfg, dict)
+            and (
+                (isinstance(_vision_model_cfg.get("primary"), str) and _vision_model_cfg.get("primary").strip())
+                or (
+                    isinstance(_vision_fallbacks, list)
+                    and any(isinstance(ref, str) and ref.strip() for ref in _vision_fallbacks)
+                )
+            )
         )
     )
+    # The MOVE arm below rewrites `_vision_model_cfg["primary"]` in place, so it
+    # may only ever consider a dict: a bare string is left exactly as the owner
+    # wrote it, which is what `_vision_primary = ""` achieves here.
     _vision_primary = (
         _vision_model_cfg.get("primary") if isinstance(_vision_model_cfg, dict) else None
     )
@@ -2403,11 +2419,27 @@ if isinstance(_clawai_token, str) and _clawai_token.startswith("claw_"):
         _image_model_fallbacks = (
             _image_model_cfg.get("fallbacks") if isinstance(_image_model_cfg, dict) else None
         )
-        _has_image_model = isinstance(_image_model_cfg, dict) and bool(
-            (isinstance(_image_model_cfg.get("primary"), str) and _image_model_cfg.get("primary").strip())
+        # A BARE STRING IS A MODEL (TASK-755). The core reaches this slot through
+        # `hasExplicitToolModelConfig`, which COERCES the value first
+        # (`coerceFactoryToolModelConfig` -> `resolvePrimaryStringValue`, which
+        # answers a bare string with itself) and only then applies the
+        # primary/fallbacks test mirrored below. Measured on 2026.8.1:
+        # `mediaModels.image: "replicate/flux-pro"` is `valid:true` with no
+        # warnings. Reading it as an empty slot is how an owner-authored model
+        # was replaced on a boot that had nothing to do with image generation —
+        # and it is the rule the take-back arm below already applies to a
+        # string, so the two halves now agree about what a string means.
+        _has_image_model = bool(
+            (isinstance(_image_model_cfg, str) and _image_model_cfg.strip())
             or (
-                isinstance(_image_model_fallbacks, list)
-                and any(isinstance(ref, str) and ref.strip() for ref in _image_model_fallbacks)
+                isinstance(_image_model_cfg, dict)
+                and (
+                    (isinstance(_image_model_cfg.get("primary"), str) and _image_model_cfg.get("primary").strip())
+                    or (
+                        isinstance(_image_model_fallbacks, list)
+                        and any(isinstance(ref, str) and ref.strip() for ref in _image_model_fallbacks)
+                    )
+                )
             )
         )
         # STAND DOWN on the image SLOT while the core's own migration still owes

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -2554,11 +2554,12 @@ if isinstance(_clawai_token, str) and _clawai_token.startswith("claw_"):
             def _slot_holds_a_decision(_cfg):
                 """Has the owner put something here the CORE would resolve?
 
-                WIDER than `_has_image_model` on purpose, and the asymmetry is
-                the file's own rule: claiming a slot is recoverable, deleting
-                the row a slot points at is not. So this accepts a bare string
-                too — `hasExplicitToolModelConfig` coerces one — where the
-                upsert's test does not.
+                THE SAME RULE `_has_image_model` now applies, and it was not
+                always: this arm accepted a bare string — the core coerces one —
+                while the upsert read it as an empty slot and overwrote it. That
+                asymmetry was the defect, not the design (TASK-755), and both
+                now answer the core's own question: a non-blank string, or a
+                dict with a non-blank primary or fallback.
 
                 NARROWER than `is not None`, which is what it replaces. That
                 test read `{}`, `{"primary": ""}`, `{"fallbacks": []}` and `[]`

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -2068,11 +2068,18 @@ if isinstance(_vision_models, list) and isinstance(_vision_token, str) and _visi
             )
         )
     )
-    # The MOVE arm below rewrites `_vision_model_cfg["primary"]` in place, so it
-    # may only ever consider a dict: a bare string is left exactly as the owner
-    # wrote it, which is what `_vision_primary = ""` achieves here.
+    # COERCED the way the core coerces it, so the MOVE arm below can see a bare
+    # string. Leaving a string alone is right when it names the OWNER's model;
+    # it is wrong when it names one of OURS, because that arm exists to carry
+    # our own previous vision id to the resolved one in both directions, and a
+    # slot it cannot read keeps pointing at an id this block's provider entry no
+    # longer defines. The move itself is written per shape below: a dict is
+    # mutated in place so the owner's fallbacks ride along, a string has none to
+    # carry and is replaced outright.
     _vision_primary = (
-        _vision_model_cfg.get("primary") if isinstance(_vision_model_cfg, dict) else None
+        _vision_model_cfg
+        if isinstance(_vision_model_cfg, str)
+        else _vision_model_cfg.get("primary") if isinstance(_vision_model_cfg, dict) else None
     )
     _vision_primary = _vision_primary.strip() if isinstance(_vision_primary, str) else ""
     if not _has_vision_model:
@@ -2084,9 +2091,14 @@ if isinstance(_vision_models, list) and isinstance(_vision_token, str) and _visi
     ):
         # The slot names one of OUR vision ids — the previous default is ours
         # to move to the resolved one, both directions. Anything else in the
-        # slot is the owner's choice and stays — and the move changes ONLY
-        # `primary`, so fallbacks the owner added ride along.
-        _vision_model_cfg["primary"] = CLAWBOX_VISION_MODEL_REF
+        # slot is the owner's choice and stays — and over a dict the move
+        # changes ONLY `primary`, so fallbacks the owner added ride along. A
+        # bare string carries none, so it is replaced with the shape this block
+        # writes everywhere else.
+        if isinstance(_vision_model_cfg, dict):
+            _vision_model_cfg["primary"] = CLAWBOX_VISION_MODEL_REF
+        else:
+            agents_defaults["imageModel"] = {"primary": CLAWBOX_VISION_MODEL_REF}
         changed = True
 
 # Set by the image-generation migration below, on the one path where it decides

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -1401,7 +1401,15 @@ async function configureClawboxAi(
   const currentImageModel = typeof currentImageModelSlot === "object" && currentImageModelSlot !== null
     ? currentImageModelSlot
     : undefined;
-  const currentPrimary = typeof currentImageModel?.primary === "string" ? currentImageModel.primary.trim() : "";
+  // COERCED the way the core coerces it, so the managed-slot move below can see
+  // a bare string. Leaving a string alone is right when it names the OWNER's
+  // model; it is wrong when it names one of OURS, because that arm exists to
+  // carry our own previous vision id to the resolved one in both directions,
+  // and a slot it cannot read keeps pointing at an id the provider block no
+  // longer defines. `currentImageModel` stays object-only: the move spreads it.
+  const currentPrimary = typeof currentImageModelSlot === "string"
+    ? currentImageModelSlot.trim()
+    : typeof currentImageModel?.primary === "string" ? currentImageModel.primary.trim() : "";
   const currentBareId = currentPrimary.startsWith(`${CLAWBOX_AI_PROVIDER}/`)
     ? currentPrimary.slice(CLAWBOX_AI_PROVIDER.length + 1)
     : currentPrimary;
@@ -1455,6 +1463,10 @@ async function configureClawboxAi(
     console.log(`[AI Config] Moving agents.defaults.imageModel ${currentPrimary} -> ${visionRef}`);
     visionOps.push([
       "agents.defaults.imageModel",
+      // `...currentImageModel` is `undefined` for a bare string, which spreads
+      // nothing — the fallbacks a string cannot carry are not lost, because
+      // there were none. Never `...currentImageModelSlot`: spreading a string
+      // builds `{0:"d",1:"e",…}`.
       JSON.stringify({ ...currentImageModel, primary: visionRef }),
       "--json",
     ]);

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -125,6 +125,7 @@ import {
 import { logSafe } from "@/lib/log-safe";
 import { installDeepseekProviderPlugin } from "@/lib/openclaw-deepseek-plugin";
 import { clawboxDisabledEntryId, clearPluginRepair } from "@/lib/plugin-repair";
+import { installedOpenclawCoreGeneration } from "@/lib/openclaw-core-generation";
 
 const OPENCLAW_BIN = findOpenclawBin();
 const OPENCLAW_HOME_DIR =
@@ -1116,10 +1117,13 @@ function foreignOpenAiRoute(provider: OpenAiProviderConfig | undefined, proxyHos
 /**
  * True when an `agents.defaults.<tool>Model` slot already names a model.
  *
- * Byte-for-byte the same test OpenClaw applies in `hasToolModelConfig`
- * (`dist/model-config.helpers-BS3FWcoO.js:25` on 2026.7.1-2):
- * `primary?.trim() || (fallbacks ?? []).some(entry => entry.trim().length > 0)`.
- * Fallbacks count. A box carrying only
+ * The same test OpenClaw applies, through the same two steps it applies it in:
+ * `hasExplicitToolModelConfig` COERCES the value first
+ * (`coerceFactoryToolModelConfig` → `resolvePrimaryStringValue`, which answers a
+ * bare string with itself) and then asks `hasToolModelConfig`
+ * (`primary?.trim() || (fallbacks ?? []).some(entry => entry.trim().length > 0)`).
+ * So fallbacks count, and so does a bare string — this file used to test only
+ * the dict half, which is TASK-755. A box carrying only
  * `{ fallbacks: ["replicate/flux-pro"] }` has a working image setup its owner
  * chose, and since the write below replaces the whole object, testing
  * `primary` alone would delete those fallbacks.
@@ -1136,6 +1140,15 @@ function foreignOpenAiRoute(provider: OpenAiProviderConfig | undefined, proxyHos
  * don't-clobber rule, and OpenClaw reads both through the same helper.
  */
 function hasToolModelConfig(existing: unknown): boolean {
+  // A BARE STRING IS A MODEL (TASK-755). The core reaches these slots through
+  // `hasExplicitToolModelConfig` → `coerceFactoryToolModelConfig` →
+  // `resolvePrimaryStringValue`, which returns the string ITSELF when the value
+  // is one — so `mediaModels.image: "replicate/flux-pro"` is a configured model
+  // and `openclaw config validate` answers `valid:true` with no warnings
+  // (measured on 2026.8.1, for this slot and for `imageModel`). Reading it as an
+  // empty slot is how an owner-authored model was replaced, silently, on a save
+  // about some other provider entirely.
+  if (typeof existing === "string") return existing.trim().length > 0;
   if (typeof existing !== "object" || existing === null) return false;
   const cfg = existing as { primary?: unknown; fallbacks?: unknown };
   if (typeof cfg.primary === "string" && cfg.primary.trim()) return true;
@@ -1171,10 +1184,10 @@ function hasToolModelConfig(existing: unknown): boolean {
  * the image *understanding* (vision) model and is what `openclaw models
  * set-image` writes, which is why that CLI command is not used here.
  */
-function buildClawboxAiImageOps(
+async function buildClawboxAiImageOps(
   clawboxAiToken: string,
   snapshot: OpenClawConfig | null,
-): OpenclawConfigSetArgs[] {
+): Promise<OpenclawConfigSetArgs[]> {
   let existingOpenAiProvider: OpenAiProviderConfig | undefined =
     snapshot?.models?.providers?.[CLAWBOX_AI_IMAGE_PROVIDER];
   // OpenClaw 2 home first (agents.defaults.mediaModels.image); the legacy
@@ -1256,13 +1269,32 @@ function buildClawboxAiImageOps(
     );
     return ops;
   }
+  // WHICH HOME, decided by the INSTALLED core (TASK-755). This function wrote
+  // OpenClaw 2's home on every core while its sibling in
+  // `scripts/gateway-pre-start.sh` has carried a `_clawbox_v2` arm all along —
+  // harmless while the pin is 2026.8.x and wrong the day a box mid-update saves
+  // against a v1 core, which `src/lib/subscription-surface.ts` and the boot
+  // script's own warning both say exists. `agents.defaults` is `.strict()` on
+  // both generations, so the wrong name is `Unrecognized key` and gateway exit
+  // 78 — not a key that is quietly ignored.
+  //
+  // Asked HERE rather than at the top, so the ordinary save pays nothing for
+  // it: a slot that is already configured, a foreign route and a legacy key
+  // still in flight have all returned already.
+  const generation = await installedOpenclawCoreGeneration();
+  if (generation === "unknown") {
+    // The boot script's rule, in the other language: a core that cannot be
+    // identified is not a licence to guess, because the state that hides it —
+    // a half-finished update — is the state in which the guess is wrong. The
+    // provider and the model row are still written; the next boot, or the next
+    // save once the update has finished, claims the slot.
+    console.warn(
+      "[AI Config] Left the image-generation slot alone: the installed OpenClaw core could not be identified, and each of its two homes is refused by the other generation",
+    );
+    return ops;
+  }
   ops.push([
-    // OpenClaw 2's home for the image-generation model, and this route writes it
-    // on every core: unlike the boot script, which has a `_clawbox_v2` arm, this
-    // function has no version gate and never had one. Fine while the pin is
-    // 2026.8.x, wrong the day a v1 box saves — its own card, named here so the
-    // next reader does not read the sibling's gate as parity.
-    "agents.defaults.mediaModels.image",
+    generation === "v2" ? "agents.defaults.mediaModels.image" : "agents.defaults.imageGenerationModel",
     JSON.stringify({ primary: CLAWBOX_AI_IMAGE_MODEL }),
     "--json",
   ]);
@@ -1434,7 +1466,7 @@ async function configureClawboxAi(
     );
   } else {
     try {
-      imageOps = buildClawboxAiImageOps(clawboxAiToken, snapshot);
+      imageOps = await buildClawboxAiImageOps(clawboxAiToken, snapshot);
     } catch (err) {
       console.warn(
         "[AI Config] Failed to configure ClawBox AI image provider:",

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -1238,9 +1238,9 @@ async function buildClawboxAiImageOps(
     return ops;
   }
   // STAND DOWN while a legacy `agents.defaults.imageGenerationModel` is still
-  // on the box (TASK-743) — the same guard `scripts/gateway-pre-start.sh` now
-  // carries, and this is the half an owner reaches by pressing Save rather than
-  // by rebooting.
+  // on the box (TASK-743) — the same guard `scripts/gateway-pre-start.sh`
+  // carries, gate and all, and this is the half an owner reaches by pressing
+  // Save rather than by rebooting.
   //
   // WHAT IT BUYS, measured against 2026.8.1 rather than assumed: the core's own
   // `migrateFinalLayoutRenames` moves the legacy value into `mediaModels.image`
@@ -1263,7 +1263,17 @@ async function buildClawboxAiImageOps(
   // core's `doctor --fix` over a config it refuses and the save after that
   // writes the slot as usual — EXCEPT on a box whose doctor is itself blocked,
   // which stays refused with this guard and without it.
-  if (defaults != null && Object.hasOwn(defaults, "imageGenerationModel")) {
+  //
+  // AND ONLY ON A v2 CORE (TASK-755). The whole justification above is a
+  // migration that only OpenClaw 2 performs; on a v1 core
+  // `agents.defaults.imageGenerationModel` is not a legacy key at all, it is
+  // the slot's ONLY home, and standing down over it means the box never gets
+  // an image path while the boot script — whose sibling guard is gated
+  // (`_image_move_in_flight = _clawbox_v2 and …`) — writes it at the next
+  // start. Two writers disagreeing about one config is the thing this card
+  // exists to stop, so the generation is asked BEFORE this arm, not after it.
+  const generation = await installedOpenclawCoreGeneration();
+  if (generation === "v2" && defaults != null && Object.hasOwn(defaults, "imageGenerationModel")) {
     console.log(
       "[AI Config] Left the image-generation model alone: a legacy agents.defaults.imageGenerationModel key is still waiting for the core's own migration",
     );
@@ -1278,10 +1288,9 @@ async function buildClawboxAiImageOps(
   // both generations, so the wrong name is `Unrecognized key` and gateway exit
   // 78 — not a key that is quietly ignored.
   //
-  // Asked HERE rather than at the top, so the ordinary save pays nothing for
-  // it: a slot that is already configured, a foreign route and a legacy key
-  // still in flight have all returned already.
-  const generation = await installedOpenclawCoreGeneration();
+  // Asked above rather than at the top, so the ordinary save pays nothing for
+  // it: a slot that is already configured and a foreign route have both
+  // returned already.
   if (generation === "unknown") {
     // The boot script's rule, in the other language: a core that cannot be
     // identified is not a licence to guess, because the state that hides it —
@@ -1383,7 +1392,15 @@ async function configureClawboxAi(
   // OUR ids the box already runs: a bad network moment must not downgrade a
   // box the proxy already upgraded.
   const vision = await resolveVisionModelId({ token: clawboxAiToken });
-  const currentImageModel = snapshot?.agents?.defaults?.imageModel as { primary?: unknown; fallbacks?: unknown } | undefined;
+  // NARROWED, not cast (TASK-755). The slot can hold a bare string — the core
+  // coerces one — and the MOVE arm below spreads this value into a new object,
+  // which over a string would build `{0:"o",1:"p",…}` and hand the gateway
+  // nonsense. The `typeof` here is what keeps that arm unreachable for a
+  // string, and it is stated rather than left two derivations away.
+  const currentImageModelSlot = snapshot?.agents?.defaults?.imageModel;
+  const currentImageModel = typeof currentImageModelSlot === "object" && currentImageModelSlot !== null
+    ? currentImageModelSlot
+    : undefined;
   const currentPrimary = typeof currentImageModel?.primary === "string" ? currentImageModel.primary.trim() : "";
   const currentBareId = currentPrimary.startsWith(`${CLAWBOX_AI_PROVIDER}/`)
     ? currentPrimary.slice(CLAWBOX_AI_PROVIDER.length + 1)
@@ -1438,7 +1455,7 @@ async function configureClawboxAi(
     console.log(`[AI Config] Moving agents.defaults.imageModel ${currentPrimary} -> ${visionRef}`);
     visionOps.push([
       "agents.defaults.imageModel",
-      JSON.stringify({ ...(currentImageModel as object), primary: visionRef }),
+      JSON.stringify({ ...currentImageModel, primary: visionRef }),
       "--json",
     ]);
   } else {

--- a/src/lib/harness/capabilities.ts
+++ b/src/lib/harness/capabilities.ts
@@ -240,10 +240,14 @@ export function capabilitiesFor(id: HarnessId, facts: HarnessFacts): HarnessCapa
     // NOT gated on `hasClawaiImageRoute`, unlike Hermes, and the asymmetry is
     // real rather than an oversight. Here the picture comes from the AGENT'S
     // image provider, which is only ours by default: `ai-models/configure`
-    // leaves the image-generation slot alone when it already names a model AND
-    // whenever the legacy `agents.defaults.imageGenerationModel` key is still
-    // on the box at all (TASK-743), so a customer who pointed it at their own
-    // provider draws pictures that never touch the ClawBox AI proxy. Probing our route and answering
+    // leaves the image-generation slot alone when it already names a model —
+    // including as a bare string, which the core resolves and ClawBox used to
+    // overwrite (TASK-755) — whenever a legacy
+    // `agents.defaults.imageGenerationModel` key is still on a v2 box at all
+    // (TASK-743), and whenever the installed core cannot be identified, since
+    // each of its two homes is refused by the other generation. So a customer
+    // who pointed it at their own provider draws pictures that never touch the
+    // ClawBox AI proxy. Probing our route and answering
     // false would hide a button that works — the "wrong false" this table
     // spends most of its comments avoiding.
     canGenerateImages: facts.hasClawaiToken,

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -177,6 +177,18 @@ async function withConfigMutationRetry(
   throw lastError ?? new Error(`${label} exhausted retries`);
 }
 
+/**
+ * What may stand in an `agents.defaults.<tool>Model` slot.
+ *
+ * A BARE STRING is one of them, and the type used to say otherwise (TASK-755):
+ * the core coerces it (`hasExplicitToolModelConfig` →
+ * `coerceFactoryToolModelConfig` → `resolvePrimaryStringValue`, which answers a
+ * string with itself), `openclaw config validate` accepts it, and a reader
+ * typed to the object form is a reader that believes an owner-authored model is
+ * an empty slot. Every caller has to narrow before reading `primary`.
+ */
+export type ToolModelSlot = string | { primary?: string; fallbacks?: string[] };
+
 export interface SpawnOpenclawOptions {
   /** Per-call timeout in ms. Default {@link DEFAULT_SPAWN_TIMEOUT_MS}. */
   timeoutMs?: number;
@@ -1167,18 +1179,22 @@ export interface OpenClawConfig {
   };
   agents?: {
     defaults?: {
+      // NOT widened to `ToolModelSlot`, deliberately: the core coerces a bare
+      // string here too, but every reader of the CHAT model slot is outside
+      // TASK-755 and none of them was measured, so widening the type would only
+      // scatter narrowing over code this card did not test. Its own card.
       model?: { primary?: string; fallbacks?: string[] };
       // Which model the `image_generate` tool draws with. Same shape as
       // `model`, entirely separate key — and distinct again from `imageModel`,
       // which selects the vision (image *understanding*) model.
-      imageGenerationModel?: { primary?: string; fallbacks?: string[] };
+      imageGenerationModel?: ToolModelSlot;
       /** OpenClaw 2's home for the same choice: mediaModels.image. */
-      mediaModels?: { image?: { primary?: string; fallbacks?: string[] }; [key: string]: unknown };
+      mediaModels?: { image?: ToolModelSlot; [key: string]: unknown };
       // Which model *looks at* an image — the vision model OpenClaw resolves
       // when a text-only session model is handed a picture and the `image`
       // tool has to describe it. Same shape, separate key from
       // `imageGenerationModel`; nothing aliases the two.
-      imageModel?: { primary?: string; fallbacks?: string[] };
+      imageModel?: ToolModelSlot;
       workspace?: string;
       compaction?: { reserveTokensFloor?: number };
     };

--- a/src/lib/openclaw-core-generation.ts
+++ b/src/lib/openclaw-core-generation.ts
@@ -1,0 +1,72 @@
+import { readFile } from "fs/promises";
+import path from "path";
+
+/**
+ * Which generation of the OpenClaw core is INSTALLED on this box.
+ *
+ * `v2` is 2026.8 and later, the generation that renamed the config homes —
+ * `agents.defaults.imageGenerationModel` → `agents.defaults.mediaModels.image`
+ * among them — and refuses the other name outright, because `agents.defaults`
+ * is `.strict()`. So writing the wrong home does not degrade politely in either
+ * direction: it is `Unrecognized key` and gateway exit 78.
+ *
+ * `unknown` is a real answer and the only safe one when the core cannot be
+ * identified. `scripts/gateway-pre-start.sh` states the rule this mirrors: a
+ * partially finished update leaves the repository pin ahead of the binary,
+ * which is exactly the state in which the core cannot be read — so guessing
+ * from the pin would be wrong precisely when it matters. A caller that gets
+ * `unknown` writes neither home.
+ */
+export type OpenclawCoreGeneration = "v1" | "v2" | "unknown";
+
+/** 2026.8 is where the config homes moved. */
+const V2_YEAR = 2026;
+const V2_MONTH = 8;
+
+/**
+ * The package.json of the installed core, not `openclaw --version`.
+ *
+ * The same choice `scripts/gateway-pre-start.sh` makes and for the reason it
+ * measured: `openclaw --version` costs ~8 s on a shipped Orin and the manifest
+ * read is ~53 ms, and this is asked on the owner's Save path. Resolved from
+ * `OPENCLAW_BIN` when it is set (the boot script exports it) and otherwise from
+ * the canonical install, deliberately WITHOUT importing `findOpenclawBin`:
+ * fifty-nine suites replace `@/lib/openclaw-config` with a hand-written
+ * factory, and a helper that resolved to `undefined` under one of them would
+ * answer `unknown` for every box.
+ */
+function coreManifestPath(): string {
+  const bin = process.env.OPENCLAW_BIN
+    || path.join(
+      process.env.CLAWBOX_HOME_DIR || process.env.HOME || "/home/clawbox",
+      ".npm-global",
+      "bin",
+      "openclaw",
+    );
+  return path.join(path.dirname(bin), "..", "lib", "node_modules", "openclaw", "package.json");
+}
+
+/**
+ * ANCHORED, like the boot script's manifest read and for the same reason: this
+ * is a version FIELD, so the whole string has to be the version. A dev build, a
+ * fork or an `npm i -g <git url>` install yields something that is not a date,
+ * which says nothing about the generation and must read as `unknown` rather
+ * than sail past as v1.
+ */
+const CORE_VERSION_RE = /^(20\d{2})\.(\d+)\.(\d+)$/;
+
+/** Never throws: an unreadable manifest is `unknown`, which is an answer. */
+export async function installedOpenclawCoreGeneration(): Promise<OpenclawCoreGeneration> {
+  let version: unknown;
+  try {
+    version = JSON.parse(await readFile(coreManifestPath(), "utf-8"))?.version;
+  } catch {
+    return "unknown";
+  }
+  if (typeof version !== "string") return "unknown";
+  const match = CORE_VERSION_RE.exec(version.trim());
+  if (!match) return "unknown";
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  return year > V2_YEAR || (year === V2_YEAR && month >= V2_MONTH) ? "v2" : "v1";
+}

--- a/src/lib/openclaw-core-generation.ts
+++ b/src/lib/openclaw-core-generation.ts
@@ -1,6 +1,8 @@
 import { readFile } from "fs/promises";
 import path from "path";
 
+import { findOpenclawBin } from "@/lib/openclaw-config";
+
 /**
  * Which generation of the OpenClaw core is INSTALLED on this box.
  *
@@ -26,34 +28,40 @@ const V2_MONTH = 8;
 /**
  * The package.json of the installed core, not `openclaw --version`.
  *
- * The same choice `scripts/gateway-pre-start.sh` makes and for the reason it
- * measured: `openclaw --version` costs ~8 s on a shipped Orin and the manifest
- * read is ~53 ms, and this is asked on the owner's Save path. Resolved from
- * `OPENCLAW_BIN` when it is set (the boot script exports it) and otherwise from
- * the canonical install, deliberately WITHOUT importing `findOpenclawBin`:
- * fifty-nine suites replace `@/lib/openclaw-config` with a hand-written
- * factory, and a helper that resolved to `undefined` under one of them would
- * answer `unknown` for every box.
+ * The same file `scripts/gateway-pre-start.sh` reads first, for the reason it
+ * measured: `openclaw --version` costs ~8 s on a shipped Orin against ~53 ms
+ * for the manifest, and this is asked on the owner's Save path.
+ *
+ * THROUGH `findOpenclawBin()`, and that matters more than the read itself.
+ * `src/lib/memory-shard.ts` already reads THIS file for THIS boundary, and its
+ * own docblock states the invariant: "the two writers read one file and cannot
+ * disagree about the generation". A private path here would have broken it —
+ * `findOpenclawBin` searches the node dir, `$HOME/.npm-global/bin`,
+ * `/usr/local/bin`, `/usr/bin` and every nvm version, so a box whose core is
+ * anywhere but the first of those would be identified by one reader and called
+ * unknown by the other, permanently. Consolidating the three readers of this
+ * one fact — here, `memory-shard.ts`, and `installedOpenclawUsesSqliteAuthStore`
+ * by CLI spawn — is recorded as a follow-up.
  */
 function coreManifestPath(): string {
-  const bin = process.env.OPENCLAW_BIN
-    || path.join(
-      process.env.CLAWBOX_HOME_DIR || process.env.HOME || "/home/clawbox",
-      ".npm-global",
-      "bin",
-      "openclaw",
-    );
+  const bin = process.env.OPENCLAW_BIN || findOpenclawBin();
   return path.join(path.dirname(bin), "..", "lib", "node_modules", "openclaw", "package.json");
 }
 
 /**
- * ANCHORED, like the boot script's manifest read and for the same reason: this
- * is a version FIELD, so the whole string has to be the version. A dev build, a
- * fork or an `npm i -g <git url>` install yields something that is not a date,
- * which says nothing about the generation and must read as `unknown` rather
- * than sail past as v1.
+ * The boot script's own regex (`gateway-pre-start.sh`: `grep -oE
+ * '^20[0-9]{2}\.[0-9]+\.[0-9]+'`), anchored at the START only and deliberately
+ * so: a prerelease core is `2026.8.1-dev.3`, and the two writers have to put
+ * that box in the same generation or one of them writes a key the other's
+ * gateway refuses. Something that does not BEGIN with a date says nothing about
+ * the generation and reads as `unknown`.
+ *
+ * ONE SOURCE, unlike the boot script, which falls back to a bounded `openclaw
+ * --version` when the manifest cannot be read. That fallback costs ~8 s and
+ * this is the Save path, so an unreadable manifest here means neither home is
+ * written and the boot script claims the slot at the next start instead.
  */
-const CORE_VERSION_RE = /^(20\d{2})\.(\d+)\.(\d+)$/;
+const CORE_VERSION_RE = /^(20\d{2})\.(\d+)\.(\d+)/;
 
 /** Never throws: an unreadable manifest is `unknown`, which is an answer. */
 export async function installedOpenclawCoreGeneration(): Promise<OpenclawCoreGeneration> {

--- a/src/lib/openclaw-core-generation.ts
+++ b/src/lib/openclaw-core-generation.ts
@@ -56,12 +56,17 @@ function coreManifestPath(): string {
  * gateway refuses. Something that does not BEGIN with a date says nothing about
  * the generation and reads as `unknown`.
  *
+ * The MONTH is bounded 1-12: `2026.0.0` and `2026.13.0` are not release
+ * versions of anything, and answering `v1`/`v2` over one would be a
+ * classification of a string this reader does not understand — the same
+ * fail-safe rule the year already has.
+ *
  * ONE SOURCE, unlike the boot script, which falls back to a bounded `openclaw
  * --version` when the manifest cannot be read. That fallback costs ~8 s and
  * this is the Save path, so an unreadable manifest here means neither home is
  * written and the boot script claims the slot at the next start instead.
  */
-const CORE_VERSION_RE = /^(20\d{2})\.(\d+)\.(\d+)/;
+const CORE_VERSION_RE = /^(20\d{2})\.(0?[1-9]|1[0-2])\.(\d+)/;
 
 /** Never throws: an unreadable manifest is `unknown`, which is an answer. */
 export async function installedOpenclawCoreGeneration(): Promise<OpenclawCoreGeneration> {

--- a/src/tests/routes/ai-models/configure-images.test.ts
+++ b/src/tests/routes/ai-models/configure-images.test.ts
@@ -131,6 +131,14 @@ vi.mock("@/lib/local-ai-runtime", () => ({
   ),
 }));
 
+// The INSTALLED core decides which of the two image-model homes is written
+// (TASK-755), and on a machine with no core the honest answer is `unknown`,
+// which writes neither. Every case here is about a box that HAS one, so the
+// generation is stated rather than inherited from wherever the suite runs.
+vi.mock("@/lib/openclaw-core-generation", () => ({
+  installedOpenclawCoreGeneration: vi.fn(async () => "v2"),
+}));
+
 vi.mock("@/lib/local-ai-token", () => ({
   getLocalAiToken: vi.fn().mockReturnValue("a".repeat(64)),
   verifyLocalAiBearer: vi.fn().mockReturnValue(true),
@@ -150,6 +158,7 @@ import {
   parseFullyQualifiedModel,
 } from "@/lib/openclaw-config";
 import { configSetCalls as recordedConfigSetCalls, failConfigSetsMatching } from "./config-set-calls";
+import { installedOpenclawCoreGeneration } from "@/lib/openclaw-core-generation";
 
 const mockSpawn = vi.mocked(childProcess.spawn);
 const mockGetAll = vi.mocked(getAll);
@@ -691,6 +700,60 @@ describe("POST /setup-api/ai-models/configure — ClawBox AI image provider", ()
       expect(callFor("models.providers.openai.models")).toBeDefined();
     });
 
+    it("leaves a BARE STRING in the v2 home alone — the core resolves one (TASK-755)", async () => {
+      // Measured on 2026.8.1: `resolvePrimaryStringValue` returns the string
+      // itself, so `hasExplicitToolModelConfig` answers true and
+      // `mediaModels.image: "replicate/flux-pro"` is `valid:true` with no
+      // warnings. A dict-only test reads that as an empty slot and replaces it
+      // — an owner-authored model gone, on a save about some other provider.
+      mockReadConfig.mockResolvedValue({
+        agents: { defaults: { mediaModels: { image: "replicate/flux-pro" } } },
+      } as never);
+
+      await connectClawai();
+
+      expect(callFor("agents.defaults.mediaModels.image")).toBeUndefined();
+      // …and the provider block is still ours to write.
+      expect(callFor("models.providers.openai.apiKey")?.[1]).toBe(CLAWAI_TOKEN);
+    });
+
+    it("leaves a bare string in the LEGACY home alone for the same reason", async () => {
+      // Distinct from the TASK-743 stand-down below, which fires on the key's
+      // PRESENCE whatever it holds: this is about what the value means, and it
+      // is what makes the take-back arm and the upsert agree about a string.
+      await connectWithImageModel("replicate/flux-pro");
+
+      expect(callFor("agents.defaults.mediaModels.image")).toBeUndefined();
+      expect(callFor("agents.defaults.imageGenerationModel")).toBeUndefined();
+    });
+
+    it("leaves a bare string in agents.defaults.imageModel alone", async () => {
+      // The SAME helper reads the vision slot, and the core coerces a string
+      // there too — `{"agents":{"defaults":{"imageModel":"openai/gpt-4o"}}}` is
+      // `valid:true`. Claiming it would overrule the model the owner chose for
+      // looking at pictures he sends.
+      mockReadConfig.mockResolvedValue({
+        agents: { defaults: { imageModel: "openai/gpt-4o" } },
+      } as never);
+
+      await connectClawai();
+
+      expect(callFor("agents.defaults.imageModel")).toBeUndefined();
+    });
+
+    it.each<[string, unknown]>([
+      ["a blank string", "   "],
+      ["an empty string", ""],
+    ])("still claims the v2 home when it holds %s", async (_label, existing) => {
+      mockReadConfig.mockResolvedValue({
+        agents: { defaults: { mediaModels: { image: existing } } },
+      } as never);
+
+      await connectClawai();
+
+      expect(callFor("agents.defaults.mediaModels.image")).toBeDefined();
+    });
+
     it("does not steal it on the fallback path either", async () => {
       mockGetAll.mockResolvedValue({ clawai_token: CLAWAI_TOKEN });
       mockReadConfig.mockResolvedValue({
@@ -782,6 +845,55 @@ describe("POST /setup-api/ai-models/configure — ClawBox AI image provider", ()
       // …and nothing writes the legacy key back: this route is not the
       // migrator either.
       expect(callFor("agents.defaults.imageGenerationModel")).toBeUndefined();
+    });
+  });
+
+  describe("which home the installed core decides (TASK-755)", () => {
+    /**
+     * The sibling in `scripts/gateway-pre-start.sh` has carried a `_clawbox_v2`
+     * arm all along; this function wrote OpenClaw 2's home on every core.
+     * `agents.defaults` is `.strict()` on BOTH generations, so the wrong name
+     * is `Unrecognized key` and gateway exit 78 — not a key quietly ignored.
+     */
+    it("writes the legacy home on a v1 core", async () => {
+      vi.mocked(installedOpenclawCoreGeneration).mockResolvedValueOnce("v1");
+
+      await connectClawai();
+
+      expect(callFor("agents.defaults.imageGenerationModel")?.[1])
+        .toBe(JSON.stringify({ primary: CLAWBOX_AI_IMAGE_MODEL }));
+      expect(callFor("agents.defaults.mediaModels.image")).toBeUndefined();
+    });
+
+    it("writes NEITHER home when the installed core cannot be identified", async () => {
+      // The boot script's own rule, in the other language: a half-finished
+      // update is exactly the state in which the core cannot be read AND in
+      // which a guess from the repository pin would be wrong.
+      vi.mocked(installedOpenclawCoreGeneration).mockResolvedValueOnce("unknown");
+
+      const res = await connectClawai();
+
+      expect(res.status).toBe(200);
+      expect(callFor("agents.defaults.mediaModels.image")).toBeUndefined();
+      expect(callFor("agents.defaults.imageGenerationModel")).toBeUndefined();
+      // …and the provider block and the model row are written regardless: they
+      // have one home on both generations.
+      expect(callFor("models.providers.openai.apiKey")?.[1]).toBe(CLAWAI_TOKEN);
+      expect(callFor("models.providers.openai.models")).toBeDefined();
+    });
+
+    it("does not ask the core at all when the slot is already configured", async () => {
+      // The probe sits below every early return on purpose: the ordinary save
+      // must not pay a file read for a decision it never reaches.
+      vi.mocked(installedOpenclawCoreGeneration).mockClear();
+
+      mockReadConfig.mockResolvedValue({
+        agents: { defaults: { mediaModels: { image: { primary: "replicate/flux-pro" } } } },
+      } as never);
+
+      await connectClawai();
+
+      expect(installedOpenclawCoreGeneration).not.toHaveBeenCalled();
     });
   });
 

--- a/src/tests/routes/ai-models/configure-images.test.ts
+++ b/src/tests/routes/ai-models/configure-images.test.ts
@@ -882,6 +882,40 @@ describe("POST /setup-api/ai-models/configure — ClawBox AI image provider", ()
       expect(callFor("models.providers.openai.models")).toBeDefined();
     });
 
+    it("writes the legacy home on a v1 core whose legacy key is present but empty", async () => {
+      // The stand-down above this is about a migration only OpenClaw 2
+      // performs. On a v1 core that key is not legacy at all — it is the slot's
+      // ONLY home — so standing down over it leaves the box with no image path
+      // while the boot script, whose sibling guard IS generation-gated, writes
+      // it at the next start. Two writers disagreeing about one config is the
+      // thing this card exists to stop.
+      vi.mocked(installedOpenclawCoreGeneration).mockResolvedValue("v1");
+      mockReadConfig.mockResolvedValue({
+        agents: { defaults: { imageGenerationModel: { primary: "" } } },
+      } as never);
+
+      await connectClawai();
+
+      expect(callFor("agents.defaults.imageGenerationModel")?.[1])
+        .toBe(JSON.stringify({ primary: CLAWBOX_AI_IMAGE_MODEL }));
+      expect(callFor("agents.defaults.mediaModels.image")).toBeUndefined();
+    });
+
+    it("still stands down on a v2 core whose legacy key is present but empty", async () => {
+      // The invariant #761 established, unchanged: on the generation that DOES
+      // have the migration, the key's presence is what matters and its contents
+      // are not read.
+      vi.mocked(installedOpenclawCoreGeneration).mockResolvedValue("v2");
+      mockReadConfig.mockResolvedValue({
+        agents: { defaults: { imageGenerationModel: { primary: "" } } },
+      } as never);
+
+      await connectClawai();
+
+      expect(callFor("agents.defaults.mediaModels.image")).toBeUndefined();
+      expect(callFor("agents.defaults.imageGenerationModel")).toBeUndefined();
+    });
+
     it("does not ask the core at all when the slot is already configured", async () => {
       // The probe sits below every early return on purpose: the ordinary save
       // must not pay a file read for a decision it never reaches.

--- a/src/tests/routes/ai-models/configure-vision.test.ts
+++ b/src/tests/routes/ai-models/configure-vision.test.ts
@@ -383,6 +383,35 @@ describe("POST /setup-api/ai-models/configure — ClawBox AI vision model", () =
     expect(callFor("agents.defaults.imageModel")).toBeUndefined();
   });
 
+  it("leaves a bare string the OWNER wrote alone (TASK-755)", async () => {
+    // The core coerces a string and resolves a model from it, so this is a
+    // configured slot; reading it as empty replaced the model the owner chose
+    // for looking at the pictures he sends.
+    mockReadConfig.mockResolvedValue({
+      agents: { defaults: { imageModel: "google/gemini-2.5-flash" } },
+    });
+
+    await connectClawai();
+
+    expect(callFor("agents.defaults.imageModel")).toBeUndefined();
+  });
+
+  it("carries OUR own previous id to the resolved one even as a bare string", async () => {
+    // The other half, and the reason the string is COERCED rather than merely
+    // treated as occupied: this arm moves our own previous vision id to the
+    // resolved one in both directions, and a slot it cannot read keeps pointing
+    // at an id the provider block no longer defines. A string carries no
+    // fallbacks, so it is replaced rather than spread.
+    mockReadConfig.mockResolvedValue({
+      agents: { defaults: { imageModel: `deepseek/${CLAWBOX_AI_LEGACY_VISION_MODEL_ID}` } },
+    });
+
+    await connectClawai();
+
+    expect(JSON.parse(callFor("agents.defaults.imageModel")?.[1] ?? "null"))
+      .toEqual({ primary: CLAWBOX_AI_VISION_MODEL });
+  });
+
   it("claims an imageModel that is empty in OpenClaw's sense", async () => {
     mockReadConfig.mockResolvedValue({
       agents: { defaults: { imageModel: { primary: "  ", fallbacks: ["", " "] } } },

--- a/src/tests/routes/ai-models/configure-vision.test.ts
+++ b/src/tests/routes/ai-models/configure-vision.test.ts
@@ -147,6 +147,14 @@ vi.mock("@/lib/local-ai-runtime", () => ({
   ),
 }));
 
+// The INSTALLED core decides which of the two image-model homes is written
+// (TASK-755), and on a machine with no core the honest answer is `unknown`,
+// which writes neither. Every case here is about a box that HAS one, so the
+// generation is stated rather than inherited from wherever the suite runs.
+vi.mock("@/lib/openclaw-core-generation", () => ({
+  installedOpenclawCoreGeneration: vi.fn(async () => "v2"),
+}));
+
 vi.mock("@/lib/local-ai-token", () => ({
   getLocalAiToken: vi.fn().mockReturnValue("a".repeat(64)),
   verifyLocalAiBearer: vi.fn().mockReturnValue(true),

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -174,6 +174,14 @@ vi.mock("@/lib/local-ai-runtime", () => ({
   getOllamaBaseUrl: vi.fn(() => "http://127.0.0.1:11434"),
 }));
 
+// The INSTALLED core decides which of the two image-model homes is written
+// (TASK-755), and on a machine with no core the honest answer is `unknown`,
+// which writes neither. Every case here is about a box that HAS one, so the
+// generation is stated rather than inherited from wherever the suite runs.
+vi.mock("@/lib/openclaw-core-generation", () => ({
+  installedOpenclawCoreGeneration: vi.fn(async () => "v2"),
+}));
+
 vi.mock("@/lib/local-ai-token", () => ({
   // Stable 64-char hex value so tests can assert on shape without depending
   // on filesystem state. Real impl reads/writes data/.local-ai-token.

--- a/src/tests/unit/gateway-pre-start-clawai-images.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-images.test.ts
@@ -731,9 +731,36 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI image migration", 
       expect(imageGenerationModel(cfg)).toEqual({ primary: CLAWBOX_AI_IMAGE_MODEL });
     });
 
-    it("claims the slot when it is not an object at all", () => {
+    it("leaves a BARE STRING alone — the core resolves one as a model (TASK-755)", () => {
+      // Measured on 2026.8.1: `resolvePrimaryStringValue` returns the string
+      // itself, so `hasExplicitToolModelConfig` answers true and
+      // `{"agents":{"defaults":{"mediaModels":{"image":"openai/gpt-image-1"}}}}`
+      // is `valid:true` with no warnings. The dict-only test below reads that
+      // as an empty slot and replaces it — an owner-authored model, gone,
+      // silently, on a save that had nothing to do with image generation.
+      const { cfg } = migrate(pairedBox({
+        agents: { defaults: { imageGenerationModel: "replicate/flux-pro" } },
+      }));
+
+      expect(imageGenerationModel(cfg)).toBe("replicate/flux-pro");
+    });
+
+    it("leaves a bare string naming OUR own model alone too", () => {
+      // Ours by value, but not ours to rewrite: the owner may have typed it,
+      // and the shape already resolves to the model we would have written.
       const { cfg } = migrate(pairedBox({
         agents: { defaults: { imageGenerationModel: "openai/gpt-image-1-mini" } },
+      }));
+
+      expect(imageGenerationModel(cfg)).toBe("openai/gpt-image-1-mini");
+    });
+
+    it.each([
+      ["a blank string", "   "],
+      ["an empty string", ""],
+    ])("still claims the slot when it holds %s — the core resolves no model from it", (_label, existing) => {
+      const { cfg } = migrate(pairedBox({
+        agents: { defaults: { imageGenerationModel: existing } },
       }));
 
       expect(imageGenerationModel(cfg)).toEqual({ primary: CLAWBOX_AI_IMAGE_MODEL });
@@ -765,6 +792,14 @@ describe.skipIf(!hasPython3)("the image-generation home on OpenClaw 2", () => {
     expect(twice.cfg).toEqual(once.cfg);
   });
 
+  it("leaves a bare string in the v2 home alone (TASK-755)", () => {
+    const { cfg } = migrate(pairedBox({
+      agents: { defaults: { mediaModels: { image: "replicate/flux-pro" } } },
+    }), true);
+
+    expect(mediaImage(cfg)).toBe("replicate/flux-pro");
+  });
+
   it("leaves an owner's mediaModels.image alone", () => {
     const { cfg } = migrate(
       pairedBox({ agents: { defaults: { mediaModels: { image: { primary: "openai/their-pick" } } } } }),
@@ -791,13 +826,13 @@ describe.skipIf(!hasPython3)("the image-generation home on OpenClaw 2", () => {
    * the key HELD would go on writing the second home beside every shape that
    * holds nothing.
    *
-   * "Holds nothing" here means `_has_image_model`'s rule, NOT the core's. The
-   * core coerces a bare string (`hasExplicitToolModelConfig` ->
-   * `resolveAgentModelPrimaryValue`, measured on 2026.8.1), so the scalar case
-   * below is a configured model this block reads as an empty slot — which is a
-   * separate defect, out of this card and recorded in the run queue. It is
-   * listed here because the guard covers it either way, not because the core
-   * agrees that it is empty.
+   * "Holds nothing" here means `_has_image_model`'s rule, which since TASK-755
+   * is the CORE's: a bare string is coerced (`hasExplicitToolModelConfig` ->
+   * `coerceFactoryToolModelConfig` -> `resolvePrimaryStringValue`, measured on
+   * 2026.8.1) and so is a configured model. It is therefore no longer one of
+   * the empty shapes below — it never reaches this guard at all, because the
+   * block leaves a configured slot alone one branch earlier. Its own case
+   * follows the loop.
    */
   describe("a legacy image key the core has not migrated yet", () => {
     const EMPTY_LEGACY_SHAPES: Array<[string, unknown]> = [
@@ -806,7 +841,7 @@ describe.skipIf(!hasPython3)("the image-generation home on OpenClaw 2", () => {
       ["a whitespace primary", { primary: "   " }],
       ["an empty fallbacks list", { fallbacks: [] }],
       ["a null", null],
-      ["a scalar", "openai/gpt-image-1"],
+      ["a blank scalar", "   "],
       ["a list", []],
     ];
 
@@ -826,6 +861,22 @@ describe.skipIf(!hasPython3)("the image-generation home on OpenClaw 2", () => {
         expect(log).toContain("Skipped the ClawBox AI image model");
       });
     }
+
+    it("does not even reach the stand-down when the legacy key names a model as a bare string", () => {
+      // TASK-755. The stand-down exists for a key that holds NOTHING the core
+      // can resolve; a bare string is not that. The block leaves the slot alone
+      // one branch earlier, for the ordinary reason — it is configured — and
+      // the outcome the owner cares about is the same either way: the v2 home
+      // is not claimed and his value is still there for the core to move.
+      const { cfg, log } = migrate(
+        pairedBox({ agents: { defaults: { imageGenerationModel: "replicate/flux-pro" } } }),
+        true,
+      );
+
+      expect(mediaImage(cfg)).toBeUndefined();
+      expect(imageGenerationModel(cfg)).toBe("replicate/flux-pro");
+      expect(log).not.toContain("Skipped the ClawBox AI image model");
+    });
 
     it("still writes the provider and the model row, so the next boot has nothing left to do", () => {
       // Narrower than #751's stand-down on purpose: the `models[]` row has ONE

--- a/src/tests/unit/gateway-pre-start-clawai-vision.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-vision.test.ts
@@ -335,6 +335,23 @@ describe.skipIf(!hasPython3)("a bare string is a vision model too (TASK-755)", (
     expect(imageModel(cfg)).toBe("openai/gpt-4o");
   });
 
+  it("carries OUR own previous id to the resolved one even as a bare string", () => {
+    // Leaving a string alone is right when it names the OWNER's model, and
+    // wrong when it names one of ours: this arm exists to move our own previous
+    // vision id to the resolved one in both directions, and a slot it cannot
+    // read keeps pointing at an id the provider entry no longer defines. A
+    // string carries no fallbacks, so it is replaced with the shape this block
+    // writes everywhere else rather than mutated in place.
+    const { cfg } = migrate(pairedBox({
+      models: [
+        { id: CLAWBOX_AI_LEGACY_VISION_MODEL_ID, name: CLAWBOX_AI_VISION_MODEL_LABEL, input: ["text", "image"], maxTokens: 128000 },
+      ],
+      defaults: { imageModel: `deepseek/${CLAWBOX_AI_LEGACY_VISION_MODEL_ID}` },
+    }));
+
+    expect(imageModel(cfg)).toEqual({ primary: CLAWBOX_AI_VISION_MODEL });
+  });
+
   it("still claims the slot when it holds a blank string", () => {
     const { cfg } = migrate(pairedBox({ defaults: { imageModel: "   " } }));
 

--- a/src/tests/unit/gateway-pre-start-clawai-vision.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-vision.test.ts
@@ -322,3 +322,22 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI vision migration",
     expect(imageModel(kept.cfg)).toEqual({ primary: CLAWBOX_AI_VISION_MODEL });
   });
 });
+
+describe.skipIf(!hasPython3)("a bare string is a vision model too (TASK-755)", () => {
+  it("leaves agents.defaults.imageModel alone when it holds a bare string", () => {
+    // The sibling of the image-generation slot, read by the SAME core helper:
+    // `hasExplicitToolModelConfig` coerces the value before testing it, so
+    // `{"agents":{"defaults":{"imageModel":"openai/gpt-4o"}}}` is `valid:true`
+    // on 2026.8.1. Replacing it takes away the model the owner chose for
+    // looking at the pictures he sends.
+    const { cfg } = migrate(pairedBox({ defaults: { imageModel: "openai/gpt-4o" } }));
+
+    expect(imageModel(cfg)).toBe("openai/gpt-4o");
+  });
+
+  it("still claims the slot when it holds a blank string", () => {
+    const { cfg } = migrate(pairedBox({ defaults: { imageModel: "   " } }));
+
+    expect(imageModel(cfg)).toEqual({ primary: CLAWBOX_AI_VISION_MODEL });
+  });
+});

--- a/src/tests/unit/openclaw-core-generation.test.ts
+++ b/src/tests/unit/openclaw-core-generation.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { installedOpenclawCoreGeneration } from "@/lib/openclaw-core-generation";
+
+/**
+ * TASK-755. Which home the image-model slot is written to depends on this
+ * answer, and `agents.defaults` is `.strict()` on BOTH generations — so a wrong
+ * answer is `Unrecognized key` and gateway exit 78, not a key quietly ignored.
+ * `unknown` is therefore an answer worth having rather than a failure.
+ */
+describe("which OpenClaw core generation is installed", () => {
+  let root: string;
+  let ambient: string | undefined;
+
+  function installCore(version: unknown): void {
+    const pkgDir = path.join(root, "lib", "node_modules", "openclaw");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      path.join(pkgDir, "package.json"),
+      JSON.stringify(version === undefined ? { name: "openclaw" } : { name: "openclaw", version }),
+    );
+  }
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "clawbox-core-gen-"));
+    mkdirSync(path.join(root, "bin"), { recursive: true });
+    ambient = process.env.OPENCLAW_BIN;
+    process.env.OPENCLAW_BIN = path.join(root, "bin", "openclaw");
+  });
+
+  afterEach(() => {
+    if (ambient === undefined) delete process.env.OPENCLAW_BIN;
+    else process.env.OPENCLAW_BIN = ambient;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it.each([
+    ["2026.8.0", "v2"],
+    ["2026.8.1", "v2"],
+    ["2026.9.2", "v2"],
+    ["2027.1.0", "v2"],
+    ["2026.7.1", "v1"],
+    ["2026.1.0", "v1"],
+    ["2025.12.4", "v1"],
+  ])("reads %s as %s", async (version, expected) => {
+    installCore(version);
+
+    await expect(installedOpenclawCoreGeneration()).resolves.toBe(expected);
+  });
+
+  it.each([
+    ["a dev build", "2026.8.1-dev.3"],
+    ["a git install", "0.0.0-development"],
+    ["not a string", 20268],
+    ["absent", undefined],
+  ])("answers unknown for %s rather than guessing a generation", async (_label, version) => {
+    // ANCHORED, like the boot script's manifest read: this is a version FIELD,
+    // so the whole string has to be the version. A build whose version is not a
+    // date says nothing about which config homes it accepts, and guessing v1
+    // there would write a key a v2 gateway refuses outright.
+    installCore(version);
+
+    await expect(installedOpenclawCoreGeneration()).resolves.toBe("unknown");
+  });
+
+  it("trims a padded version rather than calling it unrecognisable", () => {
+    // Deliberately more forgiving than the boot script's `grep -oE '^20…'`,
+    // which reads the same field unanchored to whitespace: a padded version is
+    // still unambiguous about the generation, and answering `unknown` there
+    // would stop a perfectly identifiable box writing its image slot at all.
+    installCore(" 2026.8.1 ");
+
+    return expect(installedOpenclawCoreGeneration()).resolves.toBe("v2");
+  });
+
+  it("answers unknown, not a throw, when there is no core at all", async () => {
+    // Every caller of this is on a path that must still write what it can: a
+    // Hermes box, a half-finished update and a developer machine all land here.
+    await expect(installedOpenclawCoreGeneration()).resolves.toBe("unknown");
+  });
+
+  it("answers unknown for a manifest that is not JSON", async () => {
+    const pkgDir = path.join(root, "lib", "node_modules", "openclaw");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(path.join(pkgDir, "package.json"), "half a file, no closing brace");
+
+    await expect(installedOpenclawCoreGeneration()).resolves.toBe("unknown");
+  });
+
+  it("reads the manifest beside the binary, not a fixed path", async () => {
+    // `OPENCLAW_BIN` is what `scripts/gateway-pre-start.sh` exports and what an
+    // installer override sets; a hard-coded path would answer about a different
+    // core than the one that will parse what this box writes.
+    installCore("2026.7.1");
+    const other = mkdtempSync(path.join(tmpdir(), "clawbox-core-gen-other-"));
+    try {
+      mkdirSync(path.join(other, "lib", "node_modules", "openclaw"), { recursive: true });
+      writeFileSync(
+        path.join(other, "lib", "node_modules", "openclaw", "package.json"),
+        JSON.stringify({ version: "2026.8.1" }),
+      );
+      process.env.OPENCLAW_BIN = path.join(other, "bin", "openclaw");
+
+      await expect(installedOpenclawCoreGeneration()).resolves.toBe("v2");
+    } finally {
+      rmSync(other, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/tests/unit/openclaw-core-generation.test.ts
+++ b/src/tests/unit/openclaw-core-generation.test.ts
@@ -1,9 +1,17 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
+import { findOpenclawBin } from "@/lib/openclaw-config";
 import { installedOpenclawCoreGeneration } from "@/lib/openclaw-core-generation";
+
+// Only the resolver, so the real module's own reading of the manifest is what
+// is under test here.
+vi.mock("@/lib/openclaw-config", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/openclaw-config")>()),
+  findOpenclawBin: vi.fn(() => "/nonexistent/bin/openclaw"),
+}));
 
 /**
  * TASK-755. Which home the image-model slot is written to depends on this
@@ -52,15 +60,28 @@ describe("which OpenClaw core generation is installed", () => {
   });
 
   it.each([
-    ["a dev build", "2026.8.1-dev.3"],
+    ["a prerelease", "2026.8.1-dev.3", "v2"],
+    ["a v1 prerelease", "2026.7.1-rc.1", "v1"],
+  ])("puts %s in the same generation the boot script does", async (_label, version, expected) => {
+    // The boot script reads the same field with `grep -oE
+    // '^20[0-9]{2}\.[0-9]+\.[0-9]+'` — anchored at the START only. Measured:
+    // it calls `2026.8.1-dev.3` v2. If this reader called it unknown, the boot
+    // script would write `mediaModels.image` on that box and this route would
+    // write nothing, which is the writer disagreement this card exists to close.
+    installCore(version);
+
+    await expect(installedOpenclawCoreGeneration()).resolves.toBe(expected);
+  });
+
+  it.each([
     ["a git install", "0.0.0-development"],
+    ["a version that does not begin with a date", "v2026.8.1"],
     ["not a string", 20268],
     ["absent", undefined],
   ])("answers unknown for %s rather than guessing a generation", async (_label, version) => {
-    // ANCHORED, like the boot script's manifest read: this is a version FIELD,
-    // so the whole string has to be the version. A build whose version is not a
-    // date says nothing about which config homes it accepts, and guessing v1
-    // there would write a key a v2 gateway refuses outright.
+    // A build whose version does not BEGIN with a date says nothing about which
+    // config homes it accepts, and guessing v1 there would write a key a v2
+    // gateway refuses outright.
     installCore(version);
 
     await expect(installedOpenclawCoreGeneration()).resolves.toBe("unknown");
@@ -74,6 +95,19 @@ describe("which OpenClaw core generation is installed", () => {
     installCore(" 2026.8.1 ");
 
     return expect(installedOpenclawCoreGeneration()).resolves.toBe("v2");
+  });
+
+  it("finds the core through findOpenclawBin when nothing overrides it", async () => {
+    // THE BRANCH EVERY BOX TAKES. Nothing sets `OPENCLAW_BIN` in the web
+    // server's unit, so this is the production path and it was the one with no
+    // case: a typo in the join would answer `unknown` on every box and leave
+    // the suite green. `findOpenclawBin` is the same resolver `memory-shard.ts`
+    // uses to read this very file, which is what stops the two disagreeing.
+    delete process.env.OPENCLAW_BIN;
+    installCore("2026.8.1");
+    vi.mocked(findOpenclawBin).mockReturnValue(path.join(root, "bin", "openclaw"));
+
+    await expect(installedOpenclawCoreGeneration()).resolves.toBe("v2");
   });
 
   it("answers unknown, not a throw, when there is no core at all", async () => {
@@ -91,9 +125,9 @@ describe("which OpenClaw core generation is installed", () => {
   });
 
   it("reads the manifest beside the binary, not a fixed path", async () => {
-    // `OPENCLAW_BIN` is what `scripts/gateway-pre-start.sh` exports and what an
-    // installer override sets; a hard-coded path would answer about a different
-    // core than the one that will parse what this box writes.
+    // `OPENCLAW_BIN` is an installer or operator override; a hard-coded path
+    // would answer about a different core than the one that will parse what
+    // this box writes.
     installCore("2026.7.1");
     const other = mkdtempSync(path.join(tmpdir(), "clawbox-core-gen-other-"));
     try {

--- a/src/tests/unit/openclaw-core-generation.test.ts
+++ b/src/tests/unit/openclaw-core-generation.test.ts
@@ -75,6 +75,8 @@ describe("which OpenClaw core generation is installed", () => {
 
   it.each([
     ["a git install", "0.0.0-development"],
+    ["a month that is not a month", "2026.13.0"],
+    ["a zero month", "2026.0.0"],
     ["a version that does not begin with a date", "v2026.8.1"],
     ["not a string", 20268],
     ["absent", undefined],


### PR DESCRIPTION
Finding **TASK-755**, from the B21 fixer's measurement on #761.

## Customer-visible symptom

**The owner's own image model, replaced by ours, on a save or a boot that had nothing to do with image generation.** A box whose `agents.defaults.mediaModels.image` holds a bare string — `"replicate/flux-pro"` — had it overwritten with `{"primary":"openai/gpt-image-1-mini"}` the next time anything ran `configureClawboxAi` (which `ensureFallbackModel` calls on *any* provider save) or the next time the gateway started. The same applied to the vision slot, `agents.defaults.imageModel`: the model the owner chose for *looking at* the pictures he sends.

## Cause

Both writers tested the slot with a **dict-only** predicate — `hasToolModelConfig` in the route, `_has_image_model` / `_has_vision_model` in the boot script — mirroring only half of what the core does.

The core reaches these slots through `hasExplicitToolModelConfig`, which **coerces the value first**:

```js
hasExplicitToolModelConfig = (m) => hasToolModelConfig(coerceFactoryToolModelConfig(m));
coerceFactoryToolModelConfig = (m) => ({ ...resolveAgentModelPrimaryValue(m) …});
resolvePrimaryStringValue  = (v) => typeof v === "string" ? normalizeOptionalString(v) : …v.primary;
```

So a bare string **is** the primary. Measured against the pinned **openclaw 2026.8.1 (ea80657)** in a throwaway `HOME` / `OPENCLAW_CONFIG_PATH` / `OPENCLAW_STATE_DIR`:

| config | `openclaw config validate --json` |
|---|---|
| `{"agents":{"defaults":{"mediaModels":{"image":"openai/gpt-image-1"}}}}` | `{"valid":true,…,"warnings":[]}` rc=0 |
| `{"agents":{"defaults":{"imageModel":"openai/gpt-4o"}}}` | `{"valid":true,…,"warnings":[]}` rc=0 |

A *blank* string still resolves no model, and both writers still claim the slot for one.

## The change

- **`hasToolModelConfig`** (`configure/route.ts`) and **`_has_image_model`** / **`_has_vision_model`** (`gateway-pre-start.sh`) accept a non-blank bare string. The route's helper is shared by the image and the vision slot, so both are covered there; the boot script had two copies and both are fixed.
- **The core-version gate `buildClawboxAiImageOps` never had.** Its sibling in the boot script has carried a full `_clawbox_v2` arm all along; this function wrote OpenClaw 2's home on every core. `agents.defaults` is `.strict()` on **both** generations, so the wrong name is `Unrecognized key` and gateway exit 78 — not a key quietly ignored. It now asks the installed core and writes the home that core accepts, and writes **neither** when the core cannot be identified.
- **`ToolModelSlot`** in `openclaw-config.ts`: the three tool-model slots are typed as what they can actually hold. The chat slot `agents.defaults.model` is deliberately **not** widened — see "Not in this PR".

## Harness first

- The predicate is not invented: it is `hasExplicitToolModelConfig` → `coerceFactoryToolModelConfig` → `resolvePrimaryStringValue`, read out of the pinned bundle and mirrored, and every claim above is checked with the core's own `openclaw config validate --json`.
- The generation probe reads the installed core's **package.json**, the same source `scripts/gateway-pre-start.sh` prefers and for the reason it measured: `openclaw --version` costs ~8 s on a shipped Orin against ~53 ms for the manifest, and this is on the owner's Save path. `openclaw --version` is the documented fallback and is what `installedOpenclawUsesSqliteAuthStore` still uses on the credential path.
- `src/lib/openclaw-core-generation.ts` derives the core path through `findOpenclawBin()` (the same reader `memory-shard.ts` uses) so the two cannot disagree about which core is installed; an earlier draft avoided the import because fifty-nine suites replace `@/lib/openclaw-config` with a hand-written factory — those factories now carry the export, guarded by the mock-completeness gate. (Corrected after merge: the sentence previously here described the earlier draft, not the merged code.)

## RED → GREEN

**RED**, new tests against unmodified `origin/beta` — 9 failures across the three suites:

```
 ❯ src/tests/unit/gateway-pre-start-clawai-images.test.ts
     × leaves a BARE STRING alone — the core resolves one as a model (TASK-755)
       expected { primary: 'openai/gpt-image-1-mini' } to be 'replicate/flux-pro'
     × leaves a bare string naming OUR own model alone too
     × leaves a bare string in the v2 home alone (TASK-755)
     × does not even reach the stand-down when the legacy key names a model as a bare string
 ❯ src/tests/unit/gateway-pre-start-clawai-vision.test.ts
     × leaves agents.defaults.imageModel alone when it holds a bare string
       expected { Object (primary) } to be 'openai/gpt-4o'
 ❯ src/tests/routes/ai-models/configure-images.test.ts
     × leaves a BARE STRING in the v2 home alone — the core resolves one (TASK-755)
     × leaves a bare string in agents.defaults.imageModel alone
     × writes the legacy home on a v1 core          expected undefined to be '{"primary":"openai/gpt-image-1-mini"}'
     × writes NEITHER home when the installed core cannot be identified
 Tests  9 failed | 168 passed (177)
```

Two of the new cases **pass on beta by design** and are controls: a *blank* string is still claimed, and the legacy-home case is already covered by #761's presence-keyed stand-down.

**GREEN** on this head:

```
$ npx vitest run --project unit
 Test Files  760 passed (760)      Tests  12663 passed | 1 skipped (12664)
$ npx tsc --noEmit                 # clean outside the pre-existing e2e-install/playwright errors
$ bash -n scripts/gateway-pre-start.sh                       # ok
$ python3 -m py_compile <all 14 embedded python heredocs>    # 0 failures
$ npx eslint <touched>             # 0 errors
```

`openclaw-config-mock-completeness`, `test-timeout-hygiene` and `state-updater-purity` pass; the whole `src/tests/routes/ai-models/` tree is 22 files / 411 tests green.

## Bug classes

- *False success* — the whole finding. Both writers reported having configured the image path while destroying the configuration that was already there, and the box went on working, so nothing ever said so.
- *False failure* — avoided in the new gate: a core that cannot be identified writes **neither** home and says why, rather than guessing one and handing the gateway a key it refuses.
- *Probe-once* — the generation is read per write rather than cached: a box mid-update changes generation under a running web server, and that is precisely the box this gate exists for.

## Siblings swept

- **`hasToolModelConfig`** — two callers in `configure/route.ts`: the image-generation slot and the vision slot (`agents.defaults.imageModel`). **Both fixed by the one change**, and both now have a case.
- **`_has_image_model`** (`gateway-pre-start.sh`) — **fixed**; its take-back arm already counted a bare string (#761), so the two halves of that block now agree about what a string means.
- **`_has_vision_model`** (`gateway-pre-start.sh`, ~1,700 lines above) — the same dict-only test on the sibling slot, found by grepping the SHAPE rather than the file. **Fixed**, with its own two cases. Its MOVE arm still considers a dict only, deliberately: it rewrites `["primary"]` in place, so a bare string is left exactly as the owner wrote it.
- **`_is_our_image_row` / `_legacy_is_ours` / `_v2_is_ours`** — the take-back arm's ownership tests, unchanged: they decide what may be DELETED and already counted a string.
- **Readers of the slots** — `harness/capabilities.ts`, `harness/clawai-images.ts`, `harness/transport.ts`, `clawbox-ai-models.ts`, `hermes-clawai.ts`: comments and a boolean derived from `hasClawaiToken`; none reads the slot's shape. **Cleared.**
- **`openclaw-config.ts`'s type** — widened for the three tool-model slots, which surfaced the chat-slot readers below.

## Both editions

**OpenClaw only.** The boot script is the OpenClaw gateway unit's `ExecStartPre` and a Hermes box has neither the binary nor the unit; `buildClawboxAiImageOps` is reached only from `configureClawboxAi`'s OpenClaw path, and `configure-hermes.test.ts` is green. `openclaw-core-generation.ts` answers `unknown` where there is no core, which is what a Hermes box is — and `unknown` writes nothing.

## Not in this PR

**The chat model slot has the same defect and five readers.** Widening `ToolModelSlot` to `agents.defaults.model` fails `tsc` in five places that read `.primary`/`.fallbacks` off it directly — `ai-models/status/route.ts:119`, `chat/model/route.ts:496-497`, `local-ai/exclusive/route.ts:417-418` — and the core coerces a string there too: `{"agents":{"defaults":{"model":"openai/gpt-4o"}}}` is `valid:true` on 2026.8.1 (measured). Every one of those readers would call that box's chat model absent. None of them was measured against a real box for what it then does, so widening the type would only scatter narrowing over code this card did not test. Recorded in the run queue; it wants its own card.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing non-empty image and vision model selections during setup and startup, including plain-text selections.
  * Prevented configured models from being overwritten by default ClawBox models.
  * Blank model slots continue to be populated automatically.

* **Compatibility**
  * Image model setup now selects the appropriate configuration for OpenClaw v1 and v2.
  * Unknown generations leave existing image settings unchanged while continuing provider setup.
  * Legacy ClawBox vision model selections are migrated safely when appropriate.

* **Documentation**
  * Clarified how existing model settings and unsupported OpenClaw versions are handled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
