### PR TITLE
fix: avoid redundant gateway boot consent loads (TASK-779)

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -3894,33 +3894,20 @@ clawbox_plugin_boot_without() {
 # existing marker exactly as it found them, for the next boot or the Settings
 # Retry to resolve.
 
-# The consent question is asked at most ONCE per boot, for every id at once:
-# the CLI start is the dominant cost and this runs inside a blocking
-# ExecStartPre. Empty until the first kill asks for it.
+# Query the core BEFORE replaying an expensive, normally idempotent enable.
+# One snapshot serves all managed ids until a payload install invalidates it.
+# Only the core's positive installed-record verdict skips consent; a named
+# unindexed plugin is left untouched (not declared accepted), as above.
+# Unknown, pending and failed reports still take the existing repair path.
 #
-# ONE SNAPSHOT, TAKEN AT THE FIRST KILL OF THE BOOT, and memoised. A consent
-# recorded by a LATER killed verb is not in it, so that plugin is still named
-# and is switched off — beta's behaviour, and the reason this reads as a fix for
-# a consent that was ALREADY current before the boot (the common shape:
-# `plugins enable` is idempotent, so it is a slow no-op that gets killed) rather
-# than for one written inside the verb that was then killed. The codex verb runs
-# before the managed loop, so on a boot whose codex verb is killed the snapshot
-# predates every managed plugin's own consent write.
-#
-# STALE IN ONE DIRECTION ONLY, which is what makes it safe rather than merely
-# cautious: `plugins enable --accept-capabilities` only ever ADDS consent, so an
-# old snapshot can be wrong by naming a plugin that has since been consented — a
-# false failure, identical to beta — and a stale `consented` is unreachable.
-#
-# The memoisation is not only cost. Measured on a box, this call is ~10 s
-# against its 60 s ceiling, so re-reading it per verb would be affordable on a
-# HEALTHY box — but the box that reaches this code is one loaded enough to kill
-# `plugins enable` at 60 s, and there the inspect can reach its own deadline
-# too. Per verb that costs 5 x 65 s to produce the same refusal five times;
-# memoised it costs one 65 s attempt and every later verb reuses the answer for
-# free. Bounding the damage on that box is what this is for.
+# Consent writes only ADD consent, so reusing an earlier snapshot after enable
+# can conservatively miss a newly accepted surface, but cannot invent one.
+# A payload install CAN change a surface: invalidate the snapshot before that
+# operation so a later id never uses an answer from before the install.
+# The snapshot is in memory for this boot only, never persisted across boots.
 CLAWBOX_CONSENT_STATES=""
 CLAWBOX_CONSENT_STATES_READY=0
+CLAWBOX_CONSENT_POSTWRITE_READY=0
 
 # `@openclaw/discord`, `openclaw-discord` and `discord` are one plugin: the
 # registry answers to all three and `ensureChannelPlugin` enables whichever one
@@ -4102,6 +4089,15 @@ clawbox_plugin_consent_outcome() {
   fi
   case "$rc" in
     124|137)
+      # The preflight predates this write. Refresh once after the first killed
+      # enable, so a newly recorded consent is not mistaken for a refusal.
+      # Further killed verbs share that answer, retaining the bounded fallback
+      # cost on overloaded hardware (one preflight + one post-write report).
+      if [ "$CLAWBOX_CONSENT_POSTWRITE_READY" = "0" ]; then
+        CLAWBOX_CONSENT_STATES=""
+        CLAWBOX_CONSENT_STATES_READY=0
+        CLAWBOX_CONSENT_POSTWRITE_READY=1
+      fi
       clawbox_plugin_consent_state "$id" || state=$?
       case "$state" in
         0)
@@ -4645,11 +4641,18 @@ elif [ "$CLAWBOX_OPENCLAW_V2" = "1" ] && [ "$CODEX_SHOULD_LOAD" = "1" ]; then
   # SIGTERM, and an `openclaw` that ignores it keeps running past the ceiling.
   # It is also what makes 137 reachable, which the classifier below reads the
   # same way as 124.
-  CODEX_CONSENT_RC=0
-  timeout -k 5 60 "$OPENCLAW_BIN" plugins enable codex --accept-capabilities </dev/null >/dev/null 2>&1 \
-    || CODEX_CONSENT_RC=$?
   CODEX_CONSENT_VERDICT=0
