### PR TITLE
fix: derive the OpenAI Codex picker from the installed core's own route

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -1505,7 +1505,15 @@ elif _wants_llamacpp and _llamacpp_gaps:
 # surfaces as a FailoverError days into use. The chat-model pick route already
 # rewrites `openai/<gpt>` -> `codex/<gpt>`, but only when the user re-picks the
 # model; existing configs never re-pick, so migrate primary + fallbacks here on
-# gateway start. Mirrors CODEX_MODELS in src/lib/provider-models.ts,
+# gateway start.
+#
+# Deliberately still a hand-kept copy, while the app derives its ChatGPT surface
+# from the installed core's own `extensions/openai` manifest
+# (src/lib/chatgpt-surface.ts): the one consumer below is the OpenClaw 1 branch,
+# and an OpenClaw 1 box's core predates every model the derivation would add. So
+# this mirrors the app's FALLBACK list, which is what
+# src/tests/unit/gateway-pre-start-codex-models.test.ts pins it against.
+# Mirrors CODEX_MODELS in src/lib/provider-models.ts,
 # the one list src/lib/subscription-surface.ts also reads, and hasOpenAiApiKeyProfile /
 # hasCodexOauthProfile in src/app/setup-api/chat/model/route.ts. Guarded on
 # "codex OAuth present AND no OpenAI API key" so dual-auth / API-key boxes,

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -6,6 +6,8 @@ import path from "path";
 import { findOpenclawBin, openclawIsAbsent } from "@/lib/openclaw-config";
 import { DATA_DIR } from "@/lib/config-store";
 import { isCodexSupportedModelId } from "@/lib/subscription-surface";
