### PR TITLE
fix: clear the Hermes pairing stamps a Telegram bot change cancels

### DIFF
--- a/src/lib/hermes-telegram.ts
+++ b/src/lib/hermes-telegram.ts
@@ -21,6 +21,7 @@
 // Everything here goes through runHermesCli (argv only, never a shell).
 
 import { execFile } from "child_process";
+import { randomUUID } from "crypto";
 import fs from "fs/promises";
 import path from "path";
 import { promisify } from "util";
@@ -284,16 +285,138 @@ export async function revokeHermesPairing(userId: string, signal?: AbortSignal):
 /** Cap on the revokes a single reset will run — each is its own CLI start-up. */
 const MAX_RESET_REVOKES = 25;
 
+// Hermes rate-limits pairing REQUESTS, not approvals, and the stamps outlive the
+// bot. `generate_code` writes `<platform>:<user_id>` into the pairing store's
+// shared `_rate_limits.json` on its way out and then refuses that sender another
+// code for ten minutes (gateway/pairing.py, RATE_LIMIT_SECONDS = 600).
+// `_lockout:<platform>` holds the hour-long lockout after five failed approvals
+// and `_failures:<platform>` the consecutive-failure counter behind it.
+//
+// Cancelling the pending requests without these leaves the requester in a hole
+// neither end can see: their request is gone from the store, so Settings shows
+// nothing to approve, and the gateway answers their next message with a log line
+// and silence — `_hm_offer_pairing_code` returns before it generates anything
+// when `_is_rate_limited` says so, so the only trace is one "Unauthorized user"
+// warning per attempt until the ten minutes are up.
+//
+// BOTH pairing dirs, because Hermes merges them: `_migrate_split_pairing_dirs`
+// merges the inactive dir's `*.json` into the active one on start (the active
+// copy winning per key), so a stamp left in the legacy copy comes straight back.
+//
+// There is no command for it — `hermes pairing` is list / approve / revoke /
+// clear-pending and nothing else (hermes_cli/subcommands/pairing.py) — and
+// Hermes' own approve handler tells the operator to "delete the
+// '_lockout:<platform>' entry from ~/.hermes/platforms/pairing/
+// _rate_limits.json" when a lockout has to go early (hermes_cli/pairing.py). So
+// the file IS the mechanism, and it is edited in the shape of Hermes' own
+// `_secure_write`: whole-object read, fresh temp file, atomic rename, 0600.
+const RATE_LIMIT_FILE = "_rate_limits.json";
+
+/**
+ * Whether this reset owns a `_rate_limits.json` key.
+ *
+ * REQUEST stamps (`<platform>:<user_id>`) go for EVERY platform, because the
+ * reset cancels every platform's pending requests: `hermes pairing clear-pending`
+ * takes no platform argument (gateway/pairing.py `clear_pending(platform=None)`
+ * walks every `*-pending.json` in the dir). Dropping only Telegram's would leave
+ * a Discord or WhatsApp requester in exactly the hole described above, holding a
+ * code that no longer exists and unable to ask for another — and Hermes ships
+ * those adapters, so "Telegram is the only one configured" is an assumption, not
+ * an invariant.
+ *
+ * APPROVAL-side state — the lockout and its failure counter — is per platform and
+ * belongs to the bot being replaced, so only this platform's goes. Another
+ * platform's lockout was earned by mistyped codes there and is none of this
+ * reset's business.
+ */
+function isStampClearedByReset(key: string): boolean {
+  if (!key.startsWith("_")) return key.includes(":");
+  return key === `_lockout:${PLATFORM}` || key === `_failures:${PLATFORM}`;
+}
+
+/**
+ * A store read that means "no stamp is in force either", so there is nothing to
+ * clear and nothing to report: the file is absent, or it holds something Hermes
+ * itself reads as `{}` (`_load_json_file` swallows a JSONDecodeError). Any other
+ * failure is a real fault and gets logged by the caller.
+ */
+function isEmptyToHermes(err: unknown): boolean {
+  if (err instanceof SyntaxError) return true;
+  return (err as { code?: unknown } | null)?.code === "ENOENT";
+}
+
+/**
+ * Drop the pairing stamps this reset owns, so the next message from a stranger
+ * earns a fresh code at once.
+ *
+ * Best-effort: it never throws, because the token is saved right after it and a
+ * cleared stamp is not worth failing that save over. It does not fail SILENTLY —
+ * a reset that could not clear leaves someone denied with nothing to show them,
+ * which is the fault this whole function exists to prevent.
+ *
+ * Hermes re-reads the file on every check (`_limits()`), so a running gateway
+ * sees the cleared stamps with no restart.
+ */
+async function clearPairingRateLimitStamps(): Promise<void> {
+  await Promise.all(
+    pairingDirs().map(async (dir) => {
+      const file = path.join(dir, RATE_LIMIT_FILE);
+      let limits: Record<string, unknown>;
+      try {
+        const parsed: unknown = JSON.parse(await fs.readFile(file, "utf-8"));
+        if (!isRecord(parsed)) return;
+        limits = parsed;
+      } catch (err) {
+        // The MESSAGE only, here and below: this file names the people who asked
+        // to pair, and a thrown fs error carries its path but not its contents.
+        if (!isEmptyToHermes(err)) {
+          console.error(
+            "[telegram] Hermes' pairing rate limits could not be read, so a new request may be refused in silence:",
+            err instanceof Error ? err.message : err,
+          );
+        }
+        return;
+      }
+      const kept = Object.entries(limits).filter(([key]) => !isStampClearedByReset(key));
+      if (kept.length === Object.keys(limits).length) return;
+      // A fresh temp name per write: a shared one lets a second reset truncate
+      // this one's file between the write and the rename, and `writeFile`'s
+      // `mode` is ignored on a path that already exists — a stale 0644 temp from
+      // a crashed run would then carry its permissions over a store that names
+      // every requester. `wx` refuses an existing path outright; the chmod is the
+      // belt to that braces, as in config-store's writeConfig.
+      const tmp = path.join(dir, `.${RATE_LIMIT_FILE}.${randomUUID()}.tmp`);
+      try {
+        await fs.writeFile(tmp, JSON.stringify(Object.fromEntries(kept), null, 2), {
+          mode: 0o600,
+          flag: "wx",
+        });
+        await fs.chmod(tmp, 0o600).catch(() => {});
+        await fs.rename(tmp, file);
+      } catch (err) {
+        console.error(
+          "[telegram] Hermes' pairing rate limits could not be cleared, so a new request may be refused in silence:",
+          err instanceof Error ? err.message : err,
+        );
+        await fs.rm(tmp, { force: true }).catch(() => {});
+      }
+    }),
+  );
+}
+
 /**
  * Wipe Telegram pairing state, for when the bot token changes: approvals belong
  * to the old bot. Revokes each approved sender (so Hermes also drops it from any
- * TELEGRAM_ALLOWED_USERS mirror it maintains), clears pending codes, then removes
- * any store file left behind. Best-effort throughout: each step is a separate
- * `hermes` process that may be missing or refuse, and the store-file removal
- * at the end is the backstop.
+ * TELEGRAM_ALLOWED_USERS mirror it maintains), clears pending codes, removes any
+ * store file left behind, and drops the request rate-limit and lockout stamps it
+ * owns so everyone whose pending request this just cancelled can ask for a code
+ * straight away. Best-effort throughout: each step is a separate `hermes` process
+ * that may be missing or refuse, and the store-file removal at the end is the
+ * backstop.
  *
  * Note `hermes pairing clear-pending` takes no platform argument and clears every
- * platform's pending codes. On ClawBox Telegram is the only one configured.
+ * platform's pending codes — which is why the stamp clear above is not scoped to
+ * Telegram either (see `isStampClearedByReset`).
  */
 export async function clearHermesTelegramPairingState(): Promise<void> {
   let approved: HermesApprovedUser[] = [];
@@ -324,6 +447,7 @@ export async function clearHermesTelegramPairingState(): Promise<void> {
       ),
     ),
   );
