### PR TITLE
fix: keep ClawKeep dialogs usable above the desktop taskbar

### DIFF
--- a/e2e/clawkeep-interactions.spec.ts
+++ b/e2e/clawkeep-interactions.spec.ts
@@ -324,6 +324,7 @@ test("restore modal: clicking a snapshot opens the confirm dialog", async ({ pag
 });
 
 test("paired-without-encryption opens the passphrase setup modal on backup", async ({ page }) => {
+  await page.setViewportSize({ width: 1271, height: 594 });
   await setupDesktop(page);
 
   await page.route("**/setup-api/clawkeep", (route) =>
@@ -341,14 +342,15 @@ test("paired-without-encryption opens the passphrase setup modal on backup", asy
   const clawkeep = await openClawkeep(page);
   await clawkeep.getByRole("button", { name: "Protect my OpenClaw" }).click();
 
-  // SetPassphraseModal mounts and renders two password inputs plus an
-  // acknowledge checkbox. We fill the password fields to cover their
-  // onChange handlers + the mismatch-error render branch — but stop
-  // short of the submit click (the checkbox locator timed out cross-
-  // browser, likely because the modal's z-[100000] overlay confuses
-  // visibility heuristics in headless chromium).
-  const passwordInputs = clawkeep.locator('input[type="password"]');
+  // The dialog is portalled above the desktop, not trapped in its app window.
+  const dialog = page.getByRole("dialog", { name: "Set your backup passphrase" });
+  const passwordInputs = dialog.locator('input[type="password"]');
   await expect(passwordInputs.first()).toBeVisible();
   await passwordInputs.nth(0).fill("strong-passphrase-1234");
   await passwordInputs.nth(1).fill("strong-passphrase-1234");
+  await dialog.getByRole("checkbox").check();
+  await expect(dialog.getByRole("button", { name: "Save passphrase" })).toBeEnabled();
+  // A real pointer click must reach the controls above the desktop taskbar.
+  await dialog.getByRole("button", { name: "Cancel", exact: true }).click();
+  await expect(dialog).toHaveCount(0);
 });

--- a/src/components/ClawKeepApp.tsx
+++ b/src/components/ClawKeepApp.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
+import { useModalDialog } from "@/hooks/useModalDialog";
 import { useT } from "@/lib/i18n";
 import { backupSourceFor } from "@/lib/harness/backup-source";
 import { deriveProtection, isBackupRunning, type ProtectionState } from "@/lib/clawkeep-protection";
@@ -9,6 +10,7 @@ import ClawKeepWizard from "./ClawKeepWizard";
 import { PairChallengeCard, type PairStartResponse } from "./ClawKeepPairChallengeCard";
 import {
   CARD,
+  ClawKeepModalPortal,
   ConfirmDialog,
   Stat,
   WEEKDAY_LABEL_KEYS,
@@ -814,6 +816,12 @@ interface ScheduleSaveResponse {
   scheduleArmedAtMs: number;
 }
 
+function sameSchedule(a: ClawKeepSchedule, b: ClawKeepSchedule): boolean {
+  return a.enabled === b.enabled && a.frequency === b.frequency
+    && a.timeOfDay === b.timeOfDay && a.weekday === b.weekday
+    && a.retentionKeepLast === b.retentionKeepLast;
+}
+
 function ScheduleCard({
   schedule,
   nextRunAtMs,
@@ -828,9 +836,13 @@ function ScheduleCard({
   const { t } = useT();
   const [draft, setDraft] = useState<ClawKeepSchedule>(schedule);
   const [saving, setSaving] = useState(false);
-  // Re-sync the draft when the parent re-fetches (e.g. after a backup run
-  // bumped nextRunAtMs server-side).
-  useEffect(() => { setDraft(schedule); }, [schedule]);
+  const previousSchedule = useRef(schedule);
+  // A background status poll must not discard an owner's unsaved input.
+  useEffect(() => {
+    const previous = previousSchedule.current;
+    previousSchedule.current = schedule;
+    setDraft(current => sameSchedule(current, previous) ? schedule : current);
+  }, [schedule]);
 
   const dirty =
     draft.enabled !== schedule.enabled
@@ -1690,8 +1702,9 @@ function RestoreModal({
   }, [onClose]);
 
   return (
+    <ClawKeepModalPortal>
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/85 backdrop-blur-md"
+      className="fixed inset-0 z-[100000] flex items-center justify-center p-4 bg-black/85 backdrop-blur-md"
       role="dialog"
       aria-modal="true"
       aria-label={t("clawkeep.restoreModal.aria")}
@@ -1951,6 +1964,7 @@ function RestoreModal({
         </footer>
       </div>
     </div>
+    </ClawKeepModalPortal>
   );
 }
 
@@ -1982,18 +1996,7 @@ function SetPassphraseModal({
   const [submitting, setSubmitting] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
 
-  // Esc cancels the modal (consistent with ConfirmDialog and RestoreModal).
-  // Skip while a save is in flight so the user can't half-cancel a request.
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && !submitting) {
-        e.preventDefault();
-        onCancel();
-      }
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onCancel, submitting]);
+  const panelRef = useModalDialog<HTMLFormElement>({ onClose: () => { if (!submitting) onCancel(); } });
 
   const canSubmit =
     pw.length >= 8 && pw === confirm && acknowledged && !submitting;
@@ -2027,10 +2030,15 @@ function SetPassphraseModal({
   };
 
   return (
+    <ClawKeepModalPortal>
     <div className="fixed inset-0 z-[100000] flex items-center justify-center bg-black/70 backdrop-blur-sm p-4">
       <form
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={t("clawkeep.encryption.setTitle")}
         onSubmit={submit}
-        className="w-full max-w-md rounded-2xl border border-[var(--border-subtle)] bg-[var(--bg-deep)] p-6 shadow-2xl"
+        className="max-h-[calc(100dvh-2rem)] overflow-y-auto w-full max-w-md rounded-2xl border border-[var(--border-subtle)] bg-[var(--bg-deep)] p-6 shadow-2xl"
       >
         <h2 className="text-base font-semibold text-white mb-1">
           {t("clawkeep.encryption.setTitle")}
@@ -2125,6 +2133,7 @@ function SetPassphraseModal({
           <button
             type="button"
             onClick={onCancel}
+            disabled={submitting}
             className="px-3 py-1.5 rounded-md text-xs font-medium text-white/70 bg-white/5 hover:bg-white/10 cursor-pointer"
           >
             {t("clawkeep.cancel")}
@@ -2139,6 +2148,7 @@ function SetPassphraseModal({
         </div>
       </form>
     </div>
+    </ClawKeepModalPortal>
   );
 }
 
@@ -2165,20 +2175,7 @@ function RestorePassphraseModal({
   const [submitting, setSubmitting] = useState(false);
   const [err, setErr] = useState<string | null>(initialError ?? null);
 
-  // Esc cancels the modal (consistent with ConfirmDialog/RestoreModal).
-  // Skip while a decrypt+restore is in flight — interrupting via Esc
-  // wouldn't actually abort the underlying CLI subprocess and would
-  // leave the user thinking they cancelled when they didn't.
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && !submitting) {
-        e.preventDefault();
-        onCancel();
-      }
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onCancel, submitting]);
+  const panelRef = useModalDialog<HTMLFormElement>({ onClose: () => { if (!submitting) onCancel(); } });
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -2197,10 +2194,15 @@ function RestorePassphraseModal({
   const descSuffix = t("clawkeep.encryption.enterDescriptionSuffix");
 
   return (
+    <ClawKeepModalPortal>
     <div className="fixed inset-0 z-[100000] flex items-center justify-center bg-black/70 backdrop-blur-sm p-4">
       <form
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={t("clawkeep.encryption.enterTitle")}
         onSubmit={submit}
-        className="w-full max-w-md rounded-2xl border border-[var(--border-subtle)] bg-[var(--bg-deep)] p-6 shadow-2xl"
+        className="max-h-[calc(100dvh-2rem)] overflow-y-auto w-full max-w-md rounded-2xl border border-[var(--border-subtle)] bg-[var(--bg-deep)] p-6 shadow-2xl"
       >
         <h2 className="text-base font-semibold text-white mb-1">
           {t("clawkeep.encryption.enterTitle")}
@@ -2245,5 +2247,6 @@ function RestorePassphraseModal({
         </div>
       </form>
     </div>
+    </ClawKeepModalPortal>
   );
 }

--- a/src/components/clawkeep-ui.tsx
+++ b/src/components/clawkeep-ui.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import { useEffect, useRef, type ReactNode } from "react";
 import { useT } from "@/lib/i18n";
 import { useModalDialog } from "@/hooks/useModalDialog";
 import { CARD as KIT_CARD } from "./coding-agent-ui";
@@ -103,6 +104,11 @@ export function formatNextRun(ms: number, t: Translator): string {
   return t("clawkeep.inMinutes", { mins });
 }
 
+/** Escape the desktop window's transform/stacking context and taskbar. */
+export function ClawKeepModalPortal({ children }: { children: ReactNode }) {
+  return typeof document === "undefined" ? null : createPortal(children, document.body);
+}
+
 export function ConfirmDialog({
   title,
   body,
@@ -140,8 +146,9 @@ export function ConfirmDialog({
     : "bg-emerald-500 hover:bg-emerald-400 text-black";
 
   return (
+    <ClawKeepModalPortal>
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
+      className="fixed inset-0 z-[100001] flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
       onClick={onCancel}
     >
       {/* The role sits on the PANEL, where the trap is attached: on the
@@ -191,6 +198,7 @@ export function ConfirmDialog({
         </div>
       </div>
     </div>
+    </ClawKeepModalPortal>
   );
 }
 

--- a/src/tests/components/clawkeep-frame.test.tsx
+++ b/src/tests/components/clawkeep-frame.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, within } from "@/tests/helpers/test-utils";
+import { render, screen, within, fireEvent, act } from "@/tests/helpers/test-utils";
 import ClawKeepApp from "@/components/ClawKeepApp";
 import { I18nProvider } from "@/lib/i18n";
 
@@ -32,7 +32,7 @@ function installFetch() {
     const url = String(input);
     urls.push(url);
     const ok = (json: unknown) => ({ ok: true, status: 200, json: async () => json });
-    if (url.includes("/setup-api/clawkeep")) return ok(status);
+    if (url.includes("/setup-api/clawkeep")) return ok({ ...status, schedule: { ...(status.schedule as object) } });
     return ok({});
   }));
 }
@@ -69,6 +69,36 @@ describe("ClawKeep's frame", () => {
     expect(portal.getAttribute("href")).toBe("https://portal.example/portal/clawkeep");
     expect(portal.getAttribute("target")).toBe("_blank");
     expect(within(header).getByRole("button", { name: "Unpair" })).toBeTruthy();
+  });
+
+  it("keeps unsaved schedule input when a background status poll arrives", async () => {
+    vi.useFakeTimers();
+    let unmount: (() => void) | undefined;
+    try {
+      status = { ...BASE_STATUS, paired: true, configured: true, lastBackupAtMs: Date.now(), cloudBytes: 1024, snapshotCount: 2 };
+      await act(async () => {
+        ({ unmount } = render(<I18nProvider><ClawKeepApp /></I18nProvider>));
+      });
+      const input = screen.getByRole("spinbutton");
+      fireEvent.change(input, { target: { value: "7" } });
+      const pollsBefore = urls.length;
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+      expect(urls.length).toBeGreaterThan(pollsBefore);
+      expect((input as HTMLInputElement).value).toBe("7");
+      expect(screen.getByRole("button", { name: "Save schedule" })).toBeTruthy();
+    } finally { unmount?.(); vi.useRealTimers(); }
+  });
+
+  it("renders the encryption dialog outside the transformed app window", async () => {
+    status = { ...BASE_STATUS, paired: true, configured: true, encryptionConfigured: false, lastBackupAtMs: Date.now(), cloudBytes: 1024, snapshotCount: 2 };
+    const { container } = render(<div style={{ transform: "translate(10px, 10px)" }}><I18nProvider><ClawKeepApp /></I18nProvider></div>);
+    const button = await screen.findByRole("button", { name: /Protect my OpenClaw/i });
+    fireEvent.click(button);
+    const dialog = screen.getByRole("dialog");
+    expect(container.contains(dialog)).toBe(false);
+    expect(dialog.parentElement?.parentElement).toBe(document.body);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).toBeNull();
   });
 
   it("no longer points at Memory Shard, nor probes the memory index", async () => {


### PR DESCRIPTION
## Summary
- Fix real-Nano UI failures: ClawKeep modal controls were trapped behind the desktop taskbar by the app window transform.
- Portal restore, confirmation and passphrase dialogs to the viewport; bound passphrase forms to the available height and use the shared keyboard/focus behavior.
- Preserve unsaved schedule/retention input across background status polling.

## Validation
- 11 targeted component tests pass, including background-poll draft retention and transformed-parent dialog placement.
- TypeScript passes.
- Found during actual encrypted backup setup on Nano .199 at a 1271×594 viewport. Candidate hardware retest follows CI/review.

Beta only. No main release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Encryption, restore, and passphrase dialogs now appear reliably above other content, with improved focus handling, Escape-key dismissal, and scrolling for longer forms.
  - Dialogs use improved accessibility semantics and remain protected from accidental cancellation while submissions are in progress.

- **Bug Fixes**
  - Unsaved schedule editor changes are now preserved while background status updates refresh the page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->