### PR TITLE
fix: keep the owner's ClawBox AI pick on its row across a provider switch

### DIFF
--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -20,6 +20,7 @@ import { enableProviderPluginOps, providerPluginSwitchedOnBy } from "@/lib/provi
 import { notifyProviderSetChanged } from "@/app/setup-api/ai-models/catalog/route";
 import { sqliteGet, sqliteSet } from "@/lib/sqlite-store";
 import {
+  CLAWBOX_AI_CHAT_MODEL_IDS,
   CLAWBOX_AI_MODEL_BY_TIER,
   CLAWBOX_AI_DEFAULT_TIER,
 } from "@/lib/clawbox-ai-models";
@@ -39,7 +40,13 @@ import {
 } from "@/lib/provider-status";
 import { readProviderRunnable, type ProviderRunnable } from "@/lib/provider-runnable";
 import { ollamaModelCanChat } from "@/lib/ollama-capabilities";
-import { recordExplicitModelPick } from "@/lib/explicit-model-pick";
+import {
+  explicitPicksFrom,
+  forgetClawboxAiPickIfMovedOff,
+  pickedClawboxAiModelIdAmong,
+  recordExplicitModelPick,
+  EXPLICIT_MODEL_PICKS_KEY,
+} from "@/lib/explicit-model-pick";
 import { isClawboxAiImageModelId, isClawboxAiImageModelRef } from "@/lib/clawbox-ai-models";
 import {
   CHATGPT_AGENT_RUNTIME_ID,
@@ -475,6 +482,9 @@ async function loadChatModelState(preloaded?: OpenClawConfig) {
     sqliteGet(PRIMARY_MODEL_KEY).catch(() => null),
   ]);
   const authProfiles = openclawConfig.auth?.profiles ?? {};
+  // Off the store `getAll()` has already returned — the same read
+  // `ai-models/configure` does for the same map, and no second file read.
+  const explicitPicks = explicitPicksFrom(configStore[EXPLICIT_MODEL_PICKS_KEY]);
   // Subscription-only providers, computed ONCE: the row attribution below and
   // the `subscriptionProviders` the answer carries are the same walk of the
   // same profile map, and doing it twice per GET on a Jetson is a walk that
