### PR TITLE
fix: re-attempt a plugin a previous boot switched off, and name the cause

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -5208,9 +5208,17 @@ REATTEMPTPY
         else
           REPAIR_DETAIL="The core could not confirm the consent after a fresh attempt."
         fi
+        # The row keeps its own stage, so the sentence has to match it: an
+        # `install` row re-filed with "the plugin is installed" would contradict
+        # itself, over a Retry that is about to reinstall the payload.
+        if [ "$REPAIR_STAGE" = "install" ]; then
+          REPAIR_LEAD="The plugin could not be made loadable, so the gateway would refuse to start with it enabled."
+        else
+          REPAIR_LEAD="The plugin is installed but its capabilities could not be accepted, so the gateway would refuse to start with it enabled."
+        fi
         echo "  WARN: could not confirm $REPAIR_PLUGIN plugin capabilities after the re-attempt" >&2
         clawbox_plugin_reattempt_failed "$REPAIR_PLUGIN" "$REPAIR_STAGE" \
-          "The plugin is installed but its capabilities could not be accepted, so the gateway would refuse to start with it enabled. $REPAIR_DETAIL" \
+          "$REPAIR_LEAD $REPAIR_DETAIL" \
           "$(clawbox_managed_plugin_spec "$REPAIR_PLUGIN")"
       else
         # `clawbox_plugin_repair_clear` is the whole repair from here: the row

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -5152,11 +5152,17 @@ for key, row in rows.items():
     # `pluginConsentRepairIsAllowed`): `plugins.entries` can be keyed
     # `openclaw-discord` where the row says `discord`, and an exact lookup would
     # answer "no entry" and skip the row for ever without saying why.
-    entry_key = None
-    for key in entries:
-        if isinstance(key, str) and canonical(key) == canonical(plugin_id):
-            entry_key = key
-            break
+    # THE EXACT KEY FIRST, the canonical scan only as a fallback. Every writer
+    # files the row under the key `plugins.entries` carries, so an exact match
+    # IS the intended entry — and a config that somehow held both spellings
+    # would otherwise be resolved by whichever one JSON happened to list first,
+    # which is not a rule anybody chose.
+    entry_key = plugin_id if plugin_id in entries else None
+    if entry_key is None:
+        for key in entries:
+            if isinstance(key, str) and canonical(key) == canonical(plugin_id):
+                entry_key = key
+                break
     if entry_key is None:
         continue
     entry = entries[entry_key]

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -3650,11 +3650,27 @@ raise SystemExit(0 if isinstance(entry, dict) and entry.get("enabled") is True e
 PY
 }
 
+# Ids this boot has already filed a repair row for.
+#
+# The re-attempt block far below is for what a PREVIOUS boot switched off, and
+# nothing enforced the "previous": every `clawbox_plugin_boot_without` in this
+# script runs earlier than that block, so a plugin the managed loop had just
+# failed and disabled was fed straight back in and its `plugins enable` re-run
+# seconds later — learning nothing, and spending an enable, an inspect and a
+# config write out of a `TimeoutStartSec=600` the failed recovery had already
+# been drawing on. Collected HERE because every writer in this script goes
+# through this one function, so no new call site can forget it.
+CLAWBOX_REPAIR_MARKED_THIS_BOOT=""
+
 # Record — or update — one plugin's repair row. Never fatal: a box that cannot
 # write this file still boots without the plugin, it just cannot explain itself
 # in Settings, and the boot log says so.
 clawbox_plugin_repair_mark() {
   local id="$1" stage="$2" disabled="$3" reason="$4" spec="${5:-}"
+  # Before the write, not after: an id whose row could not be written is still
+  # one this boot has just tried and failed, and re-attempting it here would
+  # repeat that failure inside the same startup.
+  CLAWBOX_REPAIR_MARKED_THIS_BOOT="$CLAWBOX_REPAIR_MARKED_THIS_BOOT $id"
   if ! CLAWBOX_REPAIR_ID="$id" CLAWBOX_REPAIR_STAGE="$stage" \
     CLAWBOX_REPAIR_DISABLED="$disabled" CLAWBOX_REPAIR_REASON="$reason" \
     CLAWBOX_REPAIR_SPEC="$spec" \
@@ -5107,9 +5123,26 @@ fi
 # to activate for a reason that is not consent would be re-enabled here. That
 # call costs tens of seconds on an Orin because it loads every enabled plugin,
 # which a person waiting on a button can afford and an ExecStartPre cannot.
-if [ "$CLAWBOX_OPENCLAW_V2" = "1" ]; then
-  CLAWBOX_REPAIR_REATTEMPT="$(python3 - "$OPENCLAW_CONFIG" "$CLAWBOX_PLUGIN_REPAIR_FILE" <<'REATTEMPTPY' || true
-import json, sys
+#
+# AND HOW MUCH OF THE STARTUP IS LEFT, asked before anything is spent. The loops
+# above can burn minutes on a box whose plugins are failing — 120 s installs,
+# 60 s consents, 60 s config writes — and this is a blocking ExecStartPre inside
+# `TimeoutStartSec=600`. Adding a recovery on top of a startup that is already
+# late turns a box that WOULD have come back into one systemd kills, which is
+# the opposite of what this block is for. `SECONDS` is the shell's own count
+# since the script began; the threshold is an environment variable only so a
+# test can move it, and the default is the real one.
+CLAWBOX_REATTEMPT_BUDGET_S="${CLAWBOX_REATTEMPT_BUDGET_S:-300}"
+
+if [ "$CLAWBOX_OPENCLAW_V2" = "1" ] && [ "$SECONDS" -ge "$CLAWBOX_REATTEMPT_BUDGET_S" ]; then
+  # Said, not skipped in silence: a box that never reaches its own repair is
+  # exactly the shape this card is about, and the boot log is where that is
+  # looked for.
+  echo "  Startup has already used ${SECONDS}s of its budget; leaving any plugin repair to the next boot"
+elif [ "$CLAWBOX_OPENCLAW_V2" = "1" ]; then
+  CLAWBOX_REPAIR_REATTEMPT="$(CLAWBOX_REPAIR_MARKED_THIS_BOOT="$CLAWBOX_REPAIR_MARKED_THIS_BOOT" \
+    python3 - "$OPENCLAW_CONFIG" "$CLAWBOX_PLUGIN_REPAIR_FILE" <<'REATTEMPTPY' || true
+import json, os, sys
 
 # `clawbox-email-directives` is deliberately NOT here, unlike the loop above:
 # nothing can file a repairable row for it (its own arm returns before the
@@ -5147,6 +5180,14 @@ except (OSError, json.JSONDecodeError):
 if not isinstance(rows, dict):
     raise SystemExit(0)
 
+# What THIS boot has already filed a row for. Those failures are minutes old,
+# not a previous boot's, and the verb that produced them has just run.
+marked_this_boot = {
+    canonical(name)
+    for name in os.environ.get("CLAWBOX_REPAIR_MARKED_THIS_BOOT", "").split()
+    if name
+}
+
 candidates = []
 for key, row in rows.items():
     if not isinstance(row, dict):
@@ -5158,6 +5199,8 @@ for key, row in rows.items():
     if not isinstance(plugin_id, str) or not plugin_id.strip():
         plugin_id = key
     if not isinstance(plugin_id, str) or canonical(plugin_id) not in REATTEMPTABLE:
+        continue
+    if canonical(plugin_id) in marked_this_boot:
         continue
     if row.get("disabled") is not True:
         continue
@@ -5180,9 +5223,9 @@ for key, row in rows.items():
     # which is not a rule anybody chose.
     entry_key = plugin_id if plugin_id in entries else None
     if entry_key is None:
-        for key in entries:
-            if isinstance(key, str) and canonical(key) == canonical(plugin_id):
-                entry_key = key
+        for entry_name in entries:
+            if isinstance(entry_name, str) and canonical(entry_name) == canonical(plugin_id):
+                entry_key = entry_name
                 break
     if entry_key is None:
         continue
@@ -5303,7 +5346,16 @@ REATTEMPTPY
           REPAIR_DETAIL="The plugin payload is not installed on this core, so the gateway would refuse to start with it enabled."
           ;;
         *)
-          REPAIR_DETAIL="The plugin is installed but its capabilities could not be accepted, so the gateway would refuse to start with it enabled."
+          # THE SENTENCE FOLLOWS THE STAGE THE ROW KEEPS, the same rule as the
+          # verification arm above. An `install` row re-filed as "the plugin is
+          # installed but its capabilities could not be accepted" contradicts
+          # itself on the one screen the owner reads, over a Retry that is about
+          # to reinstall the payload.
+          if [ "$REPAIR_STAGE" = "install" ]; then
+            REPAIR_DETAIL="The plugin could not be made loadable, so the gateway would refuse to start with it enabled."
+          else
+            REPAIR_DETAIL="The plugin is installed but its capabilities could not be accepted, so the gateway would refuse to start with it enabled."
+          fi
           ;;
       esac
       echo "  WARN: could not confirm $REPAIR_PLUGIN plugin capabilities on the re-attempt" >&2

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -3816,6 +3816,122 @@ clawbox_plugin_boot_without() {
   clawbox_plugin_repair_mark "$id" "$stage" "$disabled" "$reason" "$spec"
 }
 
+# The mirror of `clawbox_plugin_boot_without` for a re-attempt that did not work.
+#
+# TASK-785. `boot_without` reads the config to decide what it changed, and that
+# is exactly the wrong question after a re-attempt: the entry was ALREADY off,
+# and the `plugins enable` that has just failed may or may not have flipped it
+# back on before failing (it writes `plugins.entries.<id>.enabled` first and
+# only then loads the gateway SDK). Using `boot_without` there would write
+# `disabled: false` over a row that is ClawBox's own switch-off — which is the
+# one bit the updater reads to decide it may repair this plugin at all, and the
+# one this block reads to decide it may re-attempt it again.
+#
+# So the switch-off is asserted rather than reported: put the entry back off if
+# the failed verb turned it on, and record `disabled: true` because it is —
+# unless that write itself failed, in which case the row says so and the boot
+# log carries the warning, exactly as `boot_without` does.
+clawbox_plugin_reattempt_failed() {
+  local id="$1" stage="$2" reason="$3" spec="${4:-}" disabled=1
+  if [ "$(clawbox_plugin_entry_enabled "$id")" = "1" ]; then
+    if clawbox_plugin_disable "$id"; then
+      echo "  Switched the $id plugin off again so the gateway can start"
+    else
+      disabled=0
+      echo "  WARN: could not switch the $id plugin off again — the gateway may refuse readiness until it is repaired" >&2
+    fi
+  fi
+  clawbox_plugin_repair_mark "$id" "$stage" "$disabled" "$reason" "$spec"
+}
+
+# The npm package ClawBox itself installs for a managed plugin, pinned to the
+# core that is on the box — or NOTHING for one it does not own.
+#
+# One definition for two callers: the payload reinstall below, which needs it to
+# run the install, and the repair record, which needs the SAME string so the
+# Settings Retry re-runs what this script would have run. `plugins install
+# discord` would resolve `@latest`, drift ahead of the pinned runtime and crash
+# the channel — the bug the pin exists to prevent — so a spec is either the
+# pinned one or absent, never the bare alias.
+#
+# Empty for `deepseek` (ClawHub, its own block below) and for
+# `clawbox-email-directives` (copied out of the checkout, not a registry
+# package): an `@openclaw/<id>` guess would name a package that is not the
+# plugin. The list is the same one as OFFICIAL_CHANNEL_PLUGINS in
+# src/lib/openclaw-channels.ts, which
+# gateway-pre-start-managed-plugin-payload.test.ts holds it to. Measured against
+# the core's own answer on a box: `openclaw plugins inspect discord --json`
+# reports `install.spec: @openclaw/discord@2026.8.1` under core 2026.8.1, which
+# is the string this builds.
+clawbox_managed_plugin_spec() {
+  local key="${1#@openclaw/}"
+  key="${key#openclaw-}"
+  case "$key" in
+    discord|whatsapp) ;;
+    *) return 0 ;;
+  esac
+  if [ -n "${CLAWBOX_OPENCLAW_EFFECTIVE:-}" ]; then
+    printf '@openclaw/%s@%s' "$key" "$CLAWBOX_OPENCLAW_EFFECTIVE"
+  else
+    printf '@openclaw/%s' "$key"
+  fi
+}
+
+# The core's own words about a refusal, as ONE line to append to a repair reason.
+#
+# TASK-785. A row on a box read "The plugin is installed but its capabilities
+# could not be accepted…" and nothing else — the CONSEQUENCE, with no cause —
+# for three days, over a failure that turned out to be transient. The CLI's
+# answer is the only thing on the device that can tell "the registry was locked"
+# from "the payload is gone" from "the verb was killed at its deadline", and it
+# was being thrown away (`>/dev/null 2>&1`) at every one of these call sites.
+#
+# TRIMMED HARD, because Settings renders the reason verbatim beside a Retry:
+# escape sequences and control characters out, whitespace collapsed, one line,
+# 200 characters. Emitted with a leading space so a caller can concatenate it
+# onto its own sentence, and empty output is answered with the exit code alone
+# rather than a dangling colon.
+clawbox_plugin_cli_cause() {
+  local cmd="$1" rc="$2" out="$3" script
+  script="$(cat <<'CAUSEPY'
+import os, re, sys
+
+text = sys.stdin.read()
+# ANSI first, so a colour code cannot survive as stray letters in the message.
+text = re.sub(r"\x1b\[[0-9;]*[A-Za-z]", "", text)
+text = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", " ", text)
+lines = [" ".join(line.split()) for line in text.splitlines()]
+lines = [line for line in lines if line]
+
+# The LAST line that reads like a refusal, because a CLI prints progress first
+# and its verdict last; the last line of any kind when none of them do.
+picked = ""
+for line in lines:
+    if re.search(r"error|failed|cannot|not found|denied|refus|permission", line, re.I):
+        picked = line
+if not picked and lines:
+    picked = lines[-1]
+
+cmd = os.environ["CLAWBOX_CAUSE_CMD"]
+rc = os.environ["CLAWBOX_CAUSE_RC"]
+# 124 is `timeout` at the ceiling and 137 the SIGKILL `-k 5` sends after it —
+# neither is the core saying no, and the row must not read as though it were.
+head = f"{cmd} was killed at its deadline" if rc in ("124", "137") else f"{cmd} exited {rc}"
+if not picked:
+    print(f" {head} and said nothing.")
+else:
+    if len(picked) > 200:
+        picked = picked[:199].rstrip() + "\u2026"
+    print(f" {head}: {picked}")
+CAUSEPY
+)"
+  # Never fatal and never noisy: a reason that could not be enriched is still a
+  # reason, and this runs on the path where something has already gone wrong.
+  printf '%s' "$out" \
+    | CLAWBOX_CAUSE_CMD="$cmd" CLAWBOX_CAUSE_RC="$rc" python3 -c "$script" 2>/dev/null \
+    || true
+}
+
 # ── What a capability-consent attempt actually PROVED ───────────────────────
 #
 # TASK-606 follow-up. `timeout -k 5 60 openclaw plugins enable <id>
@@ -4649,7 +4765,10 @@ elif [ "$CLAWBOX_OPENCLAW_V2" = "1" ] && [ "$CODEX_SHOULD_LOAD" = "1" ]; then
     CLAWBOX_CONSENT_DETAIL=" (the core already reports current consent; skipped enable)"
   elif [ "$CODEX_CONSENT_VERDICT" != "2" ]; then
     CODEX_CONSENT_RC=0
-    timeout -k 5 60 "$OPENCLAW_BIN" plugins enable codex --accept-capabilities </dev/null >/dev/null 2>&1 \
+    # CAPTURED, not discarded (TASK-785): the core's own refusal is the only
+    # thing that can tell the owner which failure this was, and the repair row
+    # below is where he reads it.
+    CODEX_CONSENT_OUT="$(timeout -k 5 60 "$OPENCLAW_BIN" plugins enable codex --accept-capabilities </dev/null 2>&1)" \
       || CODEX_CONSENT_RC=$?
     CODEX_CONSENT_VERDICT=0
     clawbox_plugin_consent_outcome codex "$CODEX_CONSENT_RC" || CODEX_CONSENT_VERDICT=$?
@@ -4667,8 +4786,17 @@ elif [ "$CLAWBOX_OPENCLAW_V2" = "1" ] && [ "$CODEX_SHOULD_LOAD" = "1" ]; then
     echo "  Codex runtime plugin capabilities are still unknown (the core keeps no consent record for this plugin); leaving it as it is"
   else
     echo "  WARN: could not confirm Codex plugin capabilities; booting without Codex"
