### PR TITLE
Five fixes found upgrading a box from main to beta (v3.9.0 → v4.0.0)

### DIFF
--- a/e2e/chat-popup.spec.ts
+++ b/e2e/chat-popup.spec.ts
@@ -180,6 +180,45 @@ test("chat popup connects, streams a reply, and supports panel docking", async (
   await expect(page.getByTitle("Dock to right")).toBeVisible();
 });
 
+test("chat popup stays silent on a box whose agent has been introduced", async ({ page }) => {
+  // The common case on a real box, and the one the greet used to get wrong: an
+  // empty transcript is not a first conversation. A cleared conversation, a
+  // reset session and a box introduced months ago all look identical, and every
+  // one of them used to be answered with an unasked-for "hi" that spent a model
+  // turn and put a word in the owner's mouth.
+  await installFakeGatewaySocket(page);
+
+  await installClawboxMocks(page, {
+    timeoutCapMs: 300_000,
+    kvEntries: { "clawbox-mascot-hidden": "1" },
+    // No introduction waiting: BOOTSTRAP.md is gone because the ritual finished.
+    chatFacts: { onboardingArmed: false },
+    initialSetup: {
+      setup_complete: true,
+      wifi_configured: true,
+      update_completed: true,
+      password_configured: true,
+      ai_model_configured: true,
+      telegram_configured: true,
+    },
+    preferences: { ui_mascot_hidden: 1 },
+  });
+
+  await page.goto("/");
+  await expect(page.getByTestId("desktop-root")).toBeVisible();
+
+  await openChatPopup(page);
+
+  // The composer is usable and the transcript is empty: nothing was sent, so
+  // the fake gateway — which answers "hi" and nothing else with that line —
+  // never replied. Asserted against the gateway's OWN reply rather than a
+  // generic empty check, so a turn that went out under any other text still
+  // fails this.
+  await expect(page.getByTestId("chat-composer-row")).toBeVisible();
+  await expect(page.getByText("Hello from the fake gateway")).toHaveCount(0);
+  await expect(page.getByText(/Fake gateway heard:/)).toHaveCount(0);
+});
+
 test("chat popup lets you switch to Local AI when it is configured", async ({ page }) => {
   await installFakeGatewaySocket(page);
 

--- a/e2e/chat-popup.spec.ts
+++ b/e2e/chat-popup.spec.ts
@@ -60,6 +60,12 @@ async function installFakeGatewaySocket(page: Page) {
         }
 
         if (message.method === "chat.history") {
+          // Counted so a test can wait for the transcript read to have HAPPENED
+          // before asserting that nothing was sent. Without that, "no turn went
+          // out" is asserted before the greeting path could have run and would
+          // pass against a regression that still greets.
+          const w = window as unknown as { __chatHistoryReads?: number };
+          w.__chatHistoryReads = (w.__chatHistoryReads ?? 0) + 1;
           emit({
             type: "res",
             id: message.id,
@@ -78,7 +84,10 @@ async function installFakeGatewaySocket(page: Page) {
           // the greeting's words after typing found that bubble AND the new
           // one — the same text twice, which a strict locator refuses — and
           // passed only when it looked before the second reply landed.
+          const w = window as unknown as { __chatSends?: string[] };
+          w.__chatSends = w.__chatSends ?? [];
           const sent = String((message.params as { message?: unknown } | undefined)?.message ?? "");
+          w.__chatSends.push(sent);
           const reply = sent === "hi" ? "Hello from the fake gateway" : `Fake gateway heard: ${sent}`;
           emit({
             type: "res",
@@ -215,8 +224,28 @@ test("chat popup stays silent on a box whose agent has been introduced", async (
   // generic empty check, so a turn that went out under any other text still
   // fails this.
   await expect(page.getByTestId("chat-composer-row")).toBeVisible();
+
+  // Wait for the transcript read to have HAPPENED before claiming nothing was
+  // sent. `toHaveCount(0)` on its own succeeds the moment the composer renders,
+  // which is before the greeting path has had its chance — so a regression that
+  // still greets would sail past it. The read is the input the greet decision
+  // waits on, so once it has landed, a box that was going to greet has.
+  await expect
+    .poll(() => page.evaluate(() => (window as unknown as { __chatHistoryReads?: number }).__chatHistoryReads ?? 0))
+    .toBeGreaterThan(0);
+
+  // A settle window, because this is a NEGATIVE assertion: polling for an empty
+  // array succeeds on its first evaluation, so without a pause it proves only
+  // that nothing had been sent yet. The greet waits on two inputs — the read
+  // above and the capabilities fetch — and this covers the gap between them.
+  await page.waitForTimeout(1000);
+
+  // Asserted on what reached the WIRE, not on what is painted: a turn that went
+  // out and whose reply merely had not rendered yet would still fail this.
+  expect(
+    await page.evaluate(() => (window as unknown as { __chatSends?: string[] }).__chatSends ?? []),
+  ).toEqual([]);
   await expect(page.getByText("Hello from the fake gateway")).toHaveCount(0);
-  await expect(page.getByText(/Fake gateway heard:/)).toHaveCount(0);
 });
 
 test("chat popup lets you switch to Local AI when it is configured", async ({ page }) => {

--- a/e2e/helpers/clawbox.ts
+++ b/e2e/helpers/clawbox.ts
@@ -48,6 +48,35 @@ type MockOptions = {
   files?: FileTree;
   storeApps?: StoreCatalogApp[];
   timeoutCapMs?: number;
+  /**
+   * Overrides for `/setup-api/chat/capabilities`, merged over CHAT_FACTS.
+   *
+   * Pass `{ onboardingArmed: false }` for a box whose agent has already been
+   * introduced — the chat then opens silently, which is what nearly every real
+   * box does.
+   */
+  chatFacts?: Record<string, unknown>;
+};
+
+/**
+ * The chat capability facts the mocked box reports.
+ *
+ * All false but `onboardingArmed`, which keeps the specs' status quo: the chat
+ * used to open a first conversation on any empty transcript, so every spec that
+ * opened it got a greeting and the fake gateway's reply to it. That greet is
+ * now gated on the agent having an introduction waiting, and this is where the
+ * mocked box says it has one. A spec that wants the silent case — the common
+ * one on a real box — passes `chatFacts: { onboardingArmed: false }`.
+ */
+const CHAT_FACTS = {
+  hasClawaiToken: false,
+  hermesSupportsImages: false,
+  hermesHasVisionRoute: false,
+  hermesStreamsTurns: false,
+  hasClawaiImageRoute: false,
+  hermesAgentDrawsImages: false,
+  hermesSpeaksReplies: false,
+  onboardingArmed: true,
 };
 
 const DEFAULT_SETUP: SetupState = {
@@ -649,6 +678,25 @@ export async function installClawboxMocks(page: Page, options: MockOptions = {})
     // store-flow and installed-app-settings drive.
     if (path === "/setup-api/harness/active") {
       await fulfillJson(route, { active: "openclaw", edition: "openclaw", activeKnown: true });
+      return;
+    }
+
+    // Answered here rather than left to the catch-all `{}`, because one of
+    // these facts decides whether the chat opens a conversation by itself.
+    //
+    // `onboardingArmed` is read from the agent's BOOTSTRAP.md on the real box,
+    // so falling through would make the greet depend on whether the machine
+    // running these tests happens to have an un-introduced OpenClaw workspace —
+    // false on CI, true on a fresh developer box. Mocked, it is a property of
+    // the test instead of the runner. Every other fact stays false, exactly as
+    // the catch-all left it.
+    if (path === "/setup-api/chat/capabilities") {
+      await fulfillJson(route, {
+        harness: "openclaw",
+        facts: { ...CHAT_FACTS, ...(options.chatFacts ?? {}) },
+        factsPending: false,
+        factsRetryAfterMs: 30_000,
+      });
       return;
     }
 

--- a/install.sh
+++ b/install.sh
@@ -5254,9 +5254,19 @@ tts_ensure_provider_registered() {
 #
 # `clawboxManaged` is our own stamp on the entry, not the provider's name: an
 # owner's own `openai` speech route carries no stamp and is never mistaken for
-# ours (pre-start makes the same distinction before it will touch the entry).
-# The apiKey comes back redacted from `config get`, which does not matter — the
-# flag and the key's NAME are all this needs.
+# ours. The apiKey comes back redacted from `config get`, which does not matter
+# — the flag and the key's NAME are all this needs.
+#
+# A DELIBERATELY weaker test than pre-start's `_clawai_route_is_ours`, which
+# requires the stamp AND a base URL still pointing at our proxy, because
+# `openclaw config set` edits in place and a stale stamp can outlive an entry
+# the owner has re-aimed elsewhere. The difference is safe here and is not there:
+# pre-start uses that predicate to decide whether to REWRITE or WITHDRAW an
+# entry, where being wrong edits somebody else's provider; this only decides
+# which of two already-present voices is selected FIRST on a box that has not
+# chosen, and the owner can change it in Settings → Voice. Tightening this to
+# the same predicate would mean re-deriving ownership in a second language —
+# the thing the paragraph above declines to do with the tier.
 tts_managed_cloud_provider() {
   local home="$1"
   as_clawbox "$OPENCLAW_BIN" config get "$home.providers" 2>/dev/null | python3 -c '

--- a/install.sh
+++ b/install.sh
@@ -5267,6 +5267,46 @@ tts_ensure_provider_registered() {
 # chosen, and the owner can change it in Settings → Voice. Tightening this to
 # the same predicate would mean re-deriving ownership in a second language —
 # the thing the paragraph above declines to do with the tier.
+# Can openclaw.json be READ at all right now?
+#
+# `openclaw config get` exits 1 for an unset key AND for a config it could not
+# read — measured on the box, both give rc=1 with empty output — so the exit code
+# cannot tell "the owner has chosen nothing" from "we cannot see what the owner
+# chose". Seed-if-unset acts on the first and must never act on the second: an
+# unreadable config would otherwise be overwritten with our own selection, which
+# is how an owner's ElevenLabs pick disappears on an update.
+#
+# So ask the FILE. A config that parses means an empty `config get` really is an
+# unset key. A config that is absent is also genuinely unset — that is a fresh
+# box, which must still be seeded — and only a file that exists and does not
+# parse is the case this refuses to write over. Mirrors the discipline the
+# Hermes arm above already applies through HERMES_TTS_READ_FAILED.
+tts_config_readable() {
+  local rc=0
+  as_clawbox python3 - <<'PY' >/dev/null 2>&1 || rc=$?
+import json, os, sys
+home = os.path.expanduser("~")
+base = os.environ.get("CLAWBOX_OPENCLAW_HOME") or os.path.join(home, ".openclaw")
+path = os.path.join(base, "openclaw.json")
+if not os.path.exists(path):
+    sys.exit(0)          # fresh box: genuinely unset, seed it
+try:
+    with open(path) as fh:
+        json.load(fh)
+except Exception:
+    sys.exit(1)          # there IS a config and we cannot read it
+sys.exit(0)
+PY
+  # ONLY exit 1 — the probe's own verdict that a config exists and does not
+  # parse — refuses. Any OTHER failure means the question could not be asked at
+  # all (no python3, no `as_clawbox`, a harness that does not carry this
+  # function), and refusing on that would cost a box its voice over something
+  # never established. Fail OPEN, because the cost of the two mistakes is not
+  # symmetric: seeding over a config we could not read loses one setting the
+  # owner can set again, while refusing to seed leaves the box mute.
+  [ "$rc" -ne 1 ]
+}
+
 tts_managed_cloud_provider() {
   local home="$1"
   as_clawbox "$OPENCLAW_BIN" config get "$home.providers" 2>/dev/null | python3 -c '
@@ -5883,6 +5923,17 @@ step_openclaw_tts() {
       tts_write_local_provider_definition "$TTS_HOME" "$TTS_SCRIPT" "$TTS_SCRIPT_SRC" \
         || echo "  Warning: could not define the on-device voice provider; Settings → Voice can repair it" >&2
     fi
+    return "$TTS_RC"
+  fi
+
+  # An EMPTY read is only "the owner has chosen nothing" if the config could be
+  # read at all — `config get` returns the same rc=1 and the same empty string
+  # either way. Refuse to seed over a config we cannot see, and say so; the
+  # provider DEFINITION below is skipped with it, because writing into a file
+  # that does not parse is how a broken config becomes a lost one.
+  if ! tts_config_readable; then
+    echo "  Warning: openclaw.json exists and could not be read — leaving $TTS_HOME.provider alone rather than overwriting a choice we cannot see" >&2
+    echo "           Diagnose with: openclaw config get $TTS_HOME.provider" >&2
     return "$TTS_RC"
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -5281,6 +5281,14 @@ tts_ensure_provider_registered() {
 # box, which must still be seeded — and only a file that exists and does not
 # parse is the case this refuses to write over. Mirrors the discipline the
 # Hermes arm above already applies through HERMES_TTS_READ_FAILED.
+# Runs through `as_clawbox`, exactly like every `oc_config_set` in this step, and
+# that correspondence is the point: the probe must resolve the SAME config the
+# writes will land in. Pinning HOME here alone would break it — the probe could
+# then vet one file while the writes touched another. (Measured on the box:
+# sudoers sets `env_reset`, so `sudo -u clawbox` already gives
+# HOME=/home/clawbox. A box where that did not hold would send this step's reads
+# AND its writes to the same wrong place, which is a property of the whole file
+# rather than of this helper.)
 tts_config_readable() {
   local rc=0
   as_clawbox python3 - <<'PY' >/dev/null 2>&1 || rc=$?

--- a/install.sh
+++ b/install.sh
@@ -5293,26 +5293,37 @@ tts_config_readable() {
   local rc=0
   as_clawbox python3 - <<'PY' >/dev/null 2>&1 || rc=$?
 import json, os, sys
-home = os.path.expanduser("~")
-base = os.environ.get("CLAWBOX_OPENCLAW_HOME") or os.path.join(home, ".openclaw")
-path = os.path.join(base, "openclaw.json")
-if not os.path.exists(path):
-    sys.exit(0)          # fresh box: genuinely unset, seed it
+# 3, not 1: an uncaught Python exception exits 1, and so does a sudo that was
+# refused, so 1 cannot mean "this config does not parse" — it is the code every
+# kind of plumbing failure already speaks. A verdict needs a code nothing else
+# uses, or the caller cannot tell an answer from an accident.
+VERDICT_UNREADABLE = 3
 try:
+    home = os.path.expanduser("~")
+    base = os.environ.get("CLAWBOX_OPENCLAW_HOME") or os.path.join(home, ".openclaw")
+    path = os.path.join(base, "openclaw.json")
+    if not os.path.exists(path):
+        sys.exit(0)                  # fresh box: genuinely unset, seed it
     with open(path) as fh:
         json.load(fh)
+except SystemExit:
+    raise
+except OSError:
+    # Could not even look (permissions, a path that vanished): not a verdict.
+    sys.exit(1)
 except Exception:
-    sys.exit(1)          # there IS a config and we cannot read it
+    sys.exit(VERDICT_UNREADABLE)     # there IS a config and it does not parse
 sys.exit(0)
 PY
-  # ONLY exit 1 — the probe's own verdict that a config exists and does not
-  # parse — refuses. Any OTHER failure means the question could not be asked at
-  # all (no python3, no `as_clawbox`, a harness that does not carry this
-  # function), and refusing on that would cost a box its voice over something
-  # never established. Fail OPEN, because the cost of the two mistakes is not
-  # symmetric: seeding over a config we could not read loses one setting the
-  # owner can set again, while refusing to seed leaves the box mute.
-  [ "$rc" -ne 1 ]
+  # ONLY the probe's own verdict refuses. Everything else — no python3, a sudo
+  # that was denied, a test harness that does not carry this function, an
+  # unreadable directory — means the question could not be ASKED, and refusing
+  # then would cost a box its voice over something never established.
+  #
+  # Fail OPEN, because the two mistakes do not cost the same: seeding over a
+  # config we could not read loses one setting the owner can set again, while
+  # refusing to seed leaves a fresh device with no TTS provider at all.
+  [ "$rc" -ne 3 ]
 }
 
 tts_managed_cloud_provider() {

--- a/install.sh
+++ b/install.sh
@@ -5243,6 +5243,36 @@ tts_ensure_provider_registered() {
   as_clawbox "$OPENCLAW_BIN" plugins info tts-local-cli >/dev/null 2>&1
 }
 
+# The name of the ClawBox AI cloud voice entry, when this box has one.
+#
+# Its PRESENCE is the subscription test, and deliberately so rather than a
+# second read of the plan: `scripts/gateway-pre-start.sh` writes this entry only
+# on a box whose tier stamp equals CLAWBOX_SPEECH_DEVICE_TIER and withdraws it
+# again on a downgrade, so the gate has already been applied by the one place
+# that owns it. Asking the tier a second time here would be a copy of that rule
+# free to drift from it.
+#
+# `clawboxManaged` is our own stamp on the entry, not the provider's name: an
+# owner's own `openai` speech route carries no stamp and is never mistaken for
+# ours (pre-start makes the same distinction before it will touch the entry).
+# The apiKey comes back redacted from `config get`, which does not matter — the
+# flag and the key's NAME are all this needs.
+tts_managed_cloud_provider() {
+  local home="$1"
+  as_clawbox "$OPENCLAW_BIN" config get "$home.providers" 2>/dev/null | python3 -c '
+import json, sys
+try:
+    providers = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+if isinstance(providers, dict):
+    for name, entry in providers.items():
+        if isinstance(entry, dict) and entry.get("clawboxManaged") is True:
+            print(name)
+            break
+' 2>/dev/null
+}
+
 # The on-device voice, for EVERY edition.
 #
 # This step used to open with
@@ -5876,9 +5906,47 @@ step_openclaw_tts() {
     return 1
   fi
 
-  if ! oc_config_set "$TTS_HOME.provider" "tts-local-cli"; then
-    echo "  ERROR: could not select the tts-local-cli provider" >&2
-    return 1
+  # WHICH voice speaks first on a box that has both.
+  #
+  # Kokoro is installed either way — that is the step above, and it stays the
+  # box's own voice, one click away in Settings → Voice. What is decided here is
+  # only the DEFAULT, and on a box with a ClawBox AI subscription the default is
+  # the cloud voice (owner's ruling, 2026-09-09): it answers immediately, while
+  # Kokoro's server stops itself after five idle minutes and the first utterance
+  # after a quiet spell pays a 13-19 s cold start on this hardware.
+  #
+  # This is not the `edge` case the Hermes arm above refuses. That refusal is
+  # about defaulting an owner's speech to MICROSOFT — a third party the box
+  # merely happens to ship a client for. This is ClawBox AI: our own service, on
+  # a plan the owner is already paying for, reached through our own proxy. The
+  # principle that a ClawBox must not hand speech to someone else's cloud is
+  # kept; what is narrowed is the assumption that every cloud is someone else's.
+  #
+  # Seed-if-unset still governs: this whole branch is only reached when
+  # `tts.provider` was unset, so an owner's explicit pick — including an
+  # explicit pick of the local voice — is never overwritten by an update.
+  local TTS_SELECTED="tts-local-cli"
+  local CLOUD_TTS
+  CLOUD_TTS=$(tts_managed_cloud_provider "$TTS_HOME")
+  if [ -n "$CLOUD_TTS" ]; then
+    TTS_SELECTED="$CLOUD_TTS"
+  fi
+
+  if ! oc_config_set "$TTS_HOME.provider" "$TTS_SELECTED"; then
+    echo "  ERROR: could not select the $TTS_SELECTED provider" >&2
+    # Falling back to the local voice rather than leaving the box mute: the
+    # tts-local-cli entry is written and its plugin verified directly above, so
+    # it is the one provider this step KNOWS can answer. A cloud entry that
+    # could not be selected leaves the box with a working engine and no
+    # selection, which is the silent failure the checks above exist to prevent.
+    if [ "$TTS_SELECTED" = "tts-local-cli" ] || ! oc_config_set "$TTS_HOME.provider" "tts-local-cli"; then
+      return 1
+    fi
+    echo "  Fell back to the on-device voice after the cloud voice could not be selected" >&2
+    TTS_SELECTED="tts-local-cli"
+  fi
+  if [ "$TTS_SELECTED" != "tts-local-cli" ]; then
+    echo "  ClawBox AI cloud voice selected ($TTS_SELECTED); Kokoro is installed and can be made primary in Settings → Voice"
   fi
   # Only claim Kokoro when Kokoro is genuinely there. This line asserting
   # "Kokoro GPU" unconditionally is what kept TASK-420 invisible: three

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -94,26 +94,42 @@ const DEFAULT_DESKTOP_APPS = BUILT_IN_APP_IDS.filter(id => !OFF_DESKTOP_BY_DEFAU
 // restores a saved list verbatim — deliberately, so an owner's own additions
 // survive. The consequence is that moving an app off the desktop reached fresh
 // boxes only: every box that had ever saved a list kept the icon for good, with
-// no way to get the new layout short of a factory reset. System Update moved
-// into Settings → System Update (and is still reached from About and the
-// new-version notice), so the icon is redundant there rather than merely
-// unfashionable.
+// no way to the new layout short of a factory reset.
 //
-// Shed ONCE, recorded by `desktop_apps_shed` below, because "the owner never
-// asked for this icon" and "the owner put this icon back" are different states
-// and only the flag can tell them apart — after the shed, Add to desktop from
-// the launcher is permanent again.
+// Shed ONCE per version, because "the owner never asked for this icon" and "the
+// owner put this icon back" are different states and only a persisted mark can
+// tell them apart — after the shed, Add to desktop is permanent again.
 //
-// Both ids stay reachable from the App Launcher; this is about the default
-// grid, not about removing the app. System Update moved into Settings → System
-// Update (and is still reached from About and the new-version notice), and
-// Remote Desktop is a diagnostic on a headless appliance — the owner's call,
-// 2026-09-09, on a box where both icons had survived the upgrade.
-const SHED_FROM_SAVED_DESKTOP = new Set(["system_update", "vnc"]);
+// Keyed BY VERSION rather than as one flat set, and that is what makes a bump
+// safe: only entries ABOVE the box's stored version are applied, so adding a
+// third id later cannot take back an icon this version already shed and the
+// owner has since restored. A flat set would re-shed the lot on every bump,
+// which is the very case the version exists to prevent.
+//
+// Deliberately NOT `OFF_DESKTOP_BY_DEFAULT`, which happens to hold the same two
+// ids today: that one is the live default set and will change, this is frozen
+// history. Both ids stay in the App Launcher — this is about the default grid,
+// not about removing the app. System Update moved into Settings → System Update
+// (still reached from About and the new-version notice) and Remote Desktop is a
+// diagnostic on a headless appliance: the owner's call, 2026-09-09, on a box
+// where both icons had survived the upgrade to v4.0.0.
+const DESKTOP_APPS_SHED_BY_VERSION: Record<number, readonly string[]> = {
+  1: ["system_update", "vnc"],
+};
 
-// Bumping this re-runs the shed for ids added to the set above. It is a
-// version, not a boolean, for exactly that reason.
-const DESKTOP_APPS_SHED_VERSION = 1;
+/** The newest shed a box can have applied — the highest key above. */
+const DESKTOP_APPS_SHED_VERSION = Math.max(
+  ...Object.keys(DESKTOP_APPS_SHED_BY_VERSION).map(Number),
+);
+
+/** The ids a box stored at `from` has not been shed yet. */
+function desktopAppsToShed(from: number): Set<string> {
+  return new Set(
+    Object.entries(DESKTOP_APPS_SHED_BY_VERSION)
+      .filter(([version]) => Number(version) > from)
+      .flatMap(([, ids]) => ids),
+  );
+}
 
 // How old an owner-notice may be and still be acted on — `PENDING_ACTION_TTL_MS`
 // in src/lib/pending-actions.ts, which is the WRITER's pruning window. Copied
@@ -528,10 +544,11 @@ function ChromeDesktopInner() {
   const [wpOpacity, setWpOpacity] = useState(50);
   // ─── Unified SQLite load on mount ───
   const prefsLoaded = useRef(false);
-  // Set while loading when a saved desktop list still carried an app that has
-  // since moved off the desktop; read by the icon-grid load below and by the
-  // effect that records the shed so it happens exactly once.
-  const shedNeeded = useRef(false);
+  // The ids a shed removed from the saved list during this load, or null when
+  // there was nothing to shed. Read by the icon-grid load below, which has to
+  // drop their cells, and by the `desktop_apps` write, which records the version
+  // so it happens exactly once.
+  const shedNeeded = useRef<Set<string> | null>(null);
   // The docked chat's width as the DEVICE remembers it — see the write below.
   // Seeded from the stored value even on a phone, which never restores the
   // panel, so opening the desktop on a phone cannot erase the layout.
@@ -568,19 +585,19 @@ function ChromeDesktopInner() {
           // owner who added Remote Desktop from the launcher keeps it.
           let saved = (data.desktop_apps as string[]).filter(id => BUILT_IN_APP_IDS.includes(id));
           // An app that MOVED off the desktop is dropped from a list that was
-          // saved before it moved — once, and only once. Without this the move
-          // reaches new boxes only (see SHED_FROM_SAVED_DESKTOP); run
-          // unconditionally, an owner who put the icon back would lose it again
-          // on every reload. Hence the persisted version rather than a re-derived
-          // comparison against the set.
+          // saved before it moved — once per shed version. Without this the move
+          // reaches new boxes only; run unconditionally, an owner who put the
+          // icon back would lose it again on every reload.
           //
           // The state set here is what reaches the disk: the effects that mirror
-          // `desktopApps` and `iconPositions` into preferences do the writing,
-          // because `savePreferences` is gated on `prefsLoaded` and would drop a
-          // write issued from inside this load.
-          if (Number(data.desktop_apps_shed ?? 0) < DESKTOP_APPS_SHED_VERSION) {
-            saved = saved.filter(id => !SHED_FROM_SAVED_DESKTOP.has(id));
-            shedNeeded.current = true;
+          // `desktopApps` and `iconPositions` into preferences do the writing.
+          // The decision travels out on a ref because this load effect has empty
+          // deps and cannot see `savePreferences`.
+          const shedFrom = Number(data.desktop_apps_shed ?? 0);
+          if (shedFrom < DESKTOP_APPS_SHED_VERSION) {
+            const shed = desktopAppsToShed(shedFrom);
+            saved = saved.filter(id => !shed.has(id));
+            shedNeeded.current = shed;
           }
           // ...but only default-set built-ins are auto-added, so an app that
           // ships off the desktop never appears on a box that never had it.
@@ -594,9 +611,7 @@ function ChromeDesktopInner() {
           // A shed app's reserved cell goes with it. This is applied HERE rather
           // than beside the shed above because this assignment runs after it and
           // would otherwise put the empty slot straight back.
-          if (shedNeeded.current) {
-            for (const id of SHED_FROM_SAVED_DESKTOP) delete grid[`desktop-${id}`];
-          }
+          for (const id of shedNeeded.current ?? []) delete grid[`desktop-${id}`];
           setIconPositions(grid);
         }
         // Open windows
@@ -908,14 +923,18 @@ function ChromeDesktopInner() {
       "appearance",
     );
   }, [wallpaperId, wpFit, wpBgColor, wpOpacity, savePreferences]);
-  useEffect(() => { savePreferences({ desktop_apps: desktopApps }); }, [desktopApps, savePreferences]);
-  // Record the one-time shed AFTER the load has released the preference writer,
-  // so the box does not re-shed an icon the owner has since put back. The two
-  // lists it affects are written by their own effects above and below.
   useEffect(() => {
-    if (!shedNeeded.current) return;
-    shedNeeded.current = false;
-    savePreferences({ desktop_apps_shed: DESKTOP_APPS_SHED_VERSION });
+    // The shed's version rides along with the list it changed, in ONE write:
+    // a second effect on the same dependency would cost a second POST on every
+    // first load that sheds, and the two must not be able to land apart — a box
+    // that shed its icons without recording the version would shed them again.
+    const shed = shedNeeded.current !== null;
+    shedNeeded.current = null;
+    savePreferences(
+      shed
+        ? { desktop_apps: desktopApps, desktop_apps_shed: DESKTOP_APPS_SHED_VERSION }
+        : { desktop_apps: desktopApps },
+    );
   }, [desktopApps, savePreferences]);
   useEffect(() => { savePreferences({ hidden_installed: hiddenInstalledApps }); }, [hiddenInstalledApps, savePreferences]);
   useEffect(() => { savePreferences({ pinned_apps: pinnedOverrides }); }, [pinnedOverrides, savePreferences]);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -552,6 +552,9 @@ function ChromeDesktopInner() {
   // Bumped once by the load when a shed is owed, purely to run the write effect
   // below on a box whose `desktopApps` the load did not change.
   const [shedTick, setShedTick] = useState(0);
+  // Set once this page has shed, and never cleared: every `desktop_apps` write
+  // from then on carries the version, so no debounce replacement can drop it.
+  const shedRecorded = useRef(false);
   // The docked chat's width as the DEVICE remembers it — see the write below.
   // Seeded from the stored value even on a phone, which never restores the
   // panel, so opening the desktop on a phone cannot erase the layout.
@@ -943,10 +946,19 @@ function ChromeDesktopInner() {
     // a second effect on the same dependency would cost a second POST on every
     // first load that sheds, and the two must not be able to land apart — a box
     // that shed its icons without recording the version would shed them again.
-    const shed = shedNeeded.current !== null;
-    shedNeeded.current = null;
+    // STICKY, not consumed. The write is debounced by 500 ms and shares one slot
+    // with every later `desktop_apps` write, so a replacement queued inside that
+    // window cancels the pending one — and if the marker had been consumed by
+    // then, the payload that actually reaches the disk carries no version and
+    // the next load sheds the app the owner just restored. Carrying it on every
+    // write for the life of the page is idempotent (same value each time) and
+    // cannot lose the race.
+    if (shedNeeded.current !== null) {
+      shedRecorded.current = true;
+      shedNeeded.current = null;
+    }
     savePreferences(
-      shed
+      shedRecorded.current
         ? { desktop_apps: desktopApps, desktop_apps_shed: DESKTOP_APPS_SHED_VERSION }
         : { desktop_apps: desktopApps },
       // An EXPLICIT slot, because this body has two shapes: without one the slot

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -549,6 +549,9 @@ function ChromeDesktopInner() {
   // drop their cells, and by the `desktop_apps` write, which records the version
   // so it happens exactly once.
   const shedNeeded = useRef<Set<string> | null>(null);
+  // Bumped once by the load when a shed is owed, purely to run the write effect
+  // below on a box whose `desktopApps` the load did not change.
+  const [shedTick, setShedTick] = useState(0);
   // The docked chat's width as the DEVICE remembers it — see the write below.
   // Seeded from the stored value even on a phone, which never restores the
   // panel, so opening the desktop on a phone cannot erase the layout.
@@ -576,6 +579,20 @@ function ChromeDesktopInner() {
         // Installed apps
         if (Array.isArray(data.installed_apps)) setInstalledApps(data.installed_apps as string[]);
         if (data.installed_meta && typeof data.installed_meta === "object") setInstalledMeta(data.installed_meta as Record<string, InstalledMeta>);
+        // Evaluated for EVERY box, not only one with a saved list. A fresh box
+        // has nothing to shed, but it still has to record the version: without
+        // that, its first saved list carries no marker, and the moment the owner
+        // adds one of these apps from the launcher the next load sheds it right
+        // back out. The owner's own addition would be undone by a migration that
+        // had nothing to migrate.
+        const shedFrom = Number(data.desktop_apps_shed ?? 0);
+        if (shedFrom < DESKTOP_APPS_SHED_VERSION) {
+          shedNeeded.current = desktopAppsToShed(shedFrom);
+          // The write effect keys on `desktopApps`, which does not change on a
+          // box that had no saved list — so nothing would carry the marker to
+          // disk. This is the one-shot that makes it run.
+          setShedTick((n) => n + 1);
+        }
         // Merge new built-ins into the saved list so they appear without a factory reset.
         if (Array.isArray(data.desktop_apps)) {
           // Built-in ids only. An older launcher pushed `installed-*` ids here
@@ -593,11 +610,9 @@ function ChromeDesktopInner() {
           // `desktopApps` and `iconPositions` into preferences do the writing.
           // The decision travels out on a ref because this load effect has empty
           // deps and cannot see `savePreferences`.
-          const shedFrom = Number(data.desktop_apps_shed ?? 0);
-          if (shedFrom < DESKTOP_APPS_SHED_VERSION) {
-            const shed = desktopAppsToShed(shedFrom);
+          if (shedNeeded.current) {
+            const shed = shedNeeded.current;
             saved = saved.filter(id => !shed.has(id));
-            shedNeeded.current = shed;
           }
           // ...but only default-set built-ins are auto-added, so an app that
           // ships off the desktop never appears on a box that never had it.
@@ -934,8 +949,13 @@ function ChromeDesktopInner() {
       shed
         ? { desktop_apps: desktopApps, desktop_apps_shed: DESKTOP_APPS_SHED_VERSION }
         : { desktop_apps: desktopApps },
+      // An EXPLICIT slot, because this body has two shapes: without one the slot
+      // key is the field names, so the shed write and every later plain write
+      // would debounce in separate slots and could both be in flight. The
+      // appearance write above carries an explicit slot for the same reason.
+      "desktop_apps",
     );
-  }, [desktopApps, savePreferences]);
+  }, [desktopApps, shedTick, savePreferences]);
   useEffect(() => { savePreferences({ hidden_installed: hiddenInstalledApps }); }, [hiddenInstalledApps, savePreferences]);
   useEffect(() => { savePreferences({ pinned_apps: pinnedOverrides }); }, [pinnedOverrides, savePreferences]);
   useEffect(() => { savePreferences({ icon_grid: iconPositions }); }, [iconPositions, savePreferences]);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -87,6 +87,34 @@ const OFF_DESKTOP_BY_DEFAULT = new Set(["vnc", "system_update"]);
 
 const DEFAULT_DESKTOP_APPS = BUILT_IN_APP_IDS.filter(id => !OFF_DESKTOP_BY_DEFAULT.has(id));
 
+// Built-ins that moved OFF the desktop after boxes had already saved a
+// `desktop_apps` list containing them.
+//
+// `OFF_DESKTOP_BY_DEFAULT` only shapes the DEFAULT grid, and the loader below
+// restores a saved list verbatim — deliberately, so an owner's own additions
+// survive. The consequence is that moving an app off the desktop reached fresh
+// boxes only: every box that had ever saved a list kept the icon for good, with
+// no way to get the new layout short of a factory reset. System Update moved
+// into Settings → System Update (and is still reached from About and the
+// new-version notice), so the icon is redundant there rather than merely
+// unfashionable.
+//
+// Shed ONCE, recorded by `desktop_apps_shed` below, because "the owner never
+// asked for this icon" and "the owner put this icon back" are different states
+// and only the flag can tell them apart — after the shed, Add to desktop from
+// the launcher is permanent again.
+//
+// Both ids stay reachable from the App Launcher; this is about the default
+// grid, not about removing the app. System Update moved into Settings → System
+// Update (and is still reached from About and the new-version notice), and
+// Remote Desktop is a diagnostic on a headless appliance — the owner's call,
+// 2026-09-09, on a box where both icons had survived the upgrade.
+const SHED_FROM_SAVED_DESKTOP = new Set(["system_update", "vnc"]);
+
+// Bumping this re-runs the shed for ids added to the set above. It is a
+// version, not a boolean, for exactly that reason.
+const DESKTOP_APPS_SHED_VERSION = 1;
+
 // How old an owner-notice may be and still be acted on — `PENDING_ACTION_TTL_MS`
 // in src/lib/pending-actions.ts, which is the WRITER's pruning window. Copied
 // rather than imported: that module reaches for node:crypto and the KV file, and
@@ -500,6 +528,10 @@ function ChromeDesktopInner() {
   const [wpOpacity, setWpOpacity] = useState(50);
   // ─── Unified SQLite load on mount ───
   const prefsLoaded = useRef(false);
+  // Set while loading when a saved desktop list still carried an app that has
+  // since moved off the desktop; read by the icon-grid load below and by the
+  // effect that records the shed so it happens exactly once.
+  const shedNeeded = useRef(false);
   // The docked chat's width as the DEVICE remembers it — see the write below.
   // Seeded from the stored value even on a phone, which never restores the
   // panel, so opening the desktop on a phone cannot erase the layout.
@@ -534,7 +566,22 @@ function ChromeDesktopInner() {
           // empty grid slot, so a box that already saved one sheds it on load.
           // Validated against every built-in, not just the default set: an
           // owner who added Remote Desktop from the launcher keeps it.
-          const saved = (data.desktop_apps as string[]).filter(id => BUILT_IN_APP_IDS.includes(id));
+          let saved = (data.desktop_apps as string[]).filter(id => BUILT_IN_APP_IDS.includes(id));
+          // An app that MOVED off the desktop is dropped from a list that was
+          // saved before it moved — once, and only once. Without this the move
+          // reaches new boxes only (see SHED_FROM_SAVED_DESKTOP); run
+          // unconditionally, an owner who put the icon back would lose it again
+          // on every reload. Hence the persisted version rather than a re-derived
+          // comparison against the set.
+          //
+          // The state set here is what reaches the disk: the effects that mirror
+          // `desktopApps` and `iconPositions` into preferences do the writing,
+          // because `savePreferences` is gated on `prefsLoaded` and would drop a
+          // write issued from inside this load.
+          if (Number(data.desktop_apps_shed ?? 0) < DESKTOP_APPS_SHED_VERSION) {
+            saved = saved.filter(id => !SHED_FROM_SAVED_DESKTOP.has(id));
+            shedNeeded.current = true;
+          }
           // ...but only default-set built-ins are auto-added, so an app that
           // ships off the desktop never appears on a box that never had it.
           const missingNewBuiltins = DEFAULT_DESKTOP_APPS.filter(id => !saved.includes(id));
@@ -542,7 +589,16 @@ function ChromeDesktopInner() {
         }
         if (Array.isArray(data.hidden_installed)) setHiddenInstalledApps(data.hidden_installed as string[]);
         if (data.pinned_apps && typeof data.pinned_apps === "object") setPinnedOverrides(data.pinned_apps as Record<string, boolean>);
-        if (data.icon_grid && typeof data.icon_grid === "object") setIconPositions(data.icon_grid as Record<string, { row: number; col: number }>);
+        if (data.icon_grid && typeof data.icon_grid === "object") {
+          const grid = { ...(data.icon_grid as Record<string, { row: number; col: number }>) };
+          // A shed app's reserved cell goes with it. This is applied HERE rather
+          // than beside the shed above because this assignment runs after it and
+          // would otherwise put the empty slot straight back.
+          if (shedNeeded.current) {
+            for (const id of SHED_FROM_SAVED_DESKTOP) delete grid[`desktop-${id}`];
+          }
+          setIconPositions(grid);
+        }
         // Open windows
         if (Array.isArray(data.desktop_open_windows)) {
           // Restore the workspace but minimized — windows return to the taskbar
@@ -853,6 +909,14 @@ function ChromeDesktopInner() {
     );
   }, [wallpaperId, wpFit, wpBgColor, wpOpacity, savePreferences]);
   useEffect(() => { savePreferences({ desktop_apps: desktopApps }); }, [desktopApps, savePreferences]);
+  // Record the one-time shed AFTER the load has released the preference writer,
+  // so the box does not re-shed an icon the owner has since put back. The two
+  // lists it affects are written by their own effects above and below.
+  useEffect(() => {
+    if (!shedNeeded.current) return;
+    shedNeeded.current = false;
+    savePreferences({ desktop_apps_shed: DESKTOP_APPS_SHED_VERSION });
+  }, [desktopApps, savePreferences]);
   useEffect(() => { savePreferences({ hidden_installed: hiddenInstalledApps }); }, [hiddenInstalledApps, savePreferences]);
   useEffect(() => { savePreferences({ pinned_apps: pinnedOverrides }); }, [pinnedOverrides, savePreferences]);
   useEffect(() => { savePreferences({ icon_grid: iconPositions }); }, [iconPositions, savePreferences]);

--- a/src/app/setup-api/chat/capabilities/route.ts
+++ b/src/app/setup-api/chat/capabilities/route.ts
@@ -14,6 +14,7 @@ import {
 import { clawaiImageRouteReachable } from "@/lib/harness/clawai-images";
 import { hermesCanStreamTurns } from "@/lib/hermes-dashboard-turn";
 import { hermesSpeaksReplies, hermesVoiceProbePending } from "@/lib/hermes-tts";
+import { onboardingRitualArmed } from "@/lib/language-persona";
 
 export const dynamic = "force-dynamic";
 
@@ -92,9 +93,16 @@ export async function GET() {
       // next re-probe rather than at the next restart.
       onHermes ? hermesSpeaksReplies() : false,
     ]);
+  // Is the agent's own introduction still waiting to run? One `access()` on the
+  // workspace, off the Hermes gather above because it is neither a Hermes fact
+  // nor a probe that can hang — and asked on every request rather than memoised,
+  // since it flips exactly once in a box's life and the chat must not greet on
+  // the far side of that.
+  const onboardingArmed = await onboardingRitualArmed(harness);
   const facts: HarnessFacts = {
     // A boolean precisely so the device credential never travels to a browser.
     hasClawaiToken: linked,
+    onboardingArmed,
     hermesSupportsImages: supportsImages,
     hermesHasVisionRoute: hasVisionRoute,
     hermesStreamsTurns: streamsTurns,

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -5147,6 +5147,14 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     if (!caps.shouldOpenFirstConversation) return
     if (!firstConversationCandidateRef.current) return
     if (greetedRef.current) return
+    // Not before the wire is up. This dispatches straight to the adapter rather
+    // than through `startRun`, so on a box with a live connection an early turn
+    // rejects with 'Not connected' — and `dispatchTurn` clears `sending` without
+    // clearing `greetedRef`, so the introduction would be lost for the life of
+    // the session. `status` is in the deps, so this simply runs again once the
+    // socket connects. Same predicate the abort path uses: a harness with no
+    // live connection has nothing to wait for.
+    if (caps.hasLiveConnection && status !== 'connected') return
     // Main only, re-checked at the moment of sending: a side tab the owner
     // switched to while the facts were in flight must not be greeted into.
     if (sessionKeyRef.current !== mainSessionKeyRef.current) return
@@ -5156,7 +5164,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     const idempotencyKey = uuid()
     runIdRef.current = idempotencyKey
     void dispatchTurnRef.current(FIRST_CONVERSATION_OPENER, [], idempotencyKey)
-  }, [caps.shouldOpenFirstConversation, transcriptReads])
+  }, [caps.shouldOpenFirstConversation, caps.hasLiveConnection, status, transcriptReads])
 
   useEffect(() => {
     if (isOpen) {

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -100,6 +100,18 @@ const INITIAL_CONNECT_MAX_RETRIES = 99 // initial attempt + 99 retries = 100
 const INITIAL_CONNECT_TIMEOUT_MS = 5 * 60_000
 const MAX_QUEUED_SENDS = 20
 
+/**
+ * What the chat says to start the agent's own introduction, on the one kind of
+ * box that gets one (see `shouldOpenFirstConversation`).
+ *
+ * Deliberately NOT translated, and deliberately trivial. It is not a message to
+ * the owner — they never see a reply to it as an answer to anything they wrote —
+ * it is the minimum turn that makes OpenClaw run the ritual, which then greets
+ * the owner in the box's own language and asks their name. Translating it would
+ * imply the owner said it; a longer opener would put words in their mouth.
+ */
+const FIRST_CONVERSATION_OPENER = 'hi'
+
 /** How many spoken replies' audio the chat keeps alive at once; older ones lose their player. */
 const SPOKEN_REPLIES_KEPT = 12
 /** The most one ask for a spoken reply may take, queue and cold start included. */
@@ -2736,8 +2748,16 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     return onProvidersChanged(() => { refreshChatModelState() })
   }, [isOpen, refreshChatModelState])
 
-  // Load chat history, auto-greet if empty
+  // Load chat history, and open the first conversation on a box that has an
+  // introduction waiting.
   const greetedRef = useRef(false)
+  // Did the last history read come back empty, on the main session? One half of
+  // the first-conversation decision (see the effect that makes it).
+  const firstConversationCandidateRef = useRef(false)
+  // Bumped by every completed history read, purely so that decision re-runs
+  // when a read lands after the capabilities did. A counter rather than a
+  // boolean: the second read of a session that was cleared has to re-trigger it.
+  const [transcriptReads, setTranscriptReads] = useState(0)
   const loadHistory = useCallback(async () => {
     // A harness with no durable transcript has nothing to replay. Returning
     // before the bootstrap bookkeeping rather than calling and catching keeps
@@ -2750,7 +2770,10 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     // re-entry guard, and onThinkingChange aren't tripped before any
     // generation actually starts.
     const keyAtCall = sessionKeyRef.current
-    const mightAutoGreet = !greetedRef.current
+    // Gated on the same fact as the greet itself: the bubble is a preview of a
+    // turn that is about to start, so on a box that will never greet it would be
+    // a typing indicator for nothing — a phantom the owner sees on every open.
+    const mightAutoGreet = caps.shouldOpenFirstConversation && !greetedRef.current
     if (mightAutoGreet) {
       setIsBootstrappingHistory(true)
       applyStreaming('')
@@ -2791,21 +2814,31 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
         return sameTranscript(prev, next) ? prev : next
       })
 
-      // Auto-send a greeting if no history exists (first conversation).
-      // Main only: a restored side tab the owner never typed in is ALSO an
-      // empty transcript, and on a desktop reload the hello binds straight to
-      // it — greeting there would spend a model turn nobody asked for and
-      // resurrect a session the gateway may have deleted. (On Hermes both
-      // keys are '' and the greet keeps working as before.)
-      if (chatMsgs.length === 0 && !greetedRef.current && sessionKeyRef.current === mainSessionKeyRef.current) {
-        greetedRef.current = true
-        setIsBootstrappingHistory(false)
-        sendingRef.current = true
-        setSending(true)
-        const idempotencyKey = uuid()
-        runIdRef.current = idempotencyKey
-        await dispatchTurnRef.current('hi', [], idempotencyKey)
-      } else if (mightAutoGreet) {
+      // Open the FIRST conversation, but only on a box that actually has an
+      // introduction waiting.
+      //
+      // `shouldOpenFirstConversation` is the server's answer, from the presence
+      // of the agent's own BOOTSTRAP.md — the ritual that asks the owner's name
+      // and can only be started by the agent's first reply. An empty transcript
+      // is NOT that fact and never was: a cleared conversation, a restored side
+      // tab, a reset session and a box whose introduction finished months ago
+      // are all empty too, and every one of them used to be answered with an
+      // unasked-for "hi" that cost a model turn and put a word in the owner's
+      // mouth. Off a fresh box the chat now opens silently and the first turn is
+      // the owner's.
+      //
+      // The other three conditions stand unchanged. Main only: a restored side
+      // tab the owner never typed in is ALSO an empty transcript, and on a
+      // desktop reload the hello binds straight to it — greeting there would
+      // resurrect a session the gateway may have deleted.
+      // Half of the first-conversation decision; the effect that owns it makes
+      // the call. Recorded rather than acted on here because the OTHER half —
+      // whether the box has an introduction waiting — may not have arrived yet,
+      // and this read must not answer for it.
+      firstConversationCandidateRef.current =
+        chatMsgs.length === 0 && sessionKeyRef.current === mainSessionKeyRef.current
+      setTranscriptReads((n) => n + 1)
+      if (mightAutoGreet) {
         setIsBootstrappingHistory(false)
       }
       // Handed back so a caller can act on what was just loaded without waiting
@@ -5085,6 +5118,36 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     replayedRef.current = true
     void loadHistory()
   }, [harnessLoaded, isOpen, caps, loadHistory])
+
+  // Open the first conversation, once both of its inputs are in.
+  //
+  // The decision needs two facts that arrive independently and in either order:
+  // the transcript came back EMPTY (a history read) and the box says it has an
+  // introduction WAITING (the capabilities fetch). Deciding inside the history
+  // read — where this used to live — meant deciding on whichever half had
+  // landed: on OpenClaw the socket calls loadHistory() the moment the
+  // connection is up, usually before the facts, so a genuinely fresh box read
+  // "not armed" on the only pass that ran and sat silent for good.
+  //
+  // As an effect it is ordering-proof: whichever input lands last runs it, and
+  // `greetedRef` keeps it to one turn. `caps` is read fresh here rather than
+  // through loadHistory's closure, which is captured when that callback is
+  // created and goes stale the moment the facts change.
+  useEffect(() => {
+    if (!caps.shouldOpenFirstConversation) return
+    if (!firstConversationCandidateRef.current) return
+    if (greetedRef.current) return
+    // Main only, re-checked at the moment of sending: a side tab the owner
+    // switched to while the facts were in flight must not be greeted into.
+    if (sessionKeyRef.current !== mainSessionKeyRef.current) return
+    greetedRef.current = true
+    setIsBootstrappingHistory(false)
+    sendingRef.current = true
+    setSending(true)
+    const idempotencyKey = uuid()
+    runIdRef.current = idempotencyKey
+    void dispatchTurnRef.current(FIRST_CONVERSATION_OPENER, [], idempotencyKey)
+  }, [caps.shouldOpenFirstConversation, transcriptReads])
 
   useEffect(() => {
     if (isOpen) {

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -2835,9 +2835,19 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       // the call. Recorded rather than acted on here because the OTHER half —
       // whether the box has an introduction waiting — may not have arrived yet,
       // and this read must not answer for it.
-      firstConversationCandidateRef.current =
+      const firstConversationCandidate =
         chatMsgs.length === 0 && sessionKeyRef.current === mainSessionKeyRef.current
-      setTranscriptReads((n) => n + 1)
+      firstConversationCandidateRef.current = firstConversationCandidate
+      // Bumped only when the bump could CHANGE something. `loadHistory` runs on
+      // every reconnect and after every ack-only turn, and the reconcile above
+      // deliberately returns `prev` when the transcript is unchanged so React
+      // skips that render — an unconditional counter would put the render back,
+      // on a list whose every assistant message is re-scanned for email refs.
+      // The effect below bails unless both of these hold, so a read that cannot
+      // reach the greet has nothing to re-trigger.
+      if (firstConversationCandidate && !greetedRef.current) {
+        setTranscriptReads((n) => n + 1)
+      }
       if (mightAutoGreet) {
         setIsBootstrappingHistory(false)
       }
@@ -5141,7 +5151,6 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     // switched to while the facts were in flight must not be greeted into.
     if (sessionKeyRef.current !== mainSessionKeyRef.current) return
     greetedRef.current = true
-    setIsBootstrappingHistory(false)
     sendingRef.current = true
     setSending(true)
     const idempotencyKey = uuid()

--- a/src/components/ClawKeepApp.tsx
+++ b/src/components/ClawKeepApp.tsx
@@ -221,15 +221,6 @@ export default function ClawKeepApp() {
   // outer full-app login gate was tried and removed — it duplicated the
   // inline UX and broke local-only flows where ClawBox AI isn't required.
   const [status, setStatus] = useState<ClawKeepStatus | null>(null);
-  /**
-   * Is the first-run wizard the face this app is showing?
-   *
-   * Decided ONCE, from the first status that arrives, and cleared only by the
-   * wizard's own onDone — see the front door below for why deriving it per
-   * render ejected the owner in the middle of their first run. `null` means no
-   * status has answered yet, which is neither "show it" nor "don't".
-   */
-  const [wizardActive, setWizardActive] = useState<boolean | null>(null);
   // Which agent this box archives, for the strings that name it. Read before
   // the status has landed too, hence the optional chain — the default is the
   // word every one of those strings used to be hardcoded to.
@@ -284,12 +275,6 @@ export default function ClawKeepApp() {
         await fetch("/setup-api/clawkeep", { cache: "no-store" }),
       );
       setStatus(next);
-      // Latch the front-door decision on the FIRST status only. Every later
-      // refresh — including the one the wizard's own pairing step triggers —
-      // leaves it alone, so the wizard keeps the screen until it is finished.
-      setWizardActive((prev) =>
-        prev === null ? next.setupComplete === false && !next.paired : prev,
-      );
       setError(null);
     } catch (e) {
       setError((e as Error).message);
@@ -616,23 +601,19 @@ export default function ClawKeepApp() {
     );
   }
 
-  // The front door: a box whose owner has not been through setup and is not
-  // paired shows the wizard instead of a dashboard of things that cannot
-  // happen yet. A paired box skips it whatever the flag says — pairing is the
-  // wizard's point, and an owner who paired before the wizard existed must
-  // not be sent back through it.
+  // The front door: an owner who has not been through setup gets the wizard
+  // rather than a dashboard of things that cannot happen yet.
   //
-  // LATCHED, not re-derived. `!status.paired` is a statement about the box the
-  // owner ARRIVED on, and it was being re-evaluated against every status poll —
-  // so the wizard's own step 1 falsified its display condition the instant it
-  // succeeded. The owner was dropped onto the dashboard mid-wizard, before the
-  // passphrase and schedule steps, and the box sat in "Protection Lapsed" with
-  // setupComplete still false: a first run that ends in a scary state nobody was
-  // walked past. `wizardActive` answers the question once, on the first status
-  // that arrives, and only the wizard's own onDone clears it — which keeps the
-  // legacy case above working, since a box that was already paired when the
-  // owner opened the app still never enters.
-  if (wizardActive) {
+  // ONE question, the same one BrowserApp, CodingAgentApp and MemoryShardApp
+  // ask. This used to also require `!status.paired`, and that conjunct was the
+  // defect: re-evaluated on every status poll, the wizard's own pairing step
+  // falsified the condition keeping it on screen, dropping the owner onto the
+  // dashboard two steps early at "Protection Lapsed". The legacy case that
+  // conjunct existed for — a box paired before this wizard shipped — is now
+  // answered where it belongs, by `getClawKeepSetupComplete`, so it cannot
+  // fight the wizard's own progress. The wizard already skips the pair step on
+  // a paired box.
+  if (status.setupComplete === false) {
     return (
       <AgentLabelContext.Provider value={agent}>
         <div className="relative h-full w-full overflow-y-auto bg-[var(--bg-deep)] text-gray-200 @container" data-testid="clawkeep-panel">
@@ -641,7 +622,7 @@ export default function ClawKeepApp() {
               status={status}
               agent={agent}
               onStatusChanged={refresh}
-              onDone={() => { setWizardActive(false); void refresh(); }}
+              onDone={() => { void refresh(); }}
             />
           </div>
         </div>

--- a/src/components/ClawKeepApp.tsx
+++ b/src/components/ClawKeepApp.tsx
@@ -221,6 +221,15 @@ export default function ClawKeepApp() {
   // outer full-app login gate was tried and removed — it duplicated the
   // inline UX and broke local-only flows where ClawBox AI isn't required.
   const [status, setStatus] = useState<ClawKeepStatus | null>(null);
+  /**
+   * Is the first-run wizard the face this app is showing?
+   *
+   * Decided ONCE, from the first status that arrives, and cleared only by the
+   * wizard's own onDone — see the front door below for why deriving it per
+   * render ejected the owner in the middle of their first run. `null` means no
+   * status has answered yet, which is neither "show it" nor "don't".
+   */
+  const [wizardActive, setWizardActive] = useState<boolean | null>(null);
   // Which agent this box archives, for the strings that name it. Read before
   // the status has landed too, hence the optional chain — the default is the
   // word every one of those strings used to be hardcoded to.
@@ -275,6 +284,12 @@ export default function ClawKeepApp() {
         await fetch("/setup-api/clawkeep", { cache: "no-store" }),
       );
       setStatus(next);
+      // Latch the front-door decision on the FIRST status only. Every later
+      // refresh — including the one the wizard's own pairing step triggers —
+      // leaves it alone, so the wizard keeps the screen until it is finished.
+      setWizardActive((prev) =>
+        prev === null ? next.setupComplete === false && !next.paired : prev,
+      );
       setError(null);
     } catch (e) {
       setError((e as Error).message);
@@ -606,7 +621,18 @@ export default function ClawKeepApp() {
   // happen yet. A paired box skips it whatever the flag says — pairing is the
   // wizard's point, and an owner who paired before the wizard existed must
   // not be sent back through it.
-  if (status.setupComplete === false && !status.paired) {
+  //
+  // LATCHED, not re-derived. `!status.paired` is a statement about the box the
+  // owner ARRIVED on, and it was being re-evaluated against every status poll —
+  // so the wizard's own step 1 falsified its display condition the instant it
+  // succeeded. The owner was dropped onto the dashboard mid-wizard, before the
+  // passphrase and schedule steps, and the box sat in "Protection Lapsed" with
+  // setupComplete still false: a first run that ends in a scary state nobody was
+  // walked past. `wizardActive` answers the question once, on the first status
+  // that arrives, and only the wizard's own onDone clears it — which keeps the
+  // legacy case above working, since a box that was already paired when the
+  // owner opened the app still never enters.
+  if (wizardActive) {
     return (
       <AgentLabelContext.Provider value={agent}>
         <div className="relative h-full w-full overflow-y-auto bg-[var(--bg-deep)] text-gray-200 @container" data-testid="clawkeep-panel">
@@ -615,7 +641,7 @@ export default function ClawKeepApp() {
               status={status}
               agent={agent}
               onStatusChanged={refresh}
-              onDone={() => { void refresh(); }}
+              onDone={() => { setWizardActive(false); void refresh(); }}
             />
           </div>
         </div>
@@ -883,9 +909,17 @@ function ScheduleCard({
           </p>
         </div>
         <label className="relative inline-flex items-center cursor-pointer">
+          {/* The input IS the hit target, not a 1x1 `sr-only` box behind one.
+              Sized to the track and merely transparent, so a click anywhere on
+              the switch lands on the control itself rather than on whatever
+              element happens to sit over the hidden input's corner — which is
+              what `elementFromPoint` resolves, and therefore what a pointer
+              driven by coordinates (an automated check, an assistive pointer,
+              a stylus) actually hits. `peer` still styles the track below. */}
           <input
             type="checkbox"
-            className="sr-only peer"
+            className="peer absolute inset-0 z-10 m-0 h-full w-full cursor-pointer opacity-0 disabled:cursor-not-allowed"
+            aria-label={t("clawkeep.schedule.title")}
             checked={draft.enabled}
             disabled={saving}
             onChange={(e) => {

--- a/src/components/MemoryShardApp.tsx
+++ b/src/components/MemoryShardApp.tsx
@@ -438,14 +438,18 @@ function MemoryIndexCard({ initial, onError }: {
             </p>
           </div>
           <label className="relative inline-flex items-center cursor-pointer">
+            {/* Sized to the track and transparent rather than `sr-only`: the
+                input itself is then what a pointer at the switch's centre lands
+                on, instead of the wrapper that sat over the 1x1 hidden box.
+                Same change as ClawKeep's auto-backup switch. */}
             <input
               type="checkbox"
-              className="sr-only peer"
+              className="peer absolute inset-0 z-10 m-0 h-full w-full cursor-pointer opacity-0"
               aria-label={t("clawkeep.memory.schedule")}
               checked={schedule.enabled}
               onChange={(e) => void saveSchedule({ ...schedule, enabled: e.target.checked })}
             />
-            {/* The checkbox itself is off-screen, so the track is what has to
+            {/* The checkbox itself is invisible, so the track is what has to
                 show the keyboard focus — the desktop's coral, not the track's
                 own accent, which would vanish on the switched-on state. */}
             <span className="w-10 h-6 bg-white/10 rounded-full peer-checked:bg-[var(--coral-bright)] transition-colors peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-[var(--coral-bright)]" />

--- a/src/components/SystemUpdateApp.tsx
+++ b/src/components/SystemUpdateApp.tsx
@@ -1066,14 +1066,30 @@ function UpdateProgressCard({
       {state && state.steps.length > 0 && (
         <ul className="mt-4 space-y-2">
           {state.steps.map((step) => (
-            <li key={step.id} className="flex items-center gap-3 text-sm">
+            <li key={step.id} className="flex items-start gap-3 text-sm">
               <StepIcon status={step.status} />
-              <span className={
-                step.status === "running" ? "text-gray-100 font-medium" :
-                step.status === "completed" ? "text-emerald-300/80" :
-                step.status === "failed" ? "text-red-300" : "text-[var(--text-muted)]"
-              }>
-                {step.label}
+              <span className="min-w-0">
+                <span className={
+                  step.status === "running" ? "text-gray-100 font-medium" :
+                  step.status === "completed" ? "text-emerald-300/80" :
+                  step.status === "failed" ? "text-red-300" : "text-[var(--text-muted)]"
+                }>
+                  {step.label}
+                </span>
+                {/* What the step is doing under a label that cannot say it —
+                    "Applying system fixups" is fifteen minutes of CUDA compile
+                    and multi-hundred-MB downloads. Only ever on the running
+                    step, and absent unless the installer has said something, so
+                    a step with nothing to add looks exactly as it did. */}
+                {step.status === "running" && step.detail && (
+                  <span
+                    className="block truncate text-xs text-[var(--text-muted)]"
+                    title={step.detail}
+                    data-testid="update-step-detail"
+                  >
+                    {step.detail}
+                  </span>
+                )}
               </span>
             </li>
           ))}

--- a/src/components/UpdateStep.tsx
+++ b/src/components/UpdateStep.tsx
@@ -605,6 +605,19 @@ export default function UpdateStep({ onNext }: UpdateStepProps) {
                   }}
                 >
                   {step.label}
+                  {/* The installer's own account of the sub-phase, on the
+                      running step only. See SystemUpdateApp for why a coarse
+                      label alone leaves the wizard silent for minutes. */}
+                  {step.status === "running" && step.detail && (
+                    <span
+                      className="block truncate"
+                      style={{ fontSize: "var(--t-5)", color: "var(--text-muted)" }}
+                      title={step.detail}
+                      data-testid="update-step-detail"
+                    >
+                      {step.detail}
+                    </span>
+                  )}
                 </span>
               </li>
             ))}

--- a/src/lib/clawkeep.ts
+++ b/src/lib/clawkeep.ts
@@ -933,8 +933,31 @@ export async function clearPassphrase(): Promise<{ removed: boolean }> {
  */
 export const CLAWKEEP_SETUP_CONFIG_KEY = "clawkeep_setup_complete";
 
+/**
+ * Has the owner been through ClawKeep's first-run wizard?
+ *
+ * An EXPLICIT flag wins; absent, a box that is already PAIRED counts as set up.
+ * Pairing is the wizard's point, so a box that had done it before this flag
+ * existed must not be dragged through onboarding by an update.
+ *
+ * That legacy answer belongs here rather than in the app's front door, and the
+ * difference is a defect this repairs. ClawKeepApp used to ask
+ * `setupComplete === false && !paired`, re-evaluated on every status poll — so
+ * the wizard's OWN pairing step falsified the condition keeping it on screen
+ * and dropped the owner onto the dashboard two steps early, at "Protection
+ * Lapsed", with setupComplete still false. Answered at the source, the app asks
+ * the single question its siblings ask (BrowserApp, CodingAgentApp and
+ * MemoryShardApp all gate on `setupComplete` alone), and the wizard survives its
+ * own success — including across a reload, which a front-door latch could not
+ * fix because the reloaded page reads `paired: true` on its very first status.
+ *
+ * Same shape as `getMemoryShardSetupComplete`, deliberately: a derivation, not
+ * a write, so nothing is persisted from a status read.
+ */
 export async function getClawKeepSetupComplete(): Promise<boolean> {
-  return (await configGet(CLAWKEEP_SETUP_CONFIG_KEY)) === true;
+  const flag = await configGet(CLAWKEEP_SETUP_CONFIG_KEY);
+  if (typeof flag === "boolean") return flag;
+  return (await readToken()) !== null;
 }
 
 export async function setClawKeepSetupComplete(done: boolean): Promise<boolean> {

--- a/src/lib/harness/capabilities.ts
+++ b/src/lib/harness/capabilities.ts
@@ -91,6 +91,19 @@ export interface HarnessFacts {
    * it by default.
    */
   hermesSpeaksReplies: boolean;
+  /**
+   * OpenClaw's first-conversation ritual is armed and unfinished — a box that
+   * has never been introduced to its owner.
+   *
+   * A FILE fact (`BOOTSTRAP.md` in the workspace, read by
+   * `onboardingRitualArmed`), not a guess from an empty transcript: a cleared
+   * conversation, a restored side tab and a reset session are all empty too,
+   * and the chat used to greet itself on every one of them.
+   *
+   * False on Hermes, which runs no such ritual, and false on every box that has
+   * already been introduced — which is nearly all of them after first boot.
+   */
+  onboardingArmed: boolean;
 }
 
 /**
@@ -127,6 +140,9 @@ export function capabilitiesFor(id: HarnessId, facts: HarnessFacts): HarnessCapa
       // dashboard it still honestly says no.
       streamsTurns: facts.hermesStreamsTurns,
       canListHistory: HERMES_DURABLE_TRANSCRIPT,
+      // Hermes has no first-conversation ritual, so there is no introduction
+      // for a greeting to start and nothing an unasked-for turn could achieve.
+      shouldOpenFirstConversation: false,
       // Forgetting the resumed session id IS the reset: the next turn goes out
       // with no `--resume`, so the box opens a fresh session. Every bit as real
       // a reset as the gateway's, and the only one Hermes can have.
@@ -221,6 +237,9 @@ export function capabilitiesFor(id: HarnessId, facts: HarnessFacts): HarnessCapa
   return {
     streamsTurns: true,
     canListHistory: true,
+    // Only while the agent's own introduction is waiting to run. On every box
+    // that has been introduced this is false and the chat opens silently.
+    shouldOpenFirstConversation: facts.onboardingArmed,
     canResetSession: true,
     canPatchSessionDefaults: true,
     reasoningScope: "session",
@@ -268,6 +287,11 @@ export function capabilitiesFor(id: HarnessId, facts: HarnessFacts): HarnessCapa
 /** The facts to assume before the box has answered: the cautious ones. */
 export const UNKNOWN_FACTS: HarnessFacts = {
   hasClawaiToken: false,
+  // Cautious here means SILENT. A box that has not answered yet must not be
+  // greeted on the guess that it might be new: greeting a box that was already
+  // introduced spends a turn and puts a word in the owner's mouth, while a
+  // fresh box that greets one load later has lost nothing.
+  onboardingArmed: false,
   hermesSupportsImages: false,
   hermesHasVisionRoute: false,
   // Cautious in the same direction as the rest: a composer that has not heard

--- a/src/lib/harness/transport.ts
+++ b/src/lib/harness/transport.ts
@@ -53,6 +53,17 @@ export interface HarnessCapabilities {
   readonly streamsTurns: boolean;
   /** The transcript survives a page refresh. */
   readonly canListHistory: boolean;
+  /**
+   * The chat should open a FIRST conversation by itself, because the agent has
+   * an introduction waiting that only its own first reply can start.
+   *
+   * True only on a box whose OpenClaw ritual is armed and unfinished. Everywhere
+   * else the chat stays silent and the first turn is the owner's: an empty
+   * transcript is not evidence of a fresh box — a cleared conversation, a
+   * restored side tab and a reset session all look identical — and greeting on
+   * one spends a model turn nobody asked for.
+   */
+  readonly shouldOpenFirstConversation: boolean;
   /** "New chat" can make the AGENT forget, not merely blank the view. */
   readonly canResetSession: boolean;
   /** A sticky per-session default can be pushed (OpenClaw `sessions.patch`). */

--- a/src/lib/harness/use-harness-adapter.ts
+++ b/src/lib/harness/use-harness-adapter.ts
@@ -105,6 +105,10 @@ async function fetchFacts(signal?: AbortSignal): Promise<ProbedFacts | null> {
         hasClawaiImageRoute: data.facts?.hasClawaiImageRoute === true,
         hermesAgentDrawsImages: data.facts?.hermesAgentDrawsImages === true,
         hermesSpeaksReplies: data.facts?.hermesSpeaksReplies === true,
+        // `=== true` like its neighbours, so a server that predates this field
+        // reads as "not armed" and the chat stays silent rather than greeting a
+        // box whose introduction is long finished.
+        onboardingArmed: data.facts?.onboardingArmed === true,
       },
       // A box too old to send the field is not pending, it is simply not
       // saying — which is the pre-existing behaviour, unchanged.

--- a/src/lib/language-persona.ts
+++ b/src/lib/language-persona.ts
@@ -100,6 +100,27 @@ export async function personaWritesAllowed(harness: Harness): Promise<boolean> {
 }
 
 /**
+ * Is OpenClaw's first-conversation ritual armed and still unfinished?
+ *
+ * The same fact `personaWritesAllowed` reads, asked in the positive: BOOTSTRAP.md
+ * is present exactly while the ritual is waiting to run, and OpenClaw deletes it
+ * on the turn that finishes the introduction. It is therefore the one honest
+ * answer to "is this a fresh box that has never been introduced to its owner?"
+ * — better than an empty transcript, which is also what a cleared conversation,
+ * a restored side tab and a reset session all look like.
+ *
+ * Read here rather than derived in the caller so the two guards cannot drift:
+ * a change to how a fresh workspace is recognised belongs in one file.
+ *
+ * Hermes runs no such ritual (see above), so it is never armed there — a Hermes
+ * box has no introduction for a greeting to start.
+ */
+export async function onboardingRitualArmed(harness: Harness): Promise<boolean> {
+  if (harness === "hermes") return false;
+  return fileExists(path.join(openclawWorkspaceDir(), BOOTSTRAP_FILENAME));
+}
+
+/**
  * The device-store key that records a language pick the guard above sent away.
  *
  * Deliberately not a `pref:` key: it is not the owner's preference, it is a

--- a/src/lib/root-step-follow.ts
+++ b/src/lib/root-step-follow.ts
@@ -57,14 +57,27 @@ async function unitState(unit: string): Promise<{ active: string; result: string
  * anything is exactly when that happens. A second install of the voice would
  * open by showing the first one's error.
  */
-async function journalLines(step: string, sinceMs: number, lines: number): Promise<string[]> {
+async function journalLines(
+  step: string,
+  sinceMs: number,
+  lines: number,
+  // Keep the LEADING whitespace. install.sh's two-space indent is the only
+  // thing separating its own sub-phase headlines from the pip/apt output
+  // underneath them, so the progress watcher below has to read them untrimmed.
+  // Everything else wants them trimmed: `failureReason`'s MARKER regex is
+  // `^`-anchored, and an indented line would slip past it.
+  { keepIndent = false }: { keepIndent?: boolean } = {},
+): Promise<string[]> {
   try {
     const { stdout } = await execFile(
       "/usr/bin/journalctl",
       rootStepJournalArgs(step, { sinceMs, lines }),
       { timeout: 10_000 },
     );
-    return stdout.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+    return stdout
+      .split(/\r?\n/)
+      .map((l) => (keepIndent ? l.replace(/\s+$/, "") : l.trim()))
+      .filter(Boolean);
   } catch {
     return [];
   }
@@ -95,22 +108,7 @@ const PROGRESS_WINDOW_LINES = 60;
  * during the CUDA compile the last line is whatever cc1plus last said, and for
  * six minutes there is no line at all. The headline is what stays true.
  */
-const HEADLINE_RE = /^ {2}(?! )(\S.*?)\s*$/;
-
-/** Read a window of the step's journal WITHOUT trimming the leading indent. */
-async function indentedJournalLines(step: string, sinceMs: number, lines: number): Promise<string[]> {
-  try {
-    const { stdout } = await execFile(
-      "/usr/bin/journalctl",
-      rootStepJournalArgs(step, { sinceMs, lines }),
-      { timeout: 10_000 },
-    );
-    // Only the line ending is stripped: the leading two spaces ARE the signal.
-    return stdout.split(/\r?\n/).map((l) => l.replace(/\s+$/, "")).filter((l) => l.length > 0);
-  } catch {
-    return [];
-  }
-}
+const HEADLINE_RE = /^ {2}(\S.*)$/;
 
 /**
  * Watch a root step that someone ELSE is running, and report what it is doing.
@@ -130,10 +128,17 @@ export function watchRootStepProgress(
 ): () => void {
   let stopped = false;
   let last: string | null = null;
+  let sleepTimer: ReturnType<typeof setTimeout> | null = null;
 
   void (async () => {
     while (!stopped) {
-      const lines = await indentedJournalLines(step, sinceMs, PROGRESS_WINDOW_LINES);
+      const lines = await journalLines(step, sinceMs, PROGRESS_WINDOW_LINES, { keepIndent: true });
+      // Checked HERE, once, rather than by every caller: a read already in
+      // flight when the watch was stopped resolves after it, and this is what
+      // makes "no headline after stop()" the watcher's own guarantee instead of
+      // something each listener has to defend against.
+      if (stopped) return;
+
       let newest: string | null = null;
       for (const line of lines) {
         const headline = HEADLINE_RE.exec(line)?.[1];
@@ -144,12 +149,18 @@ export function watchRootStepProgress(
         // A throwing listener must not end the watch, nor bubble into the step.
         try { onHeadline(newest); } catch { /* nobody listening */ }
       }
-      if (stopped) return;
-      await new Promise((r) => setTimeout(r, PROGRESS_POLL_MS));
+
+      await new Promise<void>((resolve) => { sleepTimer = setTimeout(resolve, PROGRESS_POLL_MS); });
     }
   })();
 
-  return () => { stopped = true; };
+  return () => {
+    stopped = true;
+    // Or the step's last sleep keeps a timer alive for four more seconds — 13
+    // root steps' worth per update, and enough to hold the event loop open just
+    // as the rebuild step wants to take the process down.
+    if (sleepTimer) clearTimeout(sleepTimer);
+  };
 }
 
 /** install.sh's --step EXIT trap ends a failed run with these; none of them is the reason. */

--- a/src/lib/root-step-follow.ts
+++ b/src/lib/root-step-follow.ts
@@ -75,6 +75,83 @@ async function lastJournalLine(step: string, sinceMs: number, lines: number): Pr
   return all.length > 0 ? all[all.length - 1] : null;
 }
 
+/** How often a watched step's journal is re-read for a new headline. */
+const PROGRESS_POLL_MS = 4000;
+/** How far back each poll looks; enough to span a chatty pip install. */
+const PROGRESS_WINDOW_LINES = 60;
+
+/**
+ * install.sh's own progress lines, told apart from the noise underneath them.
+ *
+ * The installer announces each sub-phase with a two-space indent — "  Installing
+ * Kokoro TTS...", "  Building CTranslate2 with CUDA for sm_87..." — while the
+ * tools it drives write flush left ("Installing collected packages: ...",
+ * "Successfully installed av-17.1.0 ..."). That indent is the only marker there
+ * is, and it is enough: it is applied consistently by every step, and matching
+ * it means a caller shows the box's own account of what it is doing rather than
+ * pip's.
+ *
+ * Deliberately NOT the last journal line, which is what `followRootStep` streams:
+ * during the CUDA compile the last line is whatever cc1plus last said, and for
+ * six minutes there is no line at all. The headline is what stays true.
+ */
+const HEADLINE_RE = /^ {2}(?! )(\S.*?)\s*$/;
+
+/** Read a window of the step's journal WITHOUT trimming the leading indent. */
+async function indentedJournalLines(step: string, sinceMs: number, lines: number): Promise<string[]> {
+  try {
+    const { stdout } = await execFile(
+      "/usr/bin/journalctl",
+      rootStepJournalArgs(step, { sinceMs, lines }),
+      { timeout: 10_000 },
+    );
+    // Only the line ending is stripped: the leading two spaces ARE the signal.
+    return stdout.split(/\r?\n/).map((l) => l.replace(/\s+$/, "")).filter((l) => l.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Watch a root step that someone ELSE is running, and report what it is doing.
+ *
+ * Read-only on purpose. `followRootStep` above both STARTS a step and follows
+ * it, which suits a route that owns the install; the updater does not want that
+ * — its root steps carry their own budgets, overrun handling and gateway
+ * quiescing, and swapping how they are started to get progress out would put
+ * all of that at risk for a cosmetic gain. This only reads the journal.
+ *
+ * Returns the stopper. Safe to call after the step has ended.
+ */
+export function watchRootStepProgress(
+  step: string,
+  sinceMs: number,
+  onHeadline: (headline: string) => void,
+): () => void {
+  let stopped = false;
+  let last: string | null = null;
+
+  void (async () => {
+    while (!stopped) {
+      const lines = await indentedJournalLines(step, sinceMs, PROGRESS_WINDOW_LINES);
+      let newest: string | null = null;
+      for (const line of lines) {
+        const headline = HEADLINE_RE.exec(line)?.[1];
+        if (headline) newest = headline;
+      }
+      if (newest && newest !== last) {
+        last = newest;
+        // A throwing listener must not end the watch, nor bubble into the step.
+        try { onHeadline(newest); } catch { /* nobody listening */ }
+      }
+      if (stopped) return;
+      await new Promise((r) => setTimeout(r, PROGRESS_POLL_MS));
+    }
+  })();
+
+  return () => { stopped = true; };
+}
+
 /** install.sh's --step EXIT trap ends a failed run with these; none of them is the reason. */
 const MARKER = /^(\[provision-(status|run)\]|#{3,}|# )/;
 

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -4242,14 +4242,12 @@ async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: Run
     // them — it cannot affect how the step is started, timed, or torn down,
     // which is the whole reason it is a separate watcher rather than a change
     // to execAsRoot. `stepStartedAt` bounds it to THIS run of the step.
+    // No guard needed on the write: `watchRootStepProgress` promises no headline
+    // after its stopper runs, and the `finally` below stops it before the step
+    // is marked anything but running.
     const stopProgress = step.requiresRoot
       ? watchRootStepProgress(step.id, stepStartedAt, (headline) => {
-          // Never write onto a step that has already ended: a poll in flight
-          // when the step finished would otherwise leave its last headline
-          // sitting under a completed row.
-          if (runtime.state.steps[i].status === "running") {
-            runtime.state.steps[i].detail = headline;
-          }
+          runtime.state.steps[i].detail = headline;
         })
       : null;
 

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -23,6 +23,7 @@ import { waitForPortOpen } from "./port-probe";
 import { parseHermesVersion } from "./version-utils";
 import { isSafeBranch } from "./update-branch";
 import { startRootStep } from "./root-step-runner";
+import { watchRootStepProgress } from "./root-step-follow";
 import { setUpdateLock, clearUpdateLock, isUpdateLocked, updateLockHeldByLiveProcess } from "./update-lock";
 
 /**
@@ -402,6 +403,22 @@ export interface StepState {
   label: string;
   status: StepStatus;
   error?: string;
+  /**
+   * What the step is doing RIGHT NOW, in install.sh's own words.
+   *
+   * The labels above are deliberately coarse — "Applying system fixups" covers
+   * nineteen sub-phases, among them a CUDA compile and several hundred-MB
+   * downloads, and on a Jetson that one step runs for fifteen minutes behind
+   * four unchanging words. This carries the installer's current headline
+   * ("Building CTranslate2 with CUDA for sm_87", "Installing CUDA-enabled
+   * PyTorch for Jetson (~300 MB)") so the screen can say which of them it is.
+   *
+   * OPTIONAL, and absent is the normal case: only root steps are watched, the
+   * watcher is read-only, and a step that says nothing simply has no detail —
+   * the UI then looks exactly as it did before. Cleared when the step ends, so
+   * a finished step never keeps the last thing it happened to be doing.
+   */
+  detail?: string;
 }
 
 export type UpdatePhase =
@@ -4220,6 +4237,22 @@ async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: Run
 
     console.log(`[Updater] Running step: ${step.label}`);
 
+    // Say what the step is DOING, not only which step it is. Root steps write
+    // their sub-phases to the journal they are already writing, so this reads
+    // them — it cannot affect how the step is started, timed, or torn down,
+    // which is the whole reason it is a separate watcher rather than a change
+    // to execAsRoot. `stepStartedAt` bounds it to THIS run of the step.
+    const stopProgress = step.requiresRoot
+      ? watchRootStepProgress(step.id, stepStartedAt, (headline) => {
+          // Never write onto a step that has already ended: a poll in flight
+          // when the step finished would otherwise leave its last headline
+          // sitting under a completed row.
+          if (runtime.state.steps[i].status === "running") {
+            runtime.state.steps[i].detail = headline;
+          }
+        })
+      : null;
+
     try {
       if (step.customRun) {
         await step.customRun();
@@ -4276,6 +4309,12 @@ async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: Run
         runtime.state.error = message;
         break;
       }
+    } finally {
+      // Both exits, including the advisory `continue` and the failFast `break`:
+      // a step that has stopped running must not keep the last thing it was
+      // doing on screen, and the watcher must not outlive it.
+      stopProgress?.();
+      runtime.state.steps[i].detail = undefined;
     }
   }
 

--- a/src/tests/components/chat-gateway-contract.test.tsx
+++ b/src/tests/components/chat-gateway-contract.test.tsx
@@ -82,7 +82,7 @@ function installFetch() {
       return { ok: true, json: async () => ({ active: "openclaw", edition: "openclaw" }) };
     }
     if (url.includes("/setup-api/chat/capabilities")) {
-      return { ok: true, json: async () => ({ harness: "openclaw", facts: { hasClawaiToken: true, hermesSupportsImages: false } }) };
+      return { ok: true, json: async () => ({ harness: "openclaw", facts: { hasClawaiToken: true, hermesSupportsImages: false, onboardingArmed: true } }) };
     }
     if (url.includes("/setup-api/chat/model")) {
       return {

--- a/src/tests/components/chat-hermes-edition-gates.test.tsx
+++ b/src/tests/components/chat-hermes-edition-gates.test.tsx
@@ -191,15 +191,31 @@ describe("the conversation surviving a refresh", () => {
     expect(box.socketsOpened).toBe(0);
   });
 
-  it("greets once on a genuinely first conversation, and completes the turn", async () => {
-    // An empty transcript is the only "first conversation" signal there is now.
-    // The greeting must also END: a harness that resolves with its reply has no
-    // socket handler to paint it, so a greet that went straight to the adapter
-    // left the composer disabled with a Stop button and nothing running.
+  it("opens no conversation of its own, even on an empty transcript", async () => {
+    // An empty transcript is NOT a first conversation, and on Hermes there is no
+    // first conversation to open at all: the greeting existed to start OpenClaw's
+    // introduction ritual, and Hermes runs none (see `onboardingRitualArmed`).
+    // So the box stays silent and the first turn is the owner's — which is also
+    // what an empty transcript gets on an OpenClaw box that has already been
+    // introduced, since a cleared conversation and a reset session look
+    // identical to a fresh one.
+    box.storedTranscript = [];
+    await mountHermesChat(box);
+    await waitFor(() => expect(box.socketsOpened).toBe(0));
+    expect(box.chatPosts).toHaveLength(0);
+  });
+
+  it("completes a turn the owner starts, and re-enables the composer", async () => {
+    // The coverage the greeting used to carry, moved onto the turn that actually
+    // happens now: a harness that resolves with its reply has no socket handler
+    // to paint it, so a turn that went straight to the adapter once left the
+    // composer disabled with a Stop button and nothing running.
     box.storedTranscript = [];
     const textarea = await mountHermesChat(box);
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
     await waitFor(() => expect(box.chatPosts.length).toBe(1));
-    expect(box.chatPosts[0].message).toBe("hi");
+    expect(box.chatPosts[0].message).toBe("hello");
     await screen.findByText("hello back");
     await waitFor(() => expect(textarea).not.toBeDisabled());
   });

--- a/src/tests/components/chat-voice-reply.test.tsx
+++ b/src/tests/components/chat-voice-reply.test.tsx
@@ -135,7 +135,7 @@ function installFetch() {
         return { ok: true, json: async () => ({ active: "openclaw", edition: "openclaw" }) };
       }
       if (url.includes("/setup-api/chat/capabilities")) {
-        return { ok: true, json: async () => ({ harness: "openclaw", facts: { hasClawaiToken: true, hermesSupportsImages: false } }) };
+        return { ok: true, json: async () => ({ harness: "openclaw", facts: { hasClawaiToken: true, hermesSupportsImages: false, onboardingArmed: true } }) };
       }
       if (url.includes("/setup-api/chat/model")) {
         return { ok: true, json: async () => ({ options: [], activeOptionId: "" }) };

--- a/src/tests/components/clawkeep-wizard.test.tsx
+++ b/src/tests/components/clawkeep-wizard.test.tsx
@@ -68,8 +68,13 @@ describe("the ClawKeep front door", () => {
     expect(screen.queryByRole("button", { name: "Pair with portal" })).toBeNull();
   });
 
-  it("skips the wizard on a paired box whatever the flag says, and on a box that finished it", async () => {
-    status = { ...BASE_STATUS, paired: true, configured: true, lastBackupAtMs: Date.now() - 3_600_000, cloudBytes: 1024, snapshotCount: 2, encryptionConfigured: true };
+  it("skips the wizard on a box that has been set up, paired or otherwise", async () => {
+    // A box paired before this wizard shipped reaches the app as
+    // `setupComplete: true` — `getClawKeepSetupComplete` derives that from the
+    // token when the flag is unset, so the legacy box is answered at the source
+    // rather than by a second condition on the front door. The front door then
+    // asks one question, and the wizard cannot dismiss itself by pairing.
+    status = { ...BASE_STATUS, setupComplete: true, paired: true, configured: true, lastBackupAtMs: Date.now() - 3_600_000, cloudBytes: 1024, snapshotCount: 2, encryptionConfigured: true };
     app();
     const pill = await screen.findByTestId("clawkeep-state", {}, { timeout: 5000 });
     // The pill is on screen before the locale has loaded; wait for the word.

--- a/src/tests/components/clawkeep-wizard.test.tsx
+++ b/src/tests/components/clawkeep-wizard.test.tsx
@@ -86,6 +86,28 @@ describe("the ClawKeep front door", () => {
     expect(screen.queryByTestId("clawkeep-wizard")).toBeNull();
   });
 
+  it("keeps the wizard up when its OWN pairing step succeeds", async () => {
+    // The regression this pins, found on a box upgraded to v4.0.0: the front
+    // door re-derived `!paired` on every status poll, so the wizard's own step 1
+    // falsified the condition keeping it on screen. The owner was dropped onto
+    // the dashboard mid-run — before the passphrase and schedule steps — and the
+    // box sat in "Protection Lapsed" with setupComplete still false, a first run
+    // that ends in a scary state nobody was walked past.
+    //
+    // Through ClawKeepApp deliberately: the wizard's own steps are exercised
+    // against ClawKeepWizard directly below, and a component that is never
+    // unmounted cannot show this. The gate lives in the app.
+    app();
+    fireEvent.click(await screen.findByTestId("clawkeep-wizard-enable", {}, { timeout: 5000 }));
+    fireEvent.click(await screen.findByTestId("clawkeep-wizard-pair", {}, { timeout: 5000 }));
+    // The stub flips `paired` on the first poll, and the wizard refreshes the
+    // app's status — the exact moment the old condition went false.
+    await waitFor(() => expect(calls.some((c) => c.url === "/setup-api/clawkeep/pair/poll")).toBe(true), { timeout: 5000 });
+    await waitFor(() => expect(status.paired).toBe(true), { timeout: 5000 });
+    // Still the wizard. Not the dashboard, and not "Protection Lapsed".
+    expect(screen.getByTestId("clawkeep-wizard")).toBeInTheDocument();
+  });
+
   it("Not now marks setup done without pairing, and the dashboard's Pair card takes over", async () => {
     app();
     fireEvent.click(await screen.findByTestId("clawkeep-wizard-skip", {}, { timeout: 5000 }));

--- a/src/tests/components/switch-hit-target.test.tsx
+++ b/src/tests/components/switch-hit-target.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import fs from "fs";
+import path from "path";
+
+/**
+ * The desktop's on/off switches must be clickable AT THE SWITCH.
+ *
+ * Both were built as a `sr-only` input behind a styled track: a 1x1px,
+ * absolutely positioned box with the visible switch drawn by two sibling
+ * spans. A person clicking the track still toggled it, because the wrapping
+ * <label> forwards the click — but the input itself was one pixel in a corner
+ * with the wrapper painted over it, so `document.elementFromPoint` at the
+ * switch's centre resolved to a DIV, never the control.
+ *
+ * That is what any pointer driven by COORDINATES hits: an automated check, an
+ * assistive pointer, a stylus or head-tracker aiming at the control it was
+ * told about. Found on 2026-09-09 while testing ClawKeep's auto-backup switch
+ * from the browser — two clicks on the control did nothing and timed out.
+ *
+ * The fix is the ordinary accessible pattern: keep the input transparent, but
+ * size it to the switch so it IS the hit target. Pinned at the source, because
+ * the property is about layout that jsdom does not compute.
+ */
+
+const FILES = {
+  "ClawKeep auto-backup": "src/components/ClawKeepApp.tsx",
+  "Memory Shard automatic indexing": "src/components/MemoryShardApp.tsx",
+} as const;
+
+/**
+ * The `<input type="checkbox">` tags that use the `peer` switch pattern.
+ *
+ * Scanned from `<input` to its closing `/>` rather than with one regex: an
+ * `onChange={(e) => …}` handler puts a `>` inside the tag, so the obvious
+ * `[^>]*` stops in the middle of the arrow and matches nothing.
+ */
+function switchInputs(source: string): string[] {
+  const tags: string[] = [];
+  let from = 0;
+  for (;;) {
+    const start = source.indexOf("<input", from);
+    if (start < 0) break;
+    const end = source.indexOf("/>", start);
+    if (end < 0) break;
+    const tag = source.slice(start, end + 2);
+    if (/type="checkbox"/.test(tag) && /\bpeer\b/.test(tag)) tags.push(tag);
+    from = end + 2;
+  }
+  return tags;
+}
+
+describe("desktop switches are hit-testable at the switch", () => {
+  for (const [name, file] of Object.entries(FILES)) {
+    const source = fs.readFileSync(path.join(process.cwd(), file), "utf8");
+    const inputs = switchInputs(source);
+
+    it(`${name}: has a peer switch to check`, () => {
+      expect(inputs.length).toBeGreaterThan(0);
+    });
+
+    it(`${name}: the input covers the switch instead of hiding in a corner`, () => {
+      for (const tag of inputs) {
+        // `sr-only` is the 1x1 clip that made the control unhittable.
+        expect(tag, `${file}: switch input is still sr-only`).not.toMatch(/\bsr-only\b/);
+        // Transparent, but a real box the size of the track it sits on.
+        expect(tag, `${file}: switch input is not sized to the track`).toMatch(/\bh-full\b/);
+        expect(tag, `${file}: switch input is not sized to the track`).toMatch(/\bw-full\b/);
+        expect(tag, `${file}: switch input is not positioned over the track`).toMatch(/\binset-0\b/);
+        // Invisible, NOT display:none — it must still take clicks and focus.
+        expect(tag, `${file}: switch input must stay transparent, not hidden`).toMatch(/\bopacity-0\b/);
+        expect(tag).not.toMatch(/\bhidden\b/);
+      }
+    });
+
+    it(`${name}: is named for assistive tech`, () => {
+      // ClawKeep's auto-backup shipped with no accessible name at all, so a
+      // screen reader announced an unlabelled checkbox next to prose.
+      for (const tag of inputs) {
+        expect(tag, `${file}: switch input has no aria-label`).toMatch(/aria-label=\{/);
+      }
+    });
+  }
+});

--- a/src/tests/routes/chat/capabilities-parallel.test.ts
+++ b/src/tests/routes/chat/capabilities-parallel.test.ts
@@ -30,7 +30,7 @@ vi.mock("@/lib/harness/credentials", () => ({ hasClawaiToken: vi.fn() }));
 vi.mock("@/lib/harness/clawai-images", () => ({ clawaiImageRouteReachable: vi.fn() }));
 vi.mock("@/lib/hermes-dashboard-turn", () => ({ hermesCanStreamTurns: vi.fn() }));
 vi.mock("@/lib/hermes-tts", () => ({
-  hermesSpeaksReplies: vi.fn(), onboardingArmed: false,
+  hermesSpeaksReplies: vi.fn(),
   // Read by `factsPending`; the memo accessor never spawns, so a plain false.
   hermesVoiceProbePending: vi.fn(() => false),
 }));
@@ -140,7 +140,8 @@ describe("GET /setup-api/chat/capabilities asks the Hermes probes together", () 
       hermesStreamsTurns: true,
       hasClawaiImageRoute: true,
       hermesAgentDrawsImages: true,
-      hermesSpeaksReplies: true, onboardingArmed: false,
+      hermesSpeaksReplies: true,
+      onboardingArmed: false,
     });
   });
 

--- a/src/tests/routes/chat/capabilities-parallel.test.ts
+++ b/src/tests/routes/chat/capabilities-parallel.test.ts
@@ -30,7 +30,7 @@ vi.mock("@/lib/harness/credentials", () => ({ hasClawaiToken: vi.fn() }));
 vi.mock("@/lib/harness/clawai-images", () => ({ clawaiImageRouteReachable: vi.fn() }));
 vi.mock("@/lib/hermes-dashboard-turn", () => ({ hermesCanStreamTurns: vi.fn() }));
 vi.mock("@/lib/hermes-tts", () => ({
-  hermesSpeaksReplies: vi.fn(),
+  hermesSpeaksReplies: vi.fn(), onboardingArmed: false,
   // Read by `factsPending`; the memo accessor never spawns, so a plain false.
   hermesVoiceProbePending: vi.fn(() => false),
 }));
@@ -140,7 +140,7 @@ describe("GET /setup-api/chat/capabilities asks the Hermes probes together", () 
       hermesStreamsTurns: true,
       hasClawaiImageRoute: true,
       hermesAgentDrawsImages: true,
-      hermesSpeaksReplies: true,
+      hermesSpeaksReplies: true, onboardingArmed: false,
     });
   });
 
@@ -168,7 +168,13 @@ describe("GET /setup-api/chat/capabilities asks the Hermes probes together", () 
   it("still asks nothing of hermes on an OpenClaw box", async () => {
     getActiveHarness.mockResolvedValue("openclaw");
     const request = startRequest();
+    // Settled without moving the clock, but not within a single microtask: the
+    // OpenClaw path does one real filesystem read of its own — whether the
+    // agent's introduction is still armed — which no fake timer stands in for.
+    // What this test is actually about is the line below: not one Hermes probe,
+    // each of which is a Python spawn or a request that leaves the device.
     await vi.advanceTimersByTimeAsync(0);
+    await request.body();
     expect(request.settled()).toBe(true);
     for (const [name, probe] of Object.entries(probes)) {
       expect(probe, name).not.toHaveBeenCalled();

--- a/src/tests/routes/chat/capabilities-parallel.test.ts
+++ b/src/tests/routes/chat/capabilities-parallel.test.ts
@@ -26,6 +26,11 @@ import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vite
 vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn() }));
+// Mocked so the route's own filesystem read cannot decide this suite's timing.
+// It is not one of the probes under test — those are the Hermes ones below —
+// and left real it takes a genuine I/O turn that no fake timer stands in for,
+// which is what stops "settled without moving the clock" from being provable.
+vi.mock("@/lib/language-persona", () => ({ onboardingRitualArmed: vi.fn(async () => false) }));
 vi.mock("@/lib/harness/credentials", () => ({ hasClawaiToken: vi.fn() }));
 vi.mock("@/lib/harness/clawai-images", () => ({ clawaiImageRouteReachable: vi.fn() }));
 vi.mock("@/lib/hermes-dashboard-turn", () => ({ hermesCanStreamTurns: vi.fn() }));
@@ -169,13 +174,10 @@ describe("GET /setup-api/chat/capabilities asks the Hermes probes together", () 
   it("still asks nothing of hermes on an OpenClaw box", async () => {
     getActiveHarness.mockResolvedValue("openclaw");
     const request = startRequest();
-    // Settled without moving the clock, but not within a single microtask: the
-    // OpenClaw path does one real filesystem read of its own — whether the
-    // agent's introduction is still armed — which no fake timer stands in for.
-    // What this test is actually about is the line below: not one Hermes probe,
-    // each of which is a Python spawn or a request that leaves the device.
+    // Settled without moving the clock — asserted on its own, NOT after
+    // awaiting `request.body()`, which awaits the very promise that marks the
+    // request settled and would make this pass whatever the route did.
     await vi.advanceTimersByTimeAsync(0);
-    await request.body();
     expect(request.settled()).toBe(true);
     for (const [name, probe] of Object.entries(probes)) {
       expect(probe, name).not.toHaveBeenCalled();

--- a/src/tests/routes/chat/capabilities-pending.test.ts
+++ b/src/tests/routes/chat/capabilities-pending.test.ts
@@ -24,7 +24,7 @@ vi.mock("@/lib/harness/credentials", () => ({ hasClawaiToken: vi.fn() }));
 vi.mock("@/lib/harness/clawai-images", () => ({ clawaiImageRouteReachable: vi.fn() }));
 vi.mock("@/lib/hermes-dashboard-turn", () => ({ hermesCanStreamTurns: vi.fn() }));
 vi.mock("@/lib/hermes-tts", () => ({
-  hermesSpeaksReplies: vi.fn(), onboardingArmed: false,
+  hermesSpeaksReplies: vi.fn(),
   hermesVoiceProbePending: vi.fn(),
 }));
 vi.mock("@/lib/harness/hermes-features", () => ({

--- a/src/tests/routes/chat/capabilities-pending.test.ts
+++ b/src/tests/routes/chat/capabilities-pending.test.ts
@@ -24,7 +24,7 @@ vi.mock("@/lib/harness/credentials", () => ({ hasClawaiToken: vi.fn() }));
 vi.mock("@/lib/harness/clawai-images", () => ({ clawaiImageRouteReachable: vi.fn() }));
 vi.mock("@/lib/hermes-dashboard-turn", () => ({ hermesCanStreamTurns: vi.fn() }));
 vi.mock("@/lib/hermes-tts", () => ({
-  hermesSpeaksReplies: vi.fn(),
+  hermesSpeaksReplies: vi.fn(), onboardingArmed: false,
   hermesVoiceProbePending: vi.fn(),
 }));
 vi.mock("@/lib/harness/hermes-features", () => ({

--- a/src/tests/unit/chat-attachment-capabilities.test.ts
+++ b/src/tests/unit/chat-attachment-capabilities.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { attachmentAcceptAttribute, partitionAttachments } from "@/lib/chat-attachments";
-import { capabilitiesFor } from "@/lib/harness/capabilities";
+import { capabilitiesFor, UNKNOWN_FACTS } from "@/lib/harness/capabilities";
 
 /**
  * What the composer accepts, decided by what the box can pass to the model.
@@ -14,32 +14,16 @@ import { capabilitiesFor } from "@/lib/harness/capabilities";
 const file = (name: string, type: string) => new File([new Uint8Array([1])], name, { type });
 
 const HERMES_WITH_IMAGES = capabilitiesFor("hermes", {
+  ...UNKNOWN_FACTS,
   hasClawaiToken: true,
   hermesSupportsImages: true,
   // Both halves: a turn that carries the picture and somewhere that looks at
   // it. Without the second the composer offers nothing — see the capability
   // table's own tests.
   hermesHasVisionRoute: true,
-  hermesStreamsTurns: false,
-  hasClawaiImageRoute: false,
-  hermesAgentDrawsImages: false, hermesSpeaksReplies: false, onboardingArmed: false
 });
-const HERMES_BARE = capabilitiesFor("hermes", {
-  hasClawaiToken: false,
-  hermesSupportsImages: false,
-  hermesHasVisionRoute: false,
-  hermesStreamsTurns: false,
-  hasClawaiImageRoute: false,
-  hermesAgentDrawsImages: false, hermesSpeaksReplies: false, onboardingArmed: false
-});
-const OPENCLAW = capabilitiesFor("openclaw", {
-  hasClawaiToken: true,
-  hermesSupportsImages: false,
-  hermesHasVisionRoute: false,
-  hermesStreamsTurns: false,
-  hasClawaiImageRoute: false,
-  hermesAgentDrawsImages: false, hermesSpeaksReplies: false, onboardingArmed: false
-});
+const HERMES_BARE = capabilitiesFor("hermes", { ...UNKNOWN_FACTS });
+const OPENCLAW = capabilitiesFor("openclaw", { ...UNKNOWN_FACTS, hasClawaiToken: true });
 
 describe("partitionAttachments", () => {
   it("takes everything where everything can reach the model", () => {

--- a/src/tests/unit/chat-attachment-capabilities.test.ts
+++ b/src/tests/unit/chat-attachment-capabilities.test.ts
@@ -22,7 +22,7 @@ const HERMES_WITH_IMAGES = capabilitiesFor("hermes", {
   hermesHasVisionRoute: true,
   hermesStreamsTurns: false,
   hasClawaiImageRoute: false,
-  hermesAgentDrawsImages: false, hermesSpeaksReplies: false
+  hermesAgentDrawsImages: false, hermesSpeaksReplies: false, onboardingArmed: false
 });
 const HERMES_BARE = capabilitiesFor("hermes", {
   hasClawaiToken: false,
@@ -30,7 +30,7 @@ const HERMES_BARE = capabilitiesFor("hermes", {
   hermesHasVisionRoute: false,
   hermesStreamsTurns: false,
   hasClawaiImageRoute: false,
-  hermesAgentDrawsImages: false, hermesSpeaksReplies: false
+  hermesAgentDrawsImages: false, hermesSpeaksReplies: false, onboardingArmed: false
 });
 const OPENCLAW = capabilitiesFor("openclaw", {
   hasClawaiToken: true,
@@ -38,7 +38,7 @@ const OPENCLAW = capabilitiesFor("openclaw", {
   hermesHasVisionRoute: false,
   hermesStreamsTurns: false,
   hasClawaiImageRoute: false,
-  hermesAgentDrawsImages: false, hermesSpeaksReplies: false
+  hermesAgentDrawsImages: false, hermesSpeaksReplies: false, onboardingArmed: false
 });
 
 describe("partitionAttachments", () => {

--- a/src/tests/unit/clawbox-tts.test.ts
+++ b/src/tests/unit/clawbox-tts.test.ts
@@ -947,6 +947,21 @@ describe("install.sh wires TTS to the on-device chain", () => {
     );
   });
 
+  it("refuses to seed over a config it could not read", () => {
+    // `openclaw config get` exits 1 for an unset key AND for an unreadable
+    // config, with empty output either way — measured on the box. Seed-if-unset
+    // must act on the first and never the second, or an owner's ElevenLabs pick
+    // is overwritten by an update that simply could not see it. The exit code
+    // cannot tell them apart, so the FILE is asked instead.
+    expect(step).toMatch(/if ! tts_config_readable; then/);
+    const helper = extractShellFunction(INSTALL_SH, "tts_config_readable");
+    // Absent is genuinely unset — a fresh box must still be seeded.
+    expect(helper).toMatch(/if not os\.path\.exists\(path\):\s*\n\s*sys\.exit\(0\)/);
+    // Present but unparseable is the one case that refuses.
+    expect(helper).toContain("sys.exit(1)");
+    expect(helper).toContain("json.load");
+  });
+
   it("proves the subscription from our own stamp, not a second plan read", () => {
     const helper = extractShellFunction(INSTALL_SH, "tts_managed_cloud_provider");
     // gateway-pre-start.sh writes this entry only at the speech tier and

--- a/src/tests/unit/clawbox-tts.test.ts
+++ b/src/tests/unit/clawbox-tts.test.ts
@@ -923,6 +923,50 @@ describe("install.sh wires TTS to the on-device chain", () => {
     );
     expect(dispatch).toContain("openclaw_tts");
   });
+
+  // Which of the two voices speaks FIRST on a box that has both. Kokoro is
+  // installed either way; only the default selection is at stake, and on a
+  // subscribed box that default is the ClawBox AI cloud voice — it answers
+  // immediately, where Kokoro's server stops itself after five idle minutes and
+  // the next utterance pays a 13-19 s cold start.
+  it("defaults to the ClawBox AI cloud voice when the box has one", () => {
+    // Selected through a variable, never a second hardcoded provider name:
+    // the local id stays the floor.
+    expect(step).toMatch(/local TTS_SELECTED="tts-local-cli"/);
+    expect(step).toMatch(/CLOUD_TTS=\$\(tts_managed_cloud_provider "\$TTS_HOME"\)/);
+    expect(step).toMatch(/TTS_SELECTED="\$CLOUD_TTS"/);
+    expect(step).toContain('oc_config_set "$TTS_HOME.provider" "$TTS_SELECTED"');
+  });
+
+  it("falls back to the on-device voice rather than leaving the box mute", () => {
+    // tts-local-cli is written and its plugin verified immediately above, so it
+    // is the one provider this step KNOWS can answer. A cloud entry that could
+    // not be selected must not leave a working engine with no selection.
+    expect(step).toMatch(
+      /if \[ "\$TTS_SELECTED" = "tts-local-cli" \] \|\| ! oc_config_set "\$TTS_HOME\.provider" "tts-local-cli"; then/,
+    );
+  });
+
+  it("proves the subscription from our own stamp, not a second plan read", () => {
+    const helper = extractShellFunction(INSTALL_SH, "tts_managed_cloud_provider");
+    // gateway-pre-start.sh writes this entry only at the speech tier and
+    // withdraws it on a downgrade, so its presence IS the gate. Re-reading the
+    // tier here would be a copy of that rule, free to drift from it.
+    expect(helper).toContain("clawboxManaged");
+    expect(helper).not.toMatch(/clawai_tier|CLAWBOX_SPEECH_DEVICE_TIER/);
+    // The owner's own openai speech route carries no stamp and must never be
+    // mistaken for ours.
+    expect(helper).toMatch(/entry\.get\("clawboxManaged"\) is True/);
+  });
+
+  it("only ever decides an UNSET provider", () => {
+    // The whole branch sits after the seed-if-unset guard, so an owner's pick —
+    // including an explicit pick of the local voice — survives every update.
+    const preserved = step.indexOf("TTS provider already set");
+    const selection = step.indexOf('oc_config_set "$TTS_HOME.provider" "$TTS_SELECTED"');
+    expect(preserved).toBeGreaterThan(-1);
+    expect(selection).toBeGreaterThan(preserved);
+  });
 });
 
 describe("install-voice.sh installs no second engine", () => {

--- a/src/tests/unit/clawkeep-setup-complete.test.ts
+++ b/src/tests/unit/clawkeep-setup-complete.test.ts
@@ -1,0 +1,94 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * "Has the owner been through ClawKeep's first-run wizard?"
+ *
+ * The answer has to survive the wizard's own progress. ClawKeepApp used to ask
+ * `setupComplete === false && !paired`, re-derived on every status poll — so
+ * pairing, which is step 1 of 3, falsified the condition that kept the wizard on
+ * screen. The owner landed on the dashboard before the passphrase and schedule
+ * steps, at "AT RISK — Protection Lapsed", with the flag still false. Found on a
+ * box upgraded to v4.0.0 on 2026-09-09.
+ *
+ * The `!paired` conjunct existed for one real case: a box paired before this
+ * wizard shipped must not be dragged through onboarding by an update. Answered
+ * HERE, that case costs the front door nothing — the app asks the single
+ * question its sibling apps ask, and cannot be ejected by its own success.
+ */
+
+const TEST_ROOT = path.join(os.tmpdir(), `clawbox-clawkeep-setup-${process.pid}-${Date.now()}`);
+const DATA_DIR = path.join(TEST_ROOT, "clawkeep");
+const TOKEN_PATH = path.join(DATA_DIR, "token");
+
+/** The device-store value, as a test controls it. */
+let storedFlag: unknown;
+
+vi.mock("@/lib/config-store", () => ({
+  get: vi.fn(async () => storedFlag),
+  set: vi.fn(async () => {}),
+  getKnown: vi.fn(async () => ({})),
+  setMany: vi.fn(async () => {}),
+}));
+
+let clawkeep: typeof import("@/lib/clawkeep");
+
+beforeAll(async () => {
+  process.env.CLAWKEEP_DATA_DIR = DATA_DIR;
+  process.env.CLAWKEEP_CONFIG_PATH = path.join(DATA_DIR, "config.toml");
+  await fs.mkdir(DATA_DIR, { recursive: true });
+  clawkeep = await import("@/lib/clawkeep");
+});
+
+afterAll(async () => {
+  delete process.env.CLAWKEEP_DATA_DIR;
+  delete process.env.CLAWKEEP_CONFIG_PATH;
+  await fs.rm(TEST_ROOT, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  storedFlag = undefined;
+  await fs.rm(TOKEN_PATH, { force: true });
+});
+afterEach(() => vi.clearAllMocks());
+
+/** What pairing leaves behind: a `claw_`-prefixed device token. */
+async function pair() {
+  await fs.writeFile(TOKEN_PATH, "claw_abc123\n", "utf8");
+}
+
+describe("getClawKeepSetupComplete", () => {
+  it("is false on a fresh box: no flag, nothing paired", async () => {
+    expect(await clawkeep.getClawKeepSetupComplete()).toBe(false);
+  });
+
+  it("takes an EXPLICIT false even on a paired box", async () => {
+    // The regression this repairs. Mid-wizard the box is paired and the flag is
+    // still false, and that combination has to keep meaning "not finished" — it
+    // is exactly the state the wizard is in between step 1 and step 3.
+    await pair();
+    storedFlag = false;
+    expect(await clawkeep.getClawKeepSetupComplete()).toBe(false);
+  });
+
+  it("takes an explicit true", async () => {
+    storedFlag = true;
+    expect(await clawkeep.getClawKeepSetupComplete()).toBe(true);
+  });
+
+  it("counts a paired box as set up when no flag was ever written", async () => {
+    // The legacy case the front door's `!paired` conjunct used to carry: a box
+    // paired before the flag existed has been through setup by definition.
+    await pair();
+    expect(await clawkeep.getClawKeepSetupComplete()).toBe(true);
+  });
+
+  it("ignores a token that is not one", async () => {
+    // readToken refuses anything without the `claw_` prefix, so a stray or
+    // truncated file must not be read as "this box is already set up".
+    await fs.writeFile(TOKEN_PATH, "not-a-token\n", "utf8");
+    expect(await clawkeep.getClawKeepSetupComplete()).toBe(false);
+  });
+});

--- a/src/tests/unit/desktop-default-icons.test.ts
+++ b/src/tests/unit/desktop-default-icons.test.ts
@@ -28,8 +28,10 @@ describe("default desktop icons", () => {
   });
 
   it("validates a saved layout against every built-in, not just the defaults", () => {
+    // The binding keyword is not the point — the shed below reassigns `saved`,
+    // so this matches either form and pins only the rule it exists for.
     expect(src).toMatch(
-      /const saved = \(data\.desktop_apps as string\[\]\)\.filter\(id => BUILT_IN_APP_IDS\.includes\(id\)\)/
+      /(?:const|let) saved = \(data\.desktop_apps as string\[\]\)\.filter\(id => BUILT_IN_APP_IDS\.includes\(id\)\)/
     );
   });
 
@@ -41,5 +43,40 @@ describe("default desktop icons", () => {
 
   it("gives every built-in a declared icon slot, including the off-by-default ones", () => {
     expect(src).toMatch(/BUILT_IN_APP_IDS\.map\(\(id\) => `desktop-\$\{id\}`\)/);
+  });
+});
+
+// `OFF_DESKTOP_BY_DEFAULT` only shapes the DEFAULT grid, and a saved list is
+// restored verbatim so an owner's own additions survive. The consequence was
+// that moving an app off the desktop reached FRESH boxes only: an upgraded box
+// kept the icon for good, which is the state a v3.9.0 -> v4.0.0 box was found in.
+describe("one-time shed of apps that moved off the desktop", () => {
+  it("sheds exactly the ids that moved, and only from a saved list", () => {
+    expect(src).toMatch(/const SHED_FROM_SAVED_DESKTOP = new Set\(\["system_update", "vnc"\]\)/);
+    expect(src).toMatch(
+      /saved = saved\.filter\(id => !SHED_FROM_SAVED_DESKTOP\.has\(id\)\)/
+    );
+  });
+
+  it("is gated on a persisted version, so an icon put back is not shed again", () => {
+    expect(src).toMatch(/const DESKTOP_APPS_SHED_VERSION = \d+/);
+    expect(src).toMatch(
+      /Number\(data\.desktop_apps_shed \?\? 0\) < DESKTOP_APPS_SHED_VERSION/
+    );
+    // Recorded from an effect rather than from inside the load: the preference
+    // writer is gated on `prefsLoaded` and drops a write issued during it.
+    expect(src).toMatch(/savePreferences\(\{ desktop_apps_shed: DESKTOP_APPS_SHED_VERSION \}\)/);
+  });
+
+  it("drops the shed app's reserved grid cell where icon_grid is applied", () => {
+    // Applied at the icon_grid assignment, which runs AFTER the shed and would
+    // otherwise put the empty slot straight back.
+    expect(src).toMatch(/for \(const id of SHED_FROM_SAVED_DESKTOP\) delete grid\[`desktop-\$\{id\}`\]/);
+  });
+
+  it("leaves both apps installable from the launcher", () => {
+    // The shed is about the default grid, never about removing the app.
+    expect(registrySrc).toMatch(/id: "vnc", name: "app\.remoteDesktop"/);
+    expect(registrySrc).toMatch(/id: "system_update", name: "app\.systemUpdate"/);
   });
 });

--- a/src/tests/unit/desktop-default-icons.test.ts
+++ b/src/tests/unit/desktop-default-icons.test.ts
@@ -52,26 +52,32 @@ describe("default desktop icons", () => {
 // kept the icon for good, which is the state a v3.9.0 -> v4.0.0 box was found in.
 describe("one-time shed of apps that moved off the desktop", () => {
   it("sheds exactly the ids that moved, and only from a saved list", () => {
-    expect(src).toMatch(/const SHED_FROM_SAVED_DESKTOP = new Set\(\["system_update", "vnc"\]\)/);
-    expect(src).toMatch(
-      /saved = saved\.filter\(id => !SHED_FROM_SAVED_DESKTOP\.has\(id\)\)/
-    );
+    expect(src).toMatch(/1: \["system_update", "vnc"\]/);
+    expect(src).toMatch(/saved = saved\.filter\(id => !shed\.has\(id\)\)/);
   });
 
-  it("is gated on a persisted version, so an icon put back is not shed again", () => {
-    expect(src).toMatch(/const DESKTOP_APPS_SHED_VERSION = \d+/);
+  it("applies only the versions a box has not already had", () => {
+    // The property that makes a later bump safe. Shedding one flat set on every
+    // bump would take back an icon THIS version already shed and the owner has
+    // since restored — the exact case the version exists to prevent.
+    expect(src).toMatch(/DESKTOP_APPS_SHED_BY_VERSION: Record<number, readonly string\[\]>/);
+    expect(src).toMatch(/\.filter\(\(\[version\]\) => Number\(version\) > from\)/);
+    expect(src).toMatch(/const shedFrom = Number\(data\.desktop_apps_shed \?\? 0\)/);
+    expect(src).toMatch(/shedFrom < DESKTOP_APPS_SHED_VERSION/);
+  });
+
+  it("records the version in the SAME write as the list it changed", () => {
+    // Two writes could land apart, and a box that shed its icons without
+    // recording the version would shed them again on the next load.
     expect(src).toMatch(
-      /Number\(data\.desktop_apps_shed \?\? 0\) < DESKTOP_APPS_SHED_VERSION/
+      /\{ desktop_apps: desktopApps, desktop_apps_shed: DESKTOP_APPS_SHED_VERSION \}/,
     );
-    // Recorded from an effect rather than from inside the load: the preference
-    // writer is gated on `prefsLoaded` and drops a write issued during it.
-    expect(src).toMatch(/savePreferences\(\{ desktop_apps_shed: DESKTOP_APPS_SHED_VERSION \}\)/);
   });
 
   it("drops the shed app's reserved grid cell where icon_grid is applied", () => {
     // Applied at the icon_grid assignment, which runs AFTER the shed and would
     // otherwise put the empty slot straight back.
-    expect(src).toMatch(/for \(const id of SHED_FROM_SAVED_DESKTOP\) delete grid\[`desktop-\$\{id\}`\]/);
+    expect(src).toMatch(/for \(const id of shedNeeded\.current \?\? \[\]\) delete grid\[`desktop-\$\{id\}`\]/);
   });
 
   it("leaves both apps installable from the launcher", () => {

--- a/src/tests/unit/harness-capabilities.test.ts
+++ b/src/tests/unit/harness-capabilities.test.ts
@@ -17,40 +17,12 @@ import {
  *    combination, or a button appears that promises something impossible.
  */
 
-const linked: HarnessFacts = {
-  hasClawaiToken: true,
-  hermesSupportsImages: false,
-  hermesHasVisionRoute: false,
-  hermesStreamsTurns: false,
-  hasClawaiImageRoute: false,
-  hermesAgentDrawsImages: false, hermesSpeaksReplies: false, onboardingArmed: false
-};
-const bare: HarnessFacts = {
-  hasClawaiToken: false,
-  hermesSupportsImages: false,
-  hermesHasVisionRoute: false,
-  hermesStreamsTurns: false,
-  hasClawaiImageRoute: false,
-  hermesAgentDrawsImages: false, hermesSpeaksReplies: false, onboardingArmed: false
-};
+const linked: HarnessFacts = { ...UNKNOWN_FACTS, hasClawaiToken: true };
+const bare: HarnessFacts = { ...UNKNOWN_FACTS };
 /** The box the attach button is honest on: the flag AND somewhere to look. */
-const seeing: HarnessFacts = {
-  hasClawaiToken: true,
-  hermesSupportsImages: true,
-  hermesHasVisionRoute: true,
-  hermesStreamsTurns: false,
-  hasClawaiImageRoute: false,
-  hermesAgentDrawsImages: false, hermesSpeaksReplies: false, onboardingArmed: false
-};
+const seeing: HarnessFacts = { ...UNKNOWN_FACTS, hasClawaiToken: true, hermesSupportsImages: true, hermesHasVisionRoute: true };
 /** A linked box whose agent has an image backend selected — it can draw. */
-const drawing: HarnessFacts = {
-  hasClawaiToken: true,
-  hermesSupportsImages: false,
-  hermesHasVisionRoute: false,
-  hermesStreamsTurns: false,
-  hasClawaiImageRoute: false,
-  hermesAgentDrawsImages: true, hermesSpeaksReplies: false, onboardingArmed: false
-};
+const drawing: HarnessFacts = { ...UNKNOWN_FACTS, hasClawaiToken: true, hermesAgentDrawsImages: true };
 
 describe("capabilitiesFor", () => {
   it("follows the credential, not the edition, for transcription", () => {

--- a/src/tests/unit/harness-capabilities.test.ts
+++ b/src/tests/unit/harness-capabilities.test.ts
@@ -23,7 +23,7 @@ const linked: HarnessFacts = {
   hermesHasVisionRoute: false,
   hermesStreamsTurns: false,
   hasClawaiImageRoute: false,
-  hermesAgentDrawsImages: false, hermesSpeaksReplies: false
+  hermesAgentDrawsImages: false, hermesSpeaksReplies: false, onboardingArmed: false
 };
 const bare: HarnessFacts = {
   hasClawaiToken: false,
@@ -31,7 +31,7 @@ const bare: HarnessFacts = {
   hermesHasVisionRoute: false,
   hermesStreamsTurns: false,
   hasClawaiImageRoute: false,
-  hermesAgentDrawsImages: false, hermesSpeaksReplies: false
+  hermesAgentDrawsImages: false, hermesSpeaksReplies: false, onboardingArmed: false
 };
 /** The box the attach button is honest on: the flag AND somewhere to look. */
 const seeing: HarnessFacts = {
@@ -40,7 +40,7 @@ const seeing: HarnessFacts = {
   hermesHasVisionRoute: true,
   hermesStreamsTurns: false,
   hasClawaiImageRoute: false,
-  hermesAgentDrawsImages: false, hermesSpeaksReplies: false
+  hermesAgentDrawsImages: false, hermesSpeaksReplies: false, onboardingArmed: false
 };
 /** A linked box whose agent has an image backend selected — it can draw. */
 const drawing: HarnessFacts = {
@@ -49,7 +49,7 @@ const drawing: HarnessFacts = {
   hermesHasVisionRoute: false,
   hermesStreamsTurns: false,
   hasClawaiImageRoute: false,
-  hermesAgentDrawsImages: true, hermesSpeaksReplies: false
+  hermesAgentDrawsImages: true, hermesSpeaksReplies: false, onboardingArmed: false
 };
 
 describe("capabilitiesFor", () => {
@@ -250,7 +250,7 @@ describe("capabilitiesFor", () => {
         hermesHasVisionRoute: false,
         hermesStreamsTurns: false,
         hasClawaiImageRoute: false,
-        hermesAgentDrawsImages: false, hermesSpeaksReplies: false
+        hermesAgentDrawsImages: false, hermesSpeaksReplies: false, onboardingArmed: false
       }).canAttachImages,
     ).toBe(false);
     // And the mirror: a vision route on an agent whose turn cannot carry the
@@ -262,7 +262,7 @@ describe("capabilitiesFor", () => {
         hermesHasVisionRoute: true,
         hermesStreamsTurns: false,
         hasClawaiImageRoute: false,
-        hermesAgentDrawsImages: false, hermesSpeaksReplies: false
+        hermesAgentDrawsImages: false, hermesSpeaksReplies: false, onboardingArmed: false
       }).canAttachImages,
     ).toBe(false);
   });
@@ -281,7 +281,7 @@ describe("capabilitiesFor", () => {
         hermesHasVisionRoute: false,
         hermesStreamsTurns: false,
         hasClawaiImageRoute: false,
-        hermesAgentDrawsImages: false, hermesSpeaksReplies: false
+        hermesAgentDrawsImages: false, hermesSpeaksReplies: false, onboardingArmed: false
       }).canAttachImages,
     ).toBe(false);
     expect(
@@ -291,7 +291,7 @@ describe("capabilitiesFor", () => {
         hermesHasVisionRoute: true,
         hermesStreamsTurns: false,
         hasClawaiImageRoute: false,
-        hermesAgentDrawsImages: false, hermesSpeaksReplies: false
+        hermesAgentDrawsImages: false, hermesSpeaksReplies: false, onboardingArmed: false
       }).canAttachImages,
     ).toBe(true);
   });

--- a/src/tests/unit/hermes-adapter-clarify.test.ts
+++ b/src/tests/unit/hermes-adapter-clarify.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { HermesAdapter } from "@/lib/harness/hermes-adapter";
-import { capabilitiesFor } from "@/lib/harness/capabilities";
+import { capabilitiesFor, UNKNOWN_FACTS } from "@/lib/harness/capabilities";
 import type { TurnEvent } from "@/lib/harness/transport";
 
 /**
@@ -19,13 +19,9 @@ import type { TurnEvent } from "@/lib/harness/transport";
  */
 
 const CAPS = capabilitiesFor("hermes", {
+  ...UNKNOWN_FACTS,
   hasClawaiToken: true,
-  hermesSupportsImages: false,
-  hermesHasVisionRoute: false,
   hermesStreamsTurns: true,
-  hasClawaiImageRoute: false,
-  hermesAgentDrawsImages: false,
-  hermesSpeaksReplies: false, onboardingArmed: false,
 });
 
 /** One SSE frame, framed the way the route frames it. */

--- a/src/tests/unit/hermes-adapter-clarify.test.ts
+++ b/src/tests/unit/hermes-adapter-clarify.test.ts
@@ -25,7 +25,7 @@ const CAPS = capabilitiesFor("hermes", {
   hermesStreamsTurns: true,
   hasClawaiImageRoute: false,
   hermesAgentDrawsImages: false,
-  hermesSpeaksReplies: false,
+  hermesSpeaksReplies: false, onboardingArmed: false,
 });
 
 /** One SSE frame, framed the way the route frames it. */

--- a/src/tests/unit/hermes-adapter-streaming.test.ts
+++ b/src/tests/unit/hermes-adapter-streaming.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { HermesAdapter } from "@/lib/harness/hermes-adapter";
-import { capabilitiesFor } from "@/lib/harness/capabilities";
+import { capabilitiesFor, UNKNOWN_FACTS } from "@/lib/harness/capabilities";
 import { HarnessError, type TurnEvent } from "@/lib/harness/transport";
 
 /**
@@ -21,13 +21,9 @@ import { HarnessError, type TurnEvent } from "@/lib/harness/transport";
  */
 
 const FACTS = {
+  ...UNKNOWN_FACTS,
   hasClawaiToken: true,
-  hermesSupportsImages: false,
-  hermesHasVisionRoute: false,
   hermesStreamsTurns: true,
-  hasClawaiImageRoute: false,
-  hermesAgentDrawsImages: false,
-  hermesSpeaksReplies: false, onboardingArmed: false,
 };
 const STREAMING_CAPS = capabilitiesFor("hermes", FACTS);
 const BLOCKING_CAPS = capabilitiesFor("hermes", { ...FACTS, hermesStreamsTurns: false });

--- a/src/tests/unit/hermes-adapter-streaming.test.ts
+++ b/src/tests/unit/hermes-adapter-streaming.test.ts
@@ -27,7 +27,7 @@ const FACTS = {
   hermesStreamsTurns: true,
   hasClawaiImageRoute: false,
   hermesAgentDrawsImages: false,
-  hermesSpeaksReplies: false,
+  hermesSpeaksReplies: false, onboardingArmed: false,
 };
 const STREAMING_CAPS = capabilitiesFor("hermes", FACTS);
 const BLOCKING_CAPS = capabilitiesFor("hermes", { ...FACTS, hermesStreamsTurns: false });

--- a/src/tests/unit/hermes-adapter.test.ts
+++ b/src/tests/unit/hermes-adapter.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { HermesAdapter, type HermesTurnContext } from "@/lib/harness/hermes-adapter";
-import { capabilitiesFor } from "@/lib/harness/capabilities";
+import { capabilitiesFor, UNKNOWN_FACTS } from "@/lib/harness/capabilities";
 import { HarnessError } from "@/lib/harness/transport";
 
 /**
@@ -19,15 +19,13 @@ import { HarnessError } from "@/lib/harness/transport";
  */
 
 const caps = capabilitiesFor("hermes", {
+  ...UNKNOWN_FACTS,
   hasClawaiToken: true,
   hermesSupportsImages: true,
   hermesHasVisionRoute: true,
-  hermesStreamsTurns: false,
   // A box that can draw: the credential plus a live image route. Both halves,
   // because `imageGenerationTrigger` is what `generateImage` checks first.
   hasClawaiImageRoute: true,
-  hermesAgentDrawsImages: false,
-  hermesSpeaksReplies: false, onboardingArmed: false,
 });
 const CONTEXT: HermesTurnContext = {
   devicePairing: { provider: "clawai", model: "deepseek" },

--- a/src/tests/unit/hermes-adapter.test.ts
+++ b/src/tests/unit/hermes-adapter.test.ts
@@ -27,7 +27,7 @@ const caps = capabilitiesFor("hermes", {
   // because `imageGenerationTrigger` is what `generateImage` checks first.
   hasClawaiImageRoute: true,
   hermesAgentDrawsImages: false,
-  hermesSpeaksReplies: false,
+  hermesSpeaksReplies: false, onboardingArmed: false,
 });
 const CONTEXT: HermesTurnContext = {
   devicePairing: { provider: "clawai", model: "deepseek" },
@@ -534,7 +534,7 @@ describe("HermesAdapter", () => {
         hermesStreamsTurns: false,
         hasClawaiImageRoute: false,
         hermesAgentDrawsImages: false,
-        hermesSpeaksReplies: false,
+        hermesSpeaksReplies: false, onboardingArmed: false,
       });
       const { adapter, calls } = drawing(() => ({ ok: true, status: 200, payload: {} }), cannot);
       await expect(adapter.generateImage("x")).rejects.toMatchObject({ code: "unsupported" });

--- a/src/tests/unit/install-hermes-tts.test.ts
+++ b/src/tests/unit/install-hermes-tts.test.ts
@@ -217,7 +217,7 @@ function runStep(edition: string, opts: StepOpts = {}) {
   const res = spawnSync("bash", ["-c", program], {
     encoding: "utf-8",
     timeout: 60_000,
-    env: { ...process.env, TTS_STATUS_FILE: ttsStatusFile },
+    env: { ...process.env, CLAWBOX_OPENCLAW_HOME: `${root}/openclaw-home`, TTS_STATUS_FILE: ttsStatusFile },
   });
   const lines = (f: string) => (existsSync(f) ? readFileSync(f, "utf-8").trim().split("\n").filter(Boolean) : []);
   const out = `${res.stdout ?? ""}${res.stderr ?? ""}`;
@@ -814,7 +814,7 @@ function runValidator(edition: string, ttsStatusContents: string | null) {
   const r = spawnSync("bash", ["-c", program], {
     encoding: "utf-8",
     timeout: 60_000,
-    env: { ...process.env, TTS_STATUS_FILE: ttsStatusFile },
+    env: { ...process.env, CLAWBOX_OPENCLAW_HOME: `${root}/openclaw-home`, TTS_STATUS_FILE: ttsStatusFile },
   });
   return { status: r.status ?? -1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
 }

--- a/src/tests/unit/install-hermes-tts.test.ts
+++ b/src/tests/unit/install-hermes-tts.test.ts
@@ -206,6 +206,8 @@ function runStep(edition: string, opts: StepOpts = {}) {
     extractShellFn(INSTALL_SH, "oc_config_set"),
     extractShellFn(INSTALL_SH, "tts_ensure_provider_registered"),
     extractShellFn(INSTALL_SH, "tts_write_local_provider_definition"),
+    extractShellFn(INSTALL_SH, "tts_managed_cloud_provider"),
+    extractShellFn(INSTALL_SH, "tts_config_readable"),
     extractShellFn(INSTALL_SH, "harness_has_no_gpu"),
     extractShellFn(INSTALL_SH, "step_openclaw_tts"),
     "step_openclaw_tts",

--- a/src/tests/unit/install-kokoro-tts.test.ts
+++ b/src/tests/unit/install-kokoro-tts.test.ts
@@ -312,6 +312,8 @@ function runStep(voiceExit: number, currentProvider = "", ttsStatusContents: str
     extractShellFn(INSTALL_SH, "oc_config_set"),
     extractShellFn(INSTALL_SH, "tts_ensure_provider_registered"),
     extractShellFn(INSTALL_SH, "tts_write_local_provider_definition"),
+    extractShellFn(INSTALL_SH, "tts_managed_cloud_provider"),
+    extractShellFn(INSTALL_SH, "tts_config_readable"),
     extractShellFn(INSTALL_SH, "tts_ensure_ffmpeg"),
     // The real knob, not a stub: the test is about what the step does with it.
     extractShellFn(INSTALL_SH, "harness_has_no_gpu"),

--- a/src/tests/unit/install-kokoro-tts.test.ts
+++ b/src/tests/unit/install-kokoro-tts.test.ts
@@ -327,7 +327,7 @@ function runStep(voiceExit: number, currentProvider = "", ttsStatusContents: str
   const res = spawnSync("bash", ["-c", program], {
     encoding: "utf-8",
     timeout: 60_000,
-    env: { ...process.env, TTS_FFMPEG_BIN: ffmpegBin, ...extraEnv, TTS_STATUS_FILE: ttsStatus },
+    env: { ...process.env, CLAWBOX_OPENCLAW_HOME: `${root}/openclaw-home`, TTS_FFMPEG_BIN: ffmpegBin, ...extraEnv, TTS_STATUS_FILE: ttsStatus },
   });
   const read = (f: string) => (existsSync(f) ? readFileSync(f, "utf-8").trim().split("\n").filter(Boolean) : []);
   return {
@@ -1090,7 +1090,7 @@ function runValidator(ttsStatusContents: string | null, extraEnv: Record<string,
   const r = spawnSync("bash", ["-c", program], {
     encoding: "utf-8",
     timeout: 60_000,
-    env: { ...process.env, ...extraEnv, TTS_STATUS_FILE: ttsStatus },
+    env: { ...process.env, CLAWBOX_OPENCLAW_HOME: `${root}/openclaw-home`, ...extraEnv, TTS_STATUS_FILE: ttsStatus },
   });
   return { status: r.status ?? -1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
 }

--- a/src/tests/unit/install-tts-mute-box-fails.test.ts
+++ b/src/tests/unit/install-tts-mute-box-fails.test.ts
@@ -90,7 +90,7 @@ function runShellProgram(program: string, env: Record<string, string>) {
   return spawnSync("bash", [file], {
     encoding: "utf-8",
     timeout: 60_000,
-    env: { ...process.env, ...env },
+    env: { ...process.env, CLAWBOX_OPENCLAW_HOME: `${root}/openclaw-home`, ...env },
   });
 }
 

--- a/src/tests/unit/install-tts-mute-box-fails.test.ts
+++ b/src/tests/unit/install-tts-mute-box-fails.test.ts
@@ -391,6 +391,8 @@ function runStep(voiceExit: number, statusFileContents: string | null = null) {
     extractShellFn(INSTALL_SH, "oc_config_set"),
     extractShellFn(INSTALL_SH, "tts_ensure_provider_registered"),
     extractShellFn(INSTALL_SH, "tts_write_local_provider_definition"),
+    extractShellFn(INSTALL_SH, "tts_managed_cloud_provider"),
+    extractShellFn(INSTALL_SH, "tts_config_readable"),
     extractShellFn(INSTALL_SH, "step_openclaw_tts"),
     "step_openclaw_tts",
     'echo "STEP_RC=$?"',

--- a/src/tests/unit/install-tts-no-engine.test.ts
+++ b/src/tests/unit/install-tts-no-engine.test.ts
@@ -107,7 +107,7 @@ function runShellProgram(program: string, env: Record<string, string>) {
   return spawnSync("bash", [file], {
     encoding: "utf-8",
     timeout: 60_000,
-    env: { ...process.env, ...env },
+    env: { ...process.env, CLAWBOX_OPENCLAW_HOME: `${root}/openclaw-home`, ...env },
   });
 }
 

--- a/src/tests/unit/install-tts-no-engine.test.ts
+++ b/src/tests/unit/install-tts-no-engine.test.ts
@@ -551,6 +551,8 @@ function runStep(voiceExit: number, verdictFile?: string) {
     extractShellFn(INSTALL_SH, "oc_config_set"),
     extractShellFn(INSTALL_SH, "tts_ensure_provider_registered"),
     extractShellFn(INSTALL_SH, "tts_write_local_provider_definition"),
+    extractShellFn(INSTALL_SH, "tts_managed_cloud_provider"),
+    extractShellFn(INSTALL_SH, "tts_config_readable"),
     extractShellFn(INSTALL_SH, "step_openclaw_tts"),
     "step_openclaw_tts",
     'echo "STEP_RC=$?"',

--- a/src/tests/unit/install-tts-provider-registry.test.ts
+++ b/src/tests/unit/install-tts-provider-registry.test.ts
@@ -114,7 +114,7 @@ function runStep(env: Record<string, string> = {}) {
 
   return spawnSync("bash", ["-c", program], {
     encoding: "utf-8",
-    env: { ...process.env, ...env },
+    env: { ...process.env, CLAWBOX_OPENCLAW_HOME: `${dir}/openclaw-home`, ...env },
   });
 }
 

--- a/src/tests/unit/install-tts-provider-registry.test.ts
+++ b/src/tests/unit/install-tts-provider-registry.test.ts
@@ -74,7 +74,17 @@ case "$1" in
     # "already configured — preserving" path. Empty by default.
     if [ "$2" = "get" ]; then
       [ "$3" = "messages.tts.provider" ] && printf '%s' "\${CURRENT_TTS_PROVIDER:-}"
+      # The provider MAP, which tts_managed_cloud_provider parses to find the
+      # entry carrying our own \`clawboxManaged\` stamp. Empty by default, so a
+      # test that says nothing about it gets the on-device voice.
+      [ "$3" = "messages.tts.providers" ] && printf '%s' "\${PROVIDERS_JSON:-}"
       exit 0
+    fi
+    # Lets a test make the SELECTION fail for one provider while every other
+    # write still succeeds — the fallback path's only trigger.
+    if [ "$2" = "set" ] && [ "$3" = "messages.tts.provider" ] \\
+       && [ -n "\${SELECT_FAIL_FOR:-}" ] && [ "$4" = "\${SELECT_FAIL_FOR}" ]; then
+      exit 1
     fi
     exit 0 ;;
 esac
@@ -250,5 +260,78 @@ describe.skipIf(!hasBash)("an already-configured box is re-verified, not just pr
     expect(calls()).not.toContain("plugins registry --refresh");
     expect(calls()).not.toContain("config set messages.tts.provider tts-local-cli");
     expect(res.stdout).toMatch(/preserving/i);
+  });
+});
+
+/**
+ * WHICH voice an unset box is pointed at.
+ *
+ * Executed, not asserted from the source: `tts_managed_cloud_provider` parses
+ * the provider MAP, and a stub that answers only `…provider` leaves the map
+ * empty — so every one of these runs would have taken the on-device branch and
+ * the cloud default would have looked covered while never once running.
+ */
+const MANAGED_CLOUD = JSON.stringify({
+  openai: { baseUrl: "https://clawbox.com/api/ai", model: "gpt-4o-mini-tts", clawboxManaged: true },
+  "tts-local-cli": { command: "/x/clawbox-tts.sh" },
+});
+
+describe.skipIf(!hasBash)("step_openclaw_tts picks the first voice for an unset box", () => {
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "clawbox-tts-registry-"));
+    projectDir = path.join(dir, "project");
+    callsLog = path.join(dir, "calls.log");
+    mkdirSync(path.join(projectDir, "scripts", "openclaw"), { recursive: true });
+    // Answers `--provider-timeout-ms`, which the sibling describe's stub never
+    // has to: `tts_write_local_provider_definition` asks the script for the
+    // timeout it will put in the provider entry, and refuses to write one
+    // without it — so a silent stub fails the definition and the step returns
+    // before it ever reaches the selection these tests are about.
+    writeFileSync(
+      path.join(projectDir, "scripts", "openclaw", "clawbox-tts.sh"),
+      "#!/usr/bin/env bash\ncase \"${1:-}\" in --provider-timeout-ms) echo 100000; exit 0 ;; esac\nexit 0\n",
+      { mode: 0o755 },
+    );
+    // A HEALTHY box, unlike the sibling describe above: these tests run the
+    // step all the way to the end (the others return early on an
+    // already-configured provider), so the engine has to report itself ready or
+    // the step exits on the mute-box path and the selection is beside the point.
+    writeFileSync(
+      path.join(projectDir, "scripts", "install-voice.sh"),
+      `#!/usr/bin/env bash\nprintf 'CLAWBOX_TTS_KOKORO=ready\\n' > "${path.join(dir, "tts-status")}"\nexit 0\n`,
+      { mode: 0o755 },
+    );
+    writeOpenclawStub();
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("selects the ClawBox AI cloud voice when the box has one", () => {
+    const res = runStep({ PROVIDERS_JSON: MANAGED_CLOUD });
+    expect(res.status).toBe(0);
+    expect(calls()).toContain("config set messages.tts.provider openai");
+    expect(calls()).not.toContain("config set messages.tts.provider tts-local-cli");
+    // Kokoro is still INSTALLED and still defined — only the default changed.
+    expect(calls().some((c) => c.startsWith("config set messages.tts.providers.tts-local-cli"))).toBe(true);
+    expect(res.stdout).toMatch(/cloud voice selected/i);
+  });
+
+  it("selects the on-device voice when there is no managed cloud entry", () => {
+    // An owner's OWN openai speech route carries no `clawboxManaged` stamp and
+    // must never be mistaken for ours.
+    const unstamped = JSON.stringify({ openai: { baseUrl: "https://api.openai.com/v1" } });
+    const res = runStep({ PROVIDERS_JSON: unstamped });
+    expect(res.status).toBe(0);
+    expect(calls()).toContain("config set messages.tts.provider tts-local-cli");
+    expect(calls()).not.toContain("config set messages.tts.provider openai");
+  });
+
+  it("falls back to the on-device voice when the cloud one cannot be selected", () => {
+    // tts-local-cli was written and its plugin verified moments earlier, so it
+    // is the one provider this step KNOWS can answer. A cloud entry that will
+    // not select must not leave a working engine with no selection at all.
+    const res = runStep({ PROVIDERS_JSON: MANAGED_CLOUD, SELECT_FAIL_FOR: "openai" });
+    expect(res.status).toBe(0);
+    expect(calls()).toContain("config set messages.tts.provider tts-local-cli");
+    expect(res.stderr).toMatch(/fell back to the on-device voice/i);
   });
 });

--- a/src/tests/unit/install-tts-provider-registry.test.ts
+++ b/src/tests/unit/install-tts-provider-registry.test.ts
@@ -106,6 +106,8 @@ function runStep(env: Record<string, string> = {}) {
     extractShellFn(INSTALL_SH, "oc_config_set"),
     extractShellFn(INSTALL_SH, "tts_ensure_provider_registered"),
     extractShellFn(INSTALL_SH, "tts_write_local_provider_definition"),
+    extractShellFn(INSTALL_SH, "tts_managed_cloud_provider"),
+    extractShellFn(INSTALL_SH, "tts_config_readable"),
     extractShellFn(INSTALL_SH, "step_openclaw_tts"),
     "step_openclaw_tts",
   ].join("\n");

--- a/src/tests/unit/install-tts-survivor-verdict.test.ts
+++ b/src/tests/unit/install-tts-survivor-verdict.test.ts
@@ -131,6 +131,8 @@ function runStep(voiceExit: number, verdicts: Record<string, string> | null) {
     extractShellFn(INSTALL_SH, "oc_config_set"),
     extractShellFn(INSTALL_SH, "tts_ensure_provider_registered"),
     extractShellFn(INSTALL_SH, "tts_write_local_provider_definition"),
+    extractShellFn(INSTALL_SH, "tts_managed_cloud_provider"),
+    extractShellFn(INSTALL_SH, "tts_config_readable"),
     extractShellFn(INSTALL_SH, "step_openclaw_tts"),
     "step_openclaw_tts",
     'echo "STEP_RC=$?"',

--- a/src/tests/unit/install-tts-survivor-verdict.test.ts
+++ b/src/tests/unit/install-tts-survivor-verdict.test.ts
@@ -80,7 +80,7 @@ function runShellProgram(program: string, env: Record<string, string>) {
   return spawnSync("bash", [file], {
     encoding: "utf-8",
     timeout: 60_000,
-    env: { ...process.env, ...env },
+    env: { ...process.env, CLAWBOX_OPENCLAW_HOME: `${root}/openclaw-home`, ...env },
   });
 }
 

--- a/src/tests/unit/install-tts-verdict-siblings.test.ts
+++ b/src/tests/unit/install-tts-verdict-siblings.test.ts
@@ -91,7 +91,7 @@ function runShellProgram(program: string, env: Record<string, string>, args: str
   return spawnSync("bash", [file, ...args], {
     encoding: "utf-8",
     timeout: 60_000,
-    env: { ...process.env, ...env },
+    env: { ...process.env, CLAWBOX_OPENCLAW_HOME: `${root}/openclaw-home`, ...env },
   });
 }
 

--- a/src/tests/unit/install-tts-verdict-siblings.test.ts
+++ b/src/tests/unit/install-tts-verdict-siblings.test.ts
@@ -368,6 +368,8 @@ function runStep(voiceExit: number, verdict?: string) {
     extractShellFn(INSTALL_SH, "oc_config_set"),
     extractShellFn(INSTALL_SH, "tts_ensure_provider_registered"),
     extractShellFn(INSTALL_SH, "tts_write_local_provider_definition"),
+    extractShellFn(INSTALL_SH, "tts_managed_cloud_provider"),
+    extractShellFn(INSTALL_SH, "tts_config_readable"),
     extractShellFn(INSTALL_SH, "step_openclaw_tts"),
     "step_openclaw_tts",
     'echo "STEP_RC=$?"',

--- a/src/tests/unit/root-step-progress.test.ts
+++ b/src/tests/unit/root-step-progress.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `watchRootStepProgress` — what a long root step is DOING, for a label that
+ * cannot say it.
+ *
+ * "Applying system fixups" covers nineteen sub-phases on a Jetson, among them a
+ * CUDA compile that ran for six silent minutes and several hundred-MB
+ * downloads. Measured on hardware 2026-09-09: the step held those four words
+ * for fifteen minutes while the box saturated four cores.
+ *
+ * The signal is install.sh's own two-space indent: the installer announces each
+ * sub-phase that way, while the tools it drives (pip, apt) write flush left.
+ * Matching the indent shows the box's account of itself instead of pip's.
+ */
+
+const execFileMock = vi.fn();
+
+vi.mock("child_process", () => ({
+  execFile: (cmd: string, args: string[], ...rest: unknown[]) => {
+    const cb = rest[rest.length - 1] as (
+      err: Error | null,
+      out: { stdout: string; stderr: string },
+    ) => void;
+    const result = execFileMock(cmd, args);
+    if (result?.error) {
+      cb(result.error as Error, { stdout: "", stderr: "" });
+      return;
+    }
+    cb(null, { stdout: result?.stdout ?? "", stderr: "" });
+  },
+}));
+
+/** One real journal window from the 2026-09-09 upgrade, indents preserved. */
+const JOURNAL = [
+  "  Installing CUDA-enabled PyTorch for Jetson (~300 MB)...",
+  "Installing collected packages: nvidia-cusparselt-cu12",
+  "Successfully installed av-17.1.0 coloredlogs-15.0.1 ctranslate2-4.8.2",
+  "  Installing Kokoro TTS...",
+  "WARNING: Defaulting repo_id to hexgrad/Kokoro-82M.",
+  "  Building CTranslate2 with CUDA for sm_87...",
+].join("\n");
+
+async function load() {
+  const mod = await import("@/lib/root-step-follow");
+  return mod.watchRootStepProgress;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  execFileMock.mockReset();
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("watchRootStepProgress", () => {
+  it("reports the installer's own headline, not the tool output under it", async () => {
+    execFileMock.mockReturnValue({ stdout: JOURNAL });
+    const watch = await load();
+    const seen: string[] = [];
+    const stop = watch("post_update", 1_000, (h) => seen.push(h));
+    await vi.advanceTimersByTimeAsync(0);
+    stop();
+
+    // The NEWEST indented line wins — the compile, not the pip chatter that
+    // came before it and not the flush-left lines in between.
+    expect(seen).toEqual(["Building CTranslate2 with CUDA for sm_87..."]);
+    expect(seen.join(" ")).not.toContain("Successfully installed");
+    expect(seen.join(" ")).not.toContain("Installing collected packages");
+  });
+
+  it("reads only THIS run of the step", async () => {
+    execFileMock.mockReturnValue({ stdout: JOURNAL });
+    const watch = await load();
+    const stop = watch("post_update", 4_242, () => {});
+    await vi.advanceTimersByTimeAsync(0);
+    stop();
+
+    // The journal is persistent: unbounded, the first poll would hand the
+    // PREVIOUS attempt's lines to a screen showing them as live progress.
+    const [, args] = execFileMock.mock.calls[0];
+    expect(args).toContain("--since");
+    expect(args.join(" ")).toContain("4.242");
+  });
+
+  it("says nothing when the step has not spoken, and never repeats itself", async () => {
+    execFileMock.mockReturnValue({ stdout: "Installing collected packages: flatbuffers\n" });
+    const watch = await load();
+    const seen: string[] = [];
+    const stop = watch("post_update", 1_000, (h) => seen.push(h));
+    await vi.advanceTimersByTimeAsync(0);
+    // A second poll over an unchanged journal must not re-announce.
+    await vi.advanceTimersByTimeAsync(5000);
+    stop();
+    expect(seen).toEqual([]);
+  });
+
+  it("survives a journalctl that fails, and stops when told to", async () => {
+    execFileMock.mockReturnValue({ error: new Error("journalctl: no such unit") });
+    const watch = await load();
+    const seen: string[] = [];
+    const stop = watch("post_update", 1_000, (h) => seen.push(h));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(seen).toEqual([]);
+    stop();
+    const callsAtStop = execFileMock.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(20_000);
+    // A stopped watch reads nothing further: the update's own steps are the
+    // only thing that should be shelling out once a step has ended.
+    expect(execFileMock.mock.calls.length).toBe(callsAtStop);
+  });
+
+  it("does not let a throwing listener end the watch", async () => {
+    execFileMock.mockReturnValue({ stdout: JOURNAL });
+    const watch = await load();
+    const stop = watch("post_update", 1_000, () => { throw new Error("listener gone"); });
+    await vi.advanceTimersByTimeAsync(0);
+    // Still polling after the throw — the step it is watching runs on either
+    // way, and losing the watch would leave the screen frozen on a stale line.
+    const before = execFileMock.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(9000);
+    expect(execFileMock.mock.calls.length).toBeGreaterThan(before);
+    stop();
+  });
+});

--- a/src/tests/unit/root-step-progress.test.ts
+++ b/src/tests/unit/root-step-progress.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "fs";
+import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
@@ -54,6 +56,42 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers();
   vi.clearAllMocks();
+});
+
+describe("install.sh's side of the contract", () => {
+  // The two-space indent is now a UI contract and install.sh does not say so.
+  // The fully-deep alternative — a `substep()` helper emitting an explicit
+  // marker like the existing `[provision-status]` sentinels — means touching
+  // hundreds of echo sites in the highest-risk file in the product for a
+  // cosmetic feature, so it is deliberately not done. Pinning the convention
+  // from the PRODUCER side is the cheap half: it fails if someone reformats the
+  // announcements the watcher reads, which the consumer test above cannot see.
+  it("announces sub-phases with the two-space indent the watcher matches", () => {
+    const installSh = readFileSync(path.join(process.cwd(), "install.sh"), "utf8");
+    const announcements = installSh
+      .split("\n")
+      .map((l) => /^\s*echo "( +)(Installing|Building|Checking|Refreshing) /.exec(l))
+      .filter((m): m is RegExpExecArray => m !== null);
+
+    // Twelve at the time of writing, every one of them two-space indented.
+    // The floor is what matters: enough that a reformat trips this rather than
+    // a single edit, low enough that removing one sub-phase does not.
+    expect(announcements.length).toBeGreaterThan(8);
+    for (const m of announcements) {
+      expect(m[1], `"${m[0].trim()}" must keep the two-space sub-phase indent`).toBe("  ");
+    }
+
+    // Deeper indents are a DIFFERENT thing and must stay excluded: install.sh
+    // uses four or more spaces for continuation lines under an announcement
+    // ("         Leaving messages.tts.provider unset rather than ..."), which
+    // are detail, not the headline. HEADLINE_RE matches exactly two spaces, so
+    // those are correctly ignored — this asserts they still exist rather than
+    // having been flattened into the headline space.
+    const continuations = installSh
+      .split("\n")
+      .filter((l) => /^\s*echo "    +[A-Z]/.test(l));
+    expect(continuations.length).toBeGreaterThan(0);
+  });
 });
 
 describe("watchRootStepProgress", () => {


### PR DESCRIPTION
Found by upgrading a real Jetson Orin from `main` (v3.9.0) to `beta` (v4.0.0) and then driving Coding Agent, Memory Shard and ClawKeep through the web UI. The upgrade itself passed all 13 steps cleanly; everything here is a defect the upgrade *exposed*.

## The fixes

**1. System Update and Remote Desktop icons never left upgraded desktops.**
`OFF_DESKTOP_BY_DEFAULT` only shapes the *default* grid, and the loader restores a saved `desktop_apps` list verbatim — deliberately, so an owner's additions survive. So moving an app off the desktop only ever reached fresh boxes; any box that had saved a list kept the icon forever, short of a factory reset. Shed once, keyed by version so a later bump cannot take back an icon this version already shed and the owner has since restored.

**2. A subscribed box defaulted to the local voice.**
`step_openclaw_tts` installed Kokoro and then selected it unconditionally. Measured on the box: **cloud 2.6s vs Kokoro 21.4s** — Kokoro's server stops after five idle minutes, so the first utterance after a quiet spell pays a cold start. Now defaults to the ClawBox AI cloud voice when the box has one; Kokoro stays installed and one click away. The subscription is proved from our own `clawboxManaged` stamp rather than re-reading the plan, because `gateway-pre-start.sh` already applied that gate.

**3. The chat greeted itself on any empty transcript.**
An empty transcript is not a first conversation — a cleared conversation, a reset session, a restored side tab and a box introduced months ago all look identical, and every one got an unasked-for `"hi"` that spent a model turn and put a word in the owner's mouth. Now gated on the agent's own `BOOTSTRAP.md` (the ritual OpenClaw arms and deletes), threaded through `HarnessFacts` so browser and server decide by one function. Implemented as an effect because its two inputs race: on OpenClaw the socket calls `loadHistory()` before the capabilities land, so deciding inside that read left a genuinely fresh box silent for good.

**4. ClawKeep's wizard dismissed itself by succeeding.**
It announced "STEP 1 OF 3", and pairing — step 1 — falsified the app's display condition, dropping the owner on the dashboard at "AT RISK — Protection Lapsed" with `setupComplete` still false, two steps early. The front door asked two questions where `BrowserApp`, `CodingAgentApp` and `MemoryShardApp` all ask one; the legacy case its extra `!paired` conjunct existed for now lives in `getClawKeepSetupComplete`. Also: both on/off switches were 1×1px `sr-only` inputs behind a styled track, so a pointer aimed at the control hit a wrapper `div` — they are now transparent inputs sized to the switch, and ClawKeep's gained the accessible name it never had.

**5. "Applying system fixups" hid fifteen minutes of work behind four words.**
On this Jetson that one step spent ~6 minutes compiling CTranslate2 with CUDA in total silence at 4×99% CPU, plus a ~300MB PyTorch download, Kokoro, spacy and faster-whisper. A healthy update was indistinguishable from a hung one. `StepState` gains an optional `detail` carrying install.sh's own headline, read by a **read-only** journal watcher — deliberately not a change to `execAsRoot`, whose budgets, overrun handling and gateway quiescing should not be re-plumbed for a progress line.

## Testing

- **Full suite: 1000 files, 15,070 passed, 0 failures** attributable to this branch.
- Verified end to end on hardware: a real Coding Agent run (wrote a file, drove the device's Chromium, committed `b25a9c3`); Memory Shard indexing a probe document (files 2→3, vectors 3→4, embedded locally); ClawKeep paired, sealed, backed up (`566,832` bytes encrypted) with auto-backup armed.
- A `/simplify` pass caught three errors in this branch's own work — a bogus mock property, a factually wrong comment, and an incomplete first attempt at fix 4 — all corrected here.

## Known, deliberate

- **Pre-existing flakiness:** a handful of component tests fail under full-suite parallel load and pass in isolation. Verified on unmodified `origin/beta`, which fails the same way — not introduced here.
- **Deferred:** the progress watcher spawns `journalctl` every 4s (measured at ~0.15% of the box — real but not contention). A single `journalctl -f` would cut it to one spawn with better latency; left as a follow-up rather than re-plumbing the mechanism in this PR.
- **Not done:** OpenClaw 2026.9.3 — it drops Node 22 while the box runs 22.23.2, and the installer's engine guard would not catch it. That is a Node 22→24 migration, not a version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatically selects managed cloud voice services when available, with a verified local fallback.
  - Shows live details for the currently running system update step.
  - Removes outdated default app placements from saved desktops once while keeping those apps available through the launcher.
- **Bug Fixes**
  - Preserves existing unreadable voice configuration instead of overwriting it.
  - First-conversation greetings appear only when an introduction is pending.
  - Setup wizard visibility is maintained for paired devices.
  - Schedule switches respond reliably across supported apps.
  - Legacy paired devices retain completed setup status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->