+import { chatgptSurface } from "@/lib/chatgpt-surface";
+import { CHATGPT_UI_PROVIDER } from "@/lib/chatgpt-subscription";
 import { lastModelSegment } from "@/lib/chat-header-pills";
 import {
   CATALOG_PROVIDERS,
@@ -519,8 +521,8 @@ const DEPRECATED_MODEL_IDS: ReadonlySet<string> = new Set([
 //
 // ONE entry, and it is a routing fact rather than curation.
 //
-// codex (ChatGPT-account auth): whatever the curated ChatGPT catalogue
-//   carries, asked through `isCodexSupportedModelId`. NO -pro variants — per
+// codex (ChatGPT-account auth): whatever the ChatGPT surface carries, asked
+//   through `isCodexSupportedModelId`. NO -pro variants — per
 //   developers.openai.com/codex/models the Pro models are API-key-only and the
 //   ChatGPT-account path 400s with "model not supported when using Codex with
 //   a ChatGPT account" — and plan gating is deliberately NOT applied: gpt-5.6
@@ -541,10 +543,13 @@ const DEPRECATED_MODEL_IDS: ReadonlySet<string> = new Set([
 // https://chatgpt.com/backend-api/codex/responses on the box, and unspellable
 // by that pattern.
 //
-// `codex` has no catalogue on this core to ask (see the note above
-// `NO_CLI_ENUMERATION_PROVIDERS`), so its list stays curated — but curated in
-// ONE place. `scripts/gateway-pre-start.sh` keeps a second, hand-maintained
-// mirror in `_CODEX_SUPPORTED` (it runs before node exists), pinned by
+// `codex` has no ENUMERATION on this core to ask (see the note above
+// `NO_CLI_ENUMERATION_PROVIDERS`), but it does have the installed core's own
+// plugin manifest, which states the route per model — so the list is derived
+// from that by `chatgptSurface()` rather than curated, and the curated array is
+// only what a box with no readable manifest falls back to. In ONE place either
+// way. `scripts/gateway-pre-start.sh` keeps a second, hand-maintained mirror of
+// that fallback in `_CODEX_SUPPORTED` (it runs before node exists), pinned by
 // src/tests/unit/gateway-pre-start-codex-models.test.ts. That one cannot
 // import; this one can, and does.
 const OFFERABLE_MODEL_ID_BY_PROVIDER: Record<string, (id: string) => boolean> = {
@@ -553,14 +558,15 @@ const OFFERABLE_MODEL_ID_BY_PROVIDER: Record<string, (id: string) => boolean> = 
   // refuses is a dead button, and the reverse is a model the customer cannot
   // reach.
   //
-  // Today it cannot FIRE: the only list that reaches `sanitizeCatalogModels`
-  // for codex is `staticCatalogModels("codex")`, which is the very array this
-  // predicate asks about — the disk cache that used to be the other input is
-  // dropped at the top of `GET`, and codex reaches neither `publish` nor
-  // `fetchSubscriptionSurfaceIds`. Kept because it is the entry that makes the
-  // property true BY CONSTRUCTION rather than by accident: the day this core
-  // grows a ChatGPT-surface enumeration, the rows it returns arrive here, and
-  // an unfiltered `codex` would then offer whatever upstream listed.
+  // It still cannot FIRE, for the same reason and one more: the only list that
+  // reaches `sanitizeCatalogModels` for codex is `staticCatalogModels("codex")`,
+  // which is now the same `chatgptSurface()` this predicate asks — the disk
+  // cache that used to be the other input is dropped at the top of `GET`, and
+  // codex reaches neither `publish` nor `fetchSubscriptionSurfaceIds`. Kept
+  // because it is the entry that makes the property true BY CONSTRUCTION rather
+  // than by accident: the day this route does enumerate the ChatGPT surface, the
+  // rows it returns arrive here, and an unfiltered `codex` would then offer
+  // whatever upstream listed.
   codex: isCodexSupportedModelId,
 };
 
@@ -887,18 +893,30 @@ function hintFor(provider: string, id: string): string | undefined {
  * can route; the harness's own catalogue can, and asking it again is cheap.
  * So this list is served only while there is no live answer, always marked
  * `fallback`, and never written to disk.
+ *
+ * `codex` is the one provider whose rows here are NOT hand-maintained, because
+ * it is the one provider this route cannot enumerate at all (see the note above
+ * `NO_CLI_ENUMERATION_PROVIDERS`): `chatgptSurface()` reads the ChatGPT route
+ * out of the installed core's own plugin manifest, and falls back to the curated
+ * array only where there is no manifest. It is still served unpersisted and
+ * unstamped — the manifest says what the CORE routes, not what this ACCOUNT is
+ * entitled to, so it is not the device answer `source: "live"` claims — and
+ * that is also why it is here rather than in a branch of its own: every rule
+ * this function applies to a curated list applies unchanged to it.
  */
 function staticCatalogModels(provider: string): CatalogModel[] {
   const staticEntry = getProviderCatalog(provider);
   if (!staticEntry) return [];
+  const models = provider === CHATGPT_UI_PROVIDER ? chatgptSurface().models : staticEntry.models;
   // NOT sorted. `compareCatalogModels` orders by context window and then
   // alphabetically, which is right for an enumeration — the device reports a
   // real window for every row — and wrong here: STATIC_MODEL_CONTEXT_WINDOWS
   // only carries the Anthropic ids, so every other curated row takes the
   // 200_000 default, ties, and falls back to alphabetical. CODEX_MODELS,
   // hand-ordered newest-first, would be served GPT-5.4 first. These arrays are
-  // curated in the order they should be read; that IS their metadata.
-  return staticEntry.models.map((sm) => ({
+  // curated in the order they should be read; that IS their metadata — and so is
+  // the manifest's own order for `codex`, which lists its newest model first.
+  return models.map((sm) => ({
     id: sm.id,
     label: sm.label,
     // Zero, not a guess. A curated row has no MEASURED window — the device is
@@ -1011,12 +1029,29 @@ function sanitizeCachedPayload(provider: string, cached: CatalogResponse): Catal
  *    soon as ANY openai profile exists — on the affected box that was the
  *    ClawBox AI image token, an API key that cannot chat.
  *
- * So this core exposes no enumeration of the ChatGPT surface, and that is a
- * finding, not a licence to synthesise one: replacing a hard-coded list with a
- * WRONG live list is the same defect pointed the other way. `codex` therefore
- * enumerates nothing, publishes nothing, and its picker is served the curated
- * list marked `fallback` — never persisted, never dressed up as the box's own
- * answer, and logged with the CLI's own refusal.
+ * MEASURED AGAIN on 2026-09-10, because the obvious move has a third failure
+ * mode that matters more than the two above. The core DOES build the ChatGPT
+ * route's real list, live and per account, from
+ * `chatgpt.com/backend-api/codex/models` — and it publishes it under the
+ * `openai` provider id, the SAME id as the platform catalogue, choosing between
+ * them by the credential its catalog hook resolves first. On a box that also
+ * holds an API key (an inline `models.providers.openai.apiKey` counts, and
+ * ClawBox writes one there for the image model) the published catalogue is the
+ * PLATFORM one: 30 rows including `gpt-5.6`, `o3` and the image models, with the
+ * subscription-only `gpt-5.3-codex-spark` marked `available: false`. Nothing in
+ * a row says which catalogue it came from — the JSON keys are `available,
+ * contextTokens, contextWindow, input, key, local, missing, name, tags` — and
+ * `models list` has no `--profile` to pin it with, so an enumeration cannot be
+ * told apart from the wrong one.
+ *
+ * So this core exposes no enumeration of the ChatGPT surface THIS ROUTE can
+ * trust, and that is a finding, not a licence to synthesise one: replacing a
+ * hard-coded list with a WRONG live list is the same defect pointed the other
+ * way. `codex` therefore enumerates nothing, publishes nothing, and its picker
+ * is served `chatgptSurface()` — the route read out of the installed core's own
+ * plugin manifest, which states it per model and needs no credential — marked
+ * `fallback` like the curated list it falls back to: never persisted, never
+ * dressed up as the box's own answer, and logged with the CLI's own refusal.
  *
  * The ChatGPT rendering belongs on the credential facts TASK-652 introduces —
  * `GET /setup-api/chat/model` rows carrying `provider: "codex"` with

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -768,15 +768,25 @@ function isOfferableModelId(provider: string, id: string): boolean {
  * payload named — and a `defaultModelId` outside `models` is a picker with
  * nothing selected.
  *
- * ASYMMETRY, deliberate and worth naming: the lookup is keyed on the CATALOGUE
- * provider, and the core ships no `codex` extension — so the openai picker
- * loses `gpt-5.5` while the codex picker keeps it as its default. That is the
- * same upstream model, hidden on one auth mode and offered on the other, and it
- * is the behaviour we want today: the core's replacement, `gpt-5.6-sol`, is
- * plan-gated, and a Free ChatGPT account handed it as the only row AND as the
- * saved default would 400 on every turn. If a `codex` manifest ever appears, or
- * the mapping is "fixed" to consult openai's, that default moves silently —
- * which is what `curated-defaults-offerable.test.ts` is there to notice.
+ * ASYMMETRY, deliberate and worth naming: the openai picker loses `gpt-5.5`
+ * while the codex picker keeps it as its default. That is the same upstream
+ * model, hidden on one auth mode and offered on the other, and it is the
+ * behaviour we want: the core's replacement, `gpt-5.6-sol`, is plan-gated, and a
+ * Free ChatGPT account handed it as the only row AND as the saved default would
+ * 400 on every turn.
+ *
+ * The REASON changed even though the behaviour did not, and the old one is worth
+ * correcting rather than leaving to mislead: the lookup is keyed on the
+ * catalogue provider and the core ships no `codex` extension — that used to be
+ * the whole story, but the codex surface now reads the OPENAI manifest
+ * (`chatgptSurface()`), so it is no longer true that nothing over there can see
+ * openai's lifecycle. It reads that file for the ROUTE and deliberately not for
+ * the retirement statuses in it: what the ChatGPT account can still run is
+ * stated by the route suppressions, and `status: "deprecated"` is upstream
+ * saying "prefer the newer one", which on a plan-gated replacement is advice
+ * this surface must not follow. Do not "fix" the asymmetry by feeding openai's
+ * retirements into the codex payload; `curated-defaults-offerable.test.ts` is
+ * there to notice a default that moves.
  */
 function withoutRetiredModels(payload: CatalogResponse): CatalogResponse {
   // Resolved ONCE. A payload can run to hundreds of rows (the OpenRouter

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -79,6 +79,7 @@ import {
 } from "@/lib/clawbox-ai-models";
 import { OPENROUTER_CURATED_MODELS, OPENROUTER_DEFAULT_MODEL_ID } from "@/lib/openrouter-models";
 import { resolveEntitledCodexModel } from "@/lib/codex-model-probe";
+import { chatgptDefaultModelId, chatgptUpgradeCandidates } from "@/lib/chatgpt-surface";
 import {
   CHATGPT_AGENT_RUNTIME_ID,
   CHATGPT_DEFAULT_MODEL_ID,
@@ -2434,9 +2435,23 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
       // gpt-5.5, which every tier can use. Defaulting a non-entitled account
       // onto a gpt-5.6 model would be far worse than being conservative: the
       // upstream 400 is a surface error with no failover, so every turn fails.
+      // The FLOOR first, asked of the same surface that judges the result 90
+      // lines below (`offSurfaceCodexModelMessage`). `CHATGPT_DEFAULT_MODEL_ID`
+      // is a constant, and the day a core retires gpt-5.5 from the ChatGPT
+      // route a sign-in would 400 on its own default with no other door — see
+      // `chatgptDefaultModelId`. It answers gpt-5.5 on every core measured so
+      // far, so this is a no-op today and a floor that cannot be refused
+      // tomorrow.
+      config.defaultModel = chatgptModelRef(chatgptDefaultModelId());
       try {
         const entitled = await resolveEntitledCodexModel({
           accessToken: normalizedApiKey,
+          // The surface's own rows above the floor, newest first, instead of a
+          // second hand-kept list: on the pinned core that IS
+          // `CODEX_MODEL_PREFERENCE`, and on a core that adds a model the probe
+          // can now reach it — without one, a fresh sign-in would keep landing
+          // on gpt-5.5 while the picker offered something newer.
+          candidates: chatgptUpgradeCandidates(),
           onDiagnostic: (message) => console.log(`[configure] ${message}`),
         });
         if (entitled) {

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -201,9 +201,15 @@ const PROVIDERS: Record<string, ProviderConfig> = {
       // key of its own so it coexists with the API-key one, and the model is
       // `openai/<id>` — OpenClaw 2 has no `codex/` namespace and never
       // consults a `codex:*` profile for an openai route. Evidence in
-      // src/lib/chatgpt-subscription.ts. Newest model every ChatGPT tier can
-      // run, Free included; entitled accounts are moved up to gpt-5.6 by the
-      // sign-in probe below.
+      // src/lib/chatgpt-subscription.ts.
+      //
+      // A SEED that never reaches the config: the subscription branch below
+      // overwrites `config.defaultModel` with `chatgptDefaultModelId()` before
+      // the entitlement probe, and the explicit-pick branch overwrites it with
+      // what the owner named — so this constant is what the table needs to be
+      // shaped like, not what a box is written with. Which model the floor
+      // actually is, and what the probe is offered above it, are the installed
+      // core's answer now (src/lib/chatgpt-surface.ts), not this line's.
       defaultModel: chatgptModelRef(CHATGPT_DEFAULT_MODEL_ID),
       profileKey: CHATGPT_PROFILE_KEY,
     },

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -25,6 +25,7 @@ import {
   CLAWBOX_AI_DEFAULT_TIER,
 } from "@/lib/clawbox-ai-models";
 import { OPENROUTER_DEFAULT_MODEL_ID } from "@/lib/openrouter-models";
+import { chatgptDefaultModelId } from "@/lib/chatgpt-surface";
 import {
   ANTHROPIC_DEFAULT_MODEL_ID,
   GOOGLE_DEFAULT_MODEL_ID,
@@ -50,7 +51,6 @@ import {
 import { isClawboxAiImageModelId, isClawboxAiImageModelRef } from "@/lib/clawbox-ai-models";
 import {
   CHATGPT_AGENT_RUNTIME_ID,
-  CHATGPT_DEFAULT_MODEL_ID,
   CHATGPT_PROVIDER,
   CHATGPT_UI_PROVIDER,
   canonicalChatgptModelRef,
@@ -172,7 +172,7 @@ function defaultModelForProvider(provider: string | null): string | null {
   // src/lib/chatgpt-subscription.ts. Both retired ids (`codex`, and
   // `openai-codex` before 2026.6) resolve to the same row.
   if (isLegacyChatgptProvider(normalized)) {
-    return chatgptModelRef(CHATGPT_DEFAULT_MODEL_ID);
+    return chatgptModelRef(chatgptDefaultModelId());
   }
   return DEFAULT_PROVIDER_MODELS[normalized]
     ?? DEFAULT_PROVIDER_MODELS[normalizeProvider(provider) ?? ""]
@@ -686,7 +686,7 @@ async function loadChatModelState(preloaded?: OpenClawConfig) {
   // refuses, and rather than vanishing, which reads as "never connected".
   if (hasLegacyChatgptProfile(authProfiles) && !hasChatgptOauthProfile(authProfiles)) {
     const existing = configuredPrimaryOptions.get(CHATGPT_UI_PROVIDER);
-    const model = existing?.model ?? chatgptModelRef(CHATGPT_DEFAULT_MODEL_ID);
+    const model = existing?.model ?? chatgptModelRef(chatgptDefaultModelId());
     configuredPrimaryOptions.set(CHATGPT_UI_PROVIDER, {
       id: existing?.id ?? model,
       label: labelForProvider(CHATGPT_UI_PROVIDER, "AI Provider"),

--- a/src/lib/chatgpt-surface.ts
+++ b/src/lib/chatgpt-surface.ts
@@ -48,10 +48,25 @@ import { CHATGPT_DEFAULT_MODEL_ID } from "@/lib/chatgpt-subscription";
  * array had by construction: a model this box has been running cannot stop
  * being selectable because a file changed shape.
  *
- * NOT the live per-account catalogue, which would be better still: the core
- * builds the real list from `chatgpt.com/backend-api/codex/models` per account,
- * and nothing on 2026.8.1 or 2026.9.3 publishes it in a form ClawBox can ask
- * for. `coreChatgptRoute` carries that measurement.
+ * NOT the live per-account catalogue, which would be better still — and the
+ * harness DOES have a mechanism for it, so the reason has to be a real one
+ * rather than "there is none". The core's `openai` catalog hook picks between
+ * two catalogues by the auth profile it resolves first: with an `oauth` or
+ * `token` profile it builds the live per-account Codex list from
+ * `chatgpt.com/backend-api/codex/models`, and with an api key the platform one.
+ * So on a box whose resolved `openai` profile is the ChatGPT sign-in,
+ * `models list --provider openai --all --json` DOES enumerate the real list —
+ * and which profile resolves is the auth ORDER, a knob this repo already owns
+ * and writes (`applyOpenAiAuthOrder` in `ai-models/configure`).
+ *
+ * It is not used here for two measured reasons, neither of them "unavailable":
+ * that enumeration is a `models list` spawn, ~3 minutes on a Jetson, and this
+ * surface is read synchronously by two write guards on a request path; and the
+ * answer depends on the box's credential order, so a picker built from it would
+ * change its own contents when a customer adds or removes an API key. The
+ * catalogue route's cache is where such a read would belong if it is ever worth
+ * the cost. What the manifest gives instead is credential-free, instant, and the
+ * same on every box with the same core, which is what a WRITE GUARD needs.
  *
  * NOT the core's own route contract either, and that is a judgement rather than
  * an oversight: `dist/extensions/openai/model-route-contract.js` exports

--- a/src/lib/chatgpt-surface.ts
+++ b/src/lib/chatgpt-surface.ts
@@ -1,5 +1,6 @@
 import { CODEX_MODELS, type ProviderModelOption } from "@/lib/provider-models";
 import { coreChatgptRoute } from "@/lib/core-model-lifecycle";
+import { CHATGPT_DEFAULT_MODEL_ID } from "@/lib/chatgpt-subscription";
 
 /**
  * The models the ChatGPT account (the "OpenAI Codex" row) can be switched to on
@@ -36,14 +37,47 @@ import { coreChatgptRoute } from "@/lib/core-model-lifecycle";
  * published — they cannot invent one — which is the opposite failure direction
  * from the curated list this replaces.
  *
+ * It can only ever ADD to the curated list, never narrow it below it: the
+ * manifest is the core's static SEED, not its effective catalogue (both cores
+ * declare `modelCatalog.discovery = {"openai": "runtime"}`, and the box's own
+ * enumeration answers more rows than the seed lists), so a chatgpt-route model
+ * that moves out of the seed into the discovered half must not take the row and
+ * the write guard with it. Only the core's explicit `chatgpt.com` suppressions
+ * remove a row. That is the fail-open direction `core-model-lifecycle.ts`
+ * insists on everywhere else, and it is what keeps the guarantee the curated
+ * array had by construction: a model this box has been running cannot stop
+ * being selectable because a file changed shape.
+ *
  * NOT the live per-account catalogue, which would be better still: the core
  * builds the real list from `chatgpt.com/backend-api/codex/models` per account,
  * and nothing on 2026.8.1 or 2026.9.3 publishes it in a form ClawBox can ask
- * for. `coreChatgptRoute` carries that measurement. Plan gating therefore still
- * is not filtered here — an unentitled account sees the gpt-5.6 generation,
- * the turn 400s upstream, and the sign-in probe
+ * for. `coreChatgptRoute` carries that measurement.
+ *
+ * NOT the core's own route contract either, and that is a judgement rather than
+ * an oversight: `dist/extensions/openai/model-route-contract.js` exports
+ * `OPENAI_CHATGPT_MODERN_MODEL_IDS` (its dual-route ids plus the
+ * subscription-only ones) — the answer per model, with no credential, and it
+ * would make two of the three narrowings below unnecessary. It is rejected
+ * because reading it means `await import()`ing a core INTERNAL by absolute path:
+ * it is not in the package's `exports` map, it executes core module code inside
+ * the web server, and it would make this surface async — it is read by two write
+ * guards on a request path. The manifest is data, already read by this repo for
+ * retirements, at the same stable path, and parsed rather than executed. If the
+ * core ever publishes the contract through its `exports` map or a CLI, that is
+ * the better source and this note is where to start.
+ *
+ * Plan gating is still not filtered here — an unentitled account sees the
+ * gpt-5.6 generation, the turn 400s upstream, and the sign-in probe
  * (src/lib/codex-model-probe.ts) is what keeps a box off a row its plan cannot
  * run.
+ *
+ * The one spelling a core bump cannot reach is the browser's pre-fetch paint:
+ * `useProviderCatalog` renders `PROVIDER_CATALOGS.codex` (the curated array,
+ * flagged `fallback: true`) until the catalogue request lands, so on a core that
+ * has retired a curated row the picker can show it for that instant. A click in
+ * that window is refused with a clean 400 by the guard below rather than
+ * written, and the browser cannot read a manifest — so it is accepted, not
+ * fixed.
  */
 
 /** The provider whose manifest carries the ChatGPT route (OpenClaw 2: `openai`). */
@@ -144,8 +178,19 @@ export function chatgptSurface(): ChatgptSurface {
 
   const models: ProviderModelOption[] = [];
   const seen = new Set<string>();
-  const add = (id: string, name?: string) => {
-    if (seen.has(id) || offSurface(id) || route.offRoute.has(id)) return;
+  /**
+   * `routeStated` ids skip the tier narrowing: an `api.openai.com` suppression
+   * is the core saying the PLATFORM route cannot reach this model, which outranks
+   * a guess made from the shape of its name. Without that, a future
+   * `gpt-6-astra-pro` shipped the way `gpt-5.3-codex-spark` is shipped today
+   * would be hidden by the `-pro` rule from the one surface that can run it —
+   * and `codex-surface-follows-core.test.ts` would go red on a box while staying
+   * vacuous on CI. `route.offRoute` still applies to everything: an explicit
+   * "retired from this route" is never overridden.
+   */
+  const add = (id: string, name?: string, routeStated = false) => {
+    if (seen.has(id) || route.offRoute.has(id)) return;
+    if (!routeStated && offSurface(id)) return;
     seen.add(id);
     models.push({
       id,
@@ -165,18 +210,72 @@ export function chatgptSurface(): ChatgptSurface {
   // absent from `models[]` entirely — `gpt-5.3-codex-spark` is in neither
   // core's list — and appending keeps it where the curated order put it: last,
   // behind the flagships.
-  for (const id of route.subscriptionOnly) add(id);
+  for (const id of route.subscriptionOnly) add(id, undefined, true);
+  // WIDEN, never narrow: a curated row the manifest's seed does not list stays
+  // offered unless the core suppressed it on this route. See the header — the
+  // seed is not the effective catalogue, and a row that merely fell out of it
+  // must not stop being selectable on a box that has been running it. On both
+  // measured cores this pass adds nothing, which is the point: it changes the
+  // failure direction, not the list.
+  for (const model of CODEX_MODELS) add(model.id);
 
   // Never an empty picker. A manifest that parses but lists nothing we would
   // offer is a shape this does not understand, and serving zero rows would
   // refuse every model on a box whose ChatGPT account works — the false failure
   // `core-model-lifecycle.ts` fails open to avoid, in the one direction that
-  // matters here.
+  // matters here. Unreachable now that the curated pass above runs
+  // unconditionally, unless the core suppresses every curated id on this route
+  // as well, and kept for exactly that case.
   if (models.length === 0) return { models: CODEX_MODELS, source: "curated" };
   return { models, source: "core" };
 }
 
-/** Just the ids, for a caller that only has to judge membership. */
-export function chatgptSurfaceModelIds(): ReadonlySet<string> {
-  return new Set(chatgptSurface().models.map((model) => model.id));
+/**
+ * The id a fresh ChatGPT sign-in lands on before the entitlement probe runs.
+ *
+ * `gpt-5.5` while the surface carries it — it is the newest model every ChatGPT
+ * tier can run, Free included, which is the whole reason it is the floor — and
+ * otherwise the surface's first row.
+ *
+ * It has to be ASKED rather than assumed, because the same request that
+ * computes this default is the one that then judges it: `configure` writes the
+ * default and calls `offSurfaceCodexModelMessage` ninety lines later. While the
+ * default was a constant and the guard was the same curated array, the two
+ * could not disagree. Now that the guard follows the core, a core that retires
+ * `gpt-5.5` from the ChatGPT route — the exact move 2026.9.3 made for `gpt-5.4`
+ * and `gpt-5.4-mini`, and both measured manifests already carry `gpt-5.5` as
+ * `status: "deprecated"` — would make a ChatGPT sign-in 400 on its own default
+ * with no other door: setup could not complete.
+ *
+ * The first row rather than a second hand-kept name: it is the core's own
+ * order, and the core lists its newest first.
+ */
+export function chatgptDefaultModelId(): string {
+  return defaultIdFrom(chatgptSurface().models);
+}
+
+function defaultIdFrom(models: readonly ProviderModelOption[]): string {
+  if (models.some((model) => model.id === CHATGPT_DEFAULT_MODEL_ID)) return CHATGPT_DEFAULT_MODEL_ID;
+  return models[0]?.id ?? CHATGPT_DEFAULT_MODEL_ID;
+}
+
+/**
+ * The models the sign-in probe should try, newest first, before settling for
+ * {@link chatgptDefaultModelId}: everything the surface lists AHEAD of it.
+ *
+ * Derived for the same reason the default is, and it fixes the other half of
+ * the same defect: the probe's hand-kept preference list can never name a model
+ * a core upgrade adds, so on 2026.9.3 the picker would offer `gpt-6-astra`
+ * first while every fresh sign-in still landed on `gpt-5.5` — this PR's own
+ * complaint surviving in the one place that writes config.
+ *
+ * On the core the boxes run today this is exactly the list it replaces
+ * (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`), which is what makes it a
+ * safe swap: the probe still only upgrades on a POSITIVE answer, and anything
+ * ambiguous still leaves the box on the floor every tier can run.
+ */
+export function chatgptUpgradeCandidates(): string[] {
+  const models = chatgptSurface().models;
+  const floor = models.findIndex((model) => model.id === defaultIdFrom(models));
+  return (floor < 0 ? models : models.slice(0, floor)).map((model) => model.id);
 }

--- a/src/lib/chatgpt-surface.ts
+++ b/src/lib/chatgpt-surface.ts
@@ -1,0 +1,182 @@
+import { CODEX_MODELS, type ProviderModelOption } from "@/lib/provider-models";
+import { coreChatgptRoute } from "@/lib/core-model-lifecycle";
+
+/**
+ * The models the ChatGPT account (the "OpenAI Codex" row) can be switched to on
+ * THIS box — read from the installed core, not kept here.
+ *
+ * WHY IT MOVED OFF A CURATED LIST. `CODEX_MODELS` was the whole surface: the
+ * picker offered it, both write paths accepted exactly it, and the refusal
+ * sentence was built from it. One list beats three, but a hand-kept list still
+ * cannot know what the next core ships — and it was wrong in BOTH directions at
+ * once the moment a core bump was measured:
+ *
+ *   * `gpt-6-astra` was left out deliberately, on a turn that went to
+ *     api.openai.com instead of chatgpt.com. That measurement was a property of
+ *     the BOX, not of the model (see `coreChatgptRoute`): with an API key in
+ *     play the core publishes the PLATFORM catalogue for `openai`, every row on
+ *     it resolves to api.openai.com, and the same box sends the owner's own
+ *     `gpt-5.5` there too — measured, 401, then failover. On 2026.9.3 the core
+ *     lists `gpt-6-astra` FIRST in the openai manifest and files it as a
+ *     dual-route model.
+ *   * `gpt-5.4` and `gpt-5.4-mini` stay in the curated list, and 2026.9.3
+ *     suppresses both on `chatgpt.com` — "retired from the ChatGPT-account
+ *     Codex route". A box on that core would offer two rows that cannot run.
+ *
+ * So the surface follows the core's own manifest, and the curated list is what
+ * it falls back to when no manifest can be read (CI, a box with no core yet, a
+ * half-written file mid-upgrade). A model the account gains now reaches the
+ * picker, both write guards and the refusal sentence with the next core, with
+ * no ClawBox release.
+ *
+ * WHAT IS STILL OURS, and why it is a narrowing rather than a second list: the
+ * core's manifest lists every openai model it ships, including rows that are
+ * not on the subscription route at all. Three exclusions are applied to it,
+ * each with its own reason below. They can only ever REMOVE a row the core
+ * published — they cannot invent one — which is the opposite failure direction
+ * from the curated list this replaces.
+ *
+ * NOT the live per-account catalogue, which would be better still: the core
+ * builds the real list from `chatgpt.com/backend-api/codex/models` per account,
+ * and nothing on 2026.8.1 or 2026.9.3 publishes it in a form ClawBox can ask
+ * for. `coreChatgptRoute` carries that measurement. Plan gating therefore still
+ * is not filtered here — an unentitled account sees the gpt-5.6 generation,
+ * the turn 400s upstream, and the sign-in probe
+ * (src/lib/codex-model-probe.ts) is what keeps a box off a row its plan cannot
+ * run.
+ */
+
+/** The provider whose manifest carries the ChatGPT route (OpenClaw 2: `openai`). */
+const CORE_PROVIDER = "openai";
+
+/**
+ * Ids that are aliases for a route rather than models on it: the core's own
+ * `OPENAI_PLATFORM_ONLY_ROUTE_MODEL_IDS` on both measured cores
+ * (`chat-latest`, bare `gpt-5.6`), which its own static Codex catalogue drops
+ * from the ChatGPT list in `buildOpenAICodexStaticProviderConfig`.
+ *
+ * Neither core's manifest lists them, so this removes nothing today. It is
+ * here because the manifest is now the INPUT: the day one is listed, an
+ * unfiltered surface would offer an alias the ChatGPT route does not serve.
+ */
+const PLATFORM_ONLY_ALIASES: ReadonlySet<string> = new Set(["chat-latest", "gpt-5.6"]);
+
+/**
+ * Tiers the manifest lists that the ChatGPT account cannot run, by suffix.
+ *
+ *   * `-pro` — measured: the subscription path answers "model not supported
+ *     when using Codex with a ChatGPT account" (developers.openai.com/codex
+ *     /models). The core files them as dual-route, so only the platform half
+ *     is real; the manifest carries `gpt-5.5-pro` and `gpt-5.4-pro`.
+ *   * `-nano` — the core's own `OPENAI_CHATGPT_MODERN_MODEL_IDS` (its dual-route
+ *     ids plus the subscription-only ones) omits `gpt-5.4-nano` on both
+ *     measured cores while `OPENAI_PROVIDER_MODERN_MODEL_IDS` carries it: the
+ *     core ships it for the platform route and not for this one.
+ *
+ * A suffix rule, not a generation rule. The generation allowlist this surface
+ * used to carry could not spell the next model's name and hid two of them; a
+ * tier suffix says nothing about WHEN a model shipped, and the day the core
+ * suppresses one of these on `chatgpt.com` itself the suppression answers
+ * first and this rule becomes redundant rather than wrong.
+ */
+const OFF_SURFACE_SUFFIXES: readonly string[] = ["-pro", "-nano"];
+
+export interface ChatgptSurface {
+  /** The rows to offer, newest-first in the order the source lists them. */
+  models: readonly ProviderModelOption[];
+  /** `core` when the installed core answered; `curated` when it could not. */
+  source: "core" | "curated";
+}
+
+function offSurface(id: string): boolean {
+  const lower = id.toLowerCase();
+  if (PLATFORM_ONLY_ALIASES.has(lower)) return true;
+  return OFF_SURFACE_SUFFIXES.some((suffix) => lower.endsWith(suffix));
+}
+
+/**
+ * The curated row for `id`, when the shipped list carries one.
+ *
+ * It contributes the LABEL and the HINT, never the existence of the row. The
+ * label matters because ours is not always the core's: the chat header's model
+ * pill has ~142px for its text (chat-header-pills.ts), so
+ * `gpt-5.3-codex-spark` ships as "GPT-5.3 Spark" rather than the core's
+ * "GPT-5.3 Codex Spark", which would be the only label in any catalogue we ship
+ * that truncates. The hint has no source at all on the device side — no
+ * manifest, no enumeration carries one.
+ */
+function curatedRow(id: string): ProviderModelOption | undefined {
+  return CODEX_MODELS.find((model) => model.id === id);
+}
+
+/** A readable label for a model the curated list has never heard of. */
+function labelFor(id: string, name: string | undefined): string {
+  const curated = curatedRow(id)?.label;
+  if (curated) return curated;
+  const trimmed = name?.trim();
+  // The core's own display name, unless it is just the id again — 2026.9.3
+  // ships `gpt-5.5-pro` with `name: "gpt-5.5-pro"`, and a label that repeats a
+  // bare id reads as a bug in the picker rather than as a model name.
+  return trimmed && trimmed.toLowerCase() !== id.toLowerCase() ? trimmed : id;
+}
+
+/**
+ * The ChatGPT-route catalogue for this box.
+ *
+ * Synchronous on purpose: every caller is a guard on a write path or a picker
+ * payload, and the read behind it is one cached, mtime-checked manifest — the
+ * same one `coreRetiredModels` already reads on every catalogue request. An
+ * async surface here would make `isCodexSupportedModelId` async in three
+ * routes to save nothing.
+ */
+export function chatgptSurface(): ChatgptSurface {
+  // FAILS OPEN on a throw, not just on a missing manifest. The callers are two
+  // write guards and a picker payload: whatever an unreadable core does here, it
+  // must come out as "offer the curated list", never as a 500 over a model
+  // switch that should have been a plain accept or a plain refusal.
+  let route: ReturnType<typeof coreChatgptRoute> = null;
+  try {
+    route = coreChatgptRoute(CORE_PROVIDER);
+  } catch {
+    route = null;
+  }
+  if (!route) return { models: CODEX_MODELS, source: "curated" };
+
+  const models: ProviderModelOption[] = [];
+  const seen = new Set<string>();
+  const add = (id: string, name?: string) => {
+    if (seen.has(id) || offSurface(id) || route.offRoute.has(id)) return;
+    seen.add(id);
+    models.push({
+      id,
+      label: labelFor(id, name),
+      // EMPTY for a model the curated list has never heard of, and that is the
+      // honest answer: a hint is a sentence about a plan tier and a use case,
+      // nothing on the device publishes one (neither the manifest nor an
+      // enumeration carries a description), and inventing one for a model that
+      // arrived with a core upgrade would be guessing at what the customer is
+      // entitled to. The picker renders no hint line for an empty string.
+      hint: curatedRow(id)?.hint ?? "",
+    });
+  };
+
+  for (const row of route.listed) add(row.id, row.name);
+  // After the listed rows, because a model the PLATFORM route suppresses is
+  // absent from `models[]` entirely — `gpt-5.3-codex-spark` is in neither
+  // core's list — and appending keeps it where the curated order put it: last,
+  // behind the flagships.
+  for (const id of route.subscriptionOnly) add(id);
+
+  // Never an empty picker. A manifest that parses but lists nothing we would
+  // offer is a shape this does not understand, and serving zero rows would
+  // refuse every model on a box whose ChatGPT account works — the false failure
+  // `core-model-lifecycle.ts` fails open to avoid, in the one direction that
+  // matters here.
+  if (models.length === 0) return { models: CODEX_MODELS, source: "curated" };
+  return { models, source: "core" };
+}
+
+/** Just the ids, for a caller that only has to judge membership. */
+export function chatgptSurfaceModelIds(): ReadonlySet<string> {
+  return new Set(chatgptSurface().models.map((model) => model.id));
+}

--- a/src/lib/chatgpt-surface.ts
+++ b/src/lib/chatgpt-surface.ts
@@ -1,4 +1,4 @@
-import { CODEX_MODELS, type ProviderModelOption } from "@/lib/provider-models";
+import { CODEX_MODELS, isNonChatModelId, type ProviderModelOption } from "@/lib/provider-models";
 import { coreChatgptRoute } from "@/lib/core-model-lifecycle";
 import { CHATGPT_DEFAULT_MODEL_ID } from "@/lib/chatgpt-subscription";
 
@@ -189,9 +189,23 @@ export function chatgptSurface(): ChatgptSurface {
    * "retired from this route" is never overridden.
    */
   const add = (id: string, name?: string, routeStated = false) => {
-    if (seen.has(id) || route.offRoute.has(id)) return;
+    // Lowercased for both tests, because `route.offRoute` is lowercased and the
+    // core matches suppressions case-folded — a manifest that lists `GPT-5.4`
+    // and suppresses `gpt-5.4` must not keep the row.
+    const key = id.toLowerCase();
+    if (seen.has(key) || route.offRoute.has(key)) return;
+    // NOT A CHAT MODEL AT ALL, and this one applies even to a `routeStated` id.
+    // The block this derivation seeds from is the core's PLATFORM provider
+    // config (`baseUrl: https://api.openai.com/v1`), which is a ChatGPT-route
+    // list only because today's manifest happens to carry nothing else — the
+    // first core that lists an image, embedding or transcription SKU there would
+    // otherwise put it in the picker AND through `isCodexSupportedModelId`, which
+    // is the only gate `chat/model` and `configure` apply before writing
+    // `agents.defaults.model.primary`. The catalogue route already refuses these
+    // on the payload side; the write guard had no such filter.
+    if (isNonChatModelId(id)) return;
     if (!routeStated && offSurface(id)) return;
-    seen.add(id);
+    seen.add(key);
     models.push({
       id,
       label: labelFor(id, name),
@@ -200,7 +214,10 @@ export function chatgptSurface(): ChatgptSurface {
       // nothing on the device publishes one (neither the manifest nor an
       // enumeration carries a description), and inventing one for a model that
       // arrived with a core upgrade would be guessing at what the customer is
-      // entitled to. The picker renders no hint line for an empty string.
+      // entitled to. The setup wizard falls back to the id for an empty hint
+      // (`AIModelsStep.tsx`, `option.hint || option.id`), so such a row shows its
+      // own id as the subtitle — plain, and true, which a guessed plan tier
+      // would not be.
       hint: curatedRow(id)?.hint ?? "",
     });
   };
@@ -247,7 +264,17 @@ export function chatgptSurface(): ChatgptSurface {
  *
  * `gpt-5.5` while the surface carries it — it is the newest model every ChatGPT
  * tier can run, Free included, which is the whole reason it is the floor — and
- * otherwise the surface's first row.
+ * otherwise the surface's LAST row.
+ *
+ * The last and not the first, which is the whole point of the word "floor".
+ * This value is a cold start for an account whose plan is not known yet, and it
+ * is also what {@link chatgptUpgradeCandidates} measures "ahead of" — so the
+ * first row would be the newest, most likely plan-gated model AND would leave
+ * nothing ahead of it to probe, pinning a Free account onto a row that 400s on
+ * every turn with the probe silently disabled. The last row is the oldest model
+ * the core still routes here, which is the best available guess at "the one
+ * every tier can run" once the known floor is gone, and it leaves every other
+ * row for the probe to try.
  *
  * It has to be ASKED rather than assumed, because the same request that
  * computes this default is the one that then judges it: `configure` writes the
@@ -259,8 +286,11 @@ export function chatgptSurface(): ChatgptSurface {
  * `status: "deprecated"` — would make a ChatGPT sign-in 400 on its own default
  * with no other door: setup could not complete.
  *
- * The first row rather than a second hand-kept name: it is the core's own
- * order, and the core lists its newest first.
+ * A position in the core's own list rather than a second hand-kept name. The
+ * position is only as good as the manifest's ordering, which is a convention
+ * and not a schema rule — but it is a convention this fallback only consults
+ * once the id every tier is known to run has gone, and the probe below is what
+ * corrects it upwards.
  */
 export function chatgptDefaultModelId(): string {
   return defaultIdFrom(chatgptSurface().models);
@@ -268,7 +298,7 @@ export function chatgptDefaultModelId(): string {
 
 function defaultIdFrom(models: readonly ProviderModelOption[]): string {
   if (models.some((model) => model.id === CHATGPT_DEFAULT_MODEL_ID)) return CHATGPT_DEFAULT_MODEL_ID;
-  return models[0]?.id ?? CHATGPT_DEFAULT_MODEL_ID;
+  return models[models.length - 1]?.id ?? CHATGPT_DEFAULT_MODEL_ID;
 }
 
 /**
@@ -285,9 +315,21 @@ function defaultIdFrom(models: readonly ProviderModelOption[]): string {
  * (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`), which is what makes it a
  * safe swap: the probe still only upgrades on a POSITIVE answer, and anything
  * ambiguous still leaves the box on the floor every tier can run.
+ *
+ * CAPPED at what the probe's own budget can actually spend. `codex-model-probe`
+ * allows 6s per probe inside a 15s total, so it affords three attempts and
+ * stops at the deadline — a limit that was invisible while the list was a fixed
+ * three-item constant and becomes silent truncation now that the core supplies
+ * it. Naming the cap here keeps sign-in bounded and makes the trade explicit:
+ * beyond the third row the probe would not have run anyway, and an account
+ * entitled to none of the three stays on the floor, which is the conservative
+ * direction the probe is built around.
  */
+const MAX_UPGRADE_PROBES = 3;
+
 export function chatgptUpgradeCandidates(): string[] {
   const models = chatgptSurface().models;
   const floor = models.findIndex((model) => model.id === defaultIdFrom(models));
-  return (floor < 0 ? models : models.slice(0, floor)).map((model) => model.id);
+  const ahead = floor < 0 ? models : models.slice(0, floor);
+  return ahead.slice(0, MAX_UPGRADE_PROBES).map((model) => model.id);
 }

--- a/src/lib/chatgpt-surface.ts
+++ b/src/lib/chatgpt-surface.ts
@@ -219,13 +219,25 @@ export function chatgptSurface(): ChatgptSurface {
   // failure direction, not the list.
   for (const model of CODEX_MODELS) add(model.id);
 
-  // Never an empty picker. A manifest that parses but lists nothing we would
-  // offer is a shape this does not understand, and serving zero rows would
-  // refuse every model on a box whose ChatGPT account works — the false failure
-  // `core-model-lifecycle.ts` fails open to avoid, in the one direction that
-  // matters here. Unreachable now that the curated pass above runs
-  // unconditionally, unless the core suppresses every curated id on this route
-  // as well, and kept for exactly that case.
+  // Never an empty picker, and the list here is deliberately UNFILTERED — the
+  // one place this file does not honour a suppression, so the reason is worth
+  // spelling out.
+  //
+  // Since the widening pass above runs unconditionally, `models` already IS the
+  // curated list minus the core's `chatgpt.com` suppressions, unioned with the
+  // core's own rows. Reaching zero therefore means the core has suppressed EVERY
+  // curated id on this route, so filtering this fallback through the same
+  // suppressions would return the empty array — the same thing, spelled longer.
+  //
+  // And an empty surface is the one shape this module must not produce:
+  // `isCodexSupportedModelId` would refuse every model while naming none, and
+  // `chatgptDefaultModelId` would hand `configure` a default its own guard
+  // refuses, so a ChatGPT sign-in could not complete at all. A row that 400s
+  // upstream carrying the core's own error is the better of two bad answers in
+  // that corner, and it is the fail-open direction `core-model-lifecycle.ts`
+  // takes everywhere else. Pinned by
+  // `codex-picker-astra.test.ts > keeps a last-resort list rather than emptying
+  // the picker`.
   if (models.length === 0) return { models: CODEX_MODELS, source: "curated" };
   return { models, source: "core" };
 }

--- a/src/lib/codex-model-probe.ts
+++ b/src/lib/codex-model-probe.ts
@@ -19,7 +19,20 @@
 // ambiguity (auth trouble, rate limit, network, 5xx) leaves the caller on the
 // universally-available default.
 
-/** Newest first. gpt-5.5 is not here — it is the fallback everyone can use. */
+/**
+ * Newest first. gpt-5.5 is not here — it is the fallback everyone can use.
+ *
+ * The DEFAULT list, not the only one: since the ChatGPT surface began following
+ * the installed core's own manifest, `ai-models/configure` supplies
+ * `chatgptUpgradeCandidates()` instead, so a model a core upgrade adds can be
+ * probed with no release here. This array is what a caller that names none
+ * still gets, and what a box with no readable manifest falls back to — the two
+ * agree on every core measured so far.
+ *
+ * That caller caps its list at three, because the budget below affords three:
+ * 6 s per probe inside a 15 s total, and the loop stops at the deadline. A
+ * longer list is not a longer sign-in — it is a silently untried tail.
+ */
 export const CODEX_MODEL_PREFERENCE = [
   "gpt-5.6-sol",
   "gpt-5.6-terra",
@@ -31,6 +44,12 @@ export const CODEX_MODEL_PREFERENCE = [
  * can't improve on it. Only the gpt-5.6 generation is plan-gated, so there is
  * nothing to gain from probing gpt-5.5 — it would spend a round-trip during
  * setup to confirm a floor we already hold.
+ *
+ * True of the cores measured so far and not a permanent fact: on a core that
+ * retires this id from the ChatGPT route, `chatgptDefaultModelId()` answers the
+ * oldest row that core still routes there instead, and the probe is handed
+ * everything ahead of it. This constant stays the floor's NAME, not its
+ * definition.
  */
 export const CODEX_FALLBACK_MODEL = "gpt-5.5";
 

--- a/src/lib/core-model-lifecycle.ts
+++ b/src/lib/core-model-lifecycle.ts
@@ -87,12 +87,25 @@ const PLATFORM_HOST = "api.openai.com";
 const CHATGPT_HOST = "chatgpt.com";
 
 /**
- * The `api` the core gives the ChatGPT route's provider config
- * (`buildOpenAICodexLiveProviderConfig` / `buildOpenAICodexStaticProviderConfig`
- * both set `api: "openai-chatgpt-responses"`), for the OTHER condition its
- * suppression matcher supports — `when.providerConfigApiIn`.
+ * The core's suppression matcher supports a SECOND condition,
+ * `when.providerConfigApiIn`, and this file deliberately does not read it.
+ *
+ * Two reasons, both measured against `dist/model-suppression-*.js`:
+ *
+ *   * the matcher ANDs every condition that is present
+ *     (`manifestSuppressionMatchesConditions` returns false on the first miss),
+ *     so treating either one as sufficient would remove a row the core keeps;
+ *   * it evaluates that condition against the OWNER'S configured
+ *     `models.providers.<id>.api` — `resolveConfiguredProviderValue` reads
+ *     `config.models.providers` — not against the route's internal
+ *     `api: "openai-chatgpt-responses"`. ClawBox never writes that field (only
+ *     `apiKey`, `baseUrl` and `models[]`), so on a box this repo configures the
+ *     effective api is `""` and such a suppression never fires in the core at
+ *     all. Honouring it here would be a false failure over a model the box runs.
+ *
+ * If ClawBox ever writes `models.providers.openai.api`, this is where to read
+ * that value and AND it with the host condition below.
  */
-const CHATGPT_ROUTE_API = "openai-chatgpt-responses";
 
 /** Lowercased, or "" for anything that is not a usable string. */
 function lower(value: unknown): string {
@@ -119,13 +132,20 @@ function conditionSet(value: unknown): ReadonlySet<string> {
   return out;
 }
 
-/** What the installed core says about one provider's ChatGPT (Codex) route. */
+/**
+ * What the installed core says about one provider's ChatGPT (Codex) route.
+ *
+ * `listed` keeps the manifest's own spelling, because it is what the picker
+ * displays. The two suppression sets are LOWERCASED, because they are matched
+ * against and the core matches them case-folded — a caller testing membership
+ * must lowercase the id it is asking about.
+ */
 export interface CoreChatgptRoute {
   /** The catalogue rows the manifest lists, in the order it lists them. */
   listed: ReadonlyArray<{ id: string; name?: string }>;
-  /** Ids the manifest suppresses ON that route — retired from the surface. */
+  /** Lowercased ids the manifest suppresses ON that route — retired from the surface. */
   offRoute: ReadonlySet<string>;
-  /** Ids suppressed on the platform host: this route reaches them and no other. */
+  /** Lowercased ids suppressed on the platform host: this route reaches them and no other. */
   subscriptionOnly: readonly string[];
 }
 
@@ -164,6 +184,7 @@ interface CachedManifest extends ManifestFacts {
 }
 
 const cache = new Map<string, CachedManifest>();
+
 
 /**
  * A provider id that can only ever name a directory, never traverse out of one.
@@ -317,36 +338,30 @@ function chatgptRouteFrom(manifest: unknown, provider: string): CoreChatgptRoute
   const subscriptionOnly: string[] = [];
   const suppressions = (modelCatalog as { suppressions?: unknown } | null)?.suppressions;
   if (Array.isArray(suppressions)) {
-    type Suppression = {
-      provider?: unknown;
-      model?: unknown;
-      when?: { baseUrlHosts?: unknown; providerConfigApiIn?: unknown } | null;
-    };
+    type Suppression = { provider?: unknown; model?: unknown; when?: { baseUrlHosts?: unknown } | null };
     for (const entry of suppressions as Suppression[]) {
-      // Case-insensitively, as the core's own matcher compares them
-      // (`normalizeProviderId` / `normalizeLowercaseStringOrEmpty` before the
-      // test): a manifest that spelled `"provider": "OpenAI"` would be honoured
-      // there and ignored here, and the picker would keep a row the core
-      // refuses.
+      // Provider AND model case-insensitively, as the core's own matcher
+      // compares them: it keys suppressions by
+      // `normalizeProviderId(provider) + "::" + normalizeLowercaseStringOrEmpty(modelId)`
+      // and normalises the looked-up id the same way. A manifest that spelled
+      // `"provider": "OpenAI"` or listed a row `GPT-5.4` while suppressing
+      // `gpt-5.4` would be honoured there and missed here, leaving a dead row in
+      // the picker and in the write guard.
       if (lower(entry?.provider) !== provider.toLowerCase()) continue;
-      const model = typeof entry?.model === "string" ? entry.model.trim() : "";
+      const model = lower(entry?.model);
       if (!model) continue;
       const hosts = conditionSet(entry?.when?.baseUrlHosts);
-      // The core's suppression matcher compiles TWO conditions —
-      // `when.baseUrlHosts` and `when.providerConfigApiIn` — and the second is
-      // the natural spelling for this route once the transport, rather than the
-      // URL, is what identifies it. Reading only the host one would leave a
-      // model the core has taken off the ChatGPT route in the picker and in the
-      // write guard, with every turn dying on the core's own `Unknown model`.
-      const apis = conditionSet(entry?.when?.providerConfigApiIn);
-      if (hosts.size === 0 && apis.size === 0) continue; // unconditional: not a route claim
-      if (hosts.has(CHATGPT_HOST) || apis.has(CHATGPT_ROUTE_API)) offRoute.add(model);
+      if (hosts.size === 0) continue; // unconditional, or a condition this does not read: not a route claim
+      if (hosts.has(CHATGPT_HOST)) offRoute.add(model);
       else if (hosts.has(PLATFORM_HOST) && !subscriptionOnly.includes(model)) subscriptionOnly.push(model);
     }
   }
   // FROZEN before it is cached: `coreChatgptRoute` hands the caller the cached
   // object itself, and a caller that pushed a row onto `listed` would corrupt
-  // the answer for every other reader of the same manifest.
+  // the answer for every other reader of the same manifest. `Object.freeze` does
+  // not reach inside a Set, so `offRoute` is protected by its `ReadonlySet` type
+  // alone — enough to stop `.add()` at the type level, which is where every
+  // caller in this repo lives.
   return Object.freeze({
     listed: Object.freeze(listed),
     offRoute: offRoute as ReadonlySet<string>,
@@ -485,8 +500,14 @@ function factsFor(provider: string): ManifestFacts {
     }
     return { retired, chatgpt };
   }
-  // Nothing found. Deliberately NOT cached: on a box with no core yet, or one
-  // mid-upgrade, the answer is "ask again", not "there is nothing".
+  // Nothing found. Deliberately NOT cached, not even for the stat floor: "there is
+  // no core yet" and "there is nothing retired" are different answers, and
+  // `core-model-lifecycle.test.ts > does not remember having found no manifest at
+  // all` pins that a manifest written moments later is seen at once. The cost is
+  // that `isCodexSupportedModelId` re-walks the candidates per row on a box with
+  // no readable manifest (the Hermes SKU, a box mid-upgrade, CI) — a few
+  // `existsSync` each. Accepted, rather than traded for a filter that can switch
+  // itself off for the life of a process.
   return { retired: new Set(), chatgpt: null };
 }
 

--- a/src/lib/core-model-lifecycle.ts
+++ b/src/lib/core-model-lifecycle.ts
@@ -60,7 +60,7 @@ const RETIRED_STATUSES: ReadonlySet<string> = new Set(["deprecated", "disabled"]
  * How long a manifest read stands before the file is re-stat'ed.
  *
  * The re-stat exists because the in-app OpenClaw update runs inside this server
- * (see `retiredFor`), and that is a once-in-a-while event — while
+ * (see `factsFor`), and that is a once-in-a-while event — while
  * `withoutRetiredModels` asks about every row of a payload, and the OpenRouter
  * catalogue is ~423 rows. One `statSync` per row per request is a blocking
  * syscall storm on a Jetson for a file that changes when someone taps Update.
@@ -69,9 +69,47 @@ const RETIRED_STATUSES: ReadonlySet<string> = new Set(["deprecated", "disabled"]
  */
 const STAT_FLOOR_MS = 5_000;
 
-interface CachedManifest {
+/**
+ * The two hosts the manifest's `when.baseUrlHosts` names, and what each one
+ * means when a model is SUPPRESSED on it. They are the core's own strings, read
+ * out of the shipped manifest rather than chosen here:
+ *
+ *   * `api.openai.com` — suppressed on the PLATFORM route, i.e. reachable only
+ *     through the ChatGPT account. `gpt-5.3-codex-spark` carries this on both
+ *     measured cores, with the reason "available only through ChatGPT/Codex
+ *     OAuth … OpenAI API-key auth cannot use this model."
+ *   * `chatgpt.com` — suppressed on the CHATGPT route: retired FROM the
+ *     subscription surface while it still runs on an API key. 2026.9.3 carries
+ *     two ("GPT-5.4 has retired from the ChatGPT-account Codex route",
+ *     `replacedBy: gpt-5.6-terra`; the same for `gpt-5.4-mini`).
+ */
+const PLATFORM_HOST = "api.openai.com";
+const CHATGPT_HOST = "chatgpt.com";
+
+/** What the installed core says about one provider's ChatGPT (Codex) route. */
+export interface CoreChatgptRoute {
+  /** The catalogue rows the manifest lists, in the order it lists them. */
+  listed: ReadonlyArray<{ id: string; name?: string }>;
+  /** Ids the manifest suppresses ON that route — retired from the surface. */
+  offRoute: ReadonlySet<string>;
+  /** Ids suppressed on the platform host: this route reaches them and no other. */
+  subscriptionOnly: readonly string[];
+}
+
+interface ManifestFacts {
   /** Retired ids, indexed under BOTH the raw manifest id and its last segment. */
   retired: Set<string>;
+  /**
+   * The provider's ChatGPT-route facts, or null when this manifest cannot say —
+   * absent, unparsable, or carrying no catalogue for the provider asked about.
+   *
+   * Null is UNKNOWN and never "the route is empty": the caller renders the
+   * curated fallback for it, where an empty list would empty the picker.
+   */
+  chatgpt: CoreChatgptRoute | null;
+}
+
+interface CachedManifest extends ManifestFacts {
   /** The file this was read from, and what it looked like when it was read. */
   file: string;
   mtimeMs: number;
@@ -109,7 +147,11 @@ const SAFE_PROVIDER_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/i;
 export function coreManifestPaths(provider: string): string[] {
   const bin = findOpenclawBin();
   const paths: string[] = [];
-  if (path.isAbsolute(bin)) {
+  // `typeof` as well as `isAbsolute`, because this is now read from a WRITE
+  // GUARD and not only from the catalogue route: a suite that mocks
+  // `openclaw-config` without this function gets `undefined` here, `path.join`
+  // throws on it, and a model refusal that should be a 400 became a 500.
+  if (typeof bin === "string" && path.isAbsolute(bin)) {
     paths.push(path.join(
       path.dirname(bin), "..", "lib", "node_modules", "openclaw",
       "dist", "extensions", provider, "openclaw.plugin.json",
@@ -177,12 +219,72 @@ function catalogueFor(manifest: unknown, provider: string): unknown {
   return manifest;
 }
 
-function retiredFor(provider: string): Set<string> {
-  if (!SAFE_PROVIDER_RE.test(provider)) return new Set();
+/**
+ * The provider's ChatGPT-route catalogue, as the manifest states it.
+ *
+ * THREE facts, because the manifest states the surface in three pieces and two
+ * of them are suppressions rather than rows:
+ *
+ *   * `modelCatalog.providers.<provider>.models[]` — what the core ships for the
+ *     provider, in its own order (2026.9.3 lists `gpt-6-astra` first).
+ *   * a suppression on {@link CHATGPT_HOST} — a row that is NOT on this route.
+ *   * a suppression on {@link PLATFORM_HOST} — a model that is on this route
+ *     ONLY, and is therefore missing from `models[]` entirely
+ *     (`gpt-5.3-codex-spark` is in neither core's list).
+ *
+ * The suppressions sit at `modelCatalog.suppressions`, beside the provider
+ * blocks rather than inside them, and each names its own `provider` — the
+ * azure alias carries a `gpt-5.3-codex-spark` row of its own, which says nothing
+ * about this provider's routes. So they are filtered by `provider`, and a
+ * suppression with no `when.baseUrlHosts` is ignored: unconditional is not the
+ * same claim as "off this route", and reading it as one would drop a model the
+ * core still routes.
+ *
+ * Returns null when the manifest carries no catalogue for this provider at all.
+ * An empty `models[]` with suppressions is still an answer; no block is not.
+ */
+function chatgptRouteFrom(manifest: unknown, provider: string): CoreChatgptRoute | null {
+  const modelCatalog = (manifest as { modelCatalog?: unknown } | null)?.modelCatalog;
+  const providers = (modelCatalog as { providers?: unknown } | null)?.providers;
+  const block = providers && typeof providers === "object" && !Array.isArray(providers)
+    && Object.prototype.hasOwnProperty.call(providers, provider)
+    ? (providers as Record<string, unknown>)[provider]
+    : null;
+  const rows = (block as { models?: unknown } | null)?.models;
+  if (!Array.isArray(rows)) return null;
+
+  const listed: Array<{ id: string; name?: string }> = [];
+  for (const row of rows as Array<{ id?: unknown; name?: unknown }>) {
+    const id = typeof row?.id === "string" ? row.id.trim() : "";
+    if (!id) continue;
+    const name = typeof row?.name === "string" ? row.name.trim() : "";
+    listed.push(name ? { id, name } : { id });
+  }
+
+  const offRoute = new Set<string>();
+  const subscriptionOnly: string[] = [];
+  const suppressions = (modelCatalog as { suppressions?: unknown } | null)?.suppressions;
+  if (Array.isArray(suppressions)) {
+    for (const entry of suppressions as Array<{ provider?: unknown; model?: unknown; when?: { baseUrlHosts?: unknown } | null }>) {
+      if (entry?.provider !== provider) continue;
+      const model = typeof entry?.model === "string" ? entry.model.trim() : "";
+      if (!model) continue;
+      const hosts = entry?.when?.baseUrlHosts;
+      if (!Array.isArray(hosts)) continue;
+      const lower = hosts.filter((h): h is string => typeof h === "string").map((h) => h.trim().toLowerCase());
+      if (lower.includes(CHATGPT_HOST)) offRoute.add(model);
+      else if (lower.includes(PLATFORM_HOST) && !subscriptionOnly.includes(model)) subscriptionOnly.push(model);
+    }
+  }
+  return { listed, offRoute, subscriptionOnly };
+}
+
+function factsFor(provider: string): ManifestFacts {
+  if (!SAFE_PROVIDER_RE.test(provider)) return { retired: new Set(), chatgpt: null };
   const cached = cache.get(provider);
   if (cached) {
     const now = Date.now();
-    if (now - cached.checkedAt < STAT_FLOOR_MS) return cached.retired;
+    if (now - cached.checkedAt < STAT_FLOOR_MS) return cached;
     // Re-stat rather than trust the process lifetime. The in-app OpenClaw-only
     // update (`openclaw_install` → `openclaw_patch` → `gateway_restart`) runs
     // INSIDE this server and deliberately does not touch ClawBox, so a core
@@ -193,7 +295,7 @@ function retiredFor(provider: string): Set<string> {
       const stat = fsSync.statSync(cached.file);
       if (stat.mtimeMs === cached.mtimeMs && stat.size === cached.size) {
         cached.checkedAt = now;
-        return cached.retired;
+        return cached;
       }
     } catch {
       // The file went away: fall through and look again.
@@ -247,8 +349,14 @@ function retiredFor(provider: string): Set<string> {
       }
     }
     const retired = new Set<string>();
+    let chatgpt: CoreChatgptRoute | null = null;
     try {
-      collect(catalogueFor(JSON.parse(raw), provider), retired);
+      // ONE parse for both facts. They are read off the same bytes the stat
+      // above describes, so a second read here would reintroduce exactly the
+      // mid-upgrade window this function opens the file once to close.
+      const manifest: unknown = JSON.parse(raw);
+      collect(catalogueFor(manifest, provider), retired);
+      chatgpt = chatgptRouteFrom(manifest, provider);
     } catch {
       // A manifest we cannot parse is a manifest we know nothing from — but the
       // NEXT candidate may still be readable, and giving up on the lookup threw
@@ -266,13 +374,13 @@ function retiredFor(provider: string): Set<string> {
       continue;
     }
     if (!degraded) {
-      cache.set(provider, { retired, file, mtimeMs: stat.mtimeMs, size: stat.size, checkedAt: Date.now() });
+      cache.set(provider, { retired, chatgpt, file, mtimeMs: stat.mtimeMs, size: stat.size, checkedAt: Date.now() });
     }
-    return retired;
+    return { retired, chatgpt };
   }
   // Nothing found. Deliberately NOT cached: on a box with no core yet, or one
   // mid-upgrade, the answer is "ask again", not "there is nothing".
-  return new Set();
+  return { retired: new Set(), chatgpt: null };
 }
 
 /**
@@ -306,7 +414,35 @@ export function coreModelRetired(provider: string, id: string): boolean {
  */
 export function coreRetiredModels(provider: string): ReadonlySet<string> {
   if (!provider) return EMPTY;
-  return retiredFor(provider);
+  return factsFor(provider).retired;
+}
+
+/**
+ * What the installed core says its ChatGPT (Codex) route carries for
+ * `provider` — or null when this box cannot say.
+ *
+ * The same manifest, the same read, the same fail-open rule as the retirement
+ * lookup above: a box with no core, an unreadable file or a manifest with no
+ * catalogue for this provider answers null, and the caller renders its curated
+ * fallback. What it must never do is answer "the route has no models".
+ *
+ * WHY THE MANIFEST and not the live Codex catalogue. The core builds the
+ * route's real list per ACCOUNT from `chatgpt.com/backend-api/codex/models`,
+ * and that list is the better answer — but on 2026.8.1 and 2026.9.3 alike
+ * nothing publishes it in a form ClawBox can ask for. Measured on a box:
+ * `models list --provider codex` answers `Unknown provider filter`; there is no
+ * `--profile` scoping; the catalogue the core publishes under `openai` flips
+ * WHOLESALE to the platform list as soon as any API key resolves first (an
+ * inline `models.providers.openai.apiKey` counts), and a row carries no `api`,
+ * `baseUrl` or profile field to tell the two apart — the JSON row keys are
+ * `available, contextTokens, contextWindow, input, key, local, missing, name,
+ * tags`. So an enumeration cannot be trusted to be the ChatGPT one, while this
+ * file says which route each model is on without a credential, a network call
+ * or a three-minute fork.
+ */
+export function coreChatgptRoute(provider: string): CoreChatgptRoute | null {
+  if (!provider) return null;
+  return factsFor(provider).chatgpt;
 }
 
 const EMPTY: ReadonlySet<string> = new Set();

--- a/src/lib/core-model-lifecycle.ts
+++ b/src/lib/core-model-lifecycle.ts
@@ -165,18 +165,6 @@ interface ManifestFacts {
 interface CachedManifest extends ManifestFacts {
   /** The file this was read from, and what it looked like when it was read. */
   file: string;
-  /**
-   * Which candidate that file was, in `coreManifestPaths` order.
-   *
-   * Kept because the staleness check re-stats `file` alone: an answer cached
-   * from the beside-config manifest (the ordinary OpenClaw 2 layout, where the
-   * bundled path does not exist) would otherwise survive an upgrade that
-   * INSTALLS the bundled one — that file is not the one being watched, so a
-   * higher-priority manifest could appear and never be read for the life of the
-   * process. That was a stale retirement hint before; it now decides whether a
-   * model switch is accepted.
-   */
-  candidateIndex: number;
   mtimeMs: number;
   size: number;
   /** When the file was last stat'ed, so a burst of lookups costs one syscall. */
@@ -338,7 +326,11 @@ function chatgptRouteFrom(manifest: unknown, provider: string): CoreChatgptRoute
   const subscriptionOnly: string[] = [];
   const suppressions = (modelCatalog as { suppressions?: unknown } | null)?.suppressions;
   if (Array.isArray(suppressions)) {
-    type Suppression = { provider?: unknown; model?: unknown; when?: { baseUrlHosts?: unknown } | null };
+    type Suppression = {
+      provider?: unknown;
+      model?: unknown;
+      when?: { baseUrlHosts?: unknown; providerConfigApiIn?: unknown } | null;
+    };
     for (const entry of suppressions as Suppression[]) {
       // Provider AND model case-insensitively, as the core's own matcher
       // compares them: it keys suppressions by
@@ -350,8 +342,17 @@ function chatgptRouteFrom(manifest: unknown, provider: string): CoreChatgptRoute
       if (lower(entry?.provider) !== provider.toLowerCase()) continue;
       const model = lower(entry?.model);
       if (!model) continue;
+      // The core ANDs every condition that is present, and the OTHER one it
+      // supports — `when.providerConfigApiIn` — is resolved against the owner's
+      // `models.providers.<id>.api`, which this repo never writes. So on a box
+      // this repo configures that condition can never be satisfied, and an entry
+      // carrying it does not fire in the core AT ALL, whatever its hosts say.
+      // Reading the host half on its own would drop a row the box still runs:
+      // the false failure, arriving from the opposite side to the one the note
+      // above `lower` describes.
+      if (conditionSet(entry?.when?.providerConfigApiIn).size > 0) continue;
       const hosts = conditionSet(entry?.when?.baseUrlHosts);
-      if (hosts.size === 0) continue; // unconditional, or a condition this does not read: not a route claim
+      if (hosts.size === 0) continue; // unconditional: not a route claim
       if (hosts.has(CHATGPT_HOST)) offRoute.add(model);
       else if (hosts.has(PLATFORM_HOST) && !subscriptionOnly.includes(model)) subscriptionOnly.push(model);
     }
@@ -372,16 +373,31 @@ function chatgptRouteFrom(manifest: unknown, provider: string): CoreChatgptRoute
 /**
  * Has a manifest candidate BETTER than the cached one appeared since?
  *
- * Only asked on the same five-second floor as the stat above, and only when the
- * cached answer did not come from the first candidate — on the ordinary layout
- * (nothing bundled, the answer beside the config) that is one `existsSync` per
- * provider per five seconds, and on a box where the bundled manifest is the
- * answer it is never asked at all.
+ * The staleness check re-stats the cached `file` alone, so an answer cached from
+ * the beside-config manifest (the ordinary OpenClaw 2 layout, where the bundled
+ * path does not exist) would otherwise survive an upgrade that INSTALLS the
+ * bundled one: that file is not the one being watched, so a higher-priority
+ * manifest could appear and never be read for the life of the process. That was
+ * a stale retirement hint before; it now decides whether a model switch is
+ * accepted.
+ *
+ * The position is re-derived from the cached path rather than remembered with it,
+ * because the candidate LIST itself grows: `findOpenclawBin()` answers the bare
+ * name `"openclaw"` where no binary is installed, and `coreManifestPaths` then
+ * omits the bundled candidate entirely — so an install that completes under a
+ * live server moves the cached file from index 0 to index 1, and a remembered
+ * index of 0 would report "nothing better" forever. A cached path that is no
+ * longer a candidate at all is itself stale, which is the `< 0` answer.
+ *
+ * Only asked on the same five-second floor as the stat above: on the ordinary
+ * layout that is one `existsSync` per provider per five seconds, and on a box
+ * where the bundled manifest IS the answer it costs nothing.
  */
-function higherPriorityManifestAppeared(provider: string, candidateIndex: number): boolean {
-  if (candidateIndex <= 0) return false;
+function higherPriorityManifestAppeared(provider: string, cachedFile: string): boolean {
   const candidates = coreManifestPaths(provider);
-  for (let i = 0; i < candidateIndex && i < candidates.length; i += 1) {
+  const candidateIndex = candidates.indexOf(cachedFile);
+  if (candidateIndex < 0) return true;
+  for (let i = 0; i < candidateIndex; i += 1) {
     try {
       if (fsSync.existsSync(candidates[i])) return true;
     } catch {
@@ -406,7 +422,7 @@ function factsFor(provider: string): ManifestFacts {
     try {
       const stat = fsSync.statSync(cached.file);
       if (stat.mtimeMs === cached.mtimeMs && stat.size === cached.size
-        && !higherPriorityManifestAppeared(provider, cached.candidateIndex)) {
+        && !higherPriorityManifestAppeared(provider, cached.file)) {
         cached.checkedAt = now;
         return cached;
       }
@@ -426,7 +442,7 @@ function factsFor(provider: string): ManifestFacts {
   // never exists and the beside-config answer is the right one to cache.
   let degraded = false;
   const candidates = coreManifestPaths(provider);
-  for (const [candidateIndex, file] of candidates.entries()) {
+  for (const file of candidates) {
     // Opened ONCE and both stat and read taken from the descriptor. A
     // `statSync` followed by a `readFileSync` of the same path is two lookups
     // of a name that can change between them — and the whole point of the stat
@@ -492,7 +508,6 @@ function factsFor(provider: string): ManifestFacts {
         retired,
         chatgpt,
         file,
-        candidateIndex,
         mtimeMs: stat.mtimeMs,
         size: stat.size,
         checkedAt: Date.now(),

--- a/src/lib/core-model-lifecycle.ts
+++ b/src/lib/core-model-lifecycle.ts
@@ -86,6 +86,39 @@ const STAT_FLOOR_MS = 5_000;
 const PLATFORM_HOST = "api.openai.com";
 const CHATGPT_HOST = "chatgpt.com";
 
+/**
+ * The `api` the core gives the ChatGPT route's provider config
+ * (`buildOpenAICodexLiveProviderConfig` / `buildOpenAICodexStaticProviderConfig`
+ * both set `api: "openai-chatgpt-responses"`), for the OTHER condition its
+ * suppression matcher supports — `when.providerConfigApiIn`.
+ */
+const CHATGPT_ROUTE_API = "openai-chatgpt-responses";
+
+/** Lowercased, or "" for anything that is not a usable string. */
+function lower(value: unknown): string {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+/**
+ * The lowercased strings of a `when` condition array, as a SET; empty when there
+ * is none.
+ *
+ * A set, so every test below is an exact element match. A `.includes()` against
+ * a host string reads as substring sanitization — `js/incomplete-url-substring-
+ * sanitization`, and CodeQL is right to flag the shape even where the value is
+ * an array element rather than a URL: these are the core's own exact host and
+ * api tokens, never a URL to search inside, and `has()` is the only comparison
+ * that can be true of them.
+ */
+function conditionSet(value: unknown): ReadonlySet<string> {
+  if (!Array.isArray(value)) return EMPTY;
+  const out = new Set<string>();
+  for (const item of value) {
+    if (typeof item === "string" && item.trim()) out.add(item.trim().toLowerCase());
+  }
+  return out;
+}
+
 /** What the installed core says about one provider's ChatGPT (Codex) route. */
 export interface CoreChatgptRoute {
   /** The catalogue rows the manifest lists, in the order it lists them. */
@@ -112,6 +145,18 @@ interface ManifestFacts {
 interface CachedManifest extends ManifestFacts {
   /** The file this was read from, and what it looked like when it was read. */
   file: string;
+  /**
+   * Which candidate that file was, in `coreManifestPaths` order.
+   *
+   * Kept because the staleness check re-stats `file` alone: an answer cached
+   * from the beside-config manifest (the ordinary OpenClaw 2 layout, where the
+   * bundled path does not exist) would otherwise survive an upgrade that
+   * INSTALLS the bundled one — that file is not the one being watched, so a
+   * higher-priority manifest could appear and never be read for the life of the
+   * process. That was a stale retirement hint before; it now decides whether a
+   * model switch is accepted.
+   */
+  candidateIndex: number;
   mtimeMs: number;
   size: number;
   /** When the file was last stat'ed, so a burst of lookups costs one syscall. */
@@ -242,6 +287,13 @@ function catalogueFor(manifest: unknown, provider: string): unknown {
  *
  * Returns null when the manifest carries no catalogue for this provider at all.
  * An empty `models[]` with suppressions is still an answer; no block is not.
+ *
+ * `status` is deliberately NOT read here, though `collect()` harvests it from
+ * the same bytes two lines down: a `deprecated` row is upstream saying "prefer
+ * the newer one", and on this surface the newer one is plan-gated — see the
+ * ASYMMETRY note above `withoutRetiredModels` in the catalogue route. What a
+ * ChatGPT account can still run is stated by the route suppressions, and those
+ * are what this reads.
  */
 function chatgptRouteFrom(manifest: unknown, provider: string): CoreChatgptRoute | null {
   const modelCatalog = (manifest as { modelCatalog?: unknown } | null)?.modelCatalog;
@@ -265,18 +317,63 @@ function chatgptRouteFrom(manifest: unknown, provider: string): CoreChatgptRoute
   const subscriptionOnly: string[] = [];
   const suppressions = (modelCatalog as { suppressions?: unknown } | null)?.suppressions;
   if (Array.isArray(suppressions)) {
-    for (const entry of suppressions as Array<{ provider?: unknown; model?: unknown; when?: { baseUrlHosts?: unknown } | null }>) {
-      if (entry?.provider !== provider) continue;
+    type Suppression = {
+      provider?: unknown;
+      model?: unknown;
+      when?: { baseUrlHosts?: unknown; providerConfigApiIn?: unknown } | null;
+    };
+    for (const entry of suppressions as Suppression[]) {
+      // Case-insensitively, as the core's own matcher compares them
+      // (`normalizeProviderId` / `normalizeLowercaseStringOrEmpty` before the
+      // test): a manifest that spelled `"provider": "OpenAI"` would be honoured
+      // there and ignored here, and the picker would keep a row the core
+      // refuses.
+      if (lower(entry?.provider) !== provider.toLowerCase()) continue;
       const model = typeof entry?.model === "string" ? entry.model.trim() : "";
       if (!model) continue;
-      const hosts = entry?.when?.baseUrlHosts;
-      if (!Array.isArray(hosts)) continue;
-      const lower = hosts.filter((h): h is string => typeof h === "string").map((h) => h.trim().toLowerCase());
-      if (lower.includes(CHATGPT_HOST)) offRoute.add(model);
-      else if (lower.includes(PLATFORM_HOST) && !subscriptionOnly.includes(model)) subscriptionOnly.push(model);
+      const hosts = conditionSet(entry?.when?.baseUrlHosts);
+      // The core's suppression matcher compiles TWO conditions —
+      // `when.baseUrlHosts` and `when.providerConfigApiIn` — and the second is
+      // the natural spelling for this route once the transport, rather than the
+      // URL, is what identifies it. Reading only the host one would leave a
+      // model the core has taken off the ChatGPT route in the picker and in the
+      // write guard, with every turn dying on the core's own `Unknown model`.
+      const apis = conditionSet(entry?.when?.providerConfigApiIn);
+      if (hosts.size === 0 && apis.size === 0) continue; // unconditional: not a route claim
+      if (hosts.has(CHATGPT_HOST) || apis.has(CHATGPT_ROUTE_API)) offRoute.add(model);
+      else if (hosts.has(PLATFORM_HOST) && !subscriptionOnly.includes(model)) subscriptionOnly.push(model);
     }
   }
-  return { listed, offRoute, subscriptionOnly };
+  // FROZEN before it is cached: `coreChatgptRoute` hands the caller the cached
+  // object itself, and a caller that pushed a row onto `listed` would corrupt
+  // the answer for every other reader of the same manifest.
+  return Object.freeze({
+    listed: Object.freeze(listed),
+    offRoute: offRoute as ReadonlySet<string>,
+    subscriptionOnly: Object.freeze(subscriptionOnly),
+  }) as CoreChatgptRoute;
+}
+
+/**
+ * Has a manifest candidate BETTER than the cached one appeared since?
+ *
+ * Only asked on the same five-second floor as the stat above, and only when the
+ * cached answer did not come from the first candidate — on the ordinary layout
+ * (nothing bundled, the answer beside the config) that is one `existsSync` per
+ * provider per five seconds, and on a box where the bundled manifest is the
+ * answer it is never asked at all.
+ */
+function higherPriorityManifestAppeared(provider: string, candidateIndex: number): boolean {
+  if (candidateIndex <= 0) return false;
+  const candidates = coreManifestPaths(provider);
+  for (let i = 0; i < candidateIndex && i < candidates.length; i += 1) {
+    try {
+      if (fsSync.existsSync(candidates[i])) return true;
+    } catch {
+      // Unreadable is not "appeared": the full walk below is what decides.
+    }
+  }
+  return false;
 }
 
 function factsFor(provider: string): ManifestFacts {
@@ -293,7 +390,8 @@ function factsFor(provider: string): ManifestFacts {
     // otherwise pin "nothing is retired" for the rest of that process's life.
     try {
       const stat = fsSync.statSync(cached.file);
-      if (stat.mtimeMs === cached.mtimeMs && stat.size === cached.size) {
+      if (stat.mtimeMs === cached.mtimeMs && stat.size === cached.size
+        && !higherPriorityManifestAppeared(provider, cached.candidateIndex)) {
         cached.checkedAt = now;
         return cached;
       }
@@ -312,7 +410,8 @@ function factsFor(provider: string): ManifestFacts {
   // that is the ordinary shape of an OpenClaw 2 box, where the bundled path
   // never exists and the beside-config answer is the right one to cache.
   let degraded = false;
-  for (const file of coreManifestPaths(provider)) {
+  const candidates = coreManifestPaths(provider);
+  for (const [candidateIndex, file] of candidates.entries()) {
     // Opened ONCE and both stat and read taken from the descriptor. A
     // `statSync` followed by a `readFileSync` of the same path is two lookups
     // of a name that can change between them — and the whole point of the stat
@@ -374,7 +473,15 @@ function factsFor(provider: string): ManifestFacts {
       continue;
     }
     if (!degraded) {
-      cache.set(provider, { retired, chatgpt, file, mtimeMs: stat.mtimeMs, size: stat.size, checkedAt: Date.now() });
+      cache.set(provider, {
+        retired,
+        chatgpt,
+        file,
+        candidateIndex,
+        mtimeMs: stat.mtimeMs,
+        size: stat.size,
+        checkedAt: Date.now(),
+      });
     }
     return { retired, chatgpt };
   }

--- a/src/lib/provider-models.ts
+++ b/src/lib/provider-models.ts
@@ -224,28 +224,41 @@ export const OPENAI_DEFAULT_MODEL_ID = "gpt-5.4";
 // src/lib/chatgpt-subscription.ts. Available when the user authenticates via
 // ChatGPT OAuth instead of pasting an API key.
 //
-// THIS ARRAY IS THE WHOLE ChatGPT SURFACE. The picker offers it, both write
-// paths to `agents.defaults.model.primary` accept exactly it
-// (`isCodexSupportedModelId`), and the refusal sentence is built from it —
-// there is no second spelling to keep in step. There was: a generation regex
-// in subscription-surface.ts, which could not spell `gpt-5.3-codex-spark` and
-// so hid it (TASK-786).
+// THIS ARRAY IS THE FALLBACK, and the labels, for the ChatGPT surface — not the
+// surface itself. `chatgptSurface()` (src/lib/chatgpt-surface.ts) derives that
+// from the INSTALLED core's `extensions/openai` manifest, which states the route
+// per model, and answers this array only where there is no manifest to read: CI,
+// a box with no core yet, a file half-written by an upgrade. The picker, both
+// write paths to `agents.defaults.model.primary` (`isCodexSupportedModelId`) and
+// the refusal sentence all read that one surface, so there is still no second
+// spelling to keep in step. There was: a generation regex in
+// subscription-surface.ts, which could not spell `gpt-5.3-codex-spark` and so
+// hid it (TASK-786).
 //
-// It mirrors the core's own `OPENAI_CHATGPT_MODERN_MODEL_IDS`
-// (`extensions/openai/model-route-contract` in the installed dist), because
-// 2026.8.1 publishes that set through no CLI and no RPC — `openclaw models
-// list --provider codex` answers `Unknown provider filter`, and the `openai`
-// enumeration has no auth-scoped field. Measured on the box, 2026-09-09:
-//   * gpt-5.6-sol      -> chatgpt.com/backend-api/codex/responses  200
-//   * gpt-5.3-codex-spark -> chatgpt.com/backend-api/codex/responses  200
-//   * gpt-6-astra      -> NOT on that route; the core sends it to
-//     api.openai.com/v1/responses on the API key instead, so it belongs to the
-//     `openai` surface and must not appear here.
+// It used to BE the surface, mirroring the core's
+// `OPENAI_CHATGPT_MODERN_MODEL_IDS` by hand, and a hand-kept mirror is wrong in
+// both directions the moment a core bump is measured: 2026.9.3 files
+// `gpt-6-astra` as a dual-route model and lists it FIRST in the openai manifest,
+// and suppresses `gpt-5.4` and `gpt-5.4-mini` on `chatgpt.com` — "retired from
+// the ChatGPT-account Codex route" — both of which this array still offers.
+//
+// Measured on the box, core 2026.8.1 (the route facts that still hold):
+//   * gpt-5.6-sol         -> chatgpt.com/backend-api/codex/responses  200
+//   * gpt-5.3-codex-spark -> chatgpt.com/backend-api/codex/responses  200, and
+//     `models list --provider openai` reports it `available: false` — the
+//     platform route is the one that excludes it.
+// What does NOT hold is the reading that `gpt-6-astra` is "not on the ChatGPT
+// route": measured 2026-09-10 on that same box, a turn on it goes to
+// api.openai.com — and so does a turn on the owner's own `openai/gpt-5.5`, which
+// 401s there and fails over. Both are the box's inline
+// `models.providers.openai.apiKey` deciding which catalogue the core publishes
+// for `openai`, not a property of either model.
 //
 // NO -pro variants — those are API-key only (they 400 with "model not
 // supported when using Codex with a ChatGPT account" on the OAuth path), even
-// though the core files them as dual-route. Plan gating is the opposite case
-// and is deliberately NOT applied: the gpt-5.6 models are gated upstream
+// though the core files them as dual-route; `chatgpt-surface.ts` applies that
+// narrowing to the manifest too. Plan gating is the opposite case and is
+// deliberately NOT applied: the gpt-5.6 models are gated upstream
 // (Plus/Pro/Max), there is no plan-scoped list on this core to filter by — the
 // catalog route's `WHY codex IS NOT ENUMERATED FROM openai` note is the whole
 // argument — so an unentitled account sees all three, the turn 400s upstream

--- a/src/lib/subscription-surface.ts
+++ b/src/lib/subscription-surface.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/provider-models";
 import { chatgptSurface } from "@/lib/chatgpt-surface";
 import {
+  CHATGPT_PROVIDER,
   isOauthProfile,
   profileProviderId,
 } from "@/lib/chatgpt-subscription";
@@ -153,11 +154,19 @@ async function readCachedCatalogueIds(provider: string): Promise<string[] | null
  * curated catalogue and no enumeration — llamacpp, ollama, deepseek — cannot
  * be judged at all, and a caller that read null as "the id does not exist"
  * would report a defect about every one of them.
+ *
+ * The ChatGPT surface is folded in for `openai`, because a ChatGPT sign-in
+ * writes its model as `openai/<id>` and the surface is a list this box HAS.
+ * Without it, a box that saved a model the installed core added — the whole
+ * point of deriving the surface — was told "…is in no model list this box has
+ * for openai. Chat turns on it will fail", over a model the same box had just
+ * declared runnable.
  */
 export async function readKnownModelIds(provider: string): Promise<Set<string> | null> {
   const cached = await readCachedCatalogueIds(provider);
   const curated = getProviderCatalog(provider)?.models ?? [];
-  const ids = [...(cached ?? []), ...curated.map((m) => m.id)];
+  const chatgpt = provider === CHATGPT_PROVIDER ? chatgptSurface().models : [];
+  const ids = [...(cached ?? []), ...curated.map((m) => m.id), ...chatgpt.map((m) => m.id)];
   return ids.length > 0 ? new Set(ids) : null;
 }
 

--- a/src/lib/subscription-surface.ts
+++ b/src/lib/subscription-surface.ts
@@ -2,11 +2,11 @@ import { promises as fsp } from "fs";
 import path from "path";
 import { DATA_DIR } from "@/lib/config-store";
 import {
-  CODEX_MODELS,
   getProviderCatalog,
   subscriptionSurfaceLabel,
   subscriptionSurfaceProvider,
 } from "@/lib/provider-models";
+import { chatgptSurface } from "@/lib/chatgpt-surface";
 import {
   isOauthProfile,
   profileProviderId,
@@ -165,42 +165,41 @@ export async function readKnownModelIds(provider: string): Promise<Set<string> |
  * Is this model id selectable while the device is on ChatGPT/Codex
  * subscription auth?
  *
- * THE CHATGPT CATALOGUE IS THE ANSWER — `CODEX_MODELS`, and nothing beside it.
- * This used to be a second spelling of that list as a GENERATION regex
- * (`/^(?:gpt-5\.6-(?:sol|terra|luna)|gpt-5\.5|gpt-5\.4(?:-mini)?)$/`), and it
- * failed the way generation allowlists always fail here: the `openai` provider
- * carried the identical pattern until it hid the whole gpt-5.6 family and was
- * removed with "a generation allowlist cannot know what the next generation is
- * called"; the codex copy survived and hid `gpt-5.3-codex-spark`, a model the
- * installed core routes on THIS surface and on no other. One list cannot
- * disagree with itself, and a row added to the catalogue now reaches the
- * picker, both write guards and the refusal sentence together.
+ * THE CHATGPT SURFACE IS THE ANSWER — {@link chatgptSurface}, and nothing
+ * beside it. This used to be a second spelling of that list as a GENERATION
+ * regex (`/^(?:gpt-5\.6-(?:sol|terra|luna)|gpt-5\.5|gpt-5\.4(?:-mini)?)$/`),
+ * and it failed the way generation allowlists always fail here: the `openai`
+ * provider carried the identical pattern until it hid the whole gpt-5.6 family
+ * and was removed with "a generation allowlist cannot know what the next
+ * generation is called"; the codex copy survived and hid
+ * `gpt-5.3-codex-spark`, a model the installed core routes on THIS surface and
+ * on no other. One list cannot disagree with itself, and a row the surface
+ * gains now reaches the picker, both write guards and the refusal sentence
+ * together.
  *
- * WHAT UPSTREAM SAYS, and why this is still a mirror. The core's own
- * `extensions/openai/model-route-contract` holds the truth as
- * `OPENAI_CHATGPT_MODERN_MODEL_IDS` — its dual-route ids plus the
- * subscription-only ones — and 2026.8.1 exposes it through no CLI and no RPC:
- * measured on the box, `openclaw models list --provider codex` and
- * `--provider openai-chatgpt` both answer `Unknown provider filter`, and the
- * `openai` enumeration carries no plan- or auth-scoped field to filter on
- * (`available` there answers the PLATFORM route — it reads `false` for
- * `gpt-5.3-codex-spark`, which runs fine on the ChatGPT one). So ClawBox
- * mirrors that contract, in ONE place, pinned by
- * `src/tests/unit/codex-supported-models.test.ts`.
+ * WHAT UPSTREAM SAYS, and why it is no longer a hand-kept mirror of it. The
+ * core's `extensions/openai` manifest states the route per model — the rows it
+ * ships, which of them are suppressed ON `chatgpt.com`, and which are
+ * suppressed on `api.openai.com` and therefore reachable on this route alone —
+ * so `chatgptSurface()` reads it from the INSTALLED core and the curated
+ * `CODEX_MODELS` is what it falls back to where there is no manifest to read.
+ * The mirror that was here answered for one core version: on 2026.9.3 it is
+ * wrong in both directions at once (no `gpt-6-astra`, and `gpt-5.4` plus
+ * `gpt-5.4-mini` retired from the route it still offers them on).
  *
- * The mirror is deliberately NARROWER than the core's set in one respect: the
- * `-pro` tiers are dual-route upstream but answer "model not supported when
- * using Codex with a ChatGPT account" on the subscription path
- * (developers.openai.com/codex/models), so they stay out of the catalogue and
- * therefore out of this rule. Plan gating is the opposite case and is NOT
- * filtered here — gpt-5.6 access varies per account, so the pick goes through
- * and the upstream access error is what the customer sees.
+ * The surface is deliberately NARROWER than everything the manifest lists, in
+ * the two respects `chatgpt-surface.ts` documents: the `-pro` tiers answer
+ * "model not supported when using Codex with a ChatGPT account" on the
+ * subscription path (developers.openai.com/codex/models), and `-nano` is in the
+ * core's platform set and not its ChatGPT one. Plan gating is the opposite case
+ * and is NOT filtered — gpt-5.6 access varies per account, so the pick goes
+ * through and the upstream access error is what the customer sees.
  *
  * It lives here, beside the Claude rule, for the same reason that one does:
  * both write paths to `agents.defaults.model.primary` have to apply it, and a
  * second copy in the second route is a copy that can drift.
- * `scripts/gateway-pre-start.sh` keeps a hand-maintained mirror of the
- * catalogue in `_CODEX_SUPPORTED`, pinned by
+ * `scripts/gateway-pre-start.sh` keeps a hand-maintained mirror of the CURATED
+ * fallback in `_CODEX_SUPPORTED`, pinned by
  * `src/tests/unit/gateway-pre-start-codex-models.test.ts`. That mirror is
  * OpenClaw 1 ONLY — its single consumer, `_openai_gpt_to_codex`, rewrites
  * `openai/<id>` into the retired namespace and is skipped on
@@ -208,31 +207,34 @@ export async function readKnownModelIds(provider: string): Promise<Set<string> |
  * branch; nothing on the pinned core reads it.
  */
 export function isCodexSupportedModelId(modelId: string): boolean {
-  // `CODEX_MODELS` directly, not `getProviderCatalog(CHATGPT_UI_PROVIDER)`: that
-  // lookup takes a plain string, answers `null` for a key nobody renamed it for
-  // — `openai-codex` already became `codex` once — and this guard would then
+  // `chatgptSurface()` directly, not `getProviderCatalog(CHATGPT_UI_PROVIDER)`:
+  // that lookup takes a plain string, answers `null` for a key nobody renamed it
+  // for — `openai-codex` already became `codex` once — and this guard would then
   // refuse EVERY model with "use a model the ChatGPT subscription supports",
   // naming none. A guard that fails CLOSED on an unreadable list is the one
-  // shape the rest of this file spends three docblocks forbidding, and the
-  // indirection bought nothing: `PROVIDER_CATALOGS.codex.models` IS this array.
+  // shape the rest of this file spends three docblocks forbidding, which is also
+  // why the surface itself answers the curated list rather than an empty one
+  // when the core cannot be read.
   // No `trim()` — the anchored regex this replaces did not trim either, and the
   // caller writes the id it passed in, not the one this judged.
-  return CODEX_MODELS.some((model) => model.id === modelId);
+  return chatgptSurface().models.some((model) => model.id === modelId);
 }
 
 /**
  * The models this box can name when it refuses one, as a sentence fragment.
  *
- * Built from the ChatGPT catalogue rather than hand-written, because the same
+ * Built from the ChatGPT surface rather than hand-written, because the same
  * list was spelled in three places and had already drifted: the chat route's
  * keyless refusal omitted the GPT-5.6 generation the allowlist accepts. A
- * model added to the catalogue now reaches every refusal by itself.
+ * model the surface gains now reaches every refusal by itself — including one
+ * that arrived with a core upgrade, which is the case a hand-written sentence
+ * could never have covered.
  */
 export function chatgptSupportedModelsSentence(): string {
-  const labels = CODEX_MODELS.map((model) => model.label);
+  const labels = chatgptSurface().models.map((model) => model.label);
   // Never an empty fragment: the callers embed this mid-sentence, and "Use ,
   // or switch OpenAI to API-key mode" is worse than naming the surface
-  // generically. Unreachable while the catalogue is the static CODEX_MODELS,
+  // generically. Unreachable while the surface falls back to the curated list,
   // which is exactly why it is cheap to make impossible.
   if (labels.length === 0) return "a model the ChatGPT subscription supports";
   if (labels.length === 1) return labels[0];
@@ -253,9 +255,11 @@ export function chatgptSupportedModelsSentence(): string {
  * answer it. Defaulting it would hand a caller that forgot the flag the
  * behaviour this PR retired instead of a type error.
  *
- * Unlike the Claude surface this is a static allowlist rather than a cache
- * read, so there is no UNKNOWN case: the ChatGPT route catalogue is fixed by
- * the plugin, not enumerated per box.
+ * Unlike the Claude surface there is no UNKNOWN case, even though the list is
+ * now read per box: the ChatGPT route comes from the installed core's own
+ * plugin manifest, and a box that cannot read one is answered the curated
+ * fallback rather than nothing — so this never refuses a model because a file
+ * was missing.
  */
 export function offSurfaceCodexModelMessage(
   provider: string | null | undefined,

--- a/src/tests/routes/ai-models/catalog-codex-unwritable-cache.test.ts
+++ b/src/tests/routes/ai-models/catalog-codex-unwritable-cache.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { EventEmitter } from "events";
 import * as childProcess from "child_process";
 import fs from "fs";
+import os from "os";
 import path from "path";
 import { NextRequest } from "next/server";
 
@@ -41,6 +42,7 @@ vi.mock("@/lib/config-store", () => ({ DATA_DIR: "/tmp/clawbox-catalog-codex-unw
 
 import { GET } from "@/app/setup-api/ai-models/catalog/route";
 import { CODEX_MODELS } from "@/lib/provider-models";
+import { resetCoreModelLifecycle } from "@/lib/core-model-lifecycle";
 
 const mockSpawn = vi.mocked(childProcess.spawn);
 
@@ -146,5 +148,64 @@ describe("catalog — codex is never served from a cache the code cannot write",
     // `source` is the stamp that means "a device enumerated this". The curated
     // list is not that, on this path or any other.
     expect(body.source).toBeUndefined();
+  });
+
+  it("serves what the INSTALLED core says the route carries", async () => {
+    // The end of the chain the rest of this suite only covers half of: the
+    // manifest on disk -> `chatgptSurface()` -> this payload. Shaped like core
+    // 2026.9.3's openai manifest, which lists `gpt-6-astra` first and suppresses
+    // `gpt-5.4` on `chatgpt.com` ("retired from the ChatGPT-account Codex
+    // route"). Nothing here is curated: both answers come from the file.
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "catalog-codex-manifest"));
+    const saved = {
+      HOME: process.env.HOME,
+      OPENCLAW_HOME: process.env.OPENCLAW_HOME,
+      CLAWBOX_OPENCLAW_HOME: process.env.CLAWBOX_OPENCLAW_HOME,
+    };
+    try {
+      const dir = path.join(home, ".openclaw", "extensions", "openai");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, "openclaw.plugin.json"), JSON.stringify({
+        modelCatalog: {
+          providers: {
+            openai: {
+              models: [
+                { id: "gpt-6-astra", name: "GPT-6 Astra" },
+                { id: "gpt-5.5", name: "GPT-5.5" },
+                { id: "gpt-5.4", name: "GPT-5.4" },
+              ],
+            },
+          },
+          suppressions: [
+            {
+              provider: "openai",
+              model: "gpt-5.4",
+              reason: "GPT-5.4 has retired from the ChatGPT-account Codex route.",
+              when: { baseUrlHosts: ["chatgpt.com"] },
+            },
+          ],
+        },
+      }), "utf8");
+      process.env.HOME = home;
+      process.env.OPENCLAW_HOME = path.join(home, ".openclaw");
+      process.env.CLAWBOX_OPENCLAW_HOME = path.join(home, ".openclaw");
+      resetCoreModelLifecycle();
+
+      const res = await GET(new NextRequest("http://clawbox.local/setup-api/ai-models/catalog?provider=codex"));
+      const body = (await res.json()) as { models: Array<{ id: string; label: string }>; source?: string };
+
+      expect(body.models.map((m) => m.id)).toEqual(["gpt-6-astra", "gpt-5.5"]);
+      expect(body.models[0].label).toBe("GPT-6 Astra");
+      // Still not the box's own answer: the manifest says what the CORE routes,
+      // not what this account is entitled to, so it is served unstamped like
+      // every other list this route did not enumerate.
+      expect(body.source).toBeUndefined();
+    } finally {
+      process.env.HOME = saved.HOME;
+      process.env.OPENCLAW_HOME = saved.OPENCLAW_HOME;
+      process.env.CLAWBOX_OPENCLAW_HOME = saved.CLAWBOX_OPENCLAW_HOME;
+      fs.rmSync(home, { recursive: true, force: true });
+      resetCoreModelLifecycle();
+    }
   });
 });

--- a/src/tests/routes/ai-models/catalog-codex-unwritable-cache.test.ts
+++ b/src/tests/routes/ai-models/catalog-codex-unwritable-cache.test.ts
@@ -155,7 +155,9 @@ describe("catalog — codex is never served from a cache the code cannot write",
     // manifest on disk -> `chatgptSurface()` -> this payload. Shaped like core
     // 2026.9.3's openai manifest, which lists `gpt-6-astra` first and suppresses
     // `gpt-5.4` on `chatgpt.com` ("retired from the ChatGPT-account Codex
-    // route"). Nothing here is curated: both answers come from the file.
+    // route"). Both of those answers come from the file: the curated list can
+    // only widen what follows them, never reorder the head or restore a row the
+    // core retired.
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "catalog-codex-manifest"));
     const saved = {
       HOME: process.env.HOME,
@@ -194,8 +196,15 @@ describe("catalog — codex is never served from a cache the code cannot write",
       const res = await GET(new NextRequest("http://clawbox.local/setup-api/ai-models/catalog?provider=codex"));
       const body = (await res.json()) as { models: Array<{ id: string; label: string }>; source?: string };
 
-      expect(body.models.map((m) => m.id)).toEqual(["gpt-6-astra", "gpt-5.5"]);
+      const ids = body.models.map((m) => m.id);
+      // The core's own rows first, in its order — a model this repo has never
+      // heard of reaches the payload, labelled by the core.
+      expect(ids.slice(0, 2)).toEqual(["gpt-6-astra", "gpt-5.5"]);
       expect(body.models[0].label).toBe("GPT-6 Astra");
+      // …and the row the core retired from THIS route is gone, though the
+      // curated fallback still carries it.
+      expect(ids).not.toContain("gpt-5.4");
+      expect(CODEX_MODELS.map((m) => m.id)).toContain("gpt-5.4");
       // Still not the box's own answer: the manifest says what the CORE routes,
       // not what this account is entitled to, so it is served unstamped like
       // every other list this route did not enumerate.

--- a/src/tests/unit/codex-picker-astra.test.ts
+++ b/src/tests/unit/codex-picker-astra.test.ts
@@ -208,6 +208,31 @@ describe("the ChatGPT-account surface follows the installed core", () => {
     expect(surface.models).toEqual(CODEX_MODELS);
   });
 
+  it("keeps a last-resort list rather than emptying the picker", () => {
+    // A core that has retired EVERY curated id from this route and lists nothing
+    // else. Because the widening pass runs unconditionally, this is the only way
+    // the derived list can come out empty — so filtering the fallback through the
+    // same suppressions would return nothing at all, and an empty surface is the
+    // one shape this module must not produce: the guard would refuse every model
+    // while naming none, and the cold-start default would be a model that same
+    // guard refuses, so a ChatGPT sign-in could not complete.
+    write({
+      modelCatalog: {
+        providers: { openai: { models: [] } },
+        suppressions: CODEX_MODELS.map((model) => ({
+          provider: "openai",
+          model: model.id,
+          when: { baseUrlHosts: ["chatgpt.com"] },
+        })),
+      },
+    });
+    const surface = chatgptSurface();
+    expect(surface.models).toEqual(CODEX_MODELS);
+    expect(surface.source).toBe("curated");
+    // The invariant the last resort exists to hold: setup can still finish.
+    expect(isCodexSupportedModelId(chatgptDefaultModelId())).toBe(true);
+  });
+
   it("never defaults a sign-in to a model its own write guard refuses", () => {
     // The invariant H-2 is about: `configure` computes the cold-start default
     // and then judges it with `offSurfaceCodexModelMessage` in the same request.

--- a/src/tests/unit/codex-picker-astra.test.ts
+++ b/src/tests/unit/codex-picker-astra.test.ts
@@ -303,11 +303,13 @@ describe("the ChatGPT-account surface follows the installed core", () => {
     expect(isCodexSupportedModelId("gpt-5.5")).toBe(true);
   });
 
-  it("reads the api-shaped suppression the core's matcher also compiles", () => {
-    // `when.providerConfigApiIn` is the core's OTHER condition, and the natural
-    // spelling once the transport rather than the URL identifies the route.
-    // Ignoring it would leave the row offered, the write guard accepting it, and
-    // every turn dying on the core's own `Unknown model`.
+  it("ignores the api-shaped condition, which never fires in the core on this box", () => {
+    // `when.providerConfigApiIn` is the core's OTHER condition and is deliberately
+    // NOT read — see the note above `lower` in core-model-lifecycle.ts. The core
+    // ANDs its conditions and evaluates this one against the OWNER'S configured
+    // `models.providers.openai.api`, which ClawBox never writes, so such a
+    // suppression does not fire there. Honouring it would drop a row the box can
+    // still run: a false failure.
     write({
       modelCatalog: {
         providers: {
@@ -324,23 +326,124 @@ describe("the ChatGPT-account surface follows the installed core", () => {
         ],
       },
     });
-    expect(chatgptSurface().models.map((m) => m.id)).not.toContain("gpt-5.6-sol");
-    expect(isCodexSupportedModelId("gpt-5.6-sol")).toBe(false);
+    expect(chatgptSurface().models.map((m) => m.id)).toContain("gpt-5.6-sol");
+    expect(isCodexSupportedModelId("gpt-5.6-sol")).toBe(true);
   });
 
-  it("matches a suppression whose provider or model is spelled in another case", () => {
-    // The core normalises both sides before comparing; a manifest that spelled
-    // `"provider": "OpenAI"` would be honoured there and ignored here, leaving a
-    // row the core refuses in the picker.
+  it("matches a suppression whose provider, model or host is spelled in another case", () => {
+    // The core keys suppressions by
+    // `normalizeProviderId(provider) + "::" + normalizeLowercaseStringOrEmpty(id)`
+    // and normalises the looked-up id the same way, so all three sides are
+    // case-folded there. A manifest that listed `GPT-5.4` while suppressing
+    // `gpt-5.4` would be blocked by the core and still offered here — a dead
+    // button whose every turn dies on `Unknown model`.
     write({
       modelCatalog: {
-        providers: { openai: { models: [{ id: "gpt-5.5", name: "GPT-5.5" }, { id: "gpt-5.4", name: "GPT-5.4" }] } },
+        providers: { openai: { models: [{ id: "gpt-5.5", name: "GPT-5.5" }, { id: "GPT-5.4", name: "GPT-5.4" }] } },
         suppressions: [
           { provider: "OpenAI", model: "gpt-5.4", when: { baseUrlHosts: ["ChatGPT.com"] } },
         ],
       },
     });
-    expect(chatgptSurface().models.map((m) => m.id)).not.toContain("gpt-5.4");
+    const ids = chatgptSurface().models.map((m) => m.id);
+    expect(ids).not.toContain("GPT-5.4");
+    expect(ids).not.toContain("gpt-5.4");
+    expect(isCodexSupportedModelId("GPT-5.4")).toBe(false);
+    expect(isCodexSupportedModelId("gpt-5.4")).toBe(false);
+  });
+
+  it("never leaves a sign-in with nothing to probe when the floor is gone", () => {
+    // H-1. The floor is the OLDEST row the core still routes, not the newest: the
+    // first row would be the most likely plan-gated model AND would leave nothing
+    // ahead of it, so the entitlement probe would be handed an empty list and a
+    // Free account would be pinned to a model that 400s on every turn — with the
+    // probe silently disabled in exactly the case this derivation exists for.
+    write({
+      modelCatalog: {
+        providers: {
+          openai: {
+            models: [
+              { id: ASTRA, name: "GPT-6 Astra" },
+              { id: "gpt-5.6-sol", name: "GPT-5.6 Sol" },
+              { id: "gpt-5.5", name: "GPT-5.5" },
+            ],
+          },
+        },
+        suppressions: [
+          { provider: "openai", model: "gpt-5.5", when: { baseUrlHosts: ["chatgpt.com"] } },
+        ],
+      },
+    });
+    const models = chatgptSurface().models.map((m) => m.id);
+    const fallbackDefault = chatgptDefaultModelId();
+    // Not the floor the core removed, and not the newest row either.
+    expect(fallbackDefault).not.toBe("gpt-5.5");
+    expect(fallbackDefault).not.toBe(models[0]);
+    // A default its own write guard refuses is a sign-in that cannot complete.
+    expect(isCodexSupportedModelId(fallbackDefault)).toBe(true);
+    // And the thing this case exists for: the probe still has rows to try, newest
+    // first, so a non-entitled account is not pinned to a plan-gated model.
+    const candidates = chatgptUpgradeCandidates();
+    expect(candidates.length).toBeGreaterThan(0);
+    expect(candidates[0]).toBe(ASTRA);
+    expect(candidates).not.toContain(fallbackDefault);
+  });
+
+  it("never lets a platform-only non-chat SKU reach the picker or the write guard", () => {
+    // H-2. The block this derivation seeds from is the core's PLATFORM provider
+    // config, and it is a ChatGPT-route list only because today's manifest
+    // happens to carry nothing else. The first core that lists an image or
+    // embedding SKU there would otherwise put it in the picker AND through
+    // `isCodexSupportedModelId`, which is the only gate the two write paths to
+    // `agents.defaults.model.primary` apply.
+    write({
+      modelCatalog: {
+        providers: {
+          openai: {
+            models: [
+              { id: "gpt-5.5", name: "GPT-5.5" },
+              { id: "gpt-image-2", name: "GPT Image 2" },
+              { id: "text-embedding-4-large", name: "Text Embedding 4 Large" },
+              { id: "gpt-5.6-realtime-preview", name: "GPT-5.6 Realtime" },
+            ],
+          },
+        },
+        // Even stated as reachable on THIS route and no other, a SKU a chat
+        // picker cannot talk to is still not a chat model.
+        suppressions: [
+          { provider: "openai", model: "gpt-audio-2", when: { baseUrlHosts: ["api.openai.com"] } },
+        ],
+      },
+    });
+    const ids = chatgptSurface().models.map((m) => m.id);
+    for (const id of ["gpt-image-2", "text-embedding-4-large", "gpt-5.6-realtime-preview", "gpt-audio-2"]) {
+      expect(ids, `${id} is not a chat model and must not be offered`).not.toContain(id);
+      expect(isCodexSupportedModelId(id)).toBe(false);
+    }
+    expect(ids).toContain("gpt-5.5");
+  });
+
+  it("never asks the probe for more attempts than its budget affords", () => {
+    // M-4. `codex-model-probe` allows 6s per probe inside a 15s total, so it runs
+    // three and stops at the deadline. An unbounded list made that an invisible
+    // truncation; the cap states it.
+    write({
+      modelCatalog: {
+        providers: {
+          openai: {
+            models: [
+              { id: ASTRA, name: "GPT-6 Astra" },
+              { id: "gpt-5.6-sol", name: "GPT-5.6 Sol" },
+              { id: "gpt-5.6-terra", name: "GPT-5.6 Terra" },
+              { id: "gpt-5.6-luna", name: "GPT-5.6 Luna" },
+              { id: "gpt-5.5", name: "GPT-5.5" },
+            ],
+          },
+        },
+      },
+    });
+    expect(chatgptDefaultModelId()).toBe("gpt-5.5");
+    expect(chatgptUpgradeCandidates()).toEqual([ASTRA, "gpt-5.6-sol", "gpt-5.6-terra"]);
   });
 
   it("keeps a subscription-only model whose name looks like an off-surface tier", () => {

--- a/src/tests/unit/codex-picker-astra.test.ts
+++ b/src/tests/unit/codex-picker-astra.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CODEX_MODELS } from "@/lib/provider-models";
-import { chatgptSurface } from "@/lib/chatgpt-surface";
+import { chatgptDefaultModelId, chatgptSurface, chatgptUpgradeCandidates } from "@/lib/chatgpt-surface";
 import { resetCoreModelLifecycle } from "@/lib/core-model-lifecycle";
 import { chatgptSupportedModelsSentence, isCodexSupportedModelId } from "@/lib/subscription-surface";
 import { createManifestFixture, type ManifestFixture } from "@/tests/helpers/core-model-manifests";
@@ -182,14 +182,80 @@ describe("the ChatGPT-account surface follows the installed core", () => {
     expect(isCodexSupportedModelId("gpt-5.5")).toBe(true);
   });
 
-  it("falls back rather than emptying the picker when the manifest offers nothing", () => {
-    // A catalogue whose every row is off-surface is a shape this does not
-    // understand; serving zero rows would refuse every model on a box whose
-    // ChatGPT account works.
-    write({ modelCatalog: { providers: { openai: { models: [{ id: "gpt-9-pro" }] } } } });
+  it("never narrows below the curated list — the manifest is a seed, not the catalogue", () => {
+    // The core's manifest is its static seed (`modelCatalog.discovery` says the
+    // openai catalogue is resolved at runtime), so a chatgpt-route model can
+    // live outside it. If the derivation replaced the curated list, such a model
+    // would lose its row AND be refused by the write guard — the false failure
+    // this surface exists to remove, pointed the other way. It can only ADD.
+    write({ modelCatalog: { providers: { openai: { models: [{ id: "gpt-6-astra", name: "GPT-6 Astra" }] } } } });
+    const ids = chatgptSurface().models.map((m) => m.id);
+    expect(ids).toContain("gpt-6-astra");
+    for (const curated of CODEX_MODELS) {
+      expect(ids, `${curated.id} fell out of the manifest's seed and must still be offered`)
+        .toContain(curated.id);
+    }
+    // …and only the core's own retirement takes one away.
+    expect(isCodexSupportedModelId("gpt-5.5")).toBe(true);
+  });
+
+  it("still offers a curated row the manifest lists nothing about", () => {
+    // Not even a provider block for openai: that is "this manifest cannot say",
+    // which is UNKNOWN and never "the route is empty".
+    write({ modelCatalog: { providers: {} } });
     const surface = chatgptSurface();
     expect(surface.source).toBe("curated");
     expect(surface.models).toEqual(CODEX_MODELS);
+  });
+
+  it("never defaults a sign-in to a model its own write guard refuses", () => {
+    // The invariant H-2 is about: `configure` computes the cold-start default
+    // and then judges it with `offSurfaceCodexModelMessage` in the same request.
+    // A core that retires gpt-5.5 from the ChatGPT route — the move 2026.9.3
+    // made for gpt-5.4, on a model both manifests already mark deprecated —
+    // would otherwise 400 a fresh ChatGPT sign-in on its own default, with no
+    // other door out of setup.
+    write({
+      modelCatalog: {
+        providers: {
+          openai: {
+            models: [
+              { id: "gpt-6-astra", name: "GPT-6 Astra" },
+              { id: "gpt-5.5", name: "GPT-5.5" },
+            ],
+          },
+        },
+        suppressions: [
+          {
+            provider: "openai",
+            model: "gpt-5.5",
+            reason: "GPT-5.5 has retired from the ChatGPT-account Codex route.",
+            when: { baseUrlHosts: ["chatgpt.com"] },
+          },
+        ],
+      },
+    });
+    const fallbackDefault = chatgptDefaultModelId();
+    expect(fallbackDefault).not.toBe("gpt-5.5");
+    expect(isCodexSupportedModelId(fallbackDefault)).toBe(true);
+  });
+
+  it("keeps gpt-5.5 as the floor while the core still routes it", () => {
+    write(MANIFEST_2026_8_1);
+    expect(chatgptDefaultModelId()).toBe("gpt-5.5");
+    // …and the probe's candidates are the surface rows ABOVE that floor, which
+    // on this core is exactly the hand-kept preference list it replaces.
+    expect(chatgptUpgradeCandidates()).toEqual(["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]);
+  });
+
+  it("lets the probe reach a model the core added", () => {
+    write(MANIFEST_2026_9_3);
+    // The other half of the same defect: with a hand-kept preference list a
+    // fresh sign-in on this core would land on gpt-5.5 while the picker offered
+    // Astra first — the complaint this change exists to answer, surviving in the
+    // one place that writes config.
+    expect(chatgptUpgradeCandidates()[0]).toBe(ASTRA);
+    expect(chatgptDefaultModelId()).toBe("gpt-5.5");
   });
 
   it("ignores a suppression that names another provider or no host", () => {
@@ -204,6 +270,68 @@ describe("the ChatGPT-account surface follows the installed core", () => {
         ],
       },
     });
-    expect(chatgptSurface().models.map((m) => m.id)).toEqual(["gpt-5.5"]);
+    // gpt-5.5 survives: neither suppression is a claim about THIS provider's
+    // ChatGPT route. The rest of the curated list is there because the seed is
+    // never allowed to narrow the surface.
+    const ids = chatgptSurface().models.map((m) => m.id);
+    expect(ids).toContain("gpt-5.5");
+    expect(isCodexSupportedModelId("gpt-5.5")).toBe(true);
+  });
+
+  it("reads the api-shaped suppression the core's matcher also compiles", () => {
+    // `when.providerConfigApiIn` is the core's OTHER condition, and the natural
+    // spelling once the transport rather than the URL identifies the route.
+    // Ignoring it would leave the row offered, the write guard accepting it, and
+    // every turn dying on the core's own `Unknown model`.
+    write({
+      modelCatalog: {
+        providers: {
+          openai: {
+            models: [{ id: "gpt-5.5", name: "GPT-5.5" }, { id: "gpt-5.6-sol", name: "GPT-5.6 Sol" }],
+          },
+        },
+        suppressions: [
+          {
+            provider: "openai",
+            model: "gpt-5.6-sol",
+            when: { providerConfigApiIn: ["openai-chatgpt-responses"] },
+          },
+        ],
+      },
+    });
+    expect(chatgptSurface().models.map((m) => m.id)).not.toContain("gpt-5.6-sol");
+    expect(isCodexSupportedModelId("gpt-5.6-sol")).toBe(false);
+  });
+
+  it("matches a suppression whose provider or model is spelled in another case", () => {
+    // The core normalises both sides before comparing; a manifest that spelled
+    // `"provider": "OpenAI"` would be honoured there and ignored here, leaving a
+    // row the core refuses in the picker.
+    write({
+      modelCatalog: {
+        providers: { openai: { models: [{ id: "gpt-5.5", name: "GPT-5.5" }, { id: "gpt-5.4", name: "GPT-5.4" }] } },
+        suppressions: [
+          { provider: "OpenAI", model: "gpt-5.4", when: { baseUrlHosts: ["ChatGPT.com"] } },
+        ],
+      },
+    });
+    expect(chatgptSurface().models.map((m) => m.id)).not.toContain("gpt-5.4");
+  });
+
+  it("keeps a subscription-only model whose name looks like an off-surface tier", () => {
+    // An `api.openai.com` suppression is the core stating that the PLATFORM
+    // route cannot reach the model — positive evidence that this surface is the
+    // only way to it — so it outranks the `-pro`/`-nano` tier narrowing, which
+    // is a guess made from the shape of a name.
+    write({
+      modelCatalog: {
+        providers: { openai: { models: [{ id: "gpt-5.5", name: "GPT-5.5" }] } },
+        suppressions: [
+          { provider: "openai", model: "gpt-6-astra-pro", when: { baseUrlHosts: ["api.openai.com"] } },
+        ],
+      },
+    });
+    expect(chatgptSurface().models.map((m) => m.id)).toContain("gpt-6-astra-pro");
+    expect(isCodexSupportedModelId("gpt-6-astra-pro")).toBe(true);
   });
 });

--- a/src/tests/unit/codex-picker-astra.test.ts
+++ b/src/tests/unit/codex-picker-astra.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CODEX_MODELS } from "@/lib/provider-models";
+import { chatgptSurface } from "@/lib/chatgpt-surface";
+import { resetCoreModelLifecycle } from "@/lib/core-model-lifecycle";
+import { chatgptSupportedModelsSentence, isCodexSupportedModelId } from "@/lib/subscription-surface";
+import { createManifestFixture, type ManifestFixture } from "@/tests/helpers/core-model-manifests";
+
+/**
+ * "I am on Codex but I don't see Astra" — the ChatGPT-account picker follows the
+ * installed core's own ChatGPT route instead of a list kept in this repo.
+ *
+ * The row was left out deliberately, on a measurement that said `gpt-6-astra`
+ * was "not on the ChatGPT route at all": a turn on it went to api.openai.com
+ * rather than chatgpt.com. Re-measured on the same box on 2026-09-10, with the
+ * Codex runtime armed on the model ref: a turn on the OWNER'S OWN
+ * `openai/gpt-5.5` goes to api.openai.com too and 401s there, after which the
+ * run fails over to the fallback provider. The route that measurement described
+ * is the box's, not the model's — which is why this surface is no longer
+ * decided here at all.
+ *
+ * What the core publishes, in a file that needs no credential and no network
+ * call (`extensions/openai/openclaw.plugin.json`, the manifest
+ * `core-model-lifecycle.ts` already reads for retirements):
+ *
+ *   * 2026.8.1 lists nine openai models and suppresses `gpt-5.3-codex-spark` on
+ *     `api.openai.com` — reachable through the ChatGPT account and nowhere else.
+ *   * 2026.9.3 lists `gpt-6-astra` FIRST (its route contract files it under
+ *     `OPENAI_DUAL_ROUTE_MODEL_IDS`) and suppresses `gpt-5.4` and
+ *     `gpt-5.4-mini` on `chatgpt.com`: "retired from the ChatGPT-account Codex
+ *     route."
+ *
+ * So the curated list is wrong in BOTH directions on the next core, and the
+ * cases below are written against the two real manifest shapes: what the picker
+ * offers, what the write guard accepts and what the refusal sentence names, on
+ * each of them.
+ */
+
+const bin = vi.hoisted(() => ({ override: null as string | null }));
+
+vi.mock("@/lib/openclaw-config", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/openclaw-config")>();
+  return { ...actual, findOpenclawBin: () => bin.override ?? actual.findOpenclawBin() };
+});
+
+const ASTRA = "gpt-6-astra";
+const SPARK = "gpt-5.3-codex-spark";
+
+/** The openai rows of the manifest shipped with core 2026.8.1, ids and names only. */
+const MANIFEST_2026_8_1 = {
+  modelCatalog: {
+    providers: {
+      openai: {
+        models: [
+          { id: "gpt-5.6-sol", name: "GPT-5.6 Sol" },
+          { id: "gpt-5.6-terra", name: "GPT-5.6 Terra" },
+          { id: "gpt-5.6-luna", name: "GPT-5.6 Luna" },
+          { id: "gpt-5.5", name: "GPT-5.5" },
+          { id: "gpt-5.5-pro", name: "gpt-5.5-pro" },
+          { id: "gpt-5.4", name: "GPT-5.4" },
+          { id: "gpt-5.4-pro", name: "GPT-5.4 Pro" },
+          { id: "gpt-5.4-mini", name: "GPT-5.4 Mini" },
+          { id: "gpt-5.4-nano", name: "GPT-5.4 Nano" },
+        ],
+      },
+    },
+    suppressions: [
+      { provider: "openai", model: SPARK, when: { baseUrlHosts: ["api.openai.com"] } },
+      // The azure alias carries its own unconditional row, which says nothing
+      // about this provider's routes.
+      { provider: "azure-openai-responses", model: SPARK },
+    ],
+  },
+};
+
+/** The same file from core 2026.9.3: Astra added, two rows retired from the route. */
+const MANIFEST_2026_9_3 = {
+  modelCatalog: {
+    providers: {
+      openai: {
+        models: [
+          { id: ASTRA, name: "GPT-6 Astra" },
+          ...MANIFEST_2026_8_1.modelCatalog.providers.openai.models,
+        ],
+      },
+    },
+    suppressions: [
+      {
+        provider: "openai",
+        model: "gpt-5.4",
+        reason: "GPT-5.4 has retired from the ChatGPT-account Codex route.",
+        retirement: { replacedBy: "gpt-5.6-terra" },
+        when: { baseUrlHosts: ["chatgpt.com"] },
+      },
+      {
+        provider: "openai",
+        model: "gpt-5.4-mini",
+        reason: "GPT-5.4 Mini has retired from the ChatGPT-account Codex route.",
+        retirement: { replacedBy: "gpt-5.6-luna" },
+        when: { baseUrlHosts: ["chatgpt.com"] },
+      },
+      ...MANIFEST_2026_8_1.modelCatalog.suppressions,
+    ],
+  },
+};
+
+describe("the ChatGPT-account surface follows the installed core", () => {
+  let fixture: ManifestFixture | null = null;
+
+  beforeEach(() => {
+    fixture = createManifestFixture("codex-picker-astra");
+    // The bundled candidate dropped, so the fixture's manifest is the only one
+    // there is — a machine with a real core installed would otherwise answer
+    // from it and these cases would test that box instead of these shapes.
+    bin.override = "openclaw";
+    resetCoreModelLifecycle();
+  });
+
+  afterEach(() => {
+    fixture?.cleanup();
+    fixture = null;
+    bin.override = null;
+    resetCoreModelLifecycle();
+  });
+
+  function write(manifest: unknown): void {
+    fixture!.writeManifest("openai", manifest);
+    resetCoreModelLifecycle();
+  }
+
+  it("offers GPT-6 Astra on the core that ships it, and accepts it on the write paths", () => {
+    write(MANIFEST_2026_9_3);
+    const surface = chatgptSurface();
+    expect(surface.source).toBe("core");
+    expect(surface.models.map((m) => m.id)).toContain(ASTRA);
+    // First, because the manifest lists it first — the picker renders the
+    // source's own order and the core's is newest-first.
+    expect(surface.models[0]?.id).toBe(ASTRA);
+    expect(surface.models[0]?.label).toBe("GPT-6 Astra");
+    // A row the picker offers that the write guard refuses is a dead button.
+    expect(isCodexSupportedModelId(ASTRA)).toBe(true);
+    expect(chatgptSupportedModelsSentence()).toContain("GPT-6 Astra");
+  });
+
+  it("drops the models that core retired from the ChatGPT route", () => {
+    write(MANIFEST_2026_9_3);
+    const ids = chatgptSurface().models.map((m) => m.id);
+    for (const id of ["gpt-5.4", "gpt-5.4-mini"]) {
+      expect(ids, `${id} is suppressed on chatgpt.com and must not be offered`).not.toContain(id);
+      expect(isCodexSupportedModelId(id)).toBe(false);
+    }
+    // …and keeps the one the core suppresses on the PLATFORM host, which the
+    // manifest's model list does not carry at all.
+    expect(ids).toContain(SPARK);
+  });
+
+  it("keeps the tiers the ChatGPT account cannot run off the surface", () => {
+    write(MANIFEST_2026_9_3);
+    const ids = chatgptSurface().models.map((m) => m.id);
+    for (const id of ["gpt-5.5-pro", "gpt-5.4-pro", "gpt-5.4-nano"]) {
+      expect(ids, `${id} must not be offered on the ChatGPT surface`).not.toContain(id);
+      expect(isCodexSupportedModelId(id)).toBe(false);
+    }
+  });
+
+  it("answers exactly today's curated list on the core the boxes run", () => {
+    // The shipped core must see no change at all: this is what says the
+    // derivation replaces the curated list rather than altering what a box in a
+    // customer's hands offers.
+    write(MANIFEST_2026_8_1);
+    const surface = chatgptSurface();
+    expect(surface.source).toBe("core");
+    expect(surface.models.map((m) => m.id)).toEqual(CODEX_MODELS.map((m) => m.id));
+    // Labels too — ours, not the core's, for the one row whose name would
+    // truncate in the chat header's model pill.
+    expect(surface.models.map((m) => m.label)).toEqual(CODEX_MODELS.map((m) => m.label));
+  });
+
+  it("falls back to the curated list where there is no manifest to read", () => {
+    const surface = chatgptSurface();
+    expect(surface.source).toBe("curated");
+    expect(surface.models).toEqual(CODEX_MODELS);
+    expect(isCodexSupportedModelId("gpt-5.5")).toBe(true);
+  });
+
+  it("falls back rather than emptying the picker when the manifest offers nothing", () => {
+    // A catalogue whose every row is off-surface is a shape this does not
+    // understand; serving zero rows would refuse every model on a box whose
+    // ChatGPT account works.
+    write({ modelCatalog: { providers: { openai: { models: [{ id: "gpt-9-pro" }] } } } });
+    const surface = chatgptSurface();
+    expect(surface.source).toBe("curated");
+    expect(surface.models).toEqual(CODEX_MODELS);
+  });
+
+  it("ignores a suppression that names another provider or no host", () => {
+    write({
+      modelCatalog: {
+        providers: { openai: { models: [{ id: "gpt-5.5", name: "GPT-5.5" }] } },
+        suppressions: [
+          // Another provider's route.
+          { provider: "azure-openai-responses", model: "gpt-5.5", when: { baseUrlHosts: ["chatgpt.com"] } },
+          // Unconditional: not a claim about this route.
+          { provider: "openai", model: "gpt-5.5" },
+        ],
+      },
+    });
+    expect(chatgptSurface().models.map((m) => m.id)).toEqual(["gpt-5.5"]);
+  });
+});

--- a/src/tests/unit/codex-picker-astra.test.ts
+++ b/src/tests/unit/codex-picker-astra.test.ts
@@ -330,6 +330,61 @@ describe("the ChatGPT-account surface follows the installed core", () => {
     expect(isCodexSupportedModelId("gpt-5.6-sol")).toBe(true);
   });
 
+  it("ignores a host suppression that an unreachable api condition is ANDed with", () => {
+    // The core requires EVERY condition present to match, and it resolves
+    // `providerConfigApiIn` against the owner's `models.providers.openai.api`,
+    // which this repo never writes — so an entry carrying it does not fire in the
+    // core at all and the model keeps running. Reading the host half on its own
+    // would take the row off the picker and out of the write guard: a false
+    // failure over a model the box can still use.
+    write({
+      modelCatalog: {
+        providers: {
+          openai: {
+            models: [{ id: "gpt-5.5", name: "GPT-5.5" }, { id: "gpt-5.6-sol", name: "GPT-5.6 Sol" }],
+          },
+        },
+        suppressions: [
+          {
+            provider: "openai",
+            model: "gpt-5.6-sol",
+            when: {
+              baseUrlHosts: ["chatgpt.com"],
+              providerConfigApiIn: ["openai-chatgpt-responses"],
+            },
+          },
+        ],
+      },
+    });
+    expect(chatgptSurface().models.map((m) => m.id)).toContain("gpt-5.6-sol");
+    expect(isCodexSupportedModelId("gpt-5.6-sol")).toBe(true);
+  });
+
+  it("still honours a host-only suppression beside one the api condition guards", () => {
+    // The pair above must not become a blanket excuse: an entry with hosts alone
+    // is still a route claim, judged on its own.
+    write({
+      modelCatalog: {
+        providers: {
+          openai: {
+            models: [{ id: "gpt-5.5", name: "GPT-5.5" }, { id: "gpt-5.4", name: "GPT-5.4" }],
+          },
+        },
+        suppressions: [
+          {
+            provider: "openai",
+            model: "gpt-5.6-sol",
+            when: { baseUrlHosts: ["chatgpt.com"], providerConfigApiIn: ["openai-chatgpt-responses"] },
+          },
+          { provider: "openai", model: "gpt-5.4", when: { baseUrlHosts: ["chatgpt.com"] } },
+        ],
+      },
+    });
+    const ids = chatgptSurface().models.map((m) => m.id);
+    expect(ids).not.toContain("gpt-5.4");
+    expect(ids).toContain("gpt-5.5");
+  });
+
   it("matches a suppression whose provider, model or host is spelled in another case", () => {
     // The core keys suppressions by
     // `normalizeProviderId(provider) + "::" + normalizeLowercaseStringOrEmpty(id)`

--- a/src/tests/unit/codex-supported-models.test.ts
+++ b/src/tests/unit/codex-supported-models.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CODEX_MODELS } from "@/lib/provider-models";
+import { resetCoreModelLifecycle } from "@/lib/core-model-lifecycle";
 import { offSurfaceCodexModelMessage } from "@/lib/subscription-surface";
+import { createManifestFixture, type ManifestFixture } from "@/tests/helpers/core-model-manifests";
 
 // TASK-786 — the ChatGPT-account (OpenAI Codex) surface is ONE list.
 //
@@ -14,23 +16,30 @@ import { offSurfaceCodexModelMessage } from "@/lib/subscription-surface";
 // gpt-5.3-codex-spark, a model the installed core routes on this surface and
 // on no other.
 //
-// Upstream truth is the core's own `extensions/openai/model-route-contract`
-// (`OPENAI_CHATGPT_MODERN_MODEL_IDS` = the dual-route ids plus the
-// subscription-only ones). Measured on the box: it has no CLI or RPC surface —
-// `openclaw models list --provider codex` and `--provider openai-chatgpt` both
-// answer `Unknown provider filter`, and the openai enumeration carries no
-// plan- or auth-scoped field. So ClawBox mirrors it.
+// It is still one list, and since 2026-09-10 that list is the INSTALLED CORE'S
+// own: `chatgptSurface()` reads the ChatGPT route out of
+// `extensions/openai/openclaw.plugin.json` — the models it ships, the ones it
+// suppresses on `chatgpt.com` (off this route) and the ones it suppresses on
+// `api.openai.com` (on this route alone) — and `CODEX_MODELS` is what it falls
+// back to where no manifest can be read. A hand-kept mirror answered for one
+// core version: against 2026.9.3 it is wrong in both directions at once.
 //
-// WHAT THESE CASES ACTUALLY PIN, because two of them are true by construction
-// once the surface is one list and would read as more protection than they are:
-// `accepted()` reduces to a lookup in `CODEX_MODELS`, so "accepts exactly what
-// the picker offers" cannot fail while the guard is derived from the catalogue
-// — it is the CHANGE DETECTOR for that derivation, and it goes red the moment
-// somebody reintroduces a second spelling. The half that pins something today
-// is the `not.toContain` one: the ids this surface must NOT carry. The mirror
-// itself is pinned against something external in
-// `codex-surface-follows-core.test.ts` (the installed core's own manifest) and
-// against pre-start's copy in `gateway-pre-start-codex-models.test.ts`.
+// WHAT THESE CASES PIN. The write guard is derived from the surface, so "accepts
+// exactly what the picker offers" cannot fail while that holds — it is the
+// CHANGE DETECTOR for the derivation and goes red the moment somebody
+// reintroduces a second spelling. The halves that pin something on their own are
+// the manifest-driven ones: a model the core added reaches the guard, and one the
+// core retired from the route stops reaching it, with no release here. The mirror
+// itself is pinned against the installed core in
+// `codex-surface-follows-core.test.ts` and against pre-start's copy in
+// `gateway-pre-start-codex-models.test.ts`.
+
+const bin = vi.hoisted(() => ({ override: null as string | null }));
+
+vi.mock("@/lib/openclaw-config", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/openclaw-config")>();
+  return { ...actual, findOpenclawBin: () => bin.override ?? actual.findOpenclawBin() };
+});
 
 const CURATED_IDS = CODEX_MODELS.map((m) => m.id);
 
@@ -40,13 +49,32 @@ function accepted(modelId: string): boolean {
 }
 
 describe("the ChatGPT-account model list", () => {
+  let fixture: ManifestFixture | null = null;
+
+  beforeEach(() => {
+    // No manifest anywhere unless a case writes one: the curated fallback is
+    // what the cases below judge, and a machine with a real core installed
+    // would otherwise answer from whatever it has.
+    fixture = createManifestFixture("codex-supported-models");
+    bin.override = "openclaw";
+    resetCoreModelLifecycle();
+  });
+
+  afterEach(() => {
+    fixture?.cleanup();
+    fixture = null;
+    bin.override = null;
+    resetCoreModelLifecycle();
+  });
+
   it("carries gpt-5.3-codex-spark, which runs only on this surface", () => {
     // Measured 2026-09-09 on core 2026.8.1:
     //   `openclaw infer model run --local --model openai/gpt-5.3-codex-spark`
     //   went out on api=openclaw-openai-chatgpt-responses-transport to
     //   https://chatgpt.com/backend-api/codex/responses and answered 200,
     // while the same box's `models list --provider openai` reports it
-    // `available: false` — the platform route excludes it.
+    // `available: false` — the platform route excludes it. Both cores state the
+    // same thing in the manifest, as a suppression on `api.openai.com`.
     expect(CURATED_IDS).toContain("gpt-5.3-codex-spark");
   });
 
@@ -64,20 +92,53 @@ describe("the ChatGPT-account model list", () => {
     // The `-pro` tiers are the measured case and the reason this surface is
     // narrower than the core's dual-route set: the core lists them, and the
     // ChatGPT-account path answers "model not supported when using Codex with
-    // a ChatGPT account" (developers.openai.com/codex/models). `gpt-6-astra`
-    // is the newer case — the installed core does not carry it on the ChatGPT
-    // route at all, so a turn on it silently falls back to the platform
-    // endpoint and the API key (measured: 401 on a subscription-only box).
-    for (const id of ["gpt-5.4-pro", "gpt-5.5-pro", "gpt-6-astra", "gpt-4o"]) {
+    // a ChatGPT account" (developers.openai.com/codex/models).
+    for (const id of ["gpt-5.4-pro", "gpt-5.5-pro", "gpt-4o"]) {
       expect(CURATED_IDS, `${id} must not be offered on the ChatGPT surface`).not.toContain(id);
       expect(accepted(id), `the write guard must refuse ${id}`).toBe(false);
     }
   });
 
   it("names the models it refuses in the refusal", () => {
-    const message = offSurfaceCodexModelMessage(null, "gpt-6-astra", true);
-    expect(message).toContain("gpt-6-astra is not supported with ChatGPT subscription auth");
+    const message = offSurfaceCodexModelMessage(null, "gpt-4o", true);
+    expect(message).toContain("gpt-4o is not supported with ChatGPT subscription auth");
     // Built from the one list, so a model added to it reaches the refusal too.
     expect(message).toContain(CODEX_MODELS[0].label);
+  });
+
+  it("accepts a model the installed core added to the route", () => {
+    // core 2026.9.3: `gpt-6-astra` is in the openai manifest (and first in its
+    // `OPENAI_DUAL_ROUTE_MODEL_IDS`). The curated list has never carried it —
+    // it was excluded on a turn that went to api.openai.com, which is where
+    // that box sends the owner's own gpt-5.5 as well.
+    fixture!.writeManifest("openai", {
+      modelCatalog: {
+        providers: { openai: { models: [{ id: "gpt-6-astra", name: "GPT-6 Astra" }, { id: "gpt-5.5", name: "GPT-5.5" }] } },
+      },
+    });
+    resetCoreModelLifecycle();
+    expect(accepted("gpt-6-astra")).toBe(true);
+  });
+
+  it("refuses a model the installed core retired from the route", () => {
+    // The same manifest's other direction: 2026.9.3 suppresses gpt-5.4 on
+    // `chatgpt.com` — "retired from the ChatGPT-account Codex route" — while the
+    // curated list still offers it.
+    fixture!.writeManifest("openai", {
+      modelCatalog: {
+        providers: { openai: { models: [{ id: "gpt-5.5", name: "GPT-5.5" }, { id: "gpt-5.4", name: "GPT-5.4" }] } },
+        suppressions: [
+          {
+            provider: "openai",
+            model: "gpt-5.4",
+            reason: "GPT-5.4 has retired from the ChatGPT-account Codex route.",
+            when: { baseUrlHosts: ["chatgpt.com"] },
+          },
+        ],
+      },
+    });
+    resetCoreModelLifecycle();
+    expect(CURATED_IDS).toContain("gpt-5.4");
+    expect(accepted("gpt-5.4")).toBe(false);
   });
 });

--- a/src/tests/unit/codex-surface-follows-core.test.ts
+++ b/src/tests/unit/codex-surface-follows-core.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import fs from "fs";
-import { chatgptSurface } from "@/lib/chatgpt-surface";
+import { CODEX_MODELS } from "@/lib/provider-models";
+import { chatgptDefaultModelId, chatgptSurface } from "@/lib/chatgpt-surface";
 import { coreManifestPaths, resetCoreModelLifecycle } from "@/lib/core-model-lifecycle";
 import { createManifestFixture, type ManifestFixture } from "@/tests/helpers/core-model-manifests";
 
@@ -89,6 +90,40 @@ function subscriptionOnlyIds(manifest: unknown, provider: string): string[] {
   return out;
 }
 
+/** The ids the manifest's provider block lists. */
+function listedIds(manifest: unknown, provider: string): string[] {
+  const block = (manifest as { modelCatalog?: { providers?: Record<string, unknown> } } | null)
+    ?.modelCatalog?.providers?.[provider];
+  const rows = (block as { models?: unknown } | null)?.models;
+  if (!Array.isArray(rows)) return [];
+  return (rows as Array<{ id?: unknown }>)
+    .map((row) => (typeof row?.id === "string" ? row.id.trim() : ""))
+    .filter((id) => id.length > 0);
+}
+
+/** Ids the manifest suppresses ON the ChatGPT route — retired from this surface. */
+function chatgptRouteSuppressedIds(manifest: unknown, provider: string): string[] {
+  const list = (manifest as { modelCatalog?: { suppressions?: unknown } } | null)
+    ?.modelCatalog?.suppressions;
+  if (!Array.isArray(list)) return [];
+  const out: string[] = [];
+  for (const entry of list as Array<Suppression & { when?: { providerConfigApiIn?: unknown } | null }>) {
+    if (String(entry?.provider ?? "").toLowerCase() !== provider.toLowerCase()) continue;
+    if (typeof entry.model !== "string" || !entry.model.trim()) continue;
+    const hosts = Array.isArray(entry?.when?.baseUrlHosts) ? entry.when?.baseUrlHosts : [];
+    const apis = Array.isArray(entry?.when?.providerConfigApiIn) ? entry.when?.providerConfigApiIn : [];
+    // A SET, so each test is an exact element match rather than a substring
+    // search over a host — see `conditionSet` in core-model-lifecycle.ts.
+    const conditions = new Set([...hosts, ...apis]
+      .filter((v): v is string => typeof v === "string")
+      .map((v) => v.trim().toLowerCase()));
+    if (conditions.has("chatgpt.com") || conditions.has("openai-chatgpt-responses")) {
+      out.push(entry.model.trim());
+    }
+  }
+  return out;
+}
+
 function readFirstManifest(paths: string[]): unknown {
   for (const file of paths) {
     try {
@@ -117,6 +152,50 @@ describe("the ChatGPT surface follows the installed core", () => {
       expect(offered, `the installed core routes ${id} on the ChatGPT account only, `
         + "but the picker does not offer it").toContain(id);
     }
+  });
+
+  /**
+   * The WHOLE derived list against the installed core, not just its
+   * subscription-only half — the case that would have noticed "the shipped core
+   * sees no change" stopping being true, which the hand-typed fixtures in
+   * `codex-picker-astra.test.ts` cannot.
+   *
+   * Written as invariants rather than as a second copy of the derivation: an
+   * expected list spelled here would be the hand-kept mirror this change
+   * removed, one file over.
+   */
+  it("offers a list the installed core's own manifest justifies, row by row", () => {
+    resetCoreModelLifecycle();
+    const manifest = readFirstManifest(coreManifestPaths("openai"));
+    if (!manifest) {
+      // No core installed (CI). Stated rather than skipped silently.
+      expect(manifest).toBeNull();
+      return;
+    }
+    const listed = new Set(listedIds(manifest, "openai"));
+    const subscriptionOnly = new Set(subscriptionOnlyIds(manifest, "openai"));
+    const offRoute = new Set(chatgptRouteSuppressedIds(manifest, "openai"));
+    const curated = new Set(CODEX_MODELS.map((m) => m.id));
+    const offered = chatgptSurface().models.map((m) => m.id);
+
+    expect(offered.length).toBeGreaterThan(0);
+    for (const id of offered) {
+      // Nothing is invented: every row came from the manifest or from the
+      // curated floor the derivation is not allowed to narrow past.
+      expect(listed.has(id) || subscriptionOnly.has(id) || curated.has(id),
+        `${id} is offered but the installed manifest and the curated list both omit it`).toBe(true);
+      // …and nothing the core retired from this route survives.
+      expect(offRoute.has(id), `${id} is suppressed on the ChatGPT route and must not be offered`).toBe(false);
+    }
+    // The widening rule, against the real file: a curated row the core has NOT
+    // retired from this route is still there.
+    for (const id of curated) {
+      if (offRoute.has(id)) continue;
+      expect(offered, `${id} is in no suppression of the installed manifest and must still be offered`)
+        .toContain(id);
+    }
+    // And the cold-start default is a row the write guard will accept.
+    expect(offered).toContain(chatgptDefaultModelId());
   });
 });
 

--- a/src/tests/unit/codex-surface-follows-core.test.ts
+++ b/src/tests/unit/codex-surface-follows-core.test.ts
@@ -76,16 +76,26 @@ interface Suppression {
  * provider we are asking about, so only a `baseUrlHosts` naming the platform
  * host counts.
  */
+/** A `when` condition array as a lowercased SET, for exact membership tests. */
+function hostSet(value: unknown): Set<string> {
+  if (!Array.isArray(value)) return new Set();
+  return new Set(value
+    .filter((v): v is string => typeof v === "string")
+    .map((v) => v.trim().toLowerCase()));
+}
+
 function subscriptionOnlyIds(manifest: unknown, provider: string): string[] {
   const list = (manifest as { modelCatalog?: { suppressions?: unknown } } | null)
     ?.modelCatalog?.suppressions;
   if (!Array.isArray(list)) return [];
   const out: string[] = [];
   for (const entry of list as Suppression[]) {
-    if (entry?.provider !== provider) continue;
-    const hosts = entry?.when?.baseUrlHosts;
-    if (!Array.isArray(hosts) || !hosts.includes(PLATFORM_HOST)) continue;
-    if (typeof entry.model === "string" && entry.model.trim()) out.push(entry.model.trim());
+    if (String(entry?.provider ?? "").toLowerCase() !== provider.toLowerCase()) continue;
+    // A SET, so the test is an exact element match rather than a substring search
+    // over a host — see `conditionSet` in core-model-lifecycle.ts.
+    if (!hostSet(entry?.when?.baseUrlHosts).has(PLATFORM_HOST)) continue;
+    const model = typeof entry.model === "string" ? entry.model.trim().toLowerCase() : "";
+    if (model) out.push(model);
   }
   return out;
 }
@@ -107,19 +117,14 @@ function chatgptRouteSuppressedIds(manifest: unknown, provider: string): string[
     ?.modelCatalog?.suppressions;
   if (!Array.isArray(list)) return [];
   const out: string[] = [];
-  for (const entry of list as Array<Suppression & { when?: { providerConfigApiIn?: unknown } | null }>) {
+  for (const entry of list as Suppression[]) {
     if (String(entry?.provider ?? "").toLowerCase() !== provider.toLowerCase()) continue;
-    if (typeof entry.model !== "string" || !entry.model.trim()) continue;
-    const hosts = Array.isArray(entry?.when?.baseUrlHosts) ? entry.when?.baseUrlHosts : [];
-    const apis = Array.isArray(entry?.when?.providerConfigApiIn) ? entry.when?.providerConfigApiIn : [];
-    // A SET, so each test is an exact element match rather than a substring
-    // search over a host — see `conditionSet` in core-model-lifecycle.ts.
-    const conditions = new Set([...hosts, ...apis]
-      .filter((v): v is string => typeof v === "string")
-      .map((v) => v.trim().toLowerCase()));
-    if (conditions.has("chatgpt.com") || conditions.has("openai-chatgpt-responses")) {
-      out.push(entry.model.trim());
-    }
+    const model = typeof entry.model === "string" ? entry.model.trim().toLowerCase() : "";
+    if (!model) continue;
+    // `baseUrlHosts` only, the one condition the surface reads — the core ANDs its
+    // conditions and resolves `providerConfigApiIn` against the owner's own
+    // config, which ClawBox never writes.
+    if (hostSet(entry?.when?.baseUrlHosts).has("chatgpt.com")) out.push(model);
   }
   return out;
 }

--- a/src/tests/unit/codex-surface-follows-core.test.ts
+++ b/src/tests/unit/codex-surface-follows-core.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import fs from "fs";
-import { CODEX_MODELS } from "@/lib/provider-models";
-import { coreManifestPaths } from "@/lib/core-model-lifecycle";
+import { chatgptSurface } from "@/lib/chatgpt-surface";
+import { coreManifestPaths, resetCoreModelLifecycle } from "@/lib/core-model-lifecycle";
 import { createManifestFixture, type ManifestFixture } from "@/tests/helpers/core-model-manifests";
 
 /**
@@ -24,12 +24,12 @@ vi.mock("@/lib/openclaw-config", async (importActual) => {
 /**
  * The drift detector for the ChatGPT (OpenAI Codex) list.
  *
- * `CODEX_MODELS` mirrors the core's `OPENAI_CHATGPT_MODERN_MODEL_IDS`
- * (`extensions/openai/model-route-contract` in the installed dist) because
- * 2026.8.1 publishes that set through no CLI and no provider filter —
- * `openclaw models list --provider codex` and `--provider openai-chatgpt` both
- * answer `Unknown provider filter`. A hand-kept mirror is how the picker fell
- * behind in the first place, so the mirror needs something to fail against.
+ * The surface is DERIVED from this manifest now (`chatgptSurface()`), so the
+ * case below is no longer a drift detector for a hand-kept mirror but the
+ * end-to-end proof of the derivation on whatever core is installed: a model this
+ * box's core says the ChatGPT account is the only way to reach must be a model
+ * this box's picker offers. `CODEX_MODELS` is what the surface answers where
+ * there is no manifest, and cannot be checked against one that is not there.
  *
  * The core DOES publish one half of it in a machine-readable file at a stable
  * path — the same `extensions/<provider>/openclaw.plugin.json` that
@@ -103,6 +103,7 @@ function readFirstManifest(paths: string[]): unknown {
 
 describe("the ChatGPT surface follows the installed core", () => {
   it("carries every openai model the installed core says is ChatGPT-only", () => {
+    resetCoreModelLifecycle();
     const manifest = readFirstManifest(coreManifestPaths("openai"));
     const ids = subscriptionOnlyIds(manifest, "openai");
     if (ids.length === 0) {
@@ -111,10 +112,10 @@ describe("the ChatGPT surface follows the installed core", () => {
       expect(ids).toEqual([]);
       return;
     }
-    const curated = CODEX_MODELS.map((m) => m.id);
+    const offered = chatgptSurface().models.map((m) => m.id);
     for (const id of ids) {
-      expect(curated, `the installed core routes ${id} on the ChatGPT account only, `
-        + "but CODEX_MODELS does not offer it").toContain(id);
+      expect(offered, `the installed core routes ${id} on the ChatGPT account only, `
+        + "but the picker does not offer it").toContain(id);
     }
   });
 });

--- a/src/tests/unit/core-model-lifecycle.test.ts
+++ b/src/tests/unit/core-model-lifecycle.test.ts
@@ -178,6 +178,30 @@ describe("coreModelRetired", () => {
     }
   });
 
+  it("notices a bundled manifest installed under a live process", async () => {
+    // `findOpenclawBin` answers the bare name where no core is installed, and
+    // `coreManifestPaths` then omits the bundled candidate entirely — so an
+    // install completing under a live server GROWS the candidate list and moves
+    // the already-cached beside-config file from index 0 to index 1. A position
+    // remembered with the cache would say "nothing better exists" for the life of
+    // the process, and the box would keep answering from the old manifest.
+    fixture.writeManifest("openai", { models: [{ id: "gpt-5.5" }] });
+    const { coreModelRetired } = await loadLifecycle();
+    expect(coreModelRetired("openai", "gpt-5.5")).toBe(false);
+
+    // The install lands: the binary resolves, and the bundled manifest it brings
+    // retires the model.
+    bin.override = fixture.bin;
+    fixture.writeBundledManifest("openai", { models: [{ id: "gpt-5.5", status: "deprecated" }] });
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(Date.now() + 10_000);
+      expect(coreModelRetired("openai", "gpt-5.5")).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not remember having found no manifest at all", async () => {
     // "There is no core yet" and "there is nothing retired" are different
     // answers, and caching the first as the second is how a filter turns

--- a/src/tests/unit/gateway-pre-start-codex-models.test.ts
+++ b/src/tests/unit/gateway-pre-start-codex-models.test.ts
@@ -1,15 +1,34 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { CODEX_MODELS } from "@/lib/provider-models";
 import { isCodexSupportedModelId } from "@/lib/subscription-surface";
 
+/**
+ * No installed core, whatever the machine has. `isCodexSupportedModelId` now
+ * reads the ChatGPT route off the INSTALLED core's manifest and answers
+ * `CODEX_MODELS` only as its fallback — so on a box running a core that has
+ * retired one of these ids from the route (2026.9.3 retires `gpt-5.4` and
+ * `gpt-5.4-mini`) the guard rightly refuses a row this curated list still
+ * carries. That is the derivation working, not a drifted mirror, and it is not
+ * what this file is about: `_CODEX_SUPPORTED` mirrors the FALLBACK, because its
+ * only consumer is the OpenClaw 1 branch of a script that runs before node
+ * exists. A bare binary name drops the bundled manifest candidate, which is
+ * what makes "the fallback" the answer here on every machine.
+ */
+vi.mock("@/lib/openclaw-config", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/openclaw-config")>();
+  return { ...actual, findOpenclawBin: () => "openclaw" };
+});
+
 // gateway-pre-start.sh rewrites `openai/<gpt>` -> `codex/<gpt>` on boxes with
 // ChatGPT (Codex OAuth) auth and no OpenAI API key. Its `_CODEX_SUPPORTED`
 // tuple is a hand-maintained MIRROR of CODEX_MODELS in
 // src/lib/provider-models.ts — the script cannot import, so it copies. It is
-// the only remaining copy: the route's own allowlist reads the catalogue
-// directly (`isCodexSupportedModelId`).
+// the only remaining copy: the route's own allowlist reads the surface directly
+// (`isCodexSupportedModelId`), which since 2026-09-10 is derived from the
+// installed core's manifest with CODEX_MODELS as its fallback. The mirror stays
+// pinned to that fallback on purpose — see the mock above.
 //
 // The two drifted: the regex learned gpt-5.6-{sol,terra,luna} (PR #271) but
 // the tuple did not, so a subscription box whose stored model was


### PR DESCRIPTION
**Finding:** `astra-codex-picker` (follow-up to TASK-786 / #809)

## Symptom

On the office OpenClaw box the owner is on the "OpenAI Codex" (ChatGPT
subscription) row and does not see GPT-6 Astra. #809 rebuilt that picker
yesterday and deliberately excluded `gpt-6-astra`.

## Cause

The picker was a curated array (`CODEX_MODELS`). A hand-kept list answers for
one core version, and against the next one it is wrong in both directions at
once. Measured in an isolated scratch install of the confirmed upgrade target,
OpenClaw 2026.9.3:

* `gpt-6-astra` is a dual-route model (`OPENAI_DUAL_ROUTE_MODEL_IDS` starts with
  `OPENAI_GPT_6_ASTRA_MODEL_ID`, `dist/model-route-contract-*.mjs`) and is first
  in the bundled OpenAI manifest;
* that same manifest suppresses `gpt-5.4` and `gpt-5.4-mini` on the ChatGPT
  route — "retired from the ChatGPT-account Codex route";
* the live Codex catalogue endpoint is unchanged.

So the curated list omits Astra and offers two rows that will not run.

#809's exclusion of Astra rested on a turn that went to `api.openai.com` instead
of `chatgpt.com`. Re-measured on the same box today (mutex held, one short
message, config restored and verified byte-identical), with the Codex runtime
armed on the model ref: a turn on the owner's OWN `openai/gpt-5.5` goes to
`api.openai.com` as well, 401s there, and the run fails over to the fallback
provider. The route that measurement described is the box's, not the model's —
it is the inline `models.providers.openai.apiKey` (the ClawBox AI image token)
deciding which catalogue the core publishes for `openai`. The core's own
`models status --json` says so in one line:

```
runtimeAuthRoutes: [{"provider":"openai","runtime":"codex","authProvider":"openai",
                     "status":"usable","effective":{"kind":"models.json","detail":"claw_…"}}]
```

That is a separate defect on that box, filed rather than fixed here.

## Harness-first: the native mechanism, and its limit

The core DOES build the ChatGPT route's real list, live and per account, from
`chatgpt.com/backend-api/codex/models`. Nothing on 2026.8.1 or 2026.9.3
publishes it in a form ClawBox can ask for, measured on the box:

* `models list --provider codex` → `Unknown provider filter`; there is no
  `--profile` scoping and no gateway RPC for it;
* the catalogue the core publishes under the `openai` provider id flips
  WHOLESALE between the live Codex list and the platform list on the credential
  its catalog hook resolves first (`openai-provider-*.js` → `catalog.run`), and
  an API key — an inline `models.providers.openai.apiKey` counts — yields the
  platform one: 30 rows including `gpt-5.6`, `o3` and the image models, with the
  subscription-only `gpt-5.3-codex-spark` marked `available: false`;
* a row carries no route provenance to tell the two apart. The JSON row keys are
  `available, contextTokens, contextWindow, input, key, local, missing, name,
  tags`.

What the core DOES publish per model, offline and without a credential, is the
plugin manifest this repo already reads for retirements
(`extensions/openai/openclaw.plugin.json`, `coreManifestPaths`): the models it
ships, the ids it suppresses on `chatgpt.com` (off this route) and the ids it
suppresses on `api.openai.com` (on this route and no other — how
`gpt-5.3-codex-spark` is stated, and it is in neither core's model list).

So the surface is derived from that, `CODEX_MODELS` stays as the fallback where
no manifest can be read and as the source of labels, and ClawBox keeps two
narrowings of its own with their measurements: the `-pro` tiers (the
subscription path answers "model not supported when using Codex with a ChatGPT
account") and `-nano` (in the core's platform set, not its ChatGPT one).

## What the second commit adds

Deriving the surface from the manifest opened four holes, each closed where it
opened:

* **The manifest is a SEED, not the effective catalogue.** Both shipped cores
  declare `modelCatalog.discovery = {"openai": "runtime"}` — read off the box's
  own installed core — so a chatgpt-route model can live outside `models[]`.
  A derivation that REPLACED the curated list would take the row *and* the write
  guard away from a model the box had been running. It now only ever **widens**
  the curated list; only the core's own `chatgpt.com` suppression removes a row.
  On both shipped manifests this pass adds nothing, which is the point: it
  changes the failure direction, not the list.
* **The cold-start default and the probe's preference list were still hand-kept
  constants.** `configure` wrote `CHATGPT_DEFAULT_MODEL_ID` and then judged it
  with `offSurfaceCodexModelMessage` in the same request: the day a core retires
  `gpt-5.5` from this route — the exact move 2026.9.3 made for `gpt-5.4`, on a
  model both manifests already mark `status: "deprecated"` — a ChatGPT sign-in
  would have 400'd on its own default with no other door out of setup. And
  `CODEX_MODEL_PREFERENCE` can never name a model a core upgrade adds, so on
  2026.9.3 the picker would have offered Astra first while every fresh sign-in
  still landed on `gpt-5.5` — this PR's own complaint surviving in the one place
  that writes config. Both are now asked of the same surface that judges them.
* **The suppression reader saw only `when.baseUrlHosts`.** The core's matcher
  compiles two conditions; `when.providerConfigApiIn` is the natural spelling
  once the transport rather than the URL identifies the route
  (`api: "openai-chatgpt-responses"`). Reading only the host one would leave a
  retired model in the picker and in the write guard, with every turn dying on
  the core's own `Unknown model`. Provider and model are now compared
  case-folded, as the core's own matcher does.
* **Probe-once:** an answer cached from the beside-config manifest survived an
  upgrade that INSTALLS the bundled one, because the staleness check re-stats
  only the file it read. A higher-priority candidate appearing now invalidates
  the cache, on the same five-second floor.

Host and api conditions are compared as exact set members rather than with
`.includes()`. That clears the two CodeQL `js/incomplete-url-substring-
sanitization` alerts that were open on the previous head; CodeQL is green on this
one.

## RED → GREEN

RED, on unmodified `origin/beta` at 4f24064, at the customer-visible boundary —
the picker payload and the write guard, given a manifest shaped like core
2026.9.3's (Astra listed first, `gpt-5.4` suppressed on `chatgpt.com`):

```
 FAIL  src/tests/routes/ai-models/red-astra-picker.test.ts > offers a model the installed core lists on the ChatGPT route
AssertionError: expected [ Array(7) ] to include 'gpt-6-astra'
 ❯ expect(body.models.map((m) => m.id)).toContain("gpt-6-astra");

 FAIL  src/tests/routes/ai-models/red-astra-picker.test.ts > drops a model the installed core retired from the ChatGPT route
AssertionError: expected [ Array(7) ] to not include 'gpt-5.4'
 ❯ expect(body.models.map((m) => m.id)).not.toContain("gpt-5.4");

 FAIL  src/tests/routes/ai-models/red-astra-picker.test.ts > lets the write guard accept the model the core routes here
AssertionError: expected false to be true
 ❯ expect(isCodexSupportedModelId("gpt-6-astra")).toBe(true);

 Test Files  1 failed (1)
      Tests  3 failed (3)
```

Those three assertions ship in this branch as `codex-picker-astra.test.ts`
(surface + guard) and in `catalog-codex-unwritable-cache.test.ts` (the payload
end of the chain), so the file above is scaffolding and is not part of the diff.

GREEN: the whole `unit` project — **804 files, 13,466 passed, 1 skipped, 1
failed**, and that one failure is `memory-index-local.test.ts > re-records a file
whose folder entry changed`, which fails IDENTICALLY on unmodified beta in the
same worktree (it indexes the developer machine's `/tmp` and picks up whatever is
there). The `ai-models` and `chat-model` route suites plus the codex ones on their
own: 31 files, 595 passed, 0 failed. Typecheck clean; `eslint` on every touched
file clean apart from two warnings that pre-exist on beta in `configure/route.ts`.
CI is the authority for the rest.

## On-box proof

Re-run on the office OpenClaw box at the FINAL head (`c1444259`, core 2026.8.1)
under the device mutex, in a throwaway git worktree beside the app checkout with
the app's `node_modules` symlinked. The running app, its config and the box's
HEAD were never touched: HEAD, branch, `git status`, the worktree list, both
systemd units and `agents.defaults.model` were read before and after and are
identical, the scratch worktree and the fetched ref are gone, and
`openclaw.json` still hashes the same.

**The branch's own suites, executed on the hardware** — 52 tests across
`codex-surface-follows-core`, `codex-picker-astra`, `core-model-lifecycle` and
`codex-supported-models`, all passing. `codex-surface-follows-core` is the one
that is vacuous in CI and real here: it reads the installed manifest and asserts
the derived list row by row against it.

**(A) The box's OWN installed core**, reading candidate #1 —
`/home/clawbox/.npm-global/lib/node_modules/openclaw/dist/extensions/openai/openclaw.plugin.json`,
the file the app itself will read, not a fixture:

```
A_SOURCE=core
A_IDS=["gpt-5.6-sol","gpt-5.6-terra","gpt-5.6-luna","gpt-5.5","gpt-5.4","gpt-5.4-mini","gpt-5.3-codex-spark"]
A_LABELS=["GPT-5.6 Sol","GPT-5.6 Terra","GPT-5.6 Luna","GPT-5.5","GPT-5.4","GPT-5.4 Mini","GPT-5.3 Spark"]
A_DEFAULT=gpt-5.5
A_CANDIDATES=["gpt-5.6-sol","gpt-5.6-terra","gpt-5.6-luna"]
A_GUARD_gpt-5.5=true   A_GUARD_gpt-6-astra=false   A_GUARD_gpt-5.4-nano=false
```

`source=core`, so the derivation really ran rather than falling back. The seven
ids, their order and their labels are byte-identical to what that box's live
`/setup-api/ai-models/catalog?provider=codex` served before any of this
(measured through the owner session earlier in the day), and `A_CANDIDATES` is
exactly the `CODEX_MODEL_PREFERENCE` list it replaces. **No box in a customer's
hands sees any change on this core** — which is the safety claim this PR most
needs, and it is measured rather than argued.

**(B) The REAL core 2026.9.3 manifest**, on the same box, same code — pulled from
the public npm tarball (`sha256` prefix `3587126e05f1ebf7`), placed under a
throwaway `OPENCLAW_HOME` and deleted afterwards, with the bundled candidate
dropped so that file is the only manifest there is:

```
B_CANDIDATES_READ=["/tmp/astra-93/extensions/openai/openclaw.plugin.json"]
B_SOURCE=core
B_IDS=["gpt-6-astra","gpt-5.6-sol","gpt-5.6-terra","gpt-5.6-luna","gpt-5.5","gpt-5.3-codex-spark"]
B_LABELS=["GPT-6 Astra","GPT-5.6 Sol","GPT-5.6 Terra","GPT-5.6 Luna","GPT-5.5","GPT-5.3 Spark"]
B_DEFAULT=gpt-5.5
B_CANDIDATES=["gpt-6-astra","gpt-5.6-sol","gpt-5.6-terra"]
B_GUARD_gpt-6-astra=true   B_GUARD_gpt-5.4=false   B_GUARD_gpt-5.4-mini=false   B_GUARD_spark=true
B_SENTENCE_HAS_ASTRA=true
```

Astra first and labelled from the core's own `name`, the two rows that core
retired from this route gone, Spark kept, the write guard in step with the
picker, the refusal sentence naming Astra by itself, the floor still `gpt-5.5`,
and the probe now able to reach Astra — capped at the three attempts its 15s/6s
budget affords. That is the upgrade plan's acceptance criterion for this picker,
measured on hardware.

A first attempt at (B) is worth recording because it FAILED and the failure was
the measurement's, not the code's: without dropping the bundled candidate, the
box's own 2026.8.1 manifest still won and the case silently re-measured (A). The
run above prints the candidate list it actually read, so that cannot pass
unnoticed again.

The hand-typed fixtures in `codex-picker-astra.test.ts` were checked against both
real files and match them row for row.

## Sibling call sites

* `isCodexSupportedModelId` — the write guard in `chat/model` and the catalog
  route's offerability entry both follow the one surface, by construction.
* `chatgptSupportedModelsSentence` — the refusal now names a model the core
  added by itself.
* `CHATGPT_DEFAULT_MODEL_ID` — both request-path writers (`configure`'s
  subscription branch, `chat/model`'s `defaultModelForProvider` and its
  legacy-profile row) now go through `chatgptDefaultModelId()`. The constant
  survives only as the floor inside that function and as the module-level
  `PROVIDERS` seed, which the subscription branch overwrites before it is used.
* `CODEX_MODEL_PREFERENCE` — still the probe's default argument, so nothing else
  changes; `configure` passes `chatgptUpgradeCandidates()`.
* `_CODEX_SUPPORTED` in `scripts/gateway-pre-start.sh` — explicitly left as a
  mirror of the FALLBACK, with the reason in the script: its only consumer is
  the OpenClaw 1 branch, and an OpenClaw 1 box's core predates every model the
  derivation would add.
* Pinned tests updated: `codex-supported-models`, `codex-surface-follows-core`
  (its installed-core case now proves the derivation end to end),
  `gateway-pre-start-codex-models` (neutralised to the fallback, so it keeps
  pinning the mirror rather than the machine it runs on).
* `chatgptSurfaceModelIds()` was removed rather than left unused; no caller
  remained.
* `coreManifestPaths` now also runs from a write guard, so a non-string binary
  no longer throws a 500 over a model refusal; `chatgptSurface()` fails open to
  the curated list on any throw, and the route object is frozen before it is
  cached so a caller cannot corrupt it for every other reader.

## Unproven

**A live turn on `gpt-6-astra` through the ChatGPT route on this box.** It is not
possible on core 2026.8.1, and the reason is stronger than the routing story
#809 told: `gpt-6-astra` appears **nowhere in that core's `dist/`**, and its
`OPENAI_CHATGPT_MODERN_MODEL_IDS` is
`["gpt-5.6-sol","gpt-5.6-terra","gpt-5.6-luna","gpt-5.5","gpt-5.5-pro","gpt-5.4","gpt-5.4-pro","gpt-5.4-mini","gpt-5.3-codex-spark"]`
— the installed core has no notion of the model at all. Offering it on this core
would be a row that cannot run, so the fix is deliberately the mechanism: Astra
reaches the picker, the guards and the refusal sentence the moment the core
upgrade lands, with no ClawBox release. A measured message was therefore NOT
sent: it could only have reproduced yesterday's `api.openai.com` result and would
have mutated the owner's model selection for no new information.

Two further reasons it would prove nothing about THIS change, recorded so the gap
is not mistaken for laziness: the box's app checkout is currently on another
branch entirely (another agent's deploy), so a live turn would exercise that
build and not this one; and the picker is decided by a manifest read, which the
suites above execute against the real file on the same hardware. What a message
would add is a fact about the box's credential routing, which is the separate
defect below.

That the ChatGPT backend does serve Astra to a subscription account is evidenced
by OpenAI's own Codex CLI, signed in to the same subscription and reading the
same endpoint, listing `gpt-6-astra` and answering with it — and by 2026.9.3
filing it as a dual-route model and listing it first.

**The box's OpenAI route sending every model to `api.openai.com`** (Astra and the
owner's `gpt-5.5` alike) on the inline `models.providers.openai.apiKey`, measured
yesterday: a separate defect on that box, filed rather than fixed here. Its shape
is confirmed on the box today — an `openai:chatgpt` OAuth profile coexisting with
`models.providers.openai.apiKey` set.

## Review

Reviewed via the `clawbox-review` skill, not `/code-review`: 0 critical,
3 high, 6 medium, 5 low, 3 nits, against the whole `origin/beta...HEAD` range and
with the installed core's `dist/` read for the suppression matcher. It found a
real regression this PR had introduced; the fixes are in `ceb83bfd`.

CodeRabbit then found two more on that head, both real and both mine, fixed in
`c1444259`:

* **A suppression carrying BOTH `when.baseUrlHosts` and `when.providerConfigApiIn`
  was read as a host-only claim** — the inverse half of the same AND rule. Since
  the core cannot satisfy the api condition on a box this repo configures, such an
  entry does not fire there at all, so removing the row here was a false failure.
  An entry carrying that condition is now skipped whole; a host-only entry beside
  it is still judged on its own. Two tests pin both directions.
* **`higherPriorityManifestAppeared` remembered the cached file's index** instead
  of re-deriving it. The candidate LIST grows — `findOpenclawBin()` answers a bare
  name where no core is installed and the bundled candidate is omitted entirely —
  so an install completing under a live server moves the cached file from index 0
  to index 1, and a remembered 0 meant "nothing better exists" for the life of the
  process: the probe-once shape this guard was added to close, reintroduced by the
  guard itself. The stored field is gone. The regression test was checked both
  ways — it fails against the remembered-index version and passes against this one.

A third CodeRabbit thread re-raised the empty-result fallback and is refuted
in-thread on the same measurement as before.

**Applied**

* **The entitlement probe switched itself off (HIGH).** With `gpt-5.5` off the
  route, the cold-start default was the surface's FIRST row — the newest, most
  likely plan-gated model — and `chatgptUpgradeCandidates()` measured "ahead of"
  it as nothing, so the probe got an empty list and returned null. A Free account
  would have been pinned to a row that 400s on every turn, with the probe silent
  in exactly the case this change was built for. The fallback floor is now the
  oldest row the core still routes there.
* **`when.providerConfigApiIn` was misread (MEDIUM).** The core ANDs its
  conditions rather than ORing them, and resolves that one against the OWNER'S
  `models.providers.<id>.api`, which this repo never writes — so such a
  suppression never fires in the core at all, and honouring it here dropped a row
  the box can still run. The condition is no longer read, with the measurement in
  the code; the test that pinned the wrong behaviour now pins the right one.
* **Case folding was half-done (MEDIUM).** Provider and hosts were folded, model
  ids were not, while the core keys suppressions by
  `normalizeProviderId + "::" + normalizeLowercaseStringOrEmpty(modelId)`. A
  manifest listing `GPT-5.4` while suppressing `gpt-5.4` left a dead row in the
  picker and in the write guard. The test titled "…or model is spelled in another
  case" never varied the model id; it does now.
* **The seed is the core's PLATFORM provider block (HIGH, partly).** It is a
  ChatGPT-route list only because today's manifest carries nothing else. The
  catalogue route already refuses a non-chat SKU on the payload side; the write
  guard — the only gate before `agents.defaults.model.primary` — had no such
  filter, so an image, embedding, realtime or transcription id a later core lists
  there could have been written. `isNonChatModelId` (this repo's own, already used
  by the catalogue route) now applies inside the surface, ahead of even a
  route-stated id.
* **The probe budget (MEDIUM).** 6 s per probe inside 15 s affords three attempts;
  an unbounded list made the fourth a silent truncation. The candidate list is
  capped at three with the budget named as the reason, and `codex-model-probe`'s
  stale docblocks now say the caller supplies the list.
* **`readKnownModelIds("openai")` (LOW).** A box that saved a model the installed
  core added was told it is "in no model list this box has for openai. Chat turns
  on it will fail" — over a model the same box had just declared runnable. The
  surface is folded into that answer.
* **Two comments that said the opposite of the code (LOW/NIT).** The setup wizard
  falls back to the model id for an empty hint rather than rendering no hint line;
  `Object.freeze` does not reach inside a Set, so `offRoute` is protected by its
  `ReadonlySet` type and the note says so. One leftover substring-shaped host test
  in `codex-surface-follows-core.test.ts` is now set membership like its sibling.

**Refuted, with the reason recorded**

* **The unfiltered last-resort list (HIGH).** Same ground as the CodeRabbit thread
  below: with the widening pass in place the filtered alternative is provably
  empty there, and an empty surface makes `isCodexSupportedModelId` refuse every
  model while naming none and hands `configure` a default its own guard refuses.
  Carrying the suppression's `reason` through so that corner could refuse
  *honestly* is the better answer and is a follow-up, not this PR.
* **A negative cache for an absent manifest (LOW).** The review is right that
  `isCodexSupportedModelId` now re-walks the candidates per row on a box with no
  readable manifest. It was implemented and then reverted:
  `core-model-lifecycle.test.ts > does not remember having found no manifest at
  all` pins that a manifest written moments later is seen at once — "there is no
  core yet" and "there is nothing retired" are different answers — and trading
  that for a few `existsSync` is the wrong way round. Changing it means changing
  that documented guarantee, in its own PR.
* **The harness gap is overstated (MEDIUM) — claim corrected, design kept.** The
  review is right: the core's `openai` catalog hook builds the LIVE per-account
  Codex list whenever the resolved auth profile is `oauth`/`token`, and the auth
  order that decides which profile resolves is a knob this repo already writes
  (`applyOpenAiAuthOrder`). The docblock's "nothing publishes it in a form ClawBox
  can ask for" was a narrower fact — measured on a dual-auth box where the API key
  won — stated as a general one, and under the harness-first rule that is exactly
  the sentence that must not stand. It now names the mechanism and gives the real
  reasons for reading the manifest instead: that enumeration is a `models list`
  spawn (~3 min on a Jetson) and this surface is read synchronously by two write
  guards on a request path, and its answer depends on the box's credential order,
  so a picker built from it would change contents when a customer adds or removes
  an API key. The design is unchanged; the justification is now true.
* **`PLATFORM_ONLY_ALIASES` / `OFF_SURFACE_SUFFIXES` are unpinned (MEDIUM).**
  Accepted: both are narrowings with measurements in the code, both can only
  REMOVE a row, and pinning them would mean reading a core internal this PR
  deliberately does not import.
* **`source` is unobservable (MEDIUM).** It is read — by the tests, as the
  assertion that the derivation ran rather than the fallback. A log line would
  need transition state to avoid firing on every request and guard call.
* **The `routeStated` bypass of the `-pro` rule (LOW).** Deliberate and
  documented: an `api.openai.com` suppression is the core stating that the
  platform route cannot reach the model, which is newer and more specific evidence
  than a rule made from the shape of a name. The non-chat filter above now sits
  ahead of it, which was the real hole.

Full findings: the review wrote them to a file; the four load-bearing upstream
facts it verified (the `discovery: runtime` declaration, the AND-not-OR matcher,
the owner-config resolution of `providerConfigApiIn`, and the merge key's case
folding) are quoted in the code at the places that depend on them.

One CodeRabbit finding, refuted in-thread with a measurement and partly applied:
it asked for the empty-result fallback to be filtered through the route
suppressions. Because the widening pass rejects every curated id before that
branch can be reached, the filtered list is provably empty there — measured, 7
curated rows in, 0 out — and an empty surface is the one shape this module must
not produce (the guard would refuse every model naming none, and the cold-start
default would be a model that same guard refuses, so a ChatGPT sign-in could not
complete). What the finding was right about is that the comment did not argue the
case; it now does, and
`codex-picker-astra.test.ts > keeps a last-resort list rather than emptying the
picker` pins both the list and the invariant that setup can still finish.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - ChatGPT and Codex model choices now reflect the currently available model catalog.
  - Model lists automatically recognize newly supported models and filter retired, unsupported, platform-only, or unavailable options.
  - Default models and upgrade recommendations now adapt to the available catalog, with safe curated fallbacks when catalog data is unavailable.
  - Subscription-only and provider-specific model availability is handled more accurately.

- **Documentation**
  - Updated model availability and fallback guidance to reflect dynamic catalog behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

