### PR TITLE
fix: scope model catalogue fallback by provider

### DIFF
--- a/src/lib/core-model-lifecycle.ts
+++ b/src/lib/core-model-lifecycle.ts
@@ -164,14 +164,16 @@ function catalogueFor(manifest: unknown, provider: string): unknown {
   const modelCatalog = (manifest as { modelCatalog?: unknown } | null)?.modelCatalog;
   const providers = (modelCatalog as { providers?: unknown } | null)?.providers;
   if (providers && typeof providers === "object" && !Array.isArray(providers)) {
-    const own = (providers as Record<string, unknown>)[provider];
-    if (own !== undefined) return own;
+    if (Object.prototype.hasOwnProperty.call(providers, provider)) {
+      return (providers as Record<string, unknown>)[provider];
+    }
     return {};
   }
   const topLevelProviders = (manifest as { providers?: unknown } | null)?.providers;
   if (topLevelProviders && typeof topLevelProviders === "object" && !Array.isArray(topLevelProviders)) {
-    const shared = (topLevelProviders as Record<string, unknown>)[provider];
-    if (shared !== undefined) return shared;
+    if (Object.prototype.hasOwnProperty.call(topLevelProviders, provider)) {
+      return (topLevelProviders as Record<string, unknown>)[provider];
+    }
   }
   return manifest;
 }

--- a/src/lib/core-model-lifecycle.ts
+++ b/src/lib/core-model-lifecycle.ts
@@ -166,6 +166,12 @@ function catalogueFor(manifest: unknown, provider: string): unknown {
   if (providers && typeof providers === "object" && !Array.isArray(providers)) {
     const own = (providers as Record<string, unknown>)[provider];
     if (own !== undefined) return own;
+    return {};
+  }
+  const topLevelProviders = (manifest as { providers?: unknown } | null)?.providers;
+  if (topLevelProviders && typeof topLevelProviders === "object" && !Array.isArray(topLevelProviders)) {
+    const shared = (topLevelProviders as Record<string, unknown>)[provider];
+    if (shared !== undefined) return shared;
   }
   return manifest;
 }

--- a/src/lib/core-model-lifecycle.ts
+++ b/src/lib/core-model-lifecycle.ts
@@ -167,13 +167,6 @@ function catalogueFor(manifest: unknown, provider: string): unknown {
     if (Object.prototype.hasOwnProperty.call(providers, provider)) {
       return (providers as Record<string, unknown>)[provider];
     }
-    return {};
-  }
-  const topLevelProviders = (manifest as { providers?: unknown } | null)?.providers;
-  if (topLevelProviders && typeof topLevelProviders === "object" && !Array.isArray(topLevelProviders)) {
-    if (Object.prototype.hasOwnProperty.call(topLevelProviders, provider)) {
-      return (topLevelProviders as Record<string, unknown>)[provider];
-    }
   }
   return manifest;
 }

--- a/src/tests/unit/core-model-lifecycle.test.ts
+++ b/src/tests/unit/core-model-lifecycle.test.ts
@@ -114,7 +114,7 @@ describe("coreModelRetired", () => {
     expect(coreModelRetired("anthropic", "claude-opus-4-8")).toBe(true);
   });
 
