### PR TITLE
fix: Read on demand did not give the agent the mailbox read tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,8 @@ of them kept failing.
     `code_project_init/list/build/delete`, `browser_open/navigate/screenshot/close`,
     `describe_image`,
     `coding_agent_run/status/stop` (registered only while the owner's switch is on
-    and the `claude-ds` harness is ready — probed at startup like `email_list`)
+    and the `claude-ds` harness is ready — probed at startup, and unlike
+    `email_list` never re-probed after it)
   - **The browser family** (`mcp/tools/browser.ts`) relays the route's
     `browser` field: the header line names the device's own window on the
     screen or the invisible one, said ONCE per session and again when a fresh

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -272,23 +272,39 @@ which of these tools exist:
 | **Answer senders** | Hermes' native adapter polls and replies to an allowlist | yes |
 
 `email_list`/`email_read` are **not registered at all** unless a mail account is
-connected AND the mode allows reading (probed once at startup — `mcp/lib/context.ts`).
-Same rule as edition gating and for the same reason: a tool that could only ever
-answer 409 is a tool that trips Hermes' circuit breaker and takes every ClawBox
-tool offline. The route enforces the gate independently, because the two live on
-opposite sides of a process boundary and the owner can change the mode under a
-running server.
+connected AND the mode allows reading (`mcp/lib/context.ts` probes it at
+startup). Same rule as edition gating and for the same reason: a tool that could
+only ever answer 409 is a tool that trips Hermes' circuit breaker and takes every
+ClawBox tool offline. The route enforces the gate independently, because the two
+live on opposite sides of a process boundary and the owner can change the mode
+under a running server.
 
-Because the probe is startup-only, a mode or credential change would otherwise
-leave a long-lived server with the tool list it built at boot — a mailbox
-connected under a running server stayed invisible to the agent until something
-respawned the server. So `/setup-api/email/configure` now asks Hermes to reload
-its MCP servers (`reload.mcp` on the dashboard socket, `confirm: true`) whenever
-a save or a disconnect **flips** `canRead`; the server starts again and re-probes
-the gate, and live sessions pick the new list up at their next turn boundary.
-Only on a flip: a reload respawns every MCP child process and invalidates the
-model's prompt cache, so it is not free and must not fire on an ordinary save.
-See `src/lib/email-mcp-refresh.ts`.
+This is the ONE gate here that is not startup-only, because it is the one the
+owner changes with the agent already running. A startup-only answer left a
+long-lived server holding the tool list it built at boot: measured on an OpenClaw
+box (2026-09-10), seven minutes after the mode moved to "Read on demand" the MCP
+child serving the chat still advertised `email_send` alone, while a fresh spawn
+of the same server advertised all three. So the server re-asks
+`/setup-api/email/status` every `EMAIL_READABILITY_POLL_MS` (30 s) and, on a
+CHANGE of the answer, registers or withdraws the pair on the live connection
+(`watchEmailReadability`, `mcp/tools/email.ts`). The MCP SDK turns each of those
+into a `notifications/tools/list_changed`, which is what the harness acts on —
+OpenClaw's bundle MCP runtime invalidates the tool catalogue it cached for this
+server and re-lists at the next turn. A probe that could not REACH the device
+answers `null` and changes nothing, so one slow moment cannot take a working
+mailbox away from the agent.
+
+That notification is also the only mechanism that reaches a RUNNING OpenClaw
+gateway: `openclaw mcp reload` disposes the MCP runtimes cached in the CLI's own
+process (`disposeAllSessionMcpRuntimes`, OpenClaw 2026.8.1) and the gateway never
+hears of it, and the gateway's JSON-RPC exposes no MCP method at all.
+
+On Hermes there IS a way to ask, and it is faster than a poll, so it stays:
+`/setup-api/email/configure` asks the dashboard to reload its MCP servers
+(`reload.mcp`, `confirm: true`) whenever a save or a disconnect **flips**
+`canRead`. Only on a flip: a reload respawns every MCP child process and
+invalidates the model's prompt cache, so it is not free and must not fire on an
+ordinary save. See `src/lib/email-mcp-refresh.ts`.
 
 Both read tools ARE `readOnly`, and that claim is literal rather than polite: the
 mailbox is opened with `EXAMINE` (read-only at the protocol level) and every

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -195,8 +195,9 @@ is to name the reason (ClawBox AI is not connected) and the fix (Settings → AI
 Providers) and to forbid improvising around it.
 
 The probe is `canGenerateImages` off `/setup-api/chat/capabilities`, resolved
-once at startup like the rest — so the same staleness the email tools had applies
-here, in both directions: after linking, the refusal must go, and the harness's
+once at startup and never re-asked — so unlike the mailbox gate, which the server
+now follows while it runs, the startup staleness still applies here, in both
+directions: after linking, the refusal must go, and the harness's
 own image tool must actually appear. Linking asks for both
 (`src/lib/hermes-image-refresh.ts`): `reload.env`, because the backend's
 credential lives in `~/.hermes/.env` and only reaches a running agent that way;
@@ -586,8 +587,10 @@ running forever.
 **Registered only when `GET /setup-api/coding-agent/status` answers
 `enabled && ready` at startup** (`mcp/lib/context.ts`): the owner's switch in
 the Coding Agent desktop app is on AND Claude Code, the wrapper and a
-ClawBox AI token are all present. Same rule as `email_list`, for the same
-circuit-breaker reason. The run route enforces the switch again — 409, which
+ClawBox AI token are all present. Same gate as `email_list`, for the same
+circuit-breaker reason — but not the same timing: this one is asked at startup
+and never again, so a switch flipped under a running server reaches the agent
+when that server is next spawned. The run route enforces the switch again — 409, which
 the tool maps to CONFLICT / do-not-retry — because the owner can flip it under
 a live server. `POST /setup-api/coding-agent/enable` is the second route in
 the API that **refuses the MCP bearer** (`src/lib/owner-session.ts`): the

--- a/mcp/clawbox-mcp.ts
+++ b/mcp/clawbox-mcp.ts
@@ -48,13 +48,18 @@ import { API_BASE, authHeader, primeApiToken } from "./lib/api";
 import { buildContext, type McpContext } from "./lib/context";
 import { installEdition, resolveAppHarness, resolveEdition, type Ed } from "./lib/edition";
 import { resolveProfile } from "./lib/profile";
-import { createRegistrar, type Profile } from "./lib/register";
+import { createRegistrar, type Profile, type Registrar } from "./lib/register";
 import { registerAiTools } from "./tools/ai";
 import { registerBrowserTools } from "./tools/browser";
 import { registerCodingTools } from "./tools/coding";
 import { registerCodingAgentTools, registerCodingTeamTools } from "./tools/coding-agent";
 import { registerDesktopTools } from "./tools/desktop";
-import { registerEmailTools, watchEmailReadability } from "./tools/email";
+import {
+  hasMailboxSurface,
+  registerEmailTools,
+  watchEmailReadability,
+  type EmailReadabilityWatchOptions,
+} from "./tools/email";
 import { registerMediaTools } from "./tools/media";
 import { registerOrientationTools } from "./tools/orientation";
 import { registerSkillTools } from "./tools/skills";
@@ -183,8 +188,10 @@ export async function buildServer(
   );
   const reg = createRegistrar(server, edition, profile);
 
-  // Order matters only for readability; registration is complete before the
-  // transport connects, so tools/list is stable for the process lifetime.
+  // Order matters only for readability. Registration is complete before the
+  // transport connects, and the list then holds for the process lifetime with
+  // ONE exception: the mailbox read tools follow Settings → Email afterwards
+  // (see `watchEmailReadability` in main()). Nothing else here is re-asked.
   registerOrientationTools(reg, ctx);
   registerSkillTools(reg);
   registerMemoryTools(reg);
@@ -207,6 +214,47 @@ export async function buildServer(
   return { server, reg, ctx };
 }
 
