### PR TITLE
The chat header stops naming a model nobody picked on ClawBox AI

### DIFF
--- a/docs-site/setup/choose-ai-provider.mdx
+++ b/docs-site/setup/choose-ai-provider.mdx
@@ -19,10 +19,10 @@ See [AI Providers on Hermes](/editions/hermes-providers).
 Works immediately, no keys to manage. The simplest way to get started — and a great
 default for most people.
 
-ClawBox AI chat uses **Flash 4.1** automatically. The chat header shows the model
-without a Max plan selector. Thinking starts off; you can enable it from the
-reasoning control when needed. Existing conversations are kept when an older
-model selection moves to Flash.
+ClawBox AI chat uses **Flash 4.1** automatically. There is nothing to choose, so the
+chat header names the provider and stops there — no model chip and no plan selector
+beside it. Thinking starts off; you can enable it from the reasoning control when
+needed. Existing conversations are kept when an older model selection moves to Flash.
 
 ## Bring your own provider
 

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -400,7 +400,7 @@ import {
   type HermesReasoningLevel,
 } from '@/lib/hermes-reasoning'
 import { readHermesChatPrefs, writeHermesChatPrefs } from '@/lib/hermes-chat-prefs'
-import { CLAWBOX_AI_FLASH_MODEL_ID, CLAWBOX_AI_MODEL_BY_TIER, CLAWBOX_AI_CHAT_MODEL_LABEL } from '@/lib/clawbox-ai-models'
+import { CLAWBOX_AI_FLASH_MODEL_ID, CLAWBOX_AI_MODEL_BY_TIER, CLAWBOX_AI_CHAT_MODEL_LABEL, isClawboxAiProvider } from '@/lib/clawbox-ai-models'
 import { HeaderDropdown } from '@/components/HeaderDropdown'
 import { buildDeviceConnectParams } from '@/lib/gateway-device-identity'
 import NewAppWizardCard, { DEFAULT_MAX_TASK_CHARS } from '@/components/NewAppWizardCard' 
@@ -1304,7 +1304,10 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   const effectiveThinkingLevel: ThinkingLevel = visibleThinkingLevels.includes(thinkingLevel)
     ? thinkingLevel
     : reasoningConfig.default
-  const isClawboxAiChat = headerProvider === 'clawai' || headerProvider === 'deepseek'
+  // Is this chat on ClawBox AI? Both spellings count — `clawai` from the UI's
+  // own normalisation and `deepseek` from the gateway config — which is why the
+  // test lives in clawbox-ai-models.ts rather than being re-typed per call site.
+  const isClawboxAiChat = isClawboxAiProvider(headerProvider)
   const chatProviderCatalog = useProviderCatalog(isClawboxAiChat ? null : headerProvider)
   // Does the greying-out rule apply to THIS box? `chatModelState` is refetched
   // whenever the provider changes or a configure lands, so this follows the
@@ -6811,11 +6814,16 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
                   triggerMaxWidth={130}
                   popoverWidth={220}
                 />
