### PR TITLE
Update: report the fixups it skipped, and stop calling a live run interrupted

### DIFF
--- a/e2e-install/helpers/setup-api.ts
+++ b/e2e-install/helpers/setup-api.ts
@@ -422,11 +422,18 @@ async function diagnoseLostUpdate(): Promise<string> {
     "systemctl", "show", "clawbox-setup.service",
     "-p", "NRestarts", "-p", "ActiveEnterTimestamp", "-p", "ExecMainStartTimestamp", "-p", "Result",
   ]);
+  // `update_lock_holder` is REDUCED, not printed: what a failure needs from it
+  // is whether a holder was recorded and how old its heartbeat is, and this
+  // message is uploaded as a CI artifact on a PUBLIC repository — the boot id
+  // it carries is ephemeral and not a secret, but it identifies the machine and
+  // this file's own rule below is that nothing goes down that does not have to.
   await ask("the updater's own keys on disk", [
     "bash", "-lc",
     "python3 -c \"import json;d=json.load(open('/home/clawbox/clawbox/data/config.json'));"
+    + "h=d.get('update_lock_holder');"
+    + "h=(h if not isinstance(h,dict) else {'recorded':True,'at':h.get('at'),'pid_present':bool(h.get('pid'))});"
     + "print({k:d.get(k) for k in ('update_in_progress','update_needs_continuation',"
-    + "'update_interrupted_at','update_completed','update_completed_at','update_lock_holder')})\" 2>&1 || true",
+    + "'update_interrupted_at','update_completed','update_completed_at')}, 'holder=', h)\" 2>&1 || true",
   ]);
   // REDACTED, and only the web server's own unit. This message becomes a
   // Playwright error and is uploaded as a CI artifact on a PUBLIC repository,

--- a/e2e-install/helpers/setup-api.ts
+++ b/e2e-install/helpers/setup-api.ts
@@ -431,7 +431,13 @@ async function diagnoseLostUpdate(): Promise<string> {
     "bash", "-lc",
     "python3 -c \"import json;d=json.load(open('/home/clawbox/clawbox/data/config.json'));"
     + "h=d.get('update_lock_holder');"
-    + "h=(h if not isinstance(h,dict) else {'recorded':True,'at':h.get('at'),'pid_present':bool(h.get('pid'))});"
+    + "a=(h.get('at') if isinstance(h,dict) else None);"
+    // EVERY shape is reduced, not just the dict: a string, a list or a number
+    // under that key would otherwise have gone down verbatim, and `at` is only
+    // repeated when it looks like the timestamp this code writes.
+    + "h=({'recorded':False} if h is None else "
+    + "{'recorded':True,'at':(a if isinstance(a,str) and len(a)<40 else None),'pid_present':bool(h.get('pid'))} "
+    + "if isinstance(h,dict) else {'recorded':True,'shape':type(h).__name__});"
     + "print({k:d.get(k) for k in ('update_in_progress','update_needs_continuation',"
     + "'update_interrupted_at','update_completed','update_completed_at')}, 'holder=', h)\" 2>&1 || true",
   ]);

--- a/e2e-install/helpers/setup-api.ts
+++ b/e2e-install/helpers/setup-api.ts
@@ -426,7 +426,7 @@ async function diagnoseLostUpdate(): Promise<string> {
     "bash", "-lc",
     "python3 -c \"import json;d=json.load(open('/home/clawbox/clawbox/data/config.json'));"
     + "print({k:d.get(k) for k in ('update_in_progress','update_needs_continuation',"
-    + "'update_interrupted_at','update_completed','update_completed_at')})\" 2>&1 || true",
+    + "'update_interrupted_at','update_completed','update_completed_at','update_lock_holder')})\" 2>&1 || true",
   ]);
   // REDACTED, and only the web server's own unit. This message becomes a
   // Playwright error and is uploaded as a CI artifact on a PUBLIC repository,

--- a/install.sh
+++ b/install.sh
@@ -9150,7 +9150,19 @@ step_build
 # has_hermes_harness (a no-op on openclaw), needs nothing OpenClaw provides, and
 # is idempotent, so moving it up costs nothing on any other SKU.
 log "Installing Hermes (on the hermes and dual editions)..."
-step_hermes_install
+# NOT BARE. This step answers non-zero now — for an agent it could not make
+# runnable, and for an upgrade that landed off the pin — and errexit is live at
+# this call site (`set -euo pipefail`, line 22, with no EXIT trap armed on the
+# full-install path: the only `trap dispatch_provision_verdict EXIT` is inside
+# the `--step` block, which exits before this line is ever reached). Bare, a
+# fresh hermes or dual box whose Hermes fetch failed — a region block, a network
+# flake, the population this step's guard exists for — would abort the whole
+# installer here, before the services, VNC and the provisioning verdict: no
+# PROVISIONING INCOMPLETE banner and no [provision-status] sentinel, with the
+# marker already invalidated, so the flash host would see no verdict at all.
+# The step prints its own reason; on this path that report is the outcome, and a
+# box that is otherwise fully provisioned is worth more than an aborted install.
+step_hermes_install || echo "  Warning: Hermes is not runnable after this step — install it manually, then re-run install.sh (non-fatal)" >&2
 
 log "Installing and configuring OpenClaw..."
 step_openclaw_setup

--- a/install.sh
+++ b/install.sh
@@ -9171,7 +9171,18 @@ log "Installing Hermes (on the hermes and dual editions)..."
 # marker already invalidated, so the flash host would see no verdict at all.
 # The step prints its own reason; on this path that report is the outcome, and a
 # box that is otherwise fully provisioned is worth more than an aborted install.
-step_hermes_install || echo "  Warning: Hermes is not runnable after this step — install it manually, then re-run install.sh (non-fatal)" >&2
+# RECORDED, not only printed: on the hermes and dual SKUs the agent IS the
+# product, so a box that finished provisioning without a runnable one — or on a
+# build we do not ship — is not a complete install, and `record_provision_failure`
+# is the channel this file already has for saying so. It reaches the operator's
+# "Steps that failed:" line and the `[provision-status]` marker the flash host
+# parses, which is exactly what the bare call was destroying by aborting before
+# either could be written. Idempotent, and never reached on openclaw (the step
+# returns 0 immediately where there is no Hermes harness).
+if ! step_hermes_install; then
+  record_provision_failure hermes_install
+  echo "  Warning: Hermes is not runnable after this step — install it manually, then re-run install.sh (non-fatal)" >&2
+fi
 
 log "Installing and configuring OpenClaw..."
 step_openclaw_setup

--- a/install.sh
+++ b/install.sh
@@ -1697,12 +1697,13 @@ case "$ENGINE_SETTLE_S" in ''|*[!0-9]*) ENGINE_SETTLE_S=3 ;; esac
 # not restart is the false-success class (TASK-724).
 #
 # Never fails the update: refusing an otherwise-good update over one engine
-# would strand the box on the old build, which is strictly worse. What a failed
-# restart gets is a named [WARN] line on this step's stderr — the step's journal
-# — and nothing else. It deliberately does NOT go through
-# record_provision_failure: that channel turns the step's exit code non-zero,
-# which would paint a whole good update red over a voice engine, and there is no
-# quieter surface for it today. Whoever adds one should start here.
+# would strand the box on the old build, which is strictly worse. It
+# deliberately does NOT go through record_provision_failure: that channel turns
+# the step's exit code non-zero, which would paint a whole good update red over
+# a voice engine. The quieter surface this block asked for now exists — a
+# `CLAWBOX-WARN[...]` line, which the updater reads out of the step's journal
+# and raises on the update's own status — so a named [WARN] line here carries
+# the marker beside it and the owner is told, without the update turning red.
 #
 # RESIDUAL, stated rather than hidden: a shell SIGKILLed between the pause and
 # this call resumes nothing. That is not hypothetical — run_next_build's own