+    # The spec is the PINNED one or nothing, never the bare `codex` alias the
+    # install arm above falls back to: a Retry that resolved `@latest` would
+    # drift ahead of the runtime and crash every Codex chat. Codex pins to
+    # `OPENCLAW_TARGET` (the release this box is being brought to) rather than
+    # to `CLAWBOX_OPENCLAW_EFFECTIVE`, which is why it does not share the
+    # channel plugins' spec builder.
+    CODEX_CONSENT_SPEC=""
+    [ -n "${OPENCLAW_TARGET:-}" ] && CODEX_CONSENT_SPEC="@openclaw/codex@$OPENCLAW_TARGET"
     clawbox_plugin_boot_without codex consent \
-      "The ChatGPT (Codex) plugin is installed but its capabilities could not be accepted, so the gateway would refuse to start with it enabled."
+      "The ChatGPT (Codex) plugin is installed but its capabilities could not be accepted, so the gateway would refuse to start with it enabled.$(clawbox_plugin_cli_cause "openclaw plugins enable" "${CODEX_CONSENT_RC:-}" "${CODEX_CONSENT_OUT:-}")" \
+      "$CODEX_CONSENT_SPEC"
   fi
 fi
 
@@ -4784,19 +4912,10 @@ MANAGEDPY
     case "$MANAGED_PLUGIN_OUT" in
       *"Plugin not found"*)
         # The payload is gone, and only ClawBox's own npm packages may be
-        # replaced here: deepseek comes from ClawHub and clawbox-email-directives
-        # is copied out of the checkout — both have their own block in this
-        # script, and an `@openclaw/<id>` guess would fetch a package that is not
-        # the plugin. Same list as OFFICIAL_CHANNEL_PLUGINS in
-        # src/lib/openclaw-channels.ts, which
-        # gateway-pre-start-managed-plugin-payload.test.ts holds it to.
-        MANAGED_PLUGIN_KEY="${MANAGED_PLUGIN#@openclaw/}"
-        MANAGED_PLUGIN_KEY="${MANAGED_PLUGIN_KEY#openclaw-}"
-        MANAGED_PLUGIN_PKG=""
-        case "$MANAGED_PLUGIN_KEY" in
-          discord|whatsapp) MANAGED_PLUGIN_PKG="@openclaw/$MANAGED_PLUGIN_KEY" ;;
-        esac
-        if [ -z "$MANAGED_PLUGIN_PKG" ]; then
+        # replaced here — which is the whole question `clawbox_managed_plugin_spec`
+        # answers, and where the list of them lives.
+        MANAGED_PLUGIN_SPEC="$(clawbox_managed_plugin_spec "$MANAGED_PLUGIN")"
+        if [ -z "$MANAGED_PLUGIN_SPEC" ]; then
           # NOT switched off here: the block that owns this plugin runs later in
           # this same script and installs it properly, and it has its own
           # boot-without on failure. Disabling it now would have that block
@@ -4804,22 +4923,13 @@ MANAGEDPY
           echo "  WARN: the $MANAGED_PLUGIN payload is missing and ClawBox has no npm package of its own for it; its own installer owns that repair"
           continue
         fi
-        # Pinned to the INSTALLED core, like the deepseek block below and unlike
-        # the codex one above: this script never installs the core, so on a box
-        # that pulled new ClawBox code before its core update landed the pin file
-        # names a release the running runtime cannot load.
-        # `CLAWBOX_OPENCLAW_EFFECTIVE` is already normalised to
-        # MAJOR.MINOR.PATCH above, so an npm republish (2026.7.1 -> 2026.7.1-2)
-        # cannot turn into a 404 here. The unpinned spec is the fallback for a
-        # core whose release could not be read at all, never a second attempt:
-        # this is a BLOCKING ExecStartPre, so ONE 120 s install per plugin is the
-        # whole budget — at most 6 minutes for the two ids above, and only on a
-        # box whose gateway would not come up at all.
-        if [ -n "$CLAWBOX_OPENCLAW_EFFECTIVE" ]; then
-          MANAGED_PLUGIN_SPEC="$MANAGED_PLUGIN_PKG@$CLAWBOX_OPENCLAW_EFFECTIVE"
-        else
-          MANAGED_PLUGIN_SPEC="$MANAGED_PLUGIN_PKG"
-        fi
+        # `clawbox_managed_plugin_spec` pins to the INSTALLED core, like the
+        # deepseek block below and unlike the codex one above: this script never
+        # installs the core, so on a box that pulled new ClawBox code before its
+        # core update landed the pin file names a release the running runtime
+        # cannot load. This is a BLOCKING ExecStartPre, so ONE 120 s install per
+        # plugin is the whole budget — at most 6 minutes for the two ids above,
+        # and only on a box whose gateway would not come up at all.
         CLAWBOX_CONSENT_STATES=""
         CLAWBOX_CONSENT_STATES_READY=0
         CLAWBOX_CONSENT_POSTWRITE_READY=0
@@ -4854,8 +4964,158 @@ MANAGEDPY
     # The 2026-09-01 outage was this branch, on discord: readiness refused,
     # `Restart=always`, and the start limit gone in a quarter of an hour.
     echo "  WARN: could not confirm $MANAGED_PLUGIN plugin capabilities; booting without it"
+    # WITH THE CAUSE AND THE SPEC (TASK-785). The generic sentence explains the
+    # consequence and is what the owner needs first; the core's own refusal is
+    # what tells him — and the next person reading the row — whether this was a
+    # locked registry, a missing payload or a verb killed at its deadline. The
+    # spec is recorded for a consent row too: the row is the only description of
+    # this failure that survives the boot, and an empty one made the row unable
+    # to escalate to the install its own `Plugin not found` implies.
     clawbox_plugin_boot_without "$MANAGED_PLUGIN" consent \
-      "The plugin is installed but its capabilities could not be accepted, so the gateway would refuse to start with it enabled."
+      "The plugin is installed but its capabilities could not be accepted, so the gateway would refuse to start with it enabled.$(clawbox_plugin_cli_cause "openclaw plugins enable" "${MANAGED_PLUGIN_RC:-}" "${MANAGED_PLUGIN_OUT:-}")" \
+      "$(clawbox_managed_plugin_spec "$MANAGED_PLUGIN")"
+  done
+fi
+
+# ── Re-attempting a plugin a PREVIOUS boot switched off ─────────────────────
+#
+# TASK-785, and the half of TASK-606 that was missing. Every loop above visits
+# only entries openclaw.json ALREADY says to load — which is exactly what a
+# boot-without has just stopped being true. Measured on the OpenClaw box:
+# `data/plugin-repair.json` held discord at `stage: consent`, `disabled: true`,
+# written on 2026-09-06; the box was rebooted eighteen times and not one of
+# those boots re-attempted it, while every boot happily consented the plugins
+# that were still enabled. The owner's Retry then repaired it on the FIRST
+# press — so a transient failure had been showing as "Needs repair" for three
+# days, and the only thing standing between the box and its own repair was a
+# click nobody knew to make. Probe-once, over a whole plugin.
+#
+# HARNESS FIRST, and there is no harness answer to borrow: measured on the
+# pinned 2026.8.1 core, `openclaw plugins` offers `enable`, `install`,
+# `doctor`, `update` and `inspect` — `plugins enable <id> --accept-capabilities`
+# IS the consent verb ("Accept the plugin's declared capabilities") and
+# `plugins inspect <id> --json` IS the report — but nothing in the core
+# re-attempts a consent of its own accord. So the re-attempt is ClawBox's to
+# own, and it runs the CORE'S verb rather than writing consent by hand.
+#
+# ONLY WHAT CLAWBOX SWITCHED OFF, which `disabled: true` is the only record of.
+# The updater already draws this exact line (`pluginConsentRepairIsAllowed` /
+# `clawboxSwitchedPluginOff` in src/lib/updater.ts): an entry that is explicitly
+# `false` is indistinguishable from a person running `openclaw plugins disable
+# discord`, and a boot script that guessed would switch a channel on in its
+# owner's name. A row with `disabled: false` records a failure over which this
+# script changed nothing — the entry is off because he said so, and it stays off.
+#
+# BOUNDED, and deliberately smaller than the loop above. One `plugins enable`
+# per row, at most three rows (`deepseek`, `discord`, `whatsapp`), and NO
+# payload reinstall: this is a blocking ExecStartPre under TimeoutStartSec=600
+# and the enabled-entry loop above already rations 120 s installs out of it. A
+# re-attempt that hits `Plugin not found` therefore re-files the row as an
+# `install` with the pinned spec — which is the repair, and which the Retry and
+# the updater both have the budget to run — instead of doing it here.
+if [ "$CLAWBOX_OPENCLAW_V2" = "1" ]; then
+  CLAWBOX_REPAIR_REATTEMPT="$(python3 - "$OPENCLAW_CONFIG" "$CLAWBOX_PLUGIN_REPAIR_FILE" <<'REATTEMPTPY' || true
+import json, sys
+
+# `clawbox-email-directives` is deliberately NOT here, unlike the loop above:
+# nothing can file a repairable row for it (its own arm returns before the
+# boot-without) and the block ~450 lines below writes `enabled: true` over it
+# unconditionally, so a re-attempt would be racing this same script run.
+REATTEMPTABLE = ("deepseek", "discord", "whatsapp")
+# `not-installed` is excluded on purpose. It records an entry an older core
+# BUNDLED and this one does not, and the repair for it is installing a package
+# nothing on this box has ever installed — which means accepting a plugin's
+# declared capabilities for an owner who never chose it. That one waits for his
+# press; see src/app/setup-api/plugins/repair/route.ts.
+REATTEMPTABLE_STAGES = ("install", "consent")
+
+
+def canonical(name):
+    for prefix in ("@openclaw/", "openclaw-"):
+        if name.startswith(prefix):
+            return name[len(prefix):]
+    return name
+
+
+try:
+    with open(sys.argv[1], encoding="utf-8") as fh:
+        entries = (json.load(fh).get("plugins") or {}).get("entries") or {}
+except (OSError, json.JSONDecodeError):
+    raise SystemExit(0)
+if not isinstance(entries, dict):
+    raise SystemExit(0)
+try:
+    with open(sys.argv[2], encoding="utf-8") as fh:
+        rows = json.load(fh)
+except (OSError, json.JSONDecodeError):
+    raise SystemExit(0)
+if not isinstance(rows, dict):
+    raise SystemExit(0)
+
+for key, row in rows.items():
+    if not isinstance(row, dict):
+        continue
+    # The RECORD's own id wins over the map key, the same rule the TypeScript
+    # reader uses: it is the spelling openclaw.json carries and the one the
+    # config writes below have to address.
+    plugin_id = row.get("id")
+    if not isinstance(plugin_id, str) or not plugin_id.strip():
+        plugin_id = key
+    if not isinstance(plugin_id, str) or canonical(plugin_id) not in REATTEMPTABLE:
+        continue
+    if row.get("disabled") is not True:
+        continue
+    if row.get("stage") not in REATTEMPTABLE_STAGES:
+        continue
+    # The entry has to BE there and BE off. A row whose entry the owner has
+    # since deleted is stale, and `plugins enable` would resurrect an entry he
+    # removed; one that is already `true` is the enabled loop's, not this one's.
+    entry = entries.get(plugin_id)
+    if not isinstance(entry, dict) or entry.get("enabled") is not False:
+        continue
+    print(plugin_id)
+REATTEMPTPY
+)"
+  for REPAIR_PLUGIN in $CLAWBOX_REPAIR_REATTEMPT; do
+    echo "  Re-attempting the $REPAIR_PLUGIN plugin a previous boot switched off…"
+    REPAIR_RC=0
+    REPAIR_OUT="$(timeout -k 5 60 "$OPENCLAW_BIN" plugins enable "$REPAIR_PLUGIN" --accept-capabilities </dev/null 2>&1)" \
+      || REPAIR_RC=$?
+    REPAIR_VERDICT=0
+    CLAWBOX_CONSENT_DETAIL=""
+    clawbox_plugin_consent_outcome "$REPAIR_PLUGIN" "$REPAIR_RC" || REPAIR_VERDICT=$?
+    if [ "$REPAIR_VERDICT" = "0" ]; then
+      # `clawbox_plugin_repair_clear` is the whole repair from here: the row says
+      # ClawBox switched this entry off, so it writes `enabled: true` back,
+      # PROVES it against the file, and only then removes the badge.
+      echo "  $REPAIR_PLUGIN plugin capabilities accepted on the re-attempt$CLAWBOX_CONSENT_DETAIL"
+      clawbox_plugin_repair_clear "$REPAIR_PLUGIN"
+      continue
+    fi
+    # It still will not consent. `plugins enable` writes
+    # `plugins.entries.<id>.enabled` BEFORE it loads the gateway SDK and can
+    # fail, so the entry may now be ON over a plugin that does not load — which
+    # is the readiness refusal the previous boot switched it off to avoid.
+    # `clawbox_plugin_reattempt_failed` puts the box back exactly where that
+    # boot left it and refreshes the row with this attempt's own cause.
+    case "$REPAIR_OUT" in
+      # The core's own wording for a payload that is not on disk. A row filed as
+      # `consent` here can never clear, because the Retry it offers runs
+      # `plugins enable` — which is the verb that has just said this. Re-filed
+      # as the install it actually needs, with the spec to run it.
+      *"Plugin not found"*)
+        echo "  WARN: the $REPAIR_PLUGIN plugin payload is missing; leaving it switched off for repair from Settings" >&2
+        clawbox_plugin_reattempt_failed "$REPAIR_PLUGIN" install \
+          "The plugin payload is not installed on this core, so the gateway would refuse to start with it enabled.$(clawbox_plugin_cli_cause "openclaw plugins enable" "$REPAIR_RC" "$REPAIR_OUT")" \
+          "$(clawbox_managed_plugin_spec "$REPAIR_PLUGIN")"
+        ;;
+      *)
+        echo "  WARN: could not confirm $REPAIR_PLUGIN plugin capabilities on the re-attempt; leaving it switched off" >&2
+        clawbox_plugin_reattempt_failed "$REPAIR_PLUGIN" consent \
+          "The plugin is installed but its capabilities could not be accepted, so the gateway would refuse to start with it enabled.$(clawbox_plugin_cli_cause "openclaw plugins enable" "$REPAIR_RC" "$REPAIR_OUT")" \
+          "$(clawbox_managed_plugin_spec "$REPAIR_PLUGIN")"
+        ;;
+    esac
   done
 fi
 

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -5146,8 +5146,37 @@ for key, row in rows.items():
     # The entry has to BE there and BE off. A row whose entry the owner has
     # since deleted is stale, and `plugins enable` would resurrect an entry he
     # removed; one that is already `true` is the enabled loop's, not this one's.
-    entry = entries.get(plugin_id)
+    #
+    # FOUND BY THE CANONICAL ID, like the allowlist above and like every other
+    # reader of this record (`clearPluginRepair`, `clawboxDisabledEntryId`,
+    # `pluginConsentRepairIsAllowed`): `plugins.entries` can be keyed
+    # `openclaw-discord` where the row says `discord`, and an exact lookup would
+    # answer "no entry" and skip the row for ever without saying why.
+    entry_key = None
+    for key in entries:
+        if isinstance(key, str) and canonical(key) == canonical(plugin_id):
+            entry_key = key
+            break
+    if entry_key is None:
+        continue
+    entry = entries[entry_key]
     if not isinstance(entry, dict) or entry.get("enabled") is not False:
+        continue
+    # AND ADDRESSABLE UNDER ONE NAME. Everything downstream takes a single id
+    # and uses it for both halves of the repair: `plugins enable` and the
+    # `config set` write-back address the CONFIGURED key (this script's own rule
+    # — "the CONFIGURED key is what `plugins enable` is given", above), while
+    # `clawbox_plugin_repair_clear` deletes the record row by its exact key. On
+    # every writer today those are the same string. If they ever diverge,
+    # enabling by the row id would write a SECOND entry under the other
+    # spelling, so this says so and leaves the row for the Retry, which
+    # canonicalises both sides itself.
+    if entry_key != plugin_id:
+        print(
+            f"  WARN: the {plugin_id} repair row and its config entry {entry_key} are keyed "
+            "differently; leaving this one to the Retry in Settings",
+            file=sys.stderr,
+        )
         continue
     at_ms = row.get("atMs")
     candidates.append(((at_ms if isinstance(at_ms, (int, float)) else 0), plugin_id, stage))

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -3677,6 +3677,10 @@ except OSError as err:
     raise SystemExit(1)
 
 plugin_id = os.environ["CLAWBOX_REPAIR_ID"]
