### PR TITLE
fix: pin the Hermes agent to v0.21.1 and restart the dashboard after an upgrade

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3529,9 +3529,13 @@ hermes_dashboard_restart_warn() {
 # DIFFERENT process is now the unit's main one, and the socket says that
 # process is serving. Neither alone is the bounce."
 hermes_dashboard_restart_after_install() {
-  local unit state before after settled waited budget settle restart_rc
+  local unit state before after settled budget settle restart_rc
 
-  # Bounds BOTH the blocking bounce and the wait for the replacement process.
+  # ONE budget for the whole bounce of ONE unit — the blocking call and the
+  # wait after it are two phases of the same restart, so the clock is not
+  # restarted between them. Giving each phase its own `budget` would double the
+  # worst case (a hung `try-restart` spends it, then the poll spends it again),
+  # which is what makes the arithmetic below wrong at a glance.
   #
   # `systemctl try-restart` without `--no-block` waits for the job to finish,
   # and this unit declares TimeoutStartSec=300 with systemd's default 90 s stop
@@ -3540,6 +3544,9 @@ hermes_dashboard_restart_after_install() {
   # it; the poll after it is for the cases where the call did NOT block to a
   # finished restart (it timed out, or it exited 0 having done nothing because
   # the unit stopped in the gap since the is-active probe).
+  #
+  # Worst case, therefore: `budget + settle` per unit, so ~246 s for the pair on
+  # the shipped defaults, before the warm-up's own 300 s.
   budget="${HERMES_DASHBOARD_RESTART_WAIT_S:-120}"
   # Digits, at most four of them, and at least one second. The hazard is not
   # errexit — the `-lt` below is the left side of a `||`, which errexit never
@@ -3579,6 +3586,10 @@ hermes_dashboard_restart_after_install() {
     before="$(systemctl show "$unit" -p MainPID --value 2>/dev/null || true)"
 
     restart_rc=0
+    # bash's own second counter, reset here and read below: the elapsed time has
+    # to survive a `date` that is missing or fails, and an external command that
+    # answers 0 on failure would make the deadline below never arrive.
+    SECONDS=0
     timeout "$budget" systemctl try-restart "$unit" >/dev/null 2>&1 || restart_rc=$?
     # 124 is `timeout`'s: the job outlived the budget and may still be running,
     # which the checks below can still answer. Anything else is systemd saying
@@ -3588,7 +3599,6 @@ hermes_dashboard_restart_after_install() {
       continue
     fi
 
-    waited=0
     while :; do
       after="$(systemctl show "$unit" -p MainPID --value 2>/dev/null || true)"
       # Empty (no systemd, a failed query), 0 (stopped, or still in an
@@ -3597,9 +3607,10 @@ hermes_dashboard_restart_after_install() {
         ''|0|"$before") ;;
         *) break ;;
       esac
-      [ "$waited" -lt "$budget" ] || break
+      # Against the SAME deadline the blocking call above drew from, so a
+      # `try-restart` that already spent the budget does not get it again.
+      [ "$SECONDS" -lt "$budget" ] || break
       sleep 1
-      waited=$((waited + 1))
     done
 
     # A new main process is HALF the answer. Both units are Type=simple, so

--- a/install.sh
+++ b/install.sh
@@ -918,8 +918,8 @@ OPENCLAW_VERSION="2026.8.1"
 # Bump the default in a PR, ship it through beta -> main, and the fleet
 # follows on its next update.
 #
-# Current pin: upstream tag v2026.8.19 == "Hermes Agent v0.20.5".
-HERMES_PIN_COMMIT="${HERMES_PIN_COMMIT:-fcbd1076a93841fa88855acce810e342a5b78101}"
+# Current pin: upstream tag v2026.9.7 == "Hermes Agent v0.21.1" (TASK-784).
+HERMES_PIN_COMMIT="${HERMES_PIN_COMMIT:-2237be355906fbe6065ce1815711eee52b2d646e}"
 
 # The OpenAI Codex CLI (TASK-439). The pinned version and the digest that
 # authorises it live in config/codex-target.txt; these two are only WHERE the
@@ -3472,6 +3472,96 @@ step_openclaw_setup() {
   esac
 }
 
+# Put the Hermes dashboard back onto the agent the step above just replaced.
+#
+# A pinned upgrade is a move-aside plus a FRESH CLONE, and the tree it moved
+# aside is deleted a few lines later — while clawbox-hermes-dashboard is a
+# long-lived Python process holding the OLD files open. Measured on the Hermes
+# box (TASK-784) right after an upgrade from v0.20.5 to v0.21.1: the dashboard
+# was still the pid it had been an hour earlier, `grep -c "(deleted)"
+# /proc/<pid>/maps` returned 84, and `journalctl -u clawbox-hermes-dashboard`
+# had NO entries — nothing had signalled it at all. Python imports lazily, so
+# such a process keeps answering until it reaches a module it had not yet
+# imported, which is now unreachable. A full chat battery PASSED on that box in
+# that state — three turns, correct answers, all of it served by an agent that
+# no longer existed on disk. That is the false green this exists to close.
+#
+# `Restart=always` is not a mechanism here: nothing stops the process, so
+# nothing restarts it, and neither unit has an ExecStop.
+#
+# `try-restart`, never `restart`: `restart` STARTS a stopped unit, and a box
+# whose Hermes units are stopped and disabled — the openclaw direction of
+# step_edition_foreign_teardown, or a fresh install where step_hermes_edition
+# has not installed them yet — must never have them resurrected by an agent
+# upgrade. Same invariant src/lib/hermes-dashboard-control.ts is built around
+# and the same call refresh_agent_coding_tools makes, for the same reason.
+#
+# HARNESS-FIRST, and the answer is that there is nothing to defer to. Hermes
+# owns a STOP — `hermes dashboard --stop`, its own SIGTERM-grace-SIGKILL path,
+# which this unit already runs as an ExecStartPre — but no restart hook and no
+# supervision of its own. The only thing upstream offers around an upgrade is
+# `hermes update`, which reattaches a detached checkout to main
+# (hermes_cli/update_cmd.py), the exact outcome the pin exists to prevent. The
+# proxy is not Hermes's at all: scripts/hermes-dashboard-proxy.js is our node
+# process. systemd owns both units on this box, so systemd is what gets asked.
+#
+# Returns non-zero when a unit that WAS running could not be put back on the new
+# agent: "still serving files that were deleted" is a real outcome and the
+# update's own status has to carry it, not just a line in the journal.
+hermes_dashboard_restart_after_install() {
+  local unit before after waited budget rc=0
+  # Overridable so a slow box — or a test that cannot spend the whole budget
+  # proving a unit never came back — can say so without a rebuild, the same
+  # shape as HERMES_DASHBOARD_WAIT_MS in the web app. Guarded: a malformed
+  # value would make the `-lt` below a fatal arithmetic error and take the step
+  # down AFTER a successful install.
+  budget="${HERMES_DASHBOARD_RESTART_WAIT_S:-90}"
+  case "$budget" in ''|*[!0-9]*) budget=90 ;; esac
+
+  for unit in clawbox-hermes-dashboard.service clawbox-hermes-dashboard-proxy.service; do
+    if [ "$(systemctl is-active "$unit" 2>/dev/null || true)" != "active" ]; then
+      echo "  $unit is not running — it will pick up the new agent when it next starts"
+      continue
+    fi
+    # Read BEFORE the restart, because a NEW main process is the only proof one
+    # happened: `try-restart` exits 0 both when it restarted the unit and when
+    # the unit had stopped in the gap since the probe above, and it returns as
+    # soon as the start job is queued — before a unit that cannot come back has
+    # failed. Reading its exit code as the outcome would be this step's
+    # original defect in a new place.
+    before="$(systemctl show "$unit" -p MainPID --value 2>/dev/null || true)"
+    if ! systemctl try-restart "$unit" >/dev/null 2>&1; then
+      echo "  Warning: could not restart $unit — it is still serving the agent this step replaced" >&2
+      rc=1
+      continue
+    fi
+    waited=0
+    after="$before"
+    while :; do
+      after="$(systemctl show "$unit" -p MainPID --value 2>/dev/null || true)"
+      # Empty (no systemd, a failed query), 0 (stopped or still in
+      # ExecStartPre) and the pid we started with are all "not yet".
+      case "$after" in
+        ''|0|"$before") ;;
+        *) break ;;
+      esac
+      [ "$waited" -lt "$budget" ] || break
+      sleep 1
+      waited=$((waited + 1))
+    done
+    case "$after" in
+      ''|0|"$before")
+        echo "  Warning: $unit did not report a new main process within ${budget}s — it may still be serving the agent this step replaced (systemctl status $unit)" >&2
+        rc=1
+        ;;
+      *)
+        echo "  Restarted $unit on the new agent (main pid ${before:-unknown} -> $after)"
+        ;;
+    esac
+  done
+  return "$rc"
+}
+
 # Install the Hermes agent (git-based install into ~/.hermes). Needed by every
 # edition that runs Hermes — the hermes SKU and the premium dual SKU (which was
 # previously skipped here, so a dual box got the switcher but no second
