### PR TITLE
fix: read the appliance root from CLAWBOX_ROOT, not a hardcoded path

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -132,6 +132,11 @@ const nextConfig: NextConfig = {
   poweredByHeader: false,
   env: {
     NEXT_PUBLIC_APP_VERSION: APP_VERSION,
+    // The appliance root is not always /home/clawbox/clawbox (a dev box runs the
+    // app from another user's home). Baked at build time because the coding-agent
+    // run page builds its terminal command in the browser, where a runtime
+    // process.env read is not available.
+    NEXT_PUBLIC_CLAWBOX_ROOT: process.env.CLAWBOX_ROOT || "/home/clawbox/clawbox",
   },
   async rewrites() {
     return {

--- a/src/components/CodingAgentApp.tsx
+++ b/src/components/CodingAgentApp.tsx
@@ -199,8 +199,6 @@ function elapsedShort(from: number, to: number): string {
 /** How many pictures a run's evidence card shows before it asks to be unfolded. */
 const ARTIFACT_PREVIEW = 4;
 const RUNS_PAGE = 10;
-/** Where the preview script lives on the device. */
-const CLAWBOX_ROOT = "/home/clawbox/clawbox";
 const POLL_MS = 5_000;
 /** How long a two-tap confirmation stays armed before the offer is taken back. */
 const CONFIRM_MS = 5_000;

--- a/src/lib/coding-run-preview.ts
+++ b/src/lib/coding-run-preview.ts
@@ -8,10 +8,12 @@
  * Null when the run has none of that yet (a run that has not written its
  * first line).
  *
- * Client-safe: strings only. The run page embeds a terminal on it, and the
- * "Open in Terminal" buttons hand it to a Terminal window.
+ * Client-safe: strings only, and the root comes from the build-time inlined
+ * NEXT_PUBLIC_CLAWBOX_ROOT — this runs in the browser, where a runtime
+ * process.env read is not available. The run page embeds a terminal on it, and
+ * the "Open in Terminal" buttons hand it to a Terminal window.
  */
-const CLAWBOX_ROOT = "/home/clawbox/clawbox";
+const CLAWBOX_ROOT = process.env.NEXT_PUBLIC_CLAWBOX_ROOT || "/home/clawbox/clawbox";
 
 function quoted(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;

--- a/src/tests/unit/coding-run-preview-root.test.ts
+++ b/src/tests/unit/coding-run-preview-root.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The coding-agent run page builds its terminal command in the BROWSER, so
+ * `livePreviewCommand` reads the appliance root from the build-time inlined
+ * NEXT_PUBLIC_CLAWBOX_ROOT rather than a runtime process.env.
+ *
+ * The regression this guards: the root was hardcoded to /home/clawbox/clawbox,
+ * so on any box whose app lives elsewhere (a dev machine) the Live terminal
+ * spawned a path that does not exist and died with "Permission denied" while
+ * the run itself was perfectly healthy.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL = process.env.NEXT_PUBLIC_CLAWBOX_ROOT;
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.NEXT_PUBLIC_CLAWBOX_ROOT;
+  else process.env.NEXT_PUBLIC_CLAWBOX_ROOT = ORIGINAL;
+  vi.resetModules();
+});
+
+/** Load the module fresh so its module-level root constant is re-evaluated. */
+async function load() {
+  vi.resetModules();
+  return await import("../../lib/coding-run-preview");
+}
+
+describe("livePreviewCommand root", () => {
+  it("uses the inlined NEXT_PUBLIC_CLAWBOX_ROOT when the app is not at the default path", async () => {
+    process.env.NEXT_PUBLIC_CLAWBOX_ROOT = "/home/nexus0/clawbox";
+    const { livePreviewCommand } = await load();
+    const cmd = livePreviewCommand({
+      transcriptPath: "/tmp/run.jsonl",
+      sessionId: null,
+      directory: null,
+      live: true,
+    });
+    expect(cmd).toBe("/home/nexus0/clawbox/scripts/coding-run-preview '/tmp/run.jsonl'");
+    expect(cmd).not.toContain("/home/clawbox/clawbox");
+  });
+
+  it("falls back to the shipped appliance path when the variable is unset", async () => {
+    delete process.env.NEXT_PUBLIC_CLAWBOX_ROOT;
+    const { livePreviewCommand } = await load();
+    const cmd = livePreviewCommand({
+      transcriptPath: "/tmp/run.jsonl",
+      sessionId: null,
+      directory: null,
+      live: true,
+    });
+    expect(cmd).toContain("/home/clawbox/clawbox/scripts/coding-run-preview");
+  });
+
+  it("still resumes a settled run by session id, without needing the root", async () => {
+    delete process.env.NEXT_PUBLIC_CLAWBOX_ROOT;
+    const { livePreviewCommand } = await load();
+    const cmd = livePreviewCommand({
+      transcriptPath: null,
+      sessionId: "61400ab6-0da9-4feb-8ad5-b547239c1367",
+      directory: "/home/nexus0/Projects/x",
+      live: false,
+    });
+    expect(cmd).toBe("cd '/home/nexus0/Projects/x' && claude-ds --resume '61400ab6-0da9-4feb-8ad5-b547239c1367'");
+  });
+});


### PR DESCRIPTION
## Problem

The coding-agent run page builds its terminal command in the browser, so the Live terminal always pointed at a hardcoded appliance path:

```
/home/clawbox/clawbox/scripts/coding-run-preview '<transcript>'
```

On any box whose app is not installed at `/home/clawbox/clawbox` (a dev machine, for example) that path does not exist. The terminal spawned a non-existent file and died with `Permission denied`, so the Live preview looked broken — while the run itself was perfectly healthy and completed normally.

## Fix

Read the root from `CLAWBOX_ROOT` instead of hardcoding it, matching what `hermes-dashboard-auth.ts` already does with the same variable.

Because `livePreviewCommand` runs in the browser, a runtime `process.env` read is not available there. The root is therefore inlined at build time via `NEXT_PUBLIC_CLAWBOX_ROOT` in `next.config.ts`, defaulting to the shipped appliance path when unset.

The default is unchanged, so existing behaviour is preserved. An unused hardcoded constant in `CodingAgentApp.tsx` is removed.

## Verification

- `tsc --noEmit` — clean
- `vitest --project unit src/tests/unit/coding-run-preview.test.ts` — 5/5 pass
- `vitest --project components src/tests/components/terminal-tabs.test.tsx` — 10/10 pass
- `vitest --project components src/tests/components/coding-agent-app.test.tsx` — 83/83 pass
- New `src/tests/unit/coding-run-preview-root.test.ts` — 3/3 pass, covering the overridden root, the unset fallback, and the session-resume path that needs no root

## Limits

Verified by unit/component tests and typecheck only — not yet exercised on a device whose app lives outside the default path. The build-time inlining means changing `CLAWBOX_ROOT` requires a rebuild, which is the intended behaviour for a value baked into the client bundle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Coding run previews can now use a configurable Clawbox installation path.
  - When no custom path is configured, previews continue to use the default location automatically.
  - Session-based resume commands remain unaffected by the configured installation path.

- **Bug Fixes**
  - Improved preview behavior across environments by honoring the configured Clawbox root instead of relying solely on a fixed path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->