### PR TITLE
fix: admit the box's own bare hostname at the host guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,9 +313,9 @@ Additional options (OAuth client IDs, ClawBox AI, llama.cpp tuning) live in `.en
 
 This is only for genuine cross-origin/custom-origin deployments — for example,
 a reverse proxy that serves the Control UI from a different hostname or port.
-Same-origin access via `<hostname>.local`, a
-Tailscale `.ts.net` name, or a private LAN IP already works out of the box
-(see `ALLOWED_HOSTS` above and the mDNS/IP handling in
+Same-origin access via the box's own hostname — bare (`http://clawbox/`) or
+`<hostname>.local` — a Tailscale `.ts.net` name, or a private LAN IP already
+works out of the box (see `ALLOWED_HOSTS` above and the hostname/IP handling in
 `src/lib/gateway-proxy.ts`) and normally needs no entry here.
 
 To trust an additional origin, put a JSON array of exact `http`/`https`

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -948,8 +948,9 @@ export CLAWBOX_LAN_IPS
 
 # Trusted control UI origins — a narrow escape hatch for genuinely
 # cross-origin/custom-origin Control UI deployments (see README and
-# scripts/gateway_origins.py). Same-origin access via `<hostname>.local`,
-# `.ts.net`, or a private LAN IP already works without any entry here.
+# scripts/gateway_origins.py). Same-origin access via the box's own hostname —
+# bare (`http://clawbox/`) or `<hostname>.local` — a `.ts.net` name, or a private
+# LAN IP already works without any entry here.
 # Loaded from CLAWBOX_CONTROL_UI_ORIGINS_FILE (or the module's default
 # path) via scripts/gateway_origins.py. Missing helper module or missing
 # config file both fall through to "no extras" — defaults still boot.

--- a/scripts/gateway_origins.py
+++ b/scripts/gateway_origins.py
@@ -2,10 +2,10 @@
 
 This is a narrow escape hatch for genuinely cross-origin or custom-origin
 Control UI deployments (for example, a reverse proxy on a different
-hostname or port). Same-origin access via `<hostname>.local`,
-Tailscale `.ts.net` names, or a private LAN IP already works without any
-entry here — see gateway-proxy.ts's isReflectableHost() and
-gateway-pre-start.sh's LAN_IPS enumeration.
+hostname or port). Same-origin access via the box's own hostname — bare
+(`http://clawbox/`) or `<hostname>.local` — a Tailscale `.ts.net` name, or a
+private LAN IP already works without any entry here — see gateway-proxy.ts's
+isReflectableHost() and gateway-pre-start.sh's LAN_IPS enumeration.
 
 Contract: a JSON array of strings at CLAWBOX_CONTROL_UI_ORIGINS_FILE (or the
 default path below) is read, validated, and merged into the gateway's

--- a/scripts/hermes-dashboard-proxy.js
+++ b/scripts/hermes-dashboard-proxy.js
@@ -32,11 +32,6 @@ const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
 
-const PORT = parseInt(process.env.HERMES_DASH_PROXY_PORT || "8090", 10);
-// Port the main ClawBox web server (and therefore /login) listens on. The proxy
-// serves EVERY path on its own port, so a relative `Location: /login` would
-// bounce back into the proxy — an infinite redirect loop. We always redirect to
-// the ClawBox origin explicitly.
 // Same rule as envPort() in src/lib/port-probe.ts, written out because this
 // script is standalone CommonJS and cannot import the TypeScript helper: an
 // integer in 1-65535 or the default. `parseInt` alone yields NaN on a typo and
@@ -45,6 +40,13 @@ function envPort(value, fallback) {
   const port = Number(value);
   return Number.isInteger(port) && port >= 1 && port <= 65535 ? port : fallback;
 }
+// This port is also compared against the Referer's port in isTrustedPeer(), so
+// a NaN from `parseInt` cost the guard a comparison as well as the socket.
+const PORT = envPort(process.env.HERMES_DASH_PROXY_PORT, 8090);
+// Port the main ClawBox web server (and therefore /login) listens on. The proxy
+// serves EVERY path on its own port, so a relative `Location: /login` would
+// bounce back into the proxy — an infinite redirect loop. We always redirect to
+// the ClawBox origin explicitly.
 const CLAWBOX_WEB_PORT = envPort(process.env.CLAWBOX_WEB_PORT, 80);
 // Host-local, non-loopback: puts the dashboard in gated cookie-auth mode
 // (see file header) while staying off the LAN.
@@ -157,24 +159,47 @@ const ALLOWED_HOSTS = new Set(
     .filter(Boolean),
 );
 
-// Single mDNS label — letters/digits/hyphens, no dots. The REGEX is shared with
-// src/lib/gateway-proxy.ts (and with the rename route's own HOSTNAME_RE, so
-// every name a rename can produce is a label this accepts). The POLICY around
-// it deliberately is not the same: this proxy accepts any `<label>.local`
-// because nothing restarts it on a rename, while the gateway path reflects only
-// a configured or cached host. TASK-553.
+// Single hostname label — letters/digits/hyphens, no dots. The REGEX is shared
+// with src/lib/gateway-proxy.ts (and with the rename route's own HOSTNAME_RE, so
+// every name a rename can produce is a label this accepts). The POLICY around it
+// deliberately is not the same: this proxy accepts any `<label>.local` because
+// nothing restarts it on a rename, while the gateway path reflects the box's own
+// name or a configured origin. TASK-553.
 const MDNS_LABEL_RE = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 