-  clawbox_plugin_consent_outcome codex "$CODEX_CONSENT_RC" || CODEX_CONSENT_VERDICT=$?
+  CLAWBOX_CONSENT_DETAIL=""
+  clawbox_plugin_consent_state codex || CODEX_CONSENT_VERDICT=$?
+  if [ "$CODEX_CONSENT_VERDICT" = "0" ]; then
+    CLAWBOX_CONSENT_DETAIL=" (the core already reports current consent; skipped enable)"
+  elif [ "$CODEX_CONSENT_VERDICT" != "2" ]; then
+    CODEX_CONSENT_RC=0
+    timeout -k 5 60 "$OPENCLAW_BIN" plugins enable codex --accept-capabilities </dev/null >/dev/null 2>&1 \
+      || CODEX_CONSENT_RC=$?
+    CODEX_CONSENT_VERDICT=0
+    clawbox_plugin_consent_outcome codex "$CODEX_CONSENT_RC" || CODEX_CONSENT_VERDICT=$?
+  fi
   if [ "$CODEX_CONSENT_VERDICT" = "0" ]; then
     echo "  Codex runtime plugin capabilities accepted/current$CLAWBOX_CONSENT_DETAIL"
     clawbox_plugin_repair_clear codex
@@ -4660,7 +4663,7 @@ elif [ "$CLAWBOX_OPENCLAW_V2" = "1" ] && [ "$CODEX_SHOULD_LOAD" = "1" ]; then
     # it enabled safe. Nothing is switched off and nothing is cleared: an
     # existing repair row is still the truest thing on the screen, and the next
     # boot or the Retry it offers resolves this.
-    echo "  Codex runtime plugin capabilities are still unknown (the consent verb was killed at its deadline and the core keeps no consent record for this plugin); leaving it as it is"
+    echo "  Codex runtime plugin capabilities are still unknown (the core keeps no consent record for this plugin); leaving it as it is"
   else
     echo "  WARN: could not confirm Codex plugin capabilities; booting without Codex"
     clawbox_plugin_boot_without codex consent \
@@ -4730,11 +4733,18 @@ for key, entry in entries.items():
 MANAGEDPY
 )"
   for MANAGED_PLUGIN in $MANAGED_ENABLED_PLUGINS; do
-    MANAGED_PLUGIN_RC=0
-    MANAGED_PLUGIN_OUT="$(timeout -k 5 60 "$OPENCLAW_BIN" plugins enable "$MANAGED_PLUGIN" --accept-capabilities </dev/null 2>&1)" \
-      || MANAGED_PLUGIN_RC=$?
     MANAGED_PLUGIN_VERDICT=0
-    clawbox_plugin_consent_outcome "$MANAGED_PLUGIN" "$MANAGED_PLUGIN_RC" || MANAGED_PLUGIN_VERDICT=$?
+    CLAWBOX_CONSENT_DETAIL=""
+    clawbox_plugin_consent_state "$MANAGED_PLUGIN" || MANAGED_PLUGIN_VERDICT=$?
+    if [ "$MANAGED_PLUGIN_VERDICT" = "0" ]; then
+      CLAWBOX_CONSENT_DETAIL=" (the core already reports current consent; skipped enable)"
+    elif [ "$MANAGED_PLUGIN_VERDICT" != "2" ]; then
+      MANAGED_PLUGIN_RC=0
+      MANAGED_PLUGIN_OUT="$(timeout -k 5 60 "$OPENCLAW_BIN" plugins enable "$MANAGED_PLUGIN" --accept-capabilities </dev/null 2>&1)" \
+        || MANAGED_PLUGIN_RC=$?
+      MANAGED_PLUGIN_VERDICT=0
+      clawbox_plugin_consent_outcome "$MANAGED_PLUGIN" "$MANAGED_PLUGIN_RC" || MANAGED_PLUGIN_VERDICT=$?
+    fi
     if [ "$MANAGED_PLUGIN_VERDICT" = "0" ]; then
       echo "  $MANAGED_PLUGIN plugin capabilities accepted/current$CLAWBOX_CONSENT_DETAIL"
       clawbox_plugin_repair_clear "$MANAGED_PLUGIN"
@@ -4747,7 +4757,7 @@ MANAGEDPY
       # box today — so the core can neither report its consent nor refuse
       # readiness over it. Change nothing, clear nothing, say which of the two
       # it is.
-      echo "  $MANAGED_PLUGIN plugin capabilities are still unknown (the consent verb was killed at its deadline and the core keeps no consent record for this plugin); leaving it as it is"
+      echo "  $MANAGED_PLUGIN plugin capabilities are still unknown (the core keeps no consent record for this plugin); leaving it as it is"
       continue
     fi
     # The consent is not established — either `enable` refused outright, or it
