### PR TITLE
ci: bind ClawReview + issue-triage jobs to protected clawreview Environment

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -14,6 +14,12 @@ concurrency:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    # Same protected Environment as pr-review.yml: `clawreview`, deployment
+    # branches beta + main only. An `issues` run evaluates the default
+    # branch, so it passes; a same-repo pull_request workflow naming this
+    # Environment would be refused. Keep the name in sync with
+    # pr-review.yml — the policy lives in the Environment, not here.
+    environment: clawreview
     # Job-scoped (not workflow-scoped) so future jobs don't inherit write
     # access: the triage script labels + comments via GH_TOKEN.
     permissions:

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -17,7 +17,7 @@ jobs:
     # Same protected Environment as pr-review.yml: `clawreview`, deployment
     # branches beta + main only. An `issues` run evaluates the default
     # branch, so it passes; a same-repo pull_request workflow naming this
-    # Environment would be refused. Keep the name in sync with
+    # Environment (run ref: refs/pull/<n>/merge) would be refused. Keep the name in sync with
     # pr-review.yml — the policy lives in the Environment, not here.
     environment: clawreview
     # Job-scoped (not workflow-scoped) so future jobs don't inherit write

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -22,6 +22,15 @@ concurrency:
 jobs:
   review:
     runs-on: ubuntu-latest
+    # Where the AI/App credentials live. The job names the protected
+    # Environment `clawreview` (deployment branches: beta + main only —
+    # created by the owner under Settings → Environments). On
+    # pull_request_target the run's ref is the BASE branch, so legitimate
+    # reviews pass the policy; a same-repo pull_request workflow that tried
+    # to name this Environment would evaluate its own PR-head ref and be
+    # refused before a step starts. The Environment is the fence — nothing
+    # in this file is, because a pull_request run does not read this file.
+    environment: clawreview
     # Job-scoped so future jobs don't inherit write access.
     permissions:
       pull-requests: write

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -27,8 +27,8 @@ jobs:
     # created by the owner under Settings → Environments). On
     # pull_request_target the run's ref is the BASE branch, so legitimate
     # reviews pass the policy; a same-repo pull_request workflow that tried
-    # to name this Environment would evaluate its own PR-head ref and be
-    # refused before a step starts. The Environment is the fence — nothing
+    # to name this Environment would evaluate the PR merge ref
+    # (refs/pull/<n>/merge) and be refused before a step starts. The Environment is the fence — nothing
     # in this file is, because a pull_request run does not read this file.
     environment: clawreview
     # Job-scoped so future jobs don't inherit write access.

--- a/src/tests/unit/ci-workflows.test.ts
+++ b/src/tests/unit/ci-workflows.test.ts
@@ -743,7 +743,7 @@ describe("credentialed review/triage runs are bound to the clawreview Environmen
     // creating it. Pin that both files carry the instruction.
     for (const [rel] of files) {
       expect(read(rel), `${rel} no longer documents the beta+main deployment-branch policy for the owner`)
-        .toMatch(/clawreview[\s\S]*?(beta|main)/i);
+        .toMatch(/clawreview(?=[\s\S]*?\bbeta\b)(?=[\s\S]*?\bmain\b)/i);
     }
   });
 });

--- a/src/tests/unit/ci-workflows.test.ts
+++ b/src/tests/unit/ci-workflows.test.ts
@@ -676,3 +676,74 @@ describe("credentialed e2e-install runs are bound to a protected Environment", (
     expect(comment).toContain("needs.e2e-install.result");
   });
 });