@@ -3487,6 +3577,10 @@ step_hermes_install() {
   # `local`, so a second call in one shell cannot inherit the first one's
   # answer.
   local _hermes_off_pin=0
+  # Whether a unit that was serving the OLD agent is still serving it. Same
+  # `local` reason, and the same channel: the box works, but it is not running
+  # what is on its disk.
+  local _hermes_dash_stale=0
 
   # The pin is spliced into a URL below and the file that URL returns is piped
   # into bash, so it is validated before it is used. A malformed value — a tag
@@ -3567,7 +3661,7 @@ step_hermes_install() {
   fi
 
   # A version string cannot answer "is this the pinned build?": upstream prints
-  # the same `v0.20.5` for the tag and for every untagged commit after it, and
+  # the same `v0.21.1` for the tag and for every untagged commit after it, and
   # there are hundreds of those a week. The checkout's HEAD is the only proof,
   # so HEAD is what decides. Read as the clawbox user for the same reason the
   # probe is: git refuses to operate on a repository owned by somebody else
@@ -3734,6 +3828,12 @@ step_hermes_install() {
     # directory a later factory reset has to be able to delete.
     rm -rf "$agent_dir.broken"
 
+    # BEFORE the bridge warm-up below, not after it. The tree the dashboard is
+    # executing has just been deleted; the warm-up is allowed 300 s and has
+    # nothing to do with the dashboard, so running it first would hold the
+    # box's chat backend on files that are gone for five more minutes.
+    hermes_dashboard_restart_after_install || _hermes_dash_stale=1
+
     # The upgrade above is a move-aside plus a FRESH clone, and the bridge's
     # ~80 MB node_modules is untracked — so every pinned upgrade deletes it.
     # Nothing is broken by that: the pairing manager runs this same `npm
@@ -3804,12 +3904,16 @@ step_hermes_install() {
   # The same two-part test the step's own probe makes (a shim alone is a
   # four-line wrapper and proves nothing about the agent under ~/.hermes).
   if [ -x "$shim" ] && [ -x "$venv_python" ]; then
-    # Runnable — and `$_hermes_off_pin` is the second half of the answer: an
-    # install that landed off the pin leaves the box working on a build we do
-    # not ship, which the fleet has to hear about even though nothing here is
-    # broken. Default 0, so every path that never attempted an upgrade returns
-    # 0 exactly as before.
-    return "$_hermes_off_pin"
+    # Runnable — and the two flags are the rest of the answer. An install that
+    # landed off the pin leaves the box working on a build we do not ship; a
+    # dashboard that could not be restarted leaves it working on a build that
+    # is no longer on its disk. Neither is broken, both have to reach the
+    # fleet. Both default 0, so every path that never attempted an upgrade
+    # returns 0 exactly as before.
+    if [ "$_hermes_off_pin" -ne 0 ] || [ "$_hermes_dash_stale" -ne 0 ]; then
+      return 1
+    fi
+    return 0
   fi
   echo "  Warning: the Hermes agent is still not runnable after this step" >&2
   return 1

--- a/install.sh
+++ b/install.sh
@@ -3472,6 +3472,21 @@ step_openclaw_setup() {
   esac
 }
 
+# One [WARN] line plus the marker the updater raises on the update's own status.
+#
+# Deliberately NOT the step's exit code. `resume_paused_engines` above records
+# the rule for exactly this class (install.sh:1720-1728): `record_provision_failure`
+# and a non-zero return paint a whole good update red, and `optional_step` would
+# report `hermes_install` as "failed and were skipped" over an install that ran
+# and succeeded. The quieter surface exists for this — `CLAWBOX-WARN[<code>]:`,
+# which src/lib/updater.ts (STEP_WARNING_LINE) reads out of the step's journal —
+# so the owner is told without the update turning red, and the agent install's
+# own answer (`_hermes_off_pin`) stays the step's return contract.
+hermes_dashboard_restart_warn() {
+  echo "    [WARN] $1 $2" >&2
+  echo "CLAWBOX-WARN[hermes-dashboard-not-restarted]: $1 $2 — it may still be serving the Hermes agent this step replaced; 'sudo systemctl restart $1' puts it on the new one"
+}
+
 # Put the Hermes dashboard back onto the agent the step above just replaced.
 #
 # A pinned upgrade is a move-aside plus a FRESH CLONE, and the tree it moved
@@ -3496,50 +3511,87 @@ step_openclaw_setup() {
 # upgrade. Same invariant src/lib/hermes-dashboard-control.ts is built around
 # and the same call refresh_agent_coding_tools makes, for the same reason.
 #
-# HARNESS-FIRST, and the answer is that there is nothing to defer to. Hermes
-# owns a STOP — `hermes dashboard --stop`, its own SIGTERM-grace-SIGKILL path,
-# which this unit already runs as an ExecStartPre — but no restart hook and no
-# supervision of its own. The only thing upstream offers around an upgrade is
-# `hermes update`, which reattaches a detached checkout to main
-# (hermes_cli/update_cmd.py), the exact outcome the pin exists to prevent. The
-# proxy is not Hermes's at all: scripts/hermes-dashboard-proxy.js is our node
-# process. systemd owns both units on this box, so systemd is what gets asked.
+# HARNESS-FIRST. Hermes owns a STOP — `hermes dashboard --stop`, its own
+# SIGTERM-grace-SIGKILL path, which this unit already runs as an ExecStartPre —
+# but `hermes dashboard --help` at this pin offers only `--stop` and `--status`
+# and no restart, and Hermes supervises nothing. The only thing upstream offers
+# around an upgrade is `hermes update`, which reattaches a detached checkout to
+# main (hermes_cli/update_cmd.py), the exact outcome the pin exists to prevent.
+# The proxy is not Hermes's at all: scripts/hermes-dashboard-proxy.js is our
+# node process. systemd owns both units here, so systemd is what gets asked.
 #
-# Returns non-zero when a unit that WAS running could not be put back on the new
-# agent: "still serving files that were deleted" is a real outcome and the
-# update's own status has to carry it, not just a line in the journal.
+# What DOES already exist in this tree is `bounceHermesDashboard()`
+# (src/lib/hermes-dashboard-control.ts) — but it is shaped for the WEB SERVER,
+# which has no root: it asks Hermes to stop itself and lets `Restart=always`
+# do the rest, precisely because a `systemctl restart` grant would let an
+# openclaw box resurrect a torn-down dashboard. Root here needs no such
+# indirection. Its VERDICT rule is borrowed wholesale, though: "systemd says a
+# DIFFERENT process is now the unit's main one, and the socket says that
+# process is serving. Neither alone is the bounce."
 hermes_dashboard_restart_after_install() {
-  local unit before after waited budget rc=0
-  # Overridable so a slow box — or a test that cannot spend the whole budget
-  # proving a unit never came back — can say so without a rebuild, the same
-  # shape as HERMES_DASHBOARD_WAIT_MS in the web app. Guarded: a malformed
-  # value would make the `-lt` below a fatal arithmetic error and take the step
-  # down AFTER a successful install.
-  budget="${HERMES_DASHBOARD_RESTART_WAIT_S:-90}"
-  case "$budget" in ''|*[!0-9]*) budget=90 ;; esac
+  local unit state before after settled waited budget settle restart_rc
 
+  # Bounds BOTH the blocking bounce and the wait for the replacement process.
+  #
+  # `systemctl try-restart` without `--no-block` waits for the job to finish,
+  # and this unit declares TimeoutStartSec=300 with systemd's default 90 s stop
+  # — so an unbounded call is a ~390 s term inside step_post_update's 900 s
+  # budget, next to the 300 s WhatsApp warm-up below. `timeout` is what bounds
+  # it; the poll after it is for the cases where the call did NOT block to a
+  # finished restart (it timed out, or it exited 0 having done nothing because
+  # the unit stopped in the gap since the is-active probe).
+  budget="${HERMES_DASHBOARD_RESTART_WAIT_S:-120}"
+  # Digits, at most four of them, and at least one second. The hazard is not
+  # errexit — the `-lt` below is the left side of a `||`, which errexit never
+  # sees — it is the two values that make the wait meaningless: a 20-digit
+  # number, which `[` rejects with "integer expression expected" once per probe
+  # and which is then printed back at the owner as a budget, and 0, which asks
+  # for the proof without waiting for it. read_configured_harness_swap caps a
+  # length for the same reason.
+  case "$budget" in ''|*[!0-9]*) budget=120 ;; esac
+  { [ "${#budget}" -le 4 ] && [ "$budget" -ge 1 ]; } || budget=120
+  # The same settle resume_paused_engines uses, and for the same reason.
+  settle="${CLAWBOX_ENGINE_SETTLE_S:-3}"
+  case "$settle" in ''|*[!0-9]*) settle=3 ;; esac
+  { [ "${#settle}" -le 3 ] && [ "$settle" -ge 1 ]; } || settle=3
+
+  # The dashboard first, then the proxy that fronts it — never the other way
+  # round: the proxy brokers a session AGAINST the dashboard, so bouncing it
+  # while the replacement dashboard is still coming up would have it fail a
+  # login and sit out LOGIN_RETRY_COOLDOWN_MS (scripts/hermes-dashboard-proxy.js).
+  # The proxy holds no deleted files of its own — it is our node process, not
+  # Hermes's — and it does recover a rejected session by itself on a 401. It is
+  # bounced anyway because the pair is provisioned and restarted together
+  # everywhere else (scripts/setup-hermes-edition.sh), and a node start is
+  # sub-second; the ordering is what makes that free.
   for unit in clawbox-hermes-dashboard.service clawbox-hermes-dashboard-proxy.service; do
-    if [ "$(systemctl is-active "$unit" 2>/dev/null || true)" != "active" ]; then
-      echo "  $unit is not running — it will pick up the new agent when it next starts"
+    state="$(systemctl is-active "$unit" 2>/dev/null || true)"
+    if [ "$state" != "active" ]; then
+      # SAY the state rather than promise a restart. `Restart=always` brings
+      # back `inactive` and `activating`; it does not promise anything for
+      # `failed`, and there is nothing at all behind an absent unit — which is
+      # the ordinary fresh-install case, before step_hermes_edition has
+      # installed either of them.
+      echo "  $unit is ${state:-not installed} — nothing to bounce here"
       continue
     fi
-    # Read BEFORE the restart, because a NEW main process is the only proof one
-    # happened: `try-restart` exits 0 both when it restarted the unit and when
-    # the unit had stopped in the gap since the probe above, and it returns as
-    # soon as the start job is queued — before a unit that cannot come back has
-    # failed. Reading its exit code as the outcome would be this step's
-    # original defect in a new place.
+
     before="$(systemctl show "$unit" -p MainPID --value 2>/dev/null || true)"
-    if ! systemctl try-restart "$unit" >/dev/null 2>&1; then
-      echo "  Warning: could not restart $unit — it is still serving the agent this step replaced" >&2
-      rc=1
+
+    restart_rc=0
+    timeout "$budget" systemctl try-restart "$unit" >/dev/null 2>&1 || restart_rc=$?
+    # 124 is `timeout`'s: the job outlived the budget and may still be running,
+    # which the checks below can still answer. Anything else is systemd saying
+    # no, and there is nothing left to verify.
+    if [ "$restart_rc" -ne 0 ] && [ "$restart_rc" -ne 124 ]; then
+      hermes_dashboard_restart_warn "$unit" "could not be restarted (systemctl exit $restart_rc)"
       continue
     fi
+
     waited=0
-    after="$before"
     while :; do
       after="$(systemctl show "$unit" -p MainPID --value 2>/dev/null || true)"
-      # Empty (no systemd, a failed query), 0 (stopped or still in
+      # Empty (no systemd, a failed query), 0 (stopped, or still in an
       # ExecStartPre) and the pid we started with are all "not yet".
       case "$after" in
         ''|0|"$before") ;;
@@ -3549,17 +3601,35 @@ hermes_dashboard_restart_after_install() {
       sleep 1
       waited=$((waited + 1))
     done
-    case "$after" in
-      ''|0|"$before")
-        echo "  Warning: $unit did not report a new main process within ${budget}s — it may still be serving the agent this step replaced (systemctl status $unit)" >&2
-        rc=1
-        ;;
-      *)
-        echo "  Restarted $unit on the new agent (main pid ${before:-unknown} -> $after)"
-        ;;
-    esac
+
+    # A new main process is HALF the answer. Both units are Type=simple, so
+    # systemd calls them active the instant ExecStart forks — before the
+    # dashboard binds its socket, and long before a fresh clone finishes the
+    # web-dist build it forces (60-90 s measured, which is why the unit allows
+    # itself TimeoutStartSec=300). A clone that cannot start hands over a new
+    # pid and then dies into `Restart=always`, so claiming the bounce on the
+    # pid alone would be this step's own false success moved one notch down.
+    # Ask again after a settle: a server that came up and one that exited two
+    # seconds later look identical until then.
+    sleep "$settle"
+    state="$(systemctl is-active "$unit" 2>/dev/null || true)"
+    settled="$(systemctl show "$unit" -p MainPID --value 2>/dev/null || true)"
+
+    if [ "$state" = "active" ] && [ -n "$after" ] && [ "$after" != "0" ] \
+      && [ "$after" != "$before" ] && [ "$settled" = "$after" ]; then
+      echo "  Restarted $unit on the new agent (main pid ${before:-unknown} -> $after, still up ${settle}s later)"
+    else
+      # One sentence carrying what was actually observed, rather than a single
+      # asserted diagnosis: `inactive` means somebody stopped it and it is
+      # serving nothing, `activating` means it is still coming, a pid that
+      # moved again means it is crash-looping. They are different problems and
+      # the owner is told which.
+      hermes_dashboard_restart_warn "$unit" \
+        "did not settle on a new main process (systemd says ${state:-unknown}, main pid ${settled:-unknown}, was ${before:-unknown})"
+    fi
   done
-  return "$rc"
+  # ALWAYS 0 — see hermes_dashboard_restart_warn.
+  return 0
 }
 
 # Install the Hermes agent (git-based install into ~/.hermes). Needed by every
