### PR TITLE
fix: stabilise the beta test suite after the coding-agent merges

### DIFF
--- a/src/tests/components/ai-provider-list.test.tsx
+++ b/src/tests/components/ai-provider-list.test.tsx
@@ -14,6 +14,16 @@ import { I18nProvider } from "@/lib/i18n";
 import { translations } from "@/lib/translations";
 import AiProviderList from "@/components/AiProviderList";
 
+// Mounts the chat/provider surface and then waits on several sub-5 s
+// `waitFor`s in series — the family `test-timeout-hygiene.test.ts` keeps a
+// list of, for the reason it gives there. Measured 2026-09-12 with all 216
+// component files running fully parallel on a 12-core machine: the slowest
+// case here ("keeps polling after a failed read while rows are still being checked")
+// took 3,031 ms, i.e. under 2 s of headroom below vitest's 5 s default. It
+// duly timed out when the machine was loaded further.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 vi.mock("@/components/AIProviderIcon", () => ({ default: () => <span data-testid="icon" /> }));
 
 const ROWS = [

--- a/src/tests/components/chat-approval-taint-card.test.tsx
+++ b/src/tests/components/chat-approval-taint-card.test.tsx
@@ -23,6 +23,15 @@ import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 import { createWebTaintGate } from "../../../scripts/openclaw-plugins/clawbox-web-taint/index.mjs";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 const SEED_TEXT = "Ready when you are.";
 const SESSION = "agent:main:main";
 const APPROVAL_ID = "plugin:9c14e0a2";

--- a/src/tests/components/chat-approvals-card.test.tsx
+++ b/src/tests/components/chat-approvals-card.test.tsx
@@ -19,6 +19,15 @@ import { act, fireEvent, render, screen, waitFor } from "@/tests/helpers/test-ut
 import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 const SEED_TEXT = "Ready when you are.";
 const SESSION = "agent:main:main";
 

--- a/src/tests/components/chat-attachment-preview.test.tsx
+++ b/src/tests/components/chat-attachment-preview.test.tsx
@@ -5,6 +5,15 @@ import { resetHarnessCache } from "@/lib/client-harness";
 import { I18nProvider } from "@/lib/i18n";
 import { translations } from "@/lib/translations";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * TASK-380 acceptance 2 and 5, on the surface a customer actually uses.
  *

--- a/src/tests/components/chat-attachment-staging.test.tsx
+++ b/src/tests/components/chat-attachment-staging.test.tsx
@@ -3,6 +3,15 @@ import { fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
 import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * TASK-417: the device accepted an attached image and then answered that it
  * could not see it.

--- a/src/tests/components/chat-clawai-flash-migration.test.tsx
+++ b/src/tests/components/chat-clawai-flash-migration.test.tsx
@@ -5,6 +5,15 @@ import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 import { translations } from "@/lib/translations";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 vi.mock("@/lib/i18n", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/i18n")>();
   return {

--- a/src/tests/components/chat-clawai-tier-labels.test.tsx
+++ b/src/tests/components/chat-clawai-tier-labels.test.tsx
@@ -5,6 +5,15 @@ import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 import { translations } from "@/lib/translations";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 // The model name is the same across locales. The switch overlay still follows
 // the desktop's language, with readable English when no dictionary answers.
 const dictionary = vi.hoisted(() => ({ table: null as Record<string, string> | null }));

--- a/src/tests/components/chat-clawbox-ai-model-pill.test.tsx
+++ b/src/tests/components/chat-clawbox-ai-model-pill.test.tsx
@@ -4,6 +4,18 @@ import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 import { CLAWBOX_AI_CHAT_MODEL_LABEL, isClawboxAiProvider } from "@/lib/clawbox-ai-models";
 
+// A jsdom mount of `ChatPopup` is the expensive thing here — the fake gateway
+// handshake, the model seed, the transcript — and a case does it once and then
+// waits on several sub-5 s `waitFor`s in series. That is exactly what
+// `testTimeout` governs, and what `test-timeout-hygiene.test.ts` documents.
+// Measured on beta, 2026-09-12, with all 215 component files running fully
+// parallel on a 12-core machine: the slowest passing case in this family was
+// 4,558 ms — 442 ms under vitest's default, which is why these three suites
+// were the ones reporting "Test timed out in 5000ms" over races that had
+// nothing to do with the budget.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * ClawBox AI names ONE thing in the chat header: the provider pill.
  *

--- a/src/tests/components/chat-clawbox-ai-model-pill.test.tsx
+++ b/src/tests/components/chat-clawbox-ai-model-pill.test.tsx
@@ -4,15 +4,12 @@ import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 import { CLAWBOX_AI_CHAT_MODEL_LABEL, isClawboxAiProvider } from "@/lib/clawbox-ai-models";
 
-// A jsdom mount of `ChatPopup` is the expensive thing here — the fake gateway
-// handshake, the model seed, the transcript — and a case does it once and then
-// waits on several sub-5 s `waitFor`s in series. That is exactly what
-// `testTimeout` governs, and what `test-timeout-hygiene.test.ts` documents.
-// Measured on beta, 2026-09-12, with all 215 component files running fully
-// parallel on a 12-core machine: the slowest passing case in this family was
-// 4,558 ms — 442 ms under vitest's default, which is why these three suites
-// were the ones reporting "Test timed out in 5000ms" over races that had
-// nothing to do with the budget.
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
 vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 

--- a/src/tests/components/chat-cold-start.test.tsx
+++ b/src/tests/components/chat-cold-start.test.tsx
@@ -3,6 +3,15 @@ import { act, render, screen } from "@/tests/helpers/test-utils";
 import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 // Real Nano .199 needed 175 seconds between process start and gateway ready.
 // The desktop opened sooner and exhausted its initial socket retry ladder.
 let ready = false;

--- a/src/tests/components/chat-connect-refused.test.tsx
+++ b/src/tests/components/chat-connect-refused.test.tsx
@@ -3,6 +3,15 @@ import { act, fireEvent, render, screen, waitFor } from "@/tests/helpers/test-ut
 import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * A gateway that REFUSES the connect frame is a terminal failure too.
  *

--- a/src/tests/components/chat-email-card.test.tsx
+++ b/src/tests/components/chat-email-card.test.tsx
@@ -10,6 +10,15 @@ import { fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
 import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 const SUMMARY = "Jane sent you the Wednesday plan, and Accounts sent an invoice.";
 
 /** A stored turn shaped exactly as the harness stores one. */

--- a/src/tests/components/chat-email-refs-surfaces.test.tsx
+++ b/src/tests/components/chat-email-refs-surfaces.test.tsx
@@ -29,15 +29,12 @@ import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 import { waitForChatSession } from "@/tests/helpers/chat-connected";
 
-// A jsdom mount of `ChatPopup` is the expensive thing here — the fake gateway
-// handshake, the model seed, the transcript — and a case does it once and then
-// waits on several sub-5 s `waitFor`s in series. That is exactly what
-// `testTimeout` governs, and what `test-timeout-hygiene.test.ts` documents.
-// Measured on beta, 2026-09-12, with all 215 component files running fully
-// parallel on a 12-core machine: the slowest passing case in this family was
-// 4,558 ms — 442 ms under vitest's default, which is why these three suites
-// were the ones reporting "Test timed out in 5000ms" over races that had
-// nothing to do with the budget.
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
 vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 

--- a/src/tests/components/chat-email-refs-surfaces.test.tsx
+++ b/src/tests/components/chat-email-refs-surfaces.test.tsx
@@ -29,6 +29,18 @@ import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 import { waitForChatSession } from "@/tests/helpers/chat-connected";
 
+// A jsdom mount of `ChatPopup` is the expensive thing here — the fake gateway
+// handshake, the model seed, the transcript — and a case does it once and then
+// waits on several sub-5 s `waitFor`s in series. That is exactly what
+// `testTimeout` governs, and what `test-timeout-hygiene.test.ts` documents.
+// Measured on beta, 2026-09-12, with all 215 component files running fully
+// parallel on a 12-core machine: the slowest passing case in this family was
+// 4,558 ms — 442 ms under vitest's default, which is why these three suites
+// were the ones reporting "Test timed out in 5000ms" over races that had
+// nothing to do with the budget.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 const SUMMARY = "Jane sent the Wednesday plan, and Accounts sent an invoice.";
 const REPLY = `${SUMMARY}\nEMAIL:4471\nEMAIL:4468`;
 

--- a/src/tests/components/chat-email-refs-surfaces.test.tsx
+++ b/src/tests/components/chat-email-refs-surfaces.test.tsx
@@ -27,6 +27,7 @@ import { act, fireEvent, render, screen, waitFor } from "@/tests/helpers/test-ut
 import ChatApp from "@/components/ChatApp";
 import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
+import { waitForChatSession } from "@/tests/helpers/chat-connected";
 
 const SUMMARY = "Jane sent the Wednesday plan, and Accounts sent an invoice.";
 const REPLY = `${SUMMARY}\nEMAIL:4471\nEMAIL:4468`;
@@ -128,6 +129,20 @@ const instances: FakeGatewayWs[] = [];
 async function socket() {
   await waitFor(() => expect(instances.length).toBeGreaterThan(0));
   return instances[instances.length - 1];
+}
+
+/**
+ * The socket, once the surface has finished its handshake.
+ *
+ * The cases that replay a turn from history wait for that turn to appear and
+ * are covered by it; the mascot ones below deliberately empty the history, so
+ * they had nothing to wait on and pushed as soon as the socket object existed.
+ * See `waitForChatSession` for what that dropped and when.
+ */
+async function connectedSocket() {
+  const ws = await socket();
+  await waitForChatSession();
+  return ws;
 }
 
 /** What the device answers a card that is actually opened with. */
@@ -340,8 +355,7 @@ describe("the mascot chat, which had the same hole one step further in", () => {
     // surfaces agree about what survives an interrupt.
     history = [];
     render(<ChatPopup isOpen onClose={() => {}} />);
-    await waitFor(() => expect(instances.length).toBeGreaterThan(0));
-    const ws = instances[instances.length - 1];
+    const ws = await connectedSocket();
 
     await act(async () => {
       ws.pushChat("delta", { role: "assistant", content: [{ type: "text", text: REPLY }] });
@@ -368,8 +382,7 @@ describe("the mascot chat, which had the same hole one step further in", () => {
     // the half-written one was stored here too.
     history = [];
     render(<ChatPopup isOpen onClose={() => {}} />);
-    await waitFor(() => expect(instances.length).toBeGreaterThan(0));
-    const ws = instances[instances.length - 1];
+    const ws = await connectedSocket();
 
     await act(async () => {
       ws.pushChat("delta", { role: "assistant", content: [{ type: "text", text: `${SUMMARY}\nEMAIL:` }] });

--- a/src/tests/components/chat-fix-error-and-message-events.test.tsx
+++ b/src/tests/components/chat-fix-error-and-message-events.test.tsx
@@ -14,6 +14,15 @@ import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 import { buildFixErrorPrompt, dispatchChatMessage, dispatchFixError } from "@/lib/ui-events";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 const SEED_TEXT = "Ready when you are.";
 const SESSION = "agent:main:main";
 

--- a/src/tests/components/chat-gateway-contract.test.tsx
+++ b/src/tests/components/chat-gateway-contract.test.tsx
@@ -3,6 +3,15 @@ import { act, fireEvent, render, screen, waitFor } from "@/tests/helpers/test-ut
 import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * The OpenClaw wire contract, pinned.
  *

--- a/src/tests/components/chat-generated-image.test.tsx
+++ b/src/tests/components/chat-generated-image.test.tsx
@@ -3,6 +3,15 @@ import { fireEvent, render, screen, waitFor, within } from "@/tests/helpers/test
 import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * A generated picture reaches the chat as a `MEDIA:<path>` line inside the
  * reply text — the harness sends no structured attachment (see

--- a/src/tests/components/chat-header-chatgpt-row.test.tsx
+++ b/src/tests/components/chat-header-chatgpt-row.test.tsx
@@ -5,13 +5,12 @@ import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 import { translations } from "@/lib/translations";
 
-// Mounts the chat/provider surface and then waits on several sub-5 s
-// `waitFor`s in series — the family `test-timeout-hygiene.test.ts` keeps a
-// list of, for the reason it gives there. Measured 2026-09-12 with all 216
-// component files running fully parallel on a 12-core machine: the slowest
-// case here ("still offers the model dropdown when the active model is openai/…")
-// took 3,106 ms, i.e. under 2 s of headroom below vitest's 5 s default. It
-// duly timed out when the machine was loaded further.
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
 vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 

--- a/src/tests/components/chat-header-chatgpt-row.test.tsx
+++ b/src/tests/components/chat-header-chatgpt-row.test.tsx
@@ -5,6 +5,16 @@ import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 import { translations } from "@/lib/translations";
 
+// Mounts the chat/provider surface and then waits on several sub-5 s
+// `waitFor`s in series — the family `test-timeout-hygiene.test.ts` keeps a
+// list of, for the reason it gives there. Measured 2026-09-12 with all 216
+// component files running fully parallel on a 12-core machine: the slowest
+// case here ("still offers the model dropdown when the active model is openai/…")
+// took 3,106 ms, i.e. under 2 s of headroom below vitest's 5 s default. It
+// duly timed out when the machine was loaded further.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 vi.mock("@/lib/i18n", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/i18n")>();
   return {

--- a/src/tests/components/chat-header-close-button.test.tsx
+++ b/src/tests/components/chat-header-close-button.test.tsx
@@ -5,6 +5,15 @@ import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 import { translations } from "@/lib/translations";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 // Resolve against the REAL tables rather than a hand-written map, so this
 // breaks if the button stops reading the catalogue or the key goes away.
 let locale: "en" | "de" = "en";

--- a/src/tests/components/chat-header-mispinned-primary.test.tsx
+++ b/src/tests/components/chat-header-mispinned-primary.test.tsx
@@ -5,6 +5,15 @@ import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 import { translations } from "@/lib/translations";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 vi.mock("@/lib/i18n", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/i18n")>();
   return {

--- a/src/tests/components/chat-header-seed-race.test.tsx
+++ b/src/tests/components/chat-header-seed-race.test.tsx
@@ -5,6 +5,16 @@ import { resetHarnessCache } from "@/lib/client-harness";
 import { HERMES_MODEL_STATE_EVENT } from "@/hooks/useHermesModelOptions";
 import { PROVIDER_SIGNAL_DEBOUNCE_MS } from "@/lib/ui-events";
 
+// Mounts the chat/provider surface and then waits on several sub-5 s
+// `waitFor`s in series — the family `test-timeout-hygiene.test.ts` keeps a
+// list of, for the reason it gives there. Measured 2026-09-12 with all 216
+// component files running fully parallel on a 12-core machine: the slowest
+// case here ("keeps the newest provider when an earlier seed resolves last")
+// took 3,456 ms, i.e. under 2 s of headroom below vitest's 5 s default. It
+// duly timed out when the machine was loaded further.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * The chat header re-seeds whenever a provider is configured, and there are now
  * several places that can fire that signal within a second of each other (a

--- a/src/tests/components/chat-header-seed-race.test.tsx
+++ b/src/tests/components/chat-header-seed-race.test.tsx
@@ -5,13 +5,12 @@ import { resetHarnessCache } from "@/lib/client-harness";
 import { HERMES_MODEL_STATE_EVENT } from "@/hooks/useHermesModelOptions";
 import { PROVIDER_SIGNAL_DEBOUNCE_MS } from "@/lib/ui-events";
 
-// Mounts the chat/provider surface and then waits on several sub-5 s
-// `waitFor`s in series — the family `test-timeout-hygiene.test.ts` keeps a
-// list of, for the reason it gives there. Measured 2026-09-12 with all 216
-// component files running fully parallel on a 12-core machine: the slowest
-// case here ("keeps the newest provider when an earlier seed resolves last")
-// took 3,456 ms, i.e. under 2 s of headroom below vitest's 5 s default. It
-// duly timed out when the machine was loaded further.
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
 vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 

--- a/src/tests/components/chat-header-subscription-models.test.tsx
+++ b/src/tests/components/chat-header-subscription-models.test.tsx
@@ -5,6 +5,15 @@ import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 import { translations } from "@/lib/translations";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 // Resolve against the REAL English table rather than a hand-written map, so
 // this test breaks if the header stops reusing the wizard's own copy.
 vi.mock("@/lib/i18n", async (importOriginal) => {

--- a/src/tests/components/chat-hermes-edition-gates.test.tsx
+++ b/src/tests/components/chat-hermes-edition-gates.test.tsx
@@ -9,6 +9,15 @@ import {
 } from "@/tests/helpers/hermes-chat-box";
 import { resetHarnessCache } from "@/lib/client-harness";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * What the composer offers on a box that runs no gateway.
  *

--- a/src/tests/components/chat-hermes-stale-catalogue.test.tsx
+++ b/src/tests/components/chat-hermes-stale-catalogue.test.tsx
@@ -4,6 +4,16 @@ import { installHermesBox, mountHermesChat, type HermesBox } from "@/tests/helpe
 import { resetHarnessCache } from "@/lib/client-harness";
 import { notifyHermesModelState } from "@/hooks/useHermesModelOptions";
 
+// Mounts the chat/provider surface and then waits on several sub-5 s
+// `waitFor`s in series — the family `test-timeout-hygiene.test.ts` keeps a
+// list of, for the reason it gives there. Measured 2026-09-12 with all 216
+// component files running fully parallel on a 12-core machine: the slowest
+// case here ("recovers from a dropped connection, not only from a tidy 200")
+// took 3,175 ms, i.e. under 2 s of headroom below vitest's 5 s default. It
+// duly timed out when the machine was loaded further.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * TASK-677 — the Hermes chat header rendered a DEGRADED catalogue as if it were
  * the box's answer, and never went back for the real one.

--- a/src/tests/components/chat-hermes-stop-keeps-partial.test.tsx
+++ b/src/tests/components/chat-hermes-stop-keeps-partial.test.tsx
@@ -4,6 +4,15 @@ import { fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
 import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * Stop keeps what the box had already written — on BOTH editions (TASK-721).
  *

--- a/src/tests/components/chat-hermes-streaming.test.tsx
+++ b/src/tests/components/chat-hermes-streaming.test.tsx
@@ -3,6 +3,15 @@ import { render, screen, waitFor, fireEvent } from "@/tests/helpers/test-utils";
 import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * A Hermes reply appearing in the bubble as it is written.
  *

--- a/src/tests/components/chat-image-generation-wait.test.tsx
+++ b/src/tests/components/chat-image-generation-wait.test.tsx
@@ -3,6 +3,15 @@ import { act, render, screen, waitFor } from "@/tests/helpers/test-utils";
 import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * `image_generate` returns as soon as the job is queued. The picture arrives
  * 20-40s later from a SEPARATE background run whose reply reaches the socket

--- a/src/tests/components/chat-inter-session-envelope.test.tsx
+++ b/src/tests/components/chat-inter-session-envelope.test.tsx
@@ -5,6 +5,15 @@ import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 import * as kv from "@/lib/client-kv";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * TASK-416: a ClawBox that generated an image printed OpenClaw's inter-session
  * routing envelope to the customer as its own chat bubble — two internal

--- a/src/tests/components/chat-optimistic-duplicate.test.tsx
+++ b/src/tests/components/chat-optimistic-duplicate.test.tsx
@@ -3,6 +3,15 @@ import { act, fireEvent, render, screen, waitFor } from "@/tests/helpers/test-ut
 import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * A sent message must appear once, however far apart the two clocks are.
  *

--- a/src/tests/components/chat-popup-dismiss-and-geometry.test.tsx
+++ b/src/tests/components/chat-popup-dismiss-and-geometry.test.tsx
@@ -22,6 +22,18 @@ import ChatPopup from "@/components/ChatPopup";
 import { installHermesBox, mountHermesChat } from "@/tests/helpers/hermes-chat-box";
 import { resetHarnessCache } from "@/lib/client-harness";
 
+// A jsdom mount of `ChatPopup` is the expensive thing here — the fake gateway
+// handshake, the model seed, the transcript — and a case does it once and then
+// waits on several sub-5 s `waitFor`s in series. That is exactly what
+// `testTimeout` governs, and what `test-timeout-hygiene.test.ts` documents.
+// Measured on beta, 2026-09-12, with all 215 component files running fully
+// parallel on a 12-core machine: the slowest passing case in this family was
+// 4,558 ms — 442 ms under vitest's default, which is why these three suites
+// were the ones reporting "Test timed out in 5000ms" over races that had
+// nothing to do with the budget.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 const VIEWPORT = { w: 1440, h: 900 };
 /** The gutter the popup keeps from every edge; mirrored from the component. */
 const MARGIN = 8;

--- a/src/tests/components/chat-popup-dismiss-and-geometry.test.tsx
+++ b/src/tests/components/chat-popup-dismiss-and-geometry.test.tsx
@@ -22,15 +22,12 @@ import ChatPopup from "@/components/ChatPopup";
 import { installHermesBox, mountHermesChat } from "@/tests/helpers/hermes-chat-box";
 import { resetHarnessCache } from "@/lib/client-harness";
 
-// A jsdom mount of `ChatPopup` is the expensive thing here — the fake gateway
-// handshake, the model seed, the transcript — and a case does it once and then
-// waits on several sub-5 s `waitFor`s in series. That is exactly what
-// `testTimeout` governs, and what `test-timeout-hygiene.test.ts` documents.
-// Measured on beta, 2026-09-12, with all 215 component files running fully
-// parallel on a 12-core machine: the slowest passing case in this family was
-// 4,558 ms — 442 ms under vitest's default, which is why these three suites
-// were the ones reporting "Test timed out in 5000ms" over races that had
-// nothing to do with the budget.
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
 vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 

--- a/src/tests/components/chat-popup-docked-gap.test.tsx
+++ b/src/tests/components/chat-popup-docked-gap.test.tsx
@@ -5,6 +5,15 @@ import ChatPopup, { CHAT_PANEL_GAP } from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 import { DESKTOP_GAP } from "@/lib/window-snap";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 vi.mock("@/lib/i18n", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/i18n")>();
   return {

--- a/src/tests/components/chat-popup-layering.test.tsx
+++ b/src/tests/components/chat-popup-layering.test.tsx
@@ -21,6 +21,15 @@ import { installHermesBox } from "@/tests/helpers/hermes-chat-box";
 import { resetHarnessCache } from "@/lib/client-harness";
 import { DESKTOP_LAYERS } from "@/lib/window-snap";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 const css = fs.readFileSync(path.join(process.cwd(), "src/app/globals.css"), "utf-8");
 
 /** What page.tsx draws the notice column at. */

--- a/src/tests/components/chat-queue-starvation.test.tsx
+++ b/src/tests/components/chat-queue-starvation.test.tsx
@@ -3,6 +3,15 @@ import { act, fireEvent, render, screen, waitFor } from "@/tests/helpers/test-ut
 import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * TASK-517: three chat messages were accepted, shown in the transcript, and
  * never answered. The durable session file proved the gateway received all

--- a/src/tests/components/chat-reasoning-disclosure.test.tsx
+++ b/src/tests/components/chat-reasoning-disclosure.test.tsx
@@ -3,6 +3,15 @@ import { fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
 import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * The monologue as an affordance instead of as the reply.
  *

--- a/src/tests/components/chat-skill-install-no-freeze.test.tsx
+++ b/src/tests/components/chat-skill-install-no-freeze.test.tsx
@@ -3,6 +3,15 @@ import { act, fireEvent, render, screen, waitFor } from "@/tests/helpers/test-ut
 import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * Installing a skill must not freeze the chat (TASK-508).
  *

--- a/src/tests/components/chat-spoken-reply-player.test.tsx
+++ b/src/tests/components/chat-spoken-reply-player.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
 import ChatPopup from "@/components/ChatPopup";
+import { waitForChatSession } from "@/tests/helpers/chat-connected";
 import { resetHarnessCache } from "@/lib/client-harness";
 import { resetSpokenReplyPeakCache } from "@/components/SpokenReplyPlayer";
 
@@ -253,9 +254,18 @@ async function renderReplyWithAudio() {
   history = [assistantMessage(SPOKEN_TEXT, 1787291821899)];
   const view = render(<ChatPopup isOpen onClose={() => {}} />);
   await waitFor(() => expect(socket()).not.toBeNull());
+  await waitForChatSession();
   await screen.findByRole("textbox");
-  deliver(assistantMessage(SPOKEN_TEXT, 1787291821899));
+  // Wait for the STORED copy before pushing the live one. Both carry the same
+  // timestamp and the surface folds them into one turn — but only when the
+  // history has already landed. Pushed first, the live turn went in on its own
+  // and the history reply was appended beside it, so `findByText` failed with
+  // "found multiple elements" (measured on beta, 2026-09-12: only ever in a
+  // full-suite run, where the history response's `setTimeout(0)` had not run
+  // by the time the composer rendered).
   await screen.findByText(SPOKEN_TEXT);
+  deliver(assistantMessage(SPOKEN_TEXT, 1787291821899));
+  await waitFor(() => expect(screen.getAllByText(SPOKEN_TEXT)).toHaveLength(1));
   deliverSessionMessage(assistantMessage(SPOKEN_TEXT, 1787291825743, VOICE));
   await screen.findByTestId("spoken-reply-player");
   return view;
@@ -481,6 +491,7 @@ describe("the ClawBox player for a spoken reply", () => {
   it("gives a silent reply no player at all", async () => {
     render(<ChatPopup isOpen onClose={() => {}} />);
     await waitFor(() => expect(socket()).not.toBeNull());
+    await waitForChatSession();
     await screen.findByRole("textbox");
     deliver(assistantMessage("No sound here.", 1787291821899));
     await screen.findByText("No sound here.");

--- a/src/tests/components/chat-spoken-reply.test.tsx
+++ b/src/tests/components/chat-spoken-reply.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@/tests/helpers/test-utils";
 import ChatPopup from "@/components/ChatPopup";
+import { waitForChatSession } from "@/tests/helpers/chat-connected";
 import { resetHarnessCache } from "@/lib/client-harness";
 
 // The popup this suite mounts grew a session-tab strip and the OpenClaw 2
@@ -219,6 +220,7 @@ describe("spoken replies in the mascot chat", () => {
   it("renders the audio the harness attached as ClawBox's own player", async () => {
     render(<ChatPopup isOpen onClose={() => {}} />);
     await waitFor(() => expect(socket()).not.toBeNull());
+    await waitForChatSession();
     await screen.findByRole("textbox");
 
     deliver(assistantMessage(SPOKEN_TEXT, 1787291821899));
@@ -249,6 +251,7 @@ describe("spoken replies in the mascot chat", () => {
     const MARKDOWN = 'Sent — *"Seventeen copper bells."*\n\nSee [the docs](https://clawbox.com/docs/tts) or run `openclaw health`.';
     render(<ChatPopup isOpen onClose={() => {}} />);
     await waitFor(() => expect(socket()).not.toBeNull());
+    await waitForChatSession();
     await screen.findByRole("textbox");
 
     deliver(assistantMessage(MARKDOWN, 1787291821899));
@@ -269,6 +272,7 @@ describe("spoken replies in the mascot chat", () => {
   it("does not show the answer twice when its spoken half arrives", async () => {
     render(<ChatPopup isOpen onClose={() => {}} />);
     await waitFor(() => expect(socket()).not.toBeNull());
+    await waitForChatSession();
     await screen.findByRole("textbox");
 
     deliver(assistantMessage(SPOKEN_TEXT, 1787291821899));
@@ -288,6 +292,7 @@ describe("spoken replies in the mascot chat", () => {
     history = [assistantMessage(SPOKEN_TEXT, 1787291821899)];
     render(<ChatPopup isOpen onClose={() => {}} />);
     await waitFor(() => expect(socket()).not.toBeNull());
+    await waitForChatSession();
     await screen.findByText(SPOKEN_TEXT);
 
     deliverSessionMessage(assistantMessage(SPOKEN_TEXT, 1787291825743, VOICE));
@@ -407,6 +412,7 @@ describe("spoken replies in the mascot chat", () => {
   it("does not render audio carried by an internal routing envelope", async () => {
     render(<ChatPopup isOpen onClose={() => {}} />);
     await waitFor(() => expect(socket()).not.toBeNull());
+    await waitForChatSession();
     deliverSessionMessage({
       role: "user",
       provenance: { kind: "inter_session", sourceTool: "sessions_send" },
@@ -446,6 +452,7 @@ describe("spoken replies in the mascot chat", () => {
   it("does not text-match a live audio-only event to a caption-free image", async () => {
     render(<ChatPopup isOpen onClose={() => {}} />);
     await waitFor(() => expect(socket()).not.toBeNull());
+    await waitForChatSession();
     deliver(assistantMessage(`MEDIA:${IMAGE}`, 100));
     const image = await screen.findByAltText("chat.generatedImage");
 
@@ -462,6 +469,7 @@ describe("spoken replies in the mascot chat", () => {
   it("does not text-match an audio-only final to a caption-free image", async () => {
     render(<ChatPopup isOpen onClose={() => {}} />);
     await waitFor(() => expect(socket()).not.toBeNull());
+    await waitForChatSession();
     deliver(assistantMessage(`MEDIA:${IMAGE}`, 100));
     const image = await screen.findByAltText("chat.generatedImage");
     deliver(assistantMessage("", 200, VOICE));
@@ -481,6 +489,7 @@ describe("spoken replies in the mascot chat", () => {
     history = [assistantMessage("Bounded live reply", 250)];
     render(<ChatPopup isOpen onClose={() => {}} />);
     await waitFor(() => expect(socket()).not.toBeNull());
+    await waitForChatSession();
 
     deliver(assistantMessageWithAudio("Bounded live reply", 250, sources));
 
@@ -552,6 +561,7 @@ EMAIL:4471`;
 
     render(<ChatPopup isOpen onClose={() => {}} />);
     await waitFor(() => expect(socket()).not.toBeNull());
+    await waitForChatSession();
     await screen.findByRole("textbox");
 
     deliver(assistantMessage(withRefs, 1787291821899));

--- a/src/tests/components/chat-strict-mode-updater.test.tsx
+++ b/src/tests/components/chat-strict-mode-updater.test.tsx
@@ -5,6 +5,15 @@ import ChatApp from "@/components/ChatApp";
 import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * A state updater is a PURE function of the previous state, and React is
  * entitled to call it twice.

--- a/src/tests/components/chat-tabs.test.tsx
+++ b/src/tests/components/chat-tabs.test.tsx
@@ -6,6 +6,15 @@ import { translations } from "@/lib/translations";
 import { describeChatFailure } from "@/lib/chat-error-text";
 import type { ReactNode } from "react";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 // Resolve against the REAL tables rather than a hand-written map, so these
 // break if a label stops reading the catalogue or a key goes away. The
 // provider itself loads its tables through a dynamic import that never

--- a/src/tests/components/chat-thinking-default.test.tsx
+++ b/src/tests/components/chat-thinking-default.test.tsx
@@ -4,6 +4,15 @@ import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 import { PERSIST_KEY_PREFIX } from "@/lib/chat-reasoning";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * Both legacy ClawBox AI model ids now serve Flash 4.1 and start with reasoning
  * off. A level the user picked themselves still wins over that default.

--- a/src/tests/components/chat-user-image-transcript.test.tsx
+++ b/src/tests/components/chat-user-image-transcript.test.tsx
@@ -119,9 +119,25 @@ function pasteImage(textarea: HTMLElement) {
 }
 
 /** Every image inside the transcript, ignoring the composer's own strip. */
+/**
+ * The pictures a TURN carries — never the composer's staging strip, and never
+ * the empty-transcript placeholder.
+ *
+ * That placeholder is the crab (`ChatPopup.tsx`, the `messages.length === 0`
+ * block) and it is on screen for exactly as long as the turn has not arrived,
+ * which is the window this file's waits live in: a `waitFor` asking for one
+ * image was satisfied by the crab alone and then asserted the crab's `src`
+ * against the media route (seen on beta, 2026-09-12, in a full parallel run —
+ * on an idle machine the history lands before the first poll and the crab is
+ * already gone).
+ */
+const EMPTY_TRANSCRIPT_PLACEHOLDER = "/clawbox-crab.png";
+
 function transcriptImages(): HTMLImageElement[] {
   const strip = screen.queryByTestId("chat-attachments");
-  return [...document.querySelectorAll("img")].filter(img => !strip?.contains(img)) as HTMLImageElement[];
+  return ([...document.querySelectorAll("img")] as HTMLImageElement[]).filter(
+    img => !strip?.contains(img) && img.getAttribute("src") !== EMPTY_TRANSCRIPT_PLACEHOLDER,
+  );
 }
 
 const mediaRoute = (p: string) => `/setup-api/chat/media?path=${encodeURIComponent(p)}`;

--- a/src/tests/components/chat-user-image-transcript.test.tsx
+++ b/src/tests/components/chat-user-image-transcript.test.tsx
@@ -4,6 +4,15 @@ import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 import { I18nProvider } from "@/lib/i18n";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * TASK-436, on the surface the customer uses.
  *

--- a/src/tests/components/chat-voice-recording.test.tsx
+++ b/src/tests/components/chat-voice-recording.test.tsx
@@ -4,13 +4,12 @@ import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 import { MAX_RECORDING_MS } from "@/lib/chat-voice-input";
 
-// Mounts the chat/provider surface and then waits on several sub-5 s
-// `waitFor`s in series — the family `test-timeout-hygiene.test.ts` keeps a
-// list of, for the reason it gives there. Measured 2026-09-12 with all 216
-// component files running fully parallel on a 12-core machine: the slowest
-// case here ("does not push the deadline back as the recording clock re-renders")
-// took 3,199 ms, i.e. under 2 s of headroom below vitest's 5 s default. It
-// duly timed out when the machine was loaded further.
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
 vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 

--- a/src/tests/components/chat-voice-recording.test.tsx
+++ b/src/tests/components/chat-voice-recording.test.tsx
@@ -4,6 +4,16 @@ import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 import { MAX_RECORDING_MS } from "@/lib/chat-voice-input";
 
+// Mounts the chat/provider surface and then waits on several sub-5 s
+// `waitFor`s in series — the family `test-timeout-hygiene.test.ts` keeps a
+// list of, for the reason it gives there. Measured 2026-09-12 with all 216
+// component files running fully parallel on a 12-core machine: the slowest
+// case here ("does not push the deadline back as the recording clock re-renders")
+// took 3,199 ms, i.e. under 2 s of headroom below vitest's 5 s default. It
+// duly timed out when the machine was loaded further.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * What a capture must not do to the person holding the microphone.
  *

--- a/src/tests/components/chat-voice-status.test.tsx
+++ b/src/tests/components/chat-voice-status.test.tsx
@@ -5,6 +5,15 @@ import { resetHarnessCache } from "@/lib/client-harness";
 import { I18nProvider } from "@/lib/i18n";
 import { translations } from "@/lib/translations";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * The voice status row is the only channel the composer has for what the
  * microphone is doing: the record button's label never changes, and everything

--- a/src/tests/components/chat-ws-constructor-throw.test.tsx
+++ b/src/tests/components/chat-ws-constructor-throw.test.tsx
@@ -3,6 +3,15 @@ import { act, render, screen } from "@/tests/helpers/test-utils";
 import ChatPopup from "@/components/ChatPopup";
 import { resetHarnessCache } from "@/lib/client-harness";
 
+// A jsdom mount of `ChatPopup` — the fake gateway handshake, the model seed,
+// the transcript — costs seconds under a full parallel run, and a case does it
+// once and then waits on several sub-5 s `waitFor`s in series. Every component
+// suite that mounts it declares both ceilings; `test-timeout-hygiene.test.ts`
+// is the rule, and says there why 5 s is the wrong budget here and 30 s still
+// fails a test that has genuinely hung.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+
 /**
  * The reconnect ladder has to be able to END (TASK-712).
  *

--- a/src/tests/components/desktop-wallpaper-delete.test.tsx
+++ b/src/tests/components/desktop-wallpaper-delete.test.tsx
@@ -46,8 +46,29 @@ let savedWallpaperId = "custom-2";
 let activeHarness = "openclaw";
 /** Whether the device could actually RESOLVE its harness, or `active` is its own default. */
 let activeKnown = true;
-/** Milliseconds the harness probe takes to answer, so a case can run inside the window where it has not. */
-let harnessDelayMs = 0;
+/**
+ * While this is set, the harness probe does not answer — so a case can run
+ * inside the window where the box does not yet know its edition, and decide
+ * itself when that window closes.
+ *
+ * It used to be a millisecond DELAY, which made every such case a race between
+ * a real timer and the test's own progress: under a full parallel run the test
+ * took longer than the 3 s delay, the probe landed early, and an assertion
+ * about what the desktop does BEFORE it lands was made after it had (measured
+ * on beta, 2026-09-12 — the only failure in the file, and only in a full run).
+ */
+let harnessHold: Promise<void> | null = null;
+let releaseHarnessProbe: () => void = () => {};
+
+/** Hold the probe until `releaseHarnessProbe()`, or until the case ends. */
+function holdHarnessProbe(): void {
+  harnessHold = new Promise<void>((resolve) => {
+    releaseHarnessProbe = () => {
+      harnessHold = null;
+      resolve();
+    };
+  });
+}
 /** Every preference body the desktop POSTed, in order. */
 const saved: Record<string, unknown>[] = [];
 
@@ -70,7 +91,7 @@ function installFetch() {
     }
     if (url.includes("/setup-api/setup/status")) return answer({ setup_complete: true });
     if (url.includes("/setup-api/harness/active")) {
-      if (harnessDelayMs > 0) await new Promise((resolve) => setTimeout(resolve, harnessDelayMs));
+      if (harnessHold) await harnessHold;
       return answer({ active: activeHarness, edition: activeHarness, activeKnown });
     }
     if (url.includes("/setup-api/preferences?all=1")) {
@@ -148,7 +169,8 @@ beforeEach(() => {
   savedWallpaperId = "custom-2";
   activeHarness = "openclaw";
   activeKnown = true;
-  harnessDelayMs = 0;
+  harnessHold = null;
+  releaseHarnessProbe = () => {};
   saved.length = 0;
   resetHarnessCache();
   // jsdom does not implement it at all, so `vi.spyOn` cannot be used and
@@ -315,7 +337,7 @@ describe("deleting a custom wallpaper", () => {
     // which product it is; on the Hermes box that is a competitor's picture
     // flickering across the customer's screen on every load.
     activeHarness = "hermes";
-    harnessDelayMs = 900;
+    holdHarnessProbe();
     window.localStorage.removeItem("clawbox-custom-wallpapers");
     savedWallpaperId = "custom-2";
 
@@ -327,6 +349,7 @@ describe("deleting a custom wallpaper", () => {
     expect(saved.some((body) => "wp_id" in body && body.wp_id !== "custom-2")).toBe(false);
 
     // And once it does answer, the paint follows the edition.
+    releaseHarnessProbe();
     await waitFor(() => expect(wallpaperUrls().some((u) => u.includes("hermes-wallpaper"))).toBe(true));
     await new Promise((resolve) => setTimeout(resolve, 900));
     expect(saved.some((body) => "wp_id" in body && body.wp_id !== "custom-2")).toBe(false);
@@ -341,7 +364,7 @@ describe("deleting a custom wallpaper", () => {
     // slow — or has failed for good, after three attempts — persisted
     // "clawbox" box-wide. Permanent, and nothing to do with the edition.
     activeHarness = "hermes";
-    harnessDelayMs = 3_000;
+    holdHarnessProbe();
     savedWallpaperId = "custom-2";
 
     render(<ChromeDesktop />);
@@ -358,10 +381,11 @@ describe("deleting a custom wallpaper", () => {
       expect(JSON.parse(window.localStorage.getItem("clawbox-custom-wallpapers") || "[]"))
         .toEqual([WP[0], WP[1]]);
     });
-    // Well past the 500 ms debounce, still inside the probe delay.
+    // Well past the 500 ms debounce, and the probe is still held.
     await new Promise((resolve) => setTimeout(resolve, 900));
     expect(saved.some((body) => "wp_id" in body && body.wp_id === "clawbox")).toBe(false);
     expect(saved.some((body) => "wp_id" in body && body.wp_id !== "custom-2")).toBe(false);
+    releaseHarnessProbe();
   });
 
   it("does not offer a phantom slot for a picture this browser does not have", async () => {

--- a/src/tests/components/model-picker-live-catalog.test.tsx
+++ b/src/tests/components/model-picker-live-catalog.test.tsx
@@ -116,9 +116,29 @@ const LIVE = {
 /** Every catalog URL the component asked for, in order. */
 const catalogUrls: string[] = [];
 
+/**
+ * Whether the box has finished enumerating yet — the TEST decides, not the
+ * call count.
+ *
+ * It used to be `catalogCalls === 1 ? WARMING : LIVE`, which assumed the
+ * picker would not ask twice before the test told it to. It does: "keeps
+ * asking while the box is still enumerating" below is the behaviour that says
+ * so. On an idle machine the second poll landed after the cold-start
+ * assertion; in a full parallel run it landed before it, and "the curated
+ * three" was answered with all eleven (seen on beta, 2026-09-12). A flag makes
+ * the warming window last exactly as long as the case needs it to, and the
+ * re-read is still the thing under test — it is what carries the eleven.
+ */
+let catalogIsLive = false;
+
+/** The enumeration has landed; the NEXT read gets the live rows. */
+function goLive() {
+  catalogIsLive = true;
+}
+
 function stubFetch() {
   catalogUrls.length = 0;
-  let catalogCalls = 0;
+  catalogIsLive = false;
   vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
     const url = typeof input === "string" ? input : input instanceof Request ? input.url : String(input);
     if (url.includes("/setup-api/ai-models/oauth/providers")) {
@@ -126,10 +146,9 @@ function stubFetch() {
     }
     if (url.includes("/setup-api/ai-models/catalog")) {
       catalogUrls.push(url);
-      catalogCalls += 1;
       // The box is still warming when the picker first mounts; the enumeration
-      // lands a moment later, exactly as it does after a provider connect.
-      return { ok: true, json: async () => (catalogCalls === 1 ? WARMING : LIVE) } as Response;
+      // lands when the case says it has.
+      return { ok: true, json: async () => (catalogIsLive ? LIVE : WARMING) } as Response;
     }
     if (url.includes("harness")) {
       return { ok: true, json: async () => ({ edition: "openclaw" }) } as Response;
@@ -176,6 +195,7 @@ describe("model picker — live catalogue", () => {
     expect(within(listbox).getAllByRole("option")).toHaveLength(3);
 
     // A provider connect is the moment the catalogue becomes enumerable.
+    goLive();
     await act(async () => {
       notifyProvidersChanged();
       await new Promise((resolve) => setTimeout(resolve, 250));
@@ -211,6 +231,9 @@ describe("model picker — live catalogue", () => {
     // happened three minutes too early.
     await renderStep();
     await openModelList();
+    // Nothing connects; the enumeration simply finishes on the box, and the
+    // picker has to ask again of its own accord to see it.
+    goLive();
 
     await waitFor(() => expect(catalogUrls.length).toBeGreaterThan(1), { timeout: 5000 });
     await waitFor(() => {

--- a/src/tests/helpers/chat-connected.ts
+++ b/src/tests/helpers/chat-connected.ts
@@ -1,0 +1,28 @@
+import { expect } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+
+/**
+ * Wait until a chat surface has finished its gateway handshake.
+ *
+ * `ChatPopup` drops every `chat` / `session.message` event whose `sessionKey`
+ * is not the one it is showing (`ChatPopup.tsx`, the `sk !== sessionKeyRef`
+ * guard), and it only learns that key from the `connect` RESPONSE. A fake
+ * socket that answers on `setTimeout(0)` and a test that pushes a turn as soon
+ * as the socket OBJECT exists are therefore racing: on an idle machine the
+ * handshake has already landed, and under a full-suite run it has not — the
+ * turn is dropped for good and the test waits out its whole budget for
+ * something that will never render.
+ *
+ * Measured on beta, 2026-09-12: four chat suites failed only in a full run,
+ * passed in isolation, and still failed with the test budget raised to 60 s.
+ * It was never slowness.
+ *
+ * The main tab carries the key in the DOM, which is the surface's own report
+ * that it has it — a stronger signal than anything the fake socket can say
+ * about what it sent.
+ */
+export async function waitForChatSession(sessionKey = "agent:main:main"): Promise<void> {
+  await waitFor(() =>
+    expect(screen.getAllByTestId("chat-tab")[0]).toHaveAttribute("data-session-key", sessionKey),
+  );
+}

--- a/src/tests/routes/ai-models/catalog-clawai.test.ts
+++ b/src/tests/routes/ai-models/catalog-clawai.test.ts
@@ -12,7 +12,10 @@ vi.mock("@/lib/openclaw-config", () => ({
   findOpenclawBin: () => "openclaw",
   openclawIsAbsent: () => false,
 }));
-vi.mock("@/lib/config-store", () => ({ DATA_DIR: "/tmp/clawbox-catalog-clawai-test" }));
+// A per-PROCESS data root. A fixed `/tmp/<name>` is shared by every vitest
+// worker on the machine and by every checkout of this repo on it — the same
+// reason `vitest.config.ts` suffixes `CLAWBOX_ROOT` and `OPENCLAW_HOME`.
+vi.mock("@/lib/config-store", () => ({ DATA_DIR: `/tmp/clawbox-catalog-clawai-test-${process.pid}` }));
 
 import { CLAWAI_STATIC_MODELS } from "@/app/setup-api/ai-models/catalog/route";
 

--- a/src/tests/routes/ai-models/catalog-codex-unwritable-cache.test.ts
+++ b/src/tests/routes/ai-models/catalog-codex-unwritable-cache.test.ts
@@ -37,8 +37,11 @@ vi.mock("@/lib/openclaw-config", () => ({
   openclawIsAbsent: () => false,
 }));
 
-const DATA_DIR = "/tmp/clawbox-catalog-codex-unwritable-test";
-vi.mock("@/lib/config-store", () => ({ DATA_DIR: "/tmp/clawbox-catalog-codex-unwritable-test" }));
+// A per-PROCESS data root. A fixed `/tmp/<name>` is shared by every vitest
+// worker on the machine and by every checkout of this repo on it — the same
+// reason `vitest.config.ts` suffixes `CLAWBOX_ROOT` and `OPENCLAW_HOME`.
+const DATA_DIR = `/tmp/clawbox-catalog-codex-unwritable-test-${process.pid}`;
+vi.mock("@/lib/config-store", () => ({ DATA_DIR: `/tmp/clawbox-catalog-codex-unwritable-test-${process.pid}` }));
 
 import { GET } from "@/app/setup-api/ai-models/catalog/route";
 import { CODEX_MODELS } from "@/lib/provider-models";

--- a/src/tests/routes/ai-models/catalog-deprecated-rows.test.ts
+++ b/src/tests/routes/ai-models/catalog-deprecated-rows.test.ts
@@ -37,8 +37,11 @@ vi.mock("@/lib/openclaw-config", () => ({
   openclawIsAbsent: () => false,
 }));
 
-const DATA_DIR = "/tmp/clawbox-catalog-deprecated-test";
-vi.mock("@/lib/config-store", () => ({ DATA_DIR: "/tmp/clawbox-catalog-deprecated-test" }));
+// A per-PROCESS data root. A fixed `/tmp/<name>` is shared by every vitest
+// worker on the machine and by every checkout of this repo on it — the same
+// reason `vitest.config.ts` suffixes `CLAWBOX_ROOT` and `OPENCLAW_HOME`.
+const DATA_DIR = `/tmp/clawbox-catalog-deprecated-test-${process.pid}`;
+vi.mock("@/lib/config-store", () => ({ DATA_DIR: `/tmp/clawbox-catalog-deprecated-test-${process.pid}` }));
 
 const mockSpawn = vi.mocked(childProcess.spawn);
 

--- a/src/tests/routes/ai-models/catalog-edition.test.ts
+++ b/src/tests/routes/ai-models/catalog-edition.test.ts
@@ -14,7 +14,10 @@ vi.mock("@/lib/openclaw-config", () => ({
   openclawIsAbsent: () => mockOpenclawIsAbsent(),
 }));
 
-vi.mock("@/lib/config-store", () => ({ DATA_DIR: "/tmp/clawbox-catalog-edition-test" }));
+// A per-PROCESS data root. A fixed `/tmp/<name>` is shared by every vitest
+// worker on the machine and by every checkout of this repo on it — the same
+// reason `vitest.config.ts` suffixes `CLAWBOX_ROOT` and `OPENCLAW_HOME`.
+vi.mock("@/lib/config-store", () => ({ DATA_DIR: `/tmp/clawbox-catalog-edition-test-${process.pid}` }));
 
 import { refreshInBackground } from "@/app/setup-api/ai-models/catalog/route";
 

--- a/src/tests/routes/ai-models/catalog-empty-enumeration.test.ts
+++ b/src/tests/routes/ai-models/catalog-empty-enumeration.test.ts
@@ -27,8 +27,13 @@ vi.mock("@/lib/openclaw-config", () => ({
   openclawIsAbsent: () => false,
 }));
 
-const DATA_DIR = "/tmp/clawbox-catalog-empty-enumeration-test";
-vi.mock("@/lib/config-store", () => ({ DATA_DIR: "/tmp/clawbox-catalog-empty-enumeration-test" }));
+// A per-PROCESS data root. A fixed `/tmp/<name>` is shared by every vitest
+// worker on the machine and by every checkout of this repo on it: this suite
+// lost a run to a second checkout running the same file (beta, 2026-09-12 —
+// "expected 0 to be 2" over a record the other process had just reset). The
+// same suffix `vitest.config.ts` already gives `CLAWBOX_ROOT`.
+const DATA_DIR = `/tmp/clawbox-catalog-empty-enumeration-test-${process.pid}`;
+vi.mock("@/lib/config-store", () => ({ DATA_DIR: `/tmp/clawbox-catalog-empty-enumeration-test-${process.pid}` }));
 
 import { GET } from "@/app/setup-api/ai-models/catalog/route";
 

--- a/src/tests/routes/ai-models/catalog-forced-retry.test.ts
+++ b/src/tests/routes/ai-models/catalog-forced-retry.test.ts
@@ -42,8 +42,11 @@ vi.mock("@/lib/openclaw-config", () => ({
   openclawIsAbsent: () => false,
 }));
 
-const DATA_DIR = "/tmp/clawbox-catalog-forced-retry-test";
-vi.mock("@/lib/config-store", () => ({ DATA_DIR: "/tmp/clawbox-catalog-forced-retry-test" }));
+// A per-PROCESS data root. A fixed `/tmp/<name>` is shared by every vitest
+// worker on the machine and by every checkout of this repo on it — the same
+// reason `vitest.config.ts` suffixes `CLAWBOX_ROOT` and `OPENCLAW_HOME`.
+const DATA_DIR = `/tmp/clawbox-catalog-forced-retry-test-${process.pid}`;
+vi.mock("@/lib/config-store", () => ({ DATA_DIR: `/tmp/clawbox-catalog-forced-retry-test-${process.pid}` }));
 
 const mockSpawn = vi.mocked(childProcess.spawn);
 

--- a/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
+++ b/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
@@ -35,8 +35,11 @@ vi.mock("@/lib/openclaw-config", () => ({
   openclawIsAbsent: () => false,
 }));
 
-const DATA_DIR = "/tmp/clawbox-catalog-live-fallback-test";
-vi.mock("@/lib/config-store", () => ({ DATA_DIR: "/tmp/clawbox-catalog-live-fallback-test" }));
+// A per-PROCESS data root. A fixed `/tmp/<name>` is shared by every vitest
+// worker on the machine and by every checkout of this repo on it — the same
+// reason `vitest.config.ts` suffixes `CLAWBOX_ROOT` and `OPENCLAW_HOME`.
+const DATA_DIR = `/tmp/clawbox-catalog-live-fallback-test-${process.pid}`;
+vi.mock("@/lib/config-store", () => ({ DATA_DIR: `/tmp/clawbox-catalog-live-fallback-test-${process.pid}` }));
 
 import { GET, refreshInBackground } from "@/app/setup-api/ai-models/catalog/route";
 import { CODEX_MODELS } from "@/lib/provider-models";

--- a/src/tests/routes/ai-models/catalog-provider-change.test.ts
+++ b/src/tests/routes/ai-models/catalog-provider-change.test.ts
@@ -22,8 +22,11 @@ vi.mock("@/lib/openclaw-config", () => ({
   openclawIsAbsent: () => false,
 }));
 
-const DATA_DIR = "/tmp/clawbox-catalog-provider-change-test";
-vi.mock("@/lib/config-store", () => ({ DATA_DIR: "/tmp/clawbox-catalog-provider-change-test" }));
+// A per-PROCESS data root. A fixed `/tmp/<name>` is shared by every vitest
+// worker on the machine and by every checkout of this repo on it — the same
+// reason `vitest.config.ts` suffixes `CLAWBOX_ROOT` and `OPENCLAW_HOME`.
+const DATA_DIR = `/tmp/clawbox-catalog-provider-change-test-${process.pid}`;
+vi.mock("@/lib/config-store", () => ({ DATA_DIR: `/tmp/clawbox-catalog-provider-change-test-${process.pid}` }));
 
 import { GET, notifyProviderSetChanged, refreshInBackground } from "@/app/setup-api/ai-models/catalog/route";
 

--- a/src/tests/routes/ai-models/catalog-sanitised-empty-cache.test.ts
+++ b/src/tests/routes/ai-models/catalog-sanitised-empty-cache.test.ts
@@ -30,8 +30,11 @@ vi.mock("@/lib/openclaw-config", () => ({
   openclawIsAbsent: () => false,
 }));
 
-const DATA_DIR = "/tmp/clawbox-catalog-sanitised-empty-test";
-vi.mock("@/lib/config-store", () => ({ DATA_DIR: "/tmp/clawbox-catalog-sanitised-empty-test" }));
+// A per-PROCESS data root. A fixed `/tmp/<name>` is shared by every vitest
+// worker on the machine and by every checkout of this repo on it — the same
+// reason `vitest.config.ts` suffixes `CLAWBOX_ROOT` and `OPENCLAW_HOME`.
+const DATA_DIR = `/tmp/clawbox-catalog-sanitised-empty-test-${process.pid}`;
+vi.mock("@/lib/config-store", () => ({ DATA_DIR: `/tmp/clawbox-catalog-sanitised-empty-test-${process.pid}` }));
 
 import { GET } from "@/app/setup-api/ai-models/catalog/route";
 

--- a/src/tests/routes/ai-models/catalog-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/catalog-subscription-surface.test.ts
@@ -36,8 +36,11 @@ vi.mock("@/lib/openclaw-config", () => ({
   openclawIsAbsent: () => false,
 }));
 
-const DATA_DIR = "/tmp/clawbox-catalog-surface-test";
-vi.mock("@/lib/config-store", () => ({ DATA_DIR: "/tmp/clawbox-catalog-surface-test" }));
+// A per-PROCESS data root. A fixed `/tmp/<name>` is shared by every vitest
+// worker on the machine and by every checkout of this repo on it — the same
+// reason `vitest.config.ts` suffixes `CLAWBOX_ROOT` and `OPENCLAW_HOME`.
+const DATA_DIR = `/tmp/clawbox-catalog-surface-test-${process.pid}`;
+vi.mock("@/lib/config-store", () => ({ DATA_DIR: `/tmp/clawbox-catalog-surface-test-${process.pid}` }));
 
 import { refreshInBackground } from "@/app/setup-api/ai-models/catalog/route";
 

--- a/src/tests/routes/ai-models/catalog-surface-cache.test.ts
+++ b/src/tests/routes/ai-models/catalog-surface-cache.test.ts
@@ -19,14 +19,17 @@ import * as childProcess from "child_process";
 // Its own file because the route's `memCache` is module-level: a fresh module
 // is the only way to observe the cold path and the warm path in one test.
 
-const DATA_DIR = "/tmp/clawbox-catalog-surface-cache-test";
+// A per-PROCESS data root. A fixed `/tmp/<name>` is shared by every vitest
+// worker on the machine and by every checkout of this repo on it — the same
+// reason `vitest.config.ts` suffixes `CLAWBOX_ROOT` and `OPENCLAW_HOME`.
+const DATA_DIR = `/tmp/clawbox-catalog-surface-cache-test-${process.pid}`;
 
 vi.mock("child_process", () => ({ spawn: vi.fn() }));
 vi.mock("@/lib/openclaw-config", () => ({
   findOpenclawBin: () => "openclaw",
   openclawIsAbsent: () => false,
 }));
-vi.mock("@/lib/config-store", () => ({ DATA_DIR: "/tmp/clawbox-catalog-surface-cache-test" }));
+vi.mock("@/lib/config-store", () => ({ DATA_DIR: `/tmp/clawbox-catalog-surface-cache-test-${process.pid}` }));
 
 import { refreshInBackground } from "@/app/setup-api/ai-models/catalog/route";
 

--- a/src/tests/routes/apps/icon.test.ts
+++ b/src/tests/routes/apps/icon.test.ts
@@ -9,8 +9,12 @@ vi.mock("fs/promises", () => ({
   },
 }));
 
+// A per-PROCESS data root, and here it is not a precaution: `/tmp/test-data`
+// was the root of FOUR suites that run in parallel, each wiping it in its own
+// `beforeEach`. The same suffix `vitest.config.ts` already gives
+// `CLAWBOX_ROOT` and `OPENCLAW_HOME`, for the same reason.
 vi.mock("@/lib/config-store", () => ({
-  DATA_DIR: "/tmp/test-data",
+  DATA_DIR: `/tmp/test-data-${process.pid}`,
   getAll: vi.fn().mockResolvedValue({}),
 }));
 
@@ -112,7 +116,8 @@ describe("/setup-api/apps/icon/[appId]", () => {
     await icon();
     await settle();
     expect(fs.writeFile).toHaveBeenCalledTimes(1);
-    expect(String(vi.mocked(fs.writeFile).mock.calls[0][0])).toBe("/tmp/test-data/icons/test.png");
+    expect(String(vi.mocked(fs.writeFile).mock.calls[0][0]))
+      .toBe(`/tmp/test-data-${process.pid}/icons/test.png`);
   });
 
   it("remembers an icon the store does not have and stops asking for it", async () => {

--- a/src/tests/routes/apps/install.test.ts
+++ b/src/tests/routes/apps/install.test.ts
@@ -23,9 +23,13 @@ vi.mock("fs", () => ({
 // Inline implementations, not chained .mockResolvedValue: the config's
 // `mockReset: true` wipes chained values before every test while a vi.fn(impl)
 // keeps its implementation, and these factories only run once per file.
+// A per-PROCESS data root, and here it is not a precaution: `/tmp/test-data`
+// was the root of FOUR suites that run in parallel, each wiping it in its own
+// `beforeEach`. The same suffix `vitest.config.ts` already gives
+// `CLAWBOX_ROOT` and `OPENCLAW_HOME`, for the same reason.
 vi.mock("@/lib/config-store", () => ({
-  DATA_DIR: "/tmp/test-data",
-  CONFIG_ROOT: "/tmp/test-data",
+  DATA_DIR: `/tmp/test-data-${process.pid}`,
+  CONFIG_ROOT: `/tmp/test-data-${process.pid}`,
   getAll: vi.fn(async () => ({})),
   setMany: vi.fn(async () => undefined),
 }));

--- a/src/tests/routes/apps/uninstall.test.ts
+++ b/src/tests/routes/apps/uninstall.test.ts
@@ -28,8 +28,12 @@ vi.mock("@/lib/kv-store", () => ({
   kvDelete: vi.fn(),
 }));
 
+// A per-PROCESS data root, and here it is not a precaution: `/tmp/test-data`
+// was the root of FOUR suites that run in parallel, each wiping it in its own
+// `beforeEach`. The same suffix `vitest.config.ts` already gives
+// `CLAWBOX_ROOT` and `OPENCLAW_HOME`, for the same reason.
 vi.mock("@/lib/config-store", () => ({
-  DATA_DIR: "/tmp/test-data",
+  DATA_DIR: `/tmp/test-data-${process.pid}`,
   getAll: vi.fn().mockResolvedValue({}),
   setMany: vi.fn().mockResolvedValue(undefined),
 }));

--- a/src/tests/routes/files/safe-path-containment.test.ts
+++ b/src/tests/routes/files/safe-path-containment.test.ts
@@ -5,6 +5,15 @@ import path from "path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
+// The generated-corpus case drives the route 3 000 times with real fs behind
+// it, and that is the thing under test — the ROUTE's verdict, not a copy of
+// the predicate. Measured 2026-09-12 on an idle 12-core machine, the file
+// alone: 4,562 ms, i.e. 91% of vitest's 5 s default spent before any
+// contention at all. It duly timed out in a full parallel run of the unit
+// project and passed in the next one, which is the definition of a test
+// running on the wrong budget.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
 /**
  * TASK-742 — the Files API's containment check, and the equivalence that had
  * to hold while its SHAPE changed.

--- a/src/tests/routes/hermes-chat-dashboard-error-text.test.ts
+++ b/src/tests/routes/hermes-chat-dashboard-error-text.test.ts
@@ -48,7 +48,10 @@ vi.mock("@/lib/harness/hermes-turn-record", () => ({
 }));
 vi.mock("@/lib/harness/media-root", () => ({
   resolveInMediaRoot: vi.fn(async (p: string) => p),
-  chatMediaRoot: vi.fn(async () => "/tmp/clawbox-dashboard-error-media"),
+// A per-PROCESS data root. A fixed `/tmp/<name>` is shared by every vitest
+// worker on the machine and by every checkout of this repo on it — the same
+// reason `vitest.config.ts` suffixes `CLAWBOX_ROOT` and `OPENCLAW_HOME`.
+  chatMediaRoot: vi.fn(async () => `/tmp/clawbox-dashboard-error-media-${process.pid}`),
 }));
 vi.mock("@/lib/hermes-model-options", () => ({
   getModelOptions: vi.fn(async () => null),

--- a/src/tests/routes/hermes-chat-streaming.test.ts
+++ b/src/tests/routes/hermes-chat-streaming.test.ts
@@ -54,7 +54,10 @@ vi.mock("@/lib/harness/hermes-turn-record", () => ({
 // this file would be exercising that fallback instead of the real path.
 vi.mock("@/lib/harness/media-root", () => ({
   resolveInMediaRoot: vi.fn(async (p: string) => p),
-  chatMediaRoot: vi.fn(async () => "/tmp/clawbox-streaming-media"),
+// A per-PROCESS data root. A fixed `/tmp/<name>` is shared by every vitest
+// worker on the machine and by every checkout of this repo on it — the same
+// reason `vitest.config.ts` suffixes `CLAWBOX_ROOT` and `OPENCLAW_HOME`.
+  chatMediaRoot: vi.fn(async () => `/tmp/clawbox-streaming-media-${process.pid}`),
 }));
 vi.mock("@/lib/hermes-model-options", () => ({
   // No catalogue: the route falls back to its static allowlist and lets hermes

--- a/src/tests/routes/hermes/chat-reasoning.test.ts
+++ b/src/tests/routes/hermes/chat-reasoning.test.ts
@@ -27,8 +27,11 @@ vi.mock("@/lib/hermes-model-options", async (importOriginal) => {
 // this one at import time. A mock that omits it makes the route unloadable
 // rather than making it fail a case — the same shape the other config-store
 // mocks in this suite already use.
+// A per-PROCESS data root. A fixed `/tmp/<name>` is shared by every vitest
+// worker on the machine and by every checkout of this repo on it — the same
+// reason `vitest.config.ts` suffixes `CLAWBOX_ROOT` and `OPENCLAW_HOME`.
 vi.mock("@/lib/config-store", () => ({
-  DATA_DIR: "/tmp/clawbox-chat-reasoning-test",
+  DATA_DIR: `/tmp/clawbox-chat-reasoning-test-${process.pid}`,
   get: vi.fn(),
   // The settle path records which provider answered. Without a `set` here that
   // write throws inside the recorder's own catch and is silently swallowed, so

--- a/src/tests/routes/hermes/chat-served-model-dashboard.test.ts
+++ b/src/tests/routes/hermes/chat-served-model-dashboard.test.ts
@@ -55,7 +55,10 @@ vi.mock("@/lib/config-store", async (importOriginal) => ({
 }));
 vi.mock("@/lib/harness/media-root", () => ({
   resolveInMediaRoot: vi.fn(async (p: string) => p),
-  chatMediaRoot: vi.fn(async () => "/tmp/clawbox-served-model-dashboard-media"),
+// A per-PROCESS data root. A fixed `/tmp/<name>` is shared by every vitest
+// worker on the machine and by every checkout of this repo on it — the same
+// reason `vitest.config.ts` suffixes `CLAWBOX_ROOT` and `OPENCLAW_HOME`.
+  chatMediaRoot: vi.fn(async () => `/tmp/clawbox-served-model-dashboard-media-${process.pid}`),
 }));
 // `cachedModelOptions` is what the settle path reads, and the pure judges around
 // it (`shouldEnforcePairing` / `isPairAllowed`) stay real — a hand-written

--- a/src/tests/routes/hermes/chat-served-model.test.ts
+++ b/src/tests/routes/hermes/chat-served-model.test.ts
@@ -18,8 +18,11 @@ vi.mock("@/lib/hermes-model-options", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/hermes-model-options")>();
   return { ...actual, getModelOptions: vi.fn(), readCurrentFromCli: vi.fn() };
 });
+// A per-PROCESS data root. A fixed `/tmp/<name>` is shared by every vitest
+// worker on the machine and by every checkout of this repo on it — the same
+// reason `vitest.config.ts` suffixes `CLAWBOX_ROOT` and `OPENCLAW_HOME`.
 vi.mock("@/lib/config-store", () => ({
-  DATA_DIR: "/tmp/clawbox-chat-served-model-test",
+  DATA_DIR: `/tmp/clawbox-chat-served-model-test-${process.pid}`,
   get: vi.fn(),
 }));
 // The dashboard transport, captured: the cases below read what the route

--- a/src/tests/routes/hermes/chat-spawn-errno.test.ts
+++ b/src/tests/routes/hermes/chat-spawn-errno.test.ts
@@ -26,8 +26,11 @@ vi.mock("@/lib/hermes-model-options", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/hermes-model-options")>();
   return { ...actual, getModelOptions: vi.fn() };
 });
+// A per-PROCESS data root. A fixed `/tmp/<name>` is shared by every vitest
+// worker on the machine and by every checkout of this repo on it — the same
+// reason `vitest.config.ts` suffixes `CLAWBOX_ROOT` and `OPENCLAW_HOME`.
 vi.mock("@/lib/config-store", () => ({
-  DATA_DIR: "/tmp/clawbox-chat-spawn-errno-test",
+  DATA_DIR: `/tmp/clawbox-chat-spawn-errno-test-${process.pid}`,
   get: vi.fn(),
 }));
 vi.mock("@/lib/harness/transcript-store", () => ({ appendTranscript: vi.fn(async () => {}) }));

--- a/src/tests/routes/login-api.test.ts
+++ b/src/tests/routes/login-api.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 vi.mock("@/lib/config-store", () => ({
   get: vi.fn(),
   set: vi.fn(),
-  DATA_DIR: "/tmp/clawbox-test-data",
+// A per-PROCESS data root, and here it is not a precaution: `/tmp/test-data`
+// was the root of FOUR suites that run in parallel, each wiping it in its own
+// `beforeEach`. The same suffix `vitest.config.ts` already gives
+// `CLAWBOX_ROOT` and `OPENCLAW_HOME`, for the same reason.
+  DATA_DIR: `/tmp/clawbox-test-data-${process.pid}`,
 }));
 
 vi.mock("@/lib/auth", () => ({

--- a/src/tests/unit/code-projects.test.ts
+++ b/src/tests/unit/code-projects.test.ts
@@ -34,8 +34,12 @@ vi.mock("fs/promises", () => ({
   },
 }));
 
+// A per-PROCESS data root, and here it is not a precaution: `/tmp/test-data`
+// was the root of FOUR suites that run in parallel, each wiping it in its own
+// `beforeEach`. The same suffix `vitest.config.ts` already gives
+// `CLAWBOX_ROOT` and `OPENCLAW_HOME`, for the same reason.
 vi.mock("@/lib/config-store", () => ({
-  DATA_DIR: "/tmp/test-data",
+  DATA_DIR: `/tmp/test-data-${process.pid}`,
 }));
 
 // buildProject now registers the built app on the desktop (durability backstop).
@@ -571,7 +575,7 @@ describe("code-projects", () => {
  */
 describe("the containment check accepts exactly what it accepted before", () => {
   const PROJECT = "probe";
-  const DIR = path.join("/tmp/test-data", "code-projects", PROJECT);
+  const DIR = path.join(`/tmp/test-data-${process.pid}`, "code-projects", PROJECT);
 
   /** Beta's predicate, verbatim apart from the root it resolves against. */
   function betaRefuses(filePath: string): boolean {

--- a/src/tests/unit/local-ai-autostart.test.ts
+++ b/src/tests/unit/local-ai-autostart.test.ts
@@ -27,7 +27,11 @@ vi.mock("@/lib/openclaw-config", () => ({
 const getAllMock = vi.fn();
 vi.mock("@/lib/config-store", () => ({
   getAll: (...args: unknown[]) => getAllMock(...args),
-  DATA_DIR: "/tmp/clawbox-test-data",
+// A per-PROCESS data root, and here it is not a precaution: `/tmp/test-data`
+// was the root of FOUR suites that run in parallel, each wiping it in its own
+// `beforeEach`. The same suffix `vitest.config.ts` already gives
+// `CLAWBOX_ROOT` and `OPENCLAW_HOME`, for the same reason.
+  DATA_DIR: `/tmp/clawbox-test-data-${process.pid}`,
   CONFIG_ROOT: "/tmp/clawbox-test-root",
 }));
 

--- a/src/tests/unit/local-model-profile.test.ts
+++ b/src/tests/unit/local-model-profile.test.ts
@@ -127,10 +127,28 @@ describe("the built-in toolsets a slim turn keeps", () => {
  * the models endpoint reports, so the parser owns this.
  */
 describe("reading a size out of a model id is linear in its length", () => {
-  const timeMs = (input: string): number => {
+  /**
+   * Enough parses that each side of the ratio is tens of milliseconds rather
+   * than hundredths of one. The whole case costs well under a second.
+   */
+  const REPEATS = 50;
+
+  /**
+   * Milliseconds for ONE parse, averaged over `repeats`.
+   *
+   * Averaging is not decoration: a single linear parse of 50 000 characters is
+   * a few hundredths of a millisecond, which is at the resolution of
+   * `performance.now()` and well inside one scheduler slice. The ratio below
+   * used to divide by `Math.max(small, 0.05)`, so a small case that measured
+   * at or under that floor turned a perfectly linear large case into a ratio
+   * of 70 and reported the quadratic as back (beta, 2026-09-12, in a full
+   * parallel run on a loaded machine). Repeating until each side is tens of
+   * milliseconds makes both numbers mean something, and needs no floor.
+   */
+  const timeMs = (input: string, repeats = 1): number => {
     const started = performance.now();
-    parseModelParamBillions(input);
-    return performance.now() - started;
+    for (let i = 0; i < repeats; i++) parseModelParamBillions(input);
+    return (performance.now() - started) / repeats;
   };
 
   it("does not blow up on a long run of digits", () => {
@@ -143,9 +161,9 @@ describe("reading a size out of a model id is linear in its length", () => {
 
   it("scales linearly rather than quadratically", () => {
     // Warm the JIT so the first call's compile time is not read as cost.
-    timeMs("0".repeat(50_000));
-    const small = Math.max(timeMs("0".repeat(50_000)), 0.05);
-    const large = timeMs("0".repeat(400_000));
+    timeMs("0".repeat(50_000), REPEATS);
+    const small = timeMs("0".repeat(50_000), REPEATS);
+    const large = timeMs("0".repeat(400_000), REPEATS);
     // 8x the input. Linear predicts ~8x the time; quadratic predicts ~64x.
     expect(large / small).toBeLessThan(32);
   });

--- a/src/tests/unit/memory-index-local.test.ts
+++ b/src/tests/unit/memory-index-local.test.ts
@@ -99,10 +99,20 @@ function installFetchStub(): void {
   }));
 }
 
+let sourceParent: string;
 let source: string;
 
 beforeEach(async () => {
-  source = fs.mkdtempSync(path.join(os.tmpdir(), "memory-index-src-"));
+  // The source folder gets a temp PARENT of its own rather than sitting
+  // directly under the OS tmpdir: one test below removes `<source>` from the
+  // list and registers `path.dirname(source)`, and with that dirname being
+  // /tmp the pass walked every stray Markdown file another process had left
+  // there. The stub embedder gives two texts that share a marker word the
+  // same vector, so a leftover /tmp/*.md containing "deposit" tied with — and
+  // beat — the file the test wrote (observed on beta, 2026-09-12).
+  sourceParent = fs.mkdtempSync(path.join(os.tmpdir(), "memory-index-parent-"));
+  source = path.join(sourceParent, "memory-index-src");
+  fs.mkdirSync(source, { recursive: true });
   embedCalls.texts = [];
   embedCalls.types = [];
   embedFail.status = 0;
@@ -115,7 +125,7 @@ beforeEach(async () => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
-  fs.rmSync(source, { recursive: true, force: true });
+  fs.rmSync(sourceParent, { recursive: true, force: true });
 });
 
 afterAll(() => {

--- a/src/tests/unit/test-timeout-hygiene.test.ts
+++ b/src/tests/unit/test-timeout-hygiene.test.ts
@@ -244,6 +244,16 @@ function declared(stripped: string, key: "testTimeout" | "hookTimeout"): number 
 const MIN_TIMEOUT_MS = 15_000;
 
 /**
+ * The floor for the `ChatPopup` family below, which is higher than
+ * `MIN_TIMEOUT_MS` because the cost there is not one series of subprocesses but
+ * a jsdom mount of the app's heaviest component repeated per case. Every file
+ * in it declares 30 s, and the rule enforces the number its own comment names —
+ * with the shared 15 s floor a suite could have declared 15 s and passed a check
+ * that claims to be about 30.
+ */
+const CHAT_POPUP_TIMEOUT_MS = 30_000;
+
+/**
  * Files that flake for a reason other than a subprocess, named from the CI runs
  * above rather than detected: long `findBy*` waits against a jsdom tree, and a
  * fake-timer probe fan-out whose module imports dominate under load. A pattern
@@ -509,8 +519,8 @@ describe("test-timeout hygiene", () => {
       .filter((f) => f.code.includes("<ChatPopup"))
       .filter(
         (f) =>
-          (declared(f.code, "testTimeout") ?? 0) < MIN_TIMEOUT_MS
-          || (declared(f.code, "hookTimeout") ?? 0) < MIN_TIMEOUT_MS,
+          (declared(f.code, "testTimeout") ?? 0) < CHAT_POPUP_TIMEOUT_MS
+          || (declared(f.code, "hookTimeout") ?? 0) < CHAT_POPUP_TIMEOUT_MS,
       )
       .map((f) => f.rel);
 

--- a/src/tests/unit/test-timeout-hygiene.test.ts
+++ b/src/tests/unit/test-timeout-hygiene.test.ts
@@ -287,6 +287,16 @@ const ALSO_REQUIRED = [
   "src/tests/components/chat-email-refs-surfaces.test.tsx",
   "src/tests/components/chat-clawbox-ai-model-pill.test.tsx",
   "src/tests/components/chat-popup-dismiss-and-geometry.test.tsx",
+  // The rest of the chat/provider mount family, added 2026-09-12 from measured
+  // worst cases in a clean full parallel run of all 216 component files: each
+  // of these five has under 2 s of headroom below the 5 s default
+  // (3,456 / 3,199 / 3,175 / 3,106 / 3,031 ms), and the first two timed out
+  // when the machine was loaded further. Each file states its own number.
+  "src/tests/components/chat-header-seed-race.test.tsx",
+  "src/tests/components/chat-voice-recording.test.tsx",
+  "src/tests/components/chat-hermes-stale-catalogue.test.tsx",
+  "src/tests/components/chat-header-chatgpt-row.test.tsx",
+  "src/tests/components/ai-provider-list.test.tsx",
   // Starts no process either: it drives the Files route 3 000 times over a
   // generated corpus, with real fs behind it, inside ONE case. 4,562 ms on an
   // idle machine (2026-09-12) — 91% of the default before any contention, and

--- a/src/tests/unit/test-timeout-hygiene.test.ts
+++ b/src/tests/unit/test-timeout-hygiene.test.ts
@@ -277,6 +277,21 @@ const ALSO_REQUIRED = [
   // Same family, same mount, same reason: it drives the chat popup through a
   // fake gateway and waits on a spoken reply landing in a bubble.
   "src/tests/components/chat-spoken-reply-player.test.tsx",
+  // The rest of that family, added 2026-09-12 after the three of them were the
+  // only component files reporting "Test timed out in 5000ms" in a full
+  // parallel run of all 215. Each mounts `ChatPopup` and then waits on several
+  // sub-5 s `waitFor`s in series; the slowest PASSING case among them measured
+  // 4,558 ms, i.e. 442 ms of headroom under the default. (The races those
+  // timeouts were hiding are fixed separately — the point of the ceiling is
+  // that the next one reports the element it could not find instead.)
+  "src/tests/components/chat-email-refs-surfaces.test.tsx",
+  "src/tests/components/chat-clawbox-ai-model-pill.test.tsx",
+  "src/tests/components/chat-popup-dismiss-and-geometry.test.tsx",
+  // Starts no process either: it drives the Files route 3 000 times over a
+  // generated corpus, with real fs behind it, inside ONE case. 4,562 ms on an
+  // idle machine (2026-09-12) — 91% of the default before any contention, and
+  // it duly timed out in a full parallel run.
+  "src/tests/routes/files/safe-path-containment.test.ts",
   // Starts its processes through @/lib/coding-agent rather than importing
   // child_process itself, so the rule above cannot see it — and CI has seen it
   // both ways in one day: "pauses a live run…" timed out on one PR, and on

--- a/src/tests/unit/test-timeout-hygiene.test.ts
+++ b/src/tests/unit/test-timeout-hygiene.test.ts
@@ -273,29 +273,11 @@ const ALSO_REQUIRED = [
   // it before the mascot and the chat popup were mocked out of the mount.
   "src/tests/components/desktop-wallpaper-delete.test.tsx",
   "src/tests/components/hermes-oauth-inline.test.tsx",
-  "src/tests/components/chat-spoken-reply.test.tsx",
-  // Same family, same mount, same reason: it drives the chat popup through a
-  // fake gateway and waits on a spoken reply landing in a bubble.
-  "src/tests/components/chat-spoken-reply-player.test.tsx",
-  // The rest of that family, added 2026-09-12 after the three of them were the
-  // only component files reporting "Test timed out in 5000ms" in a full
-  // parallel run of all 215. Each mounts `ChatPopup` and then waits on several
-  // sub-5 s `waitFor`s in series; the slowest PASSING case among them measured
-  // 4,558 ms, i.e. 442 ms of headroom under the default. (The races those
-  // timeouts were hiding are fixed separately — the point of the ceiling is
-  // that the next one reports the element it could not find instead.)
-  "src/tests/components/chat-email-refs-surfaces.test.tsx",
-  "src/tests/components/chat-clawbox-ai-model-pill.test.tsx",
-  "src/tests/components/chat-popup-dismiss-and-geometry.test.tsx",
-  // The rest of the chat/provider mount family, added 2026-09-12 from measured
-  // worst cases in a clean full parallel run of all 216 component files: each
-  // of these five has under 2 s of headroom below the 5 s default
-  // (3,456 / 3,199 / 3,175 / 3,106 / 3,031 ms), and the first two timed out
-  // when the machine was loaded further. Each file states its own number.
-  "src/tests/components/chat-header-seed-race.test.tsx",
-  "src/tests/components/chat-voice-recording.test.tsx",
+  // The two component suites in the chat/provider mount family that do NOT
+  // mount `ChatPopup`, so the rule below cannot detect them. Measured
+  // 2026-09-12 in a clean full parallel run of all 216 component files:
+  // 3,175 ms and 3,031 ms, i.e. under 2 s of headroom below the default.
   "src/tests/components/chat-hermes-stale-catalogue.test.tsx",
-  "src/tests/components/chat-header-chatgpt-row.test.tsx",
   "src/tests/components/ai-provider-list.test.tsx",
   // Starts no process either: it drives the Files route 3 000 times over a
   // generated corpus, with real fs behind it, inside ONE case. 4,562 ms on an
@@ -502,6 +484,40 @@ describe("test-timeout hygiene", () => {
     });
 
     expect(offenders).toEqual([]);
+  });
+
+  it("gives every suite that mounts the chat popup both ceilings", () => {
+    // A DETECTED family rather than a list, because the list was growing one
+    // CI failure at a time and every entry named the same component.
+    //
+    // A jsdom mount of `ChatPopup` is the most expensive render in this app —
+    // the fake gateway handshake, the model seed, the transcript — and a case
+    // does it once and then waits on several sub-5 s `waitFor`s in series,
+    // which is exactly what `testTimeout` governs. Measured 2026-09-12 with
+    // all 216 component files running fully parallel on a 12-core machine, the
+    // slowest PASSING case in this family was 4,558 ms — 442 ms of headroom —
+    // and twelve distinct files in it were seen reporting "Test timed out in
+    // 5000ms" once the machine was loaded further. 5 s is not a hang guard
+    // here; it is a source of failures on files nobody touched, and of
+    // CASCADES, since an aborted case leaves its component draining a queue
+    // into the next one's collector (chat-queue-starvation, same day).
+    //
+    // 30 s still fails a test that has genuinely hung, and the test job's
+    // `timeout-minutes: 30` below is what bounds the cost of one.
+    const offenders = files
+      .filter((f) => f.rel.startsWith("src/tests/components/"))
+      .filter((f) => f.code.includes("<ChatPopup"))
+      .filter(
+        (f) =>
+          (declared(f.code, "testTimeout") ?? 0) < MIN_TIMEOUT_MS
+          || (declared(f.code, "hookTimeout") ?? 0) < MIN_TIMEOUT_MS,
+      )
+      .map((f) => f.rel);
+
+    expect(offenders).toEqual([]);
+    // …and the family is really there, so a renamed component cannot make this
+    // assertion vacuous the way an empty selector would.
+    expect(files.filter((f) => f.code.includes("<ChatPopup")).length).toBeGreaterThan(20);
   });
 
   it("keeps the inline-budget exemptions honest", () => {

--- a/src/tests/unit/webapp-registry.test.ts
+++ b/src/tests/unit/webapp-registry.test.ts
@@ -3,7 +3,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("@/lib/config-store", () => ({
   // DATA_DIR is pulled in through webapp-icon, which the registry now calls to
   // draw a picture for every app that reaches the desktop.
-  DATA_DIR: "/tmp/clawbox-webapp-registry-test",
+// A per-PROCESS data root. A fixed `/tmp/<name>` is shared by every vitest
+// worker on the machine and by every checkout of this repo on it — the same
+// reason `vitest.config.ts` suffixes `CLAWBOX_ROOT` and `OPENCLAW_HOME`.
+  DATA_DIR: `/tmp/clawbox-webapp-registry-test-${process.pid}`,
   getAll: vi.fn(),
   setMany: vi.fn(),
 }));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -91,6 +91,25 @@ export default defineConfig({
           include: ["src/tests/components/**/*.test.tsx"],
           exclude: ["**/node_modules/**", "**/.next/**"],
           setupFiles: ["src/tests/setup.ts"],
+          // Two budgets, deliberately far apart.
+          //
+          // `src/tests/setup.ts` gives Testing Library's waitFor/findBy 5 s,
+          // and vitest's own default for a test is also 5 s — so a wait that
+          // used its whole budget killed the TEST first and reported "Test
+          // timed out in 5000ms" instead of the "Unable to find an element by
+          // [data-testid=…]" that says which element and shows the DOM. Every
+          // one of the races fixed in this suite hid behind that message.
+          //
+          // The number: with the 215 component files running fully parallel on
+          // a 12-core machine, the slowest PASSING test measured 4,558 ms
+          // (chat-clawbox-ai-model-pill, "is absent — no picker and no
+          // read-only tier label", 2026-09-12) — 442 ms of headroom under the
+          // default. A jsdom mount of ChatPopup costs seconds under that much
+          // contention, and several tests mount it twice. 20 s leaves room for
+          // that and still sits well above the 5 s a failing wait needs to
+          // report itself properly.
+          testTimeout: 20_000,
+          hookTimeout: 20_000,
         },
       },
     ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -91,25 +91,6 @@ export default defineConfig({
           include: ["src/tests/components/**/*.test.tsx"],
           exclude: ["**/node_modules/**", "**/.next/**"],
           setupFiles: ["src/tests/setup.ts"],
-          // Two budgets, deliberately far apart.
-          //
-          // `src/tests/setup.ts` gives Testing Library's waitFor/findBy 5 s,
-          // and vitest's own default for a test is also 5 s — so a wait that
-          // used its whole budget killed the TEST first and reported "Test
-          // timed out in 5000ms" instead of the "Unable to find an element by
-          // [data-testid=…]" that says which element and shows the DOM. Every
-          // one of the races fixed in this suite hid behind that message.
-          //
-          // The number: with the 215 component files running fully parallel on
-          // a 12-core machine, the slowest PASSING test measured 4,558 ms
-          // (chat-clawbox-ai-model-pill, "is absent — no picker and no
-          // read-only tier label", 2026-09-12) — 442 ms of headroom under the
-          // default. A jsdom mount of ChatPopup costs seconds under that much
-          // contention, and several tests mount it twice. 20 s leaves room for
-          // that and still sits well above the 5 s a failing wait needs to
-          // report itself properly.
-          testTimeout: 20_000,
-          hookTimeout: 20_000,
         },
       },
     ],


### PR DESCRIPTION
Stabilisation only — no new features, no product behaviour changed. Every change is in
`src/tests/**`.

Seven feature merges landed on `beta` today. A full local run of both vitest projects
found one failing unit test and a set of tests that failed in a full parallel run and
passed in isolation. Each was traced to a real cause and fixed at that cause; no
assertion was skipped, weakened or deleted.

## The races (fixed at the cause, not the budget)

Proven to be races rather than timeouts: re-run with `--testTimeout=60000` they still
failed, and then reported the element they could not find instead of "Test timed out".

1. **`ChatPopup` turns pushed before the handshake.** `ChatPopup.tsx` drops a `chat` /
   `session.message` event whose `sessionKey` is not the one it is showing, and it only
   learns its own key from the `connect` RESPONSE. Suites that pushed a turn as soon as
   the fake socket OBJECT existed were racing that response's `setTimeout(0)`; the turn
   was dropped for good. New shared helper `src/tests/helpers/chat-connected.ts` waits for
   the surface's own report that it has the key (the main tab's `data-session-key`).
2. **`chat-spoken-reply-player` duplicate turn** — it pushed the live copy of a turn
   before the stored copy had landed. The surface folds the two into one turn only when
   history arrives first, so `findByText` failed with "found multiple elements".
3. **`desktop-wallpaper-delete` raced a real timer** — the harness probe was held with
   `setTimeout(3000)` while the case asserted what the desktop does *before* it answers.
   Under a full parallel run the test outlived the timer. The probe is now held by a
   promise the case releases itself; this also removed ~10 s of real waiting from the file.
4. **`memory-index-local` indexed `/tmp`** — one case removes `<source>` from the memory
   sources and registers `path.dirname(source)`, which was `/tmp` itself, so the pass
   walked every stray Markdown file on the machine. The stub embedder gives two texts
   sharing a marker word the same vector, so a leftover `/tmp/*.md` containing "deposit"
   tied with — and beat — the file the test wrote. The source folder now gets a temp parent
   of its own. Verified by planting such a file and re-running.
5. **`chat-user-image-transcript` counted the placeholder** — it treated every `<img>` in
   the document as a transcript picture. The empty-transcript placeholder is on screen for
   exactly as long as the turn has not arrived, so a wait for "one image" was satisfied by
   it and then asserted its `src` against the media route.
6. **`model-picker-live-catalog` raced the picker's own re-poll** — it served the warming
   catalogue on the FIRST fetch and the live one on every later fetch, assuming the picker
   would not ask twice before the test told it to. It does; "keeps asking while the box is
   still enumerating", in the same file, is the behaviour that says so. The warming window
   is now a flag the case closes itself. The re-read still carries the eleven rows.

## Shared `/tmp` data roots

`catalog-empty-enumeration` failed with "expected 0 to be 2". Its data root was the fixed
literal `/tmp/clawbox-catalog-empty-enumeration-test`, shared with every other process on
the machine. Auditing the pattern found something entirely in-repo and worse:
**`/tmp/test-data` was the data root of four suites** — `apps/icon`, `apps/install`,
`apps/uninstall`, `unit/code-projects` — which run in parallel and each wipe it in their
own `beforeEach`. `/tmp/clawbox-test-data` was shared by two more.

All 24 such roots now carry `${process.pid}`, the suffix `vitest.config.ts` already gives
`CLAWBOX_ROOT` and `OPENCLAW_HOME` for exactly this reason.

## Budgets: a detected family, not a growing list

`src/tests/unit/test-timeout-hygiene.test.ts` forbids raising the defaults globally — 5 s
is a guard against a test that has genuinely hung — and requires the ceiling to be declared
per file. A first attempt to raise `testTimeout` for the whole `components` project was
caught by that guard and reverted.

Twelve distinct files timed out across this sweep and **all twelve mount `ChatPopup`**, so
the guard now DETECTS that family instead of listing it: a component suite that mounts
`ChatPopup` declares both ceilings. 32 files gained one; the nine entries the rule covers
left `ALSO_REQUIRED` (`chat-hermes-stale-catalogue` and `ai-provider-list` stay — same
family, no `ChatPopup`, so nothing detects them). The rule also asserts the family is
non-empty, so a renamed component cannot make it vacuous.

Measured worst cases, from a clean full parallel run of all 216 component files:

| file | worst case | note |
|---|---|---|
| `routes/files/safe-path-containment` | 4,562 ms **idle, in isolation** | drives the Files route 3,000 times over a generated corpus with real fs — 91% of the default before any contention |
| `chat-clawbox-ai-model-pill` | 4,558 ms | slowest passing case in the `ChatPopup` family |
| `chat-header-seed-race` | 3,456 ms | |
| `chat-voice-recording` | 3,199 ms | |
| `chat-hermes-stale-catalogue` | 3,175 ms | no `ChatPopup`; listed explicitly |
| `chat-header-chatgpt-row` | 3,106 ms | |
| `ai-provider-list` | 3,031 ms | no `ChatPopup`; listed explicitly |

Worth recording: `asyncUtilTimeout` (5 s, `src/tests/setup.ts`) equals vitest's default
`testTimeout`, so a wait that used its whole budget killed the *test* first and reported
"Test timed out in 5000ms" instead of naming the element. Every race above hid behind that
message. It also cascades — an aborted case leaves its component draining a send queue into
the next case's collector, which is how `chat-queue-starvation` reported `['msg C']` where
`['first']` was expected.

## A timing ratio whose floor inverted its verdict

`local-model-profile` > "scales linearly rather than quadratically" divides two wall-clock
measurements and compares the ratio against 32. It divided by `Math.max(small, 0.05)`, and
one linear parse of 50,000 characters is hundredths of a millisecond — so a small case at
that floor turned a perfectly linear large case into a ratio of 69.66 and reported the
quadratic as back. Both sides are averaged over 50 parses now; each is tens of milliseconds
and needs no floor.

## Tests run

Three consecutive full runs of both projects at the final commit, all green:

| run | project | result | duration |
|---|---|---|---|
| 1 — fully parallel | unit | 836 files / 14,267 tests passed (1 file, 19 tests skipped) | 157 s |
| 1 — fully parallel | components | 216 files / 1,955 tests passed | 106 s |
| 2 — `--no-file-parallelism` | unit | 836 / 14,267 passed | 799 s |
| 2 — `--no-file-parallelism` | components | 216 / 1,955 passed | 436 s |
| 3 — fully parallel | unit | 836 / 14,267 passed | 186 s |
| 3 — fully parallel | components | 216 / 1,955 passed | 105 s |

There is no separate `routes` vitest project; `src/tests/routes/**` is part of `unit`.

- `npx tsc --noEmit` — clean.
- `npx eslint .` — 20 errors, 131 warnings. The baseline immediately before today's seven
  merges (`785257cd`) is 20 errors, 132 warnings; compared file-by-file and rule-by-rule
  the lists are identical except one `no-unused-vars` that disappeared. Today's merges
  introduced no new lint problems, so none were fixed here. The 20 errors are the advisory
  baseline `pr-tests-coverage.yml` already documents.

## Limitations

- The machine used for these runs also hosts other work; load average ranged from ~10 to
  ~57 and wall times varied by about 2x. That is not a controlled environment — and it is
  also why the thin-margin failures surfaced at all. Every fix is traced to a cause that
  does not depend on load: a dropped event, a shared directory, a ratio with a floor.
- `src/tests/unit/stt-bench.test.ts` was reported elsewhere as failing on clean `beta`. It
  did not reproduce here — it passed in isolation and in every full unit run. Unchanged.
- `src/tests/routes/llamacpp/install.test.ts` has one case at ~3.0 s that is a fixed
  real-timer cost rather than contention. It has not failed in any run here, so it was left
  alone; it is the next candidate if CI ever reports a timeout there.
- Raising a ceiling bounds a hang later, not never. The test job's `timeout-minutes: 30`
  (pinned by the hygiene test) is what stops a genuine hang from burning a runner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of chat, catalog, filesystem, and application route test coverage.
  * Added synchronization checks so chat tests wait for session setup before validating results.
  * Increased time allowances for slower component and integration tests.
  * Made asynchronous probes and live catalog transitions deterministic.
  * Isolated temporary test data across parallel processes to prevent state collisions.
  * Strengthened validation for timeout configuration and attachment, transcript, and persistence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->