### PR TITLE
fix(coding): show the planner every fault, and ask more than once

### DIFF
--- a/src/lib/coding-team-planner.ts
+++ b/src/lib/coding-team-planner.ts
@@ -73,16 +73,30 @@ export function parsePlan(text: string | null | undefined): PlanParse | PlanFail
   if (!Array.isArray(raw)) return { ok: false, reason: "The planner's answer is not a JSON array." };
   if (raw.length === 0) return { ok: false, reason: "The planner produced no tasks." };
   if (raw.length > MAX_TEAM_TASKS) return { ok: false, reason: `The planner produced ${raw.length} tasks; a team holds at most ${MAX_TEAM_TASKS}.` };
+  // Every task is read before answering, and every fault this plan has is
+  // named at once. Returning on the first one taught the planner about t1
+  // alone: it would shorten t1, re-answer, and be told about t2 — spending a
+  // whole planner run per fault against a budget of a few. A plan is still
+  // never repaired here; the planner is simply shown the whole list to fix.
   const tasks: PlannedTask[] = [];
+  const problems: string[] = [];
   for (let i = 0; i < raw.length; i++) {
     const item = raw[i] as Record<string, unknown>;
     const id = `t${i + 1}`;
-    if (!item || typeof item !== "object") return { ok: false, reason: `Task ${id} is not an object.` };
+    if (!item || typeof item !== "object") {
+      problems.push(`Task ${id} is not an object.`);
+      continue;
+    }
     const description = typeof item.task_description === "string" ? item.task_description.trim() : "";
-    if (!description) return { ok: false, reason: `Task ${id} has no task_description.` };
-    if (description.length > MAX_TASK_DESCRIPTION_CHARS) return { ok: false, reason: `Task ${id}'s task_description has ${description.length} characters; the maximum is ${MAX_TASK_DESCRIPTION_CHARS}. Shorten this field without dropping its verification requirements.` };
+    if (!description) problems.push(`Task ${id} has no task_description.`);
+    // The overage is spelled out: "shorten this" left the planner guessing how
+    // much, and a planner asked only to shorten has answered longer than before.
+    else if (description.length > MAX_TASK_DESCRIPTION_CHARS) problems.push(`Task ${id}'s task_description has ${description.length} characters; the maximum is ${MAX_TASK_DESCRIPTION_CHARS}, so it must lose at least ${description.length - MAX_TASK_DESCRIPTION_CHARS} characters. Shorten this field without dropping its verification requirements.`);
     const depends = item.depends_on === undefined ? [] : item.depends_on;
-    if (!Array.isArray(depends) || !depends.every((d) => typeof d === "string")) return { ok: false, reason: `Task ${id}'s depends_on is not a list of task ids.` };
+    if (!Array.isArray(depends) || !depends.every((d) => typeof d === "string")) {
+      problems.push(`Task ${id}'s depends_on is not a list of task ids.`);
+      continue;
+    }
     const depends_on = [...new Set(depends as string[])];
     for (const d of depends_on) {
       // Canonical ids only — t1, not t01: the board numbers tasks t1…t999 and
@@ -92,15 +106,29 @@ export function parsePlan(text: string | null | undefined): PlanParse | PlanFail
       // what it waits for is done, whatever the order — as long as the
       // dependencies form no cycle (checked once every task is read).
       const n = /^t([1-9][0-9]{0,2})$/.exec(d);
-      if (!n || Number(n[1]) > raw.length || Number(n[1]) === i + 1) return { ok: false, reason: `Task ${id} depends on ${d}, which is not another task in the plan.` };
+      if (!n || Number(n[1]) > raw.length || Number(n[1]) === i + 1) problems.push(`Task ${id} depends on ${d}, which is not another task in the plan.`);
     }
     const hint = item.files_hint === undefined ? [] : item.files_hint;
-    if (!Array.isArray(hint) || !hint.every((f) => typeof f === "string")) return { ok: false, reason: `Task ${id}'s files_hint is not a list of paths.` };
-    tasks.push({ task_description: description, depends_on, files_hint: (hint as string[]).map((f) => f.trim()).filter(Boolean).slice(0, 40) });
+    if (!Array.isArray(hint) || !hint.every((f) => typeof f === "string")) {
+      problems.push(`Task ${id}'s files_hint is not a list of paths.`);
+      continue;
+    }
+    if (description && description.length <= MAX_TASK_DESCRIPTION_CHARS) tasks.push({ task_description: description, depends_on, files_hint: (hint as string[]).map((f) => f.trim()).filter(Boolean).slice(0, 40) });
   }
