### PR TITLE
fix: x64 UI update recovery and coding harness delivery

### DIFF
--- a/.github/workflows/pr-tests-coverage.yml
+++ b/.github/workflows/pr-tests-coverage.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Sudoers allow-list coverage
         run: bun run check:sudoers
 
+      - name: Existing x64 desktop integration fixtures
+        run: PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts/x64-migration -p 'test_*.py'
+
       # The MCP server's tree is EXCLUDED from the root tsconfig (see its
       # `exclude`), so `tsc --noEmit` — wherever it runs — has never covered
       # mcp/**, and no workflow ran this project. Three errors sat on beta

--- a/scripts/x64-migration/README.md
+++ b/scripts/x64-migration/README.md
@@ -37,6 +37,18 @@ adapter remains installed across beta resets. Git fetches/builds in the live
 desktop checkout run as its owner. UI rebuilds preserve the previous build,
 restore it on failure, and restart only the UI to resume the existing updater.
 
+Both **Update** and **Force full update** use this desktop contract when the
+dashboard checkout matches `PROJECT_DIR` in the root-owned integration file.
+The adapter owns the maintenance guard for each core step and restores an
+already-running gateway before returning, even when the step refuses a new
+core pin or fails validation. A later UI rebuild failure therefore cannot
+strand Telegram waiting for a verification step that will never run.
+Post-update checks leave a healthy gateway running. If it is unavailable,
+verification tries its existing service once and reports failure if it stays
+unavailable; it does not run the appliance pre-start/doctor repair chain.
+The UI is unavailable during its rebuild; this desktop does not reboot.
+The existing integration package 1.0.2 supports this dashboard change.
+
 The already-installed OpenClaw version is validated without running migrations.
 The owner's idempotent backup compatibility patch is reapplied as that owner.
 A changed core pin is deliberately refused before package/database modification:

--- a/scripts/x64-migration/README.md
+++ b/scripts/x64-migration/README.md
@@ -10,10 +10,10 @@ package manager.
 PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts/x64-migration -p 'test_*.py'
 python3 scripts/x64-migration/build-package.py \
   --staging /tmp/clawbox-x64-integration-stage \
-  --output /tmp/clawbox-x64-integration_1.0.3_amd64.deb
-dpkg-deb --info /tmp/clawbox-x64-integration_1.0.3_amd64.deb
-dpkg-deb --contents /tmp/clawbox-x64-integration_1.0.3_amd64.deb
-sudo -n dpkg -i /tmp/clawbox-x64-integration_1.0.3_amd64.deb
+  --output /tmp/clawbox-x64-integration_1.0.4_amd64.deb
+dpkg-deb --info /tmp/clawbox-x64-integration_1.0.4_amd64.deb
+dpkg-deb --contents /tmp/clawbox-x64-integration_1.0.4_amd64.deb
+sudo -n dpkg -i /tmp/clawbox-x64-integration_1.0.4_amd64.deb
 ```
 
 The default host is `nexus0`, project `/home/nexus0/clawbox`, interpreter
@@ -47,19 +47,29 @@ Post-update checks leave a healthy gateway running. If it is unavailable,
 verification tries its existing service once and reports failure if it stays
 unavailable; it does not run the appliance pre-start/doctor repair chain.
 The UI is unavailable during its rebuild; this desktop does not reboot.
-Install integration package **1.0.3** as well as this dashboard update. Older
+Install integration package **1.0.4** as well as this dashboard update. Older
 packages retain their installed adapter and do not gain coding-harness delivery
 merely by fetching beta.
 
 Bootstrap and post-update install the `claude-ds` wrapper from the verified
 mirror as the desktop owner, preserving an existing Claude Code installation.
-If Claude is missing, its HTTPS installer also runs as the owner. Installation
-failure fails the update visibly. The copied wrapper defaults to this desktop's
+If Claude is missing, download the pinned Linux x64 native release over HTTPS,
+verify its pinned SHA-256, then run its native installer as the owner. A checksum
+mismatch or installation failure fails the update visibly. The copied wrapper defaults to this desktop's
 checkout, so the Coding app and an interactive shell use the same ClawBox AI
 configuration. Bootstrap delivers it before the core step restarts the gateway,
 allowing the agent's MCP server to discover the coding tools on that start.
 Neither the Codex CLI nor the appliance's network/service setup is installed
 by this step.
+
+The first-install pin is Claude Code **2.1.268**, with the `linux-x64` checksum
+from its [release manifest](https://downloads.claude.ai/claude-code-releases/2.1.268/manifest.json).
+Before changing the pin, verify that manifest's detached signature using the
+[vendor's verification procedure](https://code.claude.com/docs/en/installation#verify-the-manifest-signature)
+and key fingerprint `31DD DE24 DDFA B679 F42D 7BD2 BAA9 29FF 1A7E CACE`.
+Both the version and digest are committed in the installer; runtime environment
+variables cannot override them. Existing Claude installations keep their own
+version and update policy.
 
 For a wrapper repair without a full update, run the owner-only helper from the
 reviewed checkout (without sudo):

--- a/scripts/x64-migration/README.md
+++ b/scripts/x64-migration/README.md
@@ -47,12 +47,18 @@ Post-update checks leave a healthy gateway running. If it is unavailable,
 verification tries its existing service once and reports failure if it stays
 unavailable; it does not run the appliance pre-start/doctor repair chain.
 The UI is unavailable during its rebuild; this desktop does not reboot.
-Install integration package **1.0.4** as well as this dashboard update. Older
-packages retain their installed adapter and do not gain coding-harness delivery
-merely by fetching beta.
+Existing integration packages **1.0.2 and 1.0.3** support this dashboard update.
+After the adapter refreshes the verified mirror and installs system dependencies,
+the dashboard runs the mirrored coding installer as its own user with ambient
+and inheritable capabilities cleared and privilege escalation disabled. This
+happens before core maintenance; a failed dependency or coding install stops
+the update before the gateway is cycled. No root package replacement is needed,
+so additional repairs in an installed desktop adapter remain intact.
 
-Bootstrap and post-update install the `claude-ds` wrapper from the verified
-mirror as the desktop owner, preserving an existing Claude Code installation.
+For new package installations, **1.0.4** additionally delivers the same harness
+from bootstrap and post-update root steps, dropping to the desktop owner.
+The installer preserves an existing Claude Code installation and installs the
+`claude-ds` wrapper from the verified mirror.
 If Claude is missing, download the pinned Linux x64 native release over HTTPS,
 verify its pinned SHA-256, then run its native installer as the owner. A checksum
 mismatch or installation failure fails the update visibly. The copied wrapper defaults to this desktop's

--- a/scripts/x64-migration/README.md
+++ b/scripts/x64-migration/README.md
@@ -7,13 +7,13 @@ reviewed source, inspect the package, then install it with the normal Debian
 package manager.
 
 ```sh
-python3 scripts/x64-migration/test_integration.py
+PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts/x64-migration -p 'test_*.py'
 python3 scripts/x64-migration/build-package.py \
   --staging /tmp/clawbox-x64-integration-stage \
