### PR TITLE
fix: make the ChatGPT model list one list and stop serving a cache no refresh can write

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -1505,14 +1505,15 @@ elif _wants_llamacpp and _llamacpp_gaps:
 # surfaces as a FailoverError days into use. The chat-model pick route already
 # rewrites `openai/<gpt>` -> `codex/<gpt>`, but only when the user re-picks the
 # model; existing configs never re-pick, so migrate primary + fallbacks here on
-# gateway start. Mirrors CODEX_SUPPORTED_MODEL_RE in
-# src/lib/subscription-surface.ts, and hasOpenAiApiKeyProfile /
+# gateway start. Mirrors CODEX_MODELS in src/lib/provider-models.ts,
+# the one list src/lib/subscription-surface.ts also reads, and hasOpenAiApiKeyProfile /
 # hasCodexOauthProfile in src/app/setup-api/chat/model/route.ts. Guarded on
 # "codex OAuth present AND no OpenAI API key" so dual-auth / API-key boxes,
 # where openai/* is a valid keyed route, are left untouched.
 _CODEX_SUPPORTED = (
     "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",
     "gpt-5.5", "gpt-5.4", "gpt-5.4-mini",
+    "gpt-5.3-codex-spark",
 )
 
 def _auth_profiles():

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -5,7 +5,7 @@ import { promises as fsp } from "fs";
 import path from "path";
 import { findOpenclawBin, openclawIsAbsent } from "@/lib/openclaw-config";
 import { DATA_DIR } from "@/lib/config-store";
-import { CODEX_SUPPORTED_MODEL_RE } from "@/lib/subscription-surface";
+import { isCodexSupportedModelId } from "@/lib/subscription-surface";
 import { lastModelSegment } from "@/lib/chat-header-pills";
 import {
   CATALOG_PROVIDERS,
@@ -379,6 +379,54 @@ async function writeDiskCache(provider: string, payload: CatalogResponse): Promi
   }
 }
 
