### PR TITLE
Dual SKU: tell Hermes about a ClawBox AI save, and stop re-arming over a refused credential

### DIFF
--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -328,6 +328,13 @@ export CLAWBOX_IMAGE_PLUGIN="clawai"
 # Mirrors HERMES_IMAGE_PLUGIN_KEY in src/lib/hermes-image-plugin.ts.
 export CLAWBOX_IMAGE_PLUGIN_KEY="image_gen/clawai"
 export CLAWBOX_IMAGE_PLUGIN_ENTRY="$HERMES_PLUGINS_DIR/image_gen/clawai/__init__.py"
+# The device store, for the ONE thing the re-arm below has to ask it: has the
+# proxy refused this box's ClawBox AI credential? The stand-down is written on
+# BOTH editions (`recordClawaiCredentialRefusal`) and, until now, read only by
+# the OpenClaw boot script — so on Hermes the image backend was armed again on
+# the next boot that repaired the plugin list, and the agent went back to
+# spending refused calls (6,554 in twelve hours from one box, TASK-727).
+export CLAWBOX_DEVICE_STORE="$PROJECT_DIR/data/config.json"
 # The protected-path table (TASK-605). The same file the OpenClaw hook plugin
 # reads; see the block that renders approvals.deny from it below.
 export CLAWBOX_PROTECTED_PATHS="$PROJECT_DIR/config/protected-paths.json"
@@ -824,6 +831,38 @@ elif isinstance(plugins_cfg, dict):
 #      reader as the allow-list, and a
 #      deny-list this script cannot read declines the re-arm rather than
 #      guessing: the cost is one Settings → Save, which asks Hermes itself.
+def clawai_credential_refused():
+    """Has the proxy refused this box's ClawBox AI credential?
+
+    The same key, the same reader and the same collapse as
+    `_clawai_credential_refused` in gateway-pre-start.sh: unreadable, absent,
+    malformed and non-numeric all mean "nobody has told us this credential is
+    dead", and a box we have not been told about is left as it is. The fact
+    does not decay — a TTL here would re-arm a path the proxy still refuses,
+    which is the storm the stand-down exists to end.
+
+    `except Exception` and it has to be that broad: this runs inside the big
+    heredoc, and anything that escapes takes the whole MCP registration with
+    it.
+    """
+    import math
+
+    store_path = os.environ.get("CLAWBOX_DEVICE_STORE") or ""
+    if not store_path:
+        return False
+    try:
+        with open(store_path) as fh:
+            store = json.load(fh)
+        if not isinstance(store, dict):
+            return False
+        at = store.get("clawai_credential_refused_at")
+        if isinstance(at, bool) or not isinstance(at, (int, float)):
+            return False
+        return math.isfinite(at) and at > 0
+    except Exception:
+        return False
+
+
 image_plugin = os.environ.get("CLAWBOX_IMAGE_PLUGIN") or ""
 image_plugin_key = os.environ.get("CLAWBOX_IMAGE_PLUGIN_KEY") or ""
 image_entry = os.environ.get("CLAWBOX_IMAGE_PLUGIN_ENTRY") or ""
@@ -848,6 +887,16 @@ if repaired_enabled and image_plugin and image_plugin in (names or []):
     elif not (image_entry and os.path.isfile(image_entry)):
         print("[register-mcp] the ClawAI image backend is not installed; "
               "leaving image_gen.provider unset")
+    #   5. the proxy has not REFUSED this box's credential. The stand-down is
+    #      written on both editions and was read on neither this side of the
+    #      house: re-arming over it puts back, unattended, exactly the path the
+    #      refusal took away, and there is no back-off downstream — the plugin
+    #      spends refused calls for as long as the box is switched on. Cleared
+    #      by every path that writes a new credential, so a re-link re-arms on
+    #      the next boot without anyone doing anything.
+    elif clawai_credential_refused():
+        print("[register-mcp] the ClawBox AI credential was refused; leaving "
+              "image_gen.provider unset until a new one is linked")
     else:
         image_cfg["provider"] = image_plugin
         cfg["image_gen"] = image_cfg

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -843,12 +843,20 @@ def clawai_credential_refused():
     does not decay — a TTL here would re-arm a path the proxy still refuses,
     which is the storm the stand-down exists to end.
 
-    An absent store and a store that CANNOT BE READ collapse to the same answer
-    on purpose (the sibling script does the same, and this one runs as clawbox
-    where that one runs as root, so a root-owned `data/config.json` lands
-    here), but they are not the same event: the unreadable one is said out
-    loud, or the log would report "re-armed image_gen.provider" as though all
-    five conditions had been weighed.
+    THREE answers, not two: True (refused), False (nothing recorded), and None
+    (this script could not look). Absent and unreadable are different events —
+    this script runs as clawbox where the sibling runs as root, so a root-owned
+    `data/config.json` lands in the second — and the caller DECLINES the re-arm
+    on None, exactly as condition 4 declines over a `plugins.disabled` it cannot
+    read. The cost of declining is one Settings → Save; the cost of guessing is
+    the refused-call storm the stand-down exists to end.
+
+    The number rule is `_clawai_credential_refused`'s, line for line: floats are
+    tested with `math.isfinite`, integers are never converted (an int past
+    Number.MAX_VALUE raises OverflowError from `isfinite` and would otherwise be
+    reported as an unreadable store), and the range is bounded by
+    Number.MAX_VALUE so both languages answer the same over every value either
+    can parse.
 
     `except Exception` and it has to be that broad: this runs inside the big
     heredoc, and anything that escapes takes the whole MCP registration with
@@ -867,17 +875,21 @@ def clawai_credential_refused():
         at = store.get("clawai_credential_refused_at")
         if isinstance(at, bool) or not isinstance(at, (int, float)):
             return False
-        return math.isfinite(at) and at > 0
+        if isinstance(at, float) and not math.isfinite(at):
+            return False
+        return 0 < at <= 1.7976931348623157e308
     except FileNotFoundError:
         # Nothing has ever been recorded on this box. Genuinely absent.
         return False
     except Exception:
         print("[register-mcp] WARNING: could not read the device store at "
-              f"{store_path}; treating the ClawBox AI credential as not refused.",
-              file=sys.stderr)
-        return False
+              f"{store_path}; not re-arming the image backend over a credential "
+              "this script cannot check.", file=sys.stderr)
+        return None
 
 
+# Asked ONCE, ahead of the chain: three answers, and two of them decline.
+_clawai_refusal = clawai_credential_refused()
 image_plugin = os.environ.get("CLAWBOX_IMAGE_PLUGIN") or ""
 image_plugin_key = os.environ.get("CLAWBOX_IMAGE_PLUGIN_KEY") or ""
 image_entry = os.environ.get("CLAWBOX_IMAGE_PLUGIN_ENTRY") or ""
@@ -910,7 +922,11 @@ if repaired_enabled and image_plugin and image_plugin in (names or []):
     #      by every path that writes a DIFFERENT credential — and only those, so
     #      a re-paste of the refused bytes is not a re-link — which means a real
     #      re-link re-arms on the next boot without anyone doing anything.
-    elif clawai_credential_refused():
+    elif _clawai_refusal is None:
+        print("[register-mcp] the device store could not be read, so whether this "
+              "box's ClawBox AI credential was refused is unknown; leaving "
+              "image_gen.provider unset")
+    elif _clawai_refusal:
         print("[register-mcp] the ClawBox AI credential was refused; leaving "
               "image_gen.provider unset until a new one is linked")
     else:

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -330,7 +330,9 @@ export CLAWBOX_IMAGE_PLUGIN_KEY="image_gen/clawai"
 export CLAWBOX_IMAGE_PLUGIN_ENTRY="$HERMES_PLUGINS_DIR/image_gen/clawai/__init__.py"
 # The device store, for the ONE thing the re-arm below has to ask it: has the
 # proxy refused this box's ClawBox AI credential? The stand-down is written on
-# BOTH editions (`recordClawaiCredentialRefusal`) and, until now, read only by
+# BOTH editions (`persistClawaiCredentialRefusal`, and
+# `noteClawaiCredentialRefused` for the once-per-window arming) and, until now,
+# read only by
 # the OpenClaw boot script — so on Hermes the image backend was armed again on
 # the next boot that repaired the plugin list, and the agent went back to
 # spending refused calls (6,554 in twelve hours from one box, TASK-727).
@@ -841,6 +843,13 @@ def clawai_credential_refused():
     does not decay — a TTL here would re-arm a path the proxy still refuses,
     which is the storm the stand-down exists to end.
 
+    An absent store and a store that CANNOT BE READ collapse to the same answer
+    on purpose (the sibling script does the same, and this one runs as clawbox
+    where that one runs as root, so a root-owned `data/config.json` lands
+    here), but they are not the same event: the unreadable one is said out
+    loud, or the log would report "re-armed image_gen.provider" as though all
+    five conditions had been weighed.
+
     `except Exception` and it has to be that broad: this runs inside the big
     heredoc, and anything that escapes takes the whole MCP registration with
     it.
@@ -859,7 +868,13 @@ def clawai_credential_refused():
         if isinstance(at, bool) or not isinstance(at, (int, float)):
             return False
         return math.isfinite(at) and at > 0
+    except FileNotFoundError:
+        # Nothing has ever been recorded on this box. Genuinely absent.
+        return False
     except Exception:
+        print("[register-mcp] WARNING: could not read the device store at "
+              f"{store_path}; treating the ClawBox AI credential as not refused.",
+              file=sys.stderr)
         return False
 
 
@@ -892,8 +907,9 @@ if repaired_enabled and image_plugin and image_plugin in (names or []):
     #      house: re-arming over it puts back, unattended, exactly the path the
     #      refusal took away, and there is no back-off downstream — the plugin
     #      spends refused calls for as long as the box is switched on. Cleared
-    #      by every path that writes a new credential, so a re-link re-arms on
-    #      the next boot without anyone doing anything.
+    #      by every path that writes a DIFFERENT credential — and only those, so
+    #      a re-paste of the refused bytes is not a re-link — which means a real
+    #      re-link re-arms on the next boot without anyone doing anything.
     elif clawai_credential_refused():
         print("[register-mcp] the ClawBox AI credential was refused; leaving "
               "image_gen.provider unset until a new one is linked")

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -3280,6 +3280,15 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
               // The PORTAL's answer, which only this route has; the plan is
               // written beside the tier and deleted with it.
               portalPlan,
