### PR TITLE
fix: restore Hermes cloud voice after subscription re-upgrade

### DIFF
--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -1355,7 +1355,8 @@ standdown, standdown_error = load(os.environ["CLAWBOX_HERMES_CONFIG"] + ".clawbo
 restore_cloud = (
     standdown_error is None and isinstance(standdown, dict)
     and standdown.get("version") == 1 and standdown.get("provider") == LOCAL_PROVIDER
-    and provider == LOCAL_PROVIDER and route_is_ours
+    and provider == LOCAL_PROVIDER
+    and (slot_is_empty or base_url.rstrip("/") in OUR_PROXIES)
 )
 
 if token and arm_tier == ENTITLED_TIER:
@@ -1643,8 +1644,10 @@ TOKENPY
     case "$CLAWBOX_VOICE_TARGET" in
       keep) hermes_voice_stamp clear || log "could not clear the old voice restoration marker" ;;
       "$CLAWBOX_VOICE_LOCAL")
-        hermes_voice_stamp remember || log "could not remember the cloud voice for restoration after renewal"
-        if ! hermes_voice_write config set tts.provider "$CLAWBOX_VOICE_LOCAL"; then
+        if ! hermes_voice_stamp remember; then
+          log "could not remember the cloud voice — leaving its selection and definition unchanged for retry"
+          CLAWBOX_VOICE_STOOD_DOWN=false
+        elif ! hermes_voice_write config set tts.provider "$CLAWBOX_VOICE_LOCAL"; then
           hermes_voice_stamp clear || log "could not clear the failed voice restoration marker"
           log "could not move this box off the ClawBox AI cloud voice (exit $CLAWBOX_VOICE_RC) — its definition is left in place so the box keeps speaking through our own proxy rather than through a slot with nothing behind it; the next start will try again"
           CLAWBOX_VOICE_STOOD_DOWN=false

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -1351,6 +1351,12 @@ model = text(slot.get("model"))
 key_is_ours = api_key.startswith("claw_")
 slot_is_empty = base_url == "" and api_key == ""
 route_is_ours = key_is_ours or slot_is_empty or base_url.rstrip("/") == PROXY
+standdown, standdown_error = load(os.environ["CLAWBOX_HERMES_CONFIG"] + ".clawbox-voice-standdown.json", json.load)
+restore_cloud = (
+    standdown_error is None and isinstance(standdown, dict)
+    and standdown.get("version") == 1 and standdown.get("provider") == LOCAL_PROVIDER
+    and provider == LOCAL_PROVIDER and route_is_ours
+)
 
 if token and arm_tier == ENTITLED_TIER:
     # ALREADY SPEAKING THROUGH US. The selection is not touched again; the
@@ -1364,6 +1370,8 @@ if token and arm_tier == ENTITLED_TIER:
         say("refresh")
     if provider not in ("", FACTORY_PROVIDER, LOCAL_PROVIDER):
         say("hold this box has already chosen how it speaks (%s)" % short(provider))
+    if restore_cloud:
+        say("restore")
     # UNCHOSEN IS ALL THREE, and the engine question is asked of all three.
     # `clawbox-local` is here because `install.sh` `step_openclaw_tts` selects it
     # on every install and every update WHATEVER the engine answered —
@@ -1462,13 +1470,16 @@ if plan_tier and plan_tier != ENTITLED_TIER:
     providers = tts.get("providers")
     providers = providers if isinstance(providers, dict) else {}
     local = providers.get(LOCAL_PROVIDER)
+    if not isinstance(local, dict):
+        local = tts.get(LOCAL_PROVIDER)
     local = local if isinstance(local, dict) else {}
     local_command = local.get("command")
     local_type = local.get("type")
+    local_type = local_type.strip().lower() if isinstance(local_type, str) else local_type
     if (
         isinstance(local_command, str)
         and local_command.strip()
-        and local_type in (None, "command")
+        and local_type in (None, "", "command")
     ):
         say("withdraw %s" % LOCAL_PROVIDER)
     # NOWHERE SAFE TO STAND DOWN TO, so nothing is withdrawn at all.
@@ -1496,6 +1507,43 @@ say("hold nothing to do")
 PY
 )
 CLAWBOX_VOICE_VERDICT="${CLAWBOX_VOICE_PLAN%% *}"
+
+# This history contains no credential. Only our own automatic selection is
+# remembered; the Voice panel clears it whenever the owner makes a choice.
+hermes_voice_stamp() {
+  CLAWBOX_HERMES_CONFIG="$HERMES_CONFIG" CLAWBOX_STAMP_ACTION="$1" python3 - <<'STAMPPY'
+import json, os, tempfile, yaml
+cfg_path = os.environ["CLAWBOX_HERMES_CONFIG"]
+stamp_path = cfg_path + ".clawbox-voice-standdown.json"
+action = os.environ["CLAWBOX_STAMP_ACTION"]
+if action == "clear":
+    try: os.unlink(stamp_path)
+    except FileNotFoundError: pass
+elif action == "remember":
+    cfg = yaml.safe_load(open(cfg_path)) or {}
+    voice = ((cfg.get("tts") or {}).get("openai") or {}).get("voice")
+    stamp = {"version": 1, "provider": "clawbox-local"}
+    if isinstance(voice, str) and voice.strip(): stamp["cloudVoice"] = voice
+    fd, tmp = tempfile.mkstemp(prefix=".voice-standdown-", dir=os.path.dirname(cfg_path))
+    try:
+        with os.fdopen(fd, "w") as f: json.dump(stamp, f)
+        os.replace(tmp, stamp_path)
+    finally:
+        if os.path.exists(tmp): os.unlink(tmp)
+elif action == "voice":
+    try:
+        voice = json.load(open(stamp_path)).get("cloudVoice", "")
+        if isinstance(voice, str): print(voice)
+    except (OSError, ValueError, AttributeError): pass
+STAMPPY
+}
+
+hermes_voice_restore_name() {
+  [ "$CLAWBOX_VOICE_VERDICT" = restore ] || return 0
+  local voice
+  voice=$(hermes_voice_stamp voice)
+  [ -z "$voice" ] || hermes_voice_write config set tts.openai.voice "$voice"
+}
 
 # One bounded CLI call, with the exit status kept. Braces and `-k 5` for the
 # reason §4's `tools disable` documents at length: `timeout` SIGKILLs its own
@@ -1532,7 +1580,7 @@ hermes_voice_write() {
 CLAWBOX_VOICE_DEADLINE=$(( $(date +%s) + HERMES_CLI_TIMEOUT ))
 
 case "$CLAWBOX_VOICE_VERDICT" in
-  arm|refresh)
+  arm|refresh|restore)
     # DEFINITION BEFORE SELECTION, the same order `selectHermesEngine` keeps:
     # the endpoint, credential and model land first, so a failure leaves
     # `tts.provider` untouched rather than selecting a provider with nowhere to
@@ -1565,10 +1613,18 @@ TOKENPY
       # here to keep the credential and the endpoint current, and re-selecting
       # would buy a fourth CLI spawn for nothing.
       log "refreshed the ClawBox AI speech credential"