+/**
+ * Drop a `<provider>.json` that no code path can rewrite, and the memory copy
+ * of it.
+ *
+ * `refreshInBackground` returns at the `hasNoEnumerationOnThisCore` branch
+ * BEFORE `writeDiskCache`, so for such a provider the file can only be a
+ * leftover from a build that predates that branch — and `GET` preferred it,
+ * with `sanitizeCachedPayload` rebuilding the payload from the DISK rows
+ * rather than from the curated list. Measured on the box, 2026-09-09:
+ * `codex.json` was stamped 2026-09-02T19:37:36Z while every other cache file
+ * was three hours old, and the picker had been served that snapshot ever
+ * since. It happened to match the curated rows that day, which is exactly why
+ * nobody saw it — and why a model added to `CODEX_MODELS` would have gone out
+ * in a release and reached no box carrying the file.
+ *
+ * Deleting is TIDYING, not the fix. What actually keeps the file out of the
+ * answer is that `GET` never reads a cache for such a provider at all (see
+ * `serveCuratedOnly` below) — because an unlink can fail, and a delete whose
+ * failure is logged and then ignored while the same file is read and served is
+ * this route's own false success. `catalog-cache/` is a public subtree, so a
+ * leftover owned by another uid, a restore that reinstated the recorded owner
+ * or a read-only remount are all real ways for it to stay put; none of them may
+ * decide whether the release applies. Asked on EVERY request rather than
+ * remembered per process — "checked once at startup and treated as fact" is the
+ * bug this file already carries scars from — and the steady-state cost is one
+ * `unlink` that answers ENOENT.
+ *
+ * `src/lib/subscription-surface.ts` reads the same file through
+ * `readCachedCatalogueIds`, so this is a cross-module delete: `readKnownModelIds`
+ * unions the cache with the curated list, which is why removing it changes
+ * nothing there — it only stops an older build's ids being added back.
+ */
+async function discardUnwritableDiskCache(provider: string): Promise<void> {
+  memCache.delete(provider);
+  try {
+    await fsp.unlink(path.join(CACHE_DIR, `${provider}.json`));
+    console.log(`[catalog] ${provider}: dropped a disk cache no refresh can rewrite`);
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException | null)?.code;
+    // ENOENT is the steady state: the file only exists on a box upgraded from
+    // a build that used to write it. Anything else is reported and no more —
+    // the answer this route serves does not depend on it.
+    if (code !== "ENOENT") {
+      console.warn(`[catalog] ${provider}: could not drop the stale disk cache:`, code ?? e);
+    }
+  }
+}
+
 interface OpenclawListResponse {
   count: number;
   /**
@@ -466,44 +514,54 @@ const DEPRECATED_MODEL_IDS: ReadonlySet<string> = new Set([
   "claude-opus-4-20250514",
 ]);
 
-// Per-provider allowlist regex. When set, only model ids matching the
-// pattern survive the catalog filter.
+// Per-provider id allowlist. When set, only model ids the predicate accepts
+// survive the catalog filter.
 //
 // ONE entry, and it is a routing fact rather than curation.
 //
-// codex (ChatGPT-account auth): 5.4, 5.4-mini, 5.5, plus the 5.6
-//   gpt-5.6-{sol,terra,luna} models — NO -pro variants. Per
-//   developers.openai.com/codex/models, the Pro models are API-key-only
-//   and the Codex/ChatGPT-account auth path 400s with "model not
-//   supported when using Codex with a ChatGPT account" if you try
-//   gpt-5.4-pro or gpt-5.5-pro. The gpt-5.6-sol/terra/luna models DO run
-//   on the ChatGPT-account path for accounts whose plan (Plus/Pro/Max)
-//   includes them — the live upstream catalog only returns them for such
-//   accounts, so this allowlist just stops us from stripping them; boxes
-//   on plans without 5.6 never see the entries (no dead buttons).
+// codex (ChatGPT-account auth): whatever the curated ChatGPT catalogue
+//   carries, asked through `isCodexSupportedModelId`. NO -pro variants — per
+//   developers.openai.com/codex/models the Pro models are API-key-only and the
+//   ChatGPT-account path 400s with "model not supported when using Codex with
+//   a ChatGPT account" — and plan gating is deliberately NOT applied: gpt-5.6
+//   access varies per account, so the pick goes through and the upstream
+//   access error is what the customer sees.
 //
-// `openai` USED to carry /^gpt-5\.[45](-pro|-mini)?$/, to keep older
-// generations out of the picker. It aged into the opposite of its purpose: on
-// OpenClaw 2026.8.1 the openai catalogue is already curated upstream — one row
-// on a stock host (`openai/gpt-5.6-sol`, tagged default), ten on a linked box —
-// and that pattern matched NONE of the 5.6 generation, so the newest models the
-// box could run were filtered out of their own catalogue and the picker fell
-// back to a hand-written list. A generation allowlist cannot know what the next
+// This entry USED to be `CODEX_SUPPORTED_MODEL_RE`, a generation regex, and
+// `openai` USED to carry /^gpt-5\.[45](-pro|-mini)?$/ for the same job. The
+// openai one aged into the opposite of its purpose: on OpenClaw 2026.8.1 the
+// openai catalogue is already curated upstream — one row on a stock host
+// (`openai/gpt-5.6-sol`, tagged default), ten on a linked box — and that
+// pattern matched NONE of the 5.6 generation, so the newest models the box
+// could run were filtered out of their own catalogue and the picker fell back
+// to a hand-written list. A generation allowlist cannot know what the next
 // generation is called; the harness's catalogue can, and the whole point of
-// this route is to ask it.
-const ALLOWED_MODEL_RE_BY_PROVIDER: Record<string, RegExp> = {
-  // IMPORTED, not spelled again. `CODEX_SUPPORTED_MODEL_RE` is the same
-  // alternation, and its own doc says it lives there so that "a second copy in
-  // the second route is a copy that can drift" — this route was that second
-  // copy. It is the rule the write path enforces, so the picker must offer
-  // exactly it: a row this list shows and that guard refuses is a dead button,
-  // and the reverse is a model the customer cannot reach.
+// this route is to ask it. The codex copy then did the same thing to
+// `gpt-5.3-codex-spark` (TASK-786) — measured 200 through
+// https://chatgpt.com/backend-api/codex/responses on the box, and unspellable
+// by that pattern.
+//
+// `codex` has no catalogue on this core to ask (see the note above
+// `NO_CLI_ENUMERATION_PROVIDERS`), so its list stays curated — but curated in
+// ONE place. `scripts/gateway-pre-start.sh` keeps a second, hand-maintained
+// mirror in `_CODEX_SUPPORTED` (it runs before node exists), pinned by
+// src/tests/unit/gateway-pre-start-codex-models.test.ts. That one cannot
+// import; this one can, and does.
+const OFFERABLE_MODEL_ID_BY_PROVIDER: Record<string, (id: string) => boolean> = {
+  // IMPORTED, not spelled again: it is the rule the write paths enforce, so
+  // the picker must offer exactly it. A row this list shows and that guard
+  // refuses is a dead button, and the reverse is a model the customer cannot
+  // reach.
   //
-  // `scripts/gateway-pre-start.sh` keeps a third, hand-maintained mirror in
-  // `_CODEX_SUPPORTED` (it runs before node exists), pinned by
-  // src/tests/unit/gateway-pre-start-codex-models.test.ts. That one cannot
-  // import; this one could, and now does.
-  codex: CODEX_SUPPORTED_MODEL_RE,
+  // Today it cannot FIRE: the only list that reaches `sanitizeCatalogModels`
+  // for codex is `staticCatalogModels("codex")`, which is the very array this
+  // predicate asks about — the disk cache that used to be the other input is
+  // dropped at the top of `GET`, and codex reaches neither `publish` nor
+  // `fetchSubscriptionSurfaceIds`. Kept because it is the entry that makes the
+  // property true BY CONSTRUCTION rather than by accident: the day this core
+  // grows a ChatGPT-surface enumeration, the rows it returns arrive here, and
+  // an unfiltered `codex` would then offer whatever upstream listed.
+  codex: isCodexSupportedModelId,
 };
 
 // Newest-first ordering: bigger context generally means newer model on
@@ -672,8 +730,8 @@ const MODALITY_REPORTING_PROVIDERS: ReadonlySet<string> = new Set(["openrouter"]
 
 function isOfferableModelId(provider: string, id: string): boolean {
   if (!id) return false;
-  const allowed = ALLOWED_MODEL_RE_BY_PROVIDER[provider];
-  if (allowed && !allowed.test(id)) return false;
+  const isOffered = OFFERABLE_MODEL_ID_BY_PROVIDER[provider];
+  if (isOffered && !isOffered(id)) return false;
   if (!MODALITY_REPORTING_PROVIDERS.has(provider) && isNonChatModelId(id)) return false;
   // Matched on the last path segment, like `isNonChatModelId`, because
   // OpenRouter ids keep their `<org>/` slug: tested against the whole id this
@@ -1566,6 +1624,18 @@ export async function GET(req: NextRequest) {
   const force = req.nextUrl.searchParams.get("refresh") === "1";
 
   bootWarmup();
+
+  // A provider this core cannot enumerate has exactly ONE possible answer — the
+  // curated list — so it is served without consulting either cache. Structural
+  // on purpose: nothing here can be reached by a file, whether or not the
+  // `unlink` beside it succeeds.
+  if (hasNoEnumerationOnThisCore(provider)) {
+    await discardUnwritableDiskCache(provider);
+    return NextResponse.json(
+      withoutRetiredModels(buildFallbackPayload(provider)),
+      { headers: noStore() },
+    );
+  }
 
   // Hot path: in-memory cache.
   let cached = memCache.get(provider);

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -66,9 +66,9 @@ import {
 } from "@/lib/chatgpt-subscription";
 import type { AuthProfileEntries } from "@/lib/subscription-surface";
 import {
-  CODEX_SUPPORTED_MODEL_RE,
   chatgptSupportedModelsSentence,
   isClaudeSubscriptionOnly,
+  isCodexSupportedModelId,
   isKeyModeProfile,
   offSurfaceClaudeModelMessage,
   offSurfaceCodexModelMessage,
@@ -134,7 +134,7 @@ const DEFAULT_PROVIDER_MODELS: Record<string, string> = {
   openrouter: `openrouter/${OPENROUTER_DEFAULT_MODEL_ID}`,
 };
 
-// CODEX_SUPPORTED_MODEL_RE moved to @/lib/subscription-surface: the wizard/
+// The ChatGPT allowlist lives in @/lib/subscription-surface: the wizard/
 // Settings save resolves onto the same ChatGPT credential and has to apply the
 // same allowlist, and a second copy of it there would be a copy that can
 // drift. Which pick is on that credential is no longer readable from the
@@ -308,7 +308,7 @@ function resolveChatgptPick(
     return { refusal: refuseKeylessOpenAiModel(parsed.modelId, credentials.hasApiKey) };
   }
   if (legacy) return { model: canonicalChatgptModelRef(ref) };
-  if (CODEX_SUPPORTED_MODEL_RE.test(parsed.modelId)) return { model: chatgptModelRef(parsed.modelId) };
+  if (isCodexSupportedModelId(parsed.modelId)) return { model: chatgptModelRef(parsed.modelId) };
   return { refusal: refuseKeylessOpenAiModel(parsed.modelId, credentials.hasApiKey) };
 }
 
@@ -622,11 +622,11 @@ async function loadChatModelState(preloaded?: OpenClawConfig) {
     // OpenAI key it was the FIRST row — so the OpenAI dropdown row was
     // represented by an image model that fails on every chat turn.
     //
-    // Deliberately NOT the catalog route's `ALLOWED_MODEL_RE_BY_PROVIDER`.
-    // That list curates a noisy UPSTREAM catalog down for a picker; this list
+    // Deliberately NOT the catalog route's `OFFERABLE_MODEL_ID_BY_PROVIDER`.
+    // That rule curates a noisy UPSTREAM catalog down for a picker; this list
     // is what the owner configured, which this route's own sibling
     // (`foreignOpenAiRoute` in ai-models/configure) treats as "the owner's own
-    // work". Running it through the curation regex empties `models[]` for a
+    // work". Running it through the curation rule empties `models[]` for a
     // self-hosted openai-compatible endpoint and falls the row through to a
     // hard-coded default that endpoint does not serve.
     const definedModels = (providerDef?.models ?? []).filter(

--- a/src/lib/core-model-lifecycle.ts
+++ b/src/lib/core-model-lifecycle.ts
@@ -99,8 +99,14 @@ const SAFE_PROVIDER_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/i;
  * PATHS are that script's; the fallback RULE is not the same one — it falls
  * back on existence alone (`[ ! -f … ]`) and gives up outright on a manifest it
  * cannot parse, while this reads on to the next candidate.
+ *
+ * Exported because the manifest carries more than the lifecycle: its
+ * `modelCatalog.suppressions` are how the core says a model runs on ONE auth
+ * only, which is what `src/tests/unit/codex-surface-follows-core.test.ts` reads
+ * to catch the ChatGPT list drifting behind a core bump. Where the manifest
+ * lives is written down once.
  */
-function manifestPaths(provider: string): string[] {
+export function coreManifestPaths(provider: string): string[] {
   const bin = findOpenclawBin();
   const paths: string[] = [];
   if (path.isAbsolute(bin)) {
@@ -204,7 +210,7 @@ function retiredFor(provider: string): Set<string> {
   // that is the ordinary shape of an OpenClaw 2 box, where the bundled path
   // never exists and the beside-config answer is the right one to cache.
   let degraded = false;
-  for (const file of manifestPaths(provider)) {
+  for (const file of coreManifestPaths(provider)) {
     // Opened ONCE and both stat and read taken from the descriptor. A
     // `statSync` followed by a `readFileSync` of the same path is two lookups
     // of a name that can change between them — and the whole point of the stat

--- a/src/lib/provider-models.ts
+++ b/src/lib/provider-models.ts
@@ -222,15 +222,35 @@ export const OPENAI_DEFAULT_MODEL_ID = "gpt-5.4";
 // subscription; the models themselves are written as `openai/<id>` — OpenClaw
 // 2 retired the `codex` provider id (`openai-codex` before 2026.6), see
 // src/lib/chatgpt-subscription.ts. Available when the user authenticates via
-// ChatGPT OAuth instead of pasting an API key. NO -pro variants — those are
-// API-key only (they 400 with "model
-// not supported when using Codex with a ChatGPT account" on the OAuth
-// path). Per developers.openai.com/codex/models the supported set via
-// ChatGPT-account auth is gpt-5.6-{sol,terra,luna}, gpt-5.5, gpt-5.4,
-// gpt-5.4-mini. The gpt-5.6 models are plan-gated upstream (Plus/Pro/Max)
-// — the live catalog only returns them for entitled accounts, so listing
-// them here just gives them stable labels; accounts without the plan
-// never see them. Filter lives in ALLOWED_MODEL_RE_BY_PROVIDER (catalog).
+// ChatGPT OAuth instead of pasting an API key.
+//
+// THIS ARRAY IS THE WHOLE ChatGPT SURFACE. The picker offers it, both write
+// paths to `agents.defaults.model.primary` accept exactly it
+// (`isCodexSupportedModelId`), and the refusal sentence is built from it —
+// there is no second spelling to keep in step. There was: a generation regex
+// in subscription-surface.ts, which could not spell `gpt-5.3-codex-spark` and
+// so hid it (TASK-786).
+//
+// It mirrors the core's own `OPENAI_CHATGPT_MODERN_MODEL_IDS`
+// (`extensions/openai/model-route-contract` in the installed dist), because
+// 2026.8.1 publishes that set through no CLI and no RPC — `openclaw models
+// list --provider codex` answers `Unknown provider filter`, and the `openai`
+// enumeration has no auth-scoped field. Measured on the box, 2026-09-09:
+//   * gpt-5.6-sol      -> chatgpt.com/backend-api/codex/responses  200
+//   * gpt-5.3-codex-spark -> chatgpt.com/backend-api/codex/responses  200
+//   * gpt-6-astra      -> NOT on that route; the core sends it to
+//     api.openai.com/v1/responses on the API key instead, so it belongs to the
+//     `openai` surface and must not appear here.
+//
+// NO -pro variants — those are API-key only (they 400 with "model not
+// supported when using Codex with a ChatGPT account" on the OAuth path), even
+// though the core files them as dual-route. Plan gating is the opposite case
+// and is deliberately NOT applied: the gpt-5.6 models are gated upstream
+// (Plus/Pro/Max), there is no plan-scoped list on this core to filter by — the
+// catalog route's `WHY codex IS NOT ENUMERATED FROM openai` note is the whole
+// argument — so an unentitled account sees all three, the turn 400s upstream
+// and the sign-in probe (src/lib/codex-model-probe.ts) is what keeps a box off
+// a row its plan cannot run. Listing them here gives them stable labels.
 export const CODEX_MODELS: readonly ProviderModelOption[] = [
   { id: "gpt-5.6-sol", label: "GPT-5.6 Sol", hint: "Newest flagship. Plus/Pro." },
   { id: "gpt-5.6-terra", label: "GPT-5.6 Terra", hint: "GPT-5.6. Plus/Pro." },
@@ -238,6 +258,17 @@ export const CODEX_MODELS: readonly ProviderModelOption[] = [
   { id: "gpt-5.5", label: "GPT-5.5", hint: "Default. Every tier." },
   { id: "gpt-5.4", label: "GPT-5.4", hint: "Previous gen. 1M context." },
   { id: "gpt-5.4-mini", label: "GPT-5.4 Mini", hint: "Fast, cheap." },
+  // Subscription-ONLY upstream: the core's route contract lists it under
+  // OPENAI_SUBSCRIPTION_ONLY_ROUTE_MODEL_IDS, and the box's own `models list
+  // --provider openai` reports it `available: false` because the platform
+  // route excludes it. This is the only surface that can offer it.
+  // Label deliberately short of the core's "GPT-5.3 Codex Spark": the chat
+  // header's model pill has ~142px for its text (chat-header-pills.ts) and
+  // drops only a LEADING or TRAILING token that repeats the provider pill —
+  // "Codex" sits in the middle here, so the full name would be the longest
+  // label in any catalogue we ship and the only one that truncates. The
+  // popover still shows the whole id.
+  { id: "gpt-5.3-codex-spark", label: "GPT-5.3 Spark", hint: "Codex, fast. ChatGPT sign-in only." },
 ] as const;
 
 // Unlike the other picker lists, GOOGLE_MODELS is ALSO the seed for

--- a/src/lib/subscription-surface.ts
+++ b/src/lib/subscription-surface.ts
@@ -2,12 +2,12 @@ import { promises as fsp } from "fs";
 import path from "path";
 import { DATA_DIR } from "@/lib/config-store";
 import {
+  CODEX_MODELS,
   getProviderCatalog,
   subscriptionSurfaceLabel,
   subscriptionSurfaceProvider,
 } from "@/lib/provider-models";
 import {
-  CHATGPT_UI_PROVIDER,
   isOauthProfile,
   profileProviderId,
 } from "@/lib/chatgpt-subscription";
@@ -119,7 +119,10 @@ export async function readSubscriptionSurfaceIds(
  * The file read only — the two callers below draw OPPOSITE conclusions from an
  * absent cache and each states its own, which is why the policy is not in here.
  * Read-only and spawn-free: the catalog route owns enumerating and refreshing
- * (`openclaw models list` takes ~3 minutes on a Jetson).
+ * (`openclaw models list` takes ~3 minutes on a Jetson) — and, for a provider
+ * that core cannot enumerate, DELETING: `discardUnwritableDiskCache` drops
+ * `codex.json`, so this answers null for it and `readKnownModelIds` falls back
+ * to the curated list alone rather than adding an older build's ids back.
  */
 async function readCachedCatalogueIds(provider: string): Promise<string[] | null> {
   try {
@@ -159,43 +162,74 @@ export async function readKnownModelIds(provider: string): Promise<Set<string> |
 }
 
 /**
- * Models selectable while the device is on ChatGPT/Codex subscription auth.
+ * Is this model id selectable while the device is on ChatGPT/Codex
+ * subscription auth?
  *
- * GPT-5.6 Sol/Terra/Luna are subscription-eligible — OpenClaw's ChatGPT route
- * catalog carries all three, and `openai/gpt-5.6-sol` is the documented
- * default for a fresh Codex OAuth setup. Keeping them out of this allowlist
- * rejected them locally with "not supported with ChatGPT subscription auth"
- * before the request ever reached OpenAI. GPT-5.6 is a limited preview, so
- * per-account access still varies: let the pick through and surface the
- * upstream access error instead of pre-rejecting it here. `-pro` tiers stay
- * out — those remain API-key only.
+ * THE CHATGPT CATALOGUE IS THE ANSWER — `CODEX_MODELS`, and nothing beside it.
+ * This used to be a second spelling of that list as a GENERATION regex
+ * (`/^(?:gpt-5\.6-(?:sol|terra|luna)|gpt-5\.5|gpt-5\.4(?:-mini)?)$/`), and it
+ * failed the way generation allowlists always fail here: the `openai` provider
+ * carried the identical pattern until it hid the whole gpt-5.6 family and was
+ * removed with "a generation allowlist cannot know what the next generation is
+ * called"; the codex copy survived and hid `gpt-5.3-codex-spark`, a model the
+ * installed core routes on THIS surface and on no other. One list cannot
+ * disagree with itself, and a row added to the catalogue now reaches the
+ * picker, both write guards and the refusal sentence together.
+ *
+ * WHAT UPSTREAM SAYS, and why this is still a mirror. The core's own
+ * `extensions/openai/model-route-contract` holds the truth as
+ * `OPENAI_CHATGPT_MODERN_MODEL_IDS` — its dual-route ids plus the
+ * subscription-only ones — and 2026.8.1 exposes it through no CLI and no RPC:
+ * measured on the box, `openclaw models list --provider codex` and
+ * `--provider openai-chatgpt` both answer `Unknown provider filter`, and the
+ * `openai` enumeration carries no plan- or auth-scoped field to filter on
+ * (`available` there answers the PLATFORM route — it reads `false` for
+ * `gpt-5.3-codex-spark`, which runs fine on the ChatGPT one). So ClawBox
+ * mirrors that contract, in ONE place, pinned by
+ * `src/tests/unit/codex-supported-models.test.ts`.
+ *
+ * The mirror is deliberately NARROWER than the core's set in one respect: the
+ * `-pro` tiers are dual-route upstream but answer "model not supported when
+ * using Codex with a ChatGPT account" on the subscription path
+ * (developers.openai.com/codex/models), so they stay out of the catalogue and
+ * therefore out of this rule. Plan gating is the opposite case and is NOT
+ * filtered here — gpt-5.6 access varies per account, so the pick goes through
+ * and the upstream access error is what the customer sees.
  *
  * It lives here, beside the Claude rule, for the same reason that one does:
  * both write paths to `agents.defaults.model.primary` have to apply it, and a
  * second copy in the second route is a copy that can drift.
- * `scripts/gateway-pre-start.sh` keeps a hand-maintained mirror of this list
- * in `_CODEX_SUPPORTED`, pinned by
+ * `scripts/gateway-pre-start.sh` keeps a hand-maintained mirror of the
+ * catalogue in `_CODEX_SUPPORTED`, pinned by
  * `src/tests/unit/gateway-pre-start-codex-models.test.ts`. That mirror is
  * OpenClaw 1 ONLY — its single consumer, `_openai_gpt_to_codex`, rewrites
  * `openai/<id>` into the retired namespace and is skipped on
  * `CLAWBOX_OPENCLAW_V2`. It stays because a box mid-update still runs the v1
  * branch; nothing on the pinned core reads it.
  */
-export const CODEX_SUPPORTED_MODEL_RE = /^(?:gpt-5\.6-(?:sol|terra|luna)|gpt-5\.5|gpt-5\.4(?:-mini)?)$/;
+export function isCodexSupportedModelId(modelId: string): boolean {
+  // `CODEX_MODELS` directly, not `getProviderCatalog(CHATGPT_UI_PROVIDER)`: that
+  // lookup takes a plain string, answers `null` for a key nobody renamed it for
+  // — `openai-codex` already became `codex` once — and this guard would then
+  // refuse EVERY model with "use a model the ChatGPT subscription supports",
+  // naming none. A guard that fails CLOSED on an unreadable list is the one
+  // shape the rest of this file spends three docblocks forbidding, and the
+  // indirection bought nothing: `PROVIDER_CATALOGS.codex.models` IS this array.
+  // No `trim()` — the anchored regex this replaces did not trim either, and the
+  // caller writes the id it passed in, not the one this judged.
+  return CODEX_MODELS.some((model) => model.id === modelId);
+}
 
 /**
  * The models this box can name when it refuses one, as a sentence fragment.
  *
- * Built from the ChatGPT catalogue filtered by the allowlist above rather than
- * hand-written, because the same list was spelled in three places and had
- * already drifted: the chat route's keyless refusal omitted the GPT-5.6
- * generation the allowlist accepts. A model added to the catalogue and to the
- * regex now reaches every refusal by itself.
+ * Built from the ChatGPT catalogue rather than hand-written, because the same
+ * list was spelled in three places and had already drifted: the chat route's
+ * keyless refusal omitted the GPT-5.6 generation the allowlist accepts. A
+ * model added to the catalogue now reaches every refusal by itself.
  */
 export function chatgptSupportedModelsSentence(): string {
-  const labels = (getProviderCatalog(CHATGPT_UI_PROVIDER)?.models ?? [])
-    .filter((model) => CODEX_SUPPORTED_MODEL_RE.test(model.id))
-    .map((model) => model.label);
+  const labels = CODEX_MODELS.map((model) => model.label);
   // Never an empty fragment: the callers embed this mid-sentence, and "Use ,
   // or switch OpenAI to API-key mode" is worse than naming the surface
   // generically. Unreachable while the catalogue is the static CODEX_MODELS,
@@ -229,7 +263,7 @@ export function offSurfaceCodexModelMessage(
   chatgptSubscription: boolean,
 ): string | null {
   if (!chatgptSubscription) return null;
-  if (CODEX_SUPPORTED_MODEL_RE.test(modelId)) return null;
+  if (isCodexSupportedModelId(modelId)) return null;
   return `${modelId} is not supported with ChatGPT subscription auth. `
     + `Use ${chatgptSupportedModelsSentence()}, `
     + "or switch OpenAI to API-key mode for Pro/API-only models.";

--- a/src/tests/helpers/core-model-manifests.ts
+++ b/src/tests/helpers/core-model-manifests.ts
@@ -14,7 +14,7 @@ import { saveEnv } from "@/tests/helpers/env";
  * candidate and the other only neutralised it. One helper, so that where the
  * core keeps a manifest is written down once.
  *
- * `manifestPaths` reads `CLAWBOX_OPENCLAW_HOME` first, then `OPENCLAW_HOME`,
+ * `coreManifestPaths` reads `CLAWBOX_OPENCLAW_HOME` first, then `OPENCLAW_HOME`,
  * then `$HOME/.openclaw`, so all three are aimed at the fixture — pointing only
  * one leaves the lookup wherever the surrounding environment aimed it, and
  * `vitest.config.ts` deliberately aims them at empty directories.

--- a/src/tests/routes/ai-models/catalog-codex-unwritable-cache.test.ts
+++ b/src/tests/routes/ai-models/catalog-codex-unwritable-cache.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+import * as childProcess from "child_process";
+import fs from "fs";
+import path from "path";
+import { NextRequest } from "next/server";
+
+// TASK-786 — `data/catalog-cache/codex.json`, a file no code path can write.
+//
+// Measured on the OpenClaw box (2026-09-09, core 2026.8.1): every other cache
+// file was stamped that morning; `codex.json` was seven days old, holding the
+// six curated rows of a build that predates `hasNoEnumerationOnThisCore`.
+// `refreshInBackground` now returns at that branch BEFORE `writeDiskCache`, so
+// nothing can ever restamp it — but `GET` still preferred it, and
+// `sanitizeCachedPayload` rebuilds the payload from the DISK rows rather than
+// from the curated catalogue. The picker was therefore serving a 2026-09-02
+// snapshot of a list this repo believes it owns.
+//
+// The customer-visible half: a model added to `CODEX_MODELS` never reaches a
+// box that carries this file. The contents happened to match on the day it was
+// found, which is exactly why it would have silently swallowed the fix.
+//
+// Its own file because it needs a module whose `memCache` is empty for `codex`
+// — the disk cache is only consulted when nothing is in memory.
+//
+// THREE of these four are red on unmodified beta: the served list, the file
+// left behind, and the missing gpt-5.3-codex-spark row. The `source` case is a
+// forward guard — the seeded fixture carries no `source` and the sanitiser
+// copies it through, so it holds before the fix too — and is here so a later
+// change cannot start stamping the curated list as a device's answer.
+
+vi.mock("child_process", () => ({ spawn: vi.fn() }));
+
+vi.mock("@/lib/openclaw-config", () => ({
+  findOpenclawBin: () => "openclaw",
+  openclawIsAbsent: () => false,
+}));
+
+const DATA_DIR = "/tmp/clawbox-catalog-codex-unwritable-test";
+vi.mock("@/lib/config-store", () => ({ DATA_DIR: "/tmp/clawbox-catalog-codex-unwritable-test" }));
+
+import { GET } from "@/app/setup-api/ai-models/catalog/route";
+import { CODEX_MODELS } from "@/lib/provider-models";
+
+const mockSpawn = vi.mocked(childProcess.spawn);
+
+function fakeChild(json: unknown) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: () => void;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = () => {};
+  queueMicrotask(() => {
+    child.stdout.emit("data", Buffer.from(JSON.stringify(json), "utf8"));
+    child.emit("close", 0);
+  });
+  return child;
+}
+
+const CACHE_DIR = path.join(DATA_DIR, "catalog-cache");
+const CODEX_CACHE = path.join(CACHE_DIR, "codex.json");
+
+/**
+ * The file as it sat on the box: the curated list of an older build, minus one
+ * row, under the real `fetchedAt` (2026-09-02T19:37:36Z). A row the current
+ * curated list does not carry is what makes the difference visible — with an
+ * identical copy the defect is invisible, which is how it survived.
+ */
+function seedStaleCodexCache(): void {
+  fs.mkdirSync(CACHE_DIR, { recursive: true });
+  fs.writeFileSync(
+    CODEX_CACHE,
+    JSON.stringify({
+      provider: "codex",
+      models: [
+        { id: "gpt-5.6-sol", label: "GPT-5.6 Sol", contextWindow: 0 },
+        { id: "gpt-5.6-terra", label: "GPT-5.6 Terra", contextWindow: 0 },
+        { id: "gpt-5.5", label: "GPT-5.5", contextWindow: 0 },
+        { id: "gpt-5.4", label: "GPT-5.4", contextWindow: 0 },
+        { id: "gpt-5.4-mini", label: "GPT-5.4 Mini", contextWindow: 0 },
+      ],
+      defaultModelId: "gpt-5.5",
+      allowCustom: true,
+      fetchedAt: 1_788_377_856_920,
+    }),
+    "utf8",
+  );
+}
+
+beforeEach(() => {
+  // The boot warmup would otherwise reach openrouter.ai for real.
+  vi.stubGlobal("fetch", vi.fn(async () => {
+    throw new Error("no network in this suite");
+  }));
+  vi.clearAllMocks();
+  fs.rmSync(CACHE_DIR, { recursive: true, force: true });
+  mockSpawn.mockImplementation(
+    () => fakeChild({ count: 0, models: [] }) as unknown as ReturnType<typeof childProcess.spawn>,
+  );
+});
+
+describe("catalog — codex is never served from a cache the code cannot write", () => {
+  it("serves the curated ChatGPT catalogue, not the stale file", async () => {
+    seedStaleCodexCache();
+
+    const res = await GET(new NextRequest("http://clawbox.local/setup-api/ai-models/catalog?provider=codex"));
+    const body = (await res.json()) as { models: Array<{ id: string }> };
+
+    expect(body.models.map((m) => m.id)).toEqual(CODEX_MODELS.map((m) => m.id));
+  });
+
+  it("removes the leftover file so nothing can serve it again", async () => {
+    seedStaleCodexCache();
+
+    await GET(new NextRequest("http://clawbox.local/setup-api/ai-models/catalog?provider=codex"));
+
+    expect(fs.existsSync(CODEX_CACHE)).toBe(false);
+  });
+
+  it("offers gpt-5.3-codex-spark, which the core routes on this surface", async () => {
+    // Measured on the box, 2026-09-09, core 2026.8.1:
+    //   openclaw infer model run --local --model openai/gpt-5.3-codex-spark
+    //   -> api=openclaw-openai-chatgpt-responses-transport
+    //      url=https://chatgpt.com/backend-api/codex/responses  status=200
+    // The core's own route contract files it under
+    // OPENAI_SUBSCRIPTION_ONLY_ROUTE_MODEL_IDS — it runs on the ChatGPT
+    // account and NOWHERE else — and the openai (platform) enumeration
+    // reports it `available: false` for exactly that reason. The generation
+    // regex this surface used as its allowlist could not spell it, so the one
+    // surface that can run it was the one surface that hid it.
+    const res = await GET(new NextRequest("http://clawbox.local/setup-api/ai-models/catalog?provider=codex"));
+    const body = (await res.json()) as { models: Array<{ id: string }> };
+
+    expect(body.models.map((m) => m.id)).toContain("gpt-5.3-codex-spark");
+  });
+
+  it("does not claim the curated list is the box's own answer", async () => {
+    seedStaleCodexCache();
+
+    const res = await GET(new NextRequest("http://clawbox.local/setup-api/ai-models/catalog?provider=codex"));
+    const body = (await res.json()) as Record<string, unknown>;
+
+    // `source` is the stamp that means "a device enumerated this". The curated
+    // list is not that, on this path or any other.
+    expect(body.source).toBeUndefined();
+  });
+});

--- a/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
+++ b/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
@@ -39,6 +39,7 @@ const DATA_DIR = "/tmp/clawbox-catalog-live-fallback-test";
 vi.mock("@/lib/config-store", () => ({ DATA_DIR: "/tmp/clawbox-catalog-live-fallback-test" }));
 
 import { GET, refreshInBackground } from "@/app/setup-api/ai-models/catalog/route";
+import { CODEX_MODELS } from "@/lib/provider-models";
 
 const mockSpawn = vi.mocked(childProcess.spawn);
 
@@ -305,14 +306,13 @@ describe("catalog — the ChatGPT surface has no enumeration on this core", () =
     // Curated newest-first, and it stays that way: sorting by context window
     // put GPT-5.4 at the top, because only the Anthropic ids carry a real
     // window in the cold-start table.
-    expect((body.models as Array<{ id: string }>).map((m) => m.id)).toEqual([
-      "gpt-5.6-sol",
-      "gpt-5.6-terra",
-      "gpt-5.6-luna",
-      "gpt-5.5",
-      "gpt-5.4",
-      "gpt-5.4-mini",
-    ]);
+    //
+    // Read from CODEX_MODELS rather than copied out of it. A copy here is a
+    // fourth spelling of the ChatGPT list, and this route's whole defect was
+    // that the list had more than one — a row added to the catalogue would
+    // fail this test instead of proving it reaches the picker.
+    expect((body.models as Array<{ id: string }>).map((m) => m.id))
+      .toEqual(CODEX_MODELS.map((m) => m.id));
     expect(body.defaultModelId).toBe("gpt-5.5");
   });
 

--- a/src/tests/unit/codex-supported-models.test.ts
+++ b/src/tests/unit/codex-supported-models.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { CODEX_MODELS } from "@/lib/provider-models";
+import { offSurfaceCodexModelMessage } from "@/lib/subscription-surface";
+
+// TASK-786 — the ChatGPT-account (OpenAI Codex) surface is ONE list.
+//
+// It used to be three: `CODEX_MODELS` (what the picker offers),
+// `CODEX_SUPPORTED_MODEL_RE` (what the write paths accept) and
+// `_CODEX_SUPPORTED` in scripts/gateway-pre-start.sh. The middle one was a
+// GENERATION regex — `/^(?:gpt-5\.6-(?:sol|terra|luna)|gpt-5\.5|…)$/` — and a
+// generation allowlist cannot know what the next generation is called. The
+// same allowlist was removed from the `openai` provider for that reason after
+// it hid the whole gpt-5.6 family; the codex copy survived and hid
+// gpt-5.3-codex-spark, a model the installed core routes on this surface and
+// on no other.
+//
+// Upstream truth is the core's own `extensions/openai/model-route-contract`
+// (`OPENAI_CHATGPT_MODERN_MODEL_IDS` = the dual-route ids plus the
+// subscription-only ones). Measured on the box: it has no CLI or RPC surface —
+// `openclaw models list --provider codex` and `--provider openai-chatgpt` both
+// answer `Unknown provider filter`, and the openai enumeration carries no
+// plan- or auth-scoped field. So ClawBox mirrors it.
+//
+// WHAT THESE CASES ACTUALLY PIN, because two of them are true by construction
+// once the surface is one list and would read as more protection than they are:
+// `accepted()` reduces to a lookup in `CODEX_MODELS`, so "accepts exactly what
+// the picker offers" cannot fail while the guard is derived from the catalogue
+// — it is the CHANGE DETECTOR for that derivation, and it goes red the moment
+// somebody reintroduces a second spelling. The half that pins something today
+// is the `not.toContain` one: the ids this surface must NOT carry. The mirror
+// itself is pinned against something external in
+// `codex-surface-follows-core.test.ts` (the installed core's own manifest) and
+// against pre-start's copy in `gateway-pre-start-codex-models.test.ts`.
+
+const CURATED_IDS = CODEX_MODELS.map((m) => m.id);
+
+/** The write guard's verdict: null means "this box may be switched to it". */
+function accepted(modelId: string): boolean {
+  return offSurfaceCodexModelMessage(null, modelId, true) === null;
+}
+
+describe("the ChatGPT-account model list", () => {
+  it("carries gpt-5.3-codex-spark, which runs only on this surface", () => {
+    // Measured 2026-09-09 on core 2026.8.1:
+    //   `openclaw infer model run --local --model openai/gpt-5.3-codex-spark`
+    //   went out on api=openclaw-openai-chatgpt-responses-transport to
+    //   https://chatgpt.com/backend-api/codex/responses and answered 200,
+    // while the same box's `models list --provider openai` reports it
+    // `available: false` — the platform route excludes it.
+    expect(CURATED_IDS).toContain("gpt-5.3-codex-spark");
+  });
+
+  it("accepts exactly what the picker offers, by construction", () => {
+    // A row the picker shows that the guard refuses is a dead button; a model
+    // the guard accepts that the picker never shows is unreachable. One list
+    // makes both impossible instead of pinning them against each other — so
+    // this case is red only if the guard stops being derived from the list.
+    for (const id of CURATED_IDS) {
+      expect(accepted(id), `the picker offers ${id} but the write guard refuses it`).toBe(true);
+    }
+  });
+
+  it("refuses the models this surface must not carry", () => {
+    // The `-pro` tiers are the measured case and the reason this surface is
+    // narrower than the core's dual-route set: the core lists them, and the
+    // ChatGPT-account path answers "model not supported when using Codex with
+    // a ChatGPT account" (developers.openai.com/codex/models). `gpt-6-astra`
+    // is the newer case — the installed core does not carry it on the ChatGPT
+    // route at all, so a turn on it silently falls back to the platform
+    // endpoint and the API key (measured: 401 on a subscription-only box).
+    for (const id of ["gpt-5.4-pro", "gpt-5.5-pro", "gpt-6-astra", "gpt-4o"]) {
+      expect(CURATED_IDS, `${id} must not be offered on the ChatGPT surface`).not.toContain(id);
+      expect(accepted(id), `the write guard must refuse ${id}`).toBe(false);
+    }
+  });
+
+  it("names the models it refuses in the refusal", () => {
+    const message = offSurfaceCodexModelMessage(null, "gpt-6-astra", true);
+    expect(message).toContain("gpt-6-astra is not supported with ChatGPT subscription auth");
+    // Built from the one list, so a model added to it reaches the refusal too.
+    expect(message).toContain(CODEX_MODELS[0].label);
+  });
+});

--- a/src/tests/unit/codex-surface-follows-core.test.ts
+++ b/src/tests/unit/codex-surface-follows-core.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import fs from "fs";
+import { CODEX_MODELS } from "@/lib/provider-models";
+import { coreManifestPaths } from "@/lib/core-model-lifecycle";
+import { createManifestFixture, type ManifestFixture } from "@/tests/helpers/core-model-manifests";
+
+/**
+ * The binary the path resolver resolves from, steerable per case — the mock
+ * `curated-defaults-offerable.test.ts` uses, for the reason it documents and
+ * this file reproduced on the first run: a machine WITH a core installed has a
+ * real openai manifest at the bundled candidate, which is tried before the
+ * fixture's home, so a fixture case that does not neutralise it reads the real
+ * `gpt-5.3-codex-spark` suppression instead of what it just wrote. A bare name
+ * is what `findOpenclawBin` answers where no core is installed, and it drops
+ * the bundled candidate entirely.
+ */
+const bin = vi.hoisted(() => ({ override: null as string | null }));
+
+vi.mock("@/lib/openclaw-config", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/openclaw-config")>();
+  return { ...actual, findOpenclawBin: () => bin.override ?? actual.findOpenclawBin() };
+});
+
+/**
+ * The drift detector for the ChatGPT (OpenAI Codex) list.
+ *
+ * `CODEX_MODELS` mirrors the core's `OPENAI_CHATGPT_MODERN_MODEL_IDS`
+ * (`extensions/openai/model-route-contract` in the installed dist) because
+ * 2026.8.1 publishes that set through no CLI and no provider filter —
+ * `openclaw models list --provider codex` and `--provider openai-chatgpt` both
+ * answer `Unknown provider filter`. A hand-kept mirror is how the picker fell
+ * behind in the first place, so the mirror needs something to fail against.
+ *
+ * The core DOES publish one half of it in a machine-readable file at a stable
+ * path — the same `extensions/<provider>/openclaw.plugin.json` that
+ * `core-model-lifecycle.ts` already reads for retirements. Measured on the box
+ * (2026-09-09, core 2026.8.1):
+ *
+ *   "modelCatalog": { "suppressions": [
+ *     { "provider": "openai", "model": "gpt-5.3-codex-spark",
+ *       "when": { "baseUrlHosts": ["api.openai.com"] },
+ *       "reason": "gpt-5.3-codex-spark is available only through ChatGPT/Codex
+ *                  OAuth … OpenAI API-key auth cannot use this model." } ] }
+ *
+ * A model suppressed on the PLATFORM host is one the ChatGPT-account path is
+ * the only way to reach — exactly the row `gpt-5.3-codex-spark` was, and the
+ * kind this picker used to hide. So: every such model the installed core
+ * declares must be on the ChatGPT surface.
+ *
+ * It only catches the SUBSCRIPTION-ONLY half. The dual-route set (gpt-5.6-*,
+ * 5.5, 5.4…) is not declared anywhere the manifest exposes, and ClawBox is
+ * deliberately narrower than it anyway (`-pro` 400s on the ChatGPT path). That
+ * gap is stated rather than papered over — deriving the whole surface from the
+ * manifest is a change of its own.
+ *
+ * WHERE EACH CASE BITES, in the shape `curated-defaults-offerable.test.ts`
+ * established: the installed-core case is real on a box and on a dev machine
+ * with a core, and VACUOUS on CI, which installs none. The fixture cases below
+ * assert everywhere.
+ */
+
+const PLATFORM_HOST = "api.openai.com";
+
+interface Suppression {
+  provider?: unknown;
+  model?: unknown;
+  when?: { baseUrlHosts?: unknown } | null;
+}
+
+/**
+ * Ids the manifest suppresses for `provider` on the platform host.
+ *
+ * A suppression with no `when` is unconditional — the manifest carries one for
+ * `azure-openai-responses` — and says nothing about the ChatGPT route of the
+ * provider we are asking about, so only a `baseUrlHosts` naming the platform
+ * host counts.
+ */
+function subscriptionOnlyIds(manifest: unknown, provider: string): string[] {
+  const list = (manifest as { modelCatalog?: { suppressions?: unknown } } | null)
+    ?.modelCatalog?.suppressions;
+  if (!Array.isArray(list)) return [];
+  const out: string[] = [];
+  for (const entry of list as Suppression[]) {
+    if (entry?.provider !== provider) continue;
+    const hosts = entry?.when?.baseUrlHosts;
+    if (!Array.isArray(hosts) || !hosts.includes(PLATFORM_HOST)) continue;
+    if (typeof entry.model === "string" && entry.model.trim()) out.push(entry.model.trim());
+  }
+  return out;
+}
+
+function readFirstManifest(paths: string[]): unknown {
+  for (const file of paths) {
+    try {
+      return JSON.parse(fs.readFileSync(file, "utf-8"));
+    } catch {
+      // Absent, unreadable or not JSON: try the next candidate, exactly as the
+      // lifecycle reader does.
+    }
+  }
+  return null;
+}
+
+describe("the ChatGPT surface follows the installed core", () => {
+  it("carries every openai model the installed core says is ChatGPT-only", () => {
+    const manifest = readFirstManifest(coreManifestPaths("openai"));
+    const ids = subscriptionOnlyIds(manifest, "openai");
+    if (ids.length === 0) {
+      // No core installed (CI), or a core that declares no such suppression.
+      // Stated, not claimed away: this case proves nothing here.
+      expect(ids).toEqual([]);
+      return;
+    }
+    const curated = CODEX_MODELS.map((m) => m.id);
+    for (const id of ids) {
+      expect(curated, `the installed core routes ${id} on the ChatGPT account only, `
+        + "but CODEX_MODELS does not offer it").toContain(id);
+    }
+  });
+});
+
+describe("the drift detector itself", () => {
+  let fixture: ManifestFixture | null = null;
+
+  afterEach(() => {
+    fixture?.cleanup();
+    fixture = null;
+    bin.override = null;
+  });
+
+  it("reads a suppression out of a manifest beside the config", () => {
+    fixture = createManifestFixture("codex-surface-follows-core");
+    // The bundled candidate dropped, so the beside-config manifest is the only
+    // one there is — see the note on `bin` above.
+    bin.override = "openclaw";
+    fixture.writeManifest("openai", {
+      modelCatalog: {
+        suppressions: [
+          { provider: "openai", model: "gpt-7-nova", when: { baseUrlHosts: [PLATFORM_HOST] } },
+        ],
+      },
+    });
+    const manifest = readFirstManifest(coreManifestPaths("openai"));
+    expect(subscriptionOnlyIds(manifest, "openai")).toEqual(["gpt-7-nova"]);
+  });
+
+  it("ignores a suppression that is not about the platform host", () => {
+    const manifest = {
+      modelCatalog: {
+        suppressions: [
+          // No `when` at all: the azure row's shape, unconditional and silent
+          // about this provider's ChatGPT route.
+          { provider: "azure-openai-responses", model: "gpt-5.3-codex-spark" },
+          // A different host: not the platform route.
+          { provider: "openai", model: "gpt-7-nova", when: { baseUrlHosts: ["example.invalid"] } },
+        ],
+      },
+    };
+    expect(subscriptionOnlyIds(manifest, "openai")).toEqual([]);
+  });
+
+  it("answers nothing for a manifest with no suppressions", () => {
+    expect(subscriptionOnlyIds({ modelCatalog: { providers: {} } }, "openai")).toEqual([]);
+    expect(subscriptionOnlyIds(null, "openai")).toEqual([]);
+  });
+});

--- a/src/tests/unit/gateway-pre-start-codex-models.test.ts
+++ b/src/tests/unit/gateway-pre-start-codex-models.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { CODEX_MODELS } from "@/lib/provider-models";
-import { CODEX_SUPPORTED_MODEL_RE } from "@/lib/subscription-surface";
+import { isCodexSupportedModelId } from "@/lib/subscription-surface";
 
 // gateway-pre-start.sh rewrites `openai/<gpt>` -> `codex/<gpt>` on boxes with
 // ChatGPT (Codex OAuth) auth and no OpenAI API key. Its `_CODEX_SUPPORTED`
-// tuple is a hand-maintained MIRROR of CODEX_SUPPORTED_MODEL_RE in
-// src/lib/subscription-surface.ts — the script's own comment says so.
+// tuple is a hand-maintained MIRROR of CODEX_MODELS in
+// src/lib/provider-models.ts — the script cannot import, so it copies. It is
+// the only remaining copy: the route's own allowlist reads the catalogue
+// directly (`isCodexSupportedModelId`).
 //
 // The two drifted: the regex learned gpt-5.6-{sol,terra,luna} (PR #271) but
 // the tuple did not, so a subscription box whose stored model was
@@ -29,14 +31,9 @@ function readPreStartSupportedModels(): string[] {
 
 describe("gateway-pre-start.sh codex model migration", () => {
   const preStartModels = readPreStartSupportedModels();
-  // Imported, not scraped out of a route file: the allowlist is shared by both
-  // write paths to the primary model now, so there is a real module to pin
-  // against and no regex to go stale when the constant moves house again.
-  const routeRe = CODEX_SUPPORTED_MODEL_RE;
-
-  it("mirrors CODEX_SUPPORTED_MODEL_RE — every listed id is route-supported", () => {
+  it("mirrors the ChatGPT catalogue — every listed id is route-supported", () => {
     for (const id of preStartModels) {
-      expect(routeRe.test(id), `${id} is in _CODEX_SUPPORTED but not CODEX_SUPPORTED_MODEL_RE`).toBe(true);
+      expect(isCodexSupportedModelId(id), `${id} is in _CODEX_SUPPORTED but not in CODEX_MODELS`).toBe(true);
     }
   });
 
@@ -46,7 +43,7 @@ describe("gateway-pre-start.sh codex model migration", () => {
     // stuck on a keyless `openai/*` route.
     for (const model of CODEX_MODELS) {
       expect(preStartModels, `picker offers ${model.id} but pre-start won't migrate it`).toContain(model.id);
-      expect(routeRe.test(model.id), `picker offers ${model.id} but the route rejects it`).toBe(true);
+      expect(isCodexSupportedModelId(model.id), `picker offers ${model.id} but the route rejects it`).toBe(true);
     }
   });
 
@@ -61,7 +58,7 @@ describe("gateway-pre-start.sh codex model migration", () => {
     // codex/* would swap a working keyed route for a broken one.
     for (const id of ["gpt-5.4-pro", "gpt-5.5-pro", "gpt-4o"]) {
       expect(preStartModels).not.toContain(id);
-      expect(routeRe.test(id)).toBe(false);
+      expect(isCodexSupportedModelId(id)).toBe(false);
     }
   });
 });


### PR DESCRIPTION
TASK-786 — the OpenAI Codex (ChatGPT-subscription) model picker could not change.

## Customer-visible symptom

The owner asked why the newest OpenAI model does not show on the box. It showed
on the **OpenAI** picker and on the **OpenRouter** picker (four rows), and not
on the **OpenAI Codex** one — the surface that box actually uses. Chasing it
found two defects that together mean *no* change to that list ever reaches a
box: one hides models, the other freezes whatever the picker was last given.

## What the harness actually says (measured, not assumed)

The native mechanism is the core's own route contract,
`OPENAI_CHATGPT_MODERN_MODEL_IDS` in `extensions/openai/model-route-contract`
(dual-route ids + subscription-only ids). It decides which OpenAI models go out
on the ChatGPT-account transport. Measured on the OpenClaw dev box, core
2026.8.1, through the core's own one-shot surface
(`openclaw infer model run --local --model openai/<id>`):

| model | transport the core chose | result |
|---|---|---|
| `gpt-5.6-sol` | `openclaw-openai-chatgpt-responses-transport` → `chatgpt.com/backend-api/codex/responses` | **200** |
| `gpt-5.3-codex-spark` | same ChatGPT transport | **200** |
| `gpt-6-astra` | `openai-responses` → `api.openai.com/v1/responses` | not on the ChatGPT route at all |

**So `gpt-6-astra` is deliberately NOT added here.** The pinned core does not
carry it on the ChatGPT route, so the core silently sends it to the platform
endpoint on whatever API key exists. Offering it on the "OpenAI Codex" row
would be a dead button on a subscription-only box and a silently mis-billed
turn on a keyed one. It belongs to the `openai` surface, where it already
appears. `gpt-5.3-codex-spark` is the row that was genuinely missing: the core
files it under `OPENAI_SUBSCRIPTION_ONLY_ROUTE_MODEL_IDS`, and the box's own
`models list --provider openai` reports it `available: false` because the
platform route excludes it — this is the only surface that can offer it.

**What the harness does and does not publish.** The dual-route half of that
contract has no CLI and no provider-filter surface on 2026.8.1: `openclaw
models list --provider codex` and `--provider openai-chatgpt` both answer
`Unknown provider filter`, and the `openai` enumeration rows carry no plan- or
auth-scoped field to filter on (`available` there answers the *platform* route —
it reads `false` for `gpt-5.3-codex-spark`, which runs fine on the ChatGPT one).
The **subscription-only** half IS published, machine-readably, at a stable path
this repo already reads for retirements
(`extensions/openai/openclaw.plugin.json`, resolved by
`core-model-lifecycle.ts`):

```json
"modelCatalog": { "suppressions": [
  { "provider": "openai", "model": "gpt-5.3-codex-spark",
    "when": { "baseUrlHosts": ["api.openai.com"] },
    "reason": "gpt-5.3-codex-spark is available only through ChatGPT/Codex OAuth …
               OpenAI API-key auth cannot use this model." } ] }
```

So this PR keeps a mirror — **one**, where there were three — and gives it
something external to fail against: `codex-surface-follows-core.test.ts` reads
that manifest and goes red when a core bump declares a ChatGPT-only model the
curated list does not carry. Deriving the *whole* surface from the manifest is
not possible today (the dual-route set is not declared there, and ClawBox is
deliberately narrower than it anyway) and is left as a follow-up rather than
claimed.

## Cause

**1. A generation allowlist.** `CODEX_SUPPORTED_MODEL_RE` was the sole picker
allowlist for the codex surface (`ALLOWED_MODEL_RE_BY_PROVIDER`, enforced in
`isOfferableModelId`) and a second spelling of the curated `CODEX_MODELS`
table. The identical pattern had already been removed from the `openai`
provider — *"a generation allowlist cannot know what the next generation is
called"* — and the codex copy survived and hid `gpt-5.3-codex-spark`.

**2. A disk cache the code can no longer write.** `refreshInBackground` returns
at the `hasNoEnumerationOnThisCore` branch *before* `writeDiskCache`, so
`data/catalog-cache/codex.json` can never be restamped — yet `GET` still
preferred it, and `sanitizeCachedPayload` rebuilds the payload from the **disk**
rows, not from the curated table. On the box that file was stamped
2026-09-02T19:37:36Z while every other cache file was three hours old. Its
contents happened to match the curated rows, which is why nobody saw it — and
why a model added to `CODEX_MODELS` would have shipped and reached no box
carrying the file.

## The change

- `isCodexSupportedModelId` replaces `CODEX_SUPPORTED_MODEL_RE`: the curated
  ChatGPT catalogue **is** the allowlist. Picker, both write guards
  (`offSurfaceCodexModelMessage`, the chat/model pick route) and the refusal
  sentence now read one list.
- `CODEX_MODELS` gains `gpt-5.3-codex-spark` (measured above). The `-pro` tiers
  stay out — they are dual-route upstream but 400 on the ChatGPT-account path —
  and plan gating stays unapplied, so gpt-5.6 access errors still come from
  upstream rather than a local pre-rejection.
- `discardUnwritableDiskCache` drops `<provider>.json` (and the memory copy) for
  a provider with no enumeration on this core, before the caches are read.
  Asked on every request rather than remembered per process: "checked once and
  treated as fact" is a bug class this file already carries scars from.
- Mirrors swept: `scripts/gateway-pre-start.sh` `_CODEX_SUPPORTED` (v1-only,
  cannot import) gains the id and its pinning test now asserts against the
  catalogue instead of the regex. `catalog-live-vs-fallback.test.ts` stopped
  keeping a fourth hand-written copy of the ids and reads `CODEX_MODELS`.
  **Not measured:** that tuple's only consumer rewrites `openai/<id>` into the
  retired `codex/` namespace and is skipped on `CLAWBOX_OPENCLAW_V2`, so it can
  only run on a box mid-update (new app, old core); no v1 core was available to
  check that its codex plugin carries the id. The row is there because the
  mirror test requires every offerable id to be migratable — the alternative
  leaves a keyless `openai/*` route that 401s, which is the bug that test exists
  for.

## RED → GREEN

RED, on unmodified `beta`:

```
 FAIL  src/tests/unit/codex-supported-models.test.ts > carries gpt-5.3-codex-spark, which runs only on this surface
AssertionError: expected [ Array(6) ] to include 'gpt-5.3-codex-spark'

 FAIL  src/tests/routes/ai-models/catalog-codex-unwritable-cache.test.ts > serves the curated ChatGPT catalogue, not the stale file
AssertionError: expected [ Array(5) ] to deeply equal [ Array(6) ]
  [ "gpt-5.6-sol", "gpt-5.6-terra", -"gpt-5.6-luna", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini" ]

 FAIL  src/tests/routes/ai-models/catalog-codex-unwritable-cache.test.ts > removes the leftover file so nothing can serve it again
AssertionError: expected true to be false

 FAIL  src/tests/routes/ai-models/catalog-codex-unwritable-cache.test.ts > offers gpt-5.3-codex-spark, which the core routes on this surface
AssertionError: expected [ Array(5) ] to include 'gpt-5.3-codex-spark'

 Test Files  2 failed (2)
      Tests  4 failed | 4 passed (8)
```

Note the second failure: the route served the **five** seeded rows of the stale
file, not the six the curated table carries — the frozen-picker defect, exactly
as found on the box.

GREEN, on this head, neighbouring suites included (`src/tests/routes/ai-models`,
`chat-model`, both subscription-surface unit files, the pre-start mirror, the
model-lifecycle and curated-defaults suites the manifest reader touches, the
chat-header ChatGPT row, and the three new files):

```
 Test Files  33 passed (33)
      Tests  578 passed (578)
```

Full suite: `1002 passed (1003) | 15091 tests passed`, plus one unrelated
`chat-email-refs-surfaces.test.tsx` 5 s timeout under a loaded four-worker run.
It passes on its own (`10 passed`), references none of the touched files, and
failed identically on the run *before* these changes — a load-dependent flake,
not this PR's.
`tsc --noEmit` clean, `eslint` clean on every changed file, `bash -n
scripts/gateway-pre-start.sh` clean.

## Review

`clawbox-review` (one review agent): **0 blockers, 4 Medium, 8 Low** — all
addressed in this head.

- **M-01 (false success)** — the `unlink` was logged on failure and the same
  file read and served anyway, so on a box where `catalog-cache/` is not
  writable by the server's uid the release silently would not apply. The
  curated answer is now returned **before** either cache is consulted; the
  delete is tidying, and its failure cannot change the outcome.
- **M-02 (harness survey incomplete)** — the survey covered the CLI and the
  provider filter but not the installed core's shipped manifest. It does carry
  the subscription-only half; see above. Drift detector added.
- **M-03 (fails closed)** — the guard resolved the list through
  `getProviderCatalog(CHATGPT_UI_PROVIDER)`, a plain-string lookup that answers
  `null` for a renamed key (`openai-codex` → `codex` already happened once) and
  would then refuse *every* ChatGPT model while naming none. It reads
  `CODEX_MODELS` directly now.
- **M-04 (evidence was a transport turn, not the picker's write)** — closed on
  the box with the core's own validator, and with a negative control so a pass
  means something:

  ```
  $ openclaw config set agents.defaults.model.primary "openai/gpt-5.3-codex-spark" --strict-json --dry-run
  Dry run successful: 1 update(s) validated against ~/.openclaw/openclaw.json.

  $ openclaw config set agents.defaults.model.primary "openai/gpt-9-doesnotexist" --strict-json --dry-run
  Dry run failed: model reference validation failed.
  - Cannot set model reference "openai/gpt-9-doesnotexist" … Unknown model
  ```

  Both runs left `openclaw.json` byte-identical (md5 before/after). So the
  picker's own write is accepted — no dead button, and nothing on the box was
  mutated to find out.
- Lows applied: the stale "the live catalog only returns them for entitled
  accounts" premise (there is no live codex catalog) removed; the pill label
  shortened to `GPT-5.3 Spark` (the header's model pill drops only a leading or
  trailing token repeating the provider, and "Codex" sits in the middle, so the
  full name would be the only label that truncates); the cross-module read of
  `codex.json` documented on both sides; `trim()` dropped from the guard so it
  cannot accept an id the caller then writes unnormalised; and the two test
  cases that assert `CODEX_MODELS` against itself renamed and annotated as
  change detectors rather than presented as protection they are not.

## Device proof owed after merge

On the box: the OpenAI Codex picker should list **GPT-5.3 Spark** alongside the
existing six, `data/catalog-cache/codex.json` should be gone, and the control
model (GPT-5.6 Sol) should still run. Astra stays where it already works — the
OpenAI and OpenRouter pickers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GPT-5.3 Spark to ChatGPT/Codex model selection, displayed as “GPT-5.3 Spark.”
  * ChatGPT model availability now consistently reflects the supported subscription model list.

* **Bug Fixes**
  * Improved Codex catalog behavior when cached data is stale, unwritable, or unavailable by showing the curated supported model list.
  * Prevented unsupported or outdated Codex models from appearing as available options.
  * Updated model validation and routing to consistently recognize supported ChatGPT/Codex models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