@@ -602,8 +612,10 @@ async function loadChatModelState(preloaded?: OpenClawConfig) {
     // Pick which model represents this provider in the dropdown:
     //  1. activeModel if it belongs to this provider (so the row's
     //     "model" field matches what the gateway is actually using).
-    //  2. The first model in the openclaw provider definition.
-    //  3. The hard-coded default for this provider.
+    //  2. For the ClawBox AI row only: the model the owner picked, while the
+    //     row still offers it (`pickedClawboxAiModelIdAmong`, TASK-769).
+    //  3. The first model in the openclaw provider definition.
+    //  4. The hard-coded default for this provider.
     const providerDef = providerDefinitions[rawProvider];
     // Minus the ClawBox AI image entry, and nothing else: `models.providers
     // .openai.models[]` carries it on every paired box, and on a box with an
@@ -622,6 +634,18 @@ async function loadChatModelState(preloaded?: OpenClawConfig) {
         typeof m?.id === "string" && m.id.trim().length > 0 && !isClawboxAiImageModelId(m.id),
     );
 
+    // The owner's own ClawBox AI pick, judged against what the row still
+    // offers: the configured list where there is one, and otherwise the closed
+    // set itself, so a legacy install carrying no `models.providers.deepseek`
+    // entry — the case `DEFAULT_PROVIDER_MODELS` exists for — keeps the choice
+    // too. `pickedClawboxAiModelIdAmong` says why this is the one slot read.
+    const pickedModelId = provider === "clawai"
+      ? pickedClawboxAiModelIdAmong(
+          explicitPicks,
+          definedModels.length > 0 ? definedModels.map((m) => m.id) : CLAWBOX_AI_CHAT_MODEL_IDS,
+        )
+      : null;
+
     let model: string | null = null;
     // `!isClawboxAiImageModelRef` matters here, not only in the filter above:
     // this branch wins whenever the primary belongs to this provider, so on
@@ -632,6 +656,8 @@ async function loadChatModelState(preloaded?: OpenClawConfig) {
     // provider" is what lets the owner's configured rows be consulted.
     if (activeModel && !isClawboxAiImageModelRef(activeModel) && uiProviderForModel(activeModel) === provider) {
       model = activeModel;
+    } else if (pickedModelId) {
+      model = `${rawProvider}/${pickedModelId}`;
     } else if (!isChatgptSignIn && definedModels.length > 0) {
       model = `${rawProvider}/${definedModels[0].id}`;
     } else {
@@ -1268,6 +1294,10 @@ export async function POST(request: Request) {
       // exists for a caller that does arrive — an API client, a future picker
       // that stops short-circuiting — and is honest for it.
       if (!automaticSwitch) await recordExplicitModelPick(targetModel);
+      // ...and its mirror: a switch the BOX made to a different ClawBox AI
+      // model retires the pick it moved off, so the entitlement guard's
+      // recovery cannot leave a refused Max id on the row for ever (TASK-769).
+      else await forgetClawboxAiPickIfMovedOff(targetModel);
       // Already the primary — but a ChatGPT pick can arrive as `codex/<id>`
       // and remap onto a primary that IS `openai/<id>` already, on a box whose
       // Codex runtime entry is missing (written by an older ClawBox, or lost).
@@ -1409,6 +1439,11 @@ export async function POST(request: Request) {
     //       that as a choice would pin the box to Flash for good — the box's
     //       own recovery, read back as the owner's decision.
     if (!automaticSwitch) await recordExplicitModelPick(targetModel);
+    //       And its mirror, for the same reason the exemption exists: the
+    //       guard's drop to Flash must also RETIRE the Max pick it moved off,
+    //       or the row this card teaches to honour a pick would offer a model
+    //       the portal refuses and leave ClawBox AI unreachable (TASK-769).
+    else await forgetClawboxAiPickIfMovedOff(targetModel);
 
     // 1c. The other side of the arm: a pick that is NOT the subscription's, on
     //     a reference an earlier ChatGPT pick armed, has to clear it — a

--- a/src/lib/explicit-model-pick.ts
+++ b/src/lib/explicit-model-pick.ts
@@ -233,6 +233,55 @@ export async function recordExplicitModelPick(model: string): Promise<void> {
 }
 
 /**
+ * Forget the ClawBox AI pick, because the BOX has just moved off it.
+ *
+ * WHY A PICK MUST BE FORGETTABLE (TASK-769, closing the hole the read opened).
+ * The chat's entitlement guard drops a Max model the portal positively refuses
+ * down to Flash and posts it `automatic: true`, which correctly records no new
+ * pick — recording the box's own recovery as the owner's decision would pin the
+ * box to Flash for good. But it left the refused pick in the store for ever,
+ * and nothing else clears it: {@link picksWithoutProvider} is wired only to a
+ * ClawBox AI TOKEN change, and the same account keeps its token through a plan
+ * downgrade. Until the row read this the stale value was inert; the moment the
+ * row honours it, a downgraded box offers Max on the one ClawBox AI row it has,
+ * every click on it is refused by the same guard, and ClawBox AI becomes
+ * unreachable from the picker — the very failure this card is about, moved to
+ * another account state. (It also already had teeth: `decideClawboxAiModelId`
+ * writes that stale Max id as the primary on the next pair or re-pair.)
+ *
+ * WHY THIS IS SAFE TO DRIVE FROM AN AUTOMATIC SWITCH, and why it cannot fire
+ * from the OTHER caller that sends `automatic`. Only two things post an
+ * automatic ClawBox AI model: the entitlement guard, which fires solely on a
+ * positive `portalDeniesClawboxAiModel` (false on any doubt, so never on a
+ * network blip); and `/setup-api/providers/default`, which resolves the ROW's
+ * own model — and with this card's fix that row IS the pick, so the ids match
+ * and nothing is cleared. Hence the test is "the box automatically moved to a
+ * DIFFERENT ClawBox AI model than the one on record".
+ *
+ * FAIL-SOFT like its sibling: this is bookkeeping behind a model change that
+ * has already landed on disk.
+ */
+export async function forgetClawboxAiPickIfMovedOff(model: string): Promise<void> {
+  const landed = clawboxAiModelIdOf(model);
+  if (!landed) return;
+  return serialise(async () => {
+    try {
+      const { value } = await getKnown(EXPLICIT_MODEL_PICKS_KEY);
+      const picks = explicitPicksFrom(value);
+      const picked = clawboxAiModelIdOf(picks.clawai);
+      if (!picked || picked === landed) return;
+      const next = picksWithoutProvider(picks, "clawai");
+      if (next) await setMany({ [EXPLICIT_MODEL_PICKS_KEY]: next });
+    } catch (err) {
+      console.warn(
+        "[explicit-model-pick] could not clear a ClawBox AI pick the box moved off:",
+        err instanceof Error ? err.message : err,
+      );
+    }
+  });
+}
+
+/**
  * The picks map without one provider's entry, or null when it had none.
  *
  * The shape every ClawBox AI token writer needs: a pick belongs to the ACCOUNT
@@ -254,6 +303,52 @@ export function picksWithoutProvider(
   const next = { ...picks };
   delete next[provider];
   return next;
+}
+
+/**
+ * The ClawBox AI model the owner picked, as a BARE id, when `offered` still
+ * carries it — or null, meaning "fall through to this surface's own default".
+ *
+ * WHY A ROW BUILDER NEEDS THIS (TASK-769). A provider's picker row is
+ * represented by the primary while the primary is that provider's, and by a
+ * DEFAULT the rest of the time. The ClawBox AI list is ordered Flash first
+ * ({@link CLAWBOX_AI_CHAT_MODEL_IDS}, and the live list on a paired box), so
+ * one switch to another provider turned the ClawBox AI row from the Max model
+ * the owner had chosen into Flash — and clicking "ClawBox AI" to come back
+ * landed on Flash with no notice and no route back to Max from the picker at
+ * all. TASK-713's ruling is that a default fills a gap and never overwrites a
+ * choice; both editions already RECORD the choice on every switch and neither
+ * read it back.
+ *
+ * CLAWBOX AI ONLY, deliberately, and the other four slots are a stated gap
+ * rather than an oversight. Two things are true of `clawai` and of nothing
+ * else in this map. Its slot is EXACT: `clawboxAiModelIdOf` decides membership
+ * from a closed set of two ids and accepts every spelling the surfaces write
+ * (`deepseek/…`, `clawai/…`, and Hermes' bare id), so no prefix has to be
+ * guessed at — and guessing is not idle, because Hermes records a bare
+ * `openai/gpt-5.4` for an OPENROUTER save, which `pickSlotFor` files under
+ * `openai`. And its slot is ACCOUNT-BOUND: three writers drop it in the same
+ * `setMany` that stores a new ClawBox AI token ({@link picksWithoutProvider}),
+ * so it cannot outlive the account that made it. Neither holds for
+ * `anthropic`, `openai`, `openrouter` or `google`, and honouring a slot whose
+ * spelling is ambiguous and whose account binding nobody maintains would
+ * resurrect one account's model as another's default.
+ *
+ * VALIDATED AGAINST WHAT THE SURFACE STILL OFFERS. Not an entitlement check
+ * and not claimed as one: both tiers are declared on EVERY box whatever the
+ * plan (see `CLAWBOX_AI_CHAT_MODEL_IDS`), and the portal is what gates them.
+ * What this rejects is an id that has left the list — a retired alias, a
+ * provider row rewritten by hand — so the row can never name a model the
+ * surface has no entry for.
+ */
+export function pickedClawboxAiModelIdAmong(
+  picks: ExplicitModelPicks,
+  offered: Iterable<string>,
+): string | null {
+  const picked = clawboxAiModelIdOf(picks.clawai);
+  if (!picked) return null;
+  for (const id of offered) if (id === picked) return picked;
+  return null;
 }
 
 /** The stored picks, for a caller that has not already loaded the whole store. */

--- a/src/lib/hermes-model-options.ts
+++ b/src/lib/hermes-model-options.ts
@@ -33,6 +33,7 @@ import {
 } from "@/lib/hermes-dashboard-control";
 import { get } from "@/lib/config-store";
 import { CLAWBOX_AI_CHAT_MODEL_IDS } from "@/lib/clawbox-ai-models";
+import { pickedClawboxAiModelIdAmong, readExplicitModelPicks } from "@/lib/explicit-model-pick";
 import {
   CLAWAI_PROVIDER,
   HERMES_AUTO_PROVIDER,
@@ -1067,10 +1068,33 @@ export async function scopeFromPayload(
 
   let defaultModel = inScopeCurrent;
   if (!defaultModel && models.length) {
-    const recommended = await recommendedDefault(provider, payload.fetchedAt);
-    defaultModel = models.some((m) => m.id === recommended)
-      ? recommended
-      : (models.find((m) => m.featured)?.id ?? models[0].id);
+    // The owner's own ClawBox AI pick outranks every default there is — the
+    // dashboard's recommendation, Hermes' `featured` flag and the list's own
+    // order alike (TASK-769). `/setup-api/hermes/models` RECORDS that pick on
+    // a save that names a model and never read it back, so a device saved on
+    // another provider was offered the ClawBox AI scope's FIRST id — Flash —
+    // and an owner who had chosen Max came back to Flash with no notice.
+    //
+    // CLAWBOX AI ONLY, and the store is not even read for another scope. The
+    // reason is `pickedClawboxAiModelIdAmong`'s: Hermes saves model ids BARE,
+    // so `pickSlotFor` files an OpenRouter save of `openai/gpt-5.4` under
+    // `openai` and records nothing at all for a slashless `claude-opus-4-8`.
+    // Only ClawBox AI's two ids survive that intact, through a closed set
+    // rather than a guessed prefix. Every other Hermes provider still lands on
+    // `recommendedDefault` after a switch — the harness's own
+    // `pick_silent_default_model`, which is the right answer for a provider
+    // whose pick this box cannot reliably remember.
+    const picked = provider === CLAWAI_PROVIDER
+      ? pickedClawboxAiModelIdAmong(await readExplicitModelPicks(), models.map((m) => m.id))
+      : null;
+    if (picked) {
+      defaultModel = picked;
+    } else {
+      const recommended = await recommendedDefault(provider, payload.fetchedAt);
+      defaultModel = models.some((m) => m.id === recommended)
+        ? recommended
+        : (models.find((m) => m.featured)?.id ?? models[0].id);
+    }
   }
 
   return {

--- a/src/tests/routes/chat-model.test.ts
+++ b/src/tests/routes/chat-model.test.ts
@@ -92,7 +92,8 @@ import { sqliteGet, sqliteSet } from "@/lib/sqlite-store";
 import { notifyProviderSetChanged } from "@/app/setup-api/ai-models/catalog/route";
 import { readProviderRunnable } from "@/lib/provider-runnable";
 import { ollamaModelCanChat } from "@/lib/ollama-capabilities";
-import { setMany } from "@/lib/config-store";
+import { getKnown, setMany } from "@/lib/config-store";
+import { recordExplicitModelPick } from "@/lib/explicit-model-pick";
 import { promisify } from "util";
 
 describe("/setup-api/chat/model", () => {
@@ -546,6 +547,42 @@ describe("/setup-api/chat/model", () => {
       });
     });
 
+    it("retires a ClawBox AI pick the box automatically moved OFF", async () => {
+      // The entitlement guard drops a refused Max model to Flash with
+      // `automatic: true`. Recording that as a choice would pin the box to
+      // Flash; leaving the refused Max pick on record makes the row this card
+      // teaches to honour a pick offer a model every click is refused for, so
+      // it is retired instead (TASK-769).
+      boxWithClawaiAndAnthropic();
+      vi.mocked(getKnown).mockResolvedValue({
+        value: { clawai: "deepseek/deepseek-v4-pro", anthropic: "anthropic/claude-opus-5" },
+        known: true,
+      });
+
+      expect((await post({ model: "deepseek/deepseek-v4-flash", automatic: true })).status).toBe(200);
+
+      expect(setMany).toHaveBeenCalledWith({
+        ai_model_explicit_picks: { anthropic: "anthropic/claude-opus-5" },
+      });
+    });
+
+    it("leaves the pick alone when the automatic switch lands ON it", async () => {
+      // `/setup-api/providers/default` also posts `automatic` — it resolves the
+      // ROW's own model, which with this card's fix IS the pick. Same id, so
+      // there is nothing to retire and the owner's choice must survive.
+      boxWithClawaiAndAnthropic();
+      vi.mocked(getKnown).mockResolvedValue({
+        value: { clawai: "deepseek/deepseek-v4-pro" },
+        known: true,
+      });
+
+      expect((await post({ model: "deepseek/deepseek-v4-pro", automatic: true })).status).toBe(200);
+
+      expect(setMany).not.toHaveBeenCalledWith(
+        expect.objectContaining({ ai_model_explicit_picks: expect.anything() }),
+      );
+    });
+
     it("records NOTHING for a switch the box made for itself", async () => {
       // The chat's entitlement guard drops a Max model the portal refuses down
       // to Flash so chat keeps working. Remembering the box's own recovery as
@@ -558,6 +595,144 @@ describe("/setup-api/chat/model", () => {
       expect(setMany).not.toHaveBeenCalledWith(
         expect.objectContaining({ ai_model_explicit_picks: expect.anything() }),
       );
+    });
+  });
+
+  describe("offering back the model the OWNER chose (TASK-769)", () => {
+    /**
+     * The READ half of TASK-713's ruling, and the half that was missing.
+     *
+     * A provider's row is built from `models.providers.<p>.models[0]` whenever
+     * the primary belongs to some OTHER provider — and the ClawBox AI list is
+     * ordered Flash first (`CLAWBOX_AI_CHAT_MODEL_IDS`, and the live list on a
+     * paired box: `deepseek-v4-flash`, `deepseek-v4-pro`, ...). So one switch
+     * to Anthropic turned the ClawBox AI row from the Max model the owner had
+     * picked into Flash, and clicking "ClawBox AI" to come back landed on
+     * Flash with no notice and no way back to Max from the picker at all.
+     */
+    function boxOnAnthropicAfterPickingMax(store: Record<string, unknown>) {
+      vi.mocked(getAll).mockResolvedValue(store);
+      vi.mocked(readConfig).mockResolvedValue({
+        auth: {
+          profiles: {
+            "deepseek:default": { provider: "deepseek", mode: "api_key" },
+            "anthropic:default": { provider: "anthropic", mode: "oauth" },
+          },
+        },
+        models: { providers: { deepseek: { models: [
+          { id: "deepseek-v4-flash", name: "ClawBox AI Flash" },
+          { id: "deepseek-v4-pro", name: "ClawBox AI Pro" },
+        ] } } },
+        agents: { defaults: { model: { primary: "anthropic/claude-opus-5" } } },
+      } as never);
+    }
+
+    async function clawaiRow() {
+      const body = await (await GET()).json();
+      return body.options.find(
+        (option: { provider: string | null }) => option.provider === "clawai",
+      );
+    }
+
+    it("keeps the recorded pick on the row while another provider is active", async () => {
+      boxOnAnthropicAfterPickingMax({
+        ai_model_explicit_picks: { clawai: "deepseek/deepseek-v4-pro" },
+      });
+
+      expect(await clawaiRow()).toMatchObject({
+        id: "deepseek/deepseek-v4-pro",
+        model: "deepseek/deepseek-v4-pro",
+        label: "ClawBox AI",
+      });
+    });
+
+    it("falls back to the provider's first model when the owner never picked one", async () => {
+      // The other half of the ruling: a default still FILLS a gap. Nothing
+      // recorded is nothing to honour, and the row is beta's answer.
+      boxOnAnthropicAfterPickingMax({});
+
+      expect(await clawaiRow()).toMatchObject({
+        id: "deepseek/deepseek-v4-flash",
+        model: "deepseek/deepseek-v4-flash",
+      });
+    });
+
+    it("honours the pick on a legacy install that declares no models at all", async () => {
+      // `models.providers.deepseek.models` is absent on an install that
+      // predates the explicit V4 aliases — the case `DEFAULT_PROVIDER_MODELS`
+      // exists for. ClawBox AI's own closed set is what the pick is judged
+      // against there, so such a box keeps the choice too instead of falling
+      // to the tier default.
+      vi.mocked(getAll).mockResolvedValue({
+        ai_model_explicit_picks: { clawai: "deepseek/deepseek-v4-pro" },
+      });
+      vi.mocked(readConfig).mockResolvedValue({
+        auth: {
+          profiles: {
+            "deepseek:default": { provider: "deepseek", mode: "api_key" },
+            "anthropic:default": { provider: "anthropic", mode: "oauth" },
+          },
+        },
+        models: { mode: "replace", providers: {} },
+        agents: { defaults: { model: { primary: "anthropic/claude-opus-5" } } },
+      } as never);
+
+      expect(await clawaiRow()).toMatchObject({
+        model: "deepseek/deepseek-v4-pro",
+      });
+    });
+
+    it("ignores a recorded pick the row no longer offers", async () => {
+      // Judged against what the surface still lists — a retired alias, a
+      // provider row rewritten by hand — so the row can never name a model
+      // there is no entry for. NOT an entitlement check: both tiers are
+      // declared on every box whatever the plan, and the portal gates them.
+      boxOnAnthropicAfterPickingMax({
+        ai_model_explicit_picks: { clawai: "deepseek/deepseek-v3-retired" },
+      });
+
+      expect(await clawaiRow()).toMatchObject({
+        model: "deepseek/deepseek-v4-flash",
+      });
+    });
+
+    it("reads the ClawBox AI slot and no other", async () => {
+      // Hermes records model ids BARE, so `pickSlotFor` files an OpenRouter
+      // save of `openai/gpt-5.4` under `openai` and drops a slashless
+      // `claude-opus-4-8` entirely; and only the clawai slot is dropped when
+      // the account's token changes. Honouring another slot would let one
+      // account's choice become another's row.
+      vi.mocked(getAll).mockResolvedValue({
+        ai_model_explicit_picks: { anthropic: "anthropic/claude-haiku-4.5" },
+      });
+      vi.mocked(readConfig).mockResolvedValue({
+        auth: { profiles: { "anthropic:default": { provider: "anthropic", mode: "oauth" } } },
+        models: { providers: { anthropic: { models: [
+          { id: "claude-opus-5" },
+          { id: "claude-haiku-4.5" },
+        ] } } },
+        agents: { defaults: { model: { primary: "deepseek/deepseek-v4-pro" } } },
+      } as never);
+
+      const body = await (await GET()).json();
+      const anthropic = body.options.find(
+        (option: { provider: string | null }) => option.provider === "anthropic",
+      );
+      expect(anthropic).toMatchObject({ model: "anthropic/claude-opus-5" });
+    });
+
+    it("survives the round trip through the surface that records the pick", async () => {
+      // The fixtures above inject the map by hand. This one records through
+      // `recordExplicitModelPick` the way a picker click does, then reads the
+      // row back — so the two halves cannot drift apart in spelling.
+      boxOnAnthropicAfterPickingMax({});
+      vi.mocked(setMany).mockImplementation(async (patch: Record<string, unknown>) => {
+        vi.mocked(getAll).mockResolvedValue(patch);
+      });
+
+      await recordExplicitModelPick("deepseek/deepseek-v4-pro");
+
+      expect(await clawaiRow()).toMatchObject({ model: "deepseek/deepseek-v4-pro" });
     });
   });
 

--- a/src/tests/unit/hermes-model-options-explicit-pick.test.ts
+++ b/src/tests/unit/hermes-model-options-explicit-pick.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * TASK-769, the Hermes half.
+ *
+ * `scopeFromPayload` answers "which model should this provider land on" and
+ * only ever honoured the SAVED model while the save belonged to the provider
+ * being asked about (`inScopeCurrent`). Ask for the ClawBox AI scope while the
+ * device is saved on another provider and it fell through to the dashboard's
+ * recommended default, then to `featured`, then to `models[0]` — and the
+ * ClawBox AI list is ordered Flash first, so an owner who had chosen Max came
+ * back to Flash.
+ *
+ * Same defect, same shape, same ruling as the OpenClaw chat picker: a default
+ * fills a gap and never overwrites a choice (TASK-713). `/setup-api/hermes/
+ * models` already RECORDS the pick on every save; this is the read back.
+ */
+
+const dashboardFetchMock = vi.fn();
+const runHermesCliMock = vi.fn();
+const readFileMock = vi.fn();
+const getKnownMock = vi.fn();
+
+vi.mock("@/lib/hermes-dashboard-auth", () => ({
+  dashboardFetch: dashboardFetchMock,
+  __esModule: true,
+}));
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: runHermesCliMock }));
+vi.mock("@/lib/config-store", () => ({
+  get: vi.fn(),
+  getKnown: getKnownMock,
+  setMany: vi.fn(),
+}));
+vi.mock("fs/promises", () => ({
+  default: { readFile: readFileMock },
+  readFile: readFileMock,
+}));
+
+// Env-overridable ids (clawbox-ai-models.ts): imported, never retyped.
+import { CLAWBOX_AI_FLASH_MODEL_ID, CLAWBOX_AI_PRO_MODEL_ID } from "@/lib/clawbox-ai-models";
+
+/**
+ * A device saved on Anthropic, with a ClawBox AI row offering both tiers in
+ * the order the seed writes them — Flash first, which is what made the
+ * downgrade silent.
+ */
+function payloadSavedOnAnthropic(): import("@/lib/hermes-model-options").ModelOptionsPayload {
+  return {
+    providers: [
+      {
+        id: "clawai",
+        name: "ClawBox AI",
+        authenticated: true,
+        models: [
+          { id: CLAWBOX_AI_FLASH_MODEL_ID, description: "" },
+          { id: CLAWBOX_AI_PRO_MODEL_ID, description: "" },
+        ],
+      },
+      {
+        id: "anthropic",
+        name: "Anthropic",
+        authenticated: true,
+        models: [{ id: "claude-opus-5", description: "" }],
+      },
+    ],
+    current: { provider: "anthropic", model: "claude-opus-5" },
+    reasoning: "",
+    fetchedAt: Date.now(),
+    source: "dashboard",
+    stale: false,
+  } as import("@/lib/hermes-model-options").ModelOptionsPayload;
+}
+
+describe("the ClawBox AI scope while the device is saved elsewhere", () => {
+  let mod: typeof import("@/lib/hermes-model-options");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    dashboardFetchMock.mockReset();
+    runHermesCliMock.mockReset();
+    readFileMock.mockReset();
+    getKnownMock.mockReset();
+    runHermesCliMock.mockResolvedValue({ stdout: "", stderr: "", code: 0 });
+    // No recommended default from the dashboard unless a test says otherwise;
+    // `recommendedDefault` treats a non-ok answer as "none".
+    dashboardFetchMock.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
+    getKnownMock.mockResolvedValue({ value: undefined, known: true });
+    mod = await import("@/lib/hermes-model-options");
+  });
+
+  it("lands on the model the owner picked, not the first one listed", async () => {
+    getKnownMock.mockResolvedValue({
+      value: { clawai: CLAWBOX_AI_PRO_MODEL_ID },
+      known: true,
+    });
+
+    const scope = await mod.scopeFromPayload(payloadSavedOnAnthropic(), "clawai");
+
+    expect(scope.defaultModel).toBe(CLAWBOX_AI_PRO_MODEL_ID);
+  });
+
+  it("honours a pick recorded with the OpenClaw picker's prefixed spelling", async () => {
+    // One map, two surfaces: the OpenClaw picker records
+    // `deepseek/deepseek-v4-pro`, Hermes' own config takes the bare id.
+    getKnownMock.mockResolvedValue({
+      value: { clawai: `deepseek/${CLAWBOX_AI_PRO_MODEL_ID}` },
+      known: true,
+    });
+
+    const scope = await mod.scopeFromPayload(payloadSavedOnAnthropic(), "clawai");
+
+    expect(scope.defaultModel).toBe(CLAWBOX_AI_PRO_MODEL_ID);
+  });
+
+  it("still falls to the provider's own default when nothing was picked", async () => {
+    const scope = await mod.scopeFromPayload(payloadSavedOnAnthropic(), "clawai");
+
+    expect(scope.defaultModel).toBe(CLAWBOX_AI_FLASH_MODEL_ID);
+  });
+
+  it("ignores a pick the provider no longer offers", async () => {
+    getKnownMock.mockResolvedValue({
+      value: { clawai: "deepseek-v3-retired" },
+      known: true,
+    });
+
+    const scope = await mod.scopeFromPayload(payloadSavedOnAnthropic(), "clawai");
+
+    expect(scope.defaultModel).toBe(CLAWBOX_AI_FLASH_MODEL_ID);
+  });
+
+  it("leaves the saved model alone when the scope IS the saved provider", async () => {
+    // `inScopeCurrent` still wins: the device's live selection is a fact, not
+    // a default, and a stale pick must never move a provider off it.
+    getKnownMock.mockResolvedValue({
+      value: { anthropic: "claude-haiku-4.5" },
+      known: true,
+    });
+
+    const scope = await mod.scopeFromPayload(payloadSavedOnAnthropic(), "anthropic");
+
+    expect(scope.current).toBe("claude-opus-5");
+    expect(scope.defaultModel).toBe("claude-opus-5");
+  });
+});


### PR DESCRIPTION
**TASK-769** — the chat picker silently downgrades the ClawBox AI row from Max to Flash after a switch to another provider.

## Customer-visible symptom

The owner is on ClawBox AI Max (`deepseek/deepseek-v4-pro`, a `pro` account with `-pro` in `clawaiAllowedModels`). He tries Anthropic for a while. When he clicks "ClawBox AI" in the chat picker to come back, he lands on **Flash** — a quieter, cheaper model — with no notice, and there is no way back to Max through the chat picker at all. Against the existing TASK-713 ruling that a default fills a gap and never overwrites a choice.

## Cause

A provider's picker row is represented by the primary while the primary is that provider's, and by a **default** the rest of the time:

- OpenClaw `loadChatModelState` (`src/app/setup-api/chat/model/route.ts`): `activeModel` → `models.providers.<p>.models[0]` → `DEFAULT_PROVIDER_MODELS`.
- Hermes `scopeFromPayload` (`src/lib/hermes-model-options.ts`): `inScopeCurrent` → the dashboard's `recommended-default` → `featured` → `models[0]`.

`CLAWBOX_AI_CHAT_MODEL_IDS` is `[flash, pro]` — **Flash first** — and three writers seed the provider's list in that order (`buildClawboxAiProviderDefinition`, `applyClawaiToHermes`, `reconcileClawaiModelsWithHermes`). Measured on the OpenClaw box: `models.providers.deepseek.models` = `['deepseek-v4-flash', 'deepseek-v4-pro', 'deepseek-v4-flash-vision-exp']`. So the moment the primary belongs to another provider, both editions hand back Flash.

Both editions already **record** the owner's pick on every switch — `recordExplicitModelPick` at `chat/model/route.ts` and `setup-api/hermes/models/route.ts` (TASK-713's `ai_model_explicit_picks`) — and **neither ever read it back** when building a row.

It is not merely cosmetic. `ChatPopup` posts the row's own model on a click with no `automatic` flag, so clicking the (now Flash) ClawBox AI row **re-records the pick as Flash**, after which the configure route's TASK-713 protection loyally defends Flash. One Anthropic → ClawBox AI round trip made the downgrade permanent.

## Fix

`pickedClawboxAiModelIdAmong` (`src/lib/explicit-model-pick.ts`, beside the map's other readers) answers "the ClawBox AI model the owner picked, bare, if the row still offers it". Both row builders consult it ahead of their defaults:

- OpenClaw: between `activeModel` and `models[0]`, judged against the configured list — or against the closed set itself when there is none, so a legacy install with no `models.providers.deepseek` entry keeps the choice too.
- Hermes: ahead of the dashboard's `recommended-default`, `featured` and `models[0]`. `inScopeCurrent` still wins — the device's live selection is a fact, not a default.

**ClawBox AI only, and the other four slots are a stated gap rather than an oversight.** Two things are true of `clawai` and of nothing else in this map. Its slot is exact: `clawboxAiModelIdOf` decides membership from a closed set of two ids and accepts every spelling the surfaces write, so no prefix has to be guessed at — and guessing is not idle, because Hermes records model ids **bare**, so `pickSlotFor` files an OpenRouter save of `openai/gpt-5.4` under `openai` and records nothing at all for a slashless `claude-opus-4-8`. And its slot is account-bound: three writers drop it in the same `setMany` that stores a new ClawBox AI token (`picksWithoutProvider`), so it cannot outlive the account that made it. Neither holds for `anthropic`, `openai`, `openrouter` or `google` — honouring those slots would let one account's choice become another's row, and would let an OpenRouter choice decide the direct vendor's scope. Those providers still land on their own default after a switch; the mis-keying in `pickSlotFor` is the thing to fix before they can be read, and it is a finding, not part of this card.

**A pick the box itself moved off is now retired** (`forgetClawboxAiPickIfMovedOff`). The chat's entitlement guard drops a Max model the portal positively refuses down to Flash and posts it `automatic: true`, which correctly records no new pick — but nothing cleared the refused one, and `picksWithoutProvider` is wired only to a token change, which a plan downgrade does not cause. Until the row read the pick that stale value was inert; the moment the row honours it, a downgraded box offers Max on its one ClawBox AI row, every click is refused by the same guard, and ClawBox AI becomes unreachable from the picker — this card's own failure in another account state. It also already had teeth on beta: `decideClawboxAiModelId` writes that stale Max id as the primary on the next pair or re-pair. The clearing cannot misfire from `/setup-api/providers/default`, the other caller that sends `automatic`: that one resolves the row's own model, which with this fix **is** the pick, so the ids match and nothing is retired.

This is **not** an entitlement check and is not claimed as one: both tiers are declared on every box whatever the plan (`CLAWBOX_AI_CHAT_MODEL_IDS`, and `buildClawboxAiProviderDefinition` seeds flash+pro+vision unconditionally), and the portal is what gates them. What the membership test rejects is an id that has left the list.

## Harness-first

**There is no native mechanism, and that is a finding rather than a gap I invented around.** OpenClaw's sticky model selection (`modelSelectionScope`) propagates an owner's session pick into `agents.defaults.model.primary` but records no provenance where it lands; Hermes' `model.default` carries none either; the portal publishes a per-device `deviceTier` (a default) and `allowedModels` (an entitlement) but no per-device model. So the primary itself can never be asked "did the owner choose this?" — which is exactly why TASK-713 created ClawBox's own marker. This PR reads that marker; it does not invent a second one.

The one thing that IS native here is Hermes' own landing-model answer — `GET /api/model/recommended-default`, the dashboard's `pick_silent_default_model`, which deliberately avoids the priciest flagship. This PR puts the owner's recorded ClawBox AI pick **above** it and leaves it in charge of every other provider, which is the honest split: the harness has a good default and no memory of a choice.

The behavioural precedent is already shipped on the other edition: `setup-api/hermes/clawai/route.ts` answers `(active && storedModel) || clawboxAiModelIdOf(picks.clawai) || clawaiModelForTier(tier)`, pinned by `src/tests/routes/hermes/clawai-coding-agent.test.ts`. This is the same rule on the two surfaces that were missing it.

## Sibling sweep

Fixed here:
- `src/app/setup-api/chat/model/route.ts` — `loadChatModelState`, the defect.
- `src/lib/hermes-model-options.ts` — `scopeFromPayload`, the Hermes twin, structurally identical and with five consumers.

Downstream call sites that inherit the fix (they read the row rather than deriving their own): `setup-api/providers/default` (the Settings "Make default" star and `LocalAiPanel`'s "use as fallback") on OpenClaw, `src/lib/hermes-cloud-provider.ts:143`, `setup-api/hermes/models` provider-only POST, and the MCP `ai_set_provider` tool. All four are the provider-only path — precisely where the ruling says a recorded pick must outrank a default. They previously wrote Flash into `agents.defaults.model.primary` / `model.default`.

Cleared, with the reason:
- `setup-api/ai-models/status` — reports the ACTIVE model; it derives no per-provider representative.
- `setup-api/ai-models/catalog` — the catalogue's own `defaultModelId` feeds the SECONDARY picker, never written as primary by these routes.
- `ChatPopup`'s secondary picker — renders only for the active provider, so it never derives a model for an inactive row.
- `ChatPopup`'s entitlement guard — writes `automatic: true` and must keep doing so.
- `src/lib/hermes-clawai.ts`, `setup-api/hermes/clawai`, `setup-api/ai-models/configure` — already read the picks.
- The tail `defaultModelForProvider(primaryProvider)` fallback in `loadChatModelState` runs after the profile loop, which has already claimed every provider holding a credential; a provider named only by the drifting config store has none.

**Not fixed, stated rather than left silent (1/2):** the OpenAI row. `models.providers.openai.models[]` carries only the ClawBox AI image entry on a normal box, which the row builder filters out, so that row falls to `OPENAI_DEFAULT_MODEL_ID` after a switch whatever the owner picked. Reading it would need the pick validated against the catalogue the picker shows rather than against a list that is empty by construction — and it is one of the four slots whose keying is unreliable anyway.

**Not fixed, stated rather than left silent (2/2):** `AIModelsStep.tsx` (the Settings/wizard picker) pre-selects `PROVIDER_CATALOGS.clawai.defaultModelId` = Flash when the box is on another provider. It is display-only — `ai-models/configure`'s clawai branch ignores the named model and lets `decideClawboxAiModelId` decide, so the Save still writes Max — but the owner is shown Flash while Max is saved. Closing it means making the catalogue's `defaultModelId` pick-aware, a different surface from the two row builders this card names.

## Review

One `clawbox-review` pass: **1 High, 4 Medium, 4 Low**. The High was a regression this PR introduced — honouring a stale, entitlement-refused Max pick made ClawBox AI unreachable from the picker on a downgraded account, and `providers/default` would have written a denied model into `agents.defaults.model.primary`. Three of the Mediums were the same root: the map's slot is inferred from the model string, which is wrong for Hermes' bare ids and for OpenRouter's vendor-prefixed ones. Both are addressed by narrowing the read to the one slot that is exact and account-bound, and by retiring a pick the box moved off; the comments that claimed the list was entitlement-filtered were false and are gone. The remaining Lows are answered in this body (the OpenAI row, the native `recommendedDefault`) or by the round-trip tests added below.

## RED → GREEN

RED, unmodified beta `6a0cd011` — **6 failures, 68 passes**; the passes are the guards that must not change:

```
 FAIL  src/tests/routes/chat-model.test.ts > offering back the model the OWNER chose (TASK-769)
       > keeps the recorded pick on the row while another provider is active
AssertionError: expected { …(7) } to match object { Object (id, model, ...) }
-   "id": "deepseek/deepseek-v4-pro",
+   "id": "deepseek/deepseek-v4-flash",
    "label": "ClawBox AI",
-   "model": "deepseek/deepseek-v4-pro",
+   "model": "deepseek/deepseek-v4-flash",
```

```
 FAIL  chat-model.test.ts > honours the pick on a legacy install that declares no models at all
 FAIL  chat-model.test.ts > survives the round trip through the surface that records the pick
AssertionError: expected { …(7) } to match object { model: 'deepseek/deepseek-v4-pro' }
-   "model": "deepseek/deepseek-v4-pro",
+   "model": "deepseek/deepseek-v4-flash",

 FAIL  chat-model.test.ts > remembering that the OWNER chose this model
       > retires a ClawBox AI pick the box automatically moved OFF
AssertionError: expected "vi.fn()" to be called with arguments: [ { …(1) } ]

 FAIL  hermes-model-options-explicit-pick.test.ts > lands on the model the owner picked, not the first one listed
 FAIL  hermes-model-options-explicit-pick.test.ts > honours a pick recorded with the OpenClaw picker's prefixed spelling
AssertionError: expected 'deepseek-v4-flash' to be 'deepseek-v4-pro'
```

The guards pass on beta and must keep passing: nothing recorded still falls to the row's first model, a pick the row no longer offers is ignored, only the ClawBox AI slot is read, an automatic switch that lands **on** the pick leaves it alone, and `inScopeCurrent` still wins on Hermes.

GREEN, after the fix and after the rebase onto beta head: **71 files, 1045 tests** across `routes/chat-model*`, `routes/providers`, `routes/ai-models`, `routes/hermes`, `unit/hermes-model-options-*` and `unit/hermes-clawai-explicit-pick`, plus `tsc --noEmit` clean and eslint clean on every changed file.

## Device proof — OpenClaw box, under the device lock, restored byte-identical

Read-only first: the box already had the owner's pick recorded — `ai_model_explicit_picks.clawai = "deepseek/deepseek-v4-pro"` — and `models.providers.deepseek.models` ordered Flash-first, so the row builder had the answer available and never asked for it.

```
BASELINE   openclaw.json sha256 19d07c76…da12   data/config.json sha256 e06ed32d…e035
           picker: active deepseek/deepseek-v4-pro | row clawai = deepseek/deepseek-v4-pro

POST /setup-api/chat/model {"model":"anthropic/claude-opus-5","provider":"anthropic"}  → http 200 in 65 s
           switch response's own options: row clawai = deepseek/deepseek-v4-flash     ← RED
           fresh GET  /setup-api/chat/model: row clawai = deepseek/deepseek-v4-flash  ← RED

POST /setup-api/chat/model {"model":"deepseek/deepseek-v4-pro","provider":"clawai"}   → http 200 in 64 s
           picker: active deepseek/deepseek-v4-pro | row clawai = deepseek/deepseek-v4-pro

AFTER      openclaw.json sha256 19d07c76…da12   data/config.json sha256 e06ed32d…e035
           primary deepseek/deepseek-v4-pro   fallbacks ['llamacpp/gemma4-e2b-it-q4_0']   thinking unset
           clawbox-gateway active running, clawbox-setup active running, web answers
```

Both hashes byte-identical before and after; the device lock was taken with a reason and released, verified FREE. The credential-writing `ai-models/configure` route was not driven and no credential on the box was touched — the reproduction used the chat picker's own route throughout. The measured 64–65 s switch cost is the gateway restart every model change pays; it is on the card as a separate question and is not changed here.

The fixed build is not on the box: the caller merges serially and deploys beta head afterwards.

## Note on the local suite

The `components` vitest project is flaky on the development PC under parallel load (React `act()` and per-test timeouts). Unmodified `origin/beta` fails 14 of its tests across 11 files on the same machine, and a different subset fails on each run; run sequentially the suites this PR touches are 1028/1028. CI is the proof for the full suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remembers users’ selected ClawBox AI models when they remain available.
  * Restores saved model selections across provider-state loading, including legacy configurations.
  * Automatically discards saved selections when a model is no longer available after recovery.
* **Bug Fixes**
  * Prevents invalid, unrelated, or retired model selections from overriding valid defaults.
* **Tests**
  * Added coverage for model selection persistence, restoration, fallback behavior, and legacy compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