@@ -4809,6 +4819,9 @@ MANAGEDPY
         else
           MANAGED_PLUGIN_SPEC="$MANAGED_PLUGIN_PKG"
         fi
+        CLAWBOX_CONSENT_STATES=""
+        CLAWBOX_CONSENT_STATES_READY=0
+        CLAWBOX_CONSENT_POSTWRITE_READY=0
         if timeout -k 5 120 "$OPENCLAW_BIN" plugins install "$MANAGED_PLUGIN_SPEC" --force --accept-capabilities </dev/null >/dev/null 2>&1; then
           echo "  $MANAGED_PLUGIN plugin payload reinstalled ($MANAGED_PLUGIN_SPEC)"
           clawbox_plugin_repair_clear "$MANAGED_PLUGIN"

--- a/src/tests/unit/gateway-pre-start-codex-runtime.test.ts
+++ b/src/tests/unit/gateway-pre-start-codex-runtime.test.ts
@@ -341,6 +341,7 @@ describe("gateway-pre-start.sh managed-plugin capability consent", () => {
         "clawbox-email-directives": { enabled: true },
       },
     })).toEqual([
+      "plugins inspect --all --json",
       "plugins enable deepseek --accept-capabilities",
       "plugins enable discord --accept-capabilities",
       "plugins enable whatsapp --accept-capabilities",
@@ -374,6 +375,7 @@ describe("gateway-pre-start.sh managed-plugin capability consent", () => {
         "@openclaw/whatsapp": { enabled: true },
       },
     })).toEqual([
+      "plugins inspect --all --json",
       "plugins enable openclaw-discord --accept-capabilities",
       "plugins enable @openclaw/whatsapp --accept-capabilities",
     ]);
@@ -509,7 +511,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh agentRuntime policy", () => {
       enabledByConfig: probeCodexEnabled(normalizedConfig) === "1",
       installedVersion: "2026.8.1",
       peerHealthy: true,
-    })).toEqual(["plugins enable codex --accept-capabilities"]);
+    })).toEqual(["plugins inspect --all --json", "plugins enable codex --accept-capabilities"]);
   });
 
   it("repairs a stale default-enabled v2 plugin at the pinned version", () => {
@@ -545,7 +547,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh agentRuntime policy", () => {
       peerHealthy: false,
       layout: "registry",
       registryDependenciesOk: true,
-    })).toEqual(["plugins enable codex --accept-capabilities"]);
+    })).toEqual(["plugins inspect --all --json", "plugins enable codex --accept-capabilities"]);
   });
 
   it("trusts parent-resolved registry dependencies for a project-managed plugin", () => {
@@ -557,7 +559,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh agentRuntime policy", () => {
       peerHealthy: false,
       layout: "project-managed",
       registryDependenciesOk: true,
-    })).toEqual(["plugins enable codex --accept-capabilities"]);
+    })).toEqual(["plugins inspect --all --json", "plugins enable codex --accept-capabilities"]);
   });
 
   it("consents a healthy default-enabled v2 plugin without reinstalling it", () => {
@@ -567,7 +569,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh agentRuntime policy", () => {
       enabledByConfig: true,
       installedVersion: "2026.8.1",
       peerHealthy: true,
-    })).toEqual(["plugins enable codex --accept-capabilities"]);
+    })).toEqual(["plugins inspect --all --json", "plugins enable codex --accept-capabilities"]);
   });
 
   // ── The consent verb killed at its deadline (TASK-606 follow-up) ─────────
@@ -588,7 +590,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh agentRuntime policy", () => {
       consentExit: code,
       inspectJson: inspectAllJson([{ id: "codex" }]),
     });
-    expect(argv).toContain("plugins inspect --all --json");
+    expect(argv).toEqual(["plugins inspect --all --json"]);
     expect(stdout).toContain("Codex runtime plugin capabilities accepted/current");
     expect(stdout).not.toContain("booting without Codex");
     expect(marker).toEqual({});
@@ -651,8 +653,8 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh agentRuntime policy", () => {
     // needs an openclaw.json this fragment's environment does not set, and is
     // pinned in gateway-pre-start-managed-plugin-payload.test.ts.
     expect(marker.codex?.stage).toBe("consent");