+
+/**
+ * ClawReview / issue-triage credentials are bound to a protected Environment.
+ *
+ * Both jobs read paid API credentials (CLAUDE_CODE_OAUTH_TOKEN /
+ * ANTHROPIC_API_KEY / CLAWREVIEW_APP_*). pr-review.yml runs on
+ * pull_request_target and issue-triage.yml on issues — neither executes
+ * PR-controlled code, so the workflows themselves are safe. The residual
+ * risk is a same-repo pull_request editing ANY workflow to name the same
+ * credentials scope: GitHub lets any workflow reference any Environment,
+ * so the Environment's deployment-branch policy (beta + main only, set by
+ * the owner in repo settings) is the only fence. What this pins is that
+ * both jobs ASK for that Environment by its exact name — a rename in one
+ * file but not the other, or a dropped declaration, would either detach
+ * the job from the fence or fail every run.
+ */
+describe("credentialed review/triage runs are bound to the clawreview Environment", () => {
+  const files: Array<[string, string]> = [
+    [".github/workflows/pr-review.yml", "review"],
+    [".github/workflows/issue-triage.yml", "triage"],
+  ];
+
+  for (const [rel, jobName] of files) {
+    describe(rel, () => {
+      const yml = read(rel);
+      const text = yml.split("\n").filter((line) => !/^\s*#/.test(line)).join("\n");
+      // The one job: from its key to the end of the file (both workflows
+      // are single-job; a second job added later makes this fail loudly
+      // rather than silently testing the wrong slice).
+      const jobStart = text.indexOf(`\n  ${jobName}:\n`);
+      const job = jobStart === -1 ? "" : text.slice(jobStart);
+      // Preamble = job header before the first step; `environment:` must be
+      // the JOB's, not a step's `with:`.
+      const [preamble] = job.split(/^ *- (?=name:|uses:|run:)/m);
+
+      it("exists as a single job", () => {
+        expect(jobStart, `the ${jobName} job is gone`).toBeGreaterThan(-1);
+      });
+
+      it("declares the job-level clawreview Environment exactly once", () => {
+        const declarations = preamble.match(/^ {4}environment: (.+)$/gm) ?? [];
+        expect(declarations, `the ${jobName} job declares no job-level \`environment:\``).toHaveLength(1);
+        expect(declarations[0]).toBe("    environment: clawreview");
+      });
+
+      it("never parameterises the Environment name by event", () => {
+        // e2e-install.yml switches Environments by event because PR runs
+        // execute PR code; these two never do, so a conditional name here
+        // would only ever open a path that names a secretless twin — or
+        // worse, let an expression be coaxed into the credentialed one.
+        expect(preamble).not.toMatch(/environment:.*github\.event_name/);
+      });
+    });
+  }
+
+  it("both workflows name the same Environment (one fence, one settings page)", () => {
+    const names = files.map(([rel]) => /^ {4}environment: (.+)$/m.exec(read(rel))?.[1]);
+    expect(new Set(names).size, "the two jobs name different Environments").toBe(1);
+    expect(names[0]).toBe("clawreview");
+  });
+
+  it("the deployment-branch policy is documented where the owner creates the Environment", () => {
+    // The policy itself is a settings change no test can see; the workflow
+    // comments are where the owner learns the required restriction while
+    // creating it. Pin that both files carry the instruction.
+    for (const [rel] of files) {
+      expect(read(rel), `${rel} no longer documents the beta+main deployment-branch policy for the owner`)
+        .toMatch(/clawreview[\s\S]*?(beta|main)/i);
+    }
+  });
+});


### PR DESCRIPTION
## What

Binds the two credentialed jobs to a protected GitHub Environment named `clawreview`:

- `pr-review.yml` (ClawReview, `pull_request_target`) — job-level `environment: clawreview`
- `issue-triage.yml` (`issues` trigger) — job-level `environment: clawreview`
- **8** new focused workflow-policy tests in `src/tests/unit/ci-workflows.test.ts` (3 per workflow file via the parameterized loop + 2 file-level)

## Why

Both jobs read paid credentials (`CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` / `CLAWREVIEW_APP_*`) that currently sit at repository scope. The workflows themselves are safe (`pull_request_target` + base-only checkout + PR-as-data; no PR code executed), but repo-scope secrets are readable by ANY same-repo PR that edits workflow YAML. An Environment is only a fence when its deployment-branch policy restricts it — any workflow can name any Environment, so unrestricted is not a boundary (and selected-repo org secrets are not either).

Policy by event:
- `pull_request_target` / `issues` runs evaluate the **base/default branch** (`refs/heads/main` or `beta`) → inside the allowlist → secrets resolve.
- A same-repo `pull_request` workflow naming `clawreview` evaluates the **PR merge ref** (`refs/pull/<n>/merge`) → outside the allowlist → job refused before any step starts.

## Environment status (updated 2026-09-08 ~21:58 EEST)

**Already created by Mike**: `clawreview` exists with a custom deployment-branch policy allowing exactly branch-type **beta + main**; it currently holds **zero secrets** (sanitized proof: `release/v4-2026-09-08/clawreview-environment.json`). `e2e-credentials` likewise exists, same policy, empty. `e2e-pull-request` remains empty by design.

Remaining external gates (owner):
1. **Populate** `clawreview` with `CLAUDE_CODE_OAUTH_TOKEN`, `CLAWREVIEW_APP_ID`, `CLAWREVIEW_APP_PRIVATE_KEY` (+ `ANTHROPIC_API_KEY` if used as fallback) — from owned source / newly issued replacement credentials; GitHub values cannot be read back.
2. Only after this PR lands on beta AND the workflow-only backport (#795) lands on main: delete the repository-level copies, then rotate at the providers.
3. **Positive control**: after population, a ClawReview run must show credentials resolving (review posts as clawreview[bot]).
4. **Negative control (required)**: a throwaway same-repo PR attempting `environment: clawreview` from a `pull_request` run must be refused at job start — do not trust the reading, test it.

`e2e-pull-request` stays empty; provider-free PR installer checks are untouched.

## Verification here

- `bunx vitest run src/tests/unit/ci-workflows.test.ts` → **47/47 passed** (39 existing + 8 new)
- `bunx tsc --noEmit` → clean
- Note: the green `review` checks on this PR execute the **trusted base workflow** (`pull_request_target` against beta, which has no environment binding yet) — they do NOT constitute env-policy proof. Positive proof requires a bound deployment/run post-merge (`GET deployments?environment=clawreview` non-empty + credentials resolving).

Ref: TASK-736 audit (`release/v4-2026-09-08/kimi-ci-audit/REPORT.md` rev 5). Mike owns repo settings + the workflow-only main backport (#795).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **CI/CD**
  - Pull request review and issue triage workflows now use protected environment controls.
  - Workflow execution is limited to the approved `beta` and `main` deployment branches.
  - Same-repository pull request runs that do not meet the environment policy are rejected before execution.

- **Tests**
  - Added automated checks verifying consistent protected-environment configuration and deployment-branch policy across both workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
