### PR TITLE
fix: recover desktop chat after a cold Jetson gateway start

### DIFF
--- a/e2e/chat-popup.spec.ts
+++ b/e2e/chat-popup.spec.ts
@@ -145,6 +145,8 @@ test("chat popup connects, streams a reply, and supports panel docking", async (
     // Keep the real startup deadline: the default 50 ms cap expires it
     // before this spec's asynchronous gateway handshake can complete.
     timeoutCapMs: 300_000,
+    // Hiding the mascot writes both its KV state and desktop preference.
+    kvEntries: { "clawbox-mascot-hidden": "1" },
     initialSetup: {
       setup_complete: true,
       wifi_configured: true,
@@ -185,6 +187,8 @@ test("chat popup lets you switch to Local AI when it is configured", async ({ pa
     // Keep the real startup deadline: the default 50 ms cap expires it
     // before this spec's asynchronous gateway handshake can complete.
     timeoutCapMs: 300_000,
+    // Hiding the mascot writes both its KV state and desktop preference.
+    kvEntries: { "clawbox-mascot-hidden": "1" },
     initialSetup: {
       setup_complete: true,
       wifi_configured: true,
@@ -229,6 +233,8 @@ test("chat popup provider dropdown stays visible at viewport edges", async ({ pa
     // Keep the real startup deadline: the default 50 ms cap expires it
     // before this spec's asynchronous gateway handshake can complete.
     timeoutCapMs: 300_000,
+    // Hiding the mascot writes both its KV state and desktop preference.
+    kvEntries: { "clawbox-mascot-hidden": "1" },
     initialSetup: {
       setup_complete: true,
       wifi_configured: true,
@@ -309,6 +315,8 @@ test("chat popup opens Local AI settings when local AI is not configured", async
     // Keep the real startup deadline: the default 50 ms cap expires it
     // before this spec's asynchronous gateway handshake can complete.
     timeoutCapMs: 300_000,
+    // Hiding the mascot writes both its KV state and desktop preference.
+    kvEntries: { "clawbox-mascot-hidden": "1" },
     initialSetup: {
       setup_complete: true,
       wifi_configured: true,

--- a/e2e/chat-popup.spec.ts
+++ b/e2e/chat-popup.spec.ts
@@ -111,7 +111,10 @@ async function installFakeGatewaySocket(page: Page) {
           return;
         }
 
-        if (message.method === "chat.abort") {
+        // Session RPCs are part of a real reconnect/provider switch. Leaving
+        // them unanswered only worked when the global timer cap forced their
+        // failures early; the mock must acknowledge the protocol instead.
+        if (["chat.abort", "sessions.reset", "sessions.patch", "sessions.subscribe"].includes(message.method)) {
           emit({
             type: "res",
             id: message.id,
@@ -139,6 +142,9 @@ test("chat popup connects, streams a reply, and supports panel docking", async (
   await installFakeGatewaySocket(page);
 
   await installClawboxMocks(page, {
+    // Keep the real startup deadline: the default 50 ms cap expires it
+    // before this spec's asynchronous gateway handshake can complete.
+    timeoutCapMs: 300_000,
     initialSetup: {
       setup_complete: true,
       wifi_configured: true,
@@ -176,6 +182,9 @@ test("chat popup lets you switch to Local AI when it is configured", async ({ pa
   await installFakeGatewaySocket(page);
 
   await installClawboxMocks(page, {
+    // Keep the real startup deadline: the default 50 ms cap expires it
+    // before this spec's asynchronous gateway handshake can complete.
+    timeoutCapMs: 300_000,
     initialSetup: {
       setup_complete: true,
       wifi_configured: true,
@@ -217,6 +226,9 @@ test("chat popup provider dropdown stays visible at viewport edges", async ({ pa
   await installFakeGatewaySocket(page);
 
   await installClawboxMocks(page, {
+    // Keep the real startup deadline: the default 50 ms cap expires it
+    // before this spec's asynchronous gateway handshake can complete.
+    timeoutCapMs: 300_000,
     initialSetup: {
       setup_complete: true,
       wifi_configured: true,
@@ -294,6 +306,9 @@ test("chat popup opens Local AI settings when local AI is not configured", async
   await installFakeGatewaySocket(page);
 
   await installClawboxMocks(page, {
+    // Keep the real startup deadline: the default 50 ms cap expires it
+    // before this spec's asynchronous gateway handshake can complete.
+    timeoutCapMs: 300_000,
     initialSetup: {
       setup_complete: true,
       wifi_configured: true,

--- a/e2e/helpers/clawbox.ts
+++ b/e2e/helpers/clawbox.ts
@@ -264,7 +264,12 @@ export async function installClawboxMocks(page: Page, options: MockOptions = {})
   };
   const wifiNetworks = clone(options.wifiNetworks ?? DEFAULT_WIFI_NETWORKS);
   const storeApps = clone(options.storeApps ?? DEFAULT_STORE_APPS);
-  const kvEntries: Record<string, string> = {};
+  // The desktop preference controls the shelf; Mascot reads the matching KV
+  // entry. A real hide action writes both. Keep the fixture coherent so an
+  // allegedly hidden, randomly walking mascot cannot cover tested controls.
+  const kvEntries: Record<string, string> = preferences.ui_mascot_hidden
+    ? { "clawbox-mascot-hidden": "1" }
+    : {};
   const files = clone(options.files ?? DEFAULT_FILES);
   let dismissalFingerprint: string | null = null;
   let hotspotConfig = {

--- a/e2e/helpers/clawbox.ts
+++ b/e2e/helpers/clawbox.ts
@@ -43,6 +43,7 @@ type StoreCatalogApp = {
 type MockOptions = {
   initialSetup?: Partial<SetupState>;
   preferences?: Record<string, unknown>;
+  kvEntries?: Record<string, string>;
   wifiNetworks?: WifiNetwork[];
   files?: FileTree;
   storeApps?: StoreCatalogApp[];
@@ -264,12 +265,7 @@ export async function installClawboxMocks(page: Page, options: MockOptions = {})
   };
   const wifiNetworks = clone(options.wifiNetworks ?? DEFAULT_WIFI_NETWORKS);
   const storeApps = clone(options.storeApps ?? DEFAULT_STORE_APPS);
-  // The desktop preference controls the shelf; Mascot reads the matching KV
-  // entry. A real hide action writes both. Keep the fixture coherent so an
-  // allegedly hidden, randomly walking mascot cannot cover tested controls.
-  const kvEntries: Record<string, string> = preferences.ui_mascot_hidden
-    ? { "clawbox-mascot-hidden": "1" }
-    : {};
+  const kvEntries: Record<string, string> = clone(options.kvEntries ?? {});
   const files = clone(options.files ?? DEFAULT_FILES);
   let dismissalFingerprint: string | null = null;
   let hotspotConfig = {

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -96,7 +96,8 @@ const MAX_RETRIES = 8
 // A measured Jetson cold boot takes ~175 s before its gateway listens.
 // Keep the initial connection alive for five minutes, but still end a dead
 // gateway's ladder and preserve the existing shorter reconnect/auth policies.
-const INITIAL_CONNECT_MAX_RETRIES = 100
+const INITIAL_CONNECT_MAX_RETRIES = 99 // initial attempt + 99 retries = 100
+const INITIAL_CONNECT_TIMEOUT_MS = 5 * 60_000
 const MAX_QUEUED_SENDS = 20
 
 /** How many spoken replies' audio the chat keeps alive at once; older ones lose their player. */
@@ -1973,6 +1974,10 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   }, [headerProvider, headerModel, applyThinkingLevel])
 
   // Connect to gateway
+  const connectionGenerationRef = useRef(0)
+  const connectionAbortRef = useRef<AbortController | null>(null)
+  const connectionDeadlineRef = useRef<number | null>(null)
+  const connectionDeadlineTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const retryCountRef = useRef(0)
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -2001,6 +2006,38 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       retryTimerRef.current = null
     }
     if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) return
+    const generation = ++connectionGenerationRef.current
+    const isCurrent = () => generation === connectionGenerationRef.current
+    connectionAbortRef.current?.abort()
+    const controller = new AbortController()
+    connectionAbortRef.current = controller
+    const clearDeadlineTimer = () => {
+      if (connectionDeadlineTimerRef.current) clearTimeout(connectionDeadlineTimerRef.current)
+      connectionDeadlineTimerRef.current = null
+    }
+    clearDeadlineTimer()
+    if (!hasEverConnectedRef.current) {
+      if (retryCountRef.current === 0 || connectionDeadlineRef.current === null) {
+        connectionDeadlineRef.current = Date.now() + INITIAL_CONNECT_TIMEOUT_MS
+      }
+      const expire = () => {
+        if (!isCurrent()) return
+        ++connectionGenerationRef.current
+        controller.abort()
+        if (retryTimerRef.current) clearTimeout(retryTimerRef.current)
+        retryTimerRef.current = null
+        const socket = wsRef.current
+        wsRef.current = null
+        socket?.close()
+        failPending('Gateway connection timed out')
+        tearDownReloadOverlay()
+        setStatus('error')
+        setErrorMsg('Could not connect to gateway')
+      }
+      const remaining = connectionDeadlineRef.current - Date.now()
+      if (remaining <= 0) { expire(); return }
+      connectionDeadlineTimerRef.current = setTimeout(expire, remaining)
+    }
     if (wsRef.current) {
       wsRef.current.close()
       wsRef.current = null
@@ -2018,11 +2055,14 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       // settings change, post-update). A cached ws-config response would replay
       // a stale token on every reconnect and the gateway would reject it with
       // "token mismatch" forever. Always fetch the current token.
-      const res = await fetch('/setup-api/gateway/ws-config', { cache: 'no-store' })
+      const res = await fetch('/setup-api/gateway/ws-config', { cache: 'no-store', signal: controller.signal })
       const config = await res.json()
+      if (!isCurrent()) return
       token = config.token
       wsUrl = config.wsUrl
     } catch {
+      if (!isCurrent()) return
+      clearDeadlineTimer()
       // Auto-retry if gateway config not ready yet. Extend the budget
       // during skill-install windows so the chat silently recovers once
       // the restarted gateway finishes reloading skills.
@@ -2030,10 +2070,10 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       const maxRetries = !hasEverConnectedRef.current
         ? INITIAL_CONNECT_MAX_RETRIES
         : skillInstalledRef.current ? SKILL_INSTALL_MAX_RETRIES : MAX_RETRIES
-      if (retryCountRef.current < maxRetries) {
+      if (retryCountRef.current < maxRetries && (hasEverConnectedRef.current || Date.now() + RETRY_DELAY < (connectionDeadlineRef.current ?? 0))) {
         retryCountRef.current++
         if (retryTimerRef.current) clearTimeout(retryTimerRef.current)
-        retryTimerRef.current = setTimeout(() => connect(), RETRY_DELAY)
+        retryTimerRef.current = setTimeout(() => { if (isCurrent()) void connect() }, RETRY_DELAY)
         return
       }
       // Same terminal-failure teardown as the onClose exhaustion path: a reboot
@@ -2050,12 +2090,14 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     let ws: WebSocket
 
     const sendConnect = (challenge?: Record<string, unknown>) => {
-      if (connectSent || !ws || ws.readyState !== WebSocket.OPEN) return
+      if (!isCurrent() || connectSent || !ws || ws.readyState !== WebSocket.OPEN) return
       connectSent = true
 
       const id = uuid()
       pendingRef.current.set(id, {
         resolve: (hello: unknown) => {
+          if (!isCurrent()) return
+          clearDeadlineTimer()
           setStatus('connected')
           connectedOnceRef.current = true
           hasEverConnectedRef.current = true
@@ -2176,6 +2218,8 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
           }
         },
         reject: (err: Error) => {
+          if (!isCurrent()) return
+          clearDeadlineTimer()
           // The fifth terminal-failure path, and it used to be the one that
           // forgot both halves. A gateway that REFUSES the connect frame
           // (protocol skew, a rejected device identity, a denied scope) keeps
@@ -2232,6 +2276,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     }
 
     const onMessage = (event: MessageEvent) => {
+      if (!isCurrent()) return
       let data: Record<string, unknown>
       try { data = JSON.parse(String(event.data)) } catch { return }
 
@@ -2578,7 +2623,8 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       // and describes a connection nobody is using — acting on it would null
       // the live socket's reference, reject the requests waiting on IT, and
       // schedule a reconnect on top of a healthy connection.
-      if (wsRef.current !== ws) return
+      if (!isCurrent() || wsRef.current !== ws) return
+      clearDeadlineTimer()
       wsRef.current = null
       // The socket is gone; nothing that was waiting on it can still arrive.
       failPending('Not connected')
@@ -2595,7 +2641,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
         if (retryTimerRef.current) clearTimeout(retryTimerRef.current)
         setStatus('error')
         setErrorMsg(closeReason || 'Unauthorized — retrying shortly')
-        retryTimerRef.current = setTimeout(() => { retryCountRef.current = 0; connect() }, AUTH_BACKOFF_DELAY)
+        retryTimerRef.current = setTimeout(() => { if (!isCurrent()) return; retryCountRef.current = 0; connect() }, AUTH_BACKOFF_DELAY)
         return
       }
 
@@ -2627,10 +2673,10 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       const maxRetries = !hasEverConnectedRef.current
         ? INITIAL_CONNECT_MAX_RETRIES
         : skillInstalledRef.current ? SKILL_INSTALL_MAX_RETRIES : MAX_RETRIES
-      if (retryCountRef.current < maxRetries) {
+      if (retryCountRef.current < maxRetries && (hasEverConnectedRef.current || Date.now() + RETRY_DELAY < (connectionDeadlineRef.current ?? 0))) {
         retryCountRef.current++
         if (retryTimerRef.current) clearTimeout(retryTimerRef.current)
-        retryTimerRef.current = setTimeout(() => connect(), RETRY_DELAY)
+        retryTimerRef.current = setTimeout(() => { if (isCurrent()) void connect() }, RETRY_DELAY)
         return
       }
       // Retries exhausted — the gateway isn't coming back on its own. Tear the
@@ -2646,6 +2692,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     try {
       ws = new WebSocket(wsUrl)
     } catch (err) {
+      clearDeadlineTimer()
       // The same terminal-failure teardown the other three error paths do, and
       // for the same reason. A wsUrl the browser's parser rejects throws here
       // on EVERY attempt, so leaving the overlay up left the safety-net retry
@@ -5050,6 +5097,10 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   // Cleanup on unmount
   useEffect(() => {
     return () => {
+      ++connectionGenerationRef.current
+      connectionAbortRef.current?.abort()
+      if (connectionDeadlineTimerRef.current) clearTimeout(connectionDeadlineTimerRef.current)
+      connectionDeadlineTimerRef.current = null
       wsRef.current?.close()
       wsRef.current = null
       failPending('Chat closed')

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -93,6 +93,10 @@ import {
 } from '@/lib/chat-reasoning'
 
 const MAX_RETRIES = 8
+// A measured Jetson cold boot takes ~175 s before its gateway listens.
+// Keep the initial connection alive for five minutes, but still end a dead
+// gateway's ladder and preserve the existing shorter reconnect/auth policies.
+const INITIAL_CONNECT_MAX_RETRIES = 100
 const MAX_QUEUED_SENDS = 20
 
 /** How many spoken replies' audio the chat keeps alive at once; older ones lose their player. */
@@ -1753,6 +1757,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const connectedOnceRef = useRef(false)
+  const hasEverConnectedRef = useRef(false)
   const pendingModelSwitchResetRef = useRef<{ model: string; label: string } | null>(null)
   // Sends queued while the WS handshake hasn't completed yet. Drained by
   // a useEffect when status flips to 'connected' so the user can type and
@@ -2022,7 +2027,9 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       // during skill-install windows so the chat silently recovers once
       // the restarted gateway finishes reloading skills.
 
-      const maxRetries = skillInstalledRef.current ? SKILL_INSTALL_MAX_RETRIES : MAX_RETRIES
+      const maxRetries = !hasEverConnectedRef.current
+        ? INITIAL_CONNECT_MAX_RETRIES
+        : skillInstalledRef.current ? SKILL_INSTALL_MAX_RETRIES : MAX_RETRIES
       if (retryCountRef.current < maxRetries) {
         retryCountRef.current++
         if (retryTimerRef.current) clearTimeout(retryTimerRef.current)
@@ -2051,6 +2058,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
         resolve: (hello: unknown) => {
           setStatus('connected')
           connectedOnceRef.current = true
+          hasEverConnectedRef.current = true
 
           retryCountRef.current = 0
           const h = hello as Record<string, unknown>
@@ -2616,7 +2624,9 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       // comes back, instead of bailing out with 'Could not connect to
       // gateway' and making the user click Try again manually. The normal
       // cap still applies outside of restart windows.
-      const maxRetries = skillInstalledRef.current ? SKILL_INSTALL_MAX_RETRIES : MAX_RETRIES
+      const maxRetries = !hasEverConnectedRef.current
+        ? INITIAL_CONNECT_MAX_RETRIES
+        : skillInstalledRef.current ? SKILL_INSTALL_MAX_RETRIES : MAX_RETRIES
       if (retryCountRef.current < maxRetries) {
         retryCountRef.current++
         if (retryTimerRef.current) clearTimeout(retryTimerRef.current)

--- a/src/tests/components/chat-cold-start.test.tsx
+++ b/src/tests/components/chat-cold-start.test.tsx
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@/tests/helpers/test-utils";
+import ChatPopup from "@/components/ChatPopup";
+import { resetHarnessCache } from "@/lib/client-harness";
+
+// Real Nano .199 needed 175 seconds between process start and gateway ready.
+// The desktop opened sooner and exhausted its initial socket retry ladder.
+let ready = false;
+let attempts = 0;
+let connected = 0;
+class ColdGateway {
+  static CONNECTING = 0; static OPEN = 1; static CLOSING = 2; static CLOSED = 3;
+  readyState = ColdGateway.CONNECTING;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onopen: (() => void) | null = null;
+  constructor(public url: string) {
+    attempts++;
+    setTimeout(() => {
+      if (this.readyState === ColdGateway.CLOSED) return;
+      if (!ready) { this.readyState = ColdGateway.CLOSED; this.onclose?.({ code: 1006, reason: "" } as CloseEvent); return; }
+      this.readyState = ColdGateway.OPEN;
+      this.emit({ type: "event", event: "connect.challenge", payload: { nonce: "n" } });
+    }, 1);
+  }
+  send(raw: string) {
+    const f = JSON.parse(raw);
+    if (f.type !== "req") return;
+    if (f.method === "connect") connected++;
+    const payload = f.method === "connect"
+      ? { snapshot: { sessionDefaults: { mainSessionKey: "agent:main:main" } } }
+      : f.method === "chat.history" ? { messages: [{ role: "assistant", content: [{ type: "text", text: "Ready" }] }] } : {};
+    setTimeout(() => this.emit({ type: "res", id: f.id, ok: true, payload }), 1);
+  }
+  close() { this.readyState = ColdGateway.CLOSED; }
+  emit(data: unknown) { this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent); }
+}
+async function advance(ms: number) {
+  await act(async () => { await vi.advanceTimersByTimeAsync(50); });
+  for (let left = ms; left > 0; left -= 3000) {
+    await act(async () => { await vi.advanceTimersByTimeAsync(Math.min(left, 3000)); });
+  }
+}
+
+describe("cold gateway desktop recovery", () => {
+  beforeEach(() => {
+    vi.useFakeTimers(); ready = false; attempts = 0; connected = 0;
+    resetHarnessCache(); window.localStorage.clear(); Element.prototype.scrollIntoView = vi.fn();
+    vi.stubGlobal("WebSocket", ColdGateway as unknown as typeof WebSocket);
+    vi.stubGlobal("fetch", vi.fn(async (input: unknown) => {
+      const u = String(input);
+      const data = u.includes("/gateway/ws-config") ? { token: "t", wsUrl: "ws://localhost/gw" }
+        : u.includes("/harness/active") ? { active: "openclaw", edition: "openclaw" }
+        : u.includes("/chat/model") ? { options: [], activeOptionId: "" }
+        : u.includes("/chat/spoken-history") ? { items: [] } : {};
+      return { ok: true, json: async () => data };
+    }));
+  });
+  afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); resetHarnessCache(); });
+
+  it("connects without owner Retry when a cold gateway starts after three minutes", async () => {
+    render(<ChatPopup isOpen onClose={() => {}} />);
+    await advance(180_000);
+    expect(connected).toBe(0);
+    expect(screen.queryByText("Could not connect to gateway")).toBeNull();
+    ready = true;
+    await advance(5_000);
+    expect(connected).toBe(1);
+    expect(screen.queryByText("Could not connect to gateway")).toBeNull();
+  });
+
+  it("still ends the ladder for a gateway that never starts", async () => {
+    render(<ChatPopup isOpen onClose={() => {}} />);
+    await advance(330_000);
+    expect(screen.getByText("Could not connect to gateway")).toBeTruthy();
+    const exhausted = attempts;
+    await advance(60_000);
+    expect(attempts).toBe(exhausted);
+  });
+
+  it("cancels startup retries when the chat unmounts", async () => {
+    const view = render(<ChatPopup isOpen onClose={() => {}} />);
+    await advance(10_000); view.unmount(); const last = attempts;
+    await advance(60_000); expect(attempts).toBe(last);
+  });
+});

--- a/src/tests/components/chat-cold-start.test.tsx
+++ b/src/tests/components/chat-cold-start.test.tsx
@@ -8,6 +8,7 @@ import { resetHarnessCache } from "@/lib/client-harness";
 let ready = false;
 let attempts = 0;
 let connected = 0;
+let stallHandshake = false;
 class ColdGateway {
   static CONNECTING = 0; static OPEN = 1; static CLOSING = 2; static CLOSED = 3;
   readyState = ColdGateway.CONNECTING;
@@ -20,6 +21,7 @@ class ColdGateway {
     setTimeout(() => {
       if (this.readyState === ColdGateway.CLOSED) return;
       if (!ready) { this.readyState = ColdGateway.CLOSED; this.onclose?.({ code: 1006, reason: "" } as CloseEvent); return; }
+      if (stallHandshake) return;
       this.readyState = ColdGateway.OPEN;
       this.emit({ type: "event", event: "connect.challenge", payload: { nonce: "n" } });
     }, 1);
@@ -45,7 +47,7 @@ async function advance(ms: number) {
 
 describe("cold gateway desktop recovery", () => {
   beforeEach(() => {
-    vi.useFakeTimers(); ready = false; attempts = 0; connected = 0;
+    vi.useFakeTimers(); ready = false; attempts = 0; connected = 0; stallHandshake = false;
     resetHarnessCache(); window.localStorage.clear(); Element.prototype.scrollIntoView = vi.fn();
     vi.stubGlobal("WebSocket", ColdGateway as unknown as typeof WebSocket);
     vi.stubGlobal("fetch", vi.fn(async (input: unknown) => {
@@ -74,9 +76,57 @@ describe("cold gateway desktop recovery", () => {
     render(<ChatPopup isOpen onClose={() => {}} />);
     await advance(330_000);
     expect(screen.getByText("Could not connect to gateway")).toBeTruthy();
+    expect(attempts).toBeLessThanOrEqual(100);
     const exhausted = attempts;
     await advance(60_000);
     expect(attempts).toBe(exhausted);
+  });
+
+  it("ends a pending WebSocket handshake at the shared five-minute deadline", async () => {
+    ready = true; stallHandshake = true;
+    render(<ChatPopup isOpen onClose={() => {}} />);
+    await advance(300_000);
+    expect(screen.getByText("Could not connect to gateway")).toBeTruthy();
+    expect(attempts).toBe(1);
+    expect(connected).toBe(0);
+  });
+
+  it("aborts a pending config fetch at the shared five-minute deadline", async () => {
+    const original = globalThis.fetch;
+    let signal: AbortSignal | undefined;
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).includes("/gateway/ws-config")) {
+        signal = init?.signal ?? undefined;
+        return new Promise((_resolve, reject) => signal?.addEventListener("abort", () => reject(new Error("aborted"))));
+      }
+      return original(input, init);
+    }));
+    render(<ChatPopup isOpen onClose={() => {}} />);
+    await advance(300_000);
+    expect(signal?.aborted).toBe(true);
+    expect(attempts).toBe(0);
+    expect(screen.getByText("Could not connect to gateway")).toBeTruthy();
+  });
+
+  it("ignores a late config response after unmount even when fetch ignores abort", async () => {
+    const original = globalThis.fetch;
+    let resolveConfig: ((r: Response) => void) | undefined;
+    let signal: AbortSignal | undefined;
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).includes("/gateway/ws-config")) {
+        signal = init?.signal ?? undefined;
+        return new Promise<Response>(resolve => { resolveConfig = resolve; });
+      }
+      return original(input, init);
+    }));
+    const view = render(<ChatPopup isOpen onClose={() => {}} />);
+    await advance(100);
+    expect(resolveConfig).toBeDefined();
+    view.unmount();
+    expect(signal?.aborted).toBe(true);
+    await act(async () => { resolveConfig?.({ json: async () => ({ token: "t", wsUrl: "ws://localhost/gw" }) } as Response); });
+    await advance(330_000);
+    expect(attempts).toBe(0);
   });
 
   it("cancels startup retries when the chat unmounts", async () => {


### PR DESCRIPTION
## Real hardware finding
On Nano .199 (beta f3aa547a), local Gemma setup completed before the cold OpenClaw gateway listened. The process started at 06:05:38 and reported ready at 06:08:33. Chat exhausted its eight initial retries and remained on “Could not connect to gateway”; a manual Retry later connected and produced the correct real UI reply 323 for 17 × 19.

## Fix
Allow up to five minutes of initial socket retries, bounded at 100 attempts. After the first successful handshake, existing shorter reconnect/reload policies apply. Auth backoff and deterministic constructor/refused-connect handling are unchanged.

## Verification
- Hardware-shaped delayed-gateway regression fails before the fix and passes after.
- Six component tests pass: late startup, dead-gateway exhaustion, unmount cancellation, constructor failure, refusal/manual retry.
- TypeScript passes.
- Installer/CI and installation of the fixed candidate on hardware still required.

Beta only; no main release. Part of TASK-604/778.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat connectivity during cold gateway startups with extended initial connection retries.
  * Prevented stale connection activity and retries after the chat closes or unmounts.
  * Improved handling of delayed startup, failed authentication, stalled handshakes, and interrupted requests.
  * Improved chat session recovery when switching providers or reconnecting.
  * Ensured mascot visibility preferences are reflected consistently in test environments.

* **Tests**
  * Added coverage for delayed gateway recovery, unavailable gateways, stalled connections, interrupted requests, and cleanup during unmount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->