### PR TITLE
ci: backport protected credential environments without releasing V4

### DIFF
--- a/.github/workflows/e2e-install.yml
+++ b/.github/workflows/e2e-install.yml
@@ -50,6 +50,10 @@ jobs:
     # Budget: native arm64 finishes in 10-15 min; qemu is 30-40 min; give
     # headroom for docker pulls on cold runners.
     timeout-minutes: 90
+    # e2e-pull-request is empty. e2e-credentials permits only branch-type
+    # main/beta, so untrusted PR merge refs cannot read provider secrets.
+    # Remove repository-level copies after migration; a step if is not a fence.
+    environment: ${{ github.event_name == 'pull_request' && 'e2e-pull-request' || 'e2e-credentials' }}
     env:
       CLAWBOX_PORT: "8080"
       # Default target for the in-app updater test. On PRs targeted at this
@@ -69,6 +73,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Checkout repository
         if: ${{ github.event_name != 'pull_request' }}
@@ -78,6 +83,7 @@ jobs:
           # updater can `git fetch origin <branch>`. Fetch tags too since the
           # version check polls `git ls-remote --tags`.
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Show Docker + runner info
         run: |
@@ -99,6 +105,9 @@ jobs:
       # happens to contain the EOF token or other heredoc-breaking bytes
       # can't truncate the resulting .env file.
       - name: Write .env.test
+        # Provider-free PR coverage still runs. The updater target is supplied
+        # independently by the job environment, not by this secrets file.
+        if: ${{ github.event_name != 'pull_request' }}
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -14,6 +14,11 @@ concurrency:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    # Protected by exact branch-type main/beta deployment policies. A PR
+    # merge ref cannot enter this environment, even if its YAML names it.
+    # Populate from owned credentials and remove repo-scoped copies only
+    # after both main and beta consumers are wired and verified.
+    environment: clawreview
     # Job-scoped (not workflow-scoped) so future jobs don't inherit write
     # access: the triage script labels + comments via GH_TOKEN.
     permissions:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -22,6 +22,11 @@ concurrency:
 jobs:
   review:
     runs-on: ubuntu-latest
+    # Protected by exact branch-type main/beta deployment policies. A PR
+    # merge ref cannot enter this environment, even if its YAML names it.
+    # Populate from owned credentials and remove repo-scoped copies only
+    # after both main and beta consumers are wired and verified.
+    environment: clawreview
     # Job-scoped so future jobs don't inherit write access.
     permissions:
       pull-requests: write

--- a/src/tests/unit/ci-environments.test.ts
+++ b/src/tests/unit/ci-environments.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+const read = (name: string) => readFileSync(resolve(process.cwd(), ".github/workflows", name), "utf8").split("\n").filter(line => !/^\s*#/.test(line)).join("\n");
+describe("CI credential environments", () => {
+  for (const [file, job] of [["pr-review.yml", "review"], ["issue-triage.yml", "triage"]]) {
+    it(`${job} binds its job to the protected review environment`, () => {
+      const text = read(file).split(`  ${job}:\n`)[1].split("    steps:")[0];
+      expect(text).toMatch(/^ {4}environment: clawreview$/m);
+    });
+  }
+  it("installer uses an empty environment on PRs and protected credentials otherwise", () => {
+    const job = read("e2e-install.yml").split("  e2e-install:\n")[1].split("    steps:")[0];
+    expect(job).toContain("environment: ${{ github.event_name == 'pull_request' && 'e2e-pull-request' || 'e2e-credentials' }}");
+  });
+  it("untrusted PR setup never writes the credential file", () => {
+    const step = read("e2e-install.yml").split("      - name: Write .env.test\n")[1].split("        env:")[0];
+    expect(step).toContain("if: ${{ github.event_name != 'pull_request' }}");
+  });
+  it("both installer checkouts leave no git token on disk", () => {
+    const text = read("e2e-install.yml");
+    for (const name of ["Checkout PR head", "Checkout repository"]) {
+      const step = text.split(`      - name: ${name}\n`)[1].split("      - ")[0];
+      expect(step).toContain("persist-credentials: false");
+    }
+  });
+});


### PR DESCRIPTION
## Scope
Workflow-only security backport to stable main (v3.9.0). Does not promote V4 device code or change package/build versions.

- Mirrors beta PR #794's protected `clawreview` environment wiring for ClawReview and issue triage.
- Adds the existing beta installer environment split to main: untrusted PRs use empty `e2e-pull-request`; trusted main/beta runs use restricted `e2e-credentials`.
- Adds the missing main-only guard preventing PR runs from writing `.env.test`, and disables checkout credential persistence.

## Verification
5 focused workflow policy tests pass. Existing installer tests obtain upgrade target independently from job env, so provider-free PR coverage remains active. Full CI/review still required.

## Migration dependency
Draft until beta #794 is reviewed/merged. Main/beta environment policies have been created and verified: exact branch-type main and beta only, zero secrets currently. Do not remove repository secret copies until owned source/replacement credentials are populated and both trusted consumers verified. Current repo-scoped copies still leave the security gate open. No credential value, provider token, or device software changed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - CI workflows now use protected environments for review and issue-triage jobs.
  - Pull request installation workflows select the appropriate environment and avoid writing test credentials for untrusted pull requests.
  - Checkout operations no longer persist Git credentials, improving credential isolation across supported workflows.

- **Tests**
  - Added automated coverage for environment protection, credential handling, and pull-request-specific installation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->