### PR TITLE
chore(deps): pin fast-uri to 3.1.7 on beta (6 high-severity advisories)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -48,6 +48,7 @@
     },
   },
   "overrides": {
+    "fast-uri": "3.1.7",
     "nanoid": "^3.3.17",
     "postcss": "^8.5.23",
     "sharp": "^0.35.0",
@@ -751,7 +752,7 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
-    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+    "fast-uri": ["fast-uri@3.1.7", "", {}, "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5778,9 +5778,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,10 @@
     "postcss": "^8.5.23",
     "sharp": "^0.35.0",
     "nanoid": "^3.3.17",
-    "vite": "^7.3.5"
+    "vite": "^7.3.5",
+    "fast-uri": "3.1.7"
+  },
+  "resolutions": {
+    "fast-uri": "3.1.7"
   }
 }


### PR DESCRIPTION
Dependabot opened **#591** for this against `main`. It cannot merge there (the required `CodeRabbit` check never arrives on bot PRs, and `main` has `enforce_admins: true`), and `main` is 1,929 commits behind `beta` — so merging it would not reach the product. This lands the same fix where the code lives.

## The advisories

`fast-uri` 3.1.5 → 3.1.7 closes six high-severity issues:

| Advisory | Issue |
|---|---|
| GHSA-fph4-wmhf-6fwf | SSRF via repeated hostname percent-decoding |
| GHSA-f65p-4m7j-42xc | SSRF via malformed IPv6 normalization |
| GHSA-5jgf-p345-68v8 | host confusion — skipped IDN canonicalization |
| GHSA-jqff-g426-hqxp | host confusion — percent-encoded scheme normalization |
| GHSA-58mr-gqgx-xq4g | host confusion — unbalanced IP-literal brackets |
| GHSA-qw65-cvwx-89v3 | authority injection via unvalidated port in `serialize()` |

**Severity in context:** it reaches us transitively through `ajv`, required by `eslint`, `@eslint/eslintrc`, `ajv-formats` and `@modelcontextprotocol/sdk` — lint and schema tooling, not a path where the device parses attacker-controlled URIs. Worth fixing, not an emergency.

## Two decisions worth reviewing

**An override rather than a bump.** `fast-uri` is transitive, so there is no direct dependency to raise. `bun update fast-uri` resolves to **4.1.4** — a major, outside ajv's `^3.0.1` range, and precisely what `.github/dependabot.yml` refuses to take automatically. The `overrides`/`resolutions` pair holds it at 3.1.7 inside the supported range.

**`package-lock.json` is hand-patched.** `npm install --package-lock-only` regenerates far more than this dependency — it pulled **35 unrelated version changes**, including **`@novnc/novnc 1.6.0 → 1.7.0`**. That is the exact bump `dependabot.yml` refuses in a long comment and `src/tests/unit/novnc-pin.test.ts` guards, because 1.7.0 drops `lib/` for `core/` and breaks every subpath import. So only the `fast-uri` entry is edited, with version, tarball and integrity taken from the registry.

Resulting diff: **one version change, nothing added, nothing removed.**

## Drift worth knowing about

`bun.lock` was on **3.1.0** while `package-lock.json` was on **3.1.5** — the two manifests had already diverged before this. Both now read 3.1.7.

## Verification

- `bun install --frozen-lockfile` → *"Checked 554 installs across 669 packages (no changes)"*, so CI's install matches the committed lockfile
- `novnc-pin` + `coding-team` suites: **26/26 pass** — the novnc pin specifically confirmed intact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package resolution settings to use `fast-uri` version 3.1.7 while retaining the existing Vite override.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->