### PR TITLE
fix: refuse config keys and values the store cannot actually hold

### DIFF
--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -128,7 +128,7 @@ function assertStorableValue(key: string, value: unknown): void {
   // ARRAY becomes a `null` MEMBER, at any depth: the list still has its length
   // and one entry is now nothing, which is the same false success as the
   // numbers below.
-  JSON.stringify(value, function (this: unknown, _field: string, held: unknown) {
+  JSON.stringify(value, function (this: unknown, field: string, held: unknown) {
     // `held instanceof Number` as well as the primitive: a boxed non-finite
     // number reaches the replacer as an OBJECT and is written as `null` just
     // the same, so the "at any depth" claim above would be half true without
@@ -136,6 +136,20 @@ function assertStorableValue(key: string, value: unknown): void {
     const asNumber = typeof held === "number" ? held : held instanceof Number ? held.valueOf() : null;
     if (asNumber !== null && !Number.isFinite(asNumber)) {
       throw new TypeError(`config-store: ${key} cannot hold ${String(asNumber)} — JSON writes it as null`);
+    }
+    // WHAT `toJSON` ALREADY TURNED INTO NULL. `JSON.stringify` calls a value's
+    // own `toJSON` BEFORE the replacer, so the replacer is handed the result,
+    // not the value: `new Date(NaN)` arrives here as `null` and every check
+    // above looks straight through it. The holder still has the original —
+    // `this[field]` is the pre-`toJSON` value at every depth, the top level
+    // included (there the holder is JSON's own wrapper and `field` is "") — so
+    // one lookup closes the whole class rather than only `Date`'s corner of it.
+    // A value that really IS null is stored as null, which is what the caller
+    // asked for.
+    const raw = (this as Record<string, unknown> | null)?.[field];
+    if (held === null && raw !== null && raw !== undefined) {
+      const what = raw instanceof Date ? "an invalid Date" : "a value whose toJSON answers null";
+      throw new TypeError(`config-store: ${key} cannot hold ${what} — JSON writes it as null`);
     }
     if (Array.isArray(this) && (held === undefined || typeof held === "function" || typeof held === "symbol")) {
       throw new TypeError(`config-store: ${key} cannot hold a list with a member JSON writes as null`);
@@ -257,11 +271,20 @@ export async function swap(key: string, value: unknown): Promise<unknown> {
   // Ahead of the read, so a value that cannot be stored costs no file access.
   // `JSON.stringify` throws on a BigInt or a cycle, which `writeConfig` would
   // have done anyway — here it happens before anything is opened.
-  if (JSON.stringify(value) === undefined) {
+  if (value === undefined) {
     throw new TypeError(`config-store: swap(${key}) replaces, it cannot delete — use set()`);
   }
   assertStorableKey(key);
   assertStorableValue(key, value);
+  // The catch-all behind the named guards, and the reason it comes AFTER them:
+  // they say what is wrong ("cannot hold a function", "an invalid Date"), while
+  // this only knows that nothing would be written. It still has to be here —
+  // a `toJSON` that answers `undefined` drops the whole key with none of the
+  // shapes above — and "use set()" is deliberately not its advice, since `set`
+  // refuses every one of these too.
+  if (JSON.stringify(value) === undefined) {
+    throw new TypeError(`config-store: ${key} cannot hold a value JSON omits entirely`);
+  }
   const config = readConfigStrict();
   const previous = held(config, key);
   config[key] = value;

--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -109,7 +109,7 @@ export function assertStorableKey(key: string): void {
   }
 }
 
-function assertStorableValue(key: string, value: unknown): void {
+function assertStorableValue(key: string, value: unknown): string {
   // The WHOLE value first, because the walk below cannot see it: JSON drops a
   // top-level function or symbol entirely, and the write then RENAMES a config
   // without the key over the one that had it — `set("active_harness", () => …)`
@@ -128,7 +128,7 @@ function assertStorableValue(key: string, value: unknown): void {
   // ARRAY becomes a `null` MEMBER, at any depth: the list still has its length
   // and one entry is now nothing, which is the same false success as the
   // numbers below.
-  JSON.stringify(value, function (this: unknown, field: string, held: unknown) {
+  const json = JSON.stringify(value, function (this: unknown, field: string, held: unknown) {
     // `held instanceof Number` as well as the primitive: a boxed non-finite
     // number reaches the replacer as an OBJECT and is written as `null` just
     // the same, so the "at any depth" claim above would be half true without
@@ -156,6 +156,28 @@ function assertStorableValue(key: string, value: unknown): void {
     }
     return held;
   });
+  // The catch-all behind the named guards, shared by all three writers: a
+  // `toJSON` that answers `undefined` drops the whole key with none of the
+  // shapes above, and the rename then lands a config WITHOUT it.
+  if (json === undefined) {
+    throw new TypeError(`config-store: ${key} cannot hold a value JSON omits entirely`);
+  }
+  return json;
+}
+
+/**
+ * The value as the guard SAW it — the bytes it approved, parsed back.
+ *
+ * The walk above already serialised the value, and `writeConfig` serialised it
+ * a second time: two answers from one value, and a `toJSON` that does not give
+ * the same answer twice slipped between them. A counter returning a number on
+ * the first call and `NaN` on the second passed every check and left the store
+ * holding `null` under a key the write had reported success for — the same
+ * false success, through the guard itself. What is stored is now what was
+ * checked, so there is no second answer to differ.
+ */
+function storableValue(key: string, value: unknown): unknown {
+  return JSON.parse(assertStorableValue(key, value)) as unknown;
 }
 
 /**
@@ -227,15 +249,16 @@ export async function set(key: string, value: unknown): Promise<void> {
   // and on the WRITE branch only, because `delete config["__proto__"]` does
   // remove an own property and is the way a store that already holds one is
   // cleaned.
+  let storable: unknown;
   if (value !== undefined) {
     assertStorableKey(key);
-    assertStorableValue(key, value);
+    storable = storableValue(key, value);
   }
   const config = readConfigStrict();
   if (value === undefined) {
     delete config[key];
   } else {
-    config[key] = value;
+    config[key] = storable;
   }
   writeConfig(config);
 }
@@ -275,19 +298,10 @@ export async function swap(key: string, value: unknown): Promise<unknown> {
     throw new TypeError(`config-store: swap(${key}) replaces, it cannot delete — use set()`);
   }
   assertStorableKey(key);
-  assertStorableValue(key, value);
-  // The catch-all behind the named guards, and the reason it comes AFTER them:
-  // they say what is wrong ("cannot hold a function", "an invalid Date"), while
-  // this only knows that nothing would be written. It still has to be here —
-  // a `toJSON` that answers `undefined` drops the whole key with none of the
-  // shapes above — and "use set()" is deliberately not its advice, since `set`
-  // refuses every one of these too.
-  if (JSON.stringify(value) === undefined) {
-    throw new TypeError(`config-store: ${key} cannot hold a value JSON omits entirely`);
-  }
+  const storable = storableValue(key, value);
   const config = readConfigStrict();
   const previous = held(config, key);
-  config[key] = value;
+  config[key] = storable;
   writeConfig(config);
   return previous;
 }
@@ -295,17 +309,18 @@ export async function swap(key: string, value: unknown): Promise<unknown> {
 export async function setMany(entries: Record<string, unknown>): Promise<void> {
   // The WHOLE batch, before the read: a caller handed a refusal must not find
   // half its entries applied around the one that could never land.
+  const storable = new Map<string, unknown>();
   for (const [key, value] of Object.entries(entries)) {
     if (value === undefined) continue;
     assertStorableKey(key);
-    assertStorableValue(key, value);
+    storable.set(key, storableValue(key, value));
   }
   const config = readConfigStrict();
   for (const [key, value] of Object.entries(entries)) {
     if (value === undefined) {
       delete config[key];
     } else {
-      config[key] = value;
+      config[key] = storable.get(key);
     }
   }
   writeConfig(config);

--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -110,6 +110,16 @@ export function assertStorableKey(key: string): void {
 }
 
 function assertStorableValue(key: string, value: unknown): void {
+  // The WHOLE value first, because the walk below cannot see it: JSON drops a
+  // top-level function or symbol entirely, and the write then RENAMES a config
+  // without the key over the one that had it — `set("active_harness", () => …)`
+  // deletes the harness and answers success. `swap` was saved from this only by
+  // its own `JSON.stringify(value) === undefined` test, so without this the
+  // three writers were not the same guard. `undefined` cannot arrive here: it
+  // is the documented delete and both callers filter it out first.
+  if (value === undefined || typeof value === "function" || typeof value === "symbol") {
+    throw new TypeError(`config-store: ${key} cannot hold a ${typeof value} — JSON omits it`);
+  }
   // Not an arrow: the replacer's `this` is the object or array HOLDING the
   // value, and that is what separates the two ways JSON writes `null`. An
   // OBJECT property whose value is `undefined`, a function or a symbol is
@@ -119,8 +129,13 @@ function assertStorableValue(key: string, value: unknown): void {
   // and one entry is now nothing, which is the same false success as the
   // numbers below.
   JSON.stringify(value, function (this: unknown, _field: string, held: unknown) {
-    if (typeof held === "number" && !Number.isFinite(held)) {
-      throw new TypeError(`config-store: ${key} cannot hold ${held} — JSON writes it as null`);
+    // `held instanceof Number` as well as the primitive: a boxed non-finite
+    // number reaches the replacer as an OBJECT and is written as `null` just
+    // the same, so the "at any depth" claim above would be half true without
+    // it.
+    const asNumber = typeof held === "number" ? held : held instanceof Number ? held.valueOf() : null;
+    if (asNumber !== null && !Number.isFinite(asNumber)) {
+      throw new TypeError(`config-store: ${key} cannot hold ${String(asNumber)} — JSON writes it as null`);
     }
     if (Array.isArray(this) && (held === undefined || typeof held === "function" || typeof held === "symbol")) {
       throw new TypeError(`config-store: ${key} cannot hold a list with a member JSON writes as null`);

--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -56,6 +56,53 @@ function readConfigStrict(): Record<string, unknown> {
   return parsed as Record<string, unknown>;
 }
 
+/**
+ * The one key a plain object cannot hold, and the numbers JSON cannot write.
+ *
+ * Both are the same failure the value guard on `swap` was added for — a write
+ * that reports success over a store that did not change the way the caller
+ * believes — reached by two other routes:
+ *
+ *  - `config["__proto__"] = value` never creates a property. It reaches
+ *    `Object.prototype`'s own accessor, which sets the object's PROTOTYPE for
+ *    an object value and does nothing at all for a primitive; either way the
+ *    key is absent from `JSON.stringify`'s output, so `writeConfig` renames a
+ *    config without it over the one that had it and the caller is told the
+ *    write landed. `swap` compounds it by reading the same accessor for its
+ *    `previous`, handing the caller `Object.prototype` as the value it
+ *    replaced. Refused rather than written as an own property, because a
+ *    `"__proto__"` key inside data/config.json is a loaded gun for every OTHER
+ *    reader of that file: `Object.assign({}, JSON.parse(raw))` and every
+ *    read-modify-write built on it would take the parsed own property through
+ *    a plain object's inherited setter and change that object's prototype.
+ *    Nothing on the box stores a key it does not spell out as a constant, so
+ *    the refusal costs no caller anything.
+ *
+ *  - `JSON.stringify(NaN)` is the string `"null"`, and so are `Infinity` and
+ *    `-Infinity`, so a non-finite number passes the `=== undefined` test and
+ *    the file ends up holding `null` under a key the caller believes holds a
+ *    figure. Every reader then sees "unset" — the schedules, the plan tier,
+ *    the updater's timestamps all read a missing number as "never" — over a
+ *    write that answered success. Checked at any depth, because that is how
+ *    the store actually holds figures, and through `JSON.stringify`'s own walk
+ *    rather than a hand-rolled one so a cycle is reported by the serialiser
+ *    that would have hit it anyway.
+ */
+function assertStorableKey(key: string): void {
+  if (key === "__proto__") {
+    throw new TypeError(`config-store: "${key}" cannot be a key — the object backing the store cannot hold it`);
+  }
+}
+
+function assertStorableValue(key: string, value: unknown): void {
+  JSON.stringify(value, (_field, held: unknown) => {
+    if (typeof held === "number" && !Number.isFinite(held)) {
+      throw new TypeError(`config-store: ${key} cannot hold ${held} — JSON writes it as null`);
+    }
+    return held;
+  });
+}
+
 /** One key, tri-state: `known: false` when the store could not be read. */
 export async function getKnown(key: string): Promise<{ value: unknown; known: boolean }> {
   try {
@@ -110,6 +157,9 @@ export async function get(key: string): Promise<unknown> {
  * that has never saved anything is the ordinary first write.
  */
 export async function set(key: string, value: unknown): Promise<void> {
+  // Ahead of the read, so a write that could never land costs no file access.
+  assertStorableKey(key);
+  if (value !== undefined) assertStorableValue(key, value);
   const config = readConfigStrict();
   if (value === undefined) {
     delete config[key];
@@ -138,12 +188,10 @@ export async function set(key: string, value: unknown): Promise<void> {
  * actually matters, rather than an enumeration of the values that have it. To
  * delete a key, `set` it to `undefined`.
  *
- * The VALUE half only. A `__proto__` KEY produces the same outcome by a
- * different mechanism — `config[key] = value` hits `Object.prototype`'s setter,
- * so the key never lands — and is NOT covered here, because it is identical in
- * `set` and `setMany` and belongs with a store-wide fix rather than a third
- * copy of one. Unreachable from the only caller, which passes a module
- * constant.
+ * The KEY half is `assertStorableKey`, shared with `set` and `setMany` because
+ * `__proto__` fails identically in all three, and the non-finite numbers
+ * `JSON.stringify` writes as `null` are `assertStorableValue`, shared for the
+ * same reason.
  *
  * Same strict read as `set`, for the same reason: a write over a store nobody
  * can read must throw rather than replace it with the one key being saved.
@@ -155,6 +203,8 @@ export async function swap(key: string, value: unknown): Promise<unknown> {
   if (JSON.stringify(value) === undefined) {
     throw new TypeError(`config-store: swap(${key}) replaces, it cannot delete — use set()`);
   }
+  assertStorableKey(key);
+  assertStorableValue(key, value);
   const config = readConfigStrict();
   const previous = config[key];
   config[key] = value;
@@ -163,6 +213,12 @@ export async function swap(key: string, value: unknown): Promise<unknown> {
 }
 
 export async function setMany(entries: Record<string, unknown>): Promise<void> {
+  // The WHOLE batch, before the read: a caller handed a refusal must not find
+  // half its entries applied around the one that could never land.
+  for (const [key, value] of Object.entries(entries)) {
+    assertStorableKey(key);
+    if (value !== undefined) assertStorableValue(key, value);
+  }
   const config = readConfigStrict();
   for (const [key, value] of Object.entries(entries)) {
     if (value === undefined) {

--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -53,11 +53,20 @@ function readConfigStrict(): Record<string, unknown> {
   if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error("data/config.json does not hold a JSON object");
   }
+  // A `"__proto__"` the FILE carries — a hand-edit, a restored backup of an
+  // older data/ — is an own property here, because `JSON.parse` creates it as
+  // one. Dropped on the way in, so the read side answers `undefined` for it
+  // like any other absent key (`config[key]` would otherwise reach
+  // `Object.prototype`'s getter and hand a caller the prototype object), and so
+  // the next write does not re-emit it: `assertStorableKey` refuses to CREATE
+  // one, and a store that already holds one must have a way back out.
+  Reflect.deleteProperty(parsed, "__proto__");
   return parsed as Record<string, unknown>;
 }
 
 /**
- * The one key a plain object cannot hold, and the numbers JSON cannot write.
+ * The one STORE key a plain object cannot hold, and the values JSON cannot
+ * write faithfully.
  *
  * Both are the same failure the value guard on `swap` was added for — a write
  * that reports success over a store that did not change the way the caller
@@ -81,32 +90,61 @@ function readConfigStrict(): Record<string, unknown> {
  *  - `JSON.stringify(NaN)` is the string `"null"`, and so are `Infinity` and
  *    `-Infinity`, so a non-finite number passes the `=== undefined` test and
  *    the file ends up holding `null` under a key the caller believes holds a
- *    figure. Every reader then sees "unset" — the schedules, the plan tier,
- *    the updater's timestamps all read a missing number as "never" — over a
- *    write that answered success. Checked at any depth, because that is how
- *    the store actually holds figures, and through `JSON.stringify`'s own walk
- *    rather than a hand-rolled one so a cycle is reported by the serialiser
- *    that would have hit it anyway.
+ *    figure. Every reader then sees "unset" over a write that answered success
+ *    — `session_generation` back to 0 invalidates every live cookie,
+ *    `clawai_credential_refused_at` back to "never refused" re-arms the write
+ *    the refusal exists to stop, `setup_progress_step` reopens the wizard.
+ *    Checked at any depth, through `JSON.stringify`'s own walk rather than a
+ *    hand-rolled one, so a cycle is reported by the serialiser that would have
+ *    hit it anyway.
+ *
+ * The KEY half is the STORE's own key, not every key in the value: a nested
+ * `"__proto__"` is part of an object the caller built and is written as it
+ * stands (`JSON.parse` reads it back as an own property, so a ClawBox reader
+ * sees what was stored). Only the top-level key can silently fail to land here.
  */
-function assertStorableKey(key: string): void {
+export function assertStorableKey(key: string): void {
   if (key === "__proto__") {
     throw new TypeError(`config-store: "${key}" cannot be a key — the object backing the store cannot hold it`);
   }
 }
 
 function assertStorableValue(key: string, value: unknown): void {
-  JSON.stringify(value, (_field, held: unknown) => {
+  // Not an arrow: the replacer's `this` is the object or array HOLDING the
+  // value, and that is what separates the two ways JSON writes `null`. An
+  // OBJECT property whose value is `undefined`, a function or a symbol is
+  // omitted from the file, and a reader then sees `undefined` — which is what
+  // the caller stored, so nothing is misreported. The same value inside an
+  // ARRAY becomes a `null` MEMBER, at any depth: the list still has its length
+  // and one entry is now nothing, which is the same false success as the
+  // numbers below.
+  JSON.stringify(value, function (this: unknown, _field: string, held: unknown) {
     if (typeof held === "number" && !Number.isFinite(held)) {
       throw new TypeError(`config-store: ${key} cannot hold ${held} — JSON writes it as null`);
+    }
+    if (Array.isArray(this) && (held === undefined || typeof held === "function" || typeof held === "symbol")) {
+      throw new TypeError(`config-store: ${key} cannot hold a list with a member JSON writes as null`);
     }
     return held;
   });
 }
 
+/**
+ * The value the store HOLDS under `key`, never one it inherits.
+ *
+ * `config[key]` walks the prototype chain, so `"__proto__"` answers
+ * `Object.prototype` and `"constructor"` the `Object` function — objects, under
+ * a signature that says "whatever was stored", for keys the store holds
+ * nothing under. Every reader here goes through this.
+ */
+function held(config: Record<string, unknown>, key: string): unknown {
+  return Object.hasOwn(config, key) ? config[key] : undefined;
+}
+
 /** One key, tri-state: `known: false` when the store could not be read. */
 export async function getKnown(key: string): Promise<{ value: unknown; known: boolean }> {
   try {
-    return { value: readConfigStrict()[key], known: true };
+    return { value: held(readConfigStrict(), key), known: true };
   } catch (err) {
     // The message only: a JSON parse error quotes a window of the INPUT, and
     // this file holds the mailbox password and both bot tokens.
@@ -137,8 +175,7 @@ function writeConfig(data: Record<string, unknown>): void {
 }
 
 export async function get(key: string): Promise<unknown> {
-  const config = readConfig();
-  return config[key];
+  return held(readConfig(), key);
 }
 
 /**
@@ -157,9 +194,14 @@ export async function get(key: string): Promise<unknown> {
  * that has never saved anything is the ordinary first write.
  */
 export async function set(key: string, value: unknown): Promise<void> {
-  // Ahead of the read, so a write that could never land costs no file access.
-  assertStorableKey(key);
-  if (value !== undefined) assertStorableValue(key, value);
+  // Ahead of the read, so a write that could never land costs no file access —
+  // and on the WRITE branch only, because `delete config["__proto__"]` does
+  // remove an own property and is the way a store that already holds one is
+  // cleaned.
+  if (value !== undefined) {
+    assertStorableKey(key);
+    assertStorableValue(key, value);
+  }
   const config = readConfigStrict();
   if (value === undefined) {
     delete config[key];
@@ -206,7 +248,7 @@ export async function swap(key: string, value: unknown): Promise<unknown> {
   assertStorableKey(key);
   assertStorableValue(key, value);
   const config = readConfigStrict();
-  const previous = config[key];
+  const previous = held(config, key);
   config[key] = value;
   writeConfig(config);
   return previous;
@@ -216,8 +258,9 @@ export async function setMany(entries: Record<string, unknown>): Promise<void> {
   // The WHOLE batch, before the read: a caller handed a refusal must not find
   // half its entries applied around the one that could never land.
   for (const [key, value] of Object.entries(entries)) {
+    if (value === undefined) continue;
     assertStorableKey(key);
-    if (value !== undefined) assertStorableValue(key, value);
+    assertStorableValue(key, value);
   }
   const config = readConfigStrict();
   for (const [key, value] of Object.entries(entries)) {

--- a/src/lib/kv-store.ts
+++ b/src/lib/kv-store.ts
@@ -19,7 +19,14 @@ function readKV(): Record<string, string> {
   ensureDir();
   try {
     if (!fs.existsSync(KV_PATH)) return {};
-    return JSON.parse(fs.readFileSync(KV_PATH, "utf-8"));
+    const parsed = JSON.parse(fs.readFileSync(KV_PATH, "utf-8"));
+    // The same inbound rule as config-store, for the same reason: `JSON.parse`
+    // creates `"__proto__"` as an OWN property, `writeKV` would re-emit it on
+    // every later write, and a key in this file that another reader merges into
+    // a plain object with `Object.assign` changes that object's prototype.
+    // `kvDelete` could always remove one; nothing had to keep carrying it.
+    if (parsed && typeof parsed === "object") Reflect.deleteProperty(parsed, "__proto__");
+    return parsed;
   } catch {
     return {};
   }

--- a/src/lib/kv-store.ts
+++ b/src/lib/kv-store.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import fs from "fs";
-import { DATA_DIR } from "./config-store";
+import { assertStorableKey, DATA_DIR } from "./config-store";
 
 // JSON-file-backed key-value store for persistent client state.
 // Replaces browser localStorage so state survives browser changes
@@ -43,10 +43,23 @@ function writeKV(data: Record<string, string>): void {
 }
 
 export function kvGet(key: string): string | null {
-  return readKV()[key] ?? null;
+  const data = readKV();
+  // Own keys only. `data["__proto__"]` reaches Object.prototype's getter and
+  // would hand back the prototype OBJECT under a signature that says
+  // `string | null` — a caller doing `String(kvGet(k))` gets
+  // "[object Object]". The same reasoning as the write guard below.
+  return Object.hasOwn(data, key) ? data[key] ?? null : null;
 }
 
 export function kvSet(key: string, value: string): void {
+  // The same store-wide rule as config-store, from the same helper rather than
+  // a second copy of it: `data["__proto__"] = value` reaches Object.prototype's
+  // setter, stores nothing and reports success. `/setup-api/kv` refuses that
+  // name (and `constructor`/`prototype`, which DO land as ordinary own
+  // properties) before it gets here, but the route is not the only door — the
+  // notice ring, the mascot phrases and the uninstall sweep all call in
+  // directly.
+  assertStorableKey(key);
   const data = readKV();
   data[key] = value;
   writeKV(data);
@@ -69,6 +82,8 @@ export function kvGetAll(prefix?: string): Record<string, string> {
 }
 
 export function kvSetMany(entries: Record<string, string>): void {
+  // The whole batch first, so a refusal never leaves half of it applied.
+  for (const key of Object.keys(entries)) assertStorableKey(key);
   const data = readKV();
   for (const [key, value] of Object.entries(entries)) {
     data[key] = value;

--- a/src/tests/unit/config-store.test.ts
+++ b/src/tests/unit/config-store.test.ts
@@ -368,6 +368,55 @@ describe("config-store", () => {
     });
   });
 
+  describe("a value `toJSON` has already turned into null", () => {
+    it("refuses an invalid Date in every writer, bare and nested", async () => {
+      // `JSON.stringify` calls a value's own `toJSON` BEFORE the replacer, so
+      // the guard is handed `null` and never sees the Date at all: the store
+      // then holds `null` under a key the caller believes holds a time, and
+      // every reader sees "unset" over a write that answered success.
+      await fs.writeFile(CONFIG_PATH, JSON.stringify({ keep: "kept" }), "utf-8");
+
+      await expect(configStore.set("clawai_credential_refused_at", new Date(NaN))).rejects.toThrow(TypeError);
+      await expect(configStore.set("plan", { renewsAt: new Date(NaN) })).rejects.toThrow(TypeError);
+      await expect(configStore.swap("clawai_credential_refused_at", new Date(NaN))).rejects.toThrow(TypeError);
+      await expect(configStore.setMany({ clawai_credential_refused_at: new Date(NaN) })).rejects.toThrow(TypeError);
+
+      expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8"))).toEqual({ keep: "kept" });
+    });
+
+    it("still stores a VALID Date as the string JSON makes of it, and a real null as null", async () => {
+      // The guard is about a value that comes back as something ELSE. A date
+      // that serialises is exactly what the caller asked to store, and `null`
+      // itself is a value this store has always held.
+      await configStore.set("password_configured_at", new Date("2026-09-07T12:00:00.000Z"));
+      await configStore.set("clawai_plan_tier", null);
+      expect(await configStore.get("password_configured_at")).toBe("2026-09-07T12:00:00.000Z");
+      expect(await configStore.get("clawai_plan_tier")).toBeNull();
+    });
+
+    it("refuses any toJSON that answers null, not just Date's", async () => {
+      // The class, not the corner: nothing about the failure is specific to
+      // dates — any value whose `toJSON` answers null is written as null.
+      await fs.writeFile(CONFIG_PATH, JSON.stringify({ keep: "kept" }), "utf-8");
+      await expect(configStore.set("plan", { toJSON: () => null })).rejects.toThrow(TypeError);
+      expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8"))).toEqual({ keep: "kept" });
+    });
+
+    it("refuses a value JSON omits entirely, whatever shape it arrives in", async () => {
+      // The catch-all behind the named guards: a `toJSON` that answers
+      // `undefined` drops the whole key, with none of the shapes the guards
+      // recognise. `swap` said "use set()" for this, which stopped being advice
+      // the moment `set` refused it too.
+      await fs.writeFile(CONFIG_PATH, JSON.stringify({ active_harness: "hermes" }), "utf-8");
+      await expect(configStore.swap("active_harness", { toJSON: () => undefined })).rejects.toThrow(
+        /cannot hold a value JSON omits entirely/,
+      );
+      // And `undefined` itself still gets the advice that IS true for it.
+      await expect(configStore.swap("active_harness", undefined)).rejects.toThrow(/use set\(\)/);
+      expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8"))).toEqual({ active_harness: "hermes" });
+    });
+  });
+
   describe("getAll", () => {
     it("returns full config object", async () => {
       await fs.writeFile(CONFIG_PATH, JSON.stringify({ a: 1, b: "two", c: true }), "utf-8");

--- a/src/tests/unit/config-store.test.ts
+++ b/src/tests/unit/config-store.test.ts
@@ -226,6 +226,65 @@ describe("config-store", () => {
     });
   });
 
+  describe("a key the object backing the store cannot hold", () => {
+    // `config[key] = value` for `__proto__` reaches Object.prototype's own
+    // setter instead of creating a property: nothing is stored, nothing
+    // throws, and `writeConfig` renames a config WITHOUT the key over the one
+    // that had it. The caller is told the write succeeded — `swap` even hands
+    // back a "previous" value it read through the same accessor — which is the
+    // false-success shape the value guard was added to remove, arriving on the
+    // key side instead.
+    it("swap refuses it rather than reporting a write that never happened", async () => {
+      await fs.writeFile(CONFIG_PATH, JSON.stringify({ keep: "kept" }), "utf-8");
+      await expect(configStore.swap("__proto__", { polluted: true })).rejects.toThrow(TypeError);
+      expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8"))).toEqual({ keep: "kept" });
+    });
+
+    it("set refuses it", async () => {
+      await fs.writeFile(CONFIG_PATH, JSON.stringify({ keep: "kept" }), "utf-8");
+      await expect(configStore.set("__proto__", { polluted: true })).rejects.toThrow(TypeError);
+      expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8"))).toEqual({ keep: "kept" });
+    });
+
+    it("setMany refuses the whole batch rather than landing half of it", async () => {
+      // Refused before anything is written, so the caller's other entries are
+      // not silently applied around the one that could never land.
+      await fs.writeFile(CONFIG_PATH, JSON.stringify({ keep: "kept" }), "utf-8");
+      // A COMPUTED key, deliberately: `{ __proto__: … }` in an object literal
+      // sets the literal's prototype and creates no entry at all, so a batch
+      // written that way would never reach the store's key guard and the case
+      // would pass by testing nothing.
+      await expect(
+        configStore.setMany({ telegram_bot_token: "111:x", ["__proto__"]: { polluted: true } }),
+      ).rejects.toThrow(TypeError);
+      expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8"))).toEqual({ keep: "kept" });
+    });
+  });
+
+  describe("a number JSON cannot write", () => {
+    // `JSON.stringify(NaN)` is the string "null", so a non-finite number walks
+    // straight through the `=== undefined` guard and the file ends up holding
+    // `null` under a key the caller believes holds a number. Every reader then
+    // sees "unset" where the caller stored a figure, and the write reported
+    // success — the same false success, one type further in.
+    it("swap refuses NaN and Infinity instead of storing null", async () => {
+      await fs.writeFile(CONFIG_PATH, JSON.stringify({ clawkeep_last_backup_ms: 5 }), "utf-8");
+      await expect(configStore.swap("clawkeep_last_backup_ms", NaN)).rejects.toThrow(TypeError);
+      await expect(configStore.swap("clawkeep_last_backup_ms", Infinity)).rejects.toThrow(TypeError);
+      expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8"))).toEqual({ clawkeep_last_backup_ms: 5 });
+    });
+
+    it("set and setMany refuse it too, nested as well as bare", async () => {
+      // Nested because that is how the store actually holds figures — the
+      // schedule objects, the plan tiers, the updater's step records — and a
+      // NaN one field deep is written as `null` just as quietly.
+      await fs.writeFile(CONFIG_PATH, JSON.stringify({ keep: "kept" }), "utf-8");
+      await expect(configStore.set("clawkeep_schedule", { hour: NaN })).rejects.toThrow(TypeError);
+      await expect(configStore.setMany({ update_started_at: -Infinity })).rejects.toThrow(TypeError);
+      expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8"))).toEqual({ keep: "kept" });
+    });
+  });
+
   describe("getAll", () => {
     it("returns full config object", async () => {
       await fs.writeFile(CONFIG_PATH, JSON.stringify({ a: 1, b: "two", c: true }), "utf-8");

--- a/src/tests/unit/config-store.test.ts
+++ b/src/tests/unit/config-store.test.ts
@@ -332,6 +332,42 @@ describe("config-store", () => {
     });
   });
 
+  describe("a value JSON omits altogether", () => {
+    it("is refused by all three writers, not just swap", async () => {
+      // The key half of this fix has an exact twin on the value side: a
+      // top-level function or symbol is dropped by `JSON.stringify`, so the
+      // rename lands a config WITHOUT the key — the caller's stored value is
+      // gone and the write answered success. `swap` refused it already, from
+      // its own `=== undefined` test; `set` and `setMany` did not, so the three
+      // writers were not the same guard.
+      await fs.writeFile(CONFIG_PATH, JSON.stringify({ active_harness: "hermes" }), "utf-8");
+
+      await expect(configStore.set("active_harness", () => "openclaw")).rejects.toThrow(TypeError);
+      await expect(configStore.setMany({ active_harness: Symbol("openclaw") })).rejects.toThrow(TypeError);
+      await expect(configStore.swap("active_harness", () => "openclaw")).rejects.toThrow(TypeError);
+
+      expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8"))).toEqual({ active_harness: "hermes" });
+    });
+
+    it("still lets `undefined` mean delete, in both writers that take it", async () => {
+      // The one value that must NOT throw: it is the documented removal, and
+      // both writers filter it out before the guard.
+      await fs.writeFile(CONFIG_PATH, JSON.stringify({ a: 1, b: 2 }), "utf-8");
+      await configStore.set("a", undefined);
+      await configStore.setMany({ b: undefined });
+      expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8"))).toEqual({});
+    });
+
+    it("refuses a boxed non-finite number, which stringifies to null like the bare one", async () => {
+      await fs.writeFile(CONFIG_PATH, JSON.stringify({ keep: "kept" }), "utf-8");
+      await expect(configStore.set("session_generation", new Number(NaN))).rejects.toThrow(TypeError);
+      await expect(configStore.set("plan", { limit: new Number(Infinity) })).rejects.toThrow(TypeError);
+      // A boxed FINITE number is written as the number it holds, and is fine.
+      await configStore.set("session_generation", new Number(7));
+      expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8"))).toEqual({ keep: "kept", session_generation: 7 });
+    });
+  });
+
   describe("getAll", () => {
     it("returns full config object", async () => {
       await fs.writeFile(CONFIG_PATH, JSON.stringify({ a: 1, b: "two", c: true }), "utf-8");

--- a/src/tests/unit/config-store.test.ts
+++ b/src/tests/unit/config-store.test.ts
@@ -402,18 +402,50 @@ describe("config-store", () => {
       expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8"))).toEqual({ keep: "kept" });
     });
 
-    it("refuses a value JSON omits entirely, whatever shape it arrives in", async () => {
+    it("refuses a value JSON omits entirely — in ALL THREE writers", async () => {
       // The catch-all behind the named guards: a `toJSON` that answers
       // `undefined` drops the whole key, with none of the shapes the guards
-      // recognise. `swap` said "use set()" for this, which stopped being advice
-      // the moment `set` refused it too.
+      // recognise, and the rename then lands a config WITHOUT it. It lived in
+      // `swap` alone, so `set` and `setMany` resolved and DELETED the stored
+      // value while reporting success — the same false success, through the one
+      // door the other two do not share.
       await fs.writeFile(CONFIG_PATH, JSON.stringify({ active_harness: "hermes" }), "utf-8");
-      await expect(configStore.swap("active_harness", { toJSON: () => undefined })).rejects.toThrow(
+      const dropped = { toJSON: () => undefined };
+
+      await expect(configStore.set("active_harness", dropped)).rejects.toThrow(
+        /cannot hold a value JSON omits entirely/,
+      );
+      await expect(configStore.setMany({ active_harness: dropped })).rejects.toThrow(
+        /cannot hold a value JSON omits entirely/,
+      );
+      await expect(configStore.swap("active_harness", dropped)).rejects.toThrow(
         /cannot hold a value JSON omits entirely/,
       );
       // And `undefined` itself still gets the advice that IS true for it.
       await expect(configStore.swap("active_harness", undefined)).rejects.toThrow(/use set\(\)/);
       expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8"))).toEqual({ active_harness: "hermes" });
+    });
+
+    it("stores what the guard CHECKED, so a value cannot change between the two", async () => {
+      // The walk already serialised the value and `writeConfig` serialised it
+      // again — two answers from one value, and a `toJSON` that does not give
+      // the same one twice slipped between them: valid on the guard's walk,
+      // `NaN` on the write, and the store ended up holding `null` under a key
+      // the write had reported success for. What is stored is now what was
+      // checked, and the counter proves the value is serialised ONCE.
+      let calls = 0;
+      const shifty = {
+        toJSON() {
+          calls += 1;
+          return calls === 1 ? 7 : NaN;
+        },
+      };
+
+      await configStore.set("session_generation", shifty);
+
+      expect(calls, "the value must be serialised once, not once per pass").toBe(1);
+      expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8")).session_generation).toBe(7);
+      expect(await configStore.get("session_generation")).toBe(7);
     });
   });
 

--- a/src/tests/unit/config-store.test.ts
+++ b/src/tests/unit/config-store.test.ts
@@ -261,6 +261,29 @@ describe("config-store", () => {
     });
   });
 
+  describe("a __proto__ the FILE already carries", () => {
+    // Refusing to CREATE one is only half an invariant: a store that acquired
+    // the key before this build — a hand-edit, a restored backup of an older
+    // data/ — would otherwise re-emit it on every settings change with no
+    // supported way out, and the read side would go on answering
+    // Object.prototype for it.
+    it("is dropped on the way in and does not come back out", async () => {
+      await fs.writeFile(CONFIG_PATH, '{"__proto__":{"polluted":true},"keep":"kept"}', "utf-8");
+      expect(await configStore.get("__proto__")).toBeUndefined();
+      expect(await configStore.getAll()).toEqual({ keep: "kept" });
+      expect((await configStore.getKnown("__proto__")).value).toBeUndefined();
+
+      await configStore.set("keep", "still kept");
+      expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8"))).toEqual({ keep: "still kept" });
+    });
+
+    it("can still be deleted, because a delete is not a write", async () => {
+      await fs.writeFile(CONFIG_PATH, '{"__proto__":{"polluted":true},"keep":"kept"}', "utf-8");
+      await expect(configStore.set("__proto__", undefined)).resolves.toBeUndefined();
+      expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8"))).toEqual({ keep: "kept" });
+    });
+  });
+
   describe("a number JSON cannot write", () => {
     // `JSON.stringify(NaN)` is the string "null", so a non-finite number walks
     // straight through the `=== undefined` guard and the file ends up holding
@@ -268,20 +291,44 @@ describe("config-store", () => {
     // sees "unset" where the caller stored a figure, and the write reported
     // success — the same false success, one type further in.
     it("swap refuses NaN and Infinity instead of storing null", async () => {
-      await fs.writeFile(CONFIG_PATH, JSON.stringify({ clawkeep_last_backup_ms: 5 }), "utf-8");
-      await expect(configStore.swap("clawkeep_last_backup_ms", NaN)).rejects.toThrow(TypeError);
-      await expect(configStore.swap("clawkeep_last_backup_ms", Infinity)).rejects.toThrow(TypeError);
-      expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8"))).toEqual({ clawkeep_last_backup_ms: 5 });
+      await fs.writeFile(CONFIG_PATH, JSON.stringify({ clawai_credential_refused_at: 5 }), "utf-8");
+      await expect(configStore.swap("clawai_credential_refused_at", NaN)).rejects.toThrow(TypeError);
+      await expect(configStore.swap("clawai_credential_refused_at", Infinity)).rejects.toThrow(TypeError);
+      expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8"))).toEqual({ clawai_credential_refused_at: 5 });
     });
 
     it("set and setMany refuse it too, nested as well as bare", async () => {
-      // Nested because that is how the store actually holds figures — the
-      // schedule objects, the plan tiers, the updater's step records — and a
-      // NaN one field deep is written as `null` just as quietly.
+      // Nested as well, because an object one field deep is written as `null`
+      // just as quietly as a bare figure.
       await fs.writeFile(CONFIG_PATH, JSON.stringify({ keep: "kept" }), "utf-8");
-      await expect(configStore.set("clawkeep_schedule", { hour: NaN })).rejects.toThrow(TypeError);
-      await expect(configStore.setMany({ update_started_at: -Infinity })).rejects.toThrow(TypeError);
+      await expect(configStore.set("setup_progress_step", { step: NaN })).rejects.toThrow(TypeError);
+      await expect(configStore.setMany({ session_generation: -Infinity })).rejects.toThrow(TypeError);
       expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8"))).toEqual({ keep: "kept" });
+    });
+  });
+
+  describe("a list with a member JSON cannot write", () => {
+    it("is refused rather than stored with a null in it", async () => {
+      // The other value JSON turns into `null`, and the one the top-level
+      // `=== undefined` test cannot see: inside an ARRAY, `undefined`, a
+      // function and a symbol are all written as a null MEMBER, so the list
+      // keeps its length and one entry becomes nothing. A `map` that can yield
+      // a hole — the approved-sender names, the disabled-provider list — would
+      // land that under a key the caller believes holds names.
+      await fs.writeFile(CONFIG_PATH, JSON.stringify({ keep: "kept" }), "utf-8");
+      await expect(configStore.set("telegram_approved_names", ["a", undefined, "b"]))
+        .rejects.toThrow(TypeError);
+      await expect(configStore.swap("telegram_approved_names", [{ names: [Symbol("x")] }]))
+        .rejects.toThrow(TypeError);
+      expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8"))).toEqual({ keep: "kept" });
+    });
+
+    it("still stores a property JSON omits, because nothing is misreported there", async () => {
+      // An OBJECT property whose value is `undefined` is left out of the file
+      // and reads back as `undefined` — which is what the caller stored. The
+      // guard is about values that come back as something ELSE.
+      await configStore.set("email_account", { address: "a@b.c", fromName: undefined });
+      expect(await configStore.get("email_account")).toEqual({ address: "a@b.c" });
     });
   });
 

--- a/src/tests/unit/config-store.test.ts
+++ b/src/tests/unit/config-store.test.ts
@@ -433,19 +433,31 @@ describe("config-store", () => {
       // `NaN` on the write, and the store ended up holding `null` under a key
       // the write had reported success for. What is stored is now what was
       // checked, and the counter proves the value is serialised ONCE.
-      let calls = 0;
-      const shifty = {
-        toJSON() {
-          calls += 1;
-          return calls === 1 ? 7 : NaN;
-        },
+      //
+      // Driven through ALL THREE writers, because the failure this whole change
+      // exists to remove has never been in one of them: reverting `swap` or
+      // `setMany` alone to persist the original value passed the entire suite
+      // while `set` was pinned.
+      const shifty = () => {
+        let calls = 0;
+        return { calls: () => calls, value: { toJSON: () => (++calls === 1 ? 7 : NaN) } };
       };
 
-      await configStore.set("session_generation", shifty);
-
-      expect(calls, "the value must be serialised once, not once per pass").toBe(1);
+      const forSet = shifty();
+      await configStore.set("session_generation", forSet.value);
+      expect(forSet.calls(), "the value must be serialised once, not once per pass").toBe(1);
       expect(JSON.parse(await fs.readFile(CONFIG_PATH, "utf-8")).session_generation).toBe(7);
       expect(await configStore.get("session_generation")).toBe(7);
+
+      const forSwap = shifty();
+      await configStore.swap("swapped", forSwap.value);
+      expect(forSwap.calls(), "swap must serialise once too").toBe(1);
+      expect(await configStore.get("swapped")).toBe(7);
+
+      const forMany = shifty();
+      await configStore.setMany({ batched: forMany.value });
+      expect(forMany.calls(), "setMany must serialise once too").toBe(1);
+      expect(await configStore.get("batched")).toBe(7);
     });
   });
 

--- a/src/tests/unit/kv-store.test.ts
+++ b/src/tests/unit/kv-store.test.ts
@@ -308,6 +308,14 @@ describe("kv-store", () => {
       expect(kvStore.kvGetAll()).toEqual({});
     });
 
+    it("drops a __proto__ the FILE already carries, like config-store", async () => {
+      await fs.writeFile(KV_PATH, '{"__proto__":{"polluted":true},"ui:theme":"dark"}', "utf-8");
+      expect(kvStore.kvGet("__proto__")).toBeNull();
+      expect(kvStore.kvGetAll()).toEqual({ "ui:theme": "dark" });
+      kvStore.kvSet("ui:theme", "light");
+      expect(JSON.parse(await fs.readFile(KV_PATH, "utf-8"))).toEqual({ "ui:theme": "light" });
+    });
+
     it("kvGet answers null for an inherited name, never the prototype", () => {
       expect(kvStore.kvGet("__proto__")).toBeNull();
       expect(kvStore.kvGet("constructor")).toBeNull();

--- a/src/tests/unit/kv-store.test.ts
+++ b/src/tests/unit/kv-store.test.ts
@@ -289,6 +289,32 @@ describe("kv-store", () => {
     });
   });
 
+  describe("a key the object backing the store cannot hold", () => {
+    // The same defect config-store carries, in the store whose keys really are
+    // caller-shaped: `data["__proto__"] = value` reaches Object.prototype's
+    // setter, stores nothing and answers success, and the read then hands back
+    // the PROTOTYPE under a signature that says `string | null`.
+    // `/setup-api/kv` refuses that name at the door — but the notice ring, the
+    // mascot phrases and the uninstall sweep all call the store directly.
+    it("kvSet refuses it instead of reporting a write that never happened", () => {
+      expect(() => kvStore.kvSet("__proto__", "x")).toThrow(TypeError);
+      expect(kvStore.kvGet("__proto__")).toBeNull();
+    });
+
+    it("kvSetMany refuses the whole batch rather than landing half of it", () => {
+      // A COMPUTED key: `{ __proto__: … }` in a literal sets the literal's own
+      // prototype and creates no entry at all.
+      expect(() => kvStore.kvSetMany({ "ui:theme": "dark", ["__proto__"]: "x" })).toThrow(TypeError);
+      expect(kvStore.kvGetAll()).toEqual({});
+    });
+
+    it("kvGet answers null for an inherited name, never the prototype", () => {
+      expect(kvStore.kvGet("__proto__")).toBeNull();
+      expect(kvStore.kvGet("constructor")).toBeNull();
+      expect(kvStore.kvGet("toString")).toBeNull();
+    });
+  });
+
   describe("error handling", () => {
     it("returns empty object for corrupt JSON", async () => {
       await fs.writeFile(KV_PATH, "{ invalid json !!!", "utf-8");


### PR DESCRIPTION
**TASK-762** — the residuals recorded on #734: the false-success shape the value guard removed, arriving on the KEY side and one type further in on the value side.

### Customer-visible symptom
A setting is saved, the route answers success, and the store did not change the way the caller believes:
- `swap("__proto__", x)` / `set` / `setMany` never store the key — `config[key] = value` reaches `Object.prototype`'s own accessor rather than creating a property — so `writeConfig` renames a config WITHOUT it over the one that had it, and `swap` hands the caller `Object.prototype` back as "the value it replaced".
- `NaN` and `±Infinity` stringify to `"null"`, so a non-finite number walks past the `JSON.stringify(value) === undefined` guard and the file holds `null` under a key the caller believes holds a figure. Every reader then sees "unset": `session_generation` back to 0 invalidates every live cookie, `clawai_credential_refused_at` back to "never refused" re-arms the write the refusal exists to stop, `setup_progress_step` reopens the wizard.

### Cause and fix
`src/lib/config-store.ts`. One `assertStorableKey` and one `assertStorableValue`, applied by all three writers before anything is read, and `setMany` checks the WHOLE batch first so a refusal never leaves half of it applied. The value walk is `JSON.stringify`'s own — so a cycle is reported by the serialiser that would have hit it anyway — and it also rejects the members JSON turns into `null` inside an ARRAY (`undefined`, a function, a symbol at any depth: the list keeps its length and one entry becomes nothing). An OBJECT property JSON omits is deliberately still stored: it reads back as `undefined`, which is what the caller stored.

The review pass added the other half of the invariant. Refusing to CREATE the key leaves a store that already holds one — a hand-edit, a restored backup of an older `data/` — re-emitting it on every settings change with no way out, and every read still answering `Object.prototype` for it. So: the key is dropped on the way in (`JSON.parse` creates it as an own property), reads answer own properties only (`held()`, which also stops `"constructor"` answering the `Object` function), and `set(key, undefined)` still deletes — a delete is not a write, and it is how a store that already holds one is cleaned.

### Harness-first
None to leverage: `data/config.json` is ClawBox's own device store — the file `scripts/gateway-pre-start.sh` exports as `CLAWBOX_DEVICE_STORE` and `scripts/register-mcp.sh` reads. It is not OpenClaw's `openclaw.json`, not a model list, credential store or catalogue, and neither harness has a mechanism that owns it. (`gateway-pre-start.sh` already defends against a non-finite number from a hand-edited store, and its comment about `JSON.stringify` mapping one to `null` stays true.)

### Sibling call sites
- **Every caller that writes a number** was swept: `bumpSessionGeneration` filters through `Number.isFinite`, `parseStoredStep` through `Number.isInteger`, `setMaxTurns`/`setTokenLimit` reject non-finite before the write, and the rest are `Date.now()`. So no existing caller starts throwing.
- **The largest nested-number writer is not one of those four, and is now load-bearing on another file:** `POST /setup-api/preferences` (`route.ts:171`) hands `setMany` arbitrary nested JSON from an HTTP body, and `JSON.parse('{"wp_opacity":1e999}')` really does yield `Infinity`. It is safe only because `validatePreference` → `checkShape` (`src/lib/preference-schema.ts:117-119`) refuses a non-finite number at any depth and the route answers 400 first. Stated rather than left implicit, because that guard is now what keeps this route off the new throw. Related latent gap, recorded on the queue rather than fixed here: `sanitizePreferenceWrites` passes NON-`pref:` keys through unchecked into `setPreferences`, and every caller supplies a literal `pref:*` today.
- **Every top-level key** reaching the three writers is a module constant or a prefixed dynamic key (`preferences` prefixes `pref:`, `sqlite-store` prefixes `sqlite-kv:`), so nothing legitimate is refused.
- **The sibling store, `src/lib/kv-store.ts`, is fixed rather than cleared**: it has the identical `data[key] = value` shape and its keys really are caller-shaped. `/setup-api/kv` refuses `__proto__`/`constructor`/`prototype` at the door, but the route is not the only one — the notice ring, the mascot phrases and the uninstall sweep call the store directly — so it now uses the SAME `assertStorableKey`, not a second copy, and `kvGet` answers own keys only (it returned `Object.prototype` under a `string | null` signature).
- Not in scope, recorded in the fixer queue's Found list: a NESTED `__proto__` inside a value (`pref:installed_meta[appId]`, CodeQL #511 on `webapp-registry.ts:73`) is the caller's own object shape and is written as it stands; guarding it here would refuse every preferences write on a box that already had one.

### Review-pass fixes on this head
- A value whose own `toJSON` has ALREADY turned it into null walked the guard: `JSON.stringify` calls `toJSON` before the replacer, so `new Date(NaN)` arrived as `null` and all four writers stored null under a key the caller believes holds a time. `this[field]` inside the replacer is the pre-`toJSON` value at every depth (the top level included), so a `null` whose source was not null is refused and a real `null` is still stored — the class, not `Date`'s corner of it. Not reachable from a caller today (every production writer of a time calls `.toISOString()` first, which throws `RangeError` on an invalid date), fixed anyway because the store's contract is that a write lands what the caller passed or refuses.
- `swap`'s "use set()" advice belongs to `undefined` alone now — the one value it is true for.
- The catch-all for a value JSON omits ENTIRELY (a `toJSON` answering `undefined`) lived in `swap` alone, so `set` and `setMany` resolved and deleted the stored value; it is inside the shared guard now.
- The guard serialised the value and threw the string away while `writeConfig` serialised it again — two answers from one value, and a stateful `toJSON` (valid on the walk, `NaN` on the write) left `session_generation` holding `null` under a write that reported success. The walk RETURNS its string and what is stored is that string parsed back, so there is no second answer to differ; a counter in the test proves one serialisation.
- A value JSON omits ALTOGETHER (a bare function or symbol) passed the guard: the array clause cannot see the top-level value, because the replacer's `this` there is JSON's own wrapper. `set("active_harness", () => …)` deleted the harness and reported success; `swap` was saved only by its own earlier `=== undefined` test. Refused in all three writers now — `undefined` still means delete, and both writers filter it out before the guard.
- A BOXED non-finite number (`new Number(NaN)`) reaches the replacer as an object and is written as `null` just the same; the "at any depth" claim now holds for it.
- `kv-store` drops an inbound `__proto__` the file carries, like `config-store`, instead of re-emitting it on every write.
- The on-box writer's output is unchanged: `node --experimental-strip-types` over this module and over beta's, in an isolated `CLAWBOX_ROOT`, write byte-identical `data/config.json` (103 bytes, mode 600).

### RED → GREEN
RED on unmodified beta (44681020):

```
 ❯ |unit| src/tests/unit/config-store.test.ts (44 tests | 5 failed) 58ms
       × swap refuses it rather than reporting a write that never happened 6ms
       × set refuses it 1ms
       × setMany refuses the whole batch rather than landing half of it 1ms
       × swap refuses NaN and Infinity instead of storing null 1ms
       × set and setMany refuse it too, nested as well as bare 1ms

 FAIL … > swap refuses it rather than reporting a write that never happened
AssertionError: promise resolved "{ …(12) }" instead of rejecting
```

(that `{ …(12) }` is `Object.prototype`, handed back as the replaced value.)

RED for the kv-store half, with `src/lib/kv-store.ts` restored to beta:

```
 ❯ |unit| src/tests/unit/kv-store.test.ts (43 tests | 3 failed) 53ms
       × kvSet refuses it instead of reporting a write that never happened 3ms
       × kvSetMany refuses the whole batch rather than landing half of it 1ms
       × kvGet answers null for an inherited name, never the prototype 2ms
```

RED for the review-pass half, with the top-level check removed:

```
       × is refused by all three writers, not just swap 21ms
       × refuses a boxed non-finite number, which stringifies to null like the bare one 3ms
       × drops a __proto__ the FILE already carries, like config-store 11ms
AssertionError: promise resolved "undefined" instead of rejecting
```

GREEN: `config-store` + `kv-store` = 100 tests; whole unit project 772 files, 12927 passed / 1 skipped; components project 202 files, 1729 tests; `tsc --noEmit` clean; `eslint` on the touched files clean (one pre-existing unused-import warning on beta's own line, untouched).

### Editions
Both. `data/config.json` and `data/kv.json` are the device's own stores on every SKU; nothing here is edition-conditional.

### Device
Not device-proven: pure store semantics, fully exercised by CI, with no unit, path or edition-lock behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved configuration and key-value storage security by preventing access to inherited or unsafe properties.
  - Invalid keys and values—including unsupported numbers and unserializable array contents—are now rejected before data is saved.
  - Batch updates validate all entries before applying changes, preventing partial updates.
  - Unsafe entries loaded from existing configuration data are filtered out, while supported deletion behavior remains available.
  - Key-value lookups no longer expose inherited properties such as `constructor` or `toString`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->