### PR TITLE
fix: refresh chat after changing the local AI provider

### DIFF
--- a/src/components/LocalAiPanel.tsx
+++ b/src/components/LocalAiPanel.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useT } from "@/lib/i18n";
 import { formatBytes } from "@/lib/format-bytes";
-import { dispatchOpenApp, onStandaloneAppPage } from "@/lib/ui-events";
+import { dispatchOpenApp, onStandaloneAppPage, notifyProvidersChanged } from "@/lib/ui-events";
 import type { LocalModelEntry, LocalModelsSnapshot, RunState } from "@/lib/local-models";
 
 /**
@@ -361,9 +361,14 @@ export default function LocalAiPanel({ active, edition }: { active: boolean; edi
       if (action.streams) {
         const outcome = await readInstallStream(res, (line) => setProgress((p) => ({ ...p, [entry.id]: line })));
         if (!outcome.ok) setError(outcome.error ?? t("localModels.error.changeFailed"));
+        // A successful install/activation changes the device pairing. Tell
+        // already-mounted chat and provider pickers only after the terminal
+        // success line, not the initial HTTP 200 of a still-running stream.
+        else if (entry.kind === "llm") notifyProvidersChanged();
         return;
       }
       const data = await res.json().catch(() => ({}));
+      if (entry.kind === "llm") notifyProvidersChanged();
       if (typeof data?.warning === "string" && data.warning) setNotice(data.warning);
       if (isSnapshot(data)) applySnapshot(data);
       if (data && typeof data === "object" && "fallback" in data && data.fallback) {

--- a/src/tests/components/local-ai-panel.test.tsx
+++ b/src/tests/components/local-ai-panel.test.tsx
@@ -11,7 +11,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render, screen, waitFor, within } from "@/tests/helpers/test-utils";
 import { I18nProvider } from "@/lib/i18n";
 import LocalAiPanel from "@/components/LocalAiPanel";
-import { OPEN_APP_EVENT } from "@/lib/ui-events";
+import { OPEN_APP_EVENT, PROVIDERS_CHANGED_EVENT } from "@/lib/ui-events";
 
 function model(over: Record<string, unknown>) {
   return {
@@ -71,6 +71,59 @@ afterEach(() => {
 });
 
 describe("LocalAiPanel", () => {
+
+  it("refreshes other provider surfaces only after a successful streamed model activation", async () => {
+    let finish!: () => void;
+    const changed = vi.fn();
+    window.addEventListener(PROVIDERS_CHANGED_EVENT, changed);
+    try {
+      stubFetch({ post: (url) => url === "/setup-api/llamacpp/install"
+        ? new Response(new ReadableStream<Uint8Array>({ start(controller) {
+            const encoder = new TextEncoder();
+            controller.enqueue(encoder.encode(JSON.stringify({ status: "Starting Gemma" }) + "\n"));
+            finish = () => { controller.enqueue(encoder.encode(JSON.stringify({ success: true }) + "\n")); controller.close(); };
+          } }), { headers: { "content-type": "application/x-ndjson" } })
+        : undefined });
+      renderPanel();
+      await screen.findByTestId("local-model-role-llamacpp");
+      fireEvent.click(screen.getByTestId("local-model-menu-llamacpp"));
+      fireEvent.click(await screen.findByTestId("local-model-action-llamacpp-primary"));
+      await screen.findByTestId("local-model-progress-llamacpp");
+      expect(changed).not.toHaveBeenCalled();
+      finish();
+      await waitFor(() => expect(changed).toHaveBeenCalledTimes(1));
+    } finally { window.removeEventListener(PROVIDERS_CHANGED_EVENT, changed); }
+  });
+
+  it("does not announce a provider change when a model activation stream fails", async () => {
+    const changed = vi.fn();
+    window.addEventListener(PROVIDERS_CHANGED_EVENT, changed);
+    try {
+      stubFetch({ post: (url) => url === "/setup-api/llamacpp/install"
+        ? new Response(JSON.stringify({ error: "Activation failed" }) + "\n", { headers: { "content-type": "application/x-ndjson" } }) : undefined });
+      renderPanel();
+      await screen.findByTestId("local-model-role-llamacpp");
+      fireEvent.click(screen.getByTestId("local-model-menu-llamacpp"));
+      fireEvent.click(await screen.findByTestId("local-model-action-llamacpp-primary"));
+      expect(await screen.findByRole("alert")).toHaveTextContent("Activation failed");
+      expect(changed).not.toHaveBeenCalled();
+    } finally { window.removeEventListener(PROVIDERS_CHANGED_EVENT, changed); }
+  });
+
+  it("refreshes provider surfaces after a saved fallback change even while the gateway restarts", async () => {
+    const changed = vi.fn();
+    window.addEventListener(PROVIDERS_CHANGED_EVENT, changed);
+    try {
+      stubFetch({ llmDefault: true, post: (url) => url === "/setup-api/providers/default"
+        ? new Response(JSON.stringify({ ok: true, warning: "Saved, gateway restarting" }), { headers: { "content-type": "application/json" } }) : undefined });
+      renderPanel();
+      await screen.findByTestId("local-model-role-llamacpp");
+      fireEvent.click(screen.getByTestId("local-model-menu-llamacpp"));
+      fireEvent.click(await screen.findByTestId("local-model-action-llamacpp-fallback"));
+      await waitFor(() => expect(changed).toHaveBeenCalledTimes(1));
+    } finally { window.removeEventListener(PROVIDERS_CHANGED_EVENT, changed); }
+  });
+
   it("groups the box's engines by what they are for", async () => {
     stubFetch();
     renderPanel();


### PR DESCRIPTION
## Hardware finding
On the verified Hermes Nano .183, Settings → Local AI → Gemma 4 → Make primary saved the pairing correctly, but the already-mounted chat still showed Auto and sent `anthropic/claude-opus-4.6` against `clawlocal`. The turn failed. Emitting the missing shared provider-change signal immediately refreshed the picker to Gemma; the real local model then answered 17 × 19 = 323.

## Fix
- Notify provider consumers after a successful LLM inventory/default change.
- For streamed activation, wait for the terminal success record; HTTP 200 alone is not success.
- Do not announce failed activation. Saved fallback changes still notify when gateway readiness is only a warning.

## Verification
All execution on bench Nano .4, not the production host.
- Reproduced two missing-notification failures before the fix (20 existing tests passed).
- All 22 LocalAiPanel component tests pass after the fix.
- TypeScript check running on the Nano; CI and CodeRabbit required before merge.

Beta only. No main release or host runtime changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Provider selection menus now refresh automatically after an AI model is successfully installed, activated, or used.
  - Provider menus remain unchanged when activation fails, preventing unsuccessful changes from appearing as available.
  - Provider updates also refresh correctly after fallback changes that require restarting the gateway.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->