+existing = rows.get(plugin_id)
+previous_spec = ""
+if isinstance(existing, dict) and isinstance(existing.get("spec"), str):
+    previous_spec = existing["spec"]
 rows[plugin_id] = {
     "id": plugin_id,
     "stage": os.environ["CLAWBOX_REPAIR_STAGE"],
@@ -3688,8 +3692,13 @@ rows[plugin_id] = {
     # `clawhub:@openclaw/deepseek-provider@<release>`; a Retry that ran
     # `plugins install codex` would resolve @latest, drift ahead of the pinned
     # runtime and crash every Codex chat — the exact bug the pin exists for.
-    # Empty for a consent failure, which installs nothing.
-    "spec": os.environ.get("CLAWBOX_REPAIR_SPEC") or "",
+    # AN EMPTY SPEC NEVER ERASES ONE THE ROW ALREADY CARRIES (TASK-785). Every
+    # writer used to state the whole row, which was safe while each id had one
+    # writer; the boot re-attempt added a second, and a caller that cannot build
+    # the spec — the ClawHub `deepseek` one, whose scheme only its own block
+    # knows — would otherwise wipe the string the Retry needs. Same package
+    # either way: a re-file changes the stage, never which package it is.
+    "spec": os.environ.get("CLAWBOX_REPAIR_SPEC") or previous_spec,
 }
 directory = os.path.dirname(path) or "."
 os.makedirs(directory, exist_ok=True)
@@ -3816,6 +3825,36 @@ clawbox_plugin_boot_without() {
   clawbox_plugin_repair_mark "$id" "$stage" "$disabled" "$reason" "$spec"
 }
 
+# Run one `openclaw` call under a ceiling and capture what it said.
+#
+# THROUGH A FILE, not `out="$(timeout … 2>&1)"`. This script already documents
+# why: `timeout -k 5` kills the direct child, but a surviving grandchild keeps a
+# command substitution's pipe open, and bash completes the assignment when the
+# SURVIVOR dies rather than when `timeout` returns — measured on a box as 60 s of
+# wall clock against a 2 s ceiling, and that stall is the gateway's start time
+# and then the unit's failure. `openclaw` is a Node program that spawns
+# children, and `clawbox_consent_states_load` reads its report through a file
+# for exactly this reason.
+#
+# Sets `CLAWBOX_CLI_OUT` and returns the call's own status. A box with no
+# writable temp directory still makes the call — it just cannot quote it.
+clawbox_run_openclaw_capture() {
+  local secs="$1" file="" rc=0
+  shift
+  CLAWBOX_CLI_OUT=""
+  file="$(mktemp 2>/dev/null)" || file=""
+  if [ -z "$file" ]; then
+    timeout -k 5 "$secs" "$OPENCLAW_BIN" "$@" </dev/null >/dev/null 2>&1 || rc=$?
+    return "$rc"
+  fi
+  timeout -k 5 "$secs" "$OPENCLAW_BIN" "$@" </dev/null >"$file" 2>&1 || rc=$?
+  # `cat` has no grandchildren, so this substitution cannot stall the way the
+  # one above would.
+  CLAWBOX_CLI_OUT="$(cat "$file" 2>/dev/null || true)"
+  rm -f "$file" 2>/dev/null || true
+  return "$rc"
+}
+
 # The mirror of `clawbox_plugin_boot_without` for a re-attempt that did not work.
 #
 # TASK-785. `boot_without` reads the config to decide what it changed, and that
@@ -3828,20 +3867,25 @@ clawbox_plugin_boot_without() {
 # one this block reads to decide it may re-attempt it again.
 #
 # So the switch-off is asserted rather than reported: put the entry back off if
-# the failed verb turned it on, and record `disabled: true` because it is —
-# unless that write itself failed, in which case the row says so and the boot
-# log carries the warning, exactly as `boot_without` does.
+# the failed verb turned it on, and record `disabled: true` — which is a
+# statement about WHOSE switch-off this is, not about whether the last write
+# landed. A failed write is said in the boot log, never by handing the entry
+# back to the owner: `disabled: false` means "ClawBox changed nothing, the entry
+# is off because he said so" to every reader (`plugin-repair.ts`,
+# `clawboxDisabledEntryId`, `updater.ts`), and writing it here would stop the
+# Retry switching an unloadable plugin back off and stop the next boot
+# re-attempting the row at all.
+#
+# It also owns the sentence about the outcome, so a caller cannot announce
+# "leaving it switched off" over a disable that did not work.
 clawbox_plugin_reattempt_failed() {
-  local id="$1" stage="$2" reason="$3" spec="${4:-}" disabled=1
-  if [ "$(clawbox_plugin_entry_enabled "$id")" = "1" ]; then
-    if clawbox_plugin_disable "$id"; then
-      echo "  Switched the $id plugin off again so the gateway can start"
-    else
-      disabled=0
-      echo "  WARN: could not switch the $id plugin off again — the gateway may refuse readiness until it is repaired" >&2
-    fi
+  local id="$1" stage="$2" reason="$3" spec="${4:-}"
+  if [ "$(clawbox_plugin_entry_enabled "$id")" != "1" ] || clawbox_plugin_disable "$id"; then
+    echo "  Leaving the $id plugin switched off; Settings shows it as needing repair"
+  else
+    echo "  WARN: could not switch the $id plugin off again — the gateway may refuse readiness until it is repaired" >&2
   fi
-  clawbox_plugin_repair_mark "$id" "$stage" "$disabled" "$reason" "$spec"
+  clawbox_plugin_repair_mark "$id" "$stage" 1 "$reason" "$spec"
 }
 
 # The npm package ClawBox itself installs for a managed plugin, pinned to the
@@ -3886,11 +3930,17 @@ clawbox_managed_plugin_spec() {
 # from "the payload is gone" from "the verb was killed at its deadline", and it
 # was being thrown away (`>/dev/null 2>&1`) at every one of these call sites.
 #
-# TRIMMED HARD, because Settings renders the reason verbatim beside a Retry:
-# escape sequences and control characters out, whitespace collapsed, one line,
-# 200 characters. Emitted with a leading space so a caller can concatenate it
-# onto its own sentence, and empty output is answered with the exit code alone
-# rather than a dangling colon.
+# TRIMMED HARD, because Settings renders the reason verbatim beside a Retry
+# link in an 11px row: escape sequences and control characters out, whitespace
+# collapsed, one line, 160 characters. Emitted with a leading space so a caller
+# can concatenate it onto its own sentence, and empty output is answered with
+# the exit code alone rather than a dangling colon.
+#
+# THE SIBLING ROUTE MAKES THE OPPOSITE CALL ON PURPOSE:
+# `src/app/setup-api/plugins/repair/route.ts` will not put the CLI's stderr in
+# its HTTP answer, because the owner's next move is the same whatever it says.
+# This is the other case — the boot script is the only witness there was, the
+# row outlives the boot, and a row that named no cause is what TASK-785 is.
 clawbox_plugin_cli_cause() {
   local cmd="$1" rc="$2" out="$3" script
   script="$(cat <<'CAUSEPY'
@@ -3920,8 +3970,8 @@ head = f"{cmd} was killed at its deadline" if rc in ("124", "137") else f"{cmd} 
 if not picked:
     print(f" {head} and said nothing.")
 else:
-    if len(picked) > 200:
-        picked = picked[:199].rstrip() + "\u2026"
+    if len(picked) > 160:
+        picked = picked[:159].rstrip() + "\u2026"
     print(f" {head}: {picked}")
 CAUSEPY
 )"
@@ -4768,8 +4818,9 @@ elif [ "$CLAWBOX_OPENCLAW_V2" = "1" ] && [ "$CODEX_SHOULD_LOAD" = "1" ]; then
     # CAPTURED, not discarded (TASK-785): the core's own refusal is the only
     # thing that can tell the owner which failure this was, and the repair row
     # below is where he reads it.
-    CODEX_CONSENT_OUT="$(timeout -k 5 60 "$OPENCLAW_BIN" plugins enable codex --accept-capabilities </dev/null 2>&1)" \
+    clawbox_run_openclaw_capture 60 plugins enable codex --accept-capabilities \
       || CODEX_CONSENT_RC=$?
+    CODEX_CONSENT_OUT="$CLAWBOX_CLI_OUT"
     CODEX_CONSENT_VERDICT=0
     clawbox_plugin_consent_outcome codex "$CODEX_CONSENT_RC" || CODEX_CONSENT_VERDICT=$?
   fi
@@ -4869,8 +4920,9 @@ MANAGEDPY
       CLAWBOX_CONSENT_DETAIL=" (the core already reports current consent; skipped enable)"
     elif [ "$MANAGED_PLUGIN_VERDICT" != "2" ]; then
       MANAGED_PLUGIN_RC=0
-      MANAGED_PLUGIN_OUT="$(timeout -k 5 60 "$OPENCLAW_BIN" plugins enable "$MANAGED_PLUGIN" --accept-capabilities </dev/null 2>&1)" \
+      clawbox_run_openclaw_capture 60 plugins enable "$MANAGED_PLUGIN" --accept-capabilities \
         || MANAGED_PLUGIN_RC=$?
+      MANAGED_PLUGIN_OUT="$CLAWBOX_CLI_OUT"
       MANAGED_PLUGIN_VERDICT=0
       clawbox_plugin_consent_outcome "$MANAGED_PLUGIN" "$MANAGED_PLUGIN_RC" || MANAGED_PLUGIN_VERDICT=$?
     fi
@@ -4990,13 +5042,21 @@ fi
 # days, and the only thing standing between the box and its own repair was a
 # click nobody knew to make. Probe-once, over a whole plugin.
 #
-# HARNESS FIRST, and there is no harness answer to borrow: measured on the
-# pinned 2026.8.1 core, `openclaw plugins` offers `enable`, `install`,
-# `doctor`, `update` and `inspect` — `plugins enable <id> --accept-capabilities`
-# IS the consent verb ("Accept the plugin's declared capabilities") and
-# `plugins inspect <id> --json` IS the report — but nothing in the core
-# re-attempts a consent of its own accord. So the re-attempt is ClawBox's to
-# own, and it runs the CORE'S verb rather than writing consent by hand.
+# HARNESS FIRST, and there is no harness answer to borrow. Measured read-only
+# against the pinned core (`OpenClaw 2026.8.1 (ea80657)`):
+#   * `openclaw plugins enable <id> --accept-capabilities` — "Accept the
+#     plugin's declared capabilities". THE consent verb, and what runs below.
+#   * `openclaw plugins inspect <id> --json` — the report. For the stale row it
+#     answered `status: disabled`, `activated: false`, with
+#     `install.spec: @openclaw/discord@2026.8.1`.
+#   * `openclaw plugins doctor` — "Report plugin load issues", and its only
+#     option is `--json`. It diagnoses; it cannot consent or re-attempt.
+#   * `openclaw plugins update --accept-capabilities` — accepts a WIDENED
+#     surface while updating an installed plugin. A different operation, and it
+#     would move the version this script pins.
+# So nothing in the core retries a failed consent of its own accord: the
+# re-attempt is ClawBox's to own, and it runs the CORE'S verb rather than
+# writing consent by hand.
 #
 # ONLY WHAT CLAWBOX SWITCHED OFF, which `disabled: true` is the only record of.
 # The updater already draws this exact line (`pluginConsentRepairIsAllowed` /
@@ -5006,21 +5066,35 @@ fi
 # owner's name. A row with `disabled: false` records a failure over which this
 # script changed nothing — the entry is off because he said so, and it stays off.
 #
-# BOUNDED, and deliberately smaller than the loop above. One `plugins enable`
-# per row, at most three rows (`deepseek`, `discord`, `whatsapp`), and NO
-# payload reinstall: this is a blocking ExecStartPre under TimeoutStartSec=600
-# and the enabled-entry loop above already rations 120 s installs out of it. A
-# re-attempt that hits `Plugin not found` therefore re-files the row as an
-# `install` with the pinned spec — which is the repair, and which the Retry and
-# the updater both have the budget to run — instead of doing it here.
+# ONE ROW PER BOOT, the one attempted longest ago. That is the whole bound, and
+# it is what keeps this affordable in a blocking ExecStartPre under
+# `TimeoutStartSec=600`: at most one `plugins enable` (60 s), one
+# `plugins inspect --all --json` (60 s) and one `openclaw config set` write-back
+# (60 s) — about 195 s of ceiling, seconds in practice, and nothing at all on a
+# healthy box, where the reader prints nothing and the loop never runs. Ordering
+# on `atMs` is also what stops a permanently broken row starving the others:
+# every attempt, successful or not, restamps the row, so the next boot picks a
+# different one. No payload reinstall here either — a re-attempt that hits
+# `Plugin not found` re-files the row as the `install` it needs, with the pinned
+# spec, and leaves that 120 s repair to the Retry and the updater, which have
+# the budget for it.
+#
+# WEAKER PROOF THAN THE RETRY'S, on purpose and worth naming: this verifies
+# against the cheap `plugins inspect --all --json` snapshot, while
+# `src/app/setup-api/plugins/repair/route.ts` module-loads the plugin with
+# `--runtime` and also demands `activated: true`. A plugin that loads but fails
+# to activate for a reason that is not consent would be re-enabled here. That
+# call costs tens of seconds on an Orin because it loads every enabled plugin,
+# which a person waiting on a button can afford and an ExecStartPre cannot.
 if [ "$CLAWBOX_OPENCLAW_V2" = "1" ]; then
   CLAWBOX_REPAIR_REATTEMPT="$(python3 - "$OPENCLAW_CONFIG" "$CLAWBOX_PLUGIN_REPAIR_FILE" <<'REATTEMPTPY' || true
 import json, sys
 
 # `clawbox-email-directives` is deliberately NOT here, unlike the loop above:
 # nothing can file a repairable row for it (its own arm returns before the
-# boot-without) and the block ~450 lines below writes `enabled: true` over it
-# unconditionally, so a re-attempt would be racing this same script run.
+# boot-without) and `install_clawbox_hook_plugin` further down this script
+# writes `enabled: true` over it unconditionally, so a re-attempt would be
+# racing this same script run.
 REATTEMPTABLE = ("deepseek", "discord", "whatsapp")
 # `not-installed` is excluded on purpose. It records an entry an older core
 # BUNDLED and this one does not, and the repair for it is installing a package
@@ -5052,12 +5126,13 @@ except (OSError, json.JSONDecodeError):
 if not isinstance(rows, dict):
     raise SystemExit(0)
 
+candidates = []
 for key, row in rows.items():
     if not isinstance(row, dict):
         continue
     # The RECORD's own id wins over the map key, the same rule the TypeScript
     # reader uses: it is the spelling openclaw.json carries and the one the
-    # config writes below have to address.
+    # config writes have to address.
     plugin_id = row.get("id")
     if not isinstance(plugin_id, str) or not plugin_id.strip():
         plugin_id = key
@@ -5065,7 +5140,8 @@ for key, row in rows.items():
         continue
     if row.get("disabled") is not True:
         continue
-    if row.get("stage") not in REATTEMPTABLE_STAGES:
+    stage = row.get("stage")
+    if stage not in REATTEMPTABLE_STAGES:
         continue
     # The entry has to BE there and BE off. A row whose entry the owner has
     # since deleted is stale, and `plugins enable` would resurrect an entry he
@@ -5073,50 +5149,105 @@ for key, row in rows.items():
     entry = entries.get(plugin_id)
     if not isinstance(entry, dict) or entry.get("enabled") is not False:
         continue
-    print(plugin_id)
+    at_ms = row.get("atMs")
+    candidates.append(((at_ms if isinstance(at_ms, (int, float)) else 0), plugin_id, stage))
+
+# OLDEST FIRST, and only one: the bound and the anti-starvation rule in one
+# line. `plugin_id` breaks a tie so two boots of the same box agree.
+if candidates:
+    candidates.sort(key=lambda row: (row[0], row[1]))
+    print(f"{candidates[0][2]} {candidates[0][1]}")
 REATTEMPTPY
 )"
-  for REPAIR_PLUGIN in $CLAWBOX_REPAIR_REATTEMPT; do
+  # `<stage> <id>`, or nothing at all. Split with `read` rather than `set --`,
+  # which would clobber this script's own positional parameters.
+  REPAIR_STAGE=""
+  REPAIR_PLUGIN=""
+  read -r REPAIR_STAGE REPAIR_PLUGIN <<< "$CLAWBOX_REPAIR_REATTEMPT"
+  if [ -n "$REPAIR_PLUGIN" ]; then
     echo "  Re-attempting the $REPAIR_PLUGIN plugin a previous boot switched off…"
     REPAIR_RC=0
-    REPAIR_OUT="$(timeout -k 5 60 "$OPENCLAW_BIN" plugins enable "$REPAIR_PLUGIN" --accept-capabilities </dev/null 2>&1)" \
+    clawbox_run_openclaw_capture 60 plugins enable "$REPAIR_PLUGIN" --accept-capabilities \
       || REPAIR_RC=$?
+    REPAIR_OUT="$CLAWBOX_CLI_OUT"
     REPAIR_VERDICT=0
     CLAWBOX_CONSENT_DETAIL=""
     clawbox_plugin_consent_outcome "$REPAIR_PLUGIN" "$REPAIR_RC" || REPAIR_VERDICT=$?
     if [ "$REPAIR_VERDICT" = "0" ]; then
-      # `clawbox_plugin_repair_clear` is the whole repair from here: the row says
-      # ClawBox switched this entry off, so it writes `enabled: true` back,
-      # PROVES it against the file, and only then removes the badge.
-      echo "  $REPAIR_PLUGIN plugin capabilities accepted on the re-attempt$CLAWBOX_CONSENT_DETAIL"
-      clawbox_plugin_repair_clear "$REPAIR_PLUGIN"
-      continue
+      # AN EXIT CODE IS NOT THE OUTCOME, and it matters more here than anywhere
+      # else in this script: the loops above only consent a plugin that was
+      # ALREADY enabled, while this one turns one back ON. A `plugins enable`
+      # that exited 0 without the consent landing would hand the gateway the
+      # readiness refusal the previous boot switched this entry off to avoid.
+      #
+      # So the core is asked again, against a snapshot taken AFTER the write —
+      # the preflight's predates it and describes a plugin that was still
+      # disabled. That also means this verification depends on `plugins enable`
+      # having written `plugins.entries.<id>.enabled` first: the states reader
+      # skips a plugin the report does not call `loaded`, and `status` is the
+      # config's own enablement bit under another name. It does write it, and
+      # first — the "PROVED" block above is built on that same ordering — and if
+      # a core ever stopped, this answers "could not confirm" and changes
+      # nothing, which is the safe direction.
+      CLAWBOX_CONSENT_STATES=""
+      CLAWBOX_CONSENT_STATES_READY=0
+      REPAIR_STATE=0
+      clawbox_plugin_consent_state "$REPAIR_PLUGIN" || REPAIR_STATE=$?
+      if [ "$REPAIR_STATE" != "0" ]; then
+        # ONE answer succeeds — the core's own "adjudicated, and no consent
+        # diagnostic" — and every other one puts the plugin back where the
+        # previous boot left it. That is this file's existing rule ("never
+        # leaves an unresolved plugin enabled": a readiness refusal burns
+        # StartLimitBurst=20 and the unit is then FAILED, not retried), and it
+        # binds hardest here because this is the only block that turns a plugin
+        # ON. Nothing is lost by the strictness: the box ends the boot exactly
+        # as it started it, the badge still says the true thing, and the next
+        # boot asks again.
+        if [ "$REPAIR_STATE" = "1" ]; then
+          REPAIR_DETAIL="The core still reports it as requiring capability consent after a fresh attempt."
+        else
+          REPAIR_DETAIL="The core could not confirm the consent after a fresh attempt."
+        fi
+        echo "  WARN: could not confirm $REPAIR_PLUGIN plugin capabilities after the re-attempt" >&2
+        clawbox_plugin_reattempt_failed "$REPAIR_PLUGIN" "$REPAIR_STAGE" \
+          "The plugin is installed but its capabilities could not be accepted, so the gateway would refuse to start with it enabled. $REPAIR_DETAIL" \
+          "$(clawbox_managed_plugin_spec "$REPAIR_PLUGIN")"
+      else
+        # `clawbox_plugin_repair_clear` is the whole repair from here: the row
+        # says ClawBox switched this entry off, so it writes `enabled: true`
+        # back, PROVES it against the file, and only then removes the badge.
+        echo "  $REPAIR_PLUGIN plugin capabilities accepted on the re-attempt$CLAWBOX_CONSENT_DETAIL"
+        clawbox_plugin_repair_clear "$REPAIR_PLUGIN"
+      fi
+    else
+      # It still will not consent. `plugins enable` writes
+      # `plugins.entries.<id>.enabled` BEFORE it loads the gateway SDK and can
+      # fail, so the entry may now be ON over a plugin that does not load —
+      # which is the readiness refusal the previous boot switched it off to
+      # avoid. `clawbox_plugin_reattempt_failed` puts the box back exactly where
+      # that boot left it and refreshes the row with this attempt's own cause.
+      #
+      # THE STAGE IS THE ROW'S, not this branch's. Only `Plugin not found` — the
+      # core's own wording for a payload that is not on disk — licenses changing
+      # it, and only ever upwards: a row filed as `install` that were rewritten
+      # `consent` would send every future Retry to `plugins enable`
+      # (route.ts branches on the stage) instead of the `plugins install --force`
+      # that is its repair, and the badge could then never clear.
+      case "$REPAIR_OUT" in
+        *"Plugin not found"*)
+          REPAIR_STAGE=install
+          REPAIR_DETAIL="The plugin payload is not installed on this core, so the gateway would refuse to start with it enabled."
+          ;;
+        *)
+          REPAIR_DETAIL="The plugin is installed but its capabilities could not be accepted, so the gateway would refuse to start with it enabled."
+          ;;
+      esac
+      echo "  WARN: could not confirm $REPAIR_PLUGIN plugin capabilities on the re-attempt" >&2
+      clawbox_plugin_reattempt_failed "$REPAIR_PLUGIN" "$REPAIR_STAGE" \
+        "$REPAIR_DETAIL$(clawbox_plugin_cli_cause "openclaw plugins enable" "$REPAIR_RC" "$REPAIR_OUT")" \
+        "$(clawbox_managed_plugin_spec "$REPAIR_PLUGIN")"
     fi
