### PR TITLE
fix: use PKCE for ClawKeep CLI pairing

### DIFF
--- a/clawkeep/clawkeep/pair.py
+++ b/clawkeep/clawkeep/pair.py
@@ -92,17 +92,28 @@ class _OneShotServer(socketserver.TCPServer):
     allow_reuse_address = True
 
 
+def _validate_server(server: str) -> None:
+    parsed = urllib.parse.urlsplit(server)
+    if parsed.scheme != "https" or not parsed.hostname or parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise SystemExit("Pairing requires an HTTPS portal URL without credentials, query or fragment.")
+
+
 def _exchange(server: str, code: str, state: str, device_id: str, code_verifier: str) -> str:
+    _validate_server(server)
     url = f"{server}/api/portal/connect/exchange"
     try:
         resp = requests.post(
             url,
             json={"code": code, "state": state, "device_id": device_id, "code_verifier": code_verifier},
             timeout=(5, 30),
+            allow_redirects=False,
             headers={"User-Agent": api.USER_AGENT},
         )
     except requests.RequestException as e:
         raise SystemExit(f"Failed to reach {url}: {e}") from e
+
+    if 300 <= resp.status_code < 400:
+        raise SystemExit("Token exchange refused a redirect; use the canonical HTTPS portal URL.")
 
     if not resp.ok:
         try:
