### PR TITLE
fix: bound the vendor PATH blocks a third-party installer appends to .bashrc

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -950,6 +950,100 @@ as_clawbox_login() {
   su - "$CLAWBOX_USER" -c "export PATH=\"${cuda_prefix}$CLAWBOX_HOME/.bun/bin:$CLAWBOX_HOME/.npm-global/bin:$CLAWBOX_HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:\$PATH\" && $*"
 }
 
+# The marker the third-party cua-driver-rs installer writes above its PATH
+# export, and the fence ClawBox wraps the survivor in. Matched as an ASCII
+# prefix: the vendor's own line ends in an em dash and a URL.
+CUA_BASHRC_MARKER='# Added by cua-driver-rs installer'
+CUA_BASHRC_FENCE_OPEN='# >>> ClawBox: cua-driver-rs PATH (collapsed) >>>'
+CUA_BASHRC_FENCE_CLOSE='# <<< ClawBox: cua-driver-rs PATH (collapsed) <<<'
+
+# Collapse repeated third-party PATH blocks in the clawbox user's ~/.bashrc.
+#
+# NOTHING IN THIS REPOSITORY WRITES THAT BLOCK, which is why there is no writer
+# to make idempotent: the vendor's own `cua-driver` binary appends it, and
+# Hermes' agent keeps invoking that binary on its own
+# (tools/computer_use/cua_backend.py, cua_driver_update_check). Measured
+# read-only on 2026-09-07: 23 copies and 7,049 B on the Hermes box against 1
+# copy and 4,431 B on the OpenClaw box, whose driver was installed once and
+# never updated — so the writer reaches BOTH editions and only the rate differs.
+# Each copy costs every login shell another ~119 B and nothing bounds it.
+#
+# So the fix is at this end, and it runs on EVERY update rather than once,
+# precisely because the writer is not ours and will append again: the copies
+# collapse to one, fenced, and the next append collapses into the same fence.
+#
+# Only a file with a genuine duplicate is rewritten — a box with one copy is
+# left byte-for-byte alone. The vendor's own comment is kept INSIDE the fence:
+# it says who put the path there, and it is what the next collapse matches on.
+# The block's export line is byte-identical to the one inside the Codex
+# installer's fence, so the COMMENT is the key and never the export.
+dedupe_vendor_bashrc_path_blocks() {
+  local BASHRC="$1"
+  [ -f "$BASHRC" ] || return 0
+
+  local copies=0
+  copies=$(grep -cF "$CUA_BASHRC_MARKER" "$BASHRC" 2>/dev/null) || copies=0
+  [ "$copies" -gt 1 ] 2>/dev/null || return 0
+
+  local tmp=""
+  tmp=$(mktemp "$BASHRC.clawbox.XXXXXX" 2>/dev/null) || {
+    echo "  Warning: could not collapse duplicate PATH blocks in .bashrc (mktemp failed)"
+    return 0
+  }
+
+  # A blank line belongs to the block that FOLLOWS it (the vendor writes
+  # blank/comment/export), so blanks are buffered and one is dropped with each
+  # block that goes. Our own fence lines are dropped on the way in and written
+  # back out, which is what makes a second run a no-op.
+  if awk \
+      -v MARKER="$CUA_BASHRC_MARKER" \
+      -v FOPEN="$CUA_BASHRC_FENCE_OPEN" \
+      -v FCLOSE="$CUA_BASHRC_FENCE_CLOSE" '
+      function flush(  i) { for (i = 0; i < blanks; i++) print ""; blanks = 0 }
+      BEGIN { kept = 0; blanks = 0 }
+      $0 == FOPEN || $0 == FCLOSE { next }
+      /^$/ { blanks++; next }
+      index($0, MARKER) == 1 {
+        first = $0
+        got = (getline second)
+        if (got > 0 && second ~ /^export PATH=/) {
+          if (kept) { if (blanks > 0) blanks--; next }
+          kept = 1
+          flush()
+          print FOPEN
+          print first
+          print second
+          print FCLOSE
+          next
+        }
+        flush()
+        print first
+        if (got > 0) { if (second == "") blanks++; else print second }
+        next
+      }
+      { flush(); print }
+      END { flush() }
+    ' "$BASHRC" > "$tmp"; then
+    # An empty result means the rewrite lost the file; keep what is on disk.
+    if [ -s "$tmp" ]; then
+      chown --reference="$BASHRC" "$tmp" 2>/dev/null \
+        || chown "$CLAWBOX_USER:$CLAWBOX_USER" "$tmp" 2>/dev/null || true
+      chmod --reference="$BASHRC" "$tmp" 2>/dev/null || chmod 0644 "$tmp" 2>/dev/null || true
+      # Guarded: this runs under `set -euo pipefail` from a step the dispatcher
+      # calls plainly, so a .bashrc that cannot be replaced must warn, not end
+      # the update at this line.
+      if mv -f "$tmp" "$BASHRC"; then
+        echo "  Collapsed $copies duplicate cua-driver-rs PATH blocks in .bashrc to one"
+        return 0
+      fi
+    fi
+  fi
+
+  rm -f "$tmp"
+  echo "  Warning: could not collapse duplicate PATH blocks in .bashrc (rewrite failed)"
+  return 0
+}
+
 ensure_clawbox_bashrc_path() {
   # Make ~/.npm-global/bin and ~/.local/bin available in the clawbox user's
   # interactive shells (e.g. the in-UI terminal) so CLIs like openclaw, claude,
@@ -970,6 +1064,9 @@ export PATH="$HOME/.local/bin:$PATH"
 PATHEOF
     chown "$CLAWBOX_USER:$CLAWBOX_USER" "$BASHRC"
   fi
+  # Third-party appends to the same file, bounded here because their writer is
+  # not ours to fix (TASK-758).
+  dedupe_vendor_bashrc_path_blocks "$BASHRC"
 }
 
 node_satisfies_openclaw_engine() {

--- a/install.sh
+++ b/install.sh
@@ -1048,19 +1048,23 @@ dedupe_vendor_bashrc_path_blocks() {
     # bound silently gone. An empty result means the rewrite lost the file.
     local collapsed=0
     collapsed=$(grep -cF "$CUA_BASHRC_MARKER" "$tmp" 2>/dev/null) || collapsed=0
-    local now=""
-    now=$(stat -c '%s %y %i' "$BASHRC" 2>/dev/null) || now=""
-    if [ -z "$snapshot" ] || [ "$now" != "$snapshot" ]; then
-      # Somebody wrote to .bashrc while it was being collapsed. The rewrite
-      # describes a file that no longer exists; the next update collapses it.
-      rm -f "$tmp"
-      echo "  Warning: .bashrc changed while it was being collapsed — left untouched"
-      return 0
-    fi
     if [ "$collapsed" -eq 1 ] 2>/dev/null && [ -s "$tmp" ]; then
+      # Ownership and mode FIRST, so the divergence check below is the last
+      # thing between the look and the rename. There is no atomic
+      # compare-and-rename, so the window cannot be closed — only made as
+      # narrow as one `stat` and one `rename`.
       chown --reference="$BASHRC" "$tmp" 2>/dev/null \
         || chown "$CLAWBOX_USER:$CLAWBOX_USER" "$tmp" 2>/dev/null || true
       chmod --reference="$BASHRC" "$tmp" 2>/dev/null || chmod 0644 "$tmp" 2>/dev/null || true
+      local now=""
+      now=$(stat -c '%s %y %i' "$BASHRC" 2>/dev/null) || now=""
+      if [ -z "$snapshot" ] || [ "$now" != "$snapshot" ]; then
+        # Somebody wrote to .bashrc while it was being collapsed. The rewrite
+        # describes a file that no longer exists; the next update collapses it.
+        rm -f "$tmp"
+        echo "  Warning: .bashrc changed while it was being collapsed — left untouched"
+        return 0
+      fi
       # Guarded: this runs under `set -euo pipefail` from a step the dispatcher
       # calls plainly, so a .bashrc that cannot be replaced must warn, not end
       # the update at this line.

--- a/install.sh
+++ b/install.sh
@@ -980,6 +980,12 @@ CUA_BASHRC_FENCE_CLOSE='# <<< ClawBox: cua-driver-rs PATH (collapsed) <<<'
 dedupe_vendor_bashrc_path_blocks() {
   local BASHRC="$1"
   [ -f "$BASHRC" ] || return 0
+  # A symlinked ~/.bashrc — a dotfiles checkout — would be read THROUGH the
+  # link as root and then replaced by the `mv` below with a regular file,
+  # silently breaking the owner's link. Not ours to convert.
+  if [ -L "$BASHRC" ]; then
+    return 0
+  fi
 
   local copies=0
   copies=$(grep -cF "$CUA_BASHRC_MARKER" "$BASHRC" 2>/dev/null) || copies=0
@@ -1024,8 +1030,16 @@ dedupe_vendor_bashrc_path_blocks() {
       { flush(); print }
       END { flush() }
     ' "$BASHRC" > "$tmp"; then
-    # An empty result means the rewrite lost the file; keep what is on disk.
-    if [ -s "$tmp" ]; then
+    # Judge the OUTCOME, never the attempt. The premise of this whole function
+    # is that the writer is a third party ClawBox does not own and cannot pin,
+    # so the shape it appends WILL change — one extra line between the marker
+    # and the export is enough for every block to fall through the transform.
+    # Reporting a collapse off `mv`'s exit code would then rewrite the file
+    # byte-identical and log a success on every update, for ever, with the
+    # bound silently gone. An empty result means the rewrite lost the file.
+    local collapsed=0
+    collapsed=$(grep -cF "$CUA_BASHRC_MARKER" "$tmp" 2>/dev/null) || collapsed=0
+    if [ "$collapsed" -eq 1 ] 2>/dev/null && [ -s "$tmp" ]; then
       chown --reference="$BASHRC" "$tmp" 2>/dev/null \
         || chown "$CLAWBOX_USER:$CLAWBOX_USER" "$tmp" 2>/dev/null || true
       chmod --reference="$BASHRC" "$tmp" 2>/dev/null || chmod 0644 "$tmp" 2>/dev/null || true
@@ -1036,6 +1050,13 @@ dedupe_vendor_bashrc_path_blocks() {
         echo "  Collapsed $copies duplicate cua-driver-rs PATH blocks in .bashrc to one"
         return 0
       fi
+    else
+      # The live file is left exactly as it is: a copy of itself is not an
+      # improvement, and this line is the only signal anyone gets.
+      rm -f "$tmp"
+      echo "  Warning: .bashrc carries $copies cua-driver-rs PATH blocks and the collapse"
+      echo "           left $collapsed — the vendor's block shape has changed; file untouched"
+      return 0
     fi
   fi
 
@@ -3791,10 +3812,15 @@ step_hermes_edition() {
 
 step_openclaw_install() {
   is_hermes_edition && { echo "  [hermes edition] skipping OpenClaw npm install"; return 0; }
-  # Always re-assert the .bashrc PATH stanza before any early-return. The
+  # Re-assert the .bashrc PATH stanza before the early-returns BELOW. The
   # function is idempotent (greps before appending), and skipping it here
   # was the root cause of the recurring `bash: openclaw: command not found`
   # regression in the in-UI terminal after update runs.
+  #
+  # NOT before the Hermes return on the line above — that SKU never reaches
+  # this line. Both the stanza and the `.bashrc` collapse reach a Hermes box
+  # through step_post_update -> step_coding_harness, which is why that chain is
+  # pinned by src/tests/unit/install-bashrc-vendor-path-dedupe.test.ts.
   ensure_clawbox_bashrc_path
 
   # Pinned OpenClaw version comes from config/openclaw-target.txt — ClawBox

--- a/install.sh
+++ b/install.sh
@@ -991,6 +991,15 @@ dedupe_vendor_bashrc_path_blocks() {
   copies=$(grep -cF "$CUA_BASHRC_MARKER" "$BASHRC" 2>/dev/null) || copies=0
   [ "$copies" -gt 1 ] 2>/dev/null || return 0
 
+  # The file as it is about to be read. The `mv` below is an atomic rename, so
+  # no reader ever sees half a file — but a rename replaces the INODE, so an
+  # append that lands between the read and the swap is dropped with the old one.
+  # The known concurrent writer is the vendor's installer appending exactly the
+  # block being deleted, so nothing is lost today; this exists so that stays
+  # true when something else writes here.
+  local snapshot=""
+  snapshot=$(stat -c '%s %y %i' "$BASHRC" 2>/dev/null) || snapshot=""
+
   local tmp=""
   tmp=$(mktemp "$BASHRC.clawbox.XXXXXX" 2>/dev/null) || {
     echo "  Warning: could not collapse duplicate PATH blocks in .bashrc (mktemp failed)"
@@ -1039,6 +1048,15 @@ dedupe_vendor_bashrc_path_blocks() {
     # bound silently gone. An empty result means the rewrite lost the file.
     local collapsed=0
     collapsed=$(grep -cF "$CUA_BASHRC_MARKER" "$tmp" 2>/dev/null) || collapsed=0
+    local now=""
+    now=$(stat -c '%s %y %i' "$BASHRC" 2>/dev/null) || now=""
+    if [ -z "$snapshot" ] || [ "$now" != "$snapshot" ]; then
+      # Somebody wrote to .bashrc while it was being collapsed. The rewrite
+      # describes a file that no longer exists; the next update collapses it.
+      rm -f "$tmp"
+      echo "  Warning: .bashrc changed while it was being collapsed — left untouched"
+      return 0
+    fi
     if [ "$collapsed" -eq 1 ] 2>/dev/null && [ -s "$tmp" ]; then
       chown --reference="$BASHRC" "$tmp" 2>/dev/null \
         || chown "$CLAWBOX_USER:$CLAWBOX_USER" "$tmp" 2>/dev/null || true

--- a/src/tests/unit/install-bashrc-vendor-path-dedupe.test.ts
+++ b/src/tests/unit/install-bashrc-vendor-path-dedupe.test.ts
@@ -122,10 +122,10 @@ let bashrc: string;
  * does — through `ensure_clawbox_bashrc_path`, which `step_coding_harness`
  * calls and `step_post_update` reaches on BOTH editions.
  */
-function runBashrcHygiene(): { status: number | null; stderr: string } {
+function runBashrcHygiene(home: string = sandbox): { status: number | null; stdout: string; stderr: string } {
   const script = [
     "set -euo pipefail",
-    `CLAWBOX_HOME=${JSON.stringify(sandbox)}`,
+    `CLAWBOX_HOME=${JSON.stringify(home)}`,
     'CLAWBOX_USER="$(id -un)"',
     "",
     shellConstants(),
@@ -140,7 +140,7 @@ function runBashrcHygiene(): { status: number | null; stderr: string } {
   const runner = path.join(sandbox, "run.sh");
   fs.writeFileSync(runner, script, "utf-8");
   const result = spawnSync("bash", [runner], { encoding: "utf-8", cwd: REPO });
-  return { status: result.status, stderr: result.stderr ?? "" };
+  return { status: result.status, stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
 }
 
 const read = () => fs.readFileSync(bashrc, "utf-8");
@@ -265,6 +265,77 @@ d("~/.bashrc keeps ONE vendor PATH block, however often the vendor appends", () 
     expect(fs.statSync(bashrc).mode & 0o777).toBe(0o640);
   });
 
+  it("says so, and changes nothing, when the vendor's block shape has moved", () => {
+    // The premise of the whole function is that the writer is a third party
+    // ClawBox does not own and cannot pin, so its shape WILL change — one extra
+    // line between the marker and the export is enough for every block to fall
+    // through the transform. Reporting the collapse off `mv`'s exit code would
+    // then rewrite the file byte-identical and log a success on every update,
+    // for ever, with the bound silently gone: the false-success class, on the
+    // one path whose stated design assumption is "the vendor will change".
+    const moved = ["", VENDOR_MARKER, "# a line the vendor did not use to write", VENDOR_EXPORT];
+    const before = [
+      "# ~/.bashrc",
+      'export PATH="$HOME/.npm-global/bin:$HOME/.local/bin:$PATH"',
+      ...moved,
+      ...moved,
+      ...moved,
+      "",
+    ].join("\n");
+    fs.writeFileSync(bashrc, before, "utf-8");
+
+    const run = runBashrcHygiene();
+
+    expect(run.status, run.stderr).toBe(0);
+    expect(read(), "a file the transform could not improve is not replaced").toBe(before);
+    expect(run.stdout).toContain("the vendor's block shape has changed");
+    expect(run.stdout, "and no collapse may be claimed").not.toContain("Collapsed");
+  });
+
+  it("says what it did, with the number it actually removed", () => {
+    fs.writeFileSync(bashrc, bashrcFixture(23), "utf-8");
+
+    const run = runBashrcHygiene();
+
+    expect(run.stdout).toContain("Collapsed 23 duplicate cua-driver-rs PATH blocks");
+  });
+
+  it("leaves a symlinked .bashrc alone rather than replacing the link", () => {
+    // Read THROUGH the link as root and then replaced by the `mv` with a
+    // regular file — a dotfiles checkout would quietly lose its link.
+    const real = path.join(sandbox, "dotfiles-bashrc");
+    fs.writeFileSync(real, bashrcFixture(23), "utf-8");
+    fs.symlinkSync(real, bashrc);
+
+    expect(runBashrcHygiene().status).toBe(0);
+
+    expect(fs.lstatSync(bashrc).isSymbolicLink()).toBe(true);
+    expect(fs.readFileSync(real, "utf-8")).toBe(bashrcFixture(23));
+  });
+
+  // root ignores the directory mode, so the case cannot be staged there.
+  const asUser = process.getuid?.() === 0 ? it.skip : it;
+  asUser("warns rather than ending the update when the file cannot be replaced", () => {
+    // `--step post_update` runs the step body with errexit ON and the
+    // dispatcher calls the step plainly, so an unguarded failure here would end
+    // the update at this line with none of the steps below it running.
+    const locked = path.join(sandbox, "locked");
+    fs.mkdirSync(locked);
+    const lockedBashrc = path.join(locked, ".bashrc");
+    fs.writeFileSync(lockedBashrc, bashrcFixture(23), "utf-8");
+    const before = fs.readFileSync(lockedBashrc, "utf-8");
+    fs.chmodSync(locked, 0o555); // no new file in the directory: mktemp fails
+
+    try {
+      const run = runBashrcHygiene(locked);
+      expect(run.status, run.stderr).toBe(0);
+      expect(run.stdout).toContain("Warning");
+      expect(fs.readFileSync(lockedBashrc, "utf-8")).toBe(before);
+    } finally {
+      fs.chmodSync(locked, 0o755);
+    }
+  });
+
   it("still writes the ClawBox PATH stanza into a .bashrc that has none", () => {
     // The function's own job must survive the addition.
     fs.writeFileSync(bashrc, "# empty\n", "utf-8");
@@ -286,5 +357,13 @@ d("the collapse reaches an already-shipped box", () => {
 
     const harness = extractShellFunction("step_coding_harness");
     expect(harness).toContain("ensure_clawbox_bashrc_path");
+
+    // The link that makes the claim true for an already-flashed device, and
+    // the one nothing else pins: step_openclaw_install returns on the Hermes
+    // SKU before its own call, and the bottom-of-file call runs on the full
+    // install only. Drop step_coding_harness from this list — it is edited
+    // constantly — and the collapse silently becomes fresh-install-only, which
+    // is the regression the comment above that call says already happened once.
+    expect(extractShellFunction("step_post_update")).toContain("step_coding_harness");
   });
 });

--- a/src/tests/unit/install-bashrc-vendor-path-dedupe.test.ts
+++ b/src/tests/unit/install-bashrc-vendor-path-dedupe.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Starts a real bash: vitest's 5 s test and 10 s hook defaults are not enough
+// on a loaded CI runner. See src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+/**
+ * TASK-758 — a third-party installer grows the box's `~/.bashrc` without bound.
+ *
+ * Measured on 2026-09-07, read-only, on both dev boxes:
+ *
+ *   Hermes    25 `.local/bin` exports, 23 `# Added by cua-driver-rs installer`
+ *             blocks, 7 049 B, `.bashrc` lines 122-193
+ *   OpenClaw   3 `.local/bin` exports,  1 such block,                4 431 B
+ *
+ * NOTHING IN THIS REPOSITORY WRITES THAT BLOCK. `grep -rn cua` over install.sh,
+ * install-x64.sh, scripts/, src/, config/ and mcp/ finds nothing: the writer is
+ * the vendor's own `cua-driver` binary, and it is Hermes' agent that keeps
+ * calling it — `tools/computer_use/cua_backend.py` runs `cua_driver_update_check`
+ * on its own — which is why the Hermes box has 23 of them and the OpenClaw box,
+ * whose `~/.local/bin/cua-driver` was installed once and never updated, has one.
+ * So "make the writer idempotent" is not available to us; each append costs
+ * every login shell another ~119 B and nothing bounds it.
+ *
+ * What IS available is the other end: collapse the copies to ONE and fence it,
+ * on every update, so the next append is collapsed too. It has to run on every
+ * update rather than once, precisely because the writer is not ours and will
+ * append again.
+ *
+ * The block the vendor appends, verbatim from the box (the dash is an em dash):
+ *
+ *     <blank>
+ *     # Added by cua-driver-rs installer — see https://github.com/trycua/cua
+ *     export PATH="/home/clawbox/.local/bin:$PATH"
+ *
+ * Its export line is BYTE-IDENTICAL to the one inside the vendor Codex fence
+ * (#765) three lines from the end of the same file, which is why a dedupe keyed
+ * on the export line would eat the Codex block. The marker comment is the key.
+ */
+
+const REPO = path.resolve(__dirname, "../../..");
+const INSTALL_SH = fs.readFileSync(path.join(REPO, "install.sh"), "utf-8");
+
+const CAN_RUN =
+  process.platform !== "win32"
+  && spawnSync("bash", ["-c", "true"], { stdio: "ignore" }).status === 0;
+const d = CAN_RUN ? describe : describe.skip;
+
+function extractShellFunction(name: string): string {
+  const start = INSTALL_SH.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found in install.sh`);
+  const end = INSTALL_SH.indexOf("\n}", start);
+  if (end < 0) throw new Error(`${name} has no closing brace`);
+  return `${INSTALL_SH.slice(start, end)}\n}`;
+}
+
+/** install.sh's own `CUA_BASHRC_*` assignments, so the sandbox uses the shipped strings. */
+function shellConstants(): string {
+  const lines = INSTALL_SH.split("\n").filter((l) => /^CUA_BASHRC_[A-Z_]+='/.test(l));
+  if (lines.length !== 3) {
+    throw new Error(`expected 3 CUA_BASHRC_* assignments in install.sh, found ${lines.length}`);
+  }
+  return lines.join("\n");
+}
+
+/** The vendor's block, exactly as it lands on the box. */
+const VENDOR_MARKER = "# Added by cua-driver-rs installer — see https://github.com/trycua/cua";
+const VENDOR_EXPORT = 'export PATH="/home/clawbox/.local/bin:$PATH"';
+const vendorBlock = ["", VENDOR_MARKER, VENDOR_EXPORT];
+
+/** The Codex installer's fenced block (#765) — same export line, must survive. */
+const CODEX_BLOCK = [
+  "# >>> Codex installer >>>",
+  VENDOR_EXPORT,
+  "# <<< Codex installer <<<",
+];
+
+/**
+ * The Hermes box's `~/.bashrc`, in shape: the stock tail, the bun block, the
+ * FIRST vendor block ahead of ClawBox's own stanza (that is the real order),
+ * then `copies - 1` more, then install-voice.sh's CUDA exports and the Codex
+ * fence at the end.
+ */
+function bashrcFixture(copies: number): string {
+  const lines = [
+    "# ~/.bashrc: executed by bash(1) for non-login shells.",
+    "case $- in",
+    "    *i*) ;;",
+    "      *) return;;",
+    "esac",
+    "",
+    "# bun",
+    'export BUN_INSTALL="$HOME/.bun"',
+    'export PATH="$BUN_INSTALL/bin:$PATH"',
+  ];
+  if (copies > 0) lines.push(...vendorBlock);
+  lines.push(
+    "",
+    "# npm global binaries (openclaw, codex, gemini) and user-local binaries (claude, hf, clawkeep)",
+    'export PATH="$HOME/.npm-global/bin:$HOME/.local/bin:$PATH"',
+  );
+  for (let i = 1; i < copies; i++) lines.push(...vendorBlock);
+  lines.push(
+    "export LD_LIBRARY_PATH=/home/clawbox/.local/lib:/usr/local/cuda/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}",
+    "export CUDA_HOME=/usr/local/cuda",
+    "",
+    ...CODEX_BLOCK,
+    "",
+  );
+  return lines.join("\n");
+}
+
+let sandbox: string;
+let bashrc: string;
+
+/**
+ * Run install.sh's `.bashrc` hygiene over the fixture, exactly as an update
+ * does — through `ensure_clawbox_bashrc_path`, which `step_coding_harness`
+ * calls and `step_post_update` reaches on BOTH editions.
+ */
+function runBashrcHygiene(): { status: number | null; stderr: string } {
+  const script = [
+    "set -euo pipefail",
+    `CLAWBOX_HOME=${JSON.stringify(sandbox)}`,
+    'CLAWBOX_USER="$(id -un)"',
+    "",
+    shellConstants(),
+    "",
+    extractShellFunction("dedupe_vendor_bashrc_path_blocks"),
+    "",
+    extractShellFunction("ensure_clawbox_bashrc_path"),
+    "",
+    "ensure_clawbox_bashrc_path",
+    "",
+  ].join("\n");
+  const runner = path.join(sandbox, "run.sh");
+  fs.writeFileSync(runner, script, "utf-8");
+  const result = spawnSync("bash", [runner], { encoding: "utf-8", cwd: REPO });
+  return { status: result.status, stderr: result.stderr ?? "" };
+}
+
+const read = () => fs.readFileSync(bashrc, "utf-8");
+const countOf = (text: string, needle: string) => text.split(needle).length - 1;
+
+beforeEach(() => {
+  sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-bashrc-dedupe-"));
+  bashrc = path.join(sandbox, ".bashrc");
+});
+
+afterEach(() => {
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+d("~/.bashrc keeps ONE vendor PATH block, however often the vendor appends", () => {
+  it("collapses the box's 23 copies to one fenced block", () => {
+    fs.writeFileSync(bashrc, bashrcFixture(23), "utf-8");
+    expect(countOf(read(), VENDOR_MARKER)).toBe(23);
+
+    const run = runBashrcHygiene();
+    expect(run.status, run.stderr).toBe(0);
+
+    const after = read();
+    expect(
+      countOf(after, VENDOR_MARKER),
+      "the vendor's block must survive exactly once — it says who put the path there",
+    ).toBe(1);
+    // 3 remain: ClawBox's own stanza, the surviving vendor block, and Codex's.
+    expect(countOf(after, ".local/bin")).toBe(3);
+    expect(after.length).toBeLessThan(bashrcFixture(23).length);
+  });
+
+  it("fences the survivor, so the next append is collapsed too", () => {
+    fs.writeFileSync(bashrc, bashrcFixture(23), "utf-8");
+    expect(runBashrcHygiene().status).toBe(0);
+
+    const after = read().split("\n");
+    const at = after.findIndex((l) => l === VENDOR_MARKER);
+    expect(at).toBeGreaterThan(0);
+    expect(after[at - 1]).toMatch(/^# >>> ClawBox: cua-driver-rs PATH .*>>>$/);
+    expect(after[at + 1]).toBe(VENDOR_EXPORT);
+    expect(after[at + 2]).toMatch(/^# <<< ClawBox: cua-driver-rs PATH .*<<<$/);
+  });
+
+  it("leaves everything that is not the vendor's block exactly as it was", () => {
+    fs.writeFileSync(bashrc, bashrcFixture(23), "utf-8");
+    expect(runBashrcHygiene().status).toBe(0);
+
+    const before = bashrcFixture(23).split("\n");
+    const after = read().split("\n");
+    const isOurs = (l: string) => /^# [<>]{3} ClawBox: cua-driver-rs PATH /.test(l);
+    // Every line of real content, in order — nothing else moved, changed or went.
+    const strip = (lines: string[]) =>
+      lines.filter((l) => l !== "" && l !== VENDOR_MARKER && l !== VENDOR_EXPORT && !isOurs(l));
+    expect(strip(after).join("\n")).toBe(strip(before).join("\n"));
+    // The blank line the vendor writes above each block goes WITH the block it
+    // belongs to, and with nothing else: 22 removed blocks, 22 fewer blanks.
+    const blanks = (lines: string[]) => lines.filter((l) => l === "").length;
+    expect(blanks(before) - blanks(after)).toBe(22);
+    // Named explicitly, because its export line is byte-identical to the
+    // vendor's and a dedupe keyed on that line would have eaten it.
+    expect(read()).toContain(CODEX_BLOCK.join("\n"));
+  });
+
+  it("keeps the survivor where the FIRST copy was, so PATH order does not move", () => {
+    fs.writeFileSync(bashrc, bashrcFixture(23), "utf-8");
+    expect(runBashrcHygiene().status).toBe(0);
+
+    const after = read().split("\n");
+    const vendorAt = after.findIndex((l) => l === VENDOR_MARKER);
+    const clawboxAt = after.findIndex((l) => l.includes('$HOME/.npm-global/bin:$HOME/.local/bin'));
+    expect(vendorAt).toBeGreaterThan(0);
+    expect(clawboxAt).toBeGreaterThan(vendorAt);
+  });
+
+  it("is idempotent — a second run changes nothing", () => {
+    fs.writeFileSync(bashrc, bashrcFixture(23), "utf-8");
+    expect(runBashrcHygiene().status).toBe(0);
+    const once = read();
+
+    expect(runBashrcHygiene().status).toBe(0);
+    expect(read()).toBe(once);
+  });
+
+  it("collapses again after the vendor has appended over the fence", () => {
+    // The whole reason this runs on every update: the writer is not ours.
+    fs.writeFileSync(bashrc, bashrcFixture(23), "utf-8");
+    expect(runBashrcHygiene().status).toBe(0);
+    const collapsed = read();
+
+    fs.writeFileSync(bashrc, `${collapsed}${vendorBlock.join("\n")}\n`, "utf-8");
+    expect(runBashrcHygiene().status).toBe(0);
+
+    expect(countOf(read(), VENDOR_MARKER)).toBe(1);
+    expect(countOf(read(), "# >>> ClawBox: cua-driver-rs PATH")).toBe(1);
+  });
+
+  it("does not rewrite a file with a single copy — the OpenClaw box", () => {
+    fs.writeFileSync(bashrc, bashrcFixture(1), "utf-8");
+    const before = read();
+
+    expect(runBashrcHygiene().status).toBe(0);
+
+    expect(read(), "one copy is not a duplicate; touching it would be churn").toBe(before);
+  });
+
+  it("does not rewrite a file with no vendor block at all", () => {
+    fs.writeFileSync(bashrc, bashrcFixture(0), "utf-8");
+    const before = read();
+
+    expect(runBashrcHygiene().status).toBe(0);
+
+    expect(read()).toBe(before);
+  });
+
+  it("keeps the file's mode across the rewrite", () => {
+    fs.writeFileSync(bashrc, bashrcFixture(23), "utf-8");
+    fs.chmodSync(bashrc, 0o640);
+
+    expect(runBashrcHygiene().status).toBe(0);
+
+    expect(fs.statSync(bashrc).mode & 0o777).toBe(0o640);
+  });
+
+  it("still writes the ClawBox PATH stanza into a .bashrc that has none", () => {
+    // The function's own job must survive the addition.
+    fs.writeFileSync(bashrc, "# empty\n", "utf-8");
+
+    expect(runBashrcHygiene().status).toBe(0);
+
+    expect(read()).toContain('export PATH="$HOME/.npm-global/bin:$HOME/.local/bin:$PATH"');
+  });
+});
+
+d("the collapse reaches an already-shipped box", () => {
+  it("runs from ensure_clawbox_bashrc_path, which step_coding_harness calls", () => {
+    // step_post_update -> step_coding_harness -> ensure_clawbox_bashrc_path is
+    // the only .bashrc path an in-app update takes on BOTH editions:
+    // step_openclaw_install returns before its own call on the Hermes SKU —
+    // which is the box with 23 copies.
+    const fn = extractShellFunction("ensure_clawbox_bashrc_path");
+    expect(fn).toContain("dedupe_vendor_bashrc_path_blocks");
+
+    const harness = extractShellFunction("step_coding_harness");
+    expect(harness).toContain("ensure_clawbox_bashrc_path");
+  });
+});

--- a/src/tests/unit/install-bashrc-vendor-path-dedupe.test.ts
+++ b/src/tests/unit/install-bashrc-vendor-path-dedupe.test.ts
@@ -122,13 +122,19 @@ let bashrc: string;
  * does — through `ensure_clawbox_bashrc_path`, which `step_coding_harness`
  * calls and `step_post_update` reaches on BOTH editions.
  */
-function runBashrcHygiene(home: string = sandbox): { status: number | null; stdout: string; stderr: string } {
+function runBashrcHygiene(
+  home: string = sandbox,
+  /** Shell injected before the function runs — used to stage a concurrent writer. */
+  prelude = "",
+): { status: number | null; stdout: string; stderr: string } {
   const script = [
     "set -euo pipefail",
     `CLAWBOX_HOME=${JSON.stringify(home)}`,
     'CLAWBOX_USER="$(id -un)"',
     "",
     shellConstants(),
+    "",
+    prelude,
     "",
     extractShellFunction("dedupe_vendor_bashrc_path_blocks"),
     "",
@@ -311,6 +317,30 @@ d("~/.bashrc keeps ONE vendor PATH block, however often the vendor appends", () 
 
     expect(fs.lstatSync(bashrc).isSymbolicLink()).toBe(true);
     expect(fs.readFileSync(real, "utf-8")).toBe(bashrcFixture(23));
+  });
+
+  it("leaves the file alone when something wrote to it mid-collapse", () => {
+    // The `mv` is an atomic rename, so no reader sees half a file — but a
+    // rename replaces the INODE, and an append that lands between the read and
+    // the swap would go with the old one. The vendor's installer runs on the
+    // box's own schedule, so it can be alive during an update.
+    fs.writeFileSync(bashrc, bashrcFixture(23), "utf-8");
+
+    // A writer that appends the moment the transform has read the file.
+    const concurrent = [
+      "awk() {",
+      '  command awk "$@"',
+      `  printf '\\n%s\\n%s\\n' ${JSON.stringify(VENDOR_MARKER)} ${JSON.stringify(VENDOR_EXPORT)} >> ${JSON.stringify(bashrc)}`,
+      "}",
+    ].join("\n");
+
+    const run = runBashrcHygiene(sandbox, concurrent);
+
+    expect(run.status, run.stderr).toBe(0);
+    expect(run.stdout).toContain("changed while it was being collapsed");
+    expect(run.stdout).not.toContain("Collapsed");
+    // The concurrent append survives — it was not swapped away with the inode.
+    expect(countOf(read(), VENDOR_MARKER)).toBe(24);
   });
 
   // root ignores the directory mode, so the case cannot be staged there.

--- a/src/tests/unit/install-bashrc-vendor-path-dedupe.test.ts
+++ b/src/tests/unit/install-bashrc-vendor-path-dedupe.test.ts
@@ -319,6 +319,16 @@ d("~/.bashrc keeps ONE vendor PATH block, however often the vendor appends", () 
     expect(fs.readFileSync(real, "utf-8")).toBe(bashrcFixture(23));
   });
 
+  /** A shell function that shadows `name` and appends a vendor block after it runs. */
+  function appendingWrapper(name: string): string {
+    return [
+      `${name}() {`,
+      `  command ${name} "$@"`,
+      `  printf '\\n%s\\n%s\\n' ${JSON.stringify(VENDOR_MARKER)} ${JSON.stringify(VENDOR_EXPORT)} >> ${JSON.stringify(bashrc)}`,
+      "}",
+    ].join("\n");
+  }
+
   it("leaves the file alone when something wrote to it mid-collapse", () => {
     // The `mv` is an atomic rename, so no reader sees half a file — but a
     // rename replaces the INODE, and an append that lands between the read and
@@ -327,19 +337,28 @@ d("~/.bashrc keeps ONE vendor PATH block, however often the vendor appends", () 
     fs.writeFileSync(bashrc, bashrcFixture(23), "utf-8");
 
     // A writer that appends the moment the transform has read the file.
-    const concurrent = [
-      "awk() {",
-      '  command awk "$@"',
-      `  printf '\\n%s\\n%s\\n' ${JSON.stringify(VENDOR_MARKER)} ${JSON.stringify(VENDOR_EXPORT)} >> ${JSON.stringify(bashrc)}`,
-      "}",
-    ].join("\n");
-
-    const run = runBashrcHygiene(sandbox, concurrent);
+    const run = runBashrcHygiene(sandbox, appendingWrapper("awk"));
 
     expect(run.status, run.stderr).toBe(0);
     expect(run.stdout).toContain("changed while it was being collapsed");
     expect(run.stdout).not.toContain("Collapsed");
     // The concurrent append survives — it was not swapped away with the inode.
+    expect(countOf(read(), VENDOR_MARKER)).toBe(24);
+  });
+
+  it("looks once more after the mode is set, not before it", () => {
+    // The check has to be the LAST thing between the look and the rename:
+    // `chown` and `chmod` run on the temp file in between, and an append
+    // landing in that gap would still be swapped away with the old inode.
+    // There is no atomic compare-and-rename, so the window cannot be closed —
+    // only narrowed to one `stat` and one `rename`.
+    fs.writeFileSync(bashrc, bashrcFixture(23), "utf-8");
+
+    const run = runBashrcHygiene(sandbox, appendingWrapper("chmod"));
+
+    expect(run.status, run.stderr).toBe(0);
+    expect(run.stdout).toContain("changed while it was being collapsed");
+    expect(run.stdout).not.toContain("Collapsed");
     expect(countOf(read(), VENDOR_MARKER)).toBe(24);
   });
 


### PR DESCRIPTION
**TASK-758** — a third-party installer grows the box's `~/.bashrc` without bound.

## What was measured

Read-only, on both dev boxes, 2026-09-07:

| | Hermes edition | OpenClaw edition |
|---|---|---|
| `~/.bashrc` | 7,049 B | 4,431 B |
| `grep -c '\.local/bin'` | 25 | 3 |
| `grep -cF 'Added by cua-driver-rs installer'` | **23** | 1 |
| `grep -c '>>> Codex installer >>>'` | 1 | 1 |

The 23 repeats are lines 122-193 of the file — an unfenced comment + `export` pair, appended verbatim each time:

```
<blank>
# Added by cua-driver-rs installer — see https://github.com/trycua/cua
export PATH="/home/clawbox/.local/bin:$PATH"
```

Behaviour is correct today (the directory is on PATH either way), so this is hygiene rather than breakage — but nothing bounds it, and every login shell on that box parses another ~119 B per copy.

## The writer is not ours — that is the finding, and it is what the fix had to work around

The card asked for the writer to be found and fenced. **There is none in this repository.** `grep -rn cua` over `install.sh`, `install-x64.sh`, `scripts/`, `src/`, `config/` and `mcp/` finds nothing, and `install-x64.sh` mentions neither hermes nor cua.

Traced on the box instead, read-only:

* `~/.local/bin/cua-driver` is present on **both** boxes (a symlink into `~/.cua-driver/packages/current/`), so the writer reaches both editions — only the rate differs.
* Hermes' own agent runs the installer on its own. `tools/computer_use/cua_backend.py` fails the driver's runtime contract closed and then, once per process, calls `install_cua_driver()` from `hermes_cli.tools_config` as an automatic repair; that runs the vendor's script from `raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh`, and it is that script which appends the block. `cua_driver_update_check` itself only produces a hint string.
* **The vendor's script does document an opt-out** — `--no-modify-path`, or `CUA_DRIVER_NO_MODIFY_PATH=1`, which it forwards to the Rust installer as `CUA_DRIVER_RS_NO_MODIFY_PATH`. It appends only "when `~/.local/bin` is missing from PATH", i.e. from the PATH of whatever process invoked it. Hermes' own module knobs (`HERMES_CUA_DRIVER_CMD`, `CUA_DRIVER_RS_TELEMETRY_ENABLED`) do not touch the rc write.

So the OpenClaw box has one copy because its driver was installed once and never re-repaired, and the Hermes box has 23 because that repair path has fired 23 times.

**Harness first, and the answer is a finding rather than a fix ClawBox can make here.** The opt-out exists, so the writer *can* be stopped — but only from the environment of the process that invokes it, and that process is `hermes-gateway.service`, which `install.sh:3667` records in as many words as **not written by this repository**. ClawBox invokes the computer-use installer nowhere (`grep -rn 'computer-use|computer_use'` over the tree returns only comments and this PR's own test), so there is no ClawBox call site to pass the flag on. Two further facts say the change would be unproven rather than merely out of scope: that unit already carries `/home/clawbox/.local/bin` on its `PATH`, which is precisely the condition the vendor says suppresses the append — so the 23 copies were written from some *other* invocation context, and which one is not established; and the append is conditional, so setting the variable on the wrong unit would change nothing while looking like a fix.

Naming it is the point: **setting `CUA_DRIVER_NO_MODIFY_PATH=1` wherever that installer is actually invoked would turn this collapse from forever-work into a one-time repair**, and it wants the invoking context measured first. Recorded as a follow-up below rather than half-done here. The collapse is needed either way — every box already carrying copies needs them removed, and this repository can only bound the file it owns.

## The fix

`ensure_clawbox_bashrc_path` — this repository's own `.bashrc` owner — collapses the duplicates to a single **fenced** block:

```
# >>> ClawBox: cua-driver-rs PATH (collapsed) >>>
# Added by cua-driver-rs installer — see https://github.com/trycua/cua
export PATH="/home/clawbox/.local/bin:$PATH"
# <<< ClawBox: cua-driver-rs PATH (collapsed) <<<
```

* **It runs on every update, not once**, precisely because the writer is not ours and will append again: the fence lines are dropped on the way in and written back out, so a later append collapses into the same fence and a second run is a byte-for-byte no-op.
* **The vendor's own comment stays inside the fence.** It says who put the path there, and it is what the next collapse matches on. The block's export line is byte-identical to the one inside the Codex fence three lines from the end of the same file, so the **comment** is the key and never the export — a dedupe keyed on the export would have eaten the Codex block.
* **Only a file with a genuine duplicate is rewritten.** A box with one copy or none is left byte-for-byte alone, so this is not churn on the OpenClaw edition.
* **The survivor keeps the position of the first copy**, so nothing about PATH order moves — on the measured box that copy sits *ahead* of ClawBox's own stanza.
* The blank line the vendor writes above each block goes with the block it belongs to and with nothing else.
* The rewrite is a temp file in the same directory, `chown`/`chmod --reference` from the original, then `mv` — and the `mv` is guarded, because this runs under `set -euo pipefail` from a step the dispatcher calls plainly and a `.bashrc` that cannot be replaced must warn rather than end the update at that line. An empty result is discarded rather than moved into place.

### Why `ensure_clawbox_bashrc_path`

It is the one `.bashrc` path an in-app update takes on **both** editions: `step_post_update` → `step_coding_harness` → here. `step_openclaw_install` has its own call to it but returns before it on the Hermes SKU — which is the box with 23 copies — so hanging the collapse there would have missed exactly the edition that needs it. No new step, no new dispatcher entry, no new root unit.

## RED (unmodified beta `21539548`)

```
 ❯ src/tests/unit/install-bashrc-vendor-path-dedupe.test.ts (11 tests | 4 failed)
     × collapses the box's 23 copies to one fenced block
     × fences the survivor, so the next append is collapsed too
     × collapses again after the vendor has appended over the fence
     × runs from ensure_clawbox_bashrc_path, which step_coding_harness calls

 FAIL … > collapses the box's 23 copies to one fenced block
 AssertionError: the vendor's block must survive exactly once — it says who put the path there:
   expected 23 to be 1

 Test Files  1 failed (1)
      Tests  4 failed | 7 passed (11)
```

The fixture is the measured file's shape: the stock tail, the bun block, the first vendor block *ahead* of ClawBox's own stanza, 22 more after it, install-voice.sh's CUDA exports, and the Codex fence at the end. The seven that pass on beta are the invariants the fix must not break, and they are asserted before and after.

## GREEN

17/17 in the new file (11 at the RED above, six added by the review rounds); the neighbouring install.sh suites (`install-codex-cli`, `install-coding-harness`, `install-coding-harness-repair`, `install-kokoro-tts`, `install-post-update-units`, `install-update-branch-pin`, `root-steps`) plus `openclaw-config-mock-completeness`, `test-timeout-hygiene`, `state-updater-purity` — **11 files / 229 tests**. `bash -n install.sh` clean, `tsc --noEmit` clean, `eslint` clean on the new file.

Proved explicitly rather than assumed: every line of real content survives in order (the whole file compared minus the vendor's own two lines and the fence), the blank-line accounting is exact (22 blocks removed, 22 fewer blanks), the Codex block survives verbatim, the mode survives the rewrite, a second run changes nothing, a fresh append after a collapse collapses again, and `ensure_clawbox_bashrc_path` still writes ClawBox's own stanza into a `.bashrc` that has none.

## Sibling sweep

Every other writer that appends to a box's `~/.bashrc` is already marker-guarded and cannot duplicate: `ensure_clawbox_bashrc_path` (`grep -q 'npm-global/bin'`), `install-x64.sh` (`grep -q 'ClawBox x64 runtime'`), `scripts/install-voice.sh` (`grep -q cusparselt`), `scripts/setup-optimizations.sh` (`grep -q OMP_NUM_THREADS`). The only unfenced appender measured on either box is the third-party one this PR bounds; the vendor Codex block is fenced and appears exactly once on both.

## Both editions

The writer reaches both — the driver is installed on both boxes — so the collapse is not gated on the edition, and the path it runs from (`step_post_update` → `step_coding_harness`) is taken by both. Only the OpenClaw box happens to have nothing to collapse today, and on that box the function measurably does nothing.

## Device leg — read-only, no mutex taken

The census above, plus the block's exact bytes and the installer trace, were read from the two boxes without writing anything: no edit, no message, no restart. **The dedupe deliberately ships through the next update rather than being applied by hand** — a box repaired out of band would prove nothing about the code path that has to repair the fleet.

## Review round — what changed after the first commit

* **False success, on the one path whose design assumption is "the vendor will change".** The "Collapsed N …" line was printed off `mv`'s exit code and never off the outcome, with the pre-count printed as though it were the number removed. Give the vendor's block one extra line between the marker and the export and every block falls through the transform: the file is rewritten byte-identical, the update logs a collapse, and because the count never falls to 1 it re-runs and reprints that line on every update, for ever — the bound gone, the only signal saying it works. The markers are now counted in the rewritten file *before* anything is replaced; exactly one is a collapse, anything else leaves the live file untouched and warns with both numbers.
* **A symlinked `~/.bashrc`** — a dotfiles checkout — was read through the link as root and would have been replaced by the `mv` with a regular file. Left alone now.
* **The reach test proved the wrong half of the chain**: it pinned `step_coding_harness` → `ensure_clawbox_bashrc_path` but not `step_post_update` → `step_coding_harness`, which is the only link that reaches an already-flashed device. Deleting that one call from a list that is edited constantly left the suite green while the collapse went fresh-install-only. Pinned now, along with the errexit contract the comments claim (a warn, never an aborted update) and the two cases above.
* A comment on `step_openclaw_install` that read as the opposite of the code — "before any early-return", sitting *under* the Hermes early-return — now says where that SKU actually gets the stanza.
* **A `.bashrc` that changed mid-collapse is no longer swapped away.** The `mv` is an atomic rename, so no reader sees half a file — but a rename replaces the inode, and an append landing between the read and the swap would go with the old one; the vendor's installer runs on the box's own schedule as the same user, so it can be alive during an update. Size, mtime and inode are recorded before the read and re-checked immediately before the swap, with `chown`/`chmod` done first so the comparison is the last thing before the rename. There is no atomic compare-and-rename, so the window is **narrowed to one `stat` and one `rename`, not closed** — anything stronger needs the vendor's installer to take a lock. Both windows are staged deterministically in the test by shadowing `awk` (mid-read) and `chmod` (post-mode) with functions that append: the concurrent block survives, no collapse is claimed, and moving the check back above `chown` turns the second case red.

## Follow-ups recorded, not done here

* **Stop the writer instead of mopping up**: `CUA_DRIVER_NO_MODIFY_PATH=1` in the environment of whatever invokes the vendor installer. Wants the invoking context measured first, and the unit in question is not written by this repository.
* **An upstream issue against `trycua/cua`** — its `install.sh` should marker-guard its own rc append, the way the Codex installer already does. Left for the owner to decide on posting.
* **Serialising with the vendor's writer** rather than detecting it after the fact. There is no lock either side of a third-party installer Hermes invokes on its own schedule, so the collapse detects divergence and stands down instead; a `flock` would need the writer to take it too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate `cua-driver-rs` PATH entries in `.bashrc` while preserving unrelated configuration and file permissions.
  * Improved handling of malformed, unwritable, empty, or symlinked shell configuration files without interrupting updates.
  * Continued adding the required PATH configuration after cleanup.
  * Made configuration updates safer when files change concurrently or replacement operations fail.
  * Applied consistent PATH handling across installation and update flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->