+/**
+ * Start following Settings → Email on a server that is ALREADY CONNECTED.
+ *
+ * The mailbox gate is the one thing this server probes that the owner changes
+ * while the agent is running, and a tool list that never catches up is what left
+ * the box answering "send only" seven minutes after Settings said "Read on
+ * demand". `hasMailboxSurface` is asked of the registrar rather than of
+ * `profile`/`edition` again — it owns both reasons, including the SDK one.
+ * `buildServer` deliberately does not do this: mcp/check-tools.ts builds ten
+ * servers and connects none of them.
+ *
+ * STOPPED WITH THE TRANSPORT. `unref` is what stops the poll holding an
+ * otherwise-idle process open (measured under the box's Bun: without it the same
+ * script does not exit on stdin EOF), and it is not the whole story — a request
+ * still in flight keeps the loop alive after the harness has hung up, and a poll
+ * that went on re-registering tools into a closed server would be work nobody
+ * can see the result of. `Protocol.onclose` is free for a caller (the SDK drives
+ * its own teardown through `_onclose`), and any handler a neighbour installs
+ * later is chained rather than overwritten.
+ *
+ * A function rather than four lines in `main()` because `main()` claims stdio
+ * and cannot be tested, and this is the line that carries the whole fix to a
+ * real box.
+ */
+export function armMailboxWatch(
+  server: McpServer,
+  reg: Registrar,
+  emailCanRead: boolean,
+  // The watch's own seam, forwarded so a test can drive the probe and the clock
+  // rather than the device. Never passed on a box.
+  options?: EmailReadabilityWatchOptions,
+): void {
+  if (!hasMailboxSurface(reg)) return;
+  const watch = watchEmailReadability(reg, emailCanRead, options);
+  const previous = server.server.onclose;
+  server.server.onclose = () => {
+    watch.stop();
+    previous?.();
+  };
+}
+
 async function main(): Promise<void> {
   // FIRST, before the probes below spawn anything: the bearer goes into this
   // process's cache and out of its environment, so no child — a startup probe,
@@ -219,18 +267,7 @@ async function main(): Promise<void> {
   const { server, reg, ctx } = await buildServer(edition, profile, appHarness);
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  // AFTER connect, and only here: the mailbox gate is the one thing this server
-  // probes that the owner changes while the agent is running, and a tool list
-  // that never catches up is what left the box answering "send only" seven
-  // minutes after Settings said "Read on demand". Asked of the registrar rather
-  // than of `profile`/`edition` again, so the gates that decide whether this box
-  // has email tools at all are not restated here: a server that registered no
-  // `email_send` has no mailbox surface to keep in step, and nothing to poll for.
-  // `buildServer` deliberately does not arm it — mcp/check-tools.ts builds ten
-  // servers and connects none of them.
-  if (reg.list().some((tool) => tool.name === "email_send")) {
-    watchEmailReadability(reg, ctx.emailCanRead);
-  }
+  armMailboxWatch(server, reg, ctx.emailCanRead);
   // The model is named because "why do I only have 16 tools?" is the first
   // question a slimmed device raises, and this line is the answer.
   const because = model?.provider

--- a/mcp/clawbox-mcp.ts
+++ b/mcp/clawbox-mcp.ts
@@ -54,7 +54,7 @@ import { registerBrowserTools } from "./tools/browser";
 import { registerCodingTools } from "./tools/coding";
 import { registerCodingAgentTools, registerCodingTeamTools } from "./tools/coding-agent";
 import { registerDesktopTools } from "./tools/desktop";
-import { registerEmailTools } from "./tools/email";
+import { registerEmailTools, watchEmailReadability } from "./tools/email";
 import { registerMediaTools } from "./tools/media";
 import { registerOrientationTools } from "./tools/orientation";
 import { registerSkillTools } from "./tools/skills";
@@ -219,6 +219,18 @@ async function main(): Promise<void> {
   const { server, reg, ctx } = await buildServer(edition, profile, appHarness);
   const transport = new StdioServerTransport();
   await server.connect(transport);
+  // AFTER connect, and only here: the mailbox gate is the one thing this server
+  // probes that the owner changes while the agent is running, and a tool list
+  // that never catches up is what left the box answering "send only" seven
+  // minutes after Settings said "Read on demand". Asked of the registrar rather
+  // than of `profile`/`edition` again, so the gates that decide whether this box
+  // has email tools at all are not restated here: a server that registered no
+  // `email_send` has no mailbox surface to keep in step, and nothing to poll for.
+  // `buildServer` deliberately does not arm it — mcp/check-tools.ts builds ten
+  // servers and connects none of them.
+  if (reg.list().some((tool) => tool.name === "email_send")) {
+    watchEmailReadability(reg, ctx.emailCanRead);
+  }
   // The model is named because "why do I only have 16 tools?" is the first
   // question a slimmed device raises, and this line is the answer.
   const because = model?.provider

--- a/mcp/clawbox-mcp.ts
+++ b/mcp/clawbox-mcp.ts
@@ -231,8 +231,11 @@ export async function buildServer(
  * still in flight keeps the loop alive after the harness has hung up, and a poll
  * that went on re-registering tools into a closed server would be work nobody
  * can see the result of. `Protocol.onclose` is free for a caller (the SDK drives
- * its own teardown through `_onclose`), and any handler a neighbour installs
- * later is chained rather than overwritten.
+ * its own teardown through `_onclose`), and a handler already installed when
+ * this runs is chained rather than overwritten. Note the direction: an EARLIER
+ * handler survives, while a later plain `server.server.onclose = fn` from
+ * anywhere would replace this wrapper and leave the poll outliving the
+ * transport — which is why arming is the LAST thing `main()` does.
  *
  * A function rather than four lines in `main()` because `main()` claims stdio
  * and cannot be tested, and this is the line that carries the whole fix to a

--- a/mcp/lib/context.ts
+++ b/mcp/lib/context.ts
@@ -222,9 +222,11 @@ interface EmailStatusPayload {
   /** The device's own answer to "may the agent read?" — see below. */
   canRead?: boolean;
   /**
-   * `configured: false` because the device's config store could not be READ —
-   * an EACCES from a root-owned `data/config.json`, an EIO, a half-written
-   * file. See `storeUnreadable` in src/lib/email-config.ts.
+   * The device could not trust its own answer, because the config store could
+   * not be READ — an EACCES from a root-owned `data/config.json`, an EIO, a
+   * half-written file. Decided by `emailStoreDisagrees` in
+   * src/lib/email-config.ts and attached to the payload by
+   * src/app/setup-api/email/status/route.ts.
    */
   storeUnreadable?: boolean;
 }

--- a/mcp/lib/context.ts
+++ b/mcp/lib/context.ts
@@ -1,9 +1,15 @@
-// Everything the tool modules need to know about THIS device, resolved once at
+// Everything the tool modules need to know about THIS device, resolved at
 // startup so no tool has to re-discover it per call.
 //
 // Capability probes follow the same principle as edition gating: a tool that
 // cannot work here (no screen grabber installed, no readable journal) is not
 // registered at all, rather than registered and failing.
+//
+// ONE of these answers does not stay put: `emailCanRead` is the only thing here
+// the owner changes with the agent already running, so it is the INITIAL value
+// of a question the server goes on asking (`watchEmailReadability`,
+// mcp/tools/email.ts). Everything else is settled before `connect()` and stays
+// settled for the process lifetime.
 
 import { capabilitiesFor, type HarnessFacts } from "../../src/lib/harness/capabilities";
 import { appExistsOnEdition } from "../../src/lib/desktop-app-editions";
@@ -162,8 +168,13 @@ export interface McpContext {
   /**
    * Whether the device has a mail account AND the owner picked a mode that
    * lets the agent open the mailbox. Decides whether email_list/email_read are
-   * registered at all — a tool that could only ever 409 is a tool that trips
-   * Hermes' circuit breaker and takes the whole server down with it.
+   * registered AT STARTUP — a tool that could only ever 409 is a tool that
+   * trips Hermes' circuit breaker and takes the whole server down with it.
+   *
+   * The one snapshot here that is refreshed afterwards, because it is the one
+   * an owner flips mid-session: `watchEmailReadability` (mcp/tools/email.ts)
+   * re-asks and registers or withdraws the pair on the live connection. So this
+   * field is where the tool list STARTS, not where it stays.
    *
    * Both editions, like sending: reading runs on ClawBox's own IMAP client and
    * needs nothing from Hermes.
@@ -210,6 +221,12 @@ interface EmailStatusPayload {
   configured?: boolean;
   /** The device's own answer to "may the agent read?" — see below. */
   canRead?: boolean;
+  /**
+   * `configured: false` because the device's config store could not be READ —
+   * an EACCES from a root-owned `data/config.json`, an EIO, a half-written
+   * file. See `storeUnreadable` in src/lib/email-config.ts.
+   */
+  storeUnreadable?: boolean;
 }
 
 /**
@@ -230,12 +247,24 @@ interface EmailStatusPayload {
  */
 export async function probeEmailReadStatus(): Promise<boolean | null> {
   const status = await apiTry<EmailStatusPayload>("/setup-api/email/status", { timeoutMs: 3_000 });
+  // Nothing answered at all.
   if (!status) return null;
+  // The device answered, and said its own store is the thing it could not read.
+  // A 200 carrying `configured: false` is otherwise indistinguishable from "no
+  // account", and on the RUNNING path that difference is the whole question: a
+  // root-owned `data/config.json` after an update, or one EIO off the eMMC,
+  // would otherwise read as the owner switching reading off and take the tools
+  // away from an agent whose mailbox is fine.
+  if (status.storeUnreadable === true) return null;
   if (!status.configured) return false;
+  // An account exists and the device did not answer the question — a web server
+  // rolled back to a build that predates the three-mode setting, under a live
+  // MCP child. Silence is not a "no".
+  if (typeof status.canRead !== "boolean") return null;
   // The device answers this itself (src/lib/email-config.ts modeAllowsReading).
   // Restating which modes allow reading here would be a second copy of the
   // rule, in the process least likely to be updated when a mode is added.
-  return status.canRead === true;
+  return status.canRead;
 }
 
 /** The startup gate: see `probeEmailReadStatus` for why unknown is `false` here. */

--- a/mcp/lib/context.ts
+++ b/mcp/lib/context.ts
@@ -213,18 +213,34 @@ interface EmailStatusPayload {
 }
 
 /**
- * Ask the device whether reading is switched on. A device whose status route
- * cannot be reached (an older build, a service still starting) answers null,
- * and the read tools stay UNREGISTERED — the safe direction, because the
- * failure mode of guessing "yes" is a permanently-failing tool.
+ * Ask the device whether reading is switched on, keeping "could not ask" apart
+ * from "no".
+ *
+ * `null` is a device whose status route could not be reached (an older build, a
+ * service still starting). The two callers want opposite things from it, which
+ * is why it is not collapsed here:
+ *
+ *  - at STARTUP, unknown means the read tools stay unregistered — the safe
+ *    direction, because the failure mode of guessing "yes" is a
+ *    permanently-failing tool (see `probeEmailRead`);
+ *  - while the server RUNS, unknown must change nothing at all. Reading one
+ *    timed-out request as "the owner switched reading off" would strip the
+ *    tools off a working mailbox — a failure reported over an operation that
+ *    never happened.
  */
-async function probeEmailRead(): Promise<boolean> {
+export async function probeEmailReadStatus(): Promise<boolean | null> {
   const status = await apiTry<EmailStatusPayload>("/setup-api/email/status", { timeoutMs: 3_000 });
-  if (!status?.configured) return false;
+  if (!status) return null;
+  if (!status.configured) return false;
   // The device answers this itself (src/lib/email-config.ts modeAllowsReading).
   // Restating which modes allow reading here would be a second copy of the
   // rule, in the process least likely to be updated when a mode is added.
   return status.canRead === true;
+}
+
+/** The startup gate: see `probeEmailReadStatus` for why unknown is `false` here. */
+async function probeEmailRead(): Promise<boolean> {
+  return (await probeEmailReadStatus()) === true;
 }
 
 interface CodingAgentStatusPayload {

--- a/mcp/lib/register.ts
+++ b/mcp/lib/register.ts
@@ -18,7 +18,7 @@
 //   4. THE ERROR ENVELOPE. Every throw becomes { error, code, message, next } —
 //      no stack, no upstream body, no absolute path.
 
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CallToolRequestSchema, type CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { capText } from "./guard";
@@ -106,6 +106,18 @@ export const MAX_DESCRIPTION_CHARS = 1000;
 
 export interface Registrar {
   tool(name: string, description: string, shape: Shape, opts: ToolOpts, handler: ToolHandler): void;
+  /**
+   * Withdraw one tool again, by name. A no-op for a name this registrar never
+   * registered — the edition and profile gates above drop tools silently, so a
+   * caller that withdraws a family cannot know which half of it ever existed.
+   *
+   * It exists for the ONE decision an owner changes while the agent is running:
+   * whether the agent may open the mailbox (mcp/tools/email.ts). Everything
+   * else this server gates on is settled before `connect()` and stays settled,
+   * and `tool()` is still the only way in — so the dispatcher, the tool list and
+   * the SDK's own registry cannot disagree about what exists.
+   */
+  remove(name: string): void;
   list(): RegisteredToolInfo[];
   /** Must be called once, after every tool is registered. See installCallHandler(). */
   finalize(): void;
@@ -245,13 +257,20 @@ function installCallHandler(server: McpServer, entries: Map<string, CallEntry>):
 }
 
 /**
- * Build the registrar for one server instance. Every registration decision —
- * edition, profile — is made HERE, once, before server.connect(); never per
- * call, so tools/list is stable for the life of the process.
+ * Build the registrar for one server instance. The registration RULES — edition,
+ * profile — are applied HERE and never per call, so an individual tool cannot
+ * answer the same question a second way.
+ *
+ * The list is built before `server.connect()` and, with the one exception the
+ * mailbox gate needs, does not change afterwards: `registerEmailReadTools` and
+ * `remove` follow Settings → Email on a running server, and the SDK turns each
+ * of those into a `notifications/tools/list_changed` the harness acts on.
  */
 export function createRegistrar(server: McpServer, edition: Ed, profile: Profile): Registrar {
   const registered: RegisteredToolInfo[] = [];
   const entries = new Map<string, CallEntry>();
+  // The SDK's own handle per tool, which is what can withdraw one again.
+  const handles = new Map<string, RegisteredTool>();
 
   return {
     tool(name, description, shape, opts, handler) {
@@ -284,7 +303,7 @@ export function createRegistrar(server: McpServer, edition: Ed, profile: Profile
         }
       };
 
-      server.registerTool(
+      const handle = server.registerTool(
         name,
         {
           description,
@@ -298,6 +317,21 @@ export function createRegistrar(server: McpServer, edition: Ed, profile: Profile
         // eslint-disable-next-line @typescript-eslint/no-explicit-any -- see ToolHandler
         wrapped as any,
       );
+      if (handle) handles.set(name, handle);
+    },
+    remove(name) {
+      const handle = handles.get(name);
+      if (!handle) return;
+      handles.delete(name);
+      // The DISPATCHER first. `installCallHandler` answers from `entries`, so a
+      // tool left there would still run for a host that called it from a list
+      // it had not refreshed yet — and the gate would be gone from the one
+      // place that is not the route's.
+      entries.delete(name);
+      const at = registered.findIndex((t) => t.name === name);
+      if (at >= 0) registered.splice(at, 1);
+      // Last, because this is what emits tools/list_changed.
+      handle.remove();
     },
     list() {
       return registered;

--- a/mcp/lib/register.ts
+++ b/mcp/lib/register.ts
@@ -235,11 +235,22 @@ function installCallHandler(server: McpServer, entries: Map<string, CallEntry>):
     const name = request.params.name;
     const entry = entries.get(name);
     if (!entry) {
+      // NOT "there is no such tool on this edition", which is what this said
+      // while the list could not change: a WITHDRAWN name lands here too — the
+      // mailbox read tools follow Settings → Email — and that tool does exist on
+      // this edition, it is just not being offered now. The old wording sent a
+      // model looking for an edition problem, and it was the one refusal in this
+      // module's vocabulary that did not say "do not retry", while
+      // `toolErrorResult` stamps `isError: true` — which is exactly the chronic
+      // failure Hermes' per-server circuit breaker counts, and the thing the
+      // whole registration gate exists to avoid.
       return toolErrorResult(
         new ToolError(
           "NOT_FOUND",
-          `This ClawBox has no tool called "${name}".`,
-          "Use a tool from this server's tool list; the list depends on which edition this device runs.",
+          `This ClawBox is not offering a tool called "${name}".`,
+          "Do not retry this name. Read this server's tool list again and use a name from it:"
+            + " the list depends on which edition this device runs, and a few tools are withdrawn"
+            + " while the owner has switched off what they need.",
         ),
         name,
       );
@@ -291,8 +302,6 @@ export function createRegistrar(server: McpServer, edition: Ed, profile: Profile
         // take the agent's whole tool surface down on a customer device.
         console.error(`[clawbox-mcp] TOOL CONTRACT: ${violation}`);
       }
-      registered.push(info);
-      entries.set(name, { shape, handler, maxChars });
 
       const wrapped = async (args: unknown) => {
         try {
@@ -317,6 +326,15 @@ export function createRegistrar(server: McpServer, edition: Ed, profile: Profile
         // eslint-disable-next-line @typescript-eslint/no-explicit-any -- see ToolHandler
         wrapped as any,
       );
+      // RECORDED ONLY ONCE THE SDK HAS TAKEN IT. `registerTool` throws on a name
+      // it already holds, and this used to push into `registered`/`entries`
+      // first: a throw then left a row for a tool that was never published, and
+      // — now that a family can be registered again later — one such row per
+      // attempt, with `list()` over-reporting and a later `remove()` clearing
+      // only the first of them. Nothing in the tree makes it throw today; the
+      // ordering is what keeps that true of the next caller as well.
+      registered.push(info);
+      entries.set(name, { shape, handler, maxChars });
       if (handle) handles.set(name, handle);
     },
     remove(name) {

--- a/mcp/tools/email.ts
+++ b/mcp/tools/email.ts
@@ -40,7 +40,7 @@ import { apiGet, apiPost } from "../lib/api";
 import { ApiError, ToolError } from "../lib/errors";
 import { json, type Registrar } from "../lib/register";
 import { zInt, zReqInt, zText } from "../lib/schema";
-import type { McpContext } from "../lib/context";
+import { probeEmailReadStatus, type McpContext } from "../lib/context";
 
 const UNCONFIGURED_NEXT =
   "Do not retry. Tell the user to open Settings, choose Email, and connect a mail account — for Gmail that means turning on 2-Step Verification and pasting a 16-character App Password.";
@@ -409,8 +409,32 @@ export function registerEmailTools(reg: Registrar, ctx: Pick<McpContext, "emailC
   //
   // Registered ONLY when the owner chose a mode that opens the mailbox. See the
   // circuit-breaker note on registerEmailTools.
-  if (!ctx.emailCanRead) return;
+  if (ctx.emailCanRead) registerEmailReadTools(reg);
+}
 
+/**
+ * The two tools that OPEN the mailbox, registrable on their own.
+ *
+ * Split out of `registerEmailTools` because the answer they hang on is the one
+ * the owner changes with the agent already running, and this server is a
+ * long-lived child of the harness: measured on the owner's OpenClaw box
+ * (2026-09-10) the MCP child that was serving the chat had been up for 28
+ * minutes and had probed the gate seven minutes BEFORE the mode moved to "Read
+ * on demand", so the agent had only `email_send` while Settings correctly showed
+ * reading was on. A fresh spawn of the same server advertised both tools.
+ *
+ * So the pair is registered — and withdrawn — while the server runs, by
+ * `watchEmailReadability` below. Registering after `connect()` is what makes the
+ * harness notice: the MCP SDK emits `notifications/tools/list_changed` for it,
+ * OpenClaw's bundle MCP runtime invalidates the tool catalogue it cached for
+ * this server and re-lists on the next turn, and Hermes does the same. That is
+ * the protocol's own mechanism for exactly this and the only one that reaches a
+ * RUNNING OpenClaw gateway: `openclaw mcp reload` disposes the runtimes cached
+ * in the CLI's own process (`disposeAllSessionMcpRuntimes`, OpenClaw 2026.8.1)
+ * and the gateway never hears about it, and the gateway's JSON-RPC exposes no
+ * MCP method at all.
+ */
+export function registerEmailReadTools(reg: Registrar): void {
   reg.tool(
     "email_list",
     "List the newest messages in the ClawBox's own mailbox: who each is from, its subject, its date, and whether it is unread. Returns an id for each one, which email_read takes. Use it only when the user asks you to look at their email. After summarising messages, end your reply with one `EMAIL:<id>` line per message so the user can open the full email — `show_the_user_the_real_message` in the result states the rule, including the one case where those lines must be left out.",
@@ -505,4 +529,101 @@ export function registerEmailTools(reg: Registrar, ctx: Pick<McpContext, "emailC
       }
     },
   );
+}
+
+/** The read pair, by name, for a caller that has to withdraw it again. */
+export const EMAIL_READ_TOOL_NAMES = ["email_list", "email_read"] as const;
+
+/**
+ * How often this server re-asks the device whether the agent may read the
+ * mailbox.
+ *
+ * One loopback GET of `/setup-api/email/status` — a read of the device's own
+ * config store, no network — per interval per MCP child, and there are one or
+ * two of those. That is the whole cost, and it buys the only thing that reaches
+ * a running gateway: without it the owner has to restart something before
+ * Settings → Email means anything to the agent, which is the defect.
+ *
+ * Thirty seconds because of what the owner actually does: change the mode, then
+ * ask the assistant to look at their mail. A minute would leave that first
+ * request refused often enough to look broken; polling faster buys nothing,
+ * since the harness only re-reads the tool list between turns anyway.
+ */
+export const EMAIL_READABILITY_POLL_MS = 30_000;
+
+export interface EmailReadabilityWatch {
+  /** Ask now, rather than at the next tick. */
+  refreshNow(): Promise<void>;
+  stop(): void;
+}
+
+export interface EmailReadabilityWatchOptions {
+  /** Overridden by tests only; production asks the device. */
+  probe?: () => Promise<boolean | null>;
+  intervalMs?: number;
+}
+
+/**
+ * Keep `email_list`/`email_read` in step with Settings → Email while the server
+ * runs.
+ *
+ * THREE ANSWERS, NOT TWO. `probe` returns null when the device could not be
+ * asked, and null must change nothing: reading one timed-out request as "the
+ * owner switched reading off" would take a working mailbox away from the agent
+ * over an operation that never failed. Only a definite answer that DIFFERS from
+ * the one this server is holding moves anything — an unchanged answer is not
+ * even reported, because every registration and removal costs the harness the
+ * tool catalogue it has cached for this server.
+ *
+ * The timer is `unref`ed: a stdio server exits when its transport closes, and a
+ * poll must never be the reason a child outlives the harness that spawned it.
+ */
+export function watchEmailReadability(
+  reg: Registrar,
+  initial: boolean,
+  options: EmailReadabilityWatchOptions = {},
+): EmailReadabilityWatch {
+  const probe = options.probe ?? probeEmailReadStatus;
+  const intervalMs = options.intervalMs ?? EMAIL_READABILITY_POLL_MS;
+  let canRead = initial;
+  // One probe at a time. The device answers in milliseconds and the interval is
+  // thirty seconds, but a box under load can be slower than that, and two
+  // in-flight probes could apply their answers out of order.
+  let asking = false;
+
+  async function refreshNow(): Promise<void> {
+    if (asking) return;
+    asking = true;
+    try {
+      // `probeEmailReadStatus` never throws; a test double might, and a poll
+      // that throws would take the whole server down through the interval.
+      const answer = await probe().catch(() => null);
+      if (answer === null || answer === canRead) return;
+      if (answer) registerEmailReadTools(reg);
+      else for (const name of EMAIL_READ_TOOL_NAMES) reg.remove(name);
+      // AFTER the change, never before it: the SDK refuses a second
+      // registration of a name it already holds, so a flip recorded over a
+      // registration that threw would leave this server believing it had
+      // published tools it has not — and the next flip back would be a no-op.
+      canRead = answer;
+      // Worth a line: "the agent still cannot see my mailbox" is otherwise
+      // invisible from the outside, and this is the moment that answers it.
+      console.error(
+        `[clawbox-mcp] mailbox readable=${answer}; `
+        + `${answer ? "registered" : "withdrew"} ${EMAIL_READ_TOOL_NAMES.join(" and ")}`,
+      );
+    } finally {
+      asking = false;
+    }
+  }
+
+  const timer = setInterval(() => {
+    // An unhandled rejection ends the process on Node, and this server is the
+    // agent's whole tool surface: a poll must never be what takes it down.
+    void refreshNow().catch((err) => {
+      console.error(`[clawbox-mcp] mailbox readability re-probe failed: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  }, intervalMs);
+  timer.unref?.();
+  return { refreshNow, stop: () => clearInterval(timer) };
 }

--- a/mcp/tools/email.ts
+++ b/mcp/tools/email.ts
@@ -640,14 +640,22 @@ export function watchEmailReadability(
   // like a box where nothing changed — silence over a gate that has stopped
   // working, which is the shape this module exists to remove.
   let unreachable = false;
+  // Set by `stop()`, and checked again AFTER the probe resolves. Clearing the
+  // interval only stops the NEXT tick: a probe already in flight when the
+  // transport closes would come back afterwards and register or withdraw tools
+  // on a server nobody is listening to, emitting a `tools/list_changed` into a
+  // dead connection. The await is the one suspension point here, so one check
+  // after it is enough.
+  let stopped = false;
 
   async function refreshNow(): Promise<void> {
-    if (asking) return;
+    if (asking || stopped) return;
     asking = true;
     try {
       // `probeEmailReadStatus` never throws; a test double might, and a poll
       // that throws would take the whole server down through the interval.
       const answer = await probe().catch(() => null);
+      if (stopped) return;
       if (answer === null) {
         if (!unreachable) {
           unreachable = true;
@@ -711,5 +719,11 @@ export function watchEmailReadability(
     });
   }, intervalMs);
   timer.unref?.();
-  return { refreshNow, stop: () => clearInterval(timer) };
+  return {
+    refreshNow,
+    stop: () => {
+      stopped = true;
+      clearInterval(timer);
+    },
+  };
 }

--- a/mcp/tools/email.ts
+++ b/mcp/tools/email.ts
@@ -409,7 +409,28 @@ export function registerEmailTools(reg: Registrar, ctx: Pick<McpContext, "emailC
   //
   // Registered ONLY when the owner chose a mode that opens the mailbox. See the
   // circuit-breaker note on registerEmailTools.
+  //
+  // `ctx` decides where the list STARTS and not where it stays: the owner can
+  // change the mode under a running server, and `watchEmailReadability` below is
+  // what carries that to the agent.
   if (ctx.emailCanRead) registerEmailReadTools(reg);
+}
+
+/**
+ * Whether a server with THIS registrar has a mailbox surface to keep in step.
+ *
+ * Two things ride on it, which is why it is a named predicate and not an inline
+ * test at the call site. The obvious one: a `core` or `browser` profile
+ * registers no email tool at all, so there is nothing to poll for. The other is
+ * the SDK's: the FIRST `registerTool` on a server declares the `tools`
+ * capability, and `Server.registerCapabilities` throws once a transport is
+ * connected — so a post-`connect()` registration is only safe on a server that
+ * had already registered something before connecting. `email_send` is
+ * unconditional wherever the email family exists, so its presence answers both
+ * questions at once, from the gates that actually decided them.
+ */
+export function hasMailboxSurface(reg: Registrar): boolean {
+  return reg.list().some((tool) => tool.name === "email_send");
 }
 
 /**
@@ -538,16 +559,25 @@ export const EMAIL_READ_TOOL_NAMES = ["email_list", "email_read"] as const;
  * How often this server re-asks the device whether the agent may read the
  * mailbox.
  *
- * One loopback GET of `/setup-api/email/status` — a read of the device's own
- * config store, no network — per interval per MCP child, and there are one or
- * two of those. That is the whole cost, and it buys the only thing that reaches
- * a running gateway: without it the owner has to restart something before
- * Settings → Email means anything to the agent, which is the defect.
+ * One loopback GET of `/setup-api/email/status` per interval per MCP child, and
+ * there are one or two of those. On OpenClaw that route is a read of the config
+ * store, the pending-draft file and the edition lock, and nothing else. On a
+ * Hermes or dual box it is more than it looks — the same handler also asks
+ * `hermesEmailState()`, which re-reads and re-parses `~/.hermes/.env` once per
+ * value with no cache — so the cost there is a handful of small local reads, not
+ * one. Still local, still tiny beside a model turn, and it buys the only thing
+ * that reaches a running gateway: without it the owner has to restart something
+ * before Settings → Email means anything to the agent, which is the defect.
  *
  * Thirty seconds because of what the owner actually does: change the mode, then
  * ask the assistant to look at their mail. A minute would leave that first
  * request refused often enough to look broken; polling faster buys nothing,
  * since the harness only re-reads the tool list between turns anyway.
+ *
+ * A DIRECT NUDGE would be better than any interval, and there is none to use:
+ * the device's web server and this process share no channel, the OpenClaw
+ * gateway exposes no RPC that reaches its MCP children (see
+ * `registerEmailReadTools`), and `refreshNow` is here for the day one exists.
  */
 export const EMAIL_READABILITY_POLL_MS = 30_000;
 
@@ -577,6 +607,14 @@ export interface EmailReadabilityWatchOptions {
  *
  * The timer is `unref`ed: a stdio server exits when its transport closes, and a
  * poll must never be the reason a child outlives the harness that spawned it.
+ * (Measured under the Bun the box runs this with, rather than assumed: without
+ * `unref` the same script hangs on stdin EOF instead of exiting.)
+ *
+ * A flip emits TWO `tools/list_changed` — one per tool, which is the SDK's unit
+ * — where the argument above asks for as few as possible. Both land in one
+ * synchronous tick, so no host can observe the list with only half the pair in
+ * it, and the SDK offers no way to batch them; the cost worth avoiding was a
+ * notification every interval, and that is the one this does avoid.
  */
 export function watchEmailReadability(
   reg: Registrar,
@@ -590,6 +628,12 @@ export function watchEmailReadability(
   // thirty seconds, but a box under load can be slower than that, and two
   // in-flight probes could apply their answers out of order.
   let asking = false;
+  // Whether the LAST answer was "could not ask". Kept so that state is said
+  // once, each way, rather than per tick or never: a box whose bearer went
+  // stale, or whose status route answers 500 for good, otherwise looks exactly
+  // like a box where nothing changed — silence over a gate that has stopped
+  // working, which is the shape this module exists to remove.
+  let unreachable = false;
 
   async function refreshNow(): Promise<void> {
     if (asking) return;
@@ -598,7 +642,22 @@ export function watchEmailReadability(
       // `probeEmailReadStatus` never throws; a test double might, and a poll
       // that throws would take the whole server down through the interval.
       const answer = await probe().catch(() => null);
-      if (answer === null || answer === canRead) return;
+      if (answer === null) {
+        if (!unreachable) {
+          unreachable = true;
+          console.error(
+            "[clawbox-mcp] could not ask the device whether the mailbox is readable;"
+            + ` leaving ${EMAIL_READ_TOOL_NAMES.join(" and ")} as they are`,
+          );
+        }
+        return;
+      }
+      if (unreachable) {
+        unreachable = false;
+        console.error("[clawbox-mcp] the device is answering about the mailbox again");
+      }
+      if (answer === canRead) return;
+      const before = new Set(reg.list().map((tool) => tool.name));
       if (answer) registerEmailReadTools(reg);
       else for (const name of EMAIL_READ_TOOL_NAMES) reg.remove(name);
       // AFTER the change, never before it: the SDK refuses a second
@@ -608,9 +667,17 @@ export function watchEmailReadability(
       canRead = answer;
       // Worth a line: "the agent still cannot see my mailbox" is otherwise
       // invisible from the outside, and this is the moment that answers it.
+      //
+      // What actually MOVED, read off the registrar rather than assumed from
+      // `answer`: the profile gates inside `reg.tool` drop a tool silently, and
+      // `remove` is a no-op for a name that was never there, so "what was asked
+      // for" and "what the agent's list gained or lost" are two different facts.
+      // Only the second is worth writing down.
+      const after = new Set(reg.list().map((tool) => tool.name));
+      const moved = EMAIL_READ_TOOL_NAMES.filter((name) => before.has(name) !== after.has(name));
       console.error(
         `[clawbox-mcp] mailbox readable=${answer}; `
-        + `${answer ? "registered" : "withdrew"} ${EMAIL_READ_TOOL_NAMES.join(" and ")}`,
+        + `${answer ? "registered" : "withdrew"} ${moved.join(" and ") || "nothing"}`,
       );
     } finally {
       asking = false;

--- a/mcp/tools/email.ts
+++ b/mcp/tools/email.ts
@@ -574,10 +574,16 @@ export const EMAIL_READ_TOOL_NAMES = ["email_list", "email_read"] as const;
  * request refused often enough to look broken; polling faster buys nothing,
  * since the harness only re-reads the tool list between turns anyway.
  *
- * A DIRECT NUDGE would be better than any interval, and there is none to use:
- * the device's web server and this process share no channel, the OpenClaw
- * gateway exposes no RPC that reaches its MCP children (see
- * `registerEmailReadTools`), and `refreshNow` is here for the day one exists.
+ * A DIRECT NUDGE would be better than any interval, and none is wired: the
+ * OpenClaw gateway exposes no RPC that reaches its MCP children (see
+ * `registerEmailReadTools`), and no socket runs between the device's web server
+ * and this process. The one thing the two DO share is `data/config.json`, which
+ * `config-store` replaces by rename — so an `fs.watch` on `data/` would be a
+ * real nudge (mtime only; the answer would still come from the status route, so
+ * this process would still never read the secrets). Deliberately not taken here:
+ * it couples this process to a file it otherwise does not touch, and a missed
+ * event still needs an interval underneath as the floor. `refreshNow` is the
+ * seam to wire it to.
  */
 export const EMAIL_READABILITY_POLL_MS = 30_000;
 
@@ -658,8 +664,21 @@ export function watchEmailReadability(
       }
       if (answer === canRead) return;
       const before = new Set(reg.list().map((tool) => tool.name));
-      if (answer) registerEmailReadTools(reg);
-      else for (const name of EMAIL_READ_TOOL_NAMES) reg.remove(name);
+      if (answer) {
+        try {
+          registerEmailReadTools(reg);
+        } catch (err) {
+          // ALL OR NOTHING. The pair is two registrations, and this watch is the
+          // first caller that can run it more than once in a process: a throw
+          // between the two would leave one name held while `canRead` below
+          // stays false, so every later tick would re-register a name the SDK
+          // already holds and throw again — a permanently half-published list.
+          // Undo the half that landed (a no-op for a name never added) and let
+          // the interval's own catch report it; the next tick starts clean.
+          for (const name of EMAIL_READ_TOOL_NAMES) reg.remove(name);
+          throw err;
+        }
+      } else for (const name of EMAIL_READ_TOOL_NAMES) reg.remove(name);
       // AFTER the change, never before it: the SDK refuses a second
       // registration of a name it already holds, so a flip recorded over a
       // registration that threw would leave this server believing it had

--- a/src/app/setup-api/email/status/route.ts
+++ b/src/app/setup-api/email/status/route.ts
@@ -11,7 +11,8 @@
 // agent will actually do.
 
 import { NextResponse } from "next/server";
-import { DEFAULT_IMAP_HOST, DEFAULT_SMTP_HOST, DEFAULT_SMTP_PORT, publicEmailStatus } from "@/lib/email-config";
+import { getKnown } from "@/lib/config-store";
+import { DEFAULT_IMAP_HOST, DEFAULT_SMTP_HOST, DEFAULT_SMTP_PORT, EMAIL_KEYS, publicEmailStatus } from "@/lib/email-config";
 import { countPending } from "@/lib/email-pending";
 import { getActiveHarness } from "@/lib/harness";
 import { hermesEmailState } from "@/lib/hermes-email";
@@ -22,6 +23,25 @@ export async function GET() {
   try {
     const status = await publicEmailStatus();
     const harness = await getActiveHarness();
+    // WHY `configured: false` IS NOT ALWAYS "THERE IS NO ACCOUNT".
+    //
+    // `config-store`'s ordinary read answers `{}` to a missing file, an EACCES
+    // from a `data/config.json` an update left root-owned, an EIO and a
+    // half-written JSON alike — right for the settings it was written for, and
+    // a guess here. Nothing on a SCREEN needs the difference; the MCP server
+    // does, because it WITHDRAWS email_list/email_read from a running agent on
+    // a definite "no" (mcp/lib/context.ts probeEmailReadStatus), and one
+    // unreadable moment must not look like the owner switching reading off.
+    //
+    // Asked HERE rather than inside `publicEmailStatus`, which five other
+    // callers share and none of them needs this: the question is about the
+    // store, not about the account, and this is the one reader that acts on it.
+    // ONE strict read, and only when the answer is ambiguous — an account that
+    // resolved is itself proof the store was readable.
+    //
+    // Absent rather than `false` when all is well, so a build that predates the
+    // field cannot be read as one promising a readable store.
+    const storeUnreadable = status.configured ? false : !(await getKnown(EMAIL_KEYS.address)).known;
 
     // Only Hermes can receive mail; the UI hides the inbound fields otherwise
     // rather than offering a switch that does nothing.
@@ -29,6 +49,7 @@ export async function GET() {
 
     const base = {
       ...status,
+      ...(storeUnreadable ? { storeUnreadable: true } : {}),
       harness,
       inboundSupported,
       // The approvals strip needs a count even when the panel has not opened

--- a/src/app/setup-api/email/status/route.ts
+++ b/src/app/setup-api/email/status/route.ts
@@ -42,7 +42,7 @@ export async function GET() {
     //
     // Absent rather than `false` when all is well, so a build that predates the
     // field cannot be read as one promising a readable store.
-    const storeUnreadable = await emailStoreDisagrees(status.configured);
+    const storeUnreadable = await emailStoreDisagrees(status.configured, status.canRead);
 
     // Only Hermes can receive mail; the UI hides the inbound fields otherwise
     // rather than offering a switch that does nothing.

--- a/src/app/setup-api/email/status/route.ts
+++ b/src/app/setup-api/email/status/route.ts
@@ -11,8 +11,13 @@
 // agent will actually do.
 
 import { NextResponse } from "next/server";
-import { getKnown } from "@/lib/config-store";
-import { DEFAULT_IMAP_HOST, DEFAULT_SMTP_HOST, DEFAULT_SMTP_PORT, EMAIL_KEYS, publicEmailStatus } from "@/lib/email-config";
+import {
+  DEFAULT_IMAP_HOST,
+  DEFAULT_SMTP_HOST,
+  DEFAULT_SMTP_PORT,
+  emailStoreDisagrees,
+  publicEmailStatus,
+} from "@/lib/email-config";
 import { countPending } from "@/lib/email-pending";
 import { getActiveHarness } from "@/lib/harness";
 import { hermesEmailState } from "@/lib/hermes-email";
@@ -23,25 +28,17 @@ export async function GET() {
   try {
     const status = await publicEmailStatus();
     const harness = await getActiveHarness();
-    // WHY `configured: false` IS NOT ALWAYS "THERE IS NO ACCOUNT".
-    //
-    // `config-store`'s ordinary read answers `{}` to a missing file, an EACCES
-    // from a `data/config.json` an update left root-owned, an EIO and a
-    // half-written JSON alike — right for the settings it was written for, and
-    // a guess here. Nothing on a SCREEN needs the difference; the MCP server
-    // does, because it WITHDRAWS email_list/email_read from a running agent on
-    // a definite "no" (mcp/lib/context.ts probeEmailReadStatus), and one
-    // unreadable moment must not look like the owner switching reading off.
-    //
-    // Asked HERE rather than inside `publicEmailStatus`, which five other
-    // callers share and none of them needs this: the question is about the
-    // store, not about the account, and this is the one reader that acts on it.
-    // ONE strict read, and only when the answer is ambiguous — an account that
-    // resolved is itself proof the store was readable.
+    // WHY `configured: false` IS NOT ALWAYS "THERE IS NO ACCOUNT", and why this
+    // question is asked HERE: `publicEmailStatus` is shared with five callers
+    // that want the ACCOUNT, and this is the only reader that acts on the state
+    // of the STORE — the MCP server withdraws the mailbox read tools from a
+    // running agent on a definite "no". `emailStoreDisagrees` owns the rule and
+    // the reasoning; it is asked only when the answer is ambiguous, because an
+    // account that resolved is itself proof the store was readable.
     //
     // Absent rather than `false` when all is well, so a build that predates the
     // field cannot be read as one promising a readable store.
-    const storeUnreadable = status.configured ? false : !(await getKnown(EMAIL_KEYS.address)).known;
+    const storeUnreadable = status.configured ? false : await emailStoreDisagrees();
 
     // Only Hermes can receive mail; the UI hides the inbound fields otherwise
     // rather than offering a switch that does nothing.

--- a/src/app/setup-api/email/status/route.ts
+++ b/src/app/setup-api/email/status/route.ts
@@ -28,17 +28,21 @@ export async function GET() {
   try {
     const status = await publicEmailStatus();
     const harness = await getActiveHarness();
-    // WHY `configured: false` IS NOT ALWAYS "THERE IS NO ACCOUNT", and why this
-    // question is asked HERE: `publicEmailStatus` is shared with five callers
-    // that want the ACCOUNT, and this is the only reader that acts on the state
-    // of the STORE — the MCP server withdraws the mailbox read tools from a
-    // running agent on a definite "no". `emailStoreDisagrees` owns the rule and
-    // the reasoning; it is asked only when the answer is ambiguous, because an
-    // account that resolved is itself proof the store was readable.
+    // WHY THE STORE IS QUESTIONED AT ALL, and why HERE: `publicEmailStatus` is
+    // shared with five callers that want the ACCOUNT, and this is the only
+    // reader that acts on the state of the STORE — the MCP server withdraws the
+    // mailbox read tools from a running agent on a definite "no".
+    // `emailStoreDisagrees` owns the rule and the reasoning.
+    //
+    // Asked on BOTH branches. `configured: true, canRead: false` is reachable
+    // from a store that went unreadable midway through `getEmailCredentials`'
+    // per-key reads, and is the same definite "no" as the other branch; the flag
+    // is passed so the function knows which of its two questions is the
+    // ambiguous one, not whether to look.
     //
     // Absent rather than `false` when all is well, so a build that predates the
     // field cannot be read as one promising a readable store.
-    const storeUnreadable = status.configured ? false : await emailStoreDisagrees();
+    const storeUnreadable = await emailStoreDisagrees(status.configured);
 
     // Only Hermes can receive mail; the UI hides the inbound fields otherwise
     // rather than offering a switch that does nothing.

--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -192,18 +192,59 @@ function held(config: Record<string, unknown>, key: string): unknown {
   return Object.hasOwn(config, key) ? config[key] : undefined;
 }
 
+/**
+ * WHY THIS LOGS THE KIND OF FAILURE AND NEVER THE MESSAGE.
+ *
+ * A `SyntaxError` from `JSON.parse` quotes a WINDOW OF THE INPUT in its own
+ * message — `Unexpected token '}', ..."d": "s3cret", "a": }" is not valid
+ * JSON` — and the input here is the file holding the mailbox password, both
+ * bot tokens and the portal token. Printing `err.message` therefore puts a
+ * slice of those secrets in the journal, which `logs_tail` hands straight back
+ * to the agent. The failing PATH is already in the line; the class or errno is
+ * everything an operator needs to tell "no permission" from "corrupt".
+ */
+function readFailureKind(err: unknown): string {
+  if (err instanceof SyntaxError) return "invalid JSON";
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  if (typeof code === "string" && code.length > 0) return code;
+  return err instanceof Error ? err.name : "unknown error";
+}
+
 /** One key, tri-state: `known: false` when the store could not be read. */
 export async function getKnown(key: string): Promise<{ value: unknown; known: boolean }> {
   try {
     return { value: held(readConfigStrict(), key), known: true };
   } catch (err) {
-    // The message only: a JSON parse error quotes a window of the INPUT, and
-    // this file holds the mailbox password and both bot tokens.
-    console.error(
-      "[config-store] data/config.json could not be read:",
-      err instanceof Error ? err.message : err,
-    );
+    console.error("[config-store] data/config.json could not be read:", readFailureKind(err));
     return { value: undefined, known: false };
+  }
+}
+
+/**
+ * The same tri-state, for several keys, from ONE read.
+ *
+ * Asking `getKnown` three times reads the file three times, and three reads of
+ * one file can disagree: a store readable for the first key and unreadable for
+ * the third answers a torn mixture that no single state of the disk ever had.
+ * Every caller weighing several keys against each other wants this instead.
+ */
+export async function getKnownMany(
+  keys: readonly string[],
+): Promise<{ values: Record<string, unknown>; known: boolean }> {
+  try {
+    const config = readConfigStrict();
+    // A NULL-PROTOTYPE bag, because the keys are strings from the caller and one
+    // of them can be `"__proto__"`: on an ordinary object literal
+    // `values["__proto__"] = undefined` reaches Object.prototype's setter
+    // instead of creating an own property, and the read back then answers the
+    // PROTOTYPE OBJECT for a key the store holds nothing under. `held` already
+    // guards the read side of this; the write side needs the same care.
+    const values: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+    for (const key of keys) values[key] = held(config, key);
+    return { values, known: true };
+  } catch (err) {
+    console.error("[config-store] data/config.json could not be read:", readFailureKind(err));
+    return { values: {}, known: false };
   }
 }
 

--- a/src/lib/email-config.ts
+++ b/src/lib/email-config.ts
@@ -12,7 +12,7 @@
 // boolean, because "which account is this box sending as" is a legitimate
 // question and "what is the password" is not.
 
-import { get, setMany } from "@/lib/config-store";
+import { get, getKnown, setMany } from "@/lib/config-store";
 import type { ImapConfig } from "@/lib/imap-client";
 import { isEmailAddress, isHostname, isPort, type SmtpConfig } from "@/lib/smtp-client";
 
@@ -249,6 +249,37 @@ export async function publicEmailStatus(): Promise<PublicEmailStatus> {
     canRead: modeAllowsReading(settings.mode),
     askBeforeSend: settings.askBeforeSend,
   };
+}
+
+/**
+ * Whether a `configured: false` can be TRUSTED — asked with the strict read, and
+ * kept beside `getEmailCredentials` because it is the same three keys.
+ *
+ * `config-store`'s ordinary read answers `{}` to a missing file, an EACCES from
+ * a `data/config.json` an update left root-owned, an EIO and a half-written JSON
+ * alike. That is right for the settings it was written for and a guess here: the
+ * MCP server WITHDRAWS the mailbox read tools from a running agent on a definite
+ * "no" (mcp/lib/context.ts `probeEmailReadStatus`), and one unreadable moment
+ * must not look like the owner switching reading off.
+ *
+ * TWO READS OF ONE FILE CAN DISAGREE, which is the other half. A store that was
+ * unreadable when `getEmailCredentials` looked and readable a moment later would
+ * answer `configured: false` with a clean bill of health — the first read's
+ * failure erased by the second read's success. So this reports UNREADABLE for
+ * either shape: a strict read that fails, and a strict read that finds a
+ * complete account behind a `configured: false`, which no single snapshot can
+ * produce. A half-filled account (an address and no password) is neither — it is
+ * genuinely not configured, and says so.
+ */
+export async function emailStoreDisagrees(): Promise<boolean> {
+  const [address, password, smtpHost] = await Promise.all([
+    getKnown(EMAIL_KEYS.address),
+    getKnown(EMAIL_KEYS.password),
+    getKnown(EMAIL_KEYS.smtpHost),
+  ]);
+  if (!address.known || !password.known || !smtpHost.known) return true;
+  // Presence only. The value never leaves this function.
+  return [address, password, smtpHost].every((k) => asString(k.value).length > 0);
 }
 
 export function toSmtpConfig(settings: EmailSettings): SmtpConfig {

--- a/src/lib/email-config.ts
+++ b/src/lib/email-config.ts
@@ -310,6 +310,18 @@ export async function emailStoreDisagrees(
   // The unambiguous shape, on either branch: we could not read the file at all.
   if (!known) return true;
   if (accountResolved) {
+    // The account itself has to still be there. An account that resolved from the
+    // first read and is INCOMPLETE in this one is the same disagreement as the
+    // opposite shape below, and comparing only the mode would miss it: a strict
+    // snapshot with no credentials but `email_mode: "read"` agrees about reading
+    // and has no mailbox to read, so the watch would hold the read tools open
+    // over an account that is not there.
+    const accountStillResolved = [
+      EMAIL_KEYS.address,
+      EMAIL_KEYS.password,
+      EMAIL_KEYS.smtpHost,
+    ].every((key) => asString(values[key]).length > 0);
+    if (!accountStillResolved) return true;
     // Nothing to compare against on a build that does not pass it.
     if (canRead === undefined) return false;
     const rawSenders = values[EMAIL_KEYS.allowedSenders];

--- a/src/lib/email-config.ts
+++ b/src/lib/email-config.ts
@@ -282,20 +282,46 @@ export async function publicEmailStatus(): Promise<PublicEmailStatus> {
  * produce. A half-filled account (an address and no password) is neither — it is
  * genuinely not configured, and says so.
  *
- * One read, not three: three `getKnown` calls are three reads that can disagree
- * with each other, which is the very fault this function exists to catch.
+ * A RESOLVED account is still questioned, because a store can heal between the
+ * two reads as easily as it can break: `getEmailCredentials` loses `email_mode`
+ * to a failed read, falls back to "send", and answers
+ * `{ configured: true, canRead: false }`; if the file is readable again by the
+ * time this looks, "the store is fine" would erase that failure exactly as the
+ * earlier version erased the other one. So the mode is read strictly here too
+ * and compared with the `canRead` the caller derived — a disagreement means the
+ * two reads saw different files, and the honest answer is "could not ask".
+ *
+ * One read, not several: separate `getKnown` calls are separate reads that can
+ * disagree with each other, which is the very fault this function exists to
+ * catch.
  */
-export async function emailStoreDisagrees(accountResolved: boolean): Promise<boolean> {
+export async function emailStoreDisagrees(
+  accountResolved: boolean,
+  canRead?: boolean,
+): Promise<boolean> {
   const { values, known } = await getKnownMany([
     EMAIL_KEYS.address,
     EMAIL_KEYS.password,
     EMAIL_KEYS.smtpHost,
+    EMAIL_KEYS.mode,
+    EMAIL_KEYS.imapHost,
+    EMAIL_KEYS.allowedSenders,
   ]);
   // The unambiguous shape, on either branch: we could not read the file at all.
   if (!known) return true;
-  // The store IS readable and the account resolved from it — the two reads agree,
-  // and a `canRead: false` here is the owner's own choice of mode.
-  if (accountResolved) return false;
+  if (accountResolved) {
+    // Nothing to compare against on a build that does not pass it.
+    if (canRead === undefined) return false;
+    const rawSenders = values[EMAIL_KEYS.allowedSenders];
+    const strictMode = resolveStoredMode(
+      values[EMAIL_KEYS.mode],
+      asString(values[EMAIL_KEYS.imapHost]) || undefined,
+      Array.isArray(rawSenders)
+        ? rawSenders.filter((s): s is string => typeof s === "string")
+        : undefined,
+    );
+    return modeAllowsReading(strictMode) !== canRead;
+  }
   // Presence only. The value never leaves this function.
   return [EMAIL_KEYS.address, EMAIL_KEYS.password, EMAIL_KEYS.smtpHost].every(
     (key) => asString(values[key]).length > 0,

--- a/src/lib/email-config.ts
+++ b/src/lib/email-config.ts
@@ -12,7 +12,7 @@
 // boolean, because "which account is this box sending as" is a legitimate
 // question and "what is the password" is not.
 
-import { get, getKnown, setMany } from "@/lib/config-store";
+import { get, getKnownMany, setMany } from "@/lib/config-store";
 import type { ImapConfig } from "@/lib/imap-client";
 import { isEmailAddress, isHostname, isPort, type SmtpConfig } from "@/lib/smtp-client";
 
@@ -252,8 +252,9 @@ export async function publicEmailStatus(): Promise<PublicEmailStatus> {
 }
 
 /**
- * Whether a `configured: false` can be TRUSTED — asked with the strict read, and
- * kept beside `getEmailCredentials` because it is the same three keys.
+ * Whether the answer `publicEmailStatus` just gave can be TRUSTED — asked with
+ * the strict read, and kept beside `getEmailCredentials` because it is the same
+ * three keys.
  *
  * `config-store`'s ordinary read answers `{}` to a missing file, an EACCES from
  * a `data/config.json` an update left root-owned, an EIO and a half-written JSON
@@ -261,6 +262,16 @@ export async function publicEmailStatus(): Promise<PublicEmailStatus> {
  * MCP server WITHDRAWS the mailbox read tools from a running agent on a definite
  * "no" (mcp/lib/context.ts `probeEmailReadStatus`), and one unreadable moment
  * must not look like the owner switching reading off.
+ *
+ * ASKED ON BOTH BRANCHES, not only behind a `configured: false`. An account that
+ * resolved is NOT proof the store was readable throughout:
+ * `getEmailCredentials` reads the file once per key through the forgiving
+ * reader, and only the first three gate `configured`. A store readable for those
+ * three and unreadable by the time `email_mode` is read yields
+ * `{ configured: true, canRead: false }` — `resolveStoredMode` sees `undefined`
+ * and falls back to "send" — which is the same definite "no" that costs a
+ * running agent its mailbox tools. `accountResolved` therefore selects WHICH
+ * question is ambiguous, never whether to ask.
  *
  * TWO READS OF ONE FILE CAN DISAGREE, which is the other half. A store that was
  * unreadable when `getEmailCredentials` looked and readable a moment later would
@@ -270,16 +281,25 @@ export async function publicEmailStatus(): Promise<PublicEmailStatus> {
  * complete account behind a `configured: false`, which no single snapshot can
  * produce. A half-filled account (an address and no password) is neither — it is
  * genuinely not configured, and says so.
+ *
+ * One read, not three: three `getKnown` calls are three reads that can disagree
+ * with each other, which is the very fault this function exists to catch.
  */
-export async function emailStoreDisagrees(): Promise<boolean> {
-  const [address, password, smtpHost] = await Promise.all([
-    getKnown(EMAIL_KEYS.address),
-    getKnown(EMAIL_KEYS.password),
-    getKnown(EMAIL_KEYS.smtpHost),
+export async function emailStoreDisagrees(accountResolved: boolean): Promise<boolean> {
+  const { values, known } = await getKnownMany([
+    EMAIL_KEYS.address,
+    EMAIL_KEYS.password,
+    EMAIL_KEYS.smtpHost,
   ]);
-  if (!address.known || !password.known || !smtpHost.known) return true;
+  // The unambiguous shape, on either branch: we could not read the file at all.
+  if (!known) return true;
+  // The store IS readable and the account resolved from it — the two reads agree,
+  // and a `canRead: false` here is the owner's own choice of mode.
+  if (accountResolved) return false;
   // Presence only. The value never leaves this function.
-  return [address, password, smtpHost].every((k) => asString(k.value).length > 0);
+  return [EMAIL_KEYS.address, EMAIL_KEYS.password, EMAIL_KEYS.smtpHost].every(
+    (key) => asString(values[key]).length > 0,
+  );
 }
 
 export function toSmtpConfig(settings: EmailSettings): SmtpConfig {

--- a/src/lib/email-mcp-refresh.ts
+++ b/src/lib/email-mcp-refresh.ts
@@ -27,6 +27,17 @@ import { MCP_RELOAD_ASKED, reloadMcpServers, reportMcpReloadRefused } from "@/li
  * The mechanism is Hermes' own `reload.mcp`, and it is shared with the other
  * family that has the same startup-only gate — see `hermes-mcp-reload.ts`. What
  * belongs HERE is the rule for when it is worth paying for, below.
+ *
+ * IT IS NO LONGER THE ONLY HALF, and it never worked on the OpenClaw SKU, which
+ * has no dashboard to ask and no CLI or gateway call that reaches a running
+ * agent's MCP runtimes. The same symptom therefore turned up there
+ * (2026-09-10): the owner's box had moved to "Read on demand" and the MCP child
+ * serving the chat, 28 minutes old, still advertised `email_send` alone. So the
+ * MCP server now re-probes this one gate itself and registers or withdraws the
+ * pair on a running connection (`watchEmailReadability`, mcp/tools/email.ts) —
+ * which is what fixes OpenClaw, and is the backstop on Hermes. This call stays
+ * because it is INSTANT where it works: the owner who has just pressed Save is
+ * the person waiting, and a poll interval is a wait the dashboard can skip.
  */
 
 /**
@@ -58,8 +69,15 @@ export async function refreshEmailToolsIfReadabilityChanged(before: boolean, aft
   if (!(await reloadMcpServers().catch(() => false))) {
     // Logged, not surfaced. Worth a line because "the agent still cannot see my
     // mailbox" is otherwise invisible from the outside, and this is the one
-    // place that knows the refresh was wanted and did not happen.
-    await reportMcpReloadRefused("email/mcp-refresh", became);
+    // place that knows the refresh was wanted and did not happen. The note is
+    // this family's own: unlike the other three, the MCP server re-probes this
+    // gate by itself, so a box with no dashboard is waiting a poll interval and
+    // not a restart.
+    await reportMcpReloadRefused(
+      "email/mcp-refresh",
+      became,
+      "the MCP server re-probes the mailbox gate on its own within the minute",
+    );
     return;
   }
   console.log(`[email/mcp-refresh] ${became}; ${MCP_RELOAD_ASKED}`);

--- a/src/lib/email-mcp-refresh.ts
+++ b/src/lib/email-mcp-refresh.ts
@@ -55,10 +55,10 @@ import { MCP_RELOAD_ASKED, reloadMcpServers, reportMcpReloadRefused } from "@/li
  * Never throws and never reports. A box whose dashboard is down, or an OpenClaw
  * box that has no dashboard at all, must not have its email settings save turned
  * into an error by a best-effort refresh: the settings ARE saved, the gate is
- * still enforced route-side, and the tool list catches up at the next restart —
- * which is exactly the behaviour of every box before this existed. WHICH of
- * those two it was decides how it is said; `reportMcpReloadRefused` owns that
- * rule for all three refresh helpers.
+ * still enforced route-side, and — for THIS family since 2026-09-10 — the MCP
+ * server re-probes the gate on its own within its poll, so a refusal here costs
+ * the owner seconds rather than a restart. WHICH of those it was decides how it
+ * is said; `reportMcpReloadRefused` owns that rule for all five refresh helpers.
  */
 export async function refreshEmailToolsIfReadabilityChanged(before: boolean, after: boolean): Promise<void> {
   if (before === after) return;
@@ -76,7 +76,10 @@ export async function refreshEmailToolsIfReadabilityChanged(before: boolean, aft
     await reportMcpReloadRefused(
       "email/mcp-refresh",
       became,
-      "the MCP server re-probes the mailbox gate on its own within the minute",
+      // Hedged on purpose: the re-probe belongs to a RUNNING MCP server, and a
+      // box between sessions has none. Both halves are true as written.
+      "a running MCP server re-probes the mailbox gate on its own within the minute,"
+        + " and one started later re-probes as it boots",
     );
     return;
   }

--- a/src/lib/hermes-mcp-reload.ts
+++ b/src/lib/hermes-mcp-reload.ts
@@ -57,7 +57,7 @@ const ACTED_STATUSES = new Set(["ok", "reloaded", "success", "completed", "done"
  * is a perfectly ordinary non-error reply that means NOTHING HAPPENED (see
  * `RELOAD_PARAMS`), and a `result !== null` test scored it as success. That is
  * the "reported from the fact that a call returned, not from what it returned"
- * shape, in the one helper all four refresh call sites depend on.
+ * shape, in the one helper all five refresh call sites depend on.
  *
  * A reply that names NO status stays a success: that is the historical reading,
  * and only a frame that names a state is allowed to contradict it — a dashboard
@@ -110,11 +110,17 @@ export const MCP_RELOAD_ALREADY = "the MCP servers were already reloaded for thi
  * what will actually happen next — and WHAT that is differs per family, which is
  * why a caller may supply the sentence (`noDashboardNote`). The MCP server
  * re-probes the mailbox gate on its own now (mcp/tools/email.ts), so the mailbox
- * catches up within its poll; nothing re-probes the other three, and for them
- * the honest answer is still "when the MCP server is next spawned". That is a
- * longer wait than it reads: measured on the owner's OpenClaw box (2026-09-10)
- * the child serving the chat had been up for 28 minutes across a settings
- * change, so an OpenClaw box is not quietly respawning these servers.
+ * catches up within its poll; nothing re-probes the other FOUR families, and for
+ * them the honest answer is still "when the MCP server is next spawned". That is
+ * a longer wait than it reads: measured on the owner's OpenClaw box
+ * (2026-09-10) the child serving the chat had been up for 28 minutes across a
+ * settings change, so an OpenClaw box is not quietly respawning these servers.
+ *
+ * The note rides on the REFUSAL line too, not just the no-dashboard one. A
+ * Hermes box whose dashboard answers `confirm_required` is a real refusal and
+ * stays an error — but for the family that repairs itself, an operator reading
+ * that line needs to know the tool list is not stuck, or the error is the same
+ * false alarm one branch further along.
  *
  * THE QUESTION IS THE EDITION, NOT THE ACTIVE HARNESS. Which agent serves the
  * owner right now and whether this box HAS a Hermes dashboard are different
@@ -165,5 +171,7 @@ export async function reportMcpReloadRefused(
   // Names the mechanism, like the success sentences above and for the same
   // reason: what was asked is Hermes' dashboard, whatever this box calls its
   // agent.
-  console.error(`${line}, but Hermes would not reload its MCP servers`);
+  console.error(
+    `${line}, but Hermes would not reload its MCP servers — ${logSafe(noDashboardNote, 160)}`,
+  );
 }

--- a/src/lib/hermes-mcp-reload.ts
+++ b/src/lib/hermes-mcp-reload.ts
@@ -96,17 +96,25 @@ export const MCP_RELOAD_ALREADY = "the MCP servers were already reloaded for thi
  * Every family this module serves is registered on BOTH editions (the mailbox
  * read tools, the coding-agent family, the honest-refusal `image_generate`), but
  * the only mechanism here is HERMES' dashboard JSON-RPC. An OpenClaw box has no
- * dashboard by design, so `reloadMcpServers()` can never return true there — and
- * nothing is broken when it does not: OpenClaw spawns the ClawBox MCP server
- * lazily per session and reaps it after ten idle minutes, so the probe re-runs
- * and the tool list catches up on its own. Reporting that as an ERROR is the
- * recurring false-alarm shape — a repair announced over an operation that in
- * fact succeeded — and it costs a real one: an operator who learns to skip these
- * lines skips the Hermes box that genuinely refused.
+ * dashboard by design, so `reloadMcpServers()` can never return true there, and
+ * there is nothing else to ask: `openclaw mcp reload` disposes the MCP runtimes
+ * cached in the CLI's OWN process and the running gateway never hears of it
+ * (`disposeAllSessionMcpRuntimes`, OpenClaw 2026.8.1), and that gateway's
+ * JSON-RPC exposes no MCP method at all. Reporting the absence as an ERROR is
+ * still the recurring false-alarm shape — a repair announced over a box that is
+ * behaving exactly as designed — and it costs a real one: an operator who learns
+ * to skip these lines skips the Hermes box that genuinely refused.
  *
  * So `console.error` is kept for exactly the case a human can act on: a box that
  * HAS a dashboard and it said no. Everything else is a `console.log` that says
- * what will actually happen next.
+ * what will actually happen next — and WHAT that is differs per family, which is
+ * why a caller may supply the sentence (`noDashboardNote`). The MCP server
+ * re-probes the mailbox gate on its own now (mcp/tools/email.ts), so the mailbox
+ * catches up within its poll; nothing re-probes the other three, and for them
+ * the honest answer is still "when the MCP server is next spawned". That is a
+ * longer wait than it reads: measured on the owner's OpenClaw box (2026-09-10)
+ * the child serving the chat had been up for 28 minutes across a settings
+ * change, so an OpenClaw box is not quietly respawning these servers.
  *
  * THE QUESTION IS THE EDITION, NOT THE ACTIVE HARNESS. Which agent serves the
  * owner right now and whether this box HAS a Hermes dashboard are different
@@ -129,8 +137,15 @@ export const MCP_RELOAD_ALREADY = "the MCP servers were already reloaded for thi
  * @param tag   the caller's log prefix, e.g. `coding-agent/mcp-refresh`
  * @param what  what changed, in the caller's own words, e.g. "the coding agent
  *              became available"
+ * @param noDashboardNote what happens NEXT on a box with no dashboard, in the
+ *              caller's own words. Defaults to the wait every family without a
+ *              re-probe of its own is in for.
  */
-export async function reportMcpReloadRefused(tag: string, what: string): Promise<void> {
+export async function reportMcpReloadRefused(
+  tag: string,
+  what: string,
+  noDashboardNote = "the tool list re-probes when the MCP server is next spawned",
+): Promise<void> {
   // BOUND THE RECORD, whoever the caller is. Five families share these two
   // lines — `hermes-image-refresh`, `email-mcp-refresh`, `provider-mcp-refresh`,
   // `coding-agent-mcp-refresh` and `harness-mcp-refresh` — and one of them
@@ -144,10 +159,7 @@ export async function reportMcpReloadRefused(tag: string, what: string): Promise
   const { edition, defaulted } = readEditionSource();
   const mayHaveDashboard = defaulted || edition === "hermes" || edition === "dual";
   if (!mayHaveDashboard) {
-    console.log(
-      `${line}; this edition has no dashboard to ask — the tool list re-probes `
-        + "when the MCP server is next spawned",
-    );
+    console.log(`${line}; this edition has no dashboard to ask — ${logSafe(noDashboardNote, 160)}`);
     return;
   }
   // Names the mechanism, like the success sentences above and for the same

--- a/src/tests/helpers/mcp-registrar.ts
+++ b/src/tests/helpers/mcp-registrar.ts
@@ -55,6 +55,9 @@ export function captureRegistrar(edition: "openclaw" | "hermes" = "hermes"): Cap
       if (opts.editions && !opts.editions.includes(edition)) return;
       tools.set(name, { name, description, shape, opts, handler });
     },
+    remove(name) {
+      tools.delete(name);
+    },
     list() {
       return [...tools.values()].map((t) => ({
         name: t.name,

--- a/src/tests/routes/email/status.test.ts
+++ b/src/tests/routes/email/status.test.ts
@@ -137,6 +137,35 @@ describe("GET /setup-api/email/status", () => {
     expect(data.storeUnreadable).toBe(true);
   });
 
+  it("says so when a failed mode read is healed by the time the store is re-read", async () => {
+    // The mirror of the two-reads-disagree case, on the resolved branch: the
+    // lenient per-key reads lose email_mode, resolveStoredMode falls back to
+    // "send" and the account still answers configured:true/canRead:false — and
+    // if the file is readable again a moment later, "the store is fine" would
+    // erase that failure exactly as the earlier version erased the other one,
+    // and the agent would lose the read tools over one transient EACCES.
+    storeWith({
+      email_address: "box@example.com",
+      email_password: PASSWORD,
+      email_smtp_host: "smtp.example.com",
+      // email_mode lost to the failed read.
+    });
+    mockGetKnownMany.mockResolvedValue({
+      known: true,
+      values: {
+        email_address: "box@example.com",
+        email_password: PASSWORD,
+        email_smtp_host: "smtp.example.com",
+        // The healed store still says the owner wants reading.
+        email_mode: "read",
+      },
+    });
+    const data = await (await GET()).json();
+    expect(data.configured).toBe(true);
+    expect(data.canRead).toBe(false);
+    expect(data.storeUnreadable).toBe(true);
+  });
+
   it("stays quiet about the store when a resolved account merely chose send-only", async () => {
     // The other side of that coin: the store is readable and the owner picked a
     // mode that keeps the mailbox shut. A flag here would make every send-only
@@ -153,6 +182,7 @@ describe("GET /setup-api/email/status", () => {
         email_address: "box@example.com",
         email_password: PASSWORD,
         email_smtp_host: "smtp.example.com",
+        email_mode: "send",
       },
     });
     const data = await (await GET()).json();

--- a/src/tests/routes/email/status.test.ts
+++ b/src/tests/routes/email/status.test.ts
@@ -166,6 +166,29 @@ describe("GET /setup-api/email/status", () => {
     expect(data.storeUnreadable).toBe(true);
   });
 
+  it("says so when the account itself is gone from the strict snapshot", async () => {
+    // The symmetric case. The first read resolved a complete, readable account;
+    // the strict read finds no credentials but still carries email_mode "read",
+    // so comparing the MODE alone agrees — about a mailbox that is not there.
+    // The two reads disagree about whether an account exists at all, which is
+    // the same fault as the opposite shape, and acting on the stale answer would
+    // hold email_list/email_read open over nothing.
+    storeWith({
+      email_address: "box@example.com",
+      email_password: PASSWORD,
+      email_smtp_host: "smtp.example.com",
+      email_mode: "read",
+    });
+    mockGetKnownMany.mockResolvedValue({
+      known: true,
+      values: { email_mode: "read" },
+    });
+    const data = await (await GET()).json();
+    expect(data.configured).toBe(true);
+    expect(data.canRead).toBe(true);
+    expect(data.storeUnreadable).toBe(true);
+  });
+
   it("stays quiet about the store when a resolved account merely chose send-only", async () => {
     // The other side of that coin: the store is readable and the owner picked a
     // mode that keeps the mailbox shut. A flag here would make every send-only

--- a/src/tests/routes/email/status.test.ts
+++ b/src/tests/routes/email/status.test.ts
@@ -94,6 +94,41 @@ describe("GET /setup-api/email/status", () => {
     expect(data.storeUnreadable).toBe(true);
   });
 
+  it("says so when the FIRST read failed and a later one succeeded", async () => {
+    // Two reads of one file can disagree. A store that was unreadable when the
+    // account was resolved and readable a moment later would otherwise answer
+    // `configured: false` with a clean bill of health — the first read's failure
+    // erased by the second read's success — and the agent would lose the read
+    // tools over a transient EACCES. No single snapshot can hold a complete
+    // account behind a `configured: false`, so that shape is reported as
+    // unreadable too.
+    storeWith({});
+    mockGetKnown.mockImplementation(async (key: string) => ({
+      known: true,
+      value: {
+        email_address: "box@example.com",
+        email_password: PASSWORD,
+        email_smtp_host: "smtp.gmail.com",
+      }[key],
+    }));
+    const data = await (await GET()).json();
+    expect(data.configured).toBe(false);
+    expect(data.storeUnreadable).toBe(true);
+  });
+
+  it("does not cry unreadable over an account that is genuinely half-filled", async () => {
+    // An address and no app password is not a store problem — it is a device
+    // that is not set up, and the read tools are correctly absent.
+    storeWith({ email_address: "box@example.com" });
+    mockGetKnown.mockImplementation(async (key: string) => ({
+      known: true,
+      value: key === "email_address" ? "box@example.com" : undefined,
+    }));
+    const data = await (await GET()).json();
+    expect(data.configured).toBe(false);
+    expect(data.storeUnreadable).toBeUndefined();
+  });
+
   it("carries the pending-draft count and the defaults the panel fills in with", async () => {
     // The badge on the nav item comes from here, before the panel has ever
     // opened the pending route.

--- a/src/tests/routes/email/status.test.ts
+++ b/src/tests/routes/email/status.test.ts
@@ -5,6 +5,7 @@ vi.mock("@/lib/config-store", async (importOriginal) => ({
   // email routes now reach) keeps its value.
   ...(await importOriginal<typeof import("@/lib/config-store")>()),
   get: vi.fn(),
+  getKnown: vi.fn(),
   setMany: vi.fn(),
 }));
 vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn() }));
@@ -14,12 +15,13 @@ vi.mock("@/lib/hermes-email", () => ({ hermesEmailState: vi.fn() }));
 // machine running the suite.
 vi.mock("@/lib/email-pending", () => ({ countPending: vi.fn() }));
 
-import { get } from "@/lib/config-store";
+import { get, getKnown } from "@/lib/config-store";
 import { getActiveHarness } from "@/lib/harness";
 import { countPending } from "@/lib/email-pending";
 import { hermesEmailState } from "@/lib/hermes-email";
 
 const mockGet = vi.mocked(get);
+const mockGetKnown = vi.mocked(getKnown);
 const mockHarness = vi.mocked(getActiveHarness);
 const mockHermesState = vi.mocked(hermesEmailState);
 const mockCount = vi.mocked(countPending);
@@ -38,6 +40,8 @@ beforeEach(async () => {
   vi.stubGlobal("fetch", vi.fn(async () => new Response("{}", { status: 500 })));
   mockHarness.mockResolvedValue("openclaw");
   mockCount.mockReturnValue(0);
+  // The default is a store that WAS read and holds nothing.
+  mockGetKnown.mockResolvedValue({ value: undefined, known: true });
   storeWith({});
   GET = (await import("@/app/setup-api/email/status/route")).GET;
 });
@@ -68,7 +72,26 @@ describe("GET /setup-api/email/status", () => {
   });
 
   it("answers canRead false on a device with no account", async () => {
-    expect((await (await GET()).json()).canRead).toBe(false);
+    const data = await (await GET()).json();
+    expect(data.canRead).toBe(false);
+    // …and says nothing about the store, because there was nothing wrong with
+    // it. `storeUnreadable` is absent rather than false, so a build that
+    // predates the field cannot be read as "the store was fine".
+    expect(data.storeUnreadable).toBeUndefined();
+  });
+
+  it("says so when `configured: false` only means the store could not be READ", async () => {
+    // The ordinary config read answers `{}` to an EACCES, an EIO and a
+    // half-written JSON alike, so "no account" and "could not look" arrive here
+    // as the same 200. They are not the same answer: the MCP server WITHDRAWS
+    // email_list/email_read from a running agent on a definite no, and a
+    // root-owned data/config.json after an update would otherwise take a
+    // working mailbox away from it (mcp/lib/context.ts probeEmailReadStatus).
+    mockGetKnown.mockResolvedValue({ value: undefined, known: false });
+    const data = await (await GET()).json();
+    expect(data.configured).toBe(false);
+    expect(data.canRead).toBe(false);
+    expect(data.storeUnreadable).toBe(true);
   });
 
   it("carries the pending-draft count and the defaults the panel fills in with", async () => {

--- a/src/tests/routes/email/status.test.ts
+++ b/src/tests/routes/email/status.test.ts
@@ -5,7 +5,7 @@ vi.mock("@/lib/config-store", async (importOriginal) => ({
   // email routes now reach) keeps its value.
   ...(await importOriginal<typeof import("@/lib/config-store")>()),
   get: vi.fn(),
-  getKnown: vi.fn(),
+  getKnownMany: vi.fn(),
   setMany: vi.fn(),
 }));
 vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn() }));
@@ -15,13 +15,13 @@ vi.mock("@/lib/hermes-email", () => ({ hermesEmailState: vi.fn() }));
 // machine running the suite.
 vi.mock("@/lib/email-pending", () => ({ countPending: vi.fn() }));
 
-import { get, getKnown } from "@/lib/config-store";
+import { get, getKnownMany } from "@/lib/config-store";
 import { getActiveHarness } from "@/lib/harness";
 import { countPending } from "@/lib/email-pending";
 import { hermesEmailState } from "@/lib/hermes-email";
 
 const mockGet = vi.mocked(get);
-const mockGetKnown = vi.mocked(getKnown);
+const mockGetKnownMany = vi.mocked(getKnownMany);
 const mockHarness = vi.mocked(getActiveHarness);
 const mockHermesState = vi.mocked(hermesEmailState);
 const mockCount = vi.mocked(countPending);
@@ -41,7 +41,7 @@ beforeEach(async () => {
   mockHarness.mockResolvedValue("openclaw");
   mockCount.mockReturnValue(0);
   // The default is a store that WAS read and holds nothing.
-  mockGetKnown.mockResolvedValue({ value: undefined, known: true });
+  mockGetKnownMany.mockResolvedValue({ values: {}, known: true });
   storeWith({});
   GET = (await import("@/app/setup-api/email/status/route")).GET;
 });
@@ -87,7 +87,7 @@ describe("GET /setup-api/email/status", () => {
     // email_list/email_read from a running agent on a definite no, and a
     // root-owned data/config.json after an update would otherwise take a
     // working mailbox away from it (mcp/lib/context.ts probeEmailReadStatus).
-    mockGetKnown.mockResolvedValue({ value: undefined, known: false });
+    mockGetKnownMany.mockResolvedValue({ values: {}, known: false });
     const data = await (await GET()).json();
     expect(data.configured).toBe(false);
     expect(data.canRead).toBe(false);
@@ -103,27 +103,72 @@ describe("GET /setup-api/email/status", () => {
     // account behind a `configured: false`, so that shape is reported as
     // unreadable too.
     storeWith({});
-    mockGetKnown.mockImplementation(async (key: string) => ({
+    mockGetKnownMany.mockResolvedValue({
       known: true,
-      value: {
+      values: {
         email_address: "box@example.com",
         email_password: PASSWORD,
         email_smtp_host: "smtp.gmail.com",
-      }[key],
-    }));
+      },
+    });
     const data = await (await GET()).json();
     expect(data.configured).toBe(false);
     expect(data.storeUnreadable).toBe(true);
+  });
+
+  it("says so when the store went unreadable midway, behind a RESOLVED account", async () => {
+    // The branch an `configured: false`-only guard misses. getEmailCredentials
+    // reads the file once per key through the forgiving reader, and only the
+    // first three gate `configured`: a store readable for those and unreadable
+    // by the time email_mode is read answers `configured: true` with
+    // `canRead: false`, because resolveStoredMode falls back to "send". That is
+    // the same definite "no" that costs a running agent its mailbox tools, so
+    // the store has to be questioned on this branch too.
+    storeWith({
+      email_address: "box@example.com",
+      email_password: PASSWORD,
+      email_smtp_host: "smtp.example.com",
+      // email_mode and the rest: the later reads that failed.
+    });
+    mockGetKnownMany.mockResolvedValue({ values: {}, known: false });
+    const data = await (await GET()).json();
+    expect(data.configured).toBe(true);
+    expect(data.canRead).toBe(false);
+    expect(data.storeUnreadable).toBe(true);
+  });
+
+  it("stays quiet about the store when a resolved account merely chose send-only", async () => {
+    // The other side of that coin: the store is readable and the owner picked a
+    // mode that keeps the mailbox shut. A flag here would make every send-only
+    // device answer "could not ask", and the watch would never act on a real no.
+    storeWith({
+      email_address: "box@example.com",
+      email_password: PASSWORD,
+      email_smtp_host: "smtp.example.com",
+      email_mode: "send",
+    });
+    mockGetKnownMany.mockResolvedValue({
+      known: true,
+      values: {
+        email_address: "box@example.com",
+        email_password: PASSWORD,
+        email_smtp_host: "smtp.example.com",
+      },
+    });
+    const data = await (await GET()).json();
+    expect(data.configured).toBe(true);
+    expect(data.canRead).toBe(false);
+    expect(data.storeUnreadable).toBeUndefined();
   });
 
   it("does not cry unreadable over an account that is genuinely half-filled", async () => {
     // An address and no app password is not a store problem — it is a device
     // that is not set up, and the read tools are correctly absent.
     storeWith({ email_address: "box@example.com" });
-    mockGetKnown.mockImplementation(async (key: string) => ({
+    mockGetKnownMany.mockResolvedValue({
       known: true,
-      value: key === "email_address" ? "box@example.com" : undefined,
-    }));
+      values: { email_address: "box@example.com" },
+    });
     const data = await (await GET()).json();
     expect(data.configured).toBe(false);
     expect(data.storeUnreadable).toBeUndefined();

--- a/src/tests/unit/config-store.test.ts
+++ b/src/tests/unit/config-store.test.ts
@@ -547,6 +547,64 @@ describe("config-store", () => {
 
       await expect(configStore.getKnown("present")).resolves.toEqual({ value: undefined, known: false });
     });
+
+    it("never logs a window of the file it failed to parse", async () => {
+      // A SyntaxError from JSON.parse quotes a slice of its INPUT in its own
+      // message, and the input here holds the mailbox password and both bot
+      // tokens. The mailbox-readability poll reaches this path twice a minute
+      // while a store stays corrupt, and `logs_tail` hands the journal back to
+      // the agent — so the line carries the KIND of failure and nothing else.
+      const secret = "s3cret-app-password";
+      await fs.writeFile(CONFIG_PATH, `{"email_password": "${secret}", "x": }`, "utf-8");
+      const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      await expect(configStore.getKnown("email_password")).resolves.toEqual({
+        value: undefined,
+        known: false,
+      });
+
+      const said = logged.mock.calls.map((args) => args.join(" ")).join("\n");
+      logged.mockRestore();
+      expect(said).not.toContain(secret);
+      // Not a single character of it, either: the quoted window is a substring.
+      expect(said).not.toMatch(/s3cret|app-password/);
+      expect(said).toContain("invalid JSON");
+    });
+  });
+
+  describe("getKnownMany", () => {
+    it("answers every key from ONE read", async () => {
+      await fs.writeFile(CONFIG_PATH, JSON.stringify({ a: "1", b: 2 }), "utf-8");
+
+      await expect(configStore.getKnownMany(["a", "b", "absent"])).resolves.toEqual({
+        known: true,
+        values: { a: "1", b: 2, absent: undefined },
+      });
+    });
+
+    it("cannot answer a torn mixture when the store is unreadable", async () => {
+      // The reason this exists: three getKnown calls are three reads, and a
+      // store readable for the first key and unreadable for the third would
+      // answer a state of the disk that never existed.
+      await fs.writeFile(CONFIG_PATH, "{ half written", "utf-8");
+      const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      await expect(configStore.getKnownMany(["a", "b"])).resolves.toEqual({
+        known: false,
+        values: {},
+      });
+
+      logged.mockRestore();
+    });
+
+    it("inherits nothing from the prototype chain", async () => {
+      await fs.writeFile(CONFIG_PATH, JSON.stringify({ a: "1" }), "utf-8");
+
+      const { values, known } = await configStore.getKnownMany(["__proto__", "constructor"]);
+      expect(known).toBe(true);
+      expect(values["__proto__"]).toBeUndefined();
+      expect(values.constructor).toBeUndefined();
+    });
   });
 
   describe("DATA_DIR and CONFIG_ROOT exports", () => {

--- a/src/tests/unit/mcp-email-read-probe.test.ts
+++ b/src/tests/unit/mcp-email-read-probe.test.ts
@@ -1,0 +1,74 @@
+/**
+ * "Could not ask" is not "no", on the one gate this server acts on while it
+ * runs.
+ *
+ * `probeEmailReadStatus` feeds `watchEmailReadability`, which WITHDRAWS
+ * `email_list`/`email_read` from a live connection on a definite `false`. So
+ * every way the device can fail to answer the question has to come back as
+ * `null` — including the ways that arrive as a perfectly ordinary HTTP 200,
+ * which is what `/setup-api/email/status` sends when it could not read the
+ * config store at all.
+ */
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { probeEmailReadStatus } from "../../../mcp/lib/context";
+
+function answers(body: unknown, status = 200) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    })),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("probeEmailReadStatus", () => {
+  it("answers true only when the device says the agent may read", async () => {
+    answers({ configured: true, canRead: true });
+    expect(await probeEmailReadStatus()).toBe(true);
+  });
+
+  it("answers false for a mode that keeps the mailbox shut", async () => {
+    answers({ configured: true, canRead: false });
+    expect(await probeEmailReadStatus()).toBe(false);
+  });
+
+  it("answers false for a device with no mail account", async () => {
+    answers({ configured: false, canRead: false });
+    expect(await probeEmailReadStatus()).toBe(false);
+  });
+
+  it("answers null when the device could not read its own store", async () => {
+    // The failure this exists for: `data/config.json` left root-owned by an
+    // update, or one EIO off the eMMC. The route still answers 200 and
+    // `configured: false`, because the ordinary config read swallows both — so
+    // without this flag a working mailbox loses its tools inside a poll.
+    answers({ configured: false, canRead: false, storeUnreadable: true });
+    expect(await probeEmailReadStatus()).toBeNull();
+  });
+
+  it("answers null when an account exists and the device did not answer the question", async () => {
+    // A web server rolled back to a build that predates the three-mode setting,
+    // under a live MCP child. Silence is not a "no".
+    answers({ configured: true });
+    expect(await probeEmailReadStatus()).toBeNull();
+  });
+
+  it("answers null when nothing answered at all", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => { throw new Error("connection refused"); }));
+    expect(await probeEmailReadStatus()).toBeNull();
+  });
+
+  it("answers null on an error status, rather than guessing", async () => {
+    answers({ error: "Status check failed" }, 500);
+    expect(await probeEmailReadStatus()).toBeNull();
+  });
+});

--- a/src/tests/unit/mcp-email-readability-watch.test.ts
+++ b/src/tests/unit/mcp-email-readability-watch.test.ts
@@ -44,6 +44,9 @@ async function connectedServer(emailCanRead: boolean) {
       return (await client.listTools()).tools.map((t) => t.name);
     },
     changes: () => listChanged,
+    async call(name: string, args: Record<string, unknown>) {
+      return client.callTool({ name, arguments: args });
+    },
     async close() {
       await client.close();
       await server.close();
@@ -124,6 +127,21 @@ describe("mailbox readability, after the server is already running", () => {
     watch.stop();
 
     expect(h.changes()).toBe(before);
+  });
+
+  it("refuses a withdrawn tool at the dispatcher as well as in the list", async () => {
+    // The two halves live in different places — the SDK's registry answers
+    // tools/list, and mcp/lib/register.ts owns tools/call — so a withdrawal
+    // that only hid the tool would still RUN it for a host calling from a list
+    // it had not refreshed yet, with the mailbox gate gone from the one side
+    // that is not the route's.
+    const h = await harness(true);
+
+    const watch = watchEmailReadability(h.reg, true, { probe: async () => false });
+    await watch.refreshNow();
+    watch.stop();
+
+    expect(JSON.stringify(await h.call("email_list", { count: 1 }))).toContain("no tool called");
   });
 
   it("keeps asking on its own interval, and stop() ends it", async () => {

--- a/src/tests/unit/mcp-email-readability-watch.test.ts
+++ b/src/tests/unit/mcp-email-readability-watch.test.ts
@@ -160,6 +160,33 @@ describe("mailbox readability, after the server is already running", () => {
     expect(await h.toolNames()).toContain("email_list");
   });
 
+  it("does not apply an answer that arrives after it was stopped", async () => {
+    // stop() clears the interval, which only stops the NEXT tick. A probe
+    // already in flight when the transport closes comes back afterwards, and
+    // without a second check it would register tools into a server nobody is
+    // listening to and emit a tools/list_changed down a dead connection.
+    const h = await harness(false);
+    let release: (value: boolean) => void = () => {};
+    const probe = vi.fn(() => new Promise<boolean>((resolve) => { release = resolve; }));
+
+    const watch = watchEmailReadability(h.reg, false, { probe });
+    const inFlight = watch.refreshNow();
+    expect(probe).toHaveBeenCalledTimes(1);
+
+    // The transport closes while the device is still thinking.
+    watch.stop();
+    release(true);
+    await inFlight;
+
+    // The answer said "readable" and is discarded: no registration, no notice.
+    expect(h.reg.list().map((tool) => tool.name)).not.toContain("email_list");
+    expect(await h.toolNames()).not.toContain("email_list");
+
+    // And a later call is refused outright rather than probing again.
+    await watch.refreshNow();
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
   it("registers the read pair all-or-nothing, so a later tick can retry it", async () => {
     // The watch is the first caller that can register this pair more than once
     // in a process. If the second of the two registrations threw, a server left

--- a/src/tests/unit/mcp-email-readability-watch.test.ts
+++ b/src/tests/unit/mcp-email-readability-watch.test.ts
@@ -160,6 +160,38 @@ describe("mailbox readability, after the server is already running", () => {
     expect(await h.toolNames()).toContain("email_list");
   });
 
+  it("registers the read pair all-or-nothing, so a later tick can retry it", async () => {
+    // The watch is the first caller that can register this pair more than once
+    // in a process. If the second of the two registrations threw, a server left
+    // holding only email_list — with the watch still believing reading is off —
+    // would re-register that same name on every tick, and the SDK refuses a name
+    // it already holds: a permanently half-published list plus one throw every
+    // thirty seconds. Nothing in the tree makes registerTool throw today, so the
+    // failure is injected.
+    const h = await harness(false);
+    const real = h.reg.tool.bind(h.reg);
+    let calls = 0;
+    vi.spyOn(h.reg, "tool").mockImplementation(((...args: Parameters<typeof real>) => {
+      calls += 1;
+      // The FIRST read tool lands, the second one fails.
+      if (calls === 2) throw new Error("injected registration failure");
+      return real(...args);
+    }) as typeof real);
+
+    const watch = watchEmailReadability(h.reg, false, { probe: async () => true });
+    await expect(watch.refreshNow()).rejects.toThrow("injected registration failure");
+
+    // Neither half is left behind.
+    const names = h.reg.list().map((tool) => tool.name);
+    for (const tool of READ_TOOLS) expect(names).not.toContain(tool);
+
+    // And the next tick is a clean retry rather than a duplicate-name throw.
+    vi.mocked(h.reg.tool).mockRestore();
+    await watch.refreshNow();
+    watch.stop();
+    for (const tool of READ_TOOLS) expect(await h.toolNames()).toContain(tool);
+  });
+
   it("refuses a withdrawn tool at the dispatcher as well as in the list", async () => {
     // The two halves live in different places — the SDK's registry answers
     // tools/list, and mcp/lib/register.ts owns tools/call — so a withdrawal
@@ -279,9 +311,13 @@ describe("mailbox readability, after the server is already running", () => {
     await vi.advanceTimersByTimeAsync(2_500);
     expect(probe).toHaveBeenCalledTimes(2);
 
-    // Closing the transport stops the poll AND still runs the handler that was
-    // already there.
-    h.server.server.onclose?.();
+    // Closing the TRANSPORT — not calling the hook by hand — stops the poll and
+    // still runs the handler that was already there. Driving it through a real
+    // close is the point: that `onclose` is reached at all is the SDK's
+    // behaviour (`Protocol._onclose`), and a test that invoked the hook itself
+    // would keep passing over an SDK that stopped calling it, while the poll
+    // outlived every real box's transport.
+    await h.close();
     expect(closedAfter).toBe(true);
     await vi.advanceTimersByTimeAsync(5_000);
     expect(probe).toHaveBeenCalledTimes(2);

--- a/src/tests/unit/mcp-email-readability-watch.test.ts
+++ b/src/tests/unit/mcp-email-readability-watch.test.ts
@@ -20,7 +20,12 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js";
 import { createRegistrar } from "../../../mcp/lib/register";
-import { registerEmailTools, watchEmailReadability } from "../../../mcp/tools/email";
+import {
+  EMAIL_READABILITY_POLL_MS,
+  hasMailboxSurface,
+  registerEmailTools,
+  watchEmailReadability,
+} from "../../../mcp/tools/email";
 
 const READ_TOOLS = ["email_list", "email_read"];
 
@@ -40,6 +45,7 @@ async function connectedServer(emailCanRead: boolean) {
 
   return {
     reg,
+    server,
     async toolNames(): Promise<string[]> {
       return (await client.listTools()).tools.map((t) => t.name);
     },
@@ -59,6 +65,10 @@ const open: { close(): Promise<void> }[] = [];
 afterEach(async () => {
   for (const h of open.splice(0)) await h.close();
   vi.useRealTimers();
+  // In a hook, not at the end of the body that stubs it: an assertion that
+  // failed part way through would otherwise leave `fetch` stubbed for every
+  // test after it, and clearAllMocks does not restore globals.
+  vi.unstubAllGlobals();
 });
 
 async function harness(emailCanRead: boolean) {
@@ -129,6 +139,27 @@ describe("mailbox readability, after the server is already running", () => {
     expect(h.changes()).toBe(before);
   });
 
+  it("asks the device once at a time, however often it is nudged", async () => {
+    // `refreshNow` returns immediately while a probe is in flight. Without that
+    // guard a box slower than the interval would have two answers racing to
+    // apply, and the older one could land last.
+    const h = await harness(false);
+    let release: (value: boolean) => void = () => {};
+    const probe = vi.fn(() => new Promise<boolean>((resolve) => { release = resolve; }));
+
+    const watch = watchEmailReadability(h.reg, false, { probe });
+    const first = watch.refreshNow();
+    const second = watch.refreshNow();
+    expect(probe).toHaveBeenCalledTimes(1);
+
+    release(true);
+    await Promise.all([first, second]);
+    watch.stop();
+
+    // The one answer that WAS given still lands.
+    expect(await h.toolNames()).toContain("email_list");
+  });
+
   it("refuses a withdrawn tool at the dispatcher as well as in the list", async () => {
     // The two halves live in different places — the SDK's registry answers
     // tools/list, and mcp/lib/register.ts owns tools/call — so a withdrawal
@@ -141,7 +172,139 @@ describe("mailbox readability, after the server is already running", () => {
     await watch.refreshNow();
     watch.stop();
 
-    expect(JSON.stringify(await h.call("email_list", { count: 1 }))).toContain("no tool called");
+    const refusal = await h.call("email_list", { count: 1 });
+    // The ENVELOPE, not a substring of English: this is ClawBox's own
+    // `{ error, code, message, next }` (mcp/lib/errors.ts), and what a caller
+    // acts on is `code` plus `next`. The instruction matters as much as the
+    // code — a host that retries a withdrawn name manufactures the chronic
+    // `isError: true` that Hermes' per-server circuit breaker counts, which is
+    // the failure the whole registration gate exists to avoid.
+    expect((refusal as { isError?: boolean }).isError).toBe(true);
+    const envelope = JSON.parse(
+      ((refusal as { content: { text: string }[] }).content[0]).text,
+    ) as { error: boolean; code: string; next: string };
+    expect(envelope.error).toBe(true);
+    expect(envelope.code).toBe("NOT_FOUND");
+    expect(envelope.next).toMatch(/do not retry/i);
+    expect(envelope.next).toMatch(/tool list/i);
+  });
+
+  it("gives the agent a tool that WORKS, not just one that is listed", async () => {
+    // Listing is half the contract. The dispatcher is ClawBox's own
+    // (mcp/lib/register.ts installs it at finalize(), before this tool existed),
+    // so a tool registered afterwards has to reach it too — otherwise the agent
+    // sees the tool, calls it, and is told the device has no such thing.
+    const h = await harness(false);
+    let mailbox: unknown;
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      mailbox = { total: 2, unseen: 1, messages: [] };
+      return new Response(JSON.stringify(mailbox), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }));
+
+    const watch = watchEmailReadability(h.reg, false, { probe: async () => true });
+    await watch.refreshNow();
+    watch.stop();
+
+    const result = JSON.stringify(await h.call("email_list", { count: 1 }));
+    expect(result).toContain("total_in_mailbox");
+    expect(result).not.toContain("NOT_FOUND");
+  });
+
+  it("survives being flipped back and forth", async () => {
+    // The SDK frees a removed name (`update({ name: null })`), so a second
+    // registration must not throw "already registered" — and this is the only
+    // shape that proves the withdrawal really freed it rather than just hiding
+    // the tool from tools/list.
+    const h = await harness(false);
+    const answers = [true, false, true, false];
+    const watch = watchEmailReadability(h.reg, false, {
+      probe: async () => answers.shift() ?? null,
+    });
+
+    await watch.refreshNow();
+    expect(await h.toolNames()).toContain("email_list");
+    await watch.refreshNow();
+    expect(await h.toolNames()).not.toContain("email_list");
+    await watch.refreshNow();
+    expect(await h.toolNames()).toContain("email_read");
+    await watch.refreshNow();
+    watch.stop();
+
+    const names = await h.toolNames();
+    for (const tool of READ_TOOLS) expect(names).not.toContain(tool);
+    // …and the server is still whole: nothing above disturbed the tool the
+    // mailbox surface is anchored on.
+    expect(names).toContain("email_send");
+    // No duplicate rows left behind by four registrations of the same names.
+    expect(h.reg.list().filter((t) => t.name === "email_send")).toHaveLength(1);
+  });
+
+  it("is not armed on a profile that has no email surface at all", async () => {
+    // `core` and `browser` register no email tool, so there is nothing to keep
+    // in step — and a post-connect registration on a server that had registered
+    // NOTHING before connecting would throw inside the poll, because that first
+    // registration is what declares the tools capability.
+    for (const profile of ["core", "browser"] as const) {
+      const server = new McpServer({ name: "clawbox", version: "test" });
+      const reg = createRegistrar(server, "openclaw", profile);
+      registerEmailTools(reg, { emailCanRead: true });
+      expect(reg.list().map((t) => t.name)).not.toContain("email_send");
+      expect(hasMailboxSurface(reg)).toBe(false);
+    }
+    const full = await harness(false);
+    expect(hasMailboxSurface(full.reg)).toBe(true);
+  });
+
+  it("arms the watch on a connected server, and stops it when the transport closes", async () => {
+    // The production wiring, which `main()` cannot be tested through: this is
+    // the line that carries the whole fix to a real box, and a disconnected
+    // runtime kept alive by an in-flight request must not go on re-registering
+    // tools into a server nobody is listening to.
+    process.env.CLAWBOX_MCP_NO_AUTOSTART = "1";
+    const { armMailboxWatch } = await import("../../../mcp/clawbox-mcp");
+
+    const h = await harness(false);
+    let closedAfter = false;
+    h.server.server.onclose = () => {
+      closedAfter = true;
+    };
+    const probe = vi.fn(async () => false);
+    // The clock goes first: the interval has to be created under it.
+    vi.useFakeTimers();
+    armMailboxWatch(h.server, h.reg, false, { probe, intervalMs: 1_000 });
+
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(probe).toHaveBeenCalledTimes(2);
+
+    // Closing the transport stops the poll AND still runs the handler that was
+    // already there.
+    h.server.server.onclose?.();
+    expect(closedAfter).toBe(true);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(probe).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+
+    // A registrar with no email surface is not armed at all — no timer, no
+    // onclose wrapper, nothing to poll for.
+    const bare = new McpServer({ name: "clawbox", version: "test" });
+    const bareReg = createRegistrar(bare, "openclaw", "core");
+    registerEmailTools(bareReg, { emailCanRead: true });
+    const bareProbe = vi.fn(async () => true);
+    vi.useFakeTimers();
+    armMailboxWatch(bare, bareReg, true, { probe: bareProbe, intervalMs: 1_000 });
+    expect(bare.server.onclose).toBeUndefined();
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(bareProbe).not.toHaveBeenCalled();
+  });
+
+  it("ships an interval an owner does not have to wait out", async () => {
+    // The number the device actually runs, which no other test sees: every
+    // case here injects its own.
+    expect(EMAIL_READABILITY_POLL_MS).toBeLessThanOrEqual(30_000);
+    expect(EMAIL_READABILITY_POLL_MS).toBeGreaterThanOrEqual(5_000);
   });
 
   it("keeps asking on its own interval, and stop() ends it", async () => {

--- a/src/tests/unit/mcp-email-readability-watch.test.ts
+++ b/src/tests/unit/mcp-email-readability-watch.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Settings → Email must reach a RUNNING agent.
+ *
+ * `email_list` and `email_read` are registered conditionally, on a probe of
+ * `/setup-api/email/status` taken while the MCP server boots
+ * (mcp/lib/context.ts). The server is then a long-lived child of the harness,
+ * so on the owner's OpenClaw box the two tools were still missing seven
+ * minutes after the mode was moved to "Read on demand" — the tool list was
+ * built when the mode was still "Send only" and nothing rebuilt it.
+ *
+ * The contract these tests hold is the MCP one: when the answer changes the
+ * server re-registers (or withdraws) the pair and tells the host, which is what
+ * both harnesses act on — OpenClaw's bundle MCP runtime invalidates its cached
+ * catalogue on `notifications/tools/list_changed` and re-lists on the next
+ * turn.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js";
+import { createRegistrar } from "../../../mcp/lib/register";
+import { registerEmailTools, watchEmailReadability } from "../../../mcp/tools/email";
+
+const READ_TOOLS = ["email_list", "email_read"];
+
+async function connectedServer(emailCanRead: boolean) {
+  const server = new McpServer({ name: "clawbox", version: "test" });
+  const reg = createRegistrar(server, "openclaw", "full");
+  registerEmailTools(reg, { emailCanRead });
+  reg.finalize();
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test-host", version: "0" });
+  let listChanged = 0;
+  client.setNotificationHandler(ToolListChangedNotificationSchema, () => {
+    listChanged += 1;
+  });
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+  return {
+    reg,
+    async toolNames(): Promise<string[]> {
+      return (await client.listTools()).tools.map((t) => t.name);
+    },
+    changes: () => listChanged,
+    async close() {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+const open: { close(): Promise<void> }[] = [];
+
+afterEach(async () => {
+  for (const h of open.splice(0)) await h.close();
+  vi.useRealTimers();
+});
+
+async function harness(emailCanRead: boolean) {
+  const h = await connectedServer(emailCanRead);
+  open.push(h);
+  return h;
+}
+
+describe("mailbox readability, after the server is already running", () => {
+  it("adds the read tools when the owner switches to Read on demand", async () => {
+    const h = await harness(false);
+    expect(await h.toolNames()).toContain("email_send");
+    expect(await h.toolNames()).not.toContain("email_list");
+    const before = h.changes();
+
+    const watch = watchEmailReadability(h.reg, false, { probe: async () => true });
+    await watch.refreshNow();
+    watch.stop();
+
+    const names = await h.toolNames();
+    for (const tool of READ_TOOLS) expect(names).toContain(tool);
+    // The host is TOLD. Without the notification OpenClaw keeps the catalogue
+    // it cached when the server connected and never asks again.
+    expect(h.changes()).toBeGreaterThan(before);
+  });
+
+  it("withdraws them again when the owner goes back to Send only", async () => {
+    const h = await harness(true);
+    expect(await h.toolNames()).toContain("email_list");
+    const before = h.changes();
+
+    const watch = watchEmailReadability(h.reg, true, { probe: async () => false });
+    await watch.refreshNow();
+    watch.stop();
+
+    const names = await h.toolNames();
+    for (const tool of READ_TOOLS) expect(names).not.toContain(tool);
+    expect(names).toContain("email_send");
+    expect(h.changes()).toBeGreaterThan(before);
+  });
+
+  it("leaves the tool list alone when the device cannot be asked", async () => {
+    // A probe that could not reach the device answers null. Reading that as
+    // "no" would strip a working mailbox's tools off the agent on one slow
+    // moment — the false-failure shape, over an operation that never failed.
+    const h = await harness(true);
+    const before = h.changes();
+
+    const watch = watchEmailReadability(h.reg, true, { probe: async () => null });
+    await watch.refreshNow();
+    watch.stop();
+
+    expect(await h.toolNames()).toContain("email_list");
+    expect(h.changes()).toBe(before);
+  });
+
+  it("says nothing to the host when the answer has not changed", async () => {
+    // A notification per poll would invalidate the host's catalogue every
+    // interval, for nothing.
+    const h = await harness(true);
+    const before = h.changes();
+
+    const watch = watchEmailReadability(h.reg, true, { probe: async () => true });
+    await watch.refreshNow();
+    await watch.refreshNow();
+    watch.stop();
+
+    expect(h.changes()).toBe(before);
+  });
+
+  it("keeps asking on its own interval, and stop() ends it", async () => {
+    vi.useFakeTimers();
+    const h = await harness(false);
+    const probe = vi.fn(async () => false);
+
+    const watch = watchEmailReadability(h.reg, false, { probe, intervalMs: 1_000 });
+    await vi.advanceTimersByTimeAsync(3_500);
+    expect(probe).toHaveBeenCalledTimes(3);
+
+    watch.stop();
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(probe).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/tests/unit/mcp-email-tool.test.ts
+++ b/src/tests/unit/mcp-email-tool.test.ts
@@ -25,6 +25,7 @@ function collect(emailCanRead = true): Map<string, Captured> {
         handler,
       });
     },
+    remove: (name: string) => void tools.delete(name),
     list: () => [...tools.values()].map((t) => t.info),
     finalize: () => undefined,
   };

--- a/src/tests/unit/mcp-file-tool-paths.test.ts
+++ b/src/tests/unit/mcp-file-tool-paths.test.ts
@@ -44,6 +44,9 @@ async function captureTools(): Promise<Map<string, Captured>> {
     tool(name: string, _description: string, shape: Shape, _opts, handler: ToolHandler) {
       out.set(name, { shape, handler });
     },
+    remove(name: string) {
+      out.delete(name);
+    },
     list(): RegisteredToolInfo[] {
       return [];
     },

--- a/src/tests/unit/mcp-read-file-limits.test.ts
+++ b/src/tests/unit/mcp-read-file-limits.test.ts
@@ -28,6 +28,9 @@ function captureTools(): Map<string, Captured> {
     tool(name: string, _description: string, shape: Shape, _opts, handler: ToolHandler) {
       tools.set(name, { shape, handler });
     },
+    remove(name: string) {
+      tools.delete(name);
+    },
     list(): RegisteredToolInfo[] {
       return [];
     },


### PR DESCRIPTION
**Finding:** `email-read-on-demand` — Settings → Email set to "Read on demand" leaves the agent with `email_send` only.

## Customer-visible symptom

On an OpenClaw box the owner moved Settings → Email to **Read on demand**. The panel showed the new mode, the stored mode *was* the new mode, and the agent still answered that it had only `email_send` — `email_list` and `email_read` were not in its toolbelt, so "look at my email" could not be served. Nothing the owner could click fixed it; only a restart of whatever spawned the MCP server would have.

## Cause

`email_list`/`email_read` are registered conditionally, on one probe of `/setup-api/email/status` taken while the ClawBox MCP server boots (`mcp/lib/context.ts`, `probeEmailRead`) — the probe-once class. The server is then a long-lived stdio child of the harness, so the tool list it built at boot is the tool list the agent keeps.

Measured on the reporting box (edition `openclaw`, core OpenClaw 2026.8.1, ClawBox beta `4f240644`):

- stored `email_mode` = `read`, i.e. the save had persisted and `canRead` was true — **the "errored save" half of the report is refuted**, the panel and the store agreed;
- the MCP child serving the chat was **28 minutes old** and had taken its probe **7 minutes before** the config write that set the mode;
- a fresh spawn of that same server (`openclaw mcp probe clawbox --json`) advertised **57 tools including `email_list` and `email_read`** — so the code was right and only the running instance was stale.

There was a refresh for exactly this, and it is Hermes-only: `src/lib/email-mcp-refresh.ts` → `reload.mcp` on the Hermes dashboard socket. On the OpenClaw SKU there is no dashboard, and `src/lib/hermes-mcp-reload.ts` consoled itself that "OpenClaw spawns the ClawBox MCP server lazily per session and reaps it after ten idle minutes, so the tool list catches up on its own" — the 28-minute-old child across a settings change is that claim measured false.

## The native mechanism (harness first)

Checked on the box, in the installed core:

| candidate | verdict |
| --- | --- |
| `openclaw mcp reload` | **no-op for the gateway.** It calls `disposeAllSessionMcpRuntimes()` in the CLI's *own* process and prints "Disposed cached MCP runtimes"; the running gateway holds its own singleton and never hears about it. A false success upstream — not built on. |
| OpenClaw gateway JSON-RPC | no MCP method at all (the table has `gateway.restart.request`, `plugins.refresh`, `secrets.reload` and nothing else). |
| `sessions.cleanup` / a gateway restart | would work and costs the owner their session or their agent. |
| **MCP `notifications/tools/list_changed`** | **the one that reaches a running gateway.** OpenClaw's bundle MCP runtime builds its MCP client with `listChanged: { tools: { autoRefresh: false, onChanged: () => invalidateCatalog() } }`; `invalidateCatalog()` sets the cached catalogue to null and the accessor re-lists from the server on next use. Hermes honours the same notification. |

So the fix is the protocol's own mechanism, emitted by our own server.

## The fix

`mcp/tools/email.ts`

- the read pair moves into `registerEmailReadTools(reg)`, registrable on its own;
- `watchEmailReadability(reg, initial)` re-asks `/setup-api/email/status` every 30 s and, **only when the answer changes**, registers or withdraws the pair on the live connection. The MCP SDK emits `notifications/tools/list_changed` for each, which is what the harness acts on.
- `mcp/clawbox-mcp.ts`'s `armMailboxWatch` starts it after `connect()`, and only when the registrar actually holds `email_send` — so the `core` and `browser` profiles, which register no email surface, poll nothing (and the SDK's rule that the tools capability must be declared before connecting cannot be broken). `buildServer` does not arm it, because `mcp/check-tools.ts` builds ten servers and connects none.

`mcp/lib/context.ts` — `probeEmailReadStatus()` returns `boolean | null`. Unknown stays `false` at startup (the safe direction: a guessed "yes" is a permanently-failing tool that trips Hermes' circuit breaker) and changes **nothing** while the server runs: reading one timed-out request as "the owner switched reading off" would take a working mailbox away from the agent — the false-failure class.

`mcp/lib/register.ts` — `Registrar.remove(name)`. It drops the name from the dispatcher's `entries` map first (our own `tools/call` handler answers from that map, so a tool left there would still execute for a host calling from an unrefreshed list), then from `list()`, then calls the SDK handle's `remove()`, which is what emits the notification. `tool()` is still the only way in, so the dispatcher, `list()` and the SDK's registry cannot disagree. A flip is recorded only *after* the registration succeeded — the SDK throws on a duplicate name, and a flip recorded over a throw would leave the server believing it had published tools it had not.

The Hermes `reload.mcp` call stays: it is instant where it works, and the owner who just pressed Save is the person waiting. `reportMcpReloadRefused` gained an optional per-family note, because "what happens next on a box with no dashboard" is now different for the mailbox (a poll interval) than for the other four families (a restart) — and its docblock now states the measured truth instead of the lazy-respawn story.

## RED → GREEN

RED, on unmodified `origin/beta` `4f2406447` in a detached worktree:

```
 ❯ |unit| src/tests/unit/mcp-email-readability-watch.test.ts (6 tests | 6 failed) 33ms
     × adds the read tools when the owner switches to Read on demand 18ms
     × withdraws them again when the owner goes back to Send only 4ms
     × leaves the tool list alone when the device cannot be asked 2ms
     × says nothing to the host when the answer has not changed 2ms
     × refuses a withdrawn tool at the dispatcher as well as in the list 2ms
     × keeps asking on its own interval, and stop() ends it 3ms

 Test Files  1 failed (1)
      Tests  6 failed (6)
```

The test drives a real `McpServer` and a real `Client` over `InMemoryTransport`, so it asserts the contract the harness actually relies on: after the flip the **client's** `tools/list` contains the pair and a `notifications/tools/list_changed` arrived; after the flip back they are gone; an unreachable device changes neither; an unchanged answer notifies nobody.

GREEN, on the branch — 12 in that file plus 7 in the new probe suite:

```
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

Neighbouring suites (email routes, every `*-mcp-refresh`, the reload wording, the MCP contract suites, the registrar profile suite, the two file-tool suites): `25 passed (25)`, `418 passed (418)`.

Whole unit project: `804 passed / 805 files`, `13464 passed / 1 failed`. The one failure is `memory-index-local.test.ts > re-records a file whose folder entry changed`, and it fails identically on unmodified `origin/beta` in a clean worktree — pre-existing, unrelated.

`tsc -p tsconfig.json`, `tsc -p mcp/tsconfig.json`, `eslint` on every touched file and `bun run mcp/check-tools.ts` ("Tool contract OK") are all clean. The three `eslint` errors the repo reports are in two files this branch does not touch and are present on `origin/beta`.

## Sibling call sites

| site | state |
| --- | --- |
| `probeEmailRead` (`mcp/lib/context.ts`) — sole caller `buildContext` | **fixed**, semantics unchanged at startup |
| `Registrar` implementations — `createRegistrar` plus four test doubles (`src/tests/helpers/mcp-registrar.ts`, `mcp-email-tool.test.ts`, `mcp-file-tool-paths.test.ts`, `mcp-read-file-limits.test.ts`) | **all four updated** with a real `remove`, so a double cannot pass a test the real registrar would fail |
| `registerEmailTools` callers — `buildServer`, two suites | **fixed** |
| `reportMcpReloadRefused` — five callers (`hermes-image-refresh`, `email-mcp-refresh`, `provider-mcp-refresh`, `coding-agent-mcp-refresh`, `harness-mcp-refresh`) | **cleared**: the new third parameter defaults to the old sentence, so only the email caller changes |
| `publicEmailStatus` — six callers | **cleared**: the unreadable-store question is answered in the status route instead, so no other caller changes (the first attempt put it in `publicEmailStatus` and broke a suite whose config-store double has no `getKnown` — that is what pointed at the better layering) |
| `ctx.codingAgent` → `coding_agent_*` / `coding_team_*` (`mcp/tools/coding-agent.ts:243,478`) | **cleared, not fixed** — same probe-once shape, still startup-only on OpenClaw. A separate defect; this PR fixes one. |
| `ctx.canGenerateImages` → `image_generate` (`mcp/tools/ai.ts:149`) | **cleared, not fixed** — same shape |
| `ctx.providers` → `ai_set_provider` enum (`mcp/tools/ai.ts:235`) | **cleared, not fixed** — Hermes only, where `reload.mcp` does work |
| `ctx.appHarness` → desktop app list (`mcp/tools/desktop.ts`) | **cleared, not fixed** — flips only on a `dual` harness switch, which already restarts the gateway |
| `ctx.capabilities.*` (screen grabber, journal, `du`, `convert`) | **cleared** — binaries, not a Settings switch |
| `emailStoreDisagrees` — signature gained `accountResolved` | **fixed**; the status route is still its only caller |
| `getKnown` — eleven other prod call sites (`explicit-model-pick`, `harness`, `updater` ×3, `clawai-credential-refusal`, `hermes-clawai`, `email-approval`) | **cleared, and they all benefit**: only the LOG LINE changed, at the one layer they share, so none of them can disclose a parse window either. No test asserted the old text. |
| `src/lib/hermes-config-yaml.ts:306,352` — the same `err.message` shape on a secret-bearing file | **cleared**: its throws come from `fs` (errno plus path); `getTopLevelScalar` is a line scanner and quotes no file content |
| ~20 other `src/lib` modules that parse JSON and log a message somewhere | **named, not fixed** — a codebase-wide audit, not this defect (see below) |

`mcp/README.md` is the authoritative tool doc and said the gate was startup-only; it and one line of `CLAUDE.md` now say which gate is re-probed and which are not.

## Review pass

An independent code review of the branch raised 1 HIGH, 4 MEDIUM and 9 LOW, and refuted seven other candidates (the `unref` is honoured under the box's Bun — re-measured here: exits 0 with it, hangs without it; re-registration after `remove()` is safe in SDK 1.30.0; a post-`finalize` `registerTool` does not clobber this repo's own dispatcher). CodeRabbit raised three more. Everything actionable is applied in the second fix commit:

- **HIGH — an unreadable store read as "reading switched off".** `/setup-api/email/status` answers 200 with `configured: false` when `data/config.json` is merely UNREADABLE: the ordinary config read swallows an EACCES from a root-owned file (which is exactly what an update can leave behind), an EIO and a half-written JSON alike. The probe scored that a definite `false` and the watch withdrew the tools from a working mailbox — the false-failure class, in the one place this PR added an ACTION. The route now takes the strict read on that one ambiguous branch and reports `storeUnreadable`, which the probe maps to "could not ask"; an account that resolved is itself proof the store was readable, so nothing else pays for it.
- **An account with no `canRead` at all** (a web server rolled back under a live child) is now unknown rather than a no.
- **The registrar records a tool only once the SDK has accepted it**, so a refused registration cannot leave a row for a tool that was never published — one per attempt, now that a family can be registered again later.
- **A withdrawn name is refused with a sentence that is true for it.** It used to say the device has no such tool and that the list depends on the edition; a withdrawn tool *does* exist on this edition. It was also the one refusal in this module's vocabulary that never said "do not retry", while every retry is another `isError: true` against the harness's per-server circuit breaker — the chronic failure the registration gate exists to avoid.
- **The poll says once when it cannot reach the device, and once when it can again**, instead of being silent either way; and the log line is derived from what the tool list actually gained or lost rather than from what was asked for.
- **The watch is stopped from the server's `onclose`**, so a runtime kept alive by an in-flight request cannot go on registering tools into a closed server. `StdioServerTransport`'s own close on stdin EOF chains into the same hook.
- **Tests**, because the first round passed with load-bearing halves deleted: the probe's four answers, the route's unreadable-store branch, a tool call that WORKS after a flip (not merely one that is listed), an on→off→on→off round trip, the arming predicate on the `core` and `browser` profiles, the arming and the close hook themselves, and one probe at a time under overlapping nudges. Three mutations were used to check they bite — dropping `entries.delete`, never arming the watch, and treating `storeUnreadable` as an ordinary no each fail exactly one test.

Not taken: an `fs.watch` on the config store instead of a poll (cheaper when idle, but it couples this process to a file it deliberately does not read, and still needs a timer as a floor for a missed event), and an instant device→server nudge (there is no channel; `refreshNow` is the seam for the day there is one).

## Second review pass, on the final head

The two commits that answered the first pass and CodeRabbit (`4229064`, `7dcd634`) had never themselves been reviewed — 562 insertions across 12 files. A second independent pass over them raised **1 HIGH, 1 MEDIUM, 5 LOW, 2 INFO**; both of the first two were real and are fixed here.

- **HIGH — the new poll path logged a window of `data/config.json`, which holds the mailbox password.** `getKnown`'s failure branch printed `err.message` on the stated belief that "the message only" was the safe half. It is the opposite: a `SyntaxError` from `JSON.parse` quotes a slice of its INPUT in its own message (measured — `Unexpected token 'o', "not json pa"... is not valid JSON`), and the input is the file holding the mailbox password, both bot tokens and the portal token. `logs_tail` is registered on both editions, so the agent can read those lines back. The defect is pre-existing, but it sat on cold paths until this branch made it a twice-a-minute path for as long as a store stays corrupt. The line now carries the KIND of failure — the `SyntaxError` as "invalid JSON", an errno as its code — and never the message; the failing path was always in the line anyway.
- **MEDIUM — the unreadable-store guard was one-sided, and missed the branch that actually withdraws the tools.** `emailStoreDisagrees` was asked only behind a `configured: false`, reasoning that a resolved account proves the store was readable. It does not: `getEmailCredentials` reads the file once per key through the forgiving reader and only the first three gate `configured`, so a store readable for those three and unreadable by the time `email_mode` is read answers `{ configured: true, canRead: false }` — `resolveStoredMode` falls back to `"send"`. That is the same definite "no" the watch acts on, on the branch the guard does not cover: an update that chowns the file under a poll in flight, or one EIO between the third read and the sixth, and the agent loses the mailbox tools while Settings still says Read on demand. The question is now asked on both branches, with `accountResolved` selecting which of the two shapes is ambiguous rather than whether to look.

  The review's own suggested minimum — calling `emailStoreDisagrees()` unconditionally — was **not** applied: it returns true whenever all three keys are present and non-empty, so on every healthy configured box it would have reported the store permanently unreadable and the watch would never have acted on a real "no" again. Verified before rejecting it.

- `getKnownMany` answers several keys from ONE read, because three `getKnown` calls are three reads and a store readable for the first key and unreadable for the third returns a torn mixture no state of the disk ever held — the very fault the function exists to catch. Its bag is null-prototype: a test written for it caught that `values["__proto__"] = undefined` on an object literal reaches `Object.prototype`'s setter instead of creating an own property, so the read back answered the prototype object. The read side already guarded that; the write side now does too.
- **LOW, applied**: the read pair is registered all-or-nothing, so a throw between its two registrations cannot leave a half-published list that re-throws on every later tick (injected-failure test); the `armMailboxWatch` note said later handlers are chained when it is EARLIER ones that are, and a later plain assignment would clobber the wrapper — which is why arming is the last thing `main()` does; the close test called the hook by hand while claiming to close the transport, and now closes the transport, so an SDK that stopped calling `onclose` fails instead of passing; the probe payload pointed at a `storeUnreadable` symbol that does not exist in `email-config.ts`.
- **INFO**: the poll's "they share no channel" was overstated — the two processes share `data/config.json`, which `config-store` replaces by rename, so an `fs.watch` on `data/` would be a real nudge. Still not taken (it couples this process to a file it otherwise never touches and needs the interval as a floor anyway), but recorded as the option it is. The SDK's own `tools/list_changed` sends are floating promises inside the SDK; only reachable while the process is already dying, recorded for whoever next sees an MCP child exit non-zero at teardown.

Mutation-checked: restoring the one-sided guard fails exactly the new `configured: true` test, and logging the parse message again fails exactly the new disclosure test.

### A third round, from CodeRabbit on that head

- **The healed store (major).** The `configured: true` fix above only caught a store that was STILL unreadable when the strict read followed. A store that HEALED in between answered "fine" and the tools were withdrawn anyway — the mirror of the case `7dcd634` fixed, on the branch `7dcd634` did not cover. `email_mode` (plus the two keys the migration fallback needs) is now read in the same strict snapshot and `resolveStoredMode` applied to it, and the result compared with the `canRead` the caller derived: reads that disagree saw different files, so the answer is "could not ask" rather than a definite no. A readable send-only box agrees with itself and still answers no flag.
- **`stop()` did not stop an in-flight probe.** It cleared the interval, which ends the next tick and does nothing about a probe already awaiting; an answer arriving after the transport closed would mutate the registrar and push a `tools/list_changed` down a dead connection. A `stopped` flag is now checked at entry and again after the `await`, which is the function's only suspension point.

- **A fourth round, same file.** The resolved branch compared only the MODE, which missed the symmetric shape: an account that resolved from the lenient reads and is INCOMPLETE in the strict snapshot, with `email_mode` still `"read"`, agrees about reading and has no mailbox to read — so the watch would hold the read tools open over an account that is not there. Both branches now ask the one question, do the two reads agree that an account EXISTS: a complete account behind a `configured: false` and a vanished account behind a `configured: true` are one fault seen from either side.

All four have regression tests and all four are mutation-checked.

### One residual, accepted knowingly

The review's LOW-1: a poll that enters with no account configured and is overtaken by the first `Save` in that window sees `configured: false` from `publicEmailStatus` and all three keys present from the strict read — the "two reads disagreed" shape — and reports `storeUnreadable` over a store nothing was wrong with. The probe then answers "could not ask" and the watch leaves the tool list alone for one more tick.

Unchanged by this PR (the same window existed on that branch before) and deliberately left: it errs towards UNKNOWN rather than towards a false "no", which is the safe direction for the thing this whole PR protects, and it self-heals on the next poll. Closing it properly means deriving `configured`, `canRead` and `storeUnreadable` from ONE `readConfigStrict` snapshot for the whole request, which changes `publicEmailStatus`/`getEmailCredentials` — shared with six callers, and ten separate reads of one file inside `getEmailCredentials` alone. That refactor is the right end state and is the named follow-up to this PR; everything here propagates the failures that actually reach the tool list instead.

### A second finding, named not fixed

The "`err.message` over a `JSON.parse` of a secret-bearing file" shape is not unique to `config-store`: around twenty modules under `src/lib` both parse JSON and log an error message somewhere. Auditing them is a codebase-wide pass, not this defect, so it is named here rather than silently widening the diff. `src/lib/hermes-config-yaml.ts`, the nearest neighbour, is explicitly CLEARED: its logged throws come from `fs` (errno plus path), and `getTopLevelScalar` is a line scanner that quotes no content.

## Unproven

The end-to-end leg on hardware. The REPRODUCTION is measured on the box (stale 28-minute-old child vs a fresh probe of the same server, against a stored mode of `read`), and every link in the repair is verified in the installed core — the client wires `tools/list_changed` to `invalidateCatalog()`, and the catalogue accessor rebuilds from null — but "flip the mode and watch the agent gain the tools" cannot be shown until this is merged and the box is on beta head, since a box must not run a feature branch. No box state was changed for any of this: every device call was read-only, so the device mutex was never taken.

## What to click on the box to see it work

Once this is on the box: Settings → Email, switch the mode between **Send only** and **Read on demand** (the app password has to be re-entered — the save verifies SMTP, and IMAP too for a reading mode), wait up to half a minute, then ask the assistant to list the newest messages in the mailbox. Before this change that request was refused until something respawned the MCP server; after it the tools appear on the next turn. `journalctl -u clawbox-gateway` shows the server's own line, `[clawbox-mcp] mailbox readable=true; registered email_list and email_read`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Email reading tools now appear or are withdrawn automatically while the MCP connection remains active, based on current mailbox readability.
  - Mailbox status is checked periodically, with updates sent to connected clients when available tools change.
  - Email sending remains available independently of mailbox reading access.
  - Temporary or indeterminate status checks no longer change available tools.
  - Email status now distinguishes unreadable configuration from disabled reading.
  - Configuration errors are logged without exposing sensitive file contents.

- **Documentation**
  - Updated guidance explains live email-tool updates, startup-only checks for other capabilities, and behavior when dashboard-based refresh is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