-    # It still will not consent. `plugins enable` writes
-    # `plugins.entries.<id>.enabled` BEFORE it loads the gateway SDK and can
-    # fail, so the entry may now be ON over a plugin that does not load — which
-    # is the readiness refusal the previous boot switched it off to avoid.
-    # `clawbox_plugin_reattempt_failed` puts the box back exactly where that
-    # boot left it and refreshes the row with this attempt's own cause.
-    case "$REPAIR_OUT" in
-      # The core's own wording for a payload that is not on disk. A row filed as
-      # `consent` here can never clear, because the Retry it offers runs
-      # `plugins enable` — which is the verb that has just said this. Re-filed
-      # as the install it actually needs, with the spec to run it.
-      *"Plugin not found"*)
-        echo "  WARN: the $REPAIR_PLUGIN plugin payload is missing; leaving it switched off for repair from Settings" >&2
-        clawbox_plugin_reattempt_failed "$REPAIR_PLUGIN" install \
-          "The plugin payload is not installed on this core, so the gateway would refuse to start with it enabled.$(clawbox_plugin_cli_cause "openclaw plugins enable" "$REPAIR_RC" "$REPAIR_OUT")" \
-          "$(clawbox_managed_plugin_spec "$REPAIR_PLUGIN")"
-        ;;
-      *)
-        echo "  WARN: could not confirm $REPAIR_PLUGIN plugin capabilities on the re-attempt; leaving it switched off" >&2
-        clawbox_plugin_reattempt_failed "$REPAIR_PLUGIN" consent \
-          "The plugin is installed but its capabilities could not be accepted, so the gateway would refuse to start with it enabled.$(clawbox_plugin_cli_cause "openclaw plugins enable" "$REPAIR_RC" "$REPAIR_OUT")" \
-          "$(clawbox_managed_plugin_spec "$REPAIR_PLUGIN")"
-        ;;
-    esac
-  done
+  fi
 fi
 
 # Codex reads its ChatGPT session from a Codex CLI-style auth.json. Without

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -3650,17 +3650,23 @@ raise SystemExit(0 if isinstance(entry, dict) and entry.get("enabled") is True e
 PY
 }
 
-# Ids this boot has already filed a repair row for.
+# Ids THIS RUN of the script has already filed a repair row for.
 #
-# The re-attempt block far below is for what a PREVIOUS boot switched off, and
-# nothing enforced the "previous": every `clawbox_plugin_boot_without` in this
-# script runs earlier than that block, so a plugin the managed loop had just
-# failed and disabled was fed straight back in and its `plugins enable` re-run
-# seconds later — learning nothing, and spending an enable, an inspect and a
-# config write out of a `TimeoutStartSec=600` the failed recovery had already
-# been drawing on. Collected HERE because every writer in this script goes
-# through this one function, so no new call site can forget it.
-CLAWBOX_REPAIR_MARKED_THIS_BOOT=""
+# One run, not one boot, and the distinction is real: `systemctl restart
+# clawbox-gateway` runs this ExecStartPre again without rebooting, and a row an
+# earlier run wrote is then a fair candidate again.
+#
+# The re-attempt block far below is for what an earlier run switched off, and
+# nothing enforced the "earlier": every `clawbox_plugin_boot_without` in this
+# script runs before that block, so a plugin the managed loop had just failed
+# and disabled was fed straight back in and its `plugins enable` re-run seconds
+# later. It learnt nothing — the same verb, the same core, the same config —
+# and it OVERWROTE the row the managed loop had just written, replacing "the
+# payload is missing and could not be reinstalled" with "not installed on this
+# core" and losing the fact that the pinned `install --force` had already been
+# tried. Collected HERE because every writer in this script goes through this
+# one function, so no new call site can forget it.
+CLAWBOX_REPAIR_MARKED_THIS_RUN=""
 
 # Record — or update — one plugin's repair row. Never fatal: a box that cannot
 # write this file still boots without the plugin, it just cannot explain itself
