### PR TITLE
fix: a completed update stops telling the owner to update again

### DIFF
--- a/src/components/SystemUpdateApp.tsx
+++ b/src/components/SystemUpdateApp.tsx
@@ -7,6 +7,7 @@ import { useTr } from "@/lib/i18n-floor";
 import { useBuildIdentity } from "@/components/BuildIdentityPanel";
 import type { StepStatus, UpdateState } from "@/lib/updater";
 import { RESTART_STEP_ID } from "@/lib/update-constants";
+import { DRIFT_RESOLVED_CODE } from "@/lib/drift-codes";
 import { cleanVersion } from "@/lib/version-utils";
 
 export interface ComponentVersion {
@@ -1078,15 +1079,33 @@ function UpdateProgressCard({
 
       {warnings.length > 0 && (
         <ul className="mt-4 space-y-2">
-          {warnings.map((w) => (
-            <li
-              key={w.code}
-              className="flex items-start gap-2 rounded-md border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-100"
-            >
-              <span className="material-symbols-rounded text-amber-300 shrink-0" style={{ fontSize: 16 }}>warning</span>
-              <span>{w.message}</span>
-            </li>
-          ))}
+          {warnings.map((w) => {
+            // The line a finished run leaves behind about drift it RESOLVED is
+            // history, not a problem. Drawn amber with a warning triangle it
+            // alarmed the owner exactly as the stale imperative did, which is
+            // the thing the completion card is meant to stop doing.
+            const resolved = w.code === DRIFT_RESOLVED_CODE;
+            return (
+              <li
+                key={w.code}
+                data-testid={`update-warning-${w.code}`}
+                data-tone={resolved ? "info" : "warning"}
+                className={`flex items-start gap-2 rounded-md border px-3 py-2 text-xs ${
+                  resolved
+                    ? "border-[var(--border-subtle)] bg-white/5 text-[var(--text-muted)]"
+                    : "border-amber-500/20 bg-amber-500/10 text-amber-100"
+                }`}
+              >
+                <span
+                  className={`material-symbols-rounded shrink-0 ${resolved ? "text-gray-400" : "text-amber-300"}`}
+                  style={{ fontSize: 16 }}
+                >
+                  {resolved ? "history" : "warning"}
+                </span>
+                <span>{w.message}</span>
+              </li>
+            );
+          })}
         </ul>
       )}
 

--- a/src/lib/build-identity.ts
+++ b/src/lib/build-identity.ts
@@ -23,6 +23,12 @@ import { promisify } from "util";
 import { readFile, stat } from "fs/promises";
 import path from "path";
 import { isSafeBranch } from "./update-branch";
+import {
+  DRIFT_ACTION_REALIGN,
+  DRIFT_ACTION_REBUILD,
+  DRIFT_ACTION_REBUILD_FROM_CHECKOUT,
+  type DriftCode,
+} from "./drift-codes";
 
 const execFile = promisify(execFileCb);
 
@@ -91,48 +97,7 @@ export interface DriftReport {
   codes: DriftCode[];
 }
 
-/**
- * Every drift code, as a value — so a caller holding an arbitrary warning code
- * can ask whether it is one of these. The union below is DERIVED from it,
- * which is what stops the two from disagreeing: a code added to the type has
- * to be added here, and `RESOLVED_DRIFT_PHRASE` then fails to typecheck until
- * it is given its past-tense wording too.
- */
-export const DRIFT_CODES = [
-  "build-from-other-commit",
-  "build-info-not-for-deployed-assets",
-  "build-predates-checkout",
-  "build-unstamped",
-  "checkout-dirty",
-  "checkout-behind-pin",
-  "no-pin",
-] as const;
-
-export type DriftCode = (typeof DRIFT_CODES)[number];
-
-/** Is this warning code one of the drift diagnoses, rather than some other update warning? */
-export function isDriftCode(code: string): code is DriftCode {
-  return (DRIFT_CODES as readonly string[]).includes(code);
-}
-
-/**
- * How each diagnosis reads once an update has RESOLVED it.
- *
- * Past tense, and no imperative: the live `reasons` in `computeDrift` end in
- * "run Update to realign", which is the wrong thing to say to an owner whose
- * update has just realigned the box (TASK-757). Kept in this file, beside the
- * sentences they replace, so the two cannot drift apart — each phrase
- * completes "When this update started, …".
- */
-export const RESOLVED_DRIFT_PHRASE: Record<DriftCode, string> = {
-  "build-from-other-commit": "it was serving a build made from a different commit than the code on disk",
-  "build-info-not-for-deployed-assets": "the build it was serving could not be identified",
-  "build-predates-checkout": "the build it was serving was older than the code on disk",
-  "build-unstamped": "the build it was serving carried no build record",
-  "checkout-dirty": "the code on disk had uncommitted changes",
-  "checkout-behind-pin": "the code on disk was not the tested commit for its branch",
-  "no-pin": "it recorded no tested branch to update to",
-};
+export type { DriftCode } from "./drift-codes";
 
 export interface DriftInputs {
   build: BuildInfo | null;
@@ -190,7 +155,7 @@ export function computeDrift(input: DriftInputs): DriftReport {
       buildVsCheckout = "drift";
       codes.push("build-from-other-commit");
       reasons.push(
-        `This box is running a build made from ${short(build.commit)} but the code on disk is ${short(checkout.commit)} — run Update to realign.`,
+        `This box is running a build made from ${short(build.commit)} but the code on disk is ${short(checkout.commit)}${DRIFT_ACTION_REALIGN}`,
       );
     }
   } else if (!build?.commit) {
@@ -198,7 +163,7 @@ export function computeDrift(input: DriftInputs): DriftReport {
       buildVsCheckout = "drift";
       codes.push("build-unstamped");
       reasons.push(
-        "The deployed build carries no build record, so it was made before the code now on disk — run Update to rebuild from this checkout.",
+        `The deployed build carries no build record, so it was made before the code now on disk${DRIFT_ACTION_REBUILD_FROM_CHECKOUT}`,
       );
     } else if (
       buildTimestampMs !== null
@@ -208,7 +173,7 @@ export function computeDrift(input: DriftInputs): DriftReport {
       buildVsCheckout = "drift";
       codes.push("build-predates-checkout");
       reasons.push(
-        "The code on disk is newer than the deployed build — run Update to rebuild.",
+        `The code on disk is newer than the deployed build${DRIFT_ACTION_REBUILD}`,
       );
     }
   }

--- a/src/lib/build-identity.ts
+++ b/src/lib/build-identity.ts
@@ -84,6 +84,18 @@ export type DriftState = "match" | "drift" | "unknown";
 export interface DriftReport {
   /** Is the served build reproducible from the code on disk? */
   buildVsCheckout: DriftState;
+  /**
+   * The build-versus-checkout comparison ALONE, before an uncommitted change
+   * is folded into it.
+   *
+   * `buildVsCheckout` is deliberately downgraded to "drift" by a dirty tree —
+   * right for the banner, which asks "can this box be trusted to be running
+   * its own code?" — and that makes it unusable for the different question
+   * "is the deployed build the commit on disk?". A completed update has to ask
+   * the second one about its own build warnings: a stray untracked file would
+   * otherwise keep a build warning the rebuild HAS resolved alive for ever.
+   */
+  buildIsCheckout: DriftState;
   /** Is the code on disk the tested commit the fleet is pinned to? */
   checkoutVsPin: DriftState;
   /** True when either comparison came back "drift". Drives the UI banner and the updater warning. */
@@ -178,6 +190,9 @@ export function computeDrift(input: DriftInputs): DriftReport {
     }
   }
 
+  // Recorded before the override below, which answers a different question.
+  const buildIsCheckout: DriftState = buildVsCheckout;
+
   // A dirty tree is drift on an appliance: an untracked file under src/app/ is
   // a route the next build would serve and this one does not. Reported
   // separately so a matching commit is not quietly downgraded by it.
@@ -213,6 +228,7 @@ export function computeDrift(input: DriftInputs): DriftReport {
 
   return {
     buildVsCheckout,
+    buildIsCheckout,
     checkoutVsPin,
     detected: buildVsCheckout === "drift" || checkoutVsPin === "drift",
     reasons,

--- a/src/lib/build-identity.ts
+++ b/src/lib/build-identity.ts
@@ -91,14 +91,48 @@ export interface DriftReport {
   codes: DriftCode[];
 }
 
-export type DriftCode =
-  | "build-from-other-commit"
-  | "build-info-not-for-deployed-assets"
-  | "build-predates-checkout"
-  | "build-unstamped"
-  | "checkout-dirty"
-  | "checkout-behind-pin"
-  | "no-pin";
+/**
+ * Every drift code, as a value — so a caller holding an arbitrary warning code
+ * can ask whether it is one of these. The union below is DERIVED from it,
+ * which is what stops the two from disagreeing: a code added to the type has
+ * to be added here, and `RESOLVED_DRIFT_PHRASE` then fails to typecheck until
+ * it is given its past-tense wording too.
+ */
+export const DRIFT_CODES = [
+  "build-from-other-commit",
+  "build-info-not-for-deployed-assets",
+  "build-predates-checkout",
+  "build-unstamped",
+  "checkout-dirty",
+  "checkout-behind-pin",
+  "no-pin",
+] as const;
+
+export type DriftCode = (typeof DRIFT_CODES)[number];
+
+/** Is this warning code one of the drift diagnoses, rather than some other update warning? */
+export function isDriftCode(code: string): code is DriftCode {
+  return (DRIFT_CODES as readonly string[]).includes(code);
+}
+
+/**
+ * How each diagnosis reads once an update has RESOLVED it.
+ *
+ * Past tense, and no imperative: the live `reasons` in `computeDrift` end in
+ * "run Update to realign", which is the wrong thing to say to an owner whose
+ * update has just realigned the box (TASK-757). Kept in this file, beside the
+ * sentences they replace, so the two cannot drift apart — each phrase
+ * completes "When this update started, …".
+ */
+export const RESOLVED_DRIFT_PHRASE: Record<DriftCode, string> = {
+  "build-from-other-commit": "it was serving a build made from a different commit than the code on disk",
+  "build-info-not-for-deployed-assets": "the build it was serving could not be identified",
+  "build-predates-checkout": "the build it was serving was older than the code on disk",
+  "build-unstamped": "the build it was serving carried no build record",
+  "checkout-dirty": "the code on disk had uncommitted changes",
+  "checkout-behind-pin": "the code on disk was not the tested commit for its branch",
+  "no-pin": "it recorded no tested branch to update to",
+};
 
 export interface DriftInputs {
   build: BuildInfo | null;

--- a/src/lib/drift-codes.ts
+++ b/src/lib/drift-codes.ts
@@ -31,6 +31,25 @@ export function isDriftCode(code: string): code is DriftCode {
   return (DRIFT_CODES as readonly string[]).includes(code);
 }
 
+/**
+ * The codes the build-versus-checkout comparison produces.
+ *
+ * They are ALTERNATIVES in one if/else chain, not independent facts: one
+ * underlying "the build is not the code on disk" can surface as any of them,
+ * and can move between them as the box changes. So they are resolved and
+ * restated together, never one by one.
+ */
+export const BUILD_AXIS_CODES: readonly DriftCode[] = [
+  "build-from-other-commit",
+  "build-info-not-for-deployed-assets",
+  "build-predates-checkout",
+  "build-unstamped",
+];
+
+export function isBuildAxisCode(code: string): boolean {
+  return (BUILD_AXIS_CODES as readonly string[]).includes(code);
+}
+
 /** The one line a finished run leaves behind about drift it resolved. */
 export const DRIFT_RESOLVED_CODE = "drift-resolved";
 

--- a/src/lib/drift-codes.ts
+++ b/src/lib/drift-codes.ts
@@ -1,0 +1,69 @@
+/**
+ * The drift vocabulary, with NOTHING behind it.
+ *
+ * `build-identity.ts` — where these codes are produced — imports `child_process`,
+ * `fs/promises` and `path`, and `BuildIdentityPanel.tsx` already imports from it.
+ * That is safe only while every such import is type-only: the first component to
+ * reach for a runtime value would pull the Node built-ins into the browser bundle
+ * and fail the build, which is the same trap `update-constants.ts` exists for
+ * (`RESTART_STEP_ID`). So the codes, the predicate and the wording rules live
+ * here, with no imports at all, and `build-identity.ts` re-exports the type.
+ */
+
+/**
+ * Every drift code. The union below is DERIVED from it, which is what stops the
+ * two from disagreeing: a code added to the type has to be added here.
+ */
+export const DRIFT_CODES = [
+  "build-from-other-commit",
+  "build-info-not-for-deployed-assets",
+  "build-predates-checkout",
+  "build-unstamped",
+  "checkout-dirty",
+  "checkout-behind-pin",
+  "no-pin",
+] as const;
+
+export type DriftCode = (typeof DRIFT_CODES)[number];
+
+/** Is this warning code one of the drift diagnoses, rather than some other update warning? */
+export function isDriftCode(code: string): code is DriftCode {
+  return (DRIFT_CODES as readonly string[]).includes(code);
+}
+
+/** The one line a finished run leaves behind about drift it resolved. */
+export const DRIFT_RESOLVED_CODE = "drift-resolved";
+
+/**
+ * The calls to action `computeDrift` ends a reason with.
+ *
+ * Named rather than matched, because the one place they must come OFF — the
+ * past-tense history line a completed update leaves behind — has to drop
+ * exactly the imperative and keep every fact, and a regex over owner-facing
+ * English is how that goes wrong quietly. `computeDrift` builds its reasons
+ * from these, so the list cannot fall out of step with the sentences.
+ */
+export const DRIFT_ACTION_REALIGN = " — run Update to realign.";
+export const DRIFT_ACTION_REBUILD_FROM_CHECKOUT = " — run Update to rebuild from this checkout.";
+export const DRIFT_ACTION_REBUILD = " — run Update to rebuild.";
+
+const DRIFT_ACTIONS = [
+  DRIFT_ACTION_REALIGN,
+  DRIFT_ACTION_REBUILD_FROM_CHECKOUT,
+  DRIFT_ACTION_REBUILD,
+] as const;
+
+/**
+ * A drift reason with its call to action taken off, ending in a full stop.
+ *
+ * What a past-tense retelling may quote: the shas and the branch survive — a
+ * support engineer reading a screenshot can still tell a box one commit behind
+ * from one 71 behind — while "run Update to realign" does not reach an owner
+ * whose update has just realigned the box.
+ */
+export function driftFact(reason: string): string {
+  for (const action of DRIFT_ACTIONS) {
+    if (reason.endsWith(action)) return `${reason.slice(0, -action.length)}.`;
+  }
+  return reason;
+}

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -42,7 +42,13 @@ export { INTERRUPTED_MESSAGE } from "./update-constants";
 import { INTERRUPTED_MESSAGE } from "./update-constants";
 import { collectBuildIdentity, resolveBuildDir, type DriftReport } from "./build-identity";
 export { DRIFT_RESOLVED_CODE } from "./drift-codes";
-import { driftFact, DRIFT_RESOLVED_CODE, isDriftCode, type DriftCode } from "./drift-codes";
+import {
+  driftFact,
+  DRIFT_RESOLVED_CODE,
+  isBuildAxisCode,
+  isDriftCode,
+  type DriftCode,
+} from "./drift-codes";
 import type { AuthProfileEntries } from "./subscription-surface";
 import { OFFICIAL_CHANNEL_PLUGINS } from "./openclaw-channels";
 import {
@@ -1020,9 +1026,14 @@ function measuredResolved(code: DriftCode, measured: DriftMeasurement): boolean 
     case "build-info-not-for-deployed-assets":
     case "build-predates-checkout":
     case "build-unstamped":
-      // "match" means the deployed build IS the commit on disk, over a tree
-      // git called clean — the one verdict under which none of these applies.
-      return measured.drift.buildVsCheckout === "match";
+      // The comparison ALONE, never the aggregate `buildVsCheckout`: that one
+      // is downgraded to "drift" by an uncommitted change, so a stray
+      // untracked file after `post_update` would keep a build warning the
+      // rebuild HAS resolved alive for ever — and it is promoted OUT of
+      // "unknown" by the same override, which would retire one the comparison
+      // never made. The four codes resolve together because they are
+      // alternatives for one condition, which `buildIsCheckout` answers.
+      return measured.drift.buildIsCheckout === "match";
     default: {
       // A code added to DRIFT_CODES without a rule here fails to typecheck, and
       // at runtime keeps its warning: a condition nobody answered is not one
@@ -1074,9 +1085,15 @@ export function reconcileDriftWarnings(
   if (measured === null) return previous;
   if (!hasDriftWarning(previous)) return previous;
 
-  const live = new Map(driftWarnings(measured.drift).map((w) => [w.code, w]));
+  const measuredNow = driftWarnings(measured.drift);
+  const live = new Map(measuredNow.map((w) => [w.code, w]));
+  // The build codes are alternatives for one condition, so a box still drifted
+  // under a DIFFERENT one of them is described by the sentence measured now —
+  // otherwise a migration between them would keep the pre-run text on screen.
+  const liveBuildAxis = measuredNow.find((w) => isBuildAxisCode(w.code));
   const resolved: UpdateWarning[] = [];
   const next: UpdateWarning[] = [];
+  const emitted = new Set<string>();
 
   for (const warning of previous) {
     if (!isDriftCode(warning.code)) {
@@ -1088,8 +1105,16 @@ export function reconcileDriftWarnings(
       continue;
     }
     // Still drifted, or the axis could not be read: keep it. The freshly
-    // measured sentence when there is one, the captured one otherwise.
-    next.push(live.get(warning.code) ?? warning);
+    // measured sentence when there is one, the captured one otherwise — the
+    // last thing the box could actually be seen to say.
+    const substitute = live.get(warning.code)
+      ?? (isBuildAxisCode(warning.code) ? liveBuildAxis : undefined);
+    // A warning list restored from a box that predates this fix can carry two
+    // build codes (it was written from two samples), and the codes key the
+    // rendered list — so a substitution that would double one is not made.
+    const current = substitute && !emitted.has(substitute.code) ? substitute : warning;
+    emitted.add(current.code);
+    next.push(current);
   }
 
   if (resolved.length > 0) {

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -40,7 +40,13 @@ const UPDATE_INTERRUPTED_KEY = "update_interrupted_at";
 // to be able to name it without pulling this file's Node built-ins in with it.
 export { INTERRUPTED_MESSAGE } from "./update-constants";
 import { INTERRUPTED_MESSAGE } from "./update-constants";
-import { collectBuildIdentity, resolveBuildDir } from "./build-identity";
+import {
+  collectBuildIdentity,
+  isDriftCode,
+  resolveBuildDir,
+  RESOLVED_DRIFT_PHRASE,
+  type DriftCode,
+} from "./build-identity";
 import type { AuthProfileEntries } from "./subscription-surface";
 import { OFFICIAL_CHANNEL_PLUGINS } from "./openclaw-channels";
 import {
@@ -941,21 +947,105 @@ export async function repinUpdateBranch(
  * The condition this exists for: a device serving assets built from one commit
  * while its source tree sits on another. Two features 404'd on such a box for
  * a fortnight and nothing anywhere said why. Returns one warning per problem,
- * and an empty list for a healthy box.
+ * and an empty list for a healthy box — and for a box it could not read, since
+ * a diagnosis must never be what fails an update. A caller that needs those two
+ * told apart takes `measureDriftWarnings` below instead.
  */
 export async function collectDriftWarnings(
   projectDir: string = PROJECT_DIR,
 ): Promise<UpdateWarning[]> {
+  return (await measureDriftWarnings(projectDir)) ?? [];
+}
+
+/**
+ * The same diagnosis, with "could not be measured" told apart from "no drift".
+ *
+ * `collectDriftWarnings` answers `[]` for both, which is right for a sample
+ * that must never fail an update and wrong for a caller that RETIRES warnings
+ * on the strength of it: a git shell-out that timed out would otherwise read
+ * as "the box is healthy now" and clear a warning nothing has measured — the
+ * false-success class, over the very warning that says the box is broken.
+ *
+ * Same reader as the status route and the About panel (`collectBuildIdentity`
+ * — disk sha, BUILD_ID and the pin), so this adds no probe of its own.
+ */
+async function measureDriftWarnings(
+  projectDir: string = PROJECT_DIR,
+): Promise<UpdateWarning[] | null> {
   try {
     const { drift } = await collectBuildIdentity(projectDir);
     return drift.codes
       .map((code, i) => ({ code: code as string, message: drift.reasons[i] as string | undefined }))
       .filter((w): w is UpdateWarning => !!w.message);
   } catch (err) {
-    // Never fail an update because the diagnosis failed.
-    console.warn("[Updater] Could not read build identity before sync:", err);
-    return [];
+    console.warn("[Updater] Could not read build identity:", err);
+    return null;
   }
+}
+
+/** The one line a finished run leaves behind about drift it resolved. */
+const DRIFT_RESOLVED_CODE = "drift-resolved";
+
+/** Is there anything here for a finished run to re-measure? */
+function hasDriftWarning(warnings: UpdateWarning[]): boolean {
+  return warnings.some((w) => isDriftCode(w.code));
+}
+
+function resolvedDriftMessage(codes: DriftCode[]): string {
+  const phrases = codes.map((code) => RESOLVED_DRIFT_PHRASE[code]);
+  const list = phrases.length > 1
+    ? `${phrases.slice(0, -1).join(", ")} and ${phrases[phrases.length - 1]}`
+    : phrases[0];
+  return `When this update started, ${list}. This update realigned the box — nothing further is needed.`;
+}
+
+/**
+ * What a FINISHED run should say about the drift it was diagnosed with.
+ *
+ * The diagnosis is deliberately taken before step 1 and kept across the reboot
+ * (see `captureDriftBaseline`) — that part stays: a box 71 commits behind its
+ * own pin must not update in silence. What was missing is the other end. The
+ * warnings describe a tree the run has since moved, and they were still being
+ * shown, present tense, beside `phase: "completed"`: measured on the OpenClaw
+ * box on 2026-09-07, an owner whose update had just put the box on the tested
+ * commit was told "run Update to realign" by it.
+ *
+ * Pure, so every combination is testable without a device: `previous` is what
+ * the run collected, `live` is the box measured NOW — or `null` when it could
+ * not be measured, in which case nothing is retired.
+ *
+ * One-directional on purpose. A code the fresh sample still reports stays
+ * live, carrying the sha measured now rather than the pre-run one; a code it
+ * no longer reports is retired into one past-tense history line. Codes the
+ * fresh sample raises that the run never saw are NOT added here — the status
+ * route and the About panel already read live drift off an idle box, and a
+ * completion is not the place to invent a new warning.
+ */
+export function reconcileDriftWarnings(
+  previous: UpdateWarning[],
+  live: UpdateWarning[] | null,
+): UpdateWarning[] {
+  if (live === null) return previous;
+  if (!hasDriftWarning(previous)) return previous;
+
+  const stillDrifted = new Map(live.filter((w) => isDriftCode(w.code)).map((w) => [w.code, w]));
+  const resolved: DriftCode[] = [];
+  const next: UpdateWarning[] = [];
+
+  for (const warning of previous) {
+    if (!isDriftCode(warning.code)) {
+      next.push(warning);
+      continue;
+    }
+    const current = stillDrifted.get(warning.code);
+    if (current) next.push(current);
+    else resolved.push(warning.code);
+  }
+
+  if (resolved.length > 0) {
+    next.push({ code: DRIFT_RESOLVED_CODE, message: resolvedDriftMessage(resolved) });
+  }
+  return next;
 }
 
 /**
@@ -3943,6 +4033,20 @@ async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: Run
 
   state.currentStepIndex = -1;
   state.phase = failed ? "failed" : "completed";
+
+  // The drift diagnosis was taken before step 1 and carried across the reboot,
+  // so on a run that WORKED it now describes a tree that no longer exists —
+  // and it was reaching the owner as a live instruction to update a box the
+  // update had just realigned. Re-measure and retire what this run resolved;
+  // anything the box is still drifted by stays, restated from the measurement
+  // taken now. A run that FAILED realigned nothing, so it keeps every warning
+  // exactly as captured — that is the state the owner has to act on.
+  //
+  // Measured only when there IS a drift warning to settle, so a healthy box
+  // does not pay a git shell-out at the end of every run.
+  if (!failed && hasDriftWarning(state.warnings ?? [])) {
+    state.warnings = reconcileDriftWarnings(state.warnings ?? [], await measureDriftWarnings());
+  }
 
   if (!failed && options.markCompleted) {
     await setMany({

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -40,13 +40,9 @@ const UPDATE_INTERRUPTED_KEY = "update_interrupted_at";
 // to be able to name it without pulling this file's Node built-ins in with it.
 export { INTERRUPTED_MESSAGE } from "./update-constants";
 import { INTERRUPTED_MESSAGE } from "./update-constants";
-import {
-  collectBuildIdentity,
-  isDriftCode,
-  resolveBuildDir,
-  RESOLVED_DRIFT_PHRASE,
-  type DriftCode,
-} from "./build-identity";
+import { collectBuildIdentity, resolveBuildDir, type DriftReport } from "./build-identity";
+export { DRIFT_RESOLVED_CODE } from "./drift-codes";
+import { driftFact, DRIFT_RESOLVED_CODE, isDriftCode, type DriftCode } from "./drift-codes";
 import type { AuthProfileEntries } from "./subscription-surface";
 import { OFFICIAL_CHANNEL_PLUGINS } from "./openclaw-channels";
 import {
@@ -948,55 +944,101 @@ export async function repinUpdateBranch(
  * while its source tree sits on another. Two features 404'd on such a box for
  * a fortnight and nothing anywhere said why. Returns one warning per problem,
  * and an empty list for a healthy box — and for a box it could not read, since
- * a diagnosis must never be what fails an update. A caller that needs those two
- * told apart takes `measureDriftWarnings` below instead.
+ * a diagnosis must never be what fails an update. A caller that has to tell
+ * "no drift" from "could not look" takes `measureDrift` below instead.
  */
 export async function collectDriftWarnings(
   projectDir: string = PROJECT_DIR,
 ): Promise<UpdateWarning[]> {
-  return (await measureDriftWarnings(projectDir)) ?? [];
+  const measured = await measureDrift(projectDir);
+  return measured ? driftWarnings(measured.drift) : [];
+}
+
+/** The report's own `codes`/`reasons`, paired, as update warnings. */
+function driftWarnings(drift: DriftReport): UpdateWarning[] {
+  return drift.codes
+    .map((code, i) => ({ code: code as string, message: drift.reasons[i] as string | undefined }))
+    .filter((w): w is UpdateWarning => !!w.message);
 }
 
 /**
- * The same diagnosis, with "could not be measured" told apart from "no drift".
+ * What a fresh drift measurement says, keeping the facts a warning list drops.
  *
- * `collectDriftWarnings` answers `[]` for both, which is right for a sample
- * that must never fail an update and wrong for a caller that RETIRES warnings
- * on the strength of it: a git shell-out that timed out would otherwise read
- * as "the box is healthy now" and clear a warning nothing has measured — the
- * false-success class, over the very warning that says the box is broken.
+ * `codes` alone cannot answer "is this condition GONE?", because
+ * `collectBuildIdentity` never throws: every reader inside it swallows its own
+ * failure, so a `git rev-parse origin/<branch>` that timed out arrives as
+ * `checkoutVsPin: "unknown"` with NO code — indistinguishable, in a flattened
+ * list, from a box measured to be on its tested commit. Retiring a warning on
+ * that is the false-success class over the very warning that says the box is
+ * broken, so the tri-state travels with the codes and every retirement below
+ * needs a POSITIVE verdict.
+ */
+export interface DriftMeasurement {
+  drift: DriftReport;
+  /** `.update-branch` carries a usable branch — the exact negation of `no-pin`. */
+  pinned: boolean;
+  /** `null` when `git status` could not be read, which is not "clean". */
+  dirty: boolean | null;
+}
+
+/**
+ * The drift diagnosis, or null when the read itself threw.
  *
  * Same reader as the status route and the About panel (`collectBuildIdentity`
  * — disk sha, BUILD_ID and the pin), so this adds no probe of its own.
  */
-async function measureDriftWarnings(
+async function measureDrift(
   projectDir: string = PROJECT_DIR,
-): Promise<UpdateWarning[] | null> {
+): Promise<DriftMeasurement | null> {
   try {
-    const { drift } = await collectBuildIdentity(projectDir);
-    return drift.codes
-      .map((code, i) => ({ code: code as string, message: drift.reasons[i] as string | undefined }))
-      .filter((w): w is UpdateWarning => !!w.message);
+    const identity = await collectBuildIdentity(projectDir);
+    return { drift: identity.drift, pinned: identity.pin.pinned, dirty: identity.checkout.dirty };
   } catch (err) {
+    // Documented never to happen — kept because a diagnosis must never be what
+    // fails an update, and because "we could not look" must never read as "it
+    // is fixed".
     console.warn("[Updater] Could not read build identity:", err);
     return null;
   }
 }
 
-/** The one line a finished run leaves behind about drift it resolved. */
-const DRIFT_RESOLVED_CODE = "drift-resolved";
-
-/** Is there anything here for a finished run to re-measure? */
-function hasDriftWarning(warnings: UpdateWarning[]): boolean {
-  return warnings.some((w) => isDriftCode(w.code));
+/**
+ * Has this condition been measured GONE? Never "no code was emitted".
+ *
+ * Each code is answered by the fact that raised it, on the axis it belongs to:
+ * an axis that came back `"unknown"` retires nothing.
+ */
+function measuredResolved(code: DriftCode, measured: DriftMeasurement): boolean {
+  switch (code) {
+    case "checkout-dirty":
+      return measured.dirty === false;
+    case "no-pin":
+      return measured.pinned;
+    case "checkout-behind-pin":
+      return measured.drift.checkoutVsPin === "match";
+    case "build-from-other-commit":
+    case "build-info-not-for-deployed-assets":
+    case "build-predates-checkout":
+    case "build-unstamped":
+      // "match" means the deployed build IS the commit on disk, over a tree
+      // git called clean — the one verdict under which none of these applies.
+      return measured.drift.buildVsCheckout === "match";
+    default: {
+      // A code added to DRIFT_CODES without a rule here fails to typecheck, and
+      // at runtime keeps its warning: a condition nobody answered is not one
+      // this run resolved.
+      const unanswered: never = code;
+      void unanswered;
+      return false;
+    }
+  }
 }
 
-function resolvedDriftMessage(codes: DriftCode[]): string {
-  const phrases = codes.map((code) => RESOLVED_DRIFT_PHRASE[code]);
-  const list = phrases.length > 1
-    ? `${phrases.slice(0, -1).join(", ")} and ${phrases[phrases.length - 1]}`
-    : phrases[0];
-  return `When this update started, ${list}. This update realigned the box — nothing further is needed.`;
+function resolvedDriftMessage(observed: UpdateWarning[], anyDriftLeft: boolean): string {
+  const facts = observed.map((w) => driftFact(w.message)).join(" ");
+  return anyDriftLeft
+    ? `When this update started: ${facts} That much the update resolved.`
+    : `When this update started: ${facts} The update resolved that — nothing further is needed.`;
 }
 
 /**
@@ -1011,25 +1053,29 @@ function resolvedDriftMessage(codes: DriftCode[]): string {
  * commit was told "run Update to realign" by it.
  *
  * Pure, so every combination is testable without a device: `previous` is what
- * the run collected, `live` is the box measured NOW — or `null` when it could
- * not be measured, in which case nothing is retired.
+ * the run collected, `measured` is the box as it is NOW — or `null` when the
+ * read threw, in which case nothing is retired.
  *
- * One-directional on purpose. A code the fresh sample still reports stays
- * live, carrying the sha measured now rather than the pre-run one; a code it
- * no longer reports is retired into one past-tense history line. Codes the
- * fresh sample raises that the run never saw are NOT added here — the status
- * route and the About panel already read live drift off an idle box, and a
- * completion is not the place to invent a new warning.
+ * A code stays live unless it was MEASURED gone, and then carries the sentence
+ * from that measurement rather than the pre-run one. What was resolved is kept
+ * as one past-tense line quoting what the box actually looked like, minus the
+ * call to action — the shas survive, so a support engineer can still tell a box
+ * one commit behind from one 71 behind.
+ *
+ * One-directional on purpose: codes the fresh sample raises that the run never
+ * saw are NOT added here — the status route and the About panel already read
+ * live drift off an idle box, and a completion is not the place to invent a new
+ * warning.
  */
 export function reconcileDriftWarnings(
   previous: UpdateWarning[],
-  live: UpdateWarning[] | null,
+  measured: DriftMeasurement | null,
 ): UpdateWarning[] {
-  if (live === null) return previous;
+  if (measured === null) return previous;
   if (!hasDriftWarning(previous)) return previous;
 
-  const stillDrifted = new Map(live.filter((w) => isDriftCode(w.code)).map((w) => [w.code, w]));
-  const resolved: DriftCode[] = [];
+  const live = new Map(driftWarnings(measured.drift).map((w) => [w.code, w]));
+  const resolved: UpdateWarning[] = [];
   const next: UpdateWarning[] = [];
 
   for (const warning of previous) {
@@ -1037,15 +1083,27 @@ export function reconcileDriftWarnings(
       next.push(warning);
       continue;
     }
-    const current = stillDrifted.get(warning.code);
-    if (current) next.push(current);
-    else resolved.push(warning.code);
+    if (measuredResolved(warning.code, measured)) {
+      resolved.push(warning);
+      continue;
+    }
+    // Still drifted, or the axis could not be read: keep it. The freshly
+    // measured sentence when there is one, the captured one otherwise.
+    next.push(live.get(warning.code) ?? warning);
   }
 
   if (resolved.length > 0) {
-    next.push({ code: DRIFT_RESOLVED_CODE, message: resolvedDriftMessage(resolved) });
+    next.push({
+      code: DRIFT_RESOLVED_CODE,
+      message: resolvedDriftMessage(resolved, next.some((w) => isDriftCode(w.code))),
+    });
   }
   return next;
+}
+
+/** Is there anything here for a finished run to re-measure? */
+function hasDriftWarning(warnings: UpdateWarning[]): boolean {
+  return warnings.some((w) => isDriftCode(w.code));
 }
 
 /**
@@ -1063,10 +1121,12 @@ export function reconcileDriftWarnings(
  * (hwtest-round1, 2026-08-24).
  *
  * So the diagnosis is taken here, first, and persisted immediately — the run
- * reboots halfway through and only persisted warnings survive it. The step-7
- * collection stays as a second sample; `warnUpdate` de-duplicates by code, so
- * the FIRST observation — this one, the customer's actual state — is the one
- * that reaches the log.
+ * reboots halfway through and only persisted warnings survive it. It is now
+ * the ONLY sample taken during the run: the step-7 one described the sync
+ * rather than the box, and mixing the two under `warnUpdate`'s first-wins
+ * de-duplication is what put two contradictory sentences in front of an owner
+ * (TASK-757). A run that FINISHES re-measures once, at the end, where the
+ * answer is about the box as it then is.
  */
 async function captureDriftBaseline(): Promise<void> {
   for (const w of await collectDriftWarnings()) warnUpdate(w.code, w.message);
@@ -1165,11 +1225,18 @@ async function updateClawBoxAndReboot(): Promise<void> {
 
   console.log(`[Updater] Updating to branch: ${local} (upstream: ${upstream}, resolved from: ${source})`);
 
-  // WARN + AUTO-REPIN, in that order. The WARN is a SECOND sample — the one
-  // that carries the diagnosis was taken by captureDriftBaseline() before step
-  // 1 moved the tree, and warnUpdate keeps the first observation of each code.
-  // Neither step can stop the update.
-  for (const w of await collectDriftWarnings()) warnUpdate(w.code, w.message);
+  // AUTO-REPIN. The drift WARN that used to sit here was a SECOND sample, and
+  // it is gone: step 1 has already moved the tree by now, so every code it
+  // could still raise describes the sync rather than the box the owner has —
+  // `build-from-other-commit` fires on EVERY run here, the build being the old
+  // one until the rebuild replaces it. `warnUpdate` de-duplicates by code with
+  // the first observation winning, so its only effect was to add those to a
+  // list captured before step 1, and the owner was handed two present-tense
+  // sentences disagreeing about which sha was the code on disk (measured on
+  // the OpenClaw box, 2026-09-07). The baseline is the diagnosis, and a run
+  // that finishes re-measures; one sample each, at the two moments that mean
+  // something. Neither step can stop the update.
+  //
   // Only pin what the device can prove about itself — see repinUpdateBranch.
   for (const w of await repinUpdateBranch(local, PROJECT_DIR, source)) warnUpdate(w.code, w.message);
   await persistWarnings();
@@ -4031,9 +4098,6 @@ async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: Run
     }
   }
 
-  state.currentStepIndex = -1;
-  state.phase = failed ? "failed" : "completed";
-
   // The drift diagnosis was taken before step 1 and carried across the reboot,
   // so on a run that WORKED it now describes a tree that no longer exists —
   // and it was reaching the owner as a live instruction to update a box the
@@ -4042,11 +4106,22 @@ async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: Run
   // taken now. A run that FAILED realigned nothing, so it keeps every warning
   // exactly as captured — that is the state the owner has to act on.
   //
+  // BEFORE the phase is published, and this order is load-bearing: the status
+  // route answers with this very object for any non-idle phase, and the panel
+  // stops polling on the first answer that is not `running`. A poll landing
+  // between a `completed` written here and this measurement — several git
+  // shell-outs, up to their 15 s timeout — would latch the pre-run warnings on
+  // the completion card until the owner reloaded the page, which is the exact
+  // defect this fix is for.
+  //
   // Measured only when there IS a drift warning to settle, so a healthy box
   // does not pay a git shell-out at the end of every run.
   if (!failed && hasDriftWarning(state.warnings ?? [])) {
-    state.warnings = reconcileDriftWarnings(state.warnings ?? [], await measureDriftWarnings());
+    state.warnings = reconcileDriftWarnings(state.warnings ?? [], await measureDrift());
   }
+
+  state.currentStepIndex = -1;
+  state.phase = failed ? "failed" : "completed";
 
   if (!failed && options.markCompleted) {
     await setMany({

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1110,8 +1110,13 @@ export function reconcileDriftWarnings(
     const substitute = live.get(warning.code)
       ?? (isBuildAxisCode(warning.code) ? liveBuildAxis : undefined);
     // A warning list restored from a box that predates this fix can carry two
-    // build codes (it was written from two samples), and the codes key the
-    // rendered list — so a substitution that would double one is not made.
+    // build codes: it was written from two samples. They are one condition, so
+    // once the measurement has spoken for that axis a second warning about it
+    // can only be the superseded one — dropped, rather than shown beside the
+    // sentence that replaced it or doubling its code in a list the codes key.
+    if (isBuildAxisCode(warning.code) && liveBuildAxis && emitted.has(liveBuildAxis.code)) {
+      continue;
+    }
     const current = substitute && !emitted.has(substitute.code) ? substitute : warning;
     emitted.add(current.code);
     next.push(current);

--- a/src/tests/components/system-update-resolved-drift-note.test.tsx
+++ b/src/tests/components/system-update-resolved-drift-note.test.tsx
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@/tests/helpers/test-utils";
+import { translations } from "@/lib/translations";
+import SystemUpdateApp from "@/components/SystemUpdateApp";
+import { DRIFT_RESOLVED_CODE } from "@/lib/drift-codes";
+
+// The real English strings, resolved the way the app resolves them.
+vi.mock("@/lib/i18n", () => ({
+  useT: () => ({
+    locale: "en",
+    t: (key: string, params?: Record<string, string | number>) => {
+      let str = translations.en[key] ?? key;
+      if (params) for (const [k, v] of Object.entries(params)) str = str.replaceAll(`{${k}}`, String(v));
+      return str;
+    },
+  }),
+}));
+
+/**
+ * TASK-757 — the line a finished run leaves behind about drift it RESOLVED is
+ * history, not a problem.
+ *
+ * The completion card drew every warning identically: amber border, amber
+ * ground, a warning triangle. Replacing a stale imperative with a past-tense
+ * note in that same box would have swapped one alarm for another on a card
+ * whose whole job is to stop alarming an owner whose update worked. A drift
+ * code that is STILL live keeps the alarm, because that one is a problem.
+ */
+
+const STALE_DRIFT = {
+  code: "build-from-other-commit",
+  message: "This box is running a build made from 673817a but the code on disk is 2153954 — run Update to realign.",
+};
+const RESOLVED_NOTE = {
+  code: DRIFT_RESOLVED_CODE,
+  message: "When this update started: The code on disk (673817a) is not the tested commit for beta (2153954). The update resolved that — nothing further is needed.",
+};
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+function mountWith(warnings: Array<{ code: string; message: string }>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/setup-api/update/versions")) {
+        return jsonResponse({
+          clawbox: { current: "v3.9.0", target: "v3.10.0", updateAvailable: true },
+          openclaw: { current: null, target: null, updateAvailable: false },
+        });
+      }
+      if (url.includes("/setup-api/system/build-identity")) return jsonResponse({});
+      if (url.includes("/setup-api/system/update-branch")) return jsonResponse({ branch: "beta" });
+      if (url.includes("/setup-api/update/run")) return jsonResponse({ started: true });
+      if (url.includes("/setup-api/update/status")) {
+        return jsonResponse({
+          phase: "completed",
+          currentStepIndex: -1,
+          steps: [{ id: "bootstrap_updater", label: "Refreshing updater scripts", status: "completed" }],
+          warnings,
+        });
+      }
+      return jsonResponse({});
+    }),
+  );
+}
+
+/** Start a run and let the first status poll land. */
+async function runToCompletion(findByRole: ReturnType<typeof render>["findByRole"]) {
+  const button = await findByRole("button", { name: "Update everything" });
+  button.click();
+  // startPolling's first fetch is one interval in.
+  await vi.advanceTimersByTimeAsync(2100);
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("the completion card tells a resolved condition from a live one", () => {
+  it("draws the resolved line as history, not as another alarm", async () => {
+    mountWith([RESOLVED_NOTE]);
+    const { findByRole, findByTestId } = render(<SystemUpdateApp />);
+
+    await runToCompletion(findByRole);
+
+    const note = await findByTestId(`update-warning-${DRIFT_RESOLVED_CODE}`);
+    await waitFor(() => expect(note.getAttribute("data-tone")).toBe("info"));
+    expect(note.className, "no amber ground on a run that worked").not.toContain("amber");
+    expect(note.textContent).toContain("When this update started:");
+    // …and the imperative the card was filed for is nowhere on it.
+    expect(note.textContent).not.toContain("run Update");
+  });
+
+  it("keeps the alarm on a drift code that is still live", async () => {
+    mountWith([STALE_DRIFT, RESOLVED_NOTE]);
+    const { findByRole, findByTestId } = render(<SystemUpdateApp />);
+
+    await runToCompletion(findByRole);
+
+    const live = await findByTestId("update-warning-build-from-other-commit");
+    expect(live.getAttribute("data-tone")).toBe("warning");
+    expect(live.className).toContain("amber");
+
+    const note = await findByTestId(`update-warning-${DRIFT_RESOLVED_CODE}`);
+    expect(note.getAttribute("data-tone")).toBe("info");
+  });
+});

--- a/src/tests/routes/update/status.test.ts
+++ b/src/tests/routes/update/status.test.ts
@@ -42,6 +42,7 @@ const mockIsInterruptedVerdict = vi.mocked(isInterruptedVerdict);
  */
 const NO_DRIFT = {
   buildVsCheckout: "match" as const,
+  buildIsCheckout: "match" as const,
   checkoutVsPin: "match" as const,
   detected: false,
   reasons: [],
@@ -50,6 +51,7 @@ const NO_DRIFT = {
 
 const DRIFTED = {
   buildVsCheckout: "drift" as const,
+  buildIsCheckout: "drift" as const,
   checkoutVsPin: "drift" as const,
   detected: true,
   reasons: ["This box is running a build made from 1dc29ef but the code on disk is d285cfd — run Update to realign."],

--- a/src/tests/unit/updater-drift-cleared-after-success.test.ts
+++ b/src/tests/unit/updater-drift-cleared-after-success.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * TASK-757 — a box that had just updated itself correctly told its owner to
+ * update again.
+ *
+ * Measured on the OpenClaw box, 2026-09-07, at beta `21539548`, after a clean
+ * in-app update. `/setup-api/update/status` answered `phase: "completed"`,
+ * `error: null`, and these two warnings:
+ *
+ *   checkout-behind-pin      "The code on disk (673817a) is not the tested
+ *                             commit for beta (2153954)."
+ *   build-from-other-commit  "This box is running a build made from 673817a
+ *                             but the code on disk is 2153954 — run Update to
+ *                             realign."
+ *
+ * Both are false about the box as it then was: `git reflog` puts the checkout
+ * at `21539548` from 03:42:23, `.next/BUILD_ID` was written at 03:54:17 and
+ * the running bundle carried code that exists only in that commit. The second
+ * one ends in an imperative the owner would act on, over a run that had just
+ * put the box exactly where it belongs.
+ *
+ * They are also stale in two DIFFERENT ways, which is why they contradict each
+ * other about which sha is the code on disk: `captureDriftBaseline()` samples
+ * before step 1 and `updateClawBoxAndReboot` samples again after it, and
+ * `warnUpdate` de-duplicates by code with the first observation winning. So the
+ * list the owner reads mixes two samples of a tree that moved between them,
+ * and neither is re-asked when the run succeeds.
+ *
+ * The fix keeps #737's rule — the pre-run diagnosis is the customer's real
+ * state and must not be thrown away — and settles what happens to it once the
+ * run has finished: a successful run re-measures, keeps every code the box is
+ * STILL drifted by (with the shas as they are now, not as they were), and
+ * retires the rest into one past-tense history line with no imperative. A run
+ * that failed realigned nothing, so it keeps its warnings exactly as captured.
+ */
+
+import { computeDrift, type DriftInputs } from "@/lib/build-identity";
+import { reconcileDriftWarnings, type UpdateWarning } from "@/lib/updater";
+
+const BUILD_SHA = "673817a8e0a1b2c3d4e5f60718293a4b5c6d7e8f";
+const DISK_SHA = "21539548c554b30799ad6e19a94213e26eb23f2f";
+const PIN_SHA = "3b4597f1aa0c9d8e7f6a5b4c3d2e1f00998877aa";
+
+function driftInputs(over: Partial<DriftInputs> = {}): DriftInputs {
+  return {
+    build: {
+      commit: BUILD_SHA,
+      shortCommit: BUILD_SHA.slice(0, 7),
+      branch: "beta",
+      dirty: false,
+      untracked: 0,
+      committedAt: "2026-09-07T00:30:00Z",
+      builtAt: "2026-09-07T00:39:00Z",
+      buildId: "the-deployed-build",
+      node: "v22.0.0",
+      bun: "1.2.10",
+      packageVersion: "3.10.0",
+      hermesPin: null,
+      openclawPin: null,
+    },
+    deployedBuildId: "the-deployed-build",
+    buildTimestampMs: Date.parse("2026-09-07T00:39:00Z"),
+    checkout: {
+      commit: DISK_SHA,
+      shortCommit: DISK_SHA.slice(0, 7),
+      branch: "beta",
+      dirty: false,
+      committedAt: "2026-09-07T00:42:00Z",
+    },
+    pin: { branch: "beta", source: "pin-file", commit: PIN_SHA, pinned: true },
+    stamperInCheckout: true,
+    ...over,
+  };
+}
+
+function reasonFor(code: string, input: DriftInputs): string {
+  const drift = computeDrift(input);
+  const at = drift.codes.indexOf(code as never);
+  expect(at, `expected ${code} in ${JSON.stringify(drift.codes)}`).toBeGreaterThanOrEqual(0);
+  return drift.reasons[at];
+}
+
+/**
+ * Half one of the card: each warning must name its subjects correctly, tested
+ * against a fixture where the build, the code on disk and the pin are three
+ * DIFFERENT commits — the only shape in which a mislabelled subject is
+ * visible at all.
+ */
+describe("drift warnings name the right sha for the right fact", () => {
+  it("puts the build first and the checkout second, in every combination", () => {
+    const combinations: Array<[string, DriftInputs]> = [
+      ["build, disk and pin all different", driftInputs()],
+      ["the build was made from the pinned commit", driftInputs({
+        build: { ...driftInputs().build!, commit: PIN_SHA, shortCommit: PIN_SHA.slice(0, 7) },
+      })],
+      ["the disk is dirty as well", driftInputs({
+        checkout: { ...driftInputs().checkout, dirty: true },
+      })],
+    ];
+
+    for (const [name, input] of combinations) {
+      const build = reasonFor("build-from-other-commit", input);
+      expect(build, name).toContain(`build made from ${input.build!.commit!.slice(0, 7)}`);
+      expect(build, name).toContain(`the code on disk is ${input.checkout.commit!.slice(0, 7)}`);
+    }
+  });
+
+  it("names the checkout as the disk and the pin as the tested commit", () => {
+    const input = driftInputs();
+    const pin = reasonFor("checkout-behind-pin", input);
+    expect(pin).toContain(`The code on disk (${DISK_SHA.slice(0, 7)})`);
+    expect(pin).toContain(`not the tested commit for beta (${PIN_SHA.slice(0, 7)})`);
+    // The one the box contradicted: the sha the OTHER warning calls the build
+    // must never be introduced here as the code on disk.
+    expect(pin).not.toContain(BUILD_SHA.slice(0, 7));
+  });
+});
+
+/**
+ * Half two: what a FINISHED run does with the diagnosis it took before step 1.
+ */
+describe("reconcileDriftWarnings", () => {
+  const behindPin: UpdateWarning = {
+    code: "checkout-behind-pin",
+    message: `The code on disk (${BUILD_SHA.slice(0, 7)}) is not the tested commit for beta (${DISK_SHA.slice(0, 7)}).`,
+  };
+  const otherCommit: UpdateWarning = {
+    code: "build-from-other-commit",
+    message: `This box is running a build made from ${BUILD_SHA.slice(0, 7)} but the code on disk is ${DISK_SHA.slice(0, 7)} — run Update to realign.`,
+  };
+  const repinned: UpdateWarning = {
+    code: "repinned",
+    message: 'This box carried no update pin — pinned to the tested branch "beta" so future updates are repeatable.',
+  };
+
+  it("retires the drift the run resolved into one past-tense line", () => {
+    const after = reconcileDriftWarnings([behindPin, otherCommit], []);
+
+    expect(after.map((w) => w.code)).toEqual(["drift-resolved"]);
+    const line = after[0].message;
+    // The exact sentence the owner acted on, gone.
+    expect(line).not.toContain("run Update");
+    expect(line).toMatch(/^When this update started, /);
+    expect(line).toContain("was not the tested commit");
+    expect(line).toContain("a different commit than the code on disk");
+  });
+
+  it("keeps a code the box is STILL drifted by, with the sha measured now", () => {
+    // The false-success half: a run that did not realign the box must not be
+    // allowed to clear the warning that says so.
+    const live: UpdateWarning = {
+      code: "build-from-other-commit",
+      message: `This box is running a build made from ${PIN_SHA.slice(0, 7)} but the code on disk is ${DISK_SHA.slice(0, 7)} — run Update to realign.`,
+    };
+
+    const after = reconcileDriftWarnings([behindPin, otherCommit], [live]);
+
+    expect(after.map((w) => w.code)).toEqual(["build-from-other-commit", "drift-resolved"]);
+    // Measured after the run, not the pre-run text.
+    expect(after[0].message).toBe(live.message);
+  });
+
+  it("retires nothing when the box could not be measured", () => {
+    // A git shell-out that timed out is not evidence that the box is healthy.
+    expect(reconcileDriftWarnings([behindPin, otherCommit], null)).toEqual([behindPin, otherCommit]);
+  });
+
+  it("leaves warnings that are not about drift exactly where they were", () => {
+    const after = reconcileDriftWarnings([repinned, behindPin], []);
+    expect(after.map((w) => w.code)).toEqual(["repinned", "drift-resolved"]);
+    expect(after[0]).toEqual(repinned);
+  });
+
+  it("does not invent a history line when there was no drift to resolve", () => {
+    expect(reconcileDriftWarnings([repinned], [])).toEqual([repinned]);
+  });
+});

--- a/src/tests/unit/updater-drift-cleared-after-success.test.ts
+++ b/src/tests/unit/updater-drift-cleared-after-success.test.ts
@@ -315,6 +315,30 @@ describe("reconcileDriftWarnings", () => {
     expect(after[0].message).toContain("carries no build record");
   });
 
+  it("does not keep a second, superseded build sentence beside the measured one", () => {
+    // A warning list restored from a box that predates this fix was written
+    // from two samples and can carry two build codes. They are one condition,
+    // so showing the measured sentence AND a stale sibling is the two
+    // contradictory warnings this card exists to remove, from a third side.
+    const predates: UpdateWarning = {
+      code: "build-predates-checkout",
+      message: "The code on disk is newer than the deployed build — run Update to rebuild.",
+    };
+    const measured: DriftMeasurement = {
+      drift: computeDrift(driftInputs({
+        build: null,
+        deployedBuildId: "the-deployed-build",
+        stamperInCheckout: true,
+      })),
+      pinned: true,
+      dirty: false,
+    };
+
+    const after = reconcileDriftWarnings([otherCommit, predates], measured);
+
+    expect(after.map((w) => w.code)).toEqual(["build-unstamped"]);
+  });
+
   it("retires nothing when the read itself threw", () => {
     expect(reconcileDriftWarnings([behindPin, otherCommit], null)).toEqual([behindPin, otherCommit]);
   });

--- a/src/tests/unit/updater-drift-cleared-after-success.test.ts
+++ b/src/tests/unit/updater-drift-cleared-after-success.test.ts
@@ -166,6 +166,7 @@ describe("reconcileDriftWarnings", () => {
   function measuredUnknown(over: Partial<DriftMeasurement> = {}): DriftMeasurement {
     const drift: DriftReport = {
       buildVsCheckout: "unknown",
+      buildIsCheckout: "unknown",
       checkoutVsPin: "unknown",
       detected: false,
       reasons: [],
@@ -246,6 +247,72 @@ describe("reconcileDriftWarnings", () => {
     const after = reconcileDriftWarnings([noPin], measuredUnknown({ pinned: true }));
 
     expect(after.map((w) => w.code)).toEqual([DRIFT_RESOLVED_CODE]);
+  });
+
+  it("retires a build code the rebuild fixed even when the tree came back dirty", () => {
+    // `computeDrift` downgrades the AGGREGATE buildVsCheckout to "drift" for an
+    // uncommitted change — right for the banner, and unusable here: a stray
+    // untracked file after post_update would otherwise keep "run Update to
+    // realign" on the card of a box whose build IS the code on disk.
+    const measured: DriftMeasurement = {
+      drift: computeDrift(driftInputs({
+        build: { ...driftInputs().build!, commit: DISK_SHA, shortCommit: DISK_SHA.slice(0, 7) },
+        pin: { branch: "beta", source: "pin-file", commit: DISK_SHA, pinned: true },
+        checkout: { ...driftInputs().checkout, dirty: true },
+      })),
+      pinned: true,
+      dirty: true,
+    };
+    expect(measured.drift.buildVsCheckout, "the aggregate is dragged down by the dirty tree").toBe("drift");
+    expect(measured.drift.buildIsCheckout, "the comparison itself still matches").toBe("match");
+
+    const after = reconcileDriftWarnings([otherCommit], measured);
+
+    expect(after.map((w) => w.code)).toEqual([DRIFT_RESOLVED_CODE]);
+  });
+
+  it("does NOT retire a build code when the comparison was never made", () => {
+    // The same override promotes an UNMEASURABLE comparison out of "unknown":
+    // a dirty tree sets the aggregate to "drift" whatever the build said. Only
+    // `buildIsCheckout` can tell "the build matches" from "we could not look".
+    const measured: DriftMeasurement = {
+      drift: computeDrift(driftInputs({
+        build: null,
+        deployedBuildId: null,
+        buildTimestampMs: null,
+        stamperInCheckout: false,
+        checkout: { ...driftInputs().checkout, commit: null, shortCommit: null, dirty: true },
+      })),
+      pinned: true,
+      dirty: true,
+    };
+    expect(measured.drift.buildIsCheckout).toBe("unknown");
+
+    const after = reconcileDriftWarnings([otherCommit], measured);
+
+    expect(after.map((w) => w.code)).toEqual(["build-from-other-commit"]);
+    expect(after[0].message).toBe(otherCommit.message);
+  });
+
+  it("restates a build code that moved to another build code, rather than repeating the old text", () => {
+    // The four are alternatives in one if/else chain, so one condition can
+    // surface under a different code after the run. Neither retiring it nor
+    // showing the pre-run sentence would be true of the box.
+    const measured: DriftMeasurement = {
+      drift: computeDrift(driftInputs({
+        build: null,
+        deployedBuildId: "the-deployed-build",
+        stamperInCheckout: true,
+      })),
+      pinned: true,
+      dirty: false,
+    };
+    expect(measured.drift.codes).toContain("build-unstamped");
+
+    const after = reconcileDriftWarnings([otherCommit], measured);
+
+    expect(after.map((w) => w.code)).toEqual(["build-unstamped"]);
+    expect(after[0].message).toContain("carries no build record");
   });
 
   it("retires nothing when the read itself threw", () => {

--- a/src/tests/unit/updater-drift-cleared-after-success.test.ts
+++ b/src/tests/unit/updater-drift-cleared-after-success.test.ts
@@ -21,22 +21,33 @@ import { describe, expect, it } from "vitest";
  * put the box exactly where it belongs.
  *
  * They are also stale in two DIFFERENT ways, which is why they contradict each
- * other about which sha is the code on disk: `captureDriftBaseline()` samples
- * before step 1 and `updateClawBoxAndReboot` samples again after it, and
+ * other about which sha is the code on disk: `captureDriftBaseline()` sampled
+ * before step 1 and `updateClawBoxAndReboot` sampled again after it, and
  * `warnUpdate` de-duplicates by code with the first observation winning. So the
- * list the owner reads mixes two samples of a tree that moved between them,
- * and neither is re-asked when the run succeeds.
+ * list the owner read mixed two samples of a tree that moved between them, and
+ * neither was re-asked when the run succeeded.
  *
  * The fix keeps #737's rule — the pre-run diagnosis is the customer's real
- * state and must not be thrown away — and settles what happens to it once the
- * run has finished: a successful run re-measures, keeps every code the box is
- * STILL drifted by (with the shas as they are now, not as they were), and
- * retires the rest into one past-tense history line with no imperative. A run
- * that failed realigned nothing, so it keeps its warnings exactly as captured.
+ * state and must not be thrown away — and settles both ends: the second sample
+ * is gone (it only ever described the sync), and a successful run re-measures,
+ * keeps every code the box is STILL drifted by, and retires the rest into one
+ * past-tense history line with no imperative. A run that failed realigned
+ * nothing, so it keeps its warnings exactly as captured.
+ *
+ * The retirement needs a POSITIVE verdict, per axis. `collectBuildIdentity`
+ * never throws: a `git rev-parse origin/<branch>` that timed out comes back as
+ * `checkoutVsPin: "unknown"` with no code at all — and "no code was emitted"
+ * read as "the run fixed it" would be the false-success class, over the very
+ * warning that says the box is broken.
  */
 
-import { computeDrift, type DriftInputs } from "@/lib/build-identity";
-import { reconcileDriftWarnings, type UpdateWarning } from "@/lib/updater";
+import { computeDrift, type DriftInputs, type DriftReport } from "@/lib/build-identity";
+import { DRIFT_RESOLVED_CODE } from "@/lib/drift-codes";
+import {
+  reconcileDriftWarnings,
+  type DriftMeasurement,
+  type UpdateWarning,
+} from "@/lib/updater";
 
 const BUILD_SHA = "673817a8e0a1b2c3d4e5f60718293a4b5c6d7e8f";
 const DISK_SHA = "21539548c554b30799ad6e19a94213e26eb23f2f";
@@ -129,50 +140,125 @@ describe("reconcileDriftWarnings", () => {
     code: "build-from-other-commit",
     message: `This box is running a build made from ${BUILD_SHA.slice(0, 7)} but the code on disk is ${DISK_SHA.slice(0, 7)} — run Update to realign.`,
   };
+  const dirty: UpdateWarning = {
+    code: "checkout-dirty",
+    message: "The code on disk has uncommitted changes, so it no longer matches any commit.",
+  };
   const repinned: UpdateWarning = {
     code: "repinned",
     message: 'This box carried no update pin — pinned to the tested branch "beta" so future updates are repeatable.',
   };
 
-  it("retires the drift the run resolved into one past-tense line", () => {
-    const after = reconcileDriftWarnings([behindPin, otherCommit], []);
+  /** A box measured healthy on every axis — what a finished update leaves behind. */
+  function measuredClean(over: Partial<DriftMeasurement> = {}): DriftMeasurement {
+    return {
+      drift: computeDrift(driftInputs({
+        build: { ...driftInputs().build!, commit: DISK_SHA, shortCommit: DISK_SHA.slice(0, 7) },
+        pin: { branch: "beta", source: "pin-file", commit: DISK_SHA, pinned: true },
+      })),
+      pinned: true,
+      dirty: false,
+      ...over,
+    };
+  }
 
-    expect(after.map((w) => w.code)).toEqual(["drift-resolved"]);
+  /** A report with the given axes and no codes — what an unreadable box produces. */
+  function measuredUnknown(over: Partial<DriftMeasurement> = {}): DriftMeasurement {
+    const drift: DriftReport = {
+      buildVsCheckout: "unknown",
+      checkoutVsPin: "unknown",
+      detected: false,
+      reasons: [],
+      codes: [],
+    };
+    return { drift, pinned: true, dirty: null, ...over };
+  }
+
+  it("retires the drift the run resolved into one past-tense line", () => {
+    const after = reconcileDriftWarnings([behindPin, otherCommit], measuredClean());
+
+    expect(after.map((w) => w.code)).toEqual([DRIFT_RESOLVED_CODE]);
     const line = after[0].message;
     // The exact sentence the owner acted on, gone.
     expect(line).not.toContain("run Update");
-    expect(line).toMatch(/^When this update started, /);
-    expect(line).toContain("was not the tested commit");
-    expect(line).toContain("a different commit than the code on disk");
+    expect(line).toMatch(/^When this update started: /);
+    expect(line).toContain("nothing further is needed");
+  });
+
+  it("keeps the shas the box was actually on, so support can still read them", () => {
+    // #737's rule is that the customer's REAL pre-run state reaches a human; a
+    // generic phrase cannot tell a box one commit behind from one 71 behind.
+    const line = reconcileDriftWarnings([behindPin, otherCommit], measuredClean())[0].message;
+
+    expect(line).toContain(BUILD_SHA.slice(0, 7));
+    expect(line).toContain(DISK_SHA.slice(0, 7));
+    expect(line).toContain("is not the tested commit for beta");
+    // …with the call to action taken off the sentence that carried one.
+    expect(line).toContain(`the code on disk is ${DISK_SHA.slice(0, 7)}.`);
   });
 
   it("keeps a code the box is STILL drifted by, with the sha measured now", () => {
     // The false-success half: a run that did not realign the box must not be
     // allowed to clear the warning that says so.
-    const live: UpdateWarning = {
-      code: "build-from-other-commit",
-      message: `This box is running a build made from ${PIN_SHA.slice(0, 7)} but the code on disk is ${DISK_SHA.slice(0, 7)} — run Update to realign.`,
-    };
+    const stillDrifted = computeDrift(driftInputs({
+      build: { ...driftInputs().build!, commit: PIN_SHA, shortCommit: PIN_SHA.slice(0, 7) },
+      pin: { branch: "beta", source: "pin-file", commit: DISK_SHA, pinned: true },
+    }));
+    const measured: DriftMeasurement = { drift: stillDrifted, pinned: true, dirty: false };
 
-    const after = reconcileDriftWarnings([behindPin, otherCommit], [live]);
+    const after = reconcileDriftWarnings([behindPin, otherCommit], measured);
 
-    expect(after.map((w) => w.code)).toEqual(["build-from-other-commit", "drift-resolved"]);
+    expect(after.map((w) => w.code)).toEqual(["build-from-other-commit", DRIFT_RESOLVED_CODE]);
     // Measured after the run, not the pre-run text.
-    expect(after[0].message).toBe(live.message);
+    expect(after[0].message).toContain(`build made from ${PIN_SHA.slice(0, 7)}`);
+    // And the history line does not claim the box is finished with.
+    expect(after[1].message).not.toContain("nothing further is needed");
+    expect(after[1].message).toContain("That much the update resolved.");
   });
 
-  it("retires nothing when the box could not be measured", () => {
-    // A git shell-out that timed out is not evidence that the box is healthy.
+  it("keeps checkout-behind-pin when the PIN could not be resolved", () => {
+    // `collectBuildIdentity` never throws: a `git rev-parse origin/<branch>`
+    // that failed or timed out comes back as `checkoutVsPin: "unknown"` with no
+    // code — and an absent code is not evidence that the run fixed anything.
+    const after = reconcileDriftWarnings([behindPin], measuredUnknown());
+
+    expect(after.map((w) => w.code)).toEqual(["checkout-behind-pin"]);
+    expect(after[0].message, "the pre-run sentence, unchanged").toBe(behindPin.message);
+  });
+
+  it("keeps checkout-dirty when git status could not be read", () => {
+    // `dirty: null` is "we could not look", and it is falsy — so a test for the
+    // absence of the code would have retired this one too.
+    const after = reconcileDriftWarnings([dirty], measuredUnknown({ dirty: null }));
+
+    expect(after.map((w) => w.code)).toEqual(["checkout-dirty"]);
+  });
+
+  it("retires no-pin once the box carries a pin, whatever the pin axis says", () => {
+    // The repin is what resolves it, and `pin.pinned` is the exact negation of
+    // the condition — the axis stays "unknown" on a box whose origin ref this
+    // checkout cannot resolve, and that must not keep the warning alive.
+    const noPin: UpdateWarning = {
+      code: "no-pin",
+      message: "This box records no tested branch to update to — the next update will pin it automatically.",
+    };
+
+    const after = reconcileDriftWarnings([noPin], measuredUnknown({ pinned: true }));
+
+    expect(after.map((w) => w.code)).toEqual([DRIFT_RESOLVED_CODE]);
+  });
+
+  it("retires nothing when the read itself threw", () => {
     expect(reconcileDriftWarnings([behindPin, otherCommit], null)).toEqual([behindPin, otherCommit]);
   });
 
   it("leaves warnings that are not about drift exactly where they were", () => {
-    const after = reconcileDriftWarnings([repinned, behindPin], []);
-    expect(after.map((w) => w.code)).toEqual(["repinned", "drift-resolved"]);
+    const after = reconcileDriftWarnings([repinned, behindPin], measuredClean());
+    expect(after.map((w) => w.code)).toEqual(["repinned", DRIFT_RESOLVED_CODE]);
     expect(after[0]).toEqual(repinned);
   });
 
   it("does not invent a history line when there was no drift to resolve", () => {
-    expect(reconcileDriftWarnings([repinned], [])).toEqual([repinned]);
+    expect(reconcileDriftWarnings([repinned], measuredClean())).toEqual([repinned]);
   });
 });

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -678,12 +678,13 @@ describe("updater", () => {
      * They are the PRE-RUN diagnosis, kept on purpose (a box 71 commits behind
      * its own pin must not update in silence) and never re-asked once the run
      * succeeded. Both codes describe a tree step 1 moved and the rebuild
-     * replaced, so a finished run has to retire them.
+     * replaced, so a finished run has to retire them — on a POSITIVE verdict
+     * per axis, never on the absence of a code.
      */
-    it("retires the pre-run drift warnings once the run has resolved them", async () => {
+    describe("the drift warnings a finished run resolved", () => {
       const OLD_SHA = "673817a8e0a1b2c3d4e5f60718293a4b5c6d7e8f";
       const NEW_SHA = "21539548c554b30799ad6e19a94213e26eb23f2f";
-      // Exactly what the box answered, as the run restored it from disk.
+      /** Exactly what the box answered, as the run restored it from disk. */
       const capturedBeforeStepOne = JSON.stringify([
         {
           code: "checkout-behind-pin",
@@ -695,91 +696,154 @@ describe("updater", () => {
         },
       ]);
 
-      vi.resetModules();
-      mockSet.mockResolvedValue();
-      mockSetMany.mockResolvedValue();
-      mockGet.mockImplementation(async (key: string) =>
-        key === "update_warnings" ? capturedBeforeStepOne : true);
-      // The box AFTER the run: the rebuild stamped the commit the checkout is
-      // on, and the pin file names the branch it is on. `builtAt` is what keeps
-      // this read off `fs/promises.stat`, which this file does not mock.
-      mockReadFile.mockImplementation(async (file) => {
-        const p = String(file);
-        if (p.endsWith("BUILD_ID")) return "rebuilt-build-id\n";
-        if (p.endsWith(".update-branch")) return "beta\n";
-        if (p.endsWith("build-info.json")) {
-          return JSON.stringify({
-            commit: NEW_SHA,
-            shortCommit: NEW_SHA.slice(0, 7),
-            branch: "beta",
-            dirty: false,
-            untracked: 0,
-            committedAt: "2026-09-07T00:42:00Z",
-            builtAt: "2026-09-07T00:54:17Z",
-            buildId: "rebuilt-build-id",
-            node: "v22.0.0",
-            bun: "1.2.10",
-            packageVersion: "3.10.0",
-            hermesPin: null,
-            openclawPin: null,
-          });
-        }
-        throw new Error("ENOENT");
-      });
-      setupExecFileMock({
-        "rev-parse --abbrev-ref HEAD": { stdout: "beta\n", stderr: "" },
-        "rev-parse HEAD": { stdout: `${NEW_SHA}\n`, stderr: "" },
-        "status --porcelain": { stdout: "", stderr: "" },
-        ping: { stdout: "", stderr: "" },
-        systemctl: { stdout: "", stderr: "" },
-        openclaw: { stdout: "1.0.0", stderr: "" },
-      });
-      updater = await import("@/lib/updater");
-
-      updater.resetUpdateState();
-      expect(await updater.checkContinuation()).toBe(true);
-      await vi.waitFor(() => {
-        expect(updater.getUpdateState().phase).toBe("completed");
+      const buildInfo = JSON.stringify({
+        commit: NEW_SHA,
+        shortCommit: NEW_SHA.slice(0, 7),
+        branch: "beta",
+        dirty: false,
+        untracked: 0,
+        committedAt: "2026-09-07T00:42:00Z",
+        builtAt: "2026-09-07T00:54:17Z",
+        buildId: "rebuilt-build-id",
+        node: "v22.0.0",
+        bun: "1.2.10",
+        packageVersion: "3.10.0",
+        hermesPin: null,
+        openclawPin: null,
       });
 
-      const warnings = updater.getUpdateState().warnings ?? [];
-      const codes = warnings.map((w) => w.code);
-      expect(codes, "a finished update must not still be reporting the tree it replaced")
-        .not.toContain("checkout-behind-pin");
-      expect(codes).not.toContain("build-from-other-commit");
-      // The sentence the owner acted on.
-      expect(warnings.filter((w) => w.message.includes("run Update"))).toEqual([]);
-      // Kept, in the past tense, as the run's own history.
-      const history = warnings.find((w) => w.code === "drift-resolved");
-      expect(history?.message, JSON.stringify(warnings)).toMatch(/^When this update started, /);
-      expect(history?.message).toContain("realigned the box");
-    });
+      /**
+       * The box AFTER the run: the rebuild stamped the commit the checkout is
+       * on, `.update-branch` names the branch, and `origin/beta` resolves to
+       * that same commit — so BOTH axes are a measured "match" rather than a
+       * pin nothing could look up. `builtAt` is what keeps this read off
+       * `fs/promises.stat`, which this file does not mock.
+       */
+      function boxAfterTheRun(buildInfoBody: string | Promise<string> = buildInfo): void {
+        mockReadFile.mockImplementation(async (file) => {
+          const p = String(file);
+          if (p.endsWith("BUILD_ID")) return "rebuilt-build-id\n";
+          if (p.endsWith(".update-branch")) return "beta\n";
+          if (p.endsWith("build-info.json")) return buildInfoBody;
+          throw new Error("ENOENT");
+        });
+      }
 
-    it("keeps them live when the run FAILED — nothing was realigned", async () => {
-      const capturedBeforeStepOne = JSON.stringify([
-        {
-          code: "checkout-behind-pin",
-          message: "The code on disk (673817a) is not the tested commit for beta (2153954).",
-        },
-      ]);
+      function gitAnswers(over: Record<string, { stdout: string; stderr: string } | Error> = {}) {
+        setupExecFileMock({
+          "rev-parse --abbrev-ref HEAD": { stdout: "beta\n", stderr: "" },
+          "rev-parse HEAD": { stdout: `${NEW_SHA}\n`, stderr: "" },
+          "status --porcelain": { stdout: "", stderr: "" },
+          "log -1 --format": { stdout: "2026-09-07T00:42:00+03:00\n", stderr: "" },
+          "origin/beta": { stdout: `${NEW_SHA}\n`, stderr: "" },
+          ...over,
+          ping: { stdout: "", stderr: "" },
+          systemctl: { stdout: "", stderr: "" },
+          openclaw: { stdout: "1.0.0", stderr: "" },
+        });
+      }
 
-      vi.resetModules();
-      mockSet.mockResolvedValue();
-      mockSetMany.mockResolvedValue();
-      mockGet.mockImplementation(async (key: string) =>
-        key === "update_warnings" ? capturedBeforeStepOne : true);
-      mockRebuiltBox();
-      // `gateway_verify` is failFast: the second half stops there.
-      mockGatewayUp.mockResolvedValue(false);
-      updater = await import("@/lib/updater");
+      async function loadWithBaseline(): Promise<void> {
+        vi.resetModules();
+        mockSet.mockResolvedValue();
+        mockSetMany.mockResolvedValue();
+        mockGet.mockImplementation(async (key: string) =>
+          key === "update_warnings" ? capturedBeforeStepOne : true);
+        updater = await import("@/lib/updater");
+        updater.resetUpdateState();
+      }
 
-      updater.resetUpdateState();
-      expect(await updater.checkContinuation()).toBe(true);
-      await vi.waitFor(() => {
-        expect(updater.getUpdateState().phase).toBe("failed");
+      it("retires them once the run has resolved them", async () => {
+        boxAfterTheRun();
+        gitAnswers();
+        await loadWithBaseline();
+
+        expect(await updater.checkContinuation()).toBe(true);
+        await vi.waitFor(() => {
+          expect(updater.getUpdateState().phase).toBe("completed");
+        });
+
+        const warnings = updater.getUpdateState().warnings ?? [];
+        const codes = warnings.map((w) => w.code);
+        expect(codes, "a finished update must not still be reporting the tree it replaced")
+          .not.toContain("checkout-behind-pin");
+        expect(codes).not.toContain("build-from-other-commit");
+        // The sentence the owner acted on.
+        expect(warnings.filter((w) => w.message.includes("run Update"))).toEqual([]);
+        // Kept, in the past tense, as the run's own history — with the shas.
+        const history = warnings.find((w) => w.code === "drift-resolved");
+        expect(history?.message, JSON.stringify(warnings)).toMatch(/^When this update started: /);
+        expect(history?.message).toContain(OLD_SHA.slice(0, 7));
       });
 
-      expect(updater.getUpdateState().warnings?.map((w) => w.code)).toEqual(["checkout-behind-pin"]);
+      it("keeps them when the tested commit could not be looked up", async () => {
+        // `collectBuildIdentity` never throws: a failed `git rev-parse
+        // origin/beta` arrives as `checkoutVsPin: "unknown"` with NO code. An
+        // absent code is not evidence that the run realigned anything, and
+        // retiring on it would be the false success this card is about, in the
+        // other direction.
+        boxAfterTheRun();
+        gitAnswers({ "origin/beta": new Error("fatal: could not read origin/beta") });
+        await loadWithBaseline();
+
+        expect(await updater.checkContinuation()).toBe(true);
+        await vi.waitFor(() => {
+          expect(updater.getUpdateState().phase).toBe("completed");
+        });
+
+        const warnings = updater.getUpdateState().warnings ?? [];
+        expect(warnings.map((w) => w.code)).toContain("checkout-behind-pin");
+        // The build axis WAS measured, so its own warning still goes.
+        expect(warnings.map((w) => w.code)).not.toContain("build-from-other-commit");
+      });
+
+      it("does not publish `completed` until the re-measurement has answered", async () => {
+        // The status route answers with this state object verbatim for any
+        // non-idle phase, and the panel stops polling on the first answer that
+        // is not `running`. A `completed` written before the measurement would
+        // therefore latch the pre-run warnings on the completion card until the
+        // owner reloaded the page — the very defect, surviving its own fix.
+        const gate = deferred<string>();
+        boxAfterTheRun(gate.promise);
+        gitAnswers();
+        await loadWithBaseline();
+
+        expect(await updater.checkContinuation()).toBe(true);
+        await vi.waitFor(() => {
+          expect(
+            mockReadFile.mock.calls.some(([f]) => String(f).endsWith("build-info.json")),
+            "the run should have reached the re-measurement",
+          ).toBe(true);
+        });
+
+        expect(
+          updater.getUpdateState().phase,
+          "the phase must not be published while the measurement is still out",
+        ).toBe("running");
+
+        gate.resolve(buildInfo);
+        await vi.waitFor(() => {
+          expect(updater.getUpdateState().phase).toBe("completed");
+        });
+        expect(updater.getUpdateState().warnings?.map((w) => w.code))
+          .not.toContain("checkout-behind-pin");
+      });
+
+      it("keeps them live when the run FAILED — nothing was realigned", async () => {
+        boxAfterTheRun();
+        gitAnswers();
+        await loadWithBaseline();
+        // `gateway_verify` is failFast: the second half stops there.
+        mockGatewayUp.mockResolvedValue(false);
+
+        expect(await updater.checkContinuation()).toBe(true);
+        await vi.waitFor(() => {
+          expect(updater.getUpdateState().phase).toBe("failed");
+        });
+
+        expect(updater.getUpdateState().warnings?.map((w) => w.code))
+          .toEqual(["checkout-behind-pin", "build-from-other-commit"]);
+      });
     });
 
     it("does not stop the gateway while its pre-start is still running", async () => {

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -668,6 +668,120 @@ describe("updater", () => {
       );
     });
 
+    /**
+     * TASK-757. Measured on the OpenClaw box on 2026-09-07 at beta `21539548`,
+     * after a clean in-app update: `phase: "completed"`, `error: null`, and two
+     * warnings that were false about the box as it then was — the second of
+     * them ending in "run Update to realign", over the run that had just
+     * realigned it.
+     *
+     * They are the PRE-RUN diagnosis, kept on purpose (a box 71 commits behind
+     * its own pin must not update in silence) and never re-asked once the run
+     * succeeded. Both codes describe a tree step 1 moved and the rebuild
+     * replaced, so a finished run has to retire them.
+     */
+    it("retires the pre-run drift warnings once the run has resolved them", async () => {
+      const OLD_SHA = "673817a8e0a1b2c3d4e5f60718293a4b5c6d7e8f";
+      const NEW_SHA = "21539548c554b30799ad6e19a94213e26eb23f2f";
+      // Exactly what the box answered, as the run restored it from disk.
+      const capturedBeforeStepOne = JSON.stringify([
+        {
+          code: "checkout-behind-pin",
+          message: `The code on disk (${OLD_SHA.slice(0, 7)}) is not the tested commit for beta (${NEW_SHA.slice(0, 7)}).`,
+        },
+        {
+          code: "build-from-other-commit",
+          message: `This box is running a build made from ${OLD_SHA.slice(0, 7)} but the code on disk is ${NEW_SHA.slice(0, 7)} — run Update to realign.`,
+        },
+      ]);
+
+      vi.resetModules();
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockGet.mockImplementation(async (key: string) =>
+        key === "update_warnings" ? capturedBeforeStepOne : true);
+      // The box AFTER the run: the rebuild stamped the commit the checkout is
+      // on, and the pin file names the branch it is on. `builtAt` is what keeps
+      // this read off `fs/promises.stat`, which this file does not mock.
+      mockReadFile.mockImplementation(async (file) => {
+        const p = String(file);
+        if (p.endsWith("BUILD_ID")) return "rebuilt-build-id\n";
+        if (p.endsWith(".update-branch")) return "beta\n";
+        if (p.endsWith("build-info.json")) {
+          return JSON.stringify({
+            commit: NEW_SHA,
+            shortCommit: NEW_SHA.slice(0, 7),
+            branch: "beta",
+            dirty: false,
+            untracked: 0,
+            committedAt: "2026-09-07T00:42:00Z",
+            builtAt: "2026-09-07T00:54:17Z",
+            buildId: "rebuilt-build-id",
+            node: "v22.0.0",
+            bun: "1.2.10",
+            packageVersion: "3.10.0",
+            hermesPin: null,
+            openclawPin: null,
+          });
+        }
+        throw new Error("ENOENT");
+      });
+      setupExecFileMock({
+        "rev-parse --abbrev-ref HEAD": { stdout: "beta\n", stderr: "" },
+        "rev-parse HEAD": { stdout: `${NEW_SHA}\n`, stderr: "" },
+        "status --porcelain": { stdout: "", stderr: "" },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+      });
+      updater = await import("@/lib/updater");
+
+      updater.resetUpdateState();
+      expect(await updater.checkContinuation()).toBe(true);
+      await vi.waitFor(() => {
+        expect(updater.getUpdateState().phase).toBe("completed");
+      });
+
+      const warnings = updater.getUpdateState().warnings ?? [];
+      const codes = warnings.map((w) => w.code);
+      expect(codes, "a finished update must not still be reporting the tree it replaced")
+        .not.toContain("checkout-behind-pin");
+      expect(codes).not.toContain("build-from-other-commit");
+      // The sentence the owner acted on.
+      expect(warnings.filter((w) => w.message.includes("run Update"))).toEqual([]);
+      // Kept, in the past tense, as the run's own history.
+      const history = warnings.find((w) => w.code === "drift-resolved");
+      expect(history?.message, JSON.stringify(warnings)).toMatch(/^When this update started, /);
+      expect(history?.message).toContain("realigned the box");
+    });
+
+    it("keeps them live when the run FAILED — nothing was realigned", async () => {
+      const capturedBeforeStepOne = JSON.stringify([
+        {
+          code: "checkout-behind-pin",
+          message: "The code on disk (673817a) is not the tested commit for beta (2153954).",
+        },
+      ]);
+
+      vi.resetModules();
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockGet.mockImplementation(async (key: string) =>
+        key === "update_warnings" ? capturedBeforeStepOne : true);
+      mockRebuiltBox();
+      // `gateway_verify` is failFast: the second half stops there.
+      mockGatewayUp.mockResolvedValue(false);
+      updater = await import("@/lib/updater");
+
+      updater.resetUpdateState();
+      expect(await updater.checkContinuation()).toBe(true);
+      await vi.waitFor(() => {
+        expect(updater.getUpdateState().phase).toBe("failed");
+      });
+
+      expect(updater.getUpdateState().warnings?.map((w) => w.code)).toEqual(["checkout-behind-pin"]);
+    });
+
     it("does not stop the gateway while its pre-start is still running", async () => {
       // At boot clawbox-gateway.service and clawbox-setup.service start
       // together, and the gateway's ExecStartPre (gateway-pre-start.sh) can


### PR DESCRIPTION
**TASK-757** — after a clean in-app update, System Update tells the owner to update again.

## What the owner sees

Settings → System Update, on a box whose update has just finished:

```json
"phase": "completed", "error": null,
"warnings": [
  {"code": "checkout-behind-pin",
   "message": "The code on disk (673817a) is not the tested commit for beta (2153954)."},
  {"code": "build-from-other-commit",
   "message": "This box is running a build made from 673817a but the code on disk is 2153954 — run Update to realign."}
]
```

Both sentences are false about the box as it then is, they contradict each other about which sha is the code on disk, and the second ends in an imperative the owner would act on — over the run that has just put the box exactly where it belongs.

Measured read-only on the OpenClaw box at beta `21539548`, again while writing this fix:

| fact | measurement |
|---|---|
| the code on disk | `git rev-parse HEAD` = `21539548c554b30799ad6e19a94213e26eb23f2f`, worktree clean |
| the build that is running | `.next/build-info.json` commit = the same `21539548`, `BUILD_ID` written 03:54:17 |
| the pin | `.update-branch` = `beta` |
| what is on disk about it | `data/config.json` carries `update_completed` and `update_completed_at` and **no** drift key — the warnings live only in the running process's memory |

That last row is why the Hermes box showed `warnings: []` at the same head: its web server had restarted since, so the state was gone. Nothing was wrong with the box; the payload was.

## Cause

Two halves, and they are the same defect from both ends.

`captureDriftBaseline()` samples the drift **before step 1**, deliberately — a box 71 commits behind its own pin must not update in silence (#737) — and persists it across the reboot. `updateClawBoxAndReboot` then sampled again **after step 1 had already hard-synced the tree**, where `build-from-other-commit` fires on *every* run, the build being the old one until the rebuild replaces it. `warnUpdate` de-duplicates by code with the first observation winning, so the list handed to the owner mixed two samples of a tree that moved between them — one sentence naming the pre-sync sha as "the code on disk", the other naming the post-sync sha the same way.

And nothing re-asked either of them when the run succeeded.

## Fix

- **One sample during the run.** The post-sync sample is gone: it only ever described the sync. The baseline stays exactly as it was, so #737's rule is untouched.
- **A finished run re-measures.** A successful run asks once more, at the end, where the answer is about the box as it then is; what it resolved is retired into one past-tense line that quotes what the box actually looked like — shas and branch included, so support can still tell a box one commit behind from one 71 behind — with the call to action taken off. A run that FAILED realigned nothing and keeps every warning exactly as captured.
- **Retirement needs a positive verdict, per axis.** `collectBuildIdentity` never throws: a `git rev-parse origin/<branch>` that timed out comes back as an `"unknown"` axis with no code at all. Reading an absent code as "the run fixed it" would clear the warning on a measurement that never happened, so each code is answered by the fact that raised it — the pin axis for `checkout-behind-pin`, `pin.pinned` for `no-pin`, `checkout.dirty === false` for `checkout-dirty`, the build axis for the four build codes — and an unknown axis retires nothing. A code added without a rule fails to typecheck and keeps its warning at runtime.
- **The measurement happens before the phase is published.** The status route answers with that state object for any non-idle phase and the panel stops polling on the first answer that is not `running`; a `completed` written first would latch the pre-run warnings on the completion card until the owner reloaded the page.
- The retired line renders as history rather than as another amber alarm, and the drift codes plus the wording rules moved to a module with no Node imports so a component can name them without pulling `child_process` into the browser bundle.

## Native mechanism

Nothing in OpenClaw or Hermes owns this: the device-update state machine, its markers and its drift readers are ClawBox's own, and neither harness has an equivalent of "is the deployed build the code on disk". What is **reused rather than reinvented** is this repository's own reader — `collectBuildIdentity` (disk sha, `.next/BUILD_ID`, the `.update-branch` pin), the same one `/setup-api/update/status` and the About panel already call. No second probe, no new marker, no new store; the tri-state it already computes is what the retirement is judged on, and it was previously being thrown away by flattening the report to a list of codes.

## RED (unmodified beta `21539548`)

```
 ❯ src/tests/unit/updater-drift-cleared-after-success.test.ts (7 tests | 4 failed | 1 skipped)
     × retires the drift the run resolved into one past-tense line
     × keeps a code the box is STILL drifted by, with the sha measured now
     × leaves warnings that are not about drift exactly where they were
     × does not invent a history line when there was no drift to resolve
 ❯ src/tests/unit/updater.test.ts (96 tests | 1 failed | 95 skipped)
       × retires the pre-run drift warnings once the run has resolved them

 FAIL … > retires the pre-run drift warnings once the run has resolved them
 AssertionError: a finished update must not still be reporting the tree it replaced:
   expected [ 'checkout-behind-pin', …(2) ] to not include 'checkout-behind-pin'

 FAIL … > retires the drift the run resolved into one past-tense line
 TypeError: reconcileDriftWarnings is not a function

 Test Files  2 failed (2)
      Tests  5 failed | 2 passed | 96 skipped (103)
```

The integration case drives a real continuation to `completed` with the device's own warnings restored from disk, and reproduces the payload exactly.

Two of the seven cases **pass on unmodified beta**, and that is the answer to the card's first half: with a fixture where the build, the code on disk and the pin are three different commits, in every combination, `computeDrift`'s two sentences already name their subjects correctly. They can only disagree across two samples — which is what was measured, and what the sample removal above fixes structurally. Those two cases stay as the pin.

## GREEN

Every case, plus the neighbours (`updater`, `build-identity`, `build-identity-hygiene`, `updater-build-identity`, `updater-interrupted-run`, `updater-completed-outranks-interrupted`, `updater-continuation-boot`, `update-lock`, `openclaw-config-mock-completeness`, `test-timeout-hygiene`, `state-updater-purity`) — **12 files / 222 tests**; the route and component suites (`routes/update/*`, `routes/build-identity`, `system-update-app-drift`, `build-identity-panel`, `update-remote-refusal`, `desktop-csp-header`) — **10 files / 75 tests**. `tsc --noEmit` clean. `eslint` on every changed file introduces nothing (three pre-existing warnings, byte for byte the same as on `origin/beta`).

The two guards that matter were mutation-checked rather than assumed: reverting the retirement to "no code was emitted" and moving the phase back above the measurement each turn exactly one of the new cases red.

## Both editions

The updater is shared and the reconcile is edition-agnostic — `PROJECT_DIR` and `PROJECT_ROOT` resolve identically on a device, and the `applicableSteps()` differences (`gateway_verify`, `hermes_edition`) do not touch it. The OpenClaw-only flow captures no baseline and the guard keeps it from paying for a git shell-out at all. The same fixture drives both.

## Device leg — read-only, no mutex taken

On the OpenClaw box, before the fix: `/setup-api/update/status` answered `phase: "completed"`, `error: null` and the two warnings above, while the checkout, the build stamp and the pin all agreed on `21539548` and the config store carried no drift key. Nothing was written, sent or restarted.

What this cannot prove on hardware is the after: the warnings live in the running process's memory, so a box only shows the new behaviour on its next update — which is the acceptance test, on the next deploy.

## Follow-ups recorded, not done here

- A FAILED run still hands the owner its captured warnings unchanged. With the second sample gone they now come from one moment, so they can no longer contradict each other, but they still describe the tree as it was when the run began — correct for a run that changed nothing, worth re-stating explicitly if a failure path is ever reworked.
- The build-axis codes are alternatives in one if/else chain, so one underlying condition can surface under a different code after the run. The per-axis verdict covers that (the axis, not the code, is what is asked), and `verify_build_identity` fails the run outright on a build/checkout mismatch.
- The warning text is server-generated English, as every drift warning already is; the box ships ten locales and nothing here changes that either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Update results now accurately identify which build or checkout drift issues were resolved.
  - Resolved drift warnings are retained as history, while active warnings remain visible with refreshed details.
  - Drift warnings remain visible when the current state cannot be verified.
  - Successful updates wait for final verification before reporting completion.

- **User Interface**
  - Resolved warnings now use a subdued informational style and history indicator, distinguishing them from active warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->