### PR TITLE
Setup: "use only local AI" actually configures local AI (was a no-op)

### DIFF
--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -1015,6 +1015,7 @@ export default function AIModelsStep({
     llamaCppProgress,
     checkLlamaCppStatus,
     saveLlamaCppConfig,
+    activateLocalOnly,
   } = useLlamaCppModels(llamaCppCallbacks, configureScope);
 
   const getAvailableAuthOptionsForProvider = useCallback((providerId: string | null) => {
@@ -1167,7 +1168,15 @@ export default function AIModelsStep({
   ]);
 
   useEffect(() => {
-    if (selectedProvider !== "llamacpp" || !llamaCppSaving) return;
+    // Deliberately NOT gated on `selectedProvider` any more. `llamaCppSaving`
+    // is set by exactly one thing — this hook's install — so it is the whole
+    // condition. "Skip — I'll use only local AI" runs that install with a
+    // DIFFERENT radio still selected (ClawBox AI is the wizard's default and
+    // the customer never left it), and under the old gate its NDJSON status
+    // lines landed in `llamaCppProgress` and were simply never painted: an
+    // install that can spend minutes provisioning sat behind a form that
+    // looked idle.
+    if (!llamaCppSaving) return;
 
     const next = getLlamaCppOverlayProgress(llamaCppProgress, llamaCppInstallSteps.length);
     setConfiguringState({
@@ -1178,7 +1187,7 @@ export default function AIModelsStep({
       progressPercent: next.progressPercent,
       completed: false,
     });
-  }, [llamaCppInstallSteps.length, llamaCppProgress, llamaCppSaving, selectedProvider]);
+  }, [llamaCppInstallSteps.length, llamaCppProgress, llamaCppSaving]);
 
   const selectProvider = useCallback((id: string) => {
     userSelectedProviderRef.current = true;
@@ -1386,11 +1395,49 @@ export default function AIModelsStep({
     selectProvider(normalizedRequestedProvider);
   }, [allowedProviders, providerSelectionRequest, requestedProviderId, selectProvider]);
 
-  const handleSkipAction = useCallback(() => {
+  /**
+   * One button, two meanings — and only one of them is a decline.
+   *
+   * In the embedded Local-AI scope the label is a plain t("skip"), which claims
+   * nothing beyond moving on, so it still only moves on.
+   *
+   * In the wizard the label is t("ai.skipUseLocalOnly") — "Skip — I'll use only
+   * local AI" — which is a CHOICE of provider wearing a skip's clothes. It used
+   * to only advance, and the box it left behind had
+   * `agents.defaults.model.primary` set to `llamacpp/gemma4-e2b-it-q4_0` with
+   * `models.providers` still EMPTY: nothing had registered the provider that
+   * name resolves through, so every chat turn died with "Unknown model:
+   * llamacpp/gemma4-e2b-it-q4_0" on a box whose GGUF had been on disk the whole
+   * time. So configure it here, through the same request Settings → Local AI →
+   * "Make primary" sends (see `activateLocalOnly`).
+   */
+  const handleSkipAction = useCallback(async () => {
     setStatus(null);
     stopPolling();
-    onNext?.();
-  }, [onNext, stopPolling]);
+    // Only the wizard's primary-scope step makes the local-AI promise, and only
+    // a step that was actually given `llamacpp` to offer can keep it. A
+    // cloud-only `providerIds` list still gets the honest no-op rather than an
+    // install of a provider this screen is not configuring.
+    const canConfigureLocal =
+      configureScope !== "local"
+      && allowedProviders.some((provider) => provider.id === "llamacpp");
+    if (!canConfigureLocal) {
+      onNext?.();
+      return;
+    }
+    // The selected radio is deliberately left alone: the customer never chose
+    // it and moving it would abort a half-finished OAuth and discard a typed
+    // key (see syncProviderSelection). The progress overlay does not need it —
+    // its effect keys on `llamaCppSaving` alone.
+    //
+    // Deliberately no onNext() here either: the hook's callbacks own both
+    // terminal transitions. Success runs showSuccessAndContinue → the overlay's
+    // completion → onNext, so the wizard advances only once the box can
+    // actually answer; failure runs showError, which keeps the customer on this
+    // step with the reason instead of advancing a wizard that configured
+    // nothing and calling that "use only local AI".
+    await activateLocalOnly();
+  }, [activateLocalOnly, allowedProviders, configureScope, onNext, stopPolling]);
 
   // Save token received from any OAuth flow (device or redirect)
   const saveOAuthToken = useCallback(async (
@@ -2556,9 +2603,15 @@ export default function AIModelsStep({
             <button
               type="button"
               onClick={handleSkipAction}
-              disabled={saving}
+              // In the wizard this button now installs, starts and registers the
+              // local model, which takes tens of seconds — so it stays down for
+              // its own work as well as the Connect button's. The progress and
+              // any failure are reported by the same overlay and status line
+              // every other configure on this step uses.
+              disabled={saving || llamaCppSaving !== false}
               className="min-h-[40px] px-3 rounded-[var(--r-1)] text-[length:var(--t-2)] font-semibold text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--fill-2)] bg-transparent border-none cursor-pointer transition-colors duration-[var(--d-2)] ease-[var(--ease-standard)] disabled:cursor-not-allowed"
             >
+              {llamaCppSaving !== false && ButtonSpinner}
               {configureScope === "local" ? t("skip") : t("ai.skipUseLocalOnly")}
             </button>
           </div>

--- a/src/hooks/useLlamaCppModels.ts
+++ b/src/hooks/useLlamaCppModels.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useState } from "react";
+import { getDefaultLlamaCppModel } from "@/lib/llamacpp";
 
 export interface LlamaCppModel {
   id: string;
@@ -46,17 +47,25 @@ export function useLlamaCppModels(callbacks: LlamaCppCallbacks, configureScope: 
     }
   }, []);
 
-  // `options.activate` = the user clicked "Switch to Gemma 4", i.e. asked for
-  // this model to become the one that answers. A plain enable omits it and
-  // keeps the customer's chosen provider in place.
-  const saveLlamaCppConfig = useCallback(async (model: string, options?: { activate?: boolean }) => {
-    const trimmedModel = model.trim();
-    if (!trimmedModel) {
-      onSaveError("Enter the llama.cpp model ID first.");
-      return;
-    }
-
-    setLlamaCppSaving(trimmedModel);
+  /**
+   * One POST to /setup-api/llamacpp/install with its NDJSON progress stream
+   * read to a terminal line, reported through the shared callbacks.
+   *
+   * Both entry points below go through here, and the only thing that differs
+   * between them is the request body. A second copy of this reader is how one
+   * of them would quietly stop surfacing failures the other still surfaces:
+   * this route reports an install error IN the stream body, not by status code,
+   * so a caller that stops reading at the headers calls a failed install a
+   * success.
+   *
+   * `savingKey` is only what `llamaCppSaving` exposes for per-row spinners; the
+   * request is `body` alone.
+   */
+  const runLlamaCppInstall = useCallback(async (
+    body: { model?: string; scope: ConfigureScope; activate: boolean },
+    savingKey: string,
+  ) => {
+    setLlamaCppSaving(savingKey);
     setLlamaCppProgress(llamaCppInstalled ? "Checking local Gemma 4 runtime..." : "Preparing llama.cpp...");
     onClearStatus?.();
 
@@ -64,11 +73,7 @@ export function useLlamaCppModels(callbacks: LlamaCppCallbacks, configureScope: 
       const res = await fetch("/setup-api/llamacpp/install", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          model: trimmedModel,
-          scope: configureScope,
-          activate: options?.activate === true,
-        }),
+        body: JSON.stringify(body),
       });
 
       if (!res.ok) {
@@ -85,7 +90,10 @@ export function useLlamaCppModels(callbacks: LlamaCppCallbacks, configureScope: 
 
       const decoder = new TextDecoder();
       let buffer = "";
-      let installedModel = trimmedModel;
+      // The server picks the alias when the body omits one, and it names the
+      // choice on the success line — so this starts at whatever was asked for
+      // (if anything) and `payload.model` corrects it.
+      let installedModel = body.model ?? savingKey;
 
       while (true) {
         const { done, value } = await reader.read();
@@ -134,7 +142,49 @@ export function useLlamaCppModels(callbacks: LlamaCppCallbacks, configureScope: 
       setLlamaCppSaving(false);
       setLlamaCppProgress(null);
     }
-  }, [checkLlamaCppStatus, configureScope, llamaCppInstalled, onClearStatus, onSaveError, onSaveSuccess]);
+  }, [checkLlamaCppStatus, llamaCppInstalled, onClearStatus, onSaveError, onSaveSuccess]);
+
+  // `options.activate` = the user clicked "Switch to Gemma 4", i.e. asked for
+  // this model to become the one that answers. A plain enable omits it and
+  // keeps the customer's chosen provider in place.
+  const saveLlamaCppConfig = useCallback(async (model: string, options?: { activate?: boolean }) => {
+    const trimmedModel = model.trim();
+    if (!trimmedModel) {
+      onSaveError("Enter the llama.cpp model ID first.");
+      return;
+    }
+
+    await runLlamaCppInstall(
+      { model: trimmedModel, scope: configureScope, activate: options?.activate === true },
+      trimmedModel,
+    );
+  }, [configureScope, onSaveError, runLlamaCppInstall]);
+
+  /**
+   * "I'll use only local AI": bring Gemma 4 up, register the `llamacpp`
+   * provider, and make it the model that answers.
+   *
+   * `scope: "local"` is deliberately NOT this hook's ambient `configureScope`,
+   * and that difference is the whole point. Only the local scope reaches the
+   * branch of ai-models/configure that writes `local_ai_configured` /
+   * `local_ai_model` and starts the runtime, and only it feeds
+   * `shouldPromoteLocalToPrimary` (src/app/setup-api/ai-models/configure/route.ts:2229).
+   * The wizard's ambient scope is "primary", which does register the provider
+   * but leaves the box with no `local_ai_model` — Settings → Local AI would
+   * then show Gemma as unconfigured, and the Local-only switch would refuse
+   * with "Local AI is not configured"
+   * (src/app/setup-api/local-ai/exclusive/route.ts:404).
+   *
+   * This is the same request Settings → Local AI → "Make primary" already sends
+   * (src/components/LocalAiPanel.tsx:445) — the path measured working on a
+   * device — down to omitting `model` so the SERVER picks the alias. Sending
+   * the browser's idea of the default instead would disagree with the server on
+   * any box that sets LLAMACPP_MODEL, since that variable is not exposed to the
+   * client bundle.
+   */
+  const activateLocalOnly = useCallback(async () => {
+    await runLlamaCppInstall({ scope: "local", activate: true }, getDefaultLlamaCppModel());
+  }, [runLlamaCppInstall]);
 
   return {
     llamaCppRunning,
@@ -145,5 +195,6 @@ export function useLlamaCppModels(callbacks: LlamaCppCallbacks, configureScope: 
     llamaCppProgress,
     checkLlamaCppStatus,
     saveLlamaCppConfig,
+    activateLocalOnly,
   };
 }

--- a/src/tests/components/ai-models-step-skip-local-only.test.tsx
+++ b/src/tests/components/ai-models-step-skip-local-only.test.tsx
@@ -1,0 +1,205 @@
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, waitFor } from "@/tests/helpers/test-utils";
+import AIModelsStep from "@/components/AIModelsStep";
+
+/**
+ * "Skip — I'll use only local AI" is a CHOICE of provider, not a decline, and
+ * it used to only advance the wizard. The box that left behind had
+ * `agents.defaults.model.primary` on `llamacpp/gemma4-e2b-it-q4_0` with
+ * `models.providers` EMPTY, so every chat turn failed with "Unknown model:
+ * llamacpp/gemma4-e2b-it-q4_0" — with the GGUF sitting on disk the whole time.
+ *
+ * These pin the two halves of the fix: the button configures local AI BEFORE it
+ * advances, and a failed configure does NOT advance. The request that configure
+ * sends is pinned separately, on the hook, in
+ * src/tests/unit/use-llamacpp-activate-local-only.test.ts.
+ */
+
+const hookState = vi.hoisted(() => ({
+  callbacks: null as null | {
+    onSaveSuccess: (model: string) => void;
+    onSaveError: (message: string) => void;
+    onClearStatus?: () => void;
+  },
+  scope: null as string | null,
+  activateLocalOnly: vi.fn(async () => {}),
+  saveLlamaCppConfig: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/i18n", () => ({
+  useT: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        "ai.title": "Connect AI Model",
+        "ai.description": "Select your AI provider.",
+        "ai.skipUseLocalOnly": "Skip — I'll use only local AI",
+        skip: "Skip",
+        "ai.runLocally": "Run AI models locally on device",
+        "ai.fullyLocal": "Fully local",
+        "ai.showMore": "Show more providers...",
+        connecting: "Connecting...",
+        "settings.connect": "Connect",
+        "settings.aiProvider": "AI Provider",
+        "settings.providers.radioGroupLabel": "AI Provider",
+      };
+      return translations[key] ?? key;
+    },
+  }),
+  I18nProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/hooks/useOllamaModels", () => ({
+  useOllamaModels: () => ({
+    ollamaRunning: false,
+    ollamaModels: [],
+    ollamaSearch: "",
+    ollamaSearchResults: [],
+    ollamaSearching: false,
+    ollamaPulling: false,
+    ollamaPullProgress: null,
+    ollamaSaving: false,
+    checkOllamaStatus: vi.fn(),
+    handleOllamaSearchChange: vi.fn(),
+    pullOllamaModel: vi.fn(),
+    saveOllamaConfig: vi.fn(),
+    deleteOllamaModel: vi.fn(),
+    formatOllamaBytes: vi.fn((bytes: number) => `${bytes}`),
+    clearSearch: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useLlamaCppModels", () => ({
+  useLlamaCppModels: (
+    callbacks: {
+      onSaveSuccess: (model: string) => void;
+      onSaveError: (message: string) => void;
+      onClearStatus?: () => void;
+    },
+    configureScope: string,
+  ) => {
+    // Captured so a test can drive the terminal callback the real hook would
+    // fire, which is what decides whether the wizard moves.
+    hookState.callbacks = callbacks;
+    hookState.scope = configureScope;
+    return {
+      llamaCppRunning: false,
+      llamaCppInstalled: true,
+      llamaCppModels: [],
+      llamaCppEndpoint: "http://127.0.0.1:8080/v1",
+      llamaCppSaving: false as const,
+      llamaCppProgress: null,
+      checkLlamaCppStatus: vi.fn(),
+      saveLlamaCppConfig: hookState.saveLlamaCppConfig,
+      activateLocalOnly: hookState.activateLocalOnly,
+    };
+  },
+}));
+
+function renderStep(props: Record<string, unknown> = {}) {
+  return render(
+    <AIModelsStep
+      providerIds={["clawai", "anthropic", "llamacpp"]}
+      defaultProviderId="clawai"
+      title="Connect AI Provider"
+      description="Pick a provider"
+      testId="wizard-ai"
+      {...props}
+    />,
+  );
+}
+
+describe("the wizard's \"use only local AI\" button", () => {
+  beforeEach(() => {
+    hookState.callbacks = null;
+    hookState.scope = null;
+    hookState.activateLocalOnly.mockClear();
+    hookState.saveLlamaCppConfig.mockClear();
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof Request ? input.url : input.toString();
+      if (url.includes("/setup-api/ai-models/oauth/providers")) {
+        return { ok: true, json: async () => ({ providers: [] }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    }));
+  });
+
+  it("configures local AI, and does not advance until that succeeds", async () => {
+    const onNext = vi.fn();
+    const { findByRole } = renderStep({ onNext });
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith("/setup-api/ai-models/oauth/providers"));
+
+    await act(async () => {
+      fireEvent.click(await findByRole("button", { name: /use only local AI/i }));
+    });
+
+    // The whole bug: this used to be zero calls and an advanced wizard.
+    expect(hookState.activateLocalOnly).toHaveBeenCalledTimes(1);
+    // Nothing has reported success yet, so the wizard has NOT moved.
+    expect(onNext).not.toHaveBeenCalled();
+
+    await act(async () => {
+      hookState.callbacks?.onSaveSuccess("gemma4-e2b-it-q4_0");
+    });
+
+    // The success overlay holds for 900 ms before handing over to the wizard.
+    await waitFor(() => expect(onNext).toHaveBeenCalledTimes(1), { timeout: 4000 });
+  });
+
+  it("does not advance when the activation fails, and says why", async () => {
+    const onNext = vi.fn();
+    const { findByRole, findByText } = renderStep({ onNext });
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith("/setup-api/ai-models/oauth/providers"));
+
+    await act(async () => {
+      fireEvent.click(await findByRole("button", { name: /use only local AI/i }));
+    });
+    await act(async () => {
+      hookState.callbacks?.onSaveError("Failed to provision the local Gemma 4 runtime");
+    });
+
+    expect(await findByText(/Failed to provision the local Gemma 4 runtime/i)).toBeInTheDocument();
+    // Advancing here would hand the owner a finished wizard and a box that
+    // cannot answer — the failure this fix exists to stop being silent.
+    expect(onNext).not.toHaveBeenCalled();
+  });
+
+  it("stays a plain skip on a step that was never offered the local provider", async () => {
+    const onNext = vi.fn();
+    const { findByRole } = renderStep({
+      onNext,
+      providerIds: ["clawai", "anthropic"],
+    });
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith("/setup-api/ai-models/oauth/providers"));
+
+    await act(async () => {
+      fireEvent.click(await findByRole("button", { name: /use only local AI/i }));
+    });
+
+    // This step is not configuring llamacpp, so the button cannot honour the
+    // promise its label makes — it must not install a provider this screen
+    // does not offer, and it must still let the customer past.
+    expect(hookState.activateLocalOnly).not.toHaveBeenCalled();
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays a plain skip in the embedded Local AI scope", async () => {
+    const onNext = vi.fn();
+    const { findByRole } = renderStep({
+      onNext,
+      configureScope: "local",
+      providerIds: ["llamacpp"],
+      defaultProviderId: "llamacpp",
+    });
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith("/setup-api/ai-models/oauth/providers"));
+
+    await act(async () => {
+      fireEvent.click(await findByRole("button", { name: /^Skip$/i }));
+    });
+
+    // Here the label is a plain "Skip" and claims nothing about configuring, so
+    // it must keep advancing immediately and touch no config.
+    expect(onNext).toHaveBeenCalledTimes(1);
+    expect(hookState.activateLocalOnly).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/unit/use-llamacpp-activate-local-only.test.ts
+++ b/src/tests/unit/use-llamacpp-activate-local-only.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useLlamaCppModels } from "@/hooks/useLlamaCppModels";
+
+/**
+ * The wizard's "Skip — I'll use only local AI" configures local AI through
+ * `activateLocalOnly`, and what makes that work is the REQUEST it sends, not
+ * the fact that it sends one.
+ *
+ * A box configured through the wizard's ambient scope ("primary") comes out
+ * with the provider registered but no `local_ai_model`, which leaves Settings →
+ * Local AI showing Gemma as unconfigured and the Local-only switch refusing
+ * with "Local AI is not configured". Only `scope: "local"` reaches the branch
+ * that writes those keys and starts the runtime
+ * (src/app/setup-api/ai-models/configure/route.ts:2229).
+ *
+ * So these assert the exact body Settings → Local AI → "Make primary" sends
+ * (src/components/LocalAiPanel.tsx:445) — `{scope:"local", activate:true}` with
+ * NO model, so the server picks the alias.
+ */
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  globalThis.fetch = realFetch;
+});
+
+/** A streamed NDJSON install response, one JSON object per line. */
+function ndjsonResponse(lines: unknown[]): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      for (const line of lines) {
+        controller.enqueue(encoder.encode(`${JSON.stringify(line)}\n`));
+      }
+      controller.close();
+    },
+  });
+  return new Response(body, { status: 200 });
+}
+
+function setup(configureScope: "primary" | "local" = "primary") {
+  const onSaveSuccess = vi.fn();
+  const onSaveError = vi.fn();
+  const onClearStatus = vi.fn();
+  const hook = renderHook(() =>
+    useLlamaCppModels({ onSaveSuccess, onSaveError, onClearStatus }, configureScope),
+  );
+  return { hook, onSaveSuccess, onSaveError, onClearStatus };
+}
+
+/** The parsed JSON body of the Nth fetch call. */
+function bodyOf(fetchMock: ReturnType<typeof vi.fn>, call = 0): Record<string, unknown> {
+  const init = fetchMock.mock.calls[call][1] as RequestInit;
+  return JSON.parse(init.body as string);
+}
+
+describe("useLlamaCppModels — activateLocalOnly", () => {
+  it("sends the local scope with activate, and no model, whatever the ambient scope is", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (String(url).includes("/setup-api/llamacpp/status")) {
+        return new Response(JSON.stringify({ running: true, installed: true, models: [] }), { status: 200 });
+      }
+      return ndjsonResponse([
+        { status: "llama.cpp is already running. Applying configuration..." },
+        { success: true, model: "gemma4-e2b-it-q4_0" },
+      ]);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    // The wizard's ambient scope is "primary" — the point is that the local-only
+    // action does NOT inherit it.
+    const { hook, onSaveSuccess, onSaveError } = setup("primary");
+    await hook.result.current.activateLocalOnly();
+
+    const installCall = fetchMock.mock.calls.findIndex(
+      ([url]) => String(url) === "/setup-api/llamacpp/install",
+    );
+    expect(installCall).toBeGreaterThanOrEqual(0);
+    expect(bodyOf(fetchMock, installCall)).toEqual({ scope: "local", activate: true });
+    // Explicitly: the server, not the browser, chooses the alias.
+    expect(bodyOf(fetchMock, installCall)).not.toHaveProperty("model");
+
+    await waitFor(() => expect(onSaveSuccess).toHaveBeenCalledWith("gemma4-e2b-it-q4_0"));
+    expect(onSaveError).not.toHaveBeenCalled();
+  });
+
+  it("reports an error line from the stream as a failure, not a success", async () => {
+    const fetchMock = vi.fn(async () =>
+      ndjsonResponse([
+        { status: "Installing llama.cpp and Gemma 4 for offline use..." },
+        { error: "Failed to provision the local Gemma 4 runtime" },
+      ]),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const { hook, onSaveSuccess, onSaveError } = setup("primary");
+    await hook.result.current.activateLocalOnly();
+
+    // The route reports install failures in the BODY with a 200, so a caller
+    // that only checked the status would call this a configured box.
+    expect(onSaveError).toHaveBeenCalledWith("Failed to provision the local Gemma 4 runtime");
+    expect(onSaveSuccess).not.toHaveBeenCalled();
+  });
+
+  it("reports a stream that ends before the server is ready as a failure", async () => {
+    const fetchMock = vi.fn(async () => ndjsonResponse([{ status: "Preparing llama.cpp..." }]));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const { hook, onSaveSuccess, onSaveError } = setup("primary");
+    await hook.result.current.activateLocalOnly();
+
+    expect(onSaveError).toHaveBeenCalledWith("llama.cpp install ended before the server became ready.");
+    expect(onSaveSuccess).not.toHaveBeenCalled();
+  });
+
+  it("still sends the ambient scope and the named model for a plain save", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (String(url).includes("/setup-api/llamacpp/status")) {
+        return new Response(JSON.stringify({ running: true, installed: true, models: [] }), { status: 200 });
+      }
+      return ndjsonResponse([{ success: true, model: "gemma4-e2b-it-q4_0" }]);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    // The existing "Switch to Gemma 4" contract is unchanged by the refactor:
+    // same scope it always used, same explicit model, same activate flag.
+    const { hook } = setup("local");
+    await hook.result.current.saveLlamaCppConfig("gemma4-e2b-it-q4_0", { activate: true });
+
+    const installCall = fetchMock.mock.calls.findIndex(
+      ([url]) => String(url) === "/setup-api/llamacpp/install",
+    );
+    expect(bodyOf(fetchMock, installCall)).toEqual({
+      model: "gemma4-e2b-it-q4_0",
+      scope: "local",
+      activate: true,
+    });
+  });
+
+  it("refuses an empty model without calling the route", async () => {
+    const fetchMock = vi.fn(async () => ndjsonResponse([{ success: true }]));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const { hook, onSaveError } = setup("primary");
+    await hook.result.current.saveLlamaCppConfig("   ");
+
+    expect(onSaveError).toHaveBeenCalledWith("Enter the llama.cpp model ID first.");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## The bug

In the first-run wizard's AI Provider step, the button **"Skip — I'll use only local AI"** (`ai.skipUseLocalOnly`, rendered at `src/components/AIModelsStep.tsx:2562`) only advanced the wizard. Its handler at `src/components/AIModelsStep.tsx:1389` was:

```ts
const handleSkipAction = useCallback(() => {
  setStatus(null);
  stopPolling();
  onNext?.();
}, [onNext, stopPolling]);
```

It never registered the `llamacpp` provider and never activated the local model, so a customer who chose "I'll use only local AI" ended up with a box that could not chat at all.

Reproduced on a real box (**192.168.50.199**) flashed to clean `main`, then upgraded to `beta` v4.0.0.

### Measured before

After a fresh setup via the Skip button, `~/.openclaw/openclaw.json`:

```json
"agents": { "defaults": { "model": { "primary": "llamacpp/gemma4-e2b-it-q4_0" } } }
"models":  { "providers": {} }
```

`providers` is **empty** — the provider was never registered. Every chat turn failed with:

```
Error: Unknown model: llamacpp/gemma4-e2b-it-q4_0
Agent failed before reply: Unknown model: llamacpp/gemma4-e2b-it-q4_0.
```

The 3.35 GB GGUF was present the whole time at `~/clawbox/data/llamacpp/models/gemma-4-E2B_q4_0-it.gguf`. This was never a missing download — only the provider registration was missing.

### Measured after (via the Settings path, which already worked)

Settings → Local AI → Gemma 4 → "Make primary":

```json
"model": {"primary": "llamacpp/gemma4-e2b-it-q4_0", "fallbacks": []}
"providers": ["llamacpp"]
```

Chat then worked — Gemma 4 answered with "LOCAL OK".

Note the primary was *already* pointing at `llamacpp/…` before anything was configured: `scripts/gateway-pre-start.sh:1126` migrates the installer's dead `anthropic/claude-sonnet-4-20250514` seed onto the local model at boot. So a wizard step that writes nothing leaves that id resolving into an empty `models.providers`. The repair pass at `gateway-pre-start.sh:1150-1290` exists for this same failure and describes it at `:1135-1149`.

## The fix

`handleSkipAction` now makes the **same request Settings → Local AI → "Make primary" makes** — `src/components/LocalAiPanel.tsx:445`:

```
POST /setup-api/llamacpp/install   { scope: "local", activate: true }
```

That route provisions/starts the runtime and funnels into `configureAiModel`, which writes `models.providers.llamacpp` (`ai-models/configure/route.ts:3392`), writes `local_ai_model` (`:3161`) and promotes the primary via `shouldPromoteLocalToPrimary` (`:2229`).

### Why `scope: "local"` and not the step's ambient `"primary"`

`isLocalScope = scope === "local"` (`configure/route.ts:2057`) gates the parts that matter. The wizard's ambient `configureScope` is `"primary"`, which would register the provider but:

| | `scope:"primary"` | `scope:"local", activate:true` |
|---|---|---|
| runtime pre-start | skipped (`:2238` requires `isLocalScope`) | `activateLocalAiProvider("llamacpp")` |
| `local_ai_model` | never written (`:3157`) | written (`:3161`) |
| `models.mode` | `"replace"` | `"merge"` |

Without `local_ai_model`, Settings → Local AI shows Gemma as unconfigured and the Local-only switch refuses with "Local AI is not configured" (`local-ai/exclusive/route.ts:404`). `scope:"local"` is the measured-working path.

### Note on `local-ai/exclusive`

That route was suggested as the starting point, but it is the **Local-only mode toggle**, not "Make primary" — its only UI callers are the Local-only switch (`LocalAiPanel.tsx:272`, `:399`). It never registers a provider; it only re-points `primary` and empties `fallbacks`. Called from the wizard it would return **400 "Local AI is not configured"**, because `local_ai_model` is written exclusively by `ai-models/configure` under `isLocalScope`. Pointing `primary` at an unregistered provider is the bug itself, so `exclusive/` is downstream of the fix, not the fix.

## Behaviour

- Awaited, with the existing llama.cpp progress overlay and status line; the button shows a spinner and stays disabled while it works.
- **Advances only on success.** On failure `showError` paints the reason and the step holds — it never advances as if local AI were configured.
- **Preserved:** when `configureScope === "local"` the label is a plain `t("skip")` and it stays a pure skip. A step never offered `llamacpp` in `providerIds` also stays a pure skip (this is what `ai-models-step.test.tsx:488` asserts).
- No i18n label text changed. Update/upgrade paths untouched.

The progress-overlay effect no longer gates on `selectedProvider === "llamacpp"`. `llamaCppSaving` is set by exactly one thing — this hook's install — so it is the whole condition. The skip runs that install with a different radio still selected, and under the old gate its NDJSON status lines landed in `llamaCppProgress` and were never painted.

## Tests

- `src/tests/unit/use-llamacpp-activate-local-only.test.ts` (new, 5 tests) — pins the request body as exactly `{scope:"local", activate:true}` with **no** `model` (the server picks the alias; `LLAMACPP_MODEL` is not exposed to the client bundle, so the browser's guess could disagree with the device). Also pins that a stream `error` line is a failure, not a success — the route reports install failures in the body with a 200.
- `src/tests/components/ai-models-step-skip-local-only.test.tsx` (new, 4 tests) — the skip configures before advancing, does not advance on failure, and stays a pure skip in both preserved cases.

Both bug-pinning component tests were verified to **fail against the original handler** and pass with the fix.

## Known trade-off (not addressed here)

This step can now fail. A box with no cloud key whose local provisioning fails deterministically has no way past step 4, where previously the skip always let it through (onto a mute box). A post-failure "skip anyway" escape hatch would close that, but it is a visible UI addition and a product call — flagging rather than slipping it into a bugfix.

## Verification

`npx tsc --noEmit` clean. `npm run lint` unchanged from `beta` (147 problems / 18 errors both with and without this change; none in the touched files).

Full suite: **14639 passed, 1 skipped, 5 failed**. All 5 failures are pre-existing, load-dependent flakes in unrelated modules (`telegram/status`, `files/safe-path-containment`, `chat-email-refs-surfaces`) — they pass in isolation both with and without this change, and the clean-`beta` baseline run failed 8 tests from the same families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The AI setup wizard can now activate an available local AI model when choosing the local-only option.
  - Installation progress is shown while the local model is being configured.
  - The wizard waits for activation to complete before continuing.

- **Bug Fixes**
  - Prevented the setup flow from advancing when local model activation fails.
  - Improved handling and display of installation errors and incomplete setup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->