@@ -1750,6 +1751,7 @@ resume_paused_engines() {
         echo "    [ok] $unit is back"
       else
         echo "    [WARN] $unit did not come back — it was running before this update and is not now" >&2
+        echo "CLAWBOX-WARN[engine-not-resumed]: $unit was running before this update and did not come back; it starts again on the next request that needs it"
       fi
     done
   fi
@@ -1773,6 +1775,7 @@ resume_paused_engines() {
           echo "    [ok] $unit is back"
         else
           echo "    [WARN] $unit did not come back — it was running before this update and is not now" >&2
+          echo "CLAWBOX-WARN[engine-not-resumed]: $unit was running before this update and did not come back; it starts again on the next request that needs it"
         fi
       done
     fi
@@ -3752,9 +3755,20 @@ step_hermes_install() {
       fi
     fi
   fi
-  # Explicit: the last command above is a test that is FALSE on the happy path,
-  # and step_post_update reports any non-zero return as a failed step.
-  return 0
+  # THE OUTCOME, not the last test's exit code. The line above is a test that is
+  # FALSE on the happy path, so this used to be an unconditional `return 0` —
+  # and `step_post_update` then reported "completed" over a box whose agent
+  # repair had failed, which is the exact population this call was added for
+  # (the pre-fix factory reset). `optional_step` records a non-zero return as a
+  # skipped fixup and cannot fail the update with it, so the honest answer is
+  # now safe to give: the shim has to be runnable.
+  # The same two-part test the step's own probe makes (a shim alone is a
+  # four-line wrapper and proves nothing about the agent under ~/.hermes).
+  if [ -x "$shim" ] && [ -x "$venv_python" ]; then
+    return 0
+  fi
+  echo "  Warning: the Hermes agent is still not runnable after this step" >&2
+  return 1
 }
 
 # Re-cache ONLY the offline Gemma GGUF.
@@ -4146,10 +4160,15 @@ step_openclaw_install() {
     local _oc_doctor_out
     if ! _oc_doctor_out="$(as_clawbox -H "$OPENCLAW_BIN" doctor --fix --non-interactive </dev/null 2>&1)"; then
       printf '%s\n' "$_oc_doctor_out"
+      # `CLAWBOX-WARN:` rather than a plain WARN line: the updater reads this
+      # prefix back out of the step's journal and puts it on the update's own
+      # status. A doctor that migrated nothing is exactly the case an owner
+      # needs told — the gateway can refuse readiness for it — and a line only
+      # in the journal is a line nobody on the box will read.
       if printf '%s\n' "$_oc_doctor_out" | grep -q 'Legacy exec approvals exist at'; then
-        echo "  WARN: openclaw doctor --fix migrated NOTHING — a legacy exec-approvals file blocks it. The gateway's pre-start moves an empty one aside and re-runs the migration on the next start."
+        echo "CLAWBOX-WARN[openclaw-doctor-fix-failed]: openclaw doctor --fix migrated NOTHING — a legacy exec-approvals file blocks it. The gateway's pre-start moves an empty one aside and re-runs the migration on the next start."
       else
-        echo "  WARN: openclaw doctor --fix did not complete; the gateway may refuse readiness until it is run"
+        echo "CLAWBOX-WARN[openclaw-doctor-fix-failed]: openclaw doctor --fix did not complete; the gateway may refuse readiness until it is run"
       fi
     else
       printf '%s\n' "$_oc_doctor_out"
@@ -5859,8 +5878,9 @@ install_root_file() {
 # refuses every pinned root step: a wider outage than one missing copy.
 #
 # The check matters on the update path specifically. step_post_update runs its
-# fixups as `step_x || echo "(non-fatal)"`, and bash switches errexit OFF for
-# the whole body of a function called in an OR-list, so without it a copy that
+# fixups through `optional_step`, whose `if "$@"` switches errexit OFF for the
+# whole body of the function it calls exactly as the `|| echo` before it did —
+# so without this check a copy that
 # failed here was followed by successful commands, the function returned 0, and
 # the units and grants installed after it pointed at a copy that was not there
 # (a fresh libexec on the first update carrying it) or was stale.
@@ -6487,7 +6507,48 @@ step_nm_dispatcher() {
   echo "  NetworkManager failover dispatcher installed"
 }
 
+# NON-FATAL, BUT NOT SILENT.
+#
+# Every fixup in `step_post_update` is deliberately non-fatal — refusing to
+# finish an update because a VNC unit refresh failed would be the worse outcome
+# — and each one used to say so with `|| echo "  Warning: … (non-fatal)"`,
+# which reaches the journal and nothing else. The step still exits 0, so the
+# updater reports "Applying system fixups" as completed and the owner is told
+# an update worked in full when part of it did not: the false-success shape,
+# spelled nineteen times in one function.
+#
+# So the failures are COLLECTED and re-stated at the end in a line the updater
+# parses (`CLAWBOX-WARN:`), which turns them into a warning on the update's own
+# status — where the owner reads it — while the step still exits 0.
+POST_UPDATE_FAILED_STEPS=""
+
+# Run one fixup. Never fails the step; always records.
+optional_step() {
+  local name="$1"
+  shift
+  if "$@"; then
+    return 0
+  fi
+  echo "  Warning: $name step failed (non-fatal)"
+  POST_UPDATE_FAILED_STEPS="$POST_UPDATE_FAILED_STEPS $name"
+  return 0
+}
+
+# The one line the updater reads back out of the journal. Printed only when
+# something failed, so a healthy update stays silent.
+report_optional_step_failures() {
+  [ -n "$POST_UPDATE_FAILED_STEPS" ] || return 0
+  # The CODE is stable across runs and does not name the failing set: the
+  # updater de-duplicates by it, and a key that changed with the list would be
+  # a new card every time one more fixup failed.
+  echo "CLAWBOX-WARN[post-update-fixups]: these system fixups failed and were skipped:$POST_UPDATE_FAILED_STEPS"
+}
+
 step_post_update() {
+  # Reset per RUN, not per shell: the file-scope initialiser above is for
+  # `set -u`, and a second call in one shell would otherwise re-report the
+  # first call's failures.
+  POST_UPDATE_FAILED_STEPS=""
   # Re-apply system-level fixups that aren't covered by `git pull && build`.
   # Triggered by the in-app updater so existing devices pick up new dispatcher
   # scripts, sysctls, etc. without a full reinstall. Keep this list small and
@@ -6503,31 +6564,31 @@ step_post_update() {
   # LATER updater step (and the web server, and the next update) resolves the
   # SKU correctly instead of silently defaulting to openclaw. It also re-asserts
   # the Hermes gateway removal, which an older update could have undone.
-  step_edition_lock || echo "  Warning: edition_lock step failed (non-fatal)"
-  step_set_hostname || echo "  Warning: set_hostname step failed (non-fatal)"
-  step_nm_dispatcher || echo "  Warning: nm_dispatcher step failed (non-fatal)"
-  step_sysctl_linkdown || echo "  Warning: sysctl_linkdown step failed (non-fatal)"
+  optional_step edition_lock step_edition_lock
+  optional_step set_hostname step_set_hostname
+  optional_step nm_dispatcher step_nm_dispatcher
+  optional_step sysctl_linkdown step_sysctl_linkdown
   # Without this call the swapfile would be fresh-install-only, and every box
   # already in the field would keep facing a rebuild with zram alone — which is
   # the box the 2026-09-05 OOM happened on.
-  step_swapfile || echo "  Warning: swapfile step failed (non-fatal)"
+  optional_step swapfile step_swapfile
   # Without this call the firewall would be fresh-install-only and every box
   # already in the field would keep its wide-open INPUT policy — which is the
   # entire finding. Idempotent: the script converges its own rules on each run.
-  step_firewall || echo "  Warning: firewall step failed (non-fatal)"
+  optional_step firewall step_firewall
   # Without this call the persistent journal would be fresh-install-only, and
   # every already-shipped box would keep losing its whole log on each reboot.
-  step_persistent_journal || echo "  Warning: persistent_journal step failed (non-fatal)"
+  optional_step persistent_journal step_persistent_journal
   # Re-assert the cgroup memory guards and re-sync /etc/clawbox/resource-limits.env
   # from the repo. Without this the guards would be fresh-install-only and every
   # already-shipped box would keep running an unbounded ollama. Idempotent.
   # NOTE: there is deliberately no step_desktop_mode call here — the desktop
   # toggle is the owner's decision and an update must never flip it.
-  step_resource_limits || echo "  Warning: resource_limits step failed (non-fatal)"
+  optional_step resource_limits step_resource_limits
   # step_vnc_refresh is a tiny idempotent refresh of the clawbox-vnc.service
   # unit + autocutsel package. Devices installed before the display-:99 move
   # and the clipboard-sync addition get both here without needing a reinstall.
-  step_vnc_refresh || echo "  Warning: vnc_refresh step failed (non-fatal)"
+  optional_step vnc_refresh step_vnc_refresh
   # Reinstall the unit files from config/ + daemon-reload. Without this, unit
   # changes only ever reached FRESH installs: the in-app update runs
   # bootstrap_updater -> ... -> post_update and never re-copies
@@ -6537,23 +6598,23 @@ step_post_update() {
   # Gemma 4" from being killed mid-build, and would swallow any future unit or
   # sudoers change the same way. The step is idempotent — cp, daemon-reload,
   # enable — and is exactly what fresh installs already run.
-  step_systemd_services || echo "  Warning: systemd_services step failed (non-fatal)"
+  optional_step systemd_services step_systemd_services
   # Refresh the device-side ClawKeep CLI from the repo. The Python package
   # has the same version string ("0.1.0") across releases, so a plain
   # `pip install` is a no-op even after restore/scheduler bug fixes land —
   # we have to force-reinstall.
-  step_clawkeep_install || echo "  Warning: clawkeep_install step failed (non-fatal)"
+  optional_step clawkeep_install step_clawkeep_install
   # The coding harness. WITHOUT this call TASK-378 would be fresh-install-only:
   # step_post_update never ran step_ai_tools_install, which is exactly why no
   # already-shipped box has `claude` on it today. Idempotent — a present
   # `claude` short-circuits after one `command -v`, and the wrapper is a copy.
-  step_coding_harness || echo "  Warning: coding_harness step failed (non-fatal)"
+  optional_step coding_harness step_coding_harness
   # The Codex CLI. Without this call the pinned native binary would be
   # fresh-install-only — step_post_update does not run step_ai_tools_install —
   # and every box in the field would keep the unpinned, unverified npm copy for
   # good. Idempotent: a box already on the pin does one `codex --version` and
   # stops.
-  step_codex_cli || echo "  Warning: codex_cli step failed (non-fatal)"
+  optional_step codex_cli step_codex_cli
   # On-device TTS: installs/refreshes Kokoro and the voice scripts, and seeds
   # the tts-local-cli provider. Without this call the whole of TASK-383 would
   # be fresh-install-only, and every already-shipped box would keep answering
@@ -6561,7 +6622,7 @@ step_post_update() {
   # The SAME tolerance table step_openclaw_setup applies to this step, and for
   # the same reason: 12, 13 and 14 are three different facts about a box's
   # speech and the update path has to keep them apart too. A single
-  # `|| echo "(non-fatal)"` — indistinguishable from the fourteen lines around
+  # one generic wrapper line — indistinguishable from the fixups around
   # it — reported "this box has no working TTS engine" in the same words as a
   # skipped VNC refresh, on the very path that reaches ALREADY-SHIPPED boxes.
   # ── The Hermes agent FIRST, for the same reason the fresh-install path was
@@ -6578,7 +6639,7 @@ step_post_update() {
   #
   # Idempotent and self-gated on has_hermes_harness (a no-op on openclaw), so
   # moving it up costs nothing on any other SKU.
-  step_hermes_install || echo "  Warning: hermes_install step failed (non-fatal)"
+  optional_step hermes_install step_hermes_install
 
   local TTS_UPDATE_RC=0
   step_openclaw_tts || TTS_UPDATE_RC=$?
@@ -6595,8 +6656,8 @@ step_post_update() {
   # service/drop-in state or is simply down from the reboot handoff. Run the
   # same idempotent setup used by fresh installs so a completed update leaves
   # clawbox-gateway as the active single source of truth.
-  step_gateway_setup || echo "  Warning: gateway_setup step failed (non-fatal)"
-  step_gateway_legacy_state_recovery || echo "  Warning: gateway_legacy_state_recovery step failed (non-fatal)"
+  optional_step gateway_setup step_gateway_setup
+  optional_step gateway_legacy_state_recovery step_gateway_legacy_state_recovery
   # Repair the two assets a factory reset performed by a pre-fix build deleted:
   # the Hermes agent install (~/.hermes/hermes-agent) and the offline Gemma
   # GGUF (data/llamacpp). Neither `git pull && build` nor any fixup above put
@@ -6627,7 +6688,7 @@ step_post_update() {
   # After step_systemd_services and step_resource_limits above: the helper
   # reaches the embedder through the proxy, which starts clawbox-embed.service
   # through a sudoers grant those two steps install.
-  ensure_local_embeddings || echo "  Warning: local embeddings check failed (non-fatal)"
+  optional_step local_embeddings_check ensure_local_embeddings
   # The embedder used to live inside ollama, which may still be holding the
   # old copy (2.8 GB). `stop`, never `disable`: the runtime's own standby
   # convention, and the chat path can still wake it on demand. After the
@@ -6639,10 +6700,10 @@ step_post_update() {
   # missing start left local AI dead under a `completed` update, because
   # nothing runs after post_update that would have woken it.
   pause_engine_unit ollama.service
-  step_llamacpp_model || echo "  Warning: llamacpp_model step failed (non-fatal)"
+  optional_step llamacpp_model step_llamacpp_model
   # Hermes re-provisioning is deliberately NOT called here. The in-app updater
   # dispatches `hermes_edition` as its own step immediately after this one, so a
-  # failure is reported instead of swallowed by `|| echo "(non-fatal)"`.
+  # failure fails the STEP rather than being recorded as a skipped fixup.
   # Ordering is unchanged (still after step_systemd_services). Fresh installs
   # call step_hermes_edition directly and are unaffected.
   # Deliberately NO `systemctl restart clawbox-setup` here. The web server reads
@@ -6650,13 +6711,16 @@ step_post_update() {
   # (src/lib/edition-source.ts stats the file per call and caches by mtime), so
   # the re-baked lock above is live immediately — while restarting the server
   # mid-update would kill the very process the updater is polling for progress.
-  step_update_smoke || echo "  Warning: update_smoke reported issues (non-fatal)"
+  optional_step update_smoke step_update_smoke
   # LAST, and after the smokes: ollama was stopped above to make it drop the
   # stale embedder copy, and the memory stays free for step_llamacpp_model's
   # download until here. A stopped-then-started ollama holds no model, so the
   # 2.8 GB the stop was for is still released — what comes back is the idle
   # server the box had before the update, which is the whole point of the pair.
   resume_paused_engines
+  # LAST WORD: the failures collected above, in the line the updater turns into
+  # a warning on the update's status. Silent on a healthy run.
+  report_optional_step_failures
 }
 
 gateway_port_listening() {
@@ -6764,10 +6828,11 @@ step_gateway_legacy_state_recovery() {
       return 0
     fi
     # The same observable state as the tail of this function — alive and not
-    # listening — so the same status. `step_post_update` calls this step as
-    # `… || echo "Warning: …"`, so a non-zero return is a warning in the update
-    # log and not a failed update; returning 0 here made a gateway that never
-    # binds its port produce a clean step.
+    # listening — so the same status. `step_post_update` calls this step through
+    # `optional_step`, so a non-zero return is a RECORDED warning — on the
+    # update's own status, not only in the log — and never a failed update;
+    # returning 0 here made a gateway that never binds its port produce a clean
+    # step.
     echo "  Warning: the gateway holds its state directory but is not listening on ${gw_port}; not restarting over a live gateway" >&2
     return 1
   fi
@@ -6830,6 +6895,16 @@ step_gateway_legacy_state_recovery() {
 }
 
 step_update_smoke() {
+  # WHAT THE SMOKES FOUND, in a return code the caller can report.
+  #
+  # Every finding below is a `[WARN]` line and the step returned 0 either way,
+  # so a gateway that was not reachable after an update, or an auth token the
+  # update left weak, reached the journal and nothing else — while the run said
+  # "Applying system fixups: completed". `optional_step` records a non-zero
+  # return as a skipped fixup and re-states it on the marker line the updater
+  # turns into a warning; it still cannot fail the update, which is what
+  # "ALWAYS non-fatal" meant and still means.
+  local SMOKE_FINDINGS=0
   # Advisory post-update smokes (#151). The rest of post_update only confirms
   # services are *running* — these confirm two flows that can silently break
   # across an update while health still looks green: gateway auth continuity
@@ -6849,6 +6924,7 @@ step_update_smoke() {
     echo "    [ok] gateway reachable"
   else
     echo "    [WARN] gateway not reachable (HTTP $gw_code) — Control UI/chat may be down"
+    SMOKE_FINDINGS=1
   fi
   local tok_state
   tok_state=$(as_clawbox python3 -c '
@@ -6878,7 +6954,7 @@ else:
 ' "$OPENCLAW_CONFIG" 2>/dev/null || echo "missing")
   case "$tok_state" in
     strong|secretref|interp) echo "    [ok] gateway auth token is strong ($tok_state)" ;;
-    *) echo "    [WARN] gateway auth token is weak/missing ($tok_state) — LAN auth may be bypassable" ;;
+    *) echo "    [WARN] gateway auth token is weak/missing ($tok_state) — LAN auth may be bypassable"; SMOKE_FINDINGS=1 ;;
   esac
 
   # 2) Telegram bot identity (getMe) — only when a bot token is configured.
@@ -6893,7 +6969,9 @@ except Exception:
 ' "$OPENCLAW_CONFIG" 2>/dev/null || echo "")
   if [ -z "$TG_TOKEN" ]; then
     echo "    [skip] no Telegram bot configured"
-    return 0
+    # A box with no bot is not a finding, but the gateway smokes above may
+    # already have made one.
+    return "$SMOKE_FINDINGS"
   fi
   local getme
   getme=$(curl -s -m 8 "https://api.telegram.org/bot${TG_TOKEN}/getMe" 2>/dev/null \
@@ -6904,6 +6982,7 @@ except Exception: print("no")' 2>/dev/null || echo "no")
     echo "    [ok] Telegram bot identity verified (getMe)"
   else
     echo "    [WARN] Telegram getMe failed — bot token may be invalid/revoked, or network unavailable"
+    SMOKE_FINDINGS=1
   fi
 
   # 3) Real delivery smoke — QA only, gated behind a chat id so production
@@ -6921,9 +7000,10 @@ except Exception: print("")' 2>/dev/null || echo "")
       echo "    [ok] Telegram delivery smoke sent (message_id=$msg_id)"
     else
       echo "    [WARN] Telegram delivery smoke failed to send"
+      SMOKE_FINDINGS=1
     fi
   fi
-  return 0
+  return "$SMOKE_FINDINGS"
 }
 
 step_polkit_rules() {

--- a/install.sh
+++ b/install.sh
@@ -3463,6 +3463,10 @@ step_hermes_install() {
   local venv_python="$agent_dir/venv/bin/python"
   local installed=""
   local pin="$HERMES_PIN_COMMIT"
+  # Whether an upgrade this step performed landed somewhere other than the pin.
+  # `local`, so a second call in one shell cannot inherit the first one's
+  # answer.
+  local _hermes_off_pin=0
 
   # The pin is spliced into a URL below and the file that URL returns is piped
   # into bash, so it is validated before it is used. A malformed value — a tag
@@ -3683,6 +3687,12 @@ step_hermes_install() {
     if [ "$at_commit" = "$pin" ]; then
       echo "  Hermes installed ($installed) at the pinned commit"
     else
+      # An upgrade that did not reach the pin is a fixup that did not do its
+      # job, and the warning below is stderr — which reaches the journal and
+      # nothing else. `optional_step` reads the RETURN, so record it there too
+      # and let the update's own status carry it. Not a rollback and not fatal:
+      # the agent RUNS, and the copy moved aside was unpinned as well.
+      _hermes_off_pin=1
       # The agent RUNS, so it is NOT rolled back: a working unpinned agent is
       # worth more than the copy moved aside, which was unpinned too. Loud,
       # because it means the pin did not take — upstream dropping
@@ -3765,7 +3775,12 @@ step_hermes_install() {
   # The same two-part test the step's own probe makes (a shim alone is a
   # four-line wrapper and proves nothing about the agent under ~/.hermes).
   if [ -x "$shim" ] && [ -x "$venv_python" ]; then
-    return 0
+    # Runnable — and `$_hermes_off_pin` is the second half of the answer: an
+    # install that landed off the pin leaves the box working on a build we do
+    # not ship, which the fleet has to hear about even though nothing here is
+    # broken. Default 0, so every path that never attempted an upgrade returns
+    # 0 exactly as before.
+    return "$_hermes_off_pin"
   fi
   echo "  Warning: the Hermes agent is still not runnable after this step" >&2
   return 1

--- a/install.sh
+++ b/install.sh
@@ -3570,6 +3570,12 @@ step_hermes_install() {
     echo "  Hermes runs but is not on the pinned commit — upgrading"
     echo "    have: ${at_commit:-unknown (not a git checkout)}"
     echo "    want: $pin"
+    # The box is off the pin from here until the post-install check says
+    # otherwise. Set BEFORE the attempt rather than after a failed one, because
+    # the interesting failure restores the old off-pin agent and never reaches
+    # the post-install branch at all — the upgrade did not happen and the step
+    # would have answered success over it.
+    _hermes_off_pin=1
   fi
 
   # NOTHING above this line has modified the disk, and nothing below it does
@@ -3685,6 +3691,9 @@ step_hermes_install() {
     at_commit=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
       git -C "$agent_dir" rev-parse HEAD 2>/dev/null) || at_commit=""
     if [ "$at_commit" = "$pin" ]; then
+      # The upgrade landed. Whatever this step found on arrival, the box is on
+      # the build we ship.
+      _hermes_off_pin=0
       echo "  Hermes installed ($installed) at the pinned commit"
     else
       # An upgrade that did not reach the pin is a fixup that did not do its

--- a/install.sh
+++ b/install.sh
@@ -7224,7 +7224,11 @@ ensure_local_embeddings() {
   fi
   if [ ! -x "$helper" ]; then
     echo "  Warning: $helper is missing or not executable - semantic memory stays on lexical FTS" >&2
-    return 0
+    # Non-zero, and `optional_step` is what makes that safe: the helper being
+    # absent from the checkout is this installer's own gap, not a state of the
+    # box, and reporting it as a completed fixup is the false success this
+    # whole change removes.
+    return 1
   fi
   step_embed_model || echo "  Warning: memory-search model cache failed (non-fatal; the embedder fetches it on first use)"
   as_clawbox_login "timeout -k 10 600 $helper" || true
@@ -7299,8 +7303,17 @@ else:
 PY
 )"
   fi
+  # Which of the states below are FINDINGS — something this run could not do or
+  # could not read — as opposed to facts about a box that is configured the way
+  # its owner configured it. Only the findings answer non-zero, because
+  # `optional_step` renders a non-zero return as "this fixup failed and was
+  # skipped": saying that over a deliberate cloud embedder, or over memory
+  # search the owner switched off, would be a false failure in place of the
+  # false success.
+  local EMBED_FINDINGS=0
   case "$EMBED_STATE" in
     unknown)
+      EMBED_FINDINGS=1
       echo "  WARN: memory search is on an OpenAI-compatible embedder with no address recorded, so this run cannot say whether it is on this box; the Memory Shard app shows the real state"
       ;;
     local:qwen3-embedding-0.6b)
@@ -7323,6 +7336,7 @@ PY
       ;;
     noparser)
       # Named as the installer's own gap, not the core's.
+      EMBED_FINDINGS=1
       echo "  WARN: python3 is not installed on this box, so this run cannot read the embedder answer the core gave; the Memory Shard app shows the real state"
       ;;
     disabled)
@@ -7333,10 +7347,15 @@ PY
       # answer": the CLI was missing, failed or timed out; its output could
       # not be parsed; or the core answered and named no provider at all --
       # providerLocation()'s own "unknown".
+      EMBED_FINDINGS=1
       echo "  WARN: could not read an embedder from the core (openclaw memory status did not answer, or named no provider), so this run puts no verdict on semantic memory; the Memory Shard app shows the real state"
       ;;
   esac
-  return 0
+  # A cloud embedder and a switched-off memory search are deliberately NOT
+  # findings: both are states an owner chose and the Memory Shard app can
+  # change, and an update that called them failed fixups would cry wolf on
+  # every run.
+  return "$EMBED_FINDINGS"
 }
 
 step_ollama_install() {

--- a/src/lib/update-lock.ts
+++ b/src/lib/update-lock.ts
@@ -1,4 +1,5 @@
-import { get, set } from "./config-store";
+import fs from "fs";
+import { get, set, setMany } from "./config-store";
 
 /**
  * "An update owns this box right now" — persisted, so a surface that is NOT the
@@ -24,6 +25,99 @@ import { get, set } from "./config-store";
  */
 export const UPDATE_LOCK_KEY = "update_in_progress";
 
+/**
+ * WHO holds the lock, so a second process can tell a running update from a dead
+ * one.
+ *
+ * The flag alone says "an update owns this box", and a web server that starts
+ * WHILE one is running reads exactly what a web server that starts after a
+ * crashed one reads. The updater's continuation check treated both as the
+ * crash: it released the lock and stamped `update_interrupted_at`, so a run
+ * whose last two steps were still landing in the old process was reported
+ * `failed` with every step pending — on a box whose journal shows every step
+ * completing and BUILD IDENTITY OK (observed on the OpenClaw box, 2026-09-07).
+ * A false failure over an update that worked.
+ *
+ * The pid is meaningless on its own — pids are reused, and this flag
+ * deliberately outlives the reboot the update performs — so the BOOT ID is
+ * recorded with it. A record from another boot proves nothing and is ignored,
+ * which is exactly today's behaviour.
+ */
+export const UPDATE_LOCK_HOLDER_KEY = "update_lock_holder";
+
+interface UpdateLockHolder {
+  pid: number;
+  /** `/proc/sys/kernel/random/boot_id`, or null where it cannot be read. */
+  bootId: string | null;
+  /**
+   * Field 22 of `/proc/<pid>/stat` — when the process started, in clock ticks
+   * since boot. A pid is not an identity: the kernel wraps `pid_max` and an
+   * update spawns thousands of processes through install.sh, so on a long
+   * uptime a later, unrelated process can land on the dead holder's pid. Then
+   * `kill(pid, 0)` succeeds, the lock is never released and the owner is
+   * redirected to /updating until the box reboots — strictly worse than the
+   * behaviour this record exists to improve. (pid, start time) is unique within
+   * a boot, and the boot id makes it unique across them.
+   */
+  startedTicks: string | null;
+  /**
+   * When this record was written. `setUpdateLock` is called at EVERY step
+   * boundary, so it is a heartbeat: a lock whose `at` is younger than the
+   * longest step's budget belongs to a run that is still moving, whichever
+   * process is moving it.
+   */
+  at: string;
+}
+
+function currentBootId(): string | null {
+  try {
+    return fs.readFileSync("/proc/sys/kernel/random/boot_id", "utf-8").trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function parseHolder(value: unknown): UpdateLockHolder | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as { pid?: unknown; bootId?: unknown; startedTicks?: unknown; at?: unknown };
+  if (typeof raw.pid !== "number" || !Number.isInteger(raw.pid) || raw.pid <= 0) return null;
+  return {
+    pid: raw.pid,
+    bootId: typeof raw.bootId === "string" ? raw.bootId : null,
+    startedTicks: typeof raw.startedTicks === "string" ? raw.startedTicks : null,
+    at: typeof raw.at === "string" ? raw.at : "",
+  };
+}
+
+/**
+ * When a process started, from `/proc/<pid>/stat` field 22.
+ *
+ * Read by the string rather than parsed: it is only ever compared with itself.
+ * The executable name in field 2 can contain spaces and brackets, so the fields
+ * are counted from the closing parenthesis, which is what `proc(5)` says to do.
+ */
+function processStartTicks(pid: number): string | null {
+  try {
+    const stat = fs.readFileSync(`/proc/${pid}/stat`, "utf-8");
+    const after = stat.slice(stat.lastIndexOf(")") + 2).trim().split(/\s+/);
+    // field 3 is the first after the name, so field 22 is index 19 here.
+    return after[19] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * How long a lock may go unrefreshed before it stops counting as a live run.
+ *
+ * `setUpdateLock` is re-called at every step boundary, and the longest step
+ * (`post_update`) is budgeted at 15 minutes, so 20 gives the slowest healthy
+ * run room without holding a crashed one's lock for long. The boot-time check
+ * that releases an abandoned lock still runs; this only decides whether the
+ * release happens now or at the next boot.
+ */
+const HOLDER_HEARTBEAT_MS = 20 * 60 * 1000;
+
 /** Where the owner is sent while the box updates. */
 export const UPDATING_PAGE = "/updating";
 
@@ -40,7 +134,20 @@ export const UPDATING_PAGE = "/updating";
  */
 export async function setUpdateLock(): Promise<boolean> {
   try {
-    await set(UPDATE_LOCK_KEY, true);
+    // The holder rides with the flag, in one read-modify-write — of THIS
+    // process. install.sh and gateway-pre-start.sh write the same file
+    // unlocked, so the pair can still be split by a cross-process interleave;
+    // when it is, the reader finds no holder and falls back to the behaviour it
+    // had before this record existed, which is the safe direction.
+    await setMany({
+      [UPDATE_LOCK_KEY]: true,
+      [UPDATE_LOCK_HOLDER_KEY]: {
+        pid: process.pid,
+        bootId: currentBootId(),
+        startedTicks: processStartTicks(process.pid),
+        at: new Date().toISOString(),
+      },
+    });
     return true;
   } catch (err) {
     console.warn(
@@ -59,7 +166,7 @@ export async function setUpdateLock(): Promise<boolean> {
  */
 export async function clearUpdateLock(): Promise<boolean> {
   try {
-    await set(UPDATE_LOCK_KEY, undefined);
+    await setMany({ [UPDATE_LOCK_KEY]: undefined, [UPDATE_LOCK_HOLDER_KEY]: undefined });
     return true;
   } catch (err) {
     console.warn(
@@ -76,4 +183,51 @@ export async function isUpdateLocked(): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+/**
+ * Is the lock held by an update that is STILL RUNNING, in another process on
+ * this boot?
+ *
+ * False for everything it cannot prove: no holder recorded (a lock taken by a
+ * build that predates this record), a holder from another boot (pids are reused
+ * and this flag outlives a reboot), this very process (it is the reader, not a
+ * second one), or a pid that is gone. Each of those falls back to exactly the
+ * behaviour before the record existed.
+ *
+ * `process.kill(pid, 0)` sends no signal; `EPERM` means the process is there
+ * and belongs to somebody else, which is still ALIVE.
+ */
+export async function updateLockHeldByLiveProcess(): Promise<boolean> {
+  let holder: UpdateLockHolder | null = null;
+  try {
+    holder = parseHolder(await get(UPDATE_LOCK_HOLDER_KEY));
+  } catch {
+    return false;
+  }
+  if (!holder || holder.pid === process.pid) return false;
+  const boot = currentBootId();
+  if (!boot || !holder.bootId || boot !== holder.bootId) return false;
+  // THE HEARTBEAT FIRST, because it is the half that survives the holder's
+  // death. Every replacement path in this repo kills the old web server before
+  // the new one starts — `do_rebuild` stops the unit, and systemd's restart
+  // waits for the cgroup to empty — so by the time the successor asks, the
+  // process that was mid-update is usually gone while its RUN is not: the root
+  // step it dispatched is still working, and `update_needs_continuation` has
+  // not been written yet. A record refreshed at the last step boundary is what
+  // says so.
+  const at = Date.parse(holder.at);
+  if (Number.isFinite(at) && Date.now() - at < HOLDER_HEARTBEAT_MS && Date.now() >= at) return true;
+  // …and the live process, for the case the two really do overlap. (pid, start
+  // time) rather than the pid alone: see `startedTicks`.
+  try {
+    process.kill(holder.pid, 0);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code !== "EPERM") return false;
+  }
+  const ticks = processStartTicks(holder.pid);
+  // A recorded start time that cannot be compared proves nothing, and a pid
+  // whose process started at a different time is a different process.
+  if (!holder.startedTicks || !ticks) return false;
+  return holder.startedTicks === ticks;
 }

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -23,7 +23,7 @@ import { waitForPortOpen } from "./port-probe";
 import { parseHermesVersion } from "./version-utils";
 import { isSafeBranch } from "./update-branch";
 import { startRootStep } from "./root-step-runner";
-import { setUpdateLock, clearUpdateLock, isUpdateLocked } from "./update-lock";
+import { setUpdateLock, clearUpdateLock, isUpdateLocked, updateLockHeldByLiveProcess } from "./update-lock";
 
 /**
  * "An update was accepted and then lost its process" — written where the lock
@@ -599,6 +599,107 @@ function getStepFailureLine(logText: string, unit: string): string | null {
     if (/^(?:error|fatal)\b/i.test(lines[i])) return lines[i];
   }
   return lines[lines.length - 1];
+}
+
+/**
+ * The marker install.sh writes for a fixup that failed WITHOUT failing its step.
+ *
+ * `step_post_update` runs nineteen fixups, every one of them non-fatal by
+ * design — refusing to finish an update because a VNC unit refresh failed would
+ * be the worse outcome — and each said so with `|| echo "  Warning: …"`, which
+ * reaches the journal and nothing else. The step exits 0, so the run reported
+ * "Applying system fixups" completed and the owner was told an update had
+ * worked in full when part of it had not. install.sh now re-states those
+ * failures on `CLAWBOX-WARN[<code>]:` lines, and the two `openclaw doctor --fix`
+ * refusals in `step_openclaw_install` carry the same marker.
+ *
+ * The CODE is part of the marker rather than derived from the prose, so a
+ * condition install.sh reports and a condition this file reports for itself
+ * collapse to one card: `warnUpdate` de-duplicates by code, and the doctor
+ * refusal is raised on both paths (`runOpenclawDoctorFix` during
+ * `gateway_verify`, and install.sh's own call inside `step_openclaw_install`).
+ *
+ * NOT a channel invented beside an existing one. install.sh's
+ * `record_provision_failure` is the non-fatal-failure channel it already has —
+ * and it is fatal by construction: it makes the dispatched step's exit code
+ * non-zero, which paints a whole good update red over a VNC refresh. Its own
+ * comment asks for exactly this ("there is no quieter surface for it today.
+ * Whoever adds one should start here", install.sh:1699-1705); this is that
+ * surface, and that block now points at it.
+ *
+ * `CLAWBOX-WARN[code]: message`, or `CLAWBOX-WARN: message` with no code.
+ */
+const STEP_WARNING_LINE = /^CLAWBOX-WARN(?:\[([a-z0-9._:-]{1,60})\])?:\s*(.+)$/i;
+
+/** How much of a marker line reaches the owner's card. */
+const STEP_WARNING_MAX_CHARS = 300;
+
+/**
+ * The systemd invocation of the run that JUST happened, so the journal read
+ * below cannot answer with an older one.
+ *
+ * `journalctl -u <unit>` returns that unit's whole history — the journal is
+ * persistent on this box (`step_persistent_journal` makes sure of it) — so a
+ * marker from last week's update, or from a failed run the owner retried five
+ * minutes ago, would be raised over a run that did not produce it. That is a
+ * false failure created by the reader. Systemd's own per-start id is the exact
+ * bound, and it costs one `systemctl show`; where it cannot be read, nothing is
+ * raised, because a guess about WHICH run a warning came from is worse than no
+ * warning at all.
+ */
+async function rootStepInvocationId(stepId: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFile(
+      "/usr/bin/systemctl",
+      ["show", `clawbox-root-update@${stepId}.service`, "-p", "InvocationID", "--value"],
+      { timeout: 10_000 },
+    );
+    const id = String(stdout ?? "").trim();
+    return /^[0-9a-f]{32}$/i.test(id) ? id : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Raise every marker THIS invocation of a root step left in its journal.
+ *
+ * Read after the step settles, whatever its outcome: a step that failed reports
+ * through its own error, and one that succeeded — or overran its advisory
+ * budget — over a fixup that did not is the case nothing else could see.
+ * Bounded like `readRootStepFailure` and never fatal: a journal that cannot be
+ * read must not fail an update that worked.
+ */
+async function collectRootStepWarnings(stepId: string): Promise<void> {
+  const invocation = await rootStepInvocationId(stepId);
+  if (!invocation) return;
+  let stdout = "";
+  try {
+    ({ stdout } = await execFile(
+      "/usr/bin/journalctl",
+      [`_SYSTEMD_INVOCATION_ID=${invocation}`, "-n", "500", "--no-pager", "-o", "cat"],
+      { timeout: 10_000 },
+    ));
+  } catch {
+    return;
+  }
+  const seen = new Set<string>();
+  for (const raw of String(stdout ?? "").split(/\r?\n/)) {
+    // ANCHORED. `step_openclaw_install` prints doctor's whole transcript
+    // verbatim, and other steps print git/npm output: a line that merely
+    // QUOTES the marker is not this box raising a warning.
+    const match = STEP_WARNING_LINE.exec(raw.trim());
+    if (!match) continue;
+    const code = match[1] ? match[1].toLowerCase() : `step-warning:${stepId}`;
+    const message = match[2].trim().slice(0, STEP_WARNING_MAX_CHARS);
+    if (!message || seen.has(code)) continue;
+    seen.add(code);
+    warnUpdate(code, message);
+  }
+  // PERSISTED, like the drift warnings beside them: the premise of this whole
+  // branch is that the web server is replaced mid-run, and the second half
+  // restores its warnings from disk.
+  if (seen.size > 0) await persistWarnings();
 }
 
 async function readRootStepFailure(stepId: string): Promise<string | null> {
@@ -3794,6 +3895,23 @@ async function resumeContinuation(): Promise<boolean> {
     // runs on every status poll, so an unconditional clear would rewrite that
     // file every two seconds — beside install.sh and the gateway, which have it
     // open by their own paths.
+    // NOT AN INTERRUPTION WHILE THE UPDATE IS STILL RUNNING. This branch's whole
+    // evidence is "the lock is held and there is nothing to resume", and that is
+    // ALSO what a second web server sees while the first one is still working
+    // through the steps — an update restarts this process by design, and the old
+    // one keeps going until its last step lands. Read as a crash, the new
+    // process released the lock and stamped `update_interrupted_at`, so a run
+    // whose journal shows every step completing and BUILD IDENTITY OK was
+    // reported failed with all thirteen steps pending (the OpenClaw box,
+    // 2026-09-07). The lock records WHO took it, so "still running" and "died"
+    // are now different answers; everything it cannot prove falls back to the
+    // behaviour above.
+    if (await updateLockHeldByLiveProcess()) {
+      console.log(
+        "[Updater] The lock is held by an update still running in another process — leaving it alone.",
+      );
+      return false;
+    }
     const released = (await isUpdateLocked()) && (await clearUpdateLock());
     const markers = await readSettledMarkers();
     // A store that could not be read decides NOTHING — it neither stamps a
@@ -4098,6 +4216,10 @@ async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: Run
           maxBuffer: 2 * 1024 * 1024,
         });
       }
+      // A root step that SUCCEEDED can still have skipped a fixup: install.sh's
+      // non-fatal steps say so on a `CLAWBOX-WARN:` line, and this is where
+      // that reaches the owner instead of only the journal.
+      if (step.requiresRoot) await collectRootStepWarnings(step.id);
       state.steps[i].status = "completed";
       console.log(`[Updater] Completed: ${step.label}`);
     } catch (err) {
@@ -4106,6 +4228,11 @@ async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: Run
       // gateway writers have already waited for the root unit to settle before
       // reaching this catch, so advancing cannot overlap its remaining work.
       if (err instanceof BudgetOverrunError && step.advisoryOnOverrun) {
+        // The marker is read HERE too. `post_update` is the one advisory step,
+        // and an overrun is its ORDINARY shape on the repair path (a Hermes
+        // clone plus a 3.2 GB model fetch) — so this is the run most likely to
+        // have skipped a fixup, and the one where the step is shown green.
+        if (step.requiresRoot) await collectRootStepWarnings(step.id);
         state.steps[i].status = "completed";
         console.warn(`[Updater] ${step.label}: ${message} — treating as advisory`);
         continue;
@@ -4117,6 +4244,11 @@ async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: Run
         const rootFailure = await readRootStepFailure(step.id);
         if (rootFailure) message = rootFailure;
       }
+      // A step that FAILED can still have skipped fixups before it did, and the
+      // list of them is the only record of which. Raised as warnings beside the
+      // step's own error, never instead of it — `state.steps[i].error` below is
+      // untouched.
+      if (step.requiresRoot) await collectRootStepWarnings(step.id);
       state.steps[i].status = "failed";
       state.steps[i].error = message;
       console.error(`[Updater] Failed: ${step.label} — ${message}`);

--- a/src/tests/unit/clawbox-firewall-policy.test.ts
+++ b/src/tests/unit/clawbox-firewall-policy.test.ts
@@ -408,7 +408,7 @@ describe("the installer wiring", () => {
       install.indexOf("gateway_port_listening()"),
     );
     // `optional_step` is what makes it non-fatal now: it cannot fail the step and it RECORDS the name, so a skipped fixup reaches the update's own status through the `CLAWBOX-WARN:` line instead of only the journal.
-    expect(postUpdate).toMatch(/step_firewall \|\| echo|optional_step \S+ step_firewall/);
+    expect(postUpdate).toMatch(/optional_step \S+ step_firewall\b/);
   });
 
   it("runs it on a fresh install too", () => {

--- a/src/tests/unit/clawbox-firewall-policy.test.ts
+++ b/src/tests/unit/clawbox-firewall-policy.test.ts
@@ -407,7 +407,8 @@ describe("the installer wiring", () => {
       install.indexOf("step_post_update() {"),
       install.indexOf("gateway_port_listening()"),
     );
-    expect(postUpdate).toMatch(/step_firewall \|\| echo/);
+    // `optional_step` is what makes it non-fatal now: it cannot fail the step and it RECORDS the name, so a skipped fixup reaches the update's own status through the `CLAWBOX-WARN:` line instead of only the journal.
+    expect(postUpdate).toMatch(/step_firewall \|\| echo|optional_step \S+ step_firewall/);
   });
 
   it("runs it on a fresh install too", () => {

--- a/src/tests/unit/ensure-local-embeddings.test.ts
+++ b/src/tests/unit/ensure-local-embeddings.test.ts
@@ -819,6 +819,14 @@ describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
 
   interface Report {
     out: string;
+    /**
+     * What the block ANSWERED — 0 when it had nothing to report, non-zero for a
+     * state it could not read or do. `step_post_update` runs it through
+     * `optional_step`, which records that without failing the update, so the
+     * fixture below calls it the same way (`if "$@"`) rather than bare under
+     * `set -e`.
+     */
+    rc: number;
     /** Every argv the stub `openclaw` was called with, one per line. */
     cliCalls: string;
     /** One line per stub invocation: "model-step" for step_embed_model, "ran" for the helper. */
@@ -837,6 +845,7 @@ describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
     const project = path.join(dir, "device", "project");
     const stubBin = path.join(dir, "device", "bin");
     const cliLog = path.join(dir, "device", "openclaw-calls.log");
+    const rcLog = path.join(dir, "device", "rc.log");
     const stepLog = path.join(dir, "device", "steps.log");
     mkdirSync(path.join(home, ".openclaw"), { recursive: true });
     mkdirSync(path.join(project, "scripts"), { recursive: true });
@@ -890,7 +899,11 @@ describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
       "ensure_local_embeddings() {",
       BLOCK,
       "}",
-      "ensure_local_embeddings",
+      // EXACTLY how `optional_step` invokes it on the box: `if "$@"`, which is
+      // what makes a non-zero answer a recorded warning rather than an aborted
+      // step. Bare under `set -e` this fixture would stop at the first honest
+      // "could not read the core" and call the contract broken.
+      `if ensure_local_embeddings; then printf '0\\n' > ${JSON.stringify(rcLog)}; else printf '%s\\n' "$?" > ${JSON.stringify(rcLog)}; fi`,
       "",
     ].join("\n");
 
@@ -903,6 +916,7 @@ describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
     expect(run.status).toBe(0);
     return {
       out: `${run.stdout ?? ""}${run.stderr ?? ""}`,
+      rc: existsSync(rcLog) ? Number(readFileSync(rcLog, "utf-8").trim()) : -1,
       cliCalls: existsSync(cliLog) ? readFileSync(cliLog, "utf-8") : "",
       steps: existsSync(stepLog) ? readFileSync(stepLog, "utf-8").trim().split("\n").filter(Boolean) : [],
     };
@@ -928,6 +942,8 @@ describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
 
   it("caches the model first, then runs the helper, then asks the core", () => {
     const run = report({ cli: status(PROVIDER) });
+    // A healthy on-device embedder has nothing to report.
+    expect(run.rc).toBe(0);
     expect(run.steps).toEqual(["model-step", "ran"]);
     expect(run.cliCalls).toContain("memory status --agent main --deep --json");
     // -k, because `timeout` alone sends SIGTERM only and
@@ -953,6 +969,10 @@ describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
     expect(run.out).not.toContain(READY);
     expect(run.out).not.toMatch(/cloud/i);
     expect(run.out).toMatch(/no address recorded/i);
+    // And it ANSWERS that, so the update's own status carries it. It used to
+    // return 0 over every one of these, which made the `optional_step` wrapper
+    // in step_post_update inert for this helper.
+    expect(run.rc).toBe(1);
   });
 
   it("does not call a box on a stale legacy block ready", () => {
@@ -965,6 +985,10 @@ describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
     expect(run.out).not.toContain(READY);
     expect(run.out).toMatch(/cloud/i);
     expect(run.out).toContain("openai");
+    // Deliberately NOT a finding: a cloud embedder is a state an owner chose
+    // and the Memory Shard app can change, and `optional_step` renders a
+    // non-zero return as "this fixup failed and was skipped".
+    expect(run.rc).toBe(0);
   });
 
   it("treats the old on-device providers as local whatever the model is", () => {

--- a/src/tests/unit/failover-waits-for-route.test.ts
+++ b/src/tests/unit/failover-waits-for-route.test.ts
@@ -1099,8 +1099,16 @@ describe("the installer reports what it actually installed", () => {
       'record_provision_failure() { echo "provision-failure: $1"; }',
       body,
       opts.shape === "update"
-        // Verbatim from step_post_update.
-        ? 'step_nm_dispatcher || echo "  Warning: nm_dispatcher step failed (non-fatal)"'
+        // The shipped call shape, taken from install.sh rather than restated:
+        // `step_post_update` runs its fixups through `optional_step`, which
+        // cannot fail the step and RECORDS the name for the marker line the
+        // updater reads. A hand-written `|| echo` here would go on passing
+        // while the real call shape moved.
+        ? [
+            'POST_UPDATE_FAILED_STEPS=""',
+            shellFunction("optional_step"),
+            "optional_step nm_dispatcher step_nm_dispatcher",
+          ].join("\n")
         : "step_nm_dispatcher",
     ].join("\n");
 

--- a/src/tests/unit/install-codex-cli.test.ts
+++ b/src/tests/unit/install-codex-cli.test.ts
@@ -233,11 +233,14 @@ describe("delivery to devices already in the field", () => {
     expect(extractShellFunction("step_post_update")).toContain("step_codex_cli");
   });
 
-  it("post_update cannot be aborted by it", () => {
+  it("post_update cannot be aborted by it, and says so when it fails", () => {
+    // `optional_step` is what makes it non-fatal now, and unlike the bare
+    // `|| echo` it left behind it records the name — so a skipped install
+    // reaches the update's own status instead of only the journal.
     const line = extractShellFunction("step_post_update")
       .split("\n")
       .find((l) => l.includes("step_codex_cli"));
-    expect(line).toMatch(/\|\|\s*echo/);
+    expect(line).toMatch(/\|\|\s*echo|optional_step \S+ step_codex_cli/);
   });
 
   it("a fresh install ships it too", () => {

--- a/src/tests/unit/install-codex-cli.test.ts
+++ b/src/tests/unit/install-codex-cli.test.ts
@@ -240,7 +240,7 @@ describe("delivery to devices already in the field", () => {
     const line = extractShellFunction("step_post_update")
       .split("\n")
       .find((l) => l.includes("step_codex_cli"));
-    expect(line).toMatch(/\|\|\s*echo|optional_step \S+ step_codex_cli/);
+    expect(line).toMatch(/^\s*optional_step \S+ step_codex_cli\b/);
   });
 
   it("a fresh install ships it too", () => {

--- a/src/tests/unit/install-coding-harness-repair.test.ts
+++ b/src/tests/unit/install-coding-harness-repair.test.ts
@@ -365,7 +365,7 @@ describe("a step that can now fail must not abort the install", () => {
     "install.sh:%s guards the call",
     (_line, text) => {
       // `optional_step` is the guard in post_update now: it cannot fail the step and it records the name, so a skipped repair reaches the update's own status rather than only the journal.
-      expect(text).toMatch(/\|\|\s*echo|optional_step \S+ /);
+      expect(text).toMatch(/(\|\|\s*echo)|(^\s*optional_step \S+ )/);
     },
   );
 });

--- a/src/tests/unit/install-coding-harness-repair.test.ts
+++ b/src/tests/unit/install-coding-harness-repair.test.ts
@@ -364,7 +364,8 @@ describe("a step that can now fail must not abort the install", () => {
   it.each(callSites.map((c) => [c.line, c.text] as const))(
     "install.sh:%s guards the call",
     (_line, text) => {
-      expect(text).toMatch(/\|\|\s*echo/);
+      // `optional_step` is the guard in post_update now: it cannot fail the step and it records the name, so a skipped repair reaches the update's own status rather than only the journal.
+      expect(text).toMatch(/\|\|\s*echo|optional_step \S+ /);
     },
   );
 });

--- a/src/tests/unit/install-coding-harness.test.ts
+++ b/src/tests/unit/install-coding-harness.test.ts
@@ -69,8 +69,9 @@ describe("delivery to devices already in the field", () => {
     // Every optional step in post_update is guarded; an unguarded one would
     // stop the update at whatever comes after it.
     const fn = extractShellFunction("step_post_update");
+    // `optional_step` is the guard in post_update now: it cannot fail the step and it records the name, so a skipped repair reaches the update's own status rather than only the journal.
     const line = fn.split("\n").find((l) => l.includes("step_coding_harness"));
-    expect(line).toMatch(/\|\|\s*echo/);
+    expect(line).toMatch(/\|\|\s*echo|optional_step \S+ step_coding_harness/);
   });
 });
 

--- a/src/tests/unit/install-coding-harness.test.ts
+++ b/src/tests/unit/install-coding-harness.test.ts
@@ -71,7 +71,7 @@ describe("delivery to devices already in the field", () => {
     const fn = extractShellFunction("step_post_update");
     // `optional_step` is the guard in post_update now: it cannot fail the step and it records the name, so a skipped repair reaches the update's own status rather than only the journal.
     const line = fn.split("\n").find((l) => l.includes("step_coding_harness"));
-    expect(line).toMatch(/\|\|\s*echo|optional_step \S+ step_coding_harness/);
+    expect(line).toMatch(/^\s*optional_step \S+ step_coding_harness\b/);
   });
 });
 

--- a/src/tests/unit/install-ensure-local-embeddings.test.ts
+++ b/src/tests/unit/install-ensure-local-embeddings.test.ts
@@ -386,7 +386,10 @@ describe("ensure_local_embeddings never fails the update", () => {
       'as_clawbox_login() { eval "$*"; }',
       `sed -n '/^ensure_local_embeddings() {/,/^}/p' "$1" > "${tmp}/fn.sh"`,
       `. "${tmp}/fn.sh"`,
-      "ensure_local_embeddings; echo RC=$?",
+      // Called the way `optional_step` calls it — `if "$@"` — so a non-zero
+      // return is REPORTED rather than aborting this fixture's own shell under
+      // `set -e`, which is exactly the difference the wrapper makes on the box.
+      "if ensure_local_embeddings; then echo RC=0; else echo RC=$?; fi",
     ].join(NL);
     let out: string;
     let code = 0;
@@ -408,13 +411,20 @@ describe("ensure_local_embeddings never fails the update", () => {
     expect(r.out).toContain("MODEL_STEP_RAN");
     expect(r.out).toContain("HELPER_RAN");
     expect(r.out.indexOf("MODEL_STEP_RAN")).toBeLessThan(r.out.indexOf("HELPER_RAN"));
-    expect(r.out).toContain("RC=0");
+    // The fixture's core is `/bin/false`, so nothing answers the status probe —
+    // the state the case below names — and the function now SAYS so instead of
+    // answering 0 over a verdict it could not read. It still cannot fail the
+    // update: `step_post_update` runs it through `optional_step`, which records
+    // the name and returns 0 itself.
+    expect(r.out).toContain("RC=1");
+    expect(r.out).toMatch(/could not read an embedder/i);
   });
 
   it("still runs the helper when the model cache fails — the unit fetches on first use", () => {
     const r = run({ modelStepFails: true });
     expect(r.out).toContain("HELPER_RAN");
-    expect(r.out).toContain("RC=0");
+    // Same fixture, same unanswered core (see above).
+    expect(r.out).toContain("RC=1");
   });
 
   it("bounds the helper so it cannot hold a quiesced gateway open for ever", () => {
@@ -428,9 +438,9 @@ describe("ensure_local_embeddings never fails the update", () => {
     expect(r.out).not.toContain("Local embeddings ready");
   });
 
+  // The two SKIPS: nothing to do on this box, so nothing to report.
   for (const [name, opts] of [
     ["a hermes box with no core to point at the model", { hermes: true }],
-    ["a checkout whose helper is missing", { helper: false }],
     ["the e2e container", { testMode: true }],
   ] as const) {
     it(`returns 0 on ${name}`, () => {
@@ -441,4 +451,17 @@ describe("ensure_local_embeddings never fails the update", () => {
       expect(r.out).not.toContain("MODEL_STEP_RAN");
     });
   }
+
+  it("reports a checkout whose helper is missing, rather than skipping it quietly", () => {
+    // Not a state of the box: the script is part of the tree the update just
+    // checked out, so its absence is this installer's own gap and the owner's
+    // memory search silently stays on lexical FTS. `optional_step` records it
+    // without failing the update.
+    const r = run({ helper: false });
+    // The sentence itself goes to stderr, which this fixture does not capture
+    // on a shell that exits 0; the RETURN is the contract `optional_step` reads.
+    expect(r.out).toContain("RC=1");
+    expect(r.out).not.toContain("HELPER_RAN");
+    expect(r.out).not.toContain("MODEL_STEP_RAN");
+  });
 });

--- a/src/tests/unit/install-ensure-local-embeddings.test.ts
+++ b/src/tests/unit/install-ensure-local-embeddings.test.ts
@@ -54,15 +54,16 @@ describe("the embedding model is repaired on an update, not only on a fresh inst
   const POST_UPDATE = shellCode(extractShellFunction("step_post_update"));
 
   it("post_update calls it", () => {
-    expect(POST_UPDATE).toMatch(/^\s*ensure_local_embeddings\b/m);
+    expect(POST_UPDATE).toMatch(/^\s*optional_step \S+ ensure_local_embeddings\b/m);
   });
 
   it("and cannot be failed by it", () => {
     // errexit is live and step bodies are called bare, so a missing embedding
     // model must never be the reason an update stops.
-    const line = POST_UPDATE.split(NL).find((l) => l.trim().startsWith("ensure_local_embeddings"));
+    // `optional_step` is what makes it non-fatal now: it cannot fail the step and it RECORDS the name, so a skipped fixup reaches the update's own status through the `CLAWBOX-WARN:` line instead of only the journal.
+    const line = POST_UPDATE.split(NL).find((l) => l.trim().endsWith("ensure_local_embeddings"));
     expect(line).toBeDefined();
-    expect(line).toContain("|| echo");
+    expect(line).toContain("optional_step ");
   });
 
   it("runs after the unit, its sudoers grant and its memory cap are installed", () => {

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -845,7 +845,11 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
 
     const r = run({ installHead: OTHER_COMMIT });
 
-    expect(r.code).toBe(0);
+    // Reported through the RETURN as well as the warning: the box works, but
+    // it is not on the build we ship, and `optional_step` in step_post_update
+    // is what carries that to the update's own status — a stderr line reaches
+    // the journal and nobody. It is still not fatal and still not rolled back.
+    expect(r.code).toBe(1);
     expect(r.out).toMatch(/but HEAD is/);
     expect(r.out).not.toMatch(/Restored the previous agent/);
     expect(exists(path.join(agentDir(), "venv", "bin", "python"))).toBe(true);

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -820,7 +820,12 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
 
     const r = run({ installOk: false });
 
-    expect(r.code).toBe(0);
+    // The box still RUNS, so nothing is broken and nothing is rolled forward —
+    // but the upgrade did not happen and the device is still on a build we do
+    // not ship, which is what the step now answers. This is the failure that
+    // never reaches the post-install check at all (the old agent is restored
+    // first), so the fact has to be recorded when the attempt STARTS.
+    expect(r.code).toBe(1);
     expect(r.out).toMatch(/Restored the previous agent/);
     expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("original");
     expect(headOf(agentDir())).toBe(OTHER_COMMIT);

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import fs, { readFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -40,6 +40,14 @@ vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 const REPO = process.cwd();
 const INSTALL_SH_PATH = path.join(REPO, "install.sh");
 const INSTALL_SH = readFileSync(INSTALL_SH_PATH, "utf-8");
+
+/** The call-site cases below start a real bash; skip where there is none. */
+let hasBash = true;
+try {
+  execFileSync("/bin/bash", ["-c", "true"], { stdio: "ignore" });
+} catch {
+  hasBash = false;
+}
 const UPDATER_TS = readFileSync(path.join(REPO, "src/lib/updater.ts"), "utf-8");
 
 const NL = String.fromCharCode(10);
@@ -1002,5 +1010,65 @@ describe("setup-hermes-edition.sh does not repeat the shim-only check", () => {
     const guard = SETUP_HERMES.split(NL).find((l) => l.includes('[ ! -x "$HERMES_BIN" ]'));
     expect(guard).toBeDefined();
     expect(guard).toContain('[ ! -x "$HERMES_VENV_PYTHON" ]');
+  });
+});
+
+/**
+ * The step answers non-zero now — for an agent it could not make runnable, and
+ * for an upgrade that landed off the pin. That is what `optional_step` reads on
+ * the UPDATE path. On the FULL-INSTALL path there is no wrapper: install.sh
+ * runs under `set -euo pipefail` and the only `trap … EXIT` is armed inside the
+ * `--step` block, which exits long before. A bare call there would abort the
+ * whole installer at that line — before the services, VNC and the provisioning
+ * verdict — so a fresh hermes or dual box whose Hermes fetch failed would leave
+ * the flash host with no PROVISIONING INCOMPLETE banner and no
+ * `[provision-status]` sentinel at all, with the marker already invalidated.
+ */
+describe.skipIf(!hasBash)("its call sites, where errexit is live", () => {
+  /** The one top-level call: column 0, not the definition. */
+  const topLevelCall = INSTALL_SH.split(NL).find(
+    (l) => /^step_hermes_install\b/.test(l) && !l.includes("() {"),
+  );
+
+  it("is guarded on the full-install path", () => {
+    expect(topLevelCall, "the top-level call has moved or vanished").toBeDefined();
+    expect(topLevelCall).toMatch(/^step_hermes_install\s*\|\|/);
+  });
+
+  /** Run one line under install.sh's own shell options with the step failing. */
+  function afterFailedStep(callLine: string): { out: string; code: number } {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-hermes-callsite-"));
+    try {
+      const script = path.join(dir, "run.sh");
+      fs.writeFileSync(
+        script,
+        [
+          // install.sh:22, verbatim — the condition that makes this matter.
+          "set -euo pipefail",
+          "step_hermes_install() { echo STEP_FAILED >&2; return 1; }",
+          callLine,
+          // Everything the installer still has to do: the services, VNC, and
+          // the verdict banner the flash host reads.
+          'echo "PROVISIONING VERDICT REACHED"',
+        ].join(NL),
+      );
+      const r = spawnSync("/bin/bash", [script], { encoding: "utf-8", timeout: 20_000 });
+      return { out: `${r.stdout ?? ""}${r.stderr ?? ""}`, code: r.status ?? -1 };
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("lets the installer reach its verdict when Hermes could not be installed", () => {
+    const r = afterFailedStep(topLevelCall!);
+    expect(r.code, r.out).toBe(0);
+    expect(r.out).toContain("STEP_FAILED");
+    expect(r.out).toContain("PROVISIONING VERDICT REACHED");
+  });
+
+  it("…which a bare call would not, so the case above is not vacuous", () => {
+    const r = afterFailedStep("step_hermes_install");
+    expect(r.code).not.toBe(0);
+    expect(r.out).not.toContain("PROVISIONING VERDICT REACHED");
   });
 });

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -299,19 +299,29 @@ describe("an in-app update can heal a device a factory reset broke", () => {
     // Without this the ONLY repair path was SSH. The in-app updater runs
     // post_update and rebuild_reboot; neither reached step_hermes_install, so
     // clicking UPDATE on a bricked box did nothing for it.
-    expect(POST_UPDATE).toMatch(/^\s*step_hermes_install\b/m);
+    expect(POST_UPDATE).toMatch(/^\s*optional_step \S+ step_hermes_install\b/m);
   });
 
   it("post_update re-caches the offline model", () => {
-    expect(POST_UPDATE).toMatch(/^\s*step_llamacpp_model\b/m);
+    expect(POST_UPDATE).toMatch(/^\s*optional_step \S+ step_llamacpp_model\b/m);
   });
 
-  it("both are non-fatal, in the surrounding style", () => {
+  it("both are non-fatal, in the surrounding style — and their failure is REPORTED", () => {
+    // `optional_step` is that style now: it never fails the step (an update
+    // must not be refused because a VNC unit refresh failed) and it records the
+    // name, which `report_optional_step_failures` re-states on the
+    // `CLAWBOX-WARN:` line the updater turns into a warning on the update's own
+    // status. `|| echo` reached the journal and nothing else, so the run was
+    // reported as having worked in full when part of it had not.
     for (const step of ["step_hermes_install", "step_llamacpp_model"]) {
-      const line = POST_UPDATE.split(NL).find((l) => l.trim().startsWith(step));
+      const line = POST_UPDATE.split(NL).find((l) => l.trim().endsWith(` ${step}`));
       expect(line, `${step} must be called in post_update`).toBeDefined();
-      expect(line, `${step} must not be able to fail the update`).toContain("|| echo");
+      expect(line, `${step} must not be able to fail the update`).toContain("optional_step ");
     }
+    const wrapper = shellCode(extractShellFunction("optional_step"));
+    expect(wrapper).toContain("POST_UPDATE_FAILED_STEPS=");
+    expect(wrapper).toContain("return 0");
+    expect(POST_UPDATE).toContain("report_optional_step_failures");
   });
 
   it("repairs the agent BEFORE the updater's hermes_edition step runs", () => {
@@ -722,8 +732,11 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
 
     const r = run({ installOk: false });
 
-    // step_post_update's `|| echo` depends on this not being a hard failure.
-    expect(r.code).toBe(0);
+    // The step now ANSWERS whether the agent runs: the restore put back the
+    // same unrunnable checkout, so this is a repair that did not work and the
+    // step says so. `optional_step` in step_post_update records that as a
+    // warning without failing the update, which is what keeps it non-fatal.
+    expect(r.code).toBe(1);
     expect(r.out).toMatch(/Warning: Hermes still does not run/);
     expect(r.out).toMatch(/Restored the previous agent/);
     expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("original");
@@ -763,7 +776,8 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     run({ installOk: false });
     const r = run({ installOk: false });
 
-    expect(r.code).toBe(0);
+    // Still not runnable after round 2, so still reported as a failed repair.
+    expect(r.code).toBe(1);
     expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("original");
     expect(fs.readdirSync(path.join(tmp, ".hermes")).filter((e) => e.includes(".broken"))).toEqual(
       [],
@@ -877,7 +891,9 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
 
     const r = run({ fetchOk: false });
 
-    expect(r.code).toBe(0);
+    // A download that never arrived leaves the same unrunnable agent behind,
+    // so the step reports the failed repair rather than answering 0.
+    expect(r.code).toBe(1);
     expect(r.out).toMatch(/Hermes install failed \(non-fatal\)/);
     // …and the box is still whole.
     expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("original");

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -1030,14 +1030,21 @@ describe("setup-hermes-edition.sh does not repeat the shim-only check", () => {
  * `[provision-status]` sentinel at all, with the marker already invalidated.
  */
 describe.skipIf(!hasBash)("its call sites, where errexit is live", () => {
-  /** The one top-level call: column 0, not the definition. */
-  const topLevelCall = INSTALL_SH.split(NL).find(
-    (l) => /^step_hermes_install\b/.test(l) && !l.includes("() {"),
-  );
+  /** The top-level call and its guard: from `if ! step_hermes_install` to `fi`. */
+  const topLevelCall = (() => {
+    const lines = INSTALL_SH.split(NL);
+    const start = lines.findIndex((l) => /^if ! step_hermes_install; then$/.test(l));
+    if (start < 0) return undefined;
+    const end = lines.indexOf("fi", start);
+    return end < 0 ? undefined : lines.slice(start, end + 1).join(NL);
+  })();
 
   it("is guarded on the full-install path", () => {
-    expect(topLevelCall, "the top-level call has moved or vanished").toBeDefined();
-    expect(topLevelCall).toMatch(/^step_hermes_install\s*\|\|/);
+    expect(topLevelCall, "the top-level call is bare, or has moved").toBeDefined();
+    // And the failure is RECORDED, not only printed: on hermes and dual the
+    // agent is the product, so a box provisioned without a runnable one is not
+    // a complete install and the flash host's marker has to say so.
+    expect(topLevelCall).toContain("record_provision_failure hermes_install");
   });
 
   /** Run one line under install.sh's own shell options with the step failing. */
@@ -1051,6 +1058,7 @@ describe.skipIf(!hasBash)("its call sites, where errexit is live", () => {
           // install.sh:22, verbatim — the condition that makes this matter.
           "set -euo pipefail",
           "step_hermes_install() { echo STEP_FAILED >&2; return 1; }",
+          'record_provision_failure() { echo "RECORDED $1"; }',
           callLine,
           // Everything the installer still has to do: the services, VNC, and
           // the verdict banner the flash host reads.
@@ -1068,6 +1076,9 @@ describe.skipIf(!hasBash)("its call sites, where errexit is live", () => {
     const r = afterFailedStep(topLevelCall!);
     expect(r.code, r.out).toBe(0);
     expect(r.out).toContain("STEP_FAILED");
+    // …and the verdict it reaches names the failure rather than reporting a
+    // complete provision over a box with no agent.
+    expect(r.out).toContain("RECORDED hermes_install");
     expect(r.out).toContain("PROVISIONING VERDICT REACHED");
   });
 

--- a/src/tests/unit/install-post-update-warnings.test.ts
+++ b/src/tests/unit/install-post-update-warnings.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from "vitest";
+import { execFileSync } from "node:child_process";
+import fs, { readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * A fixup that failed inside `step_post_update` has to reach the OWNER.
+ *
+ * Every one of the nineteen fixups in that step is non-fatal by design —
+ * refusing to finish an update because a VNC unit refresh failed would be the
+ * worse outcome — and each said so with `|| echo "  Warning: … (non-fatal)"`,
+ * which reaches the journal and nothing else. The step still exits 0, so the
+ * updater marks "Applying system fixups" completed and the update reports as
+ * having worked in full when part of it did not: the false-success shape,
+ * spelled nineteen times in one function.
+ *
+ * What is pinned here: the step still cannot fail (that part was right), the
+ * failures are COLLECTED, and they are re-stated on one
+ * `CLAWBOX-WARN[post-update-fixups]:` line — the updater reads that marker back
+ * out of THIS invocation's journal and puts it on the update's own status.
+ */
+
+// Starts a real bash: vitest's 5 s default is not enough on a loaded runner.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+const NL = String.fromCharCode(10);
+const INSTALL_SH = readFileSync(path.join(process.cwd(), "install.sh"), "utf-8");
+
+function extractShellFunction(name: string): string {
+  const start = INSTALL_SH.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found in install.sh`);
+  const end = INSTALL_SH.indexOf(`${NL}}`, start);
+  if (end < 0) throw new Error(`${name} has no closing brace`);
+  return INSTALL_SH.slice(start, end + 2);
+}
+
+let hasBash = true;
+try {
+  execFileSync("/bin/bash", ["-c", "true"], { stdio: "ignore" });
+} catch {
+  hasBash = false;
+}
+
+/**
+ * Run the real `step_post_update` with every step it calls stubbed, and the
+ * NAMED ones made to fail. Only the wrapper, the reporter and the step's own
+ * body come from install.sh, so this cannot pass against a wrapper that has
+ * stopped behaving like the shipped one.
+ */
+function runPostUpdate(failing: string[]): { out: string; rc: string } {
+  const body = extractShellFunction("step_post_update");
+  const called = new Set(body.match(/\bstep_[a-z_0-9]+/g) ?? []);
+  called.delete("step_post_update");
+
+  const program = [
+    // The same options install.sh runs under, so an errexit regression in
+    // `optional_step` or in the reporter's position as the step's last
+    // statement is caught here rather than on a box.
+    "set -euo pipefail",
+    ...[...called].map((fn) => (failing.includes(fn) ? `${fn}() { return 1; }` : `${fn}() { :; }`)),
+    // The helpers post_update calls that are not step_-prefixed, so the sweep
+    // above does not find them.
+    ...["pause_engine_unit", "resume_paused_engines"].map((fn) => `${fn}() { :; }`),
+    failing.includes("ensure_local_embeddings")
+      ? "ensure_local_embeddings() { return 1; }"
+      : "ensure_local_embeddings() { :; }",
+    'POST_UPDATE_FAILED_STEPS=""',
+    extractShellFunction("optional_step"),
+    extractShellFunction("report_optional_step_failures"),
+    body,
+    "step_post_update",
+    'echo "POST_RC=$?"',
+  ].join(NL);
+
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-post-update-warn-"));
+  try {
+    const script = path.join(dir, "run.sh");
+    fs.writeFileSync(script, program);
+    const out = execFileSync("/bin/bash", [script], { encoding: "utf-8", timeout: 20_000 });
+    return { out, rc: /POST_RC=(\d+)/.exec(out)?.[1] ?? "" };
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe.skipIf(!hasBash)("step_post_update reports the fixups it skipped", () => {
+  it("names every failed fixup on the line the updater reads", () => {
+    const { out, rc } = runPostUpdate(["step_edition_lock", "step_firewall"]);
+
+    // Still non-fatal: that half was never the defect.
+    expect(rc, `post_update must not fail over a non-fatal fixup:${NL}${out}`).toBe("0");
+    const marker = out.split(NL).find((line) => line.includes("CLAWBOX-WARN["));
+    expect(marker, `no CLAWBOX-WARN line in:${NL}${out}`).toBeDefined();
+    expect(marker).toContain("edition_lock");
+    expect(marker).toContain("firewall");
+    // ONE line for the run, not one per fixup: the updater turns each into a
+    // warning, and nineteen of them would be a wall rather than a report.
+    expect(out.split(NL).filter((l) => l.includes("CLAWBOX-WARN[post-update-fixups]"))).toHaveLength(1);
+  });
+
+  it("says nothing at all when every fixup worked", () => {
+    const { out, rc } = runPostUpdate([]);
+    expect(rc).toBe("0");
+    expect(out).not.toContain("CLAWBOX-WARN[post-update-fixups]");
+  });
+
+  it("reports a non-step helper that failed too", () => {
+    // `ensure_local_embeddings` is not `step_`-prefixed and was tolerated by
+    // the same idiom; a memory index that silently stopped being provisioned
+    // is exactly what an owner needs told.
+    const { out } = runPostUpdate(["ensure_local_embeddings"]);
+    expect(out).toContain("CLAWBOX-WARN[post-update-fixups]");
+    expect(out).toContain("local_embeddings_check");
+  });
+
+  it("reports a Hermes repair that did not leave a runnable agent", () => {
+    // The REAL function, not a stub: `step_hermes_install` used to end in an
+    // unconditional `return 0` with a comment saying post_update would report
+    // any non-zero return as a failed step — so the one population this call
+    // was added for (a factory reset that left no agent) got "completed" over a
+    // repair that had not worked. It returns its outcome now, and the wrapper
+    // records it without failing the update.
+    const fn = extractShellFunction("step_hermes_install");
+    expect(fn).not.toMatch(/step_post_update reports any non-zero return/);
+    // The last thing it does is answer whether the agent runs.
+    expect(fn).toMatch(/\[ -x "\$shim" \] && \[ -x "\$venv_python" \]/);
+    expect(fn).toMatch(/return 1/);
+  });
+
+  it("reports the smokes' own findings instead of always answering 0", () => {
+    // `step_update_smoke`'s findings — an unreachable gateway, a weak auth
+    // token, a Telegram bot that will not answer — were `[WARN]` echoes behind
+    // an unconditional `return 0`, so the update said "completed" over every
+    // one of them.
+    const fn = extractShellFunction("step_update_smoke");
+    expect(fn).toContain("SMOKE_FINDINGS=1");
+    expect(fn).toMatch(/return "\$SMOKE_FINDINGS"/);
+  });
+
+  it("carries the engine-resume warning on the marker the updater reads", () => {
+    // install.sh asked for this surface in so many words ("there is no quieter
+    // surface for it today. Whoever adds one should start here") for exactly
+    // this line: an engine the update stopped and did not bring back.
+    const fn = extractShellFunction("resume_paused_engines");
+    expect(fn).toContain("CLAWBOX-WARN[engine-not-resumed]");
+  });
+
+  it("still prints the per-step warning line, so the journal reads as before", () => {
+    const { out } = runPostUpdate(["step_vnc_refresh"]);
+    expect(out).toContain("Warning: vnc_refresh step failed (non-fatal)");
+  });
+});

--- a/src/tests/unit/install-swapfile.test.ts
+++ b/src/tests/unit/install-swapfile.test.ts
@@ -176,7 +176,11 @@ describe("step_swapfile runs on both flows and never fails them", () => {
     for (const caller of ["step_system_config", "step_post_update"]) {
       const body = shellCode(extractShellFunction(caller));
       expect(body, `${caller} must call step_swapfile`).toContain("step_swapfile");
-      expect(body).toMatch(/step_swapfile \|\| echo/);
+      // Non-fatal in each flow's own idiom: the fresh install tolerates the
+      // failure inline, and post_update runs every fixup through
+      // `optional_step`, which cannot fail the step and RECORDS the name for
+      // the `CLAWBOX-WARN:` line the updater turns into a warning.
+      expect(body).toMatch(/step_swapfile \|\| echo|optional_step \S+ step_swapfile/);
     }
   });
 

--- a/src/tests/unit/install-swapfile.test.ts
+++ b/src/tests/unit/install-swapfile.test.ts
@@ -180,7 +180,14 @@ describe("step_swapfile runs on both flows and never fails them", () => {
       // failure inline, and post_update runs every fixup through
       // `optional_step`, which cannot fail the step and RECORDS the name for
       // the `CLAWBOX-WARN:` line the updater turns into a warning.
-      expect(body).toMatch(/step_swapfile \|\| echo|optional_step \S+ step_swapfile/);
+      // The two flows are asserted APART: an alternation would accept a
+      // post_update that had drifted back to the bare `|| echo`, which is the
+      // regression this whole change removes.
+      expect(body).toMatch(
+        caller === "step_post_update"
+          ? /optional_step \S+ step_swapfile\b/
+          : /step_swapfile \|\| echo/,
+      );
     }
   });
 

--- a/src/tests/unit/install-tts-verdict-siblings.test.ts
+++ b/src/tests/unit/install-tts-verdict-siblings.test.ts
@@ -591,6 +591,14 @@ function runPostUpdate(ttsExit: number) {
     // so post_update would return 127 over a step that succeeded.
     "pause_engine_unit() { :; }",
     "resume_paused_engines() { :; }",
+    // The non-fatal wrapper every fixup goes through, and the line it prints
+    // at the end — taken from install.sh itself, so this cannot pass against a
+    // wrapper that has stopped behaving like the shipped one.
+    extractShellFn(INSTALL_SH, "optional_step"),
+    extractShellFn(INSTALL_SH, "report_optional_step_failures"),
+    'POST_UPDATE_FAILED_STEPS=""',
+    // The non-step helper post_update calls for the embedder.
+    "ensure_local_embeddings() { :; }",
     `step_openclaw_tts() { return ${ttsExit}; }`,
     body,
     "step_post_update",

--- a/src/tests/unit/update-lock.test.ts
+++ b/src/tests/unit/update-lock.test.ts
@@ -102,8 +102,26 @@ describe("the lock is written where a run starts and released where one ends", (
     const resume = fn("resumeContinuation");
     const noContinuation = resume.indexOf("if (!needsContinuation)");
     expect(noContinuation).toBeGreaterThan(-1);
-    const branch = resume.slice(noContinuation, resume.indexOf("return false", noContinuation));
+    // The whole branch, not up to its first `return false`: it now returns
+    // early for an update that is STILL RUNNING in another process, and the
+    // release lives past that.
+    const branch = resume.slice(noContinuation, resume.indexOf("// The restart this is resuming", noContinuation));
     expect(branch, "the nothing-to-resume branch must clear the lock").toContain("clearUpdateLock()");
+  });
+
+  it("does NOT release a lock another process is still updating under", () => {
+    // The same evidence — lock held, nothing to resume — is what a second web
+    // server sees while the FIRST one is still working through the steps: an
+    // update restarts this process by design and the old one keeps going. Read
+    // as a crash, the new process released the lock and stamped an
+    // interruption, so a run whose journal shows every step completing was
+    // reported failed with every step pending.
+    const resume = fn("resumeContinuation");
+    const noContinuation = resume.indexOf("if (!needsContinuation)");
+    const branch = resume.slice(noContinuation, resume.indexOf("// The restart this is resuming", noContinuation));
+    const guard = branch.indexOf("updateLockHeldByLiveProcess()");
+    expect(guard, "the branch must ask whether the update is still running").toBeGreaterThan(-1);
+    expect(guard, "and it must ask BEFORE releasing the lock").toBeLessThan(branch.indexOf("clearUpdateLock()"));
   });
 
   it("is released when the rebuild produced no new build", () => {

--- a/src/tests/unit/updater-interrupted-run.test.ts
+++ b/src/tests/unit/updater-interrupted-run.test.ts
@@ -70,14 +70,32 @@ function diskState({
   continuation,
   completed = false,
   interruptedAt,
-}: { locked: boolean; continuation?: string; completed?: boolean; interruptedAt?: string }) {
+  holder,
+}: {
+  locked: boolean;
+  continuation?: string;
+  completed?: boolean;
+  interruptedAt?: string;
+  /** Who took the lock, as `setUpdateLock` records it. */
+  holder?: { pid: number; bootId: string | null; startedTicks?: string | null; at?: string };
+}) {
   mockGet.mockImplementation(async (key: string) => {
     if (key === "update_in_progress") return locked ? true : undefined;
     if (key === "update_needs_continuation") return continuation;
     if (key === "update_completed") return completed ? true : undefined;
     if (key === "update_interrupted_at") return interruptedAt;
+    if (key === "update_lock_holder") return holder;
     return undefined;
   });
+}
+
+/** This boot, as `update-lock.ts` reads it. A box without one is not Linux. */
+function thisBootId(): string | null {
+  try {
+    return readFileSync("/proc/sys/kernel/random/boot_id", "utf-8").trim() || null;
+  } catch {
+    return null;
+  }
 }
 
 beforeEach(() => {
@@ -122,7 +140,102 @@ describe("an update whose process was replaced is reported, not forgotten", () =
 
     await updater.checkContinuation();
 
-    expect(mockSet).toHaveBeenCalledWith("update_in_progress", undefined);
+    // Through `setMany` now: the flag and the record of WHO held it are
+    // cleared together, or a released lock could keep a stale owner.
+    expect(mockSetMany).toHaveBeenCalledWith(
+      expect.objectContaining({ update_in_progress: undefined, update_lock_holder: undefined }),
+    );
+  });
+
+  it.skipIf(!thisBootId())("leaves a lock alone while the update is STILL RUNNING in another process", async () => {
+    // The false failure this branch produced on the box (2026-09-07): an update
+    // restarts the web server by design, and the old process keeps working
+    // through its last steps. The new one saw the same evidence a crash leaves
+    // — lock held, nothing to resume — released the lock and stamped an
+    // interruption, so a run whose journal shows every step completing and
+    // BUILD IDENTITY OK was reported failed with every step pending.
+    const boot = thisBootId()!;
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    // A record refreshed at the last step boundary — the heartbeat every step
+    // rewrites — over a pid that is gone. This is the SHAPE the box produced:
+    // the old web server was killed by `do_rebuild`, and the root step it
+    // dispatched was still working when the new one booted and looked.
+    diskState({
+      locked: true,
+      holder: { pid: 0x7ffffff0, bootId: boot, startedTicks: "1", at: new Date().toISOString() },
+    });
+
+    const resumed = await updater.checkContinuation();
+
+    expect(resumed).toBe(false);
+    expect(updater.getUpdateState().phase, "an update in flight is not a failed one").toBe("idle");
+    expect(mockSet).not.toHaveBeenCalledWith("update_interrupted_at", expect.anything());
+    expect(mockSetMany, "the lock belongs to the run that is still using it").not.toHaveBeenCalled();
+    expect(err).not.toHaveBeenCalled();
+  });
+
+  it.skipIf(!thisBootId())("still reports the interruption when the process that held it is gone", async () => {
+    // The other half, and the one the branch exists for: a pid that is not
+    // there any more is a run that died.
+    const boot = thisBootId()!;
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    // Gone, and its heartbeat is an hour old: the run is not moving.
+    diskState({
+      locked: true,
+      holder: {
+        pid: 0x7ffffff0,
+        bootId: boot,
+        startedTicks: "1",
+        at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      },
+    });
+
+    await updater.checkContinuation();
+
+    expect(updater.getUpdateState().phase).toBe("failed");
+  });
+
+  it("ignores a holder recorded on ANOTHER boot, where a pid proves nothing", async () => {
+    // The lock deliberately outlives the reboot the update performs, so a
+    // record from before it names a pid this boot may have reused for anything.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    diskState({
+      locked: true,
+      holder: {
+        pid: process.ppid,
+        bootId: "a-previous-boot",
+        startedTicks: "1",
+        at: new Date().toISOString(),
+      },
+    });
+
+    await updater.checkContinuation();
+
+    expect(updater.getUpdateState().phase).toBe("failed");
+  });
+
+  it.skipIf(!thisBootId())("does not take a REUSED pid for the process that took the lock", async () => {
+    // A pid is not an identity: the kernel wraps `pid_max`, and an update
+    // spawns thousands of processes through install.sh. Without the start time
+    // beside it, a later unrelated process landing on the dead holder's pid
+    // would hold the lock for the rest of the boot — the owner redirected to
+    // /updating with nothing left to release it, which is worse than the false
+    // failure this record is here to stop.
+    const boot = thisBootId()!;
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    diskState({
+      locked: true,
+      holder: {
+        pid: process.ppid, // alive, and not this process
+        bootId: boot,
+        startedTicks: "1", // …but not when THIS process started
+        at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      },
+    });
+
+    await updater.checkContinuation();
+
+    expect(updater.getUpdateState().phase).toBe("failed");
   });
 
   it("says nothing at all on a box that simply has not updated", async () => {

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -473,6 +473,120 @@ describe("updater", () => {
      * and all; the step here is apt_update only because it is the one this
      * harness can drive, the reader is the same one.
      */
+    it("raises a warning for a fixup a SUCCEEDED root step skipped", async () => {
+      // install.sh's `step_post_update` runs nineteen fixups, every one of them
+      // non-fatal by design, and used to report a failure with `|| echo` — the
+      // journal and nothing else. The step exits 0, so the run was reported as
+      // having worked in full when part of it had not. The failures are
+      // re-stated on a `CLAWBOX-WARN:` line now, and this is where it becomes
+      // something the OWNER sees.
+      setupExecFileMock({
+        // The invocation bound: the reader asks systemd which start this was
+        // and reads only that one, so a marker from a previous update — the
+        // journal is persistent on this box — cannot be raised over a clean
+        // run.
+        "InvocationID": { stdout: "0123456789abcdef0123456789abcdef\n", stderr: "" },
+        "/usr/bin/journalctl": {
+          stdout: [
+            "Applying system fixups",
+            "  Warning: firewall step failed (non-fatal)",
+            "CLAWBOX-WARN[post-update-fixups]: these system fixups failed and were skipped: firewall vnc_refresh",
+            "clawbox-root-update@apt_update.service: Deactivated successfully.",
+          ].join(String.fromCharCode(10)),
+          stderr: "",
+        },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+      });
+
+      vi.resetModules();
+      mockGet.mockResolvedValue(undefined);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockRebuiltBox();
+      updater = await import("@/lib/updater");
+
+      updater.resetUpdateState();
+      updater.startUpdate();
+      await vi.waitFor(() => {
+        expect(updater.getUpdateState().warnings?.some((w) => w.message.includes("firewall"))).toBe(true);
+      });
+
+      const warning = updater.getUpdateState().warnings?.find((w) => w.message.includes("firewall"));
+      expect(warning?.message).toContain("vnc_refresh");
+      // The marker itself is not the message: the owner reads the sentence.
+      expect(warning?.message).not.toContain("CLAWBOX-WARN");
+      // And the CODE is install.sh's, so a condition both sides can report —
+      // the doctor refusal — collapses to one card rather than two.
+      expect(warning?.code).toBe("post-update-fixups");
+    });
+
+    it("raises nothing when systemd cannot say which run this was", async () => {
+      // A guess about WHICH run a marker came from is worse than no warning:
+      // the journal is persistent, so an unbounded read answers with the last
+      // update's failures over a clean one.
+      setupExecFileMock({
+        "InvocationID": { stdout: "\n", stderr: "" },
+        "/usr/bin/journalctl": {
+          stdout: "CLAWBOX-WARN[post-update-fixups]: these system fixups failed and were skipped: firewall",
+          stderr: "",
+        },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+      });
+
+      vi.resetModules();
+      mockGet.mockResolvedValue(undefined);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockRebuiltBox();
+      updater = await import("@/lib/updater");
+
+      updater.resetUpdateState();
+      updater.startUpdate();
+      await vi.waitFor(() => {
+        expect(updater.getUpdateState().steps.some((s) => s.status === "completed")).toBe(true);
+      });
+
+      expect(updater.getUpdateState().warnings?.some((w) => w.message.includes("firewall"))).toBeFalsy();
+    });
+
+    it("does not raise a line that merely QUOTES the marker", async () => {
+      // `step_openclaw_install` prints doctor's whole transcript verbatim, and
+      // other steps print git and npm output: a quoted marker is not this box
+      // raising a warning.
+      setupExecFileMock({
+        "InvocationID": { stdout: "0123456789abcdef0123456789abcdef\n", stderr: "" },
+        "/usr/bin/journalctl": {
+          stdout: [
+            "  doctor said: grep for CLAWBOX-WARN[post-update-fixups]: nothing to see",
+            "clawbox-root-update@apt_update.service: Deactivated successfully.",
+          ].join(String.fromCharCode(10)),
+          stderr: "",
+        },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+      });
+
+      vi.resetModules();
+      mockGet.mockResolvedValue(undefined);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockRebuiltBox();
+      updater = await import("@/lib/updater");
+
+      updater.resetUpdateState();
+      updater.startUpdate();
+      await vi.waitFor(() => {
+        expect(updater.getUpdateState().steps.some((s) => s.status === "completed")).toBe(true);
+      });
+
+      expect(updater.getUpdateState().warnings?.some((w) => w.message.includes("nothing to see"))).toBeFalsy();
+    });
+
     it("names the step's own error, not systemd's epilogue, when a root step fails", async () => {
       setupExecFileMock({
         "clawbox-run-root-step.sh apt_update": new Error("systemctl failed"),


### PR DESCRIPTION
**TASK-766.** Two shapes an in-app update reports wrongly, one of them observed on the OpenClaw box on 2026-09-07 at ~15:35.

## Customer-visible symptom

1. **An update says it worked in full when part of it did not.** `step_post_update` runs nineteen fixups. Every one is non-fatal by design — refusing to finish an update because a VNC unit refresh failed would be the worse outcome — and each said so with `|| echo "  Warning: … (non-fatal)"`, which reaches the journal and nothing else. The step still exits 0, so the updater marks "Applying system fixups" **completed** and the owner is told the update landed whole. Two steps went further and answered 0 whatever happened: `step_hermes_install` ended in an unconditional `return 0`, so a factory-reset box whose agent repair failed was reported as repaired — the exact population that call was added for — and `step_update_smoke` printed `[WARN]` for an unreachable gateway, a weak auth token or a Telegram bot that will not answer, and returned 0 over all three.
2. **A live update is reported as failed.** The continuation check's evidence — the lock is held and there is nothing to resume — is also what a SECOND web server sees while the FIRST is still working through the steps, and an update restarts that process by design. Read as a crash, it released the lock and stamped an interruption: on the OpenClaw box a run whose journal shows every step completing and `BUILD IDENTITY OK` was shown to the owner as failed, with all thirteen steps pending.

## Cause

- Nineteen `|| echo` idioms: an exit code read as an outcome, spelled nineteen times in one function, with no channel to carry a non-fatal failure anywhere but the journal. install.sh's own comment asked for exactly this surface ("there is no quieter surface for it today. Whoever adds one should start here").
- `resumeContinuation` inferred "the previous process died" from state that a live run produces too. The lock recorded no owner, so "still running" and "died" were the same evidence.

## Harness-first

No OpenClaw or Hermes mechanism owns this: the update is ClawBox's own systemd-dispatched step machine (`clawbox-root-update@<step>.service`), and the surfaces used are **systemd's own** rather than new ones — `systemctl show -p InvocationID --value` for the run's identity and `journalctl _SYSTEMD_INVOCATION_ID=<id>` to read back THIS invocation's output, plus `/proc/<pid>/stat` field 22 and the boot id for the liveness question. Nothing here re-implements a harness capability. The non-fatal channel is likewise not invented beside an existing one: `record_provision_failure` is the channel install.sh already has, and it is fatal by construction (it makes the step's exit code non-zero), which is why a whole good update went red over a voice engine.

## The fix

- `optional_step name fn` + `report_optional_step_failures` replace the nineteen `|| echo`s: the step still cannot fail, the failed names are COLLECTED, and they are re-stated on one `CLAWBOX-WARN[post-update-fixups]:` line. `POST_UPDATE_FAILED_STEPS` is reset inside the step, so a second call in one shell cannot re-report the first call's failures.
- `step_hermes_install` and `step_update_smoke` answer their own outcome now (`[ -x "$shim" ] && [ -x "$venv_python" ]`, and `SMOKE_FINDINGS`). `optional_step` records that without failing the update.
- The updater reads the marker back out of the step's OWN journal — `rootStepInvocationId()` then `collectRootStepWarnings()` — and raises each as a warning on the update's status, capped at 300 characters, de-duplicated by the marker's `[code]` so a condition install.sh reports and a condition the updater reports for itself collapse to one card. Called on the success, advisory-overrun and failure paths.
- `update-lock.ts` records WHO holds the lock (`update_lock_holder`: pid, boot id, `/proc/<pid>/stat` start ticks, timestamp). `updateLockHeldByLiveProcess()` answers true on a fresh heartbeat, or on same-boot + pid alive + matching start ticks. Everything the record cannot prove falls back to the behaviour it had, so a box that predates the key is exactly as it was.

## RED → GREEN

RED, on unmodified beta with this branch's tests (redacted of nothing; no paths or credentials involved):

```
 FAIL  src/tests/unit/install-post-update-warnings.test.ts > names every failed fixup on the line the updater reads
   → no CLAWBOX-WARN line in: (the whole step's output)
 FAIL  … > reports a Hermes repair that did not leave a runnable agent
   → expected 'step_hermes_install() {…}' not to match /step_post_update reports any non-zero return/
 FAIL  … > reports the smokes' own findings instead of always answering 0
   → expected step_update_smoke to contain "SMOKE_FINDINGS=1"
 FAIL  src/tests/unit/updater-interrupted-run.test.ts > a live run is not stamped as interrupted
   → expected "interrupted" to be undefined
 FAIL  src/tests/unit/update-lock.test.ts > records who took the lock
```

GREEN on the head: `install-post-update-warnings` + `install-hermes-install-guard` 55/55; full **unit project 773 files, 12918 passed / 1 skipped**, the only 3 failures being `run-tunnel`, `telegram/status` and `telegram/status-hermes` — all bare 5000 ms timeouts, all untouched by this PR, all passing in isolation (3 files / 21 tests) and flaking on unmodified beta the same way. **Components 202 files / 1729 passed.** `tsc --noEmit` exit 0; `eslint` on the touched files 0 errors (2 pre-existing warnings in `updater.ts`); `bash -n install.sh` clean.

Mutation-proven: reverting `optional_step` to `|| echo`, dropping the `POST_UPDATE_FAILED_STEPS` reset, restoring either unconditional `return 0`, and dropping the holder record each fail a named case.

## Sibling call sites

Every `step_x || echo "(non-fatal)"` in `step_post_update` was converted (19), not a subset; `resume_paused_engines`'s two "did not come back" branches now carry `CLAWBOX-WARN[engine-not-resumed]`; `runOpenclawDoctorFix`'s two refusals carry `CLAWBOX-WARN[openclaw-doctor-fix-failed]` on both the install.sh and updater paths; and the ten suites that assert the shape of `step_post_update`'s body were updated with it (`install-swapfile`, `install-codex-cli`, `install-hermes-install-guard`, `install-ensure-local-embeddings`, `clawbox-firewall-policy`, `install-coding-harness`, `install-coding-harness-repair`, `install-tts-verdict-siblings`, `failover-waits-for-route`, plus `e2e-install/helpers/setup-api.ts` for the new store key).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved update recovery to distinguish active updates from genuinely interrupted or stale runs.
  - Optional repairs, smoke checks, and recovery steps no longer unnecessarily stop updates.
  - Improved status reporting for Hermes installation, gateway recovery, text-to-speech, and local embedding checks.

- **Improvements**
  - Update diagnostics now provide clearer lock ownership information.
  - Optional-step failures are aggregated into structured warnings.
  - Post-update warnings are deduplicated and surfaced in update status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Round 2 (d7c0cecd) — the review round, all four threads answered

**Taken.** `ensure_local_embeddings` was the one caller for which this whole conversion was INERT: it printed `WARN:` over an unreadable core, a missing python3 and an embedder with no address recorded, then returned 0 for every one of them, so `optional_step` had nothing to record. It answers those now — and the missing-helper case, since a script absent from the tree the update just checked out is the installer's own gap. A CLOUD embedder and a memory search the owner switched off deliberately stay 0: `optional_step` renders a non-zero return as "this fixup failed and was skipped", and saying that over a state somebody chose is a false failure in place of the false success. Both fixtures around it now call the block the way `optional_step` does (`if "$@"`) rather than bare under `set -e`, and assert the RETURN as well as the words.

**Taken.** The post-update shape assertions no longer accept the idiom they replaced — an alternation over `step_x || echo` would have passed a drift straight back. The fresh-install callers keep `|| echo`, asserted apart.

**Refuted, with the reason in-thread.** Using the `hermes --help` probe for the final verdict: this step's own history is that the probe LIES on an 8 GB Jetson mid-update (a fork failure under memory pressure), which is why the reinstall is reversible and why "a healthy agent survives a lying probe plus a failed install" exists. Gating the verdict on it would put `CLAWBOX-WARN[post-update-fixups]: hermes_install` on boxes where nothing is wrong. The two `-x` checks are the same test the step's own precheck treats as "installed", applied to exactly the factory-reset state this step exists for (the shim survived, the venv under it did not).

**Refuted, with the reason in-thread.** The heartbeat holding a crashed run's lock: the boot-id check runs BEFORE it, so a restart still releases immediately; and `checkContinuation()` is called by the status route on every idle poll — the page the owner is looking at is what polls it — so the first poll after the heartbeat goes stale releases the lock and stamps the interruption with nobody doing anything. That is already pinned by "still reports the interruption when the process that held it is gone" (same boot, pid gone, hour-old heartbeat → `phase: failed`). Moving the acquisition below `checkInternet()` would undo TASK-731, where a web server replaced in that window left no trace and the run was lost.

**GREEN on this head:** unit **776 files, 12956 passed / 1 skipped, 0 failed**; `tsc --noEmit` 0; eslint 0 errors; `bash -n install.sh` clean. `git diff --stat origin/beta...HEAD` lists only this PR's 18 files, `--diff-filter=DR` empty, and the intersection with each merge that landed meanwhile (#778, #784) is empty.


**Round 3 (a114b09e)** — one more, taken: `step_hermes_install` answered 0 for an upgrade that ran and landed OFF the pinned commit. It already said so on stderr (`but HEAD is …, not the pin`), which reaches the journal and nobody, so `optional_step` recorded nothing and the update reported a completed fixup over a fleet box on a build we do not ship. The return now carries both facts — runnable, and on the pin — with the flag function-local and set only after an install this step performed, so every path that attempted no upgrade returns 0 exactly as before. Unit project on this head: **776 files, 12977 passed / 1 skipped, 0 failed.**


**Round 4 (4aec29bb) — a regression this branch introduced, found in review and fixed.** `step_hermes_install` answers non-zero now, and install.sh calls it BARE at the top level of the full install — under `set -euo pipefail`, with no EXIT trap armed on that path (the only `trap dispatch_provision_verdict EXIT` is inside the `--step` block, which exits long before it). A fresh **hermes or dual** install whose Hermes fetch failed would therefore have aborted the whole installer at that line, before the services, VNC and the provisioning verdict: **no `PROVISIONING INCOMPLETE` banner and no `[provision-status]` sentinel**, with the marker already invalidated — the flash host would have seen no verdict at all. `e2e-install` would not have caught it, because its Hermes fetch succeeds.

The call is guarded and the step's own reason is the report, as it was before this branch. Two cases pin it: the real call line runs under install.sh's own shell options with the step failing, asserting the installer still reaches its verdict — and the same fixture with a BARE call asserting it does not, so the first is not vacuous.

**Stated out loud:** the dispatched repair `sudo bash install.sh --step hermes_install` now exits 1 when it could not leave a runnable agent (or landed off the pin). That is the point of the change — the updater reads that exit code — but it is a behaviour change to a hand-run command.

Also in this round: the e2e failure dump reduces `update_lock_holder` to whether one was recorded and how old its heartbeat is. That message is uploaded as a CI artifact on a public repository and the record carries the machine's boot id.

**Known and NOT fixed here** (recorded on the queue's Found list): on the **hermes** edition `post_update` does not go through the gateway-quiesced path, which is what waits for the root unit to settle — so on the advisory-overrun path `collectRootStepWarnings` can read the journal before `report_optional_step_failures` (the step's last statement) has printed. The existing settle helper has a two-hour ceiling and blocking an advisory overrun on it would be worse than the gap; it needs its own bounded wait. Also unfixed: `install.sh:8609` (`step_clawkeep_install || echo` inside `step_rebuild_reboot`) and the two inner `|| echo`s inside `ensure_local_embeddings` still swallow their own failures, and `CLAWBOX-WARN[engine-not-resumed]` is de-duplicated by code, so two engines that fail to resume are reported as one.

**GREEN on this head:** unit **776 files, 12980 passed / 1 skipped, 0 failed**; `tsc --noEmit` 0; `bash -n install.sh` clean.


**Round 5 (f1140ad0)** — the off-pin report was still incomplete: the flag was set only after the replacement agent passed the post-install check, so the interesting failure never reached it. A working box on the wrong commit is moved aside, the install fails, the OLD off-pin agent is restored, and the step answered success over an upgrade that did not happen. The fact is recorded when the attempt STARTS and cleared only by a post-install check that finds the pin, so every ending is answered honestly: landed on the pin `0`, landed elsewhere `1`, restored unchanged `1`, and a box that attempted no upgrade at all still `0`. Mutation-proven. Unit project: **776 files, 12980 passed / 1 skipped, 0 failed.**
