### PR TITLE
fix: an empty Memory Shard index is up to date, not a missing fingerprint

### DIFF
--- a/src/lib/memory-index-local.ts
+++ b/src/lib/memory-index-local.ts
@@ -366,7 +366,18 @@ export async function stampLocalEmbeddingIdentity(): Promise<void> {
   }
 }
 
-function identityOf(db: IndexDb): "valid" | "missing" | "mismatched" {
+/**
+ * The folder list a pass covered, as one short row it can be compared against.
+ *
+ * Sorted, because the order the owner's list happens to be in is not part of
+ * what was looked at, and hashed because the alternative is every one of the
+ * owner's paths a second time in the store.
+ */
+function sourceListKey(sources: readonly string[]): string {
+  return crypto.createHash("sha256").update(JSON.stringify([...sources].sort())).digest("hex").slice(0, 16);
+}
+
+function identityOf(db: IndexDb, sources: readonly string[]): "valid" | "missing" | "mismatched" {
   const stored = metaGet(db, "identity");
   if (!stored) return "missing";
   if (stored !== localEmbeddingIdentity()) return "mismatched";
@@ -383,16 +394,27 @@ function identityOf(db: IndexDb): "valid" | "missing" | "mismatched" {
   // `src/tests/fixtures/openclaw-memory-status.json`), so this arm was the only
   // one of the two nagging, on a card both editions draw.
   //
-  // The pass that ended wrote down which empty this is, in the same transaction
-  // as the identity: how many documents it found, and how many folders it could
-  // not look inside. Nothing found and nothing refused is an index that is
-  // empty and up to date. Files found with no chunks to show for them, a walk
-  // that failed, or no recorded scan at all — the wizard's stamp before the
-  // first pass, an index older than these rows — stay `missing`, which is also
-  // what gets the next pass to rebuild.
+  // Three things have to hold before an empty index may call itself correct,
+  // and the pass that ended recorded the first two in the same transaction as
+  // the identity. A pass has to have LOOKED (no row at all is the wizard's
+  // stamp before the first pass, and an index older than these rows); it has to
+  // have found NOTHING, since files found with no chunks to show for them are
+  // work that did not happen; and what it looked at has to still be what the
+  // owner has registered — "there is nothing to index" is a claim about now,
+  // and a folder added after that pass makes it false. An index from before
+  // this row is trusted on that last point only when nothing is registered at
+  // all, which is the one configuration that cannot have gone stale under it.
+  //
+  // A folder the walk could not open is deliberately NOT part of this: it is a
+  // real fault, but the fault is the folder and not the fingerprint, a reindex
+  // cannot clear it, and the pass already counts it where the card has a
+  // "Failed" tile for it. `missing` is not what makes the next pass rebuild
+  // either — that is `resolveIndexMode`, on the chunk count.
   const scanned = metaGet(db, "scan_total_files");
-  const refused = Number(metaGet(db, "failures") ?? 0);
-  return scanned !== null && Number(scanned) === 0 && refused === 0 ? "valid" : "missing";
+  if (scanned === null || Number(scanned) !== 0) return "missing";
+  const covered = metaGet(db, "scan_sources");
+  const stillTrue = covered === null ? sources.length === 0 : covered === sourceListKey(sources);
+  return stillTrue ? "valid" : "missing";
 }
 
 // ─── embedding ───────────────────────────────────────────────────────────────
@@ -675,7 +697,7 @@ export async function runLocalIndexPass(
     const sources = await readLocalSources();
     const scan = await scanSources(sources, signal);
 
-    const identity = identityOf(db);
+    const identity = identityOf(db, sources);
     const schema = metaGet(db, "schema_version");
     const rebuild = mode === "full" || identity === "mismatched" || schema !== SCHEMA_VERSION;
     if (rebuild) {
@@ -691,7 +713,11 @@ export async function runLocalIndexPass(
     metaSet(db, "schema_version", SCHEMA_VERSION);
 
     let chunkCount = countOf(db, "SELECT COUNT(*) AS n FROM chunks");
-    let failures = scan.unreadableSources.size;
+    // A document the extractor could not read is a failure of the same kind as
+    // a file this pass cannot open below, and it was counted nowhere: its notes
+    // are the extractor's own and are dropped here. Without it a folder of
+    // PDFs none of which convert is a silently empty index.
+    let failures = scan.unreadableSources.size + scan.unusableDocuments;
     let capped = false;
     let wrote = false;
 
@@ -892,6 +918,10 @@ export async function runLocalIndexPass(
       metaSet(db, "identity", localEmbeddingIdentity());
       metaSet(db, "built_at", String(Date.now()));
       metaSet(db, "scan_total_files", String(scan.files.length));
+      // WHICH folders that count is about. Without it, "the last pass found
+      // nothing" outlives the configuration it was true of, and a folder the
+      // owner added afterwards reads as nothing to index — see `identityOf`.
+      metaSet(db, "scan_sources", sourceListKey(sources));
       metaSet(db, "failures", String(failures));
       metaSet(db, "capped", capped ? "1" : "");
       // What the vector cache keys on. A file mtime cannot do this job under
@@ -941,6 +971,15 @@ interface ScanResult {
    * and only one of them means the documents are gone.
    */
   unreadableSources: Set<string>;
+  /**
+   * Documents the extractor could not turn into text — too large to read, gone
+   * mid-scan, or a conversion that failed. Per-DOCUMENT faults, so they are
+   * counted with the file failures the pass counts and not with the
+   * folder-level shortfall above, and nothing else on the box reports them: a
+   * folder of PDFs that every one of them refused to convert leaves an index
+   * that is empty, and it must not read as "there was nothing to index".
+   */
+  unusableDocuments: number;
 }
 
 /** Find everything there is to index, and be honest about what could not be looked at. */
@@ -948,6 +987,7 @@ async function scanSources(sources: readonly string[], signal: AbortSignal | und
   const files: PendingFile[] = [];
   const seen = new Set<string>();
   const unreadableSources = new Set<string>();
+  let unusableDocuments = 0;
 
   for (const source of sources) {
     throwIfAborted(signal);
@@ -963,6 +1003,7 @@ async function scanSources(sources: readonly string[], signal: AbortSignal | und
       const extraction = await extractDocuments(source, signal);
       origins = extraction.origins;
       derived = extraction.derived;
+      unusableDocuments += extraction.skipped;
       // The extractor's own notes are about a scan that fell short — a folder
       // it could not open, a budget it ran out of — so they carry the same
       // "do not delete from this source" meaning the walk below does.
@@ -996,7 +1037,7 @@ async function scanSources(sources: readonly string[], signal: AbortSignal | und
       }
     }
   }
-  return { files, seen, unreadableSources };
+  return { files, seen, unreadableSources, unusableDocuments };
 }
 
 function errorText(err: unknown): string {
@@ -1074,7 +1115,7 @@ export async function localMemoryStatusJson(): Promise<unknown> {
           // wizard's own stamp leaves too. `identityOf` is what tells an index
           // that is empty because there was nothing to index from one that is
           // empty because the work did not happen.
-          indexIdentity: { status: db ? identityOf(db) : "missing" },
+          indexIdentity: { status: db ? identityOf(db, sources) : "missing" },
         },
       },
     };

--- a/src/lib/memory-index-local.ts
+++ b/src/lib/memory-index-local.ts
@@ -917,7 +917,13 @@ export async function runLocalIndexPass(
     try {
       metaSet(db, "identity", localEmbeddingIdentity());
       metaSet(db, "built_at", String(Date.now()));
-      metaSet(db, "scan_total_files", String(scan.files.length));
+      // Everything this pass had to ACCOUNT FOR, which is not the same as what
+      // it could open: a document the extractor refused never becomes an
+      // indexable file, and counted only among the failures it left the card
+      // saying "Nothing to index yet" over the owner's PDFs. Counted here it is
+      // owed work — `pendingFiles` on the card — and an index that is empty
+      // because of it is not an index with nothing to index.
+      metaSet(db, "scan_total_files", String(scan.files.length + scan.unusableDocuments));
       // WHICH folders that count is about. Without it, "the last pass found
       // nothing" outlives the configuration it was true of, and a folder the
       // owner added afterwards reads as nothing to index — see `identityOf`.
@@ -974,10 +980,11 @@ interface ScanResult {
   /**
    * Documents the extractor could not turn into text — too large to read, gone
    * mid-scan, or a conversion that failed. Per-DOCUMENT faults, so they are
-   * counted with the file failures the pass counts and not with the
-   * folder-level shortfall above, and nothing else on the box reports them: a
-   * folder of PDFs that every one of them refused to convert leaves an index
-   * that is empty, and it must not read as "there was nothing to index".
+   * counted with the file failures and not with the folder-level shortfall
+   * above, and nothing else on the box reports them: one of them never becomes
+   * an indexable file, so a folder of PDFs that every one of them refused to
+   * convert leaves an index that is empty and must not read as "there was
+   * nothing to index".
    */
   unusableDocuments: number;
 }

--- a/src/lib/memory-index-local.ts
+++ b/src/lib/memory-index-local.ts
@@ -370,13 +370,29 @@ function identityOf(db: IndexDb): "valid" | "missing" | "mismatched" {
   const stored = metaGet(db, "identity");
   if (!stored) return "missing";
   if (stored !== localEmbeddingIdentity()) return "mismatched";
-  // An identity over an EMPTY index is not evidence of anything: the wizard
-  // stamps one before the first pass, and a rebuild whose first embed failed
-  // leaves exactly the same shape. Reported `valid`, the shared parser reads
-  // both as `healthy` — a green panel over a search that finds nothing. The
-  // OpenClaw arm says `missing` at that point and so does this one, which is
-  // also what gets the next pass to rebuild rather than to do nothing.
-  return countOf(db, "SELECT COUNT(*) AS n FROM chunks") > 0 ? "valid" : "missing";
+  if (countOf(db, "SELECT COUNT(*) AS n FROM chunks") > 0) return "valid";
+  // ZERO CHUNKS IS TWO DIFFERENT STATES, and only one of them is wrong. An
+  // index emptied by a rebuild whose first embed failed must not read `valid`,
+  // which the shared parser calls `healthy` — a green panel over a search that
+  // finds nothing. But on a box whose folders hold no memory file yet, empty is
+  // the FINISHED state, and reporting `missing` there put a permanent "Needs
+  // attention — the index fingerprint is missing. Run a full reindex" on it:
+  // the reindex scans the same zero files and leaves the same zero chunks, so
+  // the remedy the card named could never clear the banner. A real OpenClaw box
+  // in that state reports `valid` (the captured payload in
+  // `src/tests/fixtures/openclaw-memory-status.json`), so this arm was the only
+  // one of the two nagging, on a card both editions draw.
+  //
+  // The pass that ended wrote down which empty this is, in the same transaction
+  // as the identity: how many documents it found, and how many folders it could
+  // not look inside. Nothing found and nothing refused is an index that is
+  // empty and up to date. Files found with no chunks to show for them, a walk
+  // that failed, or no recorded scan at all — the wizard's stamp before the
+  // first pass, an index older than these rows — stay `missing`, which is also
+  // what gets the next pass to rebuild.
+  const scanned = metaGet(db, "scan_total_files");
+  const refused = Number(metaGet(db, "failures") ?? 0);
+  return scanned !== null && Number(scanned) === 0 && refused === 0 ? "valid" : "missing";
 }
 
 // ─── embedding ───────────────────────────────────────────────────────────────
@@ -1053,9 +1069,11 @@ export async function localMemoryStatusJson(): Promise<unknown> {
         batch: { failures: db ? Number(metaGet(db, "failures") ?? 0) : 0 },
         custom: {
           providerState: { mode: ready ? "active" : "degraded" },
-          // No store at all is the same answer as a store with nothing in it:
-          // the wizard stamps an identity before the first pass, and until
-          // something has been built "missing" is what the OpenClaw box says.
+          // No store at all is not the same answer as a store a pass has
+          // finished with: nothing here has ever been looked at, the state the
+          // wizard's own stamp leaves too. `identityOf` is what tells an index
+          // that is empty because there was nothing to index from one that is
+          // empty because the work did not happen.
           indexIdentity: { status: db ? identityOf(db) : "missing" },
         },
       },

--- a/src/tests/helpers/memory-run-state.ts
+++ b/src/tests/helpers/memory-run-state.ts
@@ -25,6 +25,22 @@ export interface SettledMemoryRun {
   mode?: string;
 }
 
+/**
+ * A run record for a box that has never indexed, to hand `parseMemoryStatus`
+ * directly. Here rather than in each suite for the same reason the waiter is:
+ * both arms' suites need one, and two copies of a ten-field literal drift.
+ */
+export const IDLE_MEMORY_RUN = {
+  status: "idle" as const,
+  mode: "" as const,
+  trigger: "" as const,
+  startedAtMs: 0,
+  finishedAtMs: 0,
+  durationMs: 0,
+  error: "",
+  errorCode: "" as const,
+};
+
 export async function settledMemoryRun(
   clawkeepDir: string,
   { tries = 300, everyMs = 20 }: { tries?: number; everyMs?: number } = {},

--- a/src/tests/unit/clawkeep-memory-hermes.test.ts
+++ b/src/tests/unit/clawkeep-memory-hermes.test.ts
@@ -121,6 +121,25 @@ async function buildIndex(): Promise<void> {
   await local.runLocalIndexPass("full");
 }
 
+/** The stock box: folders registered, nothing in them yet, one finished pass. */
+async function buildEmptyIndex(): Promise<void> {
+  const local = await import("@/lib/memory-index-local");
+  await local.writeLocalSources([source]);
+  await local.runLocalIndexPass("full");
+}
+
+/** A run record the status parser can be handed directly. */
+const IDLE_RUN = {
+  status: "idle" as const,
+  mode: "" as const,
+  trigger: "" as const,
+  startedAtMs: 0,
+  finishedAtMs: 0,
+  durationMs: 0,
+  error: "",
+  errorCode: "" as const,
+};
+
 
 /** Every value `MemoryStatusErrorCode` allows, which is every value a locale
  *  pack words. A status carrying anything else is English on a German desktop. */
@@ -177,6 +196,49 @@ describe("what ClawBox's own index tells the shared parser", () => {
     const status = await (await lib()).getMemoryStatus();
     expect(MEMORY_STATUS_CODES).toContain(status.errorCode);
     expect(status.errorCode).toBe("index_identity_missing");
+  });
+
+  it("draws no attention badge and no remedy on a box with nothing to index", async () => {
+    // What the card showed on the box: "Memory index ON … Needs attention — the
+    // index fingerprint is missing. Run a full reindex" over FILES 0 · CHUNKS 0
+    // and, underneath, the honest "Nothing to index yet". Three statements, two
+    // of them contradicting the third, and the remedy was the full reindex that
+    // had already run by hand four hours earlier and finished in 19 ms.
+    await buildEmptyIndex();
+    const { getMemoryStatus, invalidateMemoryStatusCache } = await lib();
+    invalidateMemoryStatusCache();
+    const status = await getMemoryStatus();
+    expect(status.files).toBe(0);
+    expect(status.chunks).toBe(0);
+    expect(status.indexIdentity).toBe("valid");
+    expect(status.health).toBe("healthy");
+    expect(status.errorCode).toBe("");
+    expect(status.error).toBe("");
+  });
+
+  it("says about an empty index exactly what the captured OpenClaw box says", async () => {
+    // The parity this arm exists for, on the one state every new box is in. The
+    // fixture is `openclaw memory status --agent main --deep --json` taken from
+    // a real OpenClaw box that had never written a memory file: zero files, zero
+    // chunks, a scan that found nothing — and `indexIdentity: valid`. So the
+    // OpenClaw edition has always shown that box as healthy, and the nag was
+    // this arm's alone. Both editions draw the same card, so they cannot be
+    // allowed to disagree about it.
+    const real = JSON.parse(
+      await fsp.readFile(new URL("../fixtures/openclaw-memory-status.json", import.meta.url), "utf8"),
+    ) as Array<{ scan: { totalFiles: number }; status: { custom: { indexIdentity: { status: string } } } }>;
+    expect(real[0].scan.totalFiles).toBe(0);
+    expect(real[0].status.custom.indexIdentity.status).toBe("valid");
+
+    const { getMemoryStatus, invalidateMemoryStatusCache, parseMemoryStatus, DEFAULT_MEMORY_SCHEDULE } = await lib();
+    const openclaw = await parseMemoryStatus(real, IDLE_RUN, DEFAULT_MEMORY_SCHEDULE);
+    await buildEmptyIndex();
+    invalidateMemoryStatusCache();
+    const hermes = await getMemoryStatus();
+    expect(hermes.indexIdentity).toBe(openclaw.indexIdentity);
+    expect(hermes.health).toBe(openclaw.health);
+    expect(hermes.errorCode).toBe(openclaw.errorCode);
+    expect(hermes.error).toBe(openclaw.error);
   });
 
   it("draws the existing amber banner when the embedder it was built for changed", async () => {

--- a/src/tests/unit/clawkeep-memory-hermes.test.ts
+++ b/src/tests/unit/clawkeep-memory-hermes.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import { promises as fsp } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { settledMemoryRun } from "@/tests/helpers/memory-run-state";
+import { IDLE_MEMORY_RUN, settledMemoryRun } from "@/tests/helpers/memory-run-state";
 
 /**
  * Memory Shard's Hermes arm, at the seam.
@@ -113,33 +113,24 @@ async function lib() {
   return await import("@/lib/clawkeep-memory");
 }
 
-/** Build a small real index in the temp DATA_DIR. */
-async function buildIndex(): Promise<void> {
+/**
+ * Build a real index in the temp DATA_DIR over the registered temp folder.
+ *
+ * With no `notes` it is the stock box — folders registered, nothing in them yet,
+ * one finished pass; `keepFolder: false` is the state the captured OpenClaw
+ * payload is in, a registered folder that is not on disk at all.
+ */
+async function buildIndex(
+  { notes, keepFolder = true }: { notes?: string; keepFolder?: boolean } = {},
+): Promise<void> {
   const local = await import("@/lib/memory-index-local");
-  fs.writeFileSync(path.join(source, "notes.md"), "The deposit is two months' rent.");
+  if (notes) fs.writeFileSync(path.join(source, "notes.md"), notes);
   await local.writeLocalSources([source]);
+  if (!keepFolder) fs.rmSync(source, { recursive: true, force: true });
   await local.runLocalIndexPass("full");
 }
 
-/** The stock box: folders registered, nothing in them yet, one finished pass. */
-async function buildEmptyIndex(): Promise<void> {
-  const local = await import("@/lib/memory-index-local");
-  await local.writeLocalSources([source]);
-  await local.runLocalIndexPass("full");
-}
-
-/** A run record the status parser can be handed directly. */
-const IDLE_RUN = {
-  status: "idle" as const,
-  mode: "" as const,
-  trigger: "" as const,
-  startedAtMs: 0,
-  finishedAtMs: 0,
-  durationMs: 0,
-  error: "",
-  errorCode: "" as const,
-};
-
+const NOTES = "The deposit is two months' rent.";
 
 /** Every value `MemoryStatusErrorCode` allows, which is every value a locale
  *  pack words. A status carrying anything else is English on a German desktop. */
@@ -158,7 +149,7 @@ describe("what ClawBox's own index tells the shared parser", () => {
     // providerLocation() reports "unknown" — an embedder running on loopback,
     // drawn as one the box cannot account for. The local arm passes its own
     // proxy URL instead.
-    await buildIndex();
+    await buildIndex({ notes: NOTES });
     const { getMemoryStatus } = await lib();
     const status = await getMemoryStatus();
     expect(status.location).toBe("local");
@@ -167,7 +158,7 @@ describe("what ClawBox's own index tells the shared parser", () => {
   });
 
   it("is healthy, with real counts and a fingerprint", async () => {
-    await buildIndex();
+    await buildIndex({ notes: NOTES });
     const { getMemoryStatus } = await lib();
     const status = await getMemoryStatus();
     expect(status.available).toBe(true);
@@ -185,7 +176,7 @@ describe("what ClawBox's own index tells the shared parser", () => {
     // The whole reason for impersonating the CLI's JSON rather than writing a
     // second status producer. A new code here would be English on a German
     // desktop, and nothing in this repo would have failed.
-    await buildIndex();
+    await buildIndex({ notes: NOTES });
     const status = await (await lib()).getMemoryStatus();
     expect(MEMORY_STATUS_CODES).toContain(status.errorCode);
     expect(status.errorCode).toBe("");
@@ -204,7 +195,7 @@ describe("what ClawBox's own index tells the shared parser", () => {
     // and, underneath, the honest "Nothing to index yet". Three statements, two
     // of them contradicting the third, and the remedy was the full reindex that
     // had already run by hand four hours earlier and finished in 19 ms.
-    await buildEmptyIndex();
+    await buildIndex();
     const { getMemoryStatus, invalidateMemoryStatusCache } = await lib();
     invalidateMemoryStatusCache();
     const status = await getMemoryStatus();
@@ -218,21 +209,26 @@ describe("what ClawBox's own index tells the shared parser", () => {
 
   it("says about an empty index exactly what the captured OpenClaw box says", async () => {
     // The parity this arm exists for, on the one state every new box is in. The
-    // fixture is `openclaw memory status --agent main --deep --json` taken from
-    // a real OpenClaw box that had never written a memory file: zero files, zero
-    // chunks, a scan that found nothing — and `indexIdentity: valid`. So the
-    // OpenClaw edition has always shown that box as healthy, and the nag was
-    // this arm's alone. Both editions draw the same card, so they cannot be
-    // allowed to disagree about it.
+    // fixture is `openclaw memory status --agent main --deep --json` taken from a
+    // real OpenClaw box that had never written a memory file: zero files, zero
+    // chunks, a scan whose only issue is that the memory DIRECTORY IS NOT THERE
+    // — and `indexIdentity: valid`. So the OpenClaw edition has always shown
+    // that box as healthy, and the nag was this arm's alone. Both editions draw
+    // the same card, so the Hermes side is driven into the fixture's own state,
+    // a registered folder that does not exist, and has to agree about it.
     const real = JSON.parse(
       await fsp.readFile(new URL("../fixtures/openclaw-memory-status.json", import.meta.url), "utf8"),
-    ) as Array<{ scan: { totalFiles: number }; status: { custom: { indexIdentity: { status: string } } } }>;
+    ) as Array<{
+      scan: { totalFiles: number; issues: string[] };
+      status: { custom: { indexIdentity: { status: string } } };
+    }>;
     expect(real[0].scan.totalFiles).toBe(0);
+    expect(real[0].scan.issues.length).toBe(1);
     expect(real[0].status.custom.indexIdentity.status).toBe("valid");
 
     const { getMemoryStatus, invalidateMemoryStatusCache, parseMemoryStatus, DEFAULT_MEMORY_SCHEDULE } = await lib();
-    const openclaw = await parseMemoryStatus(real, IDLE_RUN, DEFAULT_MEMORY_SCHEDULE);
-    await buildEmptyIndex();
+    const openclaw = await parseMemoryStatus(real, IDLE_MEMORY_RUN, DEFAULT_MEMORY_SCHEDULE);
+    await buildIndex({ keepFolder: false });
     invalidateMemoryStatusCache();
     const hermes = await getMemoryStatus();
     expect(hermes.indexIdentity).toBe(openclaw.indexIdentity);
@@ -242,7 +238,7 @@ describe("what ClawBox's own index tells the shared parser", () => {
   });
 
   it("draws the existing amber banner when the embedder it was built for changed", async () => {
-    await buildIndex();
+    await buildIndex({ notes: NOTES });
     const { LOCAL_INDEX_PATH } = await import("@/lib/memory-index-local");
     const { openSqlite } = await import("@/lib/openclaw-session-store");
     const db = openSqlite(LOCAL_INDEX_PATH, false);

--- a/src/tests/unit/clawkeep-memory.test.ts
+++ b/src/tests/unit/clawkeep-memory.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { spawn } from "node:child_process";
 import { promises as fs } from "node:fs";
 import os from "node:os";
-import { settledMemoryRun } from "@/tests/helpers/memory-run-state";
+import { IDLE_MEMORY_RUN, settledMemoryRun } from "@/tests/helpers/memory-run-state";
 import path from "node:path";
 
 /**
@@ -55,21 +55,11 @@ async function lib() {
   return await import("@/lib/clawkeep-memory");
 }
 
-const IDLE_RUN = {
-  status: "idle" as const,
-  mode: "" as const,
-  trigger: "" as const,
-  startedAtMs: 0,
-  finishedAtMs: 0,
-  durationMs: 0,
-  error: "",
-  errorCode: "" as const,
-};
 
 describe("reading the real memory status", () => {
   it("reports a local embedder as on-device, not as cloud", async () => {
     const { parseMemoryStatus, DEFAULT_MEMORY_SCHEDULE } = await lib();
-    const status = await parseMemoryStatus(REAL_STATUS, IDLE_RUN, DEFAULT_MEMORY_SCHEDULE);
+    const status = await parseMemoryStatus(REAL_STATUS, IDLE_MEMORY_RUN, DEFAULT_MEMORY_SCHEDULE);
     // The whole privacy claim rests on this one field being right.
     expect(status.provider).toBe("ollama");
     expect(status.model).toBe("qwen3-embedding:0.6b");
@@ -85,13 +75,13 @@ describe("reading the real memory status", () => {
     // red "Failed: 1" on a healthy new device.
     const raw = REAL_STATUS as Array<{ scan: { issues: string[] } }>;
     expect(raw[0].scan.issues.length).toBe(1);
-    const status = await parseMemoryStatus(REAL_STATUS, IDLE_RUN, DEFAULT_MEMORY_SCHEDULE);
+    const status = await parseMemoryStatus(REAL_STATUS, IDLE_MEMORY_RUN, DEFAULT_MEMORY_SCHEDULE);
     expect(status.failedItems).toBe(0);
   });
 
   it("never leaks a path, a model file or CLI text into what the UI renders", async () => {
     const { parseMemoryStatus, DEFAULT_MEMORY_SCHEDULE } = await lib();
-    const status = await parseMemoryStatus(REAL_STATUS, IDLE_RUN, DEFAULT_MEMORY_SCHEDULE);
+    const status = await parseMemoryStatus(REAL_STATUS, IDLE_MEMORY_RUN, DEFAULT_MEMORY_SCHEDULE);
     const rendered = JSON.stringify(status);
     // Everything in the captured payload that must not reach a customer.
     expect(rendered).not.toContain("/home/");
@@ -106,7 +96,7 @@ describe("reading the real memory status", () => {
     const rows = JSON.parse(JSON.stringify(REAL_STATUS)) as Array<Record<string, never>>;
     (rows[0] as unknown as { status: { custom: { indexIdentity: { status: string } } } })
       .status.custom.indexIdentity.status = "mismatched";
-    const status = await parseMemoryStatus(rows, IDLE_RUN, DEFAULT_MEMORY_SCHEDULE);
+    const status = await parseMemoryStatus(rows, IDLE_MEMORY_RUN, DEFAULT_MEMORY_SCHEDULE);
     expect(status.indexIdentity).toBe("mismatched");
     expect(status.error).toContain("full reindex");
   });
@@ -125,7 +115,7 @@ describe("reading the real memory status", () => {
       const rows = JSON.parse(JSON.stringify(REAL_STATUS)) as unknown;
       (rows as Array<{ status: { custom: { indexIdentity: { status: string } } } }>)[0]
         .status.custom.indexIdentity.status = identity;
-      const status = await parseMemoryStatus(rows, IDLE_RUN, DEFAULT_MEMORY_SCHEDULE);
+      const status = await parseMemoryStatus(rows, IDLE_MEMORY_RUN, DEFAULT_MEMORY_SCHEDULE);
       expect(status.indexIdentity).toBe(identity);
       expect(status.health).toBe("degraded");
       expect(status.errorCode).toBe(code);
@@ -135,7 +125,7 @@ describe("reading the real memory status", () => {
 
   it("leaves a healthy index healthy, with no code beside an empty message", async () => {
     const { parseMemoryStatus, DEFAULT_MEMORY_SCHEDULE } = await lib();
-    const status = await parseMemoryStatus(REAL_STATUS, IDLE_RUN, DEFAULT_MEMORY_SCHEDULE);
+    const status = await parseMemoryStatus(REAL_STATUS, IDLE_MEMORY_RUN, DEFAULT_MEMORY_SCHEDULE);
     expect(status.health).toBe("healthy");
     expect(status.error).toBe("");
     expect(status.errorCode).toBe("");
@@ -143,20 +133,20 @@ describe("reading the real memory status", () => {
 
   it("keeps the fingerprint stable for a configuration and changes it with the model", async () => {
     const { parseMemoryStatus, DEFAULT_MEMORY_SCHEDULE } = await lib();
-    const a = await parseMemoryStatus(REAL_STATUS, IDLE_RUN, DEFAULT_MEMORY_SCHEDULE);
-    const again = await parseMemoryStatus(REAL_STATUS, IDLE_RUN, DEFAULT_MEMORY_SCHEDULE);
+    const a = await parseMemoryStatus(REAL_STATUS, IDLE_MEMORY_RUN, DEFAULT_MEMORY_SCHEDULE);
+    const again = await parseMemoryStatus(REAL_STATUS, IDLE_MEMORY_RUN, DEFAULT_MEMORY_SCHEDULE);
     expect(a.fingerprint).toBe(again.fingerprint);
     expect(a.fingerprint).not.toBe("");
 
     const rows = JSON.parse(JSON.stringify(REAL_STATUS)) as unknown;
     (rows as Array<{ status: { model: string } }>)[0].status.model = "text-embedding-3-large";
-    const other = await parseMemoryStatus(rows, IDLE_RUN, DEFAULT_MEMORY_SCHEDULE);
+    const other = await parseMemoryStatus(rows, IDLE_MEMORY_RUN, DEFAULT_MEMORY_SCHEDULE);
     expect(other.fingerprint).not.toBe(a.fingerprint);
   });
 
   it("says unavailable rather than pretending, when the CLI says nothing", async () => {
     const { parseMemoryStatus, DEFAULT_MEMORY_SCHEDULE } = await lib();
-    const status = await parseMemoryStatus([{ agentId: "main", status: {} }], IDLE_RUN, DEFAULT_MEMORY_SCHEDULE);
+    const status = await parseMemoryStatus([{ agentId: "main", status: {} }], IDLE_MEMORY_RUN, DEFAULT_MEMORY_SCHEDULE);
     expect(status.available).toBe(false);
     expect(status.health).toBe("unavailable");
     expect(status.location).toBe("unknown");
@@ -835,7 +825,7 @@ describe("an openai-compatible embedder is on device only at the loopback proxy"
   it("reads ClawBox's own embedder behind the proxy as local", async () => {
     const { parseMemoryStatus, DEFAULT_MEMORY_SCHEDULE } = await lib();
     const status = await parseMemoryStatus(
-      row("openai-compatible"), IDLE_RUN, DEFAULT_MEMORY_SCHEDULE, new Date(),
+      row("openai-compatible"), IDLE_MEMORY_RUN, DEFAULT_MEMORY_SCHEDULE, new Date(),
       "http://127.0.0.1/setup-api/local-ai/embed/v1",
     );
     expect(status.provider).toBe("openai-compatible");
@@ -845,7 +835,7 @@ describe("an openai-compatible embedder is on device only at the loopback proxy"
   it("reads the same provider id at another host as cloud", async () => {
     const { parseMemoryStatus, DEFAULT_MEMORY_SCHEDULE } = await lib();
     const status = await parseMemoryStatus(
-      row("openai-compatible"), IDLE_RUN, DEFAULT_MEMORY_SCHEDULE, new Date(), "http://192.168.1.50:8081/v1",
+      row("openai-compatible"), IDLE_MEMORY_RUN, DEFAULT_MEMORY_SCHEDULE, new Date(), "http://192.168.1.50:8081/v1",
     );
     expect(status.location).toBe("cloud");
   });
@@ -855,7 +845,7 @@ describe("an openai-compatible embedder is on device only at the loopback proxy"
     // rests on this field, and a guess in the flattering direction is the
     // one that lies.
     const { parseMemoryStatus, DEFAULT_MEMORY_SCHEDULE } = await lib();
-    const status = await parseMemoryStatus(row("openai-compatible"), IDLE_RUN, DEFAULT_MEMORY_SCHEDULE);
+    const status = await parseMemoryStatus(row("openai-compatible"), IDLE_MEMORY_RUN, DEFAULT_MEMORY_SCHEDULE);
     expect(status.location).toBe("unknown");
   });
 
@@ -864,7 +854,7 @@ describe("an openai-compatible embedder is on device only at the loopback proxy"
     // happens to carry a remote address is still embedding on this box.
     const { parseMemoryStatus, DEFAULT_MEMORY_SCHEDULE } = await lib();
     const status = await parseMemoryStatus(
-      row("ollama", "qwen3-embedding:0.6b"), IDLE_RUN, DEFAULT_MEMORY_SCHEDULE, new Date(),
+      row("ollama", "qwen3-embedding:0.6b"), IDLE_MEMORY_RUN, DEFAULT_MEMORY_SCHEDULE, new Date(),
       "http://192.168.1.50:8081/v1",
     );
     expect(status.location).toBe("local");

--- a/src/tests/unit/memory-index-local.test.ts
+++ b/src/tests/unit/memory-index-local.test.ts
@@ -142,6 +142,18 @@ function storedMtime(file: string): number {
   }
 }
 
+/** Write one `meta` row, the way the identity tests below rewrite `identity`. */
+async function setMeta(key: string, value: string): Promise<void> {
+  const { openSqlite } = await import("@/lib/openclaw-session-store");
+  const db = openSqlite(LOCAL_INDEX_PATH, false);
+  try {
+    db.prepare("INSERT INTO meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value")
+      .run(key, value);
+  } finally {
+    db.close();
+  }
+}
+
 /** Move a file's mtime forward, since two writes in one millisecond do not. */
 function touchLater(file: string): void {
   const when = new Date(Date.now() + 5_000);
@@ -452,8 +464,9 @@ describe("the index knows what it was built for", () => {
     // identity with no rows behind it is not evidence of anything: reported
     // `valid` it reaches the shared parser as `healthy` with zero chunks — a
     // green panel over a search that finds nothing — and a rebuild whose first
-    // embed failed leaves exactly the same shape. The OpenClaw arm says
-    // `missing` at that point, and it is also what makes the next pass rebuild.
+    // embed failed leaves exactly the same shape. No pass has recorded a scan
+    // here, so nothing yet says the folders are empty; it is also what makes
+    // the next pass rebuild.
     await stampLocalEmbeddingIdentity();
     const status = await localMemoryStatusJson() as {
       status: { custom: { indexIdentity: { status: string } }; files: number; chunks: number };
@@ -478,6 +491,46 @@ describe("the index knows what it was built for", () => {
       status: { chunks: number; custom: { indexIdentity: { status: string } } };
     };
     expect(status.status.chunks).toBe(0);
+    expect(status.status.custom.indexIdentity.status).toBe("missing");
+  });
+
+  it("calls an index a finished pass found NOTHING to fill valid, not missing", async () => {
+    // The Memory Shard card on a box whose folders hold no memory file yet said
+    // "Memory index ON … Needs attention — the index fingerprint is missing. Run
+    // a full reindex", four hours after a full reindex that had succeeded in
+    // 19 ms. The remedy it named could not work: another full pass scans the
+    // same zero files and leaves the same zero chunks, so the banner came back
+    // unchanged every time. Zero chunks is TWO states and the pass that ended
+    // wrote down which one this is — an index that is empty because there was
+    // nothing to put in it is correct and up to date.
+    await runLocalIndexPass("full");
+    const row = await localMemoryStatusJson() as {
+      scan: { totalFiles: number };
+      status: { files: number; chunks: number; custom: { indexIdentity: { status: string } } };
+    };
+    expect(row.scan.totalFiles).toBe(0);
+    expect(row.status.files).toBe(0);
+    expect(row.status.chunks).toBe(0);
+    expect(row.status.custom.indexIdentity.status).toBe("valid");
+  });
+
+  it("keeps MISSING when the pass DID scan files and the index came out empty", async () => {
+    // The other empty, and the one the zero-chunk rule exists for: there were
+    // documents to index and none of them made it in. The reindex the panel
+    // offers is the right advice there, so it has to stay.
+    await runLocalIndexPass("full");
+    await setMeta("scan_total_files", "3");
+    const status = await localMemoryStatusJson() as { status: { custom: { indexIdentity: { status: string } } } };
+    expect(status.status.custom.indexIdentity.status).toBe("missing");
+  });
+
+  it("keeps MISSING when a source folder could not be read", async () => {
+    // Zero files scanned because the WALK failed is not "nothing to index":
+    // called valid it would be a green panel over an index that is empty
+    // because the folder could not be opened.
+    await runLocalIndexPass("full");
+    await setMeta("failures", "1");
+    const status = await localMemoryStatusJson() as { status: { custom: { indexIdentity: { status: string } } } };
     expect(status.status.custom.indexIdentity.status).toBe("missing");
   });
 });

--- a/src/tests/unit/memory-index-local.test.ts
+++ b/src/tests/unit/memory-index-local.test.ts
@@ -142,18 +142,6 @@ function storedMtime(file: string): number {
   }
 }
 
-/** Write one `meta` row, the way the identity tests below rewrite `identity`. */
-async function setMeta(key: string, value: string): Promise<void> {
-  const { openSqlite } = await import("@/lib/openclaw-session-store");
-  const db = openSqlite(LOCAL_INDEX_PATH, false);
-  try {
-    db.prepare("INSERT INTO meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value")
-      .run(key, value);
-  } finally {
-    db.close();
-  }
-}
-
 /** Move a file's mtime forward, since two writes in one millisecond do not. */
 function touchLater(file: string): void {
   const when = new Date(Date.now() + 5_000);
@@ -465,8 +453,7 @@ describe("the index knows what it was built for", () => {
     // `valid` it reaches the shared parser as `healthy` with zero chunks — a
     // green panel over a search that finds nothing — and a rebuild whose first
     // embed failed leaves exactly the same shape. No pass has recorded a scan
-    // here, so nothing yet says the folders are empty; it is also what makes
-    // the next pass rebuild.
+    // here, so nothing yet says the folders are empty.
     await stampLocalEmbeddingIdentity();
     const status = await localMemoryStatusJson() as {
       status: { custom: { indexIdentity: { status: string } }; files: number; chunks: number };
@@ -518,20 +505,62 @@ describe("the index knows what it was built for", () => {
     // The other empty, and the one the zero-chunk rule exists for: there were
     // documents to index and none of them made it in. The reindex the panel
     // offers is the right advice there, so it has to stay.
-    await runLocalIndexPass("full");
-    await setMeta("scan_total_files", "3");
-    const status = await localMemoryStatusJson() as { status: { custom: { indexIdentity: { status: string } } } };
-    expect(status.status.custom.indexIdentity.status).toBe("missing");
+    write("blank.md", "   \n\n  ");
+    write("also-blank.md", "\t\n");
+    const result = await runLocalIndexPass("full");
+    expect(result.chunks).toBe(0);
+    const row = await localMemoryStatusJson() as {
+      scan: { totalFiles: number };
+      status: { custom: { indexIdentity: { status: string } } };
+    };
+    expect(row.scan.totalFiles).toBe(2);
+    expect(row.status.custom.indexIdentity.status).toBe("missing");
   });
 
-  it("keeps MISSING when a source folder could not be read", async () => {
-    // Zero files scanned because the WALK failed is not "nothing to index":
-    // called valid it would be a green panel over an index that is empty
-    // because the folder could not be opened.
+  it("still calls it empty when a registered folder is not there any more", async () => {
+    // The state the captured OpenClaw payload is in — its memory directory does
+    // not exist and it reports `valid` with no failed items. A folder that
+    // cannot be opened IS a fault, but it is not a fault of the fingerprint and
+    // no reindex can clear it, so it must not come back as "run a full
+    // reindex"; the pass counts it where the card has a Failed tile.
+    fs.rmSync(source, { recursive: true, force: true });
+    const result = await runLocalIndexPass("full");
+    const row = await localMemoryStatusJson() as {
+      status: { chunks: number; custom: { indexIdentity: { status: string } } };
+    };
+    expect(result.failures).toBeGreaterThan(0);
+    expect(row.status.chunks).toBe(0);
+    expect(row.status.custom.indexIdentity.status).toBe("valid");
+  });
+
+  it("stops calling it up to date once the owner adds a folder the pass never saw", async () => {
+    // "There is nothing to index" is a claim about NOW, and the count behind it
+    // is one a finished pass wrote down. Adding a folder starts no pass and the
+    // schedule is off until the owner arms it, so trusting that count would
+    // leave a folder of documents reading as healthy and empty indefinitely.
     await runLocalIndexPass("full");
-    await setMeta("failures", "1");
-    const status = await localMemoryStatusJson() as { status: { custom: { indexIdentity: { status: string } } } };
-    expect(status.status.custom.indexIdentity.status).toBe("missing");
+    const added = fs.mkdtempSync(path.join(os.tmpdir(), "memory-index-added-"));
+    try {
+      fs.writeFileSync(path.join(added, "lease.md"), "The deposit is two months' rent.");
+      await writeLocalSources([source, added]);
+      const status = await localMemoryStatusJson() as { status: { custom: { indexIdentity: { status: string } } } };
+      expect(status.status.custom.indexIdentity.status).toBe("missing");
+    } finally {
+      fs.rmSync(added, { recursive: true, force: true });
+    }
+  });
+
+  it("counts a document it could not convert instead of reporting nothing to index", async () => {
+    // A PDF the converter refuses leaves the derived folder empty, the walk
+    // complete and the index with nothing in it — so the emptiness is correct
+    // and says nothing about the documents behind it. The extractor's own notes
+    // are dropped here, so unless the pass counts the document the card claims
+    // "Nothing to index yet" over a folder the box could not read.
+    write("scan.pdf", "this is not a PDF");
+    const result = await runLocalIndexPass("full");
+    expect(result.failures).toBe(1);
+    const row = await localMemoryStatusJson() as { status: { batch: { failures: number } } };
+    expect(row.status.batch.failures).toBe(1);
   });
 });
 

--- a/src/tests/unit/memory-index-local.test.ts
+++ b/src/tests/unit/memory-index-local.test.ts
@@ -551,16 +551,27 @@ describe("the index knows what it was built for", () => {
   });
 
   it("counts a document it could not convert instead of reporting nothing to index", async () => {
-    // A PDF the converter refuses leaves the derived folder empty, the walk
-    // complete and the index with nothing in it — so the emptiness is correct
-    // and says nothing about the documents behind it. The extractor's own notes
-    // are dropped here, so unless the pass counts the document the card claims
-    // "Nothing to index yet" over a folder the box could not read.
+    // A PDF the converter refuses never becomes an indexable file, so the walk
+    // is complete, the index is empty and — counted nowhere — the card said
+    // "Nothing to index yet" over a document the box could not read. The
+    // extractor's own notes are dropped here, so the pass is the only place
+    // that can carry it: once as a failure, and once as work this pass had to
+    // account for and did not, which is what keeps the empty index from calling
+    // itself up to date.
     write("scan.pdf", "this is not a PDF");
     const result = await runLocalIndexPass("full");
     expect(result.failures).toBe(1);
-    const row = await localMemoryStatusJson() as { status: { batch: { failures: number } } };
+    const row = await localMemoryStatusJson() as {
+      scan: { totalFiles: number };
+      status: { files: number; chunks: number; batch: { failures: number }; custom: { indexIdentity: { status: string } } };
+    };
     expect(row.status.batch.failures).toBe(1);
+    // `pendingFiles` on the card is totalFiles - files, so this is PENDING 1,
+    // which is what takes "Nothing to index yet" off the panel.
+    expect(row.scan.totalFiles).toBe(1);
+    expect(row.status.files).toBe(0);
+    expect(row.status.chunks).toBe(0);
+    expect(row.status.custom.indexIdentity.status).toBe("missing");
   });
 });
 


### PR DESCRIPTION
**Finding HL-5** (card TASK-806, epic TASK-790) — a false failure on the Memory Shard card.

## Customer-visible symptom

Open Memory Shard on a box whose folders hold no memory file yet. One card, three
statements that contradict each other:

```
Memory index  ON        …        Needs attention
The index fingerprint is missing. Run a full reindex.
FILES 0 · CHUNKS 0 · SOURCES 0 · PENDING 0 · FAILED 0 · INDEX SIZE 32.0 KB
Nothing to index yet — the assistant writes memory files as it learns.
Last run: finished 4h ago · by hand · full · 0 s
```

The remedy it names cannot work. The full reindex it asks for had already been run by
hand four hours earlier and succeeded — `run.status=succeeded, mode=full,
trigger=manual, durationMs=19` — and another one scans the same zero files and leaves
the same zero chunks, so the amber badge and the banner came back unchanged every time.
The bottom line ("Nothing to index yet") was the honest one, and it sat directly under
"Needs attention".

## Cause

`identityOf()` in `src/lib/memory-index-local.ts` overrode a stamped, matching identity
to `"missing"` on **any** zero-chunk index:

```ts
return countOf(db, "SELECT COUNT(*) AS n FROM chunks") > 0 ? "valid" : "missing";
```

The case the old comment defended is real — the wizard stamps an identity before the
first pass, and a rebuild whose first embed failed leaves an empty store — but the line
treated **two different empties as one**: empty because indexing failed, and empty
because the box has nothing to index. On a new box the second is the normal state, so
`src/lib/clawkeep-memory.ts` set `health = "degraded"` and printed the reindex
instruction, permanently.

## What the fix decides on

Three things now have to hold before an empty index may call itself correct, and the
pass that ended records the first two in the same transaction as the identity:

1. **A pass has looked.** No recorded scan at all is the wizard's stamp before the first
   pass (or an index older than these rows) → `missing`, exactly as before.
2. **It found nothing.** Files found with no chunks to show for them is work that did not
   happen → `missing`, and the reindex prompt stays.
3. **What it looked at is still what the owner has registered.** "There is nothing to
   index" is a claim about now. Adding a folder starts no pass and the schedule is off
   until the owner arms it, so the pass now records which folders its count is about
   (`scan_sources`, a hash of the sorted list) and the verdict holds only while they are
   unchanged. An index from before that row is trusted on this point only when nothing is
   registered at all — the one configuration that cannot have gone stale under it, and
   the state the reported box is in, so existing boxes are fixed without waiting for a
   pass.

A folder whose walk could not be completed is deliberately **not** part of it. It is a
real fault, but the fault is the folder and not the fingerprint, and no reindex can clear
it — making it say "run a full reindex" is the very symptom this fixes. The pass counts
it where the card already has a Failed tile.

Two supporting changes make that safe:

- **A document the extractor could not read is now counted.** `extractDocuments` tracks
  `skipped` — too large, gone mid-scan, a conversion that failed — and the pass dropped
  it along with the extractor's notes. So a folder of PDFs none of which convert left an
  index that is empty (now correctly so) with nothing anywhere saying why. Those
  documents are counted with the file failures beside them, so the card shows them.
- `LocalIndexPassResult.failures` documents itself as "files that could not be read or
  embedded", which is what it now holds, plus the folder-level shortfall it already
  counted.

## Both editions

**The native mechanism was already right, and this arm was the one out of step.** Memory
Shard's two arms share one status shape on purpose: where there is an OpenClaw, OpenClaw
owns the index and ClawBox drives its CLI; on the Hermes SKU — which ships no memory
index at all — ClawBox owns one itself and answers the same JSON
`openclaw memory status --agent main --deep --json` answers, so `parseMemoryStatus`, the
health rules, the error-code catalogue and every locale pack are shared rather than
duplicated.

The repo's own captured payload from a real OpenClaw box
(`src/tests/fixtures/openclaw-memory-status.json`) is in exactly this state — `files 0`,
`chunks 0`, `scan.totalFiles 0`, its one scan issue being that the memory directory is
not there — and reports `custom.indexIdentity.status: "valid"` with `batch.failures: 0`.
So the OpenClaw edition has always drawn that box as healthy, and the nag was the local
arm's alone. The old comment's claim that "the OpenClaw arm says `missing` at that point"
is contradicted by that fixture and is corrected. Nothing new was invented and no field
was added to the payload: the discriminating facts are rows the pass already wrote (plus
one it now writes beside them), and the verdict matches what the harness itself reports.
A parity test drives the Hermes arm into the fixture's own state and pins the two to the
same verdict, so they cannot drift apart again.

No change was needed in the shared parser or in any screen — which is the point of the
seam.

## RED → GREEN

RED on unmodified beta (`1be87420b`), the five new assertions, with the tests applied to
a clean beta worktree:

```
 × calls an index a finished pass found NOTHING to fill valid, not missing 12ms
 × still calls it empty when a registered folder is not there any more 7ms
 × counts a document it could not convert instead of reporting nothing to index 21ms
 × draws no attention badge and no remedy on a box with nothing to index 15ms
 × says about an empty index exactly what the captured OpenClaw box says 12ms

FAIL  src/tests/unit/memory-index-local.test.ts > the index knows what it was built for
      > calls an index a finished pass found NOTHING to fill valid, not missing
AssertionError: expected 'missing' to be 'valid' // Object.is equality
Expected: "valid"
Received: "missing"

FAIL  src/tests/unit/memory-index-local.test.ts > the index knows what it was built for
      > still calls it empty when a registered folder is not there any more
AssertionError: expected 'missing' to be 'valid' // Object.is equality

FAIL  src/tests/unit/memory-index-local.test.ts > the index knows what it was built for
      > counts a document it could not convert instead of reporting nothing to index
AssertionError: expected +0 to be 1 // Object.is equality

FAIL  src/tests/unit/clawkeep-memory-hermes.test.ts > what ClawBox's own index tells the
      shared parser > draws no attention badge and no remedy on a box with nothing to index
AssertionError: expected 'missing' to be 'valid' // Object.is equality

FAIL  src/tests/unit/clawkeep-memory-hermes.test.ts > what ClawBox's own index tells the
      shared parser > says about an empty index exactly what the captured OpenClaw box says
AssertionError: expected 'missing' to be 'valid' // Object.is equality

 Test Files  2 failed | 1 passed (3)
      Tests  5 failed | 82 passed (87)
```

The other 82 pass on beta on purpose: two of them are the guards that must NOT change —
a pass that scanned blank documents and left the index empty, and a folder added after
the pass — and they would fail if the new rule went too far.

GREEN after the fix, the memory area end to end (the three index/parser suites, the
scheduler, the app, the wizard, the folders component, the error-wording and
error-language screens, the four routes, the embedding keys, the i18n catalogue sweep):

```
 Test Files  15 passed (15)
      Tests  284 passed (284)
```

`tsc --noEmit` exit 0, `eslint` on all five changed files exit 0.

## Sibling call sites

Every reader of the identity verdict was checked, twice — once by hand and once in the
review pass:

- `parseMemoryStatus` health (`clawkeep-memory.ts:605`/`:611`) and
  `error`/`errorCode` (`:634-646`) — an empty box now takes the `valid` path, so it is
  healthy with no code and no sentence. No change needed; pinned by the new tests.
- `MemoryShardApp.tsx:330` `fullReindexAdvised` (`mismatched || missing`) — now false on
  an empty healthy box, so the card no longer emphasises Full reindex over Index now.
  `nothingToIndex` (`:318`, derived from the counts) still renders "Nothing to index
  yet", which is the whole card's message there.
- `resolveIndexMode` (`clawkeep-memory.ts:899`) keys on `chunks === 0`, never on the
  identity — so a first click of "Index now" on an empty box is still upgraded to a full
  build. Unchanged and still correct.
- `identityOf`'s other caller, the rebuild decision in `runLocalIndexPass`, reacts to
  `"mismatched"` only, and gets the source list it already read. A zero-chunk index
  reporting `valid` does not change what that pass does.
- The MCP memory surface (`mcp/tools/memory.ts` → `/setup-api/clawkeep/memory/search`)
  reads no identity or health field. `/setup-api/local-models` reads only
  `available/provider/model/location`. Cleared.
- No desktop badge reads memory health: `MemoryShardApp.tsx` is the only component in the
  tree that reads `health` or `indexIdentity`. Cleared.
- `failures`' own readers: the `batch.failures` field of the status payload (→ the card's
  Failed tile) and the progress line in `clawkeep-memory.ts`. Both want the extractor's
  unusable documents counted; nothing keys on the number being only folder-level.
- The seam predicate is `openclawIsAbsent()`, untouched — nothing here can reach a box
  that has OpenClaw, under either harness.

## Review

Reviewed via the `clawbox-review` skill: 11 findings, 3 HIGH. All three HIGH were real
and are fixed in the second commit — the `failures` overload (the banner returning on an
unreadable subdirectory, an over-budget tree, or a deleted folder, and the parity break
against the fixture's own state), the new false success on documents that could not be
converted, and the probe-once on the recorded scan count. Of the rest, the stale comment
claim ("`missing` is what makes the next pass rebuild" — it is `resolveIndexMode`, on the
chunk count), the two hand-written meta rows in the guard tests, the parity test
comparing two states that were not the same state, and the duplicated idle-run literal
are all fixed too.

Two of its findings are recorded and deliberately not fixed here, both pre-existing and
neither touched by this change:

- Files that legitimately produce no chunks — two whitespace-only documents, an
  image-only scanned PDF — are in the "work did not happen" bucket and keep the same
  unclearable banner. The new suite pins today's behaviour for that state so a follow-up
  has a starting point.
- A full reindex deletes the identity row up front and re-stamps it at the end, so the
  same banner shows for the length of the run while the card polls every three seconds.

A third, found while running the suite: `memory-index-local.test.ts`'s existing
"re-records a file whose folder entry changed" test registers the PARENT of its temp
source — `/tmp` on a developer machine — and walks it, so on a busy `/tmp` (3,085 entries
here) the walk hits its entry budget and the test fails for reasons unrelated to the
code. It passes with a clean `TMPDIR` and in CI.

## Device proof

Deferred, by instruction: the owner is testing on both boxes, so no box was touched, the
mutex was not taken and nothing was deployed. Everything here is exercised by CI — the
change is one pure function over sqlite `meta` rows plus the pass that writes them,
driven through a real sqlite store and the real shared parser, against the captured
real-box payload for the OpenClaw side. Worth a look on the hardware after the merge: the
Memory Shard card on a box with no memory files should read ON / Healthy with "Nothing to
index yet" and no banner; an index with documents in it is unchanged; and adding a folder
should put the card back into "run a full reindex" until a pass has run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indexing status accuracy for empty indexes by distinguishing successfully scanned sources from missing or unscanned indexes.
  * Changes to configured source folders now correctly invalidate outdated indexing results.
  * Indexing and status checks consistently validate source availability and identity.
  * Unusable documents are reflected in indexing results and status information.
  * Failed rebuilds no longer appear as healthy empty indexes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->