@@ -3577,10 +3647,6 @@ step_hermes_install() {
   # `local`, so a second call in one shell cannot inherit the first one's
   # answer.
   local _hermes_off_pin=0
-  # Whether a unit that was serving the OLD agent is still serving it. Same
-  # `local` reason, and the same channel: the box works, but it is not running
-  # what is on its disk.
-  local _hermes_dash_stale=0
 
   # The pin is spliced into a URL below and the file that URL returns is piped
   # into bash, so it is validated before it is used. A malformed value — a tag
@@ -3630,9 +3696,11 @@ step_hermes_install() {
     # Runnability stays THE SHIM'S to prove, and is asked first. `--help` goes
     # through the same shim -> `<agent_dir>/hermes` -> `hermes_cli.main` path
     # `--version` does, so a shim whose interpreter or entry script is gone
-    # still fails it — but unlike `--version` it runs no update check
-    # (`banner.check_for_updates()` has two call sites in 0.20.5:
-    # `print_fast_version_info` and the interactive welcome banner). Asking the
+    # still fails it — but unlike `--version` it runs no update check. Still
+    # true at the v0.21.1 pin, re-read at 2237be35 rather than assumed:
+    # `_startup_fast.py` calls `check_for_updates(passive=True)` from
+    # `print_fast_version_info`, and the interactive welcome banner is the
+    # other caller. (On 0.20.5 the same two, without the passive flag.) Asking the
     # venv interpreter directly instead would only prove the PACKAGE IMPORTS,
     # which is not the question this guard exists to answer: a box whose
     # `hermes` command is dead would read as "already installed" and the
@@ -3832,7 +3900,14 @@ step_hermes_install() {
     # executing has just been deleted; the warm-up is allowed 300 s and has
     # nothing to do with the dashboard, so running it first would hold the
     # box's chat backend on files that are gone for five more minutes.
-    hermes_dashboard_restart_after_install || _hermes_dash_stale=1
+    #
+    # The cost of that order, stated rather than discovered: the replacement
+    # dashboard does its post-clone web-dist build while the warm-up's npm
+    # install runs, so two heavy jobs now overlap on a device this file already
+    # documents as an OOM-kill target during updates (run_next_build). The
+    # settle inside the restart serialises the first seconds of it, and serving
+    # deleted code for five more minutes is the worse trade.
+    hermes_dashboard_restart_after_install
 
     # The upgrade above is a move-aside plus a FRESH clone, and the bridge's
     # ~80 MB node_modules is untracked — so every pinned upgrade deletes it.
@@ -3904,16 +3979,16 @@ step_hermes_install() {
   # The same two-part test the step's own probe makes (a shim alone is a
   # four-line wrapper and proves nothing about the agent under ~/.hermes).
   if [ -x "$shim" ] && [ -x "$venv_python" ]; then
-    # Runnable — and the two flags are the rest of the answer. An install that
-    # landed off the pin leaves the box working on a build we do not ship; a
-    # dashboard that could not be restarted leaves it working on a build that
-    # is no longer on its disk. Neither is broken, both have to reach the
-    # fleet. Both default 0, so every path that never attempted an upgrade
-    # returns 0 exactly as before.
-    if [ "$_hermes_off_pin" -ne 0 ] || [ "$_hermes_dash_stale" -ne 0 ]; then
-      return 1
-    fi
-    return 0
+    # Runnable — and `$_hermes_off_pin` is the second half of the answer: an
+    # install that landed off the pin leaves the box working on a build we do
+    # not ship, which the fleet has to hear about even though nothing here is
+    # broken. Default 0, so every path that never attempted an upgrade returns
+    # 0 exactly as before.
+    #
+    # A dashboard that could not be bounced is deliberately NOT folded in here:
+    # it rides the CLAWBOX-WARN channel instead, so an install that worked is
+    # never reported as a failed step. See hermes_dashboard_restart_warn.
+    return "$_hermes_off_pin"
   fi
   echo "  Warning: the Hermes agent is still not runnable after this step" >&2
   return 1
@@ -5818,7 +5893,7 @@ step_openclaw_tts() {
             # AND THE SELECTION IS MADE WHATEVER THE ENGINE ANSWERED, which is
             # the opposite of what this card first asked for, because to Hermes
             # an unset `tts.provider` is not "no voice": measured read-only on
-            # the pinned 0.20.5 package on the Hermes box —
+            # the then-pinned 0.20.5 package on the Hermes box —
             # `tools/tts_tool.py:211` `DEFAULT_PROVIDER = "edge"` and `:661`
             # `provider = (tts_config.get("provider") or DEFAULT_PROVIDER)` —
             # an ABSENT key resolves to Microsoft's Edge cloud, and the harness

--- a/install.sh
+++ b/install.sh
@@ -3478,8 +3478,8 @@ step_openclaw_setup() {
 # aside is deleted a few lines later — while clawbox-hermes-dashboard is a
 # long-lived Python process holding the OLD files open. Measured on the Hermes
 # box (TASK-784) right after an upgrade from v0.20.5 to v0.21.1: the dashboard
-# was still the pid it had been an hour earlier, `grep -c "(deleted)"
-# /proc/<pid>/maps` returned 84, and `journalctl -u clawbox-hermes-dashboard`
+# was still the pid it had been more than two hours earlier, `grep -c
+# "(deleted)" /proc/<pid>/maps` returned 83, and `journalctl -u clawbox-hermes-dashboard`
 # had NO entries — nothing had signalled it at all. Python imports lazily, so
 # such a process keeps answering until it reaches a module it had not yet
 # imported, which is now unreachable. A full chat battery PASSED on that box in

--- a/src/lib/version-utils.ts
+++ b/src/lib/version-utils.ts
@@ -24,9 +24,12 @@ export function cleanVersion(v: string | null | undefined): string | null {
  *
  * `hermes --version` is a multi-line report, not a version string:
  *
- *   Hermes Agent v0.20.5 (2026.8.19) — upstream 261a4efb — local 10914727
+ *   Hermes Agent v0.21.1 (2026.9.7) · upstream d0df3248 · local 2237be35 (+32678 carried commits)
  *   Install directory: /home/clawbox/.hermes/hermes-agent
  *   Install method: git
+ *
+ * The separator between the fields is upstream's to change — it has already
+ * been both an em dash and a middle dot — so nothing here may depend on it.
  *
  * Only the tag belongs in an About row, and `cleanVersion` cannot get it:
  * its rules are shaped for OpenClaw/git-describe output, and none of them

--- a/src/lib/version-utils.ts
+++ b/src/lib/version-utils.ts
@@ -24,7 +24,7 @@ export function cleanVersion(v: string | null | undefined): string | null {
  *
  * `hermes --version` is a multi-line report, not a version string:
  *
- *   Hermes Agent v0.21.1 (2026.9.7) · upstream d0df3248 · local 2237be35 (+32678 carried commits)
+ *   Hermes Agent v0.21.1 (2026.9.7) · upstream ead7e91d · local 2237be35 (+32678 carried commits)
  *   Install directory: /home/clawbox/.hermes/hermes-agent
  *   Install method: git
  *

--- a/src/lib/version-utils.ts
+++ b/src/lib/version-utils.ts
@@ -28,8 +28,9 @@ export function cleanVersion(v: string | null | undefined): string | null {
  *   Install directory: /home/clawbox/.hermes/hermes-agent
  *   Install method: git
  *
- * The separator between the fields is upstream's to change — it has already
- * been both an em dash and a middle dot — so nothing here may depend on it.
+ * The separator between the fields is upstream's to change — banners carrying
+ * an em dash and a middle dot have both been seen — so nothing here may depend
+ * on it: the version is the first semver-ish token on line one.
  *
  * Only the tag belongs in an About row, and `cleanVersion` cannot get it:
  * its rules are shaped for OpenClaw/git-describe output, and none of them

--- a/src/tests/unit/hermes-cli-update-check.test.ts
+++ b/src/tests/unit/hermes-cli-update-check.test.ts
@@ -62,7 +62,7 @@ const VENV_PYTHON = path.join(AGENT_DIR, "venv", "bin", "python");
 
 /** The banner a silenced probe gets, verbatim from the Hermes box. */
 const SILENT_BANNER = [
-  "Hermes Agent v0.20.5 (2026.8.19) · upstream 089bb328 · local fcbd1076 (+24396 carried commits)",
+  "Hermes Agent v0.21.1 (2026.9.7) · upstream d0df3248 · local 2237be35 (+32678 carried commits)",
   "Install directory: /home/clawbox/.hermes/hermes-agent",
   "Install method: git",
   "Python: 3.11.15",
@@ -126,7 +126,7 @@ describe("runHermesCli({ silenceUpdateCheck }) — the version probe stops payin
     expect(bin).toBe(VENV_PYTHON);
     expect(argv).toEqual(["-c", expect.stringContaining("check_updates=False")]);
     expect(result.stdout).not.toMatch(/Update available/);
-    expect(parseHermesVersion(result.stdout)).toBe("v0.20.5");
+    expect(parseHermesVersion(result.stdout)).toBe("v0.21.1");
   });
 
   it("makes the checkout importable the way the shim does, and inherits no Python home", async () => {
@@ -188,7 +188,7 @@ describe("runHermesCli({ silenceUpdateCheck }) — the version probe stops payin
 
     expect(mockSpawn).toHaveBeenCalledTimes(2);
     expect(mockSpawn.mock.calls[1][0]).toBe(HERMES_BIN);
-    expect(parseHermesVersion(result.stdout)).toBe("v0.20.5");
+    expect(parseHermesVersion(result.stdout)).toBe("v0.21.1");
   });
 
   it("does not ask the same question twice when the child said far too much", async () => {
@@ -227,7 +227,7 @@ describe("runHermesCli({ silenceUpdateCheck }) — the version probe stops payin
     // The false-failure guard: the silence being absent must cost the nag
     // line and NOTHING else — the version still reads out of the banner.
     expect(result.stdout).toContain("Update available");
-    expect(parseHermesVersion(result.stdout)).toBe("v0.20.5");
+    expect(parseHermesVersion(result.stdout)).toBe("v0.21.1");
   });
 
   it("falls open when the printer is there but refuses", async () => {
@@ -244,7 +244,7 @@ describe("runHermesCli({ silenceUpdateCheck }) — the version probe stops payin
 
     expect(mockSpawn).toHaveBeenCalledTimes(2);
     expect(mockSpawn.mock.calls[1][0]).toBe(HERMES_BIN);
-    expect(parseHermesVersion(result.stdout)).toBe("v0.20.5");
+    expect(parseHermesVersion(result.stdout)).toBe("v0.21.1");
   });
 
   it("leaves every other hermes call exactly as it was", async () => {

--- a/src/tests/unit/hermes-cli-update-check.test.ts
+++ b/src/tests/unit/hermes-cli-update-check.test.ts
@@ -62,7 +62,7 @@ const VENV_PYTHON = path.join(AGENT_DIR, "venv", "bin", "python");
 
 /** The banner a silenced probe gets, verbatim from the Hermes box. */
 const SILENT_BANNER = [
-  "Hermes Agent v0.21.1 (2026.9.7) · upstream d0df3248 · local 2237be35 (+32678 carried commits)",
+  "Hermes Agent v0.21.1 (2026.9.7) · upstream ead7e91d · local 2237be35 (+32678 carried commits)",
   "Install directory: /home/clawbox/.hermes/hermes-agent",
   "Install method: git",
   "Python: 3.11.15",

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -471,17 +471,30 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     // Whether the stubbed npm succeeds. A registry that is down must cost the
     // owner a warning and nothing else.
     npmOk = true,
-    // Whether the two Hermes units are RUNNING when the step starts. Default
-    // false, which is the fresh-install shape: step_hermes_edition has not
-    // installed them yet, so there is nothing to restart and nothing to say.
-    dashRunning = false,
-    proxyRunning = false,
-    // Whether `systemctl try-restart` succeeds.
-    restartOk = true,
-    // Whether a restarted unit comes back with a NEW main process. `false` is
-    // the unit that was asked and never returned — the case a step that reads
+    // What systemd says about the two Hermes units when the step starts.
+    // "inactive" is the fresh-install shape: step_hermes_edition has not
+    // installed them yet, so there is nothing to bounce and nothing to promise.
+    dashState = "inactive" as "active" | "inactive" | "failed" | "activating",
+    proxyState = "inactive" as "active" | "inactive" | "failed" | "activating",
+    // "ok" | "refuse" (systemd says no) | "hang" (the blocking job outlives the
+    // budget and `timeout` kills it with 124).
+    restart = "ok" as "ok" | "refuse" | "hang",
+    // Whether a restarted unit comes back with a NEW main process at all. false
+    // is the unit that was asked and never returned — the case a step reading
     // try-restart's exit code as the outcome cannot tell from success.
     newPid = true,
+    // How many MainPID probes report 0 before the replacement appears: 0 is the
+    // ordinary blocking restart, >0 exercises the wait the budget is for.
+    pidDelay = 0,
+    // The replacement forks, takes the unit's MainPID, and then dies — so a
+    // later probe shows a THIRD pid. systemd calls a Type=simple unit active
+    // the instant ExecStart forks, which is why a pid alone is not the bounce.
+    crashloop = false,
+    // What `is-active` answers once the unit has been restarted.
+    settleState = "active" as "active" | "inactive" | "failed" | "activating",
+    // The verification budget, in seconds. "" leaves it unset (the shipped
+    // default); a malformed value exercises the guard.
+    waitBudget = "2",
   } = {}) {
     // The reachability precheck is the `-o /dev/null` call; anything else is
     // the real installer being fetched to be piped into bash.
@@ -532,8 +545,9 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     // systemd, stubbed as a real executable for the same reason curl is — and
     // stubbed UNCONDITIONALLY, so no case in this file can ever reach the
     // machine's own systemctl. It records every invocation, so "was a restart
-    // issued at all" is directly observable, and it models the one thing an
-    // exit code cannot express: whether the unit came back as a NEW process.
+    // issued at all" is directly observable, and it models the things an exit
+    // code cannot express: whether a replacement main process appeared, how
+    // long it took, and whether it was still there a moment later.
     fs.mkdirSync(path.join(tmp, "sysd"), { recursive: true });
     fs.writeFileSync(
       path.join(tmp, "bin", "systemctl"),
@@ -542,27 +556,41 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
         'printf "%s\\n" "$*" >> "$SYSTEMCTL_LOG"',
         "unit=",
         'for a in "$@"; do case "$a" in *.service) unit="$a" ;; esac; done',
-        "active=0",
+        'st="$SYSD_STATE/$unit"',
         'case "$unit" in',
-        '  clawbox-hermes-dashboard.service) [ "$DASH_ACTIVE" = "1" ] && active=1 ;;',
-        '  clawbox-hermes-dashboard-proxy.service) [ "$PROXY_ACTIVE" = "1" ] && active=1 ;;',
+        '  clawbox-hermes-dashboard.service) live="$DASH_STATE"; base=1111 ;;',
+        '  clawbox-hermes-dashboard-proxy.service) live="$PROXY_STATE"; base=2222 ;;',
+        '  *) live=inactive; base=0 ;;',
         "esac",
         'case "$1" in',
         "  is-active)",
-        // An inactive unit exits non-zero, exactly as systemd's does.
-        '    if [ "$active" = "1" ]; then echo active; exit 0; fi',
-        "    echo inactive; exit 3 ;;",
+        // Once restarted, the unit answers whatever the scenario settles on.
+        '    [ -f "$st.restarted" ] && live="$SETTLE_STATE"',
+        '    echo "$live"',
+        '    [ "$live" = active ] && exit 0',
+        "    exit 3 ;;",
         "  show)",
-        // A stopped unit reports MainPID=0; a running one reports its pid, and
-        // a different one once it has actually been restarted.
-        '    if [ "$active" != "1" ]; then echo 0; exit 0; fi',
-        '    if [ -f "$SYSD_STATE/$unit.restarted" ] && [ "$NEW_PID" = "1" ]; then',
-        "      echo 4242; else echo 1111; fi",
-        "    exit 0 ;;",
+        // Answer ONLY the property that was asked for, so code that dropped
+        // `-p MainPID` (or asked for the wrong one) gets nothing, not a pid.
+        '    case " $* " in *" MainPID "*) ;; *) exit 0 ;; esac',
+        '    if [ ! -f "$st.restarted" ]; then',
+        '      [ "$live" = active ] && echo "$base" || echo 0',
+        "      exit 0",
+        "    fi",
+        // Probe counter: how many MainPID reads since the restart.
+        '    n=$(cat "$st.probes" 2>/dev/null || echo 0); n=$((n + 1)); echo "$n" > "$st.probes"',
+        '    if [ "$NEW_PID" != "1" ]; then echo "$base"; exit 0; fi',
+        '    if [ "$n" -le "$PID_DELAY" ]; then echo 0; exit 0; fi',
+        '    if [ "$CRASHLOOP" = "1" ] && [ "$n" -gt "$((PID_DELAY + 1))" ]; then',
+        '      echo "$((base + 200))"; exit 0',
+        "    fi",
+        '    echo "$((base + 100))"; exit 0 ;;',
         "  try-restart)",
-        '    [ "$RESTART_OK" = "1" ] || exit 1',
-        // try-restart is a no-op on a unit that is not running — and exits 0.
-        '    [ "$active" = "1" ] && touch "$SYSD_STATE/$unit.restarted"',
+        // A job that outlives the caller's budget: `timeout` kills this and the
+        // step sees 124, which is NOT the same as systemd refusing.
+        '    [ "$RESTART" = "hang" ] && sleep 30',
+        '    [ "$RESTART" = "refuse" ] && exit 1',
+        '    [ "$live" = active ] && touch "$st.restarted"',
         "    exit 0 ;;",
         "esac",
         "exit 0",
@@ -611,9 +639,13 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
       // lookup and never sees a function. A function stub therefore let the
       // precheck reach the real network — the test passed for the wrong reason.
       'export PATH="$1/bin:$PATH"',
-      // Both functions: the step calls the restart helper, so lifting the step
-      // alone would only prove that bash cannot find it.
-      "sed -n '/^hermes_dashboard_restart_after_install() {/,/^}/p' \"$4\" > \"$1/fn.sh\"",
+      // All three functions: the step calls the restart helper, which calls the
+      // warning helper, so lifting the step alone would only prove that bash
+      // cannot find them. Listing them by name is deliberate — renaming one
+      // without updating this fails loudly here rather than silently skipping
+      // the restart on a box.
+      "sed -n '/^hermes_dashboard_restart_warn() {/,/^}/p' \"$4\" > \"$1/fn.sh\"",
+      "sed -n '/^hermes_dashboard_restart_after_install() {/,/^}/p' \"$4\" >> \"$1/fn.sh\"",
       "sed -n '/^step_hermes_install() {/,/^}/p' \"$4\" >> \"$1/fn.sh\"",
       '. "$1/fn.sh"',
       // Merged, because the warnings that matter here are all on stderr.
@@ -645,13 +677,17 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
             NPM_RC: npmOk ? "0" : "1",
             SYSTEMCTL_LOG: path.join(tmp, "systemctl-log"),
             SYSD_STATE: path.join(tmp, "sysd"),
-            DASH_ACTIVE: dashRunning ? "1" : "0",
-            PROXY_ACTIVE: proxyRunning ? "1" : "0",
-            RESTART_OK: restartOk ? "1" : "0",
+            DASH_STATE: dashState,
+            PROXY_STATE: proxyState,
+            SETTLE_STATE: settleState,
+            RESTART: restart,
             NEW_PID: newPid ? "1" : "0",
-            // The wait for a replacement main process, cut to a value a test
-            // can afford to let expire. The shipped default is 90 s.
-            HERMES_DASHBOARD_RESTART_WAIT_S: "2",
+            PID_DELAY: String(pidDelay),
+            CRASHLOOP: crashloop ? "1" : "0",
+            // Both budgets cut to values a test can afford to let expire. The
+            // shipped defaults are 120 s and 3 s.
+            HERMES_DASHBOARD_RESTART_WAIT_S: waitBudget,
+            CLAWBOX_ENGINE_SETTLE_S: "1",
           },
         },
       );
@@ -1083,55 +1119,138 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
   ];
   /** The `try-restart` lines out of the recorded systemctl calls. */
   const restartsIn = (calls: string[]) => calls.filter((c) => c.startsWith("try-restart "));
+  /** The machine-readable warning line the updater raises on the update's status. */
+  const WARN = /^CLAWBOX-WARN\[hermes-dashboard-not-restarted\]:/m;
+  /** Both units running, which is what a provisioned Hermes box looks like. */
+  const UP = { dashState: "active", proxyState: "active" } as const;
 
   it("a pinned upgrade restarts the dashboard so the box stops serving deleted files", () => {
     giveShim();
     giveAgent({ venv: true, head: OTHER_COMMIT });
 
-    const r = run({ dashRunning: true, proxyRunning: true });
+    const r = run({ ...UP });
 
     expect(r.code).toBe(0);
     expect(r.installerRan).toBe(true);
-    // Both units: the proxy holds a brokered Hermes session against the
-    // dashboard process that is being replaced.
+    // The dashboard FIRST, then the proxy that fronts it — the proxy brokers a
+    // session against the dashboard, so the other order would have it fail a
+    // login against a replacement that is still coming up.
     expect(restartsIn(r.systemctl)).toEqual(RESTART_UNITS.map((u) => `try-restart ${u}`));
     // Said out loud, in the step's own output — an owner reading an update log
     // has to be able to see that the new agent is the one now serving.
-    expect(r.out).toMatch(/Restarted clawbox-hermes-dashboard\.service/);
-    expect(r.out).toMatch(/Restarted clawbox-hermes-dashboard-proxy\.service/);
+    expect(r.out).toMatch(/Restarted clawbox-hermes-dashboard\.service on the new agent/);
+    expect(r.out).toMatch(/Restarted clawbox-hermes-dashboard-proxy\.service on the new agent/);
+    expect(r.out).not.toMatch(WARN);
   });
 
-  it("verifies the restart instead of reading try-restart's exit code as the outcome", () => {
-    // `systemctl try-restart` exits 0 for "restarted it" AND for "it was not
-    // running, so I did nothing" — and returns before a unit that then fails
-    // to come back has failed. A step that claims a restart on that exit code
-    // is this PR's own defect in miniature, so the new main process is what
-    // proves it.
+  it("a pid alone is not the bounce — a unit that forks and dies is not reported as restarted", () => {
+    // Both units are Type=simple, so systemd hands over MainPID the instant
+    // ExecStart FORKS: before the dashboard binds its socket, and long before a
+    // fresh clone finishes the web-dist build it forces. A clone that cannot
+    // start therefore produces a new pid and then dies into `Restart=always`.
+    // Claiming the restart on the pid alone would be the same false success one
+    // notch down, which is why the unit is asked again after a settle.
     giveShim();
     giveAgent({ venv: true, head: OTHER_COMMIT });
 
-    const r = run({ dashRunning: true, proxyRunning: true, newPid: false });
+    const r = run({ ...UP, crashloop: true });
 
     expect(restartsIn(r.systemctl)).toHaveLength(2);
-    expect(r.out).not.toMatch(/Restarted clawbox-hermes-dashboard\.service/);
-    expect(r.out).toMatch(/did not report a new main process/);
-    // A box left serving an agent that is no longer on disk is not a completed
-    // fixup, and `optional_step` is what carries that to the update's status.
-    expect(r.code).toBe(1);
+    expect(r.out).not.toMatch(/Restarted clawbox-hermes-dashboard\.service on the new agent/);
+    expect(r.out).toMatch(/did not settle on a new main process/);
+    expect(r.out).toMatch(WARN);
   });
 
-  it("a restart that systemd refuses is reported, not swallowed", () => {
+  it("waits for a replacement that does not appear on the first probe", () => {
+    // `try-restart` normally blocks until the job is done, so the replacement is
+    // usually there immediately — the wait is for when it is not, and it has to
+    // actually work rather than give up on probe one.
     giveShim();
     giveAgent({ venv: true, head: OTHER_COMMIT });
 
-    const r = run({ dashRunning: true, proxyRunning: true, restartOk: false });
+    const r = run({ ...UP, pidDelay: 1 });
 
-    expect(r.out).toMatch(/could not restart clawbox-hermes-dashboard\.service/);
-    expect(r.code).toBe(1);
-    // The install itself still happened and is still reported — the agent on
-    // disk is the pinned one either way.
-    expect(headOf(agentDir())).toBe(PIN);
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/Restarted clawbox-hermes-dashboard\.service on the new agent/);
+    expect(r.out).not.toMatch(WARN);
+  });
+
+  it("a restart that never yields a new main process warns — it never fails the step", () => {
+    // THE RULE, and the reason it is a rule: `resume_paused_engines` records it
+    // for exactly this class. A non-zero return here reaches
+    // `record_provision_failure` on the install path and makes `optional_step`
+    // report `hermes_install` among the fixups that "failed and were skipped"
+    // on the update path — over an install that ran and succeeded. The quiet
+    // channel is what the updater reads instead.
+    giveShim();
+    giveAgent({ venv: true, head: OTHER_COMMIT });
+
+    const r = run({ ...UP, newPid: false });
+
+    expect(restartsIn(r.systemctl)).toHaveLength(2);
+    expect(r.out).toMatch(/did not settle on a new main process/);
+    expect(r.out).toMatch(WARN);
+    // The agent install itself worked, so the step still answers success.
+    expect(r.code).toBe(0);
     expect(r.out).toMatch(/Hermes installed \(Hermes 9\.9\.9\) at the pinned commit/);
+    expect(headOf(agentDir())).toBe(PIN);
+  });
+
+  it("a restart systemd refuses is reported, and told apart from a slow one", () => {
+    giveShim();
+    giveAgent({ venv: true, head: OTHER_COMMIT });
+
+    const refused = run({ ...UP, restart: "refuse" });
+    expect(refused.out).toMatch(/could not be restarted \(systemctl exit 1\)/);
+    expect(refused.out).toMatch(WARN);
+    expect(refused.code).toBe(0);
+  });
+
+  it("a blocking restart is bounded, and a timeout is not read as a refusal", () => {
+    // `systemctl try-restart` without --no-block waits for the job to finish,
+    // and this unit declares TimeoutStartSec=300 — so the call is bounded. What
+    // comes back then is timeout's 124, which means "it may still be running",
+    // not "systemd said no": the verification still gets to answer.
+    giveShim();
+    giveAgent({ venv: true, head: OTHER_COMMIT });
+
+    const r = run({ ...UP, restart: "hang", waitBudget: "1" });
+
+    expect(r.code).toBe(0);
+    expect(r.out).not.toMatch(/could not be restarted \(systemctl exit/);
+    // The unit never actually restarted, so the honest answer is the warning.
+    expect(r.out).toMatch(WARN);
+  });
+
+  it("names what systemd actually says instead of asserting one diagnosis", () => {
+    // A unit somebody STOPPED while the step ran is serving nothing — it is not
+    // "still serving the old agent". `bounceHermesDashboard` separates the two
+    // and this must not collapse them back together.
+    giveShim();
+    giveAgent({ venv: true, head: OTHER_COMMIT });
+
+    const r = run({ ...UP, settleState: "inactive" });
+
+    expect(r.out).toMatch(/systemd says inactive/);
+    expect(r.out).toMatch(WARN);
+    expect(r.code).toBe(0);
+  });
+
+  it("a malformed wait budget falls back to the shipped default without erroring", () => {
+    // The guard is not about errexit — the `-lt` is the left side of a `||`,
+    // which errexit never sees — it is about a value that makes `[` print
+    // "integer expression expected" once per probe and then reads back at the
+    // owner as a budget.
+    giveShim();
+    giveAgent({ venv: true, head: OTHER_COMMIT });
+
+    const r = run({ ...UP, waitBudget: "not-a-number" });
+
+    expect(r.code).toBe(0);
+    expect(r.out).not.toMatch(/integer expression expected/);
+    // The replacement is there on the first probe, so the budget is never spent
+    // and the fallback costs this test nothing.
+    expect(r.out).toMatch(/Restarted clawbox-hermes-dashboard\.service on the new agent/);
   });
 
   it("a box already on the pin restarts nothing at all", () => {
@@ -1141,7 +1260,7 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     giveShim();
     giveAgent({ venv: true, head: PIN });
 
-    const r = run({ dashRunning: true, proxyRunning: true });
+    const r = run({ ...UP });
 
     expect(r.code).toBe(0);
     expect(r.out).toMatch(/already installed at the pinned commit/);
@@ -1155,7 +1274,7 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     giveShim();
     giveAgent({ venv: true, head: OTHER_COMMIT });
 
-    const r = run({ installOk: false, dashRunning: true, proxyRunning: true });
+    const r = run({ installOk: false, ...UP });
 
     expect(r.out).toMatch(/Restored the previous agent/);
     expect(restartsIn(r.systemctl)).toEqual([]);
@@ -1165,7 +1284,7 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     giveShim();
     giveAgent({ venv: true, head: OTHER_COMMIT });
 
-    const r = run({ reachable: false, dashRunning: true, proxyRunning: true });
+    const r = run({ reachable: false, ...UP });
 
     expect(r.out).toMatch(/cannot reach the Hermes installer/);
     expect(restartsIn(r.systemctl)).toEqual([]);
@@ -1177,16 +1296,34 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     // openclaw direction of the edition teardown, or a fresh install where
     // step_hermes_edition has not installed them yet — must not have them
     // resurrected by an agent upgrade. `try-restart` acts only on a unit that
-    // is running, and the step says what it did instead of claiming a restart.
+    // is running, and the step says what it saw instead of claiming a restart.
     giveShim();
     giveAgent({ venv: true, head: OTHER_COMMIT });
 
-    const r = run({ dashRunning: false, proxyRunning: false });
+    const r = run({ dashState: "inactive", proxyState: "inactive" });
 
     expect(r.code).toBe(0);
     expect(r.systemctl.some((c) => /^(start|restart) /.test(c))).toBe(false);
     expect(r.out).not.toMatch(/Restarted clawbox-hermes-dashboard/);
-    expect(r.out).toMatch(/not running — it will pick up the new agent when it next starts/);
+    expect(r.out).toMatch(/clawbox-hermes-dashboard\.service is inactive — nothing to bounce here/);
+    // Nothing went wrong, so nothing is warned about either.
+    expect(r.out).not.toMatch(WARN);
+  });
+
+  it("does not promise a restart for a unit systemd has failed", () => {
+    // `Restart=always` brings back `inactive` and `activating`; it promises
+    // nothing for `failed`, so "it will pick up the new agent when it next
+    // starts" would be a claim the box cannot keep. Say the state instead.
+    giveShim();
+    giveAgent({ venv: true, head: OTHER_COMMIT });
+
+    const r = run({ dashState: "failed", proxyState: "activating" });
+
+    expect(restartsIn(r.systemctl)).toEqual([]);
+    expect(r.out).toMatch(/clawbox-hermes-dashboard\.service is failed — nothing to bounce here/);
+    expect(r.out).toMatch(
+      /clawbox-hermes-dashboard-proxy\.service is activating — nothing to bounce here/,
+    );
   });
 
   it("restarts the dashboard even when the upgrade landed off the pin", () => {
@@ -1196,7 +1333,7 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     giveShim();
     giveAgent({ venv: true, head: OTHER_COMMIT });
 
-    const r = run({ installHead: OTHER_COMMIT, dashRunning: true, proxyRunning: true });
+    const r = run({ installHead: OTHER_COMMIT, ...UP });
 
     expect(r.out).toMatch(/but HEAD is/);
     expect(restartsIn(r.systemctl)).toHaveLength(2);
@@ -1204,12 +1341,12 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
 
   it("restarts before the WhatsApp warm-up, not after it", () => {
     // The warm-up is allowed 300 s. Ordering it in front of the restart would
-    // hold the box on deleted code for five more minutes for a npm install
+    // hold the box on deleted code for five more minutes for an npm install
     // that has nothing to do with the dashboard.
     giveShim();
     giveAgent({ venv: true, head: OTHER_COMMIT });
 
-    const r = run({ bridge: "fresh", dashRunning: true, proxyRunning: true });
+    const r = run({ bridge: "fresh", ...UP });
 
     expect(r.npmArgs).not.toBeNull();
     const lines = r.out.split(NL);

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -90,6 +90,47 @@ const PIN = (PIN_LINE.match(/[0-9a-f]{40}/) ?? [""])[0];
 /** A well-formed commit that is not the pin: what an unpinned box looks like. */
 const OTHER_COMMIT = "0".repeat(39) + "1";
 
+/**
+ * The restart helper's own shape. Driven for real further down; these two are
+ * text assertions because what they pin is an ARITHMETIC invariant that a
+ * behavioural test could only express as a wall-clock threshold, and a timing
+ * assertion on a loaded CI runner is a flake waiting to happen.
+ */
+describe("hermes_dashboard_restart_after_install bounds one bounce with one budget", () => {
+  // Resilient on purpose: `extractShellFunction` THROWS for a function that is
+  // not there, and at describe-body scope that fails the whole FILE to collect
+  // — so a build without the helper would report "0 tests" instead of naming
+  // the cases that care. Answer "" instead and let each case fail on its own.
+  const RESTART_CODE = (() => {
+    try {
+      return shellCode(extractShellFunction("hermes_dashboard_restart_after_install"));
+    } catch {
+      return "";
+    }
+  })();
+
+  it("draws the blocking call and the wait after it from the SAME clock", () => {
+    // The two are phases of one restart. Giving each its own `budget` doubles
+    // the worst case — a hung `try-restart` spends it, then the poll spends it
+    // again — which is exactly the arithmetic the block comment reasons about
+    // against step_post_update's 900 s budget. The clock is started once,
+    // before the blocking call, and the wait is measured against it.
+    expect(RESTART_CODE, "the restart helper is missing from install.sh").not.toBe("");
+    expect(RESTART_CODE).toMatch(/SECONDS=0[\s\S]*timeout "\$budget" systemctl try-restart/);
+    expect(RESTART_CODE).toMatch(/\[ "\$SECONDS" -lt "\$budget" \]/);
+    // …and no second counter that would restart the clock.
+    expect(RESTART_CODE).not.toMatch(/waited=0/);
+  });
+
+  it("uses a shell builtin for elapsed time, not an external command", () => {
+    // `$(date +%s || echo 0)` answers 0 when date is missing or fails, and
+    // `now - started` is then 0 for ever — a wait that never ends, inside a
+    // root step. `SECONDS` is bash's own and cannot fail.
+    expect(RESTART_CODE, "the restart helper is missing from install.sh").not.toBe("");
+    expect(RESTART_CODE).not.toContain("date +%s");
+  });
+});
+
 describe("step_hermes_install treats a shim without an agent as NOT installed", () => {
   it("does not decide from the shim alone", () => {
     // The exact shape of the defect: a bare `[ -x .local/bin/hermes ]` test

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -1063,8 +1063,8 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
    * and then deletes the tree it moved aside — while `clawbox-hermes-dashboard`
    * is a long-lived process that mapped the old files. Measured on the Hermes
    * box after `install.sh --step hermes_install` took it from v0.20.5 to
-   * v0.21.1: the dashboard was still the pid it had been an hour earlier,
-   * `grep -c "(deleted)" /proc/<pid>/maps` returned 84, and
+   * v0.21.1: the dashboard was still the pid it had been more than two hours
+   * earlier, `grep -c "(deleted)" /proc/<pid>/maps` returned 83, and
    * `journalctl -u clawbox-hermes-dashboard` had no entries at all — it was
    * never signalled.
    *

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -242,7 +242,7 @@ describe("step_hermes_install installs one pinned Hermes release", () => {
   });
 
   it("decides pinned-or-not from HEAD, never from the version string", () => {
-    // `hermes --version` prints the same v0.20.5 for the tag and for every
+    // `hermes --version` prints the same v0.21.1 for the tag and for every
     // untagged commit after it — hundreds a week — so a version comparison
     // could never see the difference. Only HEAD can.
     expect(HERMES_CODE).toMatch(/git -C "\$agent_dir" rev-parse HEAD/);
@@ -471,6 +471,17 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     // Whether the stubbed npm succeeds. A registry that is down must cost the
     // owner a warning and nothing else.
     npmOk = true,
+    // Whether the two Hermes units are RUNNING when the step starts. Default
+    // false, which is the fresh-install shape: step_hermes_edition has not
+    // installed them yet, so there is nothing to restart and nothing to say.
+    dashRunning = false,
+    proxyRunning = false,
+    // Whether `systemctl try-restart` succeeds.
+    restartOk = true,
+    // Whether a restarted unit comes back with a NEW main process. `false` is
+    // the unit that was asked and never returned — the case a step that reads
+    // try-restart's exit code as the outcome cannot tell from success.
+    newPid = true,
   } = {}) {
     // The reachability precheck is the `-o /dev/null` call; anything else is
     // the real installer being fetched to be piped into bash.
@@ -518,6 +529,47 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
       ["#!/bin/sh", 'printf "%s\\n" "$*" > npm-ran', 'exit "$NPM_RC"', ""].join(NL),
       { mode: 0o755 },
     );
+    // systemd, stubbed as a real executable for the same reason curl is — and
+    // stubbed UNCONDITIONALLY, so no case in this file can ever reach the
+    // machine's own systemctl. It records every invocation, so "was a restart
+    // issued at all" is directly observable, and it models the one thing an
+    // exit code cannot express: whether the unit came back as a NEW process.
+    fs.mkdirSync(path.join(tmp, "sysd"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, "bin", "systemctl"),
+      [
+        "#!/bin/sh",
+        'printf "%s\\n" "$*" >> "$SYSTEMCTL_LOG"',
+        "unit=",
+        'for a in "$@"; do case "$a" in *.service) unit="$a" ;; esac; done',
+        "active=0",
+        'case "$unit" in',
+        '  clawbox-hermes-dashboard.service) [ "$DASH_ACTIVE" = "1" ] && active=1 ;;',
+        '  clawbox-hermes-dashboard-proxy.service) [ "$PROXY_ACTIVE" = "1" ] && active=1 ;;',
+        "esac",
+        'case "$1" in',
+        "  is-active)",
+        // An inactive unit exits non-zero, exactly as systemd's does.
+        '    if [ "$active" = "1" ]; then echo active; exit 0; fi',
+        "    echo inactive; exit 3 ;;",
+        "  show)",
+        // A stopped unit reports MainPID=0; a running one reports its pid, and
+        // a different one once it has actually been restarted.
+        '    if [ "$active" != "1" ]; then echo 0; exit 0; fi',
+        '    if [ -f "$SYSD_STATE/$unit.restarted" ] && [ "$NEW_PID" = "1" ]; then',
+        "      echo 4242; else echo 1111; fi",
+        "    exit 0 ;;",
+        "  try-restart)",
+        '    [ "$RESTART_OK" = "1" ] || exit 1',
+        // try-restart is a no-op on a unit that is not running — and exits 0.
+        '    [ "$active" = "1" ] && touch "$SYSD_STATE/$unit.restarted"',
+        "    exit 0 ;;",
+        "esac",
+        "exit 0",
+        "",
+      ].join(NL),
+      { mode: 0o755 },
+    );
     // `git -C <dir> rev-parse HEAD` is the only git the step runs, and it runs
     // it through `env`, which does a PATH lookup — so, like curl, it has to be
     // a real executable and not a shell function.
@@ -559,7 +611,10 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
       // lookup and never sees a function. A function stub therefore let the
       // precheck reach the real network — the test passed for the wrong reason.
       'export PATH="$1/bin:$PATH"',
-      "sed -n '/^step_hermes_install() {/,/^}/p' \"$4\" > \"$1/fn.sh\"",
+      // Both functions: the step calls the restart helper, so lifting the step
+      // alone would only prove that bash cannot find it.
+      "sed -n '/^hermes_dashboard_restart_after_install() {/,/^}/p' \"$4\" > \"$1/fn.sh\"",
+      "sed -n '/^step_hermes_install() {/,/^}/p' \"$4\" >> \"$1/fn.sh\"",
       '. "$1/fn.sh"',
       // Merged, because the warnings that matter here are all on stderr.
       "step_hermes_install 2>&1",
@@ -584,7 +639,20 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
         {
           encoding: "utf8",
           stdio: ["ignore", "pipe", "pipe"],
-          env: { ...process.env, BRIDGE: bridge, NPM_RC: npmOk ? "0" : "1" },
+          env: {
+            ...process.env,
+            BRIDGE: bridge,
+            NPM_RC: npmOk ? "0" : "1",
+            SYSTEMCTL_LOG: path.join(tmp, "systemctl-log"),
+            SYSD_STATE: path.join(tmp, "sysd"),
+            DASH_ACTIVE: dashRunning ? "1" : "0",
+            PROXY_ACTIVE: proxyRunning ? "1" : "0",
+            RESTART_OK: restartOk ? "1" : "0",
+            NEW_PID: newPid ? "1" : "0",
+            // The wait for a replacement main process, cut to a value a test
+            // can afford to let expire. The shipped default is 90 s.
+            HERMES_DASHBOARD_RESTART_WAIT_S: "2",
+          },
         },
       );
     } catch (e: unknown) {
@@ -593,9 +661,14 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
       out = `${err.stdout ?? ""}${err.stderr ?? ""}`;
     }
     const npmMarker = path.join(bridgeDir(), "npm-ran");
+    const sysLog = path.join(tmp, "systemctl-log");
     return {
       code,
       out,
+      /** Every `systemctl …` the step ran, in order. */
+      systemctl: exists(sysLog)
+        ? fs.readFileSync(sysLog, "utf8").split(NL).filter(Boolean)
+        : ([] as string[]),
       installerRan: exists(path.join(tmp, "installer-ran")),
       // Read out of the BRIDGE directory, so a non-null value is already proof
       // that npm ran with the bridge as its working directory.
@@ -983,6 +1056,168 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     expect(r.out).toMatch(/Hermes installed \(Hermes 9\.9\.9\) at the pinned commit/);
     expect(headOf(agentDir())).toBe(PIN);
     expect(exists(`${agentDir()}.broken`)).toBe(false);
+  });
+
+  /**
+   * TASK-784. The upgrade replaces ~/.hermes/hermes-agent with a FRESH CLONE
+   * and then deletes the tree it moved aside — while `clawbox-hermes-dashboard`
+   * is a long-lived process that mapped the old files. Measured on the Hermes
+   * box after `install.sh --step hermes_install` took it from v0.20.5 to
+   * v0.21.1: the dashboard was still the pid it had been an hour earlier,
+   * `grep -c "(deleted)" /proc/<pid>/maps` returned 84, and
+   * `journalctl -u clawbox-hermes-dashboard` had no entries at all — it was
+   * never signalled.
+   *
+   * Python imports lazily, so the process keeps serving until it reaches a
+   * module it had not yet imported, which is now unreachable. A full chat
+   * battery PASSED on that box in that state: three turns, 200s, correct
+   * answers — all of it the OLD agent answering. That is what makes this a
+   * false green rather than an outage, and why nothing downstream catches it.
+   *
+   * `Restart=always` on the unit is not a mechanism: nothing stops the process,
+   * so nothing restarts it. Neither unit has an ExecStop either.
+   */
+  const RESTART_UNITS = [
+    "clawbox-hermes-dashboard.service",
+    "clawbox-hermes-dashboard-proxy.service",
+  ];
+  /** The `try-restart` lines out of the recorded systemctl calls. */
+  const restartsIn = (calls: string[]) => calls.filter((c) => c.startsWith("try-restart "));
+
+  it("a pinned upgrade restarts the dashboard so the box stops serving deleted files", () => {
+    giveShim();
+    giveAgent({ venv: true, head: OTHER_COMMIT });
+
+    const r = run({ dashRunning: true, proxyRunning: true });
+
+    expect(r.code).toBe(0);
+    expect(r.installerRan).toBe(true);
+    // Both units: the proxy holds a brokered Hermes session against the
+    // dashboard process that is being replaced.
+    expect(restartsIn(r.systemctl)).toEqual(RESTART_UNITS.map((u) => `try-restart ${u}`));
+    // Said out loud, in the step's own output — an owner reading an update log
+    // has to be able to see that the new agent is the one now serving.
+    expect(r.out).toMatch(/Restarted clawbox-hermes-dashboard\.service/);
+    expect(r.out).toMatch(/Restarted clawbox-hermes-dashboard-proxy\.service/);
+  });
+
+  it("verifies the restart instead of reading try-restart's exit code as the outcome", () => {
+    // `systemctl try-restart` exits 0 for "restarted it" AND for "it was not
+    // running, so I did nothing" — and returns before a unit that then fails
+    // to come back has failed. A step that claims a restart on that exit code
+    // is this PR's own defect in miniature, so the new main process is what
+    // proves it.
+    giveShim();
+    giveAgent({ venv: true, head: OTHER_COMMIT });
+
+    const r = run({ dashRunning: true, proxyRunning: true, newPid: false });
+
+    expect(restartsIn(r.systemctl)).toHaveLength(2);
+    expect(r.out).not.toMatch(/Restarted clawbox-hermes-dashboard\.service/);
+    expect(r.out).toMatch(/did not report a new main process/);
+    // A box left serving an agent that is no longer on disk is not a completed
+    // fixup, and `optional_step` is what carries that to the update's status.
+    expect(r.code).toBe(1);
+  });
+
+  it("a restart that systemd refuses is reported, not swallowed", () => {
+    giveShim();
+    giveAgent({ venv: true, head: OTHER_COMMIT });
+
+    const r = run({ dashRunning: true, proxyRunning: true, restartOk: false });
+
+    expect(r.out).toMatch(/could not restart clawbox-hermes-dashboard\.service/);
+    expect(r.code).toBe(1);
+    // The install itself still happened and is still reported — the agent on
+    // disk is the pinned one either way.
+    expect(headOf(agentDir())).toBe(PIN);
+    expect(r.out).toMatch(/Hermes installed \(Hermes 9\.9\.9\) at the pinned commit/);
+  });
+
+  it("a box already on the pin restarts nothing at all", () => {
+    // The overwhelmingly common case: post_update runs this step on every
+    // update on every hermes/dual box. Nothing changed under the dashboard, so
+    // bouncing the box's chat backend would be a self-inflicted outage.
+    giveShim();
+    giveAgent({ venv: true, head: PIN });
+
+    const r = run({ dashRunning: true, proxyRunning: true });
+
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/already installed at the pinned commit/);
+    expect(restartsIn(r.systemctl)).toEqual([]);
+  });
+
+  it("a failed install, whose old agent is restored, restarts nothing", () => {
+    // The restore puts the ORIGINAL checkout back at the original path, so the
+    // running dashboard's mappings are still valid. There is nothing to pick
+    // up, and restarting would cost an owner their chat for no reason.
+    giveShim();
+    giveAgent({ venv: true, head: OTHER_COMMIT });
+
+    const r = run({ installOk: false, dashRunning: true, proxyRunning: true });
+
+    expect(r.out).toMatch(/Restored the previous agent/);
+    expect(restartsIn(r.systemctl)).toEqual([]);
+  });
+
+  it("an unreachable installer restarts nothing", () => {
+    giveShim();
+    giveAgent({ venv: true, head: OTHER_COMMIT });
+
+    const r = run({ reachable: false, dashRunning: true, proxyRunning: true });
+
+    expect(r.out).toMatch(/cannot reach the Hermes installer/);
+    expect(restartsIn(r.systemctl)).toEqual([]);
+  });
+
+  it("never STARTS a dashboard that is not running", () => {
+    // The invariant `install-foreign-edition-teardown.test.ts` guards from the
+    // other side: a box whose Hermes units were stopped and disabled — the
+    // openclaw direction of the edition teardown, or a fresh install where
+    // step_hermes_edition has not installed them yet — must not have them
+    // resurrected by an agent upgrade. `try-restart` acts only on a unit that
+    // is running, and the step says what it did instead of claiming a restart.
+    giveShim();
+    giveAgent({ venv: true, head: OTHER_COMMIT });
+
+    const r = run({ dashRunning: false, proxyRunning: false });
+
+    expect(r.code).toBe(0);
+    expect(r.systemctl.some((c) => /^(start|restart) /.test(c))).toBe(false);
+    expect(r.out).not.toMatch(/Restarted clawbox-hermes-dashboard/);
+    expect(r.out).toMatch(/not running — it will pick up the new agent when it next starts/);
+  });
+
+  it("restarts the dashboard even when the upgrade landed off the pin", () => {
+    // The tree was still replaced, so the running process is still mapping
+    // files that no longer exist. "Not the build we ship" and "serving deleted
+    // code" are two different problems and only one of them is the pin's.
+    giveShim();
+    giveAgent({ venv: true, head: OTHER_COMMIT });
+
+    const r = run({ installHead: OTHER_COMMIT, dashRunning: true, proxyRunning: true });
+
+    expect(r.out).toMatch(/but HEAD is/);
+    expect(restartsIn(r.systemctl)).toHaveLength(2);
+  });
+
+  it("restarts before the WhatsApp warm-up, not after it", () => {
+    // The warm-up is allowed 300 s. Ordering it in front of the restart would
+    // hold the box on deleted code for five more minutes for a npm install
+    // that has nothing to do with the dashboard.
+    giveShim();
+    giveAgent({ venv: true, head: OTHER_COMMIT });
+
+    const r = run({ bridge: "fresh", dashRunning: true, proxyRunning: true });
+
+    expect(r.npmArgs).not.toBeNull();
+    const lines = r.out.split(NL);
+    const restartedAt = lines.findIndex((l) => l.includes("Restarted clawbox-hermes-dashboard."));
+    const warmedAt = lines.findIndex((l) => l.includes("Warming up the WhatsApp bridge"));
+    expect(restartedAt).toBeGreaterThanOrEqual(0);
+    expect(warmedAt).toBeGreaterThanOrEqual(0);
+    expect(restartedAt).toBeLessThan(warmedAt);
   });
 
   it("a bridge that already has its node_modules is left alone", () => {

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -3605,7 +3605,7 @@ describe("updater", () => {
  */
 describe("getVersionInfo harness reporting", () => {
   const HERMES_BANNER =
-    "Hermes Agent v0.21.1 (2026.9.7) · upstream d0df3248 · local 2237be35\n" +
+    "Hermes Agent v0.21.1 (2026.9.7) · upstream ead7e91d · local 2237be35\n" +
     "Install directory: /home/clawbox/.hermes/hermes-agent";
 
   beforeEach(() => {

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -3605,7 +3605,7 @@ describe("updater", () => {
  */
 describe("getVersionInfo harness reporting", () => {
   const HERMES_BANNER =
-    "Hermes Agent v0.20.5 (2026.8.19) — upstream 261a4efb — local 10914727\n" +
+    "Hermes Agent v0.21.1 (2026.9.7) · upstream d0df3248 · local 2237be35\n" +
     "Install directory: /home/clawbox/.hermes/hermes-agent";
 
   beforeEach(() => {
@@ -3632,7 +3632,7 @@ describe("getVersionInfo harness reporting", () => {
     const info = await versionsFor("hermes");
 
     expect(info.edition).toBe("hermes");
-    expect(info.hermes?.current).toBe("v0.20.5");
+    expect(info.hermes?.current).toBe("v0.21.1");
     // TASK-613: and it asks for the banner WITHOUT the agent's passive update
     // check. `--version` is the only hermes call that runs one, and on a
     // six-hourly cache miss that check does a `git fetch` plus a GitHub
@@ -3659,7 +3659,7 @@ describe("getVersionInfo harness reporting", () => {
 
     expect(info.edition).toBe("dual");
     expect(info.openclaw.current).toBe("1.0.0");
-    expect(info.hermes?.current).toBe("v0.20.5");
+    expect(info.hermes?.current).toBe("v0.21.1");
   });
 
   it("reports a null hermes version rather than failing when the CLI is missing", async () => {

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -3605,7 +3605,7 @@ describe("updater", () => {
  */
 describe("getVersionInfo harness reporting", () => {
   const HERMES_BANNER =
-    "Hermes Agent v0.21.1 (2026.9.7) · upstream ead7e91d · local 2237be35\n" +
+    "Hermes Agent v0.21.1 (2026.9.7) · upstream ead7e91d · local 2237be35 (+32678 carried commits)\n" +
     "Install directory: /home/clawbox/.hermes/hermes-agent";
 
   beforeEach(() => {

--- a/src/tests/unit/version-utils.test.ts
+++ b/src/tests/unit/version-utils.test.ts
@@ -37,8 +37,33 @@ describe("parseHermesVersion", () => {
     "Install method: git",
   ].join("\n");
 
+  // The real banner at the commit HERMES_PIN_COMMIT now installs, read off the
+  // Hermes box (TASK-784). Kept BESIDE the older one rather than replacing it:
+  // upstream has already changed the field separator from an em dash to a
+  // middle dot between these two versions, so a parser that only ever sees one
+  // of them cannot show that it does not depend on the separator — and a box
+  // mid-update still prints the older banner.
+  const banner021 = [
+    "Hermes Agent v0.21.1 (2026.9.7) · upstream d0df3248 · local 2237be35 (+32678 carried commits)",
+    "Install directory: /home/clawbox/.hermes/hermes-agent",
+    "Install method: git",
+    "Python: 3.11.15",
+  ].join("\n");
+
   it("reduces the multi-line banner to the version tag", () => {
     expect(parseHermesVersion(banner)).toBe("v0.20.5");
+  });
+
+  it("reads the pinned build's banner, whichever separator upstream printed", () => {
+    expect(parseHermesVersion(banner021)).toBe("v0.21.1");
+  });
+
+  it("is not confused by the build date or the carried-commit count", () => {
+    // `(2026.9.7)` is semver-ish too and sits four tokens before `+32678`.
+    // Only the FIRST match on line one is the version, and the count must not
+    // be read as a build-metadata suffix on it.
+    expect(parseHermesVersion(banner021)).not.toContain("2026");
+    expect(parseHermesVersion(banner021)).not.toContain("32678");
   });
 
   it("returns null for empty values", () => {

--- a/src/tests/unit/version-utils.test.ts
+++ b/src/tests/unit/version-utils.test.ts
@@ -44,7 +44,7 @@ describe("parseHermesVersion", () => {
   // of them cannot show that it does not depend on the separator — and a box
   // mid-update still prints the older banner.
   const banner021 = [
-    "Hermes Agent v0.21.1 (2026.9.7) · upstream d0df3248 · local 2237be35 (+32678 carried commits)",
+    "Hermes Agent v0.21.1 (2026.9.7) · upstream ead7e91d · local 2237be35 (+32678 carried commits)",
     "Install directory: /home/clawbox/.hermes/hermes-agent",
     "Install method: git",
     "Python: 3.11.15",

--- a/src/tests/unit/version-utils.test.ts
+++ b/src/tests/unit/version-utils.test.ts
@@ -38,11 +38,12 @@ describe("parseHermesVersion", () => {
   ].join("\n");
 
   // The real banner at the commit HERMES_PIN_COMMIT now installs, read off the
-  // Hermes box (TASK-784). Kept BESIDE the older one rather than replacing it:
-  // upstream has already changed the field separator from an em dash to a
-  // middle dot between these two versions, so a parser that only ever sees one
-  // of them cannot show that it does not depend on the separator — and a box
-  // mid-update still prints the older banner.
+  // Hermes box (TASK-784). Kept BESIDE the older one rather than replacing it
+  // for two reasons: a box mid-update still prints the older banner, and the
+  // two differ in their field separator, which pins that the parser does not
+  // depend on one. (Which separator belongs to which VERSION is not something
+  // this tree can say — the two v0.20.5 fixtures it carries disagree — so
+  // nothing here claims it.)
   const banner021 = [
     "Hermes Agent v0.21.1 (2026.9.7) · upstream ead7e91d · local 2237be35 (+32678 carried commits)",
     "Install directory: /home/clawbox/.hermes/hermes-agent",
@@ -58,12 +59,12 @@ describe("parseHermesVersion", () => {
     expect(parseHermesVersion(banner021)).toBe("v0.21.1");
   });
 
-  it("is not confused by the build date or the carried-commit count", () => {
-    // `(2026.9.7)` is semver-ish too and sits four tokens before `+32678`.
-    // Only the FIRST match on line one is the version, and the count must not
-    // be read as a build-metadata suffix on it.
-    expect(parseHermesVersion(banner021)).not.toContain("2026");
-    expect(parseHermesVersion(banner021)).not.toContain("32678");
+  it("takes the version, not the build date, when the tag is missing its v", () => {
+    // Both tokens on this line are semver-ish and the build date comes SECOND,
+    // so only "first match on line one" gets this right. Written without a
+    // leading `v` because that is the one shape the banner tests above cannot
+    // distinguish from a date.
+    expect(parseHermesVersion("Hermes Agent 0.21.1 (2026.9.7) · local 2237be35")).toBe("0.21.1");
   });
 
   it("returns null for empty values", () => {


### PR DESCRIPTION
**TASK-784** — bump the pinned Hermes agent to v0.21.1, and stop `step_hermes_install` from leaving the box serving an agent it has just deleted.

## What the customer sees

On a Hermes or dual box, `sudo bash install.sh --step hermes_install` — the documented repair command, and the sub-step the Settings → Harness swap re-execs — upgrades the Hermes agent by moving the old checkout aside, cloning a fresh one, and then deleting the copy it moved aside. `clawbox-hermes-dashboard` is a long-lived Python process that had mapped those files. Nothing signalled it, so it carried on serving the **old** agent out of deleted inodes.

Measured on the Hermes box today, upgrading v0.20.5 → v0.21.1 with beta's own `install.sh`:

- the dashboard was still the pid it had been two hours earlier, with an unchanged `ExecMainStartTimestamp`;
- `grep -c "(deleted)" /proc/<pid>/maps` → **83**;
- `journalctl -u clawbox-hermes-dashboard --since "-12 min"` → `-- No entries --`;
- and the step printed `Hermes installed (…) at the pinned commit` and exited **0** over it.

Python imports lazily, so such a process keeps answering until it reaches a module it had not yet imported — which is now unreachable. The earlier on-box evaluation ran a full chat battery in exactly this state and **all three turns passed**, served by an agent that no longer existed on disk. That is what makes this a false green rather than an outage: nothing downstream catches it.

`Restart=always` on the unit is not a mechanism — nothing stops the process, so nothing restarts it — and neither dashboard unit has an `ExecStop`.

**Scope, stated honestly.** On the full in-app update the dashboard *is* restarted a few minutes later, incidentally, by a different step: `step_hermes_edition` → `scripts/setup-hermes-edition.sh`, which restarts both units unconditionally as part of provisioning. Verified on the box: it is why the dashboard there shows 0 deleted maps after a normal update. So this is not "every update leaves the box broken". What it is: the standalone repair path has no restart at all, the restart on the update path is a coupling to a step that can be skipped or fail rather than a property of the install, and even when it does run the box serves deleted code for the length of the rest of `post_update`.

## The pin

`HERMES_PIN_COMMIT`: `fcbd1076a93841fa88855acce810e342a5b78101` (v0.20.5, tag v2026.8.19) → `2237be355906fbe6065ce1815711eee52b2d646e` (v0.21.1, tag v2026.9.7).

Verified rather than assumed: the annotated tag `v2026.9.7` dereferences to that commit; the pinned installer URL `…/2237be35…/scripts/install.sh` answers 200; and `compare/fcbd1076…2237be35` is `status=ahead, ahead_by=8282, behind_by=0` — a clean fast-forward, nothing force-pushed under us. The bump follows the on-box evaluation battery: all 22 dashboard RPC method/event names survive upstream's `web_server.py` refactor with counts equal or higher, eight live turns none of which approached the 180 s idle timeout, both ClawBox Hermes plugins resolving to native modules (so the 2026-09-14 compat expiry does not touch us), and the scrypt dashboard-auth hash our script wrote under v0.20.5 verifying against the v0.21.1 plugin.

Declined by ruling, and deliberately not in this PR: writing `updates.check: false` into `config.yaml` to retire the TASK-613 workaround. Measured saving 2.57 s; measured price all 36 comment lines of the owner's config. The two TASK-613 blocks stay.

## Harness first

There is nothing upstream to defer to, and it was asked of the box rather than inferred: `hermes dashboard --help` at this version offers `--stop` and `--status` and **no restart**. Hermes owns a *stop* — `hermes dashboard --stop`, its own SIGTERM-grace-SIGKILL path, which our unit already runs as an `ExecStartPre` — but no restart hook and no supervision of its own. The only thing upstream offers around an upgrade is `hermes update`, which reattaches a detached checkout to `main` (`hermes_cli/update_cmd.py`) — precisely the outcome the pin exists to prevent, so it is the wrong mechanism and this step already avoids it. And the proxy is not Hermes's at all: `clawbox-hermes-dashboard-proxy` runs ClawBox's own `scripts/hermes-dashboard-proxy.js`, which Hermes has never heard of. systemd owns both units on the box, so systemd is what gets asked.

## The fix

`hermes_dashboard_restart_after_install()` in `install.sh`, called from `step_hermes_install` only on the path where the install actually replaced the tree — and **before** the WhatsApp bridge warm-up, which is allowed 300 s and has nothing to do with the dashboard.

- **`try-restart`, never `restart`.** `restart` starts a *stopped* unit, and a box whose Hermes units were stopped and disabled (the openclaw direction of `step_edition_foreign_teardown`, or a fresh install before `step_hermes_edition` has installed them) must never have them resurrected by an agent upgrade. Same invariant `src/lib/hermes-dashboard-control.ts` is built around and the same call `refresh_agent_coding_tools` already makes. A unit that is not running has its actual state named — `failed` is not a state `Restart=always` promises anything for — and is left alone.
- **The bounce is bounded, once.** `systemctl try-restart` without `--no-block` waits for the job to finish, and the dashboard unit declares `TimeoutStartSec=300` on top of systemd's default 90 s stop, so an unbounded call is a ~390 s term inside `step_post_update`'s 900 s budget. It runs under `timeout`, and the wait that follows is measured against the **same** clock (bash's `SECONDS`, reset before the call) rather than starting a second one — otherwise a hung restart would spend the budget and the poll would spend it again. Worst case is therefore `budget + settle` per unit, ~246 s for the pair on the shipped defaults. `timeout`'s 124 means "may still be running" and falls through to the verification; anything else is systemd refusing, and there is nothing left to verify.
- **A new `MainPID` is only half the proof.** Both units are `Type=simple`, so systemd hands over `MainPID` the instant `ExecStart` **forks** — before the dashboard binds its socket and long before a fresh clone finishes the 60–90 s web-dist build. A clone that cannot start hands over a new pid and then dies into `Restart=always`, which would be this step's own false success moved one notch down. So the unit is asked again after a settle, and the restart is claimed only when it is still `active` on the *same* new pid. This borrows the verdict rule already written down in `bounceHermesDashboard()`: *"systemd says a DIFFERENT process is now the unit's main one, and the socket says that process is serving. Neither alone is the bounce."*
- **A failed bounce warns; it never fails the step.** `resume_paused_engines` records the rule for exactly this class: a non-zero return reaches `record_provision_failure` on the install path and makes `optional_step` report `hermes_install` among the fixups that *"failed and were skipped"* on the update path — over an install that ran and succeeded, and over a condition `step_hermes_edition` repairs a few minutes later. So the helper always returns 0 and emits `CLAWBOX-WARN[hermes-dashboard-not-restarted]: …`, the channel `src/lib/updater.ts` (`STEP_WARNING_LINE`) already parses and raises on the update's own status. `step_hermes_install`'s return contract stays `_hermes_off_pin` alone. The warning carries what was *observed* — `systemd says inactive` / `activating` / a pid that moved again — rather than asserting one diagnosis, because a unit somebody stopped is serving nothing and a unit still starting is not a problem at all.
- **Order.** The dashboard first, then the proxy that fronts it: the proxy brokers a session *against* the dashboard, so the other order would have it fail a login and sit out its retry cooldown. The proxy holds no deleted files of its own — it is our node process, not Hermes's — and it does recover a rejected session by itself on a 401; it is bounced anyway because the pair is provisioned and restarted together everywhere else, and a node start is sub-second. The review argued for dropping it; it is kept because the card asks for both units and because the ordering removes the cost the review identified.

## RED → GREEN

**RED, unit** — fourteen cases in `src/tests/unit/install-hermes-install-guard.test.ts`, driving the real extracted shell functions against a fake HOME with `systemctl` stubbed as a real executable on PATH (stubbed unconditionally, so no case in the file can reach the machine's own systemd). Against unmodified beta:

```
 ❯ |unit| src/tests/unit/install-hermes-install-guard.test.ts (68 tests | 14 failed)
     × draws the blocking call and the wait after it from the SAME clock
     × uses a shell builtin for elapsed time, not an external command
     × a pinned upgrade restarts the dashboard so the box stops serving deleted files
     × a pid alone is not the bounce — a unit that forks and dies is not reported as restarted
     × waits for a replacement that does not appear on the first probe
     × a restart that never yields a new main process warns — it never fails the step
     × a restart systemd refuses is reported, and told apart from a slow one
     × a blocking restart is bounded, and a timeout is not read as a refusal
     × names what systemd actually says instead of asserting one diagnosis
     × a malformed wait budget falls back to the shipped default without erroring
     × never STARTS a dashboard that is not running
     × does not promise a restart for a unit systemd has failed
     × restarts the dashboard even when the upgrade landed off the pin
     × restarts before the WhatsApp warm-up, not after it

AssertionError: expected [] to deeply equal [ …(2) ]
- [ "try-restart clawbox-hermes-dashboard.service",
-   "try-restart clawbox-hermes-dashboard-proxy.service" ]
+ []
```

The stub models what an exit code cannot: whether a replacement main process appeared, how long it took, whether it was still there a settle later, and the `inactive` / `failed` / `activating` states — which is what lets the suite catch the fork-and-die case rather than only the never-restarted one. It answers `show` **only** for the property actually asked for, so code that dropped `-p MainPID` gets nothing rather than a pid.

**GREEN, unit** — `68 passed (68)` in that file; full unit project **793 files, 13300 passed, 1 skipped**; `tsc --noEmit` clean; eslint clean on the touched files; `bash -n install.sh` clean.

**RED, on hardware** (Hermes box, edition lock `hermes`, ClawBox `936b4aa0` on beta) — beta's own `install.sh`, pin overridden to v0.21.1:

```
before  dash_pid=9707  dash_start=Wed 2026-09-09 14:47:54  deleted_maps=0
  Hermes installed (Hermes Agent v0.21.1 (2026.9.7) · … · local 2237be35 …) at the pinned commit
after   dash_pid=9707  dash_start=Wed 2026-09-09 14:47:54
        dash_deleted_maps=83
        agent_head=2237be355906fbe6065ce1815711eee52b2d646e
journal: -- No entries --
```

Same pid, same start timestamp, 83 deleted mappings, never signalled — and the step exited 0 over it.

**GREEN, on hardware** — this branch's `install.sh` (sha verified on the box), at its own default pin, performing a real changed install:

```
before  dash_pid=19847 proxy_pid=19857
  Hermes runs but is not on the pinned commit — upgrading
    have: fcbd1076a93841fa88855acce810e342a5b78101
    want: 2237be355906fbe6065ce1815711eee52b2d646e
  Moved the working agent to /home/clawbox/.hermes/hermes-agent.broken
  Hermes installed (Hermes Agent v0.21.1 (2026.9.7) · upstream ead7e91d · local 2237be35 (+32678 carried commits)) at the pinned commit
  Restarted clawbox-hermes-dashboard.service on the new agent (main pid 19847 -> 22559, still up 3s later)
  Restarted clawbox-hermes-dashboard-proxy.service on the new agent (main pid 19857 -> 22590, still up 3s later)
  Warming up the WhatsApp bridge so the first pairing does not pay for it...
STEP_EXIT=0        (no CLAWBOX-WARN line)
after   dash_pid=22559 proxy_pid=22590   dash_deleted_maps=0  proxy_deleted_maps=0
        agent_head=2237be355906fbe6065ce1815711eee52b2d646e
```

and, on an earlier pass with the same code, the no-op case immediately afterwards:

```
  Hermes already installed at the pinned commit (…)
dash_pid_after=19847  (unchanged — nothing was bounced)
```

Also exercised live, and correct: a `429` from `raw.githubusercontent.com` made the reachability precheck refuse non-destructively — agent untouched, **no restart issued**, nothing half-installed. (That the step still answers 0 there is a separate pre-existing defect; it is written up in the run's Found list rather than fixed here.)

Box health afterwards: dashboard/proxy/setup all active, gate `302`, proxy `302`, `0` failed units, `0` deleted maps on both, no `hermes-agent.broken` left, `hermes --version` reporting `v0.21.1`, and one owner-session chat turn through the restarted dashboard answering correctly (`http=200`, 84 s, `harness=hermes`). The checkout was restored to beta and proved by sha — `install.sh` back to its baseline hash, root-exec mirror unchanged, `git status --porcelain` empty, HEAD `936b4aa0`. The box is deliberately left on v0.21.1, which is where this pin takes the fleet.

## Sibling sweep

`step_hermes_install` is the only thing in this repository that replaces the Hermes agent tree (it is the sole user of the upstream installer URL; `hermes update` is never invoked anywhere, only named in comments as the thing to avoid). The other candidates were checked and are cleared:

- `scripts/setup-hermes-edition.sh` — already `systemctl restart`s both units unconditionally as part of provisioning; unchanged.
- `harness_swap` — re-execs `hermes_install` → `edition_lock` → `hermes_edition`; covered twice now, and on a swap *to* Hermes the units are not yet running, so the new code says so and starts nothing.
- `step_hermes_edition` — restarts both units already.
- factory reset's `HERMES_KEEP` — *preserves* `hermes-agent` rather than replacing it, so the running process's mappings stay valid, and the route reboots the box anyway. Nothing to do.
- `refresh_agent_coding_tools` — already `try-restart`s `clawbox-hermes-dashboard.service` for the coding-tools re-probe; same mechanism, deliberately consistent with it.

## Version strings, and what upstream was re-checked

The `hermes --version` banner fixtures and the parser's documented example move to the v0.21.1 banner **read verbatim off the box**. The older v0.20.5 banner is kept beside the new one: a box mid-update still prints it, and the two differ in their field separator, which pins that `parseHermesVersion` does not depend on one. (Which separator belongs to which *version* is not something this tree can say — the two v0.20.5 fixtures it already carried disagree — so nothing claims it.) `install.sh`'s line-1 slicing is unaffected.

The pin moves ~8,300 upstream commits, and the `src/lib/hermes-*` layer is written against literal upstream behaviour. Most of it fails open on an exit code; the ones that would break **silently** were re-read at `2237be35` rather than assumed:

- `hermes_cli/_startup_fast.py` — `print_fast_version_info(*, check_updates: bool = True)` unchanged, so the TASK-613 probe optimisation still works. Corroborated live: the v0.21.1 banner in the new fixture is what a silenced probe printed on the box.
- `hermes_cli/config.py` — `_format_config_get_value(value, *, as_json)` unchanged (`json.dumps` for `--json`, `true`/`false`, `null`, YAML for containers), which is the contract `src/lib/hermes-clawai.ts` parses.
- `hermes_cli/config.py` — `unset_config_value` still ends `if not removed: _exit_invalid(f"Config key not set: {key}")`, and `_exit_invalid` still prints to stderr and exits 1. That is exactly what `src/lib/hermes-config-yaml.ts:206` records and why it discards the exit code; `install.sh`'s `grep -qi "config key not set"` was confirmed live on the box by the evaluation.

Comments elsewhere of the form *"measured / read on 0.20.5"* are left alone deliberately: they are dated records of when an upstream file was read, and rewriting them to 0.21.1 would fabricate measurements nobody took. Where the wording was present-tense false — *"the pinned 0.20.5"* — it is corrected in the two places inside files this PR already owns. The same phrasing survives in about a dozen comments across eight files this PR does not touch; they are listed with their line numbers in the run's Found list rather than swept here, so this diff stays the change it claims to be.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Upgraded the Hermes agent to v0.21.1.
  - Automatically restarts active Hermes dashboard and proxy services after a successful upgrade.
  - Reports restart issues, delays, or timeouts without interrupting installation.

- **Bug Fixes**
  - Improved compatibility with Hermes version banners using different field separators.
  - Updated version reporting to recognize the latest Hermes release format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->