+              // NOT the voice. `applyClawaiToHermes` picks Hermes' cloud voice
+              // for a box that has none, which is right when the box's own
+              // harness is being linked — it is how a hermes box gets one — and
+              // wrong to decide HERE: on the dual SKU the cloud-voice question
+              // is open with the owner, and a save made for the credential must
+              // not settle it as a side effect. Before this arm existed a dual
+              // box could not reach that writer from this route at all, and it
+              // still cannot.
+              selectCloudVoice: false,
             },
           );
           // The apply performs the coding-agent, provider and image refreshes

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -3154,6 +3154,9 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     // reads — and `undefined` again on a probe that threw, which must not turn
     // a save into a 500 or buy a reload nobody asked for.
     const codingAgentReadyBefore = isClawAI ? await codingAgentReady() : undefined;
+    // Set when the dual arm below has already told Hermes — and with it, done
+    // every refresh this route would otherwise ask for.
+    let appliedToHermes = false;
     if (isLocalScope) {
       await setMany({
         local_ai_configured: true,
@@ -3233,6 +3236,55 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
       });
       // The cloud save has landed — see `forgetLocalWasDefault`.
       await forgetLocalWasDefault();
+      // THE DUAL SKU, where OpenClaw exists and HERMES is the harness actually
+      // answering. Everything above configured OpenClaw, exactly as it does on
+      // the flagship box — and on this one that left the credential invisible
+      // to the agent the owner is talking to: Hermes keeps its own provider
+      // catalogue, its own image backend and its own speech slot, so
+      // `ai_set_provider("clawai")` went on answering "That provider is not set
+      // up on this device" over a token the owner had just pasted. The Hermes
+      // branch above cannot cover it — `openclawIsAbsent()` is
+      // `readEdition() === "hermes"`, so a dual box never reaches it (TASK-577)
+      // — and this is the same shape the LOCAL model case above already carries
+      // through `applyLocalAiToHermes`, for the same SKU and the same reason.
+      //
+      // Non-fatal: OpenClaw is configured either way and the credential is on
+      // disk, so a Hermes write that fails must not turn a save that landed
+      // into an error. It is LOUD, though — the agent's own view is what the
+      // owner will judge the save by.
+      if (isClawAI && (await getActiveHarness()) === "hermes") {
+        try {
+          await applyClawaiToHermes(
+            clawboxAiToken,
+            resolvedClawboxTier ?? CLAWBOX_AI_DEFAULT_TIER,
+            {
+              // The token was written in the batch above, so the apply's own
+              // reads of both facts would answer about THIS save rather than
+              // the state before it: `ready` would be true whatever the box
+              // looked like a moment ago (no reload), and `accountChanged`
+              // false on every real link (the previous owner's model pick
+              // applied to the new account). Both are the snapshots this route
+              // already holds — the same pair `/setup-api/hermes/clawai`
+              // passes, for the same reason.
+              codingAgentReadyBefore,
+              previousClawaiToken,
+              // The PORTAL's answer, which only this route has; the plan is
+              // written beside the tier and deleted with it.
+              portalPlan,
+            },
+          );
+          // The apply performs the coding-agent, provider and image refreshes
+          // itself, from ITS before/after pair — so the block below must not
+          // ask for a second global reload, which respawns every MCP child and
+          // invalidates the model's prompt cache again.
+          appliedToHermes = true;
+        } catch (err) {
+          console.error(
+            "[ai-models/configure] ClawBox AI is configured for OpenClaw but Hermes did not take it:",
+            err instanceof ClawaiApplyError ? err.message : err,
+          );
+        }
+      }
     }
 
     // The credential is on disk, so ask the agent to rebuild its tool list if
@@ -3245,7 +3297,7 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     // token the box already held must not buy one. Best effort by design; the
     // owner's save has already landed and an edition with no dashboard to ask
     // re-probes at the next respawn on its own.
