### PR TITLE
fix: read the device edition once per answer, and write its lock atomically

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4029,7 +4029,14 @@ step_edition_lock() {
   # after this is a failing rename of the second file, immediately after a
   # successful copy of it into the same directory; the step answers non-zero,
   # so the update reports it and the next run rewrites both from the top.
-  mkdir -p /etc/systemd/system/clawbox-setup.service.d
+  # The drop-in's DIRECTORY counts as part of staging it: created after the
+  # lock was committed, a failure here would leave the same split the ordering
+  # above exists to prevent.
+  if ! mkdir -p /etc/systemd/system/clawbox-setup.service.d; then
+    rm -f "$_edition_tmp"
+    echo "  Error: could not create the drop-in directory for $LEGACY_EDITION_DROPIN" >&2
+    return 1
+  fi
   local _dropin_tmp
   _dropin_tmp="$(mktemp)"
   if ! printf '[Service]\nEnvironment=CLAWBOX_EDITION=%s\n' "$CLAWBOX_EDITION" > "$_dropin_tmp"; then

--- a/install.sh
+++ b/install.sh
@@ -4020,6 +4020,24 @@ step_edition_lock() {
     echo "  Error: could not stage the edition lock for $CLAWBOX_EDITION_FILE" >&2
     return 1
   fi
+  # BOTH RECORDS ARE STAGED BEFORE EITHER IS COMMITTED. They are two files and
+  # no rename can cover both, but staging is where the ordinary failure lives
+  # (a full /tmp, an EIO) — and committing the lock and then failing to stage
+  # the drop-in would leave the two naming DIFFERENT editions until a later
+  # update: readers of the lock and readers of the systemd unit disagreeing
+  # about the SKU, which is the state this step exists to prevent. What is left
+  # after this is a failing rename of the second file, immediately after a
+  # successful copy of it into the same directory; the step answers non-zero,
+  # so the update reports it and the next run rewrites both from the top.
+  mkdir -p /etc/systemd/system/clawbox-setup.service.d
+  local _dropin_tmp
+  _dropin_tmp="$(mktemp)"
+  if ! printf '[Service]\nEnvironment=CLAWBOX_EDITION=%s\n' "$CLAWBOX_EDITION" > "$_dropin_tmp"; then
+    rm -f "$_edition_tmp" "$_dropin_tmp"
+    echo "  Error: could not stage the edition drop-in for $LEGACY_EDITION_DROPIN" >&2
+    return 1
+  fi
+
   # The return value is CHECKED, and it has to be on this step specifically.
   # `install_root_file` answers 1 when the copy or the rename did not land, and
   # the update path calls this step from an OR-list — for the whole body of
@@ -4029,23 +4047,21 @@ step_edition_lock() {
   # printed, and the update reported success over a lock that still names the
   # previous SKU — with the two records free to disagree.
   if ! install_root_file "$_edition_tmp" "$CLAWBOX_EDITION_FILE" 0644; then
-    rm -f "$_edition_tmp"
+    rm -f "$_edition_tmp" "$_dropin_tmp"
     echo "  Error: could not write the edition lock at $CLAWBOX_EDITION_FILE" >&2
     return 1
   fi
   rm -f "$_edition_tmp"
 
-  mkdir -p /etc/systemd/system/clawbox-setup.service.d
-  local _dropin_tmp
-  _dropin_tmp="$(mktemp)"
-  if ! printf '[Service]\nEnvironment=CLAWBOX_EDITION=%s\n' "$CLAWBOX_EDITION" > "$_dropin_tmp"; then
-    rm -f "$_dropin_tmp"
-    echo "  Error: could not stage the edition drop-in for $LEGACY_EDITION_DROPIN" >&2
-    return 1
-  fi
   if ! install_root_file "$_dropin_tmp" "$LEGACY_EDITION_DROPIN" 0644; then
     rm -f "$_dropin_tmp"
-    echo "  Error: could not write the edition drop-in at $LEGACY_EDITION_DROPIN" >&2
+    # The lock landed and this one did not, so the two records name different
+    # editions until the next run. Said in those words rather than as a generic
+    # write failure: /etc/clawbox/edition.env is the AUTHORITY (every reader in
+    # src/ and the updater unit take the SKU from it) and this drop-in is the
+    # mirror kept for tooling that still reads it, so the box behaves as the
+    # lock says while an operator reading the unit would be told otherwise.
+    echo "  Error: the edition lock now says $CLAWBOX_EDITION but the drop-in at $LEGACY_EDITION_DROPIN could not be rewritten — the two records disagree until the next update" >&2
     return 1
   fi
   rm -f "$_dropin_tmp"

--- a/install.sh
+++ b/install.sh
@@ -3993,16 +3993,31 @@ step_edition_foreign_teardown() {
 # stale hermes lock forever, because this step only ever wrote and never
 # reconciled. All three editions are baked now; "dual" used to return early
 # here, which is why the premium SKU could not be provisioned at all.
+# BOTH RECORDS ARE WRITTEN ATOMICALLY, through the same `install_root_file`
+# every other root-owned file goes through (TASK-584). `> file` is
+# open(O_TRUNC) + write + close, so for the length of the write every reader on
+# the box sees a zero-length or half-written lock — and `readEditionSource()`
+# turns that into `{edition: "openclaw", defaulted: true}`. This step runs on
+# EVERY in-app update, while the middleware, `openclawIsAbsent()`, the updater's
+# own `hasHermesHarness()`, the gateway catch-all and the MCP server are all
+# reading that file: a Hermes box briefly answers as an OpenClaw one, which is
+# how the flagship SKU's gateway-only paths stop 404-ing and the updater skips
+# `--step hermes_edition`. A rename cannot be observed half-done.
 step_edition_lock() {
   install -d -o root -g root -m 0755 /etc/clawbox
+  local _edition_tmp
+  _edition_tmp="$(mktemp)"
   printf '# ClawBox edition lock — written by install.sh (step_edition_lock).\n# Root-owned on purpose: this is the authority for the device SKU.\nCLAWBOX_EDITION=%s\n' \
-    "$CLAWBOX_EDITION" > "$CLAWBOX_EDITION_FILE"
-  chown root:root "$CLAWBOX_EDITION_FILE"
-  chmod 0644 "$CLAWBOX_EDITION_FILE"
+    "$CLAWBOX_EDITION" > "$_edition_tmp"
+  install_root_file "$_edition_tmp" "$CLAWBOX_EDITION_FILE" 0644
+  rm -f "$_edition_tmp"
 
   mkdir -p /etc/systemd/system/clawbox-setup.service.d
-  printf '[Service]\nEnvironment=CLAWBOX_EDITION=%s\n' "$CLAWBOX_EDITION" \
-    > "$LEGACY_EDITION_DROPIN"
+  local _dropin_tmp
+  _dropin_tmp="$(mktemp)"
+  printf '[Service]\nEnvironment=CLAWBOX_EDITION=%s\n' "$CLAWBOX_EDITION" > "$_dropin_tmp"
+  install_root_file "$_dropin_tmp" "$LEGACY_EDITION_DROPIN" 0644
+  rm -f "$_dropin_tmp"
   systemctl daemon-reload 2>/dev/null || true
 
   step_edition_gateway_state

--- a/install.sh
+++ b/install.sh
@@ -4009,14 +4009,30 @@ step_edition_lock() {
   _edition_tmp="$(mktemp)"
   printf '# ClawBox edition lock — written by install.sh (step_edition_lock).\n# Root-owned on purpose: this is the authority for the device SKU.\nCLAWBOX_EDITION=%s\n' \
     "$CLAWBOX_EDITION" > "$_edition_tmp"
-  install_root_file "$_edition_tmp" "$CLAWBOX_EDITION_FILE" 0644
+  # The return value is CHECKED, and it has to be on this step specifically.
+  # `install_root_file` answers 1 when the copy or the rename did not land, and
+  # the update path calls this step from an OR-list — for the whole body of
+  # which bash switches errexit OFF (the same trap `install_root_libexec`
+  # records above). Dropped, a failed write was followed by successful commands,
+  # the function returned the LAST step's status, the non-fatal warning never
+  # printed, and the update reported success over a lock that still names the
+  # previous SKU — with the two records free to disagree.
+  if ! install_root_file "$_edition_tmp" "$CLAWBOX_EDITION_FILE" 0644; then
+    rm -f "$_edition_tmp"
+    echo "  Error: could not write the edition lock at $CLAWBOX_EDITION_FILE" >&2
+    return 1
+  fi
   rm -f "$_edition_tmp"
 
   mkdir -p /etc/systemd/system/clawbox-setup.service.d
   local _dropin_tmp
   _dropin_tmp="$(mktemp)"
   printf '[Service]\nEnvironment=CLAWBOX_EDITION=%s\n' "$CLAWBOX_EDITION" > "$_dropin_tmp"
-  install_root_file "$_dropin_tmp" "$LEGACY_EDITION_DROPIN" 0644
+  if ! install_root_file "$_dropin_tmp" "$LEGACY_EDITION_DROPIN" 0644; then
+    rm -f "$_dropin_tmp"
+    echo "  Error: could not write the edition drop-in at $LEGACY_EDITION_DROPIN" >&2
+    return 1
+  fi
   rm -f "$_dropin_tmp"
   systemctl daemon-reload 2>/dev/null || true
 

--- a/install.sh
+++ b/install.sh
@@ -4007,8 +4007,19 @@ step_edition_lock() {
   install -d -o root -g root -m 0755 /etc/clawbox
   local _edition_tmp
   _edition_tmp="$(mktemp)"
-  printf '# ClawBox edition lock — written by install.sh (step_edition_lock).\n# Root-owned on purpose: this is the authority for the device SKU.\nCLAWBOX_EDITION=%s\n' \
-    "$CLAWBOX_EDITION" > "$_edition_tmp"
+  # The STAGING write is checked too. `install_root_file` copies whatever is in
+  # the temp and answers 0 for a copy that worked, so a `printf` that failed
+  # after writing a prefix — a full /tmp is the ordinary way — would be
+  # published atomically as a TRUNCATED lock, which `readEditionSource()` reads
+  # as `{edition: "openclaw", defaulted: true}`: the exact answer this step
+  # exists to stop the box giving. Errexit is off for this whole function on
+  # the update path, so nothing else would have caught it.
+  if ! printf '# ClawBox edition lock — written by install.sh (step_edition_lock).\n# Root-owned on purpose: this is the authority for the device SKU.\nCLAWBOX_EDITION=%s\n' \
+    "$CLAWBOX_EDITION" > "$_edition_tmp"; then
+    rm -f "$_edition_tmp"
+    echo "  Error: could not stage the edition lock for $CLAWBOX_EDITION_FILE" >&2
+    return 1
+  fi
   # The return value is CHECKED, and it has to be on this step specifically.
   # `install_root_file` answers 1 when the copy or the rename did not land, and
   # the update path calls this step from an OR-list — for the whole body of
@@ -4027,7 +4038,11 @@ step_edition_lock() {
   mkdir -p /etc/systemd/system/clawbox-setup.service.d
   local _dropin_tmp
   _dropin_tmp="$(mktemp)"
-  printf '[Service]\nEnvironment=CLAWBOX_EDITION=%s\n' "$CLAWBOX_EDITION" > "$_dropin_tmp"
+  if ! printf '[Service]\nEnvironment=CLAWBOX_EDITION=%s\n' "$CLAWBOX_EDITION" > "$_dropin_tmp"; then
+    rm -f "$_dropin_tmp"
+    echo "  Error: could not stage the edition drop-in for $LEGACY_EDITION_DROPIN" >&2
+    return 1
+  fi
   if ! install_root_file "$_dropin_tmp" "$LEGACY_EDITION_DROPIN" 0644; then
     rm -f "$_dropin_tmp"
     echo "  Error: could not write the edition drop-in at $LEGACY_EDITION_DROPIN" >&2

--- a/scripts/setup-hermes-edition.sh
+++ b/scripts/setup-hermes-edition.sh
@@ -228,13 +228,43 @@ done
 #
 # Note this writes $EDITION, not a hardcoded "hermes": doing the latter on a
 # dual box would silently downgrade the premium SKU.
+#
+# BOTH RECORDS ARE WRITTEN ATOMICALLY — a temp beside the target, then a
+# rename. `> "$file"` is open(O_TRUNC) + write + close, so for the length of the
+# write every reader on the box sees a zero-length or half-written lock, and
+# `readEditionSource()` turns that into `{edition: "openclaw", defaulted:
+# true}`. This script is dispatched by install.sh's `step_hermes_edition` on
+# EVERY in-app update of a hermes or dual box, while the middleware,
+# `openclawIsAbsent()`, the updater's own `hasHermesHarness()`, the gateway
+# catch-all and the MCP server are all reading that file — so a Hermes box
+# briefly answered as an OpenClaw one, which is how the flagship SKU's
+# gateway-only paths stop 404-ing and the MCP server registers the wrong tool
+# set. A rename cannot be observed half-done. install.sh:step_edition_lock is
+# the OTHER writer of these same two records and goes through
+# `install_root_file` for exactly this reason (TASK-584, TASK-761); this script
+# cannot call that function, so it does the same thing in six lines.
+# The content arrives on STDIN, so the bytes written are exactly the bytes the
+# caller printed — a `$(...)` argument would eat the trailing newline both of
+# these records end with.
+write_root_file() {
+  local dst="$1" mode="$2" tmp
+  # In the TARGET's directory, or the rename would cross filesystems and stop
+  # being atomic.
+  tmp="$(mktemp "$dst.XXXXXX")" || return 1
+  cat > "$tmp" || { rm -f "$tmp"; return 1; }
+  chown root:root "$tmp" || { rm -f "$tmp"; return 1; }
+  chmod "$mode" "$tmp" || { rm -f "$tmp"; return 1; }
+  mv -f "$tmp" "$dst" || { rm -f "$tmp"; return 1; }
+}
+
 install -d -o root -g root -m 0755 /etc/clawbox
-printf '# ClawBox edition lock — written by setup-hermes-edition.sh.\n# Root-owned on purpose: this is the authority for the device SKU.\nCLAWBOX_EDITION=%s\n' \
-  "$EDITION" > "$EDITION_FILE"
-chown root:root "$EDITION_FILE"
-chmod 0644 "$EDITION_FILE"
 mkdir -p /etc/systemd/system/clawbox-setup.service.d
-printf '[Service]\nEnvironment=CLAWBOX_EDITION=%s\n' "$EDITION" > "$EDITION_DROPIN"
+printf '# ClawBox edition lock — written by setup-hermes-edition.sh.\n# Root-owned on purpose: this is the authority for the device SKU.\nCLAWBOX_EDITION=%s\n' \
+  "$EDITION" | write_root_file "$EDITION_FILE" 0644 \
+  || fail "could not write the edition lock at $EDITION_FILE"
+printf '[Service]\nEnvironment=CLAWBOX_EDITION=%s\n' "$EDITION" \
+  | write_root_file "$EDITION_DROPIN" 0644 \
+  || fail "could not write the edition drop-in at $EDITION_DROPIN"
 log "wrote edition lock (CLAWBOX_EDITION=$EDITION)"
 
 systemctl daemon-reload

--- a/src/app/app/[id]/page.tsx
+++ b/src/app/app/[id]/page.tsx
@@ -338,14 +338,14 @@ export default function StandaloneAppPage() {
     // desktop has always retried; this is the same helper, not a second copy.
     void resolveHarnessProbe({
       signal: probe.signal,
+      // Every attempt, including one that answered nothing: this page shows its
+      // own "unknown" at once — which hides BOTH harnesses' apps, the same
+      // fail-closed answer as before — rather than sitting on "Loading…" for
+      // the whole retry budget. A later, settled answer replaces it.
       onAnswer: (d) => {
-        setHarness(d.active || "unknown");
+        setHarness(d?.active || "unknown");
         setWallpaperHarness(brandingHarness(d));
       },
-    }).then((d) => {
-      if (probe.signal.aborted) return;
-      // Nothing named a harness at all: still not a guess.
-      if (!d?.active) setHarness("unknown");
     });
     return () => { probe.abort(); };
   }, []);

--- a/src/app/app/[id]/page.tsx
+++ b/src/app/app/[id]/page.tsx
@@ -5,7 +5,7 @@ import { useParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import Image from "next/image";
 import Link from "next/link";
-import { fetchHarness } from "@/lib/client-harness";
+import { resolveHarnessProbe } from "@/lib/harness-probe";
 import { customWallpaperId, wallpaperIdAfterDelete } from "@/lib/custom-wallpapers";
 import {
   brandingHarness,
@@ -326,16 +326,28 @@ export default function StandaloneAppPage() {
   const appearance = useAppearance(id === "settings", wallpaperHarness);
 
   useEffect(() => {
-    let alive = true;
+    const probe = new AbortController();
     // "unknown" rather than a guess: this route is reachable directly (a
     // bookmark, "Open in new tab"), so falling back to "openclaw" rendered the
     // whole OpenClaw App Store on a Hermes box whenever the probe failed.
-    void fetchHarness().then((d) => {
-      if (!alive) return;
-      setHarness(d?.active || "unknown");
-      setWallpaperHarness(brandingHarness(d));
+    //
+    // Through the SHARED probe, which asks again when the device could not name
+    // its harness — `install.sh` rewrites the edition lock on every update and
+    // the browser reloads right after it, so a page that mounted inside that
+    // window used to wear the wrong product for the life of the tab. The
+    // desktop has always retried; this is the same helper, not a second copy.
+    void resolveHarnessProbe({
+      signal: probe.signal,
+      onAnswer: (d) => {
+        setHarness(d.active || "unknown");
+        setWallpaperHarness(brandingHarness(d));
+      },
+    }).then((d) => {
+      if (probe.signal.aborted) return;
+      // Nothing named a harness at all: still not a guess.
+      if (!d?.active) setHarness("unknown");
     });
-    return () => { alive = false; };
+    return () => { probe.abort(); };
   }, []);
 
   // `/app/settings?section=…` opens Settings on that section. There is no

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -398,6 +398,9 @@ function ChromeDesktopInner() {
     void resolveHarnessProbe({
       signal: probe.signal,
       onAnswer: (d) => {
+        // An attempt that answered NOTHING leaves the desktop unresolved, which
+        // hides both harnesses' apps — safe either way, and what it did before.
+        if (!d) return;
         setActiveHarness(d.active);
         const branding = brandingHarness(d);
         setWallpaperHarness(branding);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,7 +40,7 @@ import InstalledAppIcon from "@/components/InstalledAppIcon";
 import SetupWizard from "@/components/SetupWizard";
 import { I18nProvider, useT } from "@/lib/i18n";
 import { cleanVersion } from "@/lib/version-utils";
-import { fetchHarness } from "@/lib/client-harness";
+import { resolveHarnessProbe } from "@/lib/harness-probe";
 import { samePairingToken } from "@/lib/telegram-pairing-token";
 import type { InstalledMeta } from "@/lib/store-categories";
 import { SKILL_CHANGE_EVENT, announceSkillChange, installedAppRemovedDetail } from "@/lib/skill-change-message";
@@ -387,49 +387,34 @@ function ChromeDesktopInner() {
   // product's artwork on the customer's screen half the time.
   const [wallpaperHarness, setWallpaperHarness] = useState<string | null>(null);
   useEffect(() => {
-    let alive = true;
-    // Backing off and giving up, shared by the two ways this can fail to
-    // answer: no reply at all, and a reply that could not name the harness.
-    const retry = (attempt: number) => {
-      if (!alive || attempt >= 2) return; // stay unresolved = stay closed
-      setTimeout(() => { if (alive) load(attempt + 1); }, 500 * (attempt + 1));
-    };
-    const load = async (attempt: number): Promise<void> => {
-      try {
-        const d = await fetchHarness({ force: attempt > 0 });
-        if (!alive) return;
-        if (d?.active) {
-          setActiveHarness(d.active);
-          const branding = brandingHarness(d);
-          setWallpaperHarness(branding);
-          // A device that has never picked a wallpaper opens on its OWN
-          // edition's art — and on a device that has named no edition it opens
-          // on neither, since `brandWallpaperId` answers null there and no
-          // wallpaper is chosen at all. Guarded on wallpaperChosen because the
-          // preferences request and this one race, and a saved choice must
-          // survive whichever order they land in.
-          const brand = brandWallpaperId(branding);
-          if (brand && !wallpaperChosen.current) {
-            wallpaperChosen.current = true;
-            setWallpaperId(brand);
-          }
-          // A device that could not name its harness has not given a settled
-          // answer, only the honest one for now — and `force` re-reads the
-          // route rather than the cache, so asking again is not asking the same
-          // stale reply. install.sh truncates and rewrites the edition lock on
-          // EVERY update and the desktop reloads right after it, so a mount
-          // inside that window would otherwise wear no branding, and write no
-          // `wp_id`, for the life of the tab: the probe-once class.
-          if (!branding) retry(attempt);
-          return;
+    const probe = new AbortController();
+    // Backing off and asking again — `install.sh` truncates and rewrites the
+    // edition lock on EVERY update and the desktop reloads right after it, so a
+    // mount inside that window would otherwise wear no branding, and write no
+    // `wp_id`, for the life of the tab: the probe-once class. The rule lives in
+    // `resolveHarnessProbe` because `/app/<id>` needs exactly the same one and
+    // had none; `onAnswer` fires for every answer, settled or not, so the honest
+    // one paints at once and a later one improves it.
+    void resolveHarnessProbe({
+      signal: probe.signal,
+      onAnswer: (d) => {
+        setActiveHarness(d.active);
+        const branding = brandingHarness(d);
+        setWallpaperHarness(branding);
+        // A device that has never picked a wallpaper opens on its OWN
+        // edition's art — and on a device that has named no edition it opens
+        // on neither, since `brandWallpaperId` answers null there and no
+        // wallpaper is chosen at all. Guarded on wallpaperChosen because the
+        // preferences request and this one race, and a saved choice must
+        // survive whichever order they land in.
+        const brand = brandWallpaperId(branding);
+        if (brand && !wallpaperChosen.current) {
+          wallpaperChosen.current = true;
+          setWallpaperId(brand);
         }
-        throw new Error("no harness");
-      } catch {
-        retry(attempt);
-      }
-    };
-    load(0);
-    return () => { alive = false; };
+      },
+    });
+    return () => { probe.abort(); };
   }, []);
 
   // The harness-specific apps hidden on this edition (OpenClaw Control-UI +

--- a/src/app/setup-api/harness/active/route.ts
+++ b/src/app/setup-api/harness/active/route.ts
@@ -1,16 +1,19 @@
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import { getActiveHarnessSource, getEdition } from "@/lib/harness";
+import { getActiveHarnessSource } from "@/lib/harness";
 
 // Just the active harness — a config read, no health probes. The desktop chat
 // polls this on mount to decide how to route; the full /harness/status (with
 // liveness probes) is for the Settings picker that renders health dots.
 //
-// `edition` is a plain env read (getEdition) and therefore free. It lets
-// edition-aware UI skip /harness/status, whose per-harness liveness probes cost
-// ~500 ms of retry sleep on this hardware — long enough that the AI panel used
-// to paint the OpenClaw provider list before learning it was a Hermes device.
+// `edition` comes back from the SAME read that resolved `active`, never a
+// second one: `install.sh` rewrites the edition lock on every update, and a
+// re-read after the await below answered `active: "hermes"` beside
+// `edition: "openclaw"` — a pair no real SKU can be in. It lets edition-aware UI
+// skip /harness/status, whose per-harness liveness probes cost ~500 ms of retry
+// sleep on this hardware — long enough that the AI panel used to paint the
+// OpenClaw provider list before learning it was a Hermes device.
 //
 // `activeKnown` says whether `active` is a FACT or this device's own default.
 // Both fields above collapse "nobody could answer" into "openclaw" — the safe
@@ -22,6 +25,6 @@ import { getActiveHarnessSource, getEdition } from "@/lib/harness";
 // src/lib/builtin-wallpapers.ts. `getActiveHarnessSource` owns the distinction,
 // so no surface re-derives it.
 export async function GET() {
-  const { active, defaulted } = await getActiveHarnessSource();
-  return NextResponse.json({ active, edition: getEdition(), activeKnown: !defaulted });
+  const { active, defaulted, edition } = await getActiveHarnessSource();
+  return NextResponse.json({ active, edition, activeKnown: !defaulted });
 }

--- a/src/app/setup-api/harness/select/route.ts
+++ b/src/app/setup-api/harness/select/route.ts
@@ -4,7 +4,9 @@ import { NextResponse } from "next/server";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import path from "path";
-import { setActiveHarness, isHarness, harnessHealthy, isSingleHarnessEdition, type Harness } from "@/lib/harness";
+import {
+  getEditionSource, setActiveHarness, isHarness, harnessHealthy, isSingleHarnessEdition, type Harness,
+} from "@/lib/harness";
 import { refreshHarnessToolsIfSwitched } from "@/lib/harness-mcp-refresh";
 import { CONFIG_ROOT } from "@/lib/config-store";
 
@@ -15,7 +17,12 @@ const exec = promisify(execFile);
 export async function POST(request: Request) {
   // Locked device (single-harness edition, or dual without a valid premium
   // license): switching is disabled at the API too, not just hidden in the UI.
-  if (isSingleHarnessEdition()) {
+  // Read ONCE and threaded into the persist below: between this gate and that
+  // write the route runs a 60-second identity sync, and a second read landing
+  // in `install.sh`'s rewrite of the edition lock would refuse a switch this
+  // gate has already allowed — after the sync had run.
+  const { edition } = getEditionSource();
+  if (isSingleHarnessEdition(edition)) {
     return NextResponse.json(
       { error: "Harness switching is not available on this device." },
       { status: 403 },
@@ -83,7 +90,7 @@ export async function POST(request: Request) {
   // one harness with the agent's whole tool list built for the other.
   let previous: Harness;
   try {
-    previous = await setActiveHarness(harness);
+    previous = await setActiveHarness(harness, edition);
   } catch (err) {
     console.error("[harness/select] failed to persist active harness:", err instanceof Error ? err.message : err);
     return NextResponse.json(

--- a/src/app/setup-api/harness/status/route.ts
+++ b/src/app/setup-api/harness/status/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import {
-  getActiveHarness, harnessHealthy, HARNESSES, getEdition, isSingleHarnessEdition, type Harness,
+  getActiveHarnessSource, harnessHealthy, HARNESSES, isSingleHarnessEdition, type Harness,
 } from "@/lib/harness";
 import { readShellScanStatus } from "@/lib/hermes-shell-scan";
 
@@ -11,8 +11,13 @@ import { readShellScanStatus } from "@/lib/hermes-shell-scan";
 // device), whether each harness's local server is up, and — on Hermes — whether
 // the agent is scanning shell commands before it runs them.
 export async function GET() {
-  const active = await getActiveHarness();
-  const locked = isSingleHarnessEdition();
+  // ONE read of the edition for the whole response, like `/harness/active`:
+  // `active`, `locked` and `edition` are three answers about the same edition,
+  // and taken from three reads across the awaits below they can be answers
+  // about two — `install.sh` rewrites the lock on every update, and this route
+  // is what the Settings picker draws its badge from.
+  const { active, edition } = await getActiveHarnessSource();
+  const locked = isSingleHarnessEdition(edition);
   // On a locked device only the active harness's runtime is installed, so don't
   // probe (or advertise) the other one — just report the single active harness.
   const ids = locked ? [active] : (Object.keys(HARNESSES) as Harness[]);
@@ -28,7 +33,7 @@ export async function GET() {
   const healthById = new Map(health);
   return NextResponse.json({
     active,
-    edition: getEdition(),
+    edition,
     locked,
     shellScan,
     harnesses: ids.map((id) => ({

--- a/src/app/setup-api/harness/status/route.ts
+++ b/src/app/setup-api/harness/status/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import {
-  getActiveHarnessSource, harnessHealthy, HARNESSES, isSingleHarnessEdition, type Harness,
+  getActiveHarnessSource, harnessHealthy, HARNESSES, type Harness,
 } from "@/lib/harness";
 import { readShellScanStatus } from "@/lib/hermes-shell-scan";
 
@@ -11,13 +11,14 @@ import { readShellScanStatus } from "@/lib/hermes-shell-scan";
 // device), whether each harness's local server is up, and — on Hermes — whether
 // the agent is scanning shell commands before it runs them.
 export async function GET() {
-  // ONE read of the edition for the whole response, like `/harness/active`:
-  // `active`, `locked` and `edition` are three answers about the same edition,
-  // and taken from three reads across the awaits below they can be answers
-  // about two — `install.sh` rewrites the lock on every update, and this route
-  // is what the Settings picker draws its badge from.
-  const { active, edition } = await getActiveHarnessSource();
-  const locked = isSingleHarnessEdition(edition);
+  // ONE resolution for the whole response, like `/harness/active`: `active`,
+  // `locked` and `edition` are three answers about the same edition, and taken
+  // from separate reads across the awaits below they can be answers about two —
+  // `install.sh` rewrites the lock on every update, and this route is what the
+  // Settings picker draws its badge from. `locked` comes back with them rather
+  // than being re-derived, which also spares a second ed25519 licence verify
+  // per poll.
+  const { active, edition, locked } = await getActiveHarnessSource();
   // On a locked device only the active harness's runtime is installed, so don't
   // probe (or advertise) the other one — just report the single active harness.
   const ids = locked ? [active] : (Object.keys(HARNESSES) as Harness[]);

--- a/src/app/setup-api/setup/status/route.ts
+++ b/src/app/setup-api/setup/status/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { getAll } from "@/lib/config-store";
 import { inferConfiguredLocalModel, readConfig as readOpenClawConfig, type OpenClawConfig } from "@/lib/openclaw-config";
-import { getActiveHarness } from "@/lib/harness";
+import { getActiveHarnessSource } from "@/lib/harness";
 import { hasValidSession, readSetupGateFacts } from "@/lib/route-auth";
 import { readActiveTelegramBot } from "@/lib/telegram-bot-identity";
 
@@ -36,7 +36,7 @@ export async function GET(request: Request) {
       // a read whose answer it never receives. It stays a plain file read
       // either way: no probe belongs on this route.
       authenticated
-        ? getActiveHarness().then((harness) => readActiveTelegramBot(harness, config))
+        ? getActiveHarnessSource().then((source) => readActiveTelegramBot(source, config))
         : Promise.resolve(null),
     ]);
     const hasExplicitLocalAiFlag = Object.prototype.hasOwnProperty.call(config, "local_ai_configured");

--- a/src/app/setup-api/telegram/configure/route.ts
+++ b/src/app/setup-api/telegram/configure/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { set } from "@/lib/config-store";
-import { getActiveHarness } from "@/lib/harness";
+import { getActiveHarnessSource } from "@/lib/harness";
 import {
   clearTelegramPairingState,
   GatewayNotReadyError,
@@ -134,7 +134,8 @@ export async function POST(request: Request) {
     // device has no OpenClaw gateway at all (the unit is masked, the port is
     // closed), so the OpenClaw path there stored a token nothing ever read and
     // the bot never answered.
-    const harness = await getActiveHarness();
+    const harnessSource = await getActiveHarnessSource();
+    const harness = harnessSource.active;
 
     // A different bot means a fresh allowlist — previously-approved senders
     // belong to the old bot. Detect a real token change (re-saving the same
@@ -171,7 +172,7 @@ export async function POST(request: Request) {
     // clearing the allowlist is the safe reading of that. The guard next door
     // asks a different question — "would these two pollers collide" — where the
     // id is the whole point.
-    const previous = await readActiveTelegramBot(harness);
+    const previous = await readActiveTelegramBot(harnessSource);
     const tokenChanged = previous.known
       ? previous.token !== null && previous.token !== botToken
       : previous.token !== botToken;

--- a/src/app/setup-api/telegram/pairing/route.ts
+++ b/src/app/setup-api/telegram/pairing/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 import { get, set } from "@/lib/config-store";
-import { getActiveHarness, type Harness } from "@/lib/harness";
+import {
+  getActiveHarness,
+  getActiveHarnessSource,
+  type ActiveHarnessSource,
+  type Harness,
+} from "@/lib/harness";
 import {
   readTelegramAllowFrom,
   listTelegramPairingRequests,
@@ -52,8 +57,13 @@ const APPROVED_NOTICE = "You're approved — send me a message and I'll answer."
  * A plain file read, no CLI: this route is on a 20 s desktop poll, which is why
  * its Hermes paths are deliberately CLI-free.
  */
-async function isConfigured(harness: Harness): Promise<{ configured: boolean; unknown: boolean }> {
-  const { token, known } = await readActiveTelegramBot(harness);
+async function isConfigured(
+  source: ActiveHarnessSource,
+): Promise<{ configured: boolean; unknown: boolean }> {
+  // The resolved source, not the bare harness: the reader takes the edition
+  // from the same read that named the harness, so an update rewriting the lock
+  // between the two cannot make this route answer about the wrong SKU.
+  const { token, known } = await readActiveTelegramBot(source);
   // The third state is carried out rather than collapsed. "This box has no bot"
   // and "we could not read this device's Telegram configuration" have different
   // fixes, and this route's empty answer is what the desktop polls for the
@@ -98,8 +108,9 @@ async function buildApproved(
 // status refresh.
 export async function GET(request: Request) {
   try {
-    const harness = await getActiveHarness();
-    const state = await isConfigured(harness);
+    const harnessSource = await getActiveHarnessSource();
+    const harness = harnessSource.active;
+    const state = await isConfigured(harnessSource);
     // Only a CONFIDENT "this box has no bot" short-circuits. An `unknown` used
     // to take this branch too, and the desktop's 20 s poller reads an empty
     // `pending` as "nothing is waiting" and clears the pairing popup — so an

--- a/src/app/setup-api/telegram/status/route.ts
+++ b/src/app/setup-api/telegram/status/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getActiveHarness } from "@/lib/harness";
+import { getActiveHarnessSource } from "@/lib/harness";
 import { hermesGatewayStatus, hermesTelegramRegistered } from "@/lib/hermes-telegram";
 import { readActiveTelegramBot } from "@/lib/telegram-bot-identity";
 import { readCachedChannelStatus } from "@/lib/openclaw-channels";
@@ -134,10 +134,11 @@ export async function GET() {
     // so a box paired with `hermes config set` — or restored with ~/.hermes
     // intact but no ClawBox config.json — answered `configured: false` and the
     // owner was invited to set up the bot he was already chatting with.
-    const harness = await getActiveHarness();
+    const harnessSource = await getActiveHarnessSource();
+    const harness = harnessSource.active;
 
     if (harness === "hermes") {
-      const { token, known } = await readActiveTelegramBot(harness);
+      const { token, known } = await readActiveTelegramBot(harnessSource);
       // `unknown` carries the third state out instead of collapsing it: a store
       // this box could not read must not render as a box with no bot, which is
       // the false failure the whole module exists to remove. Nothing draws it
@@ -176,7 +177,7 @@ export async function GET() {
     // only a side effect of the configure route. A box paired with `openclaw
     // config set`, or restored with ~/.openclaw intact and a fresh
     // data/config.json, was told to set up the bot it already answers on.
-    const { token, known } = await readActiveTelegramBot(harness);
+    const { token, known } = await readActiveTelegramBot(harnessSource);
     if (!token) return NextResponse.json({ configured: false, unknown: !known });
     // Whether anything is LISTENING, asked of the harness's own answer rather
     // than inferred: `openclaw channels status --json` through the ONE shared

--- a/src/lib/client-harness.ts
+++ b/src/lib/client-harness.ts
@@ -93,7 +93,15 @@ export function fetchHarness(options?: {
     .then((r) => (r.ok ? r.json() : null))
     .then((d: unknown) => {
       const data = (d ?? {}) as { active?: unknown; edition?: unknown; activeKnown?: unknown };
-      if (typeof data.edition === "string") editionCache = data.edition;
+      // NEVER PIN A GUESS. `edition` is cached for the lifetime of the document
+      // on the premise that it cannot change under a live page — true of the
+      // edition itself, false of the ANSWER: while `install.sh` rewrites the
+      // root-owned lock the route answers `{edition:"openclaw", activeKnown:false}`
+      // for any box, and a page that mounted in that window wore the wrong
+      // product until it was reloaded (the OpenClaw provider picker on a Hermes
+      // box). An answer the device did not stand behind is served once and
+      // asked again next time.
+      if (typeof data.edition === "string" && data.activeKnown === true) editionCache = data.edition;
       if (typeof data.active === "string") {
         activeCache = { value: data.active, at: Date.now() };
         // Cached beside `active`, not beside `edition`: it certifies THAT
@@ -113,7 +121,12 @@ export function fetchHarness(options?: {
       if (inFlight === request) inFlight = null;
     });
 
-  if (!options?.force) inFlight = request;
+  // A SIGNALLED request is never the shared one. `inFlight` is handed to every
+  // concurrent caller, and one caller's abort rejects the fetch for all of them
+  // — a chat window closing used to make the desktop's and the AI panel's
+  // probes answer null. The signal still cancels the request its own caller
+  // made.
+  if (!options?.force && !options?.signal) inFlight = request;
   return request;
 }
 

--- a/src/lib/harness-probe.ts
+++ b/src/lib/harness-probe.ts
@@ -24,22 +24,33 @@ const BACKOFF_MS = 500;
 /** Extra asks after the first. The desktop's number, now everyone's. */
 const DEFAULT_RETRIES = 2;
 
-/** Did the DEVICE answer this, or is it the fallback nothing could improve on? */
+/**
+ * Did the DEVICE answer this, or is it the fallback nothing could improve on?
+ *
+ * The same test `brandingHarness` makes (`src/lib/builtin-wallpapers.ts`), and
+ * deliberately as narrow: `activeKnown` alone would settle on a harness name
+ * this build does not know, where the desktop's old loop asked again.
+ */
 export function harnessProbeSettled(info: HarnessInfo | null): boolean {
-  return info?.activeKnown === true && typeof info.active === "string" && info.active.length > 0;
+  if (info?.activeKnown !== true) return false;
+  return info.active === "openclaw" || info.active === "hermes";
 }
 
 export interface HarnessProbeOptions {
   /** Aborts the in-flight request AND cancels any pending retry. */
   signal?: AbortSignal;
-  /** Extra attempts after the first (default 2). */
-  retries?: number;
   /**
-   * Called for every answer that named a harness, settled or not — so a caller
-   * can paint the honest answer at once and let the retry improve it, which is
-   * what the desktop does with its wallpaper.
+   * Called after EVERY attempt with what it got — an answer that named a
+   * harness, or `null` when nothing answered at all.
+   *
+   * Both matter, and the two surfaces want opposite things from the null: the
+   * desktop stays unresolved (which hides both harnesses' apps — safe either
+   * way), while `/app/<id>` shows its own "unknown" at once rather than a
+   * spinner for the whole retry budget. Waiting for the settled answer to tell
+   * either of them anything would have made a mid-update mount sit on
+   * "Loading…" for a second and a half.
    */
-  onAnswer?: (info: HarnessInfo) => void;
+  onAnswer?: (info: HarnessInfo | null) => void;
 }
 
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
@@ -58,20 +69,19 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
 }
 
 export async function resolveHarnessProbe(options: HarnessProbeOptions = {}): Promise<HarnessInfo | null> {
-  const retries = options.retries ?? DEFAULT_RETRIES;
   let last: HarnessInfo | null = null;
-  for (let attempt = 0; attempt <= retries; attempt++) {
+  for (let attempt = 0; attempt <= DEFAULT_RETRIES; attempt++) {
     if (options.signal?.aborted) return last;
     // `force` from the second attempt on: the client cache would otherwise hand
-    // back the very answer we are asking again about.
-    const info = await fetchHarness({ signal: options.signal, force: attempt > 0 }).catch(() => null);
+    // back the very answer we are asking again about. `fetchHarness` answers
+    // null rather than rejecting, so there is nothing to catch here.
+    const info = await fetchHarness({ signal: options.signal, force: attempt > 0 });
     if (options.signal?.aborted) return last ?? info;
-    if (info?.active) {
-      last = info;
-      options.onAnswer?.(info);
-      if (harnessProbeSettled(info)) return info;
-    }
-    if (attempt < retries) await sleep(BACKOFF_MS * (attempt + 1), options.signal);
+    const answered = info?.active ? info : null;
+    if (answered) last = answered;
+    options.onAnswer?.(answered);
+    if (harnessProbeSettled(answered)) return answered;
+    if (attempt < DEFAULT_RETRIES) await sleep(BACKOFF_MS * (attempt + 1), options.signal);
   }
   return last;
 }

--- a/src/lib/harness-probe.ts
+++ b/src/lib/harness-probe.ts
@@ -1,0 +1,77 @@
+import { fetchHarness, type HarnessInfo } from "@/lib/client-harness";
+
+/**
+ * "Which harness is this box?", asked the way BOTH surfaces have to ask it.
+ *
+ * The answer can be temporarily unknowable rather than wrong: `install.sh`
+ * truncates and rewrites the root-owned edition lock on every update, and a page
+ * that mounts inside that window is told "openclaw, and that was a guess"
+ * (`activeKnown: false`). A single probe makes that permanent for the life of
+ * the tab — the probe-once class — which on `/app/<id>` meant the OpenClaw App
+ * Store rendered on a Hermes box and the box's own brand never appeared.
+ *
+ * The desktop already backed off and asked again; the standalone window did not.
+ * This is that rule, in one place, so the two cannot drift again.
+ *
+ * NOT a poll: a settled answer ends it, and so does running out of attempts. An
+ * unsettled answer is still returned — it is the honest one for now, and the
+ * caller decides what to show for it.
+ */
+
+/** Between attempts: 500 ms, then 1 s. Long enough to outlast a file rewrite. */
+const BACKOFF_MS = 500;
+
+/** Extra asks after the first. The desktop's number, now everyone's. */
+const DEFAULT_RETRIES = 2;
+
+/** Did the DEVICE answer this, or is it the fallback nothing could improve on? */
+export function harnessProbeSettled(info: HarnessInfo | null): boolean {
+  return info?.activeKnown === true && typeof info.active === "string" && info.active.length > 0;
+}
+
+export interface HarnessProbeOptions {
+  /** Aborts the in-flight request AND cancels any pending retry. */
+  signal?: AbortSignal;
+  /** Extra attempts after the first (default 2). */
+  retries?: number;
+  /**
+   * Called for every answer that named a harness, settled or not — so a caller
+   * can paint the honest answer at once and let the retry improve it, which is
+   * what the desktop does with its wallpaper.
+   */
+  onAnswer?: (info: HarnessInfo) => void;
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) return resolve();
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+export async function resolveHarnessProbe(options: HarnessProbeOptions = {}): Promise<HarnessInfo | null> {
+  const retries = options.retries ?? DEFAULT_RETRIES;
+  let last: HarnessInfo | null = null;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    if (options.signal?.aborted) return last;
+    // `force` from the second attempt on: the client cache would otherwise hand
+    // back the very answer we are asking again about.
+    const info = await fetchHarness({ signal: options.signal, force: attempt > 0 }).catch(() => null);
+    if (options.signal?.aborted) return last ?? info;
+    if (info?.active) {
+      last = info;
+      options.onAnswer?.(info);
+      if (harnessProbeSettled(info)) return info;
+    }
+    if (attempt < retries) await sleep(BACKOFF_MS * (attempt + 1), options.signal);
+  }
+  return last;
+}

--- a/src/lib/harness.ts
+++ b/src/lib/harness.ts
@@ -138,10 +138,10 @@ export interface ActiveHarnessSource {
    * the device could answer — NOT because the device answered "openclaw".
    *
    * The two ways that happens are the two reads behind the value. An edition
-   * nobody named makes `lockedHarness()` itself a guess: it reads
-   * `getEdition()`, which is `readEditionSource()`'s own "openclaw" default
-   * there, so on a Hermes box with an unreadable lock this function can only
-   * say "openclaw". And on the one SKU the edition deliberately leaves open —
+   * nobody named is `readEditionSource()`'s own "openclaw" default, so on a
+   * Hermes box with an unreadable lock this function can only say "openclaw"
+   * — that case returns before the lock is consulted at all. And on the one SKU
+   * the edition deliberately leaves open —
    * an unlocked, licensed `dual` — the answer comes from `data/config.json`,
    * which a `sudo` script can leave root-owned; the forgiving reader answers
    * `undefined` to that exactly as it does to a box that has never switched.
@@ -164,6 +164,17 @@ export interface ActiveHarnessSource {
    * lock was rewritten in between.
    */
   edition: Edition;
+  /**
+   * Whether the switcher is locked — the same answer `isSingleHarnessEdition`
+   * gives, from THIS resolution.
+   *
+   * Carried for the same reason as `edition`, one layer down: re-deriving it
+   * costs a second `verifyDualLicense()` — a file read and an ed25519 verify —
+   * across the caller's await, so a licence replaced or expired in between
+   * would answer `edition: "dual"` beside `locked: true`, hiding the switcher
+   * on a box that has it.
+   */
+  locked: boolean;
 }
 
 export async function getActiveHarnessSource(): Promise<ActiveHarnessSource> {
@@ -178,15 +189,20 @@ export async function getActiveHarnessSource(): Promise<ActiveHarnessSource> {
   // response pairing `active: "hermes"` with `edition: "openclaw"`, which no
   // real SKU can be in.
   const source = readEditionSource();
-  if (source.defaulted) return { active: DEFAULT_HARNESS, defaulted: true, edition: source.edition };
+  const edition = source.edition;
+  if (source.defaulted) {
+    // Nothing named an edition, so the switcher answer is the locked one — the
+    // same thing `lockedHarness` would say for this module's own default.
+    return { active: DEFAULT_HARNESS, defaulted: true, edition, locked: true };
+  }
   // A locked (single-harness / unlicensed-dual) device ignores the stored value
   // entirely — the edition is the source of truth, so editing config.json can't
   // change which agent runs.
-  const locked = lockedHarness(source.edition);
-  if (locked) return { active: locked, defaulted: false, edition: source.edition };
+  const locked = lockedHarness(edition);
+  if (locked) return { active: locked, defaulted: false, edition, locked: true };
   const { value, known } = await getKnown(HARNESS_CONFIG_KEY);
-  if (!known) return { active: DEFAULT_HARNESS, defaulted: true, edition: source.edition };
-  return { active: isHarness(value) ? value : DEFAULT_HARNESS, defaulted: false, edition: source.edition };
+  if (!known) return { active: DEFAULT_HARNESS, defaulted: true, edition, locked: false };
+  return { active: isHarness(value) ? value : DEFAULT_HARNESS, defaulted: false, edition, locked: false };
 }
 
 export async function getActiveHarness(): Promise<Harness> {
@@ -204,17 +220,23 @@ export async function getActiveHarness(): Promise<Harness> {
  * harness and then concluded nothing had moved, leaving the box on one harness
  * with the agent's whole tool list built for the other.
  */
-export async function setActiveHarness(harness: Harness): Promise<Harness> {
+export async function setActiveHarness(harness: Harness, edition: Edition = getEdition()): Promise<Harness> {
   // Refuse to persist a switch on a locked device (defense-in-depth — the
   // /harness/select route also rejects, and the UI hides the switcher).
-  if (isSingleHarnessEdition()) {
+  //
+  // The edition is a PARAMETER because the one caller reads it minutes earlier,
+  // for its own gate, and then runs a 60-second identity sync: a second read
+  // here landing in `install.sh`'s rewrite of the lock answers the module
+  // default, this throws, and the route reports a 500 over a switch that was
+  // legitimate — after the sync has already run. One read, threaded.
+  if (isSingleHarnessEdition(edition)) {
     throw new Error("Harness switching is disabled on this edition");
   }
   const previous = await swap(HARNESS_CONFIG_KEY, harness);
   // A store that has never held one, or holds something that is not a harness,
   // reads as the default — the same answer `getActiveHarness` gives it. Not
-  // locked: `isSingleHarnessEdition()` above is the same test `lockedHarness()`
-  // makes, so the edition cannot be overriding the stored value here.
+  // locked: the check above is the same test `lockedHarness()` makes, against
+  // the same edition, so the edition cannot be overriding the stored value.
   return isHarness(previous) ? previous : DEFAULT_HARNESS;
 }
 

--- a/src/lib/harness.ts
+++ b/src/lib/harness.ts
@@ -59,6 +59,18 @@ export function getEditionSource(): EditionSource {
 }
 
 /**
+ * ONE EDITION PER ANSWER, for the three functions below.
+ *
+ * Each takes the edition as an optional argument and reads it only when the
+ * caller did not. `/etc/clawbox/edition.env` is a file another process rewrites
+ * — `install.sh` truncates and re-`printf`s it on every update — so each read is
+ * a fresh chance to land in that window and get this module's "openclaw"
+ * default back. A caller that reads it once and threads it through cannot
+ * answer half its question about one edition and half about another; a caller
+ * with nothing to thread keeps the old shape and pays one read.
+ */
+
+/**
  * True when the dual/switcher feature is active: edition "dual" AND a valid
  * license we signed.
  *
@@ -70,24 +82,23 @@ export function getEditionSource(): EditionSource {
  * locked, never to open up. verifyDualLicense() already returns false when no
  * key is configured, so this is the whole check.
  */
-export function isDualUnlocked(): boolean {
-  if (getEdition() !== "dual") return false;
+export function isDualUnlocked(edition: Edition = getEdition()): boolean {
+  if (edition !== "dual") return false;
   return verifyDualLicense();
 }
 
 /** True when the device is pinned to a single harness (switcher disabled) —
  *  either a single-harness edition, or "dual" without a valid license. */
-export function isSingleHarnessEdition(): boolean {
-  return !isDualUnlocked();
+export function isSingleHarnessEdition(edition: Edition = getEdition()): boolean {
+  return !isDualUnlocked(edition);
 }
 
 /** The harness this device is locked to, or null when the switcher is unlocked.
  *  A single edition locks to itself; "dual" without a license degrades to the
  *  default harness rather than exposing a switcher. */
-export function lockedHarness(): Harness | null {
-  if (isDualUnlocked()) return null;
-  const e = getEdition();
-  return e === "hermes" ? "hermes" : e === "openclaw" ? "openclaw" : DEFAULT_HARNESS;
+export function lockedHarness(edition: Edition = getEdition()): Harness | null {
+  if (isDualUnlocked(edition)) return null;
+  return edition === "hermes" ? "hermes" : edition === "openclaw" ? "openclaw" : DEFAULT_HARNESS;
 }
 
 export interface HarnessInfo {
@@ -144,18 +155,38 @@ export interface ActiveHarnessSource {
    * harness take `active` and are right either way.
    */
   defaulted: boolean;
+  /**
+   * The edition `active` was resolved FROM — the same read, not a later one.
+   *
+   * Reported so a caller needing both cannot take them from two moments: the
+   * `/harness/active` route used to add its own `getEdition()` after the await
+   * below, and answered `active: "hermes"` beside `edition: "openclaw"` when the
+   * lock was rewritten in between.
+   */
+  edition: Edition;
 }
 
 export async function getActiveHarnessSource(): Promise<ActiveHarnessSource> {
-  if (readEditionSource().defaulted) return { active: DEFAULT_HARNESS, defaulted: true };
+  // READ ONCE, thread it through. This used to take three reads of the edition
+  // lock — its own, and `lockedHarness()`'s two — with the route adding a fourth
+  // for the `edition` it reports beside the answer, and that one lands AFTER the
+  // await below. Every read is a separate syscall against a file `install.sh`
+  // truncates and rewrites on every update, so a later read can answer the
+  // module default where the first read had the real edition: a Hermes box
+  // reported as `{ active: "openclaw", defaulted: false }` — a guess presented
+  // as a fact, which is the one thing `defaulted` exists to prevent — or a
+  // response pairing `active: "hermes"` with `edition: "openclaw"`, which no
+  // real SKU can be in.
+  const source = readEditionSource();
+  if (source.defaulted) return { active: DEFAULT_HARNESS, defaulted: true, edition: source.edition };
   // A locked (single-harness / unlicensed-dual) device ignores the stored value
   // entirely — the edition is the source of truth, so editing config.json can't
   // change which agent runs.
-  const locked = lockedHarness();
-  if (locked) return { active: locked, defaulted: false };
+  const locked = lockedHarness(source.edition);
+  if (locked) return { active: locked, defaulted: false, edition: source.edition };
   const { value, known } = await getKnown(HARNESS_CONFIG_KEY);
-  if (!known) return { active: DEFAULT_HARNESS, defaulted: true };
-  return { active: isHarness(value) ? value : DEFAULT_HARNESS, defaulted: false };
+  if (!known) return { active: DEFAULT_HARNESS, defaulted: true, edition: source.edition };
+  return { active: isHarness(value) ? value : DEFAULT_HARNESS, defaulted: false, edition: source.edition };
 }
 
 export async function getActiveHarness(): Promise<Harness> {

--- a/src/lib/telegram-bot-identity.ts
+++ b/src/lib/telegram-bot-identity.ts
@@ -29,7 +29,7 @@
 // allowed to make a save gate refuse.
 
 import { get as configGet } from "@/lib/config-store";
-import { getActiveHarness, getEdition, getEditionSource, type Harness } from "@/lib/harness";
+import { getActiveHarnessSource, getEdition, getEditionSource, type Harness } from "@/lib/harness";
 import { readHermesTelegramToken } from "@/lib/hermes-telegram";
 import { readConfigStrict, type OpenClawConfig } from "@/lib/openclaw-config";
 
@@ -186,7 +186,14 @@ export async function readActiveTelegramBot(
   harness?: Harness,
   clawboxConfig?: Record<string, unknown>,
 ): Promise<ActiveTelegramBot> {
-  const active = harness ?? (await getActiveHarness());
+  // ONE resolution when this call has to make it: the edition below is read
+  // from the same one. `install.sh` rewrites the edition lock on every update,
+  // and a second read landing in that window answers "openclaw" — the dual
+  // guard is then skipped and the mirror is returned as the ACTIVE harness's
+  // bot, which is the exact "report a working bot on a harness that has none"
+  // the guard exists to stop.
+  const source = harness ? null : await getActiveHarnessSource();
+  const active = harness ?? source!.active;
   const stored = await storeFor(active)();
   if (stored.token) return stored;
   // The mirror is one value for the whole box, and on `dual` the configure
@@ -195,7 +202,7 @@ export async function readActiveTelegramBot(
   // with it would report a working bot on a harness that has none. There is no
   // legacy box to protect on that SKU, which is where the fallback earns its
   // place: an OpenClaw box configured before the channel block existed.
-  if (getEdition() === "dual") return stored;
+  if ((source ? source.edition : getEdition()) === "dual") return stored;
   return { token: await clawboxMirror(clawboxConfig), known: stored.known };
 }
 

--- a/src/lib/telegram-bot-identity.ts
+++ b/src/lib/telegram-bot-identity.ts
@@ -29,7 +29,13 @@
 // allowed to make a save gate refuse.
 
 import { get as configGet } from "@/lib/config-store";
-import { getActiveHarnessSource, getEdition, getEditionSource, type Harness } from "@/lib/harness";
+import {
+  getActiveHarnessSource,
+  getEdition,
+  getEditionSource,
+  type ActiveHarnessSource,
+  type Harness,
+} from "@/lib/harness";
 import { readHermesTelegramToken } from "@/lib/hermes-telegram";
 import { readConfigStrict, type OpenClawConfig } from "@/lib/openclaw-config";
 
@@ -179,21 +185,27 @@ function installedHarnesses(): Harness[] {
  * answer rather than reporting a working bot as gone. `known` still says which
  * of the two it was.
  *
- * `harness` is optional so a caller that has already resolved it does not pay
- * for a second lookup.
+ * The first argument is optional so a caller that has already resolved the
+ * harness does not pay for a second lookup — and it takes the whole
+ * `ActiveHarnessSource` rather than the bare harness, because the edition below
+ * has to come from the SAME read as `active`. Every route that resolves the
+ * harness for its own reasons passes the source; a caller that names a fixed
+ * harness (the two OpenClaw-only notifiers) passes that and pays for the one
+ * edition read here, which is still a single read for the call.
  */
 export async function readActiveTelegramBot(
-  harness?: Harness,
+  harness?: Harness | ActiveHarnessSource,
   clawboxConfig?: Record<string, unknown>,
 ): Promise<ActiveTelegramBot> {
-  // ONE resolution when this call has to make it: the edition below is read
-  // from the same one. `install.sh` rewrites the edition lock on every update,
-  // and a second read landing in that window answers "openclaw" — the dual
-  // guard is then skipped and the mirror is returned as the ACTIVE harness's
-  // bot, which is the exact "report a working bot on a harness that has none"
-  // the guard exists to stop.
-  const source = harness ? null : await getActiveHarnessSource();
-  const active = harness ?? source!.active;
+  // ONE resolution for the whole answer. `install.sh` rewrites the edition lock
+  // on every update, and a second read landing in that window answers
+  // "openclaw" — the dual guard is then skipped and the mirror is returned as
+  // the ACTIVE harness's bot, which is the exact "report a working bot on a
+  // harness that has none" the guard exists to stop. A `Harness` is a string,
+  // so the shape of the argument says which case this is.
+  const source =
+    typeof harness === "object" ? harness : harness ? null : await getActiveHarnessSource();
+  const active = source ? source.active : (harness as Harness);
   const stored = await storeFor(active)();
   if (stored.token) return stored;
   // The mirror is one value for the whole box, and on `dual` the configure

--- a/src/tests/components/standalone-app-harness-retry.test.tsx
+++ b/src/tests/components/standalone-app-harness-retry.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+/**
+ * `/app/<id>` asks which harness this box runs — ONCE, and fails closed on the
+ * answer it gets.
+ *
+ * The desktop asks the same question with a bounded retry (`{ force: true }`,
+ * two more attempts, 500 ms apart) precisely because the answer can be
+ * temporarily unknowable: `install.sh` truncates and rewrites the root-owned
+ * edition lock on every update, and a page that mounts inside that window is
+ * told "openclaw, and that was a guess" — `activeKnown: false`. On this page a
+ * single probe made that permanent for the life of the tab: the OpenClaw App
+ * Store rendered on a Hermes box, and the box's own brand never appeared.
+ *
+ * Both surfaces now go through ONE helper, so a retry rule can never exist on
+ * one screen and not the other.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type React from "react";
+import { render, screen } from "@/tests/helpers/test-utils";
+import StandaloneAppPage from "@/app/app/[id]/page";
+
+type Probe = { active?: string; edition?: string; activeKnown?: boolean } | null;
+
+const harnessMock = vi.hoisted(() => vi.fn<(options?: { force?: boolean; signal?: AbortSignal }) => Promise<Probe>>());
+
+// `/app/store` — an app that exists on OpenClaw and not on Hermes, so the
+// answer decides what the customer sees.
+vi.mock("next/navigation", () => ({ useParams: () => ({ id: "store" }) }));
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+vi.mock("next/image", () => ({ default: () => null }));
+// Only `fetchHarness` is mocked: the retry helper under test is the real one,
+// and this is the request it makes.
+vi.mock("@/lib/client-harness", () => ({ fetchHarness: harnessMock }));
+
+beforeEach(() => {
+  harnessMock.mockReset();
+  vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, json: async () => ({}) })));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("/app/<id> — a probe that could not name the harness", () => {
+  it("asks again, and hides the OpenClaw app the box does not have", async () => {
+    // The update window, then the settled answer.
+    harnessMock
+      .mockResolvedValueOnce({ active: "openclaw", edition: "openclaw", activeKnown: false })
+      .mockResolvedValue({ active: "hermes", edition: "hermes", activeKnown: true });
+
+    render(<StandaloneAppPage />);
+
+    expect(await screen.findByText(/App not found: store/)).toBeInTheDocument();
+    expect(harnessMock.mock.calls.length).toBeGreaterThan(1);
+    // The second ask must go past the client cache, or it is the same stale
+    // reply read twice.
+    expect(harnessMock).toHaveBeenLastCalledWith(expect.objectContaining({ force: true }));
+  });
+
+  it("does not ask twice when the first answer is the device's own", async () => {
+    // The cost guard: a settled answer is the end of it. Every mount paying for
+    // three round-trips would be the other failure.
+    harnessMock.mockResolvedValue({ active: "openclaw", edition: "openclaw", activeKnown: true });
+
+    render(<StandaloneAppPage />);
+
+    expect(await screen.findByRole("link")).toBeInTheDocument();
+    expect(harnessMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/tests/routes/harness-active.test.ts
+++ b/src/tests/routes/harness-active.test.ts
@@ -128,6 +128,30 @@ describe("GET /setup-api/harness/active — the dual SKU, whose harness is a run
     expect(await get()).toEqual({ active: "openclaw", edition: "dual", activeKnown: true });
   });
 
+  it("reports the edition its harness was resolved FROM, not one read later", async () => {
+    // `install.sh` truncates and rewrites /etc/clawbox/edition.env on every
+    // update, and this SKU's answer contains an AWAIT — the config-store read —
+    // so the route's own `edition` read landed after it. Answered from two
+    // reads, the response could pair `active: "hermes"` with
+    // `edition: "openclaw"`, which no real SKU can be in: the openclaw edition
+    // is locked to its own harness. A caller that reads `edition` to decide
+    // what this box is then draws for the wrong product.
+    licenseDual();
+    vi.doMock("@/lib/config-store", async (orig) => ({
+      ...(await orig<typeof import("@/lib/config-store")>()),
+      getKnown: async () => {
+        // The rewrite, in the window it really happens in. The mtime is pushed
+        // forward explicitly because `edition-source` caches by it and a second
+        // write inside the same millisecond would be served from the cache.
+        fs.writeFileSync(lockPath, "# ClawBox edition lock\n# (being rewritten)\n");
+        const later = new Date(Date.now() + 2_000);
+        fs.utimesSync(lockPath, later, later);
+        return { value: "hermes", known: true };
+      },
+    }));
+    expect(await get()).toEqual({ active: "hermes", edition: "dual", activeKnown: true });
+  });
+
   it("says the harness is NOT resolved when the config store cannot be read", async () => {
     // The gap this pair of tests exists for. `data/config.json` left root-owned
     // by a `sudo` script: the forgiving reader answers "openclaw" for a box

--- a/src/tests/routes/harness-select-mcp-reload.test.ts
+++ b/src/tests/routes/harness-select-mcp-reload.test.ts
@@ -13,11 +13,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
  */
 
 const getActiveHarness = vi.fn(async () => "openclaw" as string);
-const setActiveHarness = vi.fn(async (_harness: string) => "openclaw" as string);
+const setActiveHarness = vi.fn(async (_harness: string, _edition?: string) => "openclaw" as string);
 const harnessHealthy = vi.fn(async () => true);
 vi.mock("@/lib/harness", () => ({
   getActiveHarness: () => getActiveHarness(),
-  setActiveHarness: (h: string) => setActiveHarness(h),
+  // The route reads the edition ONCE at the top and threads it into the
+  // persist: between the two it runs a 60-second identity sync, and a second
+  // read landing in install.sh's rewrite of the lock would refuse a switch the
+  // gate had already allowed.
+  getEditionSource: () => ({ edition: "dual", defaulted: false }),
+  setActiveHarness: (h: string, edition?: string) => setActiveHarness(h, edition),
   harnessHealthy: () => harnessHealthy(),
   isHarness: (h: unknown) => h === "openclaw" || h === "hermes",
   isSingleHarnessEdition: () => false,
@@ -77,7 +82,9 @@ describe("POST /setup-api/harness/select", () => {
     const res = await post("hermes");
 
     expect(res.status).toBe(200);
-    expect(setActiveHarness).toHaveBeenCalledWith("hermes");
+    // With the edition the route read for its own gate: one read, threaded, so
+    // the persist cannot refuse a switch the gate allowed.
+    expect(setActiveHarness).toHaveBeenCalledWith("hermes", "dual");
     expect(dashboardRpc).toHaveBeenCalledWith("reload.mcp", { confirm: true });
   });
 

--- a/src/tests/routes/harness-status.test.ts
+++ b/src/tests/routes/harness-status.test.ts
@@ -12,25 +12,37 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
  */
 
 const getActiveHarness = vi.fn(async () => "hermes");
+/** What the one resolution answers — the whole of what the route may use. */
+const harnessSource = vi.fn(async () => ({
+  active: await getActiveHarness(),
+  defaulted: false,
+  edition: "hermes" as string,
+  locked: true,
+}));
 /** Every harness these tests name is up; health is not what they are about. */
 const harnessHealthy = vi.fn(async (harness: string) => Boolean(harness));
 vi.mock("@/lib/harness", () => ({
-  // The route reads the harness AND the edition from one call now, so the
-  // response cannot be half about one edition and half about another.
-  getActiveHarnessSource: async () => ({
-    active: await getActiveHarness(),
-    defaulted: false,
-    edition: "hermes",
-  }),
+  // ONE call answers the harness, the edition AND the switcher state now, so
+  // the response cannot be half about one edition and half about another —
+  // and `locked` cannot cost a second licence verify across the awaits below.
+  getActiveHarnessSource: async () => harnessSource(),
   getActiveHarness: () => getActiveHarness(),
   harnessHealthy: (h: string) => harnessHealthy(h),
-  getEdition: () => "hermes",
-  isSingleHarnessEdition: () => true,
   HARNESSES: {
     openclaw: { id: "openclaw", label: "OpenClaw" },
     hermes: { id: "hermes", label: "Hermes" },
   },
 }));
+
+/**
+ * The response must be about ONE edition.
+ *
+ * `active`, `edition` and `locked` used to come from three reads of a file
+ * `install.sh` rewrites on every update, taken across the health probes'
+ * awaits: the route could answer `active: "hermes"` beside `edition: "openclaw"`
+ * — a pair no real SKU can be in, since the openclaw edition is locked to its
+ * own harness — and the Settings picker draws its badge from exactly that.
+ */
 
 interface ScanShape {
   state: string;
@@ -52,7 +64,13 @@ vi.mock("@/lib/hermes-shell-scan", () => ({
   readShellScanStatus: () => readShellScanStatus(),
 }));
 
-async function get() {
+async function get(): Promise<{
+  active: string;
+  edition: string;
+  locked: boolean;
+  harnesses: { id: string }[];
+  shellScan: { state: string; reason: string; scannerPath: string | null } | null;
+}> {
   vi.resetModules();
   const mod = await import("@/app/setup-api/harness/status/route");
   return (await mod.GET()).json();
@@ -79,7 +97,7 @@ describe("GET /setup-api/harness/status — shell scanning posture", () => {
       retrySuppressedUntil: null,
     });
 
-    expect((await get()).shellScan.state).toBe("on");
+    expect((await get()).shellScan?.state).toBe("on");
   });
 
   it("says nothing about scanning on the OpenClaw harness, which has no scanner", async () => {
@@ -89,5 +107,40 @@ describe("GET /setup-api/harness/status — shell scanning posture", () => {
 
     expect(body.shellScan).toBeNull();
     expect(readShellScanStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /setup-api/harness/status — one edition per response", () => {
+  it("reports the edition and the lock the harness was resolved WITH", async () => {
+    // A licensed dual: unlocked, so both harnesses are probed and offered.
+    harnessSource.mockResolvedValueOnce({
+      active: "hermes",
+      defaulted: false,
+      edition: "dual",
+      locked: false,
+    });
+
+    const body = await get();
+
+    expect(body.edition).toBe("dual");
+    expect(body.locked).toBe(false);
+    expect(body.active).toBe("hermes");
+    expect(body.harnesses.map((h: { id: string }) => h.id)).toEqual(["openclaw", "hermes"]);
+  });
+
+  it("probes only the active harness when that one resolution says locked", async () => {
+    // The other half: on a locked device the other harness's runtime is not
+    // installed, so probing it would report a missing gateway as a fault.
+    harnessSource.mockResolvedValueOnce({
+      active: "hermes",
+      defaulted: false,
+      edition: "hermes",
+      locked: true,
+    });
+
+    const body = await get();
+
+    expect(body.locked).toBe(true);
+    expect(body.harnesses.map((h: { id: string }) => h.id)).toEqual(["hermes"]);
   });
 });

--- a/src/tests/routes/harness-status.test.ts
+++ b/src/tests/routes/harness-status.test.ts
@@ -11,14 +11,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
  * a component that box will never have.
  */
 
-const getActiveHarness = vi.fn(async () => "hermes");
 /** What the one resolution answers — the whole of what the route may use. */
-const harnessSource = vi.fn(async () => ({
-  active: await getActiveHarness(),
-  defaulted: false,
-  edition: "hermes" as string,
-  locked: true,
-}));
+let source = { active: "hermes", defaulted: false, edition: "hermes", locked: true };
+const harnessSource = vi.fn(async () => source);
+/**
+ * Deliberately INDEPENDENT of the resolution above, and deliberately answering
+ * a different harness: the contract this suite pins is that the whole response
+ * comes from ONE read, so a route that also asked this would be answering about
+ * another box — which is only visible if the two can disagree. It also must
+ * never be called at all; the last case asserts that.
+ */
+const getActiveHarness = vi.fn(async () => "openclaw");
 /** Every harness these tests name is up; health is not what they are about. */
 const harnessHealthy = vi.fn(async (harness: string) => Boolean(harness));
 vi.mock("@/lib/harness", () => ({
@@ -78,7 +81,7 @@ async function get(): Promise<{
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getActiveHarness.mockResolvedValue("hermes");
+  source = { active: "hermes", defaulted: false, edition: "hermes", locked: true };
 });
 
 describe("GET /setup-api/harness/status — shell scanning posture", () => {
@@ -101,24 +104,23 @@ describe("GET /setup-api/harness/status — shell scanning posture", () => {
   });
 
   it("says nothing about scanning on the OpenClaw harness, which has no scanner", async () => {
-    getActiveHarness.mockResolvedValue("openclaw");
+    source = { active: "openclaw", defaulted: false, edition: "openclaw", locked: true };
 
     const body = await get();
 
     expect(body.shellScan).toBeNull();
     expect(readShellScanStatus).not.toHaveBeenCalled();
+    // From the one resolution and nowhere else: `getActiveHarness` answers the
+    // other harness here, so a second read would have shown up as a scan report
+    // about a box this is not.
+    expect(getActiveHarness).not.toHaveBeenCalled();
   });
 });
 
 describe("GET /setup-api/harness/status — one edition per response", () => {
   it("reports the edition and the lock the harness was resolved WITH", async () => {
     // A licensed dual: unlocked, so both harnesses are probed and offered.
-    harnessSource.mockResolvedValueOnce({
-      active: "hermes",
-      defaulted: false,
-      edition: "dual",
-      locked: false,
-    });
+    source = { active: "hermes", defaulted: false, edition: "dual", locked: false };
 
     const body = await get();
 
@@ -131,12 +133,7 @@ describe("GET /setup-api/harness/status — one edition per response", () => {
   it("probes only the active harness when that one resolution says locked", async () => {
     // The other half: on a locked device the other harness's runtime is not
     // installed, so probing it would report a missing gateway as a fault.
-    harnessSource.mockResolvedValueOnce({
-      active: "hermes",
-      defaulted: false,
-      edition: "hermes",
-      locked: true,
-    });
+    source = { active: "hermes", defaulted: false, edition: "hermes", locked: true };
 
     const body = await get();
 

--- a/src/tests/routes/harness-status.test.ts
+++ b/src/tests/routes/harness-status.test.ts
@@ -15,6 +15,13 @@ const getActiveHarness = vi.fn(async () => "hermes");
 /** Every harness these tests name is up; health is not what they are about. */
 const harnessHealthy = vi.fn(async (harness: string) => Boolean(harness));
 vi.mock("@/lib/harness", () => ({
+  // The route reads the harness AND the edition from one call now, so the
+  // response cannot be half about one edition and half about another.
+  getActiveHarnessSource: async () => ({
+    active: await getActiveHarness(),
+    defaulted: false,
+    edition: "hermes",
+  }),
   getActiveHarness: () => getActiveHarness(),
   harnessHealthy: (h: string) => harnessHealthy(h),
   getEdition: () => "hermes",

--- a/src/tests/routes/telegram/configure-hermes.test.ts
+++ b/src/tests/routes/telegram/configure-hermes.test.ts
@@ -9,7 +9,23 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
  */
 
 vi.mock("@/lib/config-store", () => ({ get: vi.fn(), set: vi.fn() }));
-vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn(), getEdition: vi.fn(() => "hermes") }));
+// `getActiveHarnessSource` answers from the same mock this suite drives, so the
+// routes' one resolution says what these cases set. The single-read contract
+// itself is pinned in harness-edition-read-once / harness-status, not here.
+vi.mock("@/lib/harness", () => {
+  const getActiveHarness = vi.fn();
+  const getEdition = vi.fn(() => "hermes");
+  return {
+    getActiveHarness,
+    getEdition,
+    getActiveHarnessSource: async () => ({
+      active: await getActiveHarness(),
+      defaulted: false,
+      edition: getEdition(),
+      locked: true,
+    }),
+  };
+});
 // The route also refuses the approvals bot's own token; mocked at the reader so
 // this suite does not drag in the email-approval module's config-store surface.
 vi.mock("@/lib/email-approval", () => ({

--- a/src/tests/routes/telegram/pairing-hermes.test.ts
+++ b/src/tests/routes/telegram/pairing-hermes.test.ts
@@ -8,7 +8,23 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
  */
 
 vi.mock("@/lib/config-store", () => ({ get: vi.fn(), set: vi.fn() }));
-vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn(), getEdition: vi.fn(() => "hermes") }));
+// `getActiveHarnessSource` answers from the same mock this suite drives, so the
+// routes' one resolution says what these cases set. The single-read contract
+// itself is pinned in harness-edition-read-once / harness-status, not here.
+vi.mock("@/lib/harness", () => {
+  const getActiveHarness = vi.fn();
+  const getEdition = vi.fn(() => "hermes");
+  return {
+    getActiveHarness,
+    getEdition,
+    getActiveHarnessSource: async () => ({
+      active: await getActiveHarness(),
+      defaulted: false,
+      edition: getEdition(),
+      locked: true,
+    }),
+  };
+});
 vi.mock("@/lib/openclaw-config", () => ({
   readTelegramAllowFrom: vi.fn(),
   listTelegramPairingRequests: vi.fn(),

--- a/src/tests/routes/telegram/status-hermes.test.ts
+++ b/src/tests/routes/telegram/status-hermes.test.ts
@@ -8,7 +8,23 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
  */
 
 vi.mock("@/lib/config-store", () => ({ get: vi.fn() }));
-vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn(), getEdition: vi.fn(() => "hermes") }));
+// `getActiveHarnessSource` answers from the same mock this suite drives, so the
+// routes' one resolution says what these cases set. The single-read contract
+// itself is pinned in harness-edition-read-once / harness-status, not here.
+vi.mock("@/lib/harness", () => {
+  const getActiveHarness = vi.fn();
+  const getEdition = vi.fn(() => "hermes");
+  return {
+    getActiveHarness,
+    getEdition,
+    getActiveHarnessSource: async () => ({
+      active: await getActiveHarness(),
+      defaulted: false,
+      edition: getEdition(),
+      locked: true,
+    }),
+  };
+});
 vi.mock("@/lib/hermes-telegram", () => ({
   hermesTelegramRegistered: vi.fn(),
   hermesGatewayStatus: vi.fn(),

--- a/src/tests/routes/telegram/status-openclaw-receiving.test.ts
+++ b/src/tests/routes/telegram/status-openclaw-receiving.test.ts
@@ -21,7 +21,22 @@
  */
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
-vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn() }));
+// `getActiveHarnessSource` answers from the same mock this suite drives, so the
+// routes' one resolution says what these cases set. The single-read contract
+// itself is pinned in harness-edition-read-once / harness-status, not here.
+vi.mock("@/lib/harness", () => {
+  const getActiveHarness = vi.fn();
+  return {
+    getActiveHarness,
+    getEdition: () => "openclaw",
+    getActiveHarnessSource: async () => ({
+      active: await getActiveHarness(),
+      defaulted: false,
+      edition: "openclaw",
+      locked: true,
+    }),
+  };
+});
 vi.mock("@/lib/openclaw-channels", () => ({ readCachedChannelStatus: vi.fn() }));
 vi.mock("@/lib/telegram-bot-identity", () => ({ readActiveTelegramBot: vi.fn() }));
 vi.mock("@/lib/hermes-telegram", () => ({

--- a/src/tests/unit/client-harness.test.ts
+++ b/src/tests/unit/client-harness.test.ts
@@ -56,7 +56,28 @@ describe("client harness cache", () => {
       edition: "openclaw",
       activeKnown: false,
     });
+    // ASKED AGAIN, deliberately. The edition is cached for the lifetime of the
+    // document on the premise that it cannot change under a live page — true of
+    // the edition, false of the ANSWER: while `install.sh` rewrites the
+    // root-owned lock this route answers `openclaw, and that was a guess` for
+    // any box, and a page that pinned it wore the wrong product until it was
+    // reloaded. A guess is served once and asked again.
     expect(await fetchHarness()).toMatchObject({ activeKnown: false });
+    expect(calls).toBe(2);
+  });
+
+  it("stops asking once the device answers for itself", async () => {
+    // The other half: a settled answer IS pinned, so a box that can name
+    // itself pays one request per document, as before.
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      calls++;
+      return {
+        ok: true,
+        json: async () => ({ active: "hermes", edition: "hermes", activeKnown: true }),
+      } as Response;
+    }));
+    expect(await fetchHarness()).toMatchObject({ activeKnown: true });
+    expect(await fetchHarness()).toMatchObject({ activeKnown: true });
     expect(calls).toBe(1);
   });
 

--- a/src/tests/unit/client-harness.test.ts
+++ b/src/tests/unit/client-harness.test.ts
@@ -88,6 +88,35 @@ describe("client harness cache", () => {
     expect(b).toEqual(c);
   });
 
+  it("one caller's abort does not answer null for every other caller", async () => {
+    // Both surfaces that probe the harness pass a signal now (the shared retry
+    // helper aborts its attempts), and `inFlight` is handed to every concurrent
+    // caller — so a signalled request stored there let a closing chat window
+    // reject the desktop's and the standalone page's probes too. Each of those
+    // reads null as "the device did not answer" and stops branding the box,
+    // which is the false failure this guard removes. The signal still cancels
+    // the request its OWN caller made.
+    const answered = { active: "hermes", edition: "hermes", activeKnown: true };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        (_url: string, init?: { signal?: AbortSignal }) =>
+          new Promise<Response>((resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+            setTimeout(() => resolve({ ok: true, json: async () => answered } as Response), 5);
+          }),
+      ),
+    );
+
+    const controller = new AbortController();
+    const signalled = fetchHarness({ signal: controller.signal });
+    const bystander = fetchHarness();
+    controller.abort();
+
+    expect(await signalled, "the aborting caller gets its own cancellation").toBeNull();
+    expect(await bystander, "and nobody else pays for it").toEqual(answered);
+  });
+
   it("exposes the resolved values synchronously afterwards", async () => {
     expect(cachedEdition()).toBeNull();
     await fetchHarness();

--- a/src/tests/unit/harness-edition-read-once.test.ts
+++ b/src/tests/unit/harness-edition-read-once.test.ts
@@ -29,7 +29,8 @@ vi.mock("@/lib/edition-source", () => ({
   readEdition: () => reads().edition,
   hasHermesHarness: () => reads().edition !== "openclaw",
 }));
-vi.mock("@/lib/edition-license", () => ({ verifyDualLicense: () => true }));
+const licenseVerifies = vi.hoisted(() => vi.fn(() => true));
+vi.mock("@/lib/edition-license", () => ({ verifyDualLicense: licenseVerifies }));
 vi.mock("@/lib/config-store", () => ({
   getKnown: async () => ({ value: "hermes", known: true }),
   swap: vi.fn(),
@@ -39,6 +40,7 @@ import { getActiveHarnessSource } from "@/lib/harness";
 
 beforeEach(() => {
   reads.mockReset();
+  licenseVerifies.mockClear();
 });
 
 describe("getActiveHarnessSource", () => {
@@ -67,6 +69,7 @@ describe("getActiveHarnessSource", () => {
       active: "hermes",
       defaulted: false,
       edition: "hermes",
+      locked: true,
     });
   });
 
@@ -82,7 +85,19 @@ describe("getActiveHarnessSource", () => {
       active: "openclaw",
       defaulted: true,
       edition: "openclaw",
+      locked: true,
     });
+  });
+
+  it("answers the switcher question from the SAME resolution, not a second licence verify", async () => {
+    // `locked` used to be re-derived by the caller, which re-ran
+    // `verifyDualLicense()` — a file read and an ed25519 verify — across the
+    // caller's own await: a licence replaced or expired in between answered
+    // `edition: "dual"` beside `locked: true`, hiding the switcher on a box
+    // that has it.
+    reads.mockReturnValue({ edition: "dual", defaulted: false });
+    expect((await getActiveHarnessSource()).locked).toBe(false);
+    expect(licenseVerifies).toHaveBeenCalledTimes(1);
   });
 
   it("reads the store for a licensed dual, still from one edition read", async () => {
@@ -92,6 +107,7 @@ describe("getActiveHarnessSource", () => {
       active: "hermes",
       defaulted: false,
       edition: "dual",
+      locked: false,
     });
     expect(reads).toHaveBeenCalledTimes(1);
   });

--- a/src/tests/unit/harness-edition-read-once.test.ts
+++ b/src/tests/unit/harness-edition-read-once.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * ONE read of the edition per answer.
+ *
+ * `getActiveHarnessSource()` resolved its answer from three separate reads of
+ * `/etc/clawbox/edition.env` — its own `readEditionSource()`, then
+ * `lockedHarness()` → `isDualUnlocked()` → `getEdition()`, then `lockedHarness`'s
+ * own `getEdition()` — and `/setup-api/harness/active` took a fourth for the
+ * `edition` field it reports beside it.
+ *
+ * `install.sh` rewrites that file with `printf >` on every update, and the reads
+ * are separate syscalls against a file another process owns: one that lands in
+ * the truncated window answers this module's "openclaw" default. The first read
+ * saying "hermes" and the second saying nothing is what turns a Hermes box into
+ * `{ active: "openclaw", defaulted: false }` — a guess reported as a fact, which
+ * is exactly what `defaulted` exists to prevent (the wallpaper ruling brands the
+ * box from it).
+ *
+ * So the source is read ONCE and its edition threaded through. The mock counts
+ * every read, which is the property; the fixture that changes its answer is what
+ * the counting is for.
+ */
+
+const reads = vi.hoisted(() => vi.fn<() => { edition: string; defaulted: boolean }>());
+
+vi.mock("@/lib/edition-source", () => ({
+  readEditionSource: reads,
+  readEdition: () => reads().edition,
+  hasHermesHarness: () => reads().edition !== "openclaw",
+}));
+vi.mock("@/lib/edition-license", () => ({ verifyDualLicense: () => true }));
+vi.mock("@/lib/config-store", () => ({
+  getKnown: async () => ({ value: "hermes", known: true }),
+  swap: vi.fn(),
+}));
+
+import { getActiveHarnessSource } from "@/lib/harness";
+
+beforeEach(() => {
+  reads.mockReset();
+});
+
+describe("getActiveHarnessSource", () => {
+  it("resolves the whole answer from one read of the edition source", async () => {
+    reads.mockReturnValue({ edition: "hermes", defaulted: false });
+
+    const source = await getActiveHarnessSource();
+
+    expect(source.active).toBe("hermes");
+    expect(reads).toHaveBeenCalledTimes(1);
+  });
+
+  it("carries the edition it resolved from, so a caller needs no second read", async () => {
+    reads.mockReturnValue({ edition: "hermes", defaulted: false });
+    expect((await getActiveHarnessSource()).edition).toBe("hermes");
+  });
+
+  it("does not report a guess as a fact when the lock is rewritten mid-answer", async () => {
+    // The update window: the first read is the real lock, everything after it
+    // lands while `install.sh` has the file truncated.
+    reads
+      .mockReturnValueOnce({ edition: "hermes", defaulted: false })
+      .mockReturnValue({ edition: "openclaw", defaulted: true });
+
+    expect(await getActiveHarnessSource()).toEqual({
+      active: "hermes",
+      defaulted: false,
+      edition: "hermes",
+    });
+  });
+
+  it("still answers the honest default when the FIRST read is the unreadable one", async () => {
+    // The mirror case, and the one that must not change: nothing on the device
+    // named an edition when we looked, so the answer is a default and says so —
+    // whatever the file says a microsecond later.
+    reads
+      .mockReturnValueOnce({ edition: "openclaw", defaulted: true })
+      .mockReturnValue({ edition: "hermes", defaulted: false });
+
+    expect(await getActiveHarnessSource()).toEqual({
+      active: "openclaw",
+      defaulted: true,
+      edition: "openclaw",
+    });
+  });
+
+  it("reads the store for a licensed dual, still from one edition read", async () => {
+    reads.mockReturnValue({ edition: "dual", defaulted: false });
+
+    expect(await getActiveHarnessSource()).toEqual({
+      active: "hermes",
+      defaulted: false,
+      edition: "dual",
+    });
+    expect(reads).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/tests/unit/harness-probe.test.ts
+++ b/src/tests/unit/harness-probe.test.ts
@@ -66,10 +66,35 @@ describe("resolveHarnessProbe", () => {
   it("reports every answer as it lands, so a caller can paint the honest one", async () => {
     fetchMock.mockResolvedValueOnce(UNSETTLED).mockResolvedValue(SETTLED);
     const seen: string[] = [];
-    const probe = resolveHarnessProbe({ onAnswer: (info) => seen.push(`${info.active}:${info.activeKnown}`) });
+    const probe = resolveHarnessProbe({
+      onAnswer: (info) => seen.push(info ? `${info.active}:${info.activeKnown}` : "nothing"),
+    });
     await vi.advanceTimersByTimeAsync(500);
     await probe;
     expect(seen).toEqual(["openclaw:false", "hermes:true"]);
+  });
+
+  it("reports an attempt that answered nothing, rather than leaving a caller waiting", async () => {
+    // `/app/<id>` shows its own "unknown" on this — a spinner for the whole
+    // 1.5 s budget is what the old single probe never did.
+    fetchMock.mockResolvedValueOnce(null).mockResolvedValue(SETTLED);
+    const seen: (string | null)[] = [];
+    const probe = resolveHarnessProbe({ onAnswer: (info) => seen.push(info?.active ?? null) });
+    await vi.advanceTimersByTimeAsync(500);
+    await probe;
+    expect(seen).toEqual([null, "hermes"]);
+  });
+
+  it("does not settle on a harness name this build does not know", async () => {
+    // `activeKnown` alone is not the test the desktop used to make: it stopped
+    // only for a name it could brand, and a future or malformed value must not
+    // end the asking early.
+    fetchMock.mockResolvedValueOnce({ active: "dual", edition: "dual", activeKnown: true })
+      .mockResolvedValue(SETTLED);
+    const probe = resolveHarnessProbe();
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(probe).resolves.toEqual(SETTLED);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("stops when the caller goes away, rather than waking a dead page", async () => {

--- a/src/tests/unit/harness-probe.test.ts
+++ b/src/tests/unit/harness-probe.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The bounded "which harness is this box?" probe, shared by the desktop and the
+ * standalone `/app/<id>` window.
+ *
+ * The rule it encodes: an answer the DEVICE gave ends the asking, an answer that
+ * is only this module's fallback does not, and the asking is bounded either way
+ * — a page must not poll a route forever because a box cannot say what it is.
+ */
+
+const fetchMock = vi.hoisted(() =>
+  vi.fn<(options?: { force?: boolean; signal?: AbortSignal }) => Promise<unknown>>(),
+);
+vi.mock("@/lib/client-harness", () => ({ fetchHarness: fetchMock }));
+
+import { resolveHarnessProbe } from "@/lib/harness-probe";
+
+const SETTLED = { active: "hermes", edition: "hermes", activeKnown: true };
+const UNSETTLED = { active: "openclaw", edition: "openclaw", activeKnown: false };
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("resolveHarnessProbe", () => {
+  it("asks once when the device answered for itself", async () => {
+    fetchMock.mockResolvedValue(SETTLED);
+    await expect(resolveHarnessProbe()).resolves.toEqual(SETTLED);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(expect.objectContaining({ force: false }));
+  });
+
+  it("asks again past the cache when the answer was only a fallback", async () => {
+    fetchMock.mockResolvedValueOnce(UNSETTLED).mockResolvedValue(SETTLED);
+    const probe = resolveHarnessProbe();
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(probe).resolves.toEqual(SETTLED);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // `force`, or the second ask is served the first answer out of the client
+    // cache and the retry is theatre.
+    expect(fetchMock).toHaveBeenLastCalledWith(expect.objectContaining({ force: true }));
+  });
+
+  it("gives up after its attempts and answers with the honest fallback", async () => {
+    fetchMock.mockResolvedValue(UNSETTLED);
+    const probe = resolveHarnessProbe();
+    await vi.advanceTimersByTimeAsync(1_500);
+    await expect(probe).resolves.toEqual(UNSETTLED);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries a request that answered nothing at all, and reports null", async () => {
+    fetchMock.mockResolvedValue(null);
+    const probe = resolveHarnessProbe();
+    await vi.advanceTimersByTimeAsync(1_500);
+    await expect(probe).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("reports every answer as it lands, so a caller can paint the honest one", async () => {
+    fetchMock.mockResolvedValueOnce(UNSETTLED).mockResolvedValue(SETTLED);
+    const seen: string[] = [];
+    const probe = resolveHarnessProbe({ onAnswer: (info) => seen.push(`${info.active}:${info.activeKnown}`) });
+    await vi.advanceTimersByTimeAsync(500);
+    await probe;
+    expect(seen).toEqual(["openclaw:false", "hermes:true"]);
+  });
+
+  it("stops when the caller goes away, rather than waking a dead page", async () => {
+    // An unmounted component's effect aborts; the pending backoff must not
+    // outlive it and fire a request nobody reads.
+    fetchMock.mockResolvedValue(UNSETTLED);
+    const controller = new AbortController();
+    const probe = resolveHarnessProbe({ signal: controller.signal });
+    await vi.advanceTimersByTimeAsync(0);
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(probe).resolves.toEqual(UNSETTLED);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/tests/unit/install-edition-lock.test.ts
+++ b/src/tests/unit/install-edition-lock.test.ts
@@ -104,10 +104,31 @@ describe("edition persistence (H7 / H9)", () => {
   it("is written to a root-owned file, for all three editions", () => {
     const fn = extractShellFunction("step_edition_lock");
     expect(fn).toContain('install -d -o root -g root -m 0755 /etc/clawbox');
-    expect(fn).toContain('chown root:root "$CLAWBOX_EDITION_FILE"');
+    // Root ownership and the mode now come from `install_root_file` — the same
+    // atomic writer every other root-owned file goes through — rather than a
+    // chown after a truncating redirect.
+    expect(fn).toContain('install_root_file "$_edition_tmp" "$CLAWBOX_EDITION_FILE" 0644');
     // No `case … dual) return 0`: dual used to bake nothing at all, so the
     // premium SKU silently ran as openclaw and could not be provisioned.
     expect(fn).not.toMatch(/case "\$CLAWBOX_EDITION"/);
+  });
+
+  it("is never observable half-written, in either record", () => {
+    // `> file` is open(O_TRUNC) + write + close, and this step runs on EVERY
+    // in-app update while the middleware, `openclawIsAbsent()`, the updater's
+    // own `hasHermesHarness()` and the MCP server are reading the lock: a
+    // reader that lands inside the write gets a zero-length file, which
+    // `readEditionSource()` answers as `{edition: "openclaw", defaulted: true}`
+    // — a Hermes box briefly reporting itself as the flagship SKU. A rename
+    // within a directory cannot be observed half-done, and the repo already
+    // ships that writer (TASK-584).
+    const fn = extractShellFunction("step_edition_lock");
+    expect(fn).not.toMatch(/>\s*"\$CLAWBOX_EDITION_FILE"/);
+    expect(fn).not.toMatch(/>\s*"\$LEGACY_EDITION_DROPIN"/);
+    expect(fn).toContain('install_root_file "$_dropin_tmp" "$LEGACY_EDITION_DROPIN" 0644');
+    // And the writer it uses really is the atomic one.
+    const writer = extractShellFunction("install_root_file");
+    expect(writer).toContain('mv -f "$dst.new" "$dst"');
   });
 
   it("clawbox-setup.service loads it AFTER the clawbox-writable .env", () => {

--- a/src/tests/unit/install-edition-lock.test.ts
+++ b/src/tests/unit/install-edition-lock.test.ts
@@ -1,6 +1,21 @@
-import { describe, it, expect } from "vitest";
-import { readFileSync, readdirSync } from "node:fs";
+import { describe, it, expect, vi } from "vitest";
+import fs, { readFileSync, readdirSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
+import { spawnSync, execFileSync } from "node:child_process";
+
+// The staging cases below start a real bash: vitest's 5 s test and 10 s hook
+// defaults are not enough on a loaded CI runner. See
+// src/tests/unit/test-timeout-hygiene.test.ts.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+/** These cases start a real bash; skip where there is none. */
+let hasBash = true;
+try {
+  execFileSync("/bin/bash", ["-c", "true"], { stdio: "ignore" });
+} catch {
+  hasBash = false;
+}
 
 // These pin the install-time invariants of the single-harness edition lock.
 // Every one of them describes a bug that shipped: a drift guard that hard-exit
@@ -141,6 +156,78 @@ describe("edition persistence (H7 / H9)", () => {
     const fn = extractShellFunction("step_edition_lock");
     expect(fn).toMatch(/if ! install_root_file "\$_edition_tmp" "\$CLAWBOX_EDITION_FILE" 0644; then/);
     expect(fn).toMatch(/if ! install_root_file "\$_dropin_tmp" "\$LEGACY_EDITION_DROPIN" 0644; then/);
+  });
+
+  /**
+   * The staging writes, run for real.
+   *
+   * `install_root_file` copies whatever is in the temp and answers 0 for a copy
+   * that worked, so a `printf` that failed after writing a prefix — a full
+   * /tmp is the ordinary way — would be published ATOMICALLY as a truncated
+   * lock, which `readEditionSource()` reads as `{edition: "openclaw",
+   * defaulted: true}`. Errexit is off for this whole function on the update
+   * path, so nothing else catches it.
+   */
+  describe.skipIf(!hasBash)("a staging write that fails", () => {
+    /** Run the real step with every side effect stubbed and ONE mktemp poisoned. */
+    function runStep(poison: "lock" | "dropin"): { out: string; rc: string } {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-edition-stage-"));
+      try {
+        const bad = path.join(dir, "no-such-directory", "tmp");
+        const good = path.join(dir, "ok.tmp");
+        const program = [
+          // No `set -e`: post_update calls this step from an OR-list, for whose
+          // whole function body bash switches errexit OFF. That is the path
+          // this case is about.
+          `CLAWBOX_EDITION=hermes`,
+          `CLAWBOX_EDITION_FILE=${JSON.stringify(path.join(dir, "edition.env"))}`,
+          `LEGACY_EDITION_DROPIN=${JSON.stringify(path.join(dir, "edition.conf"))}`,
+          "install() { :; }",
+          "mkdir() { :; }",
+          "systemctl() { :; }",
+          "step_edition_gateway_state() { echo GATEWAY_STATE; }",
+          "step_edition_foreign_teardown() { echo TEARDOWN; }",
+          'install_root_file() { echo "INSTALL_ROOT_FILE $2"; return 0; }',
+          // The counter lives in a FILE: `$(mktemp)` runs in a subshell, so a
+          // shell variable incremented inside it never reaches the caller and
+          // every call would look like the first.
+          `_c=${JSON.stringify(path.join(dir, "calls"))}`,
+          'printf 0 > "$_c"',
+          `mktemp() { local n; n=$(( $(cat "$_c") + 1 )); printf '%s' "$n" > "$_c"; if [ "$n" = ${poison === "lock" ? "1" : "2"} ]; then echo ${JSON.stringify(bad)}; else echo ${JSON.stringify(good)}; fi; }`,
+          extractShellFunction("step_edition_lock") + "\n}",
+          "if step_edition_lock; then echo RC=0; else echo RC=$?; fi",
+        ].join("\n");
+        const script = path.join(dir, "run.sh");
+        fs.writeFileSync(script, program);
+        const r = spawnSync("/bin/bash", [script], { encoding: "utf-8", timeout: 20_000 });
+        const out = `${r.stdout ?? ""}${r.stderr ?? ""}`;
+        return { out, rc: /RC=(\d+)/.exec(out)?.[1] ?? "" };
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    }
+
+    it("never publishes the lock, and fails the step", () => {
+      const { out, rc } = runStep("lock");
+      expect(rc, out).not.toBe("0");
+      expect(out).toMatch(/could not stage the edition lock/);
+      // The whole point: nothing reached the atomic writer, so no truncated
+      // record was published.
+      expect(out).not.toContain("INSTALL_ROOT_FILE");
+      // And the step stopped: the gateway state must not run over a lock the
+      // box does not have.
+      expect(out).not.toContain("GATEWAY_STATE");
+    });
+
+    it("never publishes the drop-in, and fails the step", () => {
+      const { out, rc } = runStep("dropin");
+      expect(rc, out).not.toBe("0");
+      expect(out).toMatch(/could not stage the edition drop-in/);
+      // The lock itself did land — it is staged and installed first.
+      expect(out).toContain("INSTALL_ROOT_FILE");
+      expect(out).not.toMatch(/INSTALL_ROOT_FILE.*edition\.conf/);
+      expect(out).not.toContain("GATEWAY_STATE");
+    });
   });
 
   it("the OTHER writer of the same two records is atomic too", () => {

--- a/src/tests/unit/install-edition-lock.test.ts
+++ b/src/tests/unit/install-edition-lock.test.ts
@@ -219,13 +219,18 @@ describe("edition persistence (H7 / H9)", () => {
       expect(out).not.toContain("GATEWAY_STATE");
     });
 
-    it("never publishes the drop-in, and fails the step", () => {
+    it("publishes NEITHER record when the drop-in cannot be staged", () => {
+      // Both records are staged before either is committed, so a staging
+      // failure on the second leaves the box with its previous edition in BOTH
+      // places rather than a new lock beside a stale systemd drop-in — readers
+      // of the two disagreeing about the SKU is the state this step exists to
+      // prevent, and staging is where the ordinary failure lives (a full /tmp).
       const { out, rc } = runStep("dropin");
       expect(rc, out).not.toBe("0");
       expect(out).toMatch(/could not stage the edition drop-in/);
-      // The lock itself did land — it is staged and installed first.
-      expect(out).toContain("INSTALL_ROOT_FILE");
-      expect(out).not.toMatch(/INSTALL_ROOT_FILE.*edition\.conf/);
+      expect(out, "nothing may be committed once either staging write failed").not.toContain(
+        "INSTALL_ROOT_FILE",
+      );
       expect(out).not.toContain("GATEWAY_STATE");
     });
   });

--- a/src/tests/unit/install-edition-lock.test.ts
+++ b/src/tests/unit/install-edition-lock.test.ts
@@ -169,8 +169,12 @@ describe("edition persistence (H7 / H9)", () => {
    * path, so nothing else catches it.
    */
   describe.skipIf(!hasBash)("a staging write that fails", () => {
-    /** Run the real step with every side effect stubbed and ONE mktemp poisoned. */
-    function runStep(poison: "lock" | "dropin"): { out: string; rc: string } {
+    /**
+     * Run the real step with every side effect stubbed and ONE staging step
+     * poisoned: the lock's temp, the drop-in's temp, or the drop-in's own
+     * directory.
+     */
+    function runStep(poison: "lock" | "dropin" | "dropin-dir"): { out: string; rc: string } {
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-edition-stage-"));
       try {
         const bad = path.join(dir, "no-such-directory", "tmp");
@@ -183,7 +187,7 @@ describe("edition persistence (H7 / H9)", () => {
           `CLAWBOX_EDITION_FILE=${JSON.stringify(path.join(dir, "edition.env"))}`,
           `LEGACY_EDITION_DROPIN=${JSON.stringify(path.join(dir, "edition.conf"))}`,
           "install() { :; }",
-          "mkdir() { :; }",
+          `mkdir() { ${poison === "dropin-dir" ? "return 1" : ":"}; }`,
           "systemctl() { :; }",
           "step_edition_gateway_state() { echo GATEWAY_STATE; }",
           "step_edition_foreign_teardown() { echo TEARDOWN; }",
@@ -216,6 +220,17 @@ describe("edition persistence (H7 / H9)", () => {
       expect(out).not.toContain("INSTALL_ROOT_FILE");
       // And the step stopped: the gateway state must not run over a lock the
       // box does not have.
+      expect(out).not.toContain("GATEWAY_STATE");
+    });
+
+    it("publishes NEITHER record when the drop-in's own directory cannot be made", () => {
+      // `mkdir -p` is part of staging the second record: made AFTER the lock
+      // was committed, a failure here would leave exactly the split the
+      // ordering above exists to prevent.
+      const { out, rc } = runStep("dropin-dir");
+      expect(rc, out).not.toBe("0");
+      expect(out).toMatch(/could not create the drop-in directory/);
+      expect(out).not.toContain("INSTALL_ROOT_FILE");
       expect(out).not.toContain("GATEWAY_STATE");
     });
 

--- a/src/tests/unit/install-edition-lock.test.ts
+++ b/src/tests/unit/install-edition-lock.test.ts
@@ -131,6 +131,36 @@ describe("edition persistence (H7 / H9)", () => {
     expect(writer).toContain('mv -f "$dst.new" "$dst"');
   });
 
+  it("a write that did not land fails the step, on the path that swallows it", () => {
+    // `install_root_file` answers 1 when the copy or the rename failed, and the
+    // update path calls this step from an OR-list — for the whole body of which
+    // bash switches errexit OFF. Dropped, the failed write was followed by
+    // successful commands, the step returned the LAST one's status, the
+    // non-fatal warning never printed and the update reported success over a
+    // lock still naming the previous SKU.
+    const fn = extractShellFunction("step_edition_lock");
+    expect(fn).toMatch(/if ! install_root_file "\$_edition_tmp" "\$CLAWBOX_EDITION_FILE" 0644; then/);
+    expect(fn).toMatch(/if ! install_root_file "\$_dropin_tmp" "\$LEGACY_EDITION_DROPIN" 0644; then/);
+  });
+
+  it("the OTHER writer of the same two records is atomic too", () => {
+    // `setup-hermes-edition.sh` writes THE SAME lock and THE SAME drop-in, and
+    // install.sh dispatches it (`step_hermes_edition`, on WEB_ROOT_STEPS) on
+    // every in-app update of a hermes or dual box. A truncating redirect there
+    // leaves the window the step above closed wide open on the two SKUs where
+    // answering "openclaw" is the damaging answer.
+    expect(HERMES_EDITION_SH).not.toMatch(/>\s*"\$EDITION_FILE"/);
+    expect(HERMES_EDITION_SH).not.toMatch(/>\s*"\$EDITION_DROPIN"/);
+    expect(HERMES_EDITION_SH).toContain('write_root_file "$EDITION_FILE" 0644');
+    expect(HERMES_EDITION_SH).toContain('write_root_file "$EDITION_DROPIN" 0644');
+    // Its writer really renames rather than truncating in place…
+    expect(HERMES_EDITION_SH).toMatch(/mv -f "\$tmp" "\$dst"/);
+    // …and a write that did not land is recorded, so the script's own exit
+    // code carries it back to the update.
+    expect(HERMES_EDITION_SH).toMatch(/\|\| fail "could not write the edition lock/);
+    expect(HERMES_EDITION_SH).toMatch(/\|\| fail "could not write the edition drop-in/);
+  });
+
   it("clawbox-setup.service loads it AFTER the clawbox-writable .env", () => {
     const lines = SETUP_UNIT.split("\n").map((l) => l.trim());
     const userEnv = lines.indexOf("EnvironmentFile=-/home/clawbox/clawbox/.env");

--- a/src/tests/unit/telegram-allowlist-v2.test.ts
+++ b/src/tests/unit/telegram-allowlist-v2.test.ts
@@ -12,10 +12,23 @@ import type { DatabaseSync as DatabaseSyncType } from "node:sqlite";
 // telegram-pairing.test.ts keeps covering the legacy files (v1 boxes).
 
 vi.mock("@/lib/config-store", () => ({ get: vi.fn(), set: vi.fn() }));
-vi.mock("@/lib/harness", () => ({
-  getActiveHarness: vi.fn(async () => "openclaw"),
-  getEdition: vi.fn(() => "openclaw"),
-}));
+// `getActiveHarnessSource` answers from the same mock this suite drives, so the
+// routes' one resolution says what these cases set. The single-read contract
+// itself is pinned in harness-edition-read-once / harness-status, not here.
+vi.mock("@/lib/harness", () => {
+  const getActiveHarness = vi.fn(async () => "openclaw");
+  const getEdition = vi.fn(() => "openclaw");
+  return {
+    getActiveHarness,
+    getEdition,
+    getActiveHarnessSource: async () => ({
+      active: await getActiveHarness(),
+      defaulted: false,
+      edition: getEdition(),
+      locked: true,
+    }),
+  };
+});
 vi.mock("@/lib/hermes-telegram", () => ({
   approveHermesPairing: vi.fn(),
   listHermesPairing: vi.fn(),

--- a/src/tests/unit/telegram-bot-one-edition-read.test.ts
+++ b/src/tests/unit/telegram-bot-one-edition-read.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * The panel's "which bot does this box poll?" answer comes from ONE edition
+ * read, like every other answer this sweep made single-read.
+ *
+ * `readActiveTelegramBot` resolves the ACTIVE harness and then asks the edition
+ * again to decide whether the ClawBox mirror may stand in for it. Those were two
+ * reads of `/etc/clawbox/edition.env`, taken either side of an `await` on the
+ * harness's own store — and `install.sh` rewrites that file on every update. A
+ * second read landing in the rewrite window answers "openclaw", the `dual` guard
+ * is skipped, and the mirror is returned as the ACTIVE harness's bot: a working
+ * bot reported on a harness that does not hold it, which is the fail-open this
+ * module exists to close.
+ *
+ * This route is on a 3-second tray poll, so it is the highest-frequency edition
+ * read in the tree — and the callers all resolve the harness for their own
+ * reasons anyway. They hand the whole resolution over.
+ */
+
+const editionReads = vi.hoisted(() => vi.fn<() => string>());
+const sourceReads = vi.hoisted(() =>
+  vi.fn<() => Promise<{ active: string; defaulted: boolean; edition: string; locked: boolean }>>(),
+);
+
+vi.mock("@/lib/harness", () => ({
+  getActiveHarnessSource: () => sourceReads(),
+  getEdition: () => editionReads(),
+  getEditionSource: () => ({ edition: editionReads(), defaulted: false }),
+}));
+// The harness's own store holds nothing, which is the only state in which the
+// mirror question is asked at all.
+vi.mock("@/lib/hermes-telegram", () => ({
+  readHermesTelegramToken: async () => ({ token: null, known: true }),
+}));
+vi.mock("@/lib/openclaw-config", () => ({ readConfigStrict: async () => ({}) }));
+vi.mock("@/lib/config-store", () => ({ get: async () => "111111:mirror-token" }));
+
+import { readActiveTelegramBot } from "@/lib/telegram-bot-identity";
+
+beforeEach(() => {
+  editionReads.mockReset();
+  sourceReads.mockReset();
+});
+
+describe("readActiveTelegramBot", () => {
+  it("takes the edition from the resolution it was handed, not a second read", async () => {
+    // The update window: the caller's own read said `dual`, everything after it
+    // lands while the lock is truncated and answers the module default.
+    editionReads.mockReturnValue("openclaw");
+
+    const answer = await readActiveTelegramBot({
+      active: "hermes",
+      defaulted: false,
+      edition: "dual",
+      locked: false,
+    });
+
+    // On `dual` the mirror is deliberately NOT offered: it is one value for the
+    // whole box and after a switch it names the other harness's bot.
+    expect(answer.token).toBeNull();
+    expect(editionReads, "the edition must not be read a second time").not.toHaveBeenCalled();
+    expect(sourceReads, "nor the harness resolved again").not.toHaveBeenCalled();
+  });
+
+  it("still resolves it itself for a caller that has no resolution to hand", async () => {
+    sourceReads.mockResolvedValue({
+      active: "hermes",
+      defaulted: false,
+      edition: "dual",
+      locked: false,
+    });
+
+    expect((await readActiveTelegramBot()).token).toBeNull();
+    expect(sourceReads).toHaveBeenCalledTimes(1);
+    expect(editionReads).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the mirror on the editions that have a legacy box to protect", async () => {
+    const answer = await readActiveTelegramBot({
+      active: "openclaw",
+      defaulted: false,
+      edition: "openclaw",
+      locked: true,
+    });
+
+    expect(answer.token).toBe("111111:mirror-token");
+    expect(editionReads).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * And the property that made the threading worth doing: every production caller
+ * actually hands one over. Asserted from the SOURCE rather than through a mock,
+ * because the defect it replaces was a parameter that existed and that no real
+ * call path passed — a shape no per-caller test would have noticed.
+ */
+describe("its callers", () => {
+  const repo = process.cwd();
+  const files: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === "tests" || entry.name === "node_modules") continue;
+        walk(full);
+      } else if (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx")) {
+        files.push(full);
+      }
+    }
+  };
+  walk(path.join(repo, "src"));
+
+  it("all hand it a resolution or a fixed harness, never a separately-read one", () => {
+    const callers: { file: string; arg: string }[] = [];
+    for (const file of files) {
+      if (file.endsWith("telegram-bot-identity.ts")) continue;
+      const text = fs.readFileSync(file, "utf-8");
+      for (const m of text.matchAll(/readActiveTelegramBot\(\s*([^,)\s]*)/g)) {
+        callers.push({ file: path.relative(repo, file), arg: m[1] });
+      }
+    }
+
+    // The import lines are not calls; every real call site is counted.
+    expect(callers.length, "no caller found — has the reader been renamed?").toBeGreaterThan(4);
+    const wrong = callers.filter(
+      (c) =>
+        c.arg !== "" &&
+        !/^"(openclaw|hermes)"$/.test(c.arg) &&
+        !/source$/i.test(c.arg),
+    );
+    expect(
+      wrong,
+      `these pass a harness resolved apart from the edition: ${JSON.stringify(wrong)}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
**TASK-761** — the edition read four times per response, and the harness probed once on the one surface that fails closed. Deferred from #748 (CodeRabbit, agreed).

### Customer-visible symptom
`install.sh` rewrites the root-owned edition lock on EVERY update, and the readers around it took several separate looks:
- `/setup-api/harness/active` could answer `{ active: "openclaw", activeKnown: true }` on a Hermes box — a guess reported as a fact, which is the one thing that flag exists to prevent, and what the wallpaper ruling brands the box from — or pair `active: "hermes"` with `edition: "openclaw"`, a combination no real SKU can be in (the openclaw edition is locked to its own harness).
- `/app/<id>` probed once and failed closed on whatever it got, so a page that mounted inside that window rendered the OpenClaw App Store on a Hermes box, and wore no brand, for the life of the tab. The desktop had retried since #728; the standalone window never did.

### Cause and fix, in three layers
1. **The write.** `step_edition_lock` wrote the lock with a truncating `printf >` — `open(O_TRUNC)` + `write` + `close`, so every reader on the box can see a zero-length file, which `readEditionSource()` answers as `{edition:"openclaw", defaulted:true}`. The repo already ships the atomic writer for exactly this class (`install_root_file`, TASK-584: temp name in the same directory, then `rename`), and it is used for every other root-owned file. Both records — the lock and the legacy systemd drop-in — go through it now. That is the root cause, and it fixes every reader at once: the middleware, `openclawIsAbsent()`, the updater's `hasHermesHarness()`, the gateway catch-all and the MCP server.
2. **The read.** `getActiveHarnessSource()` resolves `active`, `defaulted`, `edition` AND `locked` from ONE `readEditionSource()`, threaded through optional parameters on `isDualUnlocked` / `isSingleHarnessEdition` / `lockedHarness`. `/harness/active` and `/harness/status` report from that one resolution (the status route also stops paying a second ed25519 licence verify per poll), `/harness/select` reads the edition once for its gate and hands it to `setActiveHarness` — between those two it runs a 60-second identity sync, and a second read landing in the rewrite window refused a switch the gate had already allowed, AFTER the sync had run — and `readActiveTelegramBot` takes the edition from the same resolution rather than a second `getEdition()` after two awaits (a read there skipped the dual guard and answered ClawBox's mirror token as the active harness's bot).
3. **The probe.** One helper, `src/lib/harness-probe.ts`, called by the desktop and by `/app/<id>`: three asks, 500 ms and 1 s apart, `force` from the second so the client cache cannot serve the answer being asked about again, stopping as soon as the DEVICE has answered for itself. Every attempt is reported to the caller, including one that answered nothing, so the standalone page shows its own "unknown" at once instead of a spinner for the whole budget. The client cache also stops pinning a guess: `edition` is cached for the document's lifetime only when `activeKnown` is true, and a signalled request is never stored as the SHARED in-flight one (one caller's abort used to null the answer for every concurrent reader).

### Harness-first
Nothing new invented: the edition lock is the device's own root-owned record, and the fix for its write is `install_root_file`, the atomic writer this repo already uses everywhere else. Neither harness owns this file — it is what decides WHICH harness runs — so there is no OpenClaw or Hermes mechanism to defer to; that is stated rather than worked around.

### Sibling call sites
- Every caller of the three lock helpers keeps the no-argument form (one read each, no await in between); `/harness/status`, `/harness/select`, `setActiveHarness` and `readActiveTelegramBot` are threaded.
- Deliberately NOT changed, and why: `stt`/`tts`'s `(await getActiveHarness()) === "openclaw" && !openclawIsAbsent()` reads across an await but the conjunction is self-correcting in both directions; `pets/route.ts` and `updater.ts:3342` read twice in adjacent synchronous lines.
- Test mocks: `harness-status`, `harness-select-mcp-reload` and the read-once suite carry the new shape; the six standalone component suites keep mocking `fetchHarness` alone, because the retry helper is a separate module and their fixtures now drive it end to end.

### RED → GREEN
RED on unmodified beta — the unit half (three reads, no `edition` in the answer, and a guess reported as a fact):

```
 ❯ |unit| src/tests/unit/harness-edition-read-once.test.ts (5 tests | 5 failed) 20ms
AssertionError: expected "vi.fn()" to be called 1 times, but got 3 times
AssertionError: expected undefined to be 'hermes'
```

RED on unmodified beta — the route half, with the lock REALLY rewritten during the awaited store read:

```
 FAIL  src/tests/routes/harness-active.test.ts > reports the edition its harness was resolved FROM, not one read later
- "edition": "dual",
+ "edition": "openclaw",
```

RED on unmodified beta — the standalone window (an OpenClaw app left on screen on a Hermes box, the test times out waiting for it to disappear):

```
 ❯ |components| src/tests/components/standalone-app-harness-retry.test.tsx (2 tests | 1 failed) 5101ms
     × asks again, and hides the OpenClaw app the box does not have 5006ms
```

GREEN: whole unit project 774 files, 12922 passed / 1 skipped — the three failures in that run are the known load flakes on this dev PC (`telegram/status`, `telegram/status-hermes`, all bare 5000 ms timeouts; the eight telegram suites pass 133/133 in isolation, twice, and one of them fails on unmodified beta too). Components project 205 files, 1744 tests. `tsc --noEmit` clean; `eslint` clean on the touched files (only pre-existing warnings in `page.tsx`); `bash -n install.sh` clean.

### Editions
All three SKUs, and the change is about telling them apart. Outcomes are identical to beta for openclaw / hermes / licensed dual / unlicensed dual / an edition nothing named — what changes is that they can no longer come from two different reads.

### Device
Not device-proven. The install.sh half is `install_root_file`, which every other root-owned file on the box already goes through, and `e2e-install` exercises `step_edition_lock` on a real install; the rest is web-tier code CI covers. The window it closes is a microsecond-to-second race during an update, which cannot be produced on demand read-only, and the OpenClaw box was under another lane's lock for this run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added more reliable harness detection with bounded retries, immediate updates, and cancellation when leaving the page.
  - App availability and edition-specific wallpaper branding now update as harness information is resolved.

- **Bug Fixes**
  - Prevented uncertain harness results from being cached as confirmed values.
  - Improved consistency across harness selection, status, edition changes, and Telegram configuration.
  - Edition-lock files are now installed atomically, with clearer failure reporting and cleanup after failed installations.

- **Tests**
  - Expanded coverage for retries, cancellation, caching, edition handling, harness selection, Telegram configuration, and edition-lock updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Round 2 (a528a37b) — three things the review found, all landed

1. **The telegram half of the fix was inert.** `readActiveTelegramBot` threaded the one resolution only when the caller omitted the harness, and all six production callers pass it — so `getEdition()` still fired after the `await` on the harness's own store, on a 3-second tray poll. The reader takes the whole `ActiveHarnessSource` now and the four routes that resolve the harness anyway hand it over (`setup/status`, `telegram/status`, `telegram/configure`, `telegram/pairing`); the two callers that name a fixed harness are unchanged and still cost one read. `src/tests/unit/telegram-bot-one-edition-read.test.ts` pins the behaviour AND the caller set — the defect it replaces was a parameter no real call path passed, which no per-caller test would have caught. RED against beta named all five inert call sites by file.
2. **The other writer of the same lock still truncated.** `scripts/setup-hermes-edition.sh` wrote `/etc/clawbox/edition.env` and the drop-in with `printf > file`, and install.sh dispatches it on every in-app update of a hermes or dual box — so the window every reader-side fix here defends against stayed open on the two SKUs where "openclaw" is the damaging answer. It writes through a temp and a rename now (content on stdin, so the bytes are unchanged), and a write that did not land is recorded through the script's own failure counter.
3. **A failed lock write was swallowed on the update path.** `step_edition_lock` dropped `install_root_file`'s return value; the update path calls the step from an OR-list, for whose whole function body bash switches errexit off. Both calls are checked now. (CodeRabbit's Major, answered in-thread.)

Also: a test for the in-flight guard (a signalled request is never the shared one, so one caller's abort cannot answer null for the others — the mutation that survived the review), and `harness-status.test.ts`'s source mock no longer derives from `getActiveHarness`, so a route reading both would be caught (CodeRabbit's Minor, answered in-thread).

**GREEN on this head:** unit project **775 files, 12937 passed / 1 skipped, 0 failed**; components 203 files / 1729 passed with 2 known 5000 ms chat flakes that pass in isolation (28/28) and are untouched here; `tsc --noEmit` exit 0; eslint on all touched files 0 errors, 0 warnings; `bash -n` on both shell files. Rebased on `origin/beta` 2ac81a85 — `git diff --stat origin/beta...HEAD` lists only this PR's 29 files, `--diff-filter=DR` empty, and the file intersection with each of the two merges that landed meanwhile (#779, #784) is empty.

**Known and deliberately NOT in this PR** (recorded for the sweep, not carded): `src/lib/timezone.ts:200/:213` reads the edition on both sides of a ~5 s gateway-restarting await — a false success on dual and a false failure on hermes; `mcp/lib/edition.ts` bypasses the mtime cache with its own `readFileSync`, twice across a 3 s probe, and believes the answer for the process lifetime; and several routes (`local-ai`, `tts`, `stt`, `pets`) still take two reads per response. The mtime cache does nothing during a rewrite — it is keyed on the very thing the rewrite changes — which is why fixing the WRITERS retires the class more cheaply than any reader change, and why item 2 above matters more than it looks.


**Round 3 (a05706d3)** — one more CodeRabbit Major, taken: the STAGING writes were unchecked too. `install_root_file` copies whatever is in the temp and answers 0 for a copy that worked, so a `printf` that failed after writing a prefix would have been published atomically as a truncated lock — read as `{edition: "openclaw", defaulted: true}`, the exact answer this step exists to prevent. Both `printf`s are checked now, and two EXECUTED failure-path cases run the real step with one `mktemp` poisoned, asserting nothing reached the atomic writer and the gateway state did not run over a lock the box does not have. Unit project on this head: **778 files, 12969 passed / 1 skipped, 0 failed.**


**Round 4 (3ff6ad2d)** — both edition records are now STAGED before either is committed. Staging is where the ordinary failure lives (a full `/tmp`, an EIO), and committing the lock and then failing to stage the drop-in left `/etc/clawbox/edition.env` and the systemd drop-in naming different editions until a later update. Either staging failure now leaves the box with its previous edition in both places, and the executed case asserts nothing reaches the atomic writer at all. The residual — a failing *rename* of the second file after a successful copy into the same directory, which no two-file shell update can close — is bounded by the step answering non-zero (so the update reports a skipped fixup rather than success), by an error that names which record is the authority, and by the step being idempotent on every update.


**Round 5 (419de570)** — the drop-in's DIRECTORY is part of staging it too: `mkdir -p` ran after the lock was already committed, so a failure there left the same split. It is checked now, with an executed case that poisons `mkdir` and asserts nothing reached the atomic writer. The step commits nothing unless all three staging steps succeeded — the lock's temp, the drop-in's directory, the drop-in's temp. Unit project: **778 files, 12991 passed / 1 skipped, 0 failed.**
