### PR TITLE
test: keep Telegram configuration checks offline

### DIFF
--- a/src/tests/routes/telegram/status.test.ts
+++ b/src/tests/routes/telegram/status.test.ts
@@ -14,6 +14,15 @@ const OPENCLAW_CONFIG_PATH = path.join(OPENCLAW_HOME, "openclaw.json");
 type RouteGet = () => Promise<Response>;
 
 let telegramStatusGet: RouteGet;
+const savedRoot = process.env.CLAWBOX_ROOT;
+const savedOpenclawHome = process.env.OPENCLAW_HOME;
+
+// This suite checks which on-disk credential counts as configured. Live
+// delivery/receiving behavior has dedicated suites; neither Telegram nor an
+// installed OpenClaw CLI should be reached by these fixture-only checks.
+vi.mock("@/lib/openclaw-channels", () => ({
+  readCachedChannelStatus: async () => null,
+}));
 
 beforeAll(async () => {
   process.env.CLAWBOX_ROOT = TEST_ROOT;
@@ -25,13 +34,20 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ ok: true, result: { username: "fixture_bot", first_name: "Fixture" } }),
+  }));
   await fs.rm(CONFIG_PATH, { force: true });
   await fs.rm(OPENCLAW_CONFIG_PATH, { force: true });
 });
 
 afterAll(async () => {
-  delete process.env.CLAWBOX_ROOT;
-  delete process.env.OPENCLAW_HOME;
+  vi.unstubAllGlobals();
+  if (savedRoot === undefined) delete process.env.CLAWBOX_ROOT;
+  else process.env.CLAWBOX_ROOT = savedRoot;
+  if (savedOpenclawHome === undefined) delete process.env.OPENCLAW_HOME;
+  else process.env.OPENCLAW_HOME = savedOpenclawHome;
   await fs.rm(TEST_ROOT, { recursive: true, force: true });
 });
 
@@ -40,7 +56,7 @@ describe("GET /setup-api/telegram/status", () => {
     const res = await telegramStatusGet();
     const body = await res.json();
 
-    expect(res.status).toBe(200);
+    expect(res.status, JSON.stringify(body)).toBe(200);
     expect(body.configured).toBe(false);
   });
 
@@ -50,7 +66,7 @@ describe("GET /setup-api/telegram/status", () => {
     const res = await telegramStatusGet();
     const body = await res.json();
 
-    expect(res.status).toBe(200);
+    expect(res.status, JSON.stringify(body)).toBe(200);
     expect(body.configured).toBe(true);
   });
 
@@ -89,7 +105,7 @@ describe("GET /setup-api/telegram/status", () => {
     const res = await telegramStatusGet();
     const body = await res.json();
 
-    expect(res.status).toBe(200);
+    expect(res.status, JSON.stringify(body)).toBe(200);
     expect(body.configured).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

The clean v4 baseline had 13,210 unit-test passes but timed out in
`telegram/status.test.ts`: its fixture token was sent to the real Telegram
`getMe` endpoint (a 5-second request deadline races Vitest's 5-second limit),
and it also queried an installed OpenClaw CLI.

This suite verifies configuration-file precedence, not external delivery.
Stub the external bot lookup and channel status, preserve the real filesystem
reader and route, and restore the inherited test roots after the suite.
Dedicated OpenClaw-receiving and Hermes-status suites remain unchanged.

## Validation

- All three Telegram status suites: **21 tests passed**.
- Focused ESLint, TypeScript and `git diff --check`: passed.
- No production code, dependency or runtime behavior changed.
- Release-gate tracking: TASK-778. Full unit rerun follows this isolation fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved Telegram status test isolation by replacing live service access with cached and fixture-based data.
  - Preserved and restored existing environment settings during test cleanup.
  - Added response details to status assertion failures for easier diagnosis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->