### PR TITLE
fix: WhatsApp "Link your phone" could not start the bridge on an OpenClaw box

### DIFF
--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -5181,7 +5181,12 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                                       Hermes cannot find its Baileys script,
                                       OpenClaw has no web-login provider and
                                       could not install one. Mapping only the
-                                      first left the second saying nothing. */}
+                                      first left the second saying nothing.
+                                      Hermes' `prepare_failed` stays on the
+                                      generic tail on purpose — "something went
+                                      wrong while starting the bridge" is
+                                      precisely what it means — and so does
+                                      `start_failed`. */}
                                   {waPair.error === "bridge_missing" || waPair.error === "plugin_missing"
                                     ? t("settings.whatsappPairErrBridge")
                                     : waPair.error === "install_failed"

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -5177,7 +5177,12 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                               <div role="alert" className="mt-3 rounded-xl border border-red-500/25 bg-red-500/[0.06] px-4 py-3">
                                 <div className="text-sm text-red-200 font-medium">{t("settings.whatsappPairFailedTitle")}</div>
                                 <p className="text-xs text-[var(--text-secondary)] mt-1 leading-relaxed">
-                                  {waPair.error === "bridge_missing"
+                                  {/* Two harnesses, two words for one thing:
+                                      Hermes cannot find its Baileys script,
+                                      OpenClaw has no web-login provider and
+                                      could not install one. Mapping only the
+                                      first left the second saying nothing. */}
+                                  {waPair.error === "bridge_missing" || waPair.error === "plugin_missing"
                                     ? t("settings.whatsappPairErrBridge")
                                     : waPair.error === "install_failed"
                                       ? t("settings.whatsappPairErrInstall")

--- a/src/lib/openclaw-channels.ts
+++ b/src/lib/openclaw-channels.ts
@@ -49,31 +49,50 @@ import { clearPluginRepair } from "@/lib/plugin-repair";
  * and a channel ClawBox has no UI for has no business being installed by it.
  * `unsupported_channel` for anything else is the honest answer.
  *
- * THE SPECS ARE UNPINNED ON PURPOSE, and that is load-bearing rather than
- * merely tidy — measured read-only against the pinned core (2026.8.1) and the
- * registry, because the pairing path can now reach this install on a box whose
- * `latest` is ahead of its host:
+ * THE SPECS ARE UNPINNED, and what protects the box is the NPM install path's
+ * own version walk — which only an unpinned spec can reach. Measured read-only
+ * against the pinned core (2026.8.1) and the registry, because the pairing path
+ * can now reach this install on a box whose `latest` is ahead of its host:
  *
  *   * the installer validates the resolved package's `openclaw.compat.pluginApi`
  *     and `openclaw.install.minHostVersion` against the running host, and
- *   * when that fails it WALKS BACK — `resolveLatestCompatibleNpmResolution`
- *     tries older stable versions and installs "the newest compatible" one —
- *     but ONLY for a spec with no version selector, or the tag `latest`
+ *   * when that fails, `resolveLatestCompatibleNpmResolution` walks older stable
+ *     versions and installs "the newest compatible" one — but ONLY for a spec
+ *     with no version selector, or the tag `latest`
  *     (`shouldResolveLatestCompatibleNpmVersion`).
  *
- * So a version pinned here would not make the install safer; it would DISABLE
- * the core's own compatible-version resolution and turn a mismatch into a hard
- * refusal. Measured: `@openclaw/whatsapp@latest` is 2026.9.3 and wants
- * `pluginApi >=2026.9.3`, so a 2026.8.1 box walks past 2026.8.2 (>=2026.8.2) to
- * 2026.8.1 — exactly the version that core's own bundled
- * `dist/channel-catalog.json` names for it. A pin would also go stale the first
- * time the device updates openclaw.
+ * Measured end to end: `@openclaw/whatsapp@latest` is 2026.9.3 and declares
+ * `compat.pluginApi >=2026.9.3`, so a 2026.8.1 box walks past 2026.9.2
+ * (>=2026.9.2) and 2026.8.2 (>=2026.8.2) to 2026.8.1 — exactly the version that
+ * core's own bundled `dist/channel-catalog.json` names for it. Four stable
+ * versions sit above 2026.8.1, so the walk is three registry reads.
  *
- * `clawbox_managed_plugin_spec` in `scripts/gateway-pre-start.sh` pins the same
- * packages for its own reasons — a repair ROW is replayed long after it is
- * written — which is a separate decision about a different question, not this
- * one restated. `gateway-pre-start-managed-plugin-payload.test.ts` holds the
- * values here to the bare `@openclaw/<id>` form.
+ * WHY THE DEEPSEEK OUTAGE IS NOT A COUNTER-EXAMPLE, since it looks like one and
+ * is the reason this note is long. There, an unpinned spec resolved a build
+ * declaring `pluginApi >=2026.8.2`, the 2026.8.1 runtime refused it and every
+ * fresh install parked at a gateway that never reported ready — so that spec is
+ * now pinned (`DEEPSEEK_PROVIDER_PLUGIN_SPEC`). But it is a `clawhub:` spec, and
+ * the walk above is in the core's NPM installer: the ClawHub path validates the
+ * same compatibility and fails closed with no walk at all
+ * (`buildClawHubInstallFailure`, `INCOMPATIBLE_PLUGIN_API` — the exact sentence
+ * that incident recorded). npm specs walk back; `clawhub:` specs do not. That is
+ * the whole difference between the two policies.
+ *
+ * THE OTHER TWO PATHS THAT INSTALL THESE SAME PACKAGES, so the division of
+ * labour is on the record rather than inferred:
+ *   * `reinstallManagedPluginPayload` (`src/lib/updater.ts`) installs
+ *     `<pkg>@<core target>` FIRST and falls back to the unpinned spec, because a
+ *     republished release (2026.7.1 -> 2026.7.1-2) 404s on a pin carrying the
+ *     base version. Pinned-first is about finding a payload at all; the unpinned
+ *     fallback is the same safety net as here.
+ *   * `clawbox_managed_plugin_spec` (`scripts/gateway-pre-start.sh`) pins,
+ *     because its spec is also recorded in a repair ROW and replayed long after
+ *     it is written, where "newest compatible" is a question about a different
+ *     box than the one that wrote it.
+ * Neither contradicts this: a pin here would remove the walk from the one path
+ * that is entered by the owner pressing a button, with nothing else behind it.
+ * `gateway-pre-start-managed-plugin-payload.test.ts` holds the values here to
+ * the bare `@openclaw/<id>` form.
  */
 export const OFFICIAL_CHANNEL_PLUGINS: Readonly<Record<string, string>> = Object.freeze({
   discord: "@openclaw/discord",

--- a/src/lib/openclaw-channels.ts
+++ b/src/lib/openclaw-channels.ts
@@ -49,11 +49,31 @@ import { clearPluginRepair } from "@/lib/plugin-repair";
  * and a channel ClawBox has no UI for has no business being installed by it.
  * `unsupported_channel` for anything else is the honest answer.
  *
- * The specs are unpinned on purpose. npm resolves `latest`, which is published
- * in lockstep with the host, and OpenClaw's installer then checks the plugin's
- * own `compat.pluginApi` against the running host and refuses a mismatch — a
- * refusal this module reports rather than swallows. A version pinned here would
- * go stale the first time the device updates openclaw.
+ * THE SPECS ARE UNPINNED ON PURPOSE, and that is load-bearing rather than
+ * merely tidy — measured read-only against the pinned core (2026.8.1) and the
+ * registry, because the pairing path can now reach this install on a box whose
+ * `latest` is ahead of its host:
+ *
+ *   * the installer validates the resolved package's `openclaw.compat.pluginApi`
+ *     and `openclaw.install.minHostVersion` against the running host, and
+ *   * when that fails it WALKS BACK — `resolveLatestCompatibleNpmResolution`
+ *     tries older stable versions and installs "the newest compatible" one —
+ *     but ONLY for a spec with no version selector, or the tag `latest`
+ *     (`shouldResolveLatestCompatibleNpmVersion`).
+ *
+ * So a version pinned here would not make the install safer; it would DISABLE
+ * the core's own compatible-version resolution and turn a mismatch into a hard
+ * refusal. Measured: `@openclaw/whatsapp@latest` is 2026.9.3 and wants
+ * `pluginApi >=2026.9.3`, so a 2026.8.1 box walks past 2026.8.2 (>=2026.8.2) to
+ * 2026.8.1 — exactly the version that core's own bundled
+ * `dist/channel-catalog.json` names for it. A pin would also go stale the first
+ * time the device updates openclaw.
+ *
+ * `clawbox_managed_plugin_spec` in `scripts/gateway-pre-start.sh` pins the same
+ * packages for its own reasons — a repair ROW is replayed long after it is
+ * written — which is a separate decision about a different question, not this
+ * one restated. `gateway-pre-start-managed-plugin-payload.test.ts` holds the
+ * values here to the bare `@openclaw/<id>` form.
  */
 export const OFFICIAL_CHANNEL_PLUGINS: Readonly<Record<string, string>> = Object.freeze({
   discord: "@openclaw/discord",

--- a/src/lib/openclaw-whatsapp.ts
+++ b/src/lib/openclaw-whatsapp.ts
@@ -95,6 +95,26 @@ const RPC_HEADROOM_MS = 5_000;
 const GATEWAY_CATCHUP_ATTEMPTS = 3;
 const GATEWAY_CATCHUP_GAP_MS = 5_000;
 
+/**
+ * How long a repair that was refused may answer for the box.
+ *
+ * The refusal is real and worth remembering — it is what stops Retry bouncing
+ * the gateway once per press — but it is a MEASUREMENT of a box that people
+ * change: a compatible plugin installed by hand, a core the box has since been
+ * given. The gateway then still needs the reload only this remedy performs, so
+ * a verdict kept for the life of the web server is a box that can never be
+ * repaired from its own panel, and "a capability probed once and treated as
+ * fact for the process lifetime" is the exact shape this codebase keeps
+ * producing.
+ *
+ * Long enough that a flurry of presses, or a second panel, costs one repair;
+ * short enough that an owner who has just fixed the box by hand gets the remedy
+ * on their next press rather than after a restart of the web server. The window
+ * runs from the refusal and is never extended by a press it suppressed, or
+ * pressing Retry often enough would make it permanent again.
+ */
+const REPAIR_REFUSAL_TTL_MS = 10 * 60_000;
+
 /** What the repair answers: a code to report, or what it managed to do. */
 type RepairOutcome =
   | { ok: false; error: WhatsappPairErrorCode }
@@ -281,12 +301,16 @@ export class OpenclawWhatsappPairing {
   /** The plugin install in flight, shared by every start that is waiting on it. */
   private repairing: Promise<RepairOutcome> | null = null;
   /**
-   * The repair has already run in this process and the gateway still refuses.
+   * When the repair last ran, reloaded the gateway, and was still refused.
    *
-   * Latched so that Retry answers from what we know instead of reinstalling and
-   * restarting the device again; cleared the moment a login actually starts.
+   * A TIME, not a flag, and the difference is the whole point: this is what was
+   * MEASURED a moment ago, never a fact about the box. It keeps Retry from
+   * reinstalling and bouncing the device once per press while the answer is
+   * fresh; past {@link REPAIR_REFUSAL_TTL_MS} the box may have been changed
+   * under us and the press is owed a real attempt. Cleared outright the moment
+   * a login actually starts.
    */
-  private providerMissingAfterRepair = false;
+  private repairRefusedAt: number | null = null;
   private readonly now: () => number;
 
   constructor(deps: { now?: () => number } = {}) {
@@ -334,14 +358,14 @@ export class OpenclawWhatsappPairing {
       } catch (err) {
         if (!isProviderMissing(err)) throw err;
         if (epoch !== this.epoch) return this.peek();
-        // Already installed and reloaded once here, and the gateway still has
-        // no provider: a second npm install and a second gateway bounce cannot
-        // change that. Without this latch the red box's own Retry button
-        // restarts the whole device on every press — Telegram, the agent and
-        // every open session with it — for a failure that is now a fact about
-        // the box. `restartGateway` clears the unit's start-limit before each
-        // restart, so nothing else would stop that loop either.
-        if (this.providerMissingAfterRepair) {
+        // Installed and reloaded moments ago, and the gateway still has no
+        // provider: a second npm install and a second gateway bounce cannot
+        // change that inside the window. Without this the red box's own Retry
+        // button restarts the whole device on every press — Telegram, the agent
+        // and every open session with it — since `restartGateway` clears the
+        // unit's start-limit before each restart and nothing downstream would
+        // stop that loop either.
+        if (this.repairSuppressed()) {
           this.snap = { ...this.snap, phase: "error", error: "plugin_missing" };
           return this.peek();
         }
@@ -372,15 +396,15 @@ export class OpenclawWhatsappPairing {
       if (epoch !== this.epoch) return this.peek();
       // A login that started is proof the provider is there, whatever an
       // earlier attempt in this process concluded.
-      this.providerMissingAfterRepair = false;
+      this.repairRefusedAt = null;
       this.apply(result);
     } catch (err) {
       if (epoch !== this.epoch) return this.peek();
       const missing = isProviderMissing(err);
       // Refused again, after the plugin was installed and the gateway reloaded:
-      // this box genuinely has no WhatsApp bridge, and every later press should
-      // be told so without repeating the repair.
-      if (missing && repaired) this.providerMissingAfterRepair = true;
+      // this box has no WhatsApp bridge as it stands, and the presses that
+      // follow are answered from that rather than repeating the remedy.
+      if (missing && repaired) this.repairRefusedAt = this.now();
       this.snap = {
         ...this.snap,
         phase: "error",
@@ -398,6 +422,14 @@ export class OpenclawWhatsappPairing {
     this.clearTicking();
     this.snap = { ...IDLE };
     return this.peek();
+  }
+
+  /** Is the last refusal still recent enough to answer with? */
+  private repairSuppressed(): boolean {
+    return (
+      this.repairRefusedAt !== null &&
+      this.now() - this.repairRefusedAt < REPAIR_REFUSAL_TTL_MS
+    );
   }
 
   /** One `web.login.start`, with the budgets this module owes it. */
@@ -422,6 +454,15 @@ export class OpenclawWhatsappPairing {
   ): Promise<Record<string, unknown>> {
     const attempts = gatewayReady ? 1 : GATEWAY_CATCHUP_ATTEMPTS;
     for (let attempt = 1; ; attempt += 1) {
+      // Checked BEFORE every call, not only after one fails: this loop sleeps
+      // between attempts, and `stop()` or a newer `start()` lands inside that
+      // sleep. `web.login.start` is not a read — it stops the running channel to
+      // take the socket over, and with `force` it would tear down a login a
+      // later press has just begun — so waking up to issue one leaves a login
+      // running in the gateway that the cancelled session's keepalive is no
+      // longer there to reap. The caller discards a stale epoch before it reads
+      // this error, so it never reaches the panel.
+      if (epoch !== this.epoch) throw new Error("the pairing session was replaced");
       try {
         return await this.loginStart(force);
       } catch (err) {
@@ -448,8 +489,8 @@ export class OpenclawWhatsappPairing {
    * own bridge in `preparing`, by running the wizard's npm install itself; this
    * is that step for the harness whose installer is `openclaw plugins`.
    *
-   * Entered only from the gateway's refusal, and at most once per process (see
-   * `providerMissingAfterRepair`), so a healthy box pays nothing — not an extra
+   * Entered only from the gateway's refusal, and at most once per refusal
+   * window (see `repairRefusedAt`), so a healthy box pays nothing — not an extra
    * `plugins list`, and above all not a gateway restart, which would drop every
    * other channel mid-conversation.
    */

--- a/src/lib/openclaw-whatsapp.ts
+++ b/src/lib/openclaw-whatsapp.ts
@@ -294,6 +294,12 @@ export class OpenclawWhatsappPairing {
           this.snap = { ...this.snap, phase: "error", error: failure };
           return this.peek();
         }
+        // The caller has been blocked on this POST for the whole install, so
+        // the panel is demonstrably still open. Without this the first tick
+        // after an install longer than REAP_AFTER_MS reaps the login start() is
+        // about to return — the owner waits two minutes and gets the "Link your
+        // phone" button back, with no QR and nothing saying why.
+        this.lastPollAt = this.now();
         this.snap = { ...this.snap, phase: "starting" };
         result = await this.loginStart(opts.force === true);
       }

--- a/src/lib/openclaw-whatsapp.ts
+++ b/src/lib/openclaw-whatsapp.ts
@@ -79,6 +79,34 @@ const LOGIN_START_MS = 30_000;
 const RPC_HEADROOM_MS = 5_000;
 
 /**
+ * How many times `web.login.start` may be asked while the gateway is still
+ * coming back from the reload, and how long to leave between the attempts.
+ *
+ * `restartGateway` gives up on its readiness wait after its own budget and says
+ * so; a Jetson that has just spent three minutes on an npm install can take
+ * longer than that to bind. One immediate shot at a port nobody is listening on
+ * is not a verdict on the repair — it is a connection error reported to the
+ * owner as "something went wrong" over a plugin that is installed and about to
+ * work, and the Retry that follows succeeds. That is the false-failure shape.
+ *
+ * Only ever spent after a reload that said it had not finished: a refusal is an
+ * ANSWER and ends the loop at once, so a box with no plugin never waits here.
+ */
+const GATEWAY_CATCHUP_ATTEMPTS = 3;
+const GATEWAY_CATCHUP_GAP_MS = 5_000;
+
+/** What the repair answers: a code to report, or what it managed to do. */
+type RepairOutcome =
+  | { ok: false; error: WhatsappPairErrorCode }
+  | {
+      ok: true;
+      /** The gateway was actually bounced, so it has had a chance to load the plugin. */
+      reloaded: boolean;
+      /** It was bounced AND had finished binding when we stopped waiting. */
+      gatewayReady: boolean;
+    };
+
+/**
  * What this manager may put in `snapshot.error`.
  *
  * The panel maps each of these to a sentence, so the set is a contract rather
@@ -117,7 +145,7 @@ export interface OpenclawWhatsappSnapshot {
   user: { id: string | null; name: string | null } | null;
   gatewayRestartPending: boolean;
   /** Machine-readable reason, never a raw stack. */
-  error: string | null;
+  error: WhatsappPairErrorCode | null;
   startedAt: number | null;
 }
 
@@ -169,7 +197,16 @@ async function gatewayCall(
       "--timeout",
       String(timeoutMs),
     ],
-    { captureStdout: true, timeoutMs: RPC_SPAWN_TIMEOUT_MS },
+    {
+      captureStdout: true,
+      timeoutMs: RPC_SPAWN_TIMEOUT_MS,
+      // `spawnOpenclaw` names the process by `labelArgs ?? args` when it builds
+      // an error message, and `web.login.wait` carries `currentQrDataUrl` in its
+      // params. Without this, one spawn timeout writes live pairing material
+      // into the journal — which is exactly what /whatsapp/pair documents can
+      // never happen ("neither is ever logged").
+      labelArgs: ["gateway", "call", method, "--params", "<json>", "--json"],
+    },
   );
   const parsed: unknown = JSON.parse(out);
   if (!parsed || typeof parsed !== "object") {
@@ -242,7 +279,14 @@ export class OpenclawWhatsappPairing {
   private epoch = 0;
   private tickTimer: ReturnType<typeof setInterval> | null = null;
   /** The plugin install in flight, shared by every start that is waiting on it. */
-  private repairing: Promise<WhatsappPairErrorCode | null> | null = null;
+  private repairing: Promise<RepairOutcome> | null = null;
+  /**
+   * The repair has already run in this process and the gateway still refuses.
+   *
+   * Latched so that Retry answers from what we know instead of reinstalling and
+   * restarting the device again; cleared the moment a login actually starts.
+   */
+  private providerMissingAfterRepair = false;
   private readonly now: () => number;
 
   constructor(deps: { now?: () => number } = {}) {
@@ -271,12 +315,18 @@ export class OpenclawWhatsappPairing {
     this.lastPollAt = this.now();
     if (this.snap.phase === "paired" && !opts.force) return this.peek();
     if (this.snap.phase === "waiting" && !opts.force) return this.peek();
+    // A second panel pressing the button during an install would otherwise
+    // rewrite the phase back to `starting` — the first panel's poller then reads
+    // "Starting the bridge…" with minutes of npm still to run — and spend a
+    // whole `web.login.start` budget on a call certain to be refused.
+    if (this.snap.phase === "preparing" && !opts.force) return this.peek();
 
     this.epoch += 1;
     const epoch = this.epoch;
     this.snap = { ...IDLE, phase: "starting", startedAt: this.now() };
     this.ensureTicking();
 
+    let repaired = false;
     try {
       let result: Record<string, unknown>;
       try {
@@ -284,16 +334,32 @@ export class OpenclawWhatsappPairing {
       } catch (err) {
         if (!isProviderMissing(err)) throw err;
         if (epoch !== this.epoch) return this.peek();
+        // Already installed and reloaded once here, and the gateway still has
+        // no provider: a second npm install and a second gateway bounce cannot
+        // change that. Without this latch the red box's own Retry button
+        // restarts the whole device on every press — Telegram, the agent and
+        // every open session with it — for a failure that is now a fact about
+        // the box. `restartGateway` clears the unit's start-limit before each
+        // restart, so nothing else would stop that loop either.
+        if (this.providerMissingAfterRepair) {
+          this.snap = { ...this.snap, phase: "error", error: "plugin_missing" };
+          return this.peek();
+        }
         // The gateway named the one failure that has a remedy. Run it and ask
         // again, rather than handing the owner a red box over a plugin this
         // device can install for itself.
         this.snap = { ...this.snap, phase: "preparing" };
-        const failure = await this.repairWebLoginProvider();
+        const repair = await this.repairWebLoginProvider();
         if (epoch !== this.epoch) return this.peek();
-        if (failure) {
-          this.snap = { ...this.snap, phase: "error", error: failure };
+        if (!repair.ok) {
+          this.snap = { ...this.snap, phase: "error", error: repair.error };
           return this.peek();
         }
+        // Only a repair that actually bounced the gateway may latch a refusal
+        // below: one that skipped the reload has not given the plugin its
+        // chance, and answering `plugin_missing` for the rest of the process
+        // over that would be a verdict we never earned.
+        repaired = repair.reloaded;
         // The caller has been blocked on this POST for the whole install, so
         // the panel is demonstrably still open. Without this the first tick
         // after an install longer than REAP_AFTER_MS reaps the login start() is
@@ -301,18 +367,24 @@ export class OpenclawWhatsappPairing {
         // phone" button back, with no QR and nothing saying why.
         this.lastPollAt = this.now();
         this.snap = { ...this.snap, phase: "starting" };
-        result = await this.loginStart(opts.force === true);
+        result = await this.startAfterReload(opts.force === true, epoch, repair.gatewayReady);
       }
       if (epoch !== this.epoch) return this.peek();
+      // A login that started is proof the provider is there, whatever an
+      // earlier attempt in this process concluded.
+      this.providerMissingAfterRepair = false;
       this.apply(result);
     } catch (err) {
       if (epoch !== this.epoch) return this.peek();
+      const missing = isProviderMissing(err);
+      // Refused again, after the plugin was installed and the gateway reloaded:
+      // this box genuinely has no WhatsApp bridge, and every later press should
+      // be told so without repeating the repair.
+      if (missing && repaired) this.providerMissingAfterRepair = true;
       this.snap = {
         ...this.snap,
         phase: "error",
-        // Refused again, after the plugin was installed and the gateway
-        // reloaded: this box genuinely has no WhatsApp bridge.
-        error: isProviderMissing(err) ? "plugin_missing" : "start_failed",
+        error: missing ? "plugin_missing" : "start_failed",
       };
       console.error("[openclaw-whatsapp] login start failed:", err);
     }
@@ -338,6 +410,31 @@ export class OpenclawWhatsappPairing {
   }
 
   /**
+   * `web.login.start`, allowing for a gateway that is still coming back.
+   *
+   * A refusal ends the loop immediately: that is the gateway ANSWERING, and no
+   * amount of waiting turns a missing provider into a present one.
+   */
+  private async startAfterReload(
+    force: boolean,
+    epoch: number,
+    gatewayReady: boolean,
+  ): Promise<Record<string, unknown>> {
+    const attempts = gatewayReady ? 1 : GATEWAY_CATCHUP_ATTEMPTS;
+    for (let attempt = 1; ; attempt += 1) {
+      try {
+        return await this.loginStart(force);
+      } catch (err) {
+        if (attempt >= attempts || isProviderMissing(err) || epoch !== this.epoch) throw err;
+        console.warn(
+          "[openclaw-whatsapp] the gateway has not finished coming back; asking again",
+        );
+        await new Promise((resolve) => setTimeout(resolve, GATEWAY_CATCHUP_GAP_MS));
+      }
+    }
+  }
+
+  /**
    * Put the WhatsApp plugin in service, on the gateway's own say-so.
    *
    * WHY THIS LIVES ON THE PAIRING PATH. `@openclaw/whatsapp` is an npm plugin
@@ -351,13 +448,12 @@ export class OpenclawWhatsappPairing {
    * own bridge in `preparing`, by running the wizard's npm install itself; this
    * is that step for the harness whose installer is `openclaw plugins`.
    *
-   * Entered only from the gateway's refusal, so a healthy box pays nothing —
-   * not an extra `plugins list`, and above all not a gateway restart, which
-   * would drop every other channel mid-conversation.
-   *
-   * Answers with the code to report, or null when the retry is worth making.
+   * Entered only from the gateway's refusal, and at most once per process (see
+   * `providerMissingAfterRepair`), so a healthy box pays nothing — not an extra
+   * `plugins list`, and above all not a gateway restart, which would drop every
+   * other channel mid-conversation.
    */
-  private repairWebLoginProvider(): Promise<WhatsappPairErrorCode | null> {
+  private repairWebLoginProvider(): Promise<RepairOutcome> {
     // Two panels — or one reopened while the first install is still running —
     // must not both drive `plugins install` into the same plugin store. Whoever
     // arrives second waits for the first one's answer instead of starting a
@@ -368,7 +464,7 @@ export class OpenclawWhatsappPairing {
     return this.repairing;
   }
 
-  private async installAndLoadPlugin(): Promise<WhatsappPairErrorCode | null> {
+  private async installAndLoadPlugin(): Promise<RepairOutcome> {
     const plugin = await ensureChannelPlugin(WHATSAPP_CHANNEL_ID);
     if (!plugin.ok) {
       console.error(`[openclaw-whatsapp] installing the WhatsApp plugin failed: ${plugin.reason}`);
@@ -376,27 +472,41 @@ export class OpenclawWhatsappPairing {
       // true words for that one. `unsupported_channel` cannot happen for a
       // channel that is in OFFICIAL_CHANNEL_PLUGINS, and if it ever did it
       // would mean precisely that no plugin can be installed for it.
-      return plugin.reason === "unsupported_channel" ? "plugin_missing" : "install_failed";
+      return {
+        ok: false,
+        error: plugin.reason === "unsupported_channel" ? "plugin_missing" : "install_failed",
+      };
     }
+    // Nobody is pairing any more: the owner cancelled, or left the panel, and
+    // the DELETE that reaped the session cannot reach the install already in
+    // flight. The package is on disk, so the restart is not lost — it is what
+    // the next start pays, with someone watching. Bouncing the gateway now
+    // would drop the Telegram conversation the owner has gone back to, minutes
+    // after the pairing card they closed.
+    if (this.snap.phase !== "preparing" && this.snap.phase !== "starting") {
+      return { ok: true, reloaded: false, gatewayReady: false };
+    }
+    let gatewayReady = true;
     try {
       // Installed is not loaded: `plugins install` prints "Restart the gateway
       // to load plugins", and the gateway is what publishes web.login.*.
       await restartGateway();
     } catch (err) {
       // A gateway that took the restart but has not finished binding is
-      // starting, not broken — the retry is the probe that settles it, the same
-      // split /whatsapp/configure makes. Anything else is a restart that did
-      // not happen, and calling that a missing bridge would blame the plugin
-      // for a service failure.
+      // starting, not broken — the caller asks again while it comes up rather
+      // than calling a working repair a failure. Anything else is a restart
+      // that did not happen, and calling that a missing bridge would blame the
+      // plugin for a service failure.
       if (!(err instanceof GatewayNotReadyError)) {
         console.error("[openclaw-whatsapp] reloading the gateway after the plugin install failed:", err);
-        return "start_failed";
+        return { ok: false, error: "start_failed" };
       }
+      gatewayReady = false;
     }
     // The gateway now owns a channel it did not have, so a remembered row
     // describes the box as it was before this repair.
     invalidateChannelStatus(WHATSAPP_CHANNEL_ID);
-    return null;
+    return { ok: true, reloaded: true, gatewayReady };
   }
 
   /** Fold one RPC answer into the snapshot. */
@@ -459,6 +569,10 @@ export class OpenclawWhatsappPairing {
    */
   private async tick(): Promise<void> {
     if (this.waiting) return;
+    // `preparing` is deliberately outside the watchdog: there is no login to
+    // reap while npm runs, and the caller is still blocked on the POST that
+    // started it. The keepalive window restarts when the install ends, which is
+    // what stops the first tick afterwards from reaping a healthy login.
     if (this.snap.phase !== "waiting" && this.snap.phase !== "starting") return;
     if (this.now() - this.lastPollAt > REAP_AFTER_MS) {
       this.stop();

--- a/src/lib/openclaw-whatsapp.ts
+++ b/src/lib/openclaw-whatsapp.ts
@@ -464,6 +464,19 @@ export class OpenclawWhatsappPairing {
     return this.repairing;
   }
 
+  /**
+   * The repair itself: install, enable, reload — the half that touches the box.
+   *
+   * Split from `repairWebLoginProvider` so that the in-flight guard there wraps
+   * exactly one body, and never so that a caller can reach this directly: every
+   * entry has to go through that guard, or two panels drive `plugins install`
+   * into the same plugin store at once.
+   *
+   * Answers what it managed to do rather than a bare success, because the two
+   * facts have different consequences upstream — `reloaded: false` must never
+   * latch a `plugin_missing` verdict (the plugin was never given its chance),
+   * and `gatewayReady: false` is what buys the retry its catch-up attempts.
+   */
   private async installAndLoadPlugin(): Promise<RepairOutcome> {
     const plugin = await ensureChannelPlugin(WHATSAPP_CHANNEL_ID);
     if (!plugin.ok) {

--- a/src/lib/openclaw-whatsapp.ts
+++ b/src/lib/openclaw-whatsapp.ts
@@ -33,8 +33,17 @@
 // device credentials in the plugin's auth dir, not a bot token, so there is no
 // env-backed credential here and nothing for envSecretRef() to mint.
 
-import { runOpenclawConfigSet, spawnOpenclawCli } from "@/lib/openclaw-config";
-import { invalidateChannelStatus, readCachedChannelRowResult } from "@/lib/openclaw-channels";
+import {
+  GatewayNotReadyError,
+  restartGateway,
+  runOpenclawConfigSet,
+  spawnOpenclawCli,
+} from "@/lib/openclaw-config";
+import {
+  ensureChannelPlugin,
+  invalidateChannelStatus,
+  readCachedChannelRowResult,
+} from "@/lib/openclaw-channels";
 
 /** OpenClaw's id for this channel — the plugin's, the config key's, the CLI's. */
 export const WHATSAPP_CHANNEL_ID = "whatsapp";
@@ -68,6 +77,18 @@ const LOGIN_START_MS = 30_000;
  * window gets used up.
  */
 const RPC_HEADROOM_MS = 5_000;
+
+/**
+ * What this manager may put in `snapshot.error`.
+ *
+ * The panel maps each of these to a sentence, so the set is a contract rather
+ * than free text: `plugin_missing` shares its wording with the Hermes manager's
+ * `bridge_missing` ("no WhatsApp bridge on this ClawBox"), `install_failed` is
+ * the one that says to check the network, and `start_failed` is the generic
+ * tail. A code the panel does not know falls through to that tail, which is how
+ * `plugin_missing` used to reach the owner as "something went wrong".
+ */
+export type WhatsappPairErrorCode = "plugin_missing" | "install_failed" | "start_failed";
 
 /** Phases, identical to the Hermes pairing manager's — one panel renders both. */
 export type WhatsappPairPhase =
@@ -186,8 +207,13 @@ function readQrDataUrl(result: WebLoginResult): string | null {
 
 /**
  * "There is no WhatsApp login provider" — the gateway's answer when the plugin
- * is not loaded. Worth its own code: it is the one failure the owner fixes by
- * saving the channel again (which installs the plugin), not by rescanning.
+ * is not loaded, and the one failure on this path that has a remedy rather than
+ * a message. `respondProviderUnavailable` in the core's web-login RPC sends it
+ * whenever `resolveWebLoginProvider()` finds nothing, and appends its own
+ * install hint ONLY for a channel already present in `config.channels` — which
+ * a box that has never saved the channel is not, so what arrives is the bare
+ * sentence. Either way the fix is the same one OpenClaw would print: install
+ * the plugin and reload the gateway. See repairWebLoginProvider().
  */
 function isProviderMissing(err: unknown): boolean {
   return err instanceof Error && /login provider is not available/i.test(err.message);
@@ -215,6 +241,8 @@ export class OpenclawWhatsappPairing {
    */
   private epoch = 0;
   private tickTimer: ReturnType<typeof setInterval> | null = null;
+  /** The plugin install in flight, shared by every start that is waiting on it. */
+  private repairing: Promise<WhatsappPairErrorCode | null> | null = null;
   private readonly now: () => number;
 
   constructor(deps: { now?: () => number } = {}) {
@@ -250,11 +278,25 @@ export class OpenclawWhatsappPairing {
     this.ensureTicking();
 
     try {
-      const result = await gatewayCall(
-        "web.login.start",
-        { force: opts.force === true, timeoutMs: LOGIN_START_MS },
-        LOGIN_START_MS + RPC_HEADROOM_MS,
-      );
+      let result: Record<string, unknown>;
+      try {
+        result = await this.loginStart(opts.force === true);
+      } catch (err) {
+        if (!isProviderMissing(err)) throw err;
+        if (epoch !== this.epoch) return this.peek();
+        // The gateway named the one failure that has a remedy. Run it and ask
+        // again, rather than handing the owner a red box over a plugin this
+        // device can install for itself.
+        this.snap = { ...this.snap, phase: "preparing" };
+        const failure = await this.repairWebLoginProvider();
+        if (epoch !== this.epoch) return this.peek();
+        if (failure) {
+          this.snap = { ...this.snap, phase: "error", error: failure };
+          return this.peek();
+        }
+        this.snap = { ...this.snap, phase: "starting" };
+        result = await this.loginStart(opts.force === true);
+      }
       if (epoch !== this.epoch) return this.peek();
       this.apply(result);
     } catch (err) {
@@ -262,6 +304,8 @@ export class OpenclawWhatsappPairing {
       this.snap = {
         ...this.snap,
         phase: "error",
+        // Refused again, after the plugin was installed and the gateway
+        // reloaded: this box genuinely has no WhatsApp bridge.
         error: isProviderMissing(err) ? "plugin_missing" : "start_failed",
       };
       console.error("[openclaw-whatsapp] login start failed:", err);
@@ -276,6 +320,77 @@ export class OpenclawWhatsappPairing {
     this.clearTicking();
     this.snap = { ...IDLE };
     return this.peek();
+  }
+
+  /** One `web.login.start`, with the budgets this module owes it. */
+  private loginStart(force: boolean): Promise<Record<string, unknown>> {
+    return gatewayCall(
+      "web.login.start",
+      { force, timeoutMs: LOGIN_START_MS },
+      LOGIN_START_MS + RPC_HEADROOM_MS,
+    );
+  }
+
+  /**
+   * Put the WhatsApp plugin in service, on the gateway's own say-so.
+   *
+   * WHY THIS LIVES ON THE PAIRING PATH. `@openclaw/whatsapp` is an npm plugin
+   * OpenClaw's stock extensions do not carry, and the only thing that installed
+   * it was /whatsapp/configure — whose Enable toggle the panel keeps disabled
+   * until a phone is paired, because on Hermes enabling a channel with no
+   * creds.json is meaningless. On OpenClaw the order is the other way round, so
+   * the two rules met in the middle: pairing wanted the plugin, the plugin
+   * wanted the save, the save wanted a pairing, and "Link your phone" was the
+   * only button on the card. The Hermes manager closes exactly this gap for its
+   * own bridge in `preparing`, by running the wizard's npm install itself; this
+   * is that step for the harness whose installer is `openclaw plugins`.
+   *
+   * Entered only from the gateway's refusal, so a healthy box pays nothing —
+   * not an extra `plugins list`, and above all not a gateway restart, which
+   * would drop every other channel mid-conversation.
+   *
+   * Answers with the code to report, or null when the retry is worth making.
+   */
+  private repairWebLoginProvider(): Promise<WhatsappPairErrorCode | null> {
+    // Two panels — or one reopened while the first install is still running —
+    // must not both drive `plugins install` into the same plugin store. Whoever
+    // arrives second waits for the first one's answer instead of starting a
+    // second npm install over it.
+    this.repairing ??= this.installAndLoadPlugin().finally(() => {
+      this.repairing = null;
+    });
+    return this.repairing;
+  }
+
+  private async installAndLoadPlugin(): Promise<WhatsappPairErrorCode | null> {
+    const plugin = await ensureChannelPlugin(WHATSAPP_CHANNEL_ID);
+    if (!plugin.ok) {
+      console.error(`[openclaw-whatsapp] installing the WhatsApp plugin failed: ${plugin.reason}`);
+      // An npm install on a device is a download, and the panel already has the
+      // true words for that one. `unsupported_channel` cannot happen for a
+      // channel that is in OFFICIAL_CHANNEL_PLUGINS, and if it ever did it
+      // would mean precisely that no plugin can be installed for it.
+      return plugin.reason === "unsupported_channel" ? "plugin_missing" : "install_failed";
+    }
+    try {
+      // Installed is not loaded: `plugins install` prints "Restart the gateway
+      // to load plugins", and the gateway is what publishes web.login.*.
+      await restartGateway();
+    } catch (err) {
+      // A gateway that took the restart but has not finished binding is
+      // starting, not broken — the retry is the probe that settles it, the same
+      // split /whatsapp/configure makes. Anything else is a restart that did
+      // not happen, and calling that a missing bridge would blame the plugin
+      // for a service failure.
+      if (!(err instanceof GatewayNotReadyError)) {
+        console.error("[openclaw-whatsapp] reloading the gateway after the plugin install failed:", err);
+        return "start_failed";
+      }
+    }
+    // The gateway now owns a channel it did not have, so a remembered row
+    // describes the box as it was before this repair.
+    invalidateChannelStatus(WHATSAPP_CHANNEL_ID);
+    return null;
   }
 
   /** Fold one RPC answer into the snapshot. */

--- a/src/lib/openclaw-whatsapp.ts
+++ b/src/lib/openclaw-whatsapp.ts
@@ -100,20 +100,31 @@ const GATEWAY_CATCHUP_GAP_MS = 5_000;
  *
  * The refusal is real and worth remembering — it is what stops Retry bouncing
  * the gateway once per press — but it is a MEASUREMENT of a box that people
- * change: a compatible plugin installed by hand, a core the box has since been
- * given. The gateway then still needs the reload only this remedy performs, so
- * a verdict kept for the life of the web server is a box that can never be
- * repaired from its own panel, and "a capability probed once and treated as
+ * change, and a verdict kept for the life of the web server is a box that can
+ * never be repaired from its own panel: "a capability probed once and treated as
  * fact for the process lifetime" is the exact shape this codebase keeps
  * producing.
  *
- * Long enough that a flurry of presses, or a second panel, costs one repair;
- * short enough that an owner who has just fixed the box by hand gets the remedy
- * on their next press rather than after a restart of the web server. The window
- * runs from the refusal and is never extended by a press it suppressed, or
- * pressing Retry often enough would make it permanent again.
+ * BE PRECISE ABOUT WHAT THE WINDOW BUYS, because it is narrower than it looks.
+ * Every press already begins with a bare `web.login.start` before any remedy,
+ * and a login that starts clears this outright — so an owner who fixed the
+ * plugin by hand AND bounced the gateway is served on the next press with no
+ * window involved. The one case it unlocks is "the plugin on disk is now right
+ * and the gateway has not been reloaded since", where the reload is the only
+ * thing left to do and this remedy is the only thing on the box that does it
+ * from the panel.
+ *
+ * AND WHAT IT COSTS: on a box where the plugin genuinely cannot load, an owner
+ * who keeps pressing pays one gateway restart per window — every other channel
+ * and every open session dropped. Half an hour is the compromise: at most two of
+ * those an hour against a press-by-press bounce on one side and a box that can
+ * only be repaired by restarting the web server on the other.
+ *
+ * The window runs from the refusal and is deliberately not extended by a press
+ * it suppressed — a sliding window would make frequent pressing permanent again,
+ * which is the bug this replaced.
  */
-const REPAIR_REFUSAL_TTL_MS = 10 * 60_000;
+const REPAIR_REFUSAL_TTL_MS = 30 * 60_000;
 
 /** What the repair answers: a code to report, or what it managed to do. */
 type RepairOutcome =
@@ -311,6 +322,16 @@ export class OpenclawWhatsappPairing {
    * a login actually starts.
    */
   private repairRefusedAt: number | null = null;
+  /**
+   * `startAfterReload` is asking a gateway that has not finished coming back.
+   *
+   * Read by the keepalive, which would otherwise spend that whole window — up to
+   * ~115 s, entered precisely because the port is known not to answer — firing a
+   * `web.login.wait` every tick, each a 10-12 s CLI cold start certain to fail,
+   * competing for a Jetson that has just finished an npm install. The reap still
+   * runs: a panel that closed mid-catch-up must still end the session.
+   */
+  private catchingUp = false;
   private readonly now: () => number;
 
   constructor(deps: { now?: () => number } = {}) {
@@ -391,7 +412,12 @@ export class OpenclawWhatsappPairing {
         // phone" button back, with no QR and nothing saying why.
         this.lastPollAt = this.now();
         this.snap = { ...this.snap, phase: "starting" };
-        result = await this.startAfterReload(opts.force === true, epoch, repair.gatewayReady);
+        this.catchingUp = true;
+        try {
+          result = await this.startAfterReload(opts.force === true, epoch, repair.gatewayReady);
+        } finally {
+          this.catchingUp = false;
+        }
       }
       if (epoch !== this.epoch) return this.peek();
       // A login that started is proof the provider is there, whatever an
@@ -458,10 +484,14 @@ export class OpenclawWhatsappPairing {
       // between attempts, and `stop()` or a newer `start()` lands inside that
       // sleep. `web.login.start` is not a read — it stops the running channel to
       // take the socket over, and with `force` it would tear down a login a
-      // later press has just begun — so waking up to issue one leaves a login
-      // running in the gateway that the cancelled session's keepalive is no
-      // longer there to reap. The caller discards a stale epoch before it reads
-      // this error, so it never reaches the panel.
+      // later press has just begun — so waking up to issue one starts a login in
+      // the gateway AFTER the owner cancelled, with the answer discarded here
+      // and nothing on this side that will ever mention it again. Cancelling
+      // tells the gateway nothing (there is no `web.login.stop`: `stop()` drops
+      // local state and the plugin's own TTL is what ends an abandoned login, the
+      // one real difference from the Hermes path, which kills its bridge), so the
+      // only way not to leave one behind is not to start it. The caller discards
+      // a stale epoch before it reads this error, so it never reaches the panel.
       if (epoch !== this.epoch) throw new Error("the pairing session was replaced");
       try {
         return await this.loginStart(force);
@@ -493,6 +523,27 @@ export class OpenclawWhatsappPairing {
    * window (see `repairRefusedAt`), so a healthy box pays nothing — not an extra
    * `plugins list`, and above all not a gateway restart, which would drop every
    * other channel mid-conversation.
+   *
+   * AND IT DELIBERATELY DOES NOT WRITE `channels.whatsapp`, which is the obvious
+   * thing to suspect when this repair "did everything and the gateway still said
+   * no". Measured in the pinned core (2026.8.1) so nobody has to suspect it
+   * again:
+   *
+   *     resolveWebLoginProvider = () => listChannelPlugins().find(p =>
+   *       [...p.gatewayMethods ?? [], ...(p.gatewayMethodDescriptors ?? [])
+   *         .map(d => d.name)].some(m => WEB_LOGIN_METHODS.has(m))) ?? null
+   *
+   * with `listChannelPlugins = () => listLoadedChannelPlugins()`. The question is
+   * "is a LOADED plugin publishing `web.login.*`" and nothing in it reads
+   * `config.channels`. So installing the plugin, writing `plugins.entries`, and
+   * reloading the gateway is exactly the remedy, and enabling the channel is
+   * still `/whatsapp/configure`'s job — the one the owner reaches after a phone
+   * is linked.
+   *
+   * The same measurement settles the sequence that looks worse: `/whatsapp/
+   * unpair` writes `channels.whatsapp.enabled = false`, and a re-link after it
+   * does NOT come back here — the plugin is still loaded, so the provider still
+   * resolves, there is no refusal, and this gateway restart never happens.
    */
   private repairWebLoginProvider(): Promise<RepairOutcome> {
     // Two panels — or one reopened while the first install is still running —
@@ -526,6 +577,14 @@ export class OpenclawWhatsappPairing {
       // true words for that one. `unsupported_channel` cannot happen for a
       // channel that is in OFFICIAL_CHANNEL_PLUGINS, and if it ever did it
       // would mean precisely that no plugin can be installed for it.
+      //
+      // `install_timeout` is folded in ON PURPOSE, unlike `/whatsapp/configure`,
+      // which keeps it apart as `plugin_install_timeout`: there the owner typed a
+      // save and can be told the download ran out of time, whereas the panel's
+      // one sentence here — "could not download what the bridge needs, check the
+      // network" — is already the right words for a download killed at its
+      // deadline, and a fourth code would need eleven new locale strings to say
+      // the same thing.
       return {
         ok: false,
         error: plugin.reason === "unsupported_channel" ? "plugin_missing" : "install_failed",
@@ -627,11 +686,24 @@ export class OpenclawWhatsappPairing {
     // reap while npm runs, and the caller is still blocked on the POST that
     // started it. The keepalive window restarts when the install ends, which is
     // what stops the first tick afterwards from reaping a healthy login.
-    if (this.snap.phase !== "waiting" && this.snap.phase !== "starting") return;
+    if (this.snap.phase !== "waiting" && this.snap.phase !== "starting") {
+      // `preparing` keeps the interval, because the phase goes back to
+      // `starting` when the install ends and the keepalive is what carries it
+      // from there. A TERMINAL phase does not: an `error` or `paired` snapshot
+      // would otherwise wake this every TICK_MS for the life of the web server
+      // only to return here, and on a box that cannot be repaired the error
+      // paths are now the expected outcome. A later `start()` re-arms it.
+      if (this.snap.phase !== "preparing") this.clearTicking();
+      return;
+    }
     if (this.now() - this.lastPollAt > REAP_AFTER_MS) {
       this.stop();
       return;
     }
+    // Deliberately after the reap and before the RPC: the catch-up loop already
+    // owns the conversation with a gateway that is not listening yet, and a
+    // second caller asking it the same question cannot help. See `catchingUp`.
+    if (this.catchingUp) return;
 
     this.waiting = true;
     const epoch = this.epoch;

--- a/src/tests/components/settings-whatsapp-pair-error.test.tsx
+++ b/src/tests/components/settings-whatsapp-pair-error.test.tsx
@@ -55,7 +55,7 @@ beforeEach(() => {
 
   vi.stubGlobal(
     "fetch",
-    vi.fn((input: string | URL, init?: RequestInit) => {
+    vi.fn((input: string | URL) => {
       const url = input.toString();
       if (url.startsWith("/setup-api/whatsapp/status")) {
         return json({
@@ -73,9 +73,11 @@ beforeEach(() => {
         });
       }
       if (url.startsWith("/setup-api/whatsapp/pair")) {
-        // Only the start; the poller's GET must not answer the same snapshot
-        // and re-render it as a second failure.
-        return init?.method === "POST" ? json(pairSnapshot) : json({ supported: true, phase: "idle" });
+        // The real GET calls poll(), which returns the SAME snapshot the POST
+        // answered with — the panel re-rendering the failure is the contract,
+        // not an artefact — so the fixture answers it too rather than an idle
+        // snapshot the route would never send.
+        return json(pairSnapshot);
       }
       return json({});
     }),

--- a/src/tests/components/settings-whatsapp-pair-error.test.tsx
+++ b/src/tests/components/settings-whatsapp-pair-error.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * What the WhatsApp pairing card says when the bridge will not start.
+ *
+ * The panel renders ONE snapshot for two harnesses, and each one has its own
+ * vocabulary for the same failure: the Hermes manager says `bridge_missing`
+ * when its Baileys script is absent, the OpenClaw one says `plugin_missing`
+ * when the gateway answers "web login provider is not available". Only the
+ * first was ever mapped, so on an OpenClaw box the one diagnosable failure
+ * fell through to "Something went wrong while starting the bridge." — a
+ * sentence that names nothing and offers nothing but the same button again.
+ */
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@/tests/helpers/test-utils";
+import SettingsApp, { type UISettings } from "@/components/SettingsApp";
+
+vi.mock("@/lib/i18n", () => ({
+  LANGUAGES: [{ code: "en", name: "English" }],
+  I18nProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useT: () => ({ t: (key: string) => key, locale: "en", setLocale: vi.fn() }),
+}));
+vi.mock("next/image", () => ({ default: () => null }));
+
+const ui: UISettings = {
+  wallpaperId: "default",
+  wpFit: "fill",
+  wpBgColor: "#000000",
+  wpOpacity: 100,
+  mascotHidden: false,
+  wallpapers: [{ id: "default", name: "Default" }],
+  customWallpapers: [],
+  onWallpaperChange: vi.fn(),
+  onWpFitChange: vi.fn(),
+  onWpBgColorChange: vi.fn(),
+  onWpOpacityChange: vi.fn(),
+  onMascotToggle: vi.fn(),
+  onWallpaperUpload: vi.fn(),
+  onCustomWallpaperDelete: vi.fn(),
+};
+
+/** The snapshot POST /setup-api/whatsapp/pair answers with this run. */
+let pairSnapshot: Record<string, unknown>;
+
+function json(body: unknown) {
+  return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body) } as Response);
+}
+
+beforeEach(() => {
+  // An OpenClaw box that has never had the channel saved: nothing paired, and
+  // "Link your phone" is the only thing on the card to press.
+  pairSnapshot = { supported: true, phase: "error", error: "plugin_missing", qrCount: 0, restarts: 0 };
+
+  (window as Window & { __clawboxPendingSettingsSection?: string }).__clawboxPendingSettingsSection =
+    "whatsapp";
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((input: string | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url.startsWith("/setup-api/whatsapp/status")) {
+        return json({
+          supported: true,
+          harness: "openclaw",
+          state: "not_configured",
+          enabled: false,
+          paired: false,
+          verified: true,
+          allowlistSupported: false,
+          mode: null,
+          allowedUsers: [],
+          allowAllUsers: false,
+          receiving: false,
+        });
+      }
+      if (url.startsWith("/setup-api/whatsapp/pair")) {
+        // Only the start; the poller's GET must not answer the same snapshot
+        // and re-render it as a second failure.
+        return init?.method === "POST" ? json(pairSnapshot) : json({ supported: true, phase: "idle" });
+      }
+      return json({});
+    }),
+  );
+});
+
+/** Press "Link your phone" and wait for the card to render the refusal. */
+async function pairAndReadError(): Promise<string> {
+  render(<SettingsApp ui={ui} />);
+  const start = await screen.findByTestId("whatsapp-pair-start");
+  start.click();
+  const alert = await screen.findByRole("alert");
+  await waitFor(() => expect(alert.textContent).toContain("settings.whatsappPairErr"));
+  return alert.textContent ?? "";
+}
+
+describe("the WhatsApp pairing card's error text", () => {
+  it("names the missing bridge when OpenClaw's gateway has no login provider", async () => {
+    expect(await pairAndReadError()).toContain("settings.whatsappPairErrBridge");
+  });
+
+  it("still names the missing bridge in the Hermes wording", async () => {
+    pairSnapshot = { supported: true, phase: "error", error: "bridge_missing" };
+    expect(await pairAndReadError()).toContain("settings.whatsappPairErrBridge");
+  });
+
+  it("keeps the install failure separate — that one is a network problem", async () => {
+    pairSnapshot = { supported: true, phase: "error", error: "install_failed" };
+    expect(await pairAndReadError()).toContain("settings.whatsappPairErrInstall");
+  });
+
+  it("falls back to the generic sentence only for a code it has no words for", async () => {
+    pairSnapshot = { supported: true, phase: "error", error: "start_failed" };
+    expect(await pairAndReadError()).toContain("settings.whatsappPairErrGeneric");
+  });
+});

--- a/src/tests/routes/whatsapp/pair.test.ts
+++ b/src/tests/routes/whatsapp/pair.test.ts
@@ -18,10 +18,13 @@ vi.mock("@/lib/openclaw-whatsapp", () => ({
   setOpenclawWhatsappEnabled: openclawSetEnabled,
 }));
 vi.mock("@/lib/openclaw-config", () => ({
-  // A REAL class, not undefined: `src/lib/openclaw-whatsapp.ts` narrows on
-  // `instanceof GatewayNotReadyError` when it reloads the gateway after
-  // installing the WhatsApp plugin, and `instanceof undefined` throws a
-  // TypeError the first time a test makes the mocked restart reject.
+  // Defensive, and required: `openclaw-config-mock-completeness.test.ts` fails
+  // any suite that replaces this module without the class while importing a
+  // module that narrows on `instanceof GatewayNotReadyError` — which
+  // `openclaw-whatsapp.ts` now does when it reloads the gateway after installing
+  // the plugin. This file mocks `openclaw-whatsapp` wholesale, so the narrowing
+  // never runs HERE; the class is what keeps that true of the file rather than
+  // of the mock, for the day a test stops mocking the module.
   GatewayNotReadyError: class GatewayNotReadyError extends Error {
     constructor(message = "gateway did not come back") {
       super(message);

--- a/src/tests/routes/whatsapp/pair.test.ts
+++ b/src/tests/routes/whatsapp/pair.test.ts
@@ -17,7 +17,19 @@ vi.mock("@/lib/openclaw-whatsapp", () => ({
   logoutOpenclawWhatsapp: openclawLogout,
   setOpenclawWhatsappEnabled: openclawSetEnabled,
 }));
-vi.mock("@/lib/openclaw-config", () => ({ restartGateway: vi.fn(async () => {}) }));
+vi.mock("@/lib/openclaw-config", () => ({
+  // A REAL class, not undefined: `src/lib/openclaw-whatsapp.ts` narrows on
+  // `instanceof GatewayNotReadyError` when it reloads the gateway after
+  // installing the WhatsApp plugin, and `instanceof undefined` throws a
+  // TypeError the first time a test makes the mocked restart reject.
+  GatewayNotReadyError: class GatewayNotReadyError extends Error {
+    constructor(message = "gateway did not come back") {
+      super(message);
+      this.name = "GatewayNotReadyError";
+    }
+  },
+  restartGateway: vi.fn(async () => {}),
+}));
 
 const start = vi.fn();
 const poll = vi.fn();

--- a/src/tests/routes/whatsapp/status-cache.test.ts
+++ b/src/tests/routes/whatsapp/status-cache.test.ts
@@ -28,6 +28,16 @@ vi.mock("@/lib/hermes-telegram", () => ({ hermesGatewayStatus: vi.fn() }));
 vi.mock("@/lib/hermes-whatsapp", () => ({ readHermesWhatsappStatus: vi.fn() }));
 vi.mock("@/lib/whatsapp-pairing", () => ({ getPairingManager: vi.fn() }));
 vi.mock("@/lib/openclaw-config", () => ({
+  // A REAL class, not undefined: `src/lib/openclaw-whatsapp.ts` narrows on
+  // `instanceof GatewayNotReadyError` when it reloads the gateway after
+  // installing the WhatsApp plugin, and `instanceof undefined` throws a
+  // TypeError the first time a test makes the mocked restart reject.
+  GatewayNotReadyError: class GatewayNotReadyError extends Error {
+    constructor(message = "gateway did not come back") {
+      super(message);
+      this.name = "GatewayNotReadyError";
+    }
+  },
   openclawIsAbsent: vi.fn(() => false),
   gatewayRestartGeneration: vi.fn(() => 0),
   readConfig: vi.fn(async () => ({})),

--- a/src/tests/unit/openclaw-whatsapp.test.ts
+++ b/src/tests/unit/openclaw-whatsapp.test.ts
@@ -407,6 +407,64 @@ describe("OpenclawWhatsappPairing", () => {
     }
   });
 
+  it("does not ask a gateway that is not listening yet for a QR as well", async () => {
+    // The catch-up window runs in `starting`, which is a phase the keepalive
+    // works in — so it spent that whole window (up to ~115 s, entered precisely
+    // because the port does not answer) firing a `web.login.wait` per tick, each
+    // a 10-12 s CLI cold start certain to fail, on a Jetson that has just
+    // finished an npm install. The retries own that conversation.
+    vi.useFakeTimers();
+    try {
+      mockEnsurePlugin.mockResolvedValue({ ok: true, installed: true });
+      mockRestart.mockRejectedValue(new GatewayNotReadyError("gateway did not come back"));
+      let starts = 0;
+      let waits = 0;
+      // Only the waits issued INSIDE the catch-up window are the defect: once a
+      // QR exists the keepalive is doing its job and is supposed to ask.
+      let waitsBeforeQr: number | null = null;
+      mockSpawn.mockImplementation(async (args: readonly string[]) => {
+        if (args[2] === "web.login.wait") {
+          waits += 1;
+          throw new Error("connect ECONNREFUSED 127.0.0.1:18789");
+        }
+        starts += 1;
+        if (starts === 1) throw new Error("web login provider is not available");
+        if (starts < 3) throw new Error("connect ECONNREFUSED 127.0.0.1:18789");
+        waitsBeforeQr ??= waits;
+        return rpcOk({ qrDataUrl: QR_A });
+      });
+
+      const pairing = new lib.OpenclawWhatsappPairing();
+      const started = pairing.start();
+      await vi.advanceTimersByTimeAsync(lib.TICK_MS * 3);
+
+      expect((await started).phase).toBe("waiting");
+      expect(waitsBeforeQr).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops the keepalive once the session has nowhere left to go", async () => {
+    // `ensureTicking` is cleared by `stop()`, and a start that ends in `error`
+    // never calls it — so on a box that cannot be repaired, which is exactly
+    // where the new error paths lead, the interval woke every TICK_MS for the
+    // life of the web server only to return immediately.
+    vi.useFakeTimers();
+    try {
+      mockSpawn.mockResolvedValue(rpcError("web login provider is not available"));
+      mockEnsurePlugin.mockResolvedValue({ ok: true, installed: true });
+      const pairing = new lib.OpenclawWhatsappPairing();
+
+      expect((await pairing.start()).error).toBe("plugin_missing");
+      // One tick to notice there is nothing to keep alive.
+      await vi.advanceTimersByTimeAsync(lib.TICK_MS + 1);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("asks again while the gateway is still coming back, instead of calling the repair a failure", async () => {
     // `restartGateway` gives up on its readiness wait after its own budget; a
     // Jetson that has just spent three minutes on npm can take longer to bind.

--- a/src/tests/unit/openclaw-whatsapp.test.ts
+++ b/src/tests/unit/openclaw-whatsapp.test.ts
@@ -315,6 +315,37 @@ describe("OpenclawWhatsappPairing", () => {
     expect(mockEnsurePlugin).toHaveBeenCalledTimes(2);
   });
 
+  it("does not answer for the rest of the process from one refused repair", async () => {
+    // The other half of the same rule. A refusal that survived an install and a
+    // reload is a measurement, not a fact about the box: correct the plugin on
+    // disk — a compatible version installed by hand, a core the box has since
+    // been given — and the gateway still needs the reload only this remedy
+    // performs, so a verdict kept for the life of the web server is a box that
+    // can never be repaired from its own panel. Probe-once, one press wide.
+    vi.useFakeTimers();
+    try {
+      mockSpawn.mockResolvedValue(rpcError("web login provider is not available"));
+      mockEnsurePlugin.mockResolvedValue({ ok: true, installed: true });
+      const pairing = new lib.OpenclawWhatsappPairing();
+
+      expect((await pairing.start()).error).toBe("plugin_missing");
+      expect(mockEnsurePlugin).toHaveBeenCalledTimes(1);
+
+      // Pressed again straight away: still answered from what was just measured,
+      // so Retry cannot bounce the gateway once per press.
+      expect((await pairing.start()).error).toBe("plugin_missing");
+      expect(mockEnsurePlugin).toHaveBeenCalledTimes(1);
+
+      // An hour later the measurement is old enough that the owner may have
+      // changed the box under it, and the press is owed a real attempt.
+      await vi.advanceTimersByTimeAsync(60 * 60_000);
+      expect((await pairing.start()).error).toBe("plugin_missing");
+      expect(mockEnsurePlugin).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not skip the reload a cancelled install still owes", async () => {
     // The DELETE that reaps a cancelled session cannot reach an npm install
     // already in flight. Restarting the gateway minutes after the owner closed
@@ -338,6 +369,42 @@ describe("OpenclawWhatsappPairing", () => {
     expect((await started).phase).toBe("idle");
 
     expect(mockRestart).not.toHaveBeenCalled();
+  });
+
+  it("does not start a login the owner cancelled while the gateway was coming back", async () => {
+    // The catch-up loop SLEEPS between attempts, and a cancel lands inside that
+    // sleep. `web.login.start` is not a read — it stops the running channel to
+    // take the socket over, and with `force` it would tear down a login a later
+    // press has just begun — so waking up to issue one is a login started after
+    // the owner closed the card, with the answer discarded upstream and the
+    // keepalive already gone: nothing left to reap it.
+    vi.useFakeTimers();
+    try {
+      mockEnsurePlugin.mockResolvedValue({ ok: true, installed: true });
+      mockRestart.mockRejectedValue(new GatewayNotReadyError("gateway did not come back"));
+      let starts = 0;
+      mockSpawn.mockImplementation(async (args: readonly string[]) => {
+        if (args[2] !== "web.login.start") return rpcOk({});
+        starts += 1;
+        if (starts === 1) throw new Error("web login provider is not available");
+        throw new Error("connect ECONNREFUSED 127.0.0.1:18789");
+      });
+
+      const pairing = new lib.OpenclawWhatsappPairing();
+      const started = pairing.start();
+      // The repair has run and the first post-reload attempt has hit a port
+      // nobody is listening on yet, so the loop is now in its catch-up gap.
+      await vi.advanceTimersByTimeAsync(1);
+      expect(starts).toBe(2);
+
+      pairing.stop();
+      await vi.advanceTimersByTimeAsync(lib.TICK_MS * 2);
+
+      expect((await started).phase).toBe("idle");
+      expect(starts).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("asks again while the gateway is still coming back, instead of calling the repair a failure", async () => {

--- a/src/tests/unit/openclaw-whatsapp.test.ts
+++ b/src/tests/unit/openclaw-whatsapp.test.ts
@@ -27,7 +27,7 @@ vi.mock("@/lib/openclaw-channels", () => ({
   ensureChannelPlugin: vi.fn(),
 }));
 
-import { restartGateway, spawnOpenclawCli } from "@/lib/openclaw-config";
+import { GatewayNotReadyError, restartGateway, spawnOpenclawCli } from "@/lib/openclaw-config";
 import { ensureChannelPlugin, readCachedChannelRowResult } from "@/lib/openclaw-channels";
 
 const mockSpawn = vi.mocked(spawnOpenclawCli);
@@ -83,6 +83,10 @@ describe("OpenclawWhatsappPairing", () => {
     expect(snap.qr).toBeNull();
     expect(snap.qrCount).toBe(1);
     expect(mockSpawn.mock.calls[0][0].slice(0, 3)).toEqual(["gateway", "call", "web.login.start"]);
+    // A healthy box pays nothing for the repair path: no `plugins list`, and
+    // above all no gateway restart, which would drop every other channel.
+    expect(mockEnsurePlugin).not.toHaveBeenCalled();
+    expect(mockRestart).not.toHaveBeenCalled();
   });
 
   /** `--timeout <ms>` as it was handed to the CLI, and the method's own budget. */
@@ -159,17 +163,10 @@ describe("OpenclawWhatsappPairing", () => {
   });
 
   it("installs the plugin the gateway says is missing, then asks again", async () => {
-    // THE BOX THIS COMES FROM. A box upgraded from a build that had no WhatsApp
-    // panel has no `@openclaw/whatsapp` on disk, so the gateway refuses the
-    // login with "web login provider is not available" — and the only thing
-    // that installed the plugin was the channel SAVE, whose toggle the panel
-    // keeps disabled until a phone is paired. Pair needs the plugin, the plugin
-    // needs the save, the save needs the pairing: the owner presses "Link your
-    // phone", gets a red box, and has nothing to press that would change it.
-    //
-    // The gateway names the one failure that has a remedy, so the remedy runs
-    // here: OpenClaw's own `plugins install` / `plugins enable`, the reload that
-    // puts the plugin in service, and the same question again.
+    // The deadlock this breaks is written up in repairWebLoginProvider(): a box
+    // with no `@openclaw/whatsapp` on disk could not pair, and the only thing
+    // that installed the plugin was a channel save the panel kept behind a
+    // pairing. The gateway names the one failure with a remedy, so it runs.
     mockSpawn.mockResolvedValueOnce(rpcError("web login provider is not available"));
     mockSpawn.mockResolvedValueOnce(rpcOk({ qrDataUrl: QR_A }));
     mockEnsurePlugin.mockResolvedValue({ ok: true, installed: true });
@@ -182,6 +179,26 @@ describe("OpenclawWhatsappPairing", () => {
     expect(snap.phase).toBe("waiting");
     expect(snap.qrImage).toBe(QR_A);
     expect(snap.error).toBeNull();
+  });
+
+  it("recognises the refusal in the shape the CLI really rejects with", async () => {
+    // On a box the CLI exits 1 and the spawn rejects with its raw error payload
+    // as text, not with an exit-0 `{ok:false}` body — which the module's own
+    // comment calls the belt-and-braces path. This is the one the device
+    // produced, so the remedy has to fire on it too.
+    mockSpawn.mockRejectedValueOnce(
+      new Error(
+        '{\n "ok": false,\n "error": {\n  "code": "INVALID_REQUEST",\n' +
+          '  "message": "web login provider is not available"\n }\n}',
+      ),
+    );
+    mockSpawn.mockResolvedValueOnce(rpcOk({ qrDataUrl: QR_A }));
+    mockEnsurePlugin.mockResolvedValue({ ok: true, installed: true });
+
+    const snap = await new lib.OpenclawWhatsappPairing().start();
+
+    expect(mockEnsurePlugin).toHaveBeenCalledWith("whatsapp");
+    expect(snap.phase).toBe("waiting");
   });
 
   it("reports an install that failed as an install failure, not as a missing plugin", async () => {
@@ -212,11 +229,29 @@ describe("OpenclawWhatsappPairing", () => {
     expect(snap.error).toBe("plugin_missing");
   });
 
+  it("ignores a second press while the install is running", async () => {
+    // Without this the second press rewrites the phase back to `starting`, so
+    // the first panel's poller reads "Starting the bridge…" with minutes of npm
+    // still to run, and spends a whole `web.login.start` budget on a call that
+    // is certain to be refused.
+    mockSpawn.mockResolvedValue(rpcError("web login provider is not available"));
+    mockEnsurePlugin.mockReturnValue(new Promise(() => {}));
+
+    const pairing = new lib.OpenclawWhatsappPairing();
+    void pairing.start();
+    await vi.waitFor(() => expect(mockEnsurePlugin).toHaveBeenCalled());
+    const callsDuringInstall = mockSpawn.mock.calls.length;
+
+    expect((await pairing.start()).phase).toBe("preparing");
+    expect(mockSpawn.mock.calls.length).toBe(callsDuringInstall);
+  });
+
   it("runs one install behind two starts that overlap inside it", async () => {
     // The epoch discards the RESULT of a start a newer one replaced; it does
-    // not cancel an npm install already in flight. Two panels open on the same
-    // box would otherwise drive `plugins install` into the same plugin store
-    // twice, concurrently — which is how a store ends up half-written.
+    // not cancel an npm install already in flight. `force` is the one press the
+    // guard above lets through, so two clients forcing a relink would otherwise
+    // drive `plugins install` into the same plugin store twice, concurrently —
+    // which is how a store ends up half-written.
     mockSpawn.mockResolvedValue(rpcError("web login provider is not available"));
     let finishInstall: (result: { ok: true; installed: boolean }) => void = () => {};
     mockEnsurePlugin.mockReturnValue(
@@ -229,7 +264,7 @@ describe("OpenclawWhatsappPairing", () => {
     const first = pairing.start();
     // The first refusal has landed and the install is running.
     await vi.waitFor(() => expect(mockEnsurePlugin).toHaveBeenCalled());
-    const second = pairing.start();
+    const second = pairing.start({ force: true });
     await vi.waitFor(() => expect(mockSpawn.mock.calls.length).toBeGreaterThan(1));
 
     finishInstall({ ok: true, installed: true });
@@ -238,6 +273,108 @@ describe("OpenclawWhatsappPairing", () => {
     expect(mockEnsurePlugin).toHaveBeenCalledTimes(1);
     expect(mockRestart).toHaveBeenCalledTimes(1);
   });
+
+  it("does not reinstall and re-restart the box on every Retry press", async () => {
+    // `restartGateway` clears the unit's start limit before each restart, so
+    // nothing downstream would stop this: an unlatched repair turns the red
+    // box's own Retry button into "bounce the gateway, drop Telegram and every
+    // open session, report the same failure" — once per press, for a failure
+    // that is now a fact about the box.
+    mockSpawn.mockResolvedValue(rpcError("web login provider is not available"));
+    mockEnsurePlugin.mockResolvedValue({ ok: true, installed: true });
+    const pairing = new lib.OpenclawWhatsappPairing();
+
+    expect((await pairing.start()).error).toBe("plugin_missing");
+    expect(mockRestart).toHaveBeenCalledTimes(1);
+
+    // The owner presses Retry twice.
+    expect((await pairing.start()).error).toBe("plugin_missing");
+    expect((await pairing.start()).error).toBe("plugin_missing");
+
+    expect(mockEnsurePlugin).toHaveBeenCalledTimes(1);
+    expect(mockRestart).toHaveBeenCalledTimes(1);
+  });
+
+  it("repairs again once a login has actually started", async () => {
+    // The latch is about what we know, not a permanent verdict: a login that
+    // started proves the provider is there, so a later refusal deserves the
+    // remedy again.
+    mockEnsurePlugin.mockResolvedValue({ ok: true, installed: true });
+    const pairing = new lib.OpenclawWhatsappPairing();
+
+    mockSpawn.mockResolvedValueOnce(rpcError("web login provider is not available"));
+    mockSpawn.mockResolvedValueOnce(rpcError("web login provider is not available"));
+    expect((await pairing.start()).error).toBe("plugin_missing");
+
+    mockSpawn.mockResolvedValueOnce(rpcOk({ qrDataUrl: QR_A }));
+    expect((await pairing.start({ force: true })).phase).toBe("waiting");
+
+    mockSpawn.mockResolvedValueOnce(rpcError("web login provider is not available"));
+    mockSpawn.mockResolvedValueOnce(rpcOk({ qrDataUrl: QR_B }));
+    expect((await pairing.start({ force: true })).phase).toBe("waiting");
+    expect(mockEnsurePlugin).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not skip the reload a cancelled install still owes", async () => {
+    // The DELETE that reaps a cancelled session cannot reach an npm install
+    // already in flight. Restarting the gateway minutes after the owner closed
+    // the card would drop the Telegram conversation they went back to, with
+    // nothing anywhere saying why — and the package is on disk, so the next
+    // start pays that restart with someone watching.
+    mockSpawn.mockResolvedValue(rpcError("web login provider is not available"));
+    let finishInstall: (result: { ok: true; installed: boolean }) => void = () => {};
+    mockEnsurePlugin.mockReturnValue(
+      new Promise((resolve) => {
+        finishInstall = resolve;
+      }),
+    );
+
+    const pairing = new lib.OpenclawWhatsappPairing();
+    const started = pairing.start();
+    await vi.waitFor(() => expect(mockEnsurePlugin).toHaveBeenCalled());
+
+    pairing.stop();
+    finishInstall({ ok: true, installed: true });
+    expect((await started).phase).toBe("idle");
+
+    expect(mockRestart).not.toHaveBeenCalled();
+  });
+
+  it("asks again while the gateway is still coming back, instead of calling the repair a failure", async () => {
+    // `restartGateway` gives up on its readiness wait after its own budget; a
+    // Jetson that has just spent three minutes on npm can take longer to bind.
+    // One immediate shot at a closed port is a connection error, not a verdict
+    // on the repair, and reporting it handed the owner the least informative
+    // sentence the card has over a plugin that was about to work.
+    vi.useFakeTimers();
+    try {
+      mockEnsurePlugin.mockResolvedValue({ ok: true, installed: true });
+      mockRestart.mockRejectedValue(new GatewayNotReadyError("gateway did not come back"));
+      // Keyed on the METHOD, not on call order: the keepalive fires its own
+      // `web.login.wait` while the catch-up waits, and a queue would hand the
+      // QR to whichever call happened to arrive first.
+      let starts = 0;
+      mockSpawn.mockImplementation(async (args: readonly string[]) => {
+        if (args[2] !== "web.login.start") return rpcOk({});
+        starts += 1;
+        if (starts === 1) throw new Error("web login provider is not available");
+        // The gateway took the restart and has not finished binding yet.
+        if (starts === 2) throw new Error("connect ECONNREFUSED 127.0.0.1:18789");
+        return rpcOk({ qrDataUrl: QR_A });
+      });
+
+      const pairing = new lib.OpenclawWhatsappPairing();
+      const started = pairing.start();
+      await vi.advanceTimersByTimeAsync(lib.TICK_MS * 3);
+      const snap = await started;
+
+      expect(snap.phase).toBe("waiting");
+      expect(snap.qrImage).toBe(QR_A);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
 
   it("does not reap the login it spent the whole install getting to", async () => {
     // The keepalive reaps a login nobody is watching, and "watching" is a GET

--- a/src/tests/unit/openclaw-whatsapp.test.ts
+++ b/src/tests/unit/openclaw-whatsapp.test.ts
@@ -239,6 +239,50 @@ describe("OpenclawWhatsappPairing", () => {
     expect(mockRestart).toHaveBeenCalledTimes(1);
   });
 
+  it("does not reap the login it spent the whole install getting to", async () => {
+    // The keepalive reaps a login nobody is watching, and "watching" is a GET
+    // that renews it. A plugin install can run for minutes, during which the
+    // only thing the panel does is stay blocked on this POST — so the window
+    // has to start again when the install ends, or the first tick afterwards
+    // stops the login this very call is about to hand back.
+    vi.useFakeTimers();
+    try {
+      mockSpawn.mockResolvedValueOnce(rpcError("web login provider is not available"));
+      let finishRetry: (out: string) => void = () => {};
+      mockSpawn.mockReturnValueOnce(
+        new Promise<string>((resolve) => {
+          finishRetry = resolve;
+        }),
+      );
+      // Whatever the keepalive asks while the retry is in flight.
+      mockSpawn.mockResolvedValue(rpcOk({}));
+      let finishInstall: (result: { ok: true; installed: boolean }) => void = () => {};
+      mockEnsurePlugin.mockReturnValue(
+        new Promise((resolve) => {
+          finishInstall = resolve;
+        }),
+      );
+
+      const pairing = new lib.OpenclawWhatsappPairing();
+      const started = pairing.start();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(mockEnsurePlugin).toHaveBeenCalled();
+
+      // An npm install on a Jetson outlasts the reap window several times over.
+      await vi.advanceTimersByTimeAsync(lib.REAP_AFTER_MS + lib.TICK_MS * 2);
+      finishInstall({ ok: true, installed: true });
+      // One tick lands between the retry being issued and its answer arriving.
+      await vi.advanceTimersByTimeAsync(lib.TICK_MS + 1);
+      finishRetry(rpcOk({ qrDataUrl: QR_A }));
+
+      const snap = await started;
+      expect(snap.phase).toBe("waiting");
+      expect(snap.qrImage).toBe(QR_A);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not install anything over a failure that is not the missing provider", async () => {
     // A gateway that is down is not a plugin that is absent, and an npm install
     // plus a service restart is not what a socket error asks for.

--- a/src/tests/unit/openclaw-whatsapp.test.ts
+++ b/src/tests/unit/openclaw-whatsapp.test.ts
@@ -14,18 +14,26 @@ vi.mock("@/lib/openclaw-config", async () => {
   const actual = await vi.importActual<typeof import("@/lib/openclaw-config")>(
     "@/lib/openclaw-config",
   );
-  return { ...actual, openclawIsAbsent: () => false, spawnOpenclawCli: vi.fn() };
+  return {
+    ...actual,
+    openclawIsAbsent: () => false,
+    spawnOpenclawCli: vi.fn(),
+    restartGateway: vi.fn(),
+  };
 });
 vi.mock("@/lib/openclaw-channels", () => ({
   invalidateChannelStatus: vi.fn(),
   readCachedChannelRowResult: vi.fn(),
+  ensureChannelPlugin: vi.fn(),
 }));
 
-import { spawnOpenclawCli } from "@/lib/openclaw-config";
-import { readCachedChannelRowResult } from "@/lib/openclaw-channels";
+import { restartGateway, spawnOpenclawCli } from "@/lib/openclaw-config";
+import { ensureChannelPlugin, readCachedChannelRowResult } from "@/lib/openclaw-channels";
 
 const mockSpawn = vi.mocked(spawnOpenclawCli);
 const mockChannelResult = vi.mocked(readCachedChannelRowResult);
+const mockEnsurePlugin = vi.mocked(ensureChannelPlugin);
+const mockRestart = vi.mocked(restartGateway);
 
 /**
  * The gateway ANSWERED. A `null` row from an answering gateway means "there is
@@ -56,6 +64,10 @@ describe("OpenclawWhatsappPairing", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    // The plugin is present on a healthy box, so the repair path below is
+    // never entered by the tests that are not about it.
+    mockEnsurePlugin.mockResolvedValue({ ok: true, installed: false });
+    mockRestart.mockResolvedValue(undefined);
     lib = await import("@/lib/openclaw-whatsapp");
   });
 
@@ -146,13 +158,97 @@ describe("OpenclawWhatsappPairing", () => {
     expect((await new lib.OpenclawWhatsappPairing().start()).qrImage).toBeNull();
   });
 
-  it("names a missing plugin, because that one is fixed by saving, not rescanning", async () => {
+  it("installs the plugin the gateway says is missing, then asks again", async () => {
+    // THE BOX THIS COMES FROM. A box upgraded from a build that had no WhatsApp
+    // panel has no `@openclaw/whatsapp` on disk, so the gateway refuses the
+    // login with "web login provider is not available" — and the only thing
+    // that installed the plugin was the channel SAVE, whose toggle the panel
+    // keeps disabled until a phone is paired. Pair needs the plugin, the plugin
+    // needs the save, the save needs the pairing: the owner presses "Link your
+    // phone", gets a red box, and has nothing to press that would change it.
+    //
+    // The gateway names the one failure that has a remedy, so the remedy runs
+    // here: OpenClaw's own `plugins install` / `plugins enable`, the reload that
+    // puts the plugin in service, and the same question again.
     mockSpawn.mockResolvedValueOnce(rpcError("web login provider is not available"));
+    mockSpawn.mockResolvedValueOnce(rpcOk({ qrDataUrl: QR_A }));
+    mockEnsurePlugin.mockResolvedValue({ ok: true, installed: true });
+
+    const snap = await new lib.OpenclawWhatsappPairing().start();
+
+    expect(mockEnsurePlugin).toHaveBeenCalledWith("whatsapp");
+    // Installed is not loaded: `plugins install` says so itself.
+    expect(mockRestart).toHaveBeenCalled();
+    expect(snap.phase).toBe("waiting");
+    expect(snap.qrImage).toBe(QR_A);
+    expect(snap.error).toBeNull();
+  });
+
+  it("reports an install that failed as an install failure, not as a missing plugin", async () => {
+    // The panel has words for this one — "check the network connection" — and
+    // they are the true ones: the plugin is an npm download on a device.
+    mockSpawn.mockResolvedValueOnce(rpcError("web login provider is not available"));
+    mockEnsurePlugin.mockResolvedValue({ ok: false, reason: "install_failed" });
+
+    const snap = await new lib.OpenclawWhatsappPairing().start();
+
+    expect(snap.phase).toBe("error");
+    expect(snap.error).toBe("install_failed");
+    // Nothing was installed, so there is nothing for a gateway restart to load.
+    expect(mockRestart).not.toHaveBeenCalled();
+  });
+
+  it("names a missing plugin only once the install and the reload have both run", async () => {
+    // Still refused after OpenClaw installed its own plugin and the gateway
+    // reloaded: this box really has no WhatsApp bridge, and saying so is the
+    // one honest answer left.
+    mockSpawn.mockResolvedValueOnce(rpcError("web login provider is not available"));
+    mockSpawn.mockResolvedValueOnce(rpcError("web login provider is not available"));
+    mockEnsurePlugin.mockResolvedValue({ ok: true, installed: true });
 
     const snap = await new lib.OpenclawWhatsappPairing().start();
 
     expect(snap.phase).toBe("error");
     expect(snap.error).toBe("plugin_missing");
+  });
+
+  it("runs one install behind two starts that overlap inside it", async () => {
+    // The epoch discards the RESULT of a start a newer one replaced; it does
+    // not cancel an npm install already in flight. Two panels open on the same
+    // box would otherwise drive `plugins install` into the same plugin store
+    // twice, concurrently — which is how a store ends up half-written.
+    mockSpawn.mockResolvedValue(rpcError("web login provider is not available"));
+    let finishInstall: (result: { ok: true; installed: boolean }) => void = () => {};
+    mockEnsurePlugin.mockReturnValue(
+      new Promise((resolve) => {
+        finishInstall = resolve;
+      }),
+    );
+
+    const pairing = new lib.OpenclawWhatsappPairing();
+    const first = pairing.start();
+    // The first refusal has landed and the install is running.
+    await vi.waitFor(() => expect(mockEnsurePlugin).toHaveBeenCalled());
+    const second = pairing.start();
+    await vi.waitFor(() => expect(mockSpawn.mock.calls.length).toBeGreaterThan(1));
+
+    finishInstall({ ok: true, installed: true });
+    await Promise.all([first, second]);
+
+    expect(mockEnsurePlugin).toHaveBeenCalledTimes(1);
+    expect(mockRestart).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not install anything over a failure that is not the missing provider", async () => {
+    // A gateway that is down is not a plugin that is absent, and an npm install
+    // plus a service restart is not what a socket error asks for.
+    mockSpawn.mockResolvedValueOnce(rpcError("connect ECONNREFUSED"));
+
+    const snap = await new lib.OpenclawWhatsappPairing().start();
+
+    expect(snap.error).toBe("start_failed");
+    expect(mockEnsurePlugin).not.toHaveBeenCalled();
+    expect(mockRestart).not.toHaveBeenCalled();
   });
 
   it("reports any other start failure as a code, never as the gateway's sentence", async () => {

--- a/src/tests/unit/openclaw-whatsapp.test.ts
+++ b/src/tests/unit/openclaw-whatsapp.test.ts
@@ -336,8 +336,18 @@ describe("OpenclawWhatsappPairing", () => {
       expect((await pairing.start()).error).toBe("plugin_missing");
       expect(mockEnsurePlugin).toHaveBeenCalledTimes(1);
 
-      // An hour later the measurement is old enough that the owner may have
-      // changed the box under it, and the press is owed a real attempt.
+      // Still pressing five minutes later: the measurement is fresh enough, and
+      // this is the half that keeps a flurry of presses down to one repair.
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+      expect((await pairing.start()).error).toBe("plugin_missing");
+      expect(mockEnsurePlugin).toHaveBeenCalledTimes(1);
+
+      // An hour after the refusal the measurement is old enough that the owner
+      // may have changed the box under it, and the press is owed a real attempt.
+      // Deliberately a wall-clock contract rather than the module's own constant:
+      // a test that reads REPAIR_REFUSAL_TTL_MS would follow any future change to
+      // it and stop asserting the policy — that a press soon after is answered
+      // from the measurement and a press much later is not.
       await vi.advanceTimersByTimeAsync(60 * 60_000);
       expect((await pairing.start()).error).toBe("plugin_missing");
       expect(mockEnsurePlugin).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
**Finding:** `whatsapp-pairing-bridge` (owner report, 2026-09-10, OpenClaw-edition box right after the owner-driven update `main` v3.9.0 / core 2026.7.1 → `beta` v4.0.0 / core OpenClaw 2026.8.1).

## Customer-visible symptom

Settings → Channels → WhatsApp → **Link your phone** → a red box:

> Pairing could not start
> Something went wrong while starting the bridge.

…and a **Try again** button that does the same thing every time. There is nothing else on the card to press.

## The real error

From the setup-app journal at the moment of the failed press:

```
[openclaw-whatsapp] login start failed: Error: {
  "ok": false,
  "error": {
    "type": "gateway_request_error",
    "code": "INVALID_REQUEST",
    "message": "web login provider is not available",
    "retryable": false
  }
}
```

The gateway is right: the box has no `@openclaw/whatsapp` at all. Read-only on the device —
`openclaw plugins list --json` carries no whatsapp row, the `@openclaw/` scope directory under the
global npm prefix does not exist, the gateway's own boot line reads
`http server listening (18 plugins: … telegram …)` with no whatsapp, `channels` in `openclaw.json`
holds only `telegram`, and `plugins.entries` has no `whatsapp` key.

## Native mechanism (harness first)

The pairing route already drives OpenClaw's **own** login rather than a reimplementation: the plugin
publishes `loginWithQrStart` / `loginWithQrWait`, the gateway exposes them as the `web.login.start` /
`web.login.wait` RPC methods, and `openclaw gateway call` invokes them non-interactively. That part
was right and is unchanged.

What was missing is the other native verb. The core's `respondProviderUnavailable` sends
`web login provider is not available` whenever `resolveWebLoginProvider()` finds nothing, and
`resolveMissingOfficialExternalChannelPluginRepairHints` appends its own remedy — *install the
plugin* — but only for a channel already present in `config.channels`, which a box that has never
saved the channel is not. So the repair the harness would have named arrives as the bare sentence,
and `openclaw doctor --fix`, the command that hint names, is bounded by the same "configured channels
only" rule and would fix nothing here either. This PR runs that remedy through the door this repo
already owns for it — `ensureChannelPlugin()`, a thin wrapper over
`openclaw plugins install @openclaw/whatsapp --accept-capabilities` and `openclaw plugins enable
whatsapp` — followed by the gateway reload that `plugins install` itself asks for. Nothing is
invented and nothing is written into the harness's store by hand.

## Cause

`@openclaw/whatsapp` is an npm plugin OpenClaw's stock extensions do not carry, and by design it is
installed at **configure** time, not at flash time — `/setup-api/whatsapp/configure` with
`enabled: true` is the only caller of `ensureChannelPlugin` for this channel.

That save is unreachable on a fresh OpenClaw box. `src/components/SettingsApp.tsx` disables the
Enable toggle with `(!waStatus.paired && !waStatus.enabled)` — the right rule on Hermes, where a
bridge with no `creds.json` receives nothing, and the wrong way round on OpenClaw, where enabling is
what puts the plugin in service. So pairing wanted the plugin, the plugin wanted the save, and the
save wanted a pairing. Deadlock, with "Link your phone" as the only button on the card.

The generic wording is the second half: `src/lib/openclaw-whatsapp.ts` derived the right code,
`plugin_missing`, and the panel's error map knew only the Hermes manager's `bridge_missing` and
`install_failed`, so the one diagnosable failure fell into the generic tail.

**Not the upgrade path, and not a pre-start regression.** `scripts/gateway-pre-start.sh` states that
its managed-plugin block runs "Only for entries openclaw.json ALREADY says to load … one he never
asked for is never enabled by a boot script", and it iterates `plugins.entries`. There was never a
whatsapp entry, so nothing was attempted and nothing failed — the absent `data/plugin-repair.json` is
"no row was ever needed", not "the repair block never ran", and the gateway journal for the first boot
on this head carries no whatsapp line at all. A freshly flashed beta box is in exactly the same state.
Discord is absent for the same reason and is **not** affected: its Save is gated only on a token being
typed, so `/discord/configure` reaches `ensureChannelPlugin` whenever the owner asks.

## The fix

`OpenclawWhatsappPairing.start()` now runs the remedy on the gateway's own refusal, and only on that
refusal:

1. `ensureChannelPlugin("whatsapp")` — OpenClaw's install + enable verbs, with capability consent.
2. `restartGateway()` — installed is not loaded; `plugins install` prints "Restart the gateway to
   load plugins", and the gateway is what publishes `web.login.*`.
3. `web.login.start` again.

A healthy box pays nothing for this: no extra `plugins list`, and above all no gateway restart, which
would drop every other channel mid-conversation. An install failure is reported as `install_failed`,
which the panel already words as a network problem; `plugin_missing` now means "still no provider
after the install and the reload", and the panel gives it the same words as `bridge_missing`. No new
translation keys, so nothing lands untranslated in eleven languages.

Three things the new `preparing` window needed, each with a test that is red without it:

* **The keepalive window restarts where the install ends.** The reaper stops a login nobody is
  watching, and "watching" is a GET that renews it. An install runs for minutes while the panel does
  nothing but stay blocked on the POST — so the first tick afterwards saw a window that had expired
  two minutes earlier and reaped the login `start()` was about to return. The owner waited out the
  install and got the "Link your phone" button back: no QR, no error, and a login left running in the
  gateway with nobody showing its code.
* **One install behind overlapping starts.** The epoch guard discards the *result* of a start a newer
  one replaced; it does not cancel an npm install already in flight.
* **A second press during an install is ignored.** Otherwise it rewrote the phase back to `starting` —
  the first panel's poller then read "Starting the bridge…" with minutes of npm still to run — and
  spent a whole login budget on a call certain to be refused.

## Review

A review pass on the first head returned 1 High, 3 Medium, 9 Low. Applied, each with a test
that is red without it:

* **High — every refusal restarted the gateway.** On a box where the plugin is on disk and enabled but
  the gateway still resolves no provider (a store left half-written by a killed npm, a plugin that
  throws while loading), no install and no enable ran and it was bounced anyway: every other channel
  and every open session dropped for a minute, and the card came back with a button labelled
  **Retry**. `restartGateway` clears the unit's start limit before each restart, so nothing downstream
  stopped the loop. A refusal that survives an install and a reload is now latched and answered from
  what is known; a login that actually starts clears it, and only a repair that really bounced the
  gateway may latch.
* **Medium — the repair was uncancellable.** Cancel, or leaving the pane, bumps the epoch — which
  discards the result, not the install in flight. Ninety seconds after the owner closed the card the
  box restarted its gateway. The reload is now skipped when nobody is left waiting; the package is on
  disk, so the next start pays it with someone watching.
* **Medium — a slow restart was reported as a failure.** `restartGateway` gives up on its readiness
  wait after its own budget, and a Jetson that has just spent three minutes on npm can take longer to
  bind. The single immediate `web.login.start` then hit a closed port, and the owner got the least
  informative sentence the card has over a plugin that was about to work — with a Retry that then
  succeeds. It is now asked a few times, bounded, while the gateway comes back; a refusal is an answer
  and ends that at once.
* **Medium — the QR could reach the journal.** `spawnOpenclaw` names a failed process by its real
  argv and `web.login.wait` carries `currentQrDataUrl` in its params, so one spawn timeout wrote live
  pairing material into the log — which `/whatsapp/pair` documents can never happen. Fixed at the
  source by giving the call its own `labelArgs`.
* **Low, applied:** `preparing` closed as a hole in `start()`'s idempotence and documented as
  deliberately outside the reap watchdog; `snapshot.error` typed with the code union so this module
  and the panel's map cannot drift apart silently; Hermes' `prepare_failed` documented as deliberately
  on the generic tail; a test for the refusal shape the CLI really rejects with (exit 1, raw payload as
  text — the one the device produced); a happy-path assertion that nothing is installed or restarted;
  a panel-test GET fixture that answers what the real route answers.

Declined, with reasons:

* **Swap the module's private `gatewayCall` for `callGatewayRpc`.** Agreed as consolidation, and the
  harm it was raised for — the QR in the journal — is fixed above with one line. The swap moves the
  call from `spawnOpenclawCli` to `spawnOpenclaw` under a different exported name, which every test in
  this file mocks by name. A large rewiring for a cleanup that is not this defect; filed rather than
  done here.
* **Anchor `isProviderMissing` on the error `code` as well as the message.** It would only ever match
  the belt-and-braces exit-0 path: on the shipped path the CLI exits 1 and the spawn rejects with the
  raw payload as *text*, where there is no structured code to read. Anchoring on it would quietly stop
  matching the case this PR exists for.
* **Reword the `preparing` hint to mention the gateway reload.** With the High fixed, "this happens
  once" is true again; the download dominates the phase and the reload is seconds. Eleven locale
  strings for that nuance is the wrong trade.
* **Move the in-flight install guard into `ensureChannelPlugin`,** where it would serialise
  `/whatsapp/configure` and `/discord/configure` too. A better design, agreed — and a change to a
  module shared with Discord that needs its own regression test. Filed.

## RED → GREEN

RED, on unmodified `origin/beta` (`src/tests/unit/openclaw-whatsapp.test.ts`):

```
 FAIL  > OpenclawWhatsappPairing > installs the plugin the gateway says is missing, then asks again
AssertionError: expected "vi.fn()" to be called with arguments: [ 'whatsapp' ]
Number of calls: 0

 FAIL  > OpenclawWhatsappPairing > reports an install that failed as an install failure, not as a missing plugin
AssertionError: expected 'plugin_missing' to be 'install_failed' // Object.is equality
```

RED for the panel half (`src/tests/components/settings-whatsapp-pair-error.test.tsx`) — the box's
symptom, reproduced:

```
 FAIL  > the WhatsApp pairing card's error text > names the missing bridge when OpenClaw's gateway has no login provider
AssertionError: expected 'settings.whatsappPairFailedTitlesetti…' to contain 'settings.whatsappPairErrBridge'
Expected: "settings.whatsappPairErrBridge"
Received: "settings.whatsappPairFailedTitlesettings.whatsappPairErrGeneric"
```

Every guard added afterwards was checked the same way, against the head before it:

```
× ignores a second press while the install is running
× does not reinstall and re-restart the box on every Retry press
× does not skip the reload a cancelled install still owes
× asks again while the gateway is still coming back, instead of calling the repair a failure
× does not reap the login it spent the whole install getting to    (expected 'idle' to be 'waiting')
× runs one install behind two starts that overlap inside it        (called 2 times, expected 1)
```

GREEN — the new tests plus the neighbouring suites (unit `openclaw-whatsapp`, `whatsapp-pairing`,
`hermes-whatsapp`, `openclaw-channels`, `openclaw-config-mock-completeness`; routes `whatsapp` and
`discord`; components `settings-whatsapp-pair-error`, `settings-channel-receiving`,
`settings-channels-cold-list`): **20 files, 343 tests passed**. `tsc --noEmit` clean. `eslint` on the
changed files is clean except for `SettingsApp.tsx`'s pre-existing count, which is identical on
`origin/beta` and on this branch (9 errors / 5 warnings, all on untouched lines).

## Sibling call sites

* **The repo's own guard found one.** `src/tests/unit/openclaw-config-mock-completeness.test.ts` fails
  any suite that replaces `@/lib/openclaw-config` without `GatewayNotReadyError` while importing a
  module that narrows on it — which this module now does. It named
  `routes/whatsapp/pair.test.ts` and `routes/whatsapp/status-cache.test.ts`; both factories now carry
  the real class.
* `tick()` / `web.login.wait` — left alone deliberately. It runs only in `waiting`/`starting`, i.e.
  after a QR has already been obtained, so the provider demonstrably existed; a repair there would
  restart the gateway under a live login.
* `/whatsapp/pair` GET and DELETE — read and stop the session, never start one. DELETE's interaction
  with an install in flight is the Medium above.
* `/whatsapp/configure` — still the channel's owner for enablement, and still the only thing that
  writes `channels.whatsapp`. This PR writes no channel config.
* `/discord/configure` — same `ensureChannelPlugin` door, no pairing route, no `web.login.*`, and its
  Save is reachable. Cleared, not changed.
* `/telegram/pairing` — `telegram` is a stock bundled extension with no entry in
  `OFFICIAL_CHANNEL_PLUGINS`; nothing to install, no equivalent deadlock. Cleared.
* Hermes (`src/lib/whatsapp-pairing.ts`) and the Hermes branch of every WhatsApp route are untouched;
  the panel change is purely additive on a code Hermes never emits, so `bridge_missing` /
  `install_failed` keep their meanings and their words.

## What the owner should click afterwards

Settings → Channels → WhatsApp → **Link your phone**. The card sits on "preparing" while the plugin
downloads (first time only), then shows the QR. After scanning, the **Enable WhatsApp** toggle is no
longer greyed out — flipping it is what makes the channel actually receive.

## Declared gaps

* **Device leg unproven.** The failure was reproduced and root-caused on the owner's box read-only
  (journal, `plugins list --json`, `openclaw.json` keys, the core's own `respondProviderUnavailable`
  source, the pre-start script's managed-plugin block). Proving the repair itself requires installing a
  plugin and restarting the gateway on that box — a channel-configuration change on an owner device,
  which this task forbids. The repair is covered by unit tests only.
* **One behaviour worth a device check before merge.** The repair deliberately does not write
  `channels.whatsapp`. Read against the core and the plugin, the deadlock still breaks without it: the
  gateway's runtime snapshot enumerates loaded plugins rather than configured channels, the plugin's
  account helpers fall back to an implicit default account with no config, and `linked` derives from
  creds on disk — so after a scan the row exists, `paired` is true and the Enable toggle unlocks. If
  the row did *not* appear, the deadlock would move one step to that toggle. `openclaw channels status
  --channel whatsapp --json` after a real pairing settles it.
* **Settled, not left open (was "adjacent, pre-existing"):** whether the unpinned spec
  `@openclaw/whatsapp` in `OFFICIAL_CHANNEL_PLUGINS` can resolve a plugin this core cannot load. It
  cannot, and the unpinned form is what prevents it. Measured read-only against the pinned core
  (2026.8.1) and the registry: the installer validates the resolved package's
  `openclaw.compat.pluginApi` and `openclaw.install.minHostVersion` against the running host, and on a
  mismatch `resolveLatestCompatibleNpmResolution` walks older stable versions and installs "the newest
  compatible" one — a fallback that applies ONLY to a spec with no version selector (or the tag
  `latest`). `latest` is 2026.9.3 wanting `pluginApi >=2026.9.3`; the walk passes 2026.9.2 (`>=2026.9.2`)
  and 2026.8.2 (`>=2026.8.2`) and lands on 2026.8.1 — the version this core's own bundled
  `dist/channel-catalog.json` names for it. Pinning would disable that walk and turn a mismatch into a
  hard refusal, so the comment on `OFFICIAL_CHANNEL_PLUGINS` is corrected to say why the unpinned form
  is load-bearing rather than merely convenient. (It also corrected an earlier claim of mine here: the
  package DOES publish a `compat` block; `peerDependencies` is simply not what the installer gates on,
  and the npm install runs `--legacy-peer-deps`.) `scripts/gateway-pre-start.sh`'s
  `clawbox_managed_plugin_spec` still pins, for a repair ROW replayed long after it is written — a
  different question on a different path, deliberately not flipped from here.
* **Also flagged, not fixed:** `src/tests/unit/memory-index-local.test.ts` fails intermittently in a
  full parallel run and passes alone. Reproduced on unmodified `origin/beta` (two of three runs of the
  same trio), caused by leftover `/tmp/lobster-template-*` directories another suite creates. Nothing
  to do with this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WhatsApp pairing now automatically repairs missing login-provider plugins and retries when the gateway is ready.
  * Concurrent pairing attempts coordinate recovery to prevent duplicate repair actions.

* **Bug Fixes**
  * Missing plugin and bridge errors now display appropriate dependency guidance.
  * Persistent provider failures avoid repeated repair attempts.
  * Gateway error labels no longer expose JSON parameters.

* **Documentation**
  * Updated channel provider documentation to explain plugin compatibility and fallback behavior.

* **Tests**
  * Expanded coverage for installation, restarts, retries, cancellations, timeouts, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