-    if (codingAgentReadyBefore !== undefined) {
+    if (codingAgentReadyBefore !== undefined && !appliedToHermes) {
       const readyAfter = await codingAgentReady();
       if (readyAfter !== undefined) {
         await refreshCodingAgentToolsIfReadinessChanged(codingAgentReadyBefore, readyAfter);

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -3157,6 +3157,15 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     // Set when the dual arm below has already told Hermes — and with it, done
     // every refresh this route would otherwise ask for.
     let appliedToHermes = false;
+    // What the owner is told when that arm did NOT land. The apply is a
+    // sequence of independent `hermes config set` calls that throws on the
+    // first failing one, so it can stop with Hermes pointed at the clawai
+    // provider and the previous provider's `model.default` still in place —
+    // every turn then fails with "Model not allowed" while this route answers
+    // 200. The save itself did land (OpenClaw is configured, the credential is
+    // on disk), so this is a warning and not an error, but silence over it is
+    // the false-success shape: an outcome reported before it happened.
+    let hermesWarning: string | undefined;
     if (isLocalScope) {
       await setMany({
         local_ai_configured: true,
@@ -3283,6 +3292,8 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
             "[ai-models/configure] ClawBox AI is configured for OpenClaw but Hermes did not take it:",
             err instanceof ClawaiApplyError ? err.message : err,
           );
+          hermesWarning =
+            "Saved, but the on-device agent has not taken the credential yet — open Settings → AI Models and save again.";
         }
       }
     }
@@ -3309,7 +3320,15 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     // chat to something the provider list still shows as switched off.
     // Non-fatal — the switch is bookkeeping, the credential write is the save.
     try {
-      await setProviderEnabled(ocProvider, true);
+      // It ANSWERS rather than throwing when the provider list has no such row
+      // (`readProviderStatus` on Hermes asks the dashboard, which the apply
+      // above may have just restarted), so the result has to be read or a
+      // provider the owner just connected stays on the disabled list in
+      // silence.
+      const reEnabled = await setProviderEnabled(ocProvider, true);
+      if (!reEnabled.ok) {
+        console.error(`[ai-models/configure] could not re-enable ${ocProvider}: ${reEnabled.kind}`);
+      }
     } catch (err) {
       console.error("[ai-models/configure] could not re-enable the provider:", err instanceof Error ? err.message : err);
     }
@@ -3693,7 +3712,7 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
       await fs.unlink(pendingHandoffTokensPath).catch(() => {});
     }
 
-    const warning = [chatgptOrderWarning, unvalidatedPrimaryWarning, gatewayWarning]
+    const warning = [chatgptOrderWarning, unvalidatedPrimaryWarning, hermesWarning, gatewayWarning]
       .filter(Boolean)
       .join(" ");
     return NextResponse.json({

--- a/src/app/setup-api/hermes/clawai/route.ts
+++ b/src/app/setup-api/hermes/clawai/route.ts
@@ -182,8 +182,12 @@ export async function POST(request: Request) {
     });
     // A refusal the proxy gave the token being replaced is about that token,
     // not this one. Dropped here as well as in `applyClawaiToHermes`, because a
-    // paste that never reaches the apply still changed the credential.
-    await forgetClawaiCredentialRefusal();
+    // paste that never reaches the apply still changed the credential — and
+    // under the same condition the apply uses, because a re-paste of the very
+    // bytes the proxy refused replaces nothing: the mark is about the
+    // CREDENTIAL, and retiring it here would re-arm the boot scripts' image
+    // path against a token that is still dead.
+    if (previousClawaiToken !== suppliedToken) await forgetClawaiCredentialRefusal();
   }
 
   const token = suppliedToken || (await readToken());

--- a/src/lib/clawai-credential-refusal.ts
+++ b/src/lib/clawai-credential-refusal.ts
@@ -1,4 +1,4 @@
-import { get, set } from "@/lib/config-store";
+import { get, getKnown, set } from "@/lib/config-store";
 
 /**
  * The proxy refused this box's ClawBox AI credential, written down where the
@@ -59,6 +59,28 @@ function isRecordedRefusal(value: unknown): boolean {
  * Answers false to a store it cannot read, for the same reason the shell reader
  * does: not knowing is not a refusal.
  */
+/**
+ * The same question, with the third answer a WRITER needs: "refused", "clear",
+ * or "this box could not be asked".
+ *
+ * `clawaiCredentialRefusalOnRecord` deliberately answers false to a store it
+ * cannot read — for a caller that only REPORTS, not knowing is not a refusal
+ * and inventing one would be a false failure. A caller that ARMS has the
+ * opposite duty: `enableHermesImageGeneration` writes `image_gen.provider`, and
+ * that key is what makes both boot gates short-circuit ever after, so arming it
+ * over a store that could not be read would retire the stand-down on a guess
+ * and put the refused-call storm back with nothing left to stop it. `getKnown`
+ * is what tells an unreadable store (EACCES, EIO, invalid JSON — which
+ * `readConfig` flattens to `{}`) apart from a box that has never been refused.
+ */
+export type ClawaiRefusalState = "refused" | "clear" | "unknown";
+
+export async function clawaiRefusalState(): Promise<ClawaiRefusalState> {
+  const { value, known } = await getKnown(CLAWAI_CREDENTIAL_REFUSED_KEY);
+  if (!known) return "unknown";
+  return isRecordedRefusal(value) ? "refused" : "clear";
+}
+
 export async function clawaiCredentialRefusalOnRecord(): Promise<boolean> {
   try {
     return isRecordedRefusal(await get(CLAWAI_CREDENTIAL_REFUSED_KEY));

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -116,10 +116,11 @@ export interface ApplyClawaiOptions {
    * and that third fact IS the stored token — so a snapshot taken in here, after
    * such a caller has already written it, reads true no matter what the box
    * looked like a moment earlier. The guard then sees before === after and the
-   * reload silently never happens. `/setup-api/hermes/clawai` persists a PASTED
-   * token before it applies it and is the one caller that needs this; the two
-   * others (the configure route and the device-code finaliser) write nothing
-   * first, so they leave it unset and the snapshot below is honest.
+   * reload silently never happens. The two callers that write the token FIRST
+   * pass this — `/setup-api/hermes/clawai` (a pasted token) and
+   * `POST /setup-api/ai-models/configure` on the dual SKU, whose ClawBox AI
+   * batch lands before it tells Hermes; the device-code finaliser writes
+   * nothing first, so it leaves this unset and the snapshot below is honest.
    */
   codingAgentReadyBefore?: boolean;
   /**
@@ -131,9 +132,11 @@ export interface ApplyClawaiOptions {
    * the store if the caller has already written the new token there: the read
    * would answer with the token it is being asked about, `accountChanged` would
    * be false on every real link, and account A's Max choice would be applied to
-   * account B's Pro plan. `/setup-api/hermes/clawai` persists a PASTED token
-   * before it applies it and is the one caller that needs this; the configure
-   * route and the device-code finaliser write nothing first, so they leave it
+   * account B's Pro plan — and `credentialChanged`, which decides whether the
+   * proxy's refusal of the replaced token still applies, would be false with
+   * it. The same two callers that write the token first pass this:
+   * `/setup-api/hermes/clawai` and `POST /setup-api/ai-models/configure` on the
+   * dual SKU; the device-code finaliser writes nothing first, so it leaves this
    * unset and the read below is honest.
    */
   previousClawaiToken?: string;
@@ -199,6 +202,12 @@ export async function applyClawaiToHermes(
   // function samples.
   const previousToken = options.previousClawaiToken?.trim() ?? await getStoredClawaiToken();
   const accountChanged = Boolean(previousToken && previousToken !== trimmed);
+  // The narrower question `accountChanged` does not answer: is the credential
+  // about to be written a DIFFERENT one? It is on a first link too (no previous
+  // token), where `accountChanged` is deliberately false because there are no
+  // previous owner's picks to drop. The refusal mark below is about the
+  // CREDENTIAL, so this is the fact that decides whether it still applies.
+  const credentialChanged = previousToken !== trimmed;
   const storedPicks = await readExplicitModelPicks();
   // Null whenever there is nothing to drop — including when the CALLER has
   // already dropped it, which `/setup-api/hermes/clawai` does in the same write
@@ -367,7 +376,14 @@ export async function applyClawaiToHermes(
     // the safe moment: that mark asserts something WORKED, so losing it early
     // costs nothing; this one asserts something FAILED, so dropping it early
     // costs traffic.
-    if (r.code === 0 && args[2] === `providers.${CLAWAI_PROVIDER}.api_key`) {
+    //
+    // And ONLY when the credential actually changed, which is the same rule
+    // `configureClawboxAi` states on the OpenClaw side: re-pasting the refused
+    // bytes is not a re-link. Without it a tier-pill press — or, since this
+    // function is now called for a ClawBox AI save on the dual SKU, any such
+    // save — would retire the stand-down both boot scripts read, and the box
+    // would re-arm the image path against a token the proxy has refused.
+    if (r.code === 0 && credentialChanged && args[2] === `providers.${CLAWAI_PROVIDER}.api_key`) {
       await forgetClawaiCredentialRefusal();
     }
     // `unset` of an absent key is a no-op; only a failing `set` is fatal.

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -34,7 +34,7 @@ import {
 import { isClawboxAiVisionId, resolveVisionModelId } from "@/lib/clawbox-ai-vision";
 import { forgetProviderVerified } from "@/lib/provider-verified";
 import { forgetClawaiCredentialRefusal } from "@/lib/harness/credentials";
-import { clawaiCredentialRefusalOnRecord } from "@/lib/clawai-credential-refusal";
+import { clawaiRefusalState } from "@/lib/clawai-credential-refusal";
 // The PLAN this box's account pays for, and the badge behind it — the one rule
 // the panel and both boot scripts read for "may this box have the cloud voice"
 // (TASK-744). Written into the store by this module, read back below.
@@ -1313,9 +1313,19 @@ async function enableHermesImageGeneration(token: string): Promise<void> {
   // The DESCRIBING writes above are deliberately not gated: naming our model
   // and proxy address keeps the config true for the moment the credential is
   // replaced, and neither turns anything on.
-  if (await clawaiCredentialRefusalOnRecord()) {
+  //
+  // FAIL CLOSED on a store that could not be READ, which is the third answer
+  // `clawaiRefusalState` exists to give: `readConfig` flattens EACCES, EIO and
+  // invalid JSON to `{}`, so the plain reader would have called an unreadable
+  // store "no refusal" and armed anyway — the one direction that cannot be
+  // taken back, since the key it writes is what makes both boot gates
+  // short-circuit ever after.
+  const refusal = await clawaiRefusalState();
+  if (refusal !== "clear") {
     console.log(
-      "[hermes/clawai] the proxy has refused this box's ClawBox AI credential — leaving image_gen.provider alone",
+      refusal === "refused"
+        ? "[hermes/clawai] the proxy has refused this box's ClawBox AI credential — leaving image_gen.provider alone"
+        : "[hermes/clawai] the device store could not be read, so whether this box's credential was refused is unknown — leaving image_gen.provider alone",
     );
     return;
   }

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -34,6 +34,7 @@ import {
 import { isClawboxAiVisionId, resolveVisionModelId } from "@/lib/clawbox-ai-vision";
 import { forgetProviderVerified } from "@/lib/provider-verified";
 import { forgetClawaiCredentialRefusal } from "@/lib/harness/credentials";
+import { clawaiCredentialRefusalOnRecord } from "@/lib/clawai-credential-refusal";
 // The PLAN this box's account pays for, and the badge behind it — the one rule
 // the panel and both boot scripts read for "may this box have the cloud voice"
 // (TASK-744). Written into the store by this module, read back below.
@@ -154,6 +155,17 @@ export interface ApplyClawaiOptions {
    * (TASK-481) and must never be recorded as a plan.
    */
   portalPlan?: ClawaiPortalPlan;
+  /**
+   * Whether this call may pick Hermes' CLOUD VOICE when the box has none.
+   *
+   * True everywhere except the dual SKU's configure arm. Selecting a voice is
+   * the right thing to do when linking the box's own harness — it is how a
+   * hermes box gets one — but on `dual` the cloud-voice behaviour is an open
+   * question with the owner, and a save made for the credential must not settle
+   * it as a side effect. The call site that has to answer "not now" says so
+   * here rather than the writer guessing from the edition.
+   */
+  selectCloudVoice?: boolean;
 }
 
 /**
@@ -498,10 +510,12 @@ export async function applyClawaiToHermes(
   // portal answered (when this caller asked it) with the badge behind it, which
   // is `clawaiEntitlementTier` exactly. A function that re-read its own write
   // would also be one a fixture could satisfy without the write ever landing.
-  await selectHermesCloudVoiceIfUnvoiced(
-    trimmed,
-    clawaiEntitlementTier(clawaiPlanTierForStore(options.portalPlan), tier),
-  );
+  if (options.selectCloudVoice !== false) {
+    await selectHermesCloudVoiceIfUnvoiced(
+      trimmed,
+      clawaiEntitlementTier(clawaiPlanTierForStore(options.portalPlan), tier),
+    );
+  }
 
   // Everything above wrote to DISK. The agent that will serve the next turn is
   // a process that has been running since long before any of it, and two of the
@@ -1285,6 +1299,26 @@ async function enableHermesImageGeneration(token: string): Promise<void> {
   // customer's chosen model on every AI-Models save — including on the paths
   // that then make no claim at all — which is the mirror of the care
   // `withdrawImageProviderClaim` takes not to remove somebody else's provider.
+  // NOT OVER A CREDENTIAL THE PROXY HAS REFUSED. This is the write the
+  // stand-down is about: `gateway-pre-start.sh` and `scripts/register-mcp.sh`
+  // both decline to arm the image path while that record stands, but the boot
+  // gate is only REACHED while `image_gen.provider` is unset — so a Settings
+  // save that armed it here made every later boot short-circuit on "somebody
+  // already chose a backend" and the stand-down inert for good, while the
+  // plugin went on spending refused calls for as long as the box was on. The
+  // mark is retired above by any save carrying a DIFFERENT credential, so a
+  // genuine re-link still arms in the same request; a re-save of the refused
+  // bytes leaves the box exactly as it is.
+  //
+  // The DESCRIBING writes above are deliberately not gated: naming our model
+  // and proxy address keeps the config true for the moment the credential is
+  // replaced, and neither turns anything on.
+  if (await clawaiCredentialRefusalOnRecord()) {
+    console.log(
+      "[hermes/clawai] the proxy has refused this box's ClawBox AI credential — leaving image_gen.provider alone",
+    );
+    return;
+  }
   // Before `image_gen.provider`, so the ordering rule below still holds.
   await runOrThrow(["config", "set", "image_gen.model", CLAWBOX_AI_IMAGE_MODEL_ID]);
   await runOrThrow(["config", "set", "image_gen.provider", HERMES_IMAGE_PLUGIN_NAME]);

--- a/src/tests/routes/ai-models/configure-dual-coding-tools.test.ts
+++ b/src/tests/routes/ai-models/configure-dual-coding-tools.test.ts
@@ -182,6 +182,14 @@ vi.mock("@/lib/harness", async (importOriginal) => ({
 
 vi.mock("@/lib/coding-agent", () => ({ getCodingAgentStatus: vi.fn() }));
 
+// The Hermes apply, which on this SKU is what tells the agent anything at all.
+// Partial, so `ClawaiApplyError` stays the real class the route catches.
+const applyClawaiToHermesMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/hermes-clawai", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/hermes-clawai")>()),
+  applyClawaiToHermes: applyClawaiToHermesMock,
+}));
+
 // The transport the refresh ends at. Mocked HERE rather than mocking
 // `refreshCodingAgentToolsIfReadinessChanged` itself, so the real guard runs and
 // the assertion is about the agent being asked, not about a call being made.
@@ -318,6 +326,23 @@ describe("POST /setup-api/ai-models/configure — the coding agent's tool list o
     mockGetCodingAgentStatus = vi.mocked(codingMod.getCodingAgentStatus);
     mockGetCodingAgentStatus.mockImplementation(readyFromStore);
 
+    // The stand-in does the ONE thing the cases below pin about the real apply:
+    // it performs the coding-agent refresh from the snapshot it is handed
+    // (`hermes-clawai.ts` does that and the provider and image refreshes too;
+    // its own suites pin those). Without this the route's cases would be
+    // asserting over a helper that does nothing.
+    applyClawaiToHermesMock.mockReset();
+    applyClawaiToHermesMock.mockImplementation(
+      async (_token: string, _tier: string, options?: { codingAgentReadyBefore?: boolean }) => {
+        const { refreshCodingAgentToolsIfReadinessChanged } = await import("@/lib/coding-agent-mcp-refresh");
+        if (options?.codingAgentReadyBefore !== undefined) {
+          const after = (await mockGetCodingAgentStatus()).ready;
+          await refreshCodingAgentToolsIfReadinessChanged(options.codingAgentReadyBefore, after);
+        }
+        return { provider: "clawai", model: "deepseek-v4-flash", tier: "free", explicitPickKept: false };
+      },
+    );
+
     const reloadMod = await import("@/lib/hermes-mcp-reload");
     mockReloadMcpServers = vi.mocked(reloadMod.reloadMcpServers);
     mockReloadMcpServers.mockResolvedValue(true);
@@ -345,6 +370,57 @@ describe("POST /setup-api/ai-models/configure — the coding agent's tool list o
     // mock could be trimmed back to `getAll`/`setMany` and every case here
     // would go on passing over an image-ops gate that never ran (TASK-727).
     expect(vi.mocked(configGet)).toHaveBeenCalledWith("clawai_credential_refused_at");
+  });
+
+  it("hands the credential to HERMES, which is the agent answering on this box", async () => {
+    // The defect: everything the route does above configures OpenClaw, and on
+    // the dual SKU Hermes is what the owner is talking to. It keeps its own
+    // provider catalogue, image backend and speech slot, so
+    // `ai_set_provider("clawai")` went on answering "That provider is not set
+    // up on this device" over a token that had just been pasted and stored.
+    const res = await configurePost(jsonRequest({ provider: "clawai", apiKey: CLAWAI_TOKEN }));
+
+    expect(res.status).toBe(200);
+    expect(applyClawaiToHermesMock).toHaveBeenCalledTimes(1);
+    const [token, tier, options] = applyClawaiToHermesMock.mock.calls[0];
+    expect(token).toBe(CLAWAI_TOKEN);
+    expect(typeof tier).toBe("string");
+    // The two snapshots the route holds and the apply cannot take for itself:
+    // the token is already in the store by then, so its own reads would answer
+    // about THIS save — ready true whatever the box looked like a moment ago,
+    // and no account change on a real re-link.
+    expect(options).toMatchObject({ codingAgentReadyBefore: false });
+    expect(options).toHaveProperty("previousClawaiToken");
+  });
+
+  it("asks for ONE reload, not two, when it hands the save to Hermes", async () => {
+    // The apply performs the coding-agent, provider and image refreshes from
+    // its own before/after pair. A second global reload from this route would
+    // respawn every MCP child again and invalidate the model's prompt cache a
+    // second time for one save.
+    await configurePost(jsonRequest({ provider: "clawai", apiKey: CLAWAI_TOKEN }));
+
+    expect(applyClawaiToHermesMock).toHaveBeenCalledTimes(1);
+    expect(mockReloadMcpServers).toHaveBeenCalledTimes(1);
+  });
+
+  it("still answers 200 when Hermes will not take the credential", async () => {
+    // OpenClaw is configured and the token is on disk by then: a Hermes write
+    // that fails must not turn a save that landed into an error. It is logged,
+    // loudly, because the agent's own view is what the owner judges it by.
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    applyClawaiToHermesMock.mockRejectedValue(new Error("hermes config set failed"));
+
+    const res = await configurePost(jsonRequest({ provider: "clawai", apiKey: CLAWAI_TOKEN }));
+
+    expect(res.status).toBe(200);
+    expect(store.clawai_token).toBe(CLAWAI_TOKEN);
+    expect(err.mock.calls.flat().join(" ")).toMatch(/Hermes did not take it/);
+  });
+
+  it("does not touch Hermes for a save that is not ClawBox AI", async () => {
+    await configurePost(jsonRequest({ provider: "anthropic", apiKey: "sk-ant-test" }));
+    expect(applyClawaiToHermesMock).not.toHaveBeenCalled();
   });
 
   it("does not charge a reload for a save that changed nothing about readiness", async () => {
@@ -416,29 +492,31 @@ describe("POST /setup-api/ai-models/configure — the coding agent's tool list o
 
   it("still answers 200 when the probe throws AFTER the credential is written", async () => {
     // The other half, and the one that matters more: by then the token IS on
-    // disk. The save has landed and must be reported as landed; the tool list
-    // catches up at the next respawn, which is what every box did before this
-    // helper existed.
-    mockGetCodingAgentStatus
-      .mockImplementationOnce(readyFromStore)
-      .mockImplementationOnce(async () => {
-        // Asserted INSIDE the second probe, so the ordering is pinned and not
-        // just the count: a regression that took both readings before the write
-        // would still be called twice, still answer 200 and still buy no
-        // reload — and would be exactly the bug this whole change is about.
-        expect(store.clawai_token).toBe(CLAWAI_TOKEN);
-        throw new Error("cannot read the store");
-      });
+    // disk. The save has landed and must be reported as landed.
+    //
+    // On this SKU the post-write probe is the APPLY's — the route hands it the
+    // before-snapshot and the apply reads `ready` again for itself — so a probe
+    // that throws is a Hermes hand-off that failed, and the route's own refresh
+    // is the backstop: the credential changed, the tool list has to be asked
+    // for either way. The one thing that must NOT happen is a 500 over a save
+    // that landed.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    applyClawaiToHermesMock.mockImplementation(async () => {
+      // Asserted INSIDE the apply, so the ordering is pinned and not just the
+      // count: a regression that handed Hermes the credential BEFORE storing it
+      // would still answer 200 and still refresh.
+      expect(store.clawai_token).toBe(CLAWAI_TOKEN);
+      throw new Error("cannot read the store");
+    });
 
     const res = await configurePost(jsonRequest({ provider: "clawai", apiKey: CLAWAI_TOKEN }));
 
     expect(res.status).toBe(200);
     expect(store.clawai_token).toBe(CLAWAI_TOKEN);
-    expect(mockReloadMcpServers).not.toHaveBeenCalled();
-    // And the post-write probe was actually REACHED. Without this the case
-    // would pass over a route that skipped the second read entirely — 200, the
-    // token stored and no reload are all true of that route too.
-    expect(mockGetCodingAgentStatus).toHaveBeenCalledTimes(2);
+    // The apply was reached, and the route still asked for the rebuild the save
+    // earned.
+    expect(applyClawaiToHermesMock).toHaveBeenCalledTimes(1);
+    expect(mockReloadMcpServers).toHaveBeenCalledTimes(1);
   });
 
   /*

--- a/src/tests/routes/ai-models/configure-dual-coding-tools.test.ts
+++ b/src/tests/routes/ai-models/configure-dual-coding-tools.test.ts
@@ -339,7 +339,7 @@ describe("POST /setup-api/ai-models/configure — the coding agent's tool list o
           const after = (await mockGetCodingAgentStatus()).ready;
           await refreshCodingAgentToolsIfReadinessChanged(options.codingAgentReadyBefore, after);
         }
-        return { provider: "clawai", model: "deepseek-v4-flash", tier: "free", explicitPickKept: false };
+        return { provider: "clawai", model: "deepseek-v4-flash", tier: "flash", explicitPickKept: false };
       },
     );
 
@@ -517,6 +517,35 @@ describe("POST /setup-api/ai-models/configure — the coding agent's tool list o
     // earned.
     expect(applyClawaiToHermesMock).toHaveBeenCalledTimes(1);
     expect(mockReloadMcpServers).toHaveBeenCalledTimes(1);
+    // And the owner is TOLD. The apply is a sequence of independent
+    // `hermes config set` calls that throws on the first failing one, so it can
+    // stop with Hermes pointed at the clawai provider and the previous
+    // provider's model still named — every turn then fails while this route
+    // answers 200. Saying nothing here is the false-success shape; the journal
+    // line is not a surface the owner has.
+    expect((await res.json()).warning).toMatch(/on-device agent has not taken the credential/);
+  });
+
+  it("does not ask for a reload when the route's own backstop probe throws too", async () => {
+    // Both probes gone: the apply failed and the route's own post-write read of
+    // `getCodingAgentStatus` throws as well. A reload respawns every MCP child
+    // and invalidates the model's prompt cache, so an UNKNOWN verdict must not
+    // buy one — and the save still has to be reported as landed.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    applyClawaiToHermesMock.mockImplementation(async () => {
+      throw new Error("hermes did not take it");
+    });
+    // Ready BEFORE (the route's own snapshot, taken ahead of the write), then
+    // unreadable afterwards.
+    mockGetCodingAgentStatus
+      .mockImplementationOnce(readyFromStore)
+      .mockRejectedValue(new Error("cannot read the store"));
+
+    const res = await configurePost(jsonRequest({ provider: "clawai", apiKey: CLAWAI_TOKEN }));
+
+    expect(res.status).toBe(200);
+    expect(store.clawai_token).toBe(CLAWAI_TOKEN);
+    expect(mockReloadMcpServers).not.toHaveBeenCalled();
   });
 
   /*

--- a/src/tests/routes/ai-models/configure-dual-coding-tools.test.ts
+++ b/src/tests/routes/ai-models/configure-dual-coding-tools.test.ts
@@ -391,6 +391,12 @@ describe("POST /setup-api/ai-models/configure — the coding agent's tool list o
     // and no account change on a real re-link.
     expect(options).toMatchObject({ codingAgentReadyBefore: false });
     expect(options).toHaveProperty("previousClawaiToken");
+    // And NOT the voice. The apply picks Hermes' cloud voice for a box that
+    // has none, which is right when the box's own harness is being linked and
+    // is not this save's decision to make on `dual`, where the cloud-voice
+    // question is open with the owner. Before this arm existed the route could
+    // not reach that writer on a dual box at all.
+    expect(options).toMatchObject({ selectCloudVoice: false });
   });
 
   it("asks for ONE reload, not two, when it hands the save to Hermes", async () => {

--- a/src/tests/routes/hermes/models-explicit-pick.test.ts
+++ b/src/tests/routes/hermes/models-explicit-pick.test.ts
@@ -34,6 +34,13 @@ vi.mock("@/lib/provider-verified", () => ({ readProviderVerified: vi.fn(async ()
 vi.mock("@/lib/config-store", () => ({
   setMany: setManyMock,
   getKnown: vi.fn(async () => ({ value: undefined, known: true })),
+  // `get`/`set` are how the link reads and clears the persisted ClawBox AI
+  // credential refusal — the record that decides whether the image slot may be
+  // armed. Both calls sit inside a catch that answers a DEFAULT, so omitting
+  // them would silently put every case here on the "no refusal" branch
+  // (openclaw-config-mock-completeness.test.ts).
+  get: vi.fn(async () => undefined),
+  set: vi.fn(),
 }));
 
 import { EXPLICIT_MODEL_PICKS_KEY } from "@/lib/explicit-model-pick";

--- a/src/tests/unit/hermes-apply-error-text.test.ts
+++ b/src/tests/unit/hermes-apply-error-text.test.ts
@@ -36,6 +36,12 @@ vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
 vi.mock("@/lib/config-store", () => ({
   setMany: vi.fn(),
   get: vi.fn(async () => null),
+  // `get`/`set` are how the link reads and clears the persisted ClawBox AI
+  // credential refusal — the record that decides whether the image slot may be
+  // armed. Both calls sit inside a catch that answers a DEFAULT, so omitting
+  // them would silently put every case here on the "no refusal" branch
+  // (openclaw-config-mock-completeness.test.ts).
+  set: vi.fn(),
   // Read before the first write, to spot an account switch and the owner's
   // explicit model pick (TASK-713).
   getKnown: vi.fn(async () => ({ value: undefined, known: true })),

--- a/src/tests/unit/hermes-clawai-coding-agent.test.ts
+++ b/src/tests/unit/hermes-clawai-coding-agent.test.ts
@@ -38,6 +38,13 @@ vi.mock("@/lib/harness/hermes-features", () => ({ hermesAgentDrawsImages: drawsM
 vi.mock("@/lib/config-store", () => ({
   setMany: vi.fn(),
   getKnown: vi.fn(async () => ({ value: undefined, known: true })),
+  // `get`/`set` are how the link reads and clears the persisted ClawBox AI
+  // credential refusal — the record that decides whether the image slot may be
+  // armed. Both calls sit inside a catch that answers a DEFAULT, so omitting
+  // them would silently put every case here on the "no refusal" branch
+  // (openclaw-config-mock-completeness.test.ts).
+  get: vi.fn(async () => undefined),
+  set: vi.fn(),
 }));
 vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));

--- a/src/tests/unit/hermes-clawai-credential-refusal.test.ts
+++ b/src/tests/unit/hermes-clawai-credential-refusal.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * A ClawBox AI apply retires the proxy's REFUSAL only when the credential
+ * actually changed.
+ *
+ * When the proxy refuses this box's token, ClawBox records the fact
+ * (`clawai_credential_refused_at`) and both boot scripts stand the image path
+ * down, because there is no back-off downstream: the plugin spends refused calls
+ * for as long as the box is switched on (6,554 in twelve hours from one box,
+ * TASK-727). The mark is about the CREDENTIAL, so only a different credential
+ * retires it — the rule `configureClawboxAi` already states on the OpenClaw
+ * side, and the rule this apply did not follow: it cleared the mark the moment
+ * `config set providers.clawai.api_key` exited 0, whatever was in it.
+ *
+ * That was harmless while only a pasted token reached here. It stopped being
+ * harmless when the configure route began calling this on the dual SKU: a
+ * Settings save with the SAME token — or a tier-pill press, which falls back to
+ * the stored token — retired the stand-down, and the next boot re-armed the
+ * image path against a credential the proxy had already refused.
+ */
+
+const cliMock = vi.hoisted(() => vi.fn());
+const forgetRefusal = vi.hoisted(() => vi.fn(async () => {}));
+const storedToken = vi.hoisted(() => ({ value: "claw_stored" }));
+
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
+vi.mock("@/lib/harness/hermes-features", () => ({ hermesAgentDrawsImages: vi.fn(async () => true) }));
+vi.mock("@/lib/config-store", () => ({
+  setMany: vi.fn(),
+  // `get`/`set` too, even though the refusal write is spied below: a factory
+  // that omits them makes every read of the persisted refusal take its catch
+  // and answer the default, silently — which is what
+  // openclaw-config-mock-completeness.test.ts exists to catch.
+  get: vi.fn(async () => undefined),
+  set: vi.fn(),
+  // What the box holds BEFORE this apply — the fallback `previousClawaiToken`
+  // is read from when a caller does not pass one.
+  getKnown: vi.fn(async (key: string) =>
+    key === "clawai_token" ? { value: storedToken.value, known: true } : { value: undefined, known: true },
+  ),
+}));
+vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
+vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));
+vi.mock("@/lib/hermes-image-plugin", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/hermes-image-plugin")>()),
+  installHermesImagePlugin: vi.fn(),
+}));
+vi.mock("@/lib/clawbox-ai-vision", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/clawbox-ai-vision")>()),
+  resolveVisionModelId: vi.fn(async () => ({ id: null, verified: false, reason: "probe-failed" })),
+}));
+vi.mock("@/lib/coding-agent", () => ({ getCodingAgentStatus: vi.fn(async () => ({ ready: true })) }));
+vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn(async () => "hermes") }));
+vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: vi.fn(async () => ({ status: "ok" })) }));
+vi.mock("@/lib/hermes-dashboard-control", () => ({ bounceHermesDashboard: vi.fn(async () => "restarted") }));
+// The one write under test, spied rather than replaced wholesale so every other
+// export of the module keeps its real behaviour.
+vi.mock("@/lib/harness/credentials", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/harness/credentials")>()),
+  forgetClawaiCredentialRefusal: forgetRefusal,
+}));
+
+import { applyClawaiToHermes } from "@/lib/hermes-clawai";
+
+beforeEach(() => {
+  cliMock.mockReset();
+  forgetRefusal.mockClear();
+  storedToken.value = "claw_stored";
+  cliMock.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+});
+
+describe("applyClawaiToHermes and the credential refusal", () => {
+  it("leaves the stand-down in place when the same credential is saved again", async () => {
+    // The dual-SKU Settings save, and the tier-pill press: nothing about the
+    // credential changed, so the proxy's refusal of it is still true. Clearing
+    // here re-armed the image path both boot scripts had just stood down.
+    await applyClawaiToHermes("claw_stored", "flash", { previousClawaiToken: "claw_stored" });
+
+    expect(forgetRefusal).not.toHaveBeenCalled();
+  });
+
+  it("retires it when a DIFFERENT credential is linked", async () => {
+    // The re-link every refusal message asks for. The mark is about the token
+    // that is gone.
+    await applyClawaiToHermes("claw_new", "flash", { previousClawaiToken: "claw_stored" });
+
+    expect(forgetRefusal).toHaveBeenCalledTimes(1);
+  });
+
+  it("retires it on a first link, where the box held no token at all", async () => {
+    // No previous token is not "unchanged": whatever was refused, this is not
+    // it, and a box linking for the first time must arm.
+    storedToken.value = "";
+    await applyClawaiToHermes("claw_new", "flash");
+
+    expect(forgetRefusal).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retire it when the api_key write itself failed", async () => {
+    // The pre-existing half of the rule, kept: dropping the mark before the new
+    // credential is on disk would re-enable requests against the very token the
+    // proxy refused.
+    cliMock.mockImplementation(async (args: string[]) =>
+      args[2] === "providers.clawai.api_key"
+        ? { code: 1, stdout: "", stderr: "refused" }
+        : { code: 0, stdout: "", stderr: "" },
+    );
+
+    await expect(
+      applyClawaiToHermes("claw_new", "flash", { previousClawaiToken: "claw_stored" }),
+    ).rejects.toThrow();
+    expect(forgetRefusal).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/unit/hermes-clawai-explicit-pick.test.ts
+++ b/src/tests/unit/hermes-clawai-explicit-pick.test.ts
@@ -17,7 +17,17 @@ const getKnownMock = vi.hoisted(() => vi.fn());
 const setManyMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
-vi.mock("@/lib/config-store", () => ({ setMany: setManyMock, getKnown: getKnownMock }));
+vi.mock("@/lib/config-store", () => ({
+  setMany: setManyMock,
+  getKnown: getKnownMock,
+  // `get`/`set` are how the link reads and clears the persisted ClawBox AI
+  // credential refusal — the record that decides whether the image slot may be
+  // armed. Both calls sit inside a catch that answers a DEFAULT, so omitting
+  // them would silently put every case here on the "no refusal" branch
+  // (openclaw-config-mock-completeness.test.ts).
+  get: vi.fn(async () => undefined),
+  set: vi.fn(),
+}));
 vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));
 vi.mock("@/lib/coding-agent", () => ({ getCodingAgentStatus: vi.fn(async () => ({ ready: false })) }));

--- a/src/tests/unit/hermes-clawai-images.test.ts
+++ b/src/tests/unit/hermes-clawai-images.test.ts
@@ -18,8 +18,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
  */
 
 const cliMock = vi.hoisted(() => vi.fn());
-/** What `clawai_credential_refused_at` holds, per case. */
-const refusalRecord = vi.hoisted(() => ({ value: undefined as unknown }));
+/** What `clawai_credential_refused_at` holds, per case — and whether the store
+ * could be read at all. */
+const refusalRecord = vi.hoisted(() => ({ value: undefined as unknown, known: true }));
 const envMock = vi.hoisted(() => vi.fn());
 const installMock = vi.hoisted(() => vi.fn());
 const drawsMock = vi.hoisted(() => vi.fn());
@@ -45,7 +46,11 @@ vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }
 // badge decides, exactly as it did before the marker existed.
 vi.mock("@/lib/config-store", () => ({
   setMany: vi.fn(),
-  getKnown: vi.fn(async () => ({ value: undefined, known: true })),
+  getKnown: vi.fn(async (key: string) =>
+    key === "clawai_credential_refused_at"
+      ? { value: refusalRecord.value, known: refusalRecord.known }
+      : { value: undefined, known: true },
+  ),
   // `get`/`set` too: the link asks whether the proxy has REFUSED this box's
   // credential before it arms the image slot, and a factory without them makes
   // that read take its catch and answer "no refusal" in every case —
@@ -138,6 +143,7 @@ describe("enabling image generation when ClawBox AI is linked", () => {
     refreshMock.mockReset();
     hermesFake();
     refusalRecord.value = undefined;
+    refusalRecord.known = true;
     // Called twice per link: once before the writes, once after. The default is
     // the ordinary case — a box that could not draw, and now can.
     drawsMock.mockResolvedValueOnce(false).mockResolvedValue(true);
@@ -163,6 +169,21 @@ describe("enabling image generation when ClawBox AI is linked", () => {
     // keeps the config true for the moment the credential is replaced, and
     // neither turns anything on.
     expect(sets()).toContain(`image_gen.${HERMES_IMAGE_PLUGIN_NAME}.model=${CLAWBOX_AI_IMAGE_MODEL_ID}`);
+  });
+
+  it("does not arm it over a store it could not READ either", async () => {
+    // `readConfig` flattens EACCES, EIO and invalid JSON to `{}`, so the plain
+    // reader would call an unreadable store "no refusal" and arm anyway — and
+    // `image_gen.provider` is the key that makes both boot gates short-circuit
+    // ever after, so that is the one direction that cannot be taken back. The
+    // cost of declining is one Settings → Save on a box whose store works.
+    refusalRecord.known = false;
+
+    await applyClawaiToHermes("claw_token_abc", "flash", {
+      previousClawaiToken: "claw_token_abc",
+    });
+
+    expect(sets()).not.toContain(`image_gen.provider=${HERMES_IMAGE_PLUGIN_NAME}`);
   });
 
   it("arms it again for the re-link the refusal message asks for", async () => {

--- a/src/tests/unit/hermes-clawai-images.test.ts
+++ b/src/tests/unit/hermes-clawai-images.test.ts
@@ -18,6 +18,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
  */
 
 const cliMock = vi.hoisted(() => vi.fn());
+/** What `clawai_credential_refused_at` holds, per case. */
+const refusalRecord = vi.hoisted(() => ({ value: undefined as unknown }));
 const envMock = vi.hoisted(() => vi.fn());
 const installMock = vi.hoisted(() => vi.fn());
 const drawsMock = vi.hoisted(() => vi.fn());
@@ -44,6 +46,21 @@ vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }
 vi.mock("@/lib/config-store", () => ({
   setMany: vi.fn(),
   getKnown: vi.fn(async () => ({ value: undefined, known: true })),
+  // `get`/`set` too: the link asks whether the proxy has REFUSED this box's
+  // credential before it arms the image slot, and a factory without them makes
+  // that read take its catch and answer "no refusal" in every case —
+  // silently, which is what openclaw-config-mock-completeness.test.ts exists
+  // to catch.
+  get: vi.fn(async (key: string) =>
+    key === "clawai_credential_refused_at" ? refusalRecord.value : undefined,
+  ),
+  // Modelled rather than swallowed: a link carrying a DIFFERENT credential
+  // clears the stamp partway through, and the arming decision below has to see
+  // that clear — a `vi.fn()` that stored nothing would report the re-link case
+  // as still refused.
+  set: vi.fn(async (key: string, value: unknown) => {
+    if (key === "clawai_credential_refused_at") refusalRecord.value = value;
+  }),
 }));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: envMock }));
 // The copy is mocked; `mergePluginsEnabled` is NOT, because the merge is the
@@ -120,9 +137,45 @@ describe("enabling image generation when ClawBox AI is linked", () => {
     drawsMock.mockReset();
     refreshMock.mockReset();
     hermesFake();
+    refusalRecord.value = undefined;
     // Called twice per link: once before the writes, once after. The default is
     // the ordinary case — a box that could not draw, and now can.
     drawsMock.mockResolvedValueOnce(false).mockResolvedValue(true);
+  });
+
+  it("does not arm the image slot over a credential the proxy has refused", async () => {
+    // The gate `scripts/gateway-pre-start.sh` and `scripts/register-mcp.sh`
+    // apply at boot, applied to the WRITE. Both boot gates are reached only
+    // while `image_gen.provider` is unset, so a Settings save that armed it
+    // here made every later boot short-circuit on "somebody already chose a
+    // backend" and the stand-down inert for good — while the plugin went on
+    // spending refused calls for as long as the box was switched on (6,554 in
+    // twelve hours from one box, TASK-727).
+    refusalRecord.value = Date.now();
+
+    await applyClawaiToHermes("claw_token_abc", "flash", {
+      previousClawaiToken: "claw_token_abc",
+    });
+
+    expect(sets()).not.toContain(`image_gen.provider=${HERMES_IMAGE_PLUGIN_NAME}`);
+    expect(sets()).not.toContain(`image_gen.model=${CLAWBOX_AI_IMAGE_MODEL_ID}`);
+    // The DESCRIBING writes still land: naming our model and proxy address
+    // keeps the config true for the moment the credential is replaced, and
+    // neither turns anything on.
+    expect(sets()).toContain(`image_gen.${HERMES_IMAGE_PLUGIN_NAME}.model=${CLAWBOX_AI_IMAGE_MODEL_ID}`);
+  });
+
+  it("arms it again for the re-link the refusal message asks for", async () => {
+    // The other side: a DIFFERENT credential retires the mark inside this same
+    // call (the api_key step clears it), so the box that was stood down comes
+    // back in one save rather than waiting for a boot.
+    refusalRecord.value = Date.now();
+
+    await applyClawaiToHermes("claw_token_new", "flash", {
+      previousClawaiToken: "claw_token_old",
+    });
+
+    expect(sets()).toContain(`image_gen.provider=${HERMES_IMAGE_PLUGIN_NAME}`);
   });
 
   it("installs the backend and names it as the one to use", async () => {

--- a/src/tests/unit/hermes-clawai-vision.test.ts
+++ b/src/tests/unit/hermes-clawai-vision.test.ts
@@ -27,6 +27,13 @@ vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }
 vi.mock("@/lib/config-store", () => ({
   setMany: vi.fn(),
   getKnown: vi.fn(async () => ({ value: undefined, known: true })),
+  // `get`/`set` are how the link reads and clears the persisted ClawBox AI
+  // credential refusal — the record that decides whether the image slot may be
+  // armed. Both calls sit inside a catch that answers a DEFAULT, so omitting
+  // them would silently put every case here on the "no refusal" branch
+  // (openclaw-config-mock-completeness.test.ts).
+  get: vi.fn(async () => undefined),
+  set: vi.fn(),
 }));
 // The image half of the apply writes to ~/.hermes and copies a plugin into it.
 // Neither belongs in a unit test's blast radius, and both have their own file

--- a/src/tests/unit/hermes-clawai-voice.test.ts
+++ b/src/tests/unit/hermes-clawai-voice.test.ts
@@ -133,6 +133,27 @@ describe("pointing a linked Hermes box at a voice it can actually use", () => {
     expect(selectProviderMock).toHaveBeenCalledWith("cloud");
   });
 
+  it("leaves the voice untouched when the caller asked it to", async () => {
+    // The dual SKU's configure arm. Picking a voice for a box that has none is
+    // right when the box's OWN harness is being linked — it is how a hermes box
+    // gets one — and it is not this save's decision to make on `dual`, where
+    // the cloud-voice question is open with the owner. Before that arm existed
+    // a dual box could not reach this writer from the configure route at all,
+    // and a credential save must not settle a voice question as a side effect.
+    readVoiceMock.mockResolvedValue(voice(null));
+
+    await applyClawaiToHermes(TOKEN, ENTITLED, { selectCloudVoice: false });
+
+    expect(selectProviderMock).not.toHaveBeenCalled();
+    expect(writeCloudMock).not.toHaveBeenCalled();
+    // Nothing under `tts.` reached the CLI either — the option suppresses the
+    // whole leg, not just the selection at the end of it.
+    const ttsWrites = cliMock.mock.calls
+      .map((c) => c[0] as string[])
+      .filter((a) => a[1] === "set" && typeof a[2] === "string" && a[2].startsWith("tts."));
+    expect(ttsWrites).toEqual([]);
+  });
+
   it("replaces Hermes' factory cloud rather than speaking through Microsoft", async () => {
     // `edge` is Hermes' own default and a third cloud the customer never
     // chose; hermes-tts.ts treats it as factory-unset for exactly this reason.

--- a/src/tests/unit/hermes-plugins-enabled-readback.test.ts
+++ b/src/tests/unit/hermes-plugins-enabled-readback.test.ts
@@ -49,6 +49,13 @@ vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }
 vi.mock("@/lib/config-store", () => ({
   setMany: vi.fn(),
   getKnown: vi.fn(async () => ({ value: undefined, known: true })),
+  // `get`/`set` are how the link reads and clears the persisted ClawBox AI
+  // credential refusal — the record that decides whether the image slot may be
+  // armed. Both calls sit inside a catch that answers a DEFAULT, so omitting
+  // them would silently put every case here on the "no refusal" branch
+  // (openclaw-config-mock-completeness.test.ts).
+  get: vi.fn(async () => undefined),
+  set: vi.fn(),
 }));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: envMock }));
 // The vision probe reaches the proxy over the network and waits seconds for it.

--- a/src/tests/unit/hermes-provider-model-catalog.test.ts
+++ b/src/tests/unit/hermes-provider-model-catalog.test.ts
@@ -45,6 +45,13 @@ vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: invalidat
 vi.mock("@/lib/config-store", () => ({
   setMany: vi.fn(),
   getKnown: vi.fn(async () => ({ value: undefined, known: true })),
+  // `get`/`set` are how the link reads and clears the persisted ClawBox AI
+  // credential refusal — the record that decides whether the image slot may be
+  // armed. Both calls sit inside a catch that answers a DEFAULT, so omitting
+  // them would silently put every case here on the "no refusal" branch
+  // (openclaw-config-mock-completeness.test.ts).
+  get: vi.fn(async () => undefined),
+  set: vi.fn(),
 }));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));
 vi.mock("@/lib/coding-agent", () => ({ getCodingAgentStatus: vi.fn(async () => ({ ready: false })) }));

--- a/src/tests/unit/provider-write-paths.test.ts
+++ b/src/tests/unit/provider-write-paths.test.ts
@@ -34,7 +34,16 @@ vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: rpcMock }));
 vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn(async () => "hermes") }));
 vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
 const storeGetMock = vi.hoisted(() => vi.fn<(key: string) => Promise<unknown>>(async () => null));
