### PR TITLE
fix: check the Hermes model picker's list once a day by itself

### DIFF
--- a/src/app/setup-api/hermes/models/route.ts
+++ b/src/app/setup-api/hermes/models/route.ts
@@ -9,11 +9,13 @@ import { requireSession } from "@/lib/route-auth";
 import { reconcileClawaiModelsWithHermes } from "@/lib/hermes-clawai";
 import { reconcileLocalAiWithHermes } from "@/lib/hermes-local-ai";
 import {
+  catalogStaleness,
   getModelOptions,
   invalidateModelOptions,
   isAllowedProvider,
   isPairAllowed,
   isSafeModelId,
+  readCatalogRefreshMark,
   shouldEnforcePairing,
   scopeFromPayload,
   type HermesModelOption,
@@ -100,6 +102,25 @@ export async function GET(request: Request) {
     await reconcileClawaiModelsWithHermes();
   }
 
+  // When this box last got the harness to re-read its providers' lists, as
+  // opposed to how old this process's copy of the answer is. `fetchedAt`/
+  // `stale` below answer only the second question — they are this server's
+  // 60-second L1 cache — so a list Hermes has been carrying forward for a week
+  // reports `fetchedAt` two seconds ago and `stale: false`. TASK-781.
+  //
+  // READ AFTER `getModelOptions`, never beside it. `?refresh=1` performs the
+  // check inside that call, so a mark read up here would be the PRE-refresh one
+  // and the one action that fixes staleness would answer `catalogStale: true`
+  // — a false failure over an operation that had just succeeded.
+  //
+  // Read per request rather than baked into the cached payload, for the other
+  // direction: a payload built at 23 h old would otherwise still call itself
+  // fresh two hours later, from the L1 cache.
+  const catalogAge = async () => {
+    const mark = await readCatalogRefreshMark();
+    return { catalogCheckedAt: mark.checkedAt, catalogStale: catalogStaleness(mark) };
+  };
+
   try {
     if (provider) {
       const scoped = await getModelOptions({ refresh });
@@ -115,6 +136,7 @@ export async function GET(request: Request) {
         ...(await scopeFromPayload(scoped, provider)),
         reasoning: scoped.reasoning,
         savedPair: scoped.current,
+        ...(await catalogAge()),
       };
       return NextResponse.json(reply);
     }
@@ -171,6 +193,7 @@ export async function GET(request: Request) {
       source: payload.source,
       stale: payload.stale,
       fetchedAt: payload.fetchedAt,
+      ...(await catalogAge()),
       ...(payload.degraded ? { degraded: payload.degraded } : {}),
       ...(refreshDenied ? { refreshDenied: true } : {}),
     });

--- a/src/app/setup-api/portal/heartbeat-tick/route.ts
+++ b/src/app/setup-api/portal/heartbeat-tick/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { readTunnelUrl, startTunnelService } from "@/lib/cloudflared";
 import { isInternalRequest } from "@/lib/internal-token";
 import { applyDeferredLanguagePersona } from "@/lib/language-persona";
+import { refreshCatalogIfDue } from "@/lib/hermes-model-options";
 import { pushHeartbeatTick } from "@/lib/portal-heartbeat";
 import { requireSession } from "@/lib/route-auth";
 import { checkTunnelLiveness, markRestarted, mayRestart } from "@/lib/tunnel-liveness";
@@ -62,6 +63,24 @@ export async function GET(request: Request) {
   // applyDeferredLanguagePersona), and it never throws, so it cannot turn a
   // tick into the 500 that would make the systemd unit flap.
   await applyDeferredLanguagePersona();
+
+  // Keep the model picker's list from ageing out, for the same reason and on
+  // the same ride: nothing else on the box forces the harness to go and re-read
+  // what each provider actually serves. Hermes' own caches will carry a list
+  // forward for up to seven days, and ClawBox only ever busts them when the
+  // owner clicks Refresh — so `claude-opus-5` and `claude-fable-5-1` were
+  // missing from a box whose credential listed them live (TASK-781).
+  //
+  // NOT AWAITED, deliberately, like `pushHeartbeatTick` below. This unit runs
+  // `curl --max-time 10`, and the dead-tunnel path underneath already spends up
+  // to 7.5 s of that on DNS (see tunnel-liveness.ts) — putting a dashboard
+  // round-trip in front of it would push the tunnel repair past curl's deadline
+  // on exactly the tick that performs it, and `SuccessExitStatus` would swallow
+  // the truncation. `refreshCatalogIfDue` never rejects, so there is no
+  // unhandled rejection to catch; it decides in two cheap reads on the 287
+  // ticks a day that are not the one, and no-ops on an OpenClaw box, whose
+  // catalogue route already re-enumerates by itself on the read path.
+  void refreshCatalogIfDue();
 
   const tunnelUrl = await readTunnelUrl();
   const liveness = await checkTunnelLiveness(tunnelUrl);

--- a/src/lib/hermes-model-options.ts
+++ b/src/lib/hermes-model-options.ts
@@ -31,7 +31,9 @@ import {
   hermesDashboardUnitState,
   type HermesDashboardUnitState,
 } from "@/lib/hermes-dashboard-control";
-import { get } from "@/lib/config-store";
+import { get, set } from "@/lib/config-store";
+import { getActiveHarness } from "@/lib/harness";
+import { createSerialLock } from "@/lib/serial-lock";
 import { CLAWBOX_AI_CHAT_MODEL_IDS } from "@/lib/clawbox-ai-models";
 import { pickedClawboxAiModelIdAmong, readExplicitModelPicks } from "@/lib/explicit-model-pick";
 import {
@@ -205,6 +207,16 @@ export interface ProviderScope {
 export interface ScopedModelsReply extends ProviderScope {
   reasoning: string;
   savedPair: { provider: string; model: string };
+  /**
+   * When this box last got the harness to re-read every provider's list, and
+   * whether that was over a day ago — NOT the age of this process's copy, which
+   * is what {@link ProviderScope.fetchedAt} and `stale` describe. Both are
+   * `null` where nothing has recorded a check — not checked, never "old".
+   * See {@link CatalogRefreshMark} for what a check does and does not prove.
+   * TASK-781.
+   */
+  catalogCheckedAt: number | null;
+  catalogStale: boolean | null;
 }
 
 // ── L1 cache (in-process, SWR) ───────────────────────────────────────────────
@@ -903,8 +915,7 @@ export async function getModelOptions(opts: { refresh?: boolean } = {}): Promise
     // a click-spammer is denied the EXPENSIVE upstream sweep without also being
     // handed a placeholder the rule below would have gone back for.
     if (now - lastExplicitRefreshAt >= EXPLICIT_REFRESH_MIN_GAP_MS || !cached) {
-      lastExplicitRefreshAt = now;
-      return load(true);
+      return forceCatalogRefresh(now, { unattended: false });
     }
   }
 
@@ -977,6 +988,261 @@ export async function getModelOptions(opts: { refresh?: boolean } = {}): Promise
 export function cachedModelOptions(): ModelOptionsPayload | null {
   if (!cached) return null;
   return Date.now() - cached.fetchedAt < STALE_MS ? cached : null;
+}
+
+// ── The catalogue's own age, and who keeps it young (TASK-781) ───────────────
+//
+// NOTHING ABOVE THIS LINE EVER REFRESHES THE MODEL LIST BY ITSELF.
+//
+// `fetchedAt`/`stale` on the payload describe THIS process's 60-second L1
+// cache, not the age of the model ids in it. Behind that cache sit two more,
+// and both can carry a list forward for days:
+//   - Hermes' `provider_models_cache.json`: 1 h TTL, but a SEVEN DAY
+//     stale-serve window (`_PROVIDER_MODELS_STALE_SERVE_MAX`), and its
+//     background SWR refresh only rewrites a row when the live fetch comes
+//     back non-empty — one failed re-fetch keeps the old ids with the entry's
+//     `at` unmoved.
+//   - `load(false)` above re-asks the dashboard but carries no `refresh=true`,
+//     so it re-reads that same disk row rather than busting it.
+// Only `?refresh=1` on the models route sends `refresh=true`, and it is
+// session-gated: a human had to click Refresh. Measured on the Hermes box —
+// eleven ids from 12:14 in the picker while the same credential listed
+// thirteen live, `claude-opus-5` and `claude-fable-5-1` missing until a click.
+//
+// THE HARNESS'S OWN REFRESH is what this drives, not a re-implementation:
+// `GET /api/model/options?refresh=true` on the Hermes dashboard, which is
+// exactly what `clear_provider_models_cache` + a live per-provider `/v1/models`
+// sweep is reachable as. (`hermes model --refresh` is the same sweep, but
+// `--refresh` is a modifier on the INTERACTIVE picker — see this file's header
+// — so it cannot be driven from a server.)
+
+/** Config-store key for {@link CatalogRefreshMark}. Beside `provider_verified_at`,
+ *  and for the same reason: it has to survive a restart. */
+export const CATALOG_REFRESH_KEY = "hermes_catalog_refreshed_at";
+
+/** Past this, the model list is old enough to say so. The owner's complaint was
+ *  a list a day stale; a catalogue changes on release timescales, so a day is
+ *  both the promise ("at least daily") and the honesty bound. */
+export const CATALOG_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The floor under RETRIES, which is a different question from the cadence.
+ *
+ * A refresh that fails leaves the mark where it was, so the catalogue stays
+ * due — and the driver below is called from a five-minute timer. Without this
+ * floor a box whose dashboard is down would sweep every authenticated
+ * provider's `/v1/models` 288 times a day. One attempt an hour still recovers
+ * a transient outage well inside the daily promise.
+ */
+const CATALOG_RETRY_MIN_GAP_MS = 60 * 60 * 1000;
+
+/**
+ * When this box last successfully ASKED the harness to re-read every
+ * provider's list, and when the unattended driver last tried. `null` = never.
+ *
+ * WHAT `checkedAt` DOES NOT MEAN, precisely: that every provider's upstream
+ * `/v1/models` answered. Hermes replies 200 to `?refresh=true` whether or not
+ * its own per-provider sweep succeeded — a provider whose key has expired
+ * keeps its previous ids and Hermes serves them — and the picker envelope
+ * carries NO per-provider timestamp to say otherwise (measured on v0.21.1: the
+ * row is `{slug, name, is_current, is_user_defined, models, total_models,
+ * source}`). So this is the age of the CHECK, which is what this box can
+ * honestly observe, and the fields are named for that.
+ */
+export interface CatalogRefreshMark {
+  checkedAt: number | null;
+  attemptedAt: number | null;
+}
+
+const NEVER: CatalogRefreshMark = { checkedAt: null, attemptedAt: null };
+
+/**
+ * The store's write is a read of the WHOLE config, one field changed, and a
+ * rename back — atomic for the file, not for the update. Two forced refreshes
+ * that overlap (both callers of one single-flighted `load(true)` reach the
+ * bookkeeping together) would each read the same base, and the second rename
+ * would drop whatever another writer had saved in between — a bot token, the
+ * mailbox password. The house pattern, and the one `recordProviderVerified`
+ * already wraps its own read-modify-write in.
+ */
+const markLock = createSerialLock();
+
+function normalizeMark(raw: unknown): CatalogRefreshMark {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return NEVER;
+  const rec = raw as Record<string, unknown>;
+  const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? v : null);
+  return { checkedAt: num(rec.checkedAt), attemptedAt: num(rec.attemptedAt) };
+}
+
+/**
+ * Never throws: a store that cannot be read means "we do not know when this
+ * list was last refreshed", which is the same answer as "never" — and the safe
+ * one, because it reads as stale rather than as fresh.
+ */
+export async function readCatalogRefreshMark(): Promise<CatalogRefreshMark> {
+  try {
+    return normalizeMark(await get(CATALOG_REFRESH_KEY));
+  } catch {
+    return NEVER;
+  }
+}
+
+/**
+ * Whether the unattended check is DUE. A box that has never recorded one is due
+ * immediately — that first sweep is what gives every later answer an anchor.
+ */
+export function catalogCheckDue(mark: CatalogRefreshMark, now = Date.now()): boolean {
+  return mark.checkedAt === null || now - mark.checkedAt >= CATALOG_MAX_AGE_MS;
+}
+
+/**
+ * How old the list is, FOR THE OWNER — and `null` where this box cannot say.
+ *
+ * NOT the same question as `catalogRefreshDue`, deliberately. "Nothing has ever
+ * recorded a refresh here" is not evidence that the list is old: on a box in
+ * its first five minutes, or one restored from a backup, Hermes' own catalogue
+ * may have been fetched moments ago. Painting that as stale is the false-
+ * failure class, and this route already refuses exactly that shape one field
+ * away — `verified` stays null for a provider nothing has exercised rather than
+ * reporting `false`, so an offline box is not shown a broken credential.
+ *
+ * COMPUTED AT READ TIME, never baked into a cached payload: a payload built at
+ * 23 h old would otherwise still call itself fresh two hours later, from the L1
+ * cache, with no one the wiser — the probe-once class.
+ */
+export function catalogStaleness(mark: CatalogRefreshMark, now = Date.now()): boolean | null {
+  if (mark.checkedAt === null) return null;
+  return now - mark.checkedAt >= CATALOG_MAX_AGE_MS;
+}
+
+/**
+ * Remember that a FORCED refresh happened, and whether it landed.
+ *
+ * THE ONLY WRITER, and it is called from `getModelOptions` rather than from the
+ * daily driver below, because the driver is not the only path that busts
+ * Hermes' disk cache: the owner's Refresh click (`?refresh=1`) and every
+ * credential write that goes through `hermes-cloud-provider` do the same work.
+ * Recording only our own would have reported a catalogue the owner had just
+ * refreshed by hand as a day stale — a false failure over an operation that
+ * succeeded.
+ *
+ * Never throws: this is bookkeeping about a refresh, not the refresh.
+ */
+async function noteForcedRefresh(
+  succeeded: boolean,
+  now: number,
+  { unattended }: { unattended: boolean },
+): Promise<void> {
+  try {
+    await markLock(async () => {
+      const mark = await readCatalogRefreshMark();
+      await set(CATALOG_REFRESH_KEY, {
+        // A failure leaves the age exactly where it was. Advancing it would hide
+        // a week-old list behind a fresh timestamp for another day.
+        checkedAt: succeeded ? now : mark.checkedAt,
+        // ONLY the driver's own attempts. `attemptedAt` exists to space out the
+        // driver's RETRIES and governs nothing else — stamping it from the
+        // owner's Refresh click would mean an owner clicking Refresh on a box
+        // with a flaky dashboard silently suppressed, for an hour, the
+        // automatic recovery they were trying to trigger.
+        attemptedAt: unattended ? now : mark.attemptedAt,
+      } satisfies CatalogRefreshMark);
+    });
+  } catch {
+    // A store we cannot write means the next tick tries again an hour early.
+    // Cheap, and the alternative — letting this reject — would take a heartbeat
+    // down with it.
+  }
+}
+
+/**
+ * Did this payload come from a live dashboard read, or is it the better copy we
+ * already had?
+ *
+ * `degraded` is the whole difference. The downgrade guard returns the KEPT
+ * payload when a refresh fails, and its `source` is still `dashboard` — reading
+ * that as a refresh is the false-success class exactly.
+ */
+function isLiveAnswer(payload: ModelOptionsPayload | null): boolean {
+  return payload !== null && payload.source === "dashboard" && !payload.degraded;
+}
+
+/**
+ * ONE forced refresh, and the bookkeeping that goes with it.
+ *
+ * Both callers land here — the owner's Refresh click through
+ * `getModelOptions({refresh:true})`, and the unattended driver below — so the
+ * age this box reports moves for whoever caused it, and the two can never
+ * record it differently. It also takes the explicit-refresh throttle out of the
+ * driver's answer: routing the driver through the public `getModelOptions`
+ * meant a click ten seconds earlier made it fall through to the plain path and
+ * still report `"refreshed"`, with nothing refreshed and the mark untouched.
+ */
+async function forceCatalogRefresh(
+  now: number,
+  opts: { unattended: boolean },
+): Promise<ModelOptionsPayload> {
+  lastExplicitRefreshAt = now;
+  const payload = await load(true);
+  await noteForcedRefresh(isLiveAnswer(payload), now, opts);
+  return payload;
+}
+
+export type CatalogRefreshOutcome =
+  /** Not a Hermes box — there is no dashboard to ask. */
+  | "skipped"
+  /** Checked less than `CATALOG_MAX_AGE_MS` ago. */
+  | "not-due"
+  /** Due, but the driver's last attempt was inside `CATALOG_RETRY_MIN_GAP_MS`. */
+  | "throttled"
+  /** The harness was asked to re-read its providers' lists and answered. */
+  | "refreshed"
+  /** Asked and did not get a live answer. The mark is NOT advanced. */
+  | "failed";
+
+/**
+ * Ask the harness to re-read every authenticated provider's model list, at most
+ * once a day, from something that runs with nobody watching.
+ *
+ * Its one caller is the five-minute heartbeat tick — the only thing on a
+ * running box that fires without anyone touching it, which is why the deferred
+ * language persona already rides it. Cheap on the 287 ticks a day that are not
+ * the one: an edition read and a config-store read decide, and both stop there.
+ *
+ * NOT AWAITED by that caller, and it must stay that way. The tick's own unit
+ * runs `curl --max-time 10`, and `checkTunnelLiveness` already documents a
+ * 7.5 s worst case inside that budget on precisely the dead-tunnel path that
+ * restarts the tunnel — so a slow dashboard added in front of it would push the
+ * repair past the deadline, where `SuccessExitStatus=0 7 22 28` would report
+ * the truncated tick as a success.
+ *
+ * NEVER THROWS and never rejects, so a bare `void` call cannot become an
+ * unhandled rejection.
+ */
+export async function refreshCatalogIfDue(now = Date.now()): Promise<CatalogRefreshOutcome> {
+  try {
+    // GATED ON THE HARNESS, and here rather than at the call site, because the
+    // caller is the edition-agnostic heartbeat and this is the one function in
+    // it that is about Hermes. On an OpenClaw box there is no Hermes dashboard
+    // to ask — and its own catalogue does not need this: that route already
+    // re-enumerates on the read path once its cache passes six hours, with no
+    // click and no session (see setup-api/ai-models/catalog/route.ts).
+    if ((await getActiveHarness()) !== "hermes") return "skipped";
+
+    const mark = await readCatalogRefreshMark();
+    if (!catalogCheckDue(mark, now)) return "not-due";
+    if (mark.attemptedAt !== null && now - mark.attemptedAt < CATALOG_RETRY_MIN_GAP_MS) {
+      return "throttled";
+    }
+
+    return isLiveAnswer(await forceCatalogRefresh(now, { unattended: true }))
+      ? "refreshed"
+      : "failed";
+  } catch {
+    // Quiet on failure, by contract. The next tick past the retry floor asks
+    // again; nothing on screen changes because nothing on screen was promised.
+    return "failed";
+  }
 }
 
 // ── Scoping (REQ 1) ──────────────────────────────────────────────────────────

--- a/src/tests/routes/hermes/catalog-daily-refresh.test.ts
+++ b/src/tests/routes/hermes/catalog-daily-refresh.test.ts
@@ -1,0 +1,372 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * TASK-781 — the picker's model list never refreshed by itself.
+ *
+ * MEASURED on the Hermes box (Hermes v0.21.1): the Anthropic row served eleven
+ * model ids written at 12:14, while the same credential listed thirteen live —
+ * `claude-opus-5` and `claude-fable-5-1` were simply missing from the picker.
+ * `GET /setup-api/hermes/models?refresh=1` re-fetched and both appeared.
+ *
+ * WHY IT COULD SIT THERE. Two caches, and nothing forcing either:
+ *   - Hermes' own `provider_models_cache.json` has a 1 h TTL but a SEVEN DAY
+ *     stale-serve window (`_PROVIDER_MODELS_STALE_SERVE_MAX`). Its background
+ *     SWR refresh only rewrites the row when the live fetch comes back
+ *     non-empty (`if live:` in `cached_provider_model_ids`), so one failed
+ *     re-fetch carries the old ids forward — with the entry's `at` unmoved.
+ *   - ClawBox's own layer (`hermes-model-options.ts`) only ever sends
+ *     `refresh=true` to `/api/model/options` when a human clicks Refresh:
+ *     `?refresh=1` on this route, and that is session-gated. Its background
+ *     `load(false)` re-asks the dashboard but does NOT bust Hermes' disk cache,
+ *     so it re-serves the same stale ids.
+ *
+ * So the list only ever moved when the owner clicked. That is the defect: a
+ * user had to know to click Refresh — or re-sign-in — to see a model that
+ * shipped a week ago.
+ *
+ * The two things this pins:
+ *   1. Something that fires WITHOUT the owner forces a real re-fetch at least
+ *      daily. The only thing on a running box that fires with nobody touching
+ *      it is `clawbox-heartbeat.timer` — which is why the deferred language
+ *      persona already rides it.
+ *   2. The payload says how old the list is, calls it stale past 24 h, and says
+ *      "not checked" rather than "old" where it cannot tell.
+ *      `fetchedAt`/`stale` already in the payload cannot answer that: they
+ *      describe ClawBox's own 60-second L1 cache, so a week-old catalogue
+ *      reports `fetchedAt` = "two seconds ago", `stale: false`.
+ */
+
+const dashboardFetchMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/hermes-dashboard-auth", () => ({
+  dashboardFetch: dashboardFetchMock,
+  __esModule: true,
+}));
+
+const runHermesCliMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: runHermesCliMock }));
+
+const readFileMock = vi.hoisted(() => vi.fn());
+vi.mock("fs/promises", () => ({
+  default: { readFile: readFileMock },
+  readFile: readFileMock,
+}));
+
+// The config store, in memory: this is where the last SUCCESSFUL forced refresh
+// is remembered, and it has to survive a Next.js restart the way the provider
+// verification marks beside it do.
+const store = vi.hoisted(() => new Map<string, unknown>());
+vi.mock("@/lib/config-store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/config-store")>()),
+  get: vi.fn(async (key: string) => store.get(key)),
+  set: vi.fn(async (key: string, value: unknown) => {
+    store.set(key, value);
+  }),
+}));
+
+const activeHarnessMock = vi.hoisted(() => vi.fn(async () => "hermes"));
+vi.mock("@/lib/harness", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/harness")>()),
+  getActiveHarness: activeHarnessMock,
+}));
+
+// The models route's self-repairs spawn `hermes`; they are not what is under
+// test here.
+vi.mock("@/lib/hermes-local-ai", () => ({ reconcileLocalAiWithHermes: vi.fn(async () => {}) }));
+vi.mock("@/lib/hermes-clawai", () => ({ reconcileClawaiModelsWithHermes: vi.fn(async () => {}) }));
+
+// Everything the heartbeat tick does that is not this. The tunnel is alive, so
+// the route takes its ordinary path.
+vi.mock("@/lib/language-persona", () => ({ applyDeferredLanguagePersona: vi.fn(async () => false) }));
+vi.mock("@/lib/cloudflared", () => ({
+  readTunnelUrl: vi.fn(async () => "https://example.trycloudflare.com"),
+  startTunnelService: vi.fn(async () => ({ bootPersisted: true, bootPersistWarning: null })),
+}));
+vi.mock("@/lib/portal-heartbeat", () => ({ pushHeartbeatTick: vi.fn() }));
+vi.mock("@/lib/tunnel-liveness", () => ({
+  checkTunnelLiveness: vi.fn(async () => "alive"),
+  mayRestart: vi.fn(() => true),
+  markRestarted: vi.fn(),
+}));
+vi.mock("@/lib/route-auth", () => ({ requireSession: vi.fn(async () => null) }));
+vi.mock("@/lib/internal-token", () => ({ isInternalRequest: vi.fn(() => true) }));
+
+/** The device: Anthropic, and the two ids the box could not see. */
+const LIVE_MODELS = [
+  "claude-opus-4-8",
+  "claude-sonnet-4-6",
+  "claude-opus-5",
+  "claude-fable-5-1",
+];
+
+const DEVICE: Record<string, string> = {
+  "model.provider": "anthropic",
+  "model.default": "claude-opus-4-8",
+  "agent.reasoning_effort": "medium",
+};
+
+function dashboardUp() {
+  dashboardFetchMock.mockImplementation(async (path: string) => {
+    if (!String(path).startsWith("/api/model/options")) {
+      return { ok: true, status: 200, json: async () => ({}) };
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        providers: [{
+          slug: "anthropic",
+          name: "Anthropic",
+          authenticated: true,
+          source: "dashboard",
+          total_models: LIVE_MODELS.length,
+          models: LIVE_MODELS,
+        }],
+        provider: "anthropic",
+        model: "claude-opus-4-8",
+      }),
+    };
+  });
+}
+
+/** Every `/api/model/options` call that asked Hermes to bust its disk cache. */
+function forcedRefreshCalls(): string[] {
+  return dashboardFetchMock.mock.calls
+    .map((c) => String(c[0]))
+    .filter((p) => p.startsWith("/api/model/options") && p.includes("refresh=true"));
+}
+
+async function tick() {
+  const mod = await import("@/app/setup-api/portal/heartbeat-tick/route");
+  return mod.GET(new Request("http://127.0.0.1/setup-api/portal/heartbeat-tick"));
+}
+
+async function models() {
+  const mod = await import("@/app/setup-api/hermes/models/route");
+  const res = await mod.GET(new Request("http://127.0.0.1/setup-api/hermes/models"));
+  return res.json() as Promise<Record<string, unknown>>;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  store.clear();
+  dashboardFetchMock.mockReset();
+  runHermesCliMock.mockReset();
+  readFileMock.mockReset();
+  readFileMock.mockRejectedValue(new Error("ENOENT"));
+  runHermesCliMock.mockImplementation(async (args: string[]) => ({
+    stdout: DEVICE[args[2]] ?? "",
+    stderr: "",
+    code: 0,
+  }));
+  activeHarnessMock.mockResolvedValue("hermes");
+  dashboardUp();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("TASK-781 — the catalogue refreshes without the owner", () => {
+  it("forces a re-fetch on the heartbeat when the list was last refreshed a day ago", async () => {
+    // The box has been up for a week. The last time anything actually made
+    // Hermes go and ask Anthropic what it serves was 25 hours ago.
+    store.set("hermes_catalog_refreshed_at", {
+      checkedAt: Date.now() - 25 * 60 * 60 * 1000,
+      attemptedAt: Date.now() - 25 * 60 * 60 * 1000,
+    });
+
+    const res = await tick();
+    expect(res.status).toBe(200);
+
+    // ON BETA: zero, for ever. The tick knows nothing about the catalogue, and
+    // no other unattended path on the box ever sends `refresh=true` — so the
+    // eleven ids written at 12:14 stay in the picker until a human clicks
+    // Refresh.
+    //
+    // Awaited with `waitFor`, not by the route: the tick fires this and moves
+    // on, because its unit runs `curl --max-time 10` and the dead-tunnel repair
+    // underneath already budgets 7.5 s of that for DNS.
+    await vi.waitFor(() => expect(forcedRefreshCalls()).toHaveLength(1));
+  });
+
+  it("reports the catalogue's age, and calls it stale past a day", async () => {
+    const checkedAt = Date.now() - 25 * 60 * 60 * 1000;
+    store.set("hermes_catalog_refreshed_at", { checkedAt, attemptedAt: checkedAt });
+
+    const body = await models();
+
+    // ON BETA: both undefined. `fetchedAt` and `stale` are already in this
+    // payload and cannot answer the question — they describe ClawBox's own
+    // 60-second cache, so this week-old catalogue reports itself fresh.
+    expect(body.catalogCheckedAt).toBe(checkedAt);
+    expect(body.catalogStale).toBe(true);
+    expect(body.stale).toBe(false);
+  });
+
+  it("says \"not checked\" — never \"old\" — for a catalogue nothing has refreshed yet", async () => {
+    // A box in its first five minutes, or one restored from a backup, has no
+    // recorded refresh and a list Hermes may have fetched moments ago. Painting
+    // that stale is the false-failure class, and this route already refuses the
+    // same shape one field away: `verified` stays null for a provider nothing
+    // has exercised rather than reporting `false`.
+    const body = await models();
+
+    expect(body.catalogCheckedAt).toBeNull();
+    expect(body.catalogStale).toBeNull();
+  });
+
+  it("calls a catalogue refreshed within the day fresh", async () => {
+    const checkedAt = Date.now() - 60 * 60 * 1000;
+    store.set("hermes_catalog_refreshed_at", { checkedAt, attemptedAt: checkedAt });
+
+    const body = await models();
+
+    expect(body.catalogCheckedAt).toBe(checkedAt);
+    expect(body.catalogStale).toBe(false);
+  });
+
+  it("carries the age onto the scoped reply the picker reads", async () => {
+    const checkedAt = Date.now() - 25 * 60 * 60 * 1000;
+    store.set("hermes_catalog_refreshed_at", { checkedAt, attemptedAt: checkedAt });
+
+    const mod = await import("@/app/setup-api/hermes/models/route");
+    const res = await mod.GET(
+      new Request("http://127.0.0.1/setup-api/hermes/models?provider=anthropic"),
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(body.catalogCheckedAt).toBe(checkedAt);
+    expect(body.catalogStale).toBe(true);
+  });
+});
+
+describe("TASK-781 — the refresh is bounded and quiet", () => {
+  it("does not remember a refresh that failed, and retries on a floor rather than every tick", async () => {
+    dashboardFetchMock.mockRejectedValue(new Error("connect ECONNREFUSED"));
+
+    const res = await tick();
+    // A dashboard that is down is not a failed heartbeat.
+    expect(res.status).toBe(200);
+
+    // A failure must not be recorded as a check — the catalogue is still as old
+    // as it was, and saying otherwise would hide it for another day.
+    await vi.waitFor(() => {
+      const mark = store.get("hermes_catalog_refreshed_at") as {
+        checkedAt: number | null;
+        attemptedAt: number | null;
+      };
+      expect(mark.checkedAt).toBeNull();
+      // ...but the attempt IS recorded, which is what spaces out the retries.
+      expect(mark.attemptedAt).toBeGreaterThan(0);
+    });
+  });
+
+  it("remembers a check that succeeded, and serves the models it brought back", async () => {
+    const before = Date.now();
+    await tick();
+
+    await vi.waitFor(() => {
+      const mark = store.get("hermes_catalog_refreshed_at") as { checkedAt: number };
+      expect(mark.checkedAt).toBeGreaterThanOrEqual(before);
+    });
+
+    const body = await models();
+    expect(body.catalogStale).toBe(false);
+    // The two ids the owner could not see, in the list, with nothing clicked.
+    const ids = (body.models as { id: string }[]).map((m) => m.id);
+    expect(ids).toContain("claude-opus-5");
+    expect(ids).toContain("claude-fable-5-1");
+  });
+
+  it("counts the owner's own Refresh click as a refresh", async () => {
+    // The sibling call site. `?refresh=1` busts exactly the same Hermes disk
+    // cache the daily driver does, so if only the driver recorded it, a box the
+    // owner had just refreshed by hand would still report its list a day stale
+    // — a false failure over an operation that succeeded.
+    const stale = Date.now() - 30 * 60 * 60 * 1000;
+    store.set("hermes_catalog_refreshed_at", { checkedAt: stale, attemptedAt: stale });
+
+    const mod = await import("@/app/setup-api/hermes/models/route");
+    const before = Date.now();
+    const res = await mod.GET(new Request("http://127.0.0.1/setup-api/hermes/models?refresh=1"));
+
+    const mark = store.get("hermes_catalog_refreshed_at") as { checkedAt: number };
+    expect(mark.checkedAt).toBeGreaterThanOrEqual(before);
+
+    // ...AND the very response that performed it says so. Reading the mark
+    // beside the refresh instead of after it made the one action that fixes
+    // staleness answer `catalogStale: true`.
+    const refreshed = (await res.json()) as Record<string, unknown>;
+    expect(refreshed.catalogStale).toBe(false);
+    expect(refreshed.catalogCheckedAt).toBeGreaterThanOrEqual(before);
+
+    const body = await models();
+    expect(body.catalogStale).toBe(false);
+  });
+
+  it("forces nothing on an OpenClaw box", async () => {
+    // There is no Hermes dashboard to ask. The tick still has to answer 200.
+    activeHarnessMock.mockResolvedValue("openclaw");
+    store.set("hermes_catalog_refreshed_at", { checkedAt: null, attemptedAt: null });
+
+    const res = await tick();
+
+    expect(res.status).toBe(200);
+    // Settle every microtask the fire-and-forget could have queued before
+    // concluding that nothing was asked.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(forcedRefreshCalls()).toHaveLength(0);
+  });
+
+  // These are the gates themselves, driven with an explicit clock. The tick
+  // tests above prove the WIRING; only here can the daily cadence and the retry
+  // floor actually be exercised, because two ticks milliseconds apart are held
+  // by the module's own pre-existing 10 s explicit-refresh throttle and would
+  // pass with both gates deleted.
+  it("says which of the five things it did", async () => {
+    const { CATALOG_REFRESH_KEY, CATALOG_MAX_AGE_MS, refreshCatalogIfDue } =
+      await import("@/lib/hermes-model-options");
+    const now = Date.now();
+    const due = now - CATALOG_MAX_AGE_MS - 1;
+
+    activeHarnessMock.mockResolvedValue("openclaw");
+    expect(await refreshCatalogIfDue(now)).toBe("skipped");
+
+    activeHarnessMock.mockResolvedValue("hermes");
+    // Checked a second ago: the daily cadence holds.
+    store.set(CATALOG_REFRESH_KEY, { checkedAt: now - 1_000, attemptedAt: now - 1_000 });
+    expect(await refreshCatalogIfDue(now)).toBe("not-due");
+
+    // Due, but the driver itself tried a minute ago: the retry floor holds. A
+    // box whose dashboard is down would otherwise sweep every authenticated
+    // provider's /v1/models 288 times a day.
+    store.set(CATALOG_REFRESH_KEY, { checkedAt: due, attemptedAt: now - 60_000 });
+    expect(await refreshCatalogIfDue(now)).toBe("throttled");
+
+    store.set(CATALOG_REFRESH_KEY, { checkedAt: due, attemptedAt: due });
+    expect(await refreshCatalogIfDue(now)).toBe("refreshed");
+
+    // A dashboard that will not answer is "failed", and leaves the age alone.
+    dashboardFetchMock.mockRejectedValue(new Error("connect ECONNREFUSED"));
+    store.set(CATALOG_REFRESH_KEY, { checkedAt: due, attemptedAt: due });
+    expect(await refreshCatalogIfDue(now)).toBe("failed");
+    expect(store.get(CATALOG_REFRESH_KEY)).toEqual({ checkedAt: due, attemptedAt: now });
+  });
+
+  it("does not let the owner's failed Refresh throttle the unattended retry", async () => {
+    // `attemptedAt` spaces out the DRIVER's retries and governs nothing else.
+    // Stamped from the owner's click too, an owner hammering Refresh on a box
+    // with a flaky dashboard would silently suppress, for an hour, the
+    // automatic recovery they were trying to trigger.
+    const { CATALOG_REFRESH_KEY, CATALOG_MAX_AGE_MS } =
+      await import("@/lib/hermes-model-options");
+    const due = Date.now() - CATALOG_MAX_AGE_MS - 1;
+    store.set(CATALOG_REFRESH_KEY, { checkedAt: due, attemptedAt: due });
+    dashboardFetchMock.mockRejectedValue(new Error("connect ECONNREFUSED"));
+
+    const route = await import("@/app/setup-api/hermes/models/route");
+    await route.GET(new Request("http://127.0.0.1/setup-api/hermes/models?refresh=1"));
+
+    expect(store.get(CATALOG_REFRESH_KEY)).toEqual({ checkedAt: due, attemptedAt: due });
+  });
+});


### PR DESCRIPTION
**TASK-781** — Hermes picker: refresh the provider model list by itself daily, show its age, and drop exhausted duplicate grants.

## What the owner saw

On a Hermes box the Anthropic picker was missing `claude-opus-5` and `claude-fable-5-1` while the very same credential listed them live. The only way to see them was to click **Refresh** (or re-sign-in). Measured on the box (Hermes Agent v0.21.1): the picker served eleven ids written at **12:14**; `GET /setup-api/hermes/models?refresh=1` re-fetched and the list became **thirteen**, with both new models present.

## Cause

Nothing on the box ever forces the harness to re-read what each provider serves. Three layers, none of which recovers on its own:

- **Hermes' `provider_models_cache.json`** — `_PROVIDER_MODELS_CACHE_TTL` is 1 h, but `_PROVIDER_MODELS_STALE_SERVE_MAX` is **seven days**, and `_spawn_swr_refresh` only calls `_store_cache_entry` when the live fetch comes back non-empty. One failed re-fetch carries the old ids forward with the entry's `at` unmoved.
- **ClawBox's own layer** (`hermes-model-options.ts`) — its background `load(false)` re-asks the dashboard but carries no `refresh=true`, so it re-reads that same disk row rather than busting it.
- **`?refresh=1`** is the only path that sends `refresh=true`, and it is session-gated. A human had to click.

So the list only ever moved when the owner clicked — which is the defect: a user had to know to click Refresh to see a model that shipped a week ago.

## Harness-first: the native mechanisms, named

- **Forced refresh — used.** `GET /api/model/options?refresh=true` on the Hermes dashboard is the harness's own `clear_provider_models_cache` + live per-provider `/v1/models` sweep. ClawBox already had a verified client for it (`fetchFromDashboard`); this PR only drives it on a schedule. Nothing is re-implemented.
- **`hermes model --refresh` — exists, unusable from a server.** `hermes model --help` on v0.21.1: *"Wipe the model picker disk cache and re-fetch every provider's live /v1/models list"* — but `hermes model` is the **interactive picker** ("Interactively select your inference provider and default model"), so `--refresh` is a modifier on a TUI, not a standalone command. The module header already recorded this; re-confirmed on v0.21.1.
- **A periodic refresh inside Hermes — none exists.** `prewarm_picker_cache_async()` has exactly two non-test call sites, `tui_gateway/entry.py:269` and `cli.py:3662`, both at interactive startup. There is no timer, no daemon, nothing that re-reads a catalogue on a cadence.
- **Unattended driver — ClawBox's own established pattern.** `clawbox-heartbeat.timer` → `GET /setup-api/portal/heartbeat-tick`, every 5 min, as the `clawbox` user, with the per-install internal token. No new unit, no new route, no owner cookie. `applyDeferredLanguagePersona()` already rides this tick, with the rationale written in the route: *"the heartbeat is the only thing on a running box that fires without anyone touching it"*.
- **Per-provider catalogue age from the harness — not available.** The picker row Hermes builds is `{slug, name, is_current, is_user_defined, models, total_models, source}` (`hermes_cli/model_switch_providers.py:635-639`) — **no timestamp**. That is a genuine harness gap: ClawBox cannot report the true age of the list, only the age of its own last successful check, and the fields are named for exactly that (`catalogCheckedAt`, not `catalogRefreshedAt`).

## The change

1. **Daily unattended check.** `refreshCatalogIfDue()` rides the heartbeat tick: at most once per 24 h, at most one driver retry per hour when it fails, **fire-and-forget** (the unit runs `curl --max-time 10` and the dead-tunnel repair below already budgets 7.5 s of that for DNS, so awaiting it would truncate the tick on exactly the pass that repairs the tunnel), never throwing, and a no-op unless the active harness is Hermes.
2. **The list's age in the payload.** `catalogCheckedAt` and `catalogStale` on both the unscoped and the scoped reply. `fetchedAt`/`stale` could not answer this — they describe ClawBox's own 60-second L1 cache, so a week-old catalogue reported `fetchedAt` two seconds ago and `stale: false`. Computed per request, never baked into the cached payload (a payload built at 23 h old would otherwise still call itself fresh two hours later), and read **after** the refresh so a `?refresh=1` does not answer "stale" over the one action that fixes staleness.
3. **Unknown is not "old".** A box that has never recorded a check reports `null`, not `true` — the rule this route already follows one field away, where `verified` stays null for a provider nothing has exercised rather than reporting `false`. Without it a box in its first five minutes, one restored from a backup, and a dual box running OpenClaw all reported the list a day stale.

## Requirement (3) — exhausted duplicate grants: measured, and deliberately NOT auto-pruned

The card asks for exhausted/revoked duplicate grants to be pruned "via Hermes' native auth commands if they exist (name them)". They exist, and auto-using them would be wrong.

**Native commands:** `hermes auth list | remove <provider> <target> | reset <provider> [target] | refresh <provider> [target] | priority <provider> <target> <n> | status <provider>`.

**Why ClawBox must not call `remove` on its own:**
- `exhausted` is Hermes' **recoverable** bucket by design; `dead` is the permanent one (`credential_pool.py:78-84`). Deleting an exhausted row deletes a credential the pool is actively planning to bring back.
- A rate-limited credential is **indistinguishable** from a revoked one in stored state. On the measured box the exhausted row carries `last_error_code: null`, `last_error_reason: null`, `last_error_reset_at: null` — `hermes auth list` prints only `exhausted (43m 9s left)`, and that countdown is computed at read time, never stored. Auto-deleting on that signal deletes healthy rate-limited credentials.
- The delete is irreversible for manual sources: `remove_index` pops the entry and persists with `removed_ids`, taking the OAuth refresh token with it. The box's priority-0 row is `manual:dashboard_pkce`; nothing re-seeds a `manual:*` source, so removing one forces a full re-auth.
- For the row in question it would also be pointless churn: `hermes_pkce` is re-created by `_seed_anthropic_singletons` from `~/.hermes/.anthropic_oauth.json` on the next `load_pool`, so `remove` there is an undocumented way of doing `auth reset`.
- Hermes already self-prunes: DEAD `manual:*` entries go after `DEAD_MANUAL_PRUNE_TTL_SECONDS` (24 h).

**And on this box the premise does not hold anyway.** Both Anthropic pool entries are OAuth, and the OAuth resolver `_resolve_anthropic_pool_token` enumerates with `_available_entries`, which skips `STATUS_EXHAUSTED` while `now < exhausted_until` — so the cooling-down entry cannot be picked for a catalogue fetch. There **is** a status-blind path (`_resolve_anthropic_pool_catalog_credentials`, `models.py:1598`, a raw `read_credential_pool` that checks no `last_status`), but it only fires for an `api_key` row, which this box does not have. Real in code, latent here.

So: named, measured, and no auto-prune. Doing it safely means acting on `dead` only — which Hermes already does for itself.

## OpenClaw edition (requirement 4) — checked, and the same shape does not exist

`src/app/setup-api/ai-models/catalog/route.ts:1601-1632` already force-refreshes **on the read path** when its cache passes `REFRESH_INTERVAL_MS` (6 h) — no session, no button, no `?refresh=1` required (`?refresh=1` there is deliberately demoted to a nudge). The "only an owner click ever busts the cache" defect is Hermes-only. Nothing changed for OpenClaw beyond the driver no-opping there.

## RED → GREEN

RED, on unmodified `origin/beta` (9694b9a8), the final test file copied into a clean beta worktree — **9 of 11 fail**:

```
 ❯ src/tests/routes/hermes/catalog-daily-refresh.test.ts (11 tests | 9 failed)
     × forces a re-fetch on the heartbeat when the list was last refreshed a day ago
     × reports the catalogue's age, and calls it stale past a day
     × says "not checked" — never "old" — for a catalogue nothing has refreshed yet
     × calls a catalogue refreshed within the day fresh
     × carries the age onto the scoped reply the picker reads
     × does not remember a refresh that failed, and retries on a floor rather than every tick
     × remembers a check that succeeded, and serves the models it brought back
     × counts the owner's own Refresh click as a refresh
     × says which of the five things it did

AssertionError: expected [] to have a length of 1 but got +0
 ❯ ...:189  await vi.waitFor(() => expect(forcedRefreshCalls()).toHaveLength(1));

AssertionError: expected undefined to be 1788857153318
 ❯ ...  expect(body.catalogCheckedAt).toBe(checkedAt);
```

(The two that pass on beta are the negatives — the OpenClaw no-op and "a failed owner Refresh must not throttle the driver" — both trivially true where nothing writes the key at all.)

GREEN, on the branch:

```
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

Neighbouring suites (`src/tests/routes/hermes`, `heartbeat-tick`, the four `hermes-model-options-*` units):

```
 Test Files  41 passed (41)
      Tests  453 passed (453)
```

Whole suite, `tsc --noEmit` and `eslint` on the changed files all clean:

```
 Test Files  999 passed (999)
      Tests  15053 passed | 1 skipped (15054)
```

## Sibling call sites

Every `getModelOptions` caller was swept. Only `hermes-cloud-provider.ts:141` passes `{refresh:true}` besides the models route; `provider-mcp-refresh.ts:99`, `provider-status.ts:287`, `hermes/chat/route.ts:1027` and the route's own POST pass no `refresh`, so the bookkeeping cannot fire from them. Both forced-refresh paths now go through one helper, so the owner's Refresh click records the check too — otherwise a box the owner had just refreshed by hand still reported its list a day stale. `ScopedModelsReply` has exactly one producer (the models route, updated); the MCP reader (`mcp/tools/ai.ts`) reads a subset and is unaffected by the additive fields.

## Review

One review (`clawbox-review`), findings applied: the age being read *before* the refresh (a successful `?refresh=1` answering `catalogStale: true`); the awaited call pushing the tick past `curl --max-time 10` on the dead-tunnel repair path; `isLiveAnswer` naming a 200 from the dashboard "the list was re-fetched" (fixed by naming the field for what it measures and reporting the harness gap above); "never checked" reported as stale; the read-modify-write of `data/config.json` without the house `createSerialLock`; `attemptedAt` stamped from the owner's click, letting a hammered Refresh suppress the automatic retry for an hour; and two throttle tests that passed with their gates deleted (they leaned on the pre-existing 10 s explicit-refresh window — the gates are now driven with an explicit clock).

## Known gap, deliberately not in this PR

No surface renders the age yet — this PR delivers the API contract. A line under the model select needs a new i18n key across all ten locales, and it belongs with a design for what "checked 3 hours ago" should say.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Hermes model catalogue now refreshes automatically about once per day.
  * Model catalogue responses now show when the catalogue was last checked and whether it may be outdated.
  * Manual catalogue refreshes are tracked, and failed refresh attempts are handled without blocking heartbeat updates.

* **Bug Fixes**
  * Improved retry handling after unsuccessful catalogue refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