+  if (problems.length) return { ok: false, reason: joinProblems(problems) };
   const cycle = dependencyCycle(tasks.map((t) => t.depends_on));
   if (cycle) return { ok: false, reason: `Tasks ${cycle.join(" and ")} depend on each other.` };
   return { ok: true, tasks };
+}
+
+/** How many faults are named before the rest are only counted. */
+const MAX_REPORTED_PROBLEMS = 6;
+
+/** Every fault in one sentence the planner can act on, without an unbounded wall of text. */
+function joinProblems(problems: string[]): string {
+  if (problems.length <= MAX_REPORTED_PROBLEMS) return problems.join(" ");
+  const rest = problems.length - MAX_REPORTED_PROBLEMS;
+  return `${problems.slice(0, MAX_REPORTED_PROBLEMS).join(" ")} …and ${rest} further ${rest === 1 ? "fault" : "faults"} in the same plan.`;
 }
 
 /** The first cycle among the tasks' dependencies as their ids, or null: a cycle would wait forever. */

--- a/src/lib/coding-team-planner.ts
+++ b/src/lib/coding-team-planner.ts
@@ -92,12 +92,13 @@ export function parsePlan(text: string | null | undefined): PlanParse | PlanFail
     // The overage is spelled out: "shorten this" left the planner guessing how
     // much, and a planner asked only to shorten has answered longer than before.
     else if (description.length > MAX_TASK_DESCRIPTION_CHARS) problems.push(`Task ${id}'s task_description has ${description.length} characters; the maximum is ${MAX_TASK_DESCRIPTION_CHARS}, so it must lose at least ${description.length - MAX_TASK_DESCRIPTION_CHARS} characters. Shorten this field without dropping its verification requirements.`);
+    // No early exit on a bad field either: a task whose depends_on AND
+    // files_hint are both malformed must report both, for the same reason the
+    // plan reports every task — one fault per planner run is the bug.
     const depends = item.depends_on === undefined ? [] : item.depends_on;
-    if (!Array.isArray(depends) || !depends.every((d) => typeof d === "string")) {
-      problems.push(`Task ${id}'s depends_on is not a list of task ids.`);
-      continue;
-    }
-    const depends_on = [...new Set(depends as string[])];
+    const validDepends = Array.isArray(depends) && depends.every((d) => typeof d === "string");
+    if (!validDepends) problems.push(`Task ${id}'s depends_on is not a list of task ids.`);
+    const depends_on = validDepends ? [...new Set(depends as string[])] : [];
     for (const d of depends_on) {
       // Canonical ids only — t1, not t01: the board numbers tasks t1…t999 and
       // knows no other spelling, so a plan that said `t01` would post and
@@ -109,11 +110,11 @@ export function parsePlan(text: string | null | undefined): PlanParse | PlanFail
       if (!n || Number(n[1]) > raw.length || Number(n[1]) === i + 1) problems.push(`Task ${id} depends on ${d}, which is not another task in the plan.`);
     }
     const hint = item.files_hint === undefined ? [] : item.files_hint;