-vi.mock("@/lib/config-store", () => ({ get: storeGetMock, setMany: vi.fn() }));
+vi.mock("@/lib/config-store", () => ({
+  get: storeGetMock,
+  setMany: vi.fn(),
+  // `get`/`set` are how the link reads and clears the persisted ClawBox AI
+  // credential refusal — the record that decides whether the image slot may be
+  // armed. Both calls sit inside a catch that answers a DEFAULT, so omitting
+  // them would silently put every case here on the "no refusal" branch
+  // (openclaw-config-mock-completeness.test.ts).
+  set: vi.fn(),
+}));
 vi.mock("@/lib/hermes-config-yaml", () => ({
   patchHermesConfig: patchMock,
   readHermesConfigValue: readConfigMock,

--- a/src/tests/unit/register-mcp-image-rearm.test.ts
+++ b/src/tests/unit/register-mcp-image-rearm.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { execFileSync, spawnSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { testEnv } from "@/tests/helpers/env";
+
+/**
+ * The Hermes side of the ClawBox AI credential stand-down (TASK-727).
+ *
+ * When the proxy REFUSES this box's credential, ClawBox records the fact once
+ * (`clawai_credential_refused_at` in the device store) and stands the image
+ * path down, because there is no back-off anywhere downstream: the plugin
+ * spends refused calls for as long as the box is switched on — 6,554 in twelve
+ * hours from one box. `gateway-pre-start.sh` has read that record since the fix
+ * landed; this script never did, and it is the one that puts the image backend
+ * BACK. So on the boot after a plugin-list repair, a Hermes box re-armed itself
+ * over a credential it had been told was dead, and the storm started again with
+ * nobody looking.
+ *
+ * The re-arm's other four conditions are pinned here too, because the gate must
+ * not be the only thing standing between a refused box and the arm.
+ */
+
+// Starts real processes (bash + python3): vitest's 5 s default is not enough.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+const SCRIPT = path.join(process.cwd(), "scripts", "register-mcp.sh");
+
+function have(cmd: string, args: string[]): boolean {
+  try {
+    execFileSync(cmd, args, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const CAN_RUN =
+  have("bash", ["-c", "true"]) && have("python3", ["-c", "import yaml"]);
+const d = CAN_RUN ? describe : describe.skip;
+
+let home: string;
+let root: string;
+let configPath: string;
+let lockPath: string;
+
+function run(): { status: number; stdout: string; stderr: string } {
+  const r = spawnSync("bash", [SCRIPT], {
+    encoding: "utf-8",
+    env: testEnv({
+      PATH: process.env.PATH ?? "",
+      HOME: home,
+      CLAWBOX_ROOT: root,
+      HERMES_CONFIG: configPath,
+      HERMES_BIN: path.join(home, "fake-hermes"),
+      BUN_BIN: path.join(home, "fake-bun"),
+      CLAWBOX_EDITION_FILE: lockPath,
+    }),
+  });
+  return { status: r.status ?? -1, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+function readConfig(): Record<string, unknown> {
+  const out = execFileSync(
+    "python3",
+    ["-c", "import json,sys,yaml; print(json.dumps(yaml.safe_load(open(sys.argv[1])) or {}))", configPath],
+    { encoding: "utf-8" },
+  );
+  return JSON.parse(out) as Record<string, unknown>;
+}
+
+/** The device store the boot scripts read, with whatever this case wants in it. */
+function writeDeviceStore(entries: Record<string, unknown>): void {
+  fs.mkdirSync(path.join(root, "data"), { recursive: true });
+  fs.writeFileSync(path.join(root, "data", "config.json"), JSON.stringify(entries));
+}
+
+/**
+ * The one state the re-arm fires in: `plugins.enabled` stored as TEXT (which
+ * loads no plugins at all) naming the backend, with the backend's files really
+ * on disk and nobody's choice in `image_gen.provider`.
+ */
+function writeRepairableConfig(): void {
+  fs.mkdirSync(path.join(home, ".hermes", "plugins", "image_gen", "clawai"), { recursive: true });
+  fs.writeFileSync(
+    path.join(home, ".hermes", "plugins", "image_gen", "clawai", "__init__.py"),
+    "# stand-in for the linked backend\n",
+  );
+  fs.writeFileSync(configPath, "plugins:\n  enabled: 'clawai'\n");
+}
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-rearm-home-"));
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-rearm-root-"));
+  configPath = path.join(home, ".hermes", "config.yaml");
+  lockPath = path.join(home, "edition.env");
+
+  fs.mkdirSync(path.join(root, "mcp"), { recursive: true });
+  fs.writeFileSync(path.join(root, "mcp", "clawbox-mcp.ts"), "// stand-in\n");
+  for (const bin of ["fake-hermes", "fake-bun"]) {
+    const p = path.join(home, bin);
+    fs.writeFileSync(p, "#!/bin/sh\nexit 0\n");
+    fs.chmodSync(p, 0o755);
+  }
+  fs.mkdirSync(path.join(home, ".hermes"), { recursive: true });
+  fs.writeFileSync(lockPath, "CLAWBOX_EDITION=hermes\n");
+  writeRepairableConfig();
+});
+
+afterEach(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+d("the ClawAI image backend is not re-armed over a refused credential", () => {
+  it("leaves image_gen.provider unset, and says why", () => {
+    writeDeviceStore({ clawai_token: "claw_x", clawai_credential_refused_at: Date.now() });
+
+    const res = run();
+
+    expect(res.status).toBe(0);
+    const cfg = readConfig();
+    expect(
+      (cfg.image_gen as Record<string, unknown> | undefined)?.provider,
+      `the backend was armed over a refused credential:\n${res.stdout}${res.stderr}`,
+    ).toBeUndefined();
+    expect(`${res.stdout}${res.stderr}`).toMatch(/credential was refused/);
+  });
+
+  it("still re-arms a box nobody has been told about", () => {
+    // The other side, and the reason the gate is a fifth condition rather than
+    // a new default: the repair exists so a box whose plugin list was stored as
+    // text stops reporting that it cannot draw. Absent, unreadable and
+    // malformed records all mean "nobody has told us this credential is dead".
+    writeDeviceStore({ clawai_token: "claw_x" });
+
+    const res = run();
+
+    expect(res.status).toBe(0);
+    expect((readConfig().image_gen as Record<string, unknown>).provider).toBe("clawai");
+    expect(`${res.stdout}${res.stderr}`).toMatch(/re-armed image_gen\.provider/);
+  });
+
+  it("reads a malformed record as nothing having been said", () => {
+    // Same collapse as `_clawai_credential_refused` in gateway-pre-start.sh:
+    // a value that is not a positive number is not a refusal, and a box we have
+    // not been told about is left as it is.
+    writeDeviceStore({ clawai_credential_refused_at: "yesterday" });
+
+    const res = run();
+
+    expect(res.status).toBe(0);
+    expect((readConfig().image_gen as Record<string, unknown>).provider).toBe("clawai");
+  });
+
+  it("does not arm over a backend somebody already chose", () => {
+    // Condition 3, pinned beside the new one: `image_gen.provider` that already
+    // names something is a choice — ours or the owner's — and not this script's
+    // to move.
+    writeDeviceStore({});
+    fs.writeFileSync(configPath, "plugins:\n  enabled: 'clawai'\nimage_gen:\n  provider: someone-elses\n");
+
+    const res = run();
+
+    expect(res.status).toBe(0);
+    expect((readConfig().image_gen as Record<string, unknown>).provider).toBe("someone-elses");
+  });
+});

--- a/src/tests/unit/register-mcp-image-rearm.test.ts
+++ b/src/tests/unit/register-mcp-image-rearm.test.ts
@@ -156,19 +156,41 @@ d("the ClawAI image backend is not re-armed over a refused credential", () => {
     expect((readConfig().image_gen as Record<string, unknown>).provider).toBe("clawai");
   });
 
-  it("says so out loud when the store cannot be READ, and still leaves the box alone", () => {
-    // Absent and unreadable collapse to the same answer on purpose — the
-    // sibling gate in gateway-pre-start.sh does the same, and this script runs
-    // as clawbox where that one runs as root, so a root-owned config.json lands
-    // here — but they are not the same event. Silence would let the log print
-    // "re-armed image_gen.provider" as though all five conditions had been
-    // weighed.
+  it("declines the re-arm when the store cannot be READ, and says why", () => {
+    // Absent and unreadable are NOT the same event. This script runs as the
+    // clawbox user where its sibling gateway-pre-start.sh runs as root, so a
+    // root-owned data/config.json lands here — and arming over a credential it
+    // cannot check is the one thing the gate exists to stop. Condition 4 takes
+    // exactly this line for a `plugins.disabled` it cannot read: the cost of
+    // declining is one Settings → Save.
     fs.mkdirSync(path.join(root, "data", "config.json"), { recursive: true });
 
     const res = run();
 
     expect(res.status).toBe(0);
     expect(`${res.stdout}${res.stderr}`).toMatch(/could not read the device store/);
+    expect(
+      (readConfig().image_gen as Record<string, unknown> | undefined)?.provider,
+      "an unreadable store must not arm the image backend",
+    ).toBeUndefined();
+  });
+
+  it("a refusal stamp too large for a double is not a refusal, and not an unreadable store either", () => {
+    // `math.isfinite()` on an int past Number.MAX_VALUE raises OverflowError,
+    // which would have been reported as "could not read the device store" over
+    // a store that read perfectly. The sibling reader bounds the range instead
+    // of converting, and this one now says the same thing over every value
+    // either language can parse.
+    fs.mkdirSync(path.join(root, "data"), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, "data", "config.json"),
+      `{"clawai_credential_refused_at": ${"9".repeat(320)}}`,
+    );
+
+    const res = run();
+
+    expect(res.status).toBe(0);
+    expect(`${res.stdout}${res.stderr}`).not.toMatch(/could not read the device store/);
     expect((readConfig().image_gen as Record<string, unknown>).provider).toBe("clawai");
   });
 

--- a/src/tests/unit/register-mcp-image-rearm.test.ts
+++ b/src/tests/unit/register-mcp-image-rearm.test.ts
@@ -8,9 +8,11 @@ import { testEnv } from "@/tests/helpers/env";
 /**
  * The Hermes side of the ClawBox AI credential stand-down (TASK-727).
  *
- * When the proxy REFUSES this box's credential, ClawBox records the fact once
- * (`clawai_credential_refused_at` in the device store) and stands the image
- * path down, because there is no back-off anywhere downstream: the plugin
+ * When the proxy REFUSES this box's credential, ClawBox records the fact
+ * (`clawai_credential_refused_at` in the device store — refreshed on every
+ * refusal, never write-once, so the stamp always belongs to the credential the
+ * box holds now) and stands the image path down, because there is no back-off
+ * anywhere downstream: the plugin
  * spends refused calls for as long as the box is switched on — 6,554 in twelve
  * hours from one box. `gateway-pre-start.sh` has read that record since the fix
  * landed; this script never did, and it is the one that puts the image backend
@@ -151,6 +153,22 @@ d("the ClawAI image backend is not re-armed over a refused credential", () => {
     const res = run();
 
     expect(res.status).toBe(0);
+    expect((readConfig().image_gen as Record<string, unknown>).provider).toBe("clawai");
+  });
+
+  it("says so out loud when the store cannot be READ, and still leaves the box alone", () => {
+    // Absent and unreadable collapse to the same answer on purpose — the
+    // sibling gate in gateway-pre-start.sh does the same, and this script runs
+    // as clawbox where that one runs as root, so a root-owned config.json lands
+    // here — but they are not the same event. Silence would let the log print
+    // "re-armed image_gen.provider" as though all five conditions had been
+    // weighed.
+    fs.mkdirSync(path.join(root, "data", "config.json"), { recursive: true });
+
+    const res = run();
+
+    expect(res.status).toBe(0);
+    expect(`${res.stdout}${res.stderr}`).toMatch(/could not read the device store/);
     expect((readConfig().image_gen as Record<string, unknown>).provider).toBe("clawai");
   });
 


### PR DESCRIPTION
**TASK-765**, the two arms the card scopes: the dual+hermes configure arm and the Hermes `register-mcp.sh` refusal gate. The card's cloud-voice GATING item is deliberately **not** in this PR (owner ruling pending) — see "Scope" below for the one place that boundary is not perfectly clean, stated rather than hidden.

## Customer-visible symptom

1. **On a `dual` box running Hermes, connecting ClawBox AI configured OpenClaw and told Hermes nothing.** The agent the owner is actually talking to kept answering `ai_set_provider("clawai")` with "That provider is not set up on this device" over a token pasted seconds earlier, and its image backend and speech slot stayed unset.
2. **A Hermes box re-armed the ClawBox AI image backend over a credential the proxy had refused.** ClawBox records the refusal (`clawai_credential_refused_at`) and stands the image path down, because nothing downstream backs off — the plugin spends refused calls for as long as the box is switched on (6,554 in twelve hours from one box, TASK-727). `gateway-pre-start.sh` has read that record since the fix landed; `register-mcp.sh`, which is what puts the image backend BACK after a plugin-list repair, never did.

## Cause

`openclawIsAbsent()` is `readEdition() === "hermes"`, so a `dual` box never reaches the configure route's Hermes branch (TASK-577's funnel assumption, recorded there as having already cost a defect). And the re-arm in `register-mcp.sh` weighed four conditions, none of which was the stand-down.

## Harness-first

Nothing here re-implements a harness mechanism. The credential goes into Hermes through **Hermes' own CLI** (`hermes config set`, via the existing `applyClawaiToHermes`, which is the funnel every other Hermes connect path already uses) — the route does not write `~/.hermes/config.yaml` itself. The refusal verdict has no harness equivalent by construction: Hermes' `authSignals` is a static availability gate and the bundled OpenAI SDK does not retry a 401/403, so "declare the path or do not" is the only lever, and the device store is the only place the boot scripts and the web server can share the verdict.

## The fix

- `ai-models/configure`: after the credential is stored, `isClawAI && (await getActiveHarness()) === "hermes"` hands the save to `applyClawaiToHermes` with the two snapshots only this route holds — the coding-agent readiness taken BEFORE its own write, and the token it replaced — exactly as the LOCAL-model case beside it already hands over to `applyLocalAiToHermes`. The apply owns the coding-agent, provider and image refreshes, so the route skips its own (a reload respawns every MCP child and invalidates the model's prompt cache).
- `scripts/register-mcp.sh`: a fifth re-arm condition reading the same key, through the same reader and the same collapse as `_clawai_credential_refused` in `gateway-pre-start.sh`. Absent, malformed and non-numeric all mean "nobody has told us this credential is dead". An unreadable store still arms (parity with the sibling) but now says so — this script runs as `clawbox` where the sibling runs as root, and a root-owned `data/config.json` is a state this repo has hit before.

## Round 2 — what the review found, and it was on this PR's own line

`applyClawaiToHermes` retired the persisted refusal the moment `config set providers.clawai.api_key` exited 0, **whatever was in it**. Harmless while only a pasted token reached the apply; not harmless once the configure route calls it on the dual SKU: a Settings save with the SAME token — or a tier-pill press, which falls back to the stored token — retired the stand-down, and section 7 of the same request then re-armed the OpenClaw image path over a credential the proxy had already refused. **Hunk 2 of this very PR would have re-armed with it at the next boot.** The mark is about the CREDENTIAL, so only a different credential retires it — the rule `configureClawboxAi` already states on the OpenClaw side and that `configure-images.test.ts` pins there by name. `/setup-api/hermes/clawai` carried the same unconditional clear and follows the same rule now.

Also in that round: a failed Hermes hand-off is no longer silent (the route's existing `warning` field carries "the on-device agent has not taken the credential yet"), `setProviderEnabled`'s result is read (it ANSWERS rather than throws when the provider row cannot be found, and the apply may have just restarted the dashboard that serves it), and two comments that named a non-existent symbol and a rule that had become false were corrected.

## RED → GREEN

RED for the round-2 defect, against this branch's own previous head (the clear made unconditional again):

```
 × leaves the stand-down in place when the same credential is saved again
   AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
   Tests  1 failed | 3 passed (4)
```

RED for the two original arms is in the suites they ship with (`register-mcp-image-rearm.test.ts` fails on beta at `image_gen.provider` being armed over a refused credential; `configure-dual-coding-tools.test.ts` fails on beta with the apply never called).

GREEN: unit project **774 files, 12925 passed / 1 skipped, 0 failed**; components **202 files / 1729 passed**; `tsc --noEmit` exit 0; eslint on the touched files 0 errors (3 pre-existing warnings, none on a changed line); `bash -n scripts/register-mcp.sh` clean.

## Device leg (read-only, Hermes box)

The new store reader was run against **the box's own python 3.10.12** with no writes and no lock taken: an absent path answers `False` with no warning (the `FileNotFoundError` arm), an unreadable one answers `False` **with** the warning, and the box's real `data/config.json` answers `False` (no refusal recorded there today — the value itself was never printed). The `register-mcp.sh` gate was also executed against a hand-built fixture for six store shapes — `{}`, missing file, `"yesterday"`, `0`, `true`, a 320-digit integer and `1.5` — and every answer matched `gateway-pre-start.sh`.

## Sibling call sites

`forgetClawaiCredentialRefusal` has three production callers; all three were checked. `configureClawboxAi` was already correctly gated on `credentialChanged`; the apply and `/setup-api/hermes/clawai` were not and now are. The other two writers of `clawai_token` — `clawai/poll` and `POST /setup-api/hermes/clawai` — carry the MIRROR of the bug this PR fixes (on a dual box they configure Hermes only and never OpenClaw); that is out of this card's scope and is recorded on the queue's Found list rather than fixed here, with `POST /setup-api/ai-models/configure` on the dual SKU still telling Hermes nothing about an Anthropic/Google/OpenRouter key.

## Scope — the cloud voice, and the gate this PR's own arm could bypass

Round 3 (08ad2119) closes both, after review:

**The voice.** No hunk edits voice code, but `applyClawaiToHermes` ends with `selectHermesCloudVoiceIfUnvoiced` — so the new arm would have let a Settings save on a dual box write `tts.provider`/`tts.openai.*` for the first time. Picking a voice for a box that has none is right when the box's OWN harness is being linked (it is how a hermes box gets one) and is not a credential save's decision to make on the SKU whose cloud-voice behaviour is an open question with the owner. The call site now says so with an explicit option (`selectCloudVoice: false`) rather than the writer guessing from the edition, and the option suppresses the whole leg. RED: `hermes-clawai-voice.test.ts` — "leaves the voice untouched when the caller asked it to" asserts no selection, no cloud write, and **no `tts.` key reaching the CLI at all**; the route-level case asserts the option is what the arm passes.

**The gate this PR adds was bypassable through the path this PR adds.** The boot gate in `register-mcp.sh` is the FIFTH condition in a chain whose second short-circuits on "somebody already chose a backend" — and `enableHermesImageGeneration` wrote `image_gen.provider` with no refusal check at all. So a save carrying the same, still-refused token armed the image path and made the boot gate inert for good, while the plugin went on spending refused calls for as long as the box was switched on. The arming write asks the same record now (the describing writes above it are deliberately left alone — naming our model and proxy address turns nothing on), and a save carrying a DIFFERENT credential clears the mark earlier in the same call, so a genuine re-link still arms in one request. RED: `hermes-clawai-images.test.ts` — "does not arm the image slot over a credential the proxy has refused", with its mirror "arms it again for the re-link the refusal message asks for". Both mutation-proven.

**And the store reader answers three things, not two** — refused, nothing recorded, and could-not-look — with the caller DECLINING the re-arm on the third, exactly as condition 4 declines over a `plugins.disabled` it cannot read. This script runs as `clawbox` where its sibling runs as root, so a root-owned `data/config.json` lands in that branch. Its number rule is now the sibling's line for line, so an integer past `Number.MAX_VALUE` is answered rather than reported as an unreadable store.

Eight suites that mock `@/lib/config-store` in front of this apply gained `get`/`set`, because the arming decision now reads the persisted refusal through them — without which every case would silently take the "no refusal" branch (`openclaw-config-mock-completeness.test.ts` catches exactly that, and did).

**GREEN on this head:** unit **777 files, 12980 passed / 1 skipped, 0 failed**; `tsc --noEmit` 0; eslint 0 errors (3 pre-existing warnings); `bash -n scripts/register-mcp.sh` clean. Device leg re-run read-only on the Hermes box against its own python 3.10.12: absent → `False` with no warning, unreadable → `None` **with** the warning, the box's real store → `False` (value never printed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ClawBox AI setup on dual-device configurations by applying credentials consistently and reporting non-blocking Hermes warnings.
  - Reapplying the same refused credential no longer clears its refusal status; linking a new credential resets the status appropriately.
  - Prevented automatic image-provider re-enabling when credentials are refused, invalid, missing, or unreadable.
  - Preserved user-selected image providers during setup and improved handling of provider re-enablement failures.
  - Dual-device setup no longer overwrites existing voice selections when voice configuration is not requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


### Mutation evidence for the two guards (measured on 08ad2119)

Both writer-level REDs exist and both mutations die. They are not in the four suites a review pass sampled — they are in the two whose fixtures make them non-vacuous, which is why the grep missed them:

| mutation in `src/lib/hermes-clawai.ts` | result | killed by |
| --- | --- | --- |
| `if (options.selectCloudVoice !== false)` → the voice leg always fires | **KILLED**, 1 failed / 63 passed | `hermes-clawai-voice.test.ts` → "leaves the voice untouched when the caller asked it to" (drives the real `applyClawaiToHermes`, asserts no selection, no cloud write, and **no `tts.` key reaching the CLI**) |
| the `clawaiCredentialRefusalOnRecord()` early return deleted | **KILLED**, 1 failed / 63 passed | `hermes-clawai-images.test.ts` → "does not arm the image slot over a credential the proxy has refused" (real apply, `hermesFake` CLI, asserts `image_gen.provider` and `image_gen.model` are never written and the describing writes still are) |
| the route stops passing `selectCloudVoice: false` | KILLED | `configure-dual-coding-tools.test.ts` |

Unmutated baseline for those runs: 5 files, 70 tests, all passing (`hermes-clawai-voice`, `hermes-clawai-images`, `configure-dual-coding-tools`, `hermes-clawai-credential-refusal`, `register-mcp-image-rearm`).

The image case cannot live in `hermes-clawai-credential-refusal.test.ts` as-is: that suite's `runHermesCli` answers empty stdout to everything, so `readPluginsEnabledFromCli` reports "unreadable", `enableHermesImageGeneration` throws before either arming write, and the assertion would pass with or without the gate. `hermes-clawai-images.test.ts` has the `hermesFake` store that makes the plugin path real, which is why the case is there.


**Round 4 (3a06d41f)** — the arming write now FAILS CLOSED on a store it could not read. `readConfig` flattens EACCES, EIO and invalid JSON to `{}`, so the plain reader called an unreadable store "no refusal" and armed anyway — the one direction that cannot be taken back, since `image_gen.provider` is what makes both boot gates short-circuit ever after. `clawaiRefusalState()` gives the third answer through `getKnown` (refused / clear / unknown) and the write arms only on "clear", naming which silence it hit; the REPORTING reader keeps its old polarity and its docblock says why the two differ. The sibling shell reader was given the same three states in the previous round, so the boot gate and the write path decline for the same reason. RED: "does not arm it over a store it could not READ either", mutation-proven.
