### PR TITLE
fix: stop false OpenClaw smoke warnings on Hermes updates

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7397,6 +7397,14 @@ step_gateway_legacy_state_recovery() {
 }
 
 step_update_smoke() {
+  # These probes read OpenClaw's gateway and Telegram configuration. Hermes-only
+  # boxes deliberately have neither; their services are checked separately by
+  # validate_services. Do not turn that absence into a failed update fixup.
+  # Dual still ships OpenClaw and must keep all of these checks.
+  if ! has_openclaw_harness; then
+    echo "    [skip] OpenClaw post-update smokes (Hermes-only edition)"
+    return 0
+  fi
   # WHAT THE SMOKES FOUND, in a return code the caller can report.
   #
   # Every finding below is a `[WARN]` line and the step returned 0 either way,

--- a/src/tests/unit/update-smoke-edition.test.ts
+++ b/src/tests/unit/update-smoke-edition.test.ts
@@ -1,0 +1,61 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const installer = fs.readFileSync(path.join(process.cwd(), "install.sh"), "utf8");
+const start = installer.indexOf("step_update_smoke() {");
+const smoke = installer.slice(start, installer.indexOf("\n}", start) + 2);
+const editionHelper = installer.match(/^has_openclaw_harness\(\).*$/m)![0];
+
+function runSmoke(edition: string, healthy: boolean) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "update-smoke-edition-"));
+  try {
+    if (healthy) {
+      fs.mkdirSync(path.join(home, ".openclaw"));
+      fs.writeFileSync(path.join(home, ".openclaw/openclaw.json"), JSON.stringify({
+        gateway: { auth: { token: "fixture-token-not-a-real-secret-1234567890" } },
+      }));
+    }
+    return execFileSync("bash", ["-c", [
+      "set -euo pipefail",
+      editionHelper,
+      // No live network or device state: only the actual smoke's decisions run.
+      'curl() { echo GATEWAY_PROBED >&2; printf "%s" "$FIXTURE_HTTP"; }',
+      'as_clawbox() { echo CONFIG_PROBED >&2; "$@"; }',
+      smoke,
+      'if step_update_smoke; then echo RESULT=0; else echo RESULT=$?; fi',
+    ].join("\n")], {
+      encoding: "utf8",
+      timeout: 10_000,
+      env: { ...process.env, CLAWBOX_EDITION: edition, CLAWBOX_HOME: home,
+        FIXTURE_HTTP: healthy ? "200" : "000", CLAWBOX_SMOKE_TELEGRAM_CHAT_ID: "" },
+    });
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
+describe("post-update smoke checks the installed harness", () => {
+  it("does not report a broken OpenClaw gateway on a Hermes-only box", () => {
+    const output = runSmoke("hermes", false);
+    expect(output).toContain("RESULT=0");
+    expect(output).toContain("[skip]");
+    expect(output).not.toContain("[WARN]");
+  });
+
+  it.each(["openclaw", "dual"])("still reports a broken gateway on %s", edition => {
+    const output = runSmoke(edition, false);
+    expect(output).toContain("RESULT=1");
+    expect(output).toContain("gateway not reachable");
+    expect(output).toContain("gateway auth token is weak/missing");
+  });
+
+  it.each(["openclaw", "dual"])("accepts a healthy %s box with no Telegram bot", edition => {
+    const output = runSmoke(edition, true);
+    expect(output).toContain("RESULT=0");
+    expect(output).toContain("gateway reachable");
+    expect(output).not.toContain("[WARN]");
+  });
+});

--- a/src/tests/unit/update-smoke-edition.test.ts
+++ b/src/tests/unit/update-smoke-edition.test.ts
@@ -2,7 +2,9 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const installer = fs.readFileSync(path.join(process.cwd(), "install.sh"), "utf8");
 const start = installer.indexOf("step_update_smoke() {");


### PR DESCRIPTION
## Summary

Fix the residual recorded on TASK-766: every Hermes update reports
`post-update-fixups: update_smoke` because that smoke probes the OpenClaw gateway
and reads OpenClaw credentials, neither of which Hermes-only devices ship.

Use the existing `has_openclaw_harness` edition predicate. Hermes-only explicitly
skips these probes; OpenClaw and dual keep all existing checks. Hermes service
validation remains in the existing edition-aware service validation step.

## Verification

- New behavioral test runs the actual shell smoke with temporary configuration
  and stubbed network: **RED 1 failed / 4 passed** on beta `60a62fe0`.
- With fix: **12 tests passed** across edition smoke and post-update warnings.
- Bash syntax, focused ESLint, TypeScript and `git diff --check` passed.
- Baseline full unit suite: 13,210 passed / 1 skipped, one Telegram-status test
  timed out (unrelated; under investigation in the release gate TASK-778).
- Production build and component baseline tracked in TASK-778.
- No device flash, production setting or customer data changed.

Part of TASK-778 v4 release readiness; not a claim that the complete release gate
has passed. No new feature or dependency update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Update checks now correctly handle Hermes-only editions by skipping OpenClaw gateway and Telegram smoke checks.
  - Dual and OpenClaw editions continue receiving gateway connectivity and authentication checks.
- **Tests**
  - Added coverage for Hermes-only, dual, and OpenClaw update scenarios, including healthy, unreachable, and unauthenticated gateway configurations.
  - Verified that healthy configurations can complete without Telegram credentials where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->