-    // A refusal the core chose never pays for the second question.
-    expect(argv.some((line) => line.startsWith("plugins inspect"))).toBe(false);
+    // Failed preflight inspection does not bypass the real refusal.
+    expect(argv.filter((line) => line.startsWith("plugins inspect"))).toEqual(["plugins inspect --all --json"]);
   });
 
   it("leaves an explicitly disabled unused plugin alone", () => {

--- a/src/tests/unit/gateway-pre-start-managed-plugin-payload.test.ts
+++ b/src/tests/unit/gateway-pre-start-managed-plugin-payload.test.ts
@@ -85,6 +85,9 @@ interface RunOptions {
    * is the core saying nothing about it rather than reporting its consent.
    */
   inspectJson?: string;
+  /** A payload install can change another plugin's consent surface. */
+  inspectAfterInstallJson?: string;
+  inspectAfterEnableJson?: string;
   /** A `data/plugin-repair.json` the boot starts with. */
   existingMarker?: Record<string, Record<string, unknown>>;
   /** Install specs (argv[3]) the fake CLI refuses. */
@@ -131,6 +134,12 @@ function run(opts: RunOptions): {
       ),
       "fi",
       'if [ "$2" = "inspect" ]; then',
+      ...(opts.inspectAfterEnableJson === undefined ? [] : [
+        `  if grep -q '^plugins enable ' "${log}"; then printf '%s' '${opts.inspectAfterEnableJson}'; exit 0; fi`,
+      ]),
+      ...(opts.inspectAfterInstallJson === undefined ? [] : [
+        `  if grep -q '^plugins install ' "${log}"; then printf '%s' '${opts.inspectAfterInstallJson}'; exit 0; fi`,
+      ]),
       ...(opts.inspectJson === undefined
         ? ["  exit 1"]
         : [`  printf '%s' '${opts.inspectJson}'; exit 0`]),
@@ -203,9 +212,57 @@ function run(opts: RunOptions): {
 }
 
 describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin payload repair", () => {
+  it("uses one core snapshot to skip current and unindexed no-op consent verbs", () => {
+    const { argv, stdout, entries, marker } = run({
+      entries: { discord: { enabled: true }, "clawbox-email-directives": { enabled: true } },
+      inspectJson: inspectAllJson([{ id: "discord" }, { id: "clawbox-email-directives", installed: false }]),
+      existingMarker: { "clawbox-email-directives": { stage: "consent" } },
+    });
+    expect(argv).toEqual(["plugins inspect --all --json"]);
+    expect(stdout).toContain("discord plugin capabilities accepted/current");
+    expect(stdout).not.toContain("clawbox-email-directives plugin capabilities accepted/current");
+    expect(entries.discord.enabled).toBe(true);
+    expect(entries["clawbox-email-directives"].enabled).toBe(true);
+    expect(marker["clawbox-email-directives"].stage).toBe("consent");
+  });
+
+  it("invalidates an earlier positive snapshot after a payload reinstall", () => {
+    const { argv, marker, entries } = run({
+      entries: { discord: { enabled: true }, whatsapp: { enabled: true } },
+      payloadMissing: ["discord"],
+      enableKilled: { whatsapp: 124 },
+      inspectJson: inspectAllJson([{ id: "whatsapp" }]),
+      inspectAfterInstallJson: inspectAllJson([{ id: "discord" }, { id: "whatsapp", consentRequired: true }]),
+    });
+    expect(argv.filter((line) => line.startsWith("plugins"))).toEqual([
+      "plugins inspect --all --json",
+      "plugins enable discord --accept-capabilities",
+      "plugins install @openclaw/discord@2026.8.1 --force --accept-capabilities",
+      "plugins inspect --all --json",
+      "plugins enable whatsapp --accept-capabilities",
+      "plugins inspect --all --json",
+    ]);
+    expect(marker.whatsapp.stage).toBe("consent");
+    expect(entries.whatsapp.enabled).toBe(false);
+  });
+
+  it("rechecks consent recorded by a killed enable after a pending preflight", () => {
+    const { argv, marker, entries } = run({
+      entries: { discord: { enabled: true } },
+      enableKilled: { discord: 124 },
+      inspectJson: inspectAllJson([{ id: "discord", consentRequired: true }]),
+      inspectAfterEnableJson: inspectAllJson([{ id: "discord" }]),
+    });
+    expect(argv).toEqual([
+      "plugins inspect --all --json", "plugins enable discord --accept-capabilities", "plugins inspect --all --json",
+    ]);
+    expect(marker).toEqual({});
+    expect(entries.discord.enabled).toBe(true);
+  });
+
   it("consents and stops there while the payload is intact", () => {
     const { argv } = run({ entries: { discord: { enabled: true } } });
-    expect(argv).toEqual(["plugins enable discord --accept-capabilities"]);
+    expect(argv).toEqual(["plugins inspect --all --json", "plugins enable discord --accept-capabilities"]);
   });
 
   it("reinstalls the pinned payload when the core says the package is not there", () => {
@@ -214,6 +271,7 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
       payloadMissing: ["discord"],
     });
     expect(argv).toEqual([
+      "plugins inspect --all --json",
       "plugins enable discord --accept-capabilities",
       "plugins install @openclaw/discord@2026.8.1 --force --accept-capabilities",
     ]);
@@ -231,6 +289,7 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
       enableFails: ["discord", "whatsapp"],
     });
     expect(argv.filter((line) => line.startsWith("plugins"))).toEqual([
+      "plugins inspect --all --json",
       "plugins enable discord --accept-capabilities",
       "plugins enable whatsapp --accept-capabilities",
     ]);
@@ -357,7 +416,7 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
     expect(first.argv.some((line) => line.startsWith("config set"))).toBe(false);
     // The same directory, so this argv log carries BOTH boots.
     const second = run(opts);
-    expect(second.argv.filter((line) => line === "plugins enable deepseek --accept-capabilities"))
+    expect(second.argv.filter((line) => line === "plugins inspect --all --json"))
       .toHaveLength(2);
     expect(second.entries.deepseek?.enabled).toBe(true);
   });