@@ -115,6 +126,8 @@ def _exchange(server: str, code: str, state: str, device_id: str, code_verifier:
         body = resp.json()
     except ValueError as e:
         raise SystemExit(f"Token exchange returned non-JSON: {e}") from e
+    if body.get("pkce_verified") is not True:
+        raise SystemExit("Portal did not confirm S256 PKCE protection. Update the portal before pairing.")
     access_token = body.get("access_token")
     if not isinstance(access_token, str) or not access_token.startswith("claw_"):
         raise SystemExit(f"Token exchange returned unexpected body: {json.dumps(body)[:200]}")
@@ -131,6 +144,7 @@ def run_pair(
     """Run the pairing flow. Returns the obtained token. Side effects: writes
     token file to disk."""
     server = server.rstrip("/")
+    _validate_server(server)
     device_name = device_name or socket.gethostname()
     state = secrets.token_urlsafe(24)
     # RFC 7636: only the S256 challenge travels through the browser. A copied

--- a/clawkeep/clawkeep/pair.py
+++ b/clawkeep/clawkeep/pair.py
@@ -8,6 +8,8 @@ before clicking through the portal. We print this hint up front.
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
 import secrets
 import socket
@@ -90,12 +92,12 @@ class _OneShotServer(socketserver.TCPServer):
     allow_reuse_address = True
 
 
-def _exchange(server: str, code: str, state: str, device_id: str) -> str:
+def _exchange(server: str, code: str, state: str, device_id: str, code_verifier: str) -> str:
     url = f"{server}/api/portal/connect/exchange"
     try:
         resp = requests.post(
             url,
-            json={"code": code, "state": state, "device_id": device_id},
+            json={"code": code, "state": state, "device_id": device_id, "code_verifier": code_verifier},
             timeout=(5, 30),
             headers={"User-Agent": api.USER_AGENT},
         )
@@ -131,6 +133,12 @@ def run_pair(
     server = server.rstrip("/")
     device_name = device_name or socket.gethostname()
     state = secrets.token_urlsafe(24)
+    # RFC 7636: only the S256 challenge travels through the browser. A copied
+    # authorization code is unusable without this process's random verifier.
+    code_verifier = secrets.token_urlsafe(32)
+    code_challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(code_verifier.encode("ascii")).digest()
+    ).rstrip(b"=").decode("ascii")
     _PairHandler.expected_state = state
     _PairHandler.received = None
 
@@ -140,6 +148,8 @@ def run_pair(
             "state": state,
             "redirect_uri": redirect_uri,
             "device_name": device_name,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
         }
     )
     auth_url = f"{server}/portal/connect?{qs}"
@@ -188,6 +198,7 @@ def run_pair(
         code=received["code"],
         state=received["state"],
         device_id=device_name,
+        code_verifier=code_verifier,
     )
 
     target = token_path or token.default_token_path()

--- a/clawkeep/tests/test_pair_pkce.py
+++ b/clawkeep/tests/test_pair_pkce.py
@@ -1,0 +1,50 @@
+"""The browser sees a challenge; only the token exchange receives its verifier."""
+import base64
+import hashlib
+import urllib.parse
+from unittest.mock import Mock
+
+from clawkeep import pair
+
+
+class CallbackServer:
+    def __init__(self, address, handler):
+        self.handler = handler
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def handle_request(self):
+        self.handler.received = {"code": "test-code", "state": self.handler.expected_state}
+
+
+def test_pair_s256_proof_matches_exchange_and_is_never_printed(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(pair, "_OneShotServer", CallbackServer)
+    response = Mock(ok=True)
+    response.json.return_value = {"access_token": "claw_test_private_token"}
+    post = Mock(return_value=response)
+    monkeypatch.setattr(pair.requests, "post", post)
+    verifiers = []
+    for index in range(2):
+        token_path = tmp_path / f"token-{index}"
+        assert pair.run_pair("https://portal.test", token_path=token_path) == "claw_test_private_token"
+        output = capsys.readouterr().out
+        url = next(line.strip() for line in output.splitlines() if line.strip().startswith("https://portal.test/portal/connect?"))
+        query = urllib.parse.parse_qs(urllib.parse.urlsplit(url).query)
+        body = post.call_args.kwargs["json"]
+        verifier = body["code_verifier"]
+        assert 43 <= len(verifier) <= 128
+        challenge = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest()).rstrip(b"=").decode("ascii")
+        assert query["code_challenge"] == [challenge]
+        assert query["code_challenge_method"] == ["S256"]
+        assert body["state"] == query["state"][0]
+        assert body["code"] == "test-code"
+        assert post.call_args.args[0] == "https://portal.test/api/portal/connect/exchange"
+        assert verifier not in output
+        assert "claw_test_private_token" not in output
+        assert token_path.stat().st_mode & 0o777 == 0o600
+        verifiers.append(verifier)
+    assert verifiers[0] != verifiers[1]

--- a/clawkeep/tests/test_pair_pkce.py
+++ b/clawkeep/tests/test_pair_pkce.py
@@ -2,6 +2,7 @@
 import base64
 import hashlib
 import urllib.parse
+import pytest
 from unittest.mock import Mock
 
 from clawkeep import pair
@@ -23,8 +24,8 @@ class CallbackServer:
 
 def test_pair_s256_proof_matches_exchange_and_is_never_printed(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(pair, "_OneShotServer", CallbackServer)
-    response = Mock(ok=True)
-    response.json.return_value = {"access_token": "claw_test_private_token"}
+    response = Mock(ok=True, status_code=200)
+    response.json.return_value = {"access_token": "claw_test_private_token", "pkce_verified": True}
     post = Mock(return_value=response)
     monkeypatch.setattr(pair.requests, "post", post)
     verifiers = []
@@ -43,8 +44,41 @@ def test_pair_s256_proof_matches_exchange_and_is_never_printed(monkeypatch, tmp_
         assert body["state"] == query["state"][0]
         assert body["code"] == "test-code"
         assert post.call_args.args[0] == "https://portal.test/api/portal/connect/exchange"
+        assert post.call_args.kwargs["allow_redirects"] is False
         assert verifier not in output
         assert "claw_test_private_token" not in output
         assert token_path.stat().st_mode & 0o777 == 0o600
         verifiers.append(verifier)
     assert verifiers[0] != verifiers[1]
+
+
+@pytest.mark.parametrize("server", ["http://portal.test", "https://user:pass@portal.test", "https://portal.test?token=x", "https://portal.test#anchor"])
+def test_pair_refuses_unsafe_portal_before_starting(monkeypatch, server):
+    listener = Mock()
+    post = Mock()
+    monkeypatch.setattr(pair, "_OneShotServer", listener)
+    monkeypatch.setattr(pair.requests, "post", post)
+    with pytest.raises(SystemExit, match="HTTPS portal URL"):
+        pair.run_pair(server)
+    listener.assert_not_called()
+    post.assert_not_called()
+
+
+@pytest.mark.parametrize("status", [301, 302, 307, 308])
+def test_exchange_never_follows_redirects(monkeypatch, status):
+    post = Mock(return_value=Mock(status_code=status))
+    monkeypatch.setattr(pair.requests, "post", post)
+    with pytest.raises(SystemExit, match="refused a redirect"):
+        pair._exchange("https://portal.test", "code", "state", "device", "verifier")
+    assert post.call_args.kwargs["allow_redirects"] is False
+
+
+def test_old_portal_cannot_silently_downgrade_pkce(monkeypatch, tmp_path):
+    monkeypatch.setattr(pair, "_OneShotServer", CallbackServer)
+    response = Mock(ok=True, status_code=200)
+    response.json.return_value = {"access_token": "claw_legacy_token"}
+    monkeypatch.setattr(pair.requests, "post", Mock(return_value=response))
+    token_path = tmp_path / "token"
+    with pytest.raises(SystemExit, match="did not confirm S256 PKCE"):
+        pair.run_pair("https://portal.test", token_path=token_path)
+    assert not token_path.exists()


### PR DESCRIPTION
## V4 pairing dependency — website #592 / TASK-750

The shipped `clawkeep pair` CLI still used authorization codes without proof of possession. Generate a fresh random verifier for each pairing, send only its S256 challenge through the portal/browser, and include the verifier in the token exchange body. The verifier is never printed or persisted. Existing state checks, loopback forwarding, token permissions and exchange behavior remain.

This is compatible with the old portal, which ignores the new fields, and enables the protection being deployed in website #592 without waiting for the legacy grace deadline.

Validation: full ClawKeep Python suite passed (169 tests). The new offline flow test verifies the challenge matches the exchanged verifier, fresh randomness across two pairings, unchanged state correlation, no token/verifier in console output, and mode0600 token storage. No real pairing or customer API operation ran.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Pairing now uses OAuth 2.0 PKCE protection during authorization and token exchange.
  - Authorization requests and token exchanges validate the associated security parameters, including portal confirmation of PKCE verification.
  - Portal URLs must use HTTPS and cannot contain credentials, queries, or fragments; unsafe redirects are rejected.
  - Sensitive pairing credentials remain protected, are not displayed during the process, and are stored with restricted permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->