@@ -3668,9 +3674,9 @@ CLAWBOX_REPAIR_MARKED_THIS_BOOT=""
 clawbox_plugin_repair_mark() {
   local id="$1" stage="$2" disabled="$3" reason="$4" spec="${5:-}"
   # Before the write, not after: an id whose row could not be written is still
-  # one this boot has just tried and failed, and re-attempting it here would
+  # one this run has just tried and failed, and re-attempting it below would
   # repeat that failure inside the same startup.
-  CLAWBOX_REPAIR_MARKED_THIS_BOOT="$CLAWBOX_REPAIR_MARKED_THIS_BOOT $id"
+  CLAWBOX_REPAIR_MARKED_THIS_RUN="$CLAWBOX_REPAIR_MARKED_THIS_RUN $id"
   if ! CLAWBOX_REPAIR_ID="$id" CLAWBOX_REPAIR_STAGE="$stage" \
     CLAWBOX_REPAIR_DISABLED="$disabled" CLAWBOX_REPAIR_REASON="$reason" \
     CLAWBOX_REPAIR_SPEC="$spec" \
@@ -5123,31 +5129,8 @@ fi
 # to activate for a reason that is not consent would be re-enabled here. That
 # call costs tens of seconds on an Orin because it loads every enabled plugin,
 # which a person waiting on a button can afford and an ExecStartPre cannot.
-#
-# AND HOW MUCH OF THE STARTUP IS LEFT, asked before anything is spent. The loops
-# above can burn minutes on a box whose plugins are failing — 120 s installs,
-# 60 s consents, 60 s config writes — and this is a blocking ExecStartPre inside
-# `TimeoutStartSec=600`. `SECONDS` is the shell's own count since the script
-# began; the threshold is an environment variable only so a test can move it,
-# and the default is the real one.
-#
-# WHAT THIS DOES NOT DO, stated because the arithmetic has been done and does
-# not support the larger claim: it guards THIS block's own increment, not the
-# script's budget. On the worst path — a core bump that stranded both channel
-# payloads — the time boxes above this line already add up past 600 s on
-# unmodified beta, and roughly ten of them are unbudgeted. A deadline in front
-# of ~195 s does not save that boot; it only keeps this block from being the
-# thing that makes a marginal one worse. The script-wide budget is a separate
-# piece of work and is on the queue as a residual.
-CLAWBOX_REATTEMPT_BUDGET_S="${CLAWBOX_REATTEMPT_BUDGET_S:-300}"
-
-if [ "$CLAWBOX_OPENCLAW_V2" = "1" ] && [ "$SECONDS" -ge "$CLAWBOX_REATTEMPT_BUDGET_S" ]; then
-  # Said, not skipped in silence: a box that never reaches its own repair is
-  # exactly the shape this card is about, and the boot log is where that is
-  # looked for.
-  echo "  Startup has already used ${SECONDS}s of its budget; leaving any plugin repair to the next boot"
-elif [ "$CLAWBOX_OPENCLAW_V2" = "1" ]; then
-  CLAWBOX_REPAIR_REATTEMPT="$(CLAWBOX_REPAIR_MARKED_THIS_BOOT="$CLAWBOX_REPAIR_MARKED_THIS_BOOT" \
+if [ "$CLAWBOX_OPENCLAW_V2" = "1" ]; then
+  CLAWBOX_REPAIR_REATTEMPT="$(CLAWBOX_REPAIR_MARKED_THIS_RUN="$CLAWBOX_REPAIR_MARKED_THIS_RUN" \
     python3 - "$OPENCLAW_CONFIG" "$CLAWBOX_PLUGIN_REPAIR_FILE" <<'REATTEMPTPY' || true
 import json, os, sys
 
@@ -5187,11 +5170,11 @@ except (OSError, json.JSONDecodeError):
 if not isinstance(rows, dict):
     raise SystemExit(0)
 
-# What THIS boot has already filed a row for. Those failures are minutes old,
-# not a previous boot's, and the verb that produced them has just run.
-marked_this_boot = {
+# What THIS RUN has already filed a row for. Those failures are seconds old, not
+# an earlier run's, and the verb that produced them has just been tried.
+marked_this_run = {
     canonical(name)
-    for name in os.environ.get("CLAWBOX_REPAIR_MARKED_THIS_BOOT", "").split()
+    for name in os.environ.get("CLAWBOX_REPAIR_MARKED_THIS_RUN", "").split()
     if name
 }
 
@@ -5207,7 +5190,7 @@ for key, row in rows.items():
         plugin_id = key
     if not isinstance(plugin_id, str) or canonical(plugin_id) not in REATTEMPTABLE:
         continue
-    if canonical(plugin_id) in marked_this_boot:
+    if canonical(plugin_id) in marked_this_run:
         continue
     if row.get("disabled") is not True:
         continue

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -3921,6 +3921,27 @@ clawbox_managed_plugin_spec() {
   fi
 }
 
+# The spec for a REPAIR ROW: the pinned one, or nothing at all.
+#
+# NOT the same question the install path asks. That one falls back to the
+# unpinned `@openclaw/<id>` when the core's release could not be read at all,
+# because one bare install is better than a box with no gateway, and
+# `gateway-pre-start-managed-plugin-payload.test.ts` pins that fallback. A ROW
+# is read LATER, by a Retry that would resolve `@latest`, drift ahead of the
+# runtime and crash the channel — the exact bug the pin exists to prevent — and
+# a re-attempt that finds the payload gone can escalate the row to an `install`
+# stage, where that spec is what runs. So `plugin-repair.ts` states the field's
+# contract as the pinned spec or absent, never the bare alias, and this is
+# where that holds. The codex consent row already does the same with its own
+# `OPENCLAW_TARGET` pin.
+#
+# Empty costs nothing: `clawbox_plugin_repair_mark` keeps whatever spec the row
+# already carried rather than erasing it.
+clawbox_managed_plugin_row_spec() {
+  [ -n "${CLAWBOX_OPENCLAW_EFFECTIVE:-}" ] || return 0
+  clawbox_managed_plugin_spec "$1"
+}
+
 # The core's own words about a refusal, as ONE line to append to a repair reason.
 #
 # TASK-785. A row on a box read "The plugin is installed but its capabilities
@@ -5025,7 +5046,7 @@ MANAGEDPY
     # to escalate to the install its own `Plugin not found` implies.
     clawbox_plugin_boot_without "$MANAGED_PLUGIN" consent \
       "The plugin is installed but its capabilities could not be accepted, so the gateway would refuse to start with it enabled.$(clawbox_plugin_cli_cause "openclaw plugins enable" "${MANAGED_PLUGIN_RC:-}" "${MANAGED_PLUGIN_OUT:-}")" \
-      "$(clawbox_managed_plugin_spec "$MANAGED_PLUGIN")"
+      "$(clawbox_managed_plugin_row_spec "$MANAGED_PLUGIN")"
   done
 fi
 
@@ -5254,7 +5275,7 @@ REATTEMPTPY
         echo "  WARN: could not confirm $REPAIR_PLUGIN plugin capabilities after the re-attempt" >&2
         clawbox_plugin_reattempt_failed "$REPAIR_PLUGIN" "$REPAIR_STAGE" \
           "$REPAIR_LEAD $REPAIR_DETAIL" \
-          "$(clawbox_managed_plugin_spec "$REPAIR_PLUGIN")"
+          "$(clawbox_managed_plugin_row_spec "$REPAIR_PLUGIN")"
       else
         # `clawbox_plugin_repair_clear` is the whole repair from here: the row
         # says ClawBox switched this entry off, so it writes `enabled: true`
@@ -5288,7 +5309,7 @@ REATTEMPTPY
       echo "  WARN: could not confirm $REPAIR_PLUGIN plugin capabilities on the re-attempt" >&2
       clawbox_plugin_reattempt_failed "$REPAIR_PLUGIN" "$REPAIR_STAGE" \
         "$REPAIR_DETAIL$(clawbox_plugin_cli_cause "openclaw plugins enable" "$REPAIR_RC" "$REPAIR_OUT")" \
-        "$(clawbox_managed_plugin_spec "$REPAIR_PLUGIN")"
+        "$(clawbox_managed_plugin_row_spec "$REPAIR_PLUGIN")"
     fi
   fi
 fi

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -5127,11 +5127,18 @@ fi
 # AND HOW MUCH OF THE STARTUP IS LEFT, asked before anything is spent. The loops
 # above can burn minutes on a box whose plugins are failing — 120 s installs,
 # 60 s consents, 60 s config writes — and this is a blocking ExecStartPre inside
-# `TimeoutStartSec=600`. Adding a recovery on top of a startup that is already
-# late turns a box that WOULD have come back into one systemd kills, which is
-# the opposite of what this block is for. `SECONDS` is the shell's own count
-# since the script began; the threshold is an environment variable only so a
-# test can move it, and the default is the real one.
+# `TimeoutStartSec=600`. `SECONDS` is the shell's own count since the script
+# began; the threshold is an environment variable only so a test can move it,
+# and the default is the real one.
+#
+# WHAT THIS DOES NOT DO, stated because the arithmetic has been done and does
+# not support the larger claim: it guards THIS block's own increment, not the
+# script's budget. On the worst path — a core bump that stranded both channel
+# payloads — the time boxes above this line already add up past 600 s on
+# unmodified beta, and roughly ten of them are unbudgeted. A deadline in front
+# of ~195 s does not save that boot; it only keeps this block from being the
+# thing that makes a marginal one worse. The script-wide budget is a separate
+# piece of work and is on the queue as a residual.
 CLAWBOX_REATTEMPT_BUDGET_S="${CLAWBOX_REATTEMPT_BUDGET_S:-300}"
 
 if [ "$CLAWBOX_OPENCLAW_V2" = "1" ] && [ "$SECONDS" -ge "$CLAWBOX_REATTEMPT_BUDGET_S" ]; then

--- a/src/lib/plugin-repair.ts
+++ b/src/lib/plugin-repair.ts
@@ -77,7 +77,18 @@ export interface PluginRepairEntry {
   /** The plugin id as `openclaw plugins` takes it — what Retry passes back. */
   id: string;
   stage: PluginRepairStage;
-  /** One line, from the boot script, for the owner to read. Never a path. */
+  /**
+   * One line, from the boot script, for the owner to read.
+   *
+   * ClawBox's own sentence about the CONSEQUENCE ("the gateway would refuse to
+   * start with it enabled") and, since TASK-785, the core's own words about the
+   * CAUSE after it: the exit code of the verb that failed and one trimmed line
+   * of what it said. A row that carried only the first half stood on a box for
+   * three days saying what would have happened and nothing about why, over a
+   * failure that turned out to be transient. The boot script collapses the
+   * CLI's answer to one line of at most 200 characters (`clawbox_plugin_cli_cause`)
+   * because every renderer of this field prints it verbatim beside a Retry.
+   */
   reason: string;
   /** When the boot script gave up, epoch ms. */
   atMs: number;
@@ -90,10 +101,18 @@ export interface PluginRepairEntry {
    */
   disabled: boolean;
   /**
-   * The spec the boot script actually installs, when the failure was an
-   * install: `@openclaw/codex@<pinned core>`, or
-   * `clawhub:@openclaw/deepseek-provider@<release>`. Empty for a consent
-   * failure, which installs nothing.
+   * The spec the boot script would install: `@openclaw/codex@<pinned core>`,
+   * `@openclaw/discord@<installed core>`, or
+   * `clawhub:@openclaw/deepseek-provider@<release>`.
+   *
+   * RECORDED FOR A CONSENT ROW TOO since TASK-785, though a consent Retry does
+   * not install anything. A consent failure and a missing payload are the same
+   * refusal from the outside — `plugins enable` answers the second with "Plugin
+   * not found" — so a row filed as `consent` with no spec could never be
+   * re-filed as the install it actually needs, and the Retry it offered ran the
+   * verb that had just refused. Empty only where ClawBox owns no package for
+   * the id (`clawbox-email-directives`, which is copied out of the checkout)
+   * or where the pinned release could not be read.
    *
    * NOT derivable from the id, which is the whole reason it is recorded. A
    * Retry that ran `plugins install codex` would resolve `@latest`, drift ahead

--- a/src/lib/plugin-repair.ts
+++ b/src/lib/plugin-repair.ts
@@ -86,8 +86,10 @@ export interface PluginRepairEntry {
    * of what it said. A row that carried only the first half stood on a box for
    * three days saying what would have happened and nothing about why, over a
    * failure that turned out to be transient. The boot script collapses the
-   * CLI's answer to one line of at most 200 characters (`clawbox_plugin_cli_cause`)
+   * CLI's answer to one line of at most 160 characters (`clawbox_plugin_cli_cause`)
    * because every renderer of this field prints it verbatim beside a Retry.
+   * It is the core's English, not a translated string — the same as every other
+   * sentence the boot script writes into this field.
    */
   reason: string;
   /** When the boot script gave up, epoch ms. */
@@ -112,7 +114,10 @@ export interface PluginRepairEntry {
    * re-filed as the install it actually needs, and the Retry it offered ran the
    * verb that had just refused. Empty only where ClawBox owns no package for
    * the id (`clawbox-email-directives`, which is copied out of the checkout)
-   * or where the pinned release could not be read.
+   * or where the pinned release could not be read. A writer that cannot build
+   * the spec never ERASES one the row already carries: `deepseek`'s ClawHub
+   * scheme is known only to its own block, and the boot re-attempt refiles that
+   * row without it.
    *
    * NOT derivable from the id, which is the whole reason it is recorded. A
    * Retry that ran `plugins install codex` would resolve `@latest`, drift ahead
@@ -240,7 +245,17 @@ export async function recordPluginRepair(row: PluginRepairRecord): Promise<void>
       // Same as the boot script: an unparseable file is started over.
     }
   }
-  rows[row.id] = { ...row, atMs: Date.now() };
+  // AN EMPTY SPEC NEVER ERASES ONE THE ROW ALREADY CARRIES, the same rule
+  // `clawbox_plugin_repair_mark` follows in the boot script (TASK-785). Each id
+  // had one writer while this was safe; the boot re-attempt made a second, and
+  // a caller that cannot build the spec would otherwise wipe the string the
+  // Retry needs. A re-file changes the stage, never which package it is.
+  const previous = rows[row.id];
+  const previousSpec = previous && typeof previous === "object" && !Array.isArray(previous)
+    ? (previous as { spec?: unknown }).spec
+    : undefined;
+  const spec = row.spec || (typeof previousSpec === "string" ? previousSpec : "");
+  rows[row.id] = { ...row, spec, atMs: Date.now() };
   await writeRowsAtomically(target, rows);
 }
 

--- a/src/tests/unit/gateway-pre-start-codex-runtime.test.ts
+++ b/src/tests/unit/gateway-pre-start-codex-runtime.test.ts
@@ -188,6 +188,13 @@ interface PluginFlowOptions {
    */
   consentExit?: number;
   /**
+   * What that failing `plugins enable` says on stderr.
+   *
+   * TASK-785: the repair row carries the core's own refusal, and nothing else
+   * on the box can tell a locked registry from a missing payload.
+   */
+  consentMessage?: string;
+  /**
    * `plugins inspect --all --json` stdout; omitted = the CLI cannot answer.
    *
    * The consent answer is the `diagnostics` array. `status`/`activated` are the
@@ -214,7 +221,7 @@ function runPluginFlowFull(options: PluginFlowOptions): {
   argv: string[];
   stdout: string;
   stderr: string;
-  marker: Record<string, { stage?: string; disabled?: boolean }>;
+  marker: Record<string, { stage?: string; disabled?: boolean; reason?: string; spec?: string }>;
 } {
   const pluginDir = path.join(dir, "plugin", "node_modules", "@openclaw", "codex");
   if (options.installedVersion) {
@@ -238,7 +245,11 @@ function runPluginFlowFull(options: PluginFlowOptions): {
       "#!/usr/bin/env bash",
       'printf \'%s\\n\' "$*" >> "$CODEX_TEST_LOG"',
       ...(options.consentExit
-        ? [`if [ "$2" = "enable" ]; then exit ${options.consentExit}; fi`]
+        ? [
+          `if [ "$2" = "enable" ]; then `
+          + (options.consentMessage ? `echo '${options.consentMessage}' >&2; ` : "")
+          + `exit ${options.consentExit}; fi`,
+        ]
         : []),
       'if [ "$2" = "inspect" ]; then',
       ...(options.inspectJson
@@ -271,7 +282,7 @@ function runPluginFlowFull(options: PluginFlowOptions): {
   });
   if (result.status !== 0) throw new Error(`plugin flow exited ${result.status}: ${result.stderr}`);
 
-  let marker: Record<string, { stage?: string; disabled?: boolean }> = {};
+  let marker: Record<string, { stage?: string; disabled?: boolean; reason?: string; spec?: string }> = {};
   try {
     marker = JSON.parse(readFileSync(path.join(dir, "data", "plugin-repair.json"), "utf-8"));
   } catch {
@@ -636,6 +647,25 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh agentRuntime policy", () => {
     });
     expect(stdout).toContain("booting without Codex");
     expect(marker.codex?.stage).toBe("consent");
+  });
+
+  it("records the core's own refusal and the pinned spec on the consent row", () => {
+    // TASK-785, the sibling of the managed-plugin loop's row. A row that said
+    // only "its capabilities could not be accepted" stood on a box for three
+    // days over a transient failure, and nothing on the device could say which
+    // failure it had been. The spec goes on a consent row too, so the row can
+    // be re-filed as the install its own "Plugin not found" would imply — and
+    // never as the bare `codex` alias, which resolves @latest.
+    const { marker } = runPluginFlowFull({
+      ...CONSENTED,
+      consentExit: 1,
+      consentMessage: "Error: capability consent refused: registry snapshot is locked",
+    });
+    expect(marker.codex?.stage).toBe("consent");
+    expect(marker.codex?.reason).toMatch(/capabilities could not be accepted/i);
+    expect(marker.codex?.reason).toContain("registry snapshot is locked");
+    expect(marker.codex?.reason).toContain("exited 1");
+    expect(marker.codex?.spec).toBe("@openclaw/codex@2026.8.1");
   });
 
   it("still boots without Codex when the core cannot be asked at all", () => {

--- a/src/tests/unit/gateway-pre-start-managed-plugin-payload.test.ts
+++ b/src/tests/unit/gateway-pre-start-managed-plugin-payload.test.ts
@@ -543,13 +543,20 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
     // loses that channel — and its gateway — on the next core bump, with no
     // reboot that heals it.
     const src = readFileSync(SCRIPT, "utf-8");
-    const shellCase = /\n\s+([a-z|-]+)\)\s+MANAGED_PLUGIN_PKG="@openclaw\/\$MANAGED_PLUGIN_KEY"/.exec(src);
+    // The list lives in `clawbox_managed_plugin_spec`, which is the one place
+    // that turns a managed plugin id into the package this script installs —
+    // and, since TASK-785, into the spec a consent row records so the Retry
+    // runs the same thing.
+    const helper = /clawbox_managed_plugin_spec\(\) \{[\s\S]*?\n\}/.exec(src);
+    expect(helper, "clawbox_managed_plugin_spec was not found").not.toBeNull();
+    const shellCase = /\n\s+([a-z|-]+)\)\s*;;/.exec(helper![0]);
     expect(shellCase, "the payload-repair case arm was not found").not.toBeNull();
     expect(shellCase?.[1].split("|").sort())
       .toEqual(Object.keys(OFFICIAL_CHANNEL_PLUGINS).sort());
+    // The shell builds the spec as `@openclaw/<id>`, so a package that is not
+    // named after its plugin id would be silently mis-installed.
+    expect(helper![0]).toContain("printf '@openclaw/%s@%s'");
     for (const [id, npmPackage] of Object.entries(OFFICIAL_CHANNEL_PLUGINS)) {
-      // The shell builds the spec as `@openclaw/<id>`, so a package that is not
-      // named after its plugin id would be silently mis-installed.
       expect(npmPackage).toBe(`@openclaw/${id}`);
     }
   });

--- a/src/tests/unit/gateway-pre-start-managed-plugin-payload.test.ts
+++ b/src/tests/unit/gateway-pre-start-managed-plugin-payload.test.ts
@@ -561,6 +561,23 @@ describe.skipIf(!hasBash || !hasPython3)("gateway-pre-start.sh managed plugin pa
     }
   });
 
+  it("re-attempts exactly those channel plugins, plus deepseek, at the next boot", () => {
+    // TASK-785. The boot re-attempt is what stops a transient consent failure
+    // outliving itself, and it has its own list — so a channel added to the
+    // panel and forgotten here is a channel that can be switched off by one bad
+    // morning and never switched back on without a click. `deepseek` joins the
+    // channels because ClawBox AI rides on it and the boot-without switches it
+    // off the same way; `clawbox-email-directives` is deliberately absent,
+    // because `install_clawbox_hook_plugin` re-enables it unconditionally later
+    // in the same run and a re-attempt would be racing it.
+    const src = readFileSync(SCRIPT, "utf-8");
+    const tuple = /\nREATTEMPTABLE = \(([^)]*)\)/.exec(src);
+    expect(tuple, "REATTEMPTABLE was not found").not.toBeNull();
+    const ids = [...tuple![1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+    expect(ids.sort()).toEqual(["deepseek", ...Object.keys(OFFICIAL_CHANNEL_PLUGINS)].sort());
+    expect(ids).not.toContain("clawbox-email-directives");
+  });
+
   it("falls back to the unpinned spec only when the installed core is unknown", () => {
     // Pinned to the INSTALLED core, not to the checkout's pin file: this script
     // never installs the core, so a box that pulled new ClawBox code before its

--- a/src/tests/unit/gateway-pre-start-plugin-repair.test.ts
+++ b/src/tests/unit/gateway-pre-start-plugin-repair.test.ts
@@ -677,4 +677,41 @@ ${CONFIG_SET_STUB}`);
     // The spec the repair needs, recorded for a consent row too.
     expect(row.spec).toBe("@openclaw/discord@2026.8.1");
   });
+
+  it("records the core's LAST refusal, not the first line that merely looks like one", () => {
+    // A CLI prints progress first and its verdict last. With a one-line stub a
+    // first-match picker would pass this suite and still file the wrong
+    // sentence on the one screen the owner reads.
+    stubOpenclaw(`
+if [ "$1" = "plugins" ] && [ "$2" = "enable" ]; then
+  echo "Checking the capability manifest for errors…" >&2
+  echo "Error: capability consent failed for discord: registry snapshot is locked" >&2
+  exit 1
+fi
+${CONFIG_SET_STUB}`);
+    const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1" });
+    expect(r.status).toBe(0);
+    const row = marker().discord;
+    expect(row.reason).toContain("registry snapshot is locked");
+    expect(row.reason).not.toContain("Checking the capability manifest");
+  });
+
+  it("records no spec at all rather than a bare alias the Retry would resolve as @latest", () => {
+    // The install path falls back to the unpinned `@openclaw/<id>` when the
+    // core's release cannot be read, because one bare install beats a box with
+    // no gateway. A ROW is read later, by a Retry that would resolve `@latest`
+    // and drift ahead of the runtime — so the row's contract is the pinned spec
+    // or nothing. `CLAWBOX_OPENCLAW_EFFECTIVE` is unset here.
+    stubOpenclaw(`
+if [ "$1" = "plugins" ] && [ "$2" = "enable" ]; then
+  echo "Error: capability consent failed for discord" >&2
+  exit 1
+fi
+${CONFIG_SET_STUB}`);
+    const r = run();
+    expect(r.status).toBe(0);
+    const row = marker().discord;
+    expect(row.stage).toBe("consent");
+    expect(row.spec).toBe("");
+  });
 });

--- a/src/tests/unit/gateway-pre-start-plugin-repair.test.ts
+++ b/src/tests/unit/gateway-pre-start-plugin-repair.test.ts
@@ -465,6 +465,13 @@ ${CONFIG_SET_STUB}`);
     expect(row.stage).toBe("install");
     expect(row.spec).toBe("clawhub:@openclaw/deepseek-provider@2026.8.1");
     expect(row.disabled).toBe(true);
+    // AND THE SENTENCE KEEPS THE STAGE TOO. A row that stays `install` while
+    // being re-filed as "the plugin is installed but its capabilities could not
+    // be accepted" contradicts itself on the one screen the owner reads, over a
+    // Retry that is about to reinstall the payload.
+    expect(row.reason).toContain("could not be made loadable");
+    expect(row.reason).not.toContain("The plugin is installed but");
+    expect(row.reason).toContain("cannot find module");
   });
 
   it("keeps an install row's wording an install row's, when the consent cannot be confirmed", () => {
@@ -630,6 +637,49 @@ ${CONFIG_SET_STUB}`);
     expect(config().plugins?.entries?.["openclaw-discord"]?.enabled).toBe(false);
     // And no second entry invented under the row's spelling.
     expect(config().plugins?.entries?.discord).toBeUndefined();
+    expect(marker().discord.atMs).toBe(1788668446552);
+  });
+
+  it("does not retry a row THIS boot has just written", () => {
+    // The block is for what a PREVIOUS boot switched off, and nothing enforced
+    // the "previous". Every `clawbox_plugin_boot_without` runs earlier in this
+    // same script, so a plugin the managed loop had just failed and disabled
+    // was fed straight back in and its `plugins enable` re-run seconds later —
+    // learning nothing, and spending the enable, the inspect and the write-back
+    // out of a `TimeoutStartSec=600` the preceding recovery has already been
+    // drawing on.
+    writeFileSync(
+      configPath,
+      JSON.stringify({ plugins: { entries: { discord: { enabled: true } } } }, null, 2),
+    );
+    const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1", OC_ENABLE_EXIT: "1" });
+    expect(r.status).toBe(0);
+
+    // The managed loop did its work: switched off, recorded, booted without it.
+    expect(config().plugins?.entries?.discord?.enabled).toBe(false);
+    expect(marker().discord.stage).toBe("consent");
+
+    // And the re-attempt left it for the NEXT boot.
+    expect(r.stdout).not.toContain("Re-attempting the discord plugin");
+    const enables = readFileSync(path.join(dir, "calls.log"), "utf-8")
+      .split("\n")
+      .filter((line) => line.startsWith("plugins enable discord"));
+    expect(enables).toHaveLength(1);
+  });
+
+  it("leaves the repair to the next boot when this startup is already late", () => {
+    // The loops above can burn minutes on a box whose plugins are failing, and
+    // this is a blocking ExecStartPre inside TimeoutStartSec=600. A recovery
+    // stacked on a startup that is already late turns a box that WOULD have
+    // come back into one systemd kills — the opposite of what this block is
+    // for. The row keeps its badge and the next boot tries.
+    seedStaleConsentRow();
+    stubRealCli();
+    const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1", CLAWBOX_REATTEMPT_BUDGET_S: "0" });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("Startup has already used");
+    expect(r.stdout).not.toContain("Re-attempting the discord plugin");
+    expect(config().plugins?.entries?.discord?.enabled).toBe(false);
     expect(marker().discord.atMs).toBe(1788668446552);
   });
 

--- a/src/tests/unit/gateway-pre-start-plugin-repair.test.ts
+++ b/src/tests/unit/gateway-pre-start-plugin-repair.test.ts
@@ -640,7 +640,7 @@ ${CONFIG_SET_STUB}`);
     expect(marker().discord.atMs).toBe(1788668446552);
   });
 
-  it("does not retry a row THIS boot has just written", () => {
+  it("does not retry a row THIS RUN has just written", () => {
     // The block is for what a PREVIOUS boot switched off, and nothing enforced
     // the "previous". Every `clawbox_plugin_boot_without` runs earlier in this
     // same script, so a plugin the managed loop had just failed and disabled
@@ -665,22 +665,6 @@ ${CONFIG_SET_STUB}`);
       .split("\n")
       .filter((line) => line.startsWith("plugins enable discord"));
     expect(enables).toHaveLength(1);
-  });
-
-  it("leaves the repair to the next boot when this startup is already late", () => {
-    // The loops above can burn minutes on a box whose plugins are failing, and
-    // this is a blocking ExecStartPre inside TimeoutStartSec=600. A recovery
-    // stacked on a startup that is already late turns a box that WOULD have
-    // come back into one systemd kills — the opposite of what this block is
-    // for. The row keeps its badge and the next boot tries.
-    seedStaleConsentRow();
-    stubRealCli();
-    const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1", CLAWBOX_REATTEMPT_BUDGET_S: "0" });
-    expect(r.status).toBe(0);
-    expect(r.stdout).toContain("Startup has already used");
-    expect(r.stdout).not.toContain("Re-attempting the discord plugin");
-    expect(config().plugins?.entries?.discord?.enabled).toBe(false);
-    expect(marker().discord.atMs).toBe(1788668446552);
   });
 
   it("never turns on a disabled entry the record does not vouch for", () => {

--- a/src/tests/unit/gateway-pre-start-plugin-repair.test.ts
+++ b/src/tests/unit/gateway-pre-start-plugin-repair.test.ts
@@ -554,6 +554,45 @@ ${CONFIG_SET_STUB}`);
     expect(marker().discord.disabled).toBe(true);
   });
 
+  it("says so, rather than skipping in silence, when the row and its entry are keyed differently", () => {
+    // `plugins.entries` can be keyed `openclaw-discord` where the row says
+    // `discord`. An exact lookup answered "no entry" and skipped the row for
+    // ever without a word; the canonical one finds it. It is still not
+    // re-attempted here, and that is the honest outcome rather than a
+    // limitation: every helper downstream takes ONE id and uses it for both the
+    // config write and the record row, so enabling by the row id would write a
+    // second entry under the other spelling. The Retry canonicalises both sides
+    // and remains the way out.
+    writeFileSync(
+      configPath,
+      JSON.stringify({ plugins: { entries: { "openclaw-discord": { enabled: false } } } }, null, 2),
+    );
+    writeFileSync(
+      markerPath,
+      JSON.stringify(
+        {
+          discord: {
+            id: "discord",
+            stage: "consent",
+            reason: "The plugin is installed but its capabilities could not be accepted.",
+            atMs: 1788668446552,
+            disabled: true,
+            spec: "",
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1" });
+    expect(r.status).toBe(0);
+    expect(r.stderr).toContain("keyed differently");
+    expect(config().plugins?.entries?.["openclaw-discord"]?.enabled).toBe(false);
+    // And no second entry invented under the row's spelling.
+    expect(config().plugins?.entries?.discord).toBeUndefined();
+    expect(marker().discord.atMs).toBe(1788668446552);
+  });
+
   it("never turns on a disabled entry the record does not vouch for", () => {
     // No row at all: the entry is off because somebody meant it to be, and this
     // block must not so much as ask the CLI about it.

--- a/src/tests/unit/gateway-pre-start-plugin-repair.test.ts
+++ b/src/tests/unit/gateway-pre-start-plugin-repair.test.ts
@@ -467,6 +467,21 @@ ${CONFIG_SET_STUB}`);
     expect(row.disabled).toBe(true);
   });
 
+  it("keeps an install row's wording an install row's, when the consent cannot be confirmed", () => {
+    // The row keeps its stage, so the sentence has to keep it too: "the plugin
+    // is installed" over a row whose Retry is about to reinstall the payload
+    // contradicts itself on the one screen the owner reads.
+    seedRow("discord", { stage: "install", spec: "@openclaw/discord@2026.8.1" });
+    stubRealCli();
+    const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1", OC_CONSENT_PENDING: "discord" });
+    expect(r.status).toBe(0);
+    const row = marker().discord;
+    expect(row.stage).toBe("install");
+    expect(row.reason).toContain("could not be made loadable");
+    expect(row.reason).not.toContain("The plugin is installed but");
+    expect(row.spec).toBe("@openclaw/discord@2026.8.1");
+  });
+
   it("re-attempts one row per boot, the one attempted longest ago", () => {
     // The whole bound, and the anti-starvation rule in one: a blocking
     // ExecStartPre under TimeoutStartSec=600 cannot afford three of these, and

--- a/src/tests/unit/gateway-pre-start-plugin-repair.test.ts
+++ b/src/tests/unit/gateway-pre-start-plugin-repair.test.ts
@@ -554,6 +554,46 @@ ${CONFIG_SET_STUB}`);
     expect(marker().discord.disabled).toBe(true);
   });
 
+  it("takes the exactly-keyed entry even when an alias is listed before it", () => {
+    // A canonical scan alone resolved this by whichever spelling JSON listed
+    // first — a rule nobody chose. The row is filed under the key
+    // `plugins.entries` carries, so the exact match is the intended entry and
+    // the alias scan is only the fallback.
+    writeFileSync(
+      configPath,
+      JSON.stringify(
+        { plugins: { entries: { "openclaw-discord": { enabled: false }, discord: { enabled: false } } } },
+        null,
+        2,
+      ),
+    );
+    writeFileSync(
+      markerPath,
+      JSON.stringify(
+        {
+          discord: {
+            id: "discord",
+            stage: "consent",
+            reason: "The plugin is installed but its capabilities could not be accepted.",
+            atMs: 1788668446552,
+            disabled: true,
+            spec: "",
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    stubRealCli();
+    const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1" });
+    expect(r.status).toBe(0);
+    expect(config().plugins?.entries?.discord?.enabled).toBe(true);
+    // The alias is left exactly as it was — this repairs one entry, not two.
+    expect(config().plugins?.entries?.["openclaw-discord"]?.enabled).toBe(false);
+    expect(marker()).toEqual({});
+    expect(r.stderr).not.toContain("keyed differently");
+  });
+
   it("says so, rather than skipping in silence, when the row and its entry are keyed differently", () => {
     // `plugins.entries` can be keyed `openclaw-discord` where the row says
     // `discord`. An exact lookup answered "no entry" and skipped the row for

--- a/src/tests/unit/gateway-pre-start-plugin-repair.test.ts
+++ b/src/tests/unit/gateway-pre-start-plugin-repair.test.ts
@@ -113,7 +113,7 @@ function config(): { plugins?: { entries?: Record<string, { enabled?: boolean } 
   return JSON.parse(readFileSync(configPath, "utf-8"));
 }
 
-function marker(): Record<string, { stage?: string; reason?: string; disabled?: boolean; spec?: string }> {
+function marker(): Record<string, { stage?: string; reason?: string; disabled?: boolean; spec?: string; atMs?: number }> {
   return existsSync(markerPath) ? JSON.parse(readFileSync(markerPath, "utf-8")) : {};
 }
 
@@ -256,5 +256,178 @@ ${CONFIG_SET_STUB}`);
     expect(row.stage).toBe("install");
     expect(row.spec).toBe("@openclaw/discord@2026.8.1");
     expect(row.disabled).toBe(true);
+  });
+});
+
+// TASK-785. The two halves of the same 46-hour badge, measured on the OpenClaw
+// box: `data/plugin-repair.json` held discord at `stage: "consent"`,
+// `disabled: true`, `spec: ""`, written on 2026-09-06, and eighteen reboots
+// later it was still there. Nothing re-attempted it, because the loop above
+// only ever visits entries openclaw.json ALREADY says to load — and this row
+// describes the entry the previous boot switched OFF. The owner's Retry then
+// repaired it on the first press, so the failure had been transient for days.
+d("gateway-pre-start.sh — a plugin a PREVIOUS boot switched off", () => {
+  /** The 2026-09-06 row off the box, as the boot script wrote it. */
+  function seedStaleConsentRow() {
+    writeFileSync(
+      configPath,
+      JSON.stringify({ plugins: { entries: { discord: { enabled: false } } } }, null, 2),
+    );
+    writeFileSync(
+      markerPath,
+      JSON.stringify(
+        {
+          discord: {
+            id: "discord",
+            stage: "consent",
+            reason:
+              "The plugin is installed but its capabilities could not be accepted, "
+              + "so the gateway would refuse to start with it enabled.",
+            atMs: 1788668446552,
+            disabled: true,
+            spec: "",
+          },
+        },
+        null,
+        2,
+      ),
+    );
+  }
+
+  it("re-attempts the consent and clears the record when it works", () => {
+    seedStaleConsentRow();
+    const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1" });
+    expect(r.status).toBe(0);
+
+    // The entry the previous boot switched off is back on…
+    expect(config().plugins?.entries?.discord?.enabled).toBe(true);
+    // …and the badge is gone, because the thing it described is fixed.
+    expect(marker()).toEqual({});
+    // Through the core's own consent verb, run again — no Retry click.
+    expect(readFileSync(path.join(dir, "calls.log"), "utf-8"))
+      .toContain("plugins enable discord --accept-capabilities");
+  });
+
+  it("leaves it off and refreshes the record when the consent still fails", () => {
+    seedStaleConsentRow();
+    const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1", OC_ENABLE_EXIT: "1" });
+    expect(r.status).toBe(0);
+    // Still off: the gateway must still be able to start.
+    expect(config().plugins?.entries?.discord?.enabled).toBe(false);
+    const row = marker().discord;
+    expect(row.stage).toBe("consent");
+    expect(row.disabled).toBe(true);
+    // A fresh attempt, not the 2026-09-06 one.
+    expect(row.atMs).toBeGreaterThan(1788668446552);
+  });
+
+  it("re-files the row as the install it needs when the payload is gone", () => {
+    // A consent row over a stranded payload is a badge that can NEVER clear:
+    // the Retry it offers runs `plugins enable`, which is the verb that has
+    // just answered "Plugin not found". Re-filed as the install, with the spec.
+    seedStaleConsentRow();
+    stubOpenclaw(`
+if [ "$1" = "plugins" ] && [ "$2" = "enable" ]; then
+  echo "Plugin not found: $3. Run 'openclaw plugins list' to see installed plugins." >&2
+  exit 1
+fi
+${CONFIG_SET_STUB}`);
+    const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1" });
+    expect(r.status).toBe(0);
+    expect(config().plugins?.entries?.discord?.enabled).toBe(false);
+    const row = marker().discord;
+    expect(row.stage).toBe("install");
+    expect(row.spec).toBe("@openclaw/discord@2026.8.1");
+    expect(row.disabled).toBe(true);
+    expect(row.reason).toContain("Plugin not found");
+  });
+
+  it("puts the entry back off when the failed enable had already switched it on", () => {
+    // `plugins enable` writes `plugins.entries.<id>.enabled` FIRST and only
+    // then loads the gateway SDK, so a re-attempt that fails can leave the
+    // entry ON over a plugin that still does not load — which is the readiness
+    // refusal the previous boot switched it off to avoid. The record has to go
+    // on saying `disabled: true` too: it is the only bit that tells the updater
+    // and the next boot that this switch-off was ClawBox's own.
+    seedStaleConsentRow();
+    stubOpenclaw(`
+if [ "$1" = "plugins" ] && [ "$2" = "enable" ]; then
+  "$0" config set "plugins.entries[\\"$3\\"].enabled" true >/dev/null 2>&1 || true
+  echo "Error: the gateway SDK could not be loaded" >&2
+  exit 1
+fi
+${CONFIG_SET_STUB}`);
+    const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1" });
+    expect(r.status).toBe(0);
+    expect(config().plugins?.entries?.discord?.enabled).toBe(false);
+    expect(r.stdout).toContain("Switched the discord plugin off again");
+    const row = marker().discord;
+    expect(row.disabled).toBe(true);
+    expect(row.reason).toContain("the gateway SDK could not be loaded");
+  });
+
+  it("never turns on a disabled entry the record does not vouch for", () => {
+    // No row at all: the entry is off because somebody meant it to be, and this
+    // block must not so much as ask the CLI about it.
+    writeFileSync(
+      configPath,
+      JSON.stringify({ plugins: { entries: { discord: { enabled: false } } } }, null, 2),
+    );
+    const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1" });
+    expect(r.status).toBe(0);
+    expect(config().plugins?.entries?.discord?.enabled).toBe(false);
+    expect(existsSync(path.join(dir, "calls.log"))).toBe(false);
+  });
+
+  it("never re-attempts a plugin the OWNER switched off", () => {
+    // `disabled: false` is the boot script's record of a failure over which it
+    // changed NOTHING. An entry that is off with such a row against it is off
+    // because its owner said so, and no boot may turn a channel on for him.
+    writeFileSync(
+      configPath,
+      JSON.stringify({ plugins: { entries: { discord: { enabled: false } } } }, null, 2),
+    );
+    writeFileSync(
+      markerPath,
+      JSON.stringify(
+        {
+          discord: {
+            id: "discord",
+            stage: "consent",
+            reason: "The plugin is installed but its capabilities could not be accepted.",
+            atMs: 1788668446552,
+            disabled: false,
+            spec: "",
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1" });
+    expect(r.status).toBe(0);
+    expect(config().plugins?.entries?.discord?.enabled).toBe(false);
+    expect(marker().discord.atMs).toBe(1788668446552);
+  });
+});
+
+d("gateway-pre-start.sh — what a consent row SAYS", () => {
+  it("records the core's own refusal and the spec, not only the generic sentence", () => {
+    stubOpenclaw(`
+if [ "$1" = "plugins" ] && [ "$2" = "enable" ]; then
+  echo "Error: capability consent failed for discord: registry snapshot is locked" >&2
+  exit 1
+fi
+${CONFIG_SET_STUB}`);
+    const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1" });
+    expect(r.status).toBe(0);
+    const row = marker().discord;
+    // The generic sentence stays — it is the one that explains the consequence.
+    expect(row.reason).toMatch(/capabilities could not be accepted/i);
+    // …and the CAUSE joins it, so the row names why rather than only what.
+    expect(row.reason).toContain("registry snapshot is locked");
+    expect(row.reason).toContain("exited 1");
+    // The spec the repair needs, recorded for a consent row too.
+    expect(row.spec).toBe("@openclaw/discord@2026.8.1");
   });
 });

--- a/src/tests/unit/gateway-pre-start-plugin-repair.test.ts
+++ b/src/tests/unit/gateway-pre-start-plugin-repair.test.ts
@@ -83,8 +83,54 @@ with open(cfg_path, "w") as fh:
 PY
   exit $?
 fi
-if [ "$1" = "plugins" ] && [ "$2" = "enable" ]; then exit "\${OC_ENABLE_EXIT:-0}"; fi
+if [ "$1" = "plugins" ] && [ "$2" = "enable" ]; then
+  # THE REAL VERB'S SIDE EFFECT, which the boot script depends on and a stub
+  # that only exits was hiding: \`plugins enable\` writes
+  # \`plugins.entries.<id>.enabled = true\` — it is how a re-attempt puts an
+  # entry the previous boot switched off back on, and the post-enable
+  # verification cannot see a plugin the config still calls disabled.
+  if [ "\${OC_ENABLE_EXIT:-0}" = "0" ]; then
+    "$0" config set "plugins.entries[\\"$3\\"].enabled" true >/dev/null 2>&1 || true
+  fi
+  exit "\${OC_ENABLE_EXIT:-0}"
+fi
 exit 0
+`;
+
+/**
+ * An `openclaw plugins inspect --all --json` that answers from the CONFIG.
+ *
+ * `status` is the config's own enablement bit under another name — which is
+ * exactly why the boot script's post-enable check has to run after the enable
+ * wrote it — so a fixture that answered `loaded` unconditionally would make the
+ * re-attempt look repaired on a box where it is inert. `OC_CONSENT_PENDING`
+ * lists the ids the core still refuses, in its own wording.
+ */
+const INSPECT_STUB = `
+if [ "$1" = "plugins" ] && [ "$2" = "inspect" ]; then
+  python3 - "$OPENCLAW_CONFIG" <<'PY'
+import json, os, sys
+try:
+    with open(sys.argv[1]) as fh:
+        entries = (json.load(fh).get("plugins") or {}).get("entries") or {}
+except Exception:
+    entries = {}
+pending = {p for p in os.environ.get("OC_CONSENT_PENDING", "").split(",") if p}
+reports = []
+for key, entry in entries.items():
+    on = isinstance(entry, dict) and entry.get("enabled") is True
+    reports.append({
+        "plugin": {"id": key, "status": "loaded" if on else "disabled", "activated": on},
+        "install": {"source": "npm", "spec": "@openclaw/%s@2026.8.1" % key},
+        "diagnostics": (
+            [{"pluginId": key, "message": 'Plugin "%s" requires capability consent' % key}]
+            if key in pending else []
+        ),
+    })
+print(json.dumps(reports))
+PY
+  exit 0
+fi
 `;
 
 function run(env: Record<string, string> = {}) {
@@ -267,18 +313,32 @@ ${CONFIG_SET_STUB}`);
 // describes the entry the previous boot switched OFF. The owner's Retry then
 // repaired it on the first press, so the failure had been transient for days.
 d("gateway-pre-start.sh — a plugin a PREVIOUS boot switched off", () => {
-  /** The 2026-09-06 row off the box, as the boot script wrote it. */
-  function seedStaleConsentRow() {
+  /** A row exactly as the boot script wrote it, over an entry it switched off. */
+  function seedRow(
+    id: string,
+    row: Partial<{ stage: string; disabled: boolean; spec: string; atMs: number }> = {},
+    rest: Record<string, unknown> = {},
+  ) {
     writeFileSync(
       configPath,
-      JSON.stringify({ plugins: { entries: { discord: { enabled: false } } } }, null, 2),
+      JSON.stringify(
+        {
+          plugins: {
+            entries: Object.fromEntries(
+              [id, ...Object.keys(rest)].map((key) => [key, { enabled: false }]),
+            ),
+          },
+        },
+        null,
+        2,
+      ),
     );
     writeFileSync(
       markerPath,
       JSON.stringify(
         {
-          discord: {
-            id: "discord",
+          [id]: {
+            id,
             stage: "consent",
             reason:
               "The plugin is installed but its capabilities could not be accepted, "
@@ -286,7 +346,9 @@ d("gateway-pre-start.sh — a plugin a PREVIOUS boot switched off", () => {
             atMs: 1788668446552,
             disabled: true,
             spec: "",
+            ...row,
           },
+          ...rest,
         },
         null,
         2,
@@ -294,8 +356,15 @@ d("gateway-pre-start.sh — a plugin a PREVIOUS boot switched off", () => {
     );
   }
 
+  /** The 2026-09-06 discord row off the OpenClaw box, verbatim. */
+  const seedStaleConsentRow = () => seedRow("discord");
+
+  /** Both halves of a real box: the verb writes the config, the report reads it. */
+  const stubRealCli = () => stubOpenclaw(`${INSPECT_STUB}${CONFIG_SET_STUB}`);
+
   it("re-attempts the consent and clears the record when it works", () => {
     seedStaleConsentRow();
+    stubRealCli();
     const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1" });
     expect(r.status).toBe(0);
 
@@ -310,6 +379,7 @@ d("gateway-pre-start.sh — a plugin a PREVIOUS boot switched off", () => {
 
   it("leaves it off and refreshes the record when the consent still fails", () => {
     seedStaleConsentRow();
+    stubRealCli();
     const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1", OC_ENABLE_EXIT: "1" });
     expect(r.status).toBe(0);
     // Still off: the gateway must still be able to start.
@@ -319,6 +389,36 @@ d("gateway-pre-start.sh — a plugin a PREVIOUS boot switched off", () => {
     expect(row.disabled).toBe(true);
     // A fresh attempt, not the 2026-09-06 one.
     expect(row.atMs).toBeGreaterThan(1788668446552);
+  });
+
+  it("switches it back off when the core still says the consent is missing", () => {
+    // An exit code is not the outcome. This block turns a plugin back ON, so a
+    // `plugins enable` that exited 0 without the consent landing would hand the
+    // gateway the readiness refusal the previous boot switched the entry off to
+    // avoid — the false success this codebase keeps producing.
+    seedStaleConsentRow();
+    stubRealCli();
+    const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1", OC_CONSENT_PENDING: "discord" });
+    expect(r.status).toBe(0);
+    expect(config().plugins?.entries?.discord?.enabled).toBe(false);
+    expect(r.stderr).toContain("could not confirm discord plugin capabilities after the re-attempt");
+    const row = marker().discord;
+    expect(row.disabled).toBe(true);
+    expect(row.reason).toContain("still reports it as requiring capability consent");
+  });
+
+  it("leaves it switched off when the core cannot be asked at all", () => {
+    // The same strictness for the answer that is not an answer: the box ends
+    // this boot exactly as it started it rather than carrying an unresolved
+    // plugin into a readiness refusal, and the next boot asks again.
+    seedStaleConsentRow();
+    const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1" });
+    expect(r.status).toBe(0);
+    expect(config().plugins?.entries?.discord?.enabled).toBe(false);
+    expect(r.stderr).toContain("could not confirm discord plugin capabilities after the re-attempt");
+    const row = marker().discord;
+    expect(row.disabled).toBe(true);
+    expect(row.reason).toContain("could not confirm the consent after a fresh attempt");
   });
 
   it("re-files the row as the install it needs when the payload is gone", () => {
@@ -342,6 +442,58 @@ ${CONFIG_SET_STUB}`);
     expect(row.reason).toContain("Plugin not found");
   });
 
+  it("keeps an install row an install row, and its spec, on any other failure", () => {
+    // ONLY EVER ESCALATES. `Plugin not found` is the one answer that licenses a
+    // change of stage; rewriting an `install` row as `consent` would send every
+    // future Retry to `plugins enable` (the route branches on the stage)
+    // instead of the `plugins install --force` that is its repair, and the badge
+    // could then never clear. The ClawHub spec is the deepseek block's to build,
+    // so a re-file that cannot build one must not erase it either.
+    seedRow("deepseek", {
+      stage: "install",
+      spec: "clawhub:@openclaw/deepseek-provider@2026.8.1",
+    });
+    stubOpenclaw(`
+if [ "$1" = "plugins" ] && [ "$2" = "enable" ]; then
+  echo "Error: cannot find module '@openclaw/deepseek-provider/dist/index.js'" >&2
+  exit 1
+fi
+${CONFIG_SET_STUB}`);
+    const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1" });
+    expect(r.status).toBe(0);
+    const row = marker().deepseek;
+    expect(row.stage).toBe("install");
+    expect(row.spec).toBe("clawhub:@openclaw/deepseek-provider@2026.8.1");
+    expect(row.disabled).toBe(true);
+  });
+
+  it("re-attempts one row per boot, the one attempted longest ago", () => {
+    // The whole bound, and the anti-starvation rule in one: a blocking
+    // ExecStartPre under TimeoutStartSec=600 cannot afford three of these, and
+    // every attempt restamps its row, so the next boot picks the other one
+    // rather than the same broken row for ever.
+    seedRow("discord", { atMs: 1000 }, {
+      whatsapp: {
+        id: "whatsapp",
+        stage: "consent",
+        reason: "The plugin is installed but its capabilities could not be accepted.",
+        atMs: 2000,
+        disabled: true,
+        spec: "",
+      },
+    });
+    stubRealCli();
+    const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1", OC_ENABLE_EXIT: "1" });
+    expect(r.status).toBe(0);
+    const calls = readFileSync(path.join(dir, "calls.log"), "utf-8");
+    expect(calls).toContain("plugins enable discord --accept-capabilities");
+    expect(calls).not.toContain("plugins enable whatsapp");
+    // The older row was tried and restamped; the newer one is untouched, and
+    // is what the next boot will pick.
+    expect(marker().discord.atMs).toBeGreaterThan(1000);
+    expect(marker().whatsapp.atMs).toBe(2000);
+  });
+
   it("puts the entry back off when the failed enable had already switched it on", () => {
     // `plugins enable` writes `plugins.entries.<id>.enabled` FIRST and only
     // then loads the gateway SDK, so a re-attempt that fails can leave the
@@ -360,10 +512,31 @@ ${CONFIG_SET_STUB}`);
     const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1" });
     expect(r.status).toBe(0);
     expect(config().plugins?.entries?.discord?.enabled).toBe(false);
-    expect(r.stdout).toContain("Switched the discord plugin off again");
+    expect(r.stdout).toContain("Leaving the discord plugin switched off");
     const row = marker().discord;
     expect(row.disabled).toBe(true);
     expect(row.reason).toContain("the gateway SDK could not be loaded");
+  });
+
+  it("still records ClawBox's own switch-off when the re-disable fails", () => {
+    // `disabled` says WHOSE switch-off this is, not whether the last write
+    // landed. Handing the entry back to the owner here would stop the Retry
+    // switching an unloadable plugin off and stop the next boot re-attempting
+    // the row at all.
+    seedStaleConsentRow();
+    stubOpenclaw(`
+if [ "$1" = "plugins" ] && [ "$2" = "enable" ]; then
+  "$0" config set "plugins.entries[\\"$3\\"].enabled" true >/dev/null 2>&1 || true
+  echo "Error: the gateway SDK could not be loaded" >&2
+  exit 1
+fi
+if [ "$1" = "config" ] && [ "$2" = "set" ] && [ "$4" = "false" ]; then exit 1; fi
+${CONFIG_SET_STUB}`);
+    const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1" });
+    expect(r.status).toBe(0);
+    expect(config().plugins?.entries?.discord?.enabled).toBe(true);
+    expect(r.stderr).toContain("could not switch the discord plugin off again");
+    expect(marker().discord.disabled).toBe(true);
   });
 
   it("never turns on a disabled entry the record does not vouch for", () => {
@@ -383,27 +556,7 @@ ${CONFIG_SET_STUB}`);
     // `disabled: false` is the boot script's record of a failure over which it
     // changed NOTHING. An entry that is off with such a row against it is off
     // because its owner said so, and no boot may turn a channel on for him.
-    writeFileSync(
-      configPath,
-      JSON.stringify({ plugins: { entries: { discord: { enabled: false } } } }, null, 2),
-    );
-    writeFileSync(
-      markerPath,
-      JSON.stringify(
-        {
-          discord: {
-            id: "discord",
-            stage: "consent",
-            reason: "The plugin is installed but its capabilities could not be accepted.",
-            atMs: 1788668446552,
-            disabled: false,
-            spec: "",
-          },
-        },
-        null,
-        2,
-      ),
-    );
+    seedRow("discord", { disabled: false });
     const r = run({ CLAWBOX_OPENCLAW_EFFECTIVE: "2026.8.1" });
     expect(r.status).toBe(0);
     expect(config().plugins?.entries?.discord?.enabled).toBe(false);

--- a/src/tests/unit/plugin-repair.test.ts
+++ b/src/tests/unit/plugin-repair.test.ts
@@ -181,6 +181,57 @@ describe("plugin-repair — recording a row from the server side", () => {
     expect(Object.keys(await readPluginRepairs()).sort()).toEqual(["byteplus", "discord"]);
   });
 
+  it("does not erase a spec the row already carries", async () => {
+    // TASK-785. Each id had one writer while stating the whole row was safe;
+    // the boot re-attempt made a second, and it cannot build every spec — the
+    // ClawHub scheme is known only to the deepseek block. A re-file changes the
+    // stage, never which package it is, so an empty spec keeps the old one.
+    write({
+      deepseek: {
+        id: "deepseek",
+        stage: "install",
+        reason: "could not install",
+        atMs: 1,
+        disabled: true,
+        spec: "clawhub:@openclaw/deepseek-provider@2026.8.1",
+      },
+    });
+    const { recordPluginRepair, readPluginRepairs } = await load();
+    await recordPluginRepair({
+      id: "deepseek",
+      stage: "install",
+      reason: "still could not install",
+      disabled: true,
+      spec: "",
+    });
+    const rows = await readPluginRepairs();
+    expect(rows.deepseek.spec).toBe("clawhub:@openclaw/deepseek-provider@2026.8.1");
+    expect(rows.deepseek.reason).toBe("still could not install");
+  });
+
+  it("takes a new spec over the old one", async () => {
+    write({
+      deepseek: {
+        id: "deepseek",
+        stage: "install",
+        reason: "could not install",
+        atMs: 1,
+        disabled: true,
+        spec: "clawhub:@openclaw/deepseek-provider@2026.7.1",
+      },
+    });
+    const { recordPluginRepair, readPluginRepairs } = await load();
+    await recordPluginRepair({
+      id: "deepseek",
+      stage: "install",
+      reason: "still could not install",
+      disabled: true,
+      spec: "clawhub:@openclaw/deepseek-provider@2026.8.1",
+    });
+    expect((await readPluginRepairs()).deepseek.spec)
+      .toBe("clawhub:@openclaw/deepseek-provider@2026.8.1");
+  });
+
   it("starts over on a file it cannot parse, exactly as the boot script does", async () => {
     mkdirSync(path.join(dir, "data"), { recursive: true });
     writeFileSync(path.join(dir, "data", "plugin-repair.json"), "{ not json", "utf-8");


### PR DESCRIPTION
TASK-785 — a boot-time consent failure was never retried by a later boot, and the record it left named no cause.

## What the owner saw

Settings showed WhatsApp and Discord as **"Needs repair — The plugin is installed but its capabilities could not be accepted, so the gateway would refuse to start with it enabled."** for three days. On the box, `data/plugin-repair.json` held both at `stage: "consent"`, `disabled: true`, `spec: ""`, written on 2026-09-06. The box was rebooted eighteen times after that; every one of those boots logged `… plugin capabilities accepted/current` for the plugins that were still enabled, and not one of them touched the two it had switched off. The owner's Retry on WhatsApp then repaired it on the first press — so the 09-06 failure had been transient for days, and the only thing between the box and its own repair was a click nobody knew to make.

## Cause

Probe-once, over a whole plugin. Every consent loop in `scripts/gateway-pre-start.sh` builds its list from `plugins.entries` where `enabled` is **already** `true`:

```
for key, entry in entries.items():
    if isinstance(entry, dict) and entry.get("enabled") is True:
        print(key)
```

TASK-606's boot-without sets exactly that key to `false` so the gateway can start. So the act of recording the failure is also what hides the plugin from the loop that would have fixed it, and the record — the one thing on the device that knows ClawBox switched it off rather than its owner — was written and never read by the boot path again. `src/lib/updater.ts` already reads it (`pluginConsentRepairIsAllowed` / `clawboxSwitchedPluginOff`), but only during an update; a box that is merely broken gets reboots, not updates.

Second half: the row said what would have happened and nothing about why. The CLI's answer was thrown away at every one of these call sites (`>/dev/null 2>&1`), and `spec` was left empty for consent rows — which also meant a row whose real problem was a stranded payload could never be re-filed as the install it needed, and offered a Retry that runs `plugins enable`, the verb that had just refused.

## Harness first

Measured read-only on the OpenClaw box against the pinned core (`OpenClaw 2026.8.1 (ea80657)`):

- `openclaw plugins enable <id> --accept-capabilities` — *"Accept the plugin's declared capabilities"*. This **is** the native consent mechanism, and it is what the re-attempt runs; nothing here writes consent by hand.
- `openclaw plugins inspect <id> --json` — the native report. For the stale row it answered `status: "disabled"`, `activated: false`, `enabled: false`, with `install.spec: "@openclaw/discord@2026.8.1"`. That last field is the core's own name for the package, and the spec this branch records for a consent row is built to be the same string.
- `openclaw plugins doctor` — *"Report plugin load issues"*, and its only option is `--json`. It diagnoses; it cannot consent or re-attempt.
- `openclaw plugins update --accept-capabilities` — accepts a **widened** surface while updating an installed plugin. A different operation, and it would move the version this script pins.

**There is no native retry.** Nothing in the core re-attempts a failed consent of its own accord, so the re-attempt is ClawBox's to own — and it runs the core's verb rather than writing consent by hand. That absence is the finding: the harness has the verb and no scheduler for it.

## The change

`scripts/gateway-pre-start.sh`

1. **A boot re-attempt** of a repair row that says ClawBox itself switched the plugin off. It runs the core's consent verb, asks the core again whether the consent landed, and only then does `clawbox_plugin_repair_clear` put the entry back on, prove that against the file and remove the badge. The Retry stays for the manual path.
   - **Only `disabled: true`.** That bit is the only record of the difference between ClawBox's switch-off and a person running `openclaw plugins disable discord`; a `disabled: false` row records a failure over which the script changed nothing, and the entry stays off. The same line `updater.ts` already draws.
   - **Only an entry that is present and explicitly `false`.** A row whose entry the owner has since deleted is stale, and `plugins enable` would resurrect it.
   - **Stages `install` and `consent` only.** `not-installed` (TASK-738) is a package nothing on this box ever installed — accepting its capabilities without the owner's press is his decision, not a boot script's.
   - **One row per boot, the one attempted longest ago.** That is the whole bound — at most one `plugins enable`, one `plugins inspect --all --json` and one `config set` write-back, about 195 s of ceiling inside a blocking `ExecStartPre` under `TimeoutStartSec=600`, and 26 s in practice on the box. Ordering on `atMs` is also what stops a permanently broken row starving the others: every attempt restamps its row. No payload reinstall here either — a re-attempt that hits the core's `Plugin not found` re-files the row as the `install` it needs, with the pinned spec, and leaves that 120 s repair to the Retry and the updater, which have the budget for it.
   - **An exit code is not the outcome.** This is the only block that turns a plugin ON, so `plugins enable` exiting 0 is not enough: the core is asked again against a snapshot taken after the write, and one answer — its own "adjudicated, no consent diagnostic" — succeeds. Every other answer leaves the box exactly as the previous boot left it.
   - **It cannot leave a plugin enabled that does not load.** `plugins enable` writes `plugins.entries.<id>.enabled` before it loads the gateway SDK and can fail, so `clawbox_plugin_reattempt_failed` puts the entry back off and keeps `disabled: true` — which says whose switch-off it is, not whether the last write landed, and is the bit the updater and the next boot both read.
   - **The stage is the row's**, and only the core's `Plugin not found` licenses changing it, upwards. An `install` row rewritten as `consent` would send every future Retry to `plugins enable` — the verb that just refused — and the badge could never clear.
2. **The cause on the record.** `clawbox_plugin_cli_cause` appends the core's own refusal — one line, ANSI and control characters stripped, whitespace collapsed, 160 characters — plus the exit code, and says "was killed at its deadline" for 124/137 rather than reporting a timeout as a refusal. The UI already renders `reason` verbatim, so the Settings row carries it with no change there.
3. **The spec on consent rows**, from one shared `clawbox_managed_plugin_spec` so the row records exactly the string this script would install (pinned, never the bare alias that resolves `@latest`).

## Sibling sweep — every writer of `data/plugin-repair.json`

| writer | state |
|---|---|
| `gateway-pre-start.sh` managed-plugin consent | **fixed** — cause + spec |
| `gateway-pre-start.sh` codex consent | **fixed** — output captured instead of discarded, cause + pinned `@openclaw/codex@<target>` spec |
| `gateway-pre-start.sh` managed-plugin install / codex install / deepseek install | already carried a spec; cause comes from the branch they took, unchanged |
| `gateway-pre-start.sh` re-attempt (new) | writes through `clawbox_plugin_reattempt_failed`, which asserts the switch-off rather than reading it back |
| `src/lib/updater.ts` `recordMissingPluginRow` | already records the core's own `reason` and the core's own `spec`; `not-installed`, deliberately outside the re-attempt |
| `install.sh` / `install-x64.sh` | do not write this file (0 references) — cleared |

Readers checked and unchanged: `src/lib/plugin-repair.ts`, `src/app/setup-api/plugins/repair/route.ts`, `src/lib/provider-status.ts`, `src/lib/openclaw-channels.ts`, `src/app/setup-api/ai-models/configure/route.ts`, `src/components/PluginRepairNotice.tsx`.

## Both editions

Hermes has no channel plugins of this kind. `scripts/setup-hermes-edition.sh` stops, disables, removes and masks `clawbox-gateway.service`, so `gateway-pre-start.sh` — and this block with it — never runs on that SKU; `readPluginRepairs()` already answers `{}` there, so nothing renders and nothing errors. Inert by construction, not by an edition test.

## RED → GREEN

RED on unmodified `origin/beta`, with the 2026-09-06 row off the box as the fixture — 11 failures across the three suites:

```
 ❯ src/tests/unit/gateway-pre-start-plugin-repair.test.ts (19 tests | 9 failed)
   × re-attempts the consent and clears the record when it works
   × leaves it off and refreshes the record when the consent still fails
   × switches it back off when the core still says the consent is missing
   × leaves it switched off when the core cannot be asked at all
   × re-files the row as the install it needs when the payload is gone
   × re-attempts one row per boot, the one attempted longest ago
   × puts the entry back off when the failed enable had already switched it on
   × still records ClawBox's own switch-off when the re-disable fails
   × records the core's own refusal and the spec, not only the generic sentence
 ❯ src/tests/unit/gateway-pre-start-codex-runtime.test.ts (43 tests | 1 failed)
   × records the core's own refusal and the pinned spec on the consent row
 ❯ src/tests/unit/plugin-repair.test.ts (18 tests | 1 failed)
   × does not erase a spec the row already carries

AssertionError: expected false to be true                      // discord stayed switched off
AssertionError: expected 1788668446552 to be greater than 1788668446552   // the row was never touched
AssertionError: expected 'The plugin is installed but its capab…' to contain 'registry snapshot is locked'
```

The two guard tests — "never turns on a disabled entry the record does not vouch for" and "never re-attempts a plugin the OWNER switched off" — pass on beta, as they must.

GREEN, whole suite:

```
 Test Files  999 passed (999)
      Tests  15069 passed | 1 skipped (15070)
```

`tsc --noEmit` clean. `eslint` adds no error or warning on the touched files (the four repo-wide errors are pre-existing, in files this PR does not touch).

## Device proof — the OpenClaw box, on the stale 2026-09-06 row

Under the device lock, this branch's `gateway-pre-start.sh` was put on the box, the gateway restarted once, and the checkout restored (`git checkout --`, proved by `sha256sum` back to `ac421fb3…` with a clean `git status`; HEAD never moved).

Before — the row the owner had been looking at for three days:

```
{"discord": {"id": "discord", "stage": "consent",
  "reason": "The plugin is installed but its capabilities could not be accepted, …",
  "atMs": 1788668446552, "disabled": true, "spec": ""}}
plugins.entries: {… "discord": false, "whatsapp": true …}
openclaw plugins inspect discord --json → status: "disabled", activated: false, enabled: false
```

The boot, with no Retry click:

```
18:17:38  Re-attempting the discord plugin a previous boot switched off…
18:17:57  discord plugin capabilities accepted on the re-attempt
18:18:04  Switched the discord plugin back on after repairing it
```

26 seconds end to end, against the ~195 s ceiling the comment budgets.

After:

```
data/plugin-repair.json                    → {}
plugins.entries                            → "discord": true
openclaw plugins inspect discord --json    → status: "loaded", activated: true,
                                             enabled: true, diagnostics: []
GET /setup-api/plugins/repair (owner)      → {"ok":true,"repairs":[]}
systemctl is-active clawbox-gateway        → active
```

The core's own verdict clears even the Retry route's stricter bar (`status === "loaded" && activated === true`). Settings has no "Needs repair" row left; `GET /setup-api/discord/status` is `{"configured":false}`, i.e. Discord is offered in "Connect a channel" as a channel that is simply not connected yet — no badge. Nothing was sent on any channel and no channel configuration was changed beyond the entry the record itself had switched off.

## Review

One review pass (`clawbox-review`), findings applied in the second commit:

- **The first commit cleared the badge on `plugins enable`'s exit code alone.** It turns a plugin back ON, so an exit 0 without the consent landing would have handed the gateway the readiness refusal the previous boot switched the entry off to avoid. Now verified against a snapshot taken after the write, and only the core's own positive verdict clears the row.
- **A once-per-boot snapshot latch repaired a second row and then switched it back off** with a reason that had not happened. Answered by doing one row per boot, oldest `atMs` first — which is also the whole time bound and the anti-starvation rule.
- **An `install` row was de-escalated to `consent`** on any failure that was not literally `Plugin not found`, which would have pointed every future Retry at the verb that had just refused. The stage is now the row's, and only ever escalates.
- **`disabled` was flipped to `false` when a re-disable failed**, handing an entry ClawBox owns back to the owner and stopping both the Retry and the next boot from repairing it.
- **An empty spec erased one the row already carried** (the ClawHub `deepseek` string). Fixed in the boot script and mirrored in `recordPluginRepair`.
- **CLI output was captured through a command substitution**, which this file already documents as a way to stall past a `timeout` ceiling when a grandchild survives. Captured through a file now, at all three sites.
- **The test's `plugins enable` stub never wrote the config**, so the success path passed without exercising the ordering it depends on. The stub now writes it and the `inspect` stub answers from the config.

CodeRabbit posted one actionable comment and it was right: the boot re-attempt keeps its own plugin list, so a channel added to `OFFICIAL_CHANNEL_PLUGINS` and forgotten in `REATTEMPTABLE` is a channel one bad morning can switch off and no later boot switches back on. A drift guard now holds the shell tuple to `["deepseek", ...Object.keys(OFFICIAL_CHANNEL_PLUGINS)]`, and it was negative-tested rather than assumed — perturbing the tuple fails it.

Two further things found while re-reading the diff, in the same push: a row that keeps `stage: install` through a re-attempt was being re-filed with the consent sentence, so the one screen the owner reads said the plugin was installed over a Retry about to reinstall its payload.

A second, independent review pass then found two more, both reproduced with failing tests before being fixed:

- **The block is for what a PREVIOUS boot switched off, and nothing enforced the "previous".** Every `clawbox_plugin_boot_without` in this script runs earlier than the block, so a plugin the managed loop had just failed and disabled was fed straight back in and its consent verb re-run seconds later — learning nothing, and announcing "a previous boot switched off" over a row written thirty milliseconds earlier. Ids are now collected in the one function every writer passes through, so no new call site can forget it. (The transient case this might seem to serve is already handled where it belongs: `clawbox_plugin_consent_outcome` re-checks the core's post-write snapshot for a verb killed at its deadline, so a consent that landed is caught inside the managed loop and never reaches here.)
- **An `install` row that failed the re-attempt with an ordinary error got the capabilities wording.** The stage-aware sentence existed only in the verification arm. The existing "keeps an install row an install row" test would have passed with the wrong sentence, so it was strengthened rather than duplicated.

Also in that pass: a shadowed loop variable in the entry scan.

## Residuals (not in this PR)

- The boot block verifies with the cheap `plugins inspect --all --json` snapshot, while the Retry route module-loads with `--runtime` and also demands `activated: true`. A plugin that loads but fails to activate for a reason that is not consent would be re-enabled here. Named in the block's comment; the stronger call costs tens of seconds on an Orin, which an `ExecStartPre` cannot spend.
- `reason` is the core's English inside an otherwise translated panel — as every sentence the boot script has ever written into that field is.
- A `disabled: true` row never expires, so it licenses a re-enable indefinitely. That is the existing ruling in `updater.ts`, but this block now exercises it every boot rather than only during an update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Plugin repair records retain known package specifications when later attempts omit them.
  - Failed repairs include clearer command output, exit information, and diagnostic details.
  - Previously disabled plugins are retried once during startup, with consent rechecked and disablement restored if recovery fails.
  - Missing managed-plugin package details are resolved consistently using pinned versions.
  - Repairs with missing payloads can proceed through installation.
  - Repair records are cleared only after confirmed recovery.

- **Tests**
  - Expanded coverage for plugin retries, repair metadata, consent failures, specification handling, and disabled-state restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- **The gateway pre-start has no cumulative startup budget, and its worst path already exceeds `TimeoutStartSec=600` on beta.** On a core bump that stranded both channel payloads the time boxes add up to roughly twice the unit's ceiling before this PR's code is reached, and about ten of them are unbudgeted. This PR adds no deadline of its own: a first attempt read bash `SECONDS`, which these RTC-less boards step via timesyncd inside this very `ExecStartPre` — it made the script skip the whole repair after a clock jump, which is the failure this card exists to remove — and the file already rejects `SECONDS` for that reason elsewhere. A script-wide deadline on a monotonic clock, or a decision that this path may exceed the ceiling and lean on `Restart=always`, is its own piece of work.

