### PR TITLE
fix: safe 3.9 to beta updater handover and pre-build swap

### DIFF
--- a/config/clawbox-gateway-maintenance.sh
+++ b/config/clawbox-gateway-maintenance.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Fixed-scope root helper: a /run unit mask loses to an /etc unit file.
+# A runtime drop-in condition also applies to units installed in /etc, and
+# survives daemon-reload/unit replacement without touching the owner's masks.
+set -euo pipefail
+[ "$(id -u)" -eq 0 ] || exit 77
+[ "$#" -eq 1 ] || exit 64
+case "$1" in enter|leave) ;; *) exit 64 ;; esac
+guard=/run/clawbox-gateway-maintenance
+dropin=/run/systemd/system/clawbox-gateway.service.d/99-clawbox-maintenance.conf
+if [ "$1" = enter ]; then
+  install -d -o root -g root -m 0755 "$guard" "$(dirname "$dropin")"
+  tmp=$(mktemp "${dropin}.XXXXXX")
+  trap 'rm -f "$tmp"' EXIT
+  printf '[Unit]\nConditionPathExists=!/run/clawbox-gateway-maintenance\n' > "$tmp"
+  chmod 0644 "$tmp"
+  mv -f "$tmp" "$dropin"
+else
+  rm -f "$dropin"
+  rmdir "$guard" 2>/dev/null || { [ ! -e "$guard" ] || exit 1; }
+fi
+/usr/bin/systemctl daemon-reload
+if [ "$1" = enter ]; then
+  /usr/bin/systemctl show clawbox-gateway.service -p DropInPaths --value | grep -Fq "$dropin"
+fi

--- a/config/clawbox-sudoers
+++ b/config/clawbox-sudoers
@@ -46,6 +46,9 @@ clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl --runtime mask    clawbox-gatewa
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl --runtime mask    clawbox-gateway
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl --runtime unmask  clawbox-gateway.service
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl --runtime unmask  clawbox-gateway
+# Fixed arguments; the installed root-owned helper only gates this gateway.
+clawbox ALL=(root) NOPASSWD: /usr/local/libexec/clawbox/clawbox-gateway-maintenance.sh enter
+clawbox ALL=(root) NOPASSWD: /usr/local/libexec/clawbox/clawbox-gateway-maintenance.sh leave
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl restart clawbox-setup.service
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl restart clawbox-setup
 # clawbox-ap deliberately has NO grant. Settings -> Hotspot restarts the AP

--- a/docs/updater-legacy-handover.md
+++ b/docs/updater-legacy-handover.md
@@ -13,7 +13,7 @@ can no longer Retry.
 For a deployed 3.x app targeting a 4.x checkout, bootstrap first:
 
 1. Provisions and verifies disk swap on a low-memory appliance.
-2. Masks/stops the system gateway and stops the old dashboard for the build.
+2. Gates/stops the system gateway and stops the old dashboard for the build.
 3. Builds and verifies the new app while retaining the old app's authorization.
 4. Only after successful build, installs the new service/launcher policy.
 5. Writes an atomic `data/updater-handover.json` record and restarts the app.
@@ -39,3 +39,16 @@ In particular, a clean-image test does not cover the customer's populated
 historical session state. Verify preserved history, successful readiness and
 chat, restart stability, disk swap persistence, and failed-build Retry before
 closing the task.
+
+## Real-device maintenance guard finding
+
+On the clean-main Nano, `/run/systemd/system/clawbox-gateway.service -> /dev/null`
+coexisted with `LoadState=loaded` and `FragmentPath=/etc/systemd/system/clawbox-gateway.service`.
+The `/etc` unit wins: a successful `systemctl --runtime mask` was not a stopped-writer guarantee.
+The fixed-scope root helper installs a runtime drop-in condition, without changing
+operator masks or persistent unit files. It is installed root-owned before the
+new updater runs. Reboot clears it. A live start attempt under the guard returned
+`ActiveState=inactive`, `ConditionResult=no`; removal permits startup again.
+Post-update recovery/reachability probes defer to the final `gateway_verify`
+while the guard is held, so they neither restart a writer nor report intentional
+downtime as a failure.

--- a/docs/updater-legacy-handover.md
+++ b/docs/updater-legacy-handover.md
@@ -1,0 +1,41 @@
+# Legacy updater handover (TASK-789)
+
+## Why a beta-only runtime change was insufficient
+
+A 3.9 dashboard keeps its compiled updater in memory after bootstrap fetches
+beta's installer. It still launches raw `systemctl`, stops waiting after its
+old budgets, and may proceed while root work is unfinished. If a later rebuild
+fails after beta installs the new authorization rules, the restored old app
+can no longer Retry.
+
+## Transition
+
+For a deployed 3.x app targeting a 4.x checkout, bootstrap first:
+
+1. Provisions and verifies disk swap on a low-memory appliance.
+2. Masks/stops the system gateway and stops the old dashboard for the build.
+3. Builds and verifies the new app while retaining the old app's authorization.
+4. Only after successful build, installs the new service/launcher policy.
+5. Writes an atomic `data/updater-handover.json` record and restarts the app.
+6. The new updater requires a changed BUILD_ID and an inactive bootstrap unit,
+   then starts the **full** update. It does not treat the OS/core as upgraded.
+
+A failed build uses the existing build rollback and does not revoke the old
+app's authorization. Swap preflight failure leaves the dashboard running.
+Containers and development hosts with at least ~12 GB RAM skip the swap gate.
+On smaller hosts, at least 4 GiB active non-zram swap is required; the installer
+normally provisions 8 GiB, retaining its existing free-disk reserve.
+
+Core migration is required, not advisory. Both the system and legacy user
+OpenClaw gateways are stopped, doctor uses the device user's explicit config
+and state directory, and a nonzero result or known incomplete-migration notice
+stops the upgrade before dependent steps.
+
+## Verification status
+
+Draft implementation. Do not infer deployment or release approval from this
+file. Hardware evidence and remaining gates are tracked in TASK-789 and PR #818.
+In particular, a clean-image test does not cover the customer's populated
+historical session state. Verify preserved history, successful readiness and
+chat, restart stability, disk swap persistence, and failed-build Retry before
+closing the task.