-  --output /tmp/clawbox-x64-integration_1.0.0_amd64.deb
-dpkg-deb --info /tmp/clawbox-x64-integration_1.0.0_amd64.deb
-dpkg-deb --contents /tmp/clawbox-x64-integration_1.0.0_amd64.deb
-sudo -n dpkg -i /tmp/clawbox-x64-integration_1.0.0_amd64.deb
+  --output /tmp/clawbox-x64-integration_1.0.3_amd64.deb
+dpkg-deb --info /tmp/clawbox-x64-integration_1.0.3_amd64.deb
+dpkg-deb --contents /tmp/clawbox-x64-integration_1.0.3_amd64.deb
+sudo -n dpkg -i /tmp/clawbox-x64-integration_1.0.3_amd64.deb
 ```
 
 The default host is `nexus0`, project `/home/nexus0/clawbox`, interpreter
@@ -47,7 +47,29 @@ Post-update checks leave a healthy gateway running. If it is unavailable,
 verification tries its existing service once and reports failure if it stays
 unavailable; it does not run the appliance pre-start/doctor repair chain.
 The UI is unavailable during its rebuild; this desktop does not reboot.
-The existing integration package 1.0.2 supports this dashboard change.
+Install integration package **1.0.3** as well as this dashboard update. Older
+packages retain their installed adapter and do not gain coding-harness delivery
+merely by fetching beta.
+
+Bootstrap and post-update install the `claude-ds` wrapper from the verified
+mirror as the desktop owner, preserving an existing Claude Code installation.
+If Claude is missing, its HTTPS installer also runs as the owner. Installation
+failure fails the update visibly. The copied wrapper defaults to this desktop's
+checkout, so the Coding app and an interactive shell use the same ClawBox AI
+configuration. Bootstrap delivers it before the core step restarts the gateway,
+allowing the agent's MCP server to discover the coding tools on that start.
+Neither the Codex CLI nor the appliance's network/service setup is installed
+by this step.
+
+For a wrapper repair without a full update, run the owner-only helper from the
+reviewed checkout (without sudo):
+
+```sh
+bash scripts/x64-migration/install-coding-harness.sh scripts/claude-ds "$PWD"
+```
+
+The Coding app checks readiness on its next status request. A running agent's
+MCP server discovers newly installed tools on its next restart.
 
 The already-installed OpenClaw version is validated without running migrations.
 The owner's idempotent backup compatibility patch is reapplied as that owner.

--- a/scripts/x64-migration/build-package.py
+++ b/scripts/x64-migration/build-package.py
@@ -33,6 +33,7 @@ def replace_once(text, old, new):
 
 
 def build(args):
+    """Stage reviewed source and host adapters in an inspectable root-owned deb."""
     account = pwd.getpwnam(args.user)
     for value in [args.user, args.project, args.node_dir, args.npm_prefix, account.pw_dir]:
         if not re.fullmatch(r'[A-Za-z0-9_./-]+', value) or '..' in value:

--- a/scripts/x64-migration/build-package.py
+++ b/scripts/x64-migration/build-package.py
@@ -196,7 +196,7 @@ if __name__=='__main__':
     parser.add_argument('--project',default='/home/nexus0/clawbox')
     parser.add_argument('--node-dir',default='/usr/bin')
     parser.add_argument('--npm-prefix',default='/home/nexus0/.nvm/versions/node/v24.0.0')
-    parser.add_argument('--version',default='1.0.3')
+    parser.add_argument('--version',default='1.0.4')
     parser.add_argument('--staging',required=True)
     parser.add_argument('--output',required=True)
     build(parser.parse_args())

--- a/scripts/x64-migration/build-package.py
+++ b/scripts/x64-migration/build-package.py
@@ -149,7 +149,7 @@ exec /usr/local/bin/cloudflared "$@"
 Version: {args.version}
 Architecture: amd64
 Maintainer: Local ClawBox operator
-Depends: bash, coreutils, findutils, git, python3, sudo, systemd, util-linux
+Depends: bash, ca-certificates, coreutils, curl, findutils, git, python3, sudo, systemd, util-linux
 Description: Host integration for this existing ClawBox x64 desktop
  Root-owned updater, verified vendor source mirror, timezone support,
  and service bridge for an existing OpenClaw user gateway.
@@ -196,7 +196,7 @@ if __name__=='__main__':
     parser.add_argument('--project',default='/home/nexus0/clawbox')
     parser.add_argument('--node-dir',default='/usr/bin')
     parser.add_argument('--npm-prefix',default='/home/nexus0/.nvm/versions/node/v24.0.0')
-    parser.add_argument('--version',default='1.0.0')
+    parser.add_argument('--version',default='1.0.3')
     parser.add_argument('--staging',required=True)
     parser.add_argument('--output',required=True)
     build(parser.parse_args())

--- a/scripts/x64-migration/clawbox-x64-step.sh
+++ b/scripts/x64-migration/clawbox-x64-step.sh
@@ -78,6 +78,11 @@ PY
   echo "System timezone verified: $zone"
 }
 
+install_coding_harness() {
+  as_owner /bin/bash "$MIRROR/scripts/x64-migration/install-coding-harness.sh" \
+    "$MIRROR/scripts/claude-ds" "$PROJECT_DIR"
+}
+
 update_openclaw() {
   local target current
   target=$(head -n 1 "$MIRROR/config/openclaw-target.txt")
@@ -188,7 +193,12 @@ PY
 
 cd "$PROJECT_DIR"
 case "$step" in
-  bootstrap_updater) refresh_trusted_source ;;
+  bootstrap_updater)
+    refresh_trusted_source
+    # Deliver the harness before the core step restarts the user gateway, so
+    # its MCP server discovers the newly available coding tools on that start.
+    install_coding_harness
+    ;;
   set_timezone) apply_timezone ;;
   chpasswd)
     as_owner /usr/bin/python3 - "$PROJECT_DIR/data/.chpasswd-input" <<'PY' | /usr/bin/python3 -I -c '
@@ -246,6 +256,7 @@ PY
   post_update)
     "$MANIFEST" --verify
     "$MANIFEST" --mirror
+    install_coding_harness
     apply_timezone
     echo 'x64 root integration and trusted updater source verified'
     ;;

--- a/scripts/x64-migration/clawbox-x64-step.sh
+++ b/scripts/x64-migration/clawbox-x64-step.sh
@@ -78,6 +78,7 @@ PY
   echo "System timezone verified: $zone"
 }
 
+# Install the verified coding harness with the desktop owner's privileges.
 install_coding_harness() {
   as_owner /bin/bash "$MIRROR/scripts/x64-migration/install-coding-harness.sh" \
     "$MIRROR/scripts/claude-ds" "$PROJECT_DIR"

--- a/scripts/x64-migration/install-coding-harness.sh
+++ b/scripts/x64-migration/install-coding-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Run as the desktop owner. The root adapter supplies the verified wrapper;
-# Claude's installer and all writes into HOME run without root privileges.
+# Claude's verified native installer and all HOME writes run without root.
 set -euo pipefail
 [ "$(/usr/bin/id -u)" -ne 0 ] || { echo 'Run the coding harness installer as the desktop owner, not root.' >&2; exit 77; }
 [ "$#" -eq 2 ] || { echo 'Usage: install-coding-harness.sh WRAPPER_SOURCE PROJECT_DIR' >&2; exit 64; }
@@ -11,16 +11,25 @@ test -s "$wrapper_source"
 export PATH="$HOME/.bun/bin:$HOME/.npm-global/bin:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:/snap/bin"
 
 if ! command -v claude >/dev/null 2>&1; then
-  installer=$(mktemp)
-  trap 'rm -f "$installer"' EXIT
+  # Pin the executable, not a mutable curl-to-shell bootstrap. This checksum
+  # is from Anthropic's signed 2.1.268 manifest, verified against fingerprint
+  # 31DDDE24DDFAB679F42D7BD2BAA929FF1A7ECACE (see README). This package targets
+  # Debian/Ubuntu amd64; an existing CLI on any supported PATH is untouched.
+  readonly CLAUDE_VERSION=2.1.268
+  readonly CLAUDE_SHA256=9691a2b7bd796712ca8cffb8e32e54ff7fc45b662540233171a16a94a0425653
+  mkdir -p "$HOME/.cache/clawbox"
+  download_dir=$(mktemp -d "$HOME/.cache/clawbox/coding-installer.XXXXXX")
+  trap 'rm -rf -- "$download_dir"' EXIT
+  installer="$download_dir/claude"
   curl -fsSL --proto '=https' --proto-redir '=https' \
-    --connect-timeout 15 --max-time 300 https://claude.ai/install.sh -o "$installer"
-  if [ ! -s "$installer" ] || head -c 512 "$installer" | grep -qiE '<!doctype|<html|unavailable in region'; then
-    echo 'Claude Code installer unavailable or region-blocked; coding harness installation failed.' >&2
+    --connect-timeout 15 --max-time 300 \
+    "https://downloads.claude.ai/claude-code-releases/$CLAUDE_VERSION/linux-x64/claude" -o "$installer"
+  if ! printf '%s  %s\n' "$CLAUDE_SHA256" "$installer" | sha256sum --check --status; then
+    echo 'Claude Code checksum mismatch; refusing to execute the download.' >&2
     exit 1
   fi
-  /bin/bash -n "$installer"
-  /bin/bash "$installer" </dev/null
+  chmod 700 "$installer"
+  "$installer" install "$CLAUDE_VERSION" </dev/null
   command -v claude >/dev/null 2>&1 || { echo 'Claude Code is still missing after installation.' >&2; exit 1; }
 fi
 

--- a/scripts/x64-migration/install-coding-harness.sh
+++ b/scripts/x64-migration/install-coding-harness.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Run as the desktop owner. The root adapter supplies the verified wrapper;
+# Claude's installer and all writes into HOME run without root privileges.
+set -euo pipefail
+[ "$(/usr/bin/id -u)" -ne 0 ] || { echo 'Run the coding harness installer as the desktop owner, not root.' >&2; exit 77; }
+[ "$#" -eq 2 ] || { echo 'Usage: install-coding-harness.sh WRAPPER_SOURCE PROJECT_DIR' >&2; exit 64; }
+wrapper_source=$1
+project_dir=$2
+test -s "$wrapper_source"
+[[ "$project_dir" = /* ]] && test -d "$project_dir"
+export PATH="$HOME/.bun/bin:$HOME/.npm-global/bin:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:/snap/bin"
+
+if ! command -v claude >/dev/null 2>&1; then
+  installer=$(mktemp)
+  trap 'rm -f "$installer"' EXIT
+  curl -fsSL --proto '=https' --proto-redir '=https' \
+    --connect-timeout 15 --max-time 300 https://claude.ai/install.sh -o "$installer"
+  if [ ! -s "$installer" ] || head -c 512 "$installer" | grep -qiE '<!doctype|<html|unavailable in region'; then
+    echo 'Claude Code installer unavailable or region-blocked; coding harness installation failed.' >&2
+    exit 1
+  fi
+  /bin/bash -n "$installer"
+  /bin/bash "$installer" </dev/null
+  command -v claude >/dev/null 2>&1 || { echo 'Claude Code is still missing after installation.' >&2; exit 1; }
+fi
+
+# Keep a standalone copy, with this desktop's checkout as its default. The
+# app can still override CLAWBOX_ROOT. Atomic replacement also replaces an old
+# symlink without writing through it into a checkout or an unrelated file.
+python3 - "$wrapper_source" "$project_dir" "$HOME/.local/bin/claude-ds" <<'PY'
+import os, pathlib, shlex, sys, tempfile
+source, project, destination = sys.argv[1:]
+text = pathlib.Path(source).read_text()
+original = 'CLAWBOX_ROOT="${CLAWBOX_ROOT:-/home/clawbox/clawbox}"'
+if text.count(original) != 1:
+    raise ValueError('claude-ds default root changed; review the desktop installer')
+replacement = '_CLAWBOX_DEFAULT_ROOT=' + shlex.quote(project) + '\nCLAWBOX_ROOT="${CLAWBOX_ROOT:-$_CLAWBOX_DEFAULT_ROOT}"\nunset _CLAWBOX_DEFAULT_ROOT'
+dest = pathlib.Path(destination)
+dest.parent.mkdir(parents=True, exist_ok=True)
+fd, staged = tempfile.mkstemp(prefix='.claude-ds-', dir=dest.parent)
+try:
+    with os.fdopen(fd, 'w') as f:
+        f.write(text.replace(original, replacement))
+        os.fchmod(f.fileno(), 0o755)
+    os.replace(staged, dest)
+finally:
+    if os.path.exists(staged): os.unlink(staged)
+PY
+test -x "$HOME/.local/bin/claude-ds"
+echo "Coding harness installed: $HOME/.local/bin/claude-ds"

--- a/scripts/x64-migration/test_coding_harness.py
+++ b/scripts/x64-migration/test_coding_harness.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Owner-only installer fixtures; no vendor downloads or real coding runs."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+HERE = Path(__file__).resolve().parent
+
+
+class CodingHarnessTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix='clawbox-x64-coding-')
+        self.addCleanup(self.tmp.cleanup)
+        self.home = Path(self.tmp.name)
+        self.bin = self.home / '.local/bin'
+        self.bin.mkdir(parents=True)
+        self.project = self.home / "desktop checkout's $project"
+        (self.project / 'data').mkdir(parents=True)
+        (self.project / 'data/config.json').write_text(json.dumps({'clawai_token': 'fixture-token'}))
+        # Exclude any CI/developer CLI in /usr/local/bin. Only fixture binaries
+        # and OS utilities are available, and root CI exercises the owner path
+        # by replacing only the identity check (the real root refusal is below).
+        source = (HERE / 'install-coding-harness.sh').read_text()
+        source = source.replace('[ "$(/usr/bin/id -u)" -ne 0 ]', '[ 1000 -ne 0 ]')
+        source = source.replace('export PATH="$HOME/.bun/bin:$HOME/.npm-global/bin:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:/snap/bin"',
+                                'export PATH="$HOME/.local/bin:/usr/bin:/bin"')
+        self.installer = self.home / 'installer.sh'
+        self.installer.write_text(source)
+        self.write_bin('curl', '#!/bin/sh\necho unexpected-download >&2\nexit 99\n')
+
+    def write_bin(self, name, source):
+        p = self.bin / name
+        p.write_text(source)
+        p.chmod(0o755)
+        return p
+
+    def install(self, wrapper=None):
+        return subprocess.run(['/bin/bash', str(self.installer), str(wrapper or HERE.parent / 'claude-ds'), str(self.project)],
+                              env={'HOME': str(self.home), 'PATH': '/usr/bin:/bin'}, capture_output=True, text=True, timeout=10)
+
+    def test_existing_cli_and_codex_preserved_wrapper_runs_with_desktop_default(self):
+        claude = self.write_bin('claude', '#!/bin/sh\nprintf "%s" "$ANTHROPIC_AUTH_TOKEN" > "$HOME/claude-token"\n')
+        codex = self.write_bin('codex', '#!/bin/sh\nexit 17\n')
+        before = (claude.read_bytes(), codex.read_bytes())
+        for _ in range(2):
+            result = self.install()
+            self.assertEqual(result.returncode, 0, result.stderr)
+        wrapper = self.bin / 'claude-ds'
+        self.assertFalse(wrapper.is_symlink())
+        self.assertEqual(wrapper.stat().st_mode & 0o777, 0o755)
+        self.assertEqual((claude.read_bytes(), codex.read_bytes()), before)
+        run = subprocess.run([str(wrapper), '--version'], cwd=self.project,
+                             env={'HOME': str(self.home), 'PATH': f'{self.bin}:/usr/bin:/bin'}, capture_output=True, text=True, timeout=10)
+        self.assertEqual(run.returncode, 0, run.stderr)
+        self.assertEqual((self.home / 'claude-token').read_text(), 'fixture-token')
+
+    def test_wrapper_symlink_is_replaced_without_modifying_its_target(self):
+        self.write_bin('claude', '#!/bin/sh\nexit 0\n')
+        outside = self.home / 'old-wrapper'
+        outside.write_text('preserve')
+        (self.bin / 'claude-ds').symlink_to(outside)
+        result = self.install()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse((self.bin / 'claude-ds').is_symlink())
+        self.assertEqual(outside.read_text(), 'preserve')
+
+    def fake_download(self, body, status=0):
+        payload = self.home / 'vendor.sh'
+        payload.write_text(body)
+        self.write_bin('curl', '''#!/bin/sh
+test "$1 $2 $3 $4 $5 $6 $7 $8 $9" = '-fsSL --proto =https --proto-redir =https --connect-timeout 15 --max-time 300' || exit 98
+shift 9
+test "$1 $2" = 'https://claude.ai/install.sh -o' || exit 97
+cp "$HOME/vendor.sh" "$3"
+''' + f'exit {status}\n')
+
+    def test_missing_cli_installed_as_owner_from_https_then_verified(self):
+        self.fake_download('mkdir -p "$HOME/.local/bin"\nprintf "#!/bin/sh\\nexit 0\\n" > "$HOME/.local/bin/claude"\nchmod 755 "$HOME/.local/bin/claude"\n')
+        result = self.install()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(os.access(self.bin / 'claude', os.X_OK))
+        self.assertTrue(os.access(self.bin / 'claude-ds', os.X_OK))
+
+    def test_download_failure_invalid_response_and_missing_cli_fail_explicitly(self):
+        cases = [('exit 0\n', 22), ('', 0), ('<html>region blocked</html>', 0),
+                 ('unavailable in region', 0), ('exit 41\n', 0), ('exit 0\n', 0)]
+        for body, status in cases:
+            with self.subTest(body=body, status=status):
+                self.fake_download(body, status)
+                result = self.install()
+                self.assertNotEqual(result.returncode, 0)
+                self.assertFalse((self.bin / 'claude-ds').exists())
+
+    def test_missing_or_changed_wrapper_fails_without_replacing_old_wrapper(self):
+        self.write_bin('claude', '#!/bin/sh\nexit 0\n')
+        old = self.write_bin('claude-ds', '#!/bin/sh\nexit 17\n')
+        source = self.home / 'wrapper-source'
+        for exists in [False, True]:
+            if exists: source.write_text('#!/bin/sh\nexit 0\n')
+            result = self.install(source)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(old.read_text(), '#!/bin/sh\nexit 17\n')
+
+    def test_root_invocation_is_refused_before_home_writes(self):
+        source = (HERE / 'install-coding-harness.sh').read_text()
+        self.installer.write_text(source.replace('$(/usr/bin/id -u)', '0'))
+        result = self.install()
+        self.assertEqual(result.returncode, 77)
+        self.assertFalse((self.bin / 'claude-ds').exists())
+
+
+if __name__ == '__main__': unittest.main()

--- a/scripts/x64-migration/test_coding_harness.py
+++ b/scripts/x64-migration/test_coding_harness.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Owner-only installer fixtures; no vendor downloads or real coding runs."""
 import json
+import hashlib
 import os
 from pathlib import Path
 import subprocess
@@ -28,6 +29,7 @@ class CodingHarnessTest(unittest.TestCase):
         source = source.replace('export PATH="$HOME/.bun/bin:$HOME/.npm-global/bin:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:/snap/bin"',
                                 'export PATH="$HOME/.local/bin:/usr/bin:/bin"')
         self.installer = self.home / 'installer.sh'
+        self.installer_source = source
         self.installer.write_text(source)
         self.write_bin('curl', '#!/bin/sh\necho unexpected-download >&2\nexit 99\n')
 
@@ -67,18 +69,23 @@ class CodingHarnessTest(unittest.TestCase):
         self.assertFalse((self.bin / 'claude-ds').is_symlink())
         self.assertEqual(outside.read_text(), 'preserve')
 
-    def fake_download(self, body, status=0):
+    def fake_download(self, body, status=0, valid_checksum=True):
         payload = self.home / 'vendor.sh'
         payload.write_text(body)
+        # The real helper has no environment override for the trusted digest.
+        # Only this fixture copy substitutes a reviewed stand-in executable.
+        checksum = hashlib.sha256(payload.read_bytes()).hexdigest() if valid_checksum else '0' * 64
+        self.installer.write_text(self.installer_source.replace(
+            '9691a2b7bd796712ca8cffb8e32e54ff7fc45b662540233171a16a94a0425653', checksum))
         self.write_bin('curl', '''#!/bin/sh
 test "$1 $2 $3 $4 $5 $6 $7 $8 $9" = '-fsSL --proto =https --proto-redir =https --connect-timeout 15 --max-time 300' || exit 98
 shift 9
-test "$1 $2" = 'https://claude.ai/install.sh -o' || exit 97
+test "$1 $2" = 'https://downloads.claude.ai/claude-code-releases/2.1.268/linux-x64/claude -o' || exit 97
 cp "$HOME/vendor.sh" "$3"
 ''' + f'exit {status}\n')
 
     def test_missing_cli_installed_as_owner_from_https_then_verified(self):
-        self.fake_download('mkdir -p "$HOME/.local/bin"\nprintf "#!/bin/sh\\nexit 0\\n" > "$HOME/.local/bin/claude"\nchmod 755 "$HOME/.local/bin/claude"\n')
+        self.fake_download('#!/bin/sh\ntest "$1 $2" = "install 2.1.268" || exit 96\nmkdir -p "$HOME/.local/bin"\nprintf "#!/bin/sh\\nexit 0\\n" > "$HOME/.local/bin/claude"\nchmod 755 "$HOME/.local/bin/claude"\n')
         result = self.install()
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertTrue(os.access(self.bin / 'claude', os.X_OK))
@@ -93,6 +100,15 @@ cp "$HOME/vendor.sh" "$3"
                 result = self.install()
                 self.assertNotEqual(result.returncode, 0)
                 self.assertFalse((self.bin / 'claude-ds').exists())
+
+    def test_checksum_mismatch_never_executes_payload_and_cleans_download(self):
+        self.fake_download('#!/bin/sh\ntouch "$HOME/payload-executed"\n', valid_checksum=False)
+        result = self.install()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('checksum mismatch', result.stderr)
+        self.assertFalse((self.home / 'payload-executed').exists())
+        self.assertFalse((self.bin / 'claude-ds').exists())
+        self.assertEqual(list((self.home / '.cache/clawbox').iterdir()), [])
 
     def test_missing_or_changed_wrapper_fails_without_replacing_old_wrapper(self):
         self.write_bin('claude', '#!/bin/sh\nexit 0\n')

--- a/scripts/x64-migration/test_coding_harness.py
+++ b/scripts/x64-migration/test_coding_harness.py
@@ -12,7 +12,10 @@ HERE = Path(__file__).resolve().parent
 
 
 class CodingHarnessTest(unittest.TestCase):
+    """Run the shipped installer with an isolated home and vendor stand-ins."""
+
     def setUp(self):
+        """Prevent fixture runs from finding or replacing the host's CLIs."""
         self.tmp = tempfile.TemporaryDirectory(prefix='clawbox-x64-coding-')
         self.addCleanup(self.tmp.cleanup)
         self.home = Path(self.tmp.name)
@@ -34,16 +37,19 @@ class CodingHarnessTest(unittest.TestCase):
         self.write_bin('curl', '#!/bin/sh\necho unexpected-download >&2\nexit 99\n')
 
     def write_bin(self, name, source):
+        """Place an executable stand-in on this fixture's private PATH."""
         p = self.bin / name
         p.write_text(source)
         p.chmod(0o755)
         return p
 
     def install(self, wrapper=None):
+        """Capture a bounded installer run without inheriting host settings."""
         return subprocess.run(['/bin/bash', str(self.installer), str(wrapper or HERE.parent / 'claude-ds'), str(self.project)],
                               env={'HOME': str(self.home), 'PATH': '/usr/bin:/bin'}, capture_output=True, text=True, timeout=10)
 
     def test_existing_cli_and_codex_preserved_wrapper_runs_with_desktop_default(self):
+        """Exercise an interactive wrapper launch from a path needing quoting."""
         claude = self.write_bin('claude', '#!/bin/sh\nprintf "%s" "$ANTHROPIC_AUTH_TOKEN" > "$HOME/claude-token"\n')
         codex = self.write_bin('codex', '#!/bin/sh\nexit 17\n')
         before = (claude.read_bytes(), codex.read_bytes())
@@ -60,6 +66,7 @@ class CodingHarnessTest(unittest.TestCase):
         self.assertEqual((self.home / 'claude-token').read_text(), 'fixture-token')
 
     def test_wrapper_symlink_is_replaced_without_modifying_its_target(self):
+        """An old launcher link must not redirect the installer's write."""
         self.write_bin('claude', '#!/bin/sh\nexit 0\n')
         outside = self.home / 'old-wrapper'
         outside.write_text('preserve')
@@ -70,6 +77,7 @@ class CodingHarnessTest(unittest.TestCase):
         self.assertEqual(outside.read_text(), 'preserve')
 
     def fake_download(self, body, status=0, valid_checksum=True):
+        """Substitute a vendor payload while enforcing the HTTPS curl contract."""
         payload = self.home / 'vendor.sh'
         payload.write_text(body)
         # The real helper has no environment override for the trusted digest.
@@ -85,6 +93,7 @@ cp "$HOME/vendor.sh" "$3"
 ''' + f'exit {status}\n')
 
     def test_missing_cli_installed_as_owner_from_https_then_verified(self):
+        """Require the pinned native install command to produce a usable CLI."""
         self.fake_download('#!/bin/sh\ntest "$1 $2" = "install 2.1.268" || exit 96\nmkdir -p "$HOME/.local/bin"\nprintf "#!/bin/sh\\nexit 0\\n" > "$HOME/.local/bin/claude"\nchmod 755 "$HOME/.local/bin/claude"\n')
         result = self.install()
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -92,6 +101,7 @@ cp "$HOME/vendor.sh" "$3"
         self.assertTrue(os.access(self.bin / 'claude-ds', os.X_OK))
 
     def test_download_failure_invalid_response_and_missing_cli_fail_explicitly(self):
+        """Failures at each installation stage must propagate to the updater."""
         cases = [('exit 0\n', 22), ('', 0), ('<html>region blocked</html>', 0),
                  ('unavailable in region', 0), ('exit 41\n', 0), ('exit 0\n', 0)]
         for body, status in cases:
@@ -102,6 +112,7 @@ cp "$HOME/vendor.sh" "$3"
                 self.assertFalse((self.bin / 'claude-ds').exists())
 
     def test_checksum_mismatch_never_executes_payload_and_cleans_download(self):
+        """Prove that the digest gate precedes execution and leaves no download."""
         self.fake_download('#!/bin/sh\ntouch "$HOME/payload-executed"\n', valid_checksum=False)
         result = self.install()
         self.assertNotEqual(result.returncode, 0)
@@ -111,6 +122,7 @@ cp "$HOME/vendor.sh" "$3"
         self.assertEqual(list((self.home / '.cache/clawbox').iterdir()), [])
 
     def test_missing_or_changed_wrapper_fails_without_replacing_old_wrapper(self):
+        """Retain the last wrapper if verified source cannot produce its replacement."""
         self.write_bin('claude', '#!/bin/sh\nexit 0\n')
         old = self.write_bin('claude-ds', '#!/bin/sh\nexit 17\n')
         source = self.home / 'wrapper-source'
@@ -121,6 +133,7 @@ cp "$HOME/vendor.sh" "$3"
             self.assertEqual(old.read_text(), '#!/bin/sh\nexit 17\n')
 
     def test_root_invocation_is_refused_before_home_writes(self):
+        """A caller must drop privileges before entering the owner installer."""
         source = (HERE / 'install-coding-harness.sh').read_text()
         self.installer.write_text(source.replace('$(/usr/bin/id -u)', '0'))
         result = self.install()

--- a/scripts/x64-migration/test_integration.py
+++ b/scripts/x64-migration/test_integration.py
@@ -218,6 +218,61 @@ exit {code}
         self.assertEqual(result.returncode,78,result.stderr)
         self.assertNotIn('doctor-start',(root/'events').read_text())
         self.assertIn('reviewed state snapshot',result.stderr)
+        self.assertFalse((root/'guard').exists())
+        self.assertIn('system-start',(root/'events').read_text())
+
+    def rebuild_fixture(self,fail_at=None):
+        root,worker,_=self.core_fixture()
+        (root/'.next/standalone').mkdir(parents=True)
+        (root/'.next/BUILD_ID').write_text('old-build')
+        (root/'.next/standalone/server.js').write_text('old-server')
+        (root/'.env').write_text('FIXTURE_CONFIG=preserve\n')
+        (root/'data/owner-state').write_text('preserve sessions and configuration')
+        (root/'.bun/bin').mkdir(parents=True)
+        bun=root/'.bun/bin/bun'
+        bun.write_text(f'''#!/bin/sh
+printf 'bun-%s\\n' "$1" >> '{root}/events'
+if [ "$1" = install ]; then
+  [ '{fail_at}' != install ] || exit 37
+  exit 0
+fi
+mkdir -p .next/standalone
+printf new-build > .next/BUILD_ID
+printf new-server > .next/standalone/server.js
+[ '{fail_at}' != build ] || exit 41
+''')
+        bun.chmod(0o755)
+        return root,worker
+
+    def test_full_update_rebuild_failure_restores_ui_after_gateway_was_restored(self):
+        for failure in ['install','build']:
+            with self.subTest(failure=failure):
+                root,worker=self.rebuild_fixture(failure)
+                core=self.run_worker(worker,'openclaw_install')
+                self.assertEqual(core.returncode,0,core.stderr)
+                before=(root/'events').read_text().splitlines()
+                self.assertIn('system-start',before)
+                self.assertFalse((root/'guard').exists())
+                result=self.run_worker(worker,'rebuild_reboot')
+                self.assertEqual(result.returncode,37 if failure=='install' else 41,result.stderr)
+                self.assertEqual((root/'.next/BUILD_ID').read_text(),'old-build')
+                self.assertEqual((root/'.next/standalone/server.js').read_text(),'old-server')
+                after=(root/'events').read_text().splitlines()[len(before):]
+                self.assertNotIn('gateway-stop',after)
+                self.assertEqual(after[-1],'system-restart')
+                self.assertFalse((root/'guard').exists())
+                self.assertEqual((root/'.env').read_text(),'FIXTURE_CONFIG=preserve\n')
+                self.assertEqual((root/'data/owner-state').read_text(),'preserve sessions and configuration')
+
+    def test_successful_ui_rebuild_restarts_only_ui_and_keeps_new_build(self):
+        root,worker=self.rebuild_fixture()
+        result=self.run_worker(worker,'rebuild_reboot')
+        self.assertEqual(result.returncode,0,result.stderr)
+        self.assertEqual((root/'.next/BUILD_ID').read_text(),'new-build')
+        self.assertEqual((root/'.next/standalone/server.js').read_text(),'new-server')
+        events=(root/'events').read_text().splitlines()
+        self.assertEqual(events,['system-stop','bun-install','bun-run','system-restart'])
+        self.assertFalse((root/'guard').exists())
 
     def test_initial_bridge_activation_preserves_running_user_service(self):
         postinst=(self.stage/'DEBIAN/postinst').read_text()

--- a/scripts/x64-migration/test_integration.py
+++ b/scripts/x64-migration/test_integration.py
@@ -91,6 +91,40 @@ esac
         self.assertEqual(result.returncode,0,result.stderr)
         self.assertEqual((root/'applied').read_text(),'Europe/Sofia')
 
+    def test_update_steps_deliver_coding_harness_from_mirror_as_owner(self):
+        for step in ['bootstrap_updater', 'post_update']:
+            with self.subTest(step=step):
+                root,worker=self.fixture()
+                mirror=root/'mirror'
+                (mirror/'scripts/x64-migration').mkdir(parents=True)
+                installer=(HERE/'install-coding-harness.sh').read_text()
+                installer=installer.replace('[ "$(/usr/bin/id -u)" -ne 0 ]','[ 1000 -ne 0 ]')
+                (mirror/'scripts/x64-migration/install-coding-harness.sh').write_text(installer)
+                (mirror/'scripts/claude-ds').write_text((HERE.parent/'claude-ds').read_text())
+                (root/'.local/bin').mkdir(parents=True)
+                cli=root/'.local/bin/claude'
+                cli.write_text('#!/bin/sh\nexit 0\n'); cli.chmod(0o755)
+                # The mutable checkout is deliberately not executable source.
+                (root/'scripts/x64-migration').mkdir(parents=True)
+                (root/'scripts/x64-migration/install-coding-harness.sh').write_text('exit 99\n')
+                manifest=root/'manifest'
+                manifest.write_text(f'#!/bin/sh\nprintf "manifest-%s\\n" "$1" >> "{root}/events"\n')
+                manifest.chmod(0o755)
+                source=worker.read_text().replace('MIRROR=/var/lib/clawbox/root-exec-mirror',f'MIRROR={mirror}')
+                source=source.replace('MANIFEST=/usr/local/libexec/clawbox/clawbox-root-manifest.sh',f'MANIFEST={manifest}')
+                source=source.replace('    refresh_trusted_source\n',f'    printf "refresh-source\\n" >> "{root}/events"\n')
+                worker.write_text(source)
+                result=self.run_worker(worker,step)
+                self.assertEqual(result.returncode,0,result.stderr)
+                self.assertTrue(os.access(root/'.local/bin/claude-ds',os.X_OK))
+                events=(root/'events').read_text().splitlines()
+                self.assertEqual(events,['refresh-source'] if step=='bootstrap_updater' else ['manifest---verify','manifest---mirror'])
+                # A bad/missing verified wrapper must fail the update, rather
+                # than silently leaving the Coding app unusable again.
+                (mirror/'scripts/claude-ds').unlink()
+                result=self.run_worker(worker,step)
+                self.assertNotEqual(result.returncode,0)
+
     def test_timezone_rejects_symlinks_fifo_shell_and_invalid_values(self):
         for kind in ['symlink','fifo','shell','unknown','oversize','multiple']:
             with self.subTest(kind=kind):

--- a/scripts/x64-migration/test_integration.py
+++ b/scripts/x64-migration/test_integration.py
@@ -92,6 +92,7 @@ esac
         self.assertEqual((root/'applied').read_text(),'Europe/Sofia')
 
     def test_update_steps_deliver_coding_harness_from_mirror_as_owner(self):
+        """Both update phases use verified source even when the checkout differs."""
         for step in ['bootstrap_updater', 'post_update']:
             with self.subTest(step=step):
                 root,worker=self.fixture()
@@ -246,6 +247,7 @@ exit {code}
         self.assertFalse((root/'guard').exists())
 
     def test_changed_core_pin_is_refused_before_any_core_command(self):
+        """A refused migration must release maintenance and restore the gateway."""
         root,worker,_=self.core_fixture()
         (root/'mirror/config/openclaw-target.txt').write_text('2026.9.1\n')
         result=self.run_worker(worker,'openclaw_install')
@@ -256,6 +258,7 @@ exit {code}
         self.assertIn('system-start',(root/'events').read_text())
 
     def rebuild_fixture(self,fail_at=None):
+        """Model dependency/build failures with an old UI and owner-state sentinels."""
         root,worker,_=self.core_fixture()
         (root/'.next/standalone').mkdir(parents=True)
         (root/'.next/BUILD_ID').write_text('old-build')
@@ -279,6 +282,7 @@ printf new-server > .next/standalone/server.js
         return root,worker
 
     def test_full_update_rebuild_failure_restores_ui_after_gateway_was_restored(self):
+        """A failed rebuild must retain the UI without stranding Telegram offline."""
         for failure in ['install','build']:
             with self.subTest(failure=failure):
                 root,worker=self.rebuild_fixture(failure)
@@ -299,6 +303,7 @@ printf new-server > .next/standalone/server.js
                 self.assertEqual((root/'data/owner-state').read_text(),'preserve sessions and configuration')
 
     def test_successful_ui_rebuild_restarts_only_ui_and_keeps_new_build(self):
+        """A successful desktop rebuild replaces assets without cycling the gateway."""
         root,worker=self.rebuild_fixture()
         result=self.run_worker(worker,'rebuild_reboot')
         self.assertEqual(result.returncode,0,result.stderr)

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -4499,6 +4499,21 @@ async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: Run
           maxBuffer: 2 * 1024 * 1024,
         });
       }
+      if (desktopIntegration && step.id === "apt_update") {
+        // Existing desktop adapters already refresh the verified mirror and
+        // install these dependencies. Deliver the user-owned harness here as
+        // well, so updating the UI never requires replacing a host's installed
+        // root adapter (which can contain additional workstation repairs).
+        // Match the coding runner's capability drop: the web server can carry
+        // ambient network capabilities that its installer must not inherit.
+        await execFile("/usr/bin/setpriv", [
+          "--ambient-caps=-all", "--inh-caps=-all", "--no-new-privs", "--",
+          "/bin/bash",
+          "/var/lib/clawbox/root-exec-mirror/scripts/x64-migration/install-coding-harness.sh",
+          "/var/lib/clawbox/root-exec-mirror/scripts/claude-ds",
+          PROJECT_DIR,
+        ], { timeout: 900_000, maxBuffer: 2 * 1024 * 1024 });
+      }
       // A root step that SUCCEEDED can still have skipped a fixup: install.sh's
       // non-fatal steps say so on a `CLAWBOX-WARN:` line, and this is where
       // that reaches the owner instead of only the journal.
@@ -4536,7 +4551,7 @@ async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: Run
       runtime.state.steps[i].error = message;
       console.error(`[Updater] Failed: ${step.label} — ${message}`);
       failed = true;
-      if (step.failFast) {
+      if (step.failFast || (desktopIntegration && step.id === "apt_update")) {
         runtime.state.error = message;
         break;
       }

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -4483,10 +4483,13 @@ async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: Run
       if (step.customRun) {
         await step.customRun();
       } else if (step.requiresRoot) {
+        // Desktop bootstrap also installs a missing Claude CLI. Its HTTPS
+        // download alone allows five minutes; use the system-fixup budget.
+        const timeoutMs = desktopIntegration && step.id === "bootstrap_updater" ? 900_000 : step.timeoutMs;
         if (!desktopIntegration && GATEWAY_QUIESCED_ROOT_STEPS.has(step.id) && !gatewayIsAbsent()) {
-          await execAsRootWithGatewayQuiesced(step.id, step.timeoutMs);
+          await execAsRootWithGatewayQuiesced(step.id, timeoutMs);
         } else {
-          await execAsRoot(step.id, step.timeoutMs);
+          await execAsRoot(step.id, timeoutMs);
         }
       } else if (step.command) {
         await execShell(step.command, {

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -26,6 +26,7 @@ import { classifyUpdaterHandover } from "./updater-handover";
 import { startRootStep } from "./root-step-runner";
 import { watchRootStepProgress } from "./root-step-follow";
 import { setUpdateLock, clearUpdateLock, isUpdateLocked, updateLockHeldByLiveProcess } from "./update-lock";
+import { hasX64DesktopIntegration } from "./x64-integration";
 
 /**
  * "An update was accepted and then lost its process" — written where the lock
@@ -3076,6 +3077,16 @@ mv -v "$CLAWBOX_HOME/.openclaw/agents/carl_pir/agent/openclaw-agent.sqlite"* "$Q
 }
 
 async function ensureGatewayHealthy(options: { restartFirst?: boolean } = {}): Promise<void> {
+  if (hasX64DesktopIntegration(PROJECT_DIR)) {
+    // The desktop package restores its existing user gateway before its core
+    // step returns, including failures. It must not inherit the appliance's
+    // doctor/pre-start migrations or rewrite the owner's providers/sessions.
+    gatewayNeedsRecovery = false;
+    if (await waitForGateway(GATEWAY_HEALTH_WAIT_MS)) return;
+    await restartGateway({ awaitReady: false });
+    if (await waitForGateway(GATEWAY_RECOVERY_WAIT_MS)) return;
+    throw new Error("The existing OpenClaw user gateway did not become ready. Check its service logs before retrying the update.");
+  }
   const recoverImmediately = options.restartFirst || gatewayNeedsRecovery;
   gatewayNeedsRecovery = false;
   if (!recoverImmediately && await waitForGateway(GATEWAY_HEALTH_WAIT_MS)) return;
@@ -4348,6 +4359,11 @@ async function checkInternet(): Promise<boolean> {
 }
 
 async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: RunOptions): Promise<void> {
+  // The root-owned desktop adapter serializes its own core writers and
+  // restores the gateway on both outcomes. An outer appliance guard made it
+  // leave Telegram stopped until gateway_verify, which a failed rebuild or
+  // rejected core pin never reaches. Resolve once for this run/continuation.
+  const desktopIntegration = hasX64DesktopIntegration(PROJECT_DIR);
   // Lock the desktop FIRST, AWAITED, before anything that can take time.
   //
   // It used to sit below the internet check and the drift baseline — up to two
@@ -4467,7 +4483,7 @@ async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: Run
       if (step.customRun) {
         await step.customRun();
       } else if (step.requiresRoot) {
-        if (GATEWAY_QUIESCED_ROOT_STEPS.has(step.id) && !gatewayIsAbsent()) {
+        if (!desktopIntegration && GATEWAY_QUIESCED_ROOT_STEPS.has(step.id) && !gatewayIsAbsent()) {
           await execAsRootWithGatewayQuiesced(step.id, step.timeoutMs);
         } else {
           await execAsRoot(step.id, step.timeoutMs);

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -3076,6 +3076,7 @@ mv -v "$CLAWBOX_HOME/.openclaw/agents/carl_pir/agent/openclaw-agent.sqlite"* "$Q
   });
 }
 
+/** Recover gateway readiness using the installed desktop or appliance contract. */
 async function ensureGatewayHealthy(options: { restartFirst?: boolean } = {}): Promise<void> {
   if (hasX64DesktopIntegration(PROJECT_DIR)) {
     // The desktop package restores its existing user gateway before its core
@@ -4358,6 +4359,7 @@ async function checkInternet(): Promise<boolean> {
   return false;
 }
 
+/** Execute or resume update steps, recording failure and respecting host maintenance ownership. */
 async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: RunOptions): Promise<void> {
   // The root-owned desktop adapter serializes its own core writers and
   // restores the gateway on both outcomes. An outer appliance guard made it

--- a/src/lib/x64-integration.ts
+++ b/src/lib/x64-integration.ts
@@ -1,0 +1,34 @@
+import fs from "fs";
+import path from "path";
+
+const INTEGRATION_FILE = "/etc/clawbox/x64-integration.env";
+
+/**
+ * The existing-desktop package owns its gateway maintenance and rollback.
+ * Detect that installed contract, not the CPU: ordinary x64/ARM installs
+ * still use the appliance updater. Never source the host file as shell code.
+ */
+export function hasX64DesktopIntegration(projectDir: string): boolean {
+  let fd: number;
+  try {
+    fd = fs.openSync(INTEGRATION_FILE, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW | fs.constants.O_NONBLOCK);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw new Error("Cannot read the installed x64 integration; repair it before updating.");
+  }
+  try {
+    const stat = fs.fstatSync(fd);
+    if (!stat.isFile() || stat.uid !== 0 || (stat.mode & 0o022) !== 0 || stat.size > 4096) {
+      throw new Error("The installed x64 integration must be a small, root-owned file without group or other write access.");
+    }
+    const projects = fs.readFileSync(fd, "utf8").split(/\r?\n/)
+      .filter((line) => line.startsWith("PROJECT_DIR="));
+    const match = projects.length === 1 && /^PROJECT_DIR=([A-Za-z0-9_./-]+)$/.exec(projects[0]);
+    if (!match || !path.isAbsolute(match[1])) {
+      throw new Error("The installed x64 integration has no valid project directory; repair it before updating.");
+    }
+    return path.resolve(match[1]) === path.resolve(projectDir);
+  } finally {
+    fs.closeSync(fd);
+  }
+}

--- a/src/tests/components/power-approval-prompt.test.tsx
+++ b/src/tests/components/power-approval-prompt.test.tsx
@@ -14,7 +14,8 @@ describe("desktop power confirmation", () => {
   it("never confirms from rendering or polling; the owner's click submits the exact displayed action", async () => {
     render(<PowerApprovalPrompt />);
     await screen.findByText(prompt.reason);
-    expect(screen.getByRole("button", { name: "chat.approval.deny" })).toHaveFocus();
+    // The prompt can render before its focus effect has run.
+    await waitFor(() => expect(screen.getByRole("button", { name: "chat.approval.deny" })).toHaveFocus());
     expect(fetchMock.mock.calls.filter(([, init]) => init?.method === "POST")).toHaveLength(0);
     fireEvent.click(screen.getByRole("button", { name: "chat.approval.allowOnce" }));
     await waitFor(() => expect(fetchMock.mock.calls.filter(([, init]) => init?.method === "POST")).toHaveLength(1));

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -2395,18 +2395,20 @@ describe("updater", () => {
     beforeEach(() => { mockX64Integration.mockReturnValue(true); });
 
     /** Inspect the host commands requested by the real updater orchestration. */
-    const commands = () => mockExecFile.mock.calls.map(([cmd, args]) =>
-      `${cmd} ${(args as string[]).join(" ")}`,
-    );
+    function commands() {
+      return mockExecFile.mock.calls.map(([cmd, args]) =>
+        `${cmd} ${(args as string[]).join(" ")}`,
+      );
+    }
     /** Keep generic migrations and outer maintenance out of the desktop path. */
-    const expectNoApplianceMaintenance = () => {
+    function expectNoApplianceMaintenance() {
       expect(commands().some((call) =>
         call.includes("clawbox-gateway-maintenance.sh")
           || call.includes("systemctl stop clawbox-gateway.service")
           || call.includes("scripts/gateway-pre-start.sh")
           || call.includes("doctor --fix"),
       )).toBe(false);
-    };
+    }
 
     it("lets the desktop root step restore the gateway when the core pin is rejected", async () => {
       setupExecFileMock({

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -2424,6 +2424,26 @@ describe("updater", () => {
       // A first CLI installation must outlive the installer's five-minute
       // download allowance instead of inheriting a three-minute fetch budget.
       expect(bootstrap?.[2]).toEqual(expect.objectContaining({ timeout: 930_000 }));
+      const calls = commands();
+      const harnessIndex = calls.findIndex((call) => call.includes("/usr/bin/setpriv"));
+      expect(harnessIndex).toBeGreaterThan(calls.findIndex((call) => call.includes("clawbox-run-root-step.sh apt_update")));
+      expect(harnessIndex).toBeLessThan(calls.findIndex((call) => call.includes("clawbox-run-root-step.sh openclaw_install")));
+      expect(calls[harnessIndex]).toContain("--ambient-caps=-all --inh-caps=-all --no-new-privs -- /bin/bash /var/lib/clawbox/root-exec-mirror/scripts/x64-migration/install-coding-harness.sh");
+      expect(calls[harnessIndex]).toContain("/var/lib/clawbox/root-exec-mirror/scripts/claude-ds");
+      expectNoApplianceMaintenance();
+    });
+
+    it("reports a coding installer failure before cycling the desktop gateway", async () => {
+      setupExecFileMock({
+        "/usr/bin/setpriv": new Error("Claude Code checksum mismatch"),
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+      });
+      updater.startUpdate();
+      await vi.waitFor(() => expect(updater.getUpdateState().phase).toBe("failed"));
+      expect(updater.getUpdateState().error).toContain("checksum mismatch");
+      expect(updater.getUpdateState().steps.find((s) => s.id === "openclaw_install")?.status).toBe("pending");
+      expect(commands().some((call) => call.includes("clawbox-run-root-step.sh openclaw_install"))).toBe(false);
       expectNoApplianceMaintenance();
     });
 

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -64,6 +64,8 @@ vi.mock("@/lib/port-probe", async (orig) => ({
 // is the seam: nothing in these tests may spawn a real `hermes`.
 const { mockRunHermesCli } = vi.hoisted(() => ({ mockRunHermesCli: vi.fn() }));
 vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: mockRunHermesCli }));
+const { mockX64Integration } = vi.hoisted(() => ({ mockX64Integration: vi.fn(() => false) }));
+vi.mock("@/lib/x64-integration", () => ({ hasX64DesktopIntegration: mockX64Integration }));
 
 // The TASK-606 marker, mocked so the clears the repair paths owe can be seen.
 // `readPluginRepairs` answers `{}`, which is what the real one answers under
@@ -250,6 +252,7 @@ describe("updater", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    mockX64Integration.mockReturnValue(false);
     process.env.GATEWAY_HEALTH_WAIT_MS = "1";
     process.env.GATEWAY_RECOVERY_WAIT_MS = "1";
     process.env.GATEWAY_WAIT_INTERVAL_MS = "1";
@@ -2385,6 +2388,71 @@ describe("updater", () => {
       const aptStep = state.steps.find((step) => step.id === "apt_update");
       expect(aptStep?.status).toBe("pending");
       expect(state.error).toBe("fatal: invalid branch name in .update-branch");
+    });
+  });
+
+  describe("existing x64 desktop updates", () => {
+    beforeEach(() => { mockX64Integration.mockReturnValue(true); });
+
+    const commands = () => mockExecFile.mock.calls.map(([cmd, args]) =>
+      `${cmd} ${(args as string[]).join(" ")}`,
+    );
+    const expectNoApplianceMaintenance = () => {
+      expect(commands().some((call) =>
+        call.includes("clawbox-gateway-maintenance.sh")
+          || call.includes("systemctl stop clawbox-gateway.service")
+          || call.includes("scripts/gateway-pre-start.sh")
+          || call.includes("doctor --fix"),
+      )).toBe(false);
+    };
+
+    it("lets the desktop root step restore the gateway when the core pin is rejected", async () => {
+      setupExecFileMock({
+        "clawbox-run-root-step.sh openclaw_install": new Error("A changed core needs a reviewed migration"),
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+      });
+      updater.startUpdate();
+      await vi.waitFor(() => expect(updater.getUpdateState().phase).toBe("failed"));
+      expect(updater.getUpdateState().steps.find((s) => s.id === "openclaw_install")?.status).toBe("failed");
+      expect(updater.getUpdateState().steps.find((s) => s.id === "restart")?.status).toBe("pending");
+      expectNoApplianceMaintenance();
+    });
+
+    it("finishes the post-rebuild continuation without stopping a healthy gateway", async () => {
+      mockGet.mockResolvedValue(true);
+      expect(await updater.checkContinuation()).toBe(true);
+      await vi.waitFor(() => expect(updater.getUpdateState().phase).toBe("completed"));
+      expect(commands().some((call) => call.includes("clawbox-run-root-step.sh post_update"))).toBe(true);
+      expect(commands().some((call) => call.includes("restart clawbox-gateway"))).toBe(false);
+      expectNoApplianceMaintenance();
+    });
+
+    it("restarts a stopped desktop gateway through its bridge without rewriting its state", async () => {
+      mockGet.mockResolvedValue(true);
+      mockGatewayUp.mockImplementation(async () => commands().some((call) => call.includes("restart clawbox-gateway")));
+      expect(await updater.checkContinuation()).toBe(true);
+      await vi.waitFor(() => expect(updater.getUpdateState().phase).toBe("completed"));
+      expect(commands().filter((call) => call.includes("restart clawbox-gateway"))).toHaveLength(1);
+      expectNoApplianceMaintenance();
+    });
+
+    it("reports an unavailable desktop gateway without attempting appliance migrations", async () => {
+      mockGet.mockResolvedValue(true);
+      mockGatewayUp.mockResolvedValue(false);
+      expect(await updater.checkContinuation()).toBe(true);
+      await vi.waitFor(() => expect(updater.getUpdateState().phase).toBe("failed"));
+      expect(updater.getUpdateState().error).toContain("existing OpenClaw user gateway");
+      expectNoApplianceMaintenance();
+    });
+
+    it("reports a rolled-back rebuild without stopping the restored gateway", async () => {
+      mockGet.mockImplementation(async (key) => key === "update_needs_continuation" ? "same-build" : undefined);
+      mockRebuiltBox("same-build");
+      expect(await updater.checkContinuation()).toBe(false);
+      expect(updater.getUpdateState().phase).toBe("failed");
+      expect(commands().some((call) => call.includes("restart clawbox-gateway"))).toBe(false);
+      expectNoApplianceMaintenance();
     });
   });
 

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -2394,9 +2394,11 @@ describe("updater", () => {
   describe("existing x64 desktop updates", () => {
     beforeEach(() => { mockX64Integration.mockReturnValue(true); });
 
+    /** Inspect the host commands requested by the real updater orchestration. */
     const commands = () => mockExecFile.mock.calls.map(([cmd, args]) =>
       `${cmd} ${(args as string[]).join(" ")}`,
     );
+    /** Keep generic migrations and outer maintenance out of the desktop path. */
     const expectNoApplianceMaintenance = () => {
       expect(commands().some((call) =>
         call.includes("clawbox-gateway-maintenance.sh")

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -2416,6 +2416,12 @@ describe("updater", () => {
       await vi.waitFor(() => expect(updater.getUpdateState().phase).toBe("failed"));
       expect(updater.getUpdateState().steps.find((s) => s.id === "openclaw_install")?.status).toBe("failed");
       expect(updater.getUpdateState().steps.find((s) => s.id === "restart")?.status).toBe("pending");
+      const bootstrap = mockExecFile.mock.calls.find(([, args]) =>
+        (args as string[]).includes("bootstrap_updater"),
+      );
+      // A first CLI installation must outlive the installer's five-minute
+      // download allowance instead of inheriting a three-minute fetch budget.
+      expect(bootstrap?.[2]).toEqual(expect.objectContaining({ timeout: 930_000 }));
       expectNoApplianceMaintenance();
     });
 

--- a/src/tests/unit/x64-integration.test.ts
+++ b/src/tests/unit/x64-integration.test.ts
@@ -2,13 +2,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import fs from "fs";
 import { hasX64DesktopIntegration } from "@/lib/x64-integration";
 
-vi.mock("fs", async (original) => ({
-  ...(await original<typeof import("fs")>()),
-  default: {
-    ...(await original<typeof import("fs")>()).default,
-    openSync: vi.fn(), fstatSync: vi.fn(), readFileSync: vi.fn(), closeSync: vi.fn(),
-  },
-}));
+vi.mock("fs", async (original) => {
+  const actual = await original<typeof import("fs")>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      openSync: vi.fn(), fstatSync: vi.fn(), readFileSync: vi.fn(), closeSync: vi.fn(),
+    },
+  };
+});
 
 describe("installed x64 desktop integration", () => {
   beforeEach(() => {

--- a/src/tests/unit/x64-integration.test.ts
+++ b/src/tests/unit/x64-integration.test.ts
@@ -17,7 +17,9 @@ describe("installed x64 desktop integration", () => {
   beforeEach(() => {
     vi.mocked(fs.openSync).mockReturnValue(42);
     vi.mocked(fs.fstatSync).mockReturnValue({
-      isFile: () => true, uid: 0, mode: 0o100644, size: 200,
+      /** Model a plain file accepted by the inode-type gate. */
+      isFile() { return true; },
+      uid: 0, mode: 0o100644, size: 200,
     } as ReturnType<typeof fs.fstatSync>);
     vi.mocked(fs.readFileSync).mockReturnValue("INSTALL_USER=fixture\nPROJECT_DIR=/fixture/clawbox\n");
   });
@@ -45,10 +47,15 @@ describe("installed x64 desktop integration", () => {
   });
 
   it.each([
-    { uid: 1000 }, { mode: 0o100664 }, { size: 4097 }, { isFile: () => false },
+    { uid: 1000 }, { mode: 0o100664 }, { size: 4097 }, {
+      /** Model a special inode that must not be read as configuration. */
+      isFile() { return false; },
+    },
   ])("rejects an unsafe host file: %o", (override) => {
     vi.mocked(fs.fstatSync).mockReturnValue({
-      isFile: () => true, uid: 0, mode: 0o100644, size: 200, ...override,
+      /** Keep the inode valid unless this case overrides its type. */
+      isFile() { return true; },
+      uid: 0, mode: 0o100644, size: 200, ...override,
     } as ReturnType<typeof fs.fstatSync>);
     expect(() => hasX64DesktopIntegration("/fixture/clawbox")).toThrow("root-owned file");
     expect(fs.closeSync).toHaveBeenCalledWith(42);

--- a/src/tests/unit/x64-integration.test.ts
+++ b/src/tests/unit/x64-integration.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs";
+import { hasX64DesktopIntegration } from "@/lib/x64-integration";
+
+vi.mock("fs", async (original) => ({
+  ...(await original<typeof import("fs")>()),
+  default: {
+    ...(await original<typeof import("fs")>()).default,
+    openSync: vi.fn(), fstatSync: vi.fn(), readFileSync: vi.fn(), closeSync: vi.fn(),
+  },
+}));
+
+describe("installed x64 desktop integration", () => {
+  beforeEach(() => {
+    vi.mocked(fs.openSync).mockReturnValue(42);
+    vi.mocked(fs.fstatSync).mockReturnValue({
+      isFile: () => true, uid: 0, mode: 0o100644, size: 200,
+    } as ReturnType<typeof fs.fstatSync>);
+    vi.mocked(fs.readFileSync).mockReturnValue("INSTALL_USER=fixture\nPROJECT_DIR=/fixture/clawbox\n");
+  });
+  afterEach(() => vi.resetAllMocks());
+
+  it("uses the desktop contract only for its configured checkout", () => {
+    expect(hasX64DesktopIntegration("/fixture/clawbox")).toBe(true);
+    expect(hasX64DesktopIntegration("/another/clawbox")).toBe(false);
+    expect(fs.openSync).toHaveBeenCalledWith(
+      "/etc/clawbox/x64-integration.env",
+      fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW | fs.constants.O_NONBLOCK,
+    );
+    expect(fs.closeSync).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps ordinary installations on their existing updater", () => {
+    vi.mocked(fs.openSync).mockImplementation(() => { throw Object.assign(new Error(), { code: "ENOENT" }); });
+    expect(hasX64DesktopIntegration("/fixture/clawbox")).toBe(false);
+    expect(fs.closeSync).not.toHaveBeenCalled();
+  });
+
+  it.each(["EACCES", "ELOOP"])("refuses %s instead of falling back to appliance migrations", (code) => {
+    vi.mocked(fs.openSync).mockImplementation(() => { throw Object.assign(new Error(), { code }); });
+    expect(() => hasX64DesktopIntegration("/fixture/clawbox")).toThrow("repair it before updating");
+  });
+
+  it.each([
+    { uid: 1000 }, { mode: 0o100664 }, { size: 4097 }, { isFile: () => false },
+  ])("rejects an unsafe host file: %o", (override) => {
+    vi.mocked(fs.fstatSync).mockReturnValue({
+      isFile: () => true, uid: 0, mode: 0o100644, size: 200, ...override,
+    } as ReturnType<typeof fs.fstatSync>);
+    expect(() => hasX64DesktopIntegration("/fixture/clawbox")).toThrow("root-owned file");
+    expect(fs.closeSync).toHaveBeenCalledWith(42);
+  });
+
+  it.each([
+    "INSTALL_USER=fixture\n", "PROJECT_DIR=relative\n", "PROJECT_DIR=$(touch /tmp/never)\n",
+    "PROJECT_DIR=/fixture/clawbox\nPROJECT_DIR=/another/clawbox\n",
+  ])("refuses a malformed project without interpreting shell syntax", (text) => {
+    vi.mocked(fs.readFileSync).mockReturnValue(text);
+    expect(() => hasX64DesktopIntegration("/fixture/clawbox")).toThrow("valid project directory");
+    expect(fs.closeSync).toHaveBeenCalledWith(42);
+  });
+});


### PR DESCRIPTION
## Summary

On an existing x64 desktop, Update and Force full update can leave Telegram offline when the OpenClaw step or dashboard rebuild fails. The shared updater also skips coding-harness delivery, leaving the Coding app blocked by a missing `~/.local/bin/claude-ds` even when Claude Code is installed.

- Recognize the root-owned integration for the current checkout and let the desktop adapter own core maintenance. It restores the existing user gateway before returning, including on failure. Final verification keeps a healthy gateway running and tries its existing service once if unavailable.
- After the adapter refreshes the verified mirror and installs system dependencies, run the mirrored coding installer as the dashboard user through `setpriv`, clearing ambient/inheritable capabilities and preventing privilege escalation. A dependency or harness failure stops the update before gateway maintenance.
- Preserve an existing Claude CLI and copy the wrapper atomically with the desktop's config path. For a missing CLI, verify a pinned native executable's SHA-256 before execution. Claude 2.1.268's manifest signature was verified against Anthropic's published key fingerprint.
- Existing integration packages **1.0.2 and 1.0.3 work without replacement**, preserving additional local host repairs. Package **1.0.4** also delivers the harness from its root bootstrap/post-update steps for new package installations. No unrelated local Clawkeep commits are included.

The power-confirmation component test now waits for the focus effect before asserting the Deny button has focus. CI exposed this pre-existing render/effect race; the same focus and owner-click assertions remain enforced.

## Type of change

- [x] Bug fix
- [x] Documentation / tooling

## How was this tested?

- Final GitHub head `5e1f0134`: **15,465 tests across 1,026 files passed**, plus **25 Python x64 integration/installer fixtures**. Browser E2E, full install/updater E2E, production build identity, CodeQL, and CodeRabbit passed. All review threads are resolved.
- Regression coverage includes desktop detection, both shared update routes, capability dropping, installer failure before maintenance, rejected core pins, failed rebuild continuation, gateway recovery, wrapper delivery, preserved CLIs, desktop config resolution, and checksum rejection before execution.
- Touched TypeScript lint has no errors. Repository-wide advisory lint still reports pre-existing errors in files unchanged by this PR.
- Merged beta `285360ec` was built in an isolated worktree and deployed on nexus0. Both deployed build identities match the merge commit with a clean checkout; bundled Node builtins, login, and static assets pass verification.
- The coding wrapper was installed from the refreshed root-owned mirror using the existing integration package **1.0.3**. The actual readiness probe returns `ready: true`, and `claude-ds --version` launches Claude Code 2.1.268 successfully with capabilities dropped.
- Only the dashboard was restarted. The existing gateway retained the same PID and passes its HTTP health check; the installed root adapter and local Clawkeep restore guard are byte-for-byte unchanged. The previous dashboard build is retained for rollback.
- A full live update and a real coding prompt remain for owner testing; neither was triggered during deployment.

## Checklist

- [x] Based on beta
- [x] No credentials committed
- [x] Regression tests cover failure/recovery behavior
- [x] Desktop installation and upgrade requirements documented
- [x] CodeRabbit's integrity finding fixed; touched helpers documented