-let cachedMdnsHost; // undefined = not computed yet, null = unusable hostname
-function systemMdnsHost() {
-  if (cachedMdnsHost !== undefined) return cachedMdnsHost;
+// The name this box calls ITSELF, from the kernel's nodename: the BARE hostname,
+// `clawbox` — what a router that registers the DHCP name, or a LAN with a DNS
+// search domain, hands the browser. The desktop's Hermes tile builds its URL
+// from `window.location.hostname`, so the Host arriving here is whatever name
+// the owner typed, and a name good enough to serve the desktop has to be good
+// enough to serve the desktop's own tile. TASK-808.
+//
+// The bare label, and only this box's own. `<label>.local` is admitted
+// generically below; a BARE label cannot be, because any single label
+// ("intranet", "router") can be aimed at this box by a search domain or a hosts
+// file nobody here controls. The LAN-DOMAIN form (`clawbox.lan`,
+// `clawbox.fritz.box`) is deliberately NOT derived: its only source is the
+// DHCP-supplied search domain, so admitting `<nodename>.<whatever DHCP says>`
+// would let a hostile DHCP server nominate a publicly registrable name as a
+// rebind target. A box reached that way still has `.local`, its IP and the bare
+// name.
+//
+// Read per request, never cached for the process lifetime. `Settings → System →
+// rename` writes data/hostname.env and runs the set_hostname root step, which
+// ends in `hostnamectl set-hostname` (apply_hostname in install.sh), and nothing
+// restarts this service — so a name captured at startup would go on admitting
+// the old hostname and 403 the new one until the next reboot. os.hostname() is a
+// uname(2) call, and the check below is ordered last so the two addresses the
+// docs advertise never pay for it.
+function systemHostname() {
+  let label;
   try {
-    const label = os.hostname().trim().toLowerCase();
-    cachedMdnsHost = MDNS_LABEL_RE.test(label) ? `${label}.local` : null;
+    // A nodename carrying a domain (`clawbox.lan`) still yields `clawbox`.
+    label = os.hostname().trim().toLowerCase().split(".")[0];
   } catch {
-    cachedMdnsHost = null;
+    return null;
   }
-  return cachedMdnsHost;
+  return MDNS_LABEL_RE.test(label) ? label : null;
 }
 
 // Split a Host header into { hostname, port, authority }. Handles `[::1]:8090`.
@@ -196,12 +221,14 @@ function splitHost(raw) {
 function isAllowedHostname(hostname) {
   if (!hostname) return false;
   if (ALLOWED_HOSTS.has(hostname)) return true;
-  if (hostname === systemMdnsHost()) return true;
   // The box can be renamed after install (mDNS label changes without this
   // service restarting), so accept any well-formed `<label>.local` — .local is
   // mDNS-only and cannot be registered by a remote attacker.
   if (hostname.endsWith(".local") && MDNS_LABEL_RE.test(hostname.slice(0, -".local".length))) return true;
   if (net.isIP(hostname)) return true; // raw LAN address
+  // The box addressed by its own bare hostname. Last of the four, so a request
+  // on `<name>.local` or the LAN IP is answered without the uname(2) call.
+  if (hostname === systemHostname()) return true;
   return false;
 }
 

--- a/src/lib/control-ui-origins.ts
+++ b/src/lib/control-ui-origins.ts
@@ -5,9 +5,10 @@ import net from "net";
 //
 // Narrow escape hatch for genuinely cross-origin/custom-origin Control UI
 // deployments (for example, a reverse proxy on a different hostname or
-// port). Same-origin access via `<hostname>.local`,
-// Tailscale `.ts.net` names, or a private LAN IP already works without any
-// entry here — see gateway-proxy.ts's isReflectableHost().
+// port). Same-origin access via the box's own hostname — bare
+// (`http://clawbox/`) or `<hostname>.local` — a Tailscale `.ts.net` name, or a
+// private LAN IP already works without any entry here — see gateway-proxy.ts's
+// isReflectableHost().
 //
 // Contract: a JSON array of strings at CLAWBOX_CONTROL_UI_ORIGINS_FILE (or
 // the default path below) is read and validated. A missing file is normal

--- a/src/lib/gateway-proxy.ts
+++ b/src/lib/gateway-proxy.ts
@@ -29,21 +29,37 @@ const ALLOWED_HOSTS = new Set(
     .filter(Boolean)
 );
 
-// Single mDNS label — letters/digits/hyphens, no dots, no leading/trailing
-// hyphen. We append `.local` ourselves; allowing dots in the input would
-// let a host header like `evil..local` slip through host comparison.
+// Single hostname label — letters/digits/hyphens, no dots, no leading/trailing
+// hyphen. It validates the nodename's first label below, and we append `.local`
+// to that ourselves; allowing dots in the input would let a host header like
+// `evil..local` slip through host comparison. Same regex as MDNS_LABEL_RE in
+// scripts/hermes-dashboard-proxy.js, and as HOSTNAME_RE in the rename route, so
+// every name a rename can produce is a label all three accept.
 const MDNS_LABEL_RE = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 
-let cachedMdnsHost: string | null | undefined; // undefined = not loaded yet
-function getSystemMdnsHost(): string | null {
-  if (cachedMdnsHost !== undefined) return cachedMdnsHost;
+// The names this box calls itself, from the kernel's nodename: the BARE hostname
+// and its `<label>.local` form. The bare one is what this missed — a router that
+// registers the DHCP hostname, or a LAN with a DNS search domain, serves the
+// desktop on `http://clawbox/`, and reflecting `clawbox.local` at that browser
+// is the same dead end the rename case was. TASK-808. The LAN-domain form
+// (`clawbox.lan`) is deliberately not derived, for the reason written out beside
+// systemHostname() in scripts/hermes-dashboard-proxy.js: the DHCP search domain
+// is not ours to trust. Reflection here also stays narrower than that proxy's
+// guard — this box's two names or a configured origin, never any `<label>.local`.
+//
+// Read per call, never cached for the process lifetime: a rename applies
+// `hostnamectl set-hostname` without restarting this server, so a name captured
+// at first use would reflect the old one for the rest of the process's life.
+function systemHostnames(): string[] {
+  let label: string;
   try {
-    const label = os.hostname().trim().toLowerCase();
-    cachedMdnsHost = MDNS_LABEL_RE.test(label) ? `${label}.local` : null;
+    // A nodename carrying a domain (`clawbox.lan`) still yields `clawbox`.
+    label = os.hostname().trim().toLowerCase().split(".")[0];
   } catch {
-    cachedMdnsHost = null;
+    return [];
   }
-  return cachedMdnsHost;
+  if (!MDNS_LABEL_RE.test(label)) return [];
+  return [label, `${label}.local`];
 }
 
 // Without renamed-host support, ALLOWED_HOSTS was frozen to `clawbox.local`
@@ -51,8 +67,9 @@ function getSystemMdnsHost(): string | null {
 // the gateway was busy and we fell back to CANONICAL_ORIGIN.
 function isReflectableHost(rawHost: string): boolean {
   if (ALLOWED_HOSTS.has(rawHost)) return true;
-  if (rawHost === getSystemMdnsHost()) return true;
   if (net.isIPv4(rawHost)) return true;
+  // Last, so a listed name or a LAN IP is answered without the uname(2) call.
+  if (systemHostnames().includes(rawHost)) return true;
   return false;
 }
 

--- a/src/tests/unit/gateway-proxy-origins.test.ts
+++ b/src/tests/unit/gateway-proxy-origins.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { NextRequest } from "next/server";
+
+// gateway-proxy.ts reads the box's own name from os.hostname(); this handle is
+// the same module object its `import os from "os"` holds, so assigning here is
+// what a rename looks like from inside the process. Restored in afterEach.
+const osModule = createRequire(import.meta.url)("node:os") as { hostname: () => string };
+const realHostname = osModule.hostname;
 
 // gateway-proxy.ts's redirectToSetup() reflects the request's own origin
 // back into the /setup redirect URL when the host is trusted, instead of
@@ -35,6 +42,7 @@ describe("gateway-proxy trusted control UI origin reflection", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    osModule.hostname = realHostname;
     rmSync(dir, { recursive: true, force: true });
     if (originalEnv === undefined) delete process.env[ENV_VAR];
     else process.env[ENV_VAR] = originalEnv;
@@ -201,6 +209,41 @@ describe("gateway-proxy trusted control UI origin reflection", () => {
     const ipRequest = createRequest("http://192.0.2.3/", { host: "192.0.2.3" });
     const ipResponse = gatewayProxy.redirectToSetup(ipRequest);
     expect(ipResponse.headers.get("location")).toContain("192.0.2.3");
+  });
+
+  it("reflects the box's own BARE hostname, and follows a rename with no restart", async () => {
+    // TASK-808: `http://clawbox/` — the box's own hostname with no suffix, which
+    // a router that registers the DHCP name hands the browser. Reflecting
+    // `clawbox.local` at a browser that reached the box by the bare name is a
+    // dead end wherever mDNS does not resolve.
+    process.env[ENV_VAR] = path.join(dir, "absent.json");
+    await importFresh();
+
+    osModule.hostname = () => "krasi-workshop";
+    const bare = gatewayProxy.redirectToSetup(
+      createRequest("http://krasi-workshop/", { host: "krasi-workshop" }),
+    );
+    expect(bare.headers.get("location")).toBe("http://krasi-workshop/setup");
+    // The `<name>.local` form this has always reflected still does.
+    const mdns = gatewayProxy.redirectToSetup(
+      createRequest("http://krasi-workshop.local/", { host: "krasi-workshop.local" }),
+    );
+    expect(mdns.headers.get("location")).toBe("http://krasi-workshop.local/setup");
+
+    // A rename applies `hostnamectl set-hostname` without restarting this
+    // server, so the name cannot be captured once per process.
+    osModule.hostname = () => "kitchen";
+    const renamed = gatewayProxy.redirectToSetup(
+      createRequest("http://kitchen/", { host: "kitchen" }),
+    );
+    expect(renamed.headers.get("location")).toBe("http://kitchen/setup");
+
+    // Still narrow: a name that is not this box's falls back to the canonical
+    // origin rather than being reflected.
+    const foreign = gatewayProxy.redirectToSetup(
+      createRequest("http://intranet/", { host: "intranet" }),
+    );
+    expect(foreign.headers.get("location")).toContain("clawbox.local");
   });
 
   it("falls back to the canonical origin on a malformed Host port instead of throwing", async () => {

--- a/src/tests/unit/hermes-dashboard-proxy-bare-hostname.test.ts
+++ b/src/tests/unit/hermes-dashboard-proxy-bare-hostname.test.ts
@@ -1,0 +1,321 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createRequire } from "node:module";
+import http from "node:http";
+import net from "node:net";
+import type { Duplex } from "node:stream";
+import path from "node:path";
+import { createSessionCookie } from "@/lib/auth";
+
+/**
+ * TASK-808 — the box reached by its OWN BARE HOSTNAME.
+ *
+ * The desktop's Hermes tile builds its URL from the page it is on
+ * (`${location.protocol}//${location.hostname}:8090/`, src/app/page.tsx and
+ * src/app/app/[id]/page.tsx), so the Host the proxy sees is whatever name the
+ * owner typed. A router that registers the DHCP hostname — or a LAN with a DNS
+ * search domain — hands them `http://clawbox/`, the box's own hostname with no
+ * suffix. The desktop serves fine there; the tile answered
+ * `403 Forbidden (bad Host header).` because the guard admitted `<label>.local`,
+ * a raw IP and four literals in ALLOWED_HOSTS, and a bare label was none of
+ * those.
+ *
+ * What is pinned here:
+ *   - the box's own bare hostname is admitted, on HTTP and on the WS upgrade
+ *     (separate rejection paths — a dashboard that loads and then sits dead is
+ *     the same bug half-fixed);
+ *   - it is re-derived per request, so `Settings → System → rename` is followed
+ *     without restarting this service. Nothing restarts it on a rename, so a
+ *     name cached for the process lifetime would 403 the NEW hostname until the
+ *     next reboot — and it is the guard's only source for a bare name;
+ *   - the guard is not simply open: a bare label that is NOT this box's
+ *     hostname is still refused, because a single label can be pointed at this
+ *     box by a search domain or a hosts file nobody here controls.
+ *
+ * Scaffolding shape (module-cache bust, env snapshot, session cookie, upgrade
+ * fixture) follows hermes-dashboard-proxy-renamed-host.test.ts, which owns the
+ * `<name>.local` half of the same guard.
+ */
+
+const require_ = createRequire(import.meta.url);
+const SCRIPT = path.resolve(process.cwd(), "scripts/hermes-dashboard-proxy.js");
+
+/**
+ * The proxy reads the box's identity from `os.hostname()`. `require("os")` in
+ * the script and this handle are the same module object, so assigning here is
+ * what a rename looks like from inside the process. Restored in afterEach.
+ *
+ * This depends on the script keeping its `const os = require("os")` style: a
+ * NAMED import (`import { hostname } from "os"`) is a live binding the stub
+ * cannot reach, and these tests would then fail rather than pass wrongly.
+ */
+const osModule = require_("node:os") as { hostname: () => string };
+const realHostname = osModule.hostname;
+
+const SESSION_SECRET = "test-session-secret-for-proxy-bare-host";
+/** The box's hostname. `http://clawbox/` in the field; a distinct name here so no pass can come from a default. */
+const BOX = "krasi-workshop";
+/** The box after a rename, before anything restarts this service. */
+const RENAMED_BOX = "kitchen";
+/** A single label that is NOT this box — what a search domain could point here. */
+const FOREIGN_LABEL = "intranet";
+
+function sessionCookie(): string {
+  return `clawbox_session=${createSessionCookie(3600, SESSION_SECRET)}; hermes_session_at=stub`;
+}
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve((server.address() as net.AddressInfo).port));
+  });
+}
+
+function close(server?: http.Server): Promise<void> {
+  return new Promise((resolve) => {
+    if (!server) return resolve();
+    server.closeAllConnections();
+    server.close(() => resolve());
+  });
+}
+
+interface Reply {
+  status: number;
+  body: string;
+  location?: string;
+}
+
+function request(port: number, headers: Record<string, string>, urlPath = "/"): Promise<Reply> {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: "127.0.0.1", port, path: urlPath, method: "GET", headers }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (c) => chunks.push(c));
+      res.on("end", () =>
+        resolve({
+          status: res.statusCode ?? 0,
+          body: Buffer.concat(chunks).toString(),
+          location: res.headers.location,
+        }),
+      );
+    });
+    req.setTimeout(5_000, () => {
+      req.destroy();
+      reject(new Error("proxy never responded"));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+let upstream: http.Server;
+let upstreamPort: number;
+let proxy: http.Server | undefined;
+let proxyPort: number;
+/** Upgrade sockets the fixture answered; destroyed in afterEach. */
+const upgraded: Duplex[] = [];
+
+// The last two are not set by startProxy(): the assertions below depend on their
+// DEFAULTS (`http://<BOX>/login` needs CLAWBOX_WEB_PORT 80, and the port test
+// sets HERMES_DASH_PROXY_PORT itself), so they are snapshotted and restored too.
+const ENV_KEYS = [
+  "SESSION_SECRET",
+  "ALLOWED_HOSTS",
+  "CLAWBOX_ROOT",
+  "HERMES_DASH_HOST",
+  "HERMES_PORT",
+  "HERMES_DASH_PROXY_PORT",
+  "CLAWBOX_WEB_PORT",
+] as const;
+const envBefore = new Map<string, string | undefined>();
+
+beforeAll(async () => {
+  for (const key of ENV_KEYS) envBefore.set(key, process.env[key]);
+  upstream = http.createServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end("dashboard ok");
+  });
+  upstream.on("upgrade", (_req, socket) => {
+    upgraded.push(socket);
+    socket.write("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n");
+  });
+  upstreamPort = await listen(upstream);
+});
+
+afterAll(async () => {
+  await close(upstream);
+});
+
+afterEach(async () => {
+  // An UPGRADED socket is detached from the server's connection tracking, so
+  // closeAllConnections() cannot reach it and close() would wait on it forever.
+  while (upgraded.length) upgraded.pop()!.destroy();
+  await close(proxy);
+  proxy = undefined;
+  osModule.hostname = realHostname;
+  for (const [key, value] of envBefore) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+async function startProxy(extraEnv: Record<string, string> = {}): Promise<void> {
+  delete process.env.HERMES_DASH_PROXY_PORT;
+  delete process.env.CLAWBOX_WEB_PORT;
+  Object.assign(process.env, {
+    SESSION_SECRET,
+    // Holds neither name used below: the guard has to derive the box's own
+    // hostname, not read it from a list written at install time.
+    ALLOWED_HOSTS: "localhost",
+    CLAWBOX_ROOT: path.join(process.cwd(), "nonexistent-proxy-bare-host-root"),
+    HERMES_DASH_HOST: "127.0.0.1",
+    HERMES_PORT: String(upstreamPort),
+    ...extraEnv,
+  });
+  delete require_.cache[require_.resolve(SCRIPT)];
+  const mod = require_(SCRIPT) as { createProxyServer: () => http.Server };
+  proxy = mod.createProxyServer();
+  proxyPort = await listen(proxy);
+}
+
+/** Drive a raw WebSocket upgrade through the proxy and collect what comes back. */
+function attemptUpgrade(host: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect(proxyPort, "127.0.0.1", () => {
+      socket.write(
+        [
+          "GET /ws HTTP/1.1",
+          `Host: ${host}`,
+          "Upgrade: websocket",
+          "Connection: Upgrade",
+          "Sec-WebSocket-Version: 13",
+          "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+          // A browser always sends one on a WS handshake, and without it
+          // `checkRequestOrigin` takes its bare-navigation branch — so the
+          // upgrade would pass without the peer check ever running.
+          `Origin: http://${host}`,
+          `Cookie: ${sessionCookie()}`,
+          "",
+          "",
+        ].join("\r\n"),
+      );
+    });
+    let text = "";
+    socket.on("data", (c) => {
+      text += c.toString();
+      if (text.includes("\r\n\r\n")) {
+        socket.destroy();
+        resolve(text);
+      }
+    });
+    socket.on("close", () => resolve(text));
+    socket.on("error", reject);
+    socket.setTimeout(5_000, () => {
+      socket.destroy();
+      reject(new Error("upgrade hung — proxy never answered or closed"));
+    });
+  });
+}
+
+describe("hermes dashboard proxy — the box's own bare hostname", () => {
+  it("serves the dashboard on the bare hostname with a valid session", async () => {
+    osModule.hostname = () => BOX;
+    await startProxy();
+    const res = await request(proxyPort, { host: BOX, cookie: sessionCookie() });
+    expect(res.status).toBe(200);
+    expect(res.body).toBe("dashboard ok");
+  });
+
+  it("sends an unauthenticated visitor to the login page on the bare hostname", async () => {
+    osModule.hostname = () => BOX;
+    await startProxy();
+    const res = await request(proxyPort, { host: BOX });
+    // Not 403: the host guard passed, so what the owner meets is the login
+    // page — on the name they typed, which is the only one they can resolve.
+    expect(res.status).toBe(302);
+    expect(res.location).toBe(`http://${BOX}/login`);
+  });
+
+  it("accepts a Referer from the desktop on the bare hostname", async () => {
+    // How the tile actually arrives: a top-level navigation from the ClawBox
+    // desktop on :80, carrying no Origin and `Referer: http://<host>/`.
+    osModule.hostname = () => BOX;
+    await startProxy();
+    const res = await request(proxyPort, {
+      host: BOX,
+      referer: `http://${BOX}/`,
+      cookie: sessionCookie(),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts a WebSocket upgrade on the bare hostname", async () => {
+    // The leg that matters most in service: the dashboard's live traffic is
+    // WebSocket and handleUpgrade() owns its own 403 path.
+    osModule.hostname = () => BOX;
+    await startProxy();
+    expect(await attemptUpgrade(BOX)).toContain("101 Switching Protocols");
+  });
+
+  it("follows a rename with no restart, and stops answering for the old name", async () => {
+    osModule.hostname = () => BOX;
+    await startProxy();
+    expect((await request(proxyPort, { host: BOX, cookie: sessionCookie() })).status).toBe(200);
+
+    // Settings → System → rename: data/hostname.env plus the set_hostname root
+    // step, which ends in `hostnamectl set-hostname`. Nothing restarts this
+    // service, so the guard must re-read the name rather than cache it.
+    osModule.hostname = () => RENAMED_BOX;
+    const renamed = await request(proxyPort, { host: RENAMED_BOX, cookie: sessionCookie() });
+    expect(renamed.status).toBe(200);
+    const stale = await request(proxyPort, { host: BOX, cookie: sessionCookie() });
+    expect(stale.status).toBe(403);
+    expect(stale.body).toContain("bad Host header");
+  });
+
+  it("still refuses a bare label that is not this box, on both legs", async () => {
+    // A single label is not proof of this box: a DNS search domain or a hosts
+    // file can aim one here. Admitting every label would be a rebind hole.
+    osModule.hostname = () => BOX;
+    await startProxy();
+    const res = await request(proxyPort, { host: FOREIGN_LABEL, cookie: sessionCookie() });
+    expect(res.status).toBe(403);
+    expect(res.body).toContain("bad Host header");
+    expect(await attemptUpgrade(FOREIGN_LABEL)).toContain("403 Forbidden");
+  });
+
+  it("still refuses a DNS-rebind name, so the guard has not simply been opened", async () => {
+    osModule.hostname = () => BOX;
+    await startProxy();
+    const res = await request(proxyPort, { host: "attacker.example.com", cookie: sessionCookie() });
+    expect(res.status).toBe(403);
+    expect(res.body).toContain("bad Host header");
+  });
+
+  it("admits the tile's own request shape: bare hostname with the proxy port, referred from the desktop", async () => {
+    // What the browser really sends for the tile's URL — `Host: clawbox:8090`
+    // AND `Referer: http://clawbox/`, the desktop it was clicked on. Asserted
+    // together because that combination is the one isTrustedPeer() has to rate
+    // on the web-server port rather than on the Host's own.
+    osModule.hostname = () => BOX;
+    await startProxy();
+    const res = await request(proxyPort, {
+      host: `${BOX}:8090`,
+      referer: `http://${BOX}/`,
+      cookie: sessionCookie(),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("keeps the port guard usable when HERMES_DASH_PROXY_PORT is junk", async () => {
+    // PORT is compared against the Referer's port in isTrustedPeer(), so a bad
+    // value costs the guard a comparison as well as the socket: `parseInt`
+    // accepted "70000" — a port Node refuses — and then matched no referer.
+    // envPort() falls back to 8090, which is what this Referer carries.
+    osModule.hostname = () => BOX;
+    await startProxy({ HERMES_DASH_PROXY_PORT: "70000" });
+    const res = await request(proxyPort, {
+      host: BOX,
+      referer: `http://${BOX}:8090/`,
+      cookie: sessionCookie(),
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/tests/unit/hermes-dashboard-proxy-renamed-host.test.ts
+++ b/src/tests/unit/hermes-dashboard-proxy-renamed-host.test.ts
@@ -15,23 +15,26 @@ import { createSessionCookie } from "@/lib/auth";
  * restarts the gateway (src/app/setup-api/system/hostname/route.ts). Nothing
  * equivalent runs on Hermes, and nothing needs to:
  *
- *   - Hermes 0.20.5 has no allowed-origins list to update. Its dashboard guard
- *     (`_ws_host_origin_reason` in hermes_cli/web_server.py, read on a v0.20.5
- *     device 2026-09-04) compares Host and Origin against
- *     `app.state.bound_host` — the address the dashboard was bound to — and
- *     takes no configuration. ClawBox binds it to 127.0.0.2 and the proxy
- *     rewrites Host/Origin/Referer to that authority, so the box's LAN name
- *     never reaches Hermes at all.
+ *   - Hermes has no allowed-origins list a rename could invalidate. Its
+ *     dashboard guard (`_is_accepted_host` in hermes_cli/web_server.py, read in
+ *     hermes-agent 0.21.1) compares Host and Origin against
+ *     `app.state.bound_host` — the address the dashboard was bound to — plus
+ *     `trusted_public_hosts`, which `_dashboard_public_hosts()` fills from the
+ *     ONE hostname in `dashboard.public_url` (the same value Hermes uses as its
+ *     OAuth redirect base). That is a single exact name, not the set of names a
+ *     LAN box answers to, and ClawBox sets it nowhere, so on a device the set is
+ *     empty and the guard reduces to `bound_host`. ClawBox binds the dashboard to
+ *     127.0.0.2 and the proxy rewrites Host/Origin/Referer to that authority, so
+ *     the box's LAN name never reaches Hermes at all.
  *   - The proxy's own guard (scripts/hermes-dashboard-proxy.js,
  *     `isAllowedHostname`) accepts ANY well-formed `<label>.local` and any raw
  *     IP literal, so it needs no list either — a renamed box is accepted the
- *     moment it is renamed, with no restart and no config write. That generic
- *     rule also SUBSUMES the cached `systemMdnsHost()` branch above it: every
- *     non-null value that branch can return is a `<label>.local` the generic
- *     rule accepts anyway, so the process-lifetime cache decides no request and
- *     cannot go stale into a lockout. The cache is not a fast path worth
- *     keeping — deleting the generic rule and keeping it would break every
- *     renamed box.
+ *     moment it is renamed, with no restart and no config write. The branch
+ *     above it, `systemHostnames()`, is what carries the names that generic rule
+ *     CANNOT cover — the box's own BARE hostname and an FQDN nodename (TASK-808,
+ *     hermes-dashboard-proxy-bare-hostname.test.ts) — and it is therefore read
+ *     per request rather than cached for the process lifetime: a bare name
+ *     captured at startup would be a lockout on the new hostname after a rename.
  *
  * What is pinned here is that second property, which nothing tested before:
  * `ALLOWED_HOSTS` below deliberately holds neither name used in the requests.


### PR DESCRIPTION
**Finding HL-6** (card TASK-808, epic TASK-790) — the Hermes dashboard tile 403s whenever the box is reached by its own bare hostname.

## Customer-visible symptom

Open the desktop at `http://clawbox/` — the box's own hostname, which a router that registers the DHCP name, or a LAN with a DNS search domain, hands the browser — and click the **Hermes** tile. The tile answers:

```
Host: clawbox          -> 403   body: "Forbidden (bad Host header)."
Host: clawbox.local    -> 302
Host: <box IP>         -> 302
```

The 403 lands *before* the session gate, so it is not an auth failure the UI can explain: the tile just refuses. A name good enough to serve the desktop was not good enough to serve the desktop's own tile.

## Cause

The tile builds its URL from the page it is on (`${location.protocol}//${location.hostname}:8090/` — `src/app/page.tsx`, `src/app/app/[id]/page.tsx`, `src/components/HermesProviderConfig.tsx`), so the Host the proxy sees is whatever name the owner typed. `scripts/hermes-dashboard-proxy.js`'s `isAllowedHostname()` admitted four literals from `ALLOWED_HOSTS` (`clawbox.local,10.42.0.1,10.43.0.1,localhost`), any well-formed `<label>.local`, and any IP literal. A bare label is none of those — and nothing writes `ALLOWED_HOSTS` anywhere (the systemd unit sets `HERMES_DASH_PROXY_PORT` and `CLAWBOX_ROOT` only), so the shipped default was the whole list.

The one name that *was* derived rather than listed, the mDNS name, came from a process-lifetime cache (`systemMdnsHost()`), which only stayed harmless because the generic `<label>.local` rule covered every value it could return.

## Harness-first

Hermes **does** expose a configuration point here, and naming it precisely matters — the note previously in the renamed-host suite said it had none, which was true of v0.20.5 and is now stale. Read in **hermes-agent 0.21.1**:

- `_is_accepted_host()` (`hermes_cli/web_server.py`) accepts `host_only in trusted_public_hosts` alongside the bound host, for both the HTTP middleware and the WS guard, and `_dashboard_public_hosts()` fills that set from `dashboard.public_url`.
- But it is **one exact hostname**, and it is also Hermes's OAuth redirect base ("one source of truth for OAuth redirects, Host and WS Origin validation"). It cannot express the set of names a LAN box answers to — bare name, `.local`, several IPs — and ClawBox sets it nowhere (`public_url` has no hit in `src/`, `scripts/`, `install.sh`), so on a device the set is empty and the guard reduces to `bound_host`.
- ClawBox binds the dashboard to `127.0.0.2` and the proxy rewrites Host/Origin/Referer to that authority, so the box's LAN name never reaches Hermes at all. The guard that refused the request is ClawBox's own, at the proxy edge, where it re-implements the DNS-rebind and CSRF checks that the Host rewrite deletes upstream. That is where the fix belongs; the commit corrects the stale Hermes note in the same pass.
- The mechanism ClawBox already owns for "what is this box called" is the hostname setting — `POST /setup-api/system/hostname` writes `data/hostname.env` and runs the `set_hostname` root step, which ends in `hostnamectl set-hostname` (`apply_hostname` in `install.sh`), a *static* hostname, so it also is not something DHCP can move. The guard now follows that, by reading the kernel nodename per request, instead of growing a second list that would have to be regenerated and a service that would have to be restarted.

## Fix

`scripts/hermes-dashboard-proxy.js` — `systemHostname()` replaces the cached `systemMdnsHost()`: the box's own short name from the kernel nodename. Read per request, never cached: nothing restarts this unit on a rename, so a name captured at startup would have admitted the old hostname and 403'd the new one until the next reboot — the probe-once shape of the same bug. It is the **last** of the four rules, so a request on `<name>.local` or the LAN IP is answered without the `uname(2)` call at all.

The guard stays closed where it was closed: a bare label that is **not** this box's hostname is still refused (any single label can be aimed here by a search domain or a hosts file nobody controls), and `attacker.example.com` is still refused.

**What is deliberately not admitted:** the LAN-domain form, `clawbox.lan` / `clawbox.fritz.box`. The only available source for that domain is the DHCP-supplied search domain, and admitting `<nodename>.<whatever DHCP says>` would let a hostile DHCP server nominate a publicly registrable name (`clawbox.evil.com`) as a rebind target. An owner whose router serves a domain still reaches the tile by the bare name, by `.local` and by IP; a box whose *nodename* carries a domain contributes its first label, which is all a provisioned ClawBox ever has (`validate_hostname` in `install.sh` and the rename route's `HOSTNAME_RE` both accept a single label only).

`src/lib/gateway-proxy.ts` — the sibling that made the same decision for redirect reflection. `isReflectableHost()` did not know the bare name either, so a browser that reached the box on `http://clawbox/` and hit a busy gateway was bounced to `http://clawbox.local/setup` — unresolvable exactly where mDNS is the reason the bare name was used. Same live derivation, same narrow policy (this box's names or a configured origin; no generic `<label>.local` here).

Also in the proxy, per the review queue from #807: its own port was parsed with bare `parseInt` instead of the `envPort()` validator nine lines below it that the other two ports use. A typo there cost the Referer port comparison in `isTrustedPeer()` as well as the socket — so it rides in with its own regression test rather than on trust (`HERMES_DASH_PROXY_PORT=70000` plus a `Referer` on 8090: refused under `parseInt`, admitted after).

## Siblings — fixed or cleared

| Site | Outcome |
|---|---|
| `scripts/hermes-dashboard-proxy.js` `isAllowedHostname` | **fixed** — both legs: `handleRequest` and `handleUpgrade` share `checkRequestOrigin` but own separate 403 paths, and the dashboard's live traffic is WebSocket, so the HTTP leg alone would have loaded a dashboard that then sat dead. Both are asserted. |
| `src/lib/gateway-proxy.ts` `isReflectableHost` | **fixed** — its only caller is `redirectToSetup` (3 call sites, all reflective). |
| `setControlUiAllowedOrigins` (`src/lib/openclaw-config.ts`) and the `allowed_origins` block in `scripts/gateway-pre-start.sh` | **cleared for every path the app uses** — each one replaces the browser's Host and sets `origin: http://127.0.0.1` before the gateway sees it (`gatewayProxyHeaders`; the HTTP-upgrade and WSS paths in `production-server.js`; `serveGatewayHTML` fetches from loopback server-side and points the SPA at `location.host`, i.e. back through the upgrade proxy), so `gateway.controlUi.allowedOrigins` never sees the name the owner typed and cannot reject it. Adding an entry would put a second, staler copy of the box's identity in a file a rename has to chase. |
| `src/app/setup-api/gateway/route.ts` | **one genuine exception, recorded not patched** — it builds `ws://${host}:18789` from the client's own Host, so that socket goes straight to the gateway port carrying the browser's real Origin, and `http://clawbox` is in neither origins writer's list: on the bare name that page would sit dead. Nothing in the app fetches this route (the UI uses `/setup-api/gateway/health` and `/setup-api/gateway/ws-config`, and ws-config already returns a port-less same-origin URL), so the right fix is to make its URL port-less like ws-config's or to delete the route — a behaviour decision that wants its own RED test and a device check, not a blind edit inside a hostname PR. |
| The three tile URL builders (`src/app/page.tsx`, `src/app/app/[id]/page.tsx`, `src/components/HermesProviderConfig.tsx`) | **cleared** — all inherit `window.location.hostname`, which is precisely the name the guard now admits; no client change needed. |
| `src/lib/same-origin.ts`, `src/app/setup-api/gateway/route.ts`, `src/app/setup-api/gateway/ws-config/route.ts`, `scripts/access-log.js` | **cleared** — all reflect the request's own Host (with a character filter) and hold no allow-list, so the bare name already works there. |
| `scripts/terminal-server.mjs` | **cleared** — no Host/Origin guard at all. |
| The systemd unit / install path | **cleared** — nothing writes `ALLOWED_HOSTS`, so there is no install-time list to regenerate; the derivation is the whole mechanism. |

## RED → GREEN

RED, on unmodified beta (`1be87420`), new suite `src/tests/unit/hermes-dashboard-proxy-bare-hostname.test.ts`:

```
 ❯ |unit| src/tests/unit/hermes-dashboard-proxy-bare-hostname.test.ts (8 tests | 6 failed)
     × serves the dashboard on the bare hostname with a valid session
     × sends an unauthenticated visitor to the login page on the bare hostname
     × accepts a Referer from the desktop on the bare hostname
     × accepts a WebSocket upgrade on the bare hostname
     × follows a rename with no restart, and stops answering for the old name
     × admits the bare hostname with the proxy's own port in the Host header

AssertionError: expected 403 to be 200
AssertionError: expected 403 to be 302
  - 101 Switching Protocols
  + HTTP/1.1 403 Forbidden

 Test Files  1 failed (1)
      Tests  6 failed | 2 passed (8)
```

The two that pass on beta are the legs that must pass both before and after — a foreign bare label and a rebind name are still refused.

RED for the sibling, with `src/lib/gateway-proxy.ts` at its beta content:

```
 FAIL  src/tests/unit/gateway-proxy-origins.test.ts > reflects the box's own BARE hostname, and follows a rename with no restart
AssertionError: expected 'http://clawbox.local/setup' to be 'http://krasi-workshop/setup'
```

And the port hardening, proven the same way — with `PORT` back on bare `parseInt`, only that one case fails:

```
 FAIL  … > keeps the port guard usable when HERMES_DASH_PROXY_PORT is junk
AssertionError: expected 403 to be 200
      Tests  1 failed | 8 passed (9)
```

GREEN, with the fix, on the rebased head:

```
 Test Files  13 passed (13)
      Tests  377 passed (377)
```
(`hermes-dashboard-proxy-bare-hostname`, `hermes-dashboard-proxy-renamed-host`, `hermes-dashboard-proxy-timeouts`, `gateway-proxy-origins`, `gateway-proxy`, `gateway-proxy-attribution`, `control-ui-origins`, `port-probe`, `routes/system-hostname`, `middleware/middleware`, `routes/gateway`, `routes/gateway/gateway`, `routes/gateway/ws-config`)

plus the 23 `gateway-pre-start-*` suites, which own the shell file this PR touches a comment in:

```
 Test Files  23 passed (23)
      Tests  620 passed (620)
```

and `tsc --noEmit` clean. The whole unit project: 812 of 813 files pass; the one failure is `src/tests/unit/memory-index-local.test.ts`, which indexes its fixture's parent directory and ranked a stray file that exists in this development machine's `/tmp` — it fails the same way with this branch's source files reverted, and is unrelated to these two guards.

## Deliberately not in this PR

- The other half named in the same finding: the proxy is `http.createServer` only, while `production-server.js` binds real HTTPS once certs exist in `data/certs/`, so on a box that has certs the tile would build an `https://…:8090/` URL against an HTTP-only listener. Not reproduced (the box under test has no certs), a different defect with a different fix.
- `src/components/CredentialsStep.tsx` keys its rename hand-off on `currentHost.endsWith(".local")`, so an owner who renames the box while on `http://clawbox/` gets neither the reconnect overlay nor a target URL. Same premise as this PR, but it is a wizard flow with its own RED test and a device check.
- The three client literals for the proxy port (`src/app/page.tsx`, `src/app/app/[id]/page.tsx`, `src/components/HermesProviderConfig.tsx`) do not honour `HERMES_DASH_PROXY_PORT`, so a box that moves the port gets three URLs pointing at nothing. Pre-existing drift; it wants the port served to the client once, not a fourth literal.
- `docs-site/technical/networking.mdx` still lists two steady-state addresses while telling the customer to find "clawbox" in the router's device list — the name this PR makes work. Owed on the docs list.

## Device proof

Deferred by the brief — no box was touched for this change, no mutex taken, nothing deployed. On the next beta deploy, the check is: `curl -H 'Host: clawbox' http://<box>:8090/` on the Hermes tile path answers 302 to the login page (or 200 with a session), the same as `Host: clawbox.local`, and `curl -H 'Host: intranet' …` still answers 403. Renaming the box and repeating the first call with the new bare name must answer 302 without restarting `clawbox-hermes-dashboard-proxy.service`.

Reviewed via the clawbox-review skill.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Control UI and dashboard proxy access now supports the device’s bare hostname, such as `http://clawbox/`.
  - Hostname changes are recognized without restarting the service.
  - Dashboard proxy port configuration now safely falls back to the default for invalid values.

- **Bug Fixes**
  - Improved hostname validation helps prevent unauthorized or misleading host access while supporting valid local names.

- **Documentation**
  - Updated trusted-origin documentation to describe bare hostname access alongside local, Tailscale, and private LAN addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->