@@ -430,7 +489,7 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
   });
 
   it("still switches the plugin off when the core actually refused", () => {
-    // A refusal the core CHOSE to make never pays for the second question.
+    // A failed preflight does not override a real consent refusal.
     const { argv, stdout, marker } = run({
       entries: { discord: { enabled: true } },
       enableFails: ["discord"],
@@ -438,7 +497,7 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
     expect(argv).toContain('config set plugins.entries["discord"].enabled false --strict-json');
     expect(stdout).toContain("booting without it");
     expect(marker.discord?.stage).toBe("consent");
-    expect(argv.some((line) => line.startsWith("plugins inspect"))).toBe(false);
+    expect(argv.filter((line) => line.startsWith("plugins inspect"))).toEqual(["plugins inspect --all --json"]);
   });
 
   it("repairs the payload under the alias the registry answers to", () => {
@@ -449,6 +508,7 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
       payloadMissing: ["openclaw-whatsapp"],
     });
     expect(argv).toEqual([
+      "plugins inspect --all --json",
       "plugins enable openclaw-whatsapp --accept-capabilities",
       "plugins install @openclaw/whatsapp@2026.8.1 --force --accept-capabilities",
     ]);
@@ -473,7 +533,7 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
       entries: { deepseek: { enabled: true } },
       payloadMissing: ["deepseek"],
     });
-    expect(argv).toEqual(["plugins enable deepseek --accept-capabilities"]);
+    expect(argv).toEqual(["plugins inspect --all --json", "plugins enable deepseek --accept-capabilities"]);
     expect(stdout).toContain("ClawBox has no npm package of its own for it");
   });
 
@@ -504,6 +564,7 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
       effective: "",
     });
     expect(argv).toEqual([
+      "plugins inspect --all --json",
       "plugins enable discord --accept-capabilities",
       "plugins install @openclaw/discord --force --accept-capabilities",
     ]);


### PR DESCRIPTION
## Summary

Fix TASK-779: repeated idempotent capability-consent commands delayed gateway readiness on a real Orin Nano past the chat startup budget.

- Inspect the core's current consent report before replaying enable; skip only positively adjudicated current consent.
- Leave named plugins without install records unchanged, without falsely clearing repair markers or declaring consent.
- Preserve pending/unknown/error repair paths; recheck once after the first killed enable to recognize consent actually written.
- Invalidate the snapshot after payload replacement. Do not persist consent decisions across boots.

## Verification

- Reproduced on Nano .61 combined beta 2f50db37: two 60-second no-op enables plus slow core startup led to a failed chat connection.
- New fast-path regression assertions failed on beta, then passed with the fix.
- Dedicated Nano .4: all 23 boot-script suites / 596 tests pass; bash syntax passes.
- Real .61 restart timing and UI reconnect are being measured; results will be appended before merge.

Beta only. No main promotion and no runtime tests on the production host.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup handling for plugin capability consent.
  - Added an initial preflight check to identify current consent status before enabling managed plugins.
  - Refreshes consent information after plugin installation or interrupted enable attempts.
  - Avoids redundant enable operations when consent is already current.
  - Improved handling of plugin aliases, reinstall scenarios, timeouts, refusals, and unknown consent states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->