-                {/* ClawBox AI always uses Flash; other providers retain their model picker. */}
-                {hermesProvider === 'clawai' && (
-                  <span className="header-dropdown-trigger" style={{ cursor: 'default' }}>{CLAWBOX_AI_CHAT_MODEL_LABEL}</span>
-                )}
-                {hermesProvider !== 'clawai' && showModelPill && (
+                {/* ClawBox AI gets NO model pill at all — not a picker (it runs
+                    the one chat model) and not a read-only label either. The
+                    label was a pill-shaped thing that could not be clicked,
+                    naming a model nobody on this product chooses, and it spent
+                    the row's tightest resource — see the width budget in
+                    src/lib/chat-header-pills.ts — saying what the "ClawBox"
+                    pill beside it already says. The predicate is shared with
+                    the OpenClaw branch below so the two editions cannot drift
+                    on which spelling of the provider counts. */}
+                {!isClawboxAiProvider(hermesProvider) && showModelPill && (
                   <HeaderDropdown
                     ariaLabel={tr('chat.pillHermesModel', 'Hermes model')}
                     /* While the new provider's list loads there is no model to
@@ -6947,9 +6955,17 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
               (option) => option.id === chatModelState.activeOptionId,
             )
             if (!activeOption?.provider) return null
-            if (isClawboxAiChat) {
-              return <span className="header-dropdown-trigger" style={{ cursor: 'default' }}>{CLAWBOX_AI_CHAT_MODEL_LABEL}</span>
-            }
+            // ClawBox AI: nothing here. Same rule as the Hermes branch above,
+            // through the same predicate — one product, one chat model, so the
+            // provider pill is the last word before the thinking dial. The row
+            // collapses rather than leaving a gap: this returns no node, and
+            // .chat-header-pills only puts a gap BETWEEN pills that render.
+            //
+            // Stated here even though `chatProviderCatalog` is already null for
+            // this provider (see useProviderCatalog above), because THIS is
+            // where the pill is built: a future change that gives ClawBox AI a
+            // catalogue again must not quietly give it a pill again too.
+            if (isClawboxAiChat) return null
             const catalog = chatProviderCatalog
             if (!catalog) return null
             // Show the dropdown when there are multiple models to pick OR

--- a/src/lib/clawbox-ai-models.ts
+++ b/src/lib/clawbox-ai-models.ts
@@ -140,6 +140,29 @@ export function normalizeClawboxAiPlanTier(value: unknown): ClawboxAiPlanTier | 
 }
 
 /**
+ * Is `provider` the ClawBox AI proxy, under either of the two ids the product
+ * spells it with?
+ *
+ * `deepseek` is what the OpenClaw gateway config registers it under (the proxy
+ * forwards to DeepSeek), and `clawai` is what the UI normalises that to
+ * (`normalizeProvider` in src/app/setup-api/chat/model/route.ts) as well as
+ * Hermes' own custom-provider slug (src/lib/hermes-clawai.ts). BOTH reach the
+ * chat header — the OpenClaw branch reads a provider id that may still carry
+ * the wire spelling — so every surface that has to recognise ClawBox AI asks
+ * here instead of re-typing the pair. Two hand-written copies of this test are
+ * exactly how the header came to hide its model pill under one spelling and
+ * keep showing it under the other.
+ *
+ * Says WHICH proxy, not which model and not who may run it: see
+ * {@link isClawboxAiProModel} and {@link portalDeniesClawboxAiModel}.
+ */
+export function isClawboxAiProvider(provider: string | null | undefined): boolean {
+  if (typeof provider !== "string") return false;
+  const normalized = provider.trim().toLowerCase();
+  return normalized === CLAWBOX_AI_PROVIDER || normalized === "clawai";
+}
+
+/**
  * True if `model` is a fully-qualified ClawBox AI Pro slug
  * (`clawai/deepseek-v4-pro` or `deepseek/deepseek-v4-pro`).
  *
@@ -155,7 +178,7 @@ export function isClawboxAiProModel(model: string | null | undefined): boolean {
   const provider = model.slice(0, idx);
   const modelId = model.slice(idx + 1);
   if (modelId !== CLAWBOX_AI_PRO_MODEL_ID) return false;
-  return provider === CLAWBOX_AI_PROVIDER || provider === "clawai";
+  return isClawboxAiProvider(provider);
 }
 
 /**
@@ -194,8 +217,7 @@ function bareModelId(ref: string): string {
 function isClawboxAiModelRef(ref: string): boolean {
   const idx = ref.indexOf("/");
   if (idx <= 0) return false;
-  const provider = ref.slice(0, idx).trim().toLowerCase();
-  return provider === CLAWBOX_AI_PROVIDER || provider === "clawai";
+  return isClawboxAiProvider(ref.slice(0, idx));
 }
 
 /** The translation keys a picker draws one ClawBox AI chat tier with. */

--- a/src/tests/components/chat-clawai-tier-labels.test.tsx
+++ b/src/tests/components/chat-clawai-tier-labels.test.tsx
@@ -153,12 +153,16 @@ afterEach(() => {
 });
 
 describe("the chat composer's ClawBox AI model chip on a German desktop", () => {
-  it.each([ON_PRO, ON_FLASH])("shows Flash 4.1 without a tier picker for %s", async (model) => {
+  it.each([ON_PRO, ON_FLASH])("names no model at all, and no tier, for %s", async (model) => {
     const calls = installFetch(ENTITLED_STATUS, model);
     render(<ChatPopup isOpen onClose={() => {}} />);
 
-    const label = await screen.findByText("Flash 4.1");
-    expect(label.closest("button")).toBeNull();
+    // The provider pill is the header's last word for ClawBox AI. The model
+    // name used to sit beside it as a chip nobody could click; it is gone, and
+    // everything this test already guarded — no picker, no tier vocabulary, no
+    // catalogue fetch, one model write — still holds.
+    await screen.findByRole("button", { name: /ClawBox/ });
+    expect(screen.queryByText("Flash 4.1")).toBeNull();
     expect(screen.queryByRole("button", { name: /ClawBox AI-Modell/ })).toBeNull();
     expect(screen.queryByRole("listbox")).toBeNull();
     expect(calls.filter((call) => call.url.includes("/setup-api/ai-models/catalog"))).toHaveLength(0);
@@ -202,12 +206,14 @@ describe("the provider-switch overlay on a German desktop", () => {
 });
 
 describe("the automatic switch to Flash on a German desktop", () => {
-  it("shows the current model without a Max subscription upsell", async () => {
+  it("switches quietly, with no model chip and no Max subscription upsell", async () => {
     vi.stubGlobal("WebSocket", RefusedSocket);
     const calls = installFetch(REFUSED_STATUS);
     render(<ChatPopup isOpen onClose={() => {}} />);
     await waitFor(() => expect(modelWrites(calls)).toBe(1));
-    await screen.findByText("Flash 4.1");
+    // The write above is the synchronisation point the model name used to be.
+    await screen.findByRole("button", { name: /ClawBox/ });
+    expect(screen.queryByText("Flash 4.1")).toBeNull();
     const write = calls.find((call) => call.init?.method === "POST" && call.url.includes("/setup-api/chat/model"));
     expect(JSON.parse(String(write?.init?.body))).toEqual({ model: ON_FLASH, automatic: true });
     expect(screen.queryByRole("button", { name: /ClawBox AI-Modell/ })).toBeNull();

--- a/src/tests/components/chat-clawbox-ai-model-pill.test.tsx
+++ b/src/tests/components/chat-clawbox-ai-model-pill.test.tsx
@@ -1,0 +1,279 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import ChatPopup from "@/components/ChatPopup";
+import { resetHarnessCache } from "@/lib/client-harness";
+import { CLAWBOX_AI_CHAT_MODEL_LABEL, isClawboxAiProvider } from "@/lib/clawbox-ai-models";
+
+/**
+ * ClawBox AI names ONE thing in the chat header: the provider pill.
+ *
+ * There used to be a second pill beside it naming the model — a picker on the
+ * Hermes side, a click-less label ("Flash 4.1") on both — and for this provider
+ * it was noise twice over: the customer does not choose a ClawBox AI model (the
+ * product runs one, and the plan decides what that resolves to), and the row it
+ * sat in is the narrowest thing in the UI. The width budget in
+ * src/lib/chat-header-pills.ts is the whole reason the other pills shorten their
+ * labels at all; spending a pill of it on a word the "ClawBox" pill already
+ * implies is the opposite of that work.
+ *
+ * The rule is one predicate — `isClawboxAiProvider` — applied in BOTH edition
+ * branches of the header, which is what these tests pin: the two branches
+ * agreeing, and every OTHER provider keeping its picker.
+ *
+ * Render tests rather than source assertions: the pill's presence is the
+ * behaviour, and "no pill" is only meaningful if the surrounding pills are
+ * proven to have rendered in the same frame.
+ */
+
+/** GET /setup-api/hermes/models (unscoped) — the header's seeding read. */
+function hermesSeed(provider: string) {
+  return {
+    provider,
+    current: `${provider}/model-a`,
+    reasoning: "medium",
+    providers: [{ id: provider, name: provider, authenticated: true }],
+    models: [],
+  };
+}
+
+/** GET /setup-api/hermes/models?provider=<p> — the scoped model list. TWO
+ *  models, so `showModelPill` is true and hiding the pill is a decision this
+ *  code makes rather than an accident of an empty list. */
+function hermesScope(provider: string) {
+  return {
+    provider,
+    authenticated: true,
+    models: [{ id: "model-a", description: "" }, { id: "model-b", description: "" }],
+    defaultModel: "model-a",
+    current: "model-a",
+    savedElsewhere: null,
+    source: "dashboard",
+    stale: false,
+  };
+}
+
+/**
+ * Scoped model-list requests waiting to be answered BY HAND.
+ *
+ * The ordering matters more than it looks: the provider pill renders off the
+ * seed, which lands first, so an absence asserted right after it would be the
+ * absence of a pill whose model list had not arrived yet — a test that passes
+ * whatever the header decides. Answering the scoped request explicitly is what
+ * makes "no pill" mean "no pill once there were two models to pick from".
+ */
+const pendingScope: Array<(body: unknown) => void> = [];
+
+/** Answer the scoped request and let React apply it. */
+async function settleModels(provider: string) {
+  await waitFor(() => expect(pendingScope.length).toBe(1));
+  await act(async () => {
+    pendingScope[0](hermesScope(provider));
+    await Promise.resolve();
+  });
+}
+
+function installHermesFetch(provider: string) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: unknown) => {
+      const url = String(input);
+      if (url.includes("/setup-api/harness/active")) {
+        return { ok: true, json: async () => ({ active: "hermes", edition: "hermes" }) };
+      }
+      // Scoped first: `?provider=` is the model hook, not the header seed.
+      if (url.includes("/setup-api/hermes/models?")) {
+        const body = await new Promise<unknown>((resolve) => pendingScope.push(resolve));
+        return { ok: true, json: async () => body };
+      }
+      if (url.includes("/setup-api/hermes/models")) {
+        return { ok: true, json: async () => hermesSeed(provider) };
+      }
+      if (url.includes("/setup-api/chat/history")) {
+        return { ok: true, json: async () => ({ messages: [] }) };
+      }
+      if (url.includes("/setup-api/chat/model")) {
+        return { ok: true, json: async () => ({ options: [], activeOptionId: "" }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    }),
+  );
+}
+
+/** A two-model catalogue, so a non-ClawBox provider genuinely has a picker. */
+const ANTHROPIC_CATALOG = {
+  provider: "anthropic",
+  models: [
+    { id: "claude-opus-5", label: "Claude Opus 5", contextWindow: 200_000, availableOnSubscription: true },
+    { id: "claude-sonnet-5", label: "Claude Sonnet 5", contextWindow: 200_000, availableOnSubscription: true },
+  ],
+  defaultModelId: "claude-opus-5",
+  allowCustom: true,
+  fetchedAt: 0,
+};
+
+/**
+ * GET /setup-api/chat/model for a one-row OpenClaw box.
+ *
+ * The ClawBox AI rows deliberately pass `deepseek/deepseek-v4-flash` as the
+ * active model: that is the Flash ref the box migrates itself onto, so the
+ * auto-migration effect stays quiet and the header is the only thing under test.
+ */
+function openclawState(option: Record<string, unknown>, activeModel: string) {
+  return {
+    activeOptionId: "row-1",
+    activeModel,
+    activeSource: "primary",
+    activeLabel: option.label,
+    options: [{ id: "row-1", available: true, settingsSection: "ai", isLocal: false, ...option }],
+    primary: { available: true, label: option.label, model: activeModel },
+    local: { available: false, label: null, model: null },
+    subscriptionProviders: [],
+  };
+}
+
+function installOpenclawFetch(state: Record<string, unknown>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: unknown) => {
+      const url = String(input);
+      if (url.includes("/setup-api/harness/active")) {
+        return { ok: true, json: async () => ({ active: "openclaw", edition: "openclaw" }) };
+      }
+      if (url.includes("/setup-api/ai-models/catalog")) {
+        return { ok: true, json: async () => ANTHROPIC_CATALOG };
+      }
+      if (url.includes("/setup-api/chat/model")) {
+        return { ok: true, json: async () => state };
+      }
+      if (url.includes("/setup-api/chat/history")) {
+        return { ok: true, json: async () => ({ messages: [] }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    }),
+  );
+}
+
+const providerPill = () => screen.findByRole("button", { name: /^Chat provider:/ });
+const modelPill = () => screen.queryByRole("button", { name: /model:/i });
+
+beforeEach(() => {
+  pendingScope.length = 0;
+  resetHarnessCache();
+  window.localStorage.clear();
+  // jsdom has no layout engine, so the transcript's auto-scroll has nothing to
+  // call. Unrelated to the header.
+  Element.prototype.scrollIntoView = vi.fn();
+  vi.stubGlobal(
+    "WebSocket",
+    class {
+      close() {}
+      send() {}
+      addEventListener() {}
+      removeEventListener() {}
+    },
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetHarnessCache();
+});
+
+describe("the ClawBox AI provider id", () => {
+  it("is recognised under both spellings, and nothing else is", () => {
+    // `clawai` is what the UI normalises to; `deepseek` is what the gateway
+    // config registers the proxy under. The header reads both.
+    expect(isClawboxAiProvider("clawai")).toBe(true);
+    expect(isClawboxAiProvider("deepseek")).toBe(true);
+    expect(isClawboxAiProvider("anthropic")).toBe(false);
+    expect(isClawboxAiProvider("openrouter")).toBe(false);
+    expect(isClawboxAiProvider(null)).toBe(false);
+  });
+});
+
+describe("the chat header's model pill on ClawBox AI (Hermes edition)", () => {
+  it("is absent — no picker and no read-only tier label", async () => {
+    installHermesFetch("clawai");
+    render(<ChatPopup isOpen onClose={() => {}} />);
+
+    // The provider pill proves the header rendered at all, so the absence
+    // below is a decision and not an empty header.
+    expect(await providerPill()).toHaveAccessibleName("Chat provider: ClawBox");
+    await settleModels("clawai");
+    expect(modelPill()).toBeNull();
+    // The label pill that used to sit there was not a control, and its text is
+    // the thing the customer reported seeing beside "ClawBox".
+    expect(screen.queryByText(CLAWBOX_AI_CHAT_MODEL_LABEL)).toBeNull();
+  });
+
+  it("is absent under the wire spelling of the provider too", async () => {
+    // `deepseek` is ClawBox AI's wire id (the proxy forwards to DeepSeek), and
+    // the shared predicate treats it as ClawBox AI wherever it surfaces. On a
+    // Hermes box ClawBox AI is registered as `clawai` (see hermes-clawai.ts),
+    // so this state is reached through the id rather than through the product;
+    // the cost of covering both spellings in one predicate is that a Hermes
+    // user who separately configures DeepSeek in Hermes' own dashboard loses
+    // that row's model picker too. Cosmetic, and no routing changes with it.
+    installHermesFetch("deepseek");
+    render(<ChatPopup isOpen onClose={() => {}} />);
+
+    expect(await providerPill()).toHaveAccessibleName("Chat provider: DeepSeek");
+    await settleModels("deepseek");
+    expect(modelPill()).toBeNull();
+  });
+
+  it("still renders for a provider that has models to choose between", async () => {
+    installHermesFetch("openrouter");
+    render(<ChatPopup isOpen onClose={() => {}} />);
+
+    expect(await providerPill()).toHaveAccessibleName("Chat provider: OpenRouter");
+    // The control case: same two-model scope, answered the same way, pill
+    // present. Without this the tests above would pass on a header that had
+    // lost its model pill for everyone.
+    await settleModels("openrouter");
+    await waitFor(() => expect(modelPill()).toBeTruthy());
+    expect(modelPill()).toHaveAccessibleName("Hermes model: model-a");
+  });
+});
+
+describe("the chat header's model pill on ClawBox AI (OpenClaw edition)", () => {
+  const CLAWAI_ROW = { label: "ClawBox AI", model: "deepseek/deepseek-v4-flash", provider: "clawai" };
+  const DEEPSEEK_ROW = { label: "ClawBox AI", model: "deepseek/deepseek-v4-flash", provider: "deepseek" };
+
+  it("is absent — no picker and no read-only tier label", async () => {
+    installOpenclawFetch(openclawState(CLAWAI_ROW, "deepseek/deepseek-v4-flash"));
+    render(<ChatPopup isOpen onClose={() => {}} />);
+
+    expect(await providerPill()).toHaveAccessibleName("Chat provider: ClawBox");
+    expect(modelPill()).toBeNull();
+    expect(screen.queryByText(CLAWBOX_AI_CHAT_MODEL_LABEL)).toBeNull();
+  });
+
+  it("is absent when the row still carries the wire provider id", async () => {
+    // A state the server normally normalises to `clawai` — a legacy install, or
+    // a row read straight off the gateway config — must not grow the pill back
+    // just because it spells the same proxy the other way.
+    installOpenclawFetch(openclawState(DEEPSEEK_ROW, "deepseek/deepseek-v4-flash"));
+    render(<ChatPopup isOpen onClose={() => {}} />);
+
+    expect(await providerPill()).toBeTruthy();
+    expect(modelPill()).toBeNull();
+    expect(screen.queryByText(CLAWBOX_AI_CHAT_MODEL_LABEL)).toBeNull();
+  });
+
+  it("still renders for a provider whose models the owner does pick", async () => {
+    installOpenclawFetch(openclawState(
+      { label: "Anthropic", model: "anthropic/claude-opus-5", provider: "anthropic" },
+      "anthropic/claude-opus-5",
+    ));
+    render(<ChatPopup isOpen onClose={() => {}} />);
+
+    expect(await providerPill()).toBeTruthy();
+    await waitFor(() => expect(modelPill()).toBeTruthy());
+    // The catalogue's own label, still de-duplicated against the provider pill
+    // (nothing to drop here: this row's pill says "Anthropic", the model says
+    // "Claude") — untouched by this change, and asserted so a future attempt to
+    // widen the ClawBox AI rule cannot quietly take this pill with it.
+    expect(modelPill()).toHaveAccessibleName("Anthropic model: Claude Opus 5");
+  });
+});

--- a/src/tests/components/chat-hermes-flash-model.test.tsx
+++ b/src/tests/components/chat-hermes-flash-model.test.tsx
@@ -85,8 +85,11 @@ describe("Hermes ClawBox AI chat model", () => {
     }));
 
     const textarea = await mountHermesChat(box);
-    const label = await screen.findByText("Flash 4.1");
-    expect(label.closest("button")).toBeNull();
+    // The header names the provider and nothing more: no model picker for
+    // ClawBox AI, and no read-only chip naming the model either. What the box
+    // actually RUNS is asserted on the wire below, which is where it matters.
+    await screen.findByLabelText(/^Chat provider:/);
+    expect(screen.queryByText("Flash 4.1")).toBeNull();
     expect(screen.queryByLabelText(/^Hermes model:/)).toBeNull();
     expect(screen.queryByText("Max Tier")).toBeNull();
 

--- a/src/tests/components/chat-model-pill-stability.test.tsx
+++ b/src/tests/components/chat-model-pill-stability.test.tsx
@@ -26,7 +26,12 @@ describe("the chat's model pill across a provider switch", () => {
   it("keeps its place while the new provider's models load", () => {
     // Not `models.length > 1` directly — that is false during the fetch and is
     // what made the pill vanish.
-    expect(CHAT).toMatch(/\{hermesProvider !== 'clawai' && showModelPill && \(/);
+    //
+    // The ClawBox AI half of the gate is now the SHARED predicate rather than a
+    // literal `!== 'clawai'`, so the OpenClaw branch cannot disagree with this
+    // one about which spelling of the provider counts
+    // (chat-clawbox-ai-model-pill.test.tsx owns that behaviour).
+    expect(CHAT).toMatch(/\{!isClawboxAiProvider\(hermesProvider\) && showModelPill && \(/);
     expect(CHAT).toMatch(/showModelPill = hermesModelsLoading \? hadModelPill\.current : hermesModelCount > 1/);
   });
 


### PR DESCRIPTION
## Summary

On ClawBox AI, the chat header rendered a second pill beside **ClawBox** naming the chat model (`Flash 4.1`). It was not a control — nothing on this product chooses a ClawBox AI model — and it spent the narrowest row in the UI repeating what the provider pill already says. The header now ends at the provider pill, with the reasoning dial beside it.

Both edition branches gate on one shared predicate, `isClawboxAiProvider` (new, in `src/lib/clawbox-ai-models.ts`), which accepts the two ids the proxy is spelled with: `clawai` (what the UI normalises to) and `deepseek` (what the gateway config registers). Two hand-written copies of that comparison are why the Hermes branch and the OpenClaw branch had come to answer it separately. The predicate also replaces the same pair inside `isClawboxAiProModel` and `isClawboxAiModelRef`.

**Unchanged on purpose:** the Flash alias and tier→model routing, the wire-format `deepseek/<id>` remap, the automatic migration onto Flash and the system message it posts, and Settings' own plan wording. Every other provider keeps its model picker.

The pills live in the composer row, which is not gated on `mobile`, so the phone surface loses the pill the same way and needed no gate of its own.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [x] Documentation / tooling
- [ ] Other: ___

## How was this tested?

New `src/tests/components/chat-clawbox-ai-model-pill.test.tsx` — render tests over both edition branches: no pill for `clawai`, none for the `deepseek` wire spelling, and a control case per branch proving a non-ClawBox provider still gets its picker with the same two-model list. Each absence assertion waits for the model list to actually land first (a hand-answered scoped request), because asserting it earlier passes whatever the header decides. Verified by mutation: restoring either old code path fails all four absence cases.

Updated, keeping their original intent:
- `chat-model-pill-stability.test.tsx` (source assertions) — now pins the shared predicate in the Hermes gate instead of the literal `!== 'clawai'`; its loading-state rules are unchanged.
- `chat-clawai-tier-labels.test.tsx`, `chat-hermes-flash-model.test.tsx` — these used the model label as a synchronisation point and asserted its presence; they now assert its absence and keep every guard they already had (no picker, no tier vocabulary, no catalogue fetch, no upsell, exactly one model write, and the Flash id on the wire).

Commands run locally:
- `npx tsc --noEmit` — 0 errors
- `npx vitest run --config vitest.config.ts src/tests/components/` — 1841 passed, 1 failed
- `npx vitest run --config vitest.config.ts --project unit` — 13697 passed, 1 failed

Both full-suite failures are pre-existing load-dependent 5s timeouts, not regressions: each passes in isolation on this branch, and a clean `beta` checkout fails 2 tests in the same way in a *different* file (`chat-spoken-reply-player.test.tsx`), so which file times out varies per run.

- [ ] `bun run lint` passes
- [x] `bun run test` passes
- [ ] `bun run build` succeeds
- [ ] Manually verified on device / dev install

`npx eslint` on the touched files reports 0 errors (9 pre-existing warnings in `ChatPopup.tsx`). Lint and build were not run repo-wide; not verified on hardware.

## Checklist

- [x] Branch is up to date with the target branch
- [x] Follows the conventions in [CLAUDE.md](../CLAUDE.md) and [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No secrets, tokens, or credentials committed
- [x] Added/updated tests where it makes sense
- [x] Updated docs where user-facing behavior changed

## Limitations

One predicate for both spellings means a Hermes box whose owner separately configures Hermes' canonical `deepseek` provider loses that row's model picker too. Cosmetic, no routing changes with it — and the alternative is two rules that can disagree, which is the drift this fixes. Called out in the code and in the new test.

Not verified on real hardware: the evidence here is the render tests plus the mutation check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - ClawBox AI chat headers now show only the provider and reasoning control; model labels, tier chips, and model pickers are hidden.
  - Reasoning remains disabled by default and can be enabled from the reasoning control.
  - Other providers retain their existing model-selection controls.

- **Documentation**
  - Updated setup guidance to reflect ClawBox AI provider and model-selection behavior.

- **Tests**
  - Expanded coverage across Hermes and OpenClaw, including provider recognition and model-selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->