+      hermes_voice_stamp clear || log "could not clear the old voice restoration marker"
+    elif ! hermes_voice_restore_name; then
+      log "could not restore the previous cloud voice — leaving the local voice selected for retry"
     elif ! hermes_voice_write config set tts.provider openai; then
       log "wrote the ClawBox AI speech endpoint but could not select it (exit $CLAWBOX_VOICE_RC) — the next start will try again"
     else
-      log "armed the ClawBox AI cloud voice — this box's plan includes it and nothing else had been chosen"
+      hermes_voice_stamp clear || log "could not clear the old voice restoration marker"
+      if [ "$CLAWBOX_VOICE_VERDICT" = restore ]; then
+        log "restored the ClawBox AI cloud voice after the plan was renewed"
+      else
+        log "armed the ClawBox AI cloud voice — this box's plan includes it and nothing else had been chosen"
+      fi
     fi
     ;;
   withdraw)
@@ -1585,9 +1641,11 @@ TOKENPY
     CLAWBOX_VOICE_TARGET="${CLAWBOX_VOICE_PLAN#* }"
     CLAWBOX_VOICE_STOOD_DOWN=true
     case "$CLAWBOX_VOICE_TARGET" in
-      keep) ;;
+      keep) hermes_voice_stamp clear || log "could not clear the old voice restoration marker" ;;
       "$CLAWBOX_VOICE_LOCAL")
+        hermes_voice_stamp remember || log "could not remember the cloud voice for restoration after renewal"
         if ! hermes_voice_write config set tts.provider "$CLAWBOX_VOICE_LOCAL"; then
+          hermes_voice_stamp clear || log "could not clear the failed voice restoration marker"
           log "could not move this box off the ClawBox AI cloud voice (exit $CLAWBOX_VOICE_RC) — its definition is left in place so the box keeps speaking through our own proxy rather than through a slot with nothing behind it; the next start will try again"
           CLAWBOX_VOICE_STOOD_DOWN=false
         fi
@@ -1614,14 +1672,9 @@ TOKENPY
       # field carries `tts.openai.voice`, so unsetting it key-by-key reported a
       # failed withdrawal on every real box.
       #
-      # THE LOSS IS ONE-WAY, and worth stating: the arm writes back only
-      # `base_url`, `api_key` and `model`, so a downgrade followed by an upgrade
-      # does not restore a cloud voice the owner had picked in the Voice tab.
-      # That is the card's own instruction — a voice name for a provider this
-      # box may no longer call is residue, and it would otherwise be inherited
-      # by the next arm from the plan being withdrawn — and it is bounded by the
-      # same ownership gate as everything else here: only a slot naming an
-      # address of OURS is ever touched.
+      # The active slot is removed in full, but our non-secret stand-down
+      # marker remembers the previous voice for a later entitled restoration.
+      # An explicit owner selection clears that marker from the Voice panel.
       if hermes_voice_write config unset tts.openai; then
         if [ "$CLAWBOX_VOICE_TARGET" = keep ]; then
           log "removed the ClawBox AI cloud voice: this box's plan no longer includes it, and its speech selection was already elsewhere"

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -1373,6 +1373,8 @@ if token and arm_tier == ENTITLED_TIER:
         say("hold this box has already chosen how it speaks (%s)" % short(provider))
     if restore_cloud:
         say("restore")
+    if provider == LOCAL_PROVIDER and not (slot_is_empty or base_url.rstrip("/") in OUR_PROXIES):
+        say("hold the local selection has an owner-defined cloud endpoint")
     # UNCHOSEN IS ALL THREE, and the engine question is asked of all three.
     # `clawbox-local` is here because `install.sh` `step_openclaw_tts` selects it
     # on every install and every update WHATEVER the engine answered —

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -1515,7 +1515,7 @@ CLAWBOX_VOICE_VERDICT="${CLAWBOX_VOICE_PLAN%% *}"
 # remembered; the Voice panel clears it whenever the owner makes a choice.
 hermes_voice_stamp() {
   CLAWBOX_HERMES_CONFIG="$HERMES_CONFIG" CLAWBOX_STAMP_ACTION="$1" python3 - <<'STAMPPY'
-import json, os, tempfile, yaml
+import json, os, sys, tempfile, yaml
 cfg_path = os.environ["CLAWBOX_HERMES_CONFIG"]
 stamp_path = cfg_path + ".clawbox-voice-standdown.json"
 action = os.environ["CLAWBOX_STAMP_ACTION"]
@@ -1535,16 +1535,20 @@ elif action == "remember":
         if os.path.exists(tmp): os.unlink(tmp)
 elif action == "voice":
     try:
-        voice = json.load(open(stamp_path)).get("cloudVoice", "")
-        if isinstance(voice, str): print(voice)
-    except (OSError, ValueError, AttributeError): pass
+        with open(stamp_path) as f: stamp = json.load(f)
+        if not isinstance(stamp, dict) or stamp.get("version") != 1 or stamp.get("provider") != "clawbox-local":
+            raise ValueError("invalid stand-down marker")
+        voice = stamp.get("cloudVoice", "")
+        if not isinstance(voice, str): raise ValueError("invalid saved voice")
+        print(voice)
+    except (OSError, ValueError): sys.exit(1)
 STAMPPY
 }
 
 hermes_voice_restore_name() {
   [ "$CLAWBOX_VOICE_VERDICT" = restore ] || return 0
   local voice
-  voice=$(hermes_voice_stamp voice)
+  voice=$(hermes_voice_stamp voice) || return 1
   [ -z "$voice" ] || hermes_voice_write config set tts.openai.voice "$voice"
 }
 

--- a/src/app/setup-api/tts/route.ts
+++ b/src/app/setup-api/tts/route.ts
@@ -373,9 +373,7 @@ async function selectProvider(
     // configured".
     const engine = before.engines.find((e) => e.providerId === providerId)?.id;
     if (!engine) return refuse("That voice is not available on this box.", "not_available", 409);
-    const { clearHermesVoiceStanddown } = await import("@/lib/hermes-voice-standdown");
     await selectHermesEngine(engine, await resolveClawaiToken());
-    await clearHermesVoiceStanddown();
     return null;
   }
   await runOpenclawConfigSet([`${await ttsConfigHome()}.provider`, providerId]);
@@ -467,6 +465,10 @@ async function handleSelect(choice: VoiceChoice) {
   await withVoiceState(async () => {
     await writeVoiceState({ ...(await readVoiceState()), choice });
   });
+  if (harness === "hermes") {
+    const { clearHermesVoiceStanddown } = await import("@/lib/hermes-voice-standdown");
+    await clearHermesVoiceStanddown();
+  }
   return NextResponse.json(await status(), { headers: NO_STORE });
 }
 

