### PR TITLE
fix: give Settings headings and a landmark

### DIFF
--- a/src/app/app/[id]/page.tsx
+++ b/src/app/app/[id]/page.tsx
@@ -501,7 +501,10 @@ export default function StandaloneAppPage() {
       case "settings":
         return (
           <div className="h-full overflow-y-auto">
-            <SettingsApp ui={appearance.ui} />
+            {/* Here Settings IS the page, so it owns the document's `h1`
+                and `main` — on the desktop it is one window among several and
+                claims neither. */}
+            <SettingsApp ui={appearance.ui} asPage />
             {/* The Upload tile clicks this, exactly as the desktop's does. */}
             <input
               ref={appearance.uploadRef}

--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -2140,6 +2140,7 @@ export default function AIModelsStep({
   const shouldShowMoreProviders = providerListCollapsed;
   const resolvedTitle = title ?? t("ai.title");
   const resolvedDescription = description ?? t("ai.description");
+  const Title = embedded ? "h2" : "h1";
   const embeddedConnectLabel = t("settings.connect");
 
   // Edition resolves asynchronously (see the /harness/active effect above).
@@ -2224,9 +2225,12 @@ export default function AIModelsStep({
         )}
         {/* Hide form content when configuring overlay is shown */}
         <div className={configuringState ? "invisible h-0 overflow-hidden" : ""}>
-        <h1 className="text-[length:var(--t-6)] leading-[1.15] font-bold font-display mb-2">
+        {/* Embedded in Settings this card is one panel among several and the
+            window around it owns the page's h1, so the title drops a level
+            rather than making the document claim two titles. */}
+        <Title className="text-[length:var(--t-6)] leading-[1.15] font-bold font-display mb-2">
           {resolvedTitle}
-        </h1>
+        </Title>
         <p className="text-[length:var(--t-4)] leading-[1.6] text-[var(--text-secondary)] mb-6">
           {resolvedDescription}
         </p>

--- a/src/components/AiProviderList.tsx
+++ b/src/components/AiProviderList.tsx
@@ -89,9 +89,9 @@ export default function AiProviderList() {
     <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5" data-testid="ai-provider-list">
       <div className="flex items-center gap-2 mb-1">
         <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>smart_toy</span>
-        <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">
+        <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">
           {t("settings.providers.title")}
-        </label>
+        </h3>
       </div>
       <p className="text-[11px] text-[var(--text-muted)] mb-4 leading-relaxed">
         {t("settings.providers.hint")}
@@ -297,9 +297,9 @@ export default function AiProviderList() {
               appearing in his provider list with no explanation. The plugin id
               itself is not translated: it is what `openclaw plugins` calls it
               and what the core's own sentence beside it names. */}
-          <label className="block mb-2 text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">
+          <h4 className="block mb-2 text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">
             {t("settings.providers.strandedPlugins")}
-          </label>
+          </h4>
           <ul className="space-y-2 list-none p-0 m-0">
             {(summary?.unattachedRepairs ?? []).map((repair) => (
               <li key={repair.pluginId} className="rounded-xl border border-white/[0.08] px-3 py-2">

--- a/src/components/HermesProviderConfig.tsx
+++ b/src/components/HermesProviderConfig.tsx
@@ -966,6 +966,7 @@ export default function HermesProviderConfig({
   // the next step reads as a deliberate confirmation. Settings never advances,
   // so it never shows this. `--cyan-bright` is the product's DONE colour.
   const showConnectedAffirmation = !embedded && configured;
+  const Title = embedded ? "h2" : "h1";
 
   return (
     <div className={`w-full ${embedded ? "" : "max-w-[520px]"}`} data-testid={testId}>
@@ -1012,7 +1013,9 @@ export default function HermesProviderConfig({
             </div>
           </>
         )}
-        <h1 className="text-xl sm:text-2xl font-bold font-display mb-1">{t("hermesProvider.title")}</h1>
+        {/* Embedded in Settings the window already owns the page's h1; one
+            document with two of them claims two titles. */}
+        <Title className="text-xl sm:text-2xl font-bold font-display mb-1">{t("hermesProvider.title")}</Title>
         <p id={`${uid}-intro`} className="text-[var(--text-secondary)] mb-5 leading-relaxed text-sm">
           {t("hermesProvider.intro")}
         </p>

--- a/src/components/PetPicker.tsx
+++ b/src/components/PetPicker.tsx
@@ -95,7 +95,7 @@ export default function PetPicker() {
     <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
       <div className="flex items-center gap-2 mb-1">
         <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>pets</span>
-        <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t('settings.mascot.pets')}</label>
+        <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t('settings.mascot.pets')}</h3>
       </div>
       <p className="text-[11px] text-[var(--text-muted)] mb-4">{t('settings.mascot.petHint')}</p>
 

--- a/src/components/RemoteControlPanel.tsx
+++ b/src/components/RemoteControlPanel.tsx
@@ -233,7 +233,7 @@ export default function RemoteControlPanel() {
   return (
     <div className="max-w-xl space-y-5">
       <div>
-        <h2 className="text-lg font-semibold text-[var(--text-primary)] mb-1">{t("remoteControl.title")}</h2>
+        <h3 className="text-lg font-semibold text-[var(--text-primary)] mb-1">{t("remoteControl.title")}</h3>
         <p className="text-sm text-[var(--text-muted)]">{t("remoteControl.subtitle")}</p>
       </div>
 

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useId, useRef, useCallback } from "react";
 import SystemUpdateApp, { componentNeedsUpdate, shipsOpenclaw, type VersionInfo } from "@/components/SystemUpdateApp";
 import Image from "next/image";
 import { createPortal } from "react-dom";
@@ -68,6 +68,20 @@ export interface UISettings {
 
 interface SettingsAppProps {
   ui: UISettings;
+  /**
+   * Is Settings the whole PAGE (the standalone `/app/settings` route), or one
+   * window on the desktop?
+   *
+   * It decides which landmark the panel region may claim. The desktop mounts
+   * every open window in ONE document and six of its apps draw an `h1` of their
+   * own (ClawKeep, the App Store, Coding Agent, Memory Shard, the Hermes skills
+   * store, System Update), so a window may claim neither the document's title
+   * nor its `main`: "skip to main content" read from ClawKeep would otherwise
+   * land inside the Settings window behind it. As a window the panel is a
+   * REGION named after the panel; as a page it is the `main` under the window
+   * title's `h1`. Either way the cards' captions are the `h3`s beneath.
+   */
+  asPage?: boolean;
 }
 
 /** Exactly what /setup-api/email/status returns. The address is already
@@ -458,7 +472,7 @@ function Toggle({ on, onToggle, label }: { on: boolean; onToggle: (v: boolean) =
 
 type SectionStatus = { subtitle: string | null };
 
-export default function SettingsApp({ ui }: SettingsAppProps) {
+export default function SettingsApp({ ui, asPage = false }: SettingsAppProps) {
   const { t, locale, setLocale } = useT();
   // English is the floor for a key the locale packs do not carry yet: `t`
   // answers with the raw key when it is missing, so a string keyed here before
@@ -3008,6 +3022,21 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
     ? "channels"
     : activeSection === "localModels" ? "localAi" : activeSection;
   const visibleNavItems = NAV_ITEMS;
+  // The panel's own heading. Taken from the entry that already names it — the
+  // channels list for a channel pane, the sidebar for every other section — so
+  // a heading needs no new translation key and cannot drift from the row the
+  // owner clicked. `navSection` is what it reads for the non-channel case, so
+  // any section folded onto another's page (localModels onto Local AI) takes
+  // that page's name. Every reachable section has an entry; the fallback is
+  // there so a section added without one renders a named heading rather than an
+  // empty one.
+  const panelTitleKey =
+    CHANNEL_ITEMS.find(item => item.id === activeSection)?.labelKey
+    ?? NAV_ITEMS.find(item => item.id === navSection)?.labelKey
+    ?? "settings.title";
+  // Per instance: the desktop can have this window open beside the standalone
+  // page in another tab, and the region's name is resolved by id.
+  const panelTitleId = useId();
   const resetProgressSteps = [
     {
       id: "erase",
@@ -3221,6 +3250,27 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
     </div>
   );
 
+  /**
+   * The headings a panel owes a reader who navigates by heading, and that a
+   * sighted reader already has elsewhere: the name of the panel that is open
+   * (the lit sidebar row) and, where Settings is the whole page, the window's
+   * title (its title bar). Both are `sr-only` — drawing them a second time
+   * would change the page — and the cards' own captions are the visible `h3`s
+   * beneath them. The `h1` is the page's alone, for the reason on `asPage`.
+   */
+  const panelHeadings = (
+    <>
+      {asPage && <h1 className="sr-only">{t("settings.title")}</h1>}
+      <h2 id={panelTitleId} className="sr-only">{t(panelTitleKey)}</h2>
+    </>
+  );
+  /** `main` where Settings IS the page, a named region where it is a window. */
+  const PanelRegion = asPage ? "main" : "section";
+  /** The phone's nav-list title, for the same reason. */
+  const MobileTitle = asPage ? "h1" : "h2";
+  /** What names that region when it is a section: the panel's own heading. */
+  const panelRegionProps = asPage ? {} : { "aria-labelledby": panelTitleId };
+
   const renderContent = () => (
     <>
         {/* ─── Appearance ─── */}
@@ -3233,9 +3283,9 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                 <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>translate</span>
                 {/* A <label> named this card and pointed at nothing: htmlFor
                     only binds to form controls, and the control here is a
-                    button. A span the button names itself after is what
-                    actually reaches the accessibility tree. */}
-                <span id="settings-language-label" className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.language")}</span>
+                    button. The heading is what reaches the accessibility tree,
+                    and the button still names itself after it by id. */}
+                <h3 id="settings-language-label" className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.language")}</h3>
               </div>
               <div className="relative" ref={langRef}>
                 <button
@@ -3309,7 +3359,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
             <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
               <div className="flex items-center gap-2 mb-4">
                 <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>wallpaper</span>
-                <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.wallpaper")}</label>
+                <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.wallpaper")}</h3>
               </div>
               <div className="grid grid-cols-3 sm:grid-cols-4 gap-3">
                 {ui.wallpapers.map(wp => {
@@ -3401,7 +3451,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
             <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5 space-y-5">
               <div className="flex items-center gap-2">
                 <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>tune</span>
-                <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.display")}</label>
+                <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.display")}</h3>
               </div>
 
               {/* Fit mode */}
@@ -3473,7 +3523,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
             <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
               <div className="flex items-center gap-2 mb-4">
                 <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>auto_awesome</span>
-                <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.extras")}</label>
+                <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.extras")}</h3>
               </div>
               <Toggle on={!ui.mascotHidden} onToggle={v => {
                 const hidden = !v;
@@ -3496,7 +3546,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
             <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
               <div className="flex items-center gap-2 mb-4">
                 <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>wifi</span>
-                <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.status")}</label>
+                <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.status")}</h3>
               </div>
               {connectedSSID ? (
                 <div className="flex items-center gap-4 bg-green-500/[0.06] border border-green-500/15 rounded-xl px-4 py-3.5">
@@ -3549,7 +3599,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                 <div className="mt-4 rounded-xl border px-4 py-3 border-white/[0.06] bg-white/[0.03]">
                   <div className="flex items-center gap-2 mb-1.5">
                     <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 16 }}>link</span>
-                    <span className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)]">{tr("settings.accessDeviceAt", "Access this device at")}</span>
+                    <h4 className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)]">{tr("settings.accessDeviceAt", "Access this device at")}</h4>
                   </div>
                   <div className="flex items-center gap-2">
                     <a href={primaryUrl} className="flex-1 min-w-0 text-sm font-mono text-[var(--text-primary)] hover:text-[var(--coral-bright)] truncate underline-offset-2 hover:underline">{primaryLabel}</a>
@@ -3703,7 +3753,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
             <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
               <div className="flex items-center gap-2 mb-4">
                 <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>link</span>
-                <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.localUrl")}</label>
+                <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.localUrl")}</h3>
               </div>
               <p className="text-[11px] text-[var(--text-muted)] opacity-60 mb-3 leading-relaxed">{t("settings.localUrlDesc")}</p>
               <div className="flex items-stretch gap-2">
@@ -3734,7 +3784,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
               <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
                 <div className="flex items-center gap-2 mb-4">
                   <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>bookmark</span>
-                  <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">Saved Networks</label>
+                  <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">Saved Networks</h3>
                 </div>
                 <div className="space-y-2">
                   {savedNetworks.map(net => {
@@ -3780,7 +3830,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
             <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
               <div className="flex items-center gap-2 mb-4">
                 <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>add_circle</span>
-                <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.connectToNetworkBtn")}</label>
+                <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.connectToNetworkBtn")}</h3>
               </div>
 
               {/* Network list */}
@@ -3802,7 +3852,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                 <>
                   <div className="border border-white/[0.08] rounded-xl overflow-hidden mb-3">
                     <div className="flex items-center justify-between px-3.5 py-2 border-b border-white/[0.06]">
-                      <span className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.availableNetworks")}</span>
+                      <h4 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.availableNetworks")}</h4>
                       <button
                         onClick={scanWifiNetworks}
                         disabled={wifiScanning}
@@ -3961,9 +4011,9 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
             <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
               <div className="flex items-center gap-2 mb-1">
                 <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>forum</span>
-                <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">
+                <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">
                   {t("settings.channelsConnect")}
-                </label>
+                </h3>
               </div>
               <p className="text-[11px] text-[var(--text-muted)] mb-4 leading-relaxed">{t("settings.channelsHelper")}</p>
               <div className="rounded-xl border border-white/[0.08] overflow-hidden divide-y divide-white/[0.06]" data-testid="settings-channels-list">
@@ -4134,7 +4184,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
             <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
               <div className="flex items-center gap-2 mb-4">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="#f97316"><path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.96 6.504-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.479.33-.913.492-1.302.48-.428-.012-1.252-.242-1.865-.44-.751-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/></svg>
-                <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.status")}</label>
+                <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.status")}</h3>
               </div>
               {tgConfigured === null ? (
                 <div className="flex items-center gap-4 bg-white/[0.03] border border-white/[0.06] rounded-xl px-4 py-3.5 animate-pulse">
@@ -4248,7 +4298,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
               <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
                 <div className="flex items-center gap-2 mb-1">
                   <span className="material-symbols-rounded text-[var(--text-muted)]" style={{ fontSize: 18 }} aria-hidden="true">group</span>
-                  <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.pairingTitle")}</label>
+                  <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.pairingTitle")}</h3>
                 </div>
                 <p className="text-xs text-[var(--text-secondary)] mb-4">{t("settings.pairingHint")}</p>
 
@@ -4387,9 +4437,9 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                 <div className={tgConfiguring ? "invisible h-0 overflow-hidden" : ""}>
                 <div className="flex items-center gap-2 mb-4">
                   <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>add_circle</span>
-                  <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">
+                  <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">
                     {tgReconfigure ? t("settings.reconfigureBot") : t("settings.setupBot")}
-                  </label>
+                  </h3>
                 </div>
 
                 {/* Instructions with QR */}
@@ -4488,7 +4538,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
             <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
               <div className="flex items-center gap-2 mb-4">
                 <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }} aria-hidden="true">mail</span>
-                <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.status")}</label>
+                <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.status")}</h3>
               </div>
 
               {emailStatus === null ? (
@@ -4590,7 +4640,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
               <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5" data-testid="settings-email-approvals">
                 <div className="flex items-center gap-2 mb-4">
                   <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }} aria-hidden="true">outgoing_mail</span>
-                  <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.emailPending")}</label>
+                  <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.emailPending")}</h3>
                   <span className="ml-auto text-xs font-mono text-[var(--coral-bright)]/70 bg-orange-500/10 px-2 py-0.5 rounded-md">
                     {t("settings.emailPendingCount", { count: String(emailPending.length) })}
                   </span>
@@ -4639,7 +4689,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
               <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5" data-testid="settings-email-handled">
                 <div className="flex items-center gap-2 mb-4">
                   <span className="material-symbols-rounded text-[var(--text-muted)]" style={{ fontSize: 18 }} aria-hidden="true">history</span>
-                  <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.emailHandled")}</label>
+                  <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.emailHandled")}</h3>
                 </div>
                 <div className="space-y-3">
                   {emailHandled.map((entry) => (
@@ -4707,7 +4757,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
               <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5" data-testid="settings-email-chat-approval">
                 <div className="flex items-center gap-2 mb-2">
                   <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }} aria-hidden="true">forum</span>
-                  <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.emailChatApproval")}</label>
+                  <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.emailChatApproval")}</h3>
                 </div>
                 <p className="text-xs text-[var(--text-secondary)] mb-4">{t("settings.emailChatApprovalHelp")}</p>
 
@@ -4775,7 +4825,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
               <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
                 <div className="flex items-center gap-2 mb-3">
                   <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }} aria-hidden="true">add_circle</span>
-                  <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.emailAccount")}</label>
+                  <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.emailAccount")}</h3>
                 </div>
 
                 {/* The 3-step Gmail guide, in the panel rather than behind a docs link */}
@@ -5456,7 +5506,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
             <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
               <div className="flex items-center gap-2 mb-4">
                 <span className="material-symbols-rounded text-[#5865F2]" style={{ fontSize: 18 }} aria-hidden="true">forum</span>
-                <span className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.status")}</span>
+                <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.status")}</h3>
               </div>
               {dcConfigured === null ? (
                 <div className="flex items-center gap-4 bg-white/[0.03] border border-white/[0.06] rounded-xl px-4 py-3.5 animate-pulse">
@@ -5596,9 +5646,9 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                 className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5"
                 data-testid="discord-members"
               >
-                <span className="block text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest mb-2">
+                <h3 className="block text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest mb-2">
                   {t("settings.discordMembersTitle")}
-                </span>
+                </h3>
                 <p className="text-xs text-[var(--text-secondary)] leading-relaxed">
                   {t("settings.discordMembersHint")}
                 </p>
@@ -5665,9 +5715,9 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
               <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
                 <div className="flex items-center gap-2 mb-4">
                   <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>add_circle</span>
-                  <span className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">
+                  <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">
                     {dcReconfigure ? t("settings.reconfigureBot") : t("settings.discordGuideTitle")}
-                  </span>
+                  </h3>
                 </div>
 
                 <ol className="ml-0 pl-5 leading-[1.9] text-sm text-white/70 list-decimal">
@@ -5812,7 +5862,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
             <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
               <div className="flex items-center gap-2 mb-2">
                 <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>key</span>
-                <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.security.passwordLabel")}</label>
+                <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.security.passwordLabel")}</h3>
               </div>
               {/* Split around the font-mono span: markup can't live in a catalogue
                   value, and `sudo` is a command name that must not be translated. */}
@@ -5927,7 +5977,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                 <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
                   <div className="flex items-center gap-2 mb-4">
                     <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>computer</span>
-                    <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.device")}</label>
+                    <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.device")}</h3>
                     <span className="ml-auto text-xs font-mono text-[var(--coral-bright)]/70 bg-orange-500/10 px-2 py-0.5 rounded-md">{stats.overview.uptime}</span>
                   </div>
                   <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
@@ -5942,7 +5992,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                 <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
                   <div className="flex items-center gap-2 mb-4">
                     <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>speed</span>
-                    <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.resources")}</label>
+                    <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.resources")}</h3>
                   </div>
 
                   {/* CPU bar */}
@@ -6005,7 +6055,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                   <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
                     <div className="flex items-center gap-2 mb-4">
                       <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>thermostat</span>
-                      <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.temperature")}</label>
+                      <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.temperature")}</h3>
                     </div>
                     <div className="flex items-end gap-3">
                       <span className="text-3xl font-mono font-bold" style={{ color: stats.temperature.value > 80 ? "#ef4444" : stats.temperature.value > 60 ? "#f97316" : "#22d3ee" }}>
@@ -6034,7 +6084,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                 <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
                   <div className="flex items-center gap-2 mb-4">
                     <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>hard_drive</span>
-                    <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.storage")}</label>
+                    <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.storage")}</h3>
                   </div>
                   <div className="space-y-3">
                     {stats.storage.filter(m => m.mountpoint !== "/boot/efi").map(m => (
@@ -6069,7 +6119,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                   <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5" data-testid="settings-per-core">
                     <div className="flex items-center gap-2 mb-4">
                       <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>view_module</span>
-                      <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.perCore")}</label>
+                      <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.perCore")}</h3>
                       <span className="ml-auto text-[10px] font-mono text-[var(--text-muted)] opacity-60">
                         {t("settings.load")} {stats.cpu.loadAvg.map(v => formatLoad(v, locale)).join(" · ")}
                       </span>
@@ -6092,7 +6142,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                   <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5" data-testid="settings-processes">
                     <div className="flex items-center gap-2 mb-4">
                       <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>list_alt</span>
-                      <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.busiestProcesses")}</label>
+                      <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.busiestProcesses")}</h3>
                       {/* The ordering matters as much as the list: CPU is what a
                           slow desktop looks like, memory is what an OOM-killed
                           update looks like. The toggle is only offered when the
@@ -6173,7 +6223,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
 
         {activeSection === "about" && (<>
           <div className="max-w-xl space-y-6">
-            <h2 className="text-lg font-semibold text-[var(--text-primary)] mb-4">{t("settings.aboutClawBox")}</h2>
+            <h3 className="text-lg font-semibold text-[var(--text-primary)] mb-4">{t("settings.aboutClawBox")}</h3>
 
             <div className="bg-white/5 rounded-xl p-5 space-y-4">
               <div className="flex items-center gap-4">
@@ -6503,10 +6553,13 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
     return (
       <div className="flex flex-col h-full bg-[var(--bg-deep)]">
         {mobileSection === null ? (
-          /* Nav list — iOS-style grouped rows with status subtitles */
+          /* Nav list — iOS-style grouped rows with status subtitles. The title
+             is the page's `h1` only where Settings IS the page (see `asPage`);
+             in a window it is the list screen's own heading. Both tags paint
+             identically: the size and weight are in the class. */
           <div className="flex-1 overflow-y-auto px-4 pt-4 pb-6">
-            <h2 className="text-2xl font-bold text-[var(--text-primary)] px-1 mb-4">{t("settings.title")}</h2>
-            <nav className="bg-white/[0.04] border border-white/[0.06] rounded-2xl overflow-hidden divide-y divide-white/[0.06]">
+            <MobileTitle className="text-2xl font-bold text-[var(--text-primary)] px-1 mb-4">{t("settings.title")}</MobileTitle>
+            <nav aria-label={t("settings.title")} className="bg-white/[0.04] border border-white/[0.06] rounded-2xl overflow-hidden divide-y divide-white/[0.06]">
               {visibleNavItems.map(item => {
                 const { subtitle } = sectionStatus(item.id);
                 return (
@@ -6547,9 +6600,10 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                 <span>{t("settings.title")}</span>
               </button>
             </div>
-            <div className="flex-1 overflow-y-auto p-4">
+            <PanelRegion {...panelRegionProps} className="flex-1 overflow-y-auto p-4">
+              {panelHeadings}
               {renderContent()}
-            </div>
+            </PanelRegion>
           </>
         )}
 
@@ -6620,13 +6674,16 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
     <div className="flex h-full min-h-0 overflow-hidden bg-[var(--bg-deep)]">
       {/* Sidebar. The nav scrolls on its own so a long section list can never
           grow the row past the window body and paint outside the frame. */}
-      <nav className="w-60 shrink-0 min-h-0 overflow-y-auto bg-[var(--bg-surface)] border-r border-[var(--border-subtle)] py-4 px-2 flex flex-col gap-0.5">
+      <nav aria-label={t("settings.title")} className="w-60 shrink-0 min-h-0 overflow-y-auto bg-[var(--bg-surface)] border-r border-[var(--border-subtle)] py-4 px-2 flex flex-col gap-0.5">
         {visibleNavItems.map(item => {
           const active = navSection === item.id;
           const status = sectionStatus(item.id);
           return (
             <button
               key={item.id}
+              // The lit row is how a sighted owner knows where they are; this is
+              // the same fact for everyone else. Announced, not merely coloured.
+              aria-current={active ? "page" : undefined}
               onClick={() => setSectionGated(item.id)}
               className={`flex shrink-0 items-center gap-3 px-2.5 py-2 rounded-xl text-[15px] border-none cursor-pointer transition-colors text-left ${
                 active
@@ -6650,11 +6707,14 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         <div className="flex-1" />
       </nav>
 
-      {/* Content */}
+      {/* Content. The panel is a landmark of its own — the `main` the standalone
+          page's "skip to content" can skip to, a named region inside a desktop
+          window — where a screen reader's landmark list had nothing before. */}
       <div className="flex-1 min-w-0 min-h-0 overflow-y-auto p-6 flex flex-col items-center">
-        <div className="w-full max-w-3xl flex flex-col items-stretch [&>div]:mx-auto [&>div]:w-full">
+        <PanelRegion {...panelRegionProps} className="w-full max-w-3xl flex flex-col items-stretch [&>div]:mx-auto [&>div]:w-full">
+          {panelHeadings}
           {renderContent()}
-        </div>
+        </PanelRegion>
       </div>
 
       <ClawBoxLoginModal

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -6557,8 +6557,8 @@ export default function SettingsApp({ ui, asPage = false }: SettingsAppProps) {
              is the page's `h1` only where Settings IS the page (see `asPage`);
              in a window it is the list screen's own heading. Both tags paint
              identically: the size and weight are in the class. */
-          <div className="flex-1 overflow-y-auto px-4 pt-4 pb-6">
-            <MobileTitle className="text-2xl font-bold text-[var(--text-primary)] px-1 mb-4">{t("settings.title")}</MobileTitle>
+          <PanelRegion {...panelRegionProps} className="flex-1 overflow-y-auto px-4 pt-4 pb-6">
+            <MobileTitle id={panelTitleId} className="text-2xl font-bold text-[var(--text-primary)] px-1 mb-4">{t("settings.title")}</MobileTitle>
             <nav aria-label={t("settings.title")} className="bg-white/[0.04] border border-white/[0.06] rounded-2xl overflow-hidden divide-y divide-white/[0.06]">
               {visibleNavItems.map(item => {
                 const { subtitle } = sectionStatus(item.id);
@@ -6586,7 +6586,7 @@ export default function SettingsApp({ ui, asPage = false }: SettingsAppProps) {
                 );
               })}
             </nav>
-          </div>
+          </PanelRegion>
         ) : (
           /* Content — chrome back closes window in one tap. A small "All settings"
               link at the top lets the user switch sections without leaving. */

--- a/src/components/SystemProfilePanel.tsx
+++ b/src/components/SystemProfilePanel.tsx
@@ -154,9 +154,9 @@ export default function SystemProfilePanel() {
     <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
       <div className="flex items-center gap-2 mb-4">
         <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>tune</span>
-        <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">
+        <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">
           {t("systemProfile.title")}
-        </label>
+        </h3>
       </div>
 
       {/* Desktop environment */}

--- a/src/components/SystemUpdateApp.tsx
+++ b/src/components/SystemUpdateApp.tsx
@@ -137,10 +137,14 @@ function StepIcon({ status }: { status: StepStatus }) {
  * brings its own padding and width, so the app skips its window chrome (the
  * full-height centring) and just lays its cards out. The desktop window and
  * the standalone page keep the default.
+ *
+ * Embedded, the hero's headline is an `h2`: the pane around it already owns the
+ * window's `h1`, and two of those would have the document claim two titles.
  */
 export default function SystemUpdateApp({ embedded = false }: { embedded?: boolean } = {}) {
   const { t } = useT();
   const tr = useTr();
+  const HeroHeading = embedded ? "h2" : "h1";
   // Settings embeds this app while the desktop can have the standalone window
   // open beside it, so the label's id has to be per-instance or the second
   // toggle would borrow the first one's name.
@@ -560,7 +564,7 @@ export default function SystemUpdateApp({ embedded = false }: { embedded?: boole
                 </span>
               </div>
             </div>
-            <h1 className="font-display text-3xl font-bold">{hero.headline}</h1>
+            <HeroHeading className="font-display text-3xl font-bold">{hero.headline}</HeroHeading>
             <p className="mt-1.5 max-w-md text-sm text-[var(--text-muted)] leading-relaxed">
               {hero.subhead}
             </p>

--- a/src/components/VoiceOutputPanel.tsx
+++ b/src/components/VoiceOutputPanel.tsx
@@ -709,7 +709,7 @@ export default function VoiceOutputPanel({ active }: { active: boolean }) {
             <span className="material-symbols-rounded text-[var(--text-muted)]" style={{ fontSize: 22 }} aria-hidden="true">
               voice_over_off
             </span>
-            <h2 className="font-semibold text-[var(--text-primary)]">{t("settings.voice.channelsUnavailable.title")}</h2>
+            <h3 className="font-semibold text-[var(--text-primary)]">{t("settings.voice.channelsUnavailable.title")}</h3>
           </div>
           <p className="text-sm text-[var(--text-secondary)] leading-relaxed">
             {t("settings.voice.channelsUnavailable.body")}

--- a/src/tests/components/settings-headings-landmarks.test.tsx
+++ b/src/tests/components/settings-headings-landmarks.test.tsx
@@ -160,6 +160,22 @@ describe("Settings exposes a heading structure and a landmark", () => {
     expect(await within(region).findByRole("heading", { level: 2, name: "Connect AI Provider" })).toBeInTheDocument();
   });
 
+  // A phone lands on the section LIST, and that screen is the whole content
+  // while it is up — so it is the page's landmark, or the standalone page has
+  // none until a panel is opened.
+  it("makes the phone's section list the landmark too", async () => {
+    const width = window.innerWidth;
+    try {
+      Object.defineProperty(window, "innerWidth", { configurable: true, value: 390 });
+      render(<SettingsApp ui={ui} asPage />);
+      const main = await screen.findByRole("main");
+      expect(within(main).getByRole("heading", { level: 1, name: "settings.title" })).toBeInTheDocument();
+      expect(within(main).getByRole("navigation", { name: "settings.title" })).toBeInTheDocument();
+    } finally {
+      Object.defineProperty(window, "innerWidth", { configurable: true, value: width });
+    }
+  });
+
   // Settings → System Update draws SystemUpdateApp inside this window, and that
   // pane opens on an <h1> of its own wherever it is the window itself.
   it("keeps the embedded System Update hero out of the document's h1", async () => {

--- a/src/tests/components/settings-headings-landmarks.test.tsx
+++ b/src/tests/components/settings-headings-landmarks.test.tsx
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@/tests/helpers/test-utils";
+import SettingsApp, { type UISettings } from "@/components/SettingsApp";
+import { resetHarnessCache } from "@/lib/client-harness";
+
+// The whole settings app mounts here — every panel and every status fetch.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+// Keys stand in for copy, the way the neighbouring settings a11y suite does it:
+// this file is about the STRUCTURE of the page, not about which words fill it.
+vi.mock("@/lib/i18n", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/i18n")>()),
+  useT: () => ({ locale: "en", localeResolved: true, setLocale: () => {}, t: (key: string) => key }),
+}));
+
+vi.mock("next/image", () => ({ default: () => null }));
+vi.mock("@/components/TelegramConfiguringOverlay", () => ({ default: () => null }));
+
+const GiB = 1024 ** 3;
+
+/** The caption class on beta, byte for byte: promoting the tag must not touch it. */
+const CAPTION_CLASS = "text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest";
+
+const ui: UISettings = {
+  wallpaperId: "hermes",
+  wpFit: "fill",
+  wpBgColor: "#000000",
+  wpOpacity: 50,
+  mascotHidden: false,
+  wallpapers: [{ id: "hermes", name: "Hermes" }],
+  customWallpapers: [],
+  onWallpaperChange: vi.fn(),
+  onWpFitChange: vi.fn(),
+  onWpBgColorChange: vi.fn(),
+  onWpOpacityChange: vi.fn(),
+  onMascotToggle: vi.fn(),
+  onWallpaperUpload: vi.fn(),
+  onCustomWallpaperDelete: vi.fn(),
+};
+
+function jsonResponse(data: unknown) {
+  return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(data) });
+}
+
+const STATS = {
+  overview: { hostname: "clawbox", os: "Ubuntu", kernel: "5.15", uptime: "1h", arch: "arm64", platform: "linux" },
+  cpu: { usage: 12, model: "ARMv8", cores: 6, loadAvg: ["1.0", "1.0", "1.0"], speed: 1800, perCore: [9, 8, 7, 6, 5, 4] },
+  memory: { total: 7.4 * GiB, used: 5.8 * GiB, free: 1.6 * GiB, usedPercent: 78, swap: { used: 0, total: 0, percent: 0 } },
+  temperature: { value: 56.1, display: "56.1°C" },
+  gpu: { usage: 0 },
+  storage: [],
+  network: [],
+  processes: [],
+  timestamp: Date.now(),
+};
+
+/**
+ * Settings, read by a screen reader that navigates by heading and by landmark.
+ *
+ * HL-7, measured on beta 8140fb46: four panels enumerated 0 `h2`, 0 `h3` and no
+ * `main` at all — every visible section title ("WALLPAPER", "STATUS", "PER
+ * CORE", "RESOURCES") is a `<label>` carrying a style, and a `<label>` with no
+ * `for` and no wrapped control is inert to assistive technology. The result is
+ * one flat run of text with nothing to jump between, and no landmark to skip to.
+ *
+ * What the page owes its reader, asserted below: one `h2` naming the panel that
+ * is open, the cards' captions as `h3`, the panel region as a landmark — `main`
+ * where Settings is the whole page, a NAMED REGION where it is one window on a
+ * desktop that mounts six other apps with an `h1` each — the sidebar as a `nav`
+ * whose current row says so, never a second `h1` from a pane Settings embeds,
+ * and the captions' class strings untouched, because this is a structural fix
+ * that must not move a pixel.
+ */
+describe("Settings exposes a heading structure and a landmark", () => {
+  function serve(harness: "openclaw" | "hermes" = "openclaw") {
+    vi.stubGlobal("fetch", vi.fn((input: string | URL | undefined) => {
+      const url = String(input ?? "");
+      if (url === "/setup-api/system/stats") return jsonResponse(STATS);
+      if (url === "/setup-api/wifi/status") return jsonResponse({ connected: false, ssid: null });
+      if (url === "/setup-api/system/hotspot") return jsonResponse({ enabled: false, ssid: null });
+      if (url === "/setup-api/update/status") return jsonResponse({ phase: "idle", steps: [] });
+      if (url.startsWith("/setup-api/update/versions")) {
+        return jsonResponse({ clawbox: { current: "v1.0.0", target: null }, openclaw: { current: "1.0.0", target: null } });
+      }
+      if (url === "/setup-api/ai-models/status") return jsonResponse({ connected: false, provider: null, providerLabel: null, mode: null, model: null });
+      if (url === "/setup-api/providers/status") return jsonResponse({ harness, defaultProvider: null, degraded: false, providers: [] });
+      if (url === "/setup-api/setup/status") return jsonResponse({ setup_complete: true });
+      if (url === "/setup-api/harness/active") return jsonResponse({ active: harness, edition: harness, activeKnown: true });
+      if (url === "/setup-api/telegram/status") return jsonResponse({ configured: false });
+      return jsonResponse({});
+    }));
+  }
+
+  beforeEach(() => {
+    // The edition is cached for the document's lifetime, and a module cache
+    // outlives a test: without this seam the Hermes case below would be served
+    // the `openclaw` the earlier cases cached and would never render the pane
+    // it exists to check.
+    resetHarnessCache();
+    serve();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetHarnessCache();
+  });
+
+  function openSection(section: string, { asPage = false } = {}) {
+    render(<SettingsApp ui={ui} asPage={asPage} />);
+    window.dispatchEvent(new CustomEvent("clawbox:open-settings-section", { detail: { section } }));
+  }
+
+  /** The panel region, whichever landmark this instance is entitled to. */
+  function findPanel(asPage: boolean, name: string) {
+    return asPage
+      ? screen.findByRole("main")
+      : screen.findByRole("region", { name });
+  }
+
+  // The four panels the sweep measured, each with a card caption that must read
+  // as a heading. `ai` is the one that already had an h1 — AIModelsStep's, drawn
+  // embedded — and still owed its reader the panel's own name.
+  const PANELS = [
+    { section: "appearance", titleKey: "settings.appearance", captionKey: "settings.wallpaper" },
+    { section: "ai", titleKey: "settings.providers", captionKey: "settings.providers.title" },
+    { section: "system", titleKey: "settings.system", captionKey: "settings.device" },
+    { section: "telegram", titleKey: "settings.telegram", captionKey: "settings.status" },
+  ] as const;
+
+  for (const panel of PANELS) {
+    it(`names the ${panel.section} panel with an h2 over h3 section titles, and claims no h1`, async () => {
+      openSection(panel.section);
+
+      const region = await findPanel(false, panel.titleKey);
+      expect(within(region).getByRole("heading", { level: 2, name: panel.titleKey })).toBeInTheDocument();
+      // Awaited: the System panel draws its cards only once the figures land.
+      expect(await within(region).findByRole("heading", { level: 3, name: panel.captionKey })).toBeInTheDocument();
+      // A window is not the document's title. Counted on EVERY panel, because
+      // the h1 that has to stay down is in a pane Settings embeds — the
+      // Providers title, the System Update hero — not in Settings itself.
+      expect(screen.queryAllByRole("heading", { level: 1 })).toHaveLength(0);
+    });
+  }
+
+  it("gives the standalone page one h1 — its own title — and a main landmark", async () => {
+    openSection("appearance", { asPage: true });
+    const main = await findPanel(true, "settings.title");
+    const h1s = screen.getAllByRole("heading", { level: 1 });
+    expect(h1s).toHaveLength(1);
+    expect(h1s[0]).toHaveTextContent("settings.title");
+    expect(within(main).getByRole("heading", { level: 2, name: "settings.appearance" })).toBeInTheDocument();
+  });
+
+  // Named rather than counted, so the case cannot pass on a panel that only
+  // rendered a skeleton: this title is AIModelsStep's, drawn embedded, and it is
+  // the `h1` the Providers panel carried on beta.
+  it("demotes the embedded Providers title under the panel's own name", async () => {
+    openSection("ai");
+    const region = await findPanel(false, "settings.providers");
+    expect(await within(region).findByRole("heading", { level: 2, name: "Connect AI Provider" })).toBeInTheDocument();
+  });
+
+  // Settings → System Update draws SystemUpdateApp inside this window, and that
+  // pane opens on an <h1> of its own wherever it is the window itself.
+  it("keeps the embedded System Update hero out of the document's h1", async () => {
+    openSection("update");
+    await findPanel(false, "settings.systemUpdate");
+    expect(screen.queryAllByRole("heading", { level: 1 })).toHaveLength(0);
+  });
+
+  // The same pane on the other edition: Providers renders HermesProviderConfig
+  // there, whose title is the h1 on a Hermes box's Providers panel.
+  it("keeps the Providers title out of the document's h1 on a Hermes box", async () => {
+    serve("hermes");
+    openSection("ai");
+    const region = await findPanel(false, "settings.providers");
+    expect(within(region).getByRole("heading", { level: 2, name: "settings.providers" })).toBeInTheDocument();
+    // Named, so this cannot pass on a box that quietly rendered the OpenClaw
+    // pane instead: the title below belongs to HermesProviderConfig alone.
+    expect(await within(region).findByRole("heading", { level: 2, name: "hermesProvider.title" })).toBeInTheDocument();
+    expect(screen.queryAllByRole("heading", { level: 1 })).toHaveLength(0);
+  });
+
+  it("marks the open section in the sidebar as the current one", async () => {
+    openSection("system");
+    await findPanel(false, "settings.system");
+    const sidebar = screen.getByRole("navigation", { name: "settings.title" });
+    const current = within(sidebar).getAllByRole("button").filter(b => b.getAttribute("aria-current") === "page");
+    expect(current).toHaveLength(1);
+    expect(current[0]).toHaveTextContent("settings.system");
+  });
+
+  // The whole point of promoting a caption rather than restyling one: the class
+  // string is what paints it, so it has to survive the tag change byte for byte.
+  // A deliberate restyle updates this line and says so in its own diff.
+  it("promotes the caption without changing a single class", async () => {
+    openSection("appearance");
+    const region = await findPanel(false, "settings.appearance");
+    const caption = within(region).getAllByRole("heading", { level: 3 }).find(h => h.textContent === "settings.wallpaper");
+    expect(caption?.className).toBe(CAPTION_CLASS);
+  });
+});


### PR DESCRIPTION
**Finding HL-7** (hermes-lane sweep, 2026-09-10 · card TASK-807 under epic TASK-790).

## Customer-visible symptom

Settings is unnavigable with a screen reader. Every visible section title —
WALLPAPER, DISPLAY, EXTRAS, STATUS, CLOUD PROVIDERS, RESOURCES, PER CORE,
USER ACCESS — is a styled `<label>`, so the whole window arrives as one flat run
of text: no heading to jump between sections, no landmark to skip into, and
nothing saying which sidebar row is the open one. Measured on beta over four
panels:

    panel        h1/h2/h3   <main>   <nav>
    appearance    0/0/0        0       1
    ai            1/0/0        0       1     (the 1 is a pane's own h1, not the page's)
    system        0/0/0        0       1
    telegram      0/0/0        0       1

Everything else in this area already passed the sweep: tab order, focus rings,
button names, `alt` text and `lang`.

## Cause

`<label>` with no `for` and no wrapped control is inert to assistive technology —
it is a style carrier here, nothing more. The file already knew the convention
(14 `h2`/`h3` tags, none of them on these panels), so this is inconsistency
rather than an absent pattern, and no panel wrapper claimed a landmark.

## What changed

* Every panel names itself with an `h2` (`sr-only`: the lit sidebar row already
  says it to a sighted reader), the cards' captions are the `h3`s beneath it, and
  captions of blocks *inside* a card are `h4` under those.
* The panel region is a landmark. **Which** landmark depends on where Settings is
  drawn (new `asPage` prop): the desktop mounts every open window in one document
  and six of its apps draw an `h1` of their own, so a window may claim neither
  the document's title nor its `main` — "skip to main content" read from ClawKeep
  would otherwise land inside the Settings window behind it. As a window the
  panel is a **region named after the panel**; on the standalone `/app/settings`
  page, where Settings *is* the page, it is the **`main`** under the window
  title's `h1`. This is a deliberate departure from the brief's "a `main` around
  the panel content": one `main` per document is the rule the desktop has to obey.
* The sidebar `nav` gets a name and the open row `aria-current="page"`.
* The panel's name is read from the entry that already names it (the sidebar row,
  or the channels list), so **no translation key was added or changed** — the
  heading cannot drift from the row the owner clicked.

**No visual change, verified without screenshots:** every promoted caption keeps
its class string byte for byte (a test asserts it); Tailwind v4 preflight gives
headings `font-size: inherit; font-weight: inherit` and zeroes all margins, so
the explicit `text-[10px] font-semibold` classes are still the only thing
painting them; every promoted caption sits in a `flex items-center` row, which
blockifies its children either way, and the three that do not were block-level
already; and the one element rule that separates a heading from a label —
`globals.css`'s unlayered `h1..h6 { font-family: var(--font-display) }` — resolves
to the same `system-ui, sans-serif` stack as `--font-body`, because neither
"Clash Display" nor "Satoshi" is shipped in `public/fonts/` or linked anywhere.
That last one is latent, not unconditional: if a display face is ever dropped
into those slots, these ~30 micro-captions take it along with every other
heading. Worth knowing now rather than blaming this diff later.

## RED → GREEN

New regression test `src/tests/components/settings-headings-landmarks.test.tsx`
(10 cases; no axe in this repo — checked `package.json` — so it is the plain
role-query form the neighbouring `settings-appearance-a11y.test.tsx` uses).

RED, on unmodified beta `1be87420b`:

    FAIL  settings-headings-landmarks.test.tsx > names the appearance panel … and claims no h1
    TestingLibraryElementError: Unable to find role="region" and name "settings.appearance"
    FAIL  … > names the ai panel …          Unable to find role="region" and name "settings.providers"
    FAIL  … > names the system panel …      Unable to find role="region" and name "settings.system"
    FAIL  … > names the telegram panel …    Unable to find role="region" and name "settings.telegram"
    FAIL  … > gives the standalone page one h1 — its own title — and a main landmark
    TestingLibraryElementError: Unable to find role="main"
    FAIL  … > demotes the embedded Providers title under the panel's own name
    FAIL  … > keeps the embedded System Update hero out of the document's h1
    FAIL  … > keeps the Providers title out of the document's h1 on a Hermes box
    FAIL  … > marks the open section in the sidebar as the current one
    FAIL  … > promotes the caption without changing a single class
     Test Files  1 failed (1)
          Tests  10 failed (10)

GREEN, on this head:

     Test Files  1 passed (1)
          Tests  10 passed (10)

    # whole components project + typecheck on the rebased head
     Test Files  212 passed (212)
          Tests  1838 passed (1838)
    tsc --noEmit: clean
    eslint on the changed files: identical to beta (29 errors / 7 warnings, all
    pre-existing, none on a line this PR touches)

The unit project is 13580/13582 with one pre-existing flake
(`memory-index-local.test.ts` — it fails on unmodified beta in isolation too and
passes here).

## Sibling sites — every one fixed or cleared

**Fixed** (same label-as-heading pattern, same Settings surface):
`AiProviderList` (the providers caption → `h3`, the stranded-plugin group → `h4`),
`SystemProfilePanel`, `PetPicker`, the About card title (`h2` → `h3`),
`RemoteControlPanel`'s and `VoiceOutputPanel`'s card titles (`h2` → `h3`: they
sat at the same rank as the new panel name), and "Access this device at" /
"Available networks" on the Network panel (`span` → `h4`).

**Fixed — a second `h1` this PR would otherwise have created:** three panes draw
an `h1` of their own while embedded in Settings — `SystemUpdateApp`'s hero,
`AIModelsStep`'s title, and `HermesProviderConfig`'s title, which is the one a
Hermes box renders on its Providers panel. Each drops to `h2` when `embedded`
and is unchanged as its own window. The test pins both editions.

**Cleared, with the reason:**
* `HarnessPicker`, `LocalAiPanel`, `BackgroundJobsPanel` — already `h3` with the
  same caption class. This PR follows their precedent.
* `VoiceOutputPanel`'s five `<label>`s — every one carries `htmlFor`; real
  control labels, left alone.
* `RemoteControlPanel:343`, and the two hotspot captions in `SettingsApp` —
  they caption a control, so they stay `<label>`. (The two hotspot `<input>`s
  have no `id`/`aria-label` and so no accessible name at all — a separate,
  pre-existing defect; not widened into this diff.)
* The caption inside the password-confirm dialog — a dialog has its own title.
* `ChatPopup` (the mascot chat) — grep finds no `<label>` and no section caption
  in it; nothing to convert.
* `SystemUpdateApp`'s progress-card title, `CodingAgentApp`, `FilesApp`,
  `ClawKeepApp`, `MemoryShardSettingsPanel`, `CodingAgentSettingsPanel`,
  `/login` — other windows' captions (`p`/`div`/`span` list-group headers) whose
  apps own an `h1` and no `h2`, so promoting them to `h3` would skip a level.
  Each needs its own window's heading pass; recorded as a residual rather than
  half-done here.

## Harness

No OpenClaw or Hermes mechanism owns this: heading semantics and landmarks are
markup in ClawBox's own Next.js desktop, and neither harness exposes a heading,
landmark or label catalogue to borrow — nothing here re-implements a model list,
a session change, a credential store or a catalog. What *was* reused rather than
re-invented is in-repo: the existing a11y component-test convention
(`settings-appearance-a11y.test.tsx`), the `sr-only` idiom the sidebar already
uses, the `h3` caption precedent in `HarnessPicker`/`LocalAiPanel`/
`BackgroundJobsPanel`, `NAV_ITEMS`/`CHANNEL_ITEMS` as the existing source of
truth for a section's name (instead of new translation keys), and
`resetHarnessCache()` as the edition test seam.

## Review

Reviewed via the `clawbox-review` skill: 0 critical, 0 high, 3 medium, 8 low.
All three mediums are fixed in this head — the document-level `main`/`h1` clash
on the multi-window desktop (the `asPage` split above), the untested
`AIModelsStep` demotion, and the untested Hermes path (both now pinned by name,
not by a zero count, so neither can pass on a panel that only rendered a
skeleton). Of the lows, the three missed captions, the two card titles, the
mobile nav's missing name, and the comment that described a folded section as
live are all fixed. Two are deliberately not: the update pane's own
progress-card title stays `h2` (threading `embedded` through its sub-components
is more than the finding warrants; no level is skipped), and the exact-class
assertion is kept on purpose — it is the no-visual-change proof for the tag
swap, and a deliberate restyle should have to update it in its own diff.

## Device proof

**Deferred, by instruction** — this run touched no box and took no mutex (the
owner is testing both boxes by hand). What to check once it is on a box: open
Settings with a screen reader and confirm it lists the panels and their cards as
headings, that the open sidebar row is announced as current, and that the
standalone `/app/settings` page lands in `main` while the desktop window
announces a named region instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved heading hierarchy and landmark semantics across Settings, system updates, AI model setup, provider configuration, and related panels.
  * Added accessible names to navigation and content regions.
  * Active Settings navigation now exposes its current state to assistive technologies.
  * Standalone Settings pages now provide clearer page-level structure, while embedded views preserve appropriate nested heading levels.

* **Tests**
  * Added accessibility coverage for Settings landmarks, headings, navigation state, and embedded versus standalone layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->