### PR TITLE
fix: keep reading provider manifests after one that will not parse

### DIFF
--- a/src/lib/core-model-lifecycle.ts
+++ b/src/lib/core-model-lifecycle.ts
@@ -83,14 +83,6 @@ interface CachedManifest {
 const cache = new Map<string, CachedManifest>();
 
 /**
- * The two places the manifest lives, in the order `gateway-pre-start.sh`
- * resolves them: bundled in the core's `dist/extensions`, or beside the config
- * once OpenClaw 2 unbundled the provider into its own installed plugin. The
- * PATHS are that script's; the fallback RULE is not the same one — it falls
- * back on existence alone (`[ ! -f … ]`) and gives up outright on a manifest it
- * cannot parse, while this reads on to the next candidate.
- */
-/**
  * A provider id that can only ever name a directory, never traverse out of one.
  *
  * The id reaches this module from a request query string by way of the catalogue
@@ -100,6 +92,14 @@ const cache = new Map<string, CachedManifest>();
  */
 const SAFE_PROVIDER_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/i;
 
+/**
+ * The two places the manifest lives, in the order `gateway-pre-start.sh`
+ * resolves them: bundled in the core's `dist/extensions`, or beside the config
+ * once OpenClaw 2 unbundled the provider into its own installed plugin. The
+ * PATHS are that script's; the fallback RULE is not the same one — it falls
+ * back on existence alone (`[ ! -f … ]`) and gives up outright on a manifest it
+ * cannot parse, while this reads on to the next candidate.
+ */
 function manifestPaths(provider: string): string[] {
   const bin = findOpenclawBin();
   const paths: string[] = [];
@@ -193,7 +193,8 @@ function retiredFor(provider: string): Set<string> {
     }
     cache.delete(provider);
   }
-  // Set when a candidate EXISTED and could not be used — read or parsed. The
+  // Set when a candidate EXISTED and could not be used — it would not open, or
+  // would not read, or would not parse. The
   // answer that follows then comes from a lower-priority file, and caching it
   // would key the staleness check on that file alone (`cached.file` is the only
   // path re-stat'ed above), so the moment the better manifest became readable
@@ -213,7 +214,14 @@ function retiredFor(provider: string): Set<string> {
     let fd: number;
     try {
       fd = fsSync.openSync(file, "r");
-    } catch {
+    } catch (err) {
+      // ENOENT is genuine ABSENCE — the ordinary OpenClaw 2 layout, where the
+      // provider is unbundled and only the copy beside the config exists.
+      // Anything else (EACCES after a bad chown, EIO on a failing eMMC, EMFILE
+      // under load, ENOTDIR mid-upgrade) is a candidate that IS there and could
+      // not be used, and treating it as absence caches the lower-priority
+      // answer under a re-stat that only ever watches that lower-priority file.
+      if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") degraded = true;
       continue;
     }
     let stat: fsSync.Stats;

--- a/src/lib/core-model-lifecycle.ts
+++ b/src/lib/core-model-lifecycle.ts
@@ -39,6 +39,18 @@ import { findOpenclawBin } from "@/lib/openclaw-config";
  * that ships none, a shape this does not recognise — all answer "not retired",
  * so the picker keeps offering exactly what it offers today. The failure this
  * must never have is the other one: a parse slip that empties a model list.
+ *
+ * KEYED ON THE CATALOGUE PROVIDER, with no inverse mapping, and that is a
+ * decision rather than an oversight. ClawBox's own `clawai` catalogue is served
+ * by deepseek models (`deepseek-v4-flash` and its siblings in
+ * `provider-models.ts`) through the ClawBox AI proxy, and the core ships the
+ * manifest under `deepseek` — so a `clawai` lookup finds no manifest and every
+ * clawai row is answered "not retired". Adding the mapping would let a
+ * lifecycle the core publishes about the DIRECT deepseek route decide what our
+ * proxied plan offers, and those are not the same surface: what the proxy
+ * accepts is our contract with the customer, not the upstream provider's. The
+ * same asymmetry, for the same reason, is documented at `withoutRetiredModels`
+ * for `codex` vs `openai` and pinned by `curated-defaults-offerable.test.ts`.
  */
 
 /** What the harness treats as "do not offer this any more". */
@@ -212,7 +224,12 @@ function retiredFor(provider: string): Set<string> {
     } catch {
       // A manifest we cannot parse is a manifest we know nothing from — and it
       // is NOT cached, so a half-written file is re-read rather than believed.
-      return new Set();
+      // The NEXT candidate is still tried: `npm install -g openclaw@latest`
+      // renaming `dist/extensions` underneath is what leaves the first one
+      // half-written, and the copy beside the config is untouched by it.
+      // Failing open is the rule for a file this cannot read, not a reason to
+      // stop reading the one beside it.
+      continue;
     }
     cache.set(provider, { retired, file, mtimeMs: stat.mtimeMs, size: stat.size, checkedAt: Date.now() });
     return retired;
@@ -228,6 +245,13 @@ function retiredFor(provider: string): Set<string> {
  *
  * `id` may be the bare id (`claude-opus-4-8`) or the fully-qualified one
  * (`z-ai/glm-5.1`); both forms are indexed.
+ *
+ * NO PRODUCTION CALLER TODAY, deliberately: the only consumer, the catalogue
+ * route, holds a LIST and goes through `coreRetiredModels` so a payload of
+ * hundreds of rows costs one lookup rather than hundreds. This is the
+ * single-row form — what the cases in `core-model-lifecycle.test.ts` are
+ * written against, and what a caller asking about ONE model should use instead
+ * of re-deriving the trim-and-membership test against the set.
  */
 export function coreModelRetired(provider: string, id: string): boolean {
   if (!provider || !id) return false;

--- a/src/lib/core-model-lifecycle.ts
+++ b/src/lib/core-model-lifecycle.ts
@@ -83,9 +83,12 @@ interface CachedManifest {
 const cache = new Map<string, CachedManifest>();
 
 /**
- * The two places the manifest lives, in the order `gateway-pre-start.sh` tries
- * them: bundled in the core's `dist/extensions`, or beside the config once
- * OpenClaw 2 unbundled the provider into its own installed plugin.
+ * The two places the manifest lives, in the order `gateway-pre-start.sh`
+ * resolves them: bundled in the core's `dist/extensions`, or beside the config
+ * once OpenClaw 2 unbundled the provider into its own installed plugin. The
+ * PATHS are that script's; the fallback RULE is not the same one — it falls
+ * back on existence alone (`[ ! -f … ]`) and gives up outright on a manifest it
+ * cannot parse, while this reads on to the next candidate.
  */
 /**
  * A provider id that can only ever name a directory, never traverse out of one.
@@ -190,6 +193,15 @@ function retiredFor(provider: string): Set<string> {
     }
     cache.delete(provider);
   }
+  // Set when a candidate EXISTED and could not be used — read or parsed. The
+  // answer that follows then comes from a lower-priority file, and caching it
+  // would key the staleness check on that file alone (`cached.file` is the only
+  // path re-stat'ed above), so the moment the better manifest became readable
+  // again nothing would look at it: one bad read would pin the wrong source for
+  // the life of the process. A candidate that is simply ABSENT is not that —
+  // that is the ordinary shape of an OpenClaw 2 box, where the bundled path
+  // never exists and the beside-config answer is the right one to cache.
+  let degraded = false;
   for (const file of manifestPaths(provider)) {
     // Opened ONCE and both stat and read taken from the descriptor. A
     // `statSync` followed by a `readFileSync` of the same path is two lookups
@@ -210,6 +222,7 @@ function retiredFor(provider: string): Set<string> {
       stat = fsSync.fstatSync(fd);
       raw = fsSync.readFileSync(fd, "utf-8");
     } catch {
+      degraded = true;
       continue;
     } finally {
       try {
@@ -222,16 +235,24 @@ function retiredFor(provider: string): Set<string> {
     try {
       collect(catalogueFor(JSON.parse(raw), provider), retired);
     } catch {
-      // A manifest we cannot parse is a manifest we know nothing from — and it
-      // is NOT cached, so a half-written file is re-read rather than believed.
-      // The NEXT candidate is still tried: `npm install -g openclaw@latest`
-      // renaming `dist/extensions` underneath is what leaves the first one
-      // half-written, and the copy beside the config is untouched by it.
-      // Failing open is the rule for a file this cannot read, not a reason to
-      // stop reading the one beside it.
+      // A manifest we cannot parse is a manifest we know nothing from — but the
+      // NEXT candidate may still be readable, and giving up on the lookup threw
+      // that away. What actually produces unparsable bytes here is a write in
+      // PLACE: `gateway-pre-start.sh` rewrites this very file with python on
+      // every gateway start to declare deepseek's xhigh effort, and a truncated
+      // write (a full disk, a killed process) leaves the remains behind.
+      // `npm install -g`'s rename is not one of those cases — a rename is
+      // atomic, so a reader sees the whole old file or ENOENT, which the
+      // `openSync` catch above has always carried to the next candidate.
+      //
+      // Nothing is cached: neither this file (the next boot may repair it) nor
+      // the answer read past it (see `degraded`).
+      degraded = true;
       continue;
     }
-    cache.set(provider, { retired, file, mtimeMs: stat.mtimeMs, size: stat.size, checkedAt: Date.now() });
+    if (!degraded) {
+      cache.set(provider, { retired, file, mtimeMs: stat.mtimeMs, size: stat.size, checkedAt: Date.now() });
+    }
     return retired;
   }
   // Nothing found. Deliberately NOT cached: on a box with no core yet, or one
@@ -250,8 +271,10 @@ function retiredFor(provider: string): Set<string> {
  * route, holds a LIST and goes through `coreRetiredModels` so a payload of
  * hundreds of rows costs one lookup rather than hundreds. This is the
  * single-row form — what the cases in `core-model-lifecycle.test.ts` are
- * written against, and what a caller asking about ONE model should use instead
- * of re-deriving the trim-and-membership test against the set.
+ * written against. It is not exactly the set test: it TRIMS the id first, while
+ * `withoutRetiredModels` asks the set for the id its catalogue holds. So a
+ * per-row caller may use either, but converting a loop from one to the other
+ * changes the answer for a padded id.
  */
 export function coreModelRetired(provider: string, id: string): boolean {
   if (!provider || !id) return false;

--- a/src/tests/helpers/core-model-manifests.ts
+++ b/src/tests/helpers/core-model-manifests.ts
@@ -22,8 +22,6 @@ import { saveEnv } from "@/tests/helpers/env";
 const ENV = ["HOME", "OPENCLAW_HOME", "CLAWBOX_OPENCLAW_HOME"];
 
 export interface ManifestFixture {
-  /** The temporary home every candidate path is resolved under. */
-  home: string;
   /**
    * An absolute `openclaw` binary path whose bundled candidate
    * (`<bin>/../lib/node_modules/openclaw/dist/extensions`) lands inside the
@@ -44,7 +42,7 @@ export interface ManifestFixture {
   cleanup(): void;
 }
 
-function writeJson(file: string, raw: string): void {
+function writeFile(file: string, raw: string): void {
   fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(file, raw);
 }
@@ -62,12 +60,11 @@ export function createManifestFixture(prefix: string): ManifestFixture {
     path.join(home, "lib", "node_modules", "openclaw", "dist", "extensions", provider, "openclaw.plugin.json");
 
   return {
-    home,
     bin: path.join(home, "bin", "openclaw"),
-    writeManifest: (provider, body) => writeJson(beside(provider), JSON.stringify(body)),
-    writeRawManifest: (provider, raw) => writeJson(beside(provider), raw),
-    writeBundledManifest: (provider, body) => writeJson(bundled(provider), JSON.stringify(body)),
-    writeRawBundledManifest: (provider, raw) => writeJson(bundled(provider), raw),
+    writeManifest: (provider, body) => writeFile(beside(provider), JSON.stringify(body)),
+    writeRawManifest: (provider, raw) => writeFile(beside(provider), raw),
+    writeBundledManifest: (provider, body) => writeFile(bundled(provider), JSON.stringify(body)),
+    writeRawBundledManifest: (provider, raw) => writeFile(bundled(provider), raw),
     cleanup: () => {
       restoreEnv();
       fs.rmSync(home, { recursive: true, force: true });

--- a/src/tests/helpers/core-model-manifests.ts
+++ b/src/tests/helpers/core-model-manifests.ts
@@ -1,0 +1,83 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { saveEnv } from "@/tests/helpers/env";
+
+/**
+ * A throwaway OpenClaw home, plus the two places a provider manifest can live.
+ *
+ * Both suites that exercise `src/lib/core-model-lifecycle.ts` carried their own
+ * copy of this scaffolding — the same three env vars saved and restored, the
+ * same `mkdtemp`, the same `extensions/<provider>/openclaw.plugin.json` join —
+ * and the copies had already drifted: one could write raw bytes and the other
+ * only `JSON.stringify`ed ones, one knew the bundled `dist/extensions`
+ * candidate and the other only neutralised it. One helper, so that where the
+ * core keeps a manifest is written down once.
+ *
+ * `manifestPaths` reads `CLAWBOX_OPENCLAW_HOME` first, then `OPENCLAW_HOME`,
+ * then `$HOME/.openclaw`, so all three are aimed at the fixture — pointing only
+ * one leaves the lookup wherever the surrounding environment aimed it, and
+ * `vitest.config.ts` deliberately aims them at empty directories.
+ */
+const ENV = ["HOME", "OPENCLAW_HOME", "CLAWBOX_OPENCLAW_HOME"];
+
+export interface ManifestFixture {
+  /** The temporary home every candidate path is resolved under. */
+  home: string;
+  /**
+   * An absolute `openclaw` binary path whose bundled candidate
+   * (`<bin>/../lib/node_modules/openclaw/dist/extensions`) lands inside the
+   * fixture. Hand it to whatever the suite has mocked `findOpenclawBin` with;
+   * a bare name — what `findOpenclawBin` answers where no core is installed —
+   * drops the bundled candidate entirely.
+   */
+  bin: string;
+  /** A manifest where OpenClaw 2 puts an unbundled provider's: beside the config. */
+  writeManifest(provider: string, body: unknown): void;
+  /** The same file, byte for byte — for bytes `JSON.stringify` would repair. */
+  writeRawManifest(provider: string, raw: string): void;
+  /** A manifest bundled with the core, the candidate tried FIRST. */
+  writeBundledManifest(provider: string, body: unknown): void;
+  /** The same bundled file, byte for byte. */
+  writeRawBundledManifest(provider: string, raw: string): void;
+  /** Restore the environment and remove the temporary home. */
+  cleanup(): void;
+}
+
+function writeJson(file: string, raw: string): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, raw);
+}
+
+export function createManifestFixture(prefix: string): ManifestFixture {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const restoreEnv = saveEnv(...ENV);
+  process.env.HOME = home;
+  process.env.OPENCLAW_HOME = path.join(home, ".openclaw");
+  process.env.CLAWBOX_OPENCLAW_HOME = path.join(home, ".openclaw");
+
+  const beside = (provider: string) =>
+    path.join(home, ".openclaw", "extensions", provider, "openclaw.plugin.json");
+  const bundled = (provider: string) =>
+    path.join(home, "lib", "node_modules", "openclaw", "dist", "extensions", provider, "openclaw.plugin.json");
+
+  return {
+    home,
+    bin: path.join(home, "bin", "openclaw"),
+    writeManifest: (provider, body) => writeJson(beside(provider), JSON.stringify(body)),
+    writeRawManifest: (provider, raw) => writeJson(beside(provider), raw),
+    writeBundledManifest: (provider, body) => writeJson(bundled(provider), JSON.stringify(body)),
+    writeRawBundledManifest: (provider, raw) => writeJson(bundled(provider), raw),
+    cleanup: () => {
+      restoreEnv();
+      fs.rmSync(home, { recursive: true, force: true });
+    },
+  };
+}
+
+/** The module under test, with its manifest cache cleared. */
+export async function loadLifecycle() {
+  const mod = await import("@/lib/core-model-lifecycle");
+  mod.resetCoreModelLifecycle();
+  return mod;
+}

--- a/src/tests/unit/core-model-lifecycle.test.ts
+++ b/src/tests/unit/core-model-lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fsSync from "fs";
 import { createManifestFixture, loadLifecycle, type ManifestFixture } from "@/tests/helpers/core-model-manifests";
 
 /**
@@ -260,6 +261,66 @@ describe("coreModelRetired", () => {
       const retired = coreRetiredModels("anthropic");
       expect(retired.has("claude-opus-4-7")).toBe(true);
       expect(retired.has("claude-opus-4-8")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not treat a manifest it cannot OPEN as one that is not there", async () => {
+    // EACCES after a bad chown, EIO on a failing eMMC, EMFILE under load: the
+    // file is there and cannot be used, which is the same degraded read as a
+    // truncated one — and caching the answer found past it keys the whole
+    // provider on the lower-priority file, since the staleness re-stat only
+    // ever stats the file it cached. The repaired manifest would then never be
+    // looked at again for the life of the web server.
+    fixture.writeBundledManifest("anthropic", { models: [{ id: "claude-opus-4-7", status: "deprecated" }] });
+    fixture.writeManifest("anthropic", { models: [{ id: "claude-opus-4-8", status: "deprecated" }] });
+    bin.override = fixture.bin;
+
+    // The permission failure, mocked rather than chmod'ed: a suite that runs as
+    // root — every container CI job — reads a 000 file perfectly well, and the
+    // case would pass by testing nothing.
+    let refuseBundled = true;
+    const realOpen = fsSync.openSync;
+    vi.spyOn(fsSync, "openSync").mockImplementation(((file: fsSync.PathLike, ...rest: unknown[]) => {
+      if (refuseBundled && String(file).includes("dist/extensions")) {
+        throw Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+      }
+      return (realOpen as (...args: unknown[]) => number)(file, ...rest);
+    }) as typeof fsSync.openSync);
+
+    const { coreRetiredModels } = await loadLifecycle();
+    expect(coreRetiredModels("anthropic").has("claude-opus-4-8")).toBe(true);
+
+    // Repaired. Time frozen, so a cached answer would still be inside the stat
+    // floor and only a re-read of both candidates can change what is returned.
+    refuseBundled = false;
+    vi.useFakeTimers();
+    try {
+      const retired = coreRetiredModels("anthropic");
+      expect(retired.has("claude-opus-4-7")).toBe(true);
+      expect(retired.has("claude-opus-4-8")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still caches the answer when the better candidate is simply not there", async () => {
+    // The other half of the rule, and the load-bearing one: on every OpenClaw 2
+    // box the bundled path does not exist at all, and that is not a degraded
+    // read. Without this the whole provider would re-open and re-read a file on
+    // every catalogue request — the syscall storm the stat floor exists to stop.
+    fixture.writeManifest("openai", { models: [{ id: "gpt-5.5", status: "deprecated" }] });
+    bin.override = fixture.bin; // absolute, so the bundled candidate is TRIED
+    const { coreRetiredModels } = await loadLifecycle();
+    expect(coreRetiredModels("openai").has("gpt-5.5")).toBe(true);
+
+    // Rewritten under a frozen clock: a cached answer is the only thing that
+    // can still say "retired" here.
+    fixture.writeManifest("openai", { models: [{ id: "gpt-5.5" }] });
+    vi.useFakeTimers();
+    try {
+      expect(coreRetiredModels("openai").has("gpt-5.5")).toBe(true);
     } finally {
       vi.useRealTimers();
     }

--- a/src/tests/unit/core-model-lifecycle.test.ts
+++ b/src/tests/unit/core-model-lifecycle.test.ts
@@ -1,13 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import fs from "fs";
-import os from "os";
-import path from "path";
+import { createManifestFixture, loadLifecycle, type ManifestFixture } from "@/tests/helpers/core-model-manifests";
 
-// The installed core, when there is one, is the FIRST place the module looks —
-// and this machine has one, so a case about "no manifest anywhere" would read
-// the real /usr/lib copy instead. Neutralised to a bare name, which is exactly
-// what `findOpenclawBin` itself answers on a box with no core installed.
-vi.mock("@/lib/openclaw-config", () => ({ findOpenclawBin: () => "openclaw" }));
+/**
+ * The binary the lifecycle module resolves the BUNDLED candidate from.
+ *
+ * Defaulted to a bare name — exactly what `findOpenclawBin` answers on a box
+ * with no core installed — because this machine has a core, and a case about
+ * "no manifest anywhere" would otherwise read the real /usr/lib copy. The one
+ * case that means to exercise the bundled candidate points it at the fixture.
+ */
+const bin = vi.hoisted(() => ({ override: "openclaw" }));
+vi.mock("@/lib/openclaw-config", () => ({ findOpenclawBin: () => bin.override }));
 
 /**
  * The picker must not offer what the harness has retired.
@@ -21,56 +24,18 @@ vi.mock("@/lib/openclaw-config", () => ({ findOpenclawBin: () => "openclaw" }));
  * every way of failing to read it is harmless.
  */
 
-let tmpHome: string;
-
-/**
- * Every variable the lookup consults, aimed at the fixture.
- *
- * `CLAWBOX_OPENCLAW_HOME` is in here because `manifestPaths` reads it FIRST,
- * ahead of `OPENCLAW_HOME`, and a device carries it — `install-x64.sh` bakes it
- * into the web-server unit and `updater.ts` exports it into every gateway
- * pre-start child. `vitest.config.ts` already floors it to `""` for the whole
- * suite, so this is not a live failure; it is this file no longer depending on
- * a config-level floor to point its own fixture at itself.
- */
-const ENV = ["HOME", "OPENCLAW_HOME", "CLAWBOX_OPENCLAW_HOME"] as const;
-const saved: Record<string, string | undefined> = {};
+let fixture: ManifestFixture;
 
 beforeEach(() => {
   vi.resetModules();
-  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "core-lifecycle-"));
-  for (const key of ENV) saved[key] = process.env[key];
-  process.env.HOME = tmpHome;
-  process.env.OPENCLAW_HOME = path.join(tmpHome, ".openclaw");
-  process.env.CLAWBOX_OPENCLAW_HOME = path.join(tmpHome, ".openclaw");
+  bin.override = "openclaw";
+  fixture = createManifestFixture("core-lifecycle-");
 });
 
 afterEach(() => {
-  for (const key of ENV) {
-    if (saved[key] === undefined) delete process.env[key];
-    else process.env[key] = saved[key];
-  }
-  fs.rmSync(tmpHome, { recursive: true, force: true });
+  fixture.cleanup();
   vi.restoreAllMocks();
 });
-
-/** Write a provider manifest where OpenClaw 2 puts it: beside the config. */
-function writeManifest(provider: string, body: unknown): void {
-  writeRawManifest(provider, JSON.stringify(body));
-}
-
-/** The same file, byte for byte — for the bytes `JSON.stringify` would repair. */
-function writeRawManifest(provider: string, raw: string): void {
-  const dir = path.join(tmpHome, ".openclaw", "extensions", provider);
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(dir, "openclaw.plugin.json"), raw);
-}
-
-async function load() {
-  const mod = await import("@/lib/core-model-lifecycle");
-  mod.resetCoreModelLifecycle();
-  return mod;
-}
 
 /**
  * The anthropic manifest's REAL nesting on 2026.8.1, cut to what matters:
@@ -103,8 +68,8 @@ const ANTHROPIC = {
 
 describe("coreModelRetired", () => {
   it("reads the retirement the core itself published", async () => {
-    writeManifest("anthropic", ANTHROPIC);
-    const { coreModelRetired } = await load();
+    fixture.writeManifest("anthropic", ANTHROPIC);
+    const { coreModelRetired } = await loadLifecycle();
     expect(coreModelRetired("anthropic", "claude-opus-4-8")).toBe(true);
     expect(coreModelRetired("anthropic", "claude-opus-5")).toBe(false);
   });
@@ -113,11 +78,11 @@ describe("coreModelRetired", () => {
     // `catalog.filter(e => … e.status !== "deprecated" && e.status !== "disabled")`
     // in the installed core's list probe. `disabled` is the stronger signal;
     // reading only half the harness's predicate is not deferring to it.
-    writeManifest("google", { models: [
+    fixture.writeManifest("google", { models: [
       { id: "gemini-old", status: "disabled" },
       { id: "gemini-2.5-flash" },
     ] });
-    const { coreModelRetired } = await load();
+    const { coreModelRetired } = await loadLifecycle();
     expect(coreModelRetired("google", "gemini-old")).toBe(true);
     expect(coreModelRetired("google", "gemini-2.5-flash")).toBe(false);
   });
@@ -127,8 +92,8 @@ describe("coreModelRetired", () => {
     // slashed ones for nvidia (`z-ai/glm-5.1`). The caller holds whichever
     // form its own catalogue uses, and a lookup that only matched one would
     // fail open — silently, which is this module's stated anti-goal.
-    writeManifest("openrouter", { models: [{ id: "z-ai/glm-5.1", status: "deprecated" }] });
-    const { coreModelRetired } = await load();
+    fixture.writeManifest("openrouter", { models: [{ id: "z-ai/glm-5.1", status: "deprecated" }] });
+    const { coreModelRetired } = await loadLifecycle();
     expect(coreModelRetired("openrouter", "z-ai/glm-5.1")).toBe(true);
     expect(coreModelRetired("openrouter", "glm-5.1")).toBe(true);
     expect(coreModelRetired("openrouter", "glm-5.2")).toBe(false);
@@ -139,11 +104,11 @@ describe("coreModelRetired", () => {
     // `claude-cli` and `anthropic` — and they are different surfaces, not
     // copies. A model retired on the narrower route must not vanish from the
     // wider one, where the core still lists and routes it.
-    writeManifest("anthropic", { modelCatalog: { providers: {
+    fixture.writeManifest("anthropic", { modelCatalog: { providers: {
       "claude-cli": { models: [{ id: "claude-sonnet-5", status: "deprecated" }] },
       anthropic: { models: [{ id: "claude-sonnet-5" }, { id: "claude-opus-4-8", status: "deprecated" }] },
     } } });
-    const { coreModelRetired } = await load();
+    const { coreModelRetired } = await loadLifecycle();
     expect(coreModelRetired("anthropic", "claude-sonnet-5")).toBe(false);
     expect(coreModelRetired("anthropic", "claude-opus-4-8")).toBe(true);
   });
@@ -153,11 +118,11 @@ describe("coreModelRetired", () => {
     // does not restart it, so "cached for the process lifetime" would keep a
     // retired model on offer until a reboot — and a read taken while
     // `npm install -g` is mid-rename would pin "nothing is retired" forever.
-    writeManifest("openai", { models: [{ id: "gpt-5.5" }] });
-    const { coreModelRetired } = await load();
+    fixture.writeManifest("openai", { models: [{ id: "gpt-5.5" }] });
+    const { coreModelRetired } = await loadLifecycle();
     expect(coreModelRetired("openai", "gpt-5.5")).toBe(false);
 
-    writeManifest("openai", { models: [{ id: "gpt-5.5", status: "deprecated" }, { id: "gpt-5.6-sol" }] });
+    fixture.writeManifest("openai", { models: [{ id: "gpt-5.5", status: "deprecated" }, { id: "gpt-5.6-sol" }] });
     // Past the stat floor, which exists so a payload of hundreds of rows costs
     // one syscall rather than hundreds — not to hold an answer for a minute.
     vi.useFakeTimers();
@@ -173,9 +138,9 @@ describe("coreModelRetired", () => {
     // "There is no core yet" and "there is nothing retired" are different
     // answers, and caching the first as the second is how a filter turns
     // itself off for the life of a process with no log line.
-    const { coreModelRetired } = await load();
+    const { coreModelRetired } = await loadLifecycle();
     expect(coreModelRetired("openai", "gpt-5.5")).toBe(false);
-    writeManifest("openai", { models: [{ id: "gpt-5.5", status: "deprecated" }] });
+    fixture.writeManifest("openai", { models: [{ id: "gpt-5.5", status: "deprecated" }] });
     expect(coreModelRetired("openai", "gpt-5.5")).toBe(true);
   });
 
@@ -184,13 +149,13 @@ describe("coreModelRetired", () => {
     // modelCatalog, one copy per auth mode — and the ids are the same in all of
     // them. A fixed path that went stale would answer "nothing is deprecated",
     // which is the failure this file replaces.
-    writeManifest("openai", {
+    fixture.writeManifest("openai", {
       auth: {
         "api-key": { models: [{ id: "gpt-5.5", status: "deprecated", replacedBy: "gpt-5.6-sol" }] },
         oauth: { models: [{ id: "gpt-5.6-sol" }] },
       },
     });
-    const { coreModelRetired } = await load();
+    const { coreModelRetired } = await loadLifecycle();
     expect(coreModelRetired("openai", "gpt-5.5")).toBe(true);
     expect(coreModelRetired("openai", "gpt-5.6-sol")).toBe(false);
   });
@@ -199,19 +164,19 @@ describe("coreModelRetired", () => {
     // A box with no core, no plugin, an unreadable file or a shape this does
     // not recognise must leave the picker exactly as it is. The failure this
     // must never have is emptying a customer's model list over a parse slip.
-    const { coreModelRetired } = await load();
+    const { coreModelRetired } = await loadLifecycle();
     expect(coreModelRetired("anthropic", "claude-opus-4-8")).toBe(false);
 
     // Valid JSON, and nothing this module knows how to read.
-    writeManifest("openrouter", "not a catalogue at all");
-    const shape = await load();
+    fixture.writeManifest("openrouter", "not a catalogue at all");
+    const shape = await loadLifecycle();
     expect(shape.coreModelRetired("openrouter", "anything")).toBe(false);
 
     // Not JSON at all, written as RAW BYTES: `JSON.stringify("}{ not json")`
     // is itself a valid JSON string, so putting this through `writeManifest`
     // would take the shape path above and leave the `JSON.parse` catch unrun.
-    writeRawManifest("gemini", "}{ not json");
-    const broken = await load();
+    fixture.writeRawManifest("gemini", "}{ not json");
+    const broken = await loadLifecycle();
     expect(broken.coreModelRetired("gemini", "anything")).toBe(false);
   });
 
@@ -221,12 +186,12 @@ describe("coreModelRetired", () => {
     // a fair answer about a file it successfully read, so it is cached — which
     // is what makes the parse branch's refusal to cache a deliberate difference
     // rather than an accident of where the `return` landed.
-    writeManifest("google", "not a catalogue at all");
-    const { coreModelRetired } = await load();
+    fixture.writeManifest("google", "not a catalogue at all");
+    const { coreModelRetired } = await loadLifecycle();
     vi.useFakeTimers();
     try {
       expect(coreModelRetired("google", "gemini-old")).toBe(false);
-      writeManifest("google", { models: [{ id: "gemini-old", status: "deprecated" }] });
+      fixture.writeManifest("google", { models: [{ id: "gemini-old", status: "deprecated" }] });
       expect(coreModelRetired("google", "gemini-old")).toBe(false);
     } finally {
       vi.useRealTimers();
@@ -240,18 +205,34 @@ describe("coreModelRetired", () => {
     // failed on is the one `npm install -g openclaw@latest` is halfway through
     // writing. Caching that would pin "nothing is retired" for the life of the
     // process, which is the failure this module exists to survive.
-    writeRawManifest("openai", "}{ not json");
-    const { coreModelRetired } = await load();
+    fixture.writeRawManifest("openai", "}{ not json");
+    const { coreModelRetired } = await loadLifecycle();
     // Time frozen, so a cached empty set would still be inside the stat floor
     // and the second answer can only have come from a re-read.
     vi.useFakeTimers();
     try {
       expect(coreModelRetired("openai", "gpt-5.5")).toBe(false);
-      writeManifest("openai", { models: [{ id: "gpt-5.5", status: "deprecated" }] });
+      fixture.writeManifest("openai", { models: [{ id: "gpt-5.5", status: "deprecated" }] });
       expect(coreModelRetired("openai", "gpt-5.5")).toBe(true);
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("does not let a manifest it cannot parse hide the next candidate", async () => {
+    // There are two candidates because the provider's manifest moved: bundled
+    // in the core's `dist/extensions`, or beside the config once OpenClaw 2
+    // unbundled the provider into its own installed plugin. `npm install -g
+    // openclaw@latest` renaming `dist/extensions` underneath leaves the FIRST
+    // one half-written — the exact window this module exists to survive — and
+    // giving up on the whole lookup there discards a perfectly readable second
+    // manifest. Failing open is this file's rule for what it CANNOT read; it is
+    // not a reason to stop reading what it can.
+    fixture.writeRawBundledManifest("anthropic", "}{ not json");
+    fixture.writeManifest("anthropic", { models: [{ id: "claude-opus-4-8", status: "deprecated" }] });
+    bin.override = fixture.bin;
+    const { coreRetiredModels } = await loadLifecycle();
+    expect(coreRetiredModels("anthropic").has("claude-opus-4-8")).toBe(true);
   });
 
   it("refuses a provider id that could name anything but a directory", async () => {
@@ -260,8 +241,8 @@ describe("coreModelRetired", () => {
     // ships is outside `[a-z0-9-]`, so anything else cannot have a manifest —
     // and refusing here closes the traversal class rather than relying on the
     // caller to have validated first.
-    writeManifest("anthropic", ANTHROPIC);
-    const { coreModelRetired, coreRetiredModels } = await load();
+    fixture.writeManifest("anthropic", ANTHROPIC);
+    const { coreModelRetired, coreRetiredModels } = await loadLifecycle();
     for (const bad of ["../anthropic", "a/b", "..", "anthropic\u0000", "-leading"]) {
       expect(coreModelRetired(bad, "claude-opus-4-8")).toBe(false);
       expect(coreRetiredModels(bad).size).toBe(0);
@@ -269,8 +250,8 @@ describe("coreModelRetired", () => {
   });
 
   it("never reports a model the manifest does not name", async () => {
-    writeManifest("anthropic", ANTHROPIC);
-    const { coreModelRetired } = await load();
+    fixture.writeManifest("anthropic", ANTHROPIC);
+    const { coreModelRetired } = await loadLifecycle();
     expect(coreModelRetired("anthropic", "claude-something-else")).toBe(false);
     expect(coreModelRetired("", "claude-opus-5")).toBe(false);
     expect(coreModelRetired("anthropic", "")).toBe(false);

--- a/src/tests/unit/core-model-lifecycle.test.ts
+++ b/src/tests/unit/core-model-lifecycle.test.ts
@@ -235,6 +235,50 @@ describe("coreModelRetired", () => {
     expect(coreRetiredModels("anthropic").has("claude-opus-4-8")).toBe(true);
   });
 
+  it("goes back to the better manifest once it parses again", async () => {
+    // The other half of the fall-through, and the reason the answer read past a
+    // broken candidate is not cached: the staleness check re-stats ONE file —
+    // the one that was cached — so caching the beside-config answer here would
+    // key the whole provider on it and the repaired bundled manifest would
+    // never be looked at again. That is the probe-once class, in the file
+    // written to defeat it: a single unlucky read during an update would pin
+    // the wrong source for the life of the web server.
+    //
+    // This also pins the candidate ORDER for the case above it: the assertion
+    // can only flip if the bundled path really is where the module looks.
+    fixture.writeRawBundledManifest("anthropic", "}{ not json");
+    fixture.writeManifest("anthropic", { models: [{ id: "claude-opus-4-8", status: "deprecated" }] });
+    bin.override = fixture.bin;
+    const { coreRetiredModels } = await loadLifecycle();
+    expect(coreRetiredModels("anthropic").has("claude-opus-4-8")).toBe(true);
+
+    fixture.writeBundledManifest("anthropic", { models: [{ id: "claude-opus-4-7", status: "deprecated" }] });
+    // Time frozen, so a cached set would still be inside the stat floor and the
+    // new answer can only have come from a re-read of both candidates.
+    vi.useFakeTimers();
+    try {
+      const retired = coreRetiredModels("anthropic");
+      expect(retired.has("claude-opus-4-7")).toBe(true);
+      expect(retired.has("claude-opus-4-8")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not read the deepseek manifest for the clawai catalogue", async () => {
+    // The asymmetry the module docblock records as deliberate: ClawBox's own
+    // `clawai` catalogue is served by deepseek models through the ClawBox AI
+    // proxy, and the lookup is keyed on the CATALOGUE provider with no inverse
+    // mapping — what the proxy accepts is our contract with the customer, not
+    // the upstream provider's lifecycle. Pinned so that "fixing the missing
+    // mapping" cannot pass the suite, exactly as the codex/openai twin is
+    // pinned in curated-defaults-offerable.test.ts.
+    fixture.writeManifest("deepseek", { models: [{ id: "deepseek-v4-flash", status: "deprecated" }] });
+    const { coreRetiredModels } = await loadLifecycle();
+    expect(coreRetiredModels("deepseek").has("deepseek-v4-flash")).toBe(true);
+    expect(coreRetiredModels("clawai").has("deepseek-v4-flash")).toBe(false);
+  });
+
   it("refuses a provider id that could name anything but a directory", async () => {
     // The id reaches this module from a request query string by way of the
     // catalogue payload and is joined into a filesystem path. Nothing the core

--- a/src/tests/unit/curated-defaults-offerable.test.ts
+++ b/src/tests/unit/curated-defaults-offerable.test.ts
@@ -1,8 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import fs from "fs";
-import os from "os";
-import path from "path";
 import { CATALOG_PROVIDERS, PROVIDER_CATALOGS } from "@/lib/provider-models";
+import { createManifestFixture, loadLifecycle, type ManifestFixture } from "@/tests/helpers/core-model-manifests";
 
 /**
  * A cold-start default the picker would refuse to show is a picker with nothing
@@ -53,12 +51,6 @@ vi.mock("@/lib/openclaw-config", async (importActual) => {
   return { ...actual, findOpenclawBin: () => bin.override ?? actual.findOpenclawBin() };
 });
 
-async function lifecycle() {
-  const mod = await import("@/lib/core-model-lifecycle");
-  mod.resetCoreModelLifecycle();
-  return mod;
-}
-
 describe("every catalog provider's cold-start default is one the picker will show", () => {
   for (const provider of CATALOG_PROVIDERS) {
     const catalog = PROVIDER_CATALOGS[provider];
@@ -70,54 +62,37 @@ describe("every catalog provider's cold-start default is one the picker will sho
     });
 
     it(`${provider}: the installed core has not retired the default`, async () => {
-      const { coreRetiredModels } = await lifecycle();
+      const { coreRetiredModels } = await loadLifecycle();
       expect(coreRetiredModels(provider).has(defaultId)).toBe(false);
     });
   }
 });
 
 describe("against a manifest the module itself resolves", () => {
-  let tmpHome: string;
-  const ENV = ["HOME", "OPENCLAW_HOME", "CLAWBOX_OPENCLAW_HOME"] as const;
-  const saved: Record<string, string | undefined> = {};
+  let fixture: ManifestFixture;
 
   beforeEach(() => {
-    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "curated-defaults-"));
-    for (const key of ENV) saved[key] = process.env[key];
-    process.env.HOME = tmpHome;
-    // Both spellings, at the same fixture. `manifestPaths` reads
-    // `CLAWBOX_OPENCLAW_HOME` FIRST, so pointing only `OPENCLAW_HOME` would
-    // leave the lookup wherever the surrounding environment aimed it.
-    process.env.OPENCLAW_HOME = path.join(tmpHome, ".openclaw");
-    process.env.CLAWBOX_OPENCLAW_HOME = path.join(tmpHome, ".openclaw");
+    // The fixture aims all three home variables at itself; `bin.override`
+    // neutralises the core's bundled candidate, which on a machine with a core
+    // installed holds a REAL openai manifest and is tried first.
+    fixture = createManifestFixture("curated-defaults-");
     bin.override = "openclaw";
   });
 
   afterEach(() => {
     bin.override = null;
-    for (const key of ENV) {
-      if (saved[key] === undefined) delete process.env[key];
-      else process.env[key] = saved[key];
-    }
-    fs.rmSync(tmpHome, { recursive: true, force: true });
+    fixture.cleanup();
   });
-
-  /** Where OpenClaw 2 puts an unbundled provider's manifest: beside the config. */
-  function writeManifest(provider: string, body: unknown): void {
-    const dir = path.join(tmpHome, ".openclaw", "extensions", provider);
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(path.join(dir, "openclaw.plugin.json"), JSON.stringify(body));
-  }
 
   it("the codex default survives the openai manifest that retires the same id", async () => {
     const codexDefault = PROVIDER_CATALOGS.codex.defaultModelId;
     // The shape the pinned core actually ships: the ChatGPT picker's cold-start
     // default is the same upstream id the openai extension marks deprecated.
-    writeManifest("openai", { models: [
+    fixture.writeManifest("openai", { models: [
       { id: codexDefault, status: "deprecated", replacedBy: "gpt-5.6-sol" },
       { id: "gpt-5.6-sol" },
     ] });
-    const { coreRetiredModels } = await lifecycle();
+    const { coreRetiredModels } = await loadLifecycle();
     expect(coreRetiredModels("openai").has(codexDefault)).toBe(true);
     // Keyed on the CATALOGUE provider, and the core ships no `codex` extension
     // — so the ChatGPT picker keeps a default a Free account can actually run.
@@ -134,16 +109,11 @@ describe("against a manifest the module itself resolves", () => {
     // renamed and the whole suite would stay green while a box quietly stopped
     // filtering. Both candidates are written, with DIFFERENT answers, so the
     // order is pinned rather than assumed.
-    const dist = path.join(
-      tmpHome, "lib", "node_modules", "openclaw",
-      "dist", "extensions", "anthropic", "openclaw.plugin.json",
-    );
-    fs.mkdirSync(path.dirname(dist), { recursive: true });
-    fs.writeFileSync(dist, JSON.stringify({ models: [{ id: "claude-opus-4-8", status: "deprecated" }] }));
-    writeManifest("anthropic", { models: [{ id: "claude-opus-4-7", status: "deprecated" }] });
-    bin.override = path.join(tmpHome, "bin", "openclaw");
+    fixture.writeBundledManifest("anthropic", { models: [{ id: "claude-opus-4-8", status: "deprecated" }] });
+    fixture.writeManifest("anthropic", { models: [{ id: "claude-opus-4-7", status: "deprecated" }] });
+    bin.override = fixture.bin;
 
-    const { coreRetiredModels } = await lifecycle();
+    const { coreRetiredModels } = await loadLifecycle();
     const retired = coreRetiredModels("anthropic");
     expect(retired.has("claude-opus-4-8")).toBe(true);
     expect(retired.has("claude-opus-4-7")).toBe(false);
@@ -153,11 +123,11 @@ describe("against a manifest the module itself resolves", () => {
     // The guard the file exists for, proven capable of failing — for every
     // catalogue provider, everywhere, and not only where a core happens to be
     // installed. Without this the cases above pass by reading nothing.
-    const { coreRetiredModels, resetCoreModelLifecycle } = await lifecycle();
+    const { coreRetiredModels, resetCoreModelLifecycle } = await loadLifecycle();
     for (const provider of CATALOG_PROVIDERS) {
       const defaultId = PROVIDER_CATALOGS[provider]?.defaultModelId;
       if (!defaultId) continue;
-      writeManifest(provider, { models: [{ id: defaultId, status: "deprecated" }] });
+      fixture.writeManifest(provider, { models: [{ id: defaultId, status: "deprecated" }] });
       resetCoreModelLifecycle();
       expect(coreRetiredModels(provider).has(defaultId), provider).toBe(true);
     }


### PR DESCRIPTION
**TASK-767** — the round-2/3 LOWs left open on #738, plus the defect the review pass found under (b).

### Customer-visible symptom
A model the installed core has retired goes on being offered in the picker — or, in the mirror case, a model the core still routes disappears from it — because the lookup that reads the core's own lifecycle gave up on the first manifest it could not parse and never looked at the second.

### Cause
`retiredFor()` in `src/lib/core-model-lifecycle.ts` tries two candidates: the manifest bundled in the core's `dist/extensions`, then the copy beside the config that OpenClaw 2 leaves when a provider is unbundled. A `JSON.parse` failure on the first one `return`ed an empty set instead of continuing, so a truncated bundled manifest hid a perfectly readable one. What truncates it is a write in PLACE — `scripts/gateway-pre-start.sh` rewrites that exact file with python on every gateway start to declare deepseek's xhigh effort, and a killed process or a full disk leaves the remains. (`npm install -g`'s rename is atomic and was already handled by the `openSync` catch.)

The review pass then found the other half: falling through and CACHING what the second file said keys the staleness re-stat on that lower-priority file alone, so one bad read during a core upgrade pins the wrong manifest for the life of the web server — probe-once, in the module written to defeat it. An answer read past a candidate that existed and could not be used is no longer cached; an ABSENT candidate still is, because that is the ordinary OpenClaw 2 layout and re-reading on every catalogue request would be the regression.

### Harness-first
No new mechanism: this reads the core's OWN `openclaw.plugin.json` from the two places `scripts/gateway-pre-start.sh` resolves them. The native `openclaw models list --json` cannot answer the question — `toModelRow` builds `tags` from configured entries and never projects a model's `status`, so `anthropic/claude-opus-4-8` arrives with `tags: []` on the pinned 2026.8.1 core — and the gateway's `models.list` RPC, which does project it, has no ClawBox client. That reasoning is the file's own header and is unchanged here.

### Review-pass fix on this head
The same probe-once shape survived in the ADJACENT branch of the loop: `degraded` was set on the read catch and the parse catch and not on the `openSync` one, so every non-ENOENT open failure — EACCES after a bad chown, EIO on a failing eMMC, EMFILE under load, ENOTDIR mid-upgrade — was read as "this candidate is not there", the lower-priority answer was cached, and the re-stat then watched only that lower-priority file. ENOENT stays genuine absence, because that IS the ordinary OpenClaw 2 layout and its answer must still be cached or every catalogue request would re-open two files; both halves now have a mutation-proven test.

### The other three nits from the card
- (a) The docblock now says why the lookup is keyed on the CATALOGUE provider with no inverse mapping: ClawBox's `clawai` catalogue is served by deepseek models through the ClawBox AI proxy, so a `clawai` lookup finds no manifest and fails open — deliberately, because what the proxy accepts is our contract with the customer, not the upstream provider's lifecycle. Now pinned by a test, like the codex/openai twin beside it.
- (c) `coreModelRetired` is documented as the single-row form with no production caller, and as NOT interchangeable with the set form for a padded id (it trims; `withoutRetiredModels` does not).
- (d) The manifest fixture scaffolding both suites carried a copy of is one helper, `src/tests/helpers/core-model-manifests.ts` (it reuses `saveEnv`), and the copies had already drifted — one could write raw bytes, the other only stringified ones.

### RED → GREEN
RED on unmodified beta (44681020), the new case only:

```
 ❯ |unit| src/tests/unit/core-model-lifecycle.test.ts (13 tests | 1 failed) 43ms
     × does not let a manifest it cannot parse hide the next candidate 8ms

 FAIL  … > does not let a manifest it cannot parse hide the next candidate
AssertionError: expected false to be true // Object.is equality
- true
+ false
 ❯ src/tests/unit/core-model-lifecycle.test.ts:235:67
```

RED for the caching half, with the fix's `if (!degraded)` removed:

```
 ❯ |unit| src/tests/unit/core-model-lifecycle.test.ts (15 tests | 1 failed) 39ms
     × goes back to the better manifest once it parses again 6ms
AssertionError: expected false to be true
 ❯ src/tests/unit/core-model-lifecycle.test.ts:261:46
```

RED for the open-failure half, with the `code !== "ENOENT"` line removed, and for its twin with the catch made unconditionally degraded:

```
     × does not treat a manifest it cannot OPEN as one that is not there 7ms
     × still caches the answer when the better candidate is simply not there 6ms
AssertionError: expected false to be true
```

GREEN: `core-model-lifecycle` + `curated-defaults-offerable` + every `src/tests/routes/ai-models` suite = 24 files, 451 tests; the whole unit project 772 files, 12911 passed / 1 skipped; `tsc --noEmit` and `eslint` on the touched files clean.

### Sibling call sites
`retiredFor` is reached only through `coreRetiredModels` / `coreModelRetired`; the single production consumer is `withoutRetiredModels` in `src/app/setup-api/ai-models/catalog/route.ts`, unchanged. The other reader of the same file, `scripts/gateway-pre-start.sh`, resolves the same two paths but falls back on existence alone and gives up on a parse error — deliberate there (it PATCHES the file the core reads, so following a fall-through would patch the wrong copy), and the comment here now says so instead of claiming the two agree.

### Editions
Nothing edition-conditional. On the hermes SKU no core is installed, `findOpenclawBin()` answers a bare name, `path.isAbsolute` is false and no bundled candidate is produced — one candidate, so the fall-through is inert there.

### Device
Not device-proven: the change is a pure filesystem-read path fully exercised by CI, with no unit, path or edition-lock behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved model retirement detection when a manifest is unreadable or malformed.
  - The system now checks alternate manifest locations instead of stopping at the first invalid file.
  - Valid manifest data can be recognized again after a temporary parsing issue, improving reliability of model availability and defaults.
  - Provider-specific manifests are now handled correctly, preventing one provider’s manifest from affecting another’s model retirement status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->