### PR TITLE
fix: read the core's migration table from .mjs chunks too

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -664,6 +664,12 @@ clawbox_core_residual_issues() {
   if [ "$child_rc" -ne 0 ]; then
     if [ "$child_rc" -ne 3 ]; then
       child_why="$(head -c 400 "$preview_why" 2>/dev/null | tr '\n\t' '  ' || true)"
+      # `timeout` kills the child before it can write a reason, and that case is
+      # the one worth naming out of all of them: it is what an entry point or a
+      # chunk that blocks at module scope looks like from out here.
+      case "$child_rc" in
+        124|137) child_why="${child_why:-killed after 30 s without answering}" ;;
+      esac
       echo "  NOTE: the installed core's own migration table could not be run${child_why:+ ($child_why)}, so what it still refuses AFTER those migrations could not be worked out here" >&2
     fi
     rm -rf "$preview_dir"

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -499,7 +499,7 @@ clawbox_node_bin() {
 # the file on disk is not the whole config, so a preview built from it alone
 # would name keys an included file may already answer for.
 clawbox_core_residual_issues() {
-  local node_bin core_dist core_chunk preview_dir preview verdict remembered fingerprint
+  local node_bin core_dist core_chunks preview_dir preview preview_why verdict remembered fingerprint child_rc child_why
 
   fingerprint="$(clawbox_config_fingerprint)"
   remembered="$(head -n1 "$CLAWBOX_POST_MIGRATION_ISSUES" 2>/dev/null || true)"
@@ -536,15 +536,29 @@ clawbox_core_residual_issues() {
   # pipe is not a failure to report.
   #
   # BOTH module extensions, because which one a chunk gets is the bundler's
-  # decision and it has already changed once: 2026.8.1's dist is 5,852 `*.js`,
-  # 2026.9.3's is 275 `*.js` and 5,380 `*.mjs`, with this declaration only in
-  # the `.mjs` half. Still an allow-list rather than every file, so that a
-  # `.d.ts` or a `.map` carrying the same text as data is never imported.
-  core_chunk=""
+  # decision and it has already changed once. Counted over the whole `dist/`
+  # tree: 2026.8.1 is 7,219 `*.js` and 1 `*.mjs`; 2026.9.3 is 1,731 `*.js` and
+  # 5,383 `*.mjs`, with this declaration in no `.js` file at all. Still an
+  # allow-list rather than every file, so a `.d.ts` declaration or a `.map`
+  # carrying the same text as DATA is never a candidate to import.
+  #
+  # A LIST, not a first hit, because the declaration is in TWO files on both
+  # cores: the library chunk that exports it, and `dist/worker/worker.mjs` — a
+  # 44 MB worker ENTRY POINT that exports nothing and runs the worker at import
+  # (it exits non-zero on a closed stdin and blocks on an open one). With
+  # `--include='*.js'` alone that file was out of reach by accident of its
+  # extension; now that both extensions are searched, which of the two `grep`
+  # emits first is filesystem traversal order — inode and readdir, changed by
+  # any reinstall, rsync, image copy or restore — so a first-hit pick would be
+  # a coin toss between the answer and a 30 s timeout, on 2026.8.1 as much as on
+  # 2026.9.3. The child below settles it by what a module actually EXPORTS and
+  # tries the smallest file first, so an entry point is never imported while a
+  # library chunk can answer.
+  core_chunks=""
   if [ -d "$core_dist" ]; then
-    core_chunk="$(timeout -k 5 20 grep -rlF --include='*.js' --include='*.mjs' 'function applyLegacyDoctorMigrations(' "$core_dist" 2>/dev/null | head -n1 || true)"
+    core_chunks="$(timeout -k 5 20 grep -rlF --include='*.js' --include='*.mjs' 'function applyLegacyDoctorMigrations(' "$core_dist" 2>/dev/null | head -n 5 || true)"
   fi
-  if [ -z "$core_chunk" ]; then
+  if [ -z "$core_chunks" ]; then
     echo "  NOTE: the installed core's own migration table could not be read from $core_dist, so what it still refuses AFTER those migrations could not be worked out here" >&2
     return 1
   fi
@@ -562,19 +576,60 @@ clawbox_core_residual_issues() {
   # `cp -p`, so the preview carries the config's own mode: it holds the same
   # secrets for as long as it exists.
   cp -p "$OPENCLAW_CONFIG" "$preview" 2>/dev/null || { rm -rf "$preview_dir"; return 1; }
-  if ! CLAWBOX_PREVIEW_CHUNK="$core_chunk" \
+  # Why the child could not answer, written by the child INSIDE the same 0700
+  # directory and removed with it. Two outcomes are deliberately wordless (exit
+  # 3): a `$include`, and migrations that changed nothing — both are this arm
+  # standing down over a box that is not broken. Everything else that stops the
+  # table from RUNNING is a thing nobody would otherwise know to ask about.
+  preview_why="$preview_dir/why"
+  child_rc=0
+  CLAWBOX_PREVIEW_CHUNKS="$core_chunks" \
     CLAWBOX_PREVIEW_IN="$OPENCLAW_CONFIG" \
     CLAWBOX_PREVIEW_OUT="$preview" \
+    CLAWBOX_PREVIEW_WHY="$preview_why" \
     timeout -k 5 30 env -u OPENCLAW_HOME -u OPENCLAW_CONFIG_PATH -u OPENCLAW_STATE_DIR \
     "$node_bin" --input-type=module -e '
-    import { readFileSync, writeFileSync } from "node:fs";
+    import { readFileSync, statSync, writeFileSync } from "node:fs";
     import { pathToFileURL } from "node:url";
+    const why = (text) => {
+      try {
+        writeFileSync(process.env.CLAWBOX_PREVIEW_WHY, String(text).replace(/\s+/g, " ").slice(0, 400));
+      } catch { /* the NOTE degrades to a bare one; the exit code still stands */ }
+    };
+    // SMALLEST FILE FIRST, and the pick settled by what a module EXPORTS rather
+    // than by the order the filesystem handed the candidates back. The library
+    // chunk that exports the function is kilobytes; the worker entry point that
+    // merely inlines it is tens of megabytes and runs the worker when imported,
+    // so this order means it is never imported while a real chunk can answer,
+    // and a chunk that does not export it is skipped instead of ending the run.
+    const candidates = (process.env.CLAWBOX_PREVIEW_CHUNKS || "")
+      .split("\n")
+      .filter(Boolean)
+      .map((file) => {
+        let size = Number.POSITIVE_INFINITY;
+        try { size = statSync(file).size; } catch { /* unreadable: try it last */ }
+        return { file, size };
+      })
+      .sort((a, b) => a.size - b.size);
+    let apply;
+    const rejected = [];
+    for (const candidate of candidates) {
+      try {
+        const mod = await import(pathToFileURL(candidate.file).href);
+        const found = Object.values(mod).find(
+          (value) => typeof value === "function" && value.name === "applyLegacyDoctorMigrations",
+        );
+        if (found) { apply = found; break; }
+        rejected.push(candidate.file + ": exports no applyLegacyDoctorMigrations");
+      } catch (error) {
+        rejected.push(candidate.file + ": " + ((error && error.message) || String(error)));
+      }
+    }
+    if (!apply) {
+      why("no candidate chunk could be run: " + rejected.join("; "));
+      process.exit(1);
+    }
     try {
-      const mod = await import(pathToFileURL(process.env.CLAWBOX_PREVIEW_CHUNK).href);
-      const apply = Object.values(mod).find(
-        (value) => typeof value === "function" && value.name === "applyLegacyDoctorMigrations",
-      );
-      if (!apply) throw new Error("the chunk exports no applyLegacyDoctorMigrations");
       const raw = JSON.parse(readFileSync(process.env.CLAWBOX_PREVIEW_IN, "utf8"));
       // The same test `containsConfigIncludeDirective` makes in the core, on
       // the DECODED document: a `$include` may be written `"\u0024include"` in
@@ -586,7 +641,7 @@ clawbox_core_residual_issues() {
         if (Object.hasOwn(value, "$include")) return true;
         return Object.values(value).some(hasInclude);
       };
-      if (hasInclude(raw)) throw new Error("the config carries a $include directive");
+      if (hasInclude(raw)) process.exit(3);
       const result = apply(raw, { authoredRaw: raw, resolvedRaw: raw });
       // `{next: null, changes: []}` is the core saying it changed NOTHING, and
       // it says it in no other case. A preview built from the file anyway would
@@ -594,17 +649,23 @@ clawbox_core_residual_issues() {
       // can only repeat the issues the caller printed one line earlier — a
       // second, longer copy of the sentence this whole arm exists to shorten,
       // bought with another 65 s of a blocking ExecStartPre.
-      if (!result || !result.next) throw new Error("the core migrations changed nothing");
+      if (!result || !result.next) process.exit(3);
       writeFileSync(process.env.CLAWBOX_PREVIEW_OUT, JSON.stringify(result.next, null, 2) + "\n");
       // Exited explicitly rather than by letting the loop drain: this imports a
       // real bundle chunk and everything it pulls in, and the day one of those
       // registers a timer at module scope the bound above would fire over an
       // answer that was already written.
       process.exit(0);
-    } catch {
+    } catch (error) {
+      why("the core migration table threw: " + ((error && error.message) || String(error)));
       process.exit(1);
     }
-  ' >/dev/null 2>&1; then
+  ' >/dev/null 2>&1 || child_rc=$?
+  if [ "$child_rc" -ne 0 ]; then
+    if [ "$child_rc" -ne 3 ]; then
+      child_why="$(head -c 400 "$preview_why" 2>/dev/null | tr '\n\t' '  ' || true)"
+      echo "  NOTE: the installed core's own migration table could not be run${child_why:+ ($child_why)}, so what it still refuses AFTER those migrations could not be worked out here" >&2
+    fi
     rm -rf "$preview_dir"
     return 1
   fi

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -629,8 +629,18 @@ clawbox_core_residual_issues() {
       why("no candidate chunk could be run: " + rejected.join("; "));
       process.exit(1);
     }
+    // Read APART from the arm below, so a config that is not JSON is never
+    // reported as the core migration table throwing: it never ran. (No
+    // apostrophes anywhere in this child: it is a single-quoted shell string,
+    // and one would end it mid-program.)
+    let raw;
     try {
-      const raw = JSON.parse(readFileSync(process.env.CLAWBOX_PREVIEW_IN, "utf8"));
+      raw = JSON.parse(readFileSync(process.env.CLAWBOX_PREVIEW_IN, "utf8"));
+    } catch (error) {
+      why("the config could not be read as JSON: " + ((error && error.message) || String(error)));
+      process.exit(1);
+    }
+    try {
       // The same test `containsConfigIncludeDirective` makes in the core, on
       // the DECODED document: a `$include` may be written `"\u0024include"` in
       // JSON, which the shell pre-filter cannot see, and a preview built from

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -534,9 +534,15 @@ clawbox_core_residual_issues() {
   # `grep -rl` rather than a chunk name: every one of them is content-hashed and
   # changes with each core build. Bounded, and a SIGPIPE from `head` closing the
   # pipe is not a failure to report.
+  #
+  # BOTH module extensions, because which one a chunk gets is the bundler's
+  # decision and it has already changed once: 2026.8.1's dist is 5,852 `*.js`,
+  # 2026.9.3's is 275 `*.js` and 5,380 `*.mjs`, with this declaration only in
+  # the `.mjs` half. Still an allow-list rather than every file, so that a
+  # `.d.ts` or a `.map` carrying the same text as data is never imported.
   core_chunk=""
   if [ -d "$core_dist" ]; then
-    core_chunk="$(timeout -k 5 20 grep -rlF --include='*.js' 'function applyLegacyDoctorMigrations(' "$core_dist" 2>/dev/null | head -n1 || true)"
+    core_chunk="$(timeout -k 5 20 grep -rlF --include='*.js' --include='*.mjs' 'function applyLegacyDoctorMigrations(' "$core_dist" 2>/dev/null | head -n1 || true)"
   fi
   if [ -z "$core_chunk" ]; then
     echo "  NOTE: the installed core's own migration table could not be read from $core_dist, so what it still refuses AFTER those migrations could not be worked out here" >&2

--- a/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
+++ b/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
@@ -996,17 +996,25 @@ exit 0
   });
 
   it("never imports a file the allow-list excludes, however small it is", () => {
-    // Why the search is an allow-list and not every file under `dist/`. This
-    // decoy is NAMED like a declaration file and written as a module that would
-    // answer WRONGLY if it were ever imported — it reports migrations that
-    // changed nothing, which is this arm's "stand down" answer — and it is the
-    // smallest candidate, so the extension filter is the only thing between it
-    // and the owner's diagnosis.
+    // Why the search is an allow-list of module extensions and not every file
+    // under `dist/`. Three decoys carrying the same declaration text, all
+    // smaller than the chunk so size ordering would reach them first: the two
+    // realistic ones are a declaration file and a source map, which carry it as
+    // DATA; the third is a CommonJS module that would be imported happily and
+    // answer WRONGLY — it reports migrations that changed nothing, which is this
+    // arm's wordless stand-down — and it is there so this case can fail. With
+    // the `--include` flags dropped it does: no remainder is printed at all.
     writeFileSync(
       path.join(coreDistDir, "legacy-decoy.d.ts"),
-      `function applyLegacyDoctorMigrations(raw) { return { next: null, changes: [] }; }
-export { applyLegacyDoctorMigrations as A };
-`,
+      "declare function applyLegacyDoctorMigrations(raw: unknown): unknown;\n",
+    );
+    writeFileSync(
+      path.join(coreDistDir, "legacy-pGW3ZP3t.js.map"),
+      JSON.stringify({ version: 3, sources: ["legacy.ts"], sourcesContent: ["function applyLegacyDoctorMigrations(raw) {}"] }),
+    );
+    writeFileSync(
+      path.join(coreDistDir, "legacy-decoy.cjs"),
+      "exports.applyLegacyDoctorMigrations = function applyLegacyDoctorMigrations(raw) { return { next: null, changes: [] }; };\n",
     );
     withRealApproval();
 

--- a/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
+++ b/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
@@ -685,10 +685,10 @@ json.dump(doc, open(CFG, "w"), indent=2)
    * that only worked on a matching export name fails. It performs the moves and
    * NOT the strip, exactly as the real one does.
    */
-  function stubCoreMigrationChunk() {
+  function stubCoreMigrationChunk(chunkName = "legacy-pGW3ZP3t.js") {
     mkdirSync(coreDistDir, { recursive: true });
     writeFileSync(
-      path.join(coreDistDir, "legacy-pGW3ZP3t.js"),
+      path.join(coreDistDir, chunkName),
       `function applyLegacyDoctorMigrations(raw, context, options) {
   if (!raw || typeof raw !== "object") return { next: null, changes: [] };
   const next = structuredClone(raw);
@@ -909,6 +909,27 @@ exit 0
     delete fixed.messages.tts.voiceId;
     writeFileSync(configPath, JSON.stringify(fixed, null, 2));
     expect(run().stderr).not.toContain("after the core's own migrations these remain");
+  });
+
+  it("reads the migration table out of a bundle whose chunks are .mjs", () => {
+    // TASK-788, measured on the published 2026.9.3 tarball: that dist is 275
+    // `*.js` and 5,380 `*.mjs`, and `applyLegacyDoctorMigrations` is declared
+    // only in a `.mjs` chunk (0 `.js` hits). A discovery grep restricted to
+    // `*.js` therefore finds nothing on the new core, and this arm takes its
+    // fail-closed branch on every boot of every box — the diagnosis stops
+    // being produced without anything failing. Which extension a bundler
+    // picks for a chunk is its business; the declaration text is what this
+    // looks for, so both extensions have to be in the search.
+    rmSync(coreDistDir, { recursive: true, force: true });
+    stubCoreMigrationChunk("legacy-pGW3ZP3t.mjs");
+    withRealApproval();
+
+    const r = run();
+
+    expect(r.stderr).toContain("after the core's own migrations these remain");
+    expect(r.stderr).toContain('tts: Unrecognized key: "voiceId"');
+    expect(r.stderr).not.toContain("migration table could not be read");
+    expect(previewFiles()).toEqual([]);
   });
 
   it("says nothing about a remainder when the core's own table cannot be read", () => {

--- a/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
+++ b/src/tests/unit/gateway-pre-start-v2-config-repair.test.ts
@@ -724,6 +724,45 @@ export { applyLegacyDoctorMigrations as A };
     );
   }
 
+  /**
+   * The core's OTHER file carrying that declaration: the worker entry point.
+   *
+   * Measured on both published cores — 2026.8.1 and 2026.9.3 — the declaration
+   * text is in exactly two files, the library chunk above and
+   * `dist/worker/worker.mjs`, a 44 MB ENTRY POINT that exports nothing and does
+   * its work at import (the real one awaits `runWorkerProcess`, which exits
+   * non-zero on a closed stdin and blocks on an open one until the block's own
+   * `timeout -k 5 30` kills it). On 2026.8.1 it was out of reach by accident of
+   * its extension; searching `*.mjs` admits it, so the pick must not be the
+   * first hit `grep` happens to emit.
+   *
+   * Written BEFORE the library chunk and padded well past it, because both
+   * things the block relies on are measured here: creation order is what tilts
+   * grep's traversal order, and size is what orders the candidates.
+   */
+  function stubWorkerEntryChunk(): string {
+    const dir = path.join(coreDistDir, "worker");
+    mkdirSync(dir, { recursive: true });
+    // Importing it leaves a mark BEFORE it fails, so the assertion can be that
+    // it was never imported at all — not merely that the run recovered from
+    // importing it. On a box the cost of touching it is the 30 s the block's own
+    // timeout takes to kill a blocked worker, which no assertion about the
+    // outcome would show.
+    const marker = path.join(dir, "imported");
+    writeFileSync(
+      path.join(dir, "worker.mjs"),
+      `// ${"padding so this entry point is far larger than the chunk. ".repeat(4000)}
+import { writeFileSync as mark } from "node:fs";
+mark(${JSON.stringify(marker)}, "imported\\n");
+function applyLegacyDoctorMigrations(raw, context, options) {
+  return { next: null, changes: [] };
+}
+throw new Error("worker launch descriptor is required on stdin");
+`,
+    );
+    return marker;
+  }
+
   /** An `openclaw` that judges the FILE it is pointed at, like the real one. */
   function stubContentAwareOpenclaw() {
     const p = path.join(binDir, "openclaw");
@@ -929,6 +968,74 @@ exit 0
     expect(r.stderr).toContain("after the core's own migrations these remain");
     expect(r.stderr).toContain('tts: Unrecognized key: "voiceId"');
     expect(r.stderr).not.toContain("migration table could not be read");
+    expect(previewFiles()).toEqual([]);
+  });
+
+  it("picks the chunk that EXPORTS the table, not the first file grep emits", () => {
+    // The two-candidate layout both real cores have. Which of them `grep -rl`
+    // emits first is inode and readdir order — any reinstall, rsync, image copy
+    // or restore can change it — so a first-hit pick is a coin toss between the
+    // answer and a 30 s timeout on an entry point, on the core every box runs
+    // today as much as on the new one. Here the hazard is stacked in its
+    // favour: created first, far larger, and it throws when imported.
+    rmSync(coreDistDir, { recursive: true, force: true });
+    const workerImported = stubWorkerEntryChunk();
+    stubCoreMigrationChunk("legacy-pGW3ZP3t.mjs");
+    withRealApproval();
+
+    const r = run();
+
+    expect(r.stderr).toContain("after the core's own migrations these remain");
+    expect(r.stderr).toContain('tts: Unrecognized key: "voiceId"');
+    expect(r.stderr).not.toContain("migration table could not be");
+    // …and the entry point was never imported, which is the half a correct
+    // answer alone would not prove: on a box that import is the 30 s this arm
+    // is allowed before it is killed, paid on every restart of an exit-78 loop.
+    expect(existsSync(workerImported)).toBe(false);
+    expect(previewFiles()).toEqual([]);
+  });
+
+  it("never imports a file the allow-list excludes, however small it is", () => {
+    // Why the search is an allow-list and not every file under `dist/`. This
+    // decoy is NAMED like a declaration file and written as a module that would
+    // answer WRONGLY if it were ever imported — it reports migrations that
+    // changed nothing, which is this arm's "stand down" answer — and it is the
+    // smallest candidate, so the extension filter is the only thing between it
+    // and the owner's diagnosis.
+    writeFileSync(
+      path.join(coreDistDir, "legacy-decoy.d.ts"),
+      `function applyLegacyDoctorMigrations(raw) { return { next: null, changes: [] }; }
+export { applyLegacyDoctorMigrations as A };
+`,
+    );
+    withRealApproval();
+
+    const r = run();
+
+    expect(r.stderr).toContain("after the core's own migrations these remain");
+    expect(r.stderr).toContain('tts: Unrecognized key: "voiceId"');
+    expect(previewFiles()).toEqual([]);
+  });
+
+  it("says WHY the table could not be run, naming the candidate it tried", () => {
+    // The block's own rule, applied to the one path that used to be silent: a
+    // chunk found and not runnable looked exactly like a box with nothing to
+    // report. Every future core that moves the declaration into a file that
+    // does not export it lands here, and the log has to say so.
+    rmSync(coreDistDir, { recursive: true, force: true });
+    mkdirSync(coreDistDir, { recursive: true });
+    writeFileSync(
+      path.join(coreDistDir, "legacy-pGW3ZP3t.mjs"),
+      "function applyLegacyDoctorMigrations(raw) { return { next: null, changes: [] }; }\nexport const other = 1;\n",
+    );
+    withRealApproval();
+
+    const r = run();
+
+    expect(r.stderr).toContain("the installed core's own migration table could not be run");
+    expect(r.stderr).toContain("exports no applyLegacyDoctorMigrations");
+    expect(r.stderr).toContain("legacy-pGW3ZP3t.mjs");
+    expect(r.stderr).not.toContain("after the core's own migrations these remain");
     expect(previewFiles()).toEqual([]);
   });
 


### PR DESCRIPTION
**TASK-788, item 2.2-1 of the OpenClaw 2026.8.1 → 2026.9.3 upgrade assessment.** Independent of the pin bump: a latent break that goes live the moment a box installs a 2026.9.x core, so it should land first.

## Symptom (customer-visible)

On a box running the new core, every gateway boot over a config the core refuses prints

```
  NOTE: the installed core's own migration table could not be read from …/lib/node_modules/openclaw/dist,
        so what it still refuses AFTER those migrations could not be worked out here
```

and the one sentence that arm exists to produce — `after the core's own migrations these remain: tts: Unrecognized key: "voiceId"` — is never printed again. Nothing fails and no step goes red: the owner is left with the long list of keys the core would have migrated by itself and no way to tell which one is actually in the way. That is the diagnosis TASK-737 was built to hand him after a customer box was dark for 25 hours, and the unit is in a `Restart=always` exit-78 loop while he reads it.

## Cause

`clawbox_core_residual_issues` (`scripts/gateway-pre-start.sh`) finds the core's own `applyLegacyDoctorMigrations` by grepping the installed bundle for its declaration text, and the search was restricted to `--include='*.js'`. The bundler's chunk extension changed between the two cores — counted over the whole `dist/` tree:

| core | `dist/**/*.js` | `dist/**/*.mjs` | files declaring `applyLegacyDoctorMigrations(` |
|---|---|---|---|
| 2026.8.1 | 7,219 | 1 | `dist/io.runtime-CNGn9TXj.js` + `dist/worker/worker.mjs` |
| 2026.9.3 | 1,731 | 5,383 | `dist/io.factory-CoH0ZApo.mjs` + `dist/worker/worker.mjs` |

So on 2026.9.3 the `.js`-only grep matches nothing and the function takes its fail-closed branch.

## Fix

Two things, because the first one alone introduces a second defect.

**1. Search both module extensions.** Still an allow-list rather than every file under `dist/`, so a `.d.ts` declaration or a `.map` that carries the same text as *data* is never a candidate to import.

**2. Settle the pick by what a module EXPORTS, not by which file grep emits first.** The declaration is in **two** files on *both* cores, and the second is `dist/worker/worker.mjs` — a 44 MB worker **entry point** that exports nothing and does its work at import. With `--include='*.js'` it was out of reach by accident of its extension; widening the search admits it, and `head -n1` would then have picked between the two by filesystem traversal order (inode and readdir — changed by any reinstall, rsync, image copy or ClawKeep restore), **on 2026.8.1, the core every box runs today, as much as on 2026.9.3**. Measured on the real files: the library chunk answers rc=0 in 1.1 s with the correct preview; importing the worker dies with the core's own `worker launch descriptor is required on stdin` (rc=1, ~2 s, stdin at EOF — the systemd `ExecStartPre` case) or **blocks until the block's own `timeout -k 5 30` kills it** (rc=124) when stdin is open. Either way no preview is produced and the arm used to `return 1` printing nothing — the exact gap it exists to close, restored by the widening that was meant to restore it, and paid on every restart of the loop because failures are deliberately not remembered.

So the candidate list (bounded) now goes to the node child, which orders it **smallest file first** and imports until one actually exports a function named `applyLegacyDoctorMigrations`. An entry point is never imported while a library chunk can answer, a chunk that does not export it is skipped instead of ending the run, and the answer no longer depends on traversal order.

**3. Every reason the table could not be RUN now reaches the owner as one NOTE** naming the candidate and the reason (`… could not be run (…/legacy-x.mjs: exports no applyLegacyDoctorMigrations), so what it still refuses AFTER those migrations could not be worked out here`). The child's failures were uniformly silent before — wrong chunk, missing export, changed signature, the timeout — against the block's own rule that "a diagnosis that disappears silently is one nobody knows to ask for". The two **deliberate** stand-downs keep their silence behind their own exit code: a `$include` in the decoded document, and migrations that changed nothing (both mean the box is not broken and the caller's own line already says everything).

## Harness first

Nothing is re-implemented: the block still reads the core's own migration function out of the installed bundle and runs it — the same function `planStartupConfigRepair` and `migrateLegacyConfig` call — rather than keeping a copy of the rename table on our side, and the renamed export binding is still matched by `value.name` (2026.9.3 exports it as `applyLegacyDoctorMigrations as c`; the declaration is what the grep looks for, and its signature `(raw, context, options)` is unchanged from 2026.8.1).

**Is there a native command that would answer this instead?** Asked of a real isolated 2026.9.3 install, with the incident's config shape:

- `config validate --json` → the two **pre**-migration issues only; never `tts.voiceId`.
- `doctor --lint --json` and bare `doctor --json` (both read-only) → the same two findings under `core/doctor/final-config-validation`; never `tts.voiceId`.
- `doctor --help` on 2026.9.3 has `--lint`, `--json`, `--post-upgrade`, `--session-sqlite dry-run` — **no config-migration dry-run**; `config --help` has no `config migrate`.
- The closest native surface is `config patch --stdin --dry-run`, which prints a "Legacy config keys detected:" block naming the moves the core knows — in human text only (its `--json` omits it), and it names the **moves, not what survives them**. Config on disk unchanged by the dry-run (verified).

So running the core's own table out of the installed bundle remains the only way to get the remainder, and `openclaw doctor --fix` remains the migration owner — this arm only *names* what is left, because doctor additionally strips unknown keys (it deletes the owner's `tts.voiceId` instead of naming it).

## RED → GREEN

New cases in the existing bash-harness suite, in the shipped-block style (the tests slice the real script, so a drift in the script fails here).

RED, on unmodified `beta` — the `.mjs` case:

```
 FAIL  |unit| src/tests/unit/gateway-pre-start-v2-config-repair.test.ts >
       reads the migration table out of a bundle whose chunks are .mjs
AssertionError: expected '  NOTE: …' to contain 'after the core's own migrations these remain'

+   NOTE: the installed core's own migration table could not be read from …/lib/node_modules/openclaw/dist,
        so what it still refuses AFTER those migrations could not be worked out here
+   ERROR: the core still refuses this config — the gateway will exit 78 until this is fixed: …

 Test Files  1 failed (1)      Tests  1 failed | 30 skipped (31)
```

GREEN, with the fix — and three more cases, each proven able to fail by mutating the thing it guards:

```
 src/tests/unit/gateway-pre-start-v2-config-repair.test.ts   Test Files  1 passed (1)   Tests  34 passed (34)
```

| case | mutation | result |
|---|---|---|
| reads the migration table out of a bundle whose chunks are `.mjs` | `--include='*.mjs'` removed (i.e. beta) | fails — fail-closed NOTE, no remainder |
| picks the chunk that EXPORTS the table, not the first file grep emits (fixture: a `worker/worker.mjs` that declares the function, exports nothing, marks itself on import and throws — created first and far larger) | candidate order reversed to largest-first | fails — the entry point was imported (`expect(existsSync(workerImported)).toBe(false)`) |
| never imports a file the allow-list excludes, however small it is (fixture: `.d.ts`, a `.js.map` with the text in `sourcesContent`, and a tiny CommonJS decoy that would answer "changed nothing") | both `--include` flags dropped | fails — the CJS decoy answers and the remainder disappears |
| says WHY the table could not be run, naming the candidate it tried | the new NOTE removed (i.e. the previous head) | fails — no reason in the log |

Neighbouring suites, unchanged and green:

```
 gateway-pre-start-v2-cleanup / -plugin-repair / -corrupt-config / -version-probe /
 gateway-prestart-onboarding / test-timeout-hygiene      Test Files  7 passed (7)   Tests  146 passed (146)
```

Typecheck clean, ESLint clean.

## Sibling call sites of the same assumption

Every other place that greps a bundle with `--include='*.js'` was checked:

- `install.sh:5125-5153` and `install-x64.sh:585-609` (`$GATEWAY_DIST`, the same core `dist/`) — **cleared, not touched**: `step_openclaw_patch` returns early on `openclaw_is_v2`, and `openclaw_version_is_v2` is a `sort -V` test against `2026.8`, so every 2026.x core takes that return. OpenClaw-1-only paths no shipped box reaches.
- `scripts/check-bundled-builtins.sh:56,70` — **cleared**: it scans our own `.next/server/chunks`, which Turbopack emits as `.js`, and it carries a positive control, so an extension change there fails loudly rather than silently.
- `scripts/gateway-pre-start.sh:3454` (`dist/extensions/deepseek/openclaw.plugin.json`) and `src/lib/core-model-lifecycle.ts` — **cleared**: JSON manifest paths, not extension-filtered searches; the 60 extension manifests are present unchanged in 2026.9.3. `src/lib/gateway-static.ts:46` already allows `.js` and `.mjs`.

## Cost and risk

- Behaviour on 2026.8.1 is unchanged in outcome, and strictly safer in the getting there: the same library chunk answers, and the worker entry point that the widened search admits is now never imported.
- The discovery grep is not slower: on the real 2026.9.3 dist it completes in tens of milliseconds warm, and the old `.js`-only grep had to read 30 MB of `.js` to find nothing.
- On a core with neither extension present the fail-closed branch is still taken and the honest refusal line is still printed.
- Reviewed via the `clawbox-review` skill; this head is the result of that pass (the worker-entry-point finding, the silent-failure finding and the two-candidate fixture all come from it).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration discovery for installations using `.js` and `.mjs` files.
  * Ensured the correct migration module is selected when multiple candidate files are present.
  * Excluded unsupported files, such as declaration files, source maps, and CommonJS modules, from migration discovery.
  * Added clearer diagnostics when a discovered module cannot provide the required migration functionality.
  * Improved handling of no-op migrations and include directives during configuration repair.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->