--- a/src/app/setup-api/tts/route.ts
+++ b/src/app/setup-api/tts/route.ts
@@ -374,8 +374,8 @@ async function selectProvider(
     const engine = before.engines.find((e) => e.providerId === providerId)?.id;
     if (!engine) return refuse("That voice is not available on this box.", "not_available", 409);
     const { clearHermesVoiceStanddown } = await import("@/lib/hermes-voice-standdown");
-    await clearHermesVoiceStanddown();
     await selectHermesEngine(engine, await resolveClawaiToken());
+    await clearHermesVoiceStanddown();
     return null;
   }
   await runOpenclawConfigSet([`${await ttsConfigHome()}.provider`, providerId]);

--- a/src/app/setup-api/tts/route.ts
+++ b/src/app/setup-api/tts/route.ts
@@ -10,6 +10,7 @@ import {
   hermesVoiceConfigView,
   readHermesVoice,
   selectHermesEngine,
+  restoreHermesProviderId,
   writeHermesCloudVoice,
   HermesTtsWriteError,
 } from "@/lib/hermes-tts";
@@ -462,7 +463,14 @@ async function handleSelectUnlocked(choice: VoiceChoice, harness: Awaited<Return
     return refuse("That voice is not available on this box.", "not_available", 409);
   }
 
-  if (providerId !== before.activeProviderId) {
+  const changingProvider = providerId !== before.activeProviderId;
+  // The shared view intentionally hides custom/factory providers. Keep the
+  // native selection for rollback, rather than replacing it with that view.
+  const previousHermesVoice = harness === "hermes" && changingProvider ? await readHermesVoice() : null;
+  if (previousHermesVoice?.unread.provider) {
+    return refuse("This box could not read its current voice. Please try again.", "cannot_change", 409);
+  }
+  if (changingProvider) {
     const refused = await selectProvider(harness, before, providerId);
     if (refused) return refused;
   }
@@ -475,7 +483,12 @@ async function handleSelectUnlocked(choice: VoiceChoice, harness: Awaited<Return
       // A failed removal must not leave a persisted explicit local preference
       // alongside a marker that tells the next relink to restore cloud voice.
       const { clearHermesVoiceStanddown } = await import("@/lib/hermes-voice-standdown");
-      await clearHermesVoiceStanddown();
+      try {
+        await clearHermesVoiceStanddown();
+      } catch (error) {
+        if (previousHermesVoice) await restoreHermesProviderId(previousHermesVoice.provider);
+        throw error;
+      }
     }
     await writeVoiceState({ ...(await readVoiceState()), choice });
   });