-  it("does not read sibling provider blocks when the provider map exists", async () => {
+  it("falls back to the whole manifest when the nested provider map misses", async () => {
     writeManifest("deepseek", {
       modelCatalog: {
         providers: {
@@ -126,19 +126,20 @@ describe("coreModelRetired", () => {
       },
     });
     const { coreModelRetired } = await load();
-    expect(coreModelRetired("deepseek", "deepseek-local")).toBe(false);
-    expect(coreModelRetired("deepseek", "deepseek-web")).toBe(false);
+    expect(coreModelRetired("deepseek", "deepseek-local")).toBe(true);
+    expect(coreModelRetired("deepseek", "deepseek-web")).toBe(true);
   });
 
-  it("falls back to top-level providers when modelCatalog.providers is absent", async () => {
+  it("walks the whole flat manifest instead of selecting a top-level provider block", async () => {
     writeManifest("openrouter", {
       providers: {
         openrouter: { models: [{ id: "glm-5.1", status: "deprecated" }] },
       },
+      models: [{ id: "root-retired", status: "deprecated" }],
     });
     const { coreModelRetired } = await load();
     expect(coreModelRetired("openrouter", "glm-5.1")).toBe(true);
-    expect(coreModelRetired("openrouter", "glm-5.2")).toBe(false);
+    expect(coreModelRetired("openrouter", "root-retired")).toBe(true);
   });
 
   it("ignores inherited provider names before falling back to the flat catalogue", async () => {

--- a/src/tests/unit/core-model-lifecycle.test.ts
+++ b/src/tests/unit/core-model-lifecycle.test.ts
@@ -114,6 +114,33 @@ describe("coreModelRetired", () => {
     expect(coreModelRetired("anthropic", "claude-opus-4-8")).toBe(true);
   });
 
+  it("does not read sibling provider blocks when the provider map exists", async () => {
+    writeManifest("deepseek", {
+      modelCatalog: {
+        providers: {
+          "deepseek-cli": { models: [{ id: "deepseek-local", status: "deprecated" }] },
+        },
+      },
+      providers: {
+        deepseek: { models: [{ id: "deepseek-web", status: "deprecated" }] },
+      },
+    });
+    const { coreModelRetired } = await load();
+    expect(coreModelRetired("deepseek", "deepseek-local")).toBe(false);
+    expect(coreModelRetired("deepseek", "deepseek-web")).toBe(false);
+  });
+
+  it("falls back to top-level providers when modelCatalog.providers is absent", async () => {
+    writeManifest("openrouter", {
+      providers: {
+        openrouter: { models: [{ id: "glm-5.1", status: "deprecated" }] },
+      },
+    });
+    const { coreModelRetired } = await load();
+    expect(coreModelRetired("openrouter", "glm-5.1")).toBe(true);
+    expect(coreModelRetired("openrouter", "glm-5.2")).toBe(false);
+  });
+
   it("re-reads a manifest the core replaced under a live process", async () => {
     // The in-app OpenClaw-only update runs INSIDE this server and deliberately
     // does not restart it, so "cached for the process lifetime" would keep a

--- a/src/tests/unit/core-model-lifecycle.test.ts
+++ b/src/tests/unit/core-model-lifecycle.test.ts
@@ -115,7 +115,7 @@ describe("coreModelRetired", () => {
   });
 
   it("falls back to the whole manifest when the nested provider map misses", async () => {
-    writeManifest("deepseek", {
+    fixture.writeManifest("deepseek", {
       modelCatalog: {
         providers: {
           "deepseek-cli": { models: [{ id: "deepseek-local", status: "deprecated" }] },
@@ -125,19 +125,19 @@ describe("coreModelRetired", () => {
         deepseek: { models: [{ id: "deepseek-web", status: "deprecated" }] },
       },
     });
-    const { coreModelRetired } = await load();
+    const { coreModelRetired } = await loadLifecycle();
     expect(coreModelRetired("deepseek", "deepseek-local")).toBe(true);
     expect(coreModelRetired("deepseek", "deepseek-web")).toBe(true);
   });
 
   it("walks the whole flat manifest instead of selecting a top-level provider block", async () => {
-    writeManifest("openrouter", {
+    fixture.writeManifest("openrouter", {
       providers: {
         openrouter: { models: [{ id: "glm-5.1", status: "deprecated" }] },
       },
       models: [{ id: "root-retired", status: "deprecated" }],
     });
-    const { coreModelRetired } = await load();
+    const { coreModelRetired } = await loadLifecycle();
     expect(coreModelRetired("openrouter", "glm-5.1")).toBe(true);
     expect(coreModelRetired("openrouter", "root-retired")).toBe(true);
   });
@@ -146,13 +146,14 @@ describe("coreModelRetired", () => {
     // A provider id may legally match an Object.prototype property. That must
     // not hide the manifest's flat catalogue merely because `providers`
     // inherits `constructor` from Object.prototype.
-    writeManifest("constructor", {
+    fixture.writeManifest("constructor", {
+      modelCatalog: { providers: { openrouter: { models: [{ id: "other-model" }] } } },
       providers: {
         openrouter: { models: [{ id: "other-model" }] },
       },
       models: [{ id: "root-retired", status: "deprecated" }],
     });
-    const { coreModelRetired } = await load();
+    const { coreModelRetired } = await loadLifecycle();
     expect(coreModelRetired("constructor", "root-retired")).toBe(true);
   });
 

--- a/src/tests/unit/core-model-lifecycle.test.ts
+++ b/src/tests/unit/core-model-lifecycle.test.ts
@@ -141,6 +141,20 @@ describe("coreModelRetired", () => {
     expect(coreModelRetired("openrouter", "glm-5.2")).toBe(false);
   });
 
+  it("ignores inherited provider names before falling back to the flat catalogue", async () => {
+    // A provider id may legally match an Object.prototype property. That must
+    // not hide the manifest's flat catalogue merely because `providers`
+    // inherits `constructor` from Object.prototype.
+    writeManifest("constructor", {
+      providers: {
+        openrouter: { models: [{ id: "other-model" }] },
+      },
+      models: [{ id: "root-retired", status: "deprecated" }],
+    });
+    const { coreModelRetired } = await load();
+    expect(coreModelRetired("constructor", "root-retired")).toBe(true);
+  });
+
   it("re-reads a manifest the core replaced under a live process", async () => {
     // The in-app OpenClaw-only update runs INSIDE this server and deliberately
     // does not restart it, so "cached for the process lifetime" would keep a


### PR DESCRIPTION
Follow-up to #738 and replacement for #745, retargeted to `beta` per maintainer guidance.

The model catalogue fallback now stays provider-scoped when `modelCatalog.providers` exists, and only falls back to top-level `providers` when the nested provider map is absent. This prevents one provider from inheriting retirement data from a sibling provider.

Validation:
- focused unit test file: 14 passed
- `npx tsc --noEmit`: passed
- targeted ESLint: passed
- `git diff --check upstream/beta...HEAD`: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved provider-specific model catalogue selection during model retirement checks.
  - Ensured nested provider catalogues take precedence when explicitly available.
  - Added reliable fallback to top-level provider catalogues when nested entries are unavailable.
  - Prevented inherited provider names from being mistaken for valid catalogues.
  - Corrected handling of provider entries explicitly set to undefined, avoiding unintended fallback to the full manifest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->