--- a/install.sh
+++ b/install.sh
@@ -2439,6 +2439,9 @@ do_rebuild() {
   local rc=0 built=0 reboot_follows=0
   if [ "${1:-}" = "--reboot-follows" ]; then reboot_follows=1; fi
 
+  # Check before stopping the dashboard: zram alone did not prevent TASK-789.
+  ensure_build_swap || return $?
+
   echo "Stopping clawbox-setup.service for rebuild..."
   systemctl stop clawbox-setup.service 2>/dev/null || true
 
@@ -3341,6 +3344,70 @@ sync_repo_to_update_target() {
   chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$PROJECT_DIR"
 }
 
+# Refresh the running updater before it can replace the core or permissions.
+# The 3.x Node process otherwise keeps its old 330s timeout and raw systemctl
+# launcher even after bootstrap has fetched 4.x scripts (TASK-789).
+legacy_updater_needs_handover() {
+  python3 - "$PROJECT_DIR/.next/standalone/package.json" "$PROJECT_DIR/package.json" <<'PY'
+import json, sys
+try:
+    old, new = (str(json.load(open(p)).get('version', '')) for p in sys.argv[1:])
+except (OSError, ValueError):
+    sys.exit(1)
+sys.exit(0 if old.startswith('3.') and new.startswith('4.') else 1)
+PY
+}
+
+handover_legacy_updater() {
+  legacy_updater_needs_handover || return 0
+  echo "  Upgrading the legacy updater before changing OpenClaw or its launch permissions..."
+  ensure_build_swap || return 1
+  local previous_id mask_owned=0 gateway_was_active=0 rc=0
+  previous_id=$(cat "$PROJECT_DIR/.next/BUILD_ID") || return 1
+  [ -n "$previous_id" ] || return 1
+  systemctl is-active --quiet clawbox-gateway.service && gateway_was_active=1
+  if [ "$(systemctl is-enabled clawbox-gateway.service 2>/dev/null || true)" != masked ]; then
+    systemctl mask --runtime clawbox-gateway.service || return 1
+    mask_owned=1
+  fi
+  systemctl stop clawbox-gateway.service || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    # do_rebuild restores the OLD app on failure. Do not revoke that app's
+    # existing authorisation until a new build has actually been verified.
+    do_rebuild || rc=$?
+  fi
+  if [ "$rc" -eq 0 ]; then
+    ( step_systemd_services ) || rc=$?
+  fi
+  if [ "$rc" -eq 0 ]; then
+    ( step_polkit_rules ) || rc=$?
+  fi
+  if [ "$rc" -eq 0 ]; then
+    # A separate atomic marker avoids racing config-store's read/modify/write.
+    # New code resumes ALL update steps, not the normal post-reboot tail:
+    # neither the core nor the OS has been upgraded yet.
+    as_clawbox python3 - "$PROJECT_DIR/data/updater-handover.json" "$previous_id" <<'PY' || rc=$?
+import json, os, sys
+p, previous = sys.argv[1:]
+with open(p + '.tmp', 'w') as f:
+    json.dump({'version': 1, 'previousBuildId': previous}, f)
+    f.flush()
+    os.fsync(f.fileno())
+os.replace(p + '.tmp', p)
+PY
+  fi
+  if [ "$mask_owned" -eq 1 ]; then
+    systemctl unmask --runtime clawbox-gateway.service || rc=$?
+  fi
+  # No reboot needed for the bridge. The normal new-updater flow owns that.
+  systemctl reset-failed clawbox-setup.service 2>/dev/null || true
+  systemctl restart clawbox-setup.service || rc=$?
+  if [ "$rc" -ne 0 ] && [ "$gateway_was_active" -eq 1 ]; then
+    systemctl start clawbox-gateway.service 2>/dev/null || true
+  fi
+  return "$rc"
+}
+
 step_bootstrap_updater() {
   # Pull the latest repo files (especially install.sh) before any later update
   # steps run. The current root service finishes under the old script, but the
@@ -3356,6 +3423,7 @@ step_bootstrap_updater() {
   # It is gitignored now, so `git clean -fd` will not take it: drop it here.
   rm -f "$PROJECT_DIR/.deployed-sha"
   sync_repo_to_update_target "$UPDATE_TARGET_LOCAL" "$UPDATE_TARGET_UPSTREAM"
+  handover_legacy_updater
 }
 
 step_git_pull() {
@@ -4743,6 +4811,14 @@ step_harness_swap() {
   echo "  This box is now the $name edition"
 }
 
+openclaw_migration_complete() {
+  [ "$1" -eq 0 ] || return 1
+  if printf '%s\n' "$2" | grep -qiE 'requires stopped-writer maintenance|Legacy session store requires migration|startup migrations did not complete|Skipped historical transcript directive migration'; then
+    return 1
+  fi
+  return 0
+}
+
 step_openclaw_install() {
   is_hermes_edition && { echo "  [hermes edition] skipping OpenClaw npm install"; return 0; }
   # Re-assert the .bashrc PATH stanza before the early-returns BELOW. The
@@ -4819,6 +4895,11 @@ step_openclaw_install() {
     fi
   fi
   if [ "$CORE_NEEDS_INSTALL" -eq 1 ]; then
+    if [ "$(systemctl show clawbox-gateway.service -p LoadState --value 2>/dev/null || true)" = loaded ]; then
+      systemctl stop clawbox-gateway.service || return 1
+    fi
+    as_clawbox -H env XDG_RUNTIME_DIR="/run/user/$(id -u "$CLAWBOX_USER")" \
+      systemctl --user stop openclaw-gateway.service 2>/dev/null || true
     mkdir -p "$NPM_PREFIX"
     chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$NPM_PREFIX"
     chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$CLAWBOX_HOME/.npm" 2>/dev/null || true
@@ -4833,41 +4914,30 @@ step_openclaw_install() {
   # OpenClaw 2 (>= 2026.8) refuses gateway readiness while legacy state is
   # present: the sessions/transcripts move into SQLite and stale config keys
   # fail validation, and BOTH migrations are doctor's to run. A box upgraded
-  # without this step boots into a gateway that never comes up. Non-fatal on
-  # purpose — a doctor refusal leaves evidence in the gateway's own logs and
-  # the gateway start below will say so loudly — and non-interactive so an
-  # unattended update never parks on a prompt.
+  # without this step boots into a gateway that never comes up. A failed or
+  # incomplete migration is fatal: later steps cannot make it complete by
+  # racing another writer. Non-interactive so an update never parks on a prompt.
   if openclaw_version_is_v2 "$TARGET"; then
     echo "  Running openclaw doctor --fix (OpenClaw 2 config + session migrations)..."
     # The sessions-to-SQLite move must not race a still-running v1 gateway
     # writing the very files being migrated; gateway_setup restarts it later.
     systemctl stop clawbox-gateway.service 2>/dev/null || true
-    # Say WHICH failure this was. `|| echo WARN` over a doctor that migrated
-    # nothing is the false-success shape this repo keeps producing, and the
-    # commonest reason it exits non-zero here is a legacy exec-approvals file
-    # whose mere presence makes it refuse every migration before starting one
-    # (measured against 2026.8.1, 2026-09-06). The gateway's own ExecStartPre
-    # clears that and re-runs the migration, so this stays non-fatal — but the
-    # install log has to name it rather than imply doctor merely stumbled.
-    # `local` like every other assignment in this function (PIN_FILE, PINNED,
-    # TARGET, CORE_NEEDS_INSTALL): without it the whole doctor transcript leaks
-    # into a global for the rest of the installer run.
+    # A legacy user-service gateway is a second writer, outside the system
+    # unit's maintenance mask. Stop it too; an absent user bus is harmless.
+    as_clawbox -H env XDG_RUNTIME_DIR="/run/user/$(id -u "$CLAWBOX_USER")" \
+      systemctl --user stop openclaw-gateway.service 2>/dev/null || true
     local _oc_doctor_out
-    if ! _oc_doctor_out="$(as_clawbox -H "$OPENCLAW_BIN" doctor --fix --non-interactive </dev/null 2>&1)"; then
-      printf '%s\n' "$_oc_doctor_out"
-      # `CLAWBOX-WARN:` rather than a plain WARN line: the updater reads this
-      # prefix back out of the step's journal and puts it on the update's own
-      # status. A doctor that migrated nothing is exactly the case an owner
-      # needs told — the gateway can refuse readiness for it — and a line only
-      # in the journal is a line nobody on the box will read.
-      if printf '%s\n' "$_oc_doctor_out" | grep -q 'Legacy exec approvals exist at'; then
-        echo "CLAWBOX-WARN[openclaw-doctor-fix-failed]: openclaw doctor --fix migrated NOTHING — a legacy exec-approvals file blocks it. The gateway's pre-start moves an empty one aside and re-runs the migration on the next start."
-      else
-        echo "CLAWBOX-WARN[openclaw-doctor-fix-failed]: openclaw doctor --fix did not complete; the gateway may refuse readiness until it is run"
-      fi
-    else
-      printf '%s\n' "$_oc_doctor_out"
+    local _oc_doctor_rc=0
+    _oc_doctor_out="$(as_clawbox -H env \
+      OPENCLAW_STATE_DIR="$CLAWBOX_HOME/.openclaw" \
+      OPENCLAW_CONFIG_PATH="$CLAWBOX_HOME/.openclaw/openclaw.json" \
+      "$OPENCLAW_BIN" doctor --fix --non-interactive </dev/null 2>&1)" || _oc_doctor_rc=$?
+    printf '%s\n' "$_oc_doctor_out"
+    if ! openclaw_migration_complete "$_oc_doctor_rc" "$_oc_doctor_out"; then
+      echo "Error: OpenClaw migration did not complete; leaving the gateway stopped. Resolve the reported blocker and Retry before rebuilding." >&2
+      return 1
     fi
+
     # The stop above was for doctor's benefit. A FULL install restarts the
     # gateway later (gateway_setup), but this step is also on the standalone
     # run-step allow-list, where nothing follows — leaving it down would turn
@@ -6451,6 +6521,23 @@ step_swapfile() {
   fi
   ensure_swapfile_fstab "$file" || return 1
   echo "  Swap is now $(free -h | awk '/^Swap:/{print $2}') ($(swapon --show=NAME --noheadings | wc -l) devices)"
+}
+
+# An 8 GB appliance must not enter a known OOM-prone build with zram only.
+# Provisioning can deliberately skip on low disk; verify the outcome, not its
+# exit code. Bigger development hosts and container builds do not need this.
+ensure_build_swap() {
+  is_test_mode && return 0
+  in_container && return 0
+  local ram_kb disk_swap_kb
+  ram_kb=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)
+  [ "${ram_kb:-0}" -ge 12000000 ] && return 0
+  step_swapfile || return 1
+  disk_swap_kb=$(swapon --show=NAME,SIZE --bytes --noheadings | awk '$1 !~ /^\/dev\/zram/ {sum += $2} END {printf "%.0f", sum / 1024}') || return 1
+  if [ "${disk_swap_kb:-0}" -lt 4194304 ]; then
+    echo "Error: build requires at least 4 GiB active disk-backed swap on this low-memory device; free disk space or repair swap and Retry. Dashboard has not been stopped." >&2
+    return 1
+  fi
 }
 
 # One fstab line, written once, so the file comes back after a reboot.

--- a/install.sh
+++ b/install.sh
@@ -4824,6 +4824,58 @@ openclaw_migration_complete() {
   return 0
 }
 
+# Stop a gateway through the supplied service manager and verify it is quiescent.
+# A failed query is not evidence that the unit is absent; systemctl can fail
+# while a live service still owns the state we are about to migrate.
+stop_openclaw_unit_for_migration() {
+  local unit="$1"; shift
+  local status rc=0 load active
+  status="$("$@" show "$unit" -p LoadState -p ActiveState)" || rc=$?
+  load="$(printf '%s\n' "$status" | sed -n 's/^LoadState=//p')"
+  active="$(printf '%s\n' "$status" | sed -n 's/^ActiveState=//p')"
+  # systemctl may return nonzero for a missing unit, but still reports its
+  # explicit state. Only that known absent/inactive combination is a no-op.
+  if [ "$load" = not-found ] && [ "$active" = inactive ]; then
+    return 0
+  fi
+  if [ "$rc" -ne 0 ] || { [ "$load" != loaded ] && [ "$load" != masked ]; }; then
+    echo "Error: cannot inspect $unit before OpenClaw maintenance" >&2
+    return 1
+  fi
+  if ! "$@" stop "$unit"; then
+    echo "Error: cannot stop $unit; refusing OpenClaw maintenance" >&2
+    return 1
+  fi
+  if ! active="$("$@" show "$unit" -p ActiveState --value)"; then
+    echo "Error: cannot verify $unit stopped; refusing OpenClaw maintenance" >&2
+    return 1
+  fi
+  case "$active" in
+    inactive|failed) return 0 ;;
+    *) echo "Error: $unit is still $active; refusing OpenClaw maintenance" >&2; return 1 ;;
+  esac
+}
+
+stop_openclaw_gateways_for_migration() {
+  stop_openclaw_unit_for_migration clawbox-gateway.service systemctl || return 1
+  local uid manager_state
+  uid="$(id -u "$CLAWBOX_USER")" || return 1
+  # A stopped user manager has no user services to stop. Do not treat an
+  # inaccessible bus on an ACTIVE manager as an absent legacy gateway.
+  if ! manager_state="$(systemctl show "user@$uid.service" -p ActiveState --value)"; then
+    echo "Error: cannot inspect the legacy gateway's user manager" >&2
+    return 1
+  fi
+  case "$manager_state" in
+    inactive|failed) return 0 ;;
+    active)
+      stop_openclaw_unit_for_migration openclaw-gateway.service \
+        as_clawbox -H env XDG_RUNTIME_DIR="/run/user/$uid" systemctl --user || return 1
+      ;;
+    *) echo "Error: user manager is $manager_state; refusing OpenClaw maintenance" >&2; return 1 ;;
+  esac
+}
+
 step_openclaw_install() {
   is_hermes_edition && { echo "  [hermes edition] skipping OpenClaw npm install"; return 0; }
   # Re-assert the .bashrc PATH stanza before the early-returns BELOW. The
@@ -4900,11 +4952,7 @@ step_openclaw_install() {
     fi
   fi
   if [ "$CORE_NEEDS_INSTALL" -eq 1 ]; then
-    if [ "$(systemctl show clawbox-gateway.service -p LoadState --value 2>/dev/null || true)" = loaded ]; then
-      systemctl stop clawbox-gateway.service || return 1
-    fi
-    as_clawbox -H env XDG_RUNTIME_DIR="/run/user/$(id -u "$CLAWBOX_USER")" \
-      systemctl --user stop openclaw-gateway.service 2>/dev/null || true
+    stop_openclaw_gateways_for_migration || return 1
     mkdir -p "$NPM_PREFIX"
     chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$NPM_PREFIX"
     chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$CLAWBOX_HOME/.npm" 2>/dev/null || true
@@ -4926,11 +4974,7 @@ step_openclaw_install() {
     echo "  Running openclaw doctor --fix (OpenClaw 2 config + session migrations)..."
     # The sessions-to-SQLite move must not race a still-running v1 gateway
     # writing the very files being migrated; gateway_setup restarts it later.
-    systemctl stop clawbox-gateway.service 2>/dev/null || true
-    # A legacy user-service gateway is a second writer, outside the system
-    # unit's maintenance mask. Stop it too; an absent user bus is harmless.
-    as_clawbox -H env XDG_RUNTIME_DIR="/run/user/$(id -u "$CLAWBOX_USER")" \
-      systemctl --user stop openclaw-gateway.service 2>/dev/null || true
+    stop_openclaw_gateways_for_migration || return 1
     local _oc_doctor_out
     local _oc_doctor_rc=0
     _oc_doctor_out="$(as_clawbox -H env \

--- a/install.sh
+++ b/install.sh
@@ -3365,12 +3365,14 @@ handover_legacy_updater() {
   local previous_id mask_owned=0 gateway_was_active=0 rc=0
   previous_id=$(cat "$PROJECT_DIR/.next/BUILD_ID") || return 1
   [ -n "$previous_id" ] || return 1
-  systemctl is-active --quiet clawbox-gateway.service && gateway_was_active=1
-  if [ "$(systemctl is-enabled clawbox-gateway.service 2>/dev/null || true)" != masked ]; then
-    systemctl mask --runtime clawbox-gateway.service || return 1
-    mask_owned=1
+  if ! is_hermes_edition; then
+    systemctl is-active --quiet clawbox-gateway.service && gateway_was_active=1
+    case "$(systemctl is-enabled clawbox-gateway.service 2>/dev/null || true)" in
+      masked|masked-runtime) ;;
+      *) systemctl mask --runtime clawbox-gateway.service || return 1; mask_owned=1 ;;
+    esac
+    systemctl stop clawbox-gateway.service || rc=$?
   fi
-  systemctl stop clawbox-gateway.service || rc=$?
   if [ "$rc" -eq 0 ]; then
     # do_rebuild restores the OLD app on failure. Do not revoke that app's
     # existing authorisation until a new build has actually been verified.

--- a/install.sh
+++ b/install.sh
@@ -3367,10 +3367,10 @@ handover_legacy_updater() {
   [ -n "$previous_id" ] || return 1
   if ! is_hermes_edition; then
     systemctl is-active --quiet clawbox-gateway.service && gateway_was_active=1
-    case "$(systemctl is-enabled clawbox-gateway.service 2>/dev/null || true)" in
-      masked|masked-runtime) ;;
-      *) systemctl mask --runtime clawbox-gateway.service || return 1; mask_owned=1 ;;
-    esac
+    # /run masks cannot override the gold image's /etc unit. The root-held
+    # drop-in works before the new launcher has been installed as well.
+    bash "$SRC_DIR/config/clawbox-gateway-maintenance.sh" enter || return 1
+    mask_owned=1
     systemctl stop clawbox-gateway.service || rc=$?
   fi
   if [ "$rc" -eq 0 ]; then
@@ -3399,7 +3399,7 @@ os.replace(p + '.tmp', p)
 PY
   fi
   if [ "$mask_owned" -eq 1 ]; then
-    systemctl unmask --runtime clawbox-gateway.service || rc=$?
+    bash "$SRC_DIR/config/clawbox-gateway-maintenance.sh" leave || rc=$?
   fi
   # No reboot needed for the bridge. The normal new-updater flow owns that.
   systemctl reset-failed clawbox-setup.service 2>/dev/null || true
@@ -6822,7 +6822,7 @@ install_root_libexec() {
   local src failed=0
   # The integrity helper first: the dispatcher installed at the END of this
   # function refuses to run any step unless the manifest this writes verifies.
-  for src in clawbox-root-manifest.sh clawbox-run-root-step.sh; do
+  for src in clawbox-root-manifest.sh clawbox-run-root-step.sh clawbox-gateway-maintenance.sh; do
     if [ -f "$SRC_DIR/config/$src" ]; then
       install_root_file "$SRC_DIR/config/$src" "$ROOT_LIBEXEC_DIR/$src" || {
         echo "  Error: could not install $ROOT_LIBEXEC_DIR/$src (the copy already there, if any, is untouched)" >&2
@@ -7732,6 +7732,10 @@ wait_for_gateway_port() {
 }
 
 step_gateway_legacy_state_recovery() {
+  if [ -d /run/clawbox-gateway-maintenance ]; then
+    echo "  Gateway recovery deferred until updater maintenance ends"
+    return 0
+  fi
   # No gateway on the Hermes SKU — "not listening on 18789" is the CORRECT
   # state there, and running `openclaw doctor` + restarting a masked unit would
   # just churn (and, before the mask, resurrect it).
@@ -7860,7 +7864,9 @@ step_update_smoke() {
   #    value the Control UI authenticates with; weak/missing = LAN bypass risk).
   local gw_code
   gw_code=$(curl -s -o /dev/null -w "%{http_code}" -m 5 "http://127.0.0.1:${GW_PORT}/" 2>/dev/null || echo "000")
-  if [ "$gw_code" = "200" ]; then
+  if [ -d /run/clawbox-gateway-maintenance ]; then
+    echo "    [skip] gateway reachability deferred to the updater's gateway_verify step"
+  elif [ "$gw_code" = "200" ]; then
     echo "    [ok] gateway reachable"
   else
     echo "    [WARN] gateway not reachable (HTTP $gw_code) — Control UI/chat may be down"

--- a/install.sh
+++ b/install.sh
@@ -3494,6 +3494,9 @@ step_build() {
 }
 
 step_openclaw_setup() {
+  # Bash locals are visible to nested steps; defer their standalone restart
+  # until all required config/patch/voice work in this composite step succeeds.
+  local _oc_defer_gateway_start=1 _oc_gateway_restore_pending=0
   # NOTE (here and at every other early-return below): plain `echo`, never
   # `log`. log() is only defined at the very bottom of this file, AFTER the
   # `--step` dispatch block exits — so a `log` call inside a step function is a
@@ -3543,6 +3546,10 @@ step_openclaw_setup() {
     14) echo "  Warning: the TTS install did not complete (recorded above; provisioning continues)" ;;
     *) return "$TTS_STEP_RC" ;;
   esac
+  if [ "$_oc_gateway_restore_pending" -eq 1 ]; then
+    systemctl start clawbox-gateway.service 2>/dev/null || true
+  fi
+
 }
 
 # One [WARN] line plus the marker the updater raises on the update's own status.
@@ -4952,9 +4959,9 @@ step_openclaw_install() {
       CORE_NEEDS_INSTALL=0
     fi
   fi
+  stop_openclaw_gateways_for_migration || return 1
+  _oc_gateway_stopped=1
   if [ "$CORE_NEEDS_INSTALL" -eq 1 ]; then
-    stop_openclaw_gateways_for_migration || return 1
-    _oc_gateway_stopped=1
     mkdir -p "$NPM_PREFIX"
     chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$NPM_PREFIX"
     chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$CLAWBOX_HOME/.npm" 2>/dev/null || true
@@ -4990,14 +4997,6 @@ step_openclaw_install() {
       return 1
     fi
 
-  fi
-
-  # This step is also callable on its own. Restore the system gateway after
-  # successful maintenance for BOTH core generations, including a v1 rollback
-  # pin. Never restart after a failed stop, replacement or migration. A fresh
-  # install may have no unit yet, and an outer maintenance guard may defer start.
-  if [ "$_oc_gateway_stopped" -eq 1 ]; then
-    systemctl start clawbox-gateway.service 2>/dev/null || true
   fi
 
   # Force-reinstall every externally-installed plugin so they're bumped
@@ -5113,6 +5112,16 @@ for p in d.get("plugins", []):
   else
     echo "  No external plugins to refresh"
   fi
+  # Standalone installs restore only after plugin refresh. The composite setup
+  # step owns restoration after its remaining patch/config/voice operations.
+  if [ "$_oc_gateway_stopped" -eq 1 ]; then
+    if [ "${_oc_defer_gateway_start:-0}" -eq 1 ]; then
+      _oc_gateway_restore_pending=1
+    else
+      systemctl start clawbox-gateway.service 2>/dev/null || true
+    fi
+  fi
+
 }
 
 step_clawkeep_install() {

--- a/install.sh
+++ b/install.sh
@@ -4932,6 +4932,7 @@ step_openclaw_install() {
   fi
   local TARGET="${PINNED:-$OPENCLAW_VERSION}"
   local CORE_NEEDS_INSTALL=1
+  local _oc_gateway_stopped=0
 
   # Keep this guard inside the OpenClaw step too, not only in apt_update:
   # update retries can start from this step, and old images with Node v22.22.2
@@ -4953,6 +4954,7 @@ step_openclaw_install() {
   fi
   if [ "$CORE_NEEDS_INSTALL" -eq 1 ]; then
     stop_openclaw_gateways_for_migration || return 1
+    _oc_gateway_stopped=1
     mkdir -p "$NPM_PREFIX"
     chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$NPM_PREFIX"
     chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$CLAWBOX_HOME/.npm" 2>/dev/null || true
@@ -4975,6 +4977,7 @@ step_openclaw_install() {
     # The sessions-to-SQLite move must not race a still-running v1 gateway
     # writing the very files being migrated; gateway_setup restarts it later.
     stop_openclaw_gateways_for_migration || return 1
+    _oc_gateway_stopped=1
     local _oc_doctor_out
     local _oc_doctor_rc=0
     _oc_doctor_out="$(as_clawbox -H env \
@@ -4987,11 +4990,13 @@ step_openclaw_install() {
       return 1
     fi
 
-    # The stop above was for doctor's benefit. A FULL install restarts the
-    # gateway later (gateway_setup), but this step is also on the standalone
-    # run-step allow-list, where nothing follows — leaving it down would turn
-    # a UI-triggered core update into an outage. Best effort: a box where the
-    # unit does not exist yet (first install) has nothing to start.
+  fi
+
+  # This step is also callable on its own. Restore the system gateway after
+  # successful maintenance for BOTH core generations, including a v1 rollback
+  # pin. Never restart after a failed stop, replacement or migration. A fresh
+  # install may have no unit yet, and an outer maintenance guard may defer start.
+  if [ "$_oc_gateway_stopped" -eq 1 ]; then
     systemctl start clawbox-gateway.service 2>/dev/null || true
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -3369,8 +3369,11 @@ handover_legacy_updater() {
     systemctl is-active --quiet clawbox-gateway.service && gateway_was_active=1
     # /run masks cannot override the gold image's /etc unit. The root-held
     # drop-in works before the new launcher has been installed as well.
-    bash "$SRC_DIR/config/clawbox-gateway-maintenance.sh" enter || return 1
     mask_owned=1
+    if ! bash "$SRC_DIR/config/clawbox-gateway-maintenance.sh" enter; then
+      bash "$SRC_DIR/config/clawbox-gateway-maintenance.sh" leave || true
+      return 1
+    fi
     systemctl stop clawbox-gateway.service || rc=$?
   fi
   if [ "$rc" -eq 0 ]; then

--- a/src/lib/updater-handover.ts
+++ b/src/lib/updater-handover.ts
@@ -1,0 +1,16 @@
+/** The root bootstrap replaces only the old dashboard, then hands the full
+ * upgrade to the new updater. This is NOT the normal post-rebuild tail. */
+export function classifyUpdaterHandover(
+  marker: unknown,
+  currentBuildId: string,
+  bootstrapState: string | null,
+): "wait" | "ready" | "failed" {
+  if (!marker || typeof marker !== "object") return "failed";
+  const value = marker as { version?: unknown; previousBuildId?: unknown };
+  if (value.version !== 1 || typeof value.previousBuildId !== "string" || !value.previousBuildId) return "failed";
+  // A still-running root bootstrap may be installing the new launcher. Never
+  // overlap it, and an unreadable state cannot prove it finished.
+  if (!bootstrapState || ["activating", "active", "deactivating", "reloading"].includes(bootstrapState)) return "wait";
+  if (bootstrapState !== "inactive" || !currentBuildId || currentBuildId === value.previousBuildId) return "failed";
+  return "ready";
+}

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -22,6 +22,7 @@ import { runHermesCli } from "./hermes-cli";
 import { waitForPortOpen } from "./port-probe";
 import { parseHermesVersion } from "./version-utils";
 import { isSafeBranch } from "./update-branch";
+import { classifyUpdaterHandover } from "./updater-handover";
 import { startRootStep } from "./root-step-runner";
 import { watchRootStepProgress } from "./root-step-follow";
 import { setUpdateLock, clearUpdateLock, isUpdateLocked, updateLockHeldByLiveProcess } from "./update-lock";
@@ -3069,6 +3070,7 @@ const UPDATE_STEPS: UpdateStepDef[] = [
   },
   {
     id: "openclaw_install",
+    failFast: true,
     label: "Updating OpenClaw",
     timeoutMs: OPENCLAW_INSTALL_TIMEOUT_MS,
     requiresRoot: true,
@@ -3085,6 +3087,7 @@ const UPDATE_STEPS: UpdateStepDef[] = [
   },
   {
     id: "gateway_setup",
+    failFast: true,
     label: "Configuring gateway service",
     timeoutMs: 30_000,
     requiresRoot: true,
@@ -3878,6 +3881,44 @@ export function checkContinuation(): Promise<boolean> {
 }
 
 async function resumeContinuation(): Promise<boolean> {
+  const handoverFile = path.join(PROJECT_DIR, "data", "updater-handover.json");
+  let handover: unknown;
+  try {
+    if (existsSync(handoverFile)) handover = JSON.parse(await readFile(handoverFile, "utf8"));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+  if (handover !== undefined) {
+    let bootstrapState: string | null = null;
+    try {
+      const { stdout } = await execFile("/usr/bin/systemctl", [
+        "show", rootStepUnit("bootstrap_updater"), "-p", "ActiveState", "--value",
+      ], { timeout: 10_000 });
+      bootstrapState = stdout.trim() || null;
+    } catch { /* a later status/boot probe can retry */ }
+    const verdict = classifyUpdaterHandover(handover, await readBuildId(), bootstrapState);
+    if (verdict === "wait") return false;
+    if (verdict === "failed") {
+      runtime.state = createInitialState(applicableSteps());
+      runtime.state.phase = "failed";
+      runtime.state.error = "The legacy updater handover did not finish. Retry the upgrade; it is not complete.";
+      await rm(handoverFile);
+      await clearUpdateLock();
+      return false;
+    }
+    // The new app is real and the root bridge has settled. Resume from the
+    // beginning: marking the pre-reboot steps completed here would skip core
+    // installation and the very migration the bridge exists to serialize.
+    await rm(handoverFile);
+    await setMany({ update_needs_continuation: undefined, [UPDATE_INTERRUPTED_KEY]: undefined });
+    const steps = applicableSteps();
+    runtime.running = true;
+    runtime.state = createInitialState(steps);
+    runtime.state.phase = "running";
+    launchUpdate(steps, 0, { markCompleted: true });
+    return true;
+  }
+
   const needsContinuation = await get("update_needs_continuation");
   if (!needsContinuation) {
     // Boot safety. A run that died between setting the lock and writing its
@@ -4069,6 +4110,7 @@ export function startUpdate(): { started: boolean; error?: string } {
 const OPENCLAW_UPDATE_STEPS: UpdateStepDef[] = [
   {
     id: "openclaw_install",
+    failFast: true,
     label: "Updating OpenClaw",
     timeoutMs: OPENCLAW_INSTALL_TIMEOUT_MS,
     requiresRoot: true,

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -3887,7 +3887,8 @@ async function resumeContinuation(): Promise<boolean> {
   try {
     if (existsSync(handoverFile)) handover = JSON.parse(await readFile(handoverFile, "utf8"));
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    if (err instanceof SyntaxError) handover = null;
+    else if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
   }
   if (handover !== undefined) {
     let bootstrapState: string | null = null;
@@ -3903,14 +3904,14 @@ async function resumeContinuation(): Promise<boolean> {
       runtime.state = createInitialState(applicableSteps());
       runtime.state.phase = "failed";
       runtime.state.error = "The legacy updater handover did not finish. Retry the upgrade; it is not complete.";
-      await rm(handoverFile);
+      await rm(handoverFile, { force: true });
       await clearUpdateLock();
       return false;
     }
     // The new app is real and the root bridge has settled. Resume from the
     // beginning: marking the pre-reboot steps completed here would skip core
     // installation and the very migration the bridge exists to serialize.
-    await rm(handoverFile);
+    await rm(handoverFile, { force: true });
     await setMany({ update_needs_continuation: undefined, [UPDATE_INTERRUPTED_KEY]: undefined });
     const steps = applicableSteps();
     runtime.running = true;

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1776,14 +1776,14 @@ async function setGatewayMaintenanceMask(masked: boolean): Promise<void> {
   if (masked) {
     await execFile(
       "/usr/bin/sudo",
-      ["-n", "/usr/bin/systemctl", "--runtime", "mask", "clawbox-gateway.service"],
+      ["-n", "/usr/local/libexec/clawbox/clawbox-gateway-maintenance.sh", "enter"],
       options,
     );
     return;
   }
   await execFile(
     "/usr/bin/sudo",
-    ["-n", "/usr/bin/systemctl", "--runtime", "unmask", "clawbox-gateway.service"],
+    ["-n", "/usr/local/libexec/clawbox/clawbox-gateway-maintenance.sh", "leave"],
     options,
   );
 }
@@ -1862,9 +1862,10 @@ async function waitForGatewayPreStart(): Promise<void> {
 
 /**
  * Keep systemd from starting the gateway while an OpenClaw writer is active.
- * Mask comes before stop so a root update step cannot race the stop with its
+ * A root-owned runtime drop-in condition works even for /etc units, unlike
+ * a /run unit mask (TASK-789). The guard comes before stop so a root update step cannot race the stop with its
  * own restart, and before the pre-start wait so no new activation can slip
- * into `start-pre` behind it. The runtime mask is always removed, including
+ * into `start-pre` behind it. The runtime guard is always removed, including
  * failure paths.
  */
 async function withGatewayQuiesced<T>(operation: () => Promise<T>): Promise<T> {
@@ -1873,8 +1874,8 @@ async function withGatewayQuiesced<T>(operation: () => Promise<T>): Promise<T> {
   let masked = false;
   let outcome!: { ok: true; value: T } | { ok: false; error: unknown };
   try {
-    await setGatewayMaintenanceMask(true);
     masked = true;
+    await setGatewayMaintenanceMask(true);
     await waitForGatewayPreStart();
     await stopGatewayForMaintenance();
     outcome = { ok: true, value: await operation() };

--- a/src/tests/unit/install-build-swap-gate.test.ts
+++ b/src/tests/unit/install-build-swap-gate.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+const source=readFileSync("install.sh","utf8");
+const start=source.indexOf("\nensure_build_swap() {");
+const fn=source.slice(start+1,source.indexOf("\n}",start)+2);
+function run({ram=7800000, diskBytes=0, provisionRc=0, skip=false}={}) {
+  return spawnSync("bash",["-c",`set -euo pipefail
+is_test_mode() { ${skip ? "return 0" : "return 1"}; }
+in_container() { return 1; }
+step_swapfile() { echo provision >&2; return ${provisionRc}; }
+awk() { if [ "\${2:-}" = /proc/meminfo ]; then echo ${ram}; else command awk "$@"; fi; }
+swapon() { printf '/dev/zram0 4294967296\\n'; ${diskBytes ? `printf '/swapfile ${diskBytes}\\n';` : ""} }
+${fn}
+ensure_build_swap
+`],{encoding:"utf8"});
+}
+describe("build disk-swap prerequisite",()=>{
+  it("rejects zram-only even when optional provisioning exits zero",()=>{
+    const r=run();expect(r.status).toBe(1);expect(r.stderr).toContain("build requires at least 4 GiB");
+  });
+  it("requires usable capacity, not merely an active tiny swapfile",()=>{
+    expect(run({diskBytes:1024*1024*1024}).status).toBe(1);
+    expect(run({diskBytes:4*1024*1024*1024}).status).toBe(0);
+  });
+  it("propagates failed swap persistence instead of starting a build",()=>{
+    expect(run({diskBytes:8*1024*1024*1024,provisionRc:1}).status).toBe(1);
+  });
+  it("does not provision swap on large hosts or test containers",()=>{
+    for(const opts of [{ram:16000000},{skip:true}]) {
+      const r=run(opts);expect(r.status).toBe(0);expect(r.stderr).not.toContain("provision");
+    }
+  });
+});

--- a/src/tests/unit/install-build-swap-gate.test.ts
+++ b/src/tests/unit/install-build-swap-gate.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
+vi.setConfig({ testTimeout: 30000, hookTimeout: 30000 });
 const source=readFileSync("install.sh","utf8");
 const start=source.indexOf("\nensure_build_swap() {");
 const fn=source.slice(start+1,source.indexOf("\n}",start)+2);

--- a/src/tests/unit/install-migration-stop.test.ts
+++ b/src/tests/unit/install-migration-stop.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+vi.setConfig({ testTimeout: 30000 });
+const source = readFileSync("install.sh", "utf8");
+function fn(name: string) {
+  const start = source.indexOf(`\n${name}() {`);
+  if (start < 0) throw new Error(`Missing ${name}`);
+  return source.slice(start + 1, source.indexOf("\n}", start) + 2);
+}
+// Execute the real installer step, not a mirrored caller. Doctor deliberately
+// exits nonzero after emitting its marker so no downstream plugin work runs.
+function run(scenario: string, needsInstall = false) {
+  return spawnSync("bash", ["-c", `
+set -euo pipefail
+CLAWBOX_USER=test
+SRC_DIR=/nonexistent
+OPENCLAW_BIN=/bin/true
+OPENCLAW_PIN_VERSION=2026.8.1
+OPENCLAW_VERSION=2026.8.1
+NPM_PREFIX=/nonexistent
+CLAWBOX_HOME=/nonexistent
+id() { echo 1000; }
+is_hermes_edition() { return 1; }
+ensure_clawbox_bashrc_path() { :; }
+ensure_openclaw_node_engine() { :; }
+openclaw_version_is_v2() { return 0; }
+# The executable version probe yields an exact match unless replacement is tested.
+/bin/true() { echo 'OpenClaw ${needsInstall ? "2026.7.1" : "2026.8.1"}'; }
+mkdir() { echo CORE_REPLACEMENT; return 99; }
+systemctl() { ctl system "$@"; }
+as_clawbox() {
+  case "$*" in
+    *'systemctl --user'*) shift 5; ctl user "$@" ;;
+    *'doctor --fix'*) echo DOCTOR_CALLED; return 42 ;;
+    *) echo UNEXPECTED_COMMAND >&2; return 99 ;;
+  esac
+}
+ctl() {
+  local scope="$1"; shift
+  echo "CTL $scope $*" >&2
+  if [[ "$*" == *user@1000.service* ]]; then
+    case "$SCENARIO" in
+      manager-absent) echo inactive ;;
+      manager-query-failure) return 1 ;;
+      manager-activating) echo activating ;;
+      *) echo active ;;
+    esac
+    return 0
+  fi
+  if [[ "$*" == *LoadState* ]]; then
+    case "$SCENARIO:$scope" in
+      absent:*|user-absent:user) printf 'LoadState=not-found\nActiveState=inactive\n'; return 4 ;;
+      inspect-failure:system|user-bus-failure:user) return 1 ;;
+      masked:*) printf 'LoadState=masked\nActiveState=inactive\n' ;;
+      *) printf 'LoadState=loaded\nActiveState=active\n' ;;
+    esac
+  elif [ "$1" = stop ]; then
+    case "$SCENARIO:$scope" in system-stop-failure:system|user-stop-failure:user) return 1 ;; esac
+  else
+    case "$SCENARIO:$scope" in
+      still-active:system|user-still-active:user) echo active ;;
+      verify-failure:system) return 1 ;;
+      *) echo inactive ;;
+    esac
+  fi
+  return 0
+}
+${fn("stop_openclaw_unit_for_migration")}
+${fn("stop_openclaw_gateways_for_migration")}
+${fn("openclaw_migration_complete")}
+${fn("step_openclaw_install")}
+step_openclaw_install
+`, "test"], { encoding: "utf8", env: { ...process.env, SCENARIO: scenario } });
+}
+describe("OpenClaw stopped-writer prerequisite", () => {
+  for (const scenario of ["system-stop-failure", "user-stop-failure", "inspect-failure", "user-bus-failure", "manager-query-failure", "manager-activating", "still-active", "user-still-active", "verify-failure"]) {
+    it(`refuses doctor on ${scenario}`, () => {
+      const r = run(scenario);
+      expect(r.status, r.stderr).toBe(1);
+      expect(r.stdout).not.toContain("DOCTOR_CALLED");
+      expect(r.stdout).not.toContain("CORE_REPLACEMENT");
+    });
+  }
+  for (const scenario of ["success", "absent", "user-absent", "manager-absent", "masked"]) {
+    it(`reaches doctor safely on ${scenario}`, () => {
+      const r = run(scenario);
+      expect(r.stdout, r.stderr).toContain("DOCTOR_CALLED");
+      expect(r.status).toBe(1); // The sentinel doctor's failure propagates.
+      if (scenario === "absent") expect(r.stderr).not.toContain(" stop ");
+      if (scenario === "manager-absent") expect(r.stderr).not.toContain("CTL user");
+    });
+  }
+  for (const scenario of ["system-stop-failure", "user-stop-failure"]) {
+    it(`also refuses core replacement on ${scenario}`, () => {
+      const r = run(scenario, true);
+      expect(r.status, r.stderr).toBe(1);
+      expect(r.stdout).not.toContain("CORE_REPLACEMENT");
+      expect(r.stdout).not.toContain("DOCTOR_CALLED");
+    });
+  }
+});

--- a/src/tests/unit/install-migration-stop.test.ts
+++ b/src/tests/unit/install-migration-stop.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
-vi.setConfig({ testTimeout: 30000 });
+vi.setConfig({ testTimeout: 30000, hookTimeout: 30000 });
 const source = readFileSync("install.sh", "utf8");
 function fn(name: string) {
   const start = source.indexOf(`\n${name}() {`);
@@ -11,15 +11,16 @@ function fn(name: string) {
   return source.slice(start + 1, source.indexOf("\n}", start) + 2);
 }
 // Execute the real installer step, not a mirrored caller. Doctor deliberately
-// exits nonzero after emitting its marker so no downstream plugin work runs.
+// can fail or succeed; all side effects use isolated fixtures.
 function run(scenario: string, needsInstall = false) {
   const dir = mkdtempSync(path.join(tmpdir(), "migration-stop-"));
   const core = path.join(dir, "openclaw");
-  const v1 = scenario === "v1-replacement";
-  writeFileSync(core, `#!/bin/sh\necho 'OpenClaw ${v1 ? "2026.7.0" : needsInstall ? "2026.7.1" : "2026.8.1"}'\n`, { mode: 0o755 });
+  const v1 = scenario.startsWith("v1-");
+  writeFileSync(core, `#!/bin/sh\necho 'OpenClaw ${v1 ? (needsInstall ? "2026.7.0" : "2026.7.1") : needsInstall ? "2026.7.1" : "2026.8.1"}'\n`, { mode: 0o755 });
   try {
-  return spawnSync("bash", ["-c", `
+  const result = spawnSync("bash", ["-c", `
 set -euo pipefail
+event() { echo "$1" >> "${dir}/events"; }
 CLAWBOX_USER=test
 SRC_DIR=/nonexistent
 OPENCLAW_BIN="${core}"
@@ -38,15 +39,17 @@ systemctl() { ctl system "$@"; }
 as_clawbox() {
   case "$*" in
     *'systemctl --user'*) shift 5; ctl user "$@" ;;
-    *'doctor --fix'*) echo DOCTOR_CALLED; case "$SCENARIO" in v2-replacement|v2-current) return 0 ;; *) return 42 ;; esac ;;
+    *'doctor --fix'*) echo DOCTOR_CALLED; case "$SCENARIO" in v2-replacement|v2-current|setup-*) return 0 ;; *) return 42 ;; esac ;;
     *'npm install'*) echo NPM_CALLED; return 0 ;;
+    *'plugins list'*) event PLUGINS_LIST; printf '%s' '{"plugins":[{"id":"fixture-plugin","origin":"global"}]}'; return 0 ;;
+    *'plugins install'*) event PLUGIN_REFRESH; return 0 ;;
     *) echo UNEXPECTED_COMMAND >&2; return 99 ;;
   esac
 }
 ctl() {
   local scope="$1"; shift
   echo "CTL $scope $*" >&2
-  if [ "$1" = start ]; then echo GATEWAY_RESTARTED; exit 0; fi
+  if [ "$1" = start ]; then event START; echo GATEWAY_RESTARTED; return 0; fi
   if [[ "$*" == *user@1000.service* ]]; then
     case "$SCENARIO" in
       manager-absent) echo inactive ;;
@@ -78,8 +81,17 @@ ${fn("stop_openclaw_unit_for_migration")}
 ${fn("stop_openclaw_gateways_for_migration")}
 ${fn("openclaw_migration_complete")}
 ${fn("step_openclaw_install")}
-step_openclaw_install
+step_openclaw_patch() { event PATCH; [ "$SCENARIO" != setup-patch-failure ]; }
+step_openclaw_config() { event CONFIG; [ "$SCENARIO" != setup-config-failure ]; }
+step_openclaw_tts() { event TTS; [ "$SCENARIO" != setup-tts-failure ]; }
+${fn("step_openclaw_setup")}
+if [[ "$SCENARIO" == setup-* ]]; then
+  step_openclaw_setup
+else
+  step_openclaw_install
+fi
 `, "test"], { encoding: "utf8", env: { ...process.env, SCENARIO: scenario } });
+  return { ...result, events: existsSync(path.join(dir, "events")) ? readFileSync(path.join(dir, "events"), "utf8").trim().split("\n") : [] };
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -110,15 +122,29 @@ describe("OpenClaw stopped-writer prerequisite", () => {
       expect(r.stdout).not.toContain("DOCTOR_CALLED");
     });
   }
-  for (const scenario of ["v1-replacement", "v2-replacement", "v2-current"]) {
+  for (const scenario of ["v1-replacement", "v1-current", "v2-replacement", "v2-current"]) {
     it(`restores the gateway after successful ${scenario}`, () => {
-      const r = run(scenario, scenario !== "v2-current");
+      const r = run(scenario, scenario.endsWith("replacement"));
       expect(r.status, r.stderr).toBe(0);
       expect(r.stdout).toContain("GATEWAY_RESTARTED");
-      if (scenario === "v1-replacement") expect(r.stdout).not.toContain("DOCTOR_CALLED");
+      expect(r.events).toEqual(["PLUGINS_LIST", "PLUGIN_REFRESH", "START"]);
+      if (scenario.startsWith("v1-")) expect(r.stdout).not.toContain("DOCTOR_CALLED");
       else expect(r.stdout).toContain("DOCTOR_CALLED");
-      if (scenario !== "v2-current") expect(r.stdout).toContain("NPM_CALLED");
+      if (scenario.endsWith("replacement")) expect(r.stdout).toContain("NPM_CALLED");
       else expect(r.stdout).not.toContain("NPM_CALLED");
+    });
+  }
+
+  it("defers composite setup restart until plugin, patch, config and voice work finish", () => {
+    const r = run("setup-success");
+    expect(r.status, r.stderr).toBe(0);
+    expect(r.events).toEqual(["PLUGINS_LIST", "PLUGIN_REFRESH", "PATCH", "CONFIG", "TTS", "START"]);
+  });
+  for (const scenario of ["setup-patch-failure", "setup-config-failure", "setup-tts-failure"]) {
+    it(`does not restart after ${scenario}`, () => {
+      const r = run(scenario);
+      expect(r.status, r.stderr).toBe(1);
+      expect(r.events).not.toContain("START");
     });
   }
 

--- a/src/tests/unit/install-migration-stop.test.ts
+++ b/src/tests/unit/install-migration-stop.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { spawnSync } from "node:child_process";
 vi.setConfig({ testTimeout: 30000 });
 const source = readFileSync("install.sh", "utf8");
@@ -11,12 +13,17 @@ function fn(name: string) {
 // Execute the real installer step, not a mirrored caller. Doctor deliberately
 // exits nonzero after emitting its marker so no downstream plugin work runs.
 function run(scenario: string, needsInstall = false) {
+  const dir = mkdtempSync(path.join(tmpdir(), "migration-stop-"));
+  const core = path.join(dir, "openclaw");
+  const v1 = scenario === "v1-replacement";
+  writeFileSync(core, `#!/bin/sh\necho 'OpenClaw ${v1 ? "2026.7.0" : needsInstall ? "2026.7.1" : "2026.8.1"}'\n`, { mode: 0o755 });
+  try {
   return spawnSync("bash", ["-c", `
 set -euo pipefail
 CLAWBOX_USER=test
 SRC_DIR=/nonexistent
-OPENCLAW_BIN=/bin/true
-OPENCLAW_PIN_VERSION=2026.8.1
+OPENCLAW_BIN="${core}"
+OPENCLAW_PIN_VERSION=${v1 ? "2026.7.1" : "2026.8.1"}
 OPENCLAW_VERSION=2026.8.1
 NPM_PREFIX=/nonexistent
 CLAWBOX_HOME=/nonexistent
@@ -24,21 +31,22 @@ id() { echo 1000; }
 is_hermes_edition() { return 1; }
 ensure_clawbox_bashrc_path() { :; }
 ensure_openclaw_node_engine() { :; }
-openclaw_version_is_v2() { return 0; }
-# The executable version probe yields an exact match unless replacement is tested.
-/bin/true() { echo 'OpenClaw ${needsInstall ? "2026.7.1" : "2026.8.1"}'; }
-mkdir() { echo CORE_REPLACEMENT; return 99; }
+openclaw_version_is_v2() { [[ "$1" == 2026.8.* ]]; }
+mkdir() { echo CORE_REPLACEMENT; case "$SCENARIO" in v1-replacement|v2-replacement) return 0 ;; *) return 99 ;; esac; }
+chown() { :; }
 systemctl() { ctl system "$@"; }
 as_clawbox() {
   case "$*" in
     *'systemctl --user'*) shift 5; ctl user "$@" ;;
-    *'doctor --fix'*) echo DOCTOR_CALLED; return 42 ;;
+    *'doctor --fix'*) echo DOCTOR_CALLED; case "$SCENARIO" in v2-replacement|v2-current) return 0 ;; *) return 42 ;; esac ;;
+    *'npm install'*) echo NPM_CALLED; return 0 ;;
     *) echo UNEXPECTED_COMMAND >&2; return 99 ;;
   esac
 }
 ctl() {
   local scope="$1"; shift
   echo "CTL $scope $*" >&2
+  if [ "$1" = start ]; then echo GATEWAY_RESTARTED; exit 0; fi
   if [[ "$*" == *user@1000.service* ]]; then
     case "$SCENARIO" in
       manager-absent) echo inactive ;;
@@ -72,6 +80,9 @@ ${fn("openclaw_migration_complete")}
 ${fn("step_openclaw_install")}
 step_openclaw_install
 `, "test"], { encoding: "utf8", env: { ...process.env, SCENARIO: scenario } });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 }
 describe("OpenClaw stopped-writer prerequisite", () => {
   for (const scenario of ["system-stop-failure", "user-stop-failure", "inspect-failure", "user-bus-failure", "manager-query-failure", "manager-activating", "still-active", "user-still-active", "verify-failure"]) {
@@ -99,4 +110,16 @@ describe("OpenClaw stopped-writer prerequisite", () => {
       expect(r.stdout).not.toContain("DOCTOR_CALLED");
     });
   }
+  for (const scenario of ["v1-replacement", "v2-replacement", "v2-current"]) {
+    it(`restores the gateway after successful ${scenario}`, () => {
+      const r = run(scenario, scenario !== "v2-current");
+      expect(r.status, r.stderr).toBe(0);
+      expect(r.stdout).toContain("GATEWAY_RESTARTED");
+      if (scenario === "v1-replacement") expect(r.stdout).not.toContain("DOCTOR_CALLED");
+      else expect(r.stdout).toContain("DOCTOR_CALLED");
+      if (scenario !== "v2-current") expect(r.stdout).toContain("NPM_CALLED");
+      else expect(r.stdout).not.toContain("NPM_CALLED");
+    });
+  }
+
 });

--- a/src/tests/unit/install-migration-verdict.test.ts
+++ b/src/tests/unit/install-migration-verdict.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
+vi.setConfig({ testTimeout: 30000, hookTimeout: 30000 });
 const source=readFileSync("install.sh","utf8");
 const start=source.indexOf("\nopenclaw_migration_complete() {");
 const fn=source.slice(start+1,source.indexOf("\n}",start)+2);

--- a/src/tests/unit/install-migration-verdict.test.ts
+++ b/src/tests/unit/install-migration-verdict.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+const source=readFileSync("install.sh","utf8");
+const start=source.indexOf("\nopenclaw_migration_complete() {");
+const fn=source.slice(start+1,source.indexOf("\n}",start)+2);
+function verdict(code:number,output:string) {
+ return spawnSync("bash",["-c",`${fn}\nopenclaw_migration_complete "$1" "$2"`,"test",String(code),output]).status;
+}
+describe("required OpenClaw migration verdict",()=>{
+ it("rejects nonzero doctor even if the output looks finished",()=>expect(verdict(1,"Doctor complete.")).toBe(1));
+ it("rejects the customer's incomplete-migration warnings even on zero exit",()=>{
+  for(const output of ["Agent identity migration requires stopped-writer maintenance", "Legacy session store requires migration", "OpenClaw startup migrations did not complete cleanly", "Skipped historical transcript directive migration"]) expect(verdict(0,output)).toBe(1);
+ });
+ it("does not confuse optional maintenance notices with migration failures",()=>{
+  expect(verdict(0,"Session SQLite: Legacy entries 8; SQLite entries 8.\n5 dead-lettered ingress events.\nNo successful backup is recorded.\nDoctor complete.")).toBe(0);
+ });
+});

--- a/src/tests/unit/install-rebuild-build-verify.test.ts
+++ b/src/tests/unit/install-rebuild-build-verify.test.ts
@@ -379,6 +379,7 @@ function run(scenario: Scenario = {}): Run {
     "# can be told from the arm that starts them. Both are stubbed",
     "# unconditionally: an unstubbed one would be a 127 inside the updater's",
     "# own rebuild step with every suite still green.",
+    "ensure_build_swap() { return 0; }",
     "free_memory_for_build() { :; }",
     'resume_paused_engines() { echo "RESUMED"; }',
     'forget_paused_engines() { echo "FORGOT"; }',

--- a/src/tests/unit/install-updater-handover.test.ts
+++ b/src/tests/unit/install-updater-handover.test.ts
@@ -13,10 +13,10 @@ function fn(name: string) {
 let dir: string;
 beforeEach(() => { dir = mkdtempSync(path.join(tmpdir(), "task789-")); });
 afterEach(() => { rmSync(dir, {recursive:true, force:true}); });
-function bridge({buildRc=0, swapRc=0, version="3.9.0", hermes=false, preMasked=false} = {}) {
+function bridge({buildRc=0, swapRc=0, enterRc=0, version="3.9.0", hermes=false, preMasked=false} = {}) {
   mkdirSync(`${dir}/.next/standalone`,{recursive:true}); mkdirSync(`${dir}/data`);
   mkdirSync(`${dir}/config`);
-  writeFileSync(`${dir}/config/clawbox-gateway-maintenance.sh`, 'echo "maintenance $1" >> "$PROJECT_DIR/events"');
+  writeFileSync(`${dir}/config/clawbox-gateway-maintenance.sh`, `echo "maintenance $1" >> "$PROJECT_DIR/events"\nif [ "$1" = enter ]; then exit ${enterRc}; fi`);
   writeFileSync(`${dir}/.next/standalone/package.json`,JSON.stringify({version}));
   writeFileSync(`${dir}/package.json`,JSON.stringify({version:"4.0.0"}));
   writeFileSync(`${dir}/.next/BUILD_ID`,"old-build");
@@ -59,6 +59,14 @@ describe("legacy bootstrap handover executes shipped shell functions",()=>{
   });
   it("refuses before stopping any service when swap cannot be provisioned",()=>{
     const r=bridge({swapRc:1}); expect(r.status).toBe(1); expect(r.events).toBe("swap\n");
+  });
+  it("cleans a partially installed guard when enter fails without rebuilding or revoking permissions",()=>{
+    const r=bridge({enterRc:1});expect(r.status,r.stderr).toBe(1);
+    expect(r.events).toContain("maintenance enter\nmaintenance leave");
+    expect(r.events).not.toContain("build\n");
+    expect(r.events).not.toContain("policy\n");
+    expect(r.events).not.toContain("systemctl stop");
+    expect(r.marker).toBe(false);
   });
   it("does not touch an absent Hermes gateway",()=>{
     const r=bridge({hermes:true}); expect(r.status,r.stderr).toBe(0);

--- a/src/tests/unit/install-updater-handover.test.ts
+++ b/src/tests/unit/install-updater-handover.test.ts
@@ -15,11 +15,14 @@ beforeEach(() => { dir = mkdtempSync(path.join(tmpdir(), "task789-")); });
 afterEach(() => { rmSync(dir, {recursive:true, force:true}); });
 function bridge({buildRc=0, swapRc=0, version="3.9.0", hermes=false, preMasked=false} = {}) {
   mkdirSync(`${dir}/.next/standalone`,{recursive:true}); mkdirSync(`${dir}/data`);
+  mkdirSync(`${dir}/config`);
+  writeFileSync(`${dir}/config/clawbox-gateway-maintenance.sh`, 'echo "maintenance $1" >> "$PROJECT_DIR/events"');
   writeFileSync(`${dir}/.next/standalone/package.json`,JSON.stringify({version}));
   writeFileSync(`${dir}/package.json`,JSON.stringify({version:"4.0.0"}));
   writeFileSync(`${dir}/.next/BUILD_ID`,"old-build");
   const script = `set -euo pipefail
-PROJECT_DIR='${dir}'
+export PROJECT_DIR='${dir}'
+SRC_DIR='${dir}'
 systemctl() {
   echo "systemctl $*" >> "$PROJECT_DIR/events"
   if [ "$1" = is-enabled ]; then echo ${preMasked ? "masked-runtime" : "enabled"}; fi
@@ -43,15 +46,15 @@ describe("legacy bootstrap handover executes shipped shell functions",()=>{
   it("rebuilds before changing authorisation and leaves a full-upgrade continuation",()=>{
     const r=bridge(); expect(r.status,r.stderr).toBe(0);
     expect(r.events.indexOf("build\n")).toBeLessThan(r.events.indexOf("policy\n"));
-    expect(r.events).toContain("systemctl mask --runtime clawbox-gateway.service");
-    expect(r.events).toContain("systemctl unmask --runtime clawbox-gateway.service");
+    expect(r.events).toContain("maintenance enter");
+    expect(r.events).toContain("maintenance leave");
     expect(JSON.parse(readFileSync(`${dir}/data/updater-handover.json`,"utf8"))).toEqual({version:1,previousBuildId:"old-build"});
   });
   it("does not revoke the old app's permissions after build failure",()=>{
     const r=bridge({buildRc:137}); expect(r.status,r.stderr).toBe(137);
     expect(r.events).not.toContain("policy\n"); expect(r.events).not.toContain("services\n");
     expect(r.events).toContain("systemctl restart clawbox-setup.service");
-    expect(r.events).toContain("systemctl unmask --runtime clawbox-gateway.service");
+    expect(r.events).toContain("maintenance leave");
     expect(r.marker).toBe(false);
   });
   it("refuses before stopping any service when swap cannot be provisioned",()=>{
@@ -64,6 +67,7 @@ describe("legacy bootstrap handover executes shipped shell functions",()=>{
   it("does not remove an existing gateway maintenance mask",()=>{
     const r=bridge({preMasked:true});expect(r.status,r.stderr).toBe(0);
     expect(r.events).not.toContain("systemctl unmask");
+    expect(r.events).toContain("maintenance leave");
   });
   it("leaves the current 4.x updater alone",()=>{
     const r=bridge({version:"4.0.0"});expect(r.status).toBe(0);expect(r.events).toBe("");

--- a/src/tests/unit/install-updater-handover.test.ts
+++ b/src/tests/unit/install-updater-handover.test.ts
@@ -13,7 +13,7 @@ function fn(name: string) {
 let dir: string;
 beforeEach(() => { dir = mkdtempSync(path.join(tmpdir(), "task789-")); });
 afterEach(() => { rmSync(dir, {recursive:true, force:true}); });
-function bridge({buildRc=0, swapRc=0, version="3.9.0"} = {}) {
+function bridge({buildRc=0, swapRc=0, version="3.9.0", hermes=false, preMasked=false} = {}) {
   mkdirSync(`${dir}/.next/standalone`,{recursive:true}); mkdirSync(`${dir}/data`);
   writeFileSync(`${dir}/.next/standalone/package.json`,JSON.stringify({version}));
   writeFileSync(`${dir}/package.json`,JSON.stringify({version:"4.0.0"}));
@@ -22,9 +22,10 @@ function bridge({buildRc=0, swapRc=0, version="3.9.0"} = {}) {
 PROJECT_DIR='${dir}'
 systemctl() {
   echo "systemctl $*" >> "$PROJECT_DIR/events"
-  if [ "$1" = is-enabled ]; then echo enabled; fi
+  if [ "$1" = is-enabled ]; then echo ${preMasked ? "masked-runtime" : "enabled"}; fi
   return 0
 }
+is_hermes_edition() { return ${hermes ? 0 : 1}; }
 as_clawbox() { "$@"; }
 ensure_build_swap() { echo swap >> "$PROJECT_DIR/events"; return ${swapRc}; }
 do_rebuild() { echo build >> "$PROJECT_DIR/events"; return ${buildRc}; }
@@ -55,6 +56,14 @@ describe("legacy bootstrap handover executes shipped shell functions",()=>{
   });
   it("refuses before stopping any service when swap cannot be provisioned",()=>{
     const r=bridge({swapRc:1}); expect(r.status).toBe(1); expect(r.events).toBe("swap\n");
+  });
+  it("does not touch an absent Hermes gateway",()=>{
+    const r=bridge({hermes:true}); expect(r.status,r.stderr).toBe(0);
+    expect(r.events).not.toContain("clawbox-gateway.service"); expect(r.marker).toBe(true);
+  });
+  it("does not remove an existing gateway maintenance mask",()=>{
+    const r=bridge({preMasked:true});expect(r.status,r.stderr).toBe(0);
+    expect(r.events).not.toContain("systemctl unmask");
   });
   it("leaves the current 4.x updater alone",()=>{
     const r=bridge({version:"4.0.0"});expect(r.status).toBe(0);expect(r.events).toBe("");

--- a/src/tests/unit/install-updater-handover.test.ts
+++ b/src/tests/unit/install-updater-handover.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+vi.setConfig({testTimeout: 30000, hookTimeout: 30000});
+const source = readFileSync("install.sh", "utf8");
+function fn(name: string) {
+  const start = source.indexOf(`\n${name}() {`);
+  if(start < 0) throw Error(`Missing ${name}`);
+  return source.slice(start + 1, source.indexOf("\n}", start) + 2);
+}
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(path.join(tmpdir(), "task789-")); });
+afterEach(() => { rmSync(dir, {recursive:true, force:true}); });
+function bridge({buildRc=0, swapRc=0, version="3.9.0"} = {}) {
+  mkdirSync(`${dir}/.next/standalone`,{recursive:true}); mkdirSync(`${dir}/data`);
+  writeFileSync(`${dir}/.next/standalone/package.json`,JSON.stringify({version}));
+  writeFileSync(`${dir}/package.json`,JSON.stringify({version:"4.0.0"}));
+  writeFileSync(`${dir}/.next/BUILD_ID`,"old-build");
+  const script = `set -euo pipefail
+PROJECT_DIR='${dir}'
+systemctl() {
+  echo "systemctl $*" >> "$PROJECT_DIR/events"
+  if [ "$1" = is-enabled ]; then echo enabled; fi
+  return 0
+}
+as_clawbox() { "$@"; }
+ensure_build_swap() { echo swap >> "$PROJECT_DIR/events"; return ${swapRc}; }
+do_rebuild() { echo build >> "$PROJECT_DIR/events"; return ${buildRc}; }
+step_systemd_services() { echo services >> "$PROJECT_DIR/events"; }
+step_polkit_rules() { echo policy >> "$PROJECT_DIR/events"; }
+${fn("legacy_updater_needs_handover")}
+${fn("handover_legacy_updater")}
+handover_legacy_updater
+`;
+  const result = spawnSync("bash",["-c",script],{encoding:"utf8"});
+  const events = existsSync(`${dir}/events`) ? readFileSync(`${dir}/events`,"utf8") : "";
+  return {...result,events, marker: existsSync(`${dir}/data/updater-handover.json`)};
+}
+describe("legacy bootstrap handover executes shipped shell functions",()=>{
+  it("rebuilds before changing authorisation and leaves a full-upgrade continuation",()=>{
+    const r=bridge(); expect(r.status,r.stderr).toBe(0);
+    expect(r.events.indexOf("build\n")).toBeLessThan(r.events.indexOf("policy\n"));
+    expect(r.events).toContain("systemctl mask --runtime clawbox-gateway.service");
+    expect(r.events).toContain("systemctl unmask --runtime clawbox-gateway.service");
+    expect(JSON.parse(readFileSync(`${dir}/data/updater-handover.json`,"utf8"))).toEqual({version:1,previousBuildId:"old-build"});
+  });
+  it("does not revoke the old app's permissions after build failure",()=>{
+    const r=bridge({buildRc:137}); expect(r.status,r.stderr).toBe(137);
+    expect(r.events).not.toContain("policy\n"); expect(r.events).not.toContain("services\n");
+    expect(r.events).toContain("systemctl restart clawbox-setup.service");
+    expect(r.events).toContain("systemctl unmask --runtime clawbox-gateway.service");
+    expect(r.marker).toBe(false);
+  });
+  it("refuses before stopping any service when swap cannot be provisioned",()=>{
+    const r=bridge({swapRc:1}); expect(r.status).toBe(1); expect(r.events).toBe("swap\n");
+  });
+  it("leaves the current 4.x updater alone",()=>{
+    const r=bridge({version:"4.0.0"});expect(r.status).toBe(0);expect(r.events).toBe("");
+  });
+});

--- a/src/tests/unit/updater-handover-integration.test.ts
+++ b/src/tests/unit/updater-handover-integration.test.ts
@@ -48,4 +48,11 @@ describe("bootstrap handover resumes the actual updater",()=>{
   expect(updater.getUpdateState().phase).toBe("failed");
   expect(mocks.lock).not.toHaveBeenCalled();
  });
+ it("reports malformed handover JSON as a failed upgrade and clears the marker",async()=>{
+  writeFileSync(`${dir}/data/updater-handover.json`, '{"version":');
+  expect(await updater.checkContinuation()).toBe(false);
+  expect(updater.getUpdateState().phase).toBe("failed");
+  expect(existsSync(`${dir}/data/updater-handover.json`)).toBe(false);
+  expect(mocks.lock).not.toHaveBeenCalled();
+ });
 });

--- a/src/tests/unit/updater-handover-integration.test.ts
+++ b/src/tests/unit/updater-handover-integration.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+const mocks=vi.hoisted(()=>({state:"inactive",lock:vi.fn(),setMany:vi.fn(),get:vi.fn()}));
+vi.mock("child_process",()=>({exec:vi.fn(),execFile:vi.fn((...args:unknown[])=>{
+ const cb=args.at(-1) as (err:unknown,value:unknown)=>void;
+ cb(null,{stdout:mocks.state,stderr:""});
+})}));
+vi.mock("@/lib/config-store",()=>({get:mocks.get,set:vi.fn(),setMany:mocks.setMany,getKnown:vi.fn(),resolveConfigRoot:()=>process.env.CLAWBOX_ROOT,CONFIG_ROOT:"/nonexistent"}));
+vi.mock("@/lib/update-lock",()=>({setUpdateLock:mocks.lock,clearUpdateLock:vi.fn(),isUpdateLocked:vi.fn(),updateLockHeldByLiveProcess:vi.fn()}));
+let dir:string;
+let updater:typeof import("@/lib/updater");
+beforeEach(async()=>{
+ dir=mkdtempSync(path.join(tmpdir(),"handover-integration-"));
+ vi.stubEnv("CLAWBOX_ROOT",dir);
+ mkdirSync(`${dir}/data`);mkdirSync(`${dir}/.next/standalone/.next`,{recursive:true});
+ writeFileSync(`${dir}/.next/standalone/server.js`,"// fixture");
+ writeFileSync(`${dir}/.next/standalone/.next/BUILD_ID`,"new-build");
+ writeFileSync(`${dir}/.next/BUILD_ID`,"new-build");
+ writeFileSync(`${dir}/data/updater-handover.json`,JSON.stringify({version:1,previousBuildId:"gold-build"}));
+ mocks.state="inactive";mocks.setMany.mockReset();mocks.setMany.mockResolvedValue(undefined);
+ mocks.get.mockReset();mocks.lock.mockReset();mocks.lock.mockImplementation(()=>new Promise(()=>{}));
+ vi.resetModules();updater=await import("@/lib/updater");updater.resetUpdateState();
+});
+afterEach(()=>{updater.resetUpdateState();vi.unstubAllEnvs();rmSync(dir,{recursive:true,force:true});});
+describe("bootstrap handover resumes the actual updater",()=>{
+ it("starts the FULL flow without marking core/migration completed and consumes the marker",async()=>{
+  expect(await updater.checkContinuation()).toBe(true);
+  expect(existsSync(`${dir}/data/updater-handover.json`)).toBe(false);
+  expect(updater.getUpdateState().phase).toBe("running");
+  expect(updater.getUpdateState().steps.find(s=>s.id==="openclaw_install")?.status).toBe("pending");
+  expect(updater.getUpdateState().steps[0].status).toBe("pending");
+  expect(mocks.lock).toHaveBeenCalledTimes(1);
+  expect(updater.startUpdate().started).toBe(false);
+  expect(await updater.checkContinuation()).toBe(false);
+ });
+ it("leaves the marker and avoids another launch while root bootstrap is still active",async()=>{
+  mocks.state="activating";
+  expect(await updater.checkContinuation()).toBe(false);
+  expect(existsSync(`${dir}/data/updater-handover.json`)).toBe(true);
+  expect(mocks.lock).not.toHaveBeenCalled();
+  expect(mocks.get).not.toHaveBeenCalled();
+ });
+ it("reports a failed bridge instead of pretending the upgrade finished",async()=>{
+  mocks.state="failed";
+  expect(await updater.checkContinuation()).toBe(false);
+  expect(updater.getUpdateState().phase).toBe("failed");
+  expect(mocks.lock).not.toHaveBeenCalled();
+ });
+});

--- a/src/tests/unit/updater-handover.test.ts
+++ b/src/tests/unit/updater-handover.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { classifyUpdaterHandover } from "@/lib/updater-handover";
+const marker = { version: 1, previousBuildId: "gold-main-build" };
+describe("legacy updater handover", () => {
+  it("does not overlap root installation even when the new build already exists", () => {
+    for (const state of [null, "activating", "active", "deactivating", "reloading"]) {
+      expect(classifyUpdaterHandover(marker, "beta-build", state)).toBe("wait");
+    }
+  });
+  it("requires both a completed bootstrap and positive evidence of a new build", () => {
+    expect(classifyUpdaterHandover(marker, "beta-build", "inactive")).toBe("ready");
+    expect(classifyUpdaterHandover(marker, "gold-main-build", "inactive")).toBe("failed");
+    expect(classifyUpdaterHandover(marker, "", "inactive")).toBe("failed");
+    expect(classifyUpdaterHandover(marker, "beta-build", "failed")).toBe("failed");
+  });
+  it("does not infer success from malformed or incompatible records", () => {
+    for (const bad of [null, true, {}, {version: 2, previousBuildId: "old"}, {version: 1, previousBuildId: ""}]) {
+      expect(classifyUpdaterHandover(bad, "beta-build", "inactive")).toBe("failed");
+    }
+  });
+});

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -941,7 +941,7 @@ describe("updater", () => {
         call.includes("show clawbox-root-update@post_update.service -p ActiveState --value"),
       );
       const firstUnmaskIndex = calls.findIndex((call) =>
-        call.includes("systemctl --runtime unmask clawbox-gateway.service"),
+        call.includes("clawbox-gateway-maintenance.sh leave"),
       );
       expect(settleIndex).toBeGreaterThanOrEqual(0);
       expect(firstUnmaskIndex).toBeGreaterThan(settleIndex);
@@ -1223,7 +1223,7 @@ describe("updater", () => {
       const calls = mockExecFile.mock.calls.map(([cmd, args]) =>
         `${cmd} ${(args as string[]).join(" ")}`,
       );
-      const firstMask = calls.findIndex((call) => call.includes("systemctl --runtime mask clawbox-gateway.service"));
+      const firstMask = calls.findIndex((call) => call.includes("clawbox-gateway-maintenance.sh enter"));
       const firstStop = calls.findIndex((call) => call.includes("systemctl stop clawbox-gateway.service"));
       const subStateQueries = calls
         .map((call, index) => call.includes("show clawbox-gateway.service -p SubState --value") ? index : -1)
@@ -1445,13 +1445,13 @@ describe("updater", () => {
         call.includes("/bin/bash") && call.includes("scripts/gateway-pre-start.sh"),
       );
       const maskIndexes = calls
-        .map((call, index) => call.includes("systemctl --runtime mask clawbox-gateway.service") ? index : -1)
+        .map((call, index) => call.includes("clawbox-gateway-maintenance.sh enter") ? index : -1)
         .filter((index) => index >= 0);
       const stopIndexes = calls
         .map((call, index) => call.includes("systemctl stop clawbox-gateway.service") ? index : -1)
         .filter((index) => index >= 0);
       const unmaskIndexes = calls
-        .map((call, index) => call.includes("systemctl --runtime unmask clawbox-gateway.service") ? index : -1)
+        .map((call, index) => call.includes("clawbox-gateway-maintenance.sh leave") ? index : -1)
         .filter((index) => index >= 0);
       const consentIndex = calls.findIndex((call) =>
         call.includes("plugins install @openclaw/codex@2026.8.1 --force --accept-capabilities"),
@@ -2134,7 +2134,7 @@ describe("updater", () => {
 
     it("retries a failed maintenance unmask and surfaces the cleanup failure", async () => {
       setupExecFileMock({
-        "systemctl --runtime unmask clawbox-gateway.service": new Error("unmask failed"),
+        "clawbox-gateway-maintenance.sh leave": new Error("unmask failed"),
         "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
         ping: { stdout: "", stderr: "" },
         systemctl: { stdout: "", stderr: "" },
@@ -2158,7 +2158,7 @@ describe("updater", () => {
 
       const unmaskCalls = mockExecFile.mock.calls.filter(([cmd, args]) =>
         cmd === "/usr/bin/sudo"
-          && (args as string[]).join(" ").includes("systemctl --runtime unmask clawbox-gateway.service"),
+          && (args as string[]).join(" ").includes("clawbox-gateway-maintenance.sh leave"),
       );
       expect(unmaskCalls.length).toBeGreaterThanOrEqual(3);
       expect(updater.getUpdateState().steps.find((step) => step.id === "post_update")?.error)
@@ -2300,7 +2300,7 @@ describe("updater", () => {
       );
       expect(calls.some((call) => call.includes("plugins install @openclaw/codex"))).toBe(false);
       const finalUnmaskIndex = calls
-        .map((call, index) => call.includes("systemctl --runtime unmask clawbox-gateway.service") ? index : -1)
+        .map((call, index) => call.includes("clawbox-gateway-maintenance.sh leave") ? index : -1)
         .filter((index) => index >= 0)
         .at(-1) ?? -1;
       expect(consentIndex).toBeGreaterThan(preStartIndex);
@@ -2402,13 +2402,13 @@ describe("updater", () => {
         call.includes("/usr/bin/sudo -n /usr/local/libexec/clawbox/clawbox-run-root-step.sh openclaw_install"),
       );
       const firstMaskIndex = calls.findIndex((call) =>
-        call.includes("systemctl --runtime mask clawbox-gateway.service"),
+        call.includes("clawbox-gateway-maintenance.sh enter"),
       );
       const firstStopIndex = calls.findIndex((call) =>
         call.includes("systemctl stop clawbox-gateway.service"),
       );
       const firstUnmaskIndex = calls.findIndex((call) =>
-        call.includes("systemctl --runtime unmask clawbox-gateway.service"),
+        call.includes("clawbox-gateway-maintenance.sh leave"),
       );
 
       expect(firstMaskIndex).toBeLessThan(firstStopIndex);
@@ -2901,8 +2901,8 @@ describe("updater", () => {
         `${cmd} ${(args as string[]).join(" ")}`,
       );
       expect(calls.some((call) =>
-        call.includes("systemctl --runtime mask clawbox-gateway.service")
-          || call.includes("systemctl --runtime unmask clawbox-gateway.service")
+        call.includes("clawbox-gateway-maintenance.sh enter")
+          || call.includes("clawbox-gateway-maintenance.sh leave")
           || call.includes("systemctl stop clawbox-gateway.service")
           || call.includes("scripts/gateway-pre-start.sh"),
       )).toBe(false);

--- a/src/tests/unit/webapp-icon.test.ts
+++ b/src/tests/unit/webapp-icon.test.ts
@@ -307,8 +307,10 @@ describe("ensureWebappIcon", () => {
     mocks.generate.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
 
     const a = mod.ensureWebappIcon("todo-list", { name: "Todo List" });
-    const b = mod.ensureWebappIcon("notes", { name: "Notes" });
+    // Async file checks can complete in either order. Establish the first
+    // generation before checking that another app waits for its slot.
     await vi.waitFor(() => expect(mocks.generate).toHaveBeenCalledTimes(1));
+    const b = mod.ensureWebappIcon("notes", { name: "Notes" });
     // Give the second every chance to have jumped the queue.
     await new Promise((r) => setTimeout(r, 20));
     expect(mocks.generate).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary

Fix the 3.9 → beta updater transition:

- Build and verify the new dashboard before replacing the legacy updater authorization.
- Require disk-backed swap before low-memory builds and preserve rollback/Retry behavior.
- Prevent conflicting gateway starts during maintenance.
- Require confirmed shutdown of both system and legacy user gateways before core replacement or migration. Stop failures and unreadable service state abort; absent services remain a no-op.
- Run migration against explicit user state/config and reject incomplete migration results.
- Restore the gateway after successful maintenance for both legacy and current core targets. Standalone maintenance restores after plugin refresh; combined setup defers restart until patch, config and voice steps succeed.

## Validation

- 15,385 CI tests passed. The focused stop/order regressions execute the installer step and cover both core generations, absent services, failed shutdown, failed setup and deferred restart.
- TypeScript, shell syntax and whitespace checks passed.
- On a real Jetson Nano, an actual system gateway stop refusal blocked the migration boundary while the gateway remained active.
- A temporary legacy user-service fixture independently verified stop-refusal handling.
- After removing the restrictions, both service scopes stopped; the real offline doctor completed successfully and gateway readiness returned with zero restarts. The follow-up installer migration-to-restart path was also exercised on the device.
- Earlier real-device testing passed the full 13-step upgrade, reboot, persistent disk swap, injected build-failure rollback and Retry.

## Scope and remaining acceptance

The latest change received focused real-device maintenance testing, not a new full clean-image upgrade cycle. The earlier full cycle exercised a preceding revision. Build exit 137 was injected; an actual OOM was not reproduced. Populated historical-session preservation and credentialed chat remain separate acceptance checks. All required CI checks passed, including installer E2E, and the latest commit received CodeRabbit approval.