+  await clearPairingRateLimitStamps();
 }
 
 // ── Token + gateway service ─────────────────────────────────────────────────

--- a/src/tests/unit/hermes-telegram.test.ts
+++ b/src/tests/unit/hermes-telegram.test.ts
@@ -625,6 +625,104 @@ describe("clearHermesTelegramPairingState", () => {
     await expect(fs.access(path.join(storeDir, "telegram-pending.json"))).rejects.toThrow();
   });
 
+  // Hermes rate-limits pairing REQUESTS, not approvals, and `_rate_limits.json`
+  // outlives the bot — the mechanism, and why each key goes or stays, is in
+  // `isStampClearedByReset` and the comment above it.
+  //
+  // Left behind, the stamps leave the person whose pending request this reset
+  // just cancelled in a hole neither end can see: the request is gone, so "Check
+  // for requests" has nothing to show, and their next message is denied in
+  // silence — the gateway returns from `_hm_offer_pairing_code` before generating
+  // anything and logs one "Unauthorized user" warning, nothing else. Seen on a
+  // Hermes box: the bot issued a code and stamped the limit, the save 37 s later
+  // removed the pending entry, and the next two messages produced two warnings
+  // and no code.
+  //
+  // Both dirs, because Hermes merges them on start (`_migrate_split_pairing_dirs`),
+  // so a stamp left in the legacy copy comes straight back.
+  it("drops every requester's stamp and this platform's lockout, in both dirs", async () => {
+    const now = Date.now() / 1000;
+    const limits = {
+      "telegram:333": now,
+      "_lockout:telegram": now + 600,
+      "_failures:telegram": 3,
+      // `pairing clear-pending` takes no platform argument, so this requester's
+      // pending code is cancelled by the same reset: they have to be able to ask
+      // again too, or the bug just moves to another channel.
+      "discord:444": now,
+      // Earned by mistyped codes on Discord, not by this Telegram bot.
+      "_lockout:discord": now + 600,
+    };
+    const legacyDir = path.join(home, "pairing");
+    await fs.mkdir(legacyDir, { recursive: true });
+    for (const dir of [storeDir, legacyDir]) {
+      await fs.writeFile(path.join(dir, "_rate_limits.json"), JSON.stringify(limits), {
+        mode: 0o600,
+      });
+    }
+
+    const { clearHermesTelegramPairingState } = await import("@/lib/hermes-telegram");
+    await clearHermesTelegramPairingState();
+
+    for (const dir of [storeDir, legacyDir]) {
+      const file = path.join(dir, "_rate_limits.json");
+      expect(Object.keys(JSON.parse(await fs.readFile(file, "utf-8")))).toEqual([
+        "_lockout:discord",
+      ]);
+      // The file names the people who asked, so it stays 0600 as Hermes writes it.
+      expect((await fs.stat(file)).mode & 0o777).toBe(0o600);
+      // And no temp file is left beside it.
+      expect((await fs.readdir(dir)).filter((n) => n.endsWith(".tmp"))).toEqual([]);
+    }
+  });
+
+  it("leaves a store holding nothing of ours exactly as it was", async () => {
+    const file = path.join(storeDir, "_rate_limits.json");
+    const before = JSON.stringify({ "_lockout:discord": 1, "_failures:discord": 2 });
+    await fs.writeFile(file, before, { mode: 0o600 });
+
+    const { clearHermesTelegramPairingState } = await import("@/lib/hermes-telegram");
+    await clearHermesTelegramPairingState();
+
+    expect(await fs.readFile(file, "utf-8")).toBe(before);
+  });
+
+  // Best-effort like the rest of the reset: the token is saved right after this,
+  // and a store Hermes itself reads as `{}` holds no stamp in force either — so
+  // this one stays quiet.
+  it("leaves a corrupt rate-limit store alone, without a word", async () => {
+    const file = path.join(storeDir, "_rate_limits.json");
+    await fs.writeFile(file, "{not json", "utf-8");
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { clearHermesTelegramPairingState } = await import("@/lib/hermes-telegram");
+    await expect(clearHermesTelegramPairingState()).resolves.toBeUndefined();
+    expect(await fs.readFile(file, "utf-8")).toBe("{not json");
+    expect(logged).not.toHaveBeenCalled();
+    logged.mockRestore();
+  });
+
+  // A clear that could not happen must not pass as one: the route answers
+  // `reset: true` either way, the requester stays denied in silence, and without
+  // this line the service log holds nothing that explains it.
+  it("says so in the log when the store cannot be written", async () => {
+    const file = path.join(storeDir, "_rate_limits.json");
+    await fs.writeFile(file, JSON.stringify({ "telegram:333": Date.now() / 1000 }), {
+      mode: 0o600,
+    });
+    await fs.chmod(storeDir, 0o500);
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { clearHermesTelegramPairingState } = await import("@/lib/hermes-telegram");
+      await expect(clearHermesTelegramPairingState()).resolves.toBeUndefined();
+      expect(logged.mock.calls.map((args) => String(args[0])).join("\n")).toContain(
+        "could not be cleared",
+      );
+    } finally {
+      logged.mockRestore();
+      await fs.chmod(storeDir, 0o700);
+    }
+  });
+
   // The token is already saved when this runs, so a CLI failure must not throw
   // out of the configure route and report a failed save.
   it("still wipes the store when the CLI fails outright", async () => {

--- a/src/tests/unit/hermes-telegram.test.ts
+++ b/src/tests/unit/hermes-telegram.test.ts
@@ -704,22 +704,28 @@ describe("clearHermesTelegramPairingState", () => {
   // A clear that could not happen must not pass as one: the route answers
   // `reset: true` either way, the requester stays denied in silence, and without
   // this line the service log holds nothing that explains it.
+  //
+  // The failure is stubbed rather than provoked with a 0500 dir: a suite running
+  // as uid 0 would write straight through the permissions and test nothing.
   it("says so in the log when the store cannot be written", async () => {
     const file = path.join(storeDir, "_rate_limits.json");
     await fs.writeFile(file, JSON.stringify({ "telegram:333": Date.now() / 1000 }), {
       mode: 0o600,
     });
-    await fs.chmod(storeDir, 0o500);
+    const write = vi
+      .spyOn(fs, "writeFile")
+      .mockRejectedValue(Object.assign(new Error("EROFS: read-only file system"), { code: "EROFS" }));
     const logged = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
       const { clearHermesTelegramPairingState } = await import("@/lib/hermes-telegram");
       await expect(clearHermesTelegramPairingState()).resolves.toBeUndefined();
+      expect(write).toHaveBeenCalled();
       expect(logged.mock.calls.map((args) => String(args[0])).join("\n")).toContain(
         "could not be cleared",
       );
     } finally {
       logged.mockRestore();
-      await fs.chmod(storeDir, 0o700);
+      write.mockRestore();
     }
   });
 


### PR DESCRIPTION
**Finding tgpair** — Hermes edition, Settings → Channels → Telegram.

## Symptom
The bot never sent a pairing code and USER ACCESS stayed empty: "Check for requests" found
nothing to approve, "Approved users: No one approved yet", while the status card said
"Telegram channel active" — and every further message to the bot was answered with nothing at
all. On the device the gateway had logged one `Unauthorized user: … on telegram` warning per
attempt and no pairing reply.

## Cause
Hermes rate-limits pairing **requests**, and the stamps outlive the bot. `generate_code`
writes `<platform>:<user_id>` into the pairing store's shared `_rate_limits.json` on its way
out and then refuses that sender another code for ten minutes (`gateway/pairing.py`,
`RATE_LIMIT_SECONDS = 600`); `_lockout:<platform>` holds the hour-long lockout after five
failed approvals and `_failures:<platform>` the counter behind it.

The reset that runs when the bot token changes (`POST /setup-api/telegram/configure` →
`clearHermesTelegramPairingState`) revoked the approvals and cancelled the pending requests
but left those stamps behind. The person whose request it had just cancelled then fell into a
hole neither end could see:

* their pending request was gone, so "Check for requests" had nothing to show;
* their next message was denied in **silence** — `_hm_offer_pairing_code`
  (`gateway/run_inbound.py`) returns before generating anything when `_is_rate_limited` says
  so, leaving one warning in the log and no reply to the sender;
* and it stayed that way until the ten minutes were up (a lockout, up to an hour).

Measured on a Hermes device: the bot issued a code and stamped the limit, the save 37 s later
removed the pending entry, and the next two messages produced two warnings and no code.

## Harness first
Hermes owns this state and there is no command for it. `hermes pairing` is exactly
list / approve / revoke / clear-pending (`hermes_cli/subcommands/pairing.py`) — nothing clears
a rate limit — and Hermes' own approve handler tells the operator to delete the
`_lockout:<platform>` entry from `~/.hermes/platforms/pairing/_rate_limits.json` by hand
(`hermes_cli/pairing.py`). So the file is the mechanism, and it is edited in the shape of
Hermes' own `_secure_write`: whole-object read, fresh temp file, atomic rename, `0600`.
Hermes re-reads the file on every check (`_limits()`), so a running gateway picks the change
up with no restart.

**Every requester's stamp goes, not just Telegram's.** `hermes pairing clear-pending` takes no
platform argument and cancels every platform's pending requests, so clearing only Telegram's
stamps would have left a Discord or WhatsApp requester in exactly this hole, holding a code
that no longer exists and unable to ask for another. The lockout and its failure counter are
approval-side and per platform, so only this platform's are dropped — another platform's
lockout was earned by mistyped codes there.

**Both pairing dirs**, because `_migrate_split_pairing_dirs` merges the inactive dir's
`*.json` into the active one on start — a stamp left in the legacy copy comes straight back.

A read or write that fails now says so in the ClawBox log (message only — that file names the
people who asked to pair) instead of passing as a reset that happened. The clear still never
throws: the token is saved right after it.

## RED → GREEN
RED, on unmodified `origin/beta` (4f2406447):

```
 FAIL  clearHermesTelegramPairingState > drops every requester's stamp and this platform's lockout, in both dirs
AssertionError: expected [ 'telegram:333', …(4) ] to deeply equal [ '_lockout:discord' ]
- Expected
+ Received
  [
+   "telegram:333",
+   "_lockout:telegram",
+   "_failures:telegram",
+   "discord:444",
    "_lockout:discord",
  ]

 FAIL  clearHermesTelegramPairingState > says so in the log when the store cannot be written
AssertionError: expected '' to contain 'could not be cleared'

 Test Files  1 failed (1)
      Tests  2 failed | 45 passed (47)
```

GREEN with the fix: `hermes-telegram.test.ts` 47/47; the neighbouring suites
(`src/tests/routes/telegram/**`, `telegram-pairing-token`, `hermes-whatsapp`, `hermes-discord`,
`openclaw-config*`) 382/382; `tsc --noEmit` and `eslint` clean.

Against the **installed Hermes 0.21.1** on a device, in an isolated scratch `HERMES_HOME` (the
device's own state untouched): a first request issues an 8-character code and stamps
`telegram:<id>`; a second inside the window returns `None` — the silent branch; after a
beta-style reset the sender is **still** rate-limited; after this change's clear the very next
request issues a fresh code at once.

## Sibling call sites
* `src/app/setup-api/telegram/configure/route.ts` — the only production caller; fixed by
  construction.
* The OpenClaw path (`clearTelegramPairingState`) keeps its own store — pairing rows in the
  state database plus the legacy files, no `_rate_limits.json` — and is untouched.
* Hermes Discord and WhatsApp have no pairing-state reset of their own; their requesters are
  covered by the cross-platform scoping above.
* `POST /setup-api/setup/reset` wipes the whole Hermes home bar the agent install, so the
  stamps go with it.
* Nothing else in the tree reads or writes `_rate_limits.json`.

## Known gaps, stated rather than fixed here
* The reset runs before the token is saved and before the gateway restart (a deliberate,
  documented ordering), so a DM landing in that window can be answered by the **old** bot with
  a fresh code and a fresh stamp. The pending/approved wipe has carried the same window since
  before this change.
* `pairingDirs()` does not know profile-scoped stores
  (`<root>/profiles/<name>/platforms/pairing`), which every read and write in this file has
  shared since it was written; on a multiplex box the clear would miss the store the gateway
  reads. Worth one fix for the whole file rather than a special case here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resetting Telegram pairing now also clears related rate-limit and lockout state.
  * Unrelated entries and file permissions are preserved during cleanup.
  * Pairing resets continue safely when stored state is unreadable or cannot be updated.

* **Tests**
  * Added coverage for cleanup behavior, preservation of unrelated data, file integrity, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->