### PR TITLE
fix: say which agent was actually asked to reload its MCP servers

### DIFF
--- a/src/lib/coding-agent-mcp-refresh.ts
+++ b/src/lib/coding-agent-mcp-refresh.ts
@@ -1,7 +1,7 @@
 import { MCP_RELOAD_ALREADY, MCP_RELOAD_ASKED, reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reload";
 
 /**
- * Ask the agent to rebuild its MCP tool list when the coding agent becomes
+ * Ask HERMES to rebuild its MCP tool list when the coding agent becomes
  * usable, or stops being.
  *
  * WHY THIS EXISTS. Three tools — `coding_agent_run`, `coding_agent_status` and
@@ -24,7 +24,7 @@ import { MCP_RELOAD_ALREADY, MCP_RELOAD_ASKED, reloadMcpServers, reportMcpReload
  * instance of one shape: #486 fixed it for `email_list`/`email_read` and #503
  * for the image tools, and this was the call site left out.
  *
- * The mechanism is the agent's own `reload.mcp`, shared with both siblings — see
+ * The mechanism is HERMES' own `reload.mcp`, shared with the four siblings — see
  * `hermes-mcp-reload.ts`. What belongs HERE is the rule for when it is worth
  * paying for, below.
  */

--- a/src/lib/coding-agent-mcp-refresh.ts
+++ b/src/lib/coding-agent-mcp-refresh.ts
@@ -1,4 +1,4 @@
-import { reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reload";
+import { MCP_RELOAD_ALREADY, MCP_RELOAD_ASKED, reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reload";
 
 /**
  * Ask the agent to rebuild its MCP tool list when the coding agent becomes
@@ -102,7 +102,7 @@ export async function refreshCodingAgentToolsIfReadinessChanged(
   if (options.alreadyReloaded) {
     // Nothing to ask for: the respawn that already happened in this request
     // rebuilt EVERY family's tool list, this one included.
-    console.log(`[coding-agent/mcp-refresh] ${became}; the MCP servers were already reloaded for this change`);
+    console.log(`[coding-agent/mcp-refresh] ${became}; ${MCP_RELOAD_ALREADY}`);
     return;
   }
   // `.catch` even though `reloadMcpServers` documents that it never throws: the
@@ -116,5 +116,5 @@ export async function refreshCodingAgentToolsIfReadinessChanged(
     await reportMcpReloadRefused("coding-agent/mcp-refresh", became);
     return;
   }
-  console.log(`[coding-agent/mcp-refresh] ${became}; asked the agent to reload its MCP servers`);
+  console.log(`[coding-agent/mcp-refresh] ${became}; ${MCP_RELOAD_ASKED}`);
 }

--- a/src/lib/email-mcp-refresh.ts
+++ b/src/lib/email-mcp-refresh.ts
@@ -1,4 +1,4 @@
-import { reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reload";
+import { MCP_RELOAD_ASKED, reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reload";
 
 /**
  * Ask Hermes to rebuild its MCP tool list when the mailbox becomes readable, or
@@ -62,5 +62,5 @@ export async function refreshEmailToolsIfReadabilityChanged(before: boolean, aft
     await reportMcpReloadRefused("email/mcp-refresh", became);
     return;
   }
-  console.log(`[email/mcp-refresh] ${became}; asked Hermes to reload its MCP servers`);
+  console.log(`[email/mcp-refresh] ${became}; ${MCP_RELOAD_ASKED}`);
 }

--- a/src/lib/harness-mcp-refresh.ts
+++ b/src/lib/harness-mcp-refresh.ts
@@ -2,7 +2,7 @@ import { MCP_RELOAD_ASKED, reloadMcpServers, reportMcpReloadRefused } from "@/li
 import type { Harness } from "@/lib/harness";
 
 /**
- * Ask the agent to rebuild its tool list when the ACTIVE HARNESS moved under it.
+ * Ask HERMES to rebuild its tool list when the ACTIVE HARNESS moved under it.
  *
  * WHY THIS EXISTS — the fifth of five, and the biggest of them. The ClawBox MCP
  * server probes this device ONCE, while its stdio child boots
@@ -108,9 +108,9 @@ export async function refreshHarnessToolsIfSwitched(
     await reportMcpReloadRefused("harness/select", moved);
     return false;
   }
-  // Names WHO was asked, in the sentence every family shares — this module made
-  // the argument first (see `MCP_RELOAD_ASKED`) and two siblings still said "the
-  // agent", which reads as "whichever harness now serves the owner".
+  // Names WHO was asked, in the sentence every family shares: the mechanism is
+  // Hermes' dashboard, and "the agent" reads as "whichever harness now serves
+  // the owner" — wrong in the away direction on dual. See `MCP_RELOAD_ASKED`.
   console.log(`[harness/select] ${moved}; ${MCP_RELOAD_ASKED}`);
   return true;
 }

--- a/src/lib/harness-mcp-refresh.ts
+++ b/src/lib/harness-mcp-refresh.ts
@@ -1,4 +1,4 @@
-import { reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reload";
+import { MCP_RELOAD_ASKED, reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reload";
 import type { Harness } from "@/lib/harness";
 
 /**
@@ -108,11 +108,9 @@ export async function refreshHarnessToolsIfSwitched(
     await reportMcpReloadRefused("harness/select", moved);
     return false;
   }
-  // Names WHO was asked. "the agent" read as "whichever harness now serves the
-  // owner", which is wrong in the away direction: on dual, Hermes answers this
-  // call after the box has moved to OpenClaw, and an operator reading the
-  // journal for "the agent still thinks it is on Hermes" must not be told the
-  // OpenClaw child was reloaded.
-  console.log(`[harness/select] ${moved}; asked Hermes to reload its MCP servers`);
+  // Names WHO was asked, in the sentence every family shares — this module made
+  // the argument first (see `MCP_RELOAD_ASKED`) and two siblings still said "the
+  // agent", which reads as "whichever harness now serves the owner".
+  console.log(`[harness/select] ${moved}; ${MCP_RELOAD_ASKED}`);
   return true;
 }

--- a/src/lib/hermes-image-refresh.ts
+++ b/src/lib/hermes-image-refresh.ts
@@ -1,6 +1,6 @@
 import { bounceHermesDashboard } from "@/lib/hermes-dashboard-control";
 import { dashboardRpc } from "@/lib/hermes-dashboard-rpc";
-import { reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reload";
+import { MCP_RELOAD_ASKED, reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reload";
 
 /**
  * Make the RUNNING Hermes serve the image backend that linking just installed.
@@ -94,7 +94,15 @@ async function runningAgentCanDraw(): Promise<boolean | null> {
  *          second one.
  */
 async function reloadMcpTools(why: string): Promise<boolean> {
-  if (await reloadMcpServers().catch(() => false)) return true;
+  if (await reloadMcpServers().catch(() => false)) {
+    // Said out loud, in the sentence the other four families share. This arm
+    // used to return silently, so an operator chasing "the agent still refuses
+    // to draw" got a line when the reload FAILED and nothing at all when it
+    // worked — the one asymmetry in the five, and the reason a reader could not
+    // tell "it was asked and done" from "it was never asked".
+    console.log(`[hermes/image-refresh] ${why}; ${MCP_RELOAD_ASKED}`);
+    return true;
+  }
   // Logged, not surfaced, and in the words that are true for this edition. Worth
   // a line because "the agent still refuses to draw" is otherwise invisible from
   // the outside, and this is the one place that knows the refresh was wanted and

--- a/src/lib/hermes-mcp-reload.ts
+++ b/src/lib/hermes-mcp-reload.ts
@@ -1,4 +1,4 @@
-import { getActiveHarness } from "@/lib/harness";
+import { readEditionSource } from "@/lib/edition-source";
 import { dashboardRpc } from "@/lib/hermes-dashboard-rpc";
 import { logSafe } from "@/lib/log-safe";
 
@@ -108,10 +108,23 @@ export const MCP_RELOAD_ALREADY = "the MCP servers were already reloaded for thi
  * HAS a dashboard and it said no. Everything else is a `console.log` that says
  * what will actually happen next.
  *
- * UNKNOWN IS NOT OPENCLAW. `getActiveHarness()` swallows its own read failures
- * and answers `openclaw` by default, but if the call itself throws we keep the
- * error — a harness lookup that fell over must not be the thing that quiets a
- * real Hermes failure.
+ * THE QUESTION IS THE EDITION, NOT THE ACTIVE HARNESS. Which agent serves the
+ * owner right now and whether this box HAS a Hermes dashboard are different
+ * questions on the premium `dual` SKU: `install.sh` enables
+ * `clawbox-hermes-dashboard.service` for hermes AND dual, so the dashboard runs
+ * on a dual box whichever harness is active. Asking `getActiveHarness()` there
+ * turned a real refusal — the dashboard up and answering `confirm_required` —
+ * into the benign "this edition has no dashboard" line, on the one line that
+ * exists to make the refusal visible: the false-success shape, on the report of
+ * a false success. The predicate is `hasHermesHarness()`'s (edition `hermes` or
+ * `dual`, the mirror of install.sh's own `has_hermes_harness()`), read from ONE
+ * `readEditionSource()` so the two halves of the decision cannot come from two
+ * reads of a file `install.sh` rewrites.
+ *
+ * UNKNOWN IS NOT OPENCLAW. An edition nothing on the device named — no lock
+ * file, no `CLAWBOX_EDITION` — is this module's own default, not an answer, so
+ * it keeps the error: a lookup that could not say must not be the thing that
+ * quiets a real Hermes failure.
  *
  * @param tag   the caller's log prefix, e.g. `coding-agent/mcp-refresh`
  * @param what  what changed, in the caller's own words, e.g. "the coding agent
@@ -128,8 +141,9 @@ export async function reportMcpReloadRefused(tag: string, what: string): Promise
   // are rebuilt at their own source (see `harness-mcp-refresh.ts`); this is the
   // record's own rule.
   const line = `[${logSafe(tag, 60)}] ${logSafe(what)}`;
-  const harness = await getActiveHarness().catch(() => null);
-  if (harness !== null && harness !== "hermes") {
+  const { edition, defaulted } = readEditionSource();
+  const mayHaveDashboard = defaulted || edition === "hermes" || edition === "dual";
+  if (!mayHaveDashboard) {
     console.log(
       `${line}; this edition has no dashboard to ask — the tool list re-probes `
         + "when the MCP server is next spawned",

--- a/src/lib/hermes-mcp-reload.ts
+++ b/src/lib/hermes-mcp-reload.ts
@@ -72,6 +72,24 @@ export async function reloadMcpServers(): Promise<boolean> {
 }
 
 /**
+ * What a family may say about a reload that HAPPENED — one sentence, here,
+ * because there is one mechanism.
+ *
+ * `reloadMcpServers` talks to HERMES' dashboard JSON-RPC and to nothing else.
+ * Two of the five families said "asked the agent to reload its MCP servers",
+ * which reads as "whichever harness now serves the owner" — and on the dual SKU
+ * that is exactly wrong in the away direction: Hermes answers this call after
+ * the box has moved to OpenClaw, and an operator reading the journal for "the
+ * agent still thinks it is on Hermes" was told the OpenClaw child had been
+ * reloaded when it was never asked. `harness/select` already said Hermes, with
+ * a comment saying why; this is that comment made into the shared string.
+ */
+export const MCP_RELOAD_ASKED = "asked Hermes to reload its MCP servers";
+
+/** …and when another family in the same request already paid for the respawn. */
+export const MCP_RELOAD_ALREADY = "the MCP servers were already reloaded for this change";
+
+/**
  * Say that a wanted reload did not happen — in the words that are TRUE for THIS
  * box, which is not the same sentence on both editions.
  *
@@ -118,5 +136,8 @@ export async function reportMcpReloadRefused(tag: string, what: string): Promise
     );
     return;
   }
-  console.error(`${line}, but the agent would not reload its MCP servers`);
+  // Names the mechanism, like the success sentences above and for the same
+  // reason: what was asked is Hermes' dashboard, whatever this box calls its
+  // agent.
+  console.error(`${line}, but Hermes would not reload its MCP servers`);
 }

--- a/src/lib/provider-mcp-refresh.ts
+++ b/src/lib/provider-mcp-refresh.ts
@@ -1,5 +1,5 @@
 import { getModelOptions } from "@/lib/hermes-model-options";
-import { reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reload";
+import { MCP_RELOAD_ALREADY, MCP_RELOAD_ASKED, reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reload";
 import { logSafe } from "@/lib/log-safe";
 
 /**
@@ -191,7 +191,7 @@ export async function refreshProviderToolsIfSetChanged(
   if (options.alreadyReloaded) {
     // Nothing to ask for: the respawn that already happened in this request
     // rebuilt EVERY family's tool list, this one included.
-    console.log(`[hermes/provider-refresh] ${moved}; the MCP servers were already reloaded for this change`);
+    console.log(`[hermes/provider-refresh] ${moved}; ${MCP_RELOAD_ALREADY}`);
     return true;
   }
   // `.catch` even though `reloadMcpServers` documents that it never throws: the
@@ -204,7 +204,7 @@ export async function refreshProviderToolsIfSetChanged(
     await reportMcpReloadRefused("hermes/provider-refresh", moved);
     return false;
   }
-  console.log(`[hermes/provider-refresh] ${moved}; asked the agent to reload its MCP servers`);
+  console.log(`[hermes/provider-refresh] ${moved}; ${MCP_RELOAD_ASKED}`);
   return true;
 }
 

--- a/src/lib/provider-mcp-refresh.ts
+++ b/src/lib/provider-mcp-refresh.ts
@@ -3,7 +3,7 @@ import { MCP_RELOAD_ALREADY, MCP_RELOAD_ASKED, reloadMcpServers, reportMcpReload
 import { logSafe } from "@/lib/log-safe";
 
 /**
- * Ask the agent to re-advertise WHICH PROVIDERS it may switch this device to,
+ * Ask HERMES to re-advertise WHICH PROVIDERS it may switch this device to,
  * when a write changed the answer.
  *
  * WHY THIS EXISTS — the fourth of four. `mcp/lib/context.ts` probes this device
@@ -27,7 +27,7 @@ import { logSafe } from "@/lib/log-safe";
  * just succeeded. It is #514's shape (the panel updated, the running agent
  * stale) wearing #513's (advice that loops).
  *
- * The mechanism is the agent's own `reload.mcp`, shared with all three siblings —
+ * The mechanism is HERMES' own `reload.mcp`, shared with the four siblings —
  * see `hermes-mcp-reload.ts`. What belongs HERE is the rule for when it is worth
  * paying for.
  */

--- a/src/tests/routes/ai-models/configure-dual-coding-tools.test.ts
+++ b/src/tests/routes/ai-models/configure-dual-coding-tools.test.ts
@@ -185,7 +185,11 @@ vi.mock("@/lib/coding-agent", () => ({ getCodingAgentStatus: vi.fn() }));
 // The transport the refresh ends at. Mocked HERE rather than mocking
 // `refreshCodingAgentToolsIfReadinessChanged` itself, so the real guard runs and
 // the assertion is about the agent being asked, not about a call being made.
-vi.mock("@/lib/hermes-mcp-reload", () => ({
+// Spread the real module: the refresh families import its shared log sentences
+// (`MCP_RELOAD_ASKED`), and a factory that lists only the two functions makes
+// every one of them fail to import here rather than in production.
+vi.mock("@/lib/hermes-mcp-reload", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/hermes-mcp-reload")>()),
   reloadMcpServers: vi.fn(),
   reportMcpReloadRefused: vi.fn(),
 }));

--- a/src/tests/unit/coding-agent-mcp-refresh.test.ts
+++ b/src/tests/unit/coding-agent-mcp-refresh.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { saveEnv } from "@/tests/helpers/env";
 
 /**
  * The narrow trigger that keeps `coding_agent_run` / `_status` / `_stop` in step
@@ -28,12 +29,26 @@ const mockRpc = vi.mocked(dashboardRpc);
 const mockHarness = vi.mocked(getActiveHarness);
 let errorSpy: ReturnType<typeof vi.spyOn>;
 let logSpy: ReturnType<typeof vi.spyOn>;
+let restoreEnv: () => void;
+
+/**
+ * Which EDITION the box is, which is what decides whether a refusal is worth an
+ * error line: the dashboard the reload is asked of runs on `hermes` AND `dual`
+ * (install.sh enables it for both), whichever harness is active. `saveEnv`
+ * restores the suite-wide floor afterwards.
+ */
+function setEdition(edition: string | null): void {
+  if (edition === null) delete process.env.CLAWBOX_EDITION;
+  else process.env.CLAWBOX_EDITION = edition;
+}
 
 beforeEach(() => {
   mockRpc.mockReset();
   mockRpc.mockResolvedValue({ status: "ok" });
   mockHarness.mockReset();
   mockHarness.mockResolvedValue("hermes");
+  restoreEnv = saveEnv("CLAWBOX_EDITION");
+  setEdition("hermes");
   errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 });
@@ -41,6 +56,7 @@ beforeEach(() => {
 afterEach(() => {
   errorSpy.mockRestore();
   logSpy.mockRestore();
+  restoreEnv();
 });
 
 describe("refreshCodingAgentToolsIfReadinessChanged", () => {
@@ -100,7 +116,7 @@ describe("refreshCodingAgentToolsIfReadinessChanged", () => {
     // the probe re-runs and the tool list catches up on its own. An ERROR line
     // over an operation that needed no repair is the recurring false-alarm
     // shape, not a diagnosis.
-    mockHarness.mockResolvedValue("openclaw");
+    setEdition("openclaw");
     mockRpc.mockResolvedValue(null);
     await refreshCodingAgentToolsIfReadinessChanged(false, true);
     expect(errorSpy).not.toHaveBeenCalled();
@@ -111,16 +127,17 @@ describe("refreshCodingAgentToolsIfReadinessChanged", () => {
   it("still reports a HERMES box whose dashboard refused", async () => {
     // The one case a human should act on: a box that HAS a dashboard and it
     // said no. Softening this one too would trade a false alarm for a silence.
-    mockHarness.mockResolvedValue("hermes");
+    setEdition("hermes");
     mockRpc.mockResolvedValue(null);
     await refreshCodingAgentToolsIfReadinessChanged(false, true);
     expect(errorSpy).toHaveBeenCalled();
   });
 
   it("keeps the error when the edition cannot be read at all", async () => {
-    // Unknown is not "OpenClaw". A harness lookup that throws must not be the
-    // thing that quiets a real Hermes failure.
-    mockHarness.mockRejectedValue(new Error("no config"));
+    // Unknown is not "OpenClaw". An edition nothing on the device named — no
+    // lock file, no CLAWBOX_EDITION — is this module's own default, not an
+    // answer, and must not be the thing that quiets a real Hermes failure.
+    setEdition(null);
     mockRpc.mockResolvedValue(null);
     await refreshCodingAgentToolsIfReadinessChanged(false, true);
     expect(errorSpy).toHaveBeenCalled();

--- a/src/tests/unit/email-mcp-refresh.test.ts
+++ b/src/tests/unit/email-mcp-refresh.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { saveEnv } from "@/tests/helpers/env";
 
 /**
  * The narrow trigger that keeps `email_list`/`email_read` in step with the
@@ -26,12 +27,26 @@ const mockRpc = vi.mocked(dashboardRpc);
 const mockHarness = vi.mocked(getActiveHarness);
 let errorSpy: ReturnType<typeof vi.spyOn>;
 let logSpy: ReturnType<typeof vi.spyOn>;
+let restoreEnv: () => void;
+
+/**
+ * Which EDITION the box is, which is what decides whether a refusal is worth an
+ * error line: the dashboard the reload is asked of runs on `hermes` AND `dual`
+ * (install.sh enables it for both), whichever harness is active. `saveEnv`
+ * restores the suite-wide floor afterwards.
+ */
+function setEdition(edition: string | null): void {
+  if (edition === null) delete process.env.CLAWBOX_EDITION;
+  else process.env.CLAWBOX_EDITION = edition;
+}
 
 beforeEach(() => {
   mockRpc.mockReset();
   mockRpc.mockResolvedValue({ status: "ok" });
   mockHarness.mockReset();
   mockHarness.mockResolvedValue("hermes");
+  restoreEnv = saveEnv("CLAWBOX_EDITION");
+  setEdition("hermes");
   errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 });
@@ -39,6 +54,7 @@ beforeEach(() => {
 afterEach(() => {
   errorSpy.mockRestore();
   logSpy.mockRestore();
+  restoreEnv();
 });
 
 describe("refreshEmailToolsIfReadabilityChanged", () => {
@@ -95,7 +111,7 @@ describe("refreshEmailToolsIfReadabilityChanged", () => {
     // OpenClaw box has no dashboard BY DESIGN, so a refusal there is the
     // edition, not a fault. Its MCP server is spawned per session and reaped
     // when idle, so the tool list catches up on its own.
-    mockHarness.mockResolvedValue("openclaw");
+    setEdition("openclaw");
     mockRpc.mockResolvedValue(null);
     await refreshEmailToolsIfReadabilityChanged(false, true);
     expect(errorSpy).not.toHaveBeenCalled();
@@ -103,7 +119,7 @@ describe("refreshEmailToolsIfReadabilityChanged", () => {
   });
 
   it("still reports a HERMES box whose dashboard refused", async () => {
-    mockHarness.mockResolvedValue("hermes");
+    setEdition("hermes");
     mockRpc.mockResolvedValue(null);
     await refreshEmailToolsIfReadabilityChanged(false, true);
     expect(errorSpy).toHaveBeenCalled();

--- a/src/tests/unit/harness-mcp-refresh.test.ts
+++ b/src/tests/unit/harness-mcp-refresh.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { saveEnv } from "@/tests/helpers/env";
 
 /**
  * The fifth boot-time snapshot, and the biggest: WHICH HARNESS IS ACTIVE.
@@ -30,8 +31,21 @@ import { LOG_FIELD_MAX_LENGTH } from "@/lib/log-safe";
 let logSpy: ReturnType<typeof vi.spyOn>;
 let warnSpy: ReturnType<typeof vi.spyOn>;
 let errorSpy: ReturnType<typeof vi.spyOn>;
+let restoreEnv: () => void;
+
+/**
+ * Which EDITION the box is. That, not the active harness, is what decides
+ * whether a refused reload is worth an error line: the dashboard it is asked of
+ * runs on `hermes` AND `dual` (install.sh enables it for both), whichever
+ * harness is active at the time.
+ */
+function setEdition(edition: string): void {
+  process.env.CLAWBOX_EDITION = edition;
+}
 
 beforeEach(() => {
+  restoreEnv = saveEnv("CLAWBOX_EDITION");
+  setEdition("hermes");
   rpcMock.mockReset();
   activeHarnessMock.mockReset();
   activeHarnessMock.mockResolvedValue("hermes");
@@ -44,6 +58,7 @@ afterEach(() => {
   logSpy.mockRestore();
   warnSpy.mockRestore();
   errorSpy.mockRestore();
+  restoreEnv();
 });
 
 describe("the agent's tool list, after the owner switches harness", () => {
@@ -123,8 +138,8 @@ describe("the harness names that reach the journal", () => {
   });
 
   it("keeps the same rule on the arm that reports a refusal", async () => {
-    // The Hermes box that HAS a dashboard and it said no — `console.error`,
-    // hermes-mcp-reload.ts:110, the third of the three alerts.
+    // The Hermes box that HAS a dashboard and it said no — the error arm of
+    // `reportMcpReloadRefused`, the third of the three alerts.
     rpcMock.mockResolvedValue({ status: "confirm_required" });
 
     await refreshHarnessToolsIfSwitched("openclaw", "hermes\nWARN root login accepted");
@@ -147,7 +162,7 @@ describe("the harness names that reach the journal", () => {
  */
 describe("reportMcpReloadRefused bounds the record", () => {
   it("keeps one value to one line on the no-dashboard arm", async () => {
-    activeHarnessMock.mockResolvedValue("openclaw");
+    setEdition("openclaw");
 
     await reportMcpReloadRefused("provider/refresh", "gained a\nWARN root login accepted");
 
@@ -157,7 +172,7 @@ describe("reportMcpReloadRefused bounds the record", () => {
   });
 
   it("caps a caller-sized value on the refusal arm", async () => {
-    activeHarnessMock.mockResolvedValue("hermes");
+    setEdition("hermes");
 
     await reportMcpReloadRefused("provider/refresh", "x".repeat(LOG_FIELD_MAX_LENGTH + 500));
 

--- a/src/tests/unit/hermes-image-refresh.test.ts
+++ b/src/tests/unit/hermes-image-refresh.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { saveEnv } from "@/tests/helpers/env";
 
 /**
  * Linking ClawBox AI under a RUNNING agent has to make that agent able to draw.
@@ -46,6 +47,7 @@ function methods(): string[] {
 }
 
 let errorSpy: ReturnType<typeof vi.spyOn>;
+let restoreEnv: () => void;
 
 beforeEach(() => {
   rpcMock.mockReset();
@@ -54,11 +56,16 @@ beforeEach(() => {
   bounceMock.mockResolvedValue("restarted");
   reloadMcpMock.mockResolvedValue(true);
   agentSaysItCanDraw(true);
+  restoreEnv = saveEnv("CLAWBOX_EDITION");
+  // The box this whole file is about: the edition decides whether a refused
+  // reload is worth an error line, and every case here is a Hermes box.
+  process.env.CLAWBOX_EDITION = "hermes";
   errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 });
 
 afterEach(() => {
   errorSpy.mockRestore();
+  restoreEnv();
 });
 
 describe("refreshHermesImageTools", () => {

--- a/src/tests/unit/mcp-reload-wording.test.ts
+++ b/src/tests/unit/mcp-reload-wording.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * What the journal is allowed to say when an MCP reload was asked for.
+ *
+ * Five families ask for the same reload through the same helper, and each one
+ * writes its own line about it. Two of them said "asked the agent to reload its
+ * MCP servers" while the mechanism is HERMES' dashboard JSON-RPC and nothing
+ * else: on the dual SKU that is the harness that answers even after the box has
+ * moved to OpenClaw, so "the agent" — read as "whichever harness now serves the
+ * owner" — names the wrong process, and an operator reading the journal for
+ * "the agent still thinks it is on Hermes" is told the OpenClaw child was
+ * reloaded when it was never asked. `harness/select` already says Hermes, with
+ * a comment explaining exactly that; this pins it for the closed set.
+ *
+ * The SET is pinned too, not just the wording: a sixth family added without a
+ * line here is the way one of these drifts back.
+ */
+
+const reloadMock = vi.hoisted(() => vi.fn());
+const refusedMock = vi.hoisted(() => vi.fn(async () => {}));
+const harnessMock = vi.hoisted(() => vi.fn(async () => "hermes"));
+
+vi.mock("@/lib/harness", () => ({ getActiveHarness: harnessMock }));
+vi.mock("@/lib/hermes-mcp-reload", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/hermes-mcp-reload")>()),
+  reloadMcpServers: reloadMock,
+  reportMcpReloadRefused: refusedMock,
+}));
+
+import { refreshCodingAgentToolsIfReadinessChanged } from "@/lib/coding-agent-mcp-refresh";
+import { refreshEmailToolsIfReadabilityChanged } from "@/lib/email-mcp-refresh";
+import { refreshHarnessToolsIfSwitched } from "@/lib/harness-mcp-refresh";
+import { refreshProviderToolsIfSetChanged } from "@/lib/provider-mcp-refresh";
+
+/**
+ * The words, spelled here rather than imported: this file is what decides them,
+ * and a test that read the constant the code writes would pass whatever it said.
+ */
+const ASKED = "asked Hermes to reload its MCP servers";
+const ALREADY = "the MCP servers were already reloaded for this change";
+const REFUSED = "but Hermes would not reload its MCP servers";
+
+/** Every family that asks for a reload and writes its own line about it. */
+const FAMILIES = [
+  {
+    tag: "harness/select",
+    ask: () => refreshHarnessToolsIfSwitched("openclaw", "hermes"),
+    askAlreadyReloaded: null,
+  },
+  {
+    tag: "email/mcp-refresh",
+    ask: () => refreshEmailToolsIfReadabilityChanged(false, true),
+    askAlreadyReloaded: null,
+  },
+  {
+    tag: "hermes/provider-refresh",
+    ask: () => refreshProviderToolsIfSetChanged([], ["anthropic"]),
+    askAlreadyReloaded: () => refreshProviderToolsIfSetChanged([], ["anthropic"], { alreadyReloaded: true }),
+  },
+  {
+    tag: "coding-agent/mcp-refresh",
+    ask: () => refreshCodingAgentToolsIfReadinessChanged(false, true),
+    askAlreadyReloaded: () => refreshCodingAgentToolsIfReadinessChanged(false, true, { alreadyReloaded: true }),
+  },
+] as const;
+
+const logged: string[] = [];
+
+beforeEach(() => {
+  reloadMock.mockReset();
+  reloadMock.mockResolvedValue(true);
+  refusedMock.mockClear();
+  harnessMock.mockResolvedValue("hermes");
+  logged.length = 0;
+  vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    logged.push(String(args[0]));
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function lineFor(tag: string): string {
+  const line = logged.find((entry) => entry.startsWith(`[${tag}]`));
+  expect(line, `${tag} wrote no line`).toBeDefined();
+  return line as string;
+}
+
+describe("every family names the mechanism it actually used", () => {
+  for (const family of FAMILIES) {
+    it(`${family.tag}: says Hermes was asked, not "the agent"`, async () => {
+      await family.ask();
+      const line = lineFor(family.tag);
+      expect(line).toContain(ASKED);
+      // The wrong sentence, spelled out rather than left to the constant: the
+      // point of the case is that these two must not be the same words.
+      expect(line).not.toContain("asked the agent to reload");
+    });
+
+    if (family.askAlreadyReloaded) {
+      it(`${family.tag}: says the same thing when another family already paid`, async () => {
+        await family.askAlreadyReloaded();
+        expect(lineFor(family.tag)).toContain(ALREADY);
+        expect(reloadMock).not.toHaveBeenCalled();
+      });
+    }
+  }
+
+  it("the refusal names the same mechanism the success line does", async () => {
+    // The other half of the one flow: what was ASKED is Hermes' dashboard,
+    // whatever this box calls its agent, so the line an operator is meant to
+    // act on says so too.
+    const errors: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      errors.push(String(args[0]));
+    });
+    const { reportMcpReloadRefused } = await vi.importActual<typeof import("@/lib/hermes-mcp-reload")>(
+      "@/lib/hermes-mcp-reload",
+    );
+    await reportMcpReloadRefused("harness/select", "the active harness moved");
+    expect(errors.at(-1)).toContain(REFUSED);
+  });
+});

--- a/src/tests/unit/mcp-reload-wording.test.ts
+++ b/src/tests/unit/mcp-reload-wording.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs";
+import path from "path";
+import { saveEnv } from "@/tests/helpers/env";
 
 /**
  * What the journal is allowed to say when an MCP reload was asked for.
@@ -21,7 +24,12 @@ const reloadMock = vi.hoisted(() => vi.fn());
 const refusedMock = vi.hoisted(() => vi.fn(async () => {}));
 const harnessMock = vi.hoisted(() => vi.fn(async () => "hermes"));
 
-vi.mock("@/lib/harness", () => ({ getActiveHarness: harnessMock }));
+// Spread the original, like every other mock of this module: a family that
+// starts importing a second value from it must not fail to import in a test.
+vi.mock("@/lib/harness", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/harness")>()),
+  getActiveHarness: harnessMock,
+}));
 vi.mock("@/lib/hermes-mcp-reload", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/hermes-mcp-reload")>()),
   reloadMcpServers: reloadMock,
@@ -30,6 +38,7 @@ vi.mock("@/lib/hermes-mcp-reload", async (importOriginal) => ({
 
 import { refreshCodingAgentToolsIfReadinessChanged } from "@/lib/coding-agent-mcp-refresh";
 import { refreshEmailToolsIfReadabilityChanged } from "@/lib/email-mcp-refresh";
+import { refreshHermesImageTools } from "@/lib/hermes-image-refresh";
 import { refreshHarnessToolsIfSwitched } from "@/lib/harness-mcp-refresh";
 import { refreshProviderToolsIfSetChanged } from "@/lib/provider-mcp-refresh";
 
@@ -63,11 +72,33 @@ const FAMILIES = [
     ask: () => refreshCodingAgentToolsIfReadinessChanged(false, true),
     askAlreadyReloaded: () => refreshCodingAgentToolsIfReadinessChanged(false, true, { alreadyReloaded: true }),
   },
+  {
+    // The fifth: `refreshHermesImageTools(true, false)` is its reload path — a
+    // box that could draw and now cannot, where the only stale thing is the
+    // MCP server's view. Its dashboard BOUNCE line is a different event and is
+    // deliberately not this sentence.
+    tag: "hermes/image-refresh",
+    ask: () => refreshHermesImageTools(true, false),
+    askAlreadyReloaded: null,
+  },
 ] as const;
 
+/** Where the modules live, for the case that derives the set from the source. */
+const LIB_DIR = path.join(process.cwd(), "src", "lib");
+
 const logged: string[] = [];
+const errors: string[] = [];
+let restoreEnv: () => void;
 
 beforeEach(() => {
+  restoreEnv = saveEnv("CLAWBOX_EDITION");
+  // Every family case is a box whose dashboard answers; the refusal cases below
+  // set their own edition.
+  process.env.CLAWBOX_EDITION = "hermes";
+  errors.length = 0;
+  vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+    errors.push(String(args[0]));
+  });
   reloadMock.mockReset();
   reloadMock.mockResolvedValue(true);
   refusedMock.mockClear();
@@ -80,6 +111,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  restoreEnv();
 });
 
 function lineFor(tag: string): string {
@@ -94,6 +126,10 @@ describe("every family names the mechanism it actually used", () => {
       await family.ask();
       const line = lineFor(family.tag);
       expect(line).toContain(ASKED);
+      // And it really ASKED: a family refactored to write the sentence without
+      // calling the transport would otherwise pass this file — the exact false
+      // success `hermes-mcp-reload-verdict.test.ts` exists for.
+      expect(reloadMock).toHaveBeenCalledTimes(1);
       // The wrong sentence, spelled out rather than left to the constant: the
       // point of the case is that these two must not be the same words.
       expect(line).not.toContain("asked the agent to reload");
@@ -112,14 +148,83 @@ describe("every family names the mechanism it actually used", () => {
     // The other half of the one flow: what was ASKED is Hermes' dashboard,
     // whatever this box calls its agent, so the line an operator is meant to
     // act on says so too.
-    const errors: string[] = [];
-    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
-      errors.push(String(args[0]));
-    });
+    process.env.CLAWBOX_EDITION = "hermes";
     const { reportMcpReloadRefused } = await vi.importActual<typeof import("@/lib/hermes-mcp-reload")>(
       "@/lib/hermes-mcp-reload",
     );
     await reportMcpReloadRefused("harness/select", "the active harness moved");
     expect(errors.at(-1)).toContain(REFUSED);
+  });
+
+  it("reports a DUAL box's refusal as an error, not as 'this edition has no dashboard'", async () => {
+    // The dashboard runs on hermes AND dual (install.sh enables the unit for
+    // both), whichever harness is active — so on a licensed dual box sitting on
+    // OpenClaw, a dashboard that answered `confirm_required` is a real refusal.
+    // Gating on the ACTIVE HARNESS wrote the benign "no dashboard to ask" note
+    // over it: a false success, on the line that exists to report one.
+    process.env.CLAWBOX_EDITION = "dual";
+    harnessMock.mockResolvedValue("openclaw");
+    const { reportMcpReloadRefused } = await vi.importActual<typeof import("@/lib/hermes-mcp-reload")>(
+      "@/lib/hermes-mcp-reload",
+    );
+    await reportMcpReloadRefused("email/mcp-refresh", "mailbox readability changed to true");
+    expect(errors.at(-1)).toContain(REFUSED);
+    expect(logged.some((line) => line.includes("no dashboard to ask"))).toBe(false);
+  });
+
+  it("stays a plain note on a box that has no dashboard by design", async () => {
+    // The other side, and the one this branch exists for: an OpenClaw box has
+    // no dashboard, its MCP server is spawned per session and reaped when idle,
+    // so the tool list catches up on its own. An error line there is the
+    // false-alarm shape that teaches an operator to skip these lines.
+    process.env.CLAWBOX_EDITION = "openclaw";
+    const { reportMcpReloadRefused } = await vi.importActual<typeof import("@/lib/hermes-mcp-reload")>(
+      "@/lib/hermes-mcp-reload",
+    );
+    await reportMcpReloadRefused("email/mcp-refresh", "mailbox readability changed to true");
+    expect(errors).toHaveLength(0);
+    expect(logged.at(-1)).toContain("no dashboard to ask");
+  });
+
+  it("keeps the error when nothing on the device named an edition", async () => {
+    // Unknown is not OpenClaw: a default is not an answer, and must not be the
+    // thing that quiets a real Hermes failure.
+    delete process.env.CLAWBOX_EDITION;
+    const { reportMcpReloadRefused } = await vi.importActual<typeof import("@/lib/hermes-mcp-reload")>(
+      "@/lib/hermes-mcp-reload",
+    );
+    await reportMcpReloadRefused("email/mcp-refresh", "mailbox readability changed to true");
+    expect(errors.at(-1)).toContain(REFUSED);
+  });
+
+  it("is driven for EVERY module that asks for a reload", () => {
+    // The set, derived rather than hand-kept: a sixth family added without a
+    // line above is exactly how one of these drifts back, and a list written by
+    // hand cannot notice it. Every module that imports `reloadMcpServers` must
+    // also import the shared sentence and be driven by a case here.
+    const asking = fs
+      .readdirSync(LIB_DIR)
+      .filter((name) => name.endsWith(".ts"))
+      .filter((name) => {
+        const source = fs.readFileSync(path.join(LIB_DIR, name), "utf-8");
+        return source.includes('from "@/lib/hermes-mcp-reload"') && source.includes("reloadMcpServers");
+      })
+      .map((name) => name.replace(/\.ts$/, ""));
+
+    expect(asking.length).toBeGreaterThan(0);
+    for (const name of asking) {
+      const source = fs.readFileSync(path.join(LIB_DIR, `${name}.ts`), "utf-8");
+      expect(source, `${name} must use the shared sentence`).toContain("MCP_RELOAD_ASKED");
+    }
+    expect([...asking].sort()).toEqual(
+      [
+        "coding-agent-mcp-refresh",
+        "email-mcp-refresh",
+        "harness-mcp-refresh",
+        "hermes-image-refresh",
+        "provider-mcp-refresh",
+      ].sort(),
+    );
+    expect(FAMILIES.length).toBe(asking.length);
   });
 });

--- a/src/tests/unit/provider-mcp-refresh.test.ts
+++ b/src/tests/unit/provider-mcp-refresh.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { saveEnv } from "@/tests/helpers/env";
 
 /**
  * The fourth boot-time snapshot, and the rule for when refreshing it is worth
@@ -52,8 +53,14 @@ function payload(rows: Row[], current = "openrouter") {
 
 let logSpy: ReturnType<typeof vi.spyOn>;
 let errorSpy: ReturnType<typeof vi.spyOn>;
+let restoreEnv: () => void;
 
 beforeEach(() => {
+  // The EDITION is what decides whether a refused reload is worth an error
+  // line — the dashboard runs on hermes AND dual, whichever harness is active —
+  // and every case here is a box that has one.
+  restoreEnv = saveEnv("CLAWBOX_EDITION");
+  process.env.CLAWBOX_EDITION = "hermes";
   rpcMock.mockReset();
   rpcMock.mockResolvedValue({ status: "ok" });
   optionsMock.mockReset();
@@ -64,6 +71,7 @@ beforeEach(() => {
 afterEach(() => {
   logSpy.mockRestore();
   errorSpy.mockRestore();
+  restoreEnv();
 });
 
 describe("readUsableProviderIds", () => {


### PR DESCRIPTION
**TASK-763** — the MCP-reload refusal logging. Two of the card's three items were already on beta; this is the third, plus what the review pass found under it.

### Customer-visible symptom
An operator reading the journal is told the wrong thing about the one mechanism that rebuilds the agent's tool list:
- Two of the five refresh families said **"asked the agent to reload its MCP servers"** while the mechanism is HERMES' dashboard JSON-RPC and nothing else. On the dual SKU that is the harness answering even after the box has moved to OpenClaw, so someone chasing "the agent still thinks it is on Hermes" was told the OpenClaw child had been reloaded — it was never asked.
- Worse, the REFUSAL branch gated on the ACTIVE HARNESS as a proxy for "does this box have a dashboard". `install.sh` enables `clawbox-hermes-dashboard.service` for **hermes AND dual**, whichever harness is active — so on a licensed dual box sitting on OpenClaw, a dashboard that was up and answered `confirm_required` (the documented `approvals.mcp_reload_confirm` gate) had its refusal written as the benign *"this edition has no dashboard to ask — the tool list re-probes when the MCP server is next spawned"*. Both halves are false there: the dashboard exists and refused, and Hermes' MCP children are long-lived, so nothing re-probes them. A false success, on the line that exists to report one.
- The fifth family (`hermes-image-refresh`) wrote a line when the reload FAILED and nothing at all when it worked, so "the agent still refuses to draw" could not be told from "it was never asked".

### Cause and fix
One sentence, owned by the module that owns the mechanism: `MCP_RELOAD_ASKED` / `MCP_RELOAD_ALREADY` in `src/lib/hermes-mcp-reload.ts`, used by all five families. The refusal names the mechanism too, and its branch now asks the EDITION — `hasHermesHarness()`'s own rule (`hermes` or `dual`, the mirror of install.sh's `has_hermes_harness()`), from ONE `readEditionSource()` — with an edition nothing on the device named keeping the error, because a default is not an answer.

### Harness-first
The mechanism IS the harness's own: Hermes' dashboard JSON-RPC `reload.mcp`. Nothing here re-implements it; the change is what ClawBox says about it. On OpenClaw there is no equivalent by design — the ClawBox MCP server is spawned per session and reaped after ten idle minutes, so the tool list catches up on its own, which is exactly why the benign branch exists.

### Sibling call sites
- All five callers of `reloadMcpServers` now import the shared sentence, and the suite DERIVES that set from the source (every `src/lib/*.ts` that imports `reloadMcpServers` must import `MCP_RELOAD_ASKED` and be driven by a case) — a sixth family cannot be added silently, which a hand-kept list could not catch.
- Every test that mocked `@/lib/hermes-mcp-reload` with a bare factory now spreads the real module: a family importing a new value from it must not fail to import in a test that never exercises it.
- Five suites drove the refusal branch through the `getActiveHarness` mock and now drive it through the edition, which is what decides it.
- `hermes-image-refresh`'s dashboard BOUNCE line is a different event (it restarts the dashboard rather than asking it to reload) and is deliberately left as it is.
- The CodeQL half of the card is already on beta: alerts #516/#517/#518 (`js/log-injection` at `harness-mcp-refresh.ts:86`, `hermes-mcp-reload.ts:105,110`) are all in state `fixed` on `refs/heads/beta`, the closed-set rebuild (`HARNESS_NAMES`/`harnessName`) is there with its tests, and the two new constants are module literals that add no injection surface. Re-queried, not assumed.

### RED → GREEN
RED on unmodified beta (the wording half):

```
 ❯ |unit| src/tests/unit/mcp-reload-wording.test.ts (6 tests | 2 failed) 10ms
     × hermes/provider-refresh: says Hermes was asked, not "the agent" 5ms
     × coding-agent/mcp-refresh: says Hermes was asked, not "the agent" 1ms
Received: "[hermes/provider-refresh] the providers this box can be switched to gained anthropic; asked the agent to reload its MCP servers"
```

RED for the dual gate, with the branch put back to the active-harness form:

```
 ❯ |unit| src/tests/unit/mcp-reload-wording.test.ts (12 tests | 2 failed) 37ms
     × reports a DUAL box's refusal as an error, not as 'this edition has no dashboard' 4ms
     × stays a plain note on a box that has no dashboard by design 4ms
```

GREEN: the five refresh suites + the new wording suite + the configure route suite = 52 tests, then 12 in the wording suite after the review fixes; whole unit project 773 files, 12917 passed / 1 skipped (one unrelated pre-existing timeout flake in `telegram/status-hermes.test.ts`, `leaves the OpenClaw path alone` — it passes alone on this branch AND on beta, the TASK-702 class); `tsc --noEmit` clean; `eslint` on the touched files clean.

### Editions
Both. The change is precisely about telling them apart: `openclaw` keeps the benign note, `hermes` and `dual` get the error, and an unnamed edition keeps the error rather than guessing.

### Device
Not device-proven: journal wording on a code path CI exercises fully, no unit, path or edition-lock behaviour changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MCP reload handling across dashboard editions, including clearer behavior for Hermes, OpenClaw, dual, and unknown editions.
  - Standardized reload status messages to clearly indicate whether a reload was already completed or requested.
  - Clarified ownership and refresh reasons in MCP reload notifications.

- **Tests**
  - Added coverage for reload messaging, refusal behavior, edition-specific handling, and environment isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->