### PR TITLE
fix: contain ClawKeep restore-picker keyboard focus (TASK-780)

### DIFF
--- a/e2e/clawkeep-interactions.spec.ts
+++ b/e2e/clawkeep-interactions.spec.ts
@@ -166,7 +166,8 @@ test("restore modal opens, fetches snapshots, and Esc dismisses it", async ({ pa
   await page.evaluate(() => {
     (window as Window & { restoreEscapeLeaks?: number }).restoreEscapeLeaks = 0;
     window.addEventListener("keydown", (event) => {
-      if (event.key === "Escape") (window as Window & { restoreEscapeLeaks: number }).restoreEscapeLeaks++;
+      const state = window as Window & { restoreEscapeLeaks?: number };
+      if (event.key === "Escape") state.restoreEscapeLeaks = (state.restoreEscapeLeaks ?? 0) + 1;
     });
   });
   const close = modal.getByRole("button", { name: "Close", exact: true });
@@ -177,7 +178,7 @@ test("restore modal opens, fetches snapshots, and Esc dismisses it", async ({ pa
   await expect(close).toBeFocused();
   await page.keyboard.press("Escape");
   await expect(modal).not.toBeVisible();
-  expect(await page.evaluate(() => (window as Window & { restoreEscapeLeaks: number }).restoreEscapeLeaks)).toBe(0);
+  expect(await page.evaluate(() => (window as Window & { restoreEscapeLeaks?: number }).restoreEscapeLeaks)).toBe(0);
   await expect(clawkeep.getByRole("button", { name: "Restore from snapshot" })).toBeFocused();
 });
 

--- a/e2e/clawkeep-interactions.spec.ts
+++ b/e2e/clawkeep-interactions.spec.ts
@@ -161,9 +161,24 @@ test("restore modal opens, fetches snapshots, and Esc dismisses it", async ({ pa
   // on mount, and a count taken before it lands is the close button alone.
   await expect.poll(() => modal.getByRole("button").count()).toBeGreaterThan(2);
 
-  // Esc closes the modal — covers the keydown useEffect cleanup path.
+  // The picker traps keyboard navigation, not just the pointer. A global
+  // listener models the open chat's Escape handler behind the modal.
+  await page.evaluate(() => {
+    (window as Window & { restoreEscapeLeaks?: number }).restoreEscapeLeaks = 0;
+    window.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") (window as Window & { restoreEscapeLeaks: number }).restoreEscapeLeaks++;
+    });
+  });
+  const close = modal.getByRole("button", { name: "Close", exact: true });
+  await expect(close).toBeFocused();
+  await page.keyboard.press("Shift+Tab");
+  await expect(modal.getByRole("button").last()).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(close).toBeFocused();
   await page.keyboard.press("Escape");
   await expect(modal).not.toBeVisible();
+  expect(await page.evaluate(() => (window as Window & { restoreEscapeLeaks: number }).restoreEscapeLeaks)).toBe(0);
+  await expect(clawkeep.getByRole("button", { name: "Restore from snapshot" })).toBeFocused();
 });
 
 test("unpair flow opens the confirm dialog and Esc dismisses it without unpairing", async ({ page }) => {

--- a/src/components/ClawKeepApp.tsx
+++ b/src/components/ClawKeepApp.tsx
@@ -1691,26 +1691,22 @@ function RestoreModal({
     }
   }, [load]);
 
-  // Esc closes the modal — basic dialog hygiene; the click-on-backdrop
-  // handler covers the mouse path.
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
+  // Use the desktop's shared capture-phase trap so Escape closes only this
+  // picker, never the chat behind it, and focus cannot reach live-state actions
+  // outside the dialog. Restore focus to the trigger when the picker closes.
+  const panelRef = useModalDialog<HTMLDivElement>({ onClose });
 
   return (
     <ClawKeepModalPortal>
     <div
       className="fixed inset-0 z-[100000] flex items-center justify-center p-4 bg-black/85 backdrop-blur-md"
-      role="dialog"
-      aria-modal="true"
-      aria-label={t("clawkeep.restoreModal.aria")}
       onClick={onClose}
     >
       <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={t("clawkeep.restoreModal.aria")}
         className="w-full max-w-xl rounded-2xl border border-[var(--border-subtle)] bg-[var(--bg-deep)] shadow-2xl overflow-hidden flex flex-col max-h-[80vh]"
         onClick={(e) => e.stopPropagation()}
       >

--- a/src/tests/components/clawkeep-frame.test.tsx
+++ b/src/tests/components/clawkeep-frame.test.tsx
@@ -32,6 +32,7 @@ function installFetch() {
     const url = String(input);
     urls.push(url);
     const ok = (json: unknown) => ({ ok: true, status: 200, json: async () => json });
+    if (url.endsWith("/setup-api/clawkeep/snapshots")) return ok({ snapshots: [] });
     if (url.includes("/setup-api/clawkeep")) return ok({ ...status, schedule: { ...(status.schedule as object) } });
     return ok({});
   }));
@@ -99,6 +100,28 @@ describe("ClawKeep's frame", () => {
     expect(dialog.parentElement?.parentElement).toBe(document.body);
     fireEvent.keyDown(document, { key: "Escape" });
     expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("contains restore-picker focus and Escape without closing the background chat", async () => {
+    status = { ...BASE_STATUS, paired: true, configured: true, encryptionConfigured: true, snapshotCount: 1 };
+    const backgroundEscape = vi.fn();
+    window.addEventListener("keydown", backgroundEscape);
+    try {
+      render(<I18nProvider><ClawKeepApp /></I18nProvider>);
+      const trigger = await screen.findByRole("button", { name: "Restore from snapshot" });
+      trigger.focus();
+      fireEvent.click(trigger);
+      const dialog = screen.getByRole("dialog", { name: "Restore from cloud snapshot" });
+      expect(dialog.contains(document.activeElement)).toBe(true);
+      expect(trigger.closest("[inert]")).not.toBeNull();
+      fireEvent.keyDown(document.activeElement!, { key: "Escape" });
+      expect(screen.queryByRole("dialog")).toBeNull();
+      expect(backgroundEscape).not.toHaveBeenCalled();
+      expect(document.activeElement).toBe(trigger);
+      expect(trigger.closest("[inert]")).toBeNull();
+    } finally {
+      window.removeEventListener("keydown", backgroundEscape);
+    }
   });
 
   it("no longer points at Memory Shard, nor probes the memory index", async () => {


### PR DESCRIPTION
## Summary

Fix TASK-780, reproduced in the real ClawKeep UI on Nano .199 / combined beta2f50db37:

- Restore picker left focus on the underlying backup input.
- Escape reached the background ChatPopup as well, closing both surfaces.

Use the existing shared modal-dialog hook on the picker panel. Focus enters/stays inside; the background becomes inert; Escape stops at the picker; focus returns to the trigger. Keep the portal outside the transformed desktop window. No changes to restore or archive mutations.

## Verification

- New component regression fails on beta (focus remains outside).
- Nano .4: all34 ClawKeep component tests pass with the patch, including focus restoration and no leaked Escape.
- Added browser assertions for Shift-Tab/Tab wrap, no window Escape, and restored trigger focus. Existing stacked-confirm regression retained.
- Dedicated Nano production build and browser sweep running; results will be appended before merge.

Beta only. No production-host runtime tests or main promotion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restore dialog keyboard accessibility with focus trapping and reliable focus restoration after dismissal.
  * Escape now closes the restore dialog without triggering unrelated global keyboard handlers.
  * Background content is appropriately disabled while the dialog is open.

* **Tests**
  * Added coverage for keyboard navigation, Escape handling, focus restoration, and background interaction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->