### PR TITLE
fix: never draw a per-core CPU row that was not measured

### DIFF
--- a/mcp/tools/system.ts
+++ b/mcp/tools/system.ts
@@ -362,7 +362,7 @@ interface EthernetStatusPayload {
 export function registerSystemTools(reg: Registrar, ctx: McpContext): void {
   reg.tool(
     "system_stats",
-    "Read live device metrics: CPU, memory, temperature, GPU, network and the top processes. For disk-space questions use disk_usage, and for version questions use update_check — both give a shorter, more direct answer than this.",
+    "Read live device metrics: CPU, memory, temperature, GPU, network and the top processes. An empty `cpu.perCore` means the per-core figures have not been measured yet (the first read after a restart needs a second one to diff against) — not that the cores are idle; call again for them. For disk-space questions use disk_usage, and for version questions use update_check — both give a shorter, more direct answer than this.",
     {},
     { editions: ["openclaw", "hermes"], readOnly: true, profile: "core", maxChars: 6_000 },
     async () => json(await apiGet("/setup-api/system/stats", { timeoutMs: 15_000 })),

--- a/src/app/setup-api/system/stats/route.ts
+++ b/src/app/setup-api/system/stats/route.ts
@@ -315,8 +315,13 @@ export async function GET() {
         cores: cpus.length,
         loadAvg: os.loadavg().map((v) => v.toFixed(2)),
         speed: cpus[0]?.speed || 0,
-        // One entry per core, or empty where /proc/stat could not be read —
-        // never a row of zeros, which would be a claim that the box is idle.
+        // One entry per core, or empty where there is no reading to give:
+        // /proc/stat unreadable, or nothing to diff it against yet — the first
+        // request of a process, which every server restart (so every in-app
+        // update) creates. Never a row of zeros, which would be a claim that
+        // the box is idle, and never a partly-carried row. Readers draw no
+        // per-core row on an empty list; a polling one has real figures on its
+        // next 3 s request.
         perCore: cpuCores,
       },
       memory: {

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -6059,9 +6059,12 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                     switches left (2026-09-09) and this is what System is for.
 
                     Both degrade rather than lie: a server that predates the
-                    per-core reading sends no `perCore`, and one that cannot
-                    read /proc/stat sends an empty list — either way the row is
-                    absent, never a row of zeros claiming an idle machine. */}
+                    per-core reading sends no `perCore`, and one with no reading
+                    to give sends an empty list — it could not read /proc/stat,
+                    or has nothing to diff it against yet, which is every first
+                    request after a restart. Either way the row is absent until
+                    the next 3 s poll, never a row of zeros claiming an idle
+                    machine. */}
                 {stats.cpu.perCore && stats.cpu.perCore.length > 0 && (
                   <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5" data-testid="settings-per-core">
                     <div className="flex items-center gap-2 mb-4">

--- a/src/lib/cpu-usage.ts
+++ b/src/lib/cpu-usage.ts
@@ -34,7 +34,7 @@ const MAX_SAMPLE_AGE_MS = 60_000;
 
 let lastSample: CpuSample | null = null;
 let lastUsage: number | null = null;
-let lastCoreSamples: (CpuSample | null)[] = [];
+let lastCoreSamples: CoreSample[] = [];
 let lastCoreUsage: number[] | null = null;
 /** When `lastCoreUsage` was measured — a carried row ages out like a sample. */
 let lastCoreUsageAt = 0;
@@ -57,20 +57,35 @@ export function parseProcStat(raw: string, now: number): CpuSample | null {
   return sampleFromLine(raw.split("\n")[0], now);
 }
 
+/** One `cpuN` line of /proc/stat: which core it is, and its sample. */
+export interface CoreSample {
+  /**
+   * The `N` of `cpuN`.
+   *
+   * Kept rather than implied by the position, because Linux prints a line per
+   * ONLINE cpu: offline a middle core and every line after it shifts up, so two
+   * readings of the same LENGTH can still be about different cores.
+   */
+  id: number;
+  /** null where the line could not be read as a sample. */
+  sample: CpuSample | null;
+}
+
 /**
- * The PER-CORE lines, `cpu0`…`cpuN`, in order.
+ * The PER-CORE lines, `cpu0`…`cpuN`, in the order the file lists them.
  *
  * The same file and the same arithmetic as the aggregate above — /proc/stat
  * carries both, so a per-core reading costs no extra read and no extra sleep.
- * A core whose line is unusable is `null` rather than 0: on a six-core Orin the
- * difference between "this core is idle" and "this core could not be read" is
- * the difference between a reassuring picture and a wrong one.
+ * A core whose line is unusable has a `null` sample rather than 0: on a
+ * six-core Orin the difference between "this core is idle" and "this core could
+ * not be read" is the difference between a reassuring picture and a wrong one.
  */
-export function parseProcStatCores(raw: string, now: number): (CpuSample | null)[] {
-  const out: (CpuSample | null)[] = [];
+export function parseProcStatCores(raw: string, now: number): CoreSample[] {
+  const out: CoreSample[] = [];
   for (const line of raw.split("\n")) {
-    if (!/^cpu\d+\s/.test(line)) continue;
-    out.push(sampleFromLine(line, now));
+    const cpu = /^cpu(\d+)\s/.exec(line);
+    if (!cpu) continue;
+    out.push({ id: Number(cpu[1]), sample: sampleFromLine(line, now) });
   }
   return out;
 }
@@ -139,7 +154,13 @@ function isRecent(now: number, at: number): boolean {
  * wrong claim as a zero.
  */
 function carriedCoreUsage(now: number): number[] {
-  if (!lastCoreUsage || !isRecent(now, lastCoreUsageAt)) return [];
+  if (!lastCoreUsage) return [];
+  if (!isRecent(now, lastCoreUsageAt)) {
+    // Forgotten, not merely withheld: a row this call refused as too old must
+    // not become eligible again when the clock next steps backwards.
+    lastCoreUsage = null;
+    return [];
+  }
   return lastCoreUsage;
 }
 
@@ -166,13 +187,13 @@ function coreBusy(then: CpuSample, current: CpuSample): number | null {
  * call of the process, which every server restart creates — no previous sample
  * and no recent figures to stand in for it. Empty for the WHOLE row, never a
  * row that is measured for some cores and carried for others, and never a row
- * carried across a change in core count (a hotplug, or an nvpmodel mode that
- * offlines cores): a six-entry row reads as six measurements of these six
- * cores. The caller renders empty as no per-core row at all, and the next poll
- * 3 s later has real figures.
+ * carried across a change in which cores are online (a hotplug, or an nvpmodel
+ * mode that offlines some): a six-entry row reads as six measurements of these
+ * six cores. The caller renders empty as no per-core row at all, and the next
+ * poll 3 s later has real figures.
  */
 export function getCpuCoreUsage(now: number = Date.now()): number[] {
-  let current: (CpuSample | null)[];
+  let current: CoreSample[];
   try {
     current = parseProcStatCores(fs.readFileSync("/proc/stat", "utf-8"), now);
   } catch {
@@ -184,13 +205,16 @@ export function getCpuCoreUsage(now: number = Date.now()): number[] {
   // Set before any early return: whatever this call could not answer, the next
   // one has a sample to diff against.
   lastCoreSamples = current;
-  // A core count that changed (a hotplug, or a first call) has nothing to diff
-  // against; so does a sample too old to be about "now".
-  const comparable = previous.length === current.length;
+  // Comparable means "about the same cores", by id — a first call has nothing to
+  // diff against, and so does a reading of a different set of cores, even one
+  // that happens to be the same size (offline cpu1 while cpu2 comes back and
+  // the count is unchanged while every position has moved).
+  const comparable =
+    previous.length === current.length && previous.every((core, i) => core.id === current[i].id);
 
-  const measured = current.map((sample, i) => {
-    const then = comparable ? previous[i] : null;
-    return sample && then && isRecent(now, then.at) ? coreBusy(then, sample) : null;
+  const measured = current.map((core, i) => {
+    const then = comparable ? previous[i].sample : null;
+    return core.sample && then && isRecent(now, then.at) ? coreBusy(then, core.sample) : null;
   });
   if (measured.every((busy): busy is number => busy !== null)) {
     lastCoreUsage = measured;
@@ -205,7 +229,7 @@ export function getCpuCoreUsage(now: number = Date.now()): number[] {
   // about these cores: it is withheld whole, and forgotten so a later call
   // cannot index it.
   const carried = carriedCoreUsage(now);
-  if (measured.some((busy) => busy !== null) || carried.length !== current.length) {
+  if (measured.some((busy) => busy !== null) || !comparable || carried.length !== current.length) {
     lastCoreUsage = null;
     return [];
   }

--- a/src/lib/cpu-usage.ts
+++ b/src/lib/cpu-usage.ts
@@ -118,13 +118,28 @@ export function getCpuUsage(now: number = Date.now()): number {
 }
 
 /**
+ * Is a sample — or a row already published — recent enough to describe "now"?
+ *
+ * A NEGATIVE age is not "very recent": it means the wall clock moved backwards
+ * under us, which a box with no RTC does every boot once NTP answers. The age
+ * is then not a fact, so the window cannot be claimed to be a short one. The
+ * per-core row is the half of this module that can fabricate a reading, so it is
+ * the half held to an age it can trust; the aggregate's fallback is the load
+ * average, a real figure whichever way the clock jumped.
+ */
+function isRecent(now: number, at: number): boolean {
+  const age = now - at;
+  return age >= 0 && age <= MAX_SAMPLE_AGE_MS;
+}
+
+/**
  * The row published last time, where it is still recent enough to stand in for
  * a measurement of "now" — held to the same window as the samples themselves,
  * because figures from five minutes ago under a fresh timestamp are the same
  * wrong claim as a zero.
  */
 function carriedCoreUsage(now: number): number[] {
-  if (!lastCoreUsage || now - lastCoreUsageAt > MAX_SAMPLE_AGE_MS) return [];
+  if (!lastCoreUsage || !isRecent(now, lastCoreUsageAt)) return [];
   return lastCoreUsage;
 }
 
@@ -175,7 +190,7 @@ export function getCpuCoreUsage(now: number = Date.now()): number[] {
 
   const measured = current.map((sample, i) => {
     const then = comparable ? previous[i] : null;
-    return sample && then && now - then.at <= MAX_SAMPLE_AGE_MS ? coreBusy(then, sample) : null;
+    return sample && then && isRecent(now, then.at) ? coreBusy(then, sample) : null;
   });
   if (measured.every((busy): busy is number => busy !== null)) {
     lastCoreUsage = measured;

--- a/src/lib/cpu-usage.ts
+++ b/src/lib/cpu-usage.ts
@@ -36,6 +36,8 @@ let lastSample: CpuSample | null = null;
 let lastUsage: number | null = null;
 let lastCoreSamples: (CpuSample | null)[] = [];
 let lastCoreUsage: number[] | null = null;
+/** When `lastCoreUsage` was measured — a carried row ages out like a sample. */
+let lastCoreUsageAt = 0;
 
 /** One `cpu…` line of /proc/stat as a sample, or null if it is not one. */
 function sampleFromLine(line: string | undefined, now: number): CpuSample | null {
@@ -115,6 +117,17 @@ export function getCpuUsage(now: number = Date.now()): number {
   return usage;
 }
 
+/**
+ * The row published last time, where it is still recent enough to stand in for
+ * a measurement of "now" — held to the same window as the samples themselves,
+ * because figures from five minutes ago under a fresh timestamp are the same
+ * wrong claim as a zero.
+ */
+function carriedCoreUsage(now: number): number[] {
+  if (!lastCoreUsage || now - lastCoreUsageAt > MAX_SAMPLE_AGE_MS) return [];
+  return lastCoreUsage;
+}
+
 /** Percent busy of one core between two of its samples, or null if they do not diff. */
 function coreBusy(then: CpuSample, current: CpuSample): number | null {
   const dTotal = current.total - then.total;
@@ -136,19 +149,21 @@ function coreBusy(then: CpuSample, current: CpuSample): number | null {
  *
  * Empty where there is no figure to give: /proc/stat unreadable, or — the first
  * call of the process, which every server restart creates — no previous sample
- * and no earlier figures to stand in for it. Empty for the WHOLE row, never a
- * row that is measured for some cores and carried for others, because a
- * six-entry row reads as six measurements. The caller renders that as no
- * per-core row at all, and the next poll 3 s later has real figures.
+ * and no recent figures to stand in for it. Empty for the WHOLE row, never a
+ * row that is measured for some cores and carried for others, and never a row
+ * carried across a change in core count (a hotplug, or an nvpmodel mode that
+ * offlines cores): a six-entry row reads as six measurements of these six
+ * cores. The caller renders empty as no per-core row at all, and the next poll
+ * 3 s later has real figures.
  */
 export function getCpuCoreUsage(now: number = Date.now()): number[] {
   let current: (CpuSample | null)[];
   try {
     current = parseProcStatCores(fs.readFileSync("/proc/stat", "utf-8"), now);
   } catch {
-    return lastCoreUsage ?? [];
+    return carriedCoreUsage(now);
   }
-  if (current.length === 0) return lastCoreUsage ?? [];
+  if (current.length === 0) return carriedCoreUsage(now);
 
   const previous = lastCoreSamples;
   // Set before any early return: whatever this call could not answer, the next
@@ -158,19 +173,28 @@ export function getCpuCoreUsage(now: number = Date.now()): number[] {
   // against; so does a sample too old to be about "now".
   const comparable = previous.length === current.length;
 
-  const usage: number[] = [];
-  for (let i = 0; i < current.length; i += 1) {
-    const sample = current[i];
+  const measured = current.map((sample, i) => {
     const then = comparable ? previous[i] : null;
-    const measured =
-      sample && then && now - then.at <= MAX_SAMPLE_AGE_MS ? coreBusy(then, sample) : null;
-    // `??`, so a genuine 0% measurement stands as itself.
-    const busy = measured ?? lastCoreUsage?.[i];
-    if (typeof busy !== "number") return [];
-    usage.push(busy);
+    return sample && then && now - then.at <= MAX_SAMPLE_AGE_MS ? coreBusy(then, sample) : null;
+  });
+  if (measured.every((busy): busy is number => busy !== null)) {
+    lastCoreUsage = measured;
+    lastCoreUsageAt = now;
+    return measured;
   }
-  lastCoreUsage = usage;
-  return usage;
+
+  // Not every core was measured. The row published last time stands in only
+  // when it is the whole answer — nothing measured now, the same cores as then,
+  // and recent — which is the suspend/rollover case the aggregate handles the
+  // same way. A part-measured row, or one from a different core count, is not
+  // about these cores: it is withheld whole, and forgotten so a later call
+  // cannot index it.
+  const carried = carriedCoreUsage(now);
+  if (measured.some((busy) => busy !== null) || carried.length !== current.length) {
+    lastCoreUsage = null;
+    return [];
+  }
+  return carried;
 }
 
 /** Test seam — drops the cached sample so each test starts cold. */
@@ -179,4 +203,5 @@ export function __resetCpuUsageCache(): void {
   lastUsage = null;
   lastCoreSamples = [];
   lastCoreUsage = null;
+  lastCoreUsageAt = 0;
 }

--- a/src/lib/cpu-usage.ts
+++ b/src/lib/cpu-usage.ts
@@ -115,17 +115,31 @@ export function getCpuUsage(now: number = Date.now()): number {
   return usage;
 }
 
+/** Percent busy of one core between two of its samples, or null if they do not diff. */
+function coreBusy(then: CpuSample, current: CpuSample): number | null {
+  const dTotal = current.total - then.total;
+  const dIdle = current.idle - then.idle;
+  // A counter that went backwards means /proc/stat was re-read across a
+  // suspend/rollover — not that the core went idle.
+  if (dTotal <= 0 || dIdle < 0) return null;
+  return Math.min(100, Math.max(0, Math.round(((dTotal - dIdle) / dTotal) * 100)));
+}
+
 /**
  * Percent busy per core since the previous call, one entry per `cpuN` line.
  *
  * The htop-style bars on Settings → System. Same delta discipline as the
- * aggregate: no sleep, no block, and a first call (or a stale previous sample,
- * or a counter that went backwards over a suspend) answers the last figures it
- * had rather than a fabricated zero — a row of empty bars is a claim about the
- * box, and "not measured yet" is not that claim.
+ * aggregate: no sleep, no block, and a call with nothing to diff (a stale
+ * previous sample, or a counter that went backwards over a suspend) answers the
+ * last figures it had rather than a fabricated zero — a row of empty bars is a
+ * claim about the box, and "not measured yet" is not that claim.
  *
- * Empty when /proc/stat cannot be read at all, which the caller renders as no
- * per-core row rather than as a machine with no cores.
+ * Empty where there is no figure to give: /proc/stat unreadable, or — the first
+ * call of the process, which every server restart creates — no previous sample
+ * and no earlier figures to stand in for it. Empty for the WHOLE row, never a
+ * row that is measured for some cores and carried for others, because a
+ * six-entry row reads as six measurements. The caller renders that as no
+ * per-core row at all, and the next poll 3 s later has real figures.
  */
 export function getCpuCoreUsage(now: number = Date.now()): number[] {
   let current: (CpuSample | null)[];
@@ -137,6 +151,8 @@ export function getCpuCoreUsage(now: number = Date.now()): number[] {
   if (current.length === 0) return lastCoreUsage ?? [];
 
   const previous = lastCoreSamples;
+  // Set before any early return: whatever this call could not answer, the next
+  // one has a sample to diff against.
   lastCoreSamples = current;
   // A core count that changed (a hotplug, or a first call) has nothing to diff
   // against; so does a sample too old to be about "now".
@@ -144,19 +160,14 @@ export function getCpuCoreUsage(now: number = Date.now()): number[] {
 
   const usage: number[] = [];
   for (let i = 0; i < current.length; i += 1) {
-    const now_ = current[i];
+    const sample = current[i];
     const then = comparable ? previous[i] : null;
-    if (!now_ || !then || now - then.at > MAX_SAMPLE_AGE_MS) {
-      usage.push(lastCoreUsage?.[i] ?? 0);
-      continue;
-    }
-    const dTotal = now_.total - then.total;
-    const dIdle = now_.idle - then.idle;
-    if (dTotal <= 0 || dIdle < 0) {
-      usage.push(lastCoreUsage?.[i] ?? 0);
-      continue;
-    }
-    usage.push(Math.min(100, Math.max(0, Math.round(((dTotal - dIdle) / dTotal) * 100))));
+    const measured =
+      sample && then && now - then.at <= MAX_SAMPLE_AGE_MS ? coreBusy(then, sample) : null;
+    // `??`, so a genuine 0% measurement stands as itself.
+    const busy = measured ?? lastCoreUsage?.[i];
+    if (typeof busy !== "number") return [];
+    usage.push(busy);
   }
   lastCoreUsage = usage;
   return usage;

--- a/src/tests/components/settings-system-htop.test.tsx
+++ b/src/tests/components/settings-system-htop.test.tsx
@@ -178,6 +178,19 @@ describe("Settings → System against a server that predates the new figures", (
     expect(screen.queryByTestId("settings-per-core")).toBeNull();
   });
 
+  it("draws no per-core row when the reading itself is empty", async () => {
+    // The wire shape of a just-restarted box: no previous /proc/stat sample to
+    // diff, so the server sends `perCore: []` rather than a zero per core. The
+    // aggregate tile still shows its load-average figure — 19% here — which is
+    // exactly the pairing that made six 0% bars read as a lie.
+    serve(statsResponse({
+      cpu: { usage: 19, model: "ARMv8", cores: 6, loadAvg: ["1.15", "1.02", "0.98"], speed: 1800, perCore: [] },
+    }));
+    await openSection("system");
+    await screen.findByTestId("settings-processes");
+    expect(screen.queryByTestId("settings-per-core")).toBeNull();
+  });
+
   it("offers no ordering toggle when only one ordering was sent", async () => {
     serve(statsResponse());
     await openSection("system");

--- a/src/tests/components/settings-system-htop.test.tsx
+++ b/src/tests/components/settings-system-htop.test.tsx
@@ -189,6 +189,9 @@ describe("Settings → System against a server that predates the new figures", (
     await openSection("system");
     await screen.findByTestId("settings-processes");
     expect(screen.queryByTestId("settings-per-core")).toBeNull();
+    // The aggregate figure is still there — withholding the per-core row is not
+    // withholding the card.
+    expect(screen.getByText("19%")).toBeInTheDocument();
   });
 
   it("offers no ordering toggle when only one ordering was sent", async () => {

--- a/src/tests/routes/system/stats.test.ts
+++ b/src/tests/routes/system/stats.test.ts
@@ -39,16 +39,25 @@ describe("GET /setup-api/system/stats", () => {
       }],
     });
 
-    // Mock fs.readFileSync for /proc files
-    let readCount = 0;
+    // Mock fs.readFileSync for /proc files.
+    //
+    // /proc/stat carries the aggregate line AND one line per core, and its
+    // counters advance on every read — so a second request always has
+    // something to diff against whatever the first one sampled, without the
+    // fixture having to know how many times one request reads the file.
+    let jiffies = 0;
     mockFs.readFileSync.mockImplementation((path: fs.PathOrFileDescriptor) => {
       const pathStr = path.toString();
       if (pathStr === "/proc/stat") {
-        readCount++;
-        if (readCount === 1) {
-          return "cpu  100 50 100 800 10 5 5 0 0 0\n";
-        }
-        return "cpu  110 55 110 810 12 6 6 0 0 0\n";
+        const user = 100 + 50 * jiffies;
+        const idle = 800 + 50 * jiffies;
+        jiffies += 1;
+        return [
+          `cpu  ${user * 4} 50 100 ${idle * 4} 10 5 5 0 0 0`,
+          ...[0, 1, 2, 3].map((n) => `cpu${n} ${user} 0 0 ${idle} 0 0 0 0 0 0`),
+          "intr 12345",
+          "",
+        ].join("\n");
       }
       if (pathStr === "/proc/net/dev") {
         return `Inter-|   Receive                                                |  Transmit
@@ -140,53 +149,17 @@ SwapFree:        1500000 kB`;
     expect(Array.isArray(body.processes)).toBe(true);
   });
 
-  it("returns a per-core CPU reading beside the aggregate one", async () => {
-    const res = await systemStatsGet();
-    const body = await res.json();
-
-    // One entry per `cpuN` line in the mocked /proc/stat above, and an array
-    // either way — the panel draws no per-core row rather than a row of zeros
-    // when the file could not be read.
-    expect(Array.isArray(body.cpu.perCore)).toBe(true);
-    for (const core of body.cpu.perCore) {
-      expect(core).toBeGreaterThanOrEqual(0);
-      expect(core).toBeLessThanOrEqual(100);
-    }
-  });
-
-  it("sends no per-core row on the first call of the process, then real figures", async () => {
+  it("sends no per-core row on the first call of the process, then one figure per core", async () => {
     // HL-1: every restart of the web server makes the next stats call the first
     // of a new process, with no previous /proc/stat sample to diff against. The
     // payload used to carry a zero for each core, so Settings → System drew six
-    // idle bars beside a CPU tile reading 19% — seen on the box 23 minutes
-    // after a restart, on the first stats call since it.
-    let reads = 0;
-    mockFs.readFileSync.mockImplementation((path: fs.PathOrFileDescriptor) => {
-      const pathStr = path.toString();
-      if (pathStr === "/proc/stat") {
-        // Two reads per request — the aggregate figure and the per-core one —
-        // so the counters move once per REQUEST, which is what the route's
-        // callers see.
-        reads += 1;
-        const tick = Math.ceil(reads / 2) - 1;
-        const user = 100 + 50 * tick;
-        const idle = 800 + 50 * tick;
-        return [
-          `cpu  ${user * 4} 0 0 ${idle * 4} 0 0 0 0 0 0`,
-          ...[0, 1, 2, 3].map((n) => `cpu${n} ${user} 0 0 ${idle} 0 0 0 0 0 0`),
-          "intr 12345",
-          "",
-        ].join("\n");
-      }
-      if (pathStr === "/proc/meminfo") return "MemTotal: 8000000 kB\nMemFree: 2000000 kB\nSwapTotal: 0 kB\nSwapFree: 0 kB";
-      if (pathStr === "/proc/net/dev") return "Inter-|   Receive\n face |bytes\n  eth0: 1000 10 0 0 0 0 0 0 500 5 0 0 0 0 0 0";
-      if (pathStr.includes("/sys/devices/virtual/thermal/thermal_zone")) return "55000";
-      throw new Error(`File not found: ${pathStr}`);
-    });
-
+    // idle bars beside a CPU tile reading 19% off the load average — seen on the
+    // box 23 minutes after a restart, on the first stats call since it.
     const first = await (await systemStatsGet()).json();
     expect(first.cpu.perCore).toEqual([]);
 
+    // One entry per `cpuN` line of the mocked /proc/stat, in range, once there
+    // are two samples to diff.
     const second = await (await systemStatsGet()).json();
     expect(second.cpu.perCore).toHaveLength(4);
     for (const core of second.cpu.perCore) {

--- a/src/tests/routes/system/stats.test.ts
+++ b/src/tests/routes/system/stats.test.ts
@@ -154,6 +154,47 @@ SwapFree:        1500000 kB`;
     }
   });
 
+  it("sends no per-core row on the first call of the process, then real figures", async () => {
+    // HL-1: every restart of the web server makes the next stats call the first
+    // of a new process, with no previous /proc/stat sample to diff against. The
+    // payload used to carry a zero for each core, so Settings → System drew six
+    // idle bars beside a CPU tile reading 19% — seen on the box 23 minutes
+    // after a restart, on the first stats call since it.
+    let reads = 0;
+    mockFs.readFileSync.mockImplementation((path: fs.PathOrFileDescriptor) => {
+      const pathStr = path.toString();
+      if (pathStr === "/proc/stat") {
+        // Two reads per request — the aggregate figure and the per-core one —
+        // so the counters move once per REQUEST, which is what the route's
+        // callers see.
+        reads += 1;
+        const tick = Math.ceil(reads / 2) - 1;
+        const user = 100 + 50 * tick;
+        const idle = 800 + 50 * tick;
+        return [
+          `cpu  ${user * 4} 0 0 ${idle * 4} 0 0 0 0 0 0`,
+          ...[0, 1, 2, 3].map((n) => `cpu${n} ${user} 0 0 ${idle} 0 0 0 0 0 0`),
+          "intr 12345",
+          "",
+        ].join("\n");
+      }
+      if (pathStr === "/proc/meminfo") return "MemTotal: 8000000 kB\nMemFree: 2000000 kB\nSwapTotal: 0 kB\nSwapFree: 0 kB";
+      if (pathStr === "/proc/net/dev") return "Inter-|   Receive\n face |bytes\n  eth0: 1000 10 0 0 0 0 0 0 500 5 0 0 0 0 0 0";
+      if (pathStr.includes("/sys/devices/virtual/thermal/thermal_zone")) return "55000";
+      throw new Error(`File not found: ${pathStr}`);
+    });
+
+    const first = await (await systemStatsGet()).json();
+    expect(first.cpu.perCore).toEqual([]);
+
+    const second = await (await systemStatsGet()).json();
+    expect(second.cpu.perCore).toHaveLength(4);
+    for (const core of second.cpu.perCore) {
+      expect(core).toBeGreaterThanOrEqual(0);
+      expect(core).toBeLessThanOrEqual(100);
+    }
+  });
+
   it("returns the busiest processes by MEMORY as well as by CPU", async () => {
     // Both matter on this box and for different reasons: CPU is what a slow
     // desktop looks like, and memory is what an OOM-killed update looks like on

--- a/src/tests/unit/cpu-usage.test.ts
+++ b/src/tests/unit/cpu-usage.test.ts
@@ -153,6 +153,17 @@ describe("parseProcStat", () => {
  * must not be drawn as an idle one.
  */
 describe("getCpuCoreUsage", () => {
+  /** `cpuN` lines for the given core ids, under an aggregate line. */
+  function idCores(cores_: [number, [number, number]][]): string {
+    const total = cores_.reduce((a, [, [u, i]]) => [a[0] + u, a[1] + i] as [number, number], [0, 0]);
+    return [
+      `cpu  ${total[0]} 0 0 ${total[1]} 0 0 0 0 0 0`,
+      ...cores_.map(([id, [user, idle]]) => `cpu${id} ${user} 0 0 ${idle} 0 0 0 0 0 0`),
+      "intr 12345",
+      "",
+    ].join("\n");
+  }
+
   /** Four cores, each with its own user/idle pair, under the aggregate line. */
   function cores(pairs: [number, number][]): string {
     const total = pairs.reduce((a, [u, i]) => [a[0] + u, a[1] + i] as [number, number], [0, 0]);
@@ -272,6 +283,33 @@ describe("getCpuCoreUsage", () => {
     expect(cpuUsage.getCpuCoreUsage(7_000)).toEqual([]);
   });
 
+  it("forgets a row it has already refused as too old, so a clock rollback cannot revive it", () => {
+    mockFs.readFileSync.mockReturnValue(cores([[100, 900], [100, 900]]));
+    cpuUsage.getCpuCoreUsage(1_000);
+    mockFs.readFileSync.mockReturnValue(cores([[200, 900], [100, 1000]]));
+    expect(cpuUsage.getCpuCoreUsage(4_000)).toEqual([100, 0]);
+    // Five minutes later the file cannot be read: the cached row is too old to
+    // stand in, so it is dropped rather than kept for a later comparison…
+    mockFs.readFileSync.mockImplementation(() => { throw new Error("EACCES"); });
+    expect(cpuUsage.getCpuCoreUsage(305_000)).toEqual([]);
+    // …because the clock can step backwards under it, which would otherwise
+    // make figures from before the correction look seconds old.
+    expect(cpuUsage.getCpuCoreUsage(5_000)).toEqual([]);
+  });
+
+  it("refuses to pair cores by position when the lines are about different cores", () => {
+    // Linux prints one line per ONLINE cpu, so offlining cpu1 makes cpu2 the
+    // second line. Two readings of the same LENGTH can be about different cores,
+    // and diffing cpu2's counters against cpu1's answers a figure about neither.
+    mockFs.readFileSync.mockReturnValue(idCores([[0, [100, 900]], [2, [100, 900]]]));
+    cpuUsage.getCpuCoreUsage(1_000);
+    mockFs.readFileSync.mockReturnValue(idCores([[0, [200, 900]], [1, [500, 600]]]));
+    expect(cpuUsage.getCpuCoreUsage(4_000)).toEqual([]);
+    // The poll after it has two samples of cpu0 and cpu1, and measures them.
+    mockFs.readFileSync.mockReturnValue(idCores([[0, [300, 900]], [1, [600, 700]]]));
+    expect(cpuUsage.getCpuCoreUsage(7_000)).toEqual([100, 50]);
+  });
+
   it("answers nothing at all when /proc/stat cannot be read", () => {
     // Not a row of zeros: an empty list is "no reading", and a row of zeros
     // would be a claim that every core on the box is idle.
@@ -303,6 +341,9 @@ describe("getCpuCoreUsage", () => {
   it("skips a core line it cannot parse rather than calling it idle", () => {
     mockFs.readFileSync.mockReturnValue("cpu  100 0 0 900 0\ncpu0 1 2\ncpu1 100 0 0 900 0\n");
     expect(cpuUsage.parseProcStatCores("cpu  1 0 0 1\ncpu0 1 2\ncpu1 100 0 0 900\n", 1_000))
-      .toEqual([null, { idle: 900, total: 1000, at: 1_000 }]);
+      .toEqual([
+        { id: 0, sample: null },
+        { id: 1, sample: { idle: 900, total: 1000, at: 1_000 } },
+      ]);
   });
 });

--- a/src/tests/unit/cpu-usage.test.ts
+++ b/src/tests/unit/cpu-usage.test.ts
@@ -172,6 +172,53 @@ describe("getCpuCoreUsage", () => {
     expect(cpuUsage.getCpuCoreUsage()).toEqual([100, 0, 50, 50]);
   });
 
+  it("answers nothing on the very first call, rather than a row of idle cores", () => {
+    // HL-1: every server restart makes the next /setup-api/system/stats call the
+    // first call of a new process, with no previous sample to diff against. A
+    // `0` per core is not "not measured yet" — it is a row of empty bars
+    // claiming an idle box, which is what Settings → System drew while the
+    // aggregate tile on the same card read 19% off the load average.
+    mockFs.readFileSync.mockReturnValue(cores([[100, 900], [100, 900], [100, 900], [100, 900]]));
+    expect(cpuUsage.getCpuCoreUsage(1_000)).toEqual([]);
+    // …and the call after it is the one that has real figures, so the row
+    // appears on the next 3 s poll rather than being lost.
+    mockFs.readFileSync.mockReturnValue(cores([[200, 900], [100, 1000], [150, 950], [150, 950]]));
+    expect(cpuUsage.getCpuCoreUsage(4_000)).toEqual([100, 0, 50, 50]);
+  });
+
+  it("goes back to answering nothing when the cache is dropped under it", () => {
+    mockFs.readFileSync.mockReturnValue(cores([[100, 900], [100, 900]]));
+    cpuUsage.getCpuCoreUsage(1_000);
+    mockFs.readFileSync.mockReturnValue(cores([[200, 900], [100, 1000]]));
+    expect(cpuUsage.getCpuCoreUsage(4_000)).toEqual([100, 0]);
+    // A restarted server is exactly this state: real figures, then none.
+    cpuUsage.__resetCpuUsageCache();
+    expect(cpuUsage.getCpuCoreUsage(7_000)).toEqual([]);
+  });
+
+  it("answers nothing when its only sample is too old to be about now", () => {
+    // Nothing opened System for five minutes: the pair exists but averaging
+    // over minutes and calling it "now" is the reason MAX_SAMPLE_AGE_MS is
+    // there, and there is no earlier figure to stand in.
+    mockFs.readFileSync.mockReturnValue(cores([[100, 900], [100, 900]]));
+    cpuUsage.getCpuCoreUsage(1_000);
+    mockFs.readFileSync.mockReturnValue(cores([[500, 2000], [400, 2100]]));
+    expect(cpuUsage.getCpuCoreUsage(301_000)).toEqual([]);
+  });
+
+  it("withholds the whole row rather than mixing measured figures with carried ones", () => {
+    mockFs.readFileSync.mockReturnValue(cores([[100, 900], [100, 900]]));
+    cpuUsage.getCpuCoreUsage(1_000);
+    mockFs.readFileSync.mockReturnValue(cores([[200, 900], [100, 1000]]));
+    expect(cpuUsage.getCpuCoreUsage(4_000)).toEqual([100, 0]);
+    // A hotplug leaves cores 0 and 1 with last call's figures and core 2 with
+    // none. A three-entry row reads as three measurements, so a row that is
+    // part measurement and part invention is a second, subtler lie than the
+    // zero: nothing is the honest answer for one poll.
+    mockFs.readFileSync.mockReturnValue(cores([[300, 900], [100, 1100], [100, 1000]]));
+    expect(cpuUsage.getCpuCoreUsage(7_000)).toEqual([]);
+  });
+
   it("answers nothing at all when /proc/stat cannot be read", () => {
     // Not a row of zeros: an empty list is "no reading", and a row of zeros
     // would be a claim that every core on the box is idle.
@@ -194,9 +241,10 @@ describe("getCpuCoreUsage", () => {
     mockFs.readFileSync.mockReturnValue(cores([[100, 900], [100, 900]]));
     cpuUsage.getCpuCoreUsage();
     // A hotplug leaves nothing comparable; the next call is the one with a
-    // real figure, and this one must not diff core 2 against core 1's history.
+    // real figure, and this one must not diff core 2 against core 1's history
+    // — nor answer the zeros that diffing nothing used to produce.
     mockFs.readFileSync.mockReturnValue(cores([[200, 900], [100, 1000], [100, 1000]]));
-    expect(cpuUsage.getCpuCoreUsage()).toEqual([0, 0, 0]);
+    expect(cpuUsage.getCpuCoreUsage()).toEqual([]);
   });
 
   it("skips a core line it cannot parse rather than calling it idle", () => {

--- a/src/tests/unit/cpu-usage.test.ts
+++ b/src/tests/unit/cpu-usage.test.ts
@@ -196,14 +196,51 @@ describe("getCpuCoreUsage", () => {
     expect(cpuUsage.getCpuCoreUsage(7_000)).toEqual([]);
   });
 
-  it("answers nothing when its only sample is too old to be about now", () => {
-    // Nothing opened System for five minutes: the pair exists but averaging
-    // over minutes and calling it "now" is the reason MAX_SAMPLE_AGE_MS is
-    // there, and there is no earlier figure to stand in.
+  it("answers nothing when the figures it could carry are too old to be about now", () => {
     mockFs.readFileSync.mockReturnValue(cores([[100, 900], [100, 900]]));
     cpuUsage.getCpuCoreUsage(1_000);
+    mockFs.readFileSync.mockReturnValue(cores([[200, 900], [100, 1000]]));
+    expect(cpuUsage.getCpuCoreUsage(4_000)).toEqual([100, 0]);
+    // Nobody opened System for five minutes. The pair is too old to diff — the
+    // reason MAX_SAMPLE_AGE_MS is there — and five-minute-old figures drawn
+    // under a fresh timestamp are the same wrong claim as a zero, so the row
+    // that IS cached is refused too.
     mockFs.readFileSync.mockReturnValue(cores([[500, 2000], [400, 2100]]));
     expect(cpuUsage.getCpuCoreUsage(301_000)).toEqual([]);
+  });
+
+  it("withholds the row when cores disappear under it, rather than re-using their figures", () => {
+    // Cores go away as well as arrive: an nvpmodel mode change offlines some,
+    // and `previous.length === current.length` is then false in the other
+    // direction. Indexing a four-core row by a two-core reading answers
+    // plausible numbers about a topology that no longer exists — the same lie
+    // as the zeros, only harder to spot.
+    mockFs.readFileSync.mockReturnValue(cores([[100, 900], [100, 900], [100, 900], [100, 900]]));
+    cpuUsage.getCpuCoreUsage(1_000);
+    mockFs.readFileSync.mockReturnValue(cores([[200, 900], [100, 1000], [150, 950], [150, 950]]));
+    expect(cpuUsage.getCpuCoreUsage(4_000)).toEqual([100, 0, 50, 50]);
+    mockFs.readFileSync.mockReturnValue(cores([[300, 900], [100, 1100]]));
+    expect(cpuUsage.getCpuCoreUsage(7_000)).toEqual([]);
+    // …and the poll after it measures the two cores that are left.
+    mockFs.readFileSync.mockReturnValue(cores([[350, 950], [150, 1150]]));
+    expect(cpuUsage.getCpuCoreUsage(10_000)).toEqual([50, 50]);
+  });
+
+  it("withholds the row when one core line alone cannot be parsed", () => {
+    // The mixed case with figures already cached: core 0 has a real delta and
+    // core 1 has only last poll's number. Two entries read as two
+    // measurements, so the honest answer is the row the panel hides.
+    const two = (pairs: [number, number][], bad: number) =>
+      cores(pairs)
+        .split("\n")
+        .map((line) => (line.startsWith(`cpu${bad} `) ? `cpu${bad} 1 2` : line))
+        .join("\n");
+    mockFs.readFileSync.mockReturnValue(cores([[100, 900], [100, 900]]));
+    cpuUsage.getCpuCoreUsage(1_000);
+    mockFs.readFileSync.mockReturnValue(cores([[200, 900], [100, 1000]]));
+    expect(cpuUsage.getCpuCoreUsage(4_000)).toEqual([100, 0]);
+    mockFs.readFileSync.mockReturnValue(two([[300, 900], [100, 1100]], 1));
+    expect(cpuUsage.getCpuCoreUsage(7_000)).toEqual([]);
   });
 
   it("withholds the whole row rather than mixing measured figures with carried ones", () => {

--- a/src/tests/unit/cpu-usage.test.ts
+++ b/src/tests/unit/cpu-usage.test.ts
@@ -226,6 +226,22 @@ describe("getCpuCoreUsage", () => {
     expect(cpuUsage.getCpuCoreUsage(10_000)).toEqual([50, 50]);
   });
 
+  it("withholds the row when the clock moved backwards, so the age is not a fact", () => {
+    // A box with no RTC boots at the wrong time and NTP corrects it — backwards
+    // as well as forwards. A sample stamped in the future is not "very recent":
+    // the window between the two reads is then unknown, and neither the pair nor
+    // the row already published can be claimed to be about now.
+    mockFs.readFileSync.mockReturnValue(cores([[100, 900], [100, 900]]));
+    cpuUsage.getCpuCoreUsage(4_000);
+    mockFs.readFileSync.mockReturnValue(cores([[200, 900], [100, 1000]]));
+    expect(cpuUsage.getCpuCoreUsage(7_000)).toEqual([100, 0]);
+    mockFs.readFileSync.mockReturnValue(cores([[300, 900], [100, 1100]]));
+    expect(cpuUsage.getCpuCoreUsage(5_000)).toEqual([]);
+    // The poll after the correction measures normally again.
+    mockFs.readFileSync.mockReturnValue(cores([[400, 900], [100, 1200]]));
+    expect(cpuUsage.getCpuCoreUsage(8_000)).toEqual([100, 0]);
+  });
+
   it("withholds the row when one core line alone cannot be parsed", () => {
     // The mixed case with figures already cached: core 0 has a real delta and
     // core 1 has only last poll's number. Two entries read as two


### PR DESCRIPTION
## HL-1 — Settings → System shows every CPU core at 0% on the first view after a server restart

**Finding:** HL-1 (card TASK-805, epic TASK-790), from the Hermes-lane UI sweep. Both editions share the System page, so this lands once and serves OpenClaw and Hermes alike.

### Customer-visible symptom

Restart the box's web server (every update does), then open Settings → System. The PER CORE row drew
`0 0% · 1 0% · 2 0% · 3 0% · 4 0% · 5 0%` — six idle cores — while the CPU tile on the same card read
19% and the busiest-process list showed two processes at ~5% each. The next 3 s poll showed real
figures, so the wrong frame is transient but always present on the first view. Proven deterministically
on the box: the first `/setup-api/system/stats` call after a restart returned
`perCore=[0,0,0,0,0,0]` with the aggregate on its load-average fallback; the second returned
`perCore=[8,9,9,9,8,7]`.

A row of empty bars is a claim about the box. "Not measured yet" is not that claim — and the code
already said so in two places:

- `src/lib/cpu-usage.ts` docblock: *"a first call … answers the last figures it had rather than a
  fabricated zero"*.
- `src/app/setup-api/system/stats/route.ts` next to `perCore`: *"One entry per core, or empty where
  /proc/stat could not be read — never a row of zeros, which would be a claim that the box is idle."*

### Cause

`src/lib/cpu-usage.ts`, the per-core loop: both no-usable-pair branches pushed
`lastCoreUsage?.[i] ?? 0`. On the first call of a process `lastCoreUsage` is `null`, so the `?? 0`
fabricated a zero for every core — the one case the docblock promised it would not. The aggregate
sibling `getCpuUsage()` is honest in the same situation only because its fallback
(`lastUsage ?? loadAverageApproximation()`) is a real figure; the per-core path had nothing to fall
back on and invented one.

### Fix

`getCpuCoreUsage()` now answers a row only when **every** core has a figure — a real delta, or the
last real one it had — and an empty list otherwise:

- First call of the process (every server restart), or a sample too old to be about "now" with no
  recent figures to stand in: `[]`.
- A row that would be measured for some cores and carried for others (a hotplug adds a core with no
  history) is withheld too — a six-entry row reads as six measurements, so a part-invented row is a
  second, subtler lie than the zero.
- `lastCoreSamples` is still set before the early return, so the next poll 3 s later carries real
  values. The panel already renders an empty list as *no per-core row at all*
  (`SettingsApp.tsx`, `stats.cpu.perCore && length > 0`), which is the "defer until measured"
  behaviour — it is now pinned by a test against the `[]` wire shape the server really sends.
- The aggregate `getCpuUsage()` is untouched: its fallbacks are the load-average approximation, a
  real figure rather than an invented zero.

The delta arithmetic moved into a small `coreBusy()` helper so the two branches that duplicated it
became one expression.

**Two more cases the review pass caught, both present on beta as well** — the carry
(`lastCoreUsage?.[i]`) used to fall through only where the cached row was *shorter* than the current
one, so these published carried figures as measurements and re-cached them as if measured:

- a core count that **shrank** (a hotplug down, or an `nvpmodel` mode that offlines cores): a
  four-core row indexed by a two-core reading — plausible numbers about a topology that no longer
  exists, which is the HL-1 lie with better-looking values;
- a **single `cpuN` line that could not be parsed** while the others could: a row part measured, part
  carried, which reads as all measured.

The carry is now all-or-nothing: every core measured, or nothing measured *and* the previous row is
about the same cores, or the row is withheld whole and forgotten so a later call cannot index it.
A carried row also ages out on the same window as a sample (`MAX_SAMPLE_AGE_MS`) — figures from five
minutes ago drawn under a fresh timestamp are the same wrong claim as a zero, which is what that
window exists to refuse one branch over — and it is dropped at the moment it is refused, so a
backwards clock step cannot make it look seconds old again.

**"The same cores" is by cpu id, not by count** (from the CodeRabbit round): `show_stat()` prints a
line per ONLINE cpu, so offlining a middle core shifts every line after it, and `{cpu0,cpu2}` followed
by `{cpu0,cpu1}` is two equal-length readings about different cores — pairing them by position answers
a figure for a core it never measured (on beta, that sequence answers `[100, 0]`). Each sample now
carries its `cpuN` id, and a reading is comparable only when it is about the same cores in the same
order. A negative sample age is refused too: it means the wall clock moved backwards, which a box with
no RTC does every boot once NTP answers, so the window between the two reads is not a fact.

### Harness-first

Nothing here is harness-owned, and the sweep says so concretely: `/proc/stat` is read in exactly one
place in the repo (`src/lib/cpu-usage.ts`), neither OpenClaw nor Hermes exposes device CPU telemetry,
and the agent-facing surface (`mcp/tools/system.ts` → `system_stats`) is ClawBox's own MCP server
passing this route's payload through. The native mechanism that does exist — the load average via
`os.loadavg()` — is already what the aggregate falls back to, and is kept. No `tegrastats` / `jtop`
spawn was added either: those cost a process per poll and the file already has the numbers.

### RED → GREEN

RED — the final test set run in a second worktree on unmodified `origin/beta` (1be87420):

```
 ❯ |unit| src/tests/unit/cpu-usage.test.ts (23 tests | 7 failed)
     × answers nothing on the very first call, rather than a row of idle cores
     × goes back to answering nothing when the cache is dropped under it
     × answers nothing when the figures it could carry are too old to be about now
     × withholds the row when cores disappear under it, rather than re-using their figures
     × withholds the row when one core line alone cannot be parsed
     × withholds the whole row rather than mixing measured figures with carried ones
     × starts over when the core count changes under it
 ❯ |unit| src/tests/routes/system/stats.test.ts (12 tests | 1 failed)
     × sends no per-core row on the first call of the process, then one figure per core

 FAIL  src/tests/unit/cpu-usage.test.ts > getCpuCoreUsage > answers nothing on the very first call, rather than a row of idle cores
 AssertionError: expected [ +0, +0, +0, +0 ] to deeply equal []
 FAIL  src/tests/unit/cpu-usage.test.ts > getCpuCoreUsage > withholds the row when cores disappear under it, rather than re-using their figures
 AssertionError: expected [ 100, +0 ] to deeply equal []
 FAIL  src/tests/unit/cpu-usage.test.ts > getCpuCoreUsage > withholds the row when one core line alone cannot be parsed
 AssertionError: expected [ 100, +0 ] to deeply equal []
 FAIL  src/tests/routes/system/stats.test.ts > GET /setup-api/system/stats > sends no per-core row on the first call of the process, then one figure per core
 AssertionError: expected [ +0, +0, +0, +0 ] to deeply equal []
   187|     const first = await (await systemStatsGet()).json();
   188|     expect(first.cpu.perCore).toEqual([]);

 Test Files  2 failed | 1 passed (3)
      Tests  8 failed | 37 passed (45)
```

The third file — the component suite — **passes on beta**, and is stated as such rather than claimed
as RED: the per-core panel's guard already hid the row, so the defect was entirely server-side. The
new case there pins the `perCore: []` wire shape the fixed server actually sends, and that the
aggregate figure stays on screen beside the withheld row.

GREEN, with the fix:

```
 ✓ src/tests/unit/cpu-usage.test.ts, src/tests/routes/system/**,
   src/tests/components/settings-system-htop.test.tsx,
   src/tests/components/settings-system-figures-i18n.test.tsx   — 14 files, 155 tests passed
 ✓ full unit project                                            — 812 files, 13590 tests passed
 ✓ tsc --noEmit -p tsconfig.json and -p mcp/tsconfig.json        — clean
 ✓ bun run mcp/check-tools.ts                                    — "Tool contract OK."
 ✓ eslint on every changed file                                  — clean
```

On the final head the unit file has 26 cases, **11 of which fail on unmodified beta** — the eight
above plus the two new invariants (a cpu-id mismatch, and a refused row revived by a clock rollback)
and `parseProcStatCores`'s shape, which now carries the id.

(`eslint src/components/SettingsApp.tsx` reports 9 pre-existing errors identical on pristine beta;
this PR changes only a comment in that file.)

### Sibling call sites

Every consumer of `getCpuCoreUsage()` and of the payload's `perCore`, checked and cleared:

| site | verdict |
|---|---|
| `src/app/setup-api/system/stats/route.ts` (only caller) | its comment already stated this contract; now true, no change |
| `src/components/SettingsApp.tsx` per-core panel | hides the row on an empty/absent list — now pinned for `[]` |
| `src/components/SystemApp.tsx` (the standalone System app) | its `CpuStats` has no `perCore` and it renders only the aggregate, whose cold-start value is the load-average approximation — clear |
| `mcp/tools/system.ts` → `system_stats` | raw passthrough of this payload, so it inherits the honest shape; its description now says an empty `perCore` means "not measured yet, call again", so the model does not read it as idle cores |
| `mcp/tools/orientation.ts` → `device_status` | its `StatsPayload` reads memory/storage/temperature only; it does not expose CPU |
| `mcp/clawbox-cli.ts` (`clawbox system stats`) | prints the payload verbatim; inherits |
| `e2e/helpers/clawbox.ts`, `e2e-install/helpers/setup-api.ts` | the mock sends no `perCore`; the installer check asserts only cpu/memory/temperature presence |
| `getCpuUsage()` aggregate | untouched, its two `?? 0`-free fallbacks left as they are |
| `src/lib/system-info.ts` `cpuLoadPercent` (`/setup-api/system/info`) | a pure load-average percentage, never a `/proc/stat` delta, so it has no first-call state |

### Reviewed via the `clawbox-review` skill

1 high, 3 medium, 5 low. Applied: the high finding (the part-carried and shrunk-topology rows above),
both test-fixture findings (the stale-sample test that passed only because nothing was cached; the
route test that hard-coded two `/proc/stat` reads per request — it now drives the counters per read,
which also un-vacuums the older per-core assertion that had no `cpuN` lines to read at all), the three
stale comments, and the pairing assertion in the component test.

Refuted or deliberately left, with reasons:

- **A cold-path second sample in the route** (so a one-shot `system_stats` / `clawbox system stats`
  call gets a per-core row instead of an empty one). It would re-add the per-request sleep TASK-456
  removed, and the route's own timing test — three requests under 150 ms — fails with it. Beta
  answered those callers a row of zeros, so this is a fabrication removed, not a reading lost; the
  tool description now tells the agent to call again.
- **The aggregate tile's load-average approximation on that same first view** (`getCpuUsage()`): out
  of scope by the brief, which asks that those fallbacks stay as they are. It is a real figure rather
  than an invented one, but it is unlabelled as an estimate — worth a deliberate answer separately.
- **A `measuring…` placeholder in the card slot** instead of hiding the row: a copy change needing a
  new string in ten locales, and a product call on a card the owner's ruling reshaped two days ago.
  Deferring is what the panel already does and what the brief allows.
- One observation recorded, not fixed: `cpu.usage` and `cpu.perCore` in a single payload come from two
  separate `/proc/stat` reads, so they describe very slightly different windows. Pre-existing, and
  `os.cpus()[i].times` would let a later change take both from one read.

### CodeRabbit

Three findings, all three valid and applied (negative sample ages after a backwards clock step; a
refused row that could be revived by a later rollback; per-core samples paired by position rather than
by cpu id), each with a regression test that fails on beta, each answered in its thread. One thing
recorded rather than changed, in the thread: the payload still sends `perCore` positionally and the
panel labels each bar by its index, so while a middle core is offline the bars after the gap are
labelled one lower than the cpu they describe — a label rather than a figure, pre-existing, and fixing
it means carrying the ids through the route into the UI.

### Device proof — deferred

The owner is testing on both boxes by hand, so nothing was deployed, no mutex taken and no box
touched. What to expect once this is on a box: after a server restart, the first Settings → System
view shows the CPU tile, the load averages and the busiest processes with **no per-core row**, and the
row appears with real figures on the next 3 s poll (and on every later view). Six bars at 0% should
never appear again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Per-core CPU usage is no longer shown as zero when readings are unavailable or awaiting an initial sample.
  * Per-core values are withheld when readings are incomplete, stale, inconsistent, or system CPU configuration changes.
  * Previously measured per-core values may be retained briefly when a fresh reading is unavailable and the CPU configuration is unchanged.
  * Aggregate CPU and load information remains visible while per-core data is unavailable.

* **Documentation**
  * Clarified when per-core readings are unavailable and when they will appear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->