-    if (!Array.isArray(hint) || !hint.every((f) => typeof f === "string")) {
-      problems.push(`Task ${id}'s files_hint is not a list of paths.`);
-      continue;
-    }
-    if (description && description.length <= MAX_TASK_DESCRIPTION_CHARS) tasks.push({ task_description: description, depends_on, files_hint: (hint as string[]).map((f) => f.trim()).filter(Boolean).slice(0, 40) });
+    const validHint = Array.isArray(hint) && hint.every((f) => typeof f === "string");
+    if (!validHint) problems.push(`Task ${id}'s files_hint is not a list of paths.`);
+    // Only a task whose every field checked out is built; the plan is refused
+    // whole anyway once anything went into `problems`.
+    if (description && description.length <= MAX_TASK_DESCRIPTION_CHARS && validDepends && validHint) tasks.push({ task_description: description, depends_on, files_hint: (hint as string[]).map((f) => f.trim()).filter(Boolean).slice(0, 40) });
   }
   if (problems.length) return { ok: false, reason: joinProblems(problems) };
   const cycle = dependencyCycle(tasks.map((t) => t.depends_on));

--- a/src/lib/coding-team.ts
+++ b/src/lib/coding-team.ts
@@ -106,6 +106,9 @@ interface LiveTeam {
 
 const live = new Map<string, LiveTeam>();
 
+/** Planner runs a team will pay for before giving up on getting an array. */
+const MAX_PLANNER_ATTEMPTS = 3;
+
 const SYSTEM: Actor = { kind: "system" };
 const PLANNER: Actor = { kind: "planner" };
 const REVIEWER: Actor = { kind: "reviewer" };
@@ -227,14 +230,21 @@ async function runTeam(team: LiveTeam, source: CodingRunSource): Promise<void> {
     saveBoard(board);
     return;
   }
-  let plan = parsePlan(planned.resultText ?? planned.summary);
-  if (!plan.ok) {
+  let answer = planned.resultText ?? planned.summary;
+  let plan = parsePlan(answer);
+  // More than one correction, because one was not enough. On the box, a planner
+  // told only to "shorten" a 2835-character description answered 3013 the second
+  // time and the board died with no task ever posted — twice, on two devices.
+  // Each ask now carries every fault and how far over the limit it is; the
+  // budget is small because a planner that cannot answer an array in three
+  // tries is not going to on the fourth, and every try is a paid run.
+  for (let attempt = 2; !plan.ok && attempt <= MAX_PLANNER_ATTEMPTS; attempt++) {
     // Once more, and for the array alone: a planner that wrote its plan as
     // prose is asked to say it as the JSON the team reads. On the record as
-    // an alert, so a team that needed the second ask says so.
-    bus.send(SYSTEM, { type: "alert", reason: `The planner's answer was not a plan (${plan.reason}); asking once more for the JSON array.` });
+    // an alert, so a team that needed another ask says so.
+    bus.send(SYSTEM, { type: "alert", reason: `The planner's answer was not a plan (${plan.reason}); asking once more for the JSON array (attempt ${attempt} of ${MAX_PLANNER_ATTEMPTS}).` });
     const again = await startRun({
-      task: replanTask(board.goal, planned.resultText ?? planned.summary, plan.reason),
+      task: replanTask(board.goal, answer, plan.reason),
       projectId: board.projectId,
       directory: board.directory,
       source,
@@ -246,15 +256,21 @@ async function runTeam(team: LiveTeam, source: CodingRunSource): Promise<void> {
     saveBoard(board);
     const replanned = await settle(team, again.id);
     if (team.stopRequested) return;
-    plan = replanned?.status === "completed"
-      ? parsePlan(replanned.resultText ?? replanned.summary)
-      : { ok: false, reason: `The planner did not finish its second answer: ${replanned?.error ?? replanned?.status ?? "no run"}.` };
-    if (!plan.ok) {
-      setTeamStatus(board, SYSTEM, "failed", plan.reason);
-      saveBoard(board);
-      return;
+    if (replanned?.status !== "completed") {
+      // A planner run that did not finish is not a wording problem, so it is
+      // not re-asked: the team fails with what actually happened to it.
+      plan = { ok: false, reason: `The planner did not finish its answer: ${replanned?.error ?? replanned?.status ?? "no run"}.` };
+      break;
     }
+    answer = replanned.resultText ?? replanned.summary;
+    plan = parsePlan(answer);
   }
+  if (!plan.ok) {
+    setTeamStatus(board, SYSTEM, "failed", plan.reason);
+    saveBoard(board);
+    return;
+  }
+
   for (const task of plan.tasks) bus.send(PLANNER, { type: "task", ...task });
 
   // The team's own branch in a folder project: workers get worktrees off it

--- a/src/tests/unit/coding-team-planner.test.ts
+++ b/src/tests/unit/coding-team-planner.test.ts
@@ -5,7 +5,7 @@
  * not write — each task becomes a worker with a shell.
  */
 import { describe, expect, it } from "vitest";
-import { MAX_TEAM_TASKS } from "@/lib/coding-team-board";
+import { MAX_TASK_DESCRIPTION_CHARS, MAX_TEAM_TASKS } from "@/lib/coding-team-board";
 import { MAX_TASK_CHARS } from "@/lib/coding-agent";
 import { parsePlan, PLANNER_BRIEF, replanTask } from "@/lib/coding-team-planner";
 
@@ -99,4 +99,64 @@ it("accepts a full plan above the display-summary limit and names precise schema
   expect(parsePlan(JSON.stringify(tasks))).toMatchObject({ ok: false, reason: expect.stringMatching(/t3.*2001.*2000/) });
   expect(PLANNER_BRIEF).toContain("2000");
   expect(PLANNER_BRIEF).toContain("parallel");
+});
+
+describe("a plan whose faults must all be fixed at once", () => {
+  const over = (extra: number) => "x".repeat(MAX_TASK_DESCRIPTION_CHARS + extra);
+
+  it("names every over-long task_description in one reason, with how much each must lose", () => {
+    // Seen on two devices: the board died on t1's length alone, so the planner
+    // never learned t2 was over too and spent its one retry half-informed.
+    const out = parsePlan(JSON.stringify([
+      { task_description: over(541), files_hint: ["a.ts"] },
+      { task_description: "fine", files_hint: ["b.ts"] },
+      { task_description: over(13), files_hint: ["c.ts"] },
+    ]));
+    expect(out.ok).toBe(false);
+    if (out.ok) return;
+    expect(out.reason).toContain("Task t1");
+    expect(out.reason).toContain("Task t3");
+    expect(out.reason).toContain("must lose at least 541");
+    expect(out.reason).toContain("must lose at least 13");
+    expect(out.reason).not.toContain("Task t2");
+  });
+
+  it("names faults of different kinds together, not just the first one it meets", () => {
+    const out = parsePlan(JSON.stringify([
+      { task_description: over(1), files_hint: ["a.ts"] },
+      { task_description: "", files_hint: ["b.ts"] },
+      { task_description: "ok", depends_on: ["t9"], files_hint: ["c.ts"] },
+      { task_description: "ok", files_hint: "not-a-list" },
+    ]));
+    expect(out.ok).toBe(false);
+    if (out.ok) return;
+    expect(out.reason).toContain("must lose at least 1");
+    expect(out.reason).toContain("Task t2 has no task_description");
+    expect(out.reason).toContain("Task t3 depends on t9");
+    expect(out.reason).toContain("Task t4's files_hint is not a list");
+  });
+
+  it("counts the rest instead of printing an unbounded wall of faults", () => {
+    const out = parsePlan(JSON.stringify(Array.from({ length: 8 }, () => ({ task_description: over(7), files_hint: [] }))));
+    expect(out.ok).toBe(false);
+    if (out.ok) return;
+    expect(out.reason).toContain("Task t6");
+    expect(out.reason).not.toContain("Task t7");
+    expect(out.reason).toContain("and 2 further faults");
+  });
+
+  it("still refuses the whole plan rather than dropping the tasks that were too long", () => {
+    // The parser repairs nothing: a plan with one bad task is not silently
+    // delivered as a smaller plan, because each task becomes a worker.
+    const out = parsePlan(JSON.stringify([
+      { task_description: "fine", files_hint: [] },
+      { task_description: over(1), files_hint: [] },
+    ]));
+    expect(out.ok).toBe(false);
+  });
+
+  it("accepts a description exactly at the limit", () => {
+    const out = parsePlan(JSON.stringify([{ task_description: "y".repeat(MAX_TASK_DESCRIPTION_CHARS), files_hint: [] }]));
+    expect(out.ok).toBe(true);
+  });
 });

--- a/src/tests/unit/coding-team-planner.test.ts
+++ b/src/tests/unit/coding-team-planner.test.ts
@@ -136,6 +136,14 @@ describe("a plan whose faults must all be fixed at once", () => {
     expect(out.reason).toContain("Task t4's files_hint is not a list");
   });
 
+  it("reports both a bad depends_on and a bad files_hint on the same task", () => {
+    const out = parsePlan(JSON.stringify([{ task_description: "ok", depends_on: [7], files_hint: "nope" }]));
+    expect(out.ok).toBe(false);
+    if (out.ok) return;
+    expect(out.reason).toContain("Task t1's depends_on is not a list of task ids");
+    expect(out.reason).toContain("Task t1's files_hint is not a list of paths");
+  });
+
   it("counts the rest instead of printing an unbounded wall of faults", () => {
     const out = parsePlan(JSON.stringify(Array.from({ length: 8 }, () => ({ task_description: over(7), files_hint: [] }))));
     expect(out.ok).toBe(false);

--- a/src/tests/unit/coding-team.test.ts
+++ b/src/tests/unit/coding-team.test.ts
@@ -195,15 +195,46 @@ describe("a planner that wrote prose", () => {
     expect(done.alerts).toBe(1);
     expect(done.plannerRunId).toBe("run-00000001");
     expect(done.agents.planner).toBe(2);
-    expect(done.log.filter((e) => e.type === "alert").map((e) => e.message)[0]).toMatch(/asking once more/);
+    expect(done.log.filter((e) => e.type === "alert").map((e) => e.message)[0]).toMatch(/asking once more for the JSON array \(attempt 2 of 3\)/);
   });
 
-  it("fails the team when the second answer is no plan either, saying why", async () => {
-    outcomes = [{ summary: "prose" }, { summary: "still prose" }];
+  it("asks a third time when the second answer is no plan either", async () => {
+    // One correction was not enough on the box: a planner told to shorten a
+    // 2835-character description answered 3013 the next time, and the team
+    // died having posted no task at all.
+    outcomes = [
+      { summary: "prose" },
+      { summary: "still prose" },
+      { summary: PLAN },
+      { summary: "index done", filesTouched: ["index.html"] },
+      { summary: "app done", filesTouched: ["app.js"] },
+    ];
+    const board = await team.startTeam({ goal: "Build it", directory: "site", source: "owner" });
+    const done = await finished(board.id);
+    expect(done.status).toBe("done");
+    expect(starts.filter((s) => (s.team as { role: string }).role === "planner")).toHaveLength(3);
+    expect(done.agents.planner).toBe(3);
+    expect(done.alerts).toBe(2);
+    expect(done.plannerRunId).toBe("run-00000001");
+    expect(done.log.filter((e) => e.type === "alert").map((e) => e.message)[1]).toMatch(/attempt 3 of 3/);
+  });
+
+  it("fails the team after the third answer is no plan either, saying why", async () => {
+    outcomes = [{ summary: "prose" }, { summary: "still prose" }, { summary: "prose again" }];
     const board = await team.startTeam({ goal: "Build it", directory: "site", source: "owner" });
     const done = await finished(board.id);
     expect(done.status).toBe("failed");
     expect(done.error).toMatch(/no JSON array/);
+    expect(starts).toHaveLength(3);
+  });
+
+  it("does not spend the remaining asks on a planner run that did not finish", async () => {
+    // A crashed planner is not a wording problem; re-asking it is paid noise.
+    outcomes = [{ summary: "prose" }, { status: "failed", error: "planner exploded" }];
+    const board = await team.startTeam({ goal: "Build it", directory: "site", source: "owner" });
+    const done = await finished(board.id);
+    expect(done.status).toBe("failed");
+    expect(done.error).toMatch(/did not finish its answer/);
     expect(starts).toHaveLength(2);
   });
 });
@@ -510,14 +541,14 @@ describe("a team that works", () => {
     expect(starts).toHaveLength(2);
   });
 
-  it("fails the team, with the reason, when the planner answers no plan twice — and never starts a worker", async () => {
-    outcomes = [{ summary: "I think we should refactor everything." }, { summary: "Still prose, sorry." }];
+  it("fails the team, with the reason, when the planner answers no plan every time — and never starts a worker", async () => {
+    outcomes = [{ summary: "I think we should refactor everything." }, { summary: "Still prose, sorry." }, { summary: "Prose once more." }];
     const board = await team.startTeam({ goal: "g", directory: "site", source: "agent" });
     const done = await finished(board.id);
     expect(done.status).toBe("failed");
     expect(done.error).toMatch(/no JSON array/);
-    // The planner, and the planner asked once more; no worker.
-    expect(starts).toHaveLength(2);
+    // The planner and its two corrections; no worker, and no fourth ask.
+    expect(starts).toHaveLength(3);
     expect(starts.every((s) => (s.team as { role: string }).role === "planner")).toBe(true);
     expect(done.tasks).toEqual([]);
   });


### PR DESCRIPTION
## What happened

Tonight's coding-agent benchmark ran the same frozen brief on four Nanos. Both **Team** cells died within ~4 minutes having posted **no task at all**, on both DeepSeek Pro and Flash:

| device | first answer | after the one correction | outcome |
|---|---|---|---|
| `.4` (Team Pro) | 2541 chars | 2052 | failed |
| `.183` (Team Flash) | 2835 chars | **3013 — longer** | failed |

The planner's `task_description` ran past `MAX_TASK_DESCRIPTION_CHARS` (2000). Identical failure on both models rules out model quality.

## Two defects

**1. `parsePlan` returned on the first offending task.** A plan with several faults taught the planner about `t1` alone — it would shorten `t1`, re-answer, and be told about `t2`. One paid planner run per fault, against a budget of one.

Now every task is read before answering and every fault is named together, capped at six with the remainder counted so the reason cannot grow without bound. Over-long descriptions state the overage: `must lose at least 1013 characters`. "Shorten this" left the planner guessing, and a guessing planner answered longer than before.

**2. `runTeam` allowed exactly one correction, then failed the board.** It now spends up to three planner runs. The budget stays small deliberately: a planner that cannot answer an array in three tries will not on the fourth, and every try is paid. A planner run that *did not finish* stays terminal — that is not a wording problem, and re-asking it is paid noise.

## What did not change

The parser still repairs nothing. A plan with one bad task is refused whole, never quietly delivered as a smaller plan — every task here becomes a worker with a shell. The 2000-character cap is unchanged.

## Tests

Nine new/updated tests covering exactly the observed failure: multiple over-long descriptions named together with their overage, mixed fault kinds reported together, the six-fault cap, a description exactly at the limit, refusing the whole plan rather than dropping tasks, a third ask succeeding, failing after the third, and not spending asks on a crashed planner run.

Verified on Nano `.4` (isolated checkout, ARM):
- `tsc --noEmit` clean
- 7 team suites, **75/75 pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Plan validation now reports multiple issues together instead of stopping at the first error.
  - Overlong task descriptions identify the exact amount that must be reduced.
  - Invalid tasks are excluded while valid tasks remain available for consolidated reporting.
  - Dependency and file-hint validation now reports accumulated issues, with lengthy error lists summarized.

- **Reliability**
  - Planning can retry up to three times after invalid responses.
  - Retry alerts identify the attempt and validation issue.
  - Failed or exhausted planning attempts now report the corresponding failure status or error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->