### PR TITLE
fix: surface the skipped update fixup — read a root step's journal by unit and window, not by an invocation id systemd has already collected

### DIFF
--- a/src/app/setup-api/install/run-step/route.ts
+++ b/src/app/setup-api/install/run-step/route.ts
@@ -3,6 +3,7 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import { requireSession } from "@/lib/route-auth";
 import { UI_ROOT_STEPS } from "@/lib/root-steps";
+import { rootStepJournalArgs, rootStepUnit } from "@/lib/root-step-journal";
 import { startRootStep } from "@/lib/root-step-runner";
 
 export const dynamic = "force-dynamic";
@@ -34,11 +35,19 @@ const ALLOWED_STEPS = new Set(UI_ROOT_STEPS);
 // stare at a stuck request.
 const STEP_TIMEOUT_MS = 10 * 60 * 1000;
 
-async function getJournalTail(unit: string): Promise<string> {
+/**
+ * What THIS run of the step wrote, for the failure the caller is shown.
+ *
+ * Bounded by `sinceMs`, the moment this request started the unit: the journal
+ * is persistent, so a 60-line tail of a step the owner has already retried
+ * runs back through the previous attempt and offers its output as evidence for
+ * this one. root-step-journal.ts carries the rest of the reasoning.
+ */
+async function getJournalTail(step: string, sinceMs: number): Promise<string> {
   try {
     const { stdout } = await execFileAsync(
       "/usr/bin/journalctl",
-      ["-u", unit, "-n", "60", "--no-pager", "-o", "cat"],
+      rootStepJournalArgs(step, { sinceMs, lines: 60 }),
       { timeout: 10_000 },
     );
     return stdout.trim();
@@ -78,7 +87,9 @@ export async function POST(req: Request) {
     );
   }
 
-  const serviceName = `clawbox-root-update@${step}.service`;
+  const serviceName = rootStepUnit(step);
+  // Before the start: the journal read in the catch is bounded to this run.
+  const startedAt = Date.now();
   try {
     // Through the root-owned launcher, which clears a previous failure
     // itself and builds the unit name from a step it validates. This used to
@@ -93,7 +104,7 @@ export async function POST(req: Request) {
       { headers: { "Cache-Control": "no-store" } },
     );
   } catch (err) {
-    const tail = await getJournalTail(serviceName);
+    const tail = await getJournalTail(step, startedAt);
     // Persist a structured failure record so post-mortems don't have to
     // scrape the response body. journalctl is the source of truth, but
     // having the same tail in our service logs makes it discoverable

--- a/src/app/setup-api/llamacpp/install/route.ts
+++ b/src/app/setup-api/llamacpp/install/route.ts
@@ -19,13 +19,14 @@ import {
   writeLlamaCppPid,
 } from "@/lib/llamacpp-server";
 import { startRootStep } from "@/lib/root-step-runner";
+import { rootStepJournalArgs, rootStepUnit } from "@/lib/root-step-journal";
 
 const MODEL_ID_RE = /^[a-zA-Z0-9._:-]+$/;
 const encoder = new TextEncoder();
 const execFile = promisify(execFileCb);
 const CLAWBOX_HOME_DIR = process.env.CLAWBOX_HOME_DIR || process.env.HOME || "/home/clawbox";
-const LLAMACPP_INSTALL_SERVICE = "clawbox-root-update@llamacpp_install.service";
 const LLAMACPP_INSTALL_STEP = "llamacpp_install";
+const LLAMACPP_INSTALL_SERVICE = rootStepUnit(LLAMACPP_INSTALL_STEP);
 // Must stay >= TimeoutStartSec in config/clawbox-root-update@.service so
 // systemd, not us, owns the kill. A cold box builds llama.cpp from source with
 // CUDA and downloads a multi-GB GGUF; 30 min was not enough and the install
@@ -69,11 +70,20 @@ function shouldRepairLlamaCppRuntime(logLine: string | null): boolean {
     || normalized.includes("[llamacpp] missing local model");
 }
 
-async function readLlamaCppInstallLog(lines: number): Promise<string> {
+/**
+ * What THIS install run has written.
+ *
+ * Bounded by `sinceMs`, the moment this call started the unit: the journal is
+ * persistent and this is polled from the first second — before the unit has
+ * said anything — so an unbounded read answers with the LAST attempt's last
+ * line, which the loop below shows as live progress and then reports as this
+ * run's failure reason. root-step-journal.ts has the rest of the reasoning.
+ */
+async function readLlamaCppInstallLog(sinceMs: number, lines: number): Promise<string> {
   try {
     const { stdout } = await execFile(
       "/usr/bin/journalctl",
-      ["-u", LLAMACPP_INSTALL_SERVICE, "-n", String(lines), "--no-pager", "-o", "cat"],
+      rootStepJournalArgs(LLAMACPP_INSTALL_STEP, { sinceMs, lines }),
       { timeout: 10_000 },
     );
     return stdout;
@@ -82,8 +92,8 @@ async function readLlamaCppInstallLog(lines: number): Promise<string> {
   }
 }
 
-async function readLlamaCppInstallFailure(): Promise<string | null> {
-  return getLastLogLine(await readLlamaCppInstallLog(40));
+async function readLlamaCppInstallFailure(sinceMs: number): Promise<string | null> {
+  return getLastLogLine(await readLlamaCppInstallLog(sinceMs, 40));
 }
 
 /**
@@ -123,13 +133,16 @@ function isUnitRunning(active: string): boolean {
 async function repairLlamaCppRuntime(
   onStatus: (line: string) => void,
 ): Promise<{ ok: boolean; error?: string }> {
+  // Before the start, so nothing this run writes falls outside the window the
+  // journal reads are bounded by.
+  const startedAt = Date.now();
   try {
     await startRootStep(
       LLAMACPP_INSTALL_STEP,
       { noBlock: true, timeoutMs: SYSTEMCTL_QUERY_TIMEOUT_MS },
     );
   } catch (err) {
-    const failureLine = await readLlamaCppInstallFailure();
+    const failureLine = await readLlamaCppInstallFailure(startedAt);
     return {
       ok: false,
       error: failureLine || (err instanceof Error ? err.message : "Failed to repair llama.cpp runtime"),
@@ -145,7 +158,7 @@ async function repairLlamaCppRuntime(
     const { active, result } = await readInstallUnitState();
     if (isUnitRunning(active)) sawRunning = true;
 
-    const line = getLastLogLine(await readLlamaCppInstallLog(5));
+    const line = getLastLogLine(await readLlamaCppInstallLog(startedAt, 5));
     if (line && line !== lastLine) {
       lastLine = line;
       onStatus(line);

--- a/src/lib/harness-swap.ts
+++ b/src/lib/harness-swap.ts
@@ -43,7 +43,7 @@ import { ensureHermesGateway, retireHermesUserGateway, setHermesTelegramToken } 
 import { memAvailableMb } from "@/lib/mem-available";
 import { findOpenclawBin, readConfig, restartGateway, setTelegramToken } from "@/lib/openclaw-config";
 import { freeBytes } from "@/lib/project-import";
-import { rootStepUnit } from "@/lib/root-step-follow";
+import { rootStepUnit } from "@/lib/root-step-journal";
 import { isUpdateLocked } from "@/lib/update-lock";
 
 const execFile = promisify(execFileCb);

--- a/src/lib/root-step-follow.ts
+++ b/src/lib/root-step-follow.ts
@@ -13,6 +13,7 @@
 import { execFile as execFileCb } from "child_process";
 import { promisify } from "util";
 import { startRootStep } from "@/lib/root-step-runner";
+import { rootStepJournalArgs, rootStepUnit } from "@/lib/root-step-journal";
 
 const execFile = promisify(execFileCb);
 
@@ -31,10 +32,6 @@ export interface FollowRootStepOptions {
   label: string;
 }
 
-export function rootStepUnit(step: string): string {
-  return `clawbox-root-update@${step}.service`;
-}
-
 async function unitState(unit: string): Promise<{ active: string; result: string }> {
   try {
     const { stdout } = await execFile(
@@ -51,11 +48,20 @@ async function unitState(unit: string): Promise<{ active: string; result: string
   }
 }
 
-async function journalLines(unit: string, lines: number): Promise<string[]> {
+/**
+ * What THIS run of the step has said so far.
+ *
+ * Bounded by `sinceMs`, the moment this follow started it: the journal is
+ * persistent, so an unbounded read hands the last attempt's lines to a caller
+ * that is showing them as live progress — and the poll before the unit writes
+ * anything is exactly when that happens. A second install of the voice would
+ * open by showing the first one's error.
+ */
+async function journalLines(step: string, sinceMs: number, lines: number): Promise<string[]> {
   try {
     const { stdout } = await execFile(
       "/usr/bin/journalctl",
-      ["-u", unit, "-n", String(lines), "--no-pager", "-o", "cat"],
+      rootStepJournalArgs(step, { sinceMs, lines }),
       { timeout: 10_000 },
     );
     return stdout.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
@@ -64,8 +70,8 @@ async function journalLines(unit: string, lines: number): Promise<string[]> {
   }
 }
 
-async function lastJournalLine(unit: string, lines: number): Promise<string | null> {
-  const all = await journalLines(unit, lines);
+async function lastJournalLine(step: string, sinceMs: number, lines: number): Promise<string | null> {
+  const all = await journalLines(step, sinceMs, lines);
   return all.length > 0 ? all[all.length - 1] : null;
 }
 
@@ -85,8 +91,8 @@ export function failureReason(lines: readonly string[]): string | null {
   return telling ?? (said.length > 0 ? said[said.length - 1] : null);
 }
 
-async function failureLine(unit: string): Promise<string | null> {
-  return failureReason(await journalLines(unit, 40));
+async function failureLine(step: string, sinceMs: number): Promise<string | null> {
+  return failureReason(await journalLines(step, sinceMs, 40));
 }
 
 function running(active: string): boolean {
@@ -95,10 +101,13 @@ function running(active: string): boolean {
 
 export async function followRootStep(step: string, opts: FollowRootStepOptions): Promise<{ ok: boolean; error?: string }> {
   const unit = rootStepUnit(step);
+  // Before the start, so nothing this run writes falls outside the window the
+  // journal reads below are bounded by.
+  const startedAt = Date.now();
   try {
     await startRootStep(step, { noBlock: true, timeoutMs: SYSTEMCTL_QUERY_TIMEOUT_MS });
   } catch (err) {
-    const line = await lastJournalLine(unit, 40);
+    const line = await lastJournalLine(step, startedAt, 40);
     return { ok: false, error: line || (err instanceof Error ? err.message : `Could not start ${opts.label}.`) };
   }
 
@@ -111,7 +120,7 @@ export async function followRootStep(step: string, opts: FollowRootStepOptions):
     const { active, result } = await unitState(unit);
     if (running(active)) sawRunning = true;
 
-    const line = await lastJournalLine(unit, 5);
+    const line = await lastJournalLine(step, startedAt, 5);
     if (line && line !== lastLine) {
       lastLine = line;
       // A listener that is gone (the stream's client cancelled) must not
@@ -121,13 +130,13 @@ export async function followRootStep(step: string, opts: FollowRootStepOptions):
     }
 
     if (active === "failed") {
-      return { ok: false, error: (await failureLine(unit)) || `${opts.label} failed (${result || "unknown"})` };
+      return { ok: false, error: (await failureLine(step, startedAt)) || `${opts.label} failed (${result || "unknown"})` };
     }
 
     if (!running(active)) {
       if (sawRunning || gracePolls >= START_GRACE_POLLS) {
         if (result && result !== "success") {
-          return { ok: false, error: (await failureLine(unit)) || `${opts.label} failed (${result})` };
+          return { ok: false, error: (await failureLine(step, startedAt)) || `${opts.label} failed (${result})` };
         }
         return { ok: true };
       }

--- a/src/lib/root-step-journal.ts
+++ b/src/lib/root-step-journal.ts
@@ -74,10 +74,14 @@ export function rootStepJournalArgs(
     "-u",
     rootStepUnit(step),
     // systemd's own seconds-since-the-epoch form (systemd.time(7)), so the
-    // bound carries no timezone and no locale. FLOORED, so an entry written in
-    // the same second as the dispatch is inside the window.
+    // bound carries no timezone and no locale — and to the MILLISECOND, not
+    // floored to the second: a retry dispatched in the same second as the
+    // previous attempt's last line would otherwise open its window before it.
+    // systemd.time takes fractions down to 1 us, and the deployed journalctl
+    // (systemd 249) really filters on them — measured on the box, a window
+    // 1 ms after a marker excludes it and 1 ms before includes it.
     "--since",
-    `@${Math.floor(sinceMs / 1000)}`,
+    `@${(sinceMs / 1000).toFixed(3)}`,
     "-n",
     String(lines),
     "--no-pager",

--- a/src/lib/root-step-journal.ts
+++ b/src/lib/root-step-journal.ts
@@ -18,14 +18,41 @@
  * entries carry `_SYSTEMD_UNIT` from when they were written, so `-u <unit>`
  * answers long after the unit itself is gone.
  *
- * Which RUN is then `--since`. The journal is persistent on this box
+ * Which RUN is then `--since`, in systemd's own seconds-since-the-epoch form
+ * (systemd.time(7)). The journal is persistent on this box
  * (`step_persistent_journal` makes sure of it), so an unbounded read answers
  * with last week's update, or with the run the owner retried five minutes ago,
  * over one that said nothing — a failure invented by the reader. The window
  * opens at the moment the CALLER dispatched the step, so it cannot.
  *
- * A clock that jumps backwards mid-run narrows the window: that can lose a
- * line, it cannot invent one, which is the direction this has to fail in.
+ * What that window does and does not promise. A clock that steps mid-run only
+ * narrows it: that can lose a line, it cannot invent one. A clock that was
+ * AHEAD during an earlier run and is corrected between runs can, though —
+ * those entries carry stamps in the future and fall inside a later window
+ * until real time passes them.
+ *
+ * The other native bounds, and why not:
+ * - `$INVOCATION_ID` inside the unit (or the root launcher echoing
+ *   `systemctl show -p InvocationID` while the instance is still loaded) is
+ *   the exact per-run id and needs no clock — but it is a WRITER change: no
+ *   marker already in a box's journal could be read, and none could be read at
+ *   all until every box had taken the update that adds it.
+ * - `systemd-run`'s returned id is not our start path and cannot become one:
+ *   the polkit action that authorises it is arbitrary passwordless root for
+ *   the account the web server runs as, which is why root steps go through
+ *   `clawbox-run-root-step.sh` instead (TASK-539).
+ * - Journal CURSORS (`--show-cursor` at dispatch, `--after-cursor` on the
+ *   read) are monotonic and clock-free, and would close the corrected-clock
+ *   case above. Not used: it costs a second journalctl call at every dispatch
+ *   and a new failure mode (a cursor that could not be taken) for a clock
+ *   history timesyncd makes rare here. Whoever wants that bound should start
+ *   at this docblock — every reader goes through this one function.
+ *
+ * And NOT `RemainAfterExit=yes` on `clawbox-root-update@.service`, which would
+ * keep the instance loaded and make both `-p InvocationID` and `-p Result`
+ * answer: the unit would then sit in `active (exited)` forever, which is what
+ * `waitForRootStepToSettle` waits to leave and what the follow loops read as
+ * "still running".
  */
 
 /** The systemd instance one `install.sh --step <name>` run happens in. */

--- a/src/lib/root-step-journal.ts
+++ b/src/lib/root-step-journal.ts
@@ -1,0 +1,60 @@
+/**
+ * ONE definition of "the journal of THIS run of a root step".
+ *
+ * Every root step the web server starts runs in a
+ * `clawbox-root-update@<step>.service` instance, and every reader that wants
+ * to know what that run said — the marker a skipped fixup leaves, the line
+ * that says why a step failed, the progress a follow shows — has to answer two
+ * questions at once: WHICH unit, and WHICH run of it.
+ *
+ * By unit NAME, not by invocation id. `systemctl show
+ * clawbox-root-update@<step>.service -p InvocationID` answers EMPTY on a real
+ * box: the instance is started ad hoc and referenced by nothing, so systemd
+ * garbage-collects it as it exits and answers the query from a freshly
+ * instantiated, never-run view of it — the same trap `updater.ts` records for
+ * `-p Result`. Measured on both boxes, 2026-09-07: empty on the step that had
+ * just written a marker, while 22 statically installed oneshots on the same
+ * box still carried theirs. The journal does not have that problem: its
+ * entries carry `_SYSTEMD_UNIT` from when they were written, so `-u <unit>`
+ * answers long after the unit itself is gone.
+ *
+ * Which RUN is then `--since`. The journal is persistent on this box
+ * (`step_persistent_journal` makes sure of it), so an unbounded read answers
+ * with last week's update, or with the run the owner retried five minutes ago,
+ * over one that said nothing — a failure invented by the reader. The window
+ * opens at the moment the CALLER dispatched the step, so it cannot.
+ *
+ * A clock that jumps backwards mid-run narrows the window: that can lose a
+ * line, it cannot invent one, which is the direction this has to fail in.
+ */
+
+/** The systemd instance one `install.sh --step <name>` run happens in. */
+export function rootStepUnit(step: string): string {
+  return `clawbox-root-update@${step}.service`;
+}
+
+/**
+ * `journalctl` arguments for what THIS dispatch of `step` wrote.
+ *
+ * @param sinceMs when the caller started the step, `Date.now()`-style.
+ * @param lines   how much of the window's tail to read.
+ */
+export function rootStepJournalArgs(
+  step: string,
+  { sinceMs, lines }: { sinceMs: number; lines: number },
+): string[] {
+  return [
+    "-u",
+    rootStepUnit(step),
+    // systemd's own seconds-since-the-epoch form (systemd.time(7)), so the
+    // bound carries no timezone and no locale. FLOORED, so an entry written in
+    // the same second as the dispatch is inside the window.
+    "--since",
+    `@${Math.floor(sinceMs / 1000)}`,
+    "-n",
+    String(lines),
+    "--no-pager",
+    "-o",
+    "cat",
+  ];
+}

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -449,6 +449,11 @@ import {
 // string work with no `fs` behind it, and taking it from the reader would tie a
 // pure helper to that module's surface for no reason.
 import { canonicalPluginId } from "./plugin-repair-id";
+// The journal of THIS run of a root step, in one place: `systemctl show -p
+// InvocationID` cannot answer it (systemd has collected the instance by the
+// time anyone asks), and the same read is owed to the follow in
+// root-step-follow.ts.
+import { rootStepJournalArgs } from "./root-step-journal";
 
 // Ceiling for the rebuild/restart hand-off: bun build alone runs minutes on a
 // Jetson, plus the config/redeploy steps before it and the reboot after.
@@ -635,49 +640,24 @@ const STEP_WARNING_LINE = /^CLAWBOX-WARN(?:\[([a-z0-9._:-]{1,60})\])?:\s*(.+)$/i
 const STEP_WARNING_MAX_CHARS = 300;
 
 /**
- * The systemd invocation of the run that JUST happened, so the journal read
- * below cannot answer with an older one.
- *
- * `journalctl -u <unit>` returns that unit's whole history — the journal is
- * persistent on this box (`step_persistent_journal` makes sure of it) — so a
- * marker from last week's update, or from a failed run the owner retried five
- * minutes ago, would be raised over a run that did not produce it. That is a
- * false failure created by the reader. Systemd's own per-start id is the exact
- * bound, and it costs one `systemctl show`; where it cannot be read, nothing is
- * raised, because a guess about WHICH run a warning came from is worse than no
- * warning at all.
- */
-async function rootStepInvocationId(stepId: string): Promise<string | null> {
-  try {
-    const { stdout } = await execFile(
-      "/usr/bin/systemctl",
-      ["show", `clawbox-root-update@${stepId}.service`, "-p", "InvocationID", "--value"],
-      { timeout: 10_000 },
-    );
-    const id = String(stdout ?? "").trim();
-    return /^[0-9a-f]{32}$/i.test(id) ? id : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Raise every marker THIS invocation of a root step left in its journal.
+ * Raise every marker THIS dispatch of a root step left in its journal.
  *
  * Read after the step settles, whatever its outcome: a step that failed reports
  * through its own error, and one that succeeded — or overran its advisory
  * budget — over a fixup that did not is the case nothing else could see.
  * Bounded like `readRootStepFailure` and never fatal: a journal that cannot be
  * read must not fail an update that worked.
+ *
+ * `sinceMs` is when the runner dispatched this step, and it is what keeps a
+ * previous update's markers out of this run's cards — see root-step-journal.ts
+ * for why it, and not systemd's invocation id, is the bound.
  */
-async function collectRootStepWarnings(stepId: string): Promise<void> {
-  const invocation = await rootStepInvocationId(stepId);
-  if (!invocation) return;
+async function collectRootStepWarnings(stepId: string, sinceMs: number): Promise<void> {
   let stdout = "";
   try {
     ({ stdout } = await execFile(
       "/usr/bin/journalctl",
-      [`_SYSTEMD_INVOCATION_ID=${invocation}`, "-n", "500", "--no-pager", "-o", "cat"],
+      rootStepJournalArgs(stepId, { sinceMs, lines: 500 }),
       { timeout: 10_000 },
     ));
   } catch {
@@ -4199,6 +4179,11 @@ async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: Run
     // ten-minute run.
     if (ownsTheDesktop) await setUpdateLock();
 
+    // The window the warning read below is bounded by. Taken BEFORE the
+    // dispatch, so nothing this step writes can fall outside it, and per step,
+    // so one step's marker is never raised over the next one's.
+    const stepStartedAt = Date.now();
+
     console.log(`[Updater] Running step: ${step.label}`);
 
     try {
@@ -4219,7 +4204,7 @@ async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: Run
       // A root step that SUCCEEDED can still have skipped a fixup: install.sh's
       // non-fatal steps say so on a `CLAWBOX-WARN:` line, and this is where
       // that reaches the owner instead of only the journal.
-      if (step.requiresRoot) await collectRootStepWarnings(step.id);
+      if (step.requiresRoot) await collectRootStepWarnings(step.id, stepStartedAt);
       state.steps[i].status = "completed";
       console.log(`[Updater] Completed: ${step.label}`);
     } catch (err) {
@@ -4232,7 +4217,7 @@ async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: Run
         // and an overrun is its ORDINARY shape on the repair path (a Hermes
         // clone plus a 3.2 GB model fetch) — so this is the run most likely to
         // have skipped a fixup, and the one where the step is shown green.
-        if (step.requiresRoot) await collectRootStepWarnings(step.id);
+        if (step.requiresRoot) await collectRootStepWarnings(step.id, stepStartedAt);
         state.steps[i].status = "completed";
         console.warn(`[Updater] ${step.label}: ${message} — treating as advisory`);
         continue;
@@ -4248,7 +4233,7 @@ async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: Run
       // list of them is the only record of which. Raised as warnings beside the
       // step's own error, never instead of it — `state.steps[i].error` below is
       // untouched.
-      if (step.requiresRoot) await collectRootStepWarnings(step.id);
+      if (step.requiresRoot) await collectRootStepWarnings(step.id, stepStartedAt);
       state.steps[i].status = "failed";
       state.steps[i].error = message;
       console.error(`[Updater] Failed: ${step.label} — ${message}`);

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -453,7 +453,7 @@ import { canonicalPluginId } from "./plugin-repair-id";
 // InvocationID` cannot answer it (systemd has collected the instance by the
 // time anyone asks), and the same read is owed to the follow in
 // root-step-follow.ts.
-import { rootStepJournalArgs } from "./root-step-journal";
+import { rootStepJournalArgs, rootStepUnit } from "./root-step-journal";
 
 // Ceiling for the rebuild/restart hand-off: bun build alone runs minutes on a
 // Jetson, plus the config/redeploy steps before it and the reboot after.
@@ -479,7 +479,7 @@ async function getRootStepResult(stepId: string): Promise<string | null> {
   try {
     const { stdout } = await execFile(
       "/usr/bin/systemctl",
-      ["show", `clawbox-root-update@${stepId}.service`, "-p", "Result", "--value"],
+      ["show", rootStepUnit(stepId), "-p", "Result", "--value"],
       { timeout: 10_000 },
     );
     return stdout.trim() || null;
@@ -541,13 +541,13 @@ async function readBuildId(): Promise<string> {
  * as a failed step with the real error, and only systemd killing us counts
  * as success — this function never returns normally.
  */
-async function waitForRebuildToTakeOver(): Promise<never> {
+async function waitForRebuildToTakeOver(dispatchedAt: number): Promise<never> {
   const deadline = Date.now() + REBUILD_TAKEOVER_TIMEOUT_MS;
   let message = "Rebuild did not restart the device within the expected window";
   while (Date.now() < deadline) {
     await new Promise((resolve) => setTimeout(resolve, 5_000));
     if (rootStepResultFailed(await getRootStepResult(REBUILD_ROOT_STEP))) {
-      const lastLog = await readRootStepFailure(REBUILD_ROOT_STEP);
+      const lastLog = await readRootStepFailure(REBUILD_ROOT_STEP, dispatchedAt);
       message = lastLog
         ? `Rebuild failed: ${lastLog}`
         : "Rebuild failed — see clawbox-root-update@rebuild_reboot logs";
@@ -645,8 +645,9 @@ const STEP_WARNING_MAX_CHARS = 300;
  * Read after the step settles, whatever its outcome: a step that failed reports
  * through its own error, and one that succeeded — or overran its advisory
  * budget — over a fixup that did not is the case nothing else could see.
- * Bounded like `readRootStepFailure` and never fatal: a journal that cannot be
- * read must not fail an update that worked.
+ * Bounded like `readRootStepFailure` — to this run, and to a line and time
+ * ceiling — and never fatal: a journal that cannot be read must not fail an
+ * update that worked.
  *
  * `sinceMs` is when the runner dispatched this step, and it is what keeps a
  * previous update's markers out of this run's cards — see root-step-journal.ts
@@ -682,12 +683,30 @@ async function collectRootStepWarnings(stepId: string, sinceMs: number): Promise
   if (seen.size > 0) await persistWarnings();
 }
 
-async function readRootStepFailure(stepId: string): Promise<string | null> {
-  const unit = `clawbox-root-update@${stepId}.service`;
+/**
+ * The line that says why THIS run of a root step failed.
+ *
+ * Bounded by `sinceMs` for the same reason the warning read above is: the
+ * journal is persistent and a failed unit's tail runs back through the
+ * owner's previous attempt. A second run killed by its timeout before
+ * install.sh printed an error of its own would otherwise be reported with the
+ * FIRST attempt's `Error:` line — `getStepFailureLine` takes the newest error
+ * line in what it is given, and unbounded that is not necessarily this run's.
+ *
+ * `sinceMs: null` is the one caller that cannot know: the post-reboot
+ * continuation check runs in a process that did not dispatch the rebuild, so
+ * no start time survives to it. It reads the unit's history as it always has
+ * — bounding it needs a dispatch epoch persisted across the restart, which is
+ * a change to what the update records, not to how it reads.
+ */
+async function readRootStepFailure(stepId: string, sinceMs: number | null): Promise<string | null> {
+  const unit = rootStepUnit(stepId);
   try {
     const { stdout } = await execFile(
       "/usr/bin/journalctl",
-      ["-u", unit, "-n", "40", "--no-pager", "-o", "cat"],
+      sinceMs === null
+        ? ["-u", unit, "-n", "40", "--no-pager", "-o", "cat"]
+        : rootStepJournalArgs(stepId, { sinceMs, lines: 40 }),
       { timeout: 10_000 },
     );
     return getStepFailureLine(stdout, unit);
@@ -1414,8 +1433,11 @@ async function updateClawBoxAndReboot(): Promise<void> {
   // few seconds between unit failure and our watcher noticing would reset the
   // unit's systemd state and let the continuation fake a completed update.
   await set("update_needs_continuation", (await readBuildId()) || "no-previous-build");
+  // Captured before the dispatch, so the failure read below cannot miss a line
+  // the unit wrote in its first moments — nor pick up the previous attempt's.
+  const rebuildDispatchedAt = Date.now();
   await startRootServiceFireAndForget(REBUILD_ROOT_STEP);
-  await waitForRebuildToTakeOver();
+  await waitForRebuildToTakeOver(rebuildDispatchedAt);
 }
 
 // First-time `npm install -g openclaw` on cold Jetson caches routinely runs
@@ -3163,7 +3185,6 @@ function applicableSteps(): UpdateStepDef[] {
  * arbitrary root with no password. TASK-539.
  */
 async function execAsRoot(stepId: string, timeoutMs: number): Promise<void> {
-  const serviceName = `clawbox-root-update@${stepId}.service`;
   const startedAt = Date.now();
   try {
     await startRootStep(stepId, { timeoutMs: timeoutMs + 30_000 });
@@ -3185,7 +3206,7 @@ async function execAsRoot(stepId: string, timeoutMs: number): Promise<void> {
 }
 
 async function waitForRootStepToSettle(stepId: string): Promise<void> {
-  const serviceName = `clawbox-root-update@${stepId}.service`;
+  const serviceName = rootStepUnit(stepId);
   const deadline = Date.now() + ROOT_STEP_SETTLE_TIMEOUT_MS;
   while (Date.now() < deadline) {
     try {
@@ -3206,6 +3227,7 @@ async function waitForRootStepToSettle(stepId: string): Promise<void> {
 
 /** Run root steps that mutate OpenClaw without a live gateway/SQLite writer. */
 async function execAsRootWithGatewayQuiesced(stepId: string, timeoutMs: number): Promise<void> {
+  const startedAt = Date.now();
   await withGatewayQuiesced(async () => {
     gatewayNeedsRecovery = true;
     try {
@@ -3219,7 +3241,7 @@ async function execAsRootWithGatewayQuiesced(stepId: string, timeoutMs: number):
       await waitForRootStepToSettle(stepId);
       if (rootStepResultFailed(await getRootStepResult(stepId))) {
         throw new Error(
-          (await readRootStepFailure(stepId)) ?? `${stepId} failed after exceeding its wait budget`,
+          (await readRootStepFailure(stepId, startedAt)) ?? `${stepId} failed after exceeding its wait budget`,
         );
       }
       throw err;
@@ -3964,7 +3986,9 @@ async function resumeContinuation(): Promise<boolean> {
   const buildMissing = currentBuildId === "";
   if (unitFailed || buildUnchanged || buildMissing) {
     const message = unitFailed
-      ? (await readRootStepFailure(REBUILD_ROOT_STEP)) ?? "Rebuild failed before the restart"
+      // No start time survives the restart this check runs after — see
+      // readRootStepFailure.
+      ? (await readRootStepFailure(REBUILD_ROOT_STEP, null)) ?? "Rebuild failed before the restart"
       : buildMissing
         ? "The device restarted with no build at all (.next/BUILD_ID is missing) — see clawbox-root-update@rebuild_reboot logs"
         : "The device restarted without producing a new build — see clawbox-root-update@rebuild_reboot logs";
@@ -4226,7 +4250,7 @@ async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: Run
       // FAILED — on a generic budget overrun its last journal line can still
       // be whatever fixup happened to finish most recently.
       if (step.requiresRoot && rootStepResultFailed(await getRootStepResult(step.id))) {
-        const rootFailure = await readRootStepFailure(step.id);
+        const rootFailure = await readRootStepFailure(step.id, stepStartedAt);
         if (rootFailure) message = rootFailure;
       }
       // A step that FAILED can still have skipped fixups before it did, and the

--- a/src/tests/routes/install-run-step.test.ts
+++ b/src/tests/routes/install-run-step.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as childProcess from "child_process";
+import { startRootStep } from "@/lib/root-step-runner";
+import { rootStepUnit } from "@/lib/root-step-journal";
+
+/**
+ * POST /setup-api/install/run-step — the desktop panels' "run this install
+ * step as root" button (VNCApp, RemoteControlPanel).
+ *
+ * Pinned here: the journal tail it returns as the evidence for a failure is
+ * THIS run's. The journal on a box is persistent and a failed unit stays
+ * loaded, so a 60-line tail of a step the owner has already retried runs back
+ * through the previous attempt and offers its output as the reason this one
+ * failed.
+ */
+
+vi.mock("child_process", () => ({ execFile: vi.fn() }));
+vi.mock("@/lib/route-auth", () => ({ requireSession: vi.fn(async () => null) }));
+
+const { mockStartRootStep } = vi.hoisted(() => ({ mockStartRootStep: vi.fn(async () => {}) }));
+vi.mock("@/lib/root-step-runner", () => ({ startRootStep: mockStartRootStep }));
+
+const mockExecFile = vi.mocked(childProcess.execFile);
+const STEP = "vnc_install";
+const PREVIOUS_ATTEMPT = "Error: the previous attempt could not reach the package mirror";
+const THIS_ATTEMPT = "Setting up tigervnc-standalone-server...";
+
+function post(step: string) {
+  return new Request("http://box/setup-api/install/run-step", {
+    method: "POST",
+    body: JSON.stringify({ step }),
+  });
+}
+
+describe("POST /setup-api/install/run-step", () => {
+  let dispatchedAt = 0;
+  let journalReads: string[] = [];
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    dispatchedAt = 0;
+    journalReads = [];
+
+    // The dispatch takes a moment, as a root step does, so a window opened
+    // AFTER it — the regression that would quietly restore the unbounded read
+    // — is visible to the millisecond bound.
+    vi.mocked(startRootStep).mockImplementation(async () => {
+      dispatchedAt = Date.now();
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      throw new Error("Job for clawbox-root-update@vnc_install.service failed");
+    });
+
+    mockExecFile.mockImplementation(((
+      cmd: string,
+      args: string[],
+      optsOrCallback?: unknown,
+      maybeCallback?: (error: Error | null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      const callback = (typeof optsOrCallback === "function" ? optsOrCallback : maybeCallback) as
+        (error: Error | null, result: { stdout: string; stderr: string }) => void;
+      const key = `${cmd} ${args.join(" ")}`;
+      let stdout = "";
+      if (key.includes("journalctl")) {
+        journalReads.push(key);
+        // The OS: an unbounded read still answers with what the last attempt
+        // left behind; a window opened at or before this dispatch does not.
+        const since = Number(/--since @([\d.]+)/.exec(key)?.[1] ?? NaN);
+        stdout = since * 1000 <= dispatchedAt
+          ? THIS_ATTEMPT
+          : [PREVIOUS_ATTEMPT, THIS_ATTEMPT].join(String.fromCharCode(10));
+      }
+      callback?.(null, { stdout, stderr: "" });
+      return undefined as unknown as ReturnType<typeof childProcess.execFile>;
+    }) as unknown as typeof childProcess.execFile);
+  });
+
+  it("returns THIS run's journal as the evidence, not the attempt before it", async () => {
+    const { POST } = await import("@/app/setup-api/install/run-step/route");
+
+    const res = await POST(post(STEP));
+    const body = await res.json() as { ok: boolean; step: string; journalTail: string };
+
+    expect(res.status).toBe(500);
+    expect(body.ok).toBe(false);
+    expect(body.journalTail).toContain(THIS_ATTEMPT);
+    expect(body.journalTail).not.toContain("previous attempt");
+  });
+
+  it("reads by unit name, bounded to this run", async () => {
+    const { POST } = await import("@/app/setup-api/install/run-step/route");
+
+    await POST(post(STEP));
+
+    expect(journalReads.length).toBeGreaterThan(0);
+    for (const read of journalReads) {
+      // By NAME, which outlives an instance systemd has collected — the id is
+      // empty by the time anyone asks for it.
+      expect(read).toContain(`-u ${rootStepUnit(STEP)}`);
+      expect(read).toMatch(/--since @\d+\.\d{3}/);
+    }
+  });
+
+  it("refuses a step the UI is not allowed to start", async () => {
+    const { POST } = await import("@/app/setup-api/install/run-step/route");
+
+    const res = await POST(post("rebuild_reboot"));
+
+    expect(res.status).toBe(400);
+    expect(mockStartRootStep).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/routes/llamacpp/install.test.ts
+++ b/src/tests/routes/llamacpp/install.test.ts
@@ -374,6 +374,55 @@ describe("POST /setup-api/llamacpp/install", () => {
     expect(mockSpawn).not.toHaveBeenCalled();
   });
 
+  it("never reports the PREVIOUS install attempt's line as this run's", async () => {
+    // The unit is `clawbox-root-update@llamacpp_install.service` and the
+    // journal on this box is persistent, so an unbounded read answers with
+    // whatever the last attempt left behind — and the first poll happens
+    // before this run's unit has written anything. The owner was shown the
+    // previous failure as live progress and then handed it as this run's
+    // reason. The read is bounded to this run now; the mock is the OS.
+    mockFs.stat.mockImplementation((async () => {
+      throw new Error("ENOENT");
+    }) as typeof fsp.stat);
+
+    const journalReads: string[] = [];
+    mockExecFile.mockImplementation(((
+      cmd: string,
+      args: string[],
+      optsOrCallback?: object | ((error: Error | null, result: { stdout: string; stderr: string }) => void),
+      maybeCallback?: (error: Error | null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      const callback = typeof optsOrCallback === "function" ? optsOrCallback : maybeCallback;
+      const key = `${cmd} ${args.join(" ")}`;
+      let stdout = "";
+      if (key.includes("systemctl show")) {
+        stdout = "ActiveState=failed\nResult=exit-code\n";
+      } else if (key.includes("journalctl")) {
+        journalReads.push(key);
+        stdout = args.includes("--since")
+          ? ""
+          : "Error: yesterday's attempt could not reach huggingface.co\n";
+      }
+      callback?.(null, { stdout, stderr: "" });
+      return {} as ReturnType<typeof childProcess.execFile>;
+    }) as unknown as typeof childProcess.execFile);
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [] }),
+    }));
+
+    const res = await installPost(jsonRequest({ model: "gemma4-e2b-it-q4_0" }));
+    const text = await readStream(res);
+
+    expect(text).not.toContain("yesterday's attempt");
+    expect(journalReads.length).toBeGreaterThan(0);
+    for (const read of journalReads) {
+      expect(read).toContain("-u clawbox-root-update@llamacpp_install.service");
+      expect(read).toMatch(/--since @\d+/);
+    }
+  });
+
   it("repairs the llama.cpp runtime and retries when hf is missing", async () => {
     const runtimeError = "[llamacpp] Missing Hugging Face CLI at /home/clawbox/.local/bin/hf. Run the llama.cpp install step to repair the local runtime.\n";
     const mockFetch = vi.fn()

--- a/src/tests/routes/llamacpp/install.test.ts
+++ b/src/tests/routes/llamacpp/install.test.ts
@@ -386,6 +386,14 @@ describe("POST /setup-api/llamacpp/install", () => {
     }) as typeof fsp.stat);
 
     const journalReads: string[] = [];
+    // The dispatch takes a moment, as starting a root unit does, so a capture
+    // that slid BELOW `startRootStep` is visible here instead of landing in
+    // the same instant and looking correct.
+    let dispatchedAt = 0;
+    vi.mocked(startRootStep).mockImplementation(async () => {
+      dispatchedAt = Date.now();
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    });
     mockExecFile.mockImplementation(((
       cmd: string,
       args: string[],
@@ -399,7 +407,8 @@ describe("POST /setup-api/llamacpp/install", () => {
         stdout = "ActiveState=failed\nResult=exit-code\n";
       } else if (key.includes("journalctl")) {
         journalReads.push(key);
-        stdout = args.includes("--since")
+        const since = Number(/--since @([\d.]+)/.exec(key)?.[1] ?? NaN);
+        stdout = since * 1000 <= dispatchedAt
           ? ""
           : "Error: yesterday's attempt could not reach huggingface.co\n";
       }

--- a/src/tests/routes/llamacpp/install.test.ts
+++ b/src/tests/routes/llamacpp/install.test.ts
@@ -419,7 +419,7 @@ describe("POST /setup-api/llamacpp/install", () => {
     expect(journalReads.length).toBeGreaterThan(0);
     for (const read of journalReads) {
       expect(read).toContain("-u clawbox-root-update@llamacpp_install.service");
-      expect(read).toMatch(/--since @\d+/);
+      expect(read).toMatch(/--since @\d+\.\d{3}/);
     }
   });
 

--- a/src/tests/unit/root-step-journal.test.ts
+++ b/src/tests/unit/root-step-journal.test.ts
@@ -4,7 +4,19 @@ import { rootStepJournalArgs, rootStepUnit } from "@/lib/root-step-journal";
 
 vi.mock("child_process", () => ({ execFile: vi.fn() }));
 
-const { mockStartRootStep } = vi.hoisted(() => ({ mockStartRootStep: vi.fn(async () => {}) }));
+const { mockStartRootStep, dispatch } = vi.hoisted(() => {
+  const dispatch = { at: 0 };
+  return {
+    dispatch,
+    // A root step takes a moment to start, as one does on a box: without that
+    // a capture moved BELOW `startRootStep` still lands in the same instant
+    // and the window looks correctly opened when it is not.
+    mockStartRootStep: vi.fn(async () => {
+      dispatch.at = Date.now();
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }),
+  };
+});
 vi.mock("@/lib/root-step-runner", () => ({ startRootStep: mockStartRootStep }));
 
 const mockExecFile = vi.mocked(childProcess.execFile);
@@ -57,10 +69,16 @@ describe("rootStepJournalArgs", () => {
  * poll happens before the unit has written anything, so what came back was the
  * PREVIOUS attempt's last line — shown to the owner as this install's live
  * progress, and taken as this install's failure reason.
+ *
+ * Two properties, because the bound has two halves: the read carries a window,
+ * and that window opens BEFORE the step is started. A capture that slid below
+ * `startRootStep` would keep every argv assertion green while reading the
+ * previous attempt again.
  */
 describe("followRootStep", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    dispatch.at = 0;
     mockExecFile.mockImplementation(((
       cmd: string,
       args: string[],
@@ -73,10 +91,12 @@ describe("followRootStep", () => {
       if (cmd.includes("systemctl")) {
         stdout = "ActiveState=failed\nResult=exit-code\n";
       } else if (cmd.includes("journalctl")) {
-        // The OS, modelled: a bounded read sees only what THIS run wrote —
-        // nothing yet — while an unbounded one still answers with the line the
+        // The OS, modelled: a window opened at or before this dispatch sees
+        // only what THIS run wrote — nothing yet — while an unbounded read, or
+        // one opened after the step started, still answers with the line the
         // last attempt left behind.
-        stdout = args.includes("--since") ? "" : "ERROR: kokoro model download failed";
+        const since = Number(/--since @([\d.]+)/.exec(args.join(" "))?.[1] ?? NaN);
+        stdout = since * 1000 <= dispatch.at ? "" : "ERROR: kokoro model download failed";
       }
       callback?.(null, { stdout, stderr: "" });
       return undefined as unknown as ReturnType<typeof childProcess.execFile>;

--- a/src/tests/unit/root-step-journal.test.ts
+++ b/src/tests/unit/root-step-journal.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import * as childProcess from "child_process";
+import { rootStepJournalArgs, rootStepUnit } from "@/lib/root-step-journal";
+
+vi.mock("child_process", () => ({ execFile: vi.fn() }));
+
+const { mockStartRootStep } = vi.hoisted(() => ({ mockStartRootStep: vi.fn(async () => {}) }));
+vi.mock("@/lib/root-step-runner", () => ({ startRootStep: mockStartRootStep }));
+
+const mockExecFile = vi.mocked(childProcess.execFile);
+
+/**
+ * The journal of THIS run of a root step.
+ *
+ * `systemctl show clawbox-root-update@<step>.service -p InvocationID` answers
+ * EMPTY on a box — the instance is started ad hoc, referenced by nothing, and
+ * systemd collects it as it exits — so a reader bound to the invocation id
+ * reads nothing, ever. What is left has to answer WHICH unit and WHICH run
+ * without it.
+ */
+describe("rootStepJournalArgs", () => {
+  it("reads by unit NAME, which outlives the unit", () => {
+    const args = rootStepJournalArgs("post_update", { sinceMs: 1_700_000_000_000, lines: 500 });
+
+    expect(args).toContain("-u");
+    expect(args).toContain(rootStepUnit("post_update"));
+    expect(rootStepUnit("post_update")).toBe("clawbox-root-update@post_update.service");
+    // NOT the id: it is empty by the time anybody asks.
+    expect(args.join(" ")).not.toContain("_SYSTEMD_INVOCATION_ID");
+  });
+
+  it("bounds the read to the run the caller dispatched", () => {
+    // The journal is persistent, so an unbounded read answers with the last
+    // update's failures over a clean one.
+    const args = rootStepJournalArgs("post_update", { sinceMs: 1_700_000_000_500, lines: 500 });
+    const since = args[args.indexOf("--since") + 1];
+
+    expect(since).toBe("@1700000000");
+  });
+
+  it("floors the window, so a line written in the dispatch's own second is inside it", () => {
+    const args = rootStepJournalArgs("post_update", { sinceMs: 1_700_000_000_999, lines: 40 });
+
+    expect(args[args.indexOf("--since") + 1]).toBe("@1700000000");
+    expect(args[args.indexOf("-n") + 1]).toBe("40");
+  });
+});
+
+/**
+ * The follow reads the SAME units, and read the same way: unbounded. Its first
+ * poll happens before the unit has written anything, so what came back was the
+ * PREVIOUS attempt's last line — shown to the owner as this install's live
+ * progress, and taken as this install's failure reason.
+ */
+describe("followRootStep", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecFile.mockImplementation(((
+      cmd: string,
+      args: string[],
+      optsOrCallback?: unknown,
+      maybeCallback?: (error: Error | null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      const callback = (typeof optsOrCallback === "function" ? optsOrCallback : maybeCallback) as
+        (error: Error | null, result: { stdout: string; stderr: string }) => void;
+      let stdout = "";
+      if (cmd.includes("systemctl")) {
+        stdout = "ActiveState=failed\nResult=exit-code\n";
+      } else if (cmd.includes("journalctl")) {
+        // The OS, modelled: a bounded read sees only what THIS run wrote —
+        // nothing yet — while an unbounded one still answers with the line the
+        // last attempt left behind.
+        stdout = args.includes("--since") ? "" : "ERROR: kokoro model download failed";
+      }
+      callback?.(null, { stdout, stderr: "" });
+      return undefined as unknown as ReturnType<typeof childProcess.execFile>;
+    }) as unknown as typeof childProcess.execFile);
+  });
+
+  it("never reports the previous attempt's line as this run's", async () => {
+    const { followRootStep } = await import("@/lib/root-step-follow");
+    const statuses: string[] = [];
+
+    const result = await followRootStep("openclaw_tts", {
+      timeoutMs: 5_000,
+      label: "Voice install",
+      onStatus: (line) => statuses.push(line),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).not.toContain("kokoro model download failed");
+    expect(result.error).toContain("Voice install failed");
+    expect(statuses).toEqual([]);
+  });
+
+  it("bounds every journal read it makes to this run", async () => {
+    const { followRootStep } = await import("@/lib/root-step-follow");
+
+    await followRootStep("embed_model", {
+      timeoutMs: 5_000,
+      label: "Embedder install",
+      onStatus: () => {},
+    });
+
+    const journalReads = mockExecFile.mock.calls
+      .filter(([cmd]) => String(cmd).includes("journalctl"))
+      .map(([, args]) => (args as string[]).join(" "));
+
+    expect(journalReads.length).toBeGreaterThan(0);
+    for (const read of journalReads) {
+      expect(read).toContain(`-u ${rootStepUnit("embed_model")}`);
+      expect(read).toMatch(/--since @\d+/);
+    }
+  });
+});

--- a/src/tests/unit/root-step-journal.test.ts
+++ b/src/tests/unit/root-step-journal.test.ts
@@ -35,13 +35,19 @@ describe("rootStepJournalArgs", () => {
     const args = rootStepJournalArgs("post_update", { sinceMs: 1_700_000_000_500, lines: 500 });
     const since = args[args.indexOf("--since") + 1];
 
-    expect(since).toBe("@1700000000");
+    expect(since).toBe("@1700000000.500");
   });
 
-  it("floors the window, so a line written in the dispatch's own second is inside it", () => {
-    const args = rootStepJournalArgs("post_update", { sinceMs: 1_700_000_000_999, lines: 40 });
+  it("keeps the millisecond, so a retry in the same second excludes the previous attempt", () => {
+    // The one case a window floored to the second gets wrong: the failed
+    // attempt's last line at .100 and this dispatch at .900 share a second, so
+    // a floored bound opens BEFORE the line it exists to exclude. systemd.time
+    // takes fractions to 1 us and journalctl really filters on them.
+    const previousAttemptWroteAt = 1_700_000_000_100;
+    const args = rootStepJournalArgs("post_update", { sinceMs: 1_700_000_000_900, lines: 40 });
+    const since = Number(args[args.indexOf("--since") + 1].slice(1));
 
-    expect(args[args.indexOf("--since") + 1]).toBe("@1700000000");
+    expect(since * 1000).toBeGreaterThan(previousAttemptWroteAt);
     expect(args[args.indexOf("-n") + 1]).toBe("40");
   });
 });
@@ -109,7 +115,7 @@ describe("followRootStep", () => {
     expect(journalReads.length).toBeGreaterThan(0);
     for (const read of journalReads) {
       expect(read).toContain(`-u ${rootStepUnit("embed_model")}`);
-      expect(read).toMatch(/--since @\d+/);
+      expect(read).toMatch(/--since @\d+\.\d{3}/);
     }
   });
 });

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -481,11 +481,9 @@ describe("updater", () => {
       // re-stated on a `CLAWBOX-WARN:` line now, and this is where it becomes
       // something the OWNER sees.
       setupExecFileMock({
-        // The invocation bound: the reader asks systemd which start this was
-        // and reads only that one, so a marker from a previous update — the
-        // journal is persistent on this box — cannot be raised over a clean
-        // run.
-        "InvocationID": { stdout: "0123456789abcdef0123456789abcdef\n", stderr: "" },
+        // The run bound is the step's own dispatch time — asserted on the argv
+        // by the case below — so a marker from a previous update, on a box
+        // whose journal is persistent, cannot be raised over a clean run.
         "/usr/bin/journalctl": {
           stdout: [
             "Applying system fixups",
@@ -568,26 +566,69 @@ describe("updater", () => {
       expect(warning?.message).toContain("update_smoke");
     });
 
-    it("bounds the marker read to THIS run's dispatch of the step", async () => {
+    it("opens the marker window BEFORE the step is dispatched, not after", async () => {
       // A guess about WHICH run a marker came from is worse than no warning:
       // the journal is persistent, so an unbounded read answers with the last
       // update's failures over a clean one. Systemd's invocation id used to be
       // that bound and cannot be — it is empty once the instance is collected
       // — so the bound is the step's own start time and the OS does the
-      // filtering. Assert the ARGV: a window that is never asked for is a read
-      // that reports a previous run's failures as this one's, and the mock
-      // would answer it just the same.
+      // filtering.
+      //
+      // Which means the ONE regression that silently restores the original bug
+      // is the window being opened after the dispatch instead of before it:
+      // every argv assertion still passes and no marker is ever raised again.
+      // So the mock is the OS here — it serves the marker only to a window
+      // that opened at or before the dispatch — and the dispatch takes time,
+      // because a window floored to the second cannot tell before from after
+      // when the step returns instantly.
       const runStartedAtSeconds = Math.floor(Date.now() / 1000);
+      let dispatchedAt = 0;
       setupExecFileMock({
-        InvocationID: { stdout: "\n", stderr: "" },
-        "-u clawbox-root-update@apt_update.service": {
-          stdout: "CLAWBOX-WARN[post-update-fixups]: these system fixups failed and were skipped: firewall",
-          stderr: "",
-        },
         ping: { stdout: "", stderr: "" },
         systemctl: { stdout: "", stderr: "" },
         openclaw: { stdout: "1.0.0", stderr: "" },
       });
+      const marker = "CLAWBOX-WARN[post-update-fixups]: these system fixups failed and were skipped: firewall";
+      const fallback = mockExecFile.getMockImplementation()!;
+      mockExecFile.mockImplementation(((
+        cmd: string,
+        args: string[],
+        optsOrCallback?: object | ((error: Error | null, result: { stdout: string; stderr: string }) => void),
+        maybeCallback?: (error: Error | null, result: { stdout: string; stderr: string }) => void,
+      ) => {
+        const key = `${cmd} ${args.join(" ")}`;
+        const callback = typeof optsOrCallback === "function" ? optsOrCallback : maybeCallback;
+        const answer = (stdout: string, delayMs = 0) => {
+          const result = { stdout, stderr: "" };
+          const settle = () => callback?.(null, result);
+          if (delayMs > 0) setTimeout(settle, delayMs); else settle();
+          const thenable = {
+            then: (resolve: (value: { stdout: string; stderr: string }) => void) => {
+              if (delayMs > 0) setTimeout(() => resolve(result), delayMs); else resolve(result);
+              return thenable;
+            },
+            catch: () => thenable,
+          };
+          return thenable as unknown as ReturnType<typeof childProcess.execFile>;
+        };
+
+        if (key.includes("clawbox-run-root-step.sh apt_update")) {
+          dispatchedAt = Date.now();
+          return answer("", 1_100);
+        }
+        if (key.includes("journalctl") && key.includes("clawbox-root-update@apt_update.service")) {
+          const since = Number(/--since @(\d+)/.exec(key)?.[1] ?? NaN);
+          // The journal answers a window that opened after the step wrote with
+          // nothing at all — which is what a box would do.
+          return answer(since * 1000 <= dispatchedAt ? marker : "");
+        }
+        return (fallback as unknown as (
+          cmd: string,
+          args: string[],
+          optsOrCallback?: unknown,
+          maybeCallback?: unknown,
+        ) => ReturnType<typeof childProcess.execFile>)(cmd, args, optsOrCallback, maybeCallback);
+      }) as unknown as typeof childProcess.execFile);
 
       vi.resetModules();
       mockGet.mockResolvedValue(undefined);
@@ -601,15 +642,18 @@ describe("updater", () => {
       await vi.waitFor(() => {
         const step = updater.getUpdateState().steps.find((s) => s.id === "apt_update");
         expect(step?.status).toBe("completed");
-      });
+      }, { timeout: 4_000, interval: 25 });
+
+      const warning = updater.getUpdateState().warnings?.find((w) => w.code === "post-update-fixups");
+      expect(warning, "the window opened after the step ran — no marker can ever be read").toBeDefined();
 
       const journalRead = mockExecFile.mock.calls
         .map(([cmd, args]) => `${cmd} ${(args as string[]).join(" ")}`)
         .find((call) =>
           call.includes("journalctl") && call.includes("clawbox-root-update@apt_update.service"),
         );
-      expect(journalRead, "the step's journal was never read").toBeDefined();
-      // By unit NAME, which outlives the unit systemd has already collected.
+      // By unit NAME, which outlives the unit systemd has already collected,
+      // and never earlier than this run.
       expect(journalRead).toContain("-u clawbox-root-update@apt_update.service");
       const since = /--since @(\d+)/.exec(journalRead ?? "")?.[1];
       expect(since, "the read is not bounded to this run").toBeDefined();
@@ -621,7 +665,6 @@ describe("updater", () => {
       // other steps print git and npm output: a quoted marker is not this box
       // raising a warning.
       setupExecFileMock({
-        "InvocationID": { stdout: "0123456789abcdef0123456789abcdef\n", stderr: "" },
         "/usr/bin/journalctl": {
           stdout: [
             "  doctor said: grep for CLAWBOX-WARN[post-update-fixups]: nothing to see",

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -522,13 +522,65 @@ describe("updater", () => {
       expect(warning?.code).toBe("post-update-fixups");
     });
 
-    it("raises nothing when systemd cannot say which run this was", async () => {
+    it("raises the marker after systemd has UNLOADED the step's unit", async () => {
+      // The shape a box actually has, measured on hardware 2026-09-07: a
+      // `clawbox-root-update@<step>.service` instance is started ad hoc and
+      // referenced by nothing, so systemd garbage-collects it the moment it
+      // exits and `systemctl show -p InvocationID` answers EMPTY — while the
+      // marker the step wrote is still in the persistent journal. A reader
+      // bound to the invocation id therefore raises nothing on every box,
+      // every time, and the owner is told an update landed whole when a fixup
+      // was skipped.
+      setupExecFileMock({
+        InvocationID: { stdout: "\n", stderr: "" },
+        // The journal answers by UNIT NAME, which outlives the unit: the
+        // entries carry `_SYSTEMD_UNIT` from when they were written.
+        "-u clawbox-root-update@apt_update.service": {
+          stdout: [
+            "Starting ClawBox Root Update Step (apt_update).",
+            "  Warning: update_smoke step failed (non-fatal)",
+            "CLAWBOX-WARN[post-update-fixups]: these system fixups failed and were skipped: update_smoke",
+            "clawbox-root-update@apt_update.service: Deactivated successfully.",
+          ].join(String.fromCharCode(10)),
+          stderr: "",
+        },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+      });
+
+      vi.resetModules();
+      mockGet.mockResolvedValue(undefined);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockRebuiltBox();
+      updater = await import("@/lib/updater");
+
+      updater.resetUpdateState();
+      updater.startUpdate();
+      await vi.waitFor(() => {
+        const step = updater.getUpdateState().steps.find((s) => s.id === "apt_update");
+        expect(step?.status).toBe("completed");
+      });
+
+      const warning = updater.getUpdateState().warnings?.find((w) => w.code === "post-update-fixups");
+      expect(warning, "the skipped fixup never reached the owner").toBeDefined();
+      expect(warning?.message).toContain("update_smoke");
+    });
+
+    it("bounds the marker read to THIS run's dispatch of the step", async () => {
       // A guess about WHICH run a marker came from is worse than no warning:
       // the journal is persistent, so an unbounded read answers with the last
-      // update's failures over a clean one.
+      // update's failures over a clean one. Systemd's invocation id used to be
+      // that bound and cannot be — it is empty once the instance is collected
+      // — so the bound is the step's own start time and the OS does the
+      // filtering. Assert the ARGV: a window that is never asked for is a read
+      // that reports a previous run's failures as this one's, and the mock
+      // would answer it just the same.
+      const runStartedAtSeconds = Math.floor(Date.now() / 1000);
       setupExecFileMock({
-        "InvocationID": { stdout: "\n", stderr: "" },
-        "/usr/bin/journalctl": {
+        InvocationID: { stdout: "\n", stderr: "" },
+        "-u clawbox-root-update@apt_update.service": {
           stdout: "CLAWBOX-WARN[post-update-fixups]: these system fixups failed and were skipped: firewall",
           stderr: "",
         },
@@ -547,10 +599,21 @@ describe("updater", () => {
       updater.resetUpdateState();
       updater.startUpdate();
       await vi.waitFor(() => {
-        expect(updater.getUpdateState().steps.some((s) => s.status === "completed")).toBe(true);
+        const step = updater.getUpdateState().steps.find((s) => s.id === "apt_update");
+        expect(step?.status).toBe("completed");
       });
 
-      expect(updater.getUpdateState().warnings?.some((w) => w.message.includes("firewall"))).toBeFalsy();
+      const journalRead = mockExecFile.mock.calls
+        .map(([cmd, args]) => `${cmd} ${(args as string[]).join(" ")}`)
+        .find((call) =>
+          call.includes("journalctl") && call.includes("clawbox-root-update@apt_update.service"),
+        );
+      expect(journalRead, "the step's journal was never read").toBeDefined();
+      // By unit NAME, which outlives the unit systemd has already collected.
+      expect(journalRead).toContain("-u clawbox-root-update@apt_update.service");
+      const since = /--since @(\d+)/.exec(journalRead ?? "")?.[1];
+      expect(since, "the read is not bounded to this run").toBeDefined();
+      expect(Number(since)).toBeGreaterThanOrEqual(runStartedAtSeconds);
     });
 
     it("does not raise a line that merely QUOTES the marker", async () => {

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -464,6 +464,93 @@ describe("updater", () => {
       expect(aptStep?.error).toBe("E: Could not get lock /var/lib/dpkg/lock-frontend");
     });
 
+    it("reports THIS attempt's reason, not the one the owner already retried", async () => {
+      // The other half of the same defect: the failure reader tails the same
+      // persistent journal, and a FAILED unit stays loaded, so its tail runs
+      // back through the previous attempt. A retried step killed by its
+      // timeout before install.sh printed an error of its own was reported
+      // with the FIRST attempt's `Error:` line — getStepFailureLine takes the
+      // newest error line in what it is handed, and unbounded that is not
+      // necessarily this run's.
+      //
+      // The mock is the OS: the window this run opened sees only this run.
+      let dispatchedAt = 0;
+      const previousAttempt = "Error: apt-get update failed (exit 100)";
+      const thisAttempt = ["Fetching package lists...", "Killed"].join(String.fromCharCode(10));
+      setupExecFileMock({
+        "show clawbox-root-update@apt_update.service": { stdout: "failed\n", stderr: "" },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+      });
+      const fallback = mockExecFile.getMockImplementation()!;
+      mockExecFile.mockImplementation(((
+        cmd: string,
+        args: string[],
+        optsOrCallback?: object | ((error: Error | null, result: { stdout: string; stderr: string }) => void),
+        maybeCallback?: (error: Error | null, result: { stdout: string; stderr: string }) => void,
+      ) => {
+        const key = `${cmd} ${args.join(" ")}`;
+        const callback = typeof optsOrCallback === "function" ? optsOrCallback : maybeCallback;
+        const answer = (result: { stdout: string; stderr: string } | Error, delayMs = 0) => {
+          const settle = () => {
+            if (result instanceof Error) callback?.(result, { stdout: "", stderr: "" });
+            else callback?.(null, result);
+          };
+          if (delayMs > 0) setTimeout(settle, delayMs); else settle();
+          const thenable = {
+            then: (
+              resolve: (value: { stdout: string; stderr: string }) => void,
+              reject: (err: Error) => void,
+            ) => {
+              const finish = () => (result instanceof Error ? reject(result) : resolve(result));
+              if (delayMs > 0) setTimeout(finish, delayMs); else finish();
+              return thenable;
+            },
+            catch: () => thenable,
+          };
+          return thenable as unknown as ReturnType<typeof childProcess.execFile>;
+        };
+
+        if (key.includes("clawbox-run-root-step.sh apt_update")) {
+          dispatchedAt = Date.now();
+          return answer(new Error("systemctl failed"), 25);
+        }
+        if (key.includes("journalctl") && key.includes("clawbox-root-update@apt_update.service")) {
+          const since = Number(/--since @([\d.]+)/.exec(key)?.[1] ?? NaN);
+          const bounded = since * 1000 <= dispatchedAt;
+          return answer({
+            stdout: bounded ? thisAttempt : [previousAttempt, thisAttempt].join(String.fromCharCode(10)),
+            stderr: "",
+          });
+        }
+        return (fallback as unknown as (
+          cmd: string,
+          args: string[],
+          optsOrCallback?: unknown,
+          maybeCallback?: unknown,
+        ) => ReturnType<typeof childProcess.execFile>)(cmd, args, optsOrCallback, maybeCallback);
+      }) as unknown as typeof childProcess.execFile);
+
+      vi.resetModules();
+      mockGet.mockResolvedValue(undefined);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockRebuiltBox();
+      updater = await import("@/lib/updater");
+
+      updater.resetUpdateState();
+      updater.startUpdate();
+      await vi.waitFor(() => {
+        const aptStep = updater.getUpdateState().steps.find((step) => step.id === "apt_update");
+        expect(aptStep?.status).toBe("failed");
+      }, { timeout: 4_000, interval: 25 });
+
+      const aptStep = updater.getUpdateState().steps.find((step) => step.id === "apt_update");
+      expect(aptStep?.error).not.toContain("apt-get update failed (exit 100)");
+      expect(aptStep?.error).toBe("Killed");
+    });
+
     /**
      * 2026-09-05, on the box: the rebuild was OOM-killed and the failed step
      * recorded "clawbox-root-update@rebuild_reboot.service: Consumed 8.523s CPU

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -578,9 +578,8 @@ describe("updater", () => {
       // is the window being opened after the dispatch instead of before it:
       // every argv assertion still passes and no marker is ever raised again.
       // So the mock is the OS here — it serves the marker only to a window
-      // that opened at or before the dispatch — and the dispatch takes time,
-      // because a window floored to the second cannot tell before from after
-      // when the step returns instantly.
+      // that opened at or before the dispatch — and the dispatch takes a
+      // moment, which the millisecond bound is enough to see.
       const runStartedAtSeconds = Math.floor(Date.now() / 1000);
       let dispatchedAt = 0;
       setupExecFileMock({
@@ -614,12 +613,14 @@ describe("updater", () => {
 
         if (key.includes("clawbox-run-root-step.sh apt_update")) {
           dispatchedAt = Date.now();
-          return answer("", 1_100);
+          return answer("", 25);
         }
         if (key.includes("journalctl") && key.includes("clawbox-root-update@apt_update.service")) {
-          const since = Number(/--since @(\d+)/.exec(key)?.[1] ?? NaN);
+          const since = Number(/--since @([\d.]+)/.exec(key)?.[1] ?? NaN);
           // The journal answers a window that opened after the step wrote with
-          // nothing at all — which is what a box would do.
+          // nothing at all — which is what a box would do. The bound carries
+          // milliseconds, so the dispatch only has to take a moment for this
+          // to tell a capture before it from one after it.
           return answer(since * 1000 <= dispatchedAt ? marker : "");
         }
         return (fallback as unknown as (
@@ -655,7 +656,7 @@ describe("updater", () => {
       // By unit NAME, which outlives the unit systemd has already collected,
       // and never earlier than this run.
       expect(journalRead).toContain("-u clawbox-root-update@apt_update.service");
-      const since = /--since @(\d+)/.exec(journalRead ?? "")?.[1];
+      const since = /--since @([\d.]+)/.exec(journalRead ?? "")?.[1];
       expect(since, "the read is not bounded to this run").toBeDefined();
       expect(Number(since)).toBeGreaterThanOrEqual(runStartedAtSeconds);
     });


### PR DESCRIPTION
**TASK-766, reopened as device-lane finding J-1.** PR #785 built the writer half of the
post-update warning pipeline and it works — a box produced a genuine
`CLAWBOX-WARN[post-update-fixups]: these system fixups failed and were skipped: update_smoke`
marker during the 3.10 deploy. The reader half never fired, on either edition.

## Rebased onto `9dc3d8f5` — and one line of it belongs here

`beta` moved after this branch was pushed: the Settings → Harness swap landed a new reader that
imports `rootStepUnit` from `@/lib/root-step-follow`, the export this branch removes when the helper
moves into `root-step-journal.ts`. The two branches share no file, so git merges them clean and both
CIs were green — but the merged tree does not typecheck:

```
src/lib/harness-swap.ts(46,10): error TS2459: Module '"@/lib/root-step-follow"'
  declares 'rootStepUnit' locally, but it is not exported.
```

That is a red `test` job on `beta` the moment this merges, so the one-line import is in this PR,
rebased on `9dc3d8f5` and verified there: `tsc` 0, whole suite **991 files / 14971 passed / 1
skipped / 0 failed**.

Repointed, not re-exported from `root-step-follow`. The point of the new module is that "which unit
is this root step, and which run of it" has ONE home; a compatibility re-export would leave two
import paths for one helper and put an identity helper back inside a follow LOOP — which is how the
swap came to import it from there. Nothing else of that PR is touched: its `harness_swap` entries in
`root-steps.ts`, `clawbox-root-step.sh` and `clawbox-run-root-step.sh` are untouched and additive,
and this branch's readers pick them up for free.

## What the owner sees

An update in which a system fixup was skipped is reported as an update that landed whole:
Settings → System → Update shows `phase: completed`, every step green, **warnings = (none)**,
and no `update_warnings` key is written to the device store. That is the false success #785
exists to remove, surviving on the reading side — measured on the box that had just produced a
real marker.

## Cause

`collectRootStepWarnings` asked systemd which start of the step this was:

```
systemctl show clawbox-root-update@<step>.service -p InvocationID --value
```

and read only that invocation's journal. On a box that property answers **EMPTY**, always:
`clawbox-root-update@<step>.service` is a template instance started ad hoc and referenced by
nothing, so systemd garbage-collects it the moment it exits and answers the query from a freshly
instantiated, never-run view of the unit — the same trap `REBUILD_ROOT_STEP` already records two
hundred lines above for `-p Result`. The reader returned at its first line on every run, so every
marker install.sh raises was dropped. Measured on both editions: empty for `post_update`,
`openclaw_install` and `gateway_setup`, while 22 statically installed oneshots on the same box
still carried their ids — the units that stay loaded keep them, these do not.

## The systemd mechanism this uses, and the ones it does not

Four native options; this picks the one that survives the unit being collected **and** can read a
marker already in the journal:

| mechanism | verdict |
|---|---|
| `systemctl show -p InvocationID` | what broke: empty once the instance is collected, which is before anyone asks |
| `$INVOCATION_ID` inside the unit, written to the lock-holder heartbeat | works, but needs a writer change AND a fresh update on every box before a single warning can be read; it cannot surface the marker a box already has |
| `systemd-run`'s returned invocation id | not our start path — root steps go through the root-owned launcher (TASK-539), not `systemd-run`, and `--no-block` returns before the unit does anything |
| **`journalctl -u <unit>` + `--since @<epoch>`** | **used.** Journal entries carry `_SYSTEMD_UNIT` from when they were written, so the read outlives the unit; `--since` in systemd's own seconds-since-the-epoch form (systemd.time(7)) keeps the run bound the invocation id was there for |

`readRootStepFailure` and the e2e-install journal assertion already read by unit name — this makes
the warning reader agree with them rather than inventing a channel.

The window opens at the moment the runner dispatched the step, so a persistent journal cannot
raise last week's markers over a clean run (the box has two `post_update` runs in one journal;
the window picks the right one). A clock that jumps backwards mid-run narrows the window: that can
lose a warning, it cannot invent one, which is the direction this has to fail in.

## Sibling sweep — every `InvocationID` / journal reader in `src/lib`, `src/app` and `scripts`

| site | verdict |
|---|---|
| `updater.ts collectRootStepWarnings` | **fixed** — the defect |
| `app/setup-api/llamacpp/install/route.ts` | **fixed** — same loop, same unit family, unbounded: its first poll runs before this run's unit writes, so the PREVIOUS attempt's error was streamed as live progress and returned as this run's reason |
| `lib/root-step-follow.ts` (voice + embedder installs) | **fixed** — identical exposure, identical fix |
| `updater.ts readRootStepFailure` | **fixed** — a failed unit stays loaded, so this one always worked; but its 40-line tail runs back through the owner's previous attempt, and `getStepFailureLine` takes the newest error line in what it is handed. A retried step killed by its timeout before printing an error of its own was reported with the FIRST attempt's `Error:` line. Bounded at the three callers that dispatched the step; the post-reboot continuation check passes `null` and says why — no start time survives the restart to it, and bounding that one needs a dispatch epoch persisted across the reboot (residual, filed to the run queue's Found list) |
| `lib/gateway-health.ts` (invocation-scoped) | clear — `clawbox-gateway.service` is statically installed and stays loaded; measured on the box: `LoadState=loaded`, 32-char `InvocationID` present. It also takes the id from the same `systemctl show` output that reported the failure |
| `updater.ts readGatewayJournalTail` | clear — `-b`-bounded on a long-lived unit |
| `lib/network.ts` (wpa_supplicant) | clear — already `--since "45 seconds ago"` |
| `lib/cloudflared.ts` | clear — newest published hostname is deliberately the answer |
| `app/setup-api/install/run-step/route.ts` | **fixed** — the 60-line tail returned as the evidence for a failed UI repair ran back through the owner's earlier attempt |
| `e2e-install/90-upgrade-main-to-beta.spec.ts` | clear — reads by unit name (the shape adopted here) and its absence assertion is guarded against an empty journal |

All five fixed readers now share one definition, `src/lib/root-step-journal.ts`, so "the journal of
THIS run of a root step" cannot drift between them, and the unit name is spelled once.

## RED → GREEN

Three regression tests, each failing on unmodified `beta` (`695a105e`) — the second one run there as a
standalone copy of its `followRootStep` block, since the module it imports is new in this PR:

```
FAIL src/tests/unit/updater.test.ts > raises the marker after systemd has UNLOADED the step's unit
AssertionError: the skipped fixup never reached the owner: expected undefined to be defined
  (InvocationID answers empty — the real box shape — while the journal holds the marker)

FAIL src/tests/unit/root-step-journal.test.ts > never reports the previous attempt's line as this run's
AssertionError: expected 'ERROR: kokoro model download failed' not to contain 'kokoro model download failed'

FAIL src/tests/routes/llamacpp/install.test.ts > never reports the PREVIOUS install attempt's line as this run's
AssertionError: expected '{"status":"Checking local Gemma 4 run…' not to contain "yesterday's attempt"
  + {"status":"Installing Gemma 4 for offline use — Error: yesterday's attempt could not reach huggingface.co"}
  + {"error":"Error: yesterday's attempt could not reach huggingface.co"}
```

GREEN on this branch: unit **782 files / 13060 passed / 1 skipped / 0 failed**; components 204 files
/ 1734 passed with one 5000 ms timeout in `chat-email-refs-surfaces.test.tsx`, a file this PR does
not touch, which passes in isolation on this branch and on unmodified beta alike; `tsc` 0;
`eslint` 0 errors.

The test that pinned "raise nothing when systemd cannot say which run this was" pinned the defect,
so it is replaced by one that pins the invariant it was protecting — and pins it by behaviour, not
by argv: the mock answers a window that opened after the step wrote with nothing, and the dispatch
takes time, so the one regression that would silently restore the original bug (moving the capture
below the dispatch, which every argv assertion still passes) fails the test. Verified by mutation:

```
- const stepStartedAt = Date.now();   // before the dispatch
+ stepStartedAt = Date.now();         // after it

FAIL src/tests/unit/updater.test.ts > opens the marker window BEFORE the step is dispatched, not after
AssertionError: the window opened after the step ran — no marker can ever be read: expected undefined to be defined
```

A review pass on the branch found the two unbounded siblings above (`readRootStepFailure`,
`install/run-step`) and the argv-only test; all three are in the diff, with the module docblock now
naming the native bounds NOT taken — journal cursors (`--show-cursor`/`--after-cursor`, monotonic
and clock-free, rejected for a second journalctl call at every dispatch and a new failure mode) and
an invocation id published by the root launcher (a writer change: it could read nothing already in
a box's journal) — and why `RemainAfterExit=yes` is not the answer either.

Both sibling fixes are pinned too, because reverting either passed the whole suite before:
`readRootStepFailure` gets a two-attempt journal (reverting its bound reports the first attempt's
`Error: apt-get update failed (exit 100)` as the reason the second one failed), and
`install/run-step` — which had no test file at all — gets three cases over the 500 body's
`journalTail`. And the half none of them pinned: that each window opens BEFORE `startRootStep`, not
after it. A mocked dispatch is instantaneous, so a capture that slid below it stayed green
everywhere but the updater; the follow and llama.cpp mocks now take a moment to start the unit, the
way a box does, and answer a window opened after that with the previous attempt's line. All four
reverts fail a test now.

## Device proof (read-only, no lock taken, no update run)

The fixed reader's exact argv and the exact `CLAWBOX-WARN` regex, run as the `clawbox` user against
the journal the Hermes-edition box already holds:

```
beta reader  : systemctl show -p InvocationID -> "" (0 chars) => RETURNS EARLY, no warning can be raised
fixed reader : journalctl -u clawbox-root-update@post_update.service --since @<step dispatch> -n 500 --no-pager -o cat
  WARNING RAISED -> code=post-update-fixups message=these system fixups failed and were skipped: update_smoke
  warnings raised: 1

same reader, window opened after that marker (a later run must not inherit it):
  warnings raised: 0
```

On the OpenClaw-edition box the same query answers empty for every root step and its clean
`post_update` journal contains no marker, so the fixed reader raises nothing there — the failure is
edition-independent and the fix does not invent warnings on a clean run.

**OWNER-TEST:** after an update in which a fixup is skipped, Settings → System → Update shows an
amber card naming it (e.g. *"these system fixups failed and were skipped: update_smoke"*) instead
of a clean bill of health. Reinstalling the on-device voice or the embedder after a failed attempt
no longer opens by showing the previous attempt's error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Installation and update progress now show journal output from the current run, preventing stale messages from previous attempts.
  - Failure details and status updates are restricted to the relevant step and run window.
  - Post-update warnings continue to be detected even after the associated service has unloaded.
  - Rebuild, recovery, and follow-up reporting now provide more accurate per-step results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->