--- a/src/app/setup-api/tts/route.ts
+++ b/src/app/setup-api/tts/route.ts
@@ -415,6 +415,14 @@ async function settleOnAuto(
 
 async function handleSelect(choice: VoiceChoice) {
   const harness = await getActiveHarness();
+  if (harness === "hermes") {
+    const { withHermesVoiceTransition } = await import("@/lib/hermes-voice-transition");
+    return withHermesVoiceTransition(() => handleSelectUnlocked(choice, harness));
+  }
+  return handleSelectUnlocked(choice, harness);
+}
+
+async function handleSelectUnlocked(choice: VoiceChoice, harness: Awaited<ReturnType<typeof getActiveHarness>>) {
   let { config, probe } = await probeBox(harness);
 
   // The box's own voice, installed but not wired: Kokoro is there (stamp,
@@ -463,12 +471,14 @@ async function handleSelect(choice: VoiceChoice) {
   // call between then and now can take 12 s, and a language picked in the
   // meantime must not be written over by the stale copy.
   await withVoiceState(async () => {
+    if (harness === "hermes") {
+      // A failed removal must not leave a persisted explicit local preference
+      // alongside a marker that tells the next relink to restore cloud voice.
+      const { clearHermesVoiceStanddown } = await import("@/lib/hermes-voice-standdown");
+      await clearHermesVoiceStanddown();
+    }
     await writeVoiceState({ ...(await readVoiceState()), choice });
   });
-  if (harness === "hermes") {
-    const { clearHermesVoiceStanddown } = await import("@/lib/hermes-voice-standdown");
-    await clearHermesVoiceStanddown();
-  }
   return NextResponse.json(await status(), { headers: NO_STORE });
 }
 

--- a/src/app/setup-api/tts/route.ts
+++ b/src/app/setup-api/tts/route.ts
@@ -373,6 +373,8 @@ async function selectProvider(
     // configured".
     const engine = before.engines.find((e) => e.providerId === providerId)?.id;
     if (!engine) return refuse("That voice is not available on this box.", "not_available", 409);
+    const { clearHermesVoiceStanddown } = await import("@/lib/hermes-voice-standdown");
+    await clearHermesVoiceStanddown();
     await selectHermesEngine(engine, await resolveClawaiToken());
     return null;
   }

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -1887,7 +1887,10 @@ async function selectHermesCloudVoiceIfUnvoiced(
     // local choice has no stamp and keeps the existing on-device preference.
     const { readHermesVoiceStanddown, clearHermesVoiceStanddown } = await import("@/lib/hermes-voice-standdown");
     const stoodDown = current === HERMES_LOCAL_TTS_PROVIDER ? await readHermesVoiceStanddown() : null;
-    if (stoodDown && ownRoute) {
+    const restoreRouteIsOurs = (!voice.cloudBaseUrl && !voice.cloudHasKey)
+      || [CLAWBOX_AI_PROXY_URL, "https://clawbox.com/api/ai", "https://openclawhardware.dev/api/ai", "https://www.openclawhardware.dev/api/ai"]
+        .map(url => url.replace(/\/+$/, "")).includes((voice.cloudBaseUrl ?? "").replace(/\/+$/, ""));
+    if (stoodDown && restoreRouteIsOurs) {
       await writeHermesCloudTarget(token);
       if (stoodDown.cloudVoice) {
         const { writeHermesCloudVoice } = await import("@/lib/hermes-tts");

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -26,6 +26,7 @@ import {
 } from "@/lib/hermes-image-plugin";
 import {
   CLAWBOX_AI_CHAT_MODEL_IDS,
+  CLAWBOX_AI_PROXY_URLS,
   CLAWBOX_AI_IMAGE_MODEL_ID,
   CLAWBOX_AI_MODEL_ID_BY_TIER,
   CLAWBOX_AI_VISION_MODEL_ID,
@@ -1903,7 +1904,7 @@ async function selectHermesCloudVoiceIfUnvoicedUnlocked(
     const { readHermesVoiceStanddown, clearHermesVoiceStanddown } = await import("@/lib/hermes-voice-standdown");
     const stoodDown = current === HERMES_LOCAL_TTS_PROVIDER ? await readHermesVoiceStanddown() : null;
     const restoreRouteIsOurs = !voice.unread.cloudRoute && !voice.unread.cloudKey && ((!voice.cloudBaseUrl && !voice.cloudHasKey)
-      || [CLAWBOX_AI_PROXY_URL, "https://clawbox.com/api/ai", "https://openclawhardware.dev/api/ai", "https://www.openclawhardware.dev/api/ai"]
+      || [CLAWBOX_AI_PROXY_URL, ...CLAWBOX_AI_PROXY_URLS]
         .map(url => url.replace(/\/+$/, "")).includes((voice.cloudBaseUrl ?? "").replace(/\/+$/, "")));
     if (stoodDown && !restoreRouteIsOurs) return;
     if (stoodDown && restoreRouteIsOurs) {

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -1855,6 +1855,13 @@ async function selectHermesCloudVoiceIfUnvoicedUnlocked(
       // fill.
       if (current === HERMES_CLOUD_TTS_PROVIDER && ownRoute) {
         await writeHermesCloudTarget(token);
+        // Restoration can select cloud successfully, then fail both marker
+        // cleanup and the local rollback. Finish that interrupted transition
+        // on the next entitled link without changing the current selection.
+        if (entitlementTier === CLAWBOX_AI_SPEECH_TIER) {
+          const { readHermesVoiceStanddown, clearHermesVoiceStanddown } = await import("@/lib/hermes-voice-standdown");
+          if (await readHermesVoiceStanddown()) await clearHermesVoiceStanddown();
+        }
         console.log("[hermes-clawai] refreshed the ClawBox AI speech credential");
       } else if (current === HERMES_CLOUD_TTS_PROVIDER) {
         console.log(

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -1906,7 +1906,14 @@ async function selectHermesCloudVoiceIfUnvoicedUnlocked(
         await writeHermesCloudVoice(stoodDown.cloudVoice);
       }
       await selectHermesProvider("cloud");
-      await clearHermesVoiceStanddown();
+      try {
+        await clearHermesVoiceStanddown();
+      } catch (error) {
+        // Keep the marker and local selection together so the next link can
+        // retry restoration. The shared transition lock excludes owner picks.
+        await selectHermesProvider("local");
+        throw error;
+      }
       return;
     }
     // What this box HAS, asked in every unchosen state rather than only over a

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -1890,6 +1890,7 @@ async function selectHermesCloudVoiceIfUnvoiced(
     const restoreRouteIsOurs = (!voice.cloudBaseUrl && !voice.cloudHasKey)
       || [CLAWBOX_AI_PROXY_URL, "https://clawbox.com/api/ai", "https://openclawhardware.dev/api/ai", "https://www.openclawhardware.dev/api/ai"]
         .map(url => url.replace(/\/+$/, "")).includes((voice.cloudBaseUrl ?? "").replace(/\/+$/, ""));
+    if (stoodDown && !restoreRouteIsOurs) return;
     if (stoodDown && restoreRouteIsOurs) {
       await writeHermesCloudTarget(token);
       if (stoodDown.cloudVoice) {

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -1887,9 +1887,9 @@ async function selectHermesCloudVoiceIfUnvoiced(
     // local choice has no stamp and keeps the existing on-device preference.
     const { readHermesVoiceStanddown, clearHermesVoiceStanddown } = await import("@/lib/hermes-voice-standdown");
     const stoodDown = current === HERMES_LOCAL_TTS_PROVIDER ? await readHermesVoiceStanddown() : null;
-    const restoreRouteIsOurs = (!voice.cloudBaseUrl && !voice.cloudHasKey)
+    const restoreRouteIsOurs = !voice.unread.cloudRoute && !voice.unread.cloudKey && ((!voice.cloudBaseUrl && !voice.cloudHasKey)
       || [CLAWBOX_AI_PROXY_URL, "https://clawbox.com/api/ai", "https://openclawhardware.dev/api/ai", "https://www.openclawhardware.dev/api/ai"]
-        .map(url => url.replace(/\/+$/, "")).includes((voice.cloudBaseUrl ?? "").replace(/\/+$/, ""));
+        .map(url => url.replace(/\/+$/, "")).includes((voice.cloudBaseUrl ?? "").replace(/\/+$/, "")));
     if (stoodDown && !restoreRouteIsOurs) return;
     if (stoodDown && restoreRouteIsOurs) {
       await writeHermesCloudTarget(token);

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -1883,6 +1883,20 @@ async function selectHermesCloudVoiceIfUnvoiced(
       );
       return;
     }
+    // Restore only the cloud selection ClawBox itself stood down. An ordinary
+    // local choice has no stamp and keeps the existing on-device preference.
+    const { readHermesVoiceStanddown, clearHermesVoiceStanddown } = await import("@/lib/hermes-voice-standdown");
+    const stoodDown = current === HERMES_LOCAL_TTS_PROVIDER ? await readHermesVoiceStanddown() : null;
+    if (stoodDown && ownRoute) {
+      await writeHermesCloudTarget(token);
+      if (stoodDown.cloudVoice) {
+        const { writeHermesCloudVoice } = await import("@/lib/hermes-tts");
+        await writeHermesCloudVoice(stoodDown.cloudVoice);
+      }
+      await selectHermesProvider("cloud");
+      await clearHermesVoiceStanddown();
+      return;
+    }
     // What this box HAS, asked in every unchosen state rather than only over a
     // `clawbox-local` selection. A working on-device engine is the answer
     // wherever there is one — an owner on it is not moved off it by linking a

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -1776,6 +1776,14 @@ async function selectHermesCloudVoiceIfUnvoiced(
   token: string,
   entitlementTier: ClawaiPlanTier | null,
 ): Promise<void> {
+  const { withHermesVoiceTransition } = await import("@/lib/hermes-voice-transition");
+  await withHermesVoiceTransition(() => selectHermesCloudVoiceIfUnvoicedUnlocked(token, entitlementTier));
+}
+
+async function selectHermesCloudVoiceIfUnvoicedUnlocked(
+  token: string,
+  entitlementTier: ClawaiPlanTier | null,
+): Promise<void> {
   try {
     const [
       {

--- a/src/lib/hermes-tts.ts
+++ b/src/lib/hermes-tts.ts
@@ -406,6 +406,13 @@ export async function selectHermesProvider(engine: "local" | "cloud"): Promise<v
   await set(KEYS.provider, hermesProviderFor(engine));
 }
 
+/** Roll back only the selection, without rewriting an owner's provider settings. */
+export async function restoreHermesProviderId(provider: string | null): Promise<void> {
+  if (provider !== null) return set(KEYS.provider, provider);
+  const result = await runHermesCli(["config", "unset", KEYS.provider], { timeoutMs: 15_000 });
+  if (result.code !== 0) throw new HermesTtsWriteError("Could not restore the unset voice provider.");
+}
+
 /** The voice an engine speaks with, in Hermes' own per-provider key. */
 export async function writeHermesCloudVoice(voice: string): Promise<void> {
   await set(KEYS.cloudVoice, voice);

--- a/src/lib/hermes-voice-standdown.ts
+++ b/src/lib/hermes-voice-standdown.ts
@@ -1,0 +1,23 @@
+import fs from "fs/promises";
+import path from "path";
+import { hermesHome } from "@/lib/hermes-env";
+
+function stampPath(): string {
+  return `${path.join(hermesHome(), "config.yaml")}.clawbox-voice-standdown.json`;
+}
+
+/** Contains selection history only, never the cloud credential. */
+export async function readHermesVoiceStanddown(): Promise<{ cloudVoice?: string } | null> {
+  try {
+    const stamp = JSON.parse(await fs.readFile(stampPath(), "utf8"));
+    if (stamp.version !== 1 || stamp.provider !== "clawbox-local") return null;
+    return { cloudVoice: typeof stamp.cloudVoice === "string" ? stamp.cloudVoice : undefined };
+  } catch { return null; }
+}
+
+/** An explicit Voice-panel choice cancels automatic restoration, even if local was selected again. */
+export async function clearHermesVoiceStanddown(): Promise<void> {
+  await fs.unlink(stampPath()).catch((err: NodeJS.ErrnoException) => {
+    if (err.code !== "ENOENT") throw err;
+  });
+}

--- a/src/lib/hermes-voice-transition.ts
+++ b/src/lib/hermes-voice-transition.ts
@@ -1,0 +1,7 @@
+import { createSerialLock, type SerialLock } from "@/lib/serial-lock";
+
+// Next can load separate module graphs for link and settings routes. Both
+// transitions must see the same lock before reading the provider/marker.
+const key = Symbol.for("clawbox.hermes.voice-transition");
+const shared = globalThis as typeof globalThis & { [key]?: SerialLock };
+export const withHermesVoiceTransition = shared[key] ??= createSerialLock();

--- a/src/lib/hermes-voice-transition.ts
+++ b/src/lib/hermes-voice-transition.ts
@@ -3,5 +3,5 @@ import { createSerialLock, type SerialLock } from "@/lib/serial-lock";
 // Next can load separate module graphs for link and settings routes. Both
 // transitions must see the same lock before reading the provider/marker.
 const key = Symbol.for("clawbox.hermes.voice-transition");
-const shared = globalThis as typeof globalThis & { [key]?: SerialLock };
+const shared = globalThis as typeof globalThis & Partial<Record<symbol, SerialLock>>;
 export const withHermesVoiceTransition = shared[key] ??= createSerialLock();

--- a/src/tests/routes/tts-hermes-parity.test.ts
+++ b/src/tests/routes/tts-hermes-parity.test.ts
@@ -252,6 +252,7 @@ describe("POST /setup-api/tts on a Hermes box", () => {
     // The openclaw write is what the gate was protecting. It must be SKIPPED
     // here, not attempted and swallowed.
     expect(configSetMock).not.toHaveBeenCalled();
+    expect(clearStanddownMock).toHaveBeenCalledOnce();
   });
 
   it("writes the cloud endpoint and credential BEFORE selecting the provider", async () => {

--- a/src/tests/routes/tts-hermes-parity.test.ts
+++ b/src/tests/routes/tts-hermes-parity.test.ts
@@ -275,12 +275,30 @@ describe("POST /setup-api/tts on a Hermes box", () => {
   });
 
   it("does not persist an explicit choice when stand-down removal fails", async () => {
+    hermesConfig["tts.provider"] = "openai";
+    hermesConfig["tts.openai.base_url"] = "https://clawbox.com/api/ai";
+    hermesConfig["tts.openai.api_key"] = "claw_a_linked_hermes_box";
     clearStanddownMock.mockRejectedValueOnce(new Error("marker permission denied"));
     const { POST } = await route();
     const res = await POST(post({ action: "select", choice: "local" }));
 
     expect(res.ok).toBe(false);
     expect(clearStanddownMock).toHaveBeenCalledOnce();
+    expect(writeStateMock).not.toHaveBeenCalled();
+    const providerWrites = hermesCliMock.mock.calls
+      .map(([args]) => args as string[]).filter(args => args[2] === "tts.provider");
+    expect(providerWrites.map(args => args[3])).toEqual(["clawbox-local", "openai"]);
+  });
+
+  it.each(["elevenlabs", "edge", null])("restores the native provider %s if marker removal fails", async (provider) => {
+    if (provider === null) delete hermesConfig["tts.provider"];
+    else hermesConfig["tts.provider"] = provider;
+    clearStanddownMock.mockRejectedValueOnce(new Error("marker permission denied"));
+    const { POST } = await route();
+    expect((await POST(post({ action: "select", choice: "local" }))).ok).toBe(false);
+    const writes = hermesCliMock.mock.calls.map(([args]) => args as string[]);
+    expect(writes.at(-1)).toEqual(provider === null
+      ? ["config", "unset", "tts.provider"] : ["config", "set", "tts.provider", provider]);
     expect(writeStateMock).not.toHaveBeenCalled();
   });
 

--- a/src/tests/routes/tts-hermes-parity.test.ts
+++ b/src/tests/routes/tts-hermes-parity.test.ts
@@ -34,6 +34,8 @@ const readStateMock = vi.fn();
 const writeStateMock = vi.fn();
 const writeLocalVoiceMock = vi.fn();
 const tokenMock = vi.fn();
+const clearStanddownMock = vi.fn();
+vi.mock("@/lib/hermes-voice-standdown", () => ({ clearHermesVoiceStanddown: (...a: unknown[]) => clearStanddownMock(...a) }));
 
 vi.mock("@/lib/openclaw-config", () => ({
   readConfig: (...a: unknown[]) => readConfigMock(...a),
@@ -281,6 +283,7 @@ describe("POST /setup-api/tts on a Hermes box", () => {
     expect(res.status).toBe(409);
     const selected = hermesCliMock.mock.calls.some((c) => (c[0] as string[])[2] === "tts.provider");
     expect(selected).toBe(false);
+    expect(clearStanddownMock).not.toHaveBeenCalled();
   });
 
   it("refuses the cloud voice on a box with no ClawBox AI credential", async () => {
@@ -292,6 +295,7 @@ describe("POST /setup-api/tts on a Hermes box", () => {
     expect([409, 400]).toContain(res.status);
     const selected = hermesCliMock.mock.calls.some((c) => (c[0] as string[])[2] === "tts.provider");
     expect(selected).toBe(false);
+    expect(clearStanddownMock).not.toHaveBeenCalled();
   });
 
   it("still refuses an unknown action rather than swallowing the contract", async () => {

--- a/src/tests/routes/tts-hermes-parity.test.ts
+++ b/src/tests/routes/tts-hermes-parity.test.ts
@@ -134,6 +134,7 @@ beforeEach(() => {
   writeStateMock.mockResolvedValue(undefined);
   writeLocalVoiceMock.mockResolvedValue(undefined);
   tokenMock.mockResolvedValue("claw_a_linked_hermes_box");
+  clearStanddownMock.mockReset().mockResolvedValue(undefined);
   storeValues = { clawai_tier: "pro" };
   hermesCliMock.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
   // EXACTLY what install.sh writes on a freshly provisioned Hermes box, and
@@ -271,6 +272,16 @@ describe("POST /setup-api/tts on a Hermes box", () => {
       ["config", "set", "tts.provider", "openai"],
       expect.anything(),
     );
+  });
+
+  it("does not persist an explicit choice when stand-down removal fails", async () => {
+    clearStanddownMock.mockRejectedValueOnce(new Error("marker permission denied"));
+    const { POST } = await route();
+    const res = await POST(post({ action: "select", choice: "local" }));
+
+    expect(res.ok).toBe(false);
+    expect(clearStanddownMock).toHaveBeenCalledOnce();
+    expect(writeStateMock).not.toHaveBeenCalled();
   });
 
   it("does not select the cloud provider when the credential write fails", async () => {

--- a/src/tests/unit/hermes-clawai-voice.test.ts
+++ b/src/tests/unit/hermes-clawai-voice.test.ts
@@ -24,6 +24,12 @@ const selectProviderMock = vi.hoisted(() => vi.fn());
 const probeEngineMock = vi.hoisted(() => vi.fn());
 const runnableMock = vi.hoisted(() => vi.fn());
 const writeCloudMock = vi.hoisted(() => vi.fn());
+const standdownMock = vi.hoisted(() => vi.fn());
+const clearStanddownMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/hermes-voice-standdown", () => ({
+  readHermesVoiceStanddown: standdownMock,
+  clearHermesVoiceStanddown: clearStanddownMock,
+}));
 
 vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
 vi.mock("@/lib/harness/hermes-features", () => ({ hermesAgentDrawsImages: vi.fn(async () => false) }));
@@ -123,6 +129,18 @@ describe("pointing a linked Hermes box at a voice it can actually use", () => {
     writeCloudMock.mockResolvedValue(undefined);
     probeEngineMock.mockResolvedValue(false);
     runnableMock.mockResolvedValue(true);
+    standdownMock.mockResolvedValue(null);
+    clearStanddownMock.mockResolvedValue(undefined);
+  });
+
+  it("restores our stood-down cloud selection on re-link without replacing an ordinary local choice", async () => {
+    readVoiceMock.mockResolvedValue(voice(HERMES_LOCAL_TTS_PROVIDER));
+    probeEngineMock.mockResolvedValue(true);
+    standdownMock.mockResolvedValue({});
+    await applyClawaiToHermes(TOKEN, ENTITLED);
+    expect(writeCloudMock).toHaveBeenCalledWith(TOKEN);
+    expect(selectProviderMock).toHaveBeenCalledWith("cloud");
+    expect(clearStanddownMock).toHaveBeenCalledOnce();
   });
 
   it("selects the cloud voice when nothing has been chosen and there is no engine", async () => {

--- a/src/tests/unit/hermes-clawai-voice.test.ts
+++ b/src/tests/unit/hermes-clawai-voice.test.ts
@@ -145,7 +145,7 @@ describe("pointing a linked Hermes box at a voice it can actually use", () => {
 
   it("does not restore over a custom endpoint using a claw credential", async () => {
     readVoiceMock.mockResolvedValue({ ...voice(HERMES_LOCAL_TTS_PROVIDER), cloudBaseUrl: "https://speech.example.test/v1", cloudHasKey: true, cloudKeyIsOurs: true });
-    probeEngineMock.mockResolvedValue(true);
+    probeEngineMock.mockResolvedValue(false);
     standdownMock.mockResolvedValue({});
     await applyClawaiToHermes(TOKEN, ENTITLED);
     expect(writeCloudMock).not.toHaveBeenCalled();

--- a/src/tests/unit/hermes-clawai-voice.test.ts
+++ b/src/tests/unit/hermes-clawai-voice.test.ts
@@ -129,8 +129,8 @@ describe("pointing a linked Hermes box at a voice it can actually use", () => {
     writeCloudMock.mockResolvedValue(undefined);
     probeEngineMock.mockResolvedValue(false);
     runnableMock.mockResolvedValue(true);
-    standdownMock.mockResolvedValue(null);
-    clearStanddownMock.mockResolvedValue(undefined);
+    standdownMock.mockReset().mockResolvedValue(null);
+    clearStanddownMock.mockReset().mockResolvedValue(undefined);
   });
 
   it("restores our stood-down cloud selection on re-link without replacing an ordinary local choice", async () => {
@@ -141,6 +141,22 @@ describe("pointing a linked Hermes box at a voice it can actually use", () => {
     expect(writeCloudMock).toHaveBeenCalledWith(TOKEN);
     expect(selectProviderMock).toHaveBeenCalledWith("cloud");
     expect(clearStanddownMock).toHaveBeenCalledOnce();
+  });
+
+  it("rolls back after failed marker cleanup and restores on the next link", async () => {
+    let provider = HERMES_LOCAL_TTS_PROVIDER;
+    readVoiceMock.mockImplementation(async () => voice(provider));
+    selectProviderMock.mockImplementation(async (engine: string) => {
+      provider = engine === "local" ? HERMES_LOCAL_TTS_PROVIDER : "openai";
+    });
+    standdownMock.mockResolvedValue({});
+    clearStanddownMock.mockRejectedValueOnce(new Error("marker removal failed"));
+    await applyClawaiToHermes(TOKEN, ENTITLED);
+    expect(provider).toBe(HERMES_LOCAL_TTS_PROVIDER);
+    expect(selectProviderMock.mock.calls.map(call => call[0])).toEqual(["cloud", "local"]);
+    await applyClawaiToHermes(TOKEN, ENTITLED);
+    expect(provider).toBe("openai");
+    expect(clearStanddownMock).toHaveBeenCalledTimes(2);
   });
 
   it.each(["cloudRoute", "cloudKey"] as const)("does not restore over an unread %s", async (field) => {

--- a/src/tests/unit/hermes-clawai-voice.test.ts
+++ b/src/tests/unit/hermes-clawai-voice.test.ts
@@ -159,6 +159,29 @@ describe("pointing a linked Hermes box at a voice it can actually use", () => {
     expect(clearStanddownMock).toHaveBeenCalledTimes(2);
   });
 
+  it("finishes marker cleanup on the next link when local rollback also failed", async () => {
+    let provider = HERMES_LOCAL_TTS_PROVIDER;
+    readVoiceMock.mockImplementation(async () => ({
+      ...voice(provider),
+      cloudBaseUrl: "https://clawbox.com/api/ai",
+      cloudHasKey: true,
+      cloudKeyIsOurs: true,
+    }));
+    selectProviderMock.mockImplementation(async (engine: string) => {
+      if (engine === "local") throw new Error("provider rollback failed");
+      provider = "openai";
+    });
+    standdownMock.mockResolvedValue({});
+    clearStanddownMock.mockRejectedValueOnce(new Error("marker removal failed"));
+    await applyClawaiToHermes(TOKEN, ENTITLED);
+    expect(provider).toBe("openai");
+    expect(selectProviderMock.mock.calls.map(call => call[0])).toEqual(["cloud", "local"]);
+    await applyClawaiToHermes(TOKEN, ENTITLED);
+    expect(clearStanddownMock).toHaveBeenCalledTimes(2);
+    // The retry only completes cleanup; it never changes an existing selection.
+    expect(selectProviderMock).toHaveBeenCalledTimes(2);
+  });
+
   it.each(["cloudRoute", "cloudKey"] as const)("does not restore over an unread %s", async (field) => {
     const state = voice(HERMES_LOCAL_TTS_PROVIDER);
     state.unread[field] = true;

--- a/src/tests/unit/hermes-clawai-voice.test.ts
+++ b/src/tests/unit/hermes-clawai-voice.test.ts
@@ -143,6 +143,16 @@ describe("pointing a linked Hermes box at a voice it can actually use", () => {
     expect(clearStanddownMock).toHaveBeenCalledOnce();
   });
 
+  it("does not restore over a custom endpoint using a claw credential", async () => {
+    readVoiceMock.mockResolvedValue({ ...voice(HERMES_LOCAL_TTS_PROVIDER), cloudBaseUrl: "https://speech.example.test/v1", cloudHasKey: true, cloudKeyIsOurs: true });
+    probeEngineMock.mockResolvedValue(true);
+    standdownMock.mockResolvedValue({});
+    await applyClawaiToHermes(TOKEN, ENTITLED);
+    expect(writeCloudMock).not.toHaveBeenCalled();
+    expect(selectProviderMock).not.toHaveBeenCalled();
+    expect(clearStanddownMock).not.toHaveBeenCalled();
+  });
+
   it("selects the cloud voice when nothing has been chosen and there is no engine", async () => {
     readVoiceMock.mockResolvedValue(voice(null));
 

--- a/src/tests/unit/hermes-clawai-voice.test.ts
+++ b/src/tests/unit/hermes-clawai-voice.test.ts
@@ -143,6 +143,17 @@ describe("pointing a linked Hermes box at a voice it can actually use", () => {
     expect(clearStanddownMock).toHaveBeenCalledOnce();
   });
 
+  it.each(["cloudRoute", "cloudKey"] as const)("does not restore over an unread %s", async (field) => {
+    const state = voice(HERMES_LOCAL_TTS_PROVIDER);
+    state.unread[field] = true;
+    readVoiceMock.mockResolvedValue(state);
+    standdownMock.mockResolvedValue({});
+    await applyClawaiToHermes(TOKEN, ENTITLED);
+    expect(writeCloudMock).not.toHaveBeenCalled();
+    expect(selectProviderMock).not.toHaveBeenCalled();
+    expect(clearStanddownMock).not.toHaveBeenCalled();
+  });
+
   it("does not restore over a custom endpoint using a claw credential", async () => {
     readVoiceMock.mockResolvedValue({ ...voice(HERMES_LOCAL_TTS_PROVIDER), cloudBaseUrl: "https://speech.example.test/v1", cloudHasKey: true, cloudKeyIsOurs: true });
     probeEngineMock.mockResolvedValue(false);

--- a/src/tests/unit/hermes-voice-standdown.test.ts
+++ b/src/tests/unit/hermes-voice-standdown.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { readHermesVoiceStanddown, clearHermesVoiceStanddown } from "@/lib/hermes-voice-standdown";
+
+describe("voice restoration history", () => {
+  let home: string;
+  beforeEach(async () => {
+    home = await fs.mkdtemp(path.join(os.tmpdir(), "hermes-voice-history-"));
+    vi.stubEnv("HERMES_HOME", home);
+  });
+  afterEach(async () => { vi.unstubAllEnvs(); await fs.rm(home, { recursive: true, force: true }); });
+  it("keeps a manual local choice after its restoration marker is cleared", async () => {
+    const stamp = path.join(home, "config.yaml.clawbox-voice-standdown.json");
+    await fs.writeFile(stamp, JSON.stringify({ version: 1, provider: "clawbox-local", cloudVoice: "shimmer" }));
+    expect(await readHermesVoiceStanddown()).toEqual({ cloudVoice: "shimmer" });
+    await clearHermesVoiceStanddown();
+    expect(await readHermesVoiceStanddown()).toBeNull();
+    await clearHermesVoiceStanddown();
+  });
+  it("invalid history never grants permission to move off the local voice", async () => {
+    await fs.writeFile(path.join(home, "config.yaml.clawbox-voice-standdown.json"), "not json");
+    expect(await readHermesVoiceStanddown()).toBeNull();
+  });
+});

--- a/src/tests/unit/register-mcp-clawai-voice.test.ts
+++ b/src/tests/unit/register-mcp-clawai-voice.test.ts
@@ -645,7 +645,6 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
     it("preserves a custom endpoint even when it contains an old claw credential and a valid marker", () => {
       armedWithLocalEngine(); downgraded(); run();
       writeYaml(`${BASE_CONFIG}tts:\n  provider: clawbox-local\n  openai:\n    base_url: https://speech.example.test/v1\n    api_key: ${TOKEN}\n    model: custom-voice\n`);
-      installKokoroStamp();
       writeStore({ clawai_token: TOKEN, clawai_tier: "pro", clawai_plan_tier: "pro" });
       run();
       expect(at("tts.provider")).toBe("clawbox-local");

--- a/src/tests/unit/register-mcp-clawai-voice.test.ts
+++ b/src/tests/unit/register-mcp-clawai-voice.test.ts
@@ -116,6 +116,9 @@ else:
         raise SystemExit(1)
 with open(os.environ["CLAWBOX_TEST_CFG"], "w") as fh:
     yaml.safe_dump(cfg, fh, sort_keys=False)
+if os.environ.get("CLAWBOX_TEST_CORRUPT_MARKER") and os.environ["CLAWBOX_TEST_KEY"] == "tts.openai.model":
+    with open(os.environ["CLAWBOX_TEST_CFG"] + ".clawbox-voice-standdown.json", "w") as fh:
+        fh.write(os.environ["CLAWBOX_TEST_CORRUPT_MARKER"])
 EOPY
 `);
   fs.chmodSync(stub, 0o755);
@@ -640,6 +643,24 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
       expect(at("tts.openai.voice")).toBe("shimmer");
       expect(fs.existsSync(marker)).toBe(false);
       expect(restored.stdout).toContain("restored the ClawBox AI cloud voice");
+    });
+
+    it.each(["not-json", "[]", '{"version":1,"provider":"clawbox-local","cloudVoice":42}'])("keeps the local selection and marker when the saved voice becomes unreadable: %s", (corrupt) => {
+      armedWithLocalEngine("    voice: shimmer\n");
+      downgraded();
+      expect(run().status).toBe(0);
+      writeStore({ clawai_token: TOKEN, clawai_tier: "pro", clawai_plan_tier: "pro" });
+      run({ CLAWBOX_TEST_CORRUPT_MARKER: corrupt });
+      expect(at("tts.provider")).toBe("clawbox-local");
+      expect(fs.readFileSync(`${configPath}.clawbox-voice-standdown.json`, "utf8")).toBe(corrupt);
+    });
+
+    it("restores a valid marker without a saved cloud voice", () => {
+      armedWithLocalEngine(); downgraded(); run();
+      writeStore({ clawai_token: TOKEN, clawai_tier: "pro", clawai_plan_tier: "pro" });
+      run();
+      expect(at("tts.provider")).toBe("openai");
+      expect(fs.existsSync(`${configPath}.clawbox-voice-standdown.json`)).toBe(false);
     });
 
     it("preserves a custom endpoint even when it contains an old claw credential and a valid marker", () => {

--- a/src/tests/unit/register-mcp-clawai-voice.test.ts
+++ b/src/tests/unit/register-mcp-clawai-voice.test.ts
@@ -642,6 +642,25 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
       expect(restored.stdout).toContain("restored the ClawBox AI cloud voice");
     });
 
+    it("preserves a custom endpoint even when it contains an old claw credential and a valid marker", () => {
+      armedWithLocalEngine(); downgraded(); run();
+      writeYaml(`${BASE_CONFIG}tts:\n  provider: clawbox-local\n  openai:\n    base_url: https://speech.example.test/v1\n    api_key: ${TOKEN}\n    model: custom-voice\n`);
+      installKokoroStamp();
+      writeStore({ clawai_token: TOKEN, clawai_tier: "pro", clawai_plan_tier: "pro" });
+      run();
+      expect(at("tts.provider")).toBe("clawbox-local");
+      expect(at("tts.openai")).toEqual({ base_url: "https://speech.example.test/v1", api_key: TOKEN, model: "custom-voice" });
+    });
+
+    it("keeps the selected cloud voice intact if its restoration marker cannot be persisted", () => {
+      armedWithLocalEngine("    voice: shimmer\n"); downgraded();
+      fs.mkdirSync(`${configPath}.clawbox-voice-standdown.json`);
+      run();
+      expect(at("tts.provider")).toBe("openai");
+      expect(at("tts.openai.voice")).toBe("shimmer");
+      expect(configCalls()).not.toContain("config unset tts.openai");
+    });
+
     it("never restores over a different provider chosen after stand-down", () => {
       armedWithLocalEngine();
       downgraded();

--- a/src/tests/unit/register-mcp-clawai-voice.test.ts
+++ b/src/tests/unit/register-mcp-clawai-voice.test.ts
@@ -624,6 +624,64 @@ d("register-mcp.sh — the ClawBox AI cloud voice at boot", () => {
       writeStore({ clawai_token: TOKEN, clawai_tier: "flash", clawai_plan_tier: "flash" });
     }
 
+    it("restores an automatically stood-down cloud voice after re-upgrade even with Kokoro installed", () => {
+      armedWithLocalEngine("    voice: shimmer\n");
+      installKokoroStamp();
+      downgraded();
+      expect(run().status).toBe(0);
+      expect(at("tts.provider")).toBe("clawbox-local");
+      const marker = `${configPath}.clawbox-voice-standdown.json`;
+      expect(fs.readFileSync(marker, "utf8")).not.toContain(TOKEN);
+      expect(fs.statSync(marker).mode & 0o777).toBe(0o600);
+      writeStore({ clawai_token: TOKEN, clawai_tier: "pro", clawai_plan_tier: "pro" });
+      const restored = run();
+      expect(restored.status).toBe(0);
+      expect(at("tts.provider")).toBe("openai");
+      expect(at("tts.openai.voice")).toBe("shimmer");
+      expect(fs.existsSync(marker)).toBe(false);
+      expect(restored.stdout).toContain("restored the ClawBox AI cloud voice");
+    });
+
+    it("never restores over a different provider chosen after stand-down", () => {
+      armedWithLocalEngine();
+      downgraded();
+      run();
+      writeYaml(`${BASE_CONFIG}tts:\n  provider: elevenlabs\n`);
+      writeStore({ clawai_token: TOKEN, clawai_tier: "pro", clawai_plan_tier: "pro" });
+      run();
+      expect(at("tts.provider")).toBe("elevenlabs");
+      expect(at("tts.openai")).toBeUndefined();
+    });
+
+    it.each(["Command", ""])("accepts the harness's command type spelling %j", (kind) => {
+      armedWithLocalEngine();
+      const yaml = fs.readFileSync(configPath, "utf8").replace("type: command", `type: ${JSON.stringify(kind)}`);
+      writeYaml(yaml);
+      downgraded();
+      run();
+      expect(at("tts.provider")).toBe("clawbox-local");
+      expect(at("tts.openai")).toBeUndefined();
+    });
+
+    it("accepts the harness's legacy direct provider definition", () => {
+      writeYaml(`${BASE_CONFIG}tts:\n  provider: openai\n  openai:\n    base_url: ${PROXY}\n    api_key: ${TOKEN}\n  clawbox-local:\n    type: command\n    command: /usr/bin/true\n`);
+      downgraded();
+      run();
+      expect(at("tts.provider")).toBe("clawbox-local");
+      expect(at("tts.openai")).toBeUndefined();
+    });
+
+    it("keeps local speech and the retry marker if cloud restoration fails", () => {
+      armedWithLocalEngine();
+      downgraded();
+      run();
+      writeStore({ clawai_token: TOKEN, clawai_tier: "pro", clawai_plan_tier: "pro" });
+      writeHermesStub(1);
+      run();
+      expect(at("tts.provider")).toBe("clawbox-local");
+      expect(fs.existsSync(`${configPath}.clawbox-voice-standdown.json`)).toBe(true);
+    });
+
     it("selects the box's own voice instead of leaving a name over an emptied slot", () => {
       armedWithLocalEngine();
       downgraded();


### PR DESCRIPTION
## Summary

Fix TASK-756: a Kokoro-equipped Hermes box moved off ClawBox cloud speech after a downgrade never restored its prior voice when the plan was renewed.

- Remember only our own automatic stand-down in a private, atomic, non-secret marker.
- Restore endpoint/key/model before selecting cloud speech on boot or re-link, preserving the former voice name. Keep local speech and the marker if restoration fails.
- An explicit Voice-panel selection clears the marker; a different/custom provider is never replaced. Ordinary local choices without a marker remain local.
- Align the withdrawal predicate with measured Hermes command-provider forms: mixed-case/empty type and the legacy direct provider definition.

## Verification

- 123 focused tests pass, including the real Bash/Python registrar and actual YAML mutations, upgrade/downgrade cycle, private marker/no token, custom-provider preservation and failed restoration.
- TypeScript and Bash syntax pass.
- Full CI, installer and latest review required before merge. This is beta-only until the V4 release gate and both-edition hardware acceptance are complete.

## Scope

No customer configuration or subscription was changed during testing. The OpenClaw edition is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hermes voice settings now restore the previous cloud voice when cloud access returns.
  * Local voice selections remain preserved during cloud voice access changes.
  * Voice provider matching supports case-insensitive and unspecified provider types.
  * Voice changes are coordinated to prevent conflicting updates.

* **Bug Fixes**
  * Resolved stale voice state after entitlement recovery.
  * Improved rollback and retry handling when restoration or cleanup fails.
  * Preserved custom voice endpoints and user-selected providers.
  * Prevented